### PR TITLE
fix(docs): remove duplicate page H1 across doc versions

### DIFF
--- a/fern/pages-dev/README.md
+++ b/fern/pages-dev/README.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: How to Build and Publish Dynamo Docs
 sidebar-title: Dynamo Docs Guide
 ---
-
-# How to Build and Publish Dynamo Docs
 
 This document describes the architecture, workflows, and maintenance procedures for the
 NVIDIA Dynamo documentation website powered by [Fern](https://buildwithfern.com).

--- a/fern/pages-dev/backends/sglang/agents.md
+++ b/fern/pages-dev/backends/sglang/agents.md
@@ -5,8 +5,6 @@ title: SGLang for Agentic Workloads
 subtitle: Priority scheduling and session control for multi-turn agentic serving
 ---
 
-# SGLang for Agentic Workloads
-
 This guide covers SGLang-specific configuration for agentic serving with Dynamo. It explains which SGLang engine flags to enable, how Dynamo's [agent hints](../../components/frontend/nvext.md#agent-hints) map to SGLang behavior, and how to use session control to manage KV cache for multi-turn agent conversations.
 
 ## Overview

--- a/fern/pages-dev/backends/vllm/README.md
+++ b/fern/pages-dev/backends/vllm/README.md
@@ -4,8 +4,6 @@
 title: vLLM
 ---
 
-# LLM Deployment using vLLM
-
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
 ## Installation

--- a/fern/pages-dev/backends/vllm/vllm-examples.md
+++ b/fern/pages-dev/backends/vllm/vllm-examples.md
@@ -4,8 +4,6 @@
 title: Examples
 ---
 
-# vLLM Examples
-
 For quick start instructions, see the [vLLM README](README.md). This document provides all deployment patterns for running vLLM with Dynamo, including aggregated, disaggregated, KV-routed, and expert-parallel configurations.
 
 ## Table of Contents

--- a/fern/pages-dev/backends/vllm/vllm-kv-offloading.md
+++ b/fern/pages-dev/backends/vllm/vllm-kv-offloading.md
@@ -5,8 +5,6 @@ title: KV Cache Offloading
 subtitle: CPU and disk offloading integrations for vLLM in Dynamo
 ---
 
-# KV Cache Offloading
-
 Dynamo supports multiple KV cache offloading backends for vLLM, allowing you to extend effective KV cache capacity beyond GPU memory using CPU RAM and disk storage. Each backend integrates through vLLM's connector interface and works with both aggregated and disaggregated serving.
 
 

--- a/fern/pages-dev/backends/vllm/vllm-reference-guide.md
+++ b/fern/pages-dev/backends/vllm/vllm-reference-guide.md
@@ -5,8 +5,6 @@ title: Reference Guide
 subtitle: Configuration, arguments, and operational details for the vLLM backend
 ---
 
-# Reference Guide
-
 ## Overview
 
 The vLLM backend in Dynamo integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting.

--- a/fern/pages-dev/components/router/topology-aware-kv-transfer.md
+++ b/fern/pages-dev/components/router/topology-aware-kv-transfer.md
@@ -5,8 +5,6 @@ title: Topology-Aware KV Transfer
 subtitle: Runtime metadata and decode routing semantics for topology-aware prefill/decode handoff
 ---
 
-# Topology-Aware KV Transfer
-
 Topology-aware KV transfer constrains or biases decode worker selection after a prefill worker has been selected. The router derives standard `RoutingConstraints` from the selected prefill worker's published topology metadata, then merges those constraints into the decode request.
 
 Use the Kubernetes operator path when possible.

--- a/fern/pages-dev/contribution-guide.md
+++ b/fern/pages-dev/contribution-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Contribution Guide
 subtitle: How to contribute to Dynamo
 max-toc-depth: 3
 ---
@@ -8,8 +9,6 @@ max-toc-depth: 3
 <p align="left">
   <a href="./contribution-guide.zh-CN.md" hreflang="zh-CN"><img src="./assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Contribution Guide
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/main/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 

--- a/fern/pages-dev/design-docs/architecture.md
+++ b/fern/pages-dev/design-docs/architecture.md
@@ -9,8 +9,6 @@ subtitle: Architecture and components of the Dynamo inference runtime
   <a href="./architecture.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
 
-# Dynamo Architecture
-
 Dynamo is a distributed inference runtime for generative AI systems that must operate at high throughput, low latency, and high reliability under changing traffic conditions. It is backend-agnostic (SGLang, TRT-LLM, vLLM, and others) and is built around three cooperating concerns:
 
 - A fast **request path** for token generation

--- a/fern/pages-dev/development/backend-guide.md
+++ b/fern/pages-dev/development/backend-guide.md
@@ -6,8 +6,6 @@ sidebar-title: Writing Python Workers
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 
-# Writing Python Workers in Dynamo
-
 > **Lower-level Python worker path.** This guide documents the
 > `@dynamo_worker()` + `register_model()` + `endpoint.serve_endpoint()`
 > entry point. For new engines, prefer Dynamo's

--- a/fern/pages-dev/features/diffusion/fastvideo.md
+++ b/fern/pages-dev/features/diffusion/fastvideo.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FastVideo
 sidebar-title: FastVideo
 ---
-
-# FastVideo
 
 This guide covers deploying [FastVideo](https://github.com/hao-ai-lab/FastVideo) text-to-video generation on Dynamo using a custom worker (`worker.py`) exposed through the `/v1/videos` endpoint.
 

--- a/fern/pages-dev/getting-started/building-from-source.md
+++ b/fern/pages-dev/getting-started/building-from-source.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Building from Source
 sidebar-title: Building from Source
 description: Build Dynamo from source for development and contributions
 ---
@@ -8,8 +9,6 @@ description: Build Dynamo from source for development and contributions
 <p align="left">
   <a href="./building-from-source.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Building from Source
 
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 

--- a/fern/pages-dev/getting-started/introduction.md
+++ b/fern/pages-dev/getting-started/introduction.md
@@ -1,14 +1,13 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
 
 <p align="left">
   <a href="./introduction.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Introduction to Dynamo
 
 Dynamo is an open-source, high-throughput, low-latency inference framework,
 designed to serve generative AI workloads in distributed environments. It is

--- a/fern/pages-dev/getting-started/local-installation.md
+++ b/fern/pages-dev/getting-started/local-installation.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Local Installation
 sidebar-title: Local Installation
 description: Install and run Dynamo on a local machine or VM with containers or PyPI
 ---
@@ -8,8 +9,6 @@ description: Install and run Dynamo on a local machine or VM with containers or 
 <p align="left">
   <a href="./local-installation.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Local Installation
 
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 

--- a/fern/pages-dev/kubernetes/cloud-providers/aks/aks.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/aks/aks.md
@@ -4,8 +4,6 @@
 title: Azure Kubernetes Service (AKS)
 ---
 
-# Dynamo on AKS
-
 This guide covers setting up an AKS cluster with GPU nodes and deploying Dynamo.
 
 ## Prerequisites

--- a/fern/pages-dev/kubernetes/cloud-providers/aks/azure-lustre-csi.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/aks/azure-lustre-csi.md
@@ -4,8 +4,6 @@
 title: Azure Lustre CSI Driver for AKS
 ---
 
-# Azure Lustre CSI Driver for AKS
-
 This guide covers installing and configuring the [Azure Lustre CSI driver](https://github.com/kubernetes-sigs/azurelustre-csi-driver) on an AKS cluster so that Dynamo workloads can use Azure Managed Lustre (AMLFS) filesystems for high-performance model storage.
 
 ## Prerequisites

--- a/fern/pages-dev/kubernetes/cloud-providers/aks/rdma-infiniband.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/aks/rdma-infiniband.md
@@ -4,8 +4,6 @@
 title: RDMA / InfiniBand on AKS
 ---
 
-# RDMA / InfiniBand on AKS
-
 This guide covers setting up RDMA over InfiniBand on AKS for high-performance disaggregated inference with Dynamo. RDMA enables direct memory access between GPUs across nodes, bypassing CPU and kernel overhead — critical for low-latency KV cache transfer between prefill and decode workers.
 
 Without RDMA, disaggregated inference falls back to TCP with severe performance degradation (~98s TTFT vs ~200-500ms with RDMA). See the [Disaggregated Communication Guide](../../disagg-communication-guide.md) for details on transport options and performance expectations.

--- a/fern/pages-dev/kubernetes/cloud-providers/aks/spot-vms.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/aks/spot-vms.md
@@ -4,8 +4,6 @@
 title: AKS Spot VMs
 ---
 
-# Running Dynamo on AKS Spot VMs
-
 [Azure Spot VMs](https://azure.microsoft.com/en-us/products/virtual-machines/spot) offer significant cost savings for GPU workloads but can be evicted by Azure at any time. This guide covers the configuration required to schedule Dynamo on Spot VM node pools.
 
 ## How AKS Taints Spot Nodes

--- a/fern/pages-dev/kubernetes/cloud-providers/aks/storage.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/aks/storage.md
@@ -4,8 +4,6 @@
 title: Storage for Model Caching on AKS
 ---
 
-# Storage for Model Caching on AKS
-
 For implementing tiered storage on AKS, you can take advantage of the different storage options available in Azure. This guide covers choosing the right storage for each Dynamo cache type and configuring PVCs.
 
 ## Available Storage Options

--- a/fern/pages-dev/kubernetes/cloud-providers/ecs/ecs.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/ecs/ecs.md
@@ -4,7 +4,6 @@
 title: Amazon Elastic Container Service (ECS)
 ---
 
-# Dynamo Deployment of vLLM Example on AWS ECS
 ## 1. EC2 Cluster Setup (for vLLM workloads)
 1. Go to AWS ECS console, **Clusters** tab and click on **Create cluster** with name `dynamo-GPU`
 2. Input the cluster name and choose **AWS EC2 instances** as the infrastructure. This option will create a cluster with EC2 instances to deploy containers.

--- a/fern/pages-dev/kubernetes/cloud-providers/eks/efa.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/eks/efa.md
@@ -4,8 +4,6 @@
 title: EFA (RDMA over AWS Fabric) on EKS
 ---
 
-# EFA (RDMA over AWS Fabric) on EKS
-
 This guide covers setting up RDMA over AWS Elastic Fabric Adapter (EFA) on EKS for high-performance disaggregated inference with Dynamo. EFA is the only RDMA fabric available on AWS — InfiniBand and RoCE are not offered. With EFA, Dynamo's prefill and decode workers transfer KV cache directly between GPUs across nodes via GPU-Direct RDMA, bypassing CPU and TCP/IP stacks.
 
 Without RDMA, disaggregated inference falls back to TCP with severe performance degradation (~98s TTFT vs ~1s with EFA on Llama-3.1-8B at ISL 8000). See the [Disaggregated Communication Guide](../../disagg-communication-guide.md) for the transport-layer fundamentals.

--- a/fern/pages-dev/kubernetes/cloud-providers/eks/efs.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/eks/efs.md
@@ -4,8 +4,6 @@
 title: Amazon EFS Setup for EKS
 ---
 
-# Create an Amazon EFS File System for Amazon EKS
-
 This guide walks through creating an Amazon EFS file system and connecting it to your EKS cluster. The EFS CSI Driver was already installed as an addon via `eksctl.yaml` during cluster creation. Now we need to create the actual file system and make it available to Kubernetes workloads.
 
 This filesystem will be used by Dynamo to store shared model weights and compilation cache across nodes.

--- a/fern/pages-dev/kubernetes/cloud-providers/eks/eks.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/eks/eks.md
@@ -4,8 +4,6 @@
 title: Amazon Elastic Kubernetes Service (EKS)
 ---
 
-# Steps to create an EKS cluster
-
 This guide demonstrates the Dynamo platform on Amazon Elastic Kubernetes Service (EKS).
 
 ## Clone the repository and set working directory

--- a/fern/pages-dev/kubernetes/cloud-providers/gke/gke.md
+++ b/fern/pages-dev/kubernetes/cloud-providers/gke/gke.md
@@ -4,8 +4,6 @@
 title: Google Kubernetes Engine (GKE)
 ---
 
-# Dynamo Deployment on GKE
-
 ## Pre-requisites
 
 ### Install gcloud CLI

--- a/fern/pages-dev/kubernetes/disagg-communication-guide.md
+++ b/fern/pages-dev/kubernetes/disagg-communication-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Disaggregated Inference Communication Guide
 sidebar-title: Disagg Communication
 subtitle: Best practices for prefill/decode worker communication on Kubernetes
 ---
-
-# Disaggregated Inference Communication Guide
 
 This guide explains how prefill and decode workers communicate in Dynamo's disaggregated inference architecture on Kubernetes. It answers the frequently asked question: **Why can't prefill and decode workers use NVLink to communicate on the same node?**
 

--- a/fern/pages-dev/kubernetes/topology-aware-kv-transfer.md
+++ b/fern/pages-dev/kubernetes/topology-aware-kv-transfer.md
@@ -5,8 +5,6 @@ title: Topology-Aware KV Transfer
 subtitle: Keep disaggregated prefill and decode KV-cache transfers within a selected topology domain
 ---
 
-# Topology-Aware KV Transfer
-
 Topology-aware KV transfer lets a disaggregated Dynamo deployment route decode requests toward workers that share the selected prefill worker's topology domain, such as zone or rack. This reduces slow cross-domain KV-cache transfers when prefill and decode workers exchange KV data over NIXL.
 
 Use this feature when:

--- a/fern/pages-v1.0.0/README.md
+++ b/fern/pages-v1.0.0/README.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: How to Build and Publish Dynamo Docs
 sidebar-title: Dynamo Docs Guide
 ---
-
-# How to Build and Publish Dynamo Docs
 
 This document describes the architecture, workflows, and maintenance procedures for the
 NVIDIA Dynamo documentation website powered by [Fern](https://buildwithfern.com).

--- a/fern/pages-v1.0.0/backends/sglang/agents.md
+++ b/fern/pages-v1.0.0/backends/sglang/agents.md
@@ -5,8 +5,6 @@ title: SGLang for Agentic Workloads
 subtitle: Priority scheduling, KV cache eviction policies, and cache pinning for multi-turn agentic serving
 ---
 
-# SGLang for Agentic Workloads
-
 This guide covers SGLang-specific configuration for agentic serving with Dynamo. It explains which SGLang engine flags to enable, how Dynamo's [agent hints](../../components/frontend/nvext.md#agent-hints) map to SGLang behavior, and how to use experimental cache pinning to protect KV cache for high-value conversations.
 
 ## Overview

--- a/fern/pages-v1.0.0/backends/vllm/README.md
+++ b/fern/pages-v1.0.0/backends/vllm/README.md
@@ -4,8 +4,6 @@
 title: vLLM
 ---
 
-# LLM Deployment using vLLM
-
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
 ## Installation

--- a/fern/pages-v1.0.0/backends/vllm/vllm-examples.md
+++ b/fern/pages-v1.0.0/backends/vllm/vllm-examples.md
@@ -4,8 +4,6 @@
 title: Examples
 ---
 
-# vLLM Examples
-
 For quick start instructions, see the [vLLM README](README.md). This document provides all deployment patterns for running vLLM with Dynamo, including aggregated, disaggregated, KV-routed, and expert-parallel configurations.
 
 ## Table of Contents

--- a/fern/pages-v1.0.0/backends/vllm/vllm-kv-offloading.md
+++ b/fern/pages-v1.0.0/backends/vllm/vllm-kv-offloading.md
@@ -5,8 +5,6 @@ title: KV Cache Offloading
 subtitle: CPU and disk offloading integrations for vLLM in Dynamo
 ---
 
-# KV Cache Offloading
-
 Dynamo supports multiple KV cache offloading backends for vLLM, allowing you to extend effective KV cache capacity beyond GPU memory using CPU RAM and disk storage. Each backend integrates through vLLM's connector interface and works with both aggregated and disaggregated serving.
 
 

--- a/fern/pages-v1.0.0/backends/vllm/vllm-reference-guide.md
+++ b/fern/pages-v1.0.0/backends/vllm/vllm-reference-guide.md
@@ -5,8 +5,6 @@ title: Reference Guide
 subtitle: Configuration, arguments, and operational details for the vLLM backend
 ---
 
-# Reference Guide
-
 ## Overview
 
 The vLLM backend in Dynamo integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting.

--- a/fern/pages-v1.0.0/contribution-guide.md
+++ b/fern/pages-v1.0.0/contribution-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Contribution Guide
 subtitle: How to contribute to Dynamo
 max-toc-depth: 3
 ---
-
-# Contribution Guide
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/v1.0.0/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 

--- a/fern/pages-v1.0.0/design-docs/architecture.md
+++ b/fern/pages-v1.0.0/design-docs/architecture.md
@@ -5,8 +5,6 @@ title: Overall Architecture
 subtitle: Architecture and components of the Dynamo inference runtime
 ---
 
-# Dynamo Architecture
-
 Dynamo is a distributed inference runtime for generative AI systems that must operate at high throughput, low latency, and high reliability under changing traffic conditions. It is backend-agnostic (SGLang, TRT-LLM, vLLM, and others) and is built around three cooperating concerns:
 
 - A fast **request path** for token generation

--- a/fern/pages-v1.0.0/development/backend-guide.md
+++ b/fern/pages-v1.0.0/development/backend-guide.md
@@ -6,8 +6,6 @@ sidebar-title: Writing Python Workers
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 
-# Writing Python Workers in Dynamo
-
 This guide explains how to create your own Python worker in Dynamo.
 
 The [dynamo](https://pypi.org/project/ai-dynamo/) Python library allows you to build your own engine and attach it to Dynamo.

--- a/fern/pages-v1.0.0/features/diffusion/fastvideo.md
+++ b/fern/pages-v1.0.0/features/diffusion/fastvideo.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FastVideo
 sidebar-title: FastVideo
 ---
-
-# FastVideo
 
 This guide covers deploying [FastVideo](https://github.com/hao-ai-lab/FastVideo) text-to-video generation on Dynamo using a custom worker (`worker.py`) exposed through the `/v1/videos` endpoint.
 

--- a/fern/pages-v1.0.0/getting-started/building-from-source.md
+++ b/fern/pages-v1.0.0/getting-started/building-from-source.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Building from Source
 sidebar-title: Building from Source
 description: Build Dynamo from source for development and contributions
 ---
-
-# Building from Source
 
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 

--- a/fern/pages-v1.0.0/getting-started/introduction.md
+++ b/fern/pages-v1.0.0/getting-started/introduction.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
-
-# Introduction to Dynamo
 
 Dynamo is an open-source, high-throughput, low-latency inference framework, designed to serve generative AI workloads in distributed environments. This page gives an overview of Dynamo's design principles, performance benefits, and production-grade features.
 

--- a/fern/pages-v1.0.0/getting-started/local-installation.md
+++ b/fern/pages-v1.0.0/getting-started/local-installation.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Local Installation
 sidebar-title: Local Installation
 description: Install and run Dynamo on a local machine or VM with containers or PyPI
 ---
-
-# Local Installation
 
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 

--- a/fern/pages-v1.0.0/kubernetes/dgdr.md
+++ b/fern/pages-v1.0.0/kubernetes/dgdr.md
@@ -4,8 +4,6 @@
 title: Deploying Your First Model
 ---
 
-# Deploying Your First Model
-
 End-to-end tutorial for deploying `Qwen/Qwen3-0.6B` on Kubernetes using Dynamo's recommended
 `DynamoGraphDeploymentRequest` (DGDR) workflow — from zero to your first inference response.
 

--- a/fern/pages-v1.0.0/kubernetes/inference-gateway.md
+++ b/fern/pages-v1.0.0/kubernetes/inference-gateway.md
@@ -6,8 +6,6 @@ title: Inference Gateway (GAIE)
 
 ## Inference Gateway Setup with Dynamo
 
-# Inference Gateway (GAIE)
-
 Integrate Dynamo with the Gateway API Inference Extension for intelligent KV-aware request routing at the gateway layer.
 
 EPP's default kv-routing approach is not token-aware because the prompt is not tokenized. But the Dynamo plugin uses a token-aware KV algorithm. It employs the dynamo router which implements kv routing by running your model's tokenizer inline. The EPP plugin configuration lives in [`helm/dynamo-gaie/epp-config-dynamo.yaml`](https://github.com/ai-dynamo/dynamo/blob/v1.0.0/deploy/inference-gateway/standalone/helm/dynamo-gaie/epp-config-dynamo.yaml) per EPP [convention](https://gateway-api-inference-extension.sigs.k8s.io/guides/epp-configuration/config-text/).

--- a/fern/pages-v1.0.1/README.md
+++ b/fern/pages-v1.0.1/README.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: How to Build and Publish Dynamo Docs
 sidebar-title: Dynamo Docs Guide
 ---
-
-# How to Build and Publish Dynamo Docs
 
 This document describes the architecture, workflows, and maintenance procedures for the
 NVIDIA Dynamo documentation website powered by [Fern](https://buildwithfern.com).

--- a/fern/pages-v1.0.1/backends/sglang/agents.md
+++ b/fern/pages-v1.0.1/backends/sglang/agents.md
@@ -5,8 +5,6 @@ title: SGLang for Agentic Workloads
 subtitle: Priority scheduling, KV cache eviction policies, and cache pinning for multi-turn agentic serving
 ---
 
-# SGLang for Agentic Workloads
-
 This guide covers SGLang-specific configuration for agentic serving with Dynamo. It explains which SGLang engine flags to enable, how Dynamo's [agent hints](../../components/frontend/nvext.md#agent-hints) map to SGLang behavior, and how to use experimental cache pinning to protect KV cache for high-value conversations.
 
 ## Overview

--- a/fern/pages-v1.0.1/backends/vllm/README.md
+++ b/fern/pages-v1.0.1/backends/vllm/README.md
@@ -4,8 +4,6 @@
 title: vLLM
 ---
 
-# LLM Deployment using vLLM
-
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
 ## Installation

--- a/fern/pages-v1.0.1/backends/vllm/vllm-examples.md
+++ b/fern/pages-v1.0.1/backends/vllm/vllm-examples.md
@@ -4,8 +4,6 @@
 title: Examples
 ---
 
-# vLLM Examples
-
 For quick start instructions, see the [vLLM README](README.md). This document provides all deployment patterns for running vLLM with Dynamo, including aggregated, disaggregated, KV-routed, and expert-parallel configurations.
 
 ## Table of Contents

--- a/fern/pages-v1.0.1/backends/vllm/vllm-kv-offloading.md
+++ b/fern/pages-v1.0.1/backends/vllm/vllm-kv-offloading.md
@@ -5,8 +5,6 @@ title: KV Cache Offloading
 subtitle: CPU and disk offloading integrations for vLLM in Dynamo
 ---
 
-# KV Cache Offloading
-
 Dynamo supports multiple KV cache offloading backends for vLLM, allowing you to extend effective KV cache capacity beyond GPU memory using CPU RAM and disk storage. Each backend integrates through vLLM's connector interface and works with both aggregated and disaggregated serving.
 
 

--- a/fern/pages-v1.0.1/backends/vllm/vllm-reference-guide.md
+++ b/fern/pages-v1.0.1/backends/vllm/vllm-reference-guide.md
@@ -5,8 +5,6 @@ title: Reference Guide
 subtitle: Configuration, arguments, and operational details for the vLLM backend
 ---
 
-# Reference Guide
-
 ## Overview
 
 The vLLM backend in Dynamo integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting.

--- a/fern/pages-v1.0.1/contribution-guide.md
+++ b/fern/pages-v1.0.1/contribution-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Contribution Guide
 subtitle: How to contribute to Dynamo
 max-toc-depth: 3
 ---
-
-# Contribution Guide
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/v1.0.1/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 

--- a/fern/pages-v1.0.1/design-docs/architecture.md
+++ b/fern/pages-v1.0.1/design-docs/architecture.md
@@ -5,8 +5,6 @@ title: Overall Architecture
 subtitle: Architecture and components of the Dynamo inference runtime
 ---
 
-# Dynamo Architecture
-
 Dynamo is a distributed inference runtime for generative AI systems that must operate at high throughput, low latency, and high reliability under changing traffic conditions. It is backend-agnostic (SGLang, TRT-LLM, vLLM, and others) and is built around three cooperating concerns:
 
 - A fast **request path** for token generation

--- a/fern/pages-v1.0.1/development/backend-guide.md
+++ b/fern/pages-v1.0.1/development/backend-guide.md
@@ -6,8 +6,6 @@ sidebar-title: Writing Python Workers
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 
-# Writing Python Workers in Dynamo
-
 This guide explains how to create your own Python worker in Dynamo.
 
 The [dynamo](https://pypi.org/project/ai-dynamo/) Python library allows you to build your own engine and attach it to Dynamo.

--- a/fern/pages-v1.0.1/features/diffusion/fastvideo.md
+++ b/fern/pages-v1.0.1/features/diffusion/fastvideo.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FastVideo
 sidebar-title: FastVideo
 ---
-
-# FastVideo
 
 This guide covers deploying [FastVideo](https://github.com/hao-ai-lab/FastVideo) text-to-video generation on Dynamo using a custom worker (`worker.py`) exposed through the `/v1/videos` endpoint.
 

--- a/fern/pages-v1.0.1/getting-started/building-from-source.md
+++ b/fern/pages-v1.0.1/getting-started/building-from-source.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Building from Source
 sidebar-title: Building from Source
 description: Build Dynamo from source for development and contributions
 ---
-
-# Building from Source
 
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 

--- a/fern/pages-v1.0.1/getting-started/introduction.md
+++ b/fern/pages-v1.0.1/getting-started/introduction.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
-
-# Introduction to Dynamo
 
 Dynamo is an open-source, high-throughput, low-latency inference framework, designed to serve generative AI workloads in distributed environments. This page gives an overview of Dynamo's design principles, performance benefits, and production-grade features.
 

--- a/fern/pages-v1.0.1/getting-started/local-installation.md
+++ b/fern/pages-v1.0.1/getting-started/local-installation.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Local Installation
 sidebar-title: Local Installation
 description: Install and run Dynamo on a local machine or VM with containers or PyPI
 ---
-
-# Local Installation
 
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 

--- a/fern/pages-v1.0.1/kubernetes/dgdr.md
+++ b/fern/pages-v1.0.1/kubernetes/dgdr.md
@@ -4,8 +4,6 @@
 title: Deploying Your First Model
 ---
 
-# Deploying Your First Model
-
 End-to-end tutorial for deploying `Qwen/Qwen3-0.6B` on Kubernetes using Dynamo's recommended
 `DynamoGraphDeploymentRequest` (DGDR) workflow — from zero to your first inference response.
 

--- a/fern/pages-v1.0.1/kubernetes/inference-gateway.md
+++ b/fern/pages-v1.0.1/kubernetes/inference-gateway.md
@@ -6,8 +6,6 @@ title: Inference Gateway (GAIE)
 
 ## Inference Gateway Setup with Dynamo
 
-# Inference Gateway (GAIE)
-
 Integrate Dynamo with the Gateway API Inference Extension for intelligent KV-aware request routing at the gateway layer.
 
 EPP's default kv-routing approach is not token-aware because the prompt is not tokenized. But the Dynamo plugin uses a token-aware KV algorithm. It employs the dynamo router which implements kv routing by running your model's tokenizer inline. The EPP plugin configuration lives in [`helm/dynamo-gaie/epp-config-dynamo.yaml`](https://github.com/ai-dynamo/dynamo/blob/v1.0.1/deploy/inference-gateway/standalone/helm/dynamo-gaie/epp-config-dynamo.yaml) per EPP [convention](https://gateway-api-inference-extension.sigs.k8s.io/guides/epp-configuration/config-text/).

--- a/fern/pages-v1.0.2/README.md
+++ b/fern/pages-v1.0.2/README.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: How to Build and Publish Dynamo Docs
 sidebar-title: Dynamo Docs Guide
 ---
-
-# How to Build and Publish Dynamo Docs
 
 This document describes the architecture, workflows, and maintenance procedures for the
 NVIDIA Dynamo documentation website powered by [Fern](https://buildwithfern.com).

--- a/fern/pages-v1.0.2/backends/sglang/agents.md
+++ b/fern/pages-v1.0.2/backends/sglang/agents.md
@@ -5,8 +5,6 @@ title: SGLang for Agentic Workloads
 subtitle: Priority scheduling and session control for multi-turn agentic serving
 ---
 
-# SGLang for Agentic Workloads
-
 This guide covers SGLang-specific configuration for agentic serving with Dynamo. It explains which SGLang engine flags to enable, how Dynamo's [agent hints](../../components/frontend/nvext.md#agent-hints) map to SGLang behavior, and how to use session control to manage KV cache for multi-turn agent conversations.
 
 ## Overview

--- a/fern/pages-v1.0.2/backends/vllm/README.md
+++ b/fern/pages-v1.0.2/backends/vllm/README.md
@@ -4,8 +4,6 @@
 title: vLLM
 ---
 
-# LLM Deployment using vLLM
-
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
 ## Installation

--- a/fern/pages-v1.0.2/backends/vllm/vllm-examples.md
+++ b/fern/pages-v1.0.2/backends/vllm/vllm-examples.md
@@ -4,8 +4,6 @@
 title: Examples
 ---
 
-# vLLM Examples
-
 For quick start instructions, see the [vLLM README](README.md). This document provides all deployment patterns for running vLLM with Dynamo, including aggregated, disaggregated, KV-routed, and expert-parallel configurations.
 
 ## Table of Contents

--- a/fern/pages-v1.0.2/backends/vllm/vllm-kv-offloading.md
+++ b/fern/pages-v1.0.2/backends/vllm/vllm-kv-offloading.md
@@ -5,8 +5,6 @@ title: KV Cache Offloading
 subtitle: CPU and disk offloading integrations for vLLM in Dynamo
 ---
 
-# KV Cache Offloading
-
 Dynamo supports multiple KV cache offloading backends for vLLM, allowing you to extend effective KV cache capacity beyond GPU memory using CPU RAM and disk storage. Each backend integrates through vLLM's connector interface and works with both aggregated and disaggregated serving.
 
 

--- a/fern/pages-v1.0.2/backends/vllm/vllm-reference-guide.md
+++ b/fern/pages-v1.0.2/backends/vllm/vllm-reference-guide.md
@@ -5,8 +5,6 @@ title: Reference Guide
 subtitle: Configuration, arguments, and operational details for the vLLM backend
 ---
 
-# Reference Guide
-
 ## Overview
 
 The vLLM backend in Dynamo integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting.

--- a/fern/pages-v1.0.2/contribution-guide.md
+++ b/fern/pages-v1.0.2/contribution-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Contribution Guide
 subtitle: How to contribute to Dynamo
 max-toc-depth: 3
 ---
-
-# Contribution Guide
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/v1.0.2/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 

--- a/fern/pages-v1.0.2/design-docs/architecture.md
+++ b/fern/pages-v1.0.2/design-docs/architecture.md
@@ -5,8 +5,6 @@ title: Overall Architecture
 subtitle: Architecture and components of the Dynamo inference runtime
 ---
 
-# Dynamo Architecture
-
 Dynamo is a distributed inference runtime for generative AI systems that must operate at high throughput, low latency, and high reliability under changing traffic conditions. It is backend-agnostic (SGLang, TRT-LLM, vLLM, and others) and is built around three cooperating concerns:
 
 - A fast **request path** for token generation

--- a/fern/pages-v1.0.2/development/backend-guide.md
+++ b/fern/pages-v1.0.2/development/backend-guide.md
@@ -6,8 +6,6 @@ sidebar-title: Writing Python Workers
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 
-# Writing Python Workers in Dynamo
-
 This guide explains how to create your own Python worker in Dynamo.
 
 The [dynamo](https://pypi.org/project/ai-dynamo/) Python library allows you to build your own engine and attach it to Dynamo.

--- a/fern/pages-v1.0.2/features/diffusion/fastvideo.md
+++ b/fern/pages-v1.0.2/features/diffusion/fastvideo.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FastVideo
 sidebar-title: FastVideo
 ---
-
-# FastVideo
 
 This guide covers deploying [FastVideo](https://github.com/hao-ai-lab/FastVideo) text-to-video generation on Dynamo using a custom worker (`worker.py`) exposed through the `/v1/videos` endpoint.
 

--- a/fern/pages-v1.0.2/getting-started/building-from-source.md
+++ b/fern/pages-v1.0.2/getting-started/building-from-source.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Building from Source
 sidebar-title: Building from Source
 description: Build Dynamo from source for development and contributions
 ---
-
-# Building from Source
 
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 

--- a/fern/pages-v1.0.2/getting-started/introduction.md
+++ b/fern/pages-v1.0.2/getting-started/introduction.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
-
-# Introduction to Dynamo
 
 Dynamo is an open-source, high-throughput, low-latency inference framework, designed to serve generative AI workloads in distributed environments. This page gives an overview of Dynamo's design principles, performance benefits, and production-grade features.
 

--- a/fern/pages-v1.0.2/getting-started/local-installation.md
+++ b/fern/pages-v1.0.2/getting-started/local-installation.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Local Installation
 sidebar-title: Local Installation
 description: Install and run Dynamo on a local machine or VM with containers or PyPI
 ---
-
-# Local Installation
 
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 

--- a/fern/pages-v1.0.2/kubernetes/dgdr.md
+++ b/fern/pages-v1.0.2/kubernetes/dgdr.md
@@ -4,8 +4,6 @@
 title: Deploying Your First Model
 ---
 
-# Deploying Your First Model
-
 End-to-end tutorial for deploying `Qwen/Qwen3-0.6B` on Kubernetes using Dynamo's recommended
 `DynamoGraphDeploymentRequest` (DGDR) workflow — from zero to your first inference response.
 

--- a/fern/pages-v1.0.2/kubernetes/disagg-communication-guide.md
+++ b/fern/pages-v1.0.2/kubernetes/disagg-communication-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Disaggregated Inference Communication Guide
 sidebar-title: Disagg Communication
 subtitle: Best practices for prefill/decode worker communication on Kubernetes
 ---
-
-# Disaggregated Inference Communication Guide
 
 This guide explains how prefill and decode workers communicate in Dynamo's disaggregated inference architecture on Kubernetes. It answers the frequently asked question: **Why can't prefill and decode workers use NVLink to communicate on the same node?**
 

--- a/fern/pages-v1.0.2/kubernetes/inference-gateway.md
+++ b/fern/pages-v1.0.2/kubernetes/inference-gateway.md
@@ -6,8 +6,6 @@ title: Inference Gateway (GAIE)
 
 ## Inference Gateway Setup with Dynamo
 
-# Inference Gateway (GAIE)
-
 Integrate Dynamo with the Gateway API Inference Extension for intelligent KV-aware request routing at the gateway layer.
 
 ## Features

--- a/fern/pages-v1.1.0/README.md
+++ b/fern/pages-v1.1.0/README.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: How to Build and Publish Dynamo Docs
 sidebar-title: Dynamo Docs Guide
 ---
-
-# How to Build and Publish Dynamo Docs
 
 This document describes the architecture, workflows, and maintenance procedures for the
 NVIDIA Dynamo documentation website powered by [Fern](https://buildwithfern.com).

--- a/fern/pages-v1.1.0/backends/sglang/agents.md
+++ b/fern/pages-v1.1.0/backends/sglang/agents.md
@@ -5,8 +5,6 @@ title: SGLang for Agentic Workloads
 subtitle: Priority scheduling and session control for multi-turn agentic serving
 ---
 
-# SGLang for Agentic Workloads
-
 This guide covers SGLang-specific configuration for agentic serving with Dynamo. It explains which SGLang engine flags to enable, how Dynamo's [agent hints](../../components/frontend/nvext.md#agent-hints) map to SGLang behavior, and how to use session control to manage KV cache for multi-turn agent conversations.
 
 ## Overview

--- a/fern/pages-v1.1.0/backends/vllm/README.md
+++ b/fern/pages-v1.1.0/backends/vllm/README.md
@@ -4,8 +4,6 @@
 title: vLLM
 ---
 
-# LLM Deployment using vLLM
-
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
 ## Installation

--- a/fern/pages-v1.1.0/backends/vllm/vllm-examples.md
+++ b/fern/pages-v1.1.0/backends/vllm/vllm-examples.md
@@ -4,8 +4,6 @@
 title: Examples
 ---
 
-# vLLM Examples
-
 For quick start instructions, see the [vLLM README](README.md). This document provides all deployment patterns for running vLLM with Dynamo, including aggregated, disaggregated, KV-routed, and expert-parallel configurations.
 
 ## Table of Contents

--- a/fern/pages-v1.1.0/backends/vllm/vllm-kv-offloading.md
+++ b/fern/pages-v1.1.0/backends/vllm/vllm-kv-offloading.md
@@ -5,8 +5,6 @@ title: KV Cache Offloading
 subtitle: CPU and disk offloading integrations for vLLM in Dynamo
 ---
 
-# KV Cache Offloading
-
 Dynamo supports multiple KV cache offloading backends for vLLM, allowing you to extend effective KV cache capacity beyond GPU memory using CPU RAM and disk storage. Each backend integrates through vLLM's connector interface and works with both aggregated and disaggregated serving.
 
 

--- a/fern/pages-v1.1.0/backends/vllm/vllm-reference-guide.md
+++ b/fern/pages-v1.1.0/backends/vllm/vllm-reference-guide.md
@@ -5,8 +5,6 @@ title: Reference Guide
 subtitle: Configuration, arguments, and operational details for the vLLM backend
 ---
 
-# Reference Guide
-
 ## Overview
 
 The vLLM backend in Dynamo integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting.

--- a/fern/pages-v1.1.0/contribution-guide.md
+++ b/fern/pages-v1.1.0/contribution-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Contribution Guide
 subtitle: How to contribute to Dynamo
 max-toc-depth: 3
 ---
-
-# Contribution Guide
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/v1.1.0/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 

--- a/fern/pages-v1.1.0/design-docs/architecture.md
+++ b/fern/pages-v1.1.0/design-docs/architecture.md
@@ -5,8 +5,6 @@ title: Overall Architecture
 subtitle: Architecture and components of the Dynamo inference runtime
 ---
 
-# Dynamo Architecture
-
 Dynamo is a distributed inference runtime for generative AI systems that must operate at high throughput, low latency, and high reliability under changing traffic conditions. It is backend-agnostic (SGLang, TRT-LLM, vLLM, and others) and is built around three cooperating concerns:
 
 - A fast **request path** for token generation

--- a/fern/pages-v1.1.0/development/backend-guide.md
+++ b/fern/pages-v1.1.0/development/backend-guide.md
@@ -6,8 +6,6 @@ sidebar-title: Writing Python Workers
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 
-# Writing Python Workers in Dynamo
-
 This guide explains how to create your own Python worker in Dynamo.
 
 The [dynamo](https://pypi.org/project/ai-dynamo/) Python library allows you to build your own engine and attach it to Dynamo.

--- a/fern/pages-v1.1.0/features/diffusion/fastvideo.md
+++ b/fern/pages-v1.1.0/features/diffusion/fastvideo.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FastVideo
 sidebar-title: FastVideo
 ---
-
-# FastVideo
 
 This guide covers deploying [FastVideo](https://github.com/hao-ai-lab/FastVideo) text-to-video generation on Dynamo using a custom worker (`worker.py`) exposed through the `/v1/videos` endpoint.
 

--- a/fern/pages-v1.1.0/getting-started/building-from-source.md
+++ b/fern/pages-v1.1.0/getting-started/building-from-source.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Building from Source
 sidebar-title: Building from Source
 description: Build Dynamo from source for development and contributions
 ---
-
-# Building from Source
 
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 

--- a/fern/pages-v1.1.0/getting-started/introduction.md
+++ b/fern/pages-v1.1.0/getting-started/introduction.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
-
-# Introduction to Dynamo
 
 Dynamo is an open-source, high-throughput, low-latency inference framework, designed to serve generative AI workloads in distributed environments. This page gives an overview of Dynamo's design principles, performance benefits, and production-grade features.
 

--- a/fern/pages-v1.1.0/getting-started/local-installation.md
+++ b/fern/pages-v1.1.0/getting-started/local-installation.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Local Installation
 sidebar-title: Local Installation
 description: Install and run Dynamo on a local machine or VM with containers or PyPI
 ---
-
-# Local Installation
 
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 

--- a/fern/pages-v1.1.0/kubernetes/dgdr.md
+++ b/fern/pages-v1.1.0/kubernetes/dgdr.md
@@ -4,8 +4,6 @@
 title: Deploying Your First Model
 ---
 
-# Deploying Your First Model
-
 End-to-end tutorial for deploying `Qwen/Qwen3-0.6B` on Kubernetes using Dynamo's recommended
 `DynamoGraphDeploymentRequest` (DGDR) workflow — from zero to your first inference response.
 

--- a/fern/pages-v1.1.0/kubernetes/disagg-communication-guide.md
+++ b/fern/pages-v1.1.0/kubernetes/disagg-communication-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Disaggregated Inference Communication Guide
 sidebar-title: Disagg Communication
 subtitle: Best practices for prefill/decode worker communication on Kubernetes
 ---
-
-# Disaggregated Inference Communication Guide
 
 This guide explains how prefill and decode workers communicate in Dynamo's disaggregated inference architecture on Kubernetes. It answers the frequently asked question: **Why can't prefill and decode workers use NVLink to communicate on the same node?**
 

--- a/fern/pages-v1.1.0/kubernetes/inference-gateway.md
+++ b/fern/pages-v1.1.0/kubernetes/inference-gateway.md
@@ -6,8 +6,6 @@ title: Inference Gateway (GAIE)
 
 ## Inference Gateway Setup with Dynamo
 
-# Inference Gateway (GAIE)
-
 Integrate Dynamo with the Gateway API Inference Extension for intelligent KV-aware request routing at the gateway layer.
 
 ## Features

--- a/fern/pages-v1.1.1/README.md
+++ b/fern/pages-v1.1.1/README.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: How to Build and Publish Dynamo Docs
 sidebar-title: Dynamo Docs Guide
 ---
-
-# How to Build and Publish Dynamo Docs
 
 This document describes the architecture, workflows, and maintenance procedures for the
 NVIDIA Dynamo documentation website powered by [Fern](https://buildwithfern.com).

--- a/fern/pages-v1.1.1/backends/sglang/agents.md
+++ b/fern/pages-v1.1.1/backends/sglang/agents.md
@@ -5,8 +5,6 @@ title: SGLang for Agentic Workloads
 subtitle: Priority scheduling and session control for multi-turn agentic serving
 ---
 
-# SGLang for Agentic Workloads
-
 This guide covers SGLang-specific configuration for agentic serving with Dynamo. It explains which SGLang engine flags to enable, how Dynamo's [agent hints](../../components/frontend/nvext.md#agent-hints) map to SGLang behavior, and how to use session control to manage KV cache for multi-turn agent conversations.
 
 ## Overview

--- a/fern/pages-v1.1.1/backends/vllm/README.md
+++ b/fern/pages-v1.1.1/backends/vllm/README.md
@@ -4,8 +4,6 @@
 title: vLLM
 ---
 
-# LLM Deployment using vLLM
-
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
 ## Installation

--- a/fern/pages-v1.1.1/backends/vllm/vllm-examples.md
+++ b/fern/pages-v1.1.1/backends/vllm/vllm-examples.md
@@ -4,8 +4,6 @@
 title: Examples
 ---
 
-# vLLM Examples
-
 For quick start instructions, see the [vLLM README](README.md). This document provides all deployment patterns for running vLLM with Dynamo, including aggregated, disaggregated, KV-routed, and expert-parallel configurations.
 
 ## Table of Contents

--- a/fern/pages-v1.1.1/backends/vllm/vllm-kv-offloading.md
+++ b/fern/pages-v1.1.1/backends/vllm/vllm-kv-offloading.md
@@ -5,8 +5,6 @@ title: KV Cache Offloading
 subtitle: CPU and disk offloading integrations for vLLM in Dynamo
 ---
 
-# KV Cache Offloading
-
 Dynamo supports multiple KV cache offloading backends for vLLM, allowing you to extend effective KV cache capacity beyond GPU memory using CPU RAM and disk storage. Each backend integrates through vLLM's connector interface and works with both aggregated and disaggregated serving.
 
 

--- a/fern/pages-v1.1.1/backends/vllm/vllm-reference-guide.md
+++ b/fern/pages-v1.1.1/backends/vllm/vllm-reference-guide.md
@@ -5,8 +5,6 @@ title: Reference Guide
 subtitle: Configuration, arguments, and operational details for the vLLM backend
 ---
 
-# Reference Guide
-
 ## Overview
 
 The vLLM backend in Dynamo integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting.

--- a/fern/pages-v1.1.1/contribution-guide.md
+++ b/fern/pages-v1.1.1/contribution-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Contribution Guide
 subtitle: How to contribute to Dynamo
 max-toc-depth: 3
 ---
-
-# Contribution Guide
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/v1.1.1/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 

--- a/fern/pages-v1.1.1/design-docs/architecture.md
+++ b/fern/pages-v1.1.1/design-docs/architecture.md
@@ -5,8 +5,6 @@ title: Overall Architecture
 subtitle: Architecture and components of the Dynamo inference runtime
 ---
 
-# Dynamo Architecture
-
 Dynamo is a distributed inference runtime for generative AI systems that must operate at high throughput, low latency, and high reliability under changing traffic conditions. It is backend-agnostic (SGLang, TRT-LLM, vLLM, and others) and is built around three cooperating concerns:
 
 - A fast **request path** for token generation

--- a/fern/pages-v1.1.1/development/backend-guide.md
+++ b/fern/pages-v1.1.1/development/backend-guide.md
@@ -6,8 +6,6 @@ sidebar-title: Writing Python Workers
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 
-# Writing Python Workers in Dynamo
-
 This guide explains how to create your own Python worker in Dynamo.
 
 The [dynamo](https://pypi.org/project/ai-dynamo/) Python library allows you to build your own engine and attach it to Dynamo.

--- a/fern/pages-v1.1.1/features/diffusion/fastvideo.md
+++ b/fern/pages-v1.1.1/features/diffusion/fastvideo.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FastVideo
 sidebar-title: FastVideo
 ---
-
-# FastVideo
 
 This guide covers deploying [FastVideo](https://github.com/hao-ai-lab/FastVideo) text-to-video generation on Dynamo using a custom worker (`worker.py`) exposed through the `/v1/videos` endpoint.
 

--- a/fern/pages-v1.1.1/getting-started/building-from-source.md
+++ b/fern/pages-v1.1.1/getting-started/building-from-source.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Building from Source
 sidebar-title: Building from Source
 description: Build Dynamo from source for development and contributions
 ---
-
-# Building from Source
 
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 

--- a/fern/pages-v1.1.1/getting-started/introduction.md
+++ b/fern/pages-v1.1.1/getting-started/introduction.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
-
-# Introduction to Dynamo
 
 Dynamo is an open-source, high-throughput, low-latency inference framework, designed to serve generative AI workloads in distributed environments. This page gives an overview of Dynamo's design principles, performance benefits, and production-grade features.
 

--- a/fern/pages-v1.1.1/getting-started/local-installation.md
+++ b/fern/pages-v1.1.1/getting-started/local-installation.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Local Installation
 sidebar-title: Local Installation
 description: Install and run Dynamo on a local machine or VM with containers or PyPI
 ---
-
-# Local Installation
 
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 

--- a/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/aks.md
+++ b/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/aks.md
@@ -4,8 +4,6 @@
 title: Azure Kubernetes Service (AKS)
 ---
 
-# Dynamo on AKS
-
 This guide covers setting up an AKS cluster with GPU nodes and deploying Dynamo.
 
 ## Prerequisites

--- a/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/azure-lustre-csi.md
+++ b/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/azure-lustre-csi.md
@@ -4,8 +4,6 @@
 title: Azure Lustre CSI Driver for AKS
 ---
 
-# Azure Lustre CSI Driver for AKS
-
 This guide covers installing and configuring the [Azure Lustre CSI driver](https://github.com/kubernetes-sigs/azurelustre-csi-driver) on an AKS cluster so that Dynamo workloads can use Azure Managed Lustre (AMLFS) filesystems for high-performance model storage.
 
 ## Prerequisites

--- a/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/rdma-infiniband.md
+++ b/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/rdma-infiniband.md
@@ -4,8 +4,6 @@
 title: RDMA / InfiniBand on AKS
 ---
 
-# RDMA / InfiniBand on AKS
-
 This guide covers setting up RDMA over InfiniBand on AKS for high-performance disaggregated inference with Dynamo. RDMA enables direct memory access between GPUs across nodes, bypassing CPU and kernel overhead — critical for low-latency KV cache transfer between prefill and decode workers.
 
 Without RDMA, disaggregated inference falls back to TCP with severe performance degradation (~98s TTFT vs ~200-500ms with RDMA). See the [Disaggregated Communication Guide](../../disagg-communication-guide.md) for details on transport options and performance expectations.

--- a/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/spot-vms.md
+++ b/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/spot-vms.md
@@ -4,8 +4,6 @@
 title: AKS Spot VMs
 ---
 
-# Running Dynamo on AKS Spot VMs
-
 [Azure Spot VMs](https://azure.microsoft.com/en-us/products/virtual-machines/spot) offer significant cost savings for GPU workloads but can be evicted by Azure at any time. This guide covers the configuration required to schedule Dynamo on Spot VM node pools.
 
 ## How AKS Taints Spot Nodes

--- a/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/storage.md
+++ b/fern/pages-v1.1.1/kubernetes/cloud-providers/aks/storage.md
@@ -4,8 +4,6 @@
 title: Storage for Model Caching on AKS
 ---
 
-# Storage for Model Caching on AKS
-
 For implementing tiered storage on AKS, you can take advantage of the different storage options available in Azure. This guide covers choosing the right storage for each Dynamo cache type and configuring PVCs.
 
 ## Available Storage Options

--- a/fern/pages-v1.1.1/kubernetes/cloud-providers/ecs/ecs.md
+++ b/fern/pages-v1.1.1/kubernetes/cloud-providers/ecs/ecs.md
@@ -4,7 +4,6 @@
 title: Amazon Elastic Container Service (ECS)
 ---
 
-# Dynamo Deployment of vLLM Example on AWS ECS
 ## 1. EC2 Cluster Setup (for vLLM workloads)
 1. Go to AWS ECS console, **Clusters** tab and click on **Create cluster** with name `dynamo-GPU`
 2. Input the cluster name and choose **AWS EC2 instances** as the infrastructure. This option will create a cluster with EC2 instances to deploy containers.

--- a/fern/pages-v1.1.1/kubernetes/cloud-providers/eks/efs.md
+++ b/fern/pages-v1.1.1/kubernetes/cloud-providers/eks/efs.md
@@ -4,8 +4,6 @@
 title: Amazon EFS Setup for EKS
 ---
 
-# Create an Amazon EFS File System for Amazon EKS
-
 This guide walks through creating an Amazon EFS file system and connecting it to your EKS cluster. The EFS CSI Driver was already installed as an addon via `eksctl.yaml` during cluster creation. Now we need to create the actual file system and make it available to Kubernetes workloads.
 
 This filesystem will be used by Dynamo to store shared model weights and compilation cache across nodes.

--- a/fern/pages-v1.1.1/kubernetes/cloud-providers/eks/eks.md
+++ b/fern/pages-v1.1.1/kubernetes/cloud-providers/eks/eks.md
@@ -4,8 +4,6 @@
 title: Amazon Elastic Kubernetes Service (EKS)
 ---
 
-# Steps to create an EKS cluster
-
 This guide demonstrates the Dynamo platform on Amazon Elastic Kubernetes Service (EKS).
 
 ## Setup environment variables

--- a/fern/pages-v1.1.1/kubernetes/cloud-providers/gke/gke.md
+++ b/fern/pages-v1.1.1/kubernetes/cloud-providers/gke/gke.md
@@ -4,8 +4,6 @@
 title: Google Kubernetes Engine (GKE)
 ---
 
-# Dynamo Deployment on GKE
-
 ## Pre-requisites
 
 ### Install gcloud CLI

--- a/fern/pages-v1.1.1/kubernetes/disagg-communication-guide.md
+++ b/fern/pages-v1.1.1/kubernetes/disagg-communication-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Disaggregated Inference Communication Guide
 sidebar-title: Disagg Communication
 subtitle: Best practices for prefill/decode worker communication on Kubernetes
 ---
-
-# Disaggregated Inference Communication Guide
 
 This guide explains how prefill and decode workers communicate in Dynamo's disaggregated inference architecture on Kubernetes. It answers the frequently asked question: **Why can't prefill and decode workers use NVLink to communicate on the same node?**
 

--- a/fern/pages-v1.1.1/kubernetes/inference-gateway.md
+++ b/fern/pages-v1.1.1/kubernetes/inference-gateway.md
@@ -6,8 +6,6 @@ title: Inference Gateway (GAIE)
 
 ## Inference Gateway Setup with Dynamo
 
-# Inference Gateway (GAIE)
-
 Integrate Dynamo with the Gateway API Inference Extension for intelligent KV-aware request routing at the gateway layer.
 
 ## Features

--- a/fern/pages-v1.1.1/kubernetes/model-deployment-guide.md
+++ b/fern/pages-v1.1.1/kubernetes/model-deployment-guide.md
@@ -4,8 +4,6 @@
 title: Model Deployment Guide
 ---
 
-# Model Deployment Guide
-
 This guide explains how to deploy your model on Dynamo using a
 `DynamoGraphDeploymentRequest` (DGDR). If you've completed the
 [Quickstart](README.md) and want to understand how DGDR works end-to-end, how

--- a/fern/pages-v1.2.0/README.md
+++ b/fern/pages-v1.2.0/README.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: How to Build and Publish Dynamo Docs
 sidebar-title: Dynamo Docs Guide
 ---
-
-# How to Build and Publish Dynamo Docs
 
 This document describes the architecture, workflows, and maintenance procedures for the
 NVIDIA Dynamo documentation website powered by [Fern](https://buildwithfern.com).

--- a/fern/pages-v1.2.0/backends/sglang/agents.md
+++ b/fern/pages-v1.2.0/backends/sglang/agents.md
@@ -5,8 +5,6 @@ title: SGLang for Agentic Workloads
 subtitle: Priority scheduling and session control for multi-turn agentic serving
 ---
 
-# SGLang for Agentic Workloads
-
 This guide covers SGLang-specific configuration for agentic serving with Dynamo. It explains which SGLang engine flags to enable, how Dynamo's [agent hints](../../components/frontend/nvext.md#agent-hints) map to SGLang behavior, and how to use session control to manage KV cache for multi-turn agent conversations.
 
 ## Overview

--- a/fern/pages-v1.2.0/backends/vllm/README.md
+++ b/fern/pages-v1.2.0/backends/vllm/README.md
@@ -4,8 +4,6 @@
 title: vLLM
 ---
 
-# LLM Deployment using vLLM
-
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
 ## Installation

--- a/fern/pages-v1.2.0/backends/vllm/vllm-examples.md
+++ b/fern/pages-v1.2.0/backends/vllm/vllm-examples.md
@@ -4,8 +4,6 @@
 title: Examples
 ---
 
-# vLLM Examples
-
 For quick start instructions, see the [vLLM README](README.md). This document provides all deployment patterns for running vLLM with Dynamo, including aggregated, disaggregated, KV-routed, and expert-parallel configurations.
 
 ## Table of Contents

--- a/fern/pages-v1.2.0/backends/vllm/vllm-kv-offloading.md
+++ b/fern/pages-v1.2.0/backends/vllm/vllm-kv-offloading.md
@@ -5,8 +5,6 @@ title: KV Cache Offloading
 subtitle: CPU and disk offloading integrations for vLLM in Dynamo
 ---
 
-# KV Cache Offloading
-
 Dynamo supports multiple KV cache offloading backends for vLLM, allowing you to extend effective KV cache capacity beyond GPU memory using CPU RAM and disk storage. Each backend integrates through vLLM's connector interface and works with both aggregated and disaggregated serving.
 
 

--- a/fern/pages-v1.2.0/backends/vllm/vllm-reference-guide.md
+++ b/fern/pages-v1.2.0/backends/vllm/vllm-reference-guide.md
@@ -5,8 +5,6 @@ title: Reference Guide
 subtitle: Configuration, arguments, and operational details for the vLLM backend
 ---
 
-# Reference Guide
-
 ## Overview
 
 The vLLM backend in Dynamo integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting.

--- a/fern/pages-v1.2.0/components/router/topology-aware-kv-transfer.md
+++ b/fern/pages-v1.2.0/components/router/topology-aware-kv-transfer.md
@@ -5,8 +5,6 @@ title: Topology-Aware KV Transfer
 subtitle: Runtime metadata and decode routing semantics for topology-aware prefill/decode handoff
 ---
 
-# Topology-Aware KV Transfer
-
 Topology-aware KV transfer constrains or biases decode worker selection after a prefill worker has been selected. The router derives standard `RoutingConstraints` from the selected prefill worker's published topology metadata, then merges those constraints into the decode request.
 
 Use the Kubernetes operator path when possible.

--- a/fern/pages-v1.2.0/contribution-guide.md
+++ b/fern/pages-v1.2.0/contribution-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Contribution Guide
 subtitle: How to contribute to Dynamo
 max-toc-depth: 3
 ---
@@ -8,8 +9,6 @@ max-toc-depth: 3
 <p align="left">
   <a href="./contribution-guide.zh-CN.md" hreflang="zh-CN"><img src="./assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Contribution Guide
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/v1.2.0/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 

--- a/fern/pages-v1.2.0/design-docs/architecture.md
+++ b/fern/pages-v1.2.0/design-docs/architecture.md
@@ -9,8 +9,6 @@ subtitle: Architecture and components of the Dynamo inference runtime
   <a href="./architecture.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
 
-# Dynamo Architecture
-
 Dynamo is a distributed inference runtime for generative AI systems that must operate at high throughput, low latency, and high reliability under changing traffic conditions. It is backend-agnostic (SGLang, TRT-LLM, vLLM, and others) and is built around three cooperating concerns:
 
 - A fast **request path** for token generation

--- a/fern/pages-v1.2.0/development/backend-guide.md
+++ b/fern/pages-v1.2.0/development/backend-guide.md
@@ -6,8 +6,6 @@ sidebar-title: Writing Python Workers
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 
-# Writing Python Workers in Dynamo
-
 > **Lower-level Python worker path.** This guide documents the
 > `@dynamo_worker()` + `register_model()` + `endpoint.serve_endpoint()`
 > entry point. For new engines, prefer Dynamo's

--- a/fern/pages-v1.2.0/features/diffusion/fastvideo.md
+++ b/fern/pages-v1.2.0/features/diffusion/fastvideo.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FastVideo
 sidebar-title: FastVideo
 ---
-
-# FastVideo
 
 This guide covers deploying [FastVideo](https://github.com/hao-ai-lab/FastVideo) text-to-video generation on Dynamo using a custom worker (`worker.py`) exposed through the `/v1/videos` endpoint.
 

--- a/fern/pages-v1.2.0/getting-started/building-from-source.md
+++ b/fern/pages-v1.2.0/getting-started/building-from-source.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Building from Source
 sidebar-title: Building from Source
 description: Build Dynamo from source for development and contributions
 ---
@@ -8,8 +9,6 @@ description: Build Dynamo from source for development and contributions
 <p align="left">
   <a href="./building-from-source.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Building from Source
 
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 

--- a/fern/pages-v1.2.0/getting-started/introduction.md
+++ b/fern/pages-v1.2.0/getting-started/introduction.md
@@ -1,14 +1,13 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
 
 <p align="left">
   <a href="./introduction.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Introduction to Dynamo
 
 Dynamo is an open-source, high-throughput, low-latency inference framework,
 designed to serve generative AI workloads in distributed environments. It is

--- a/fern/pages-v1.2.0/getting-started/local-installation.md
+++ b/fern/pages-v1.2.0/getting-started/local-installation.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Local Installation
 sidebar-title: Local Installation
 description: Install and run Dynamo on a local machine or VM with containers or PyPI
 ---
@@ -8,8 +9,6 @@ description: Install and run Dynamo on a local machine or VM with containers or 
 <p align="left">
   <a href="./local-installation.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Local Installation
 
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/aks.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/aks.md
@@ -4,8 +4,6 @@
 title: Azure Kubernetes Service (AKS)
 ---
 
-# Dynamo on AKS
-
 This guide covers setting up an AKS cluster with GPU nodes and deploying Dynamo.
 
 ## Prerequisites

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/azure-lustre-csi.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/azure-lustre-csi.md
@@ -4,8 +4,6 @@
 title: Azure Lustre CSI Driver for AKS
 ---
 
-# Azure Lustre CSI Driver for AKS
-
 This guide covers installing and configuring the [Azure Lustre CSI driver](https://github.com/kubernetes-sigs/azurelustre-csi-driver) on an AKS cluster so that Dynamo workloads can use Azure Managed Lustre (AMLFS) filesystems for high-performance model storage.
 
 ## Prerequisites

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/rdma-infiniband.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/rdma-infiniband.md
@@ -4,8 +4,6 @@
 title: RDMA / InfiniBand on AKS
 ---
 
-# RDMA / InfiniBand on AKS
-
 This guide covers setting up RDMA over InfiniBand on AKS for high-performance disaggregated inference with Dynamo. RDMA enables direct memory access between GPUs across nodes, bypassing CPU and kernel overhead — critical for low-latency KV cache transfer between prefill and decode workers.
 
 Without RDMA, disaggregated inference falls back to TCP with severe performance degradation (~98s TTFT vs ~200-500ms with RDMA). See the [Disaggregated Communication Guide](../../disagg-communication-guide.md) for details on transport options and performance expectations.

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/spot-vms.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/spot-vms.md
@@ -4,8 +4,6 @@
 title: AKS Spot VMs
 ---
 
-# Running Dynamo on AKS Spot VMs
-
 [Azure Spot VMs](https://azure.microsoft.com/en-us/products/virtual-machines/spot) offer significant cost savings for GPU workloads but can be evicted by Azure at any time. This guide covers the configuration required to schedule Dynamo on Spot VM node pools.
 
 ## How AKS Taints Spot Nodes

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/storage.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/aks/storage.md
@@ -4,8 +4,6 @@
 title: Storage for Model Caching on AKS
 ---
 
-# Storage for Model Caching on AKS
-
 For implementing tiered storage on AKS, you can take advantage of the different storage options available in Azure. This guide covers choosing the right storage for each Dynamo cache type and configuring PVCs.
 
 ## Available Storage Options

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/ecs/ecs.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/ecs/ecs.md
@@ -4,7 +4,6 @@
 title: Amazon Elastic Container Service (ECS)
 ---
 
-# Dynamo Deployment of vLLM Example on AWS ECS
 ## 1. EC2 Cluster Setup (for vLLM workloads)
 1. Go to AWS ECS console, **Clusters** tab and click on **Create cluster** with name `dynamo-GPU`
 2. Input the cluster name and choose **AWS EC2 instances** as the infrastructure. This option will create a cluster with EC2 instances to deploy containers.

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/eks/efa.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/eks/efa.md
@@ -4,8 +4,6 @@
 title: EFA (RDMA over AWS Fabric) on EKS
 ---
 
-# EFA (RDMA over AWS Fabric) on EKS
-
 This guide covers setting up RDMA over AWS Elastic Fabric Adapter (EFA) on EKS for high-performance disaggregated inference with Dynamo. EFA is the only RDMA fabric available on AWS — InfiniBand and RoCE are not offered. With EFA, Dynamo's prefill and decode workers transfer KV cache directly between GPUs across nodes via GPU-Direct RDMA, bypassing CPU and TCP/IP stacks.
 
 Without RDMA, disaggregated inference falls back to TCP with severe performance degradation (~98s TTFT vs ~1s with EFA on Llama-3.1-8B at ISL 8000). See the [Disaggregated Communication Guide](../../disagg-communication-guide.md) for the transport-layer fundamentals.

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/eks/efs.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/eks/efs.md
@@ -4,8 +4,6 @@
 title: Amazon EFS Setup for EKS
 ---
 
-# Create an Amazon EFS File System for Amazon EKS
-
 This guide walks through creating an Amazon EFS file system and connecting it to your EKS cluster. The EFS CSI Driver was already installed as an addon via `eksctl.yaml` during cluster creation. Now we need to create the actual file system and make it available to Kubernetes workloads.
 
 This filesystem will be used by Dynamo to store shared model weights and compilation cache across nodes.

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/eks/eks.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/eks/eks.md
@@ -4,8 +4,6 @@
 title: Amazon Elastic Kubernetes Service (EKS)
 ---
 
-# Steps to create an EKS cluster
-
 This guide demonstrates the Dynamo platform on Amazon Elastic Kubernetes Service (EKS).
 
 ## Setup environment variables

--- a/fern/pages-v1.2.0/kubernetes/cloud-providers/gke/gke.md
+++ b/fern/pages-v1.2.0/kubernetes/cloud-providers/gke/gke.md
@@ -4,8 +4,6 @@
 title: Google Kubernetes Engine (GKE)
 ---
 
-# Dynamo Deployment on GKE
-
 ## Pre-requisites
 
 ### Install gcloud CLI

--- a/fern/pages-v1.2.0/kubernetes/disagg-communication-guide.md
+++ b/fern/pages-v1.2.0/kubernetes/disagg-communication-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Disaggregated Inference Communication Guide
 sidebar-title: Disagg Communication
 subtitle: Best practices for prefill/decode worker communication on Kubernetes
 ---
-
-# Disaggregated Inference Communication Guide
 
 This guide explains how prefill and decode workers communicate in Dynamo's disaggregated inference architecture on Kubernetes. It answers the frequently asked question: **Why can't prefill and decode workers use NVLink to communicate on the same node?**
 

--- a/fern/pages-v1.2.0/kubernetes/topology-aware-kv-transfer.md
+++ b/fern/pages-v1.2.0/kubernetes/topology-aware-kv-transfer.md
@@ -5,8 +5,6 @@ title: Topology-Aware KV Transfer
 subtitle: Keep disaggregated prefill and decode KV-cache transfers within a selected topology domain
 ---
 
-# Topology-Aware KV Transfer
-
 Topology-aware KV transfer lets a disaggregated Dynamo deployment route decode requests toward workers that share the selected prefill worker's topology domain, such as zone or rack. This reduces slow cross-domain KV-cache transfers when prefill and decode workers exchange KV data over NIXL.
 
 Use this feature when:


### PR DESCRIPTION
## Problem

Fern (currently 5.37 on this branch) **auto-generates each page's `<h1>` from the nav `page:` value** in `fern/versions/*.yml`; its docs say to start body content at `##`. Many pages also carried a body `# H1`, which renders a **second, duplicate title**.

**Root cause / why now:** the docs-website Fern CLI went **3.x → 5.x between Mar–May 2026** (two major bumps via "sync dev from main"). Newer Fern emits its own H1 from the nav; the body `# H1`s predate it (present since v1.0.0), so the upgrade silently turned them into duplicates. No page content changed — the renderer did.

## Change

Removed the body `# H1` from **147 nav-referenced pages** across `pages-dev` and `v1.0.0`–`v1.2.0`, preserving each page's visible title via frontmatter `title:` (and `sidebar-title:` to keep short nav labels where they differ). Applied with a nav-aware script; verified the in-nav duplicate count drops to **0**.

| tree | fixed |
|---|---|
| pages-dev | 30 |
| pages-v1.0.0 / .1 / .2 | 15 / 15 / 16 |
| pages-v1.1.0 / .1 | 16 / 25 |
| pages-v1.2.0 | 30 |

## Deliberately not touched

- **Standalone non-nav pages** (the `.zh-CN` language variants): not in any nav and no Fern localization configured, so their body `# H1` is the *sole* title — not a duplicate. Left intact.
- **14 multi-`#` pages** (`benchmarks/benchmarking.md`, `kubernetes/api-reference.md` per version): they use `#` for sections, not just a title, so they need manual restructuring rather than a one-line removal. Listed for follow-up.
- **v0.7–v0.9 trees**: out of this scope (v0.9.x also shows a much larger, older-convention pattern worth a separate look).

## Follow-ups
- `main`'s `docs/` source needs the same fix or these regenerate on the next version sync.
- The 14 multi-H1 pages.
- Supersedes #10420 (getting-started subset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->