### PR TITLE
fix(docs): remove duplicate page H1 in docs source

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: How to Build and Publish Dynamo Docs
 sidebar-title: Dynamo Docs Guide
 ---
-
-# How to Build and Publish Dynamo Docs
 
 This document describes the architecture, workflows, and maintenance procedures for the
 NVIDIA Dynamo documentation website powered by [Fern](https://buildwithfern.com).

--- a/docs/backends/sglang/agents.md
+++ b/docs/backends/sglang/agents.md
@@ -5,8 +5,6 @@ title: SGLang for Agentic Workloads
 subtitle: Priority scheduling and session control for multi-turn agentic serving
 ---
 
-# SGLang for Agentic Workloads
-
 This guide covers SGLang-specific configuration for agentic serving with Dynamo. It explains which SGLang engine flags to enable, how Dynamo's [agent hints](../../components/frontend/nvext.md#agent-hints) map to SGLang behavior, and how to use session control to manage KV cache for multi-turn agent conversations.
 
 ## Overview

--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -4,8 +4,6 @@
 title: vLLM
 ---
 
-# LLM Deployment using vLLM
-
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
 ## Installation

--- a/docs/backends/vllm/vllm-examples.md
+++ b/docs/backends/vllm/vllm-examples.md
@@ -4,8 +4,6 @@
 title: Examples
 ---
 
-# vLLM Examples
-
 For quick start instructions, see the [vLLM README](README.md). This document provides all deployment patterns for running vLLM with Dynamo, including aggregated, disaggregated, KV-routed, and expert-parallel configurations.
 
 ## Table of Contents

--- a/docs/backends/vllm/vllm-kv-offloading.md
+++ b/docs/backends/vllm/vllm-kv-offloading.md
@@ -5,8 +5,6 @@ title: KV Cache Offloading
 subtitle: CPU and disk offloading integrations for vLLM in Dynamo
 ---
 
-# KV Cache Offloading
-
 Dynamo supports multiple KV cache offloading backends for vLLM, allowing you to extend effective KV cache capacity beyond GPU memory using CPU RAM and disk storage. Each backend integrates through vLLM's connector interface and works with both aggregated and disaggregated serving.
 
 

--- a/docs/backends/vllm/vllm-reference-guide.md
+++ b/docs/backends/vllm/vllm-reference-guide.md
@@ -5,8 +5,6 @@ title: Reference Guide
 subtitle: Configuration, arguments, and operational details for the vLLM backend
 ---
 
-# Reference Guide
-
 ## Overview
 
 The vLLM backend in Dynamo integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting.

--- a/docs/components/router/topology-aware-kv-transfer.md
+++ b/docs/components/router/topology-aware-kv-transfer.md
@@ -5,8 +5,6 @@ title: Topology-Aware KV Transfer
 subtitle: Runtime metadata and decode routing semantics for topology-aware prefill/decode handoff
 ---
 
-# Topology-Aware KV Transfer
-
 Topology-aware KV transfer constrains or biases decode worker selection after a prefill worker has been selected. The router derives standard `RoutingConstraints` from the selected prefill worker's published topology metadata, then merges those constraints into the decode request.
 
 Use the Kubernetes operator path when possible.

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Contribution Guide
 subtitle: How to contribute to Dynamo
 max-toc-depth: 3
 ---
@@ -8,8 +9,6 @@ max-toc-depth: 3
 <p align="left">
   <a href="./contribution-guide.zh-CN.md" hreflang="zh-CN"><img src="./assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Contribution Guide
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/main/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 

--- a/docs/design-docs/architecture.md
+++ b/docs/design-docs/architecture.md
@@ -9,8 +9,6 @@ subtitle: Architecture and components of the Dynamo inference runtime
   <a href="./architecture.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
 
-# Dynamo Architecture
-
 Dynamo is a distributed inference runtime for generative AI systems that must operate at high throughput, low latency, and high reliability under changing traffic conditions. It is backend-agnostic (SGLang, TRT-LLM, vLLM, and others) and is built around three cooperating concerns:
 
 - A fast **request path** for token generation

--- a/docs/development/backend-guide.md
+++ b/docs/development/backend-guide.md
@@ -6,8 +6,6 @@ sidebar-title: Writing Python Workers
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 
-# Writing Python Workers in Dynamo
-
 > **Lower-level Python worker path.** This guide documents the
 > `@dynamo_worker()` + `register_model()` + `endpoint.serve_endpoint()`
 > entry point. For new engines, prefer Dynamo's

--- a/docs/digest/agentic-inference/agentic-harnesses.md
+++ b/docs/digest/agentic-inference/agentic-harnesses.md
@@ -1,13 +1,13 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: "Streaming Tokens and Tools: Multi-Turn Agentic Harness Support in Dynamo"
+sidebar-title: Multi-Turn Agentic Harnesses
 subtitle: "Matej Kosec, Ishan Dhanani, Benjamin Klieger, Dan Gil and Alec Flowers — April 2026"
 description: "Streaming Tokens and Tools: Multi-Turn Agentic Harness Support in Dynamo"
 keywords: agentic inference, responses api, messages api, tool calling, interleaved reasoning, prefix caching, agent hints, Dynamo
 last-updated: Apr 30, 2026
 ---
-
-# Streaming Tokens and Tools: Multi-Turn Agentic Harness Support in Dynamo
 
 An agentic exchange must preserve a structured interaction: assistant turns interleave reasoning with one or more tool calls, and subsequent user turns return the corresponding tool results to the model context. Reasoning replay is model- and turn-dependent: some reasoning should be retained, while some should be dropped. The inference engine is responsible for this more expressive interaction and for producing correctly segmented API results. Tool-call parsing and reasoning parsing need to happen before the attached harness consumes the response. High-value agentic workflows such as coding also depend on a responsive harness experience: reasoning segments, tool-call events, and request metadata need to stream back as the turn unfolds instead of arriving after a final text response. This post covers lessons from running real agentic clients against Dynamo: how we hardened parser and API coverage and how those parser layers became standalone reusable crates.
 

--- a/docs/digest/agentic-inference/agentic-inference.md
+++ b/docs/digest/agentic-inference/agentic-inference.md
@@ -1,13 +1,13 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Full-Stack Optimizations for Agentic Inference with Dynamo
+sidebar-title: Full-Stack Optimizations for Agentic Inference
 subtitle: "Ishan Dhanani and Matej Kosec — March 2026"
 description: "How Dynamo optimizes for agentic workloads at three layers: frontend API, router, and KV cache management."
 keywords: agentic inference, KV cache, prefix caching, agent hints, disaggregated serving, Dynamo
 last-updated: March 10, 2026
 ---
-
-# Full-Stack Optimizations for Agentic Inference with Dynamo
 
 Coding agents are starting to write production code at scale. [Stripe’s agents generate 1,300+ PRs per week](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents). [Ramp attributes 30% of merged PRs to agents](https://www.infoq.com/news/2026/01/ramp-coding-agent-platform/). [Spotify reports 650+ agent-generated PRs per month](https://engineering.atspotify.com/2025/11/spotifys-background-coding-agent-part-1). Tools like Claude Code and Codex make hundreds of API calls per coding session, each carrying the full conversation history. Behind every one of these workflows is an inference stack under significant KV cache pressure.
 

--- a/docs/features/diffusion/fastvideo.md
+++ b/docs/features/diffusion/fastvideo.md
@@ -1,10 +1,9 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FastVideo
 sidebar-title: FastVideo
 ---
-
-# FastVideo
 
 This guide covers deploying [FastVideo](https://github.com/hao-ai-lab/FastVideo) text-to-video generation on Dynamo using a custom worker (`worker.py`) exposed through the `/v1/videos` endpoint.
 

--- a/docs/getting-started/building-from-source.md
+++ b/docs/getting-started/building-from-source.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Building from Source
 sidebar-title: Building from Source
 description: Build Dynamo from source for development and contributions
 ---
@@ -8,8 +9,6 @@ description: Build Dynamo from source for development and contributions
 <p align="left">
   <a href="./building-from-source.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Building from Source
 
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,14 +1,13 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
 
 <p align="left">
   <a href="./introduction.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Introduction to Dynamo
 
 Dynamo is an open-source, high-throughput, low-latency inference framework,
 designed to serve generative AI workloads in distributed environments. It is

--- a/docs/getting-started/local-installation.md
+++ b/docs/getting-started/local-installation.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Local Installation
 sidebar-title: Local Installation
 description: Install and run Dynamo on a local machine or VM with containers or PyPI
 ---
@@ -8,8 +9,6 @@ description: Install and run Dynamo on a local machine or VM with containers or 
 <p align="left">
   <a href="./local-installation.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Local Installation
 
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 

--- a/docs/kubernetes/cloud-providers/aks/aks.md
+++ b/docs/kubernetes/cloud-providers/aks/aks.md
@@ -4,8 +4,6 @@
 title: Azure Kubernetes Service (AKS)
 ---
 
-# Dynamo on AKS
-
 This guide covers setting up an AKS cluster with GPU nodes and deploying Dynamo.
 
 ## Prerequisites

--- a/docs/kubernetes/cloud-providers/aks/azure-lustre-csi.md
+++ b/docs/kubernetes/cloud-providers/aks/azure-lustre-csi.md
@@ -4,8 +4,6 @@
 title: Azure Lustre CSI Driver for AKS
 ---
 
-# Azure Lustre CSI Driver for AKS
-
 This guide covers installing and configuring the [Azure Lustre CSI driver](https://github.com/kubernetes-sigs/azurelustre-csi-driver) on an AKS cluster so that Dynamo workloads can use Azure Managed Lustre (AMLFS) filesystems for high-performance model storage.
 
 ## Prerequisites

--- a/docs/kubernetes/cloud-providers/aks/rdma-infiniband.md
+++ b/docs/kubernetes/cloud-providers/aks/rdma-infiniband.md
@@ -4,8 +4,6 @@
 title: RDMA / InfiniBand on AKS
 ---
 
-# RDMA / InfiniBand on AKS
-
 This guide covers setting up RDMA over InfiniBand on AKS for high-performance disaggregated inference with Dynamo. RDMA enables direct memory access between GPUs across nodes, bypassing CPU and kernel overhead — critical for low-latency KV cache transfer between prefill and decode workers.
 
 Without RDMA, disaggregated inference falls back to TCP with severe performance degradation (~98s TTFT vs ~200-500ms with RDMA). See the [Disaggregated Communication Guide](../../disagg-communication-guide.md) for details on transport options and performance expectations.

--- a/docs/kubernetes/cloud-providers/aks/spot-vms.md
+++ b/docs/kubernetes/cloud-providers/aks/spot-vms.md
@@ -4,8 +4,6 @@
 title: AKS Spot VMs
 ---
 
-# Running Dynamo on AKS Spot VMs
-
 [Azure Spot VMs](https://azure.microsoft.com/en-us/products/virtual-machines/spot) offer significant cost savings for GPU workloads but can be evicted by Azure at any time. This guide covers the configuration required to schedule Dynamo on Spot VM node pools.
 
 ## How AKS Taints Spot Nodes

--- a/docs/kubernetes/cloud-providers/aks/storage.md
+++ b/docs/kubernetes/cloud-providers/aks/storage.md
@@ -4,8 +4,6 @@
 title: Storage for Model Caching on AKS
 ---
 
-# Storage for Model Caching on AKS
-
 For implementing tiered storage on AKS, you can take advantage of the different storage options available in Azure. This guide covers choosing the right storage for each Dynamo cache type and configuring PVCs.
 
 ## Available Storage Options

--- a/docs/kubernetes/cloud-providers/ecs/ecs.md
+++ b/docs/kubernetes/cloud-providers/ecs/ecs.md
@@ -4,7 +4,6 @@
 title: Amazon Elastic Container Service (ECS)
 ---
 
-# Dynamo Deployment of vLLM Example on AWS ECS
 ## 1. EC2 Cluster Setup (for vLLM workloads)
 1. Go to AWS ECS console, **Clusters** tab and click on **Create cluster** with name `dynamo-GPU`
 2. Input the cluster name and choose **AWS EC2 instances** as the infrastructure. This option will create a cluster with EC2 instances to deploy containers.

--- a/docs/kubernetes/cloud-providers/eks/efa.md
+++ b/docs/kubernetes/cloud-providers/eks/efa.md
@@ -4,8 +4,6 @@
 title: EFA (RDMA over AWS Fabric) on EKS
 ---
 
-# EFA (RDMA over AWS Fabric) on EKS
-
 This guide covers setting up RDMA over AWS Elastic Fabric Adapter (EFA) on EKS for high-performance disaggregated inference with Dynamo. EFA is the only RDMA fabric available on AWS — InfiniBand and RoCE are not offered. With EFA, Dynamo's prefill and decode workers transfer KV cache directly between GPUs across nodes via GPU-Direct RDMA, bypassing CPU and TCP/IP stacks.
 
 Without RDMA, disaggregated inference falls back to TCP with severe performance degradation (~98s TTFT vs ~1s with EFA on Llama-3.1-8B at ISL 8000). See the [Disaggregated Communication Guide](../../disagg-communication-guide.md) for the transport-layer fundamentals.

--- a/docs/kubernetes/cloud-providers/eks/efs.md
+++ b/docs/kubernetes/cloud-providers/eks/efs.md
@@ -4,8 +4,6 @@
 title: Amazon EFS Setup for EKS
 ---
 
-# Create an Amazon EFS File System for Amazon EKS
-
 This guide walks through creating an Amazon EFS file system and connecting it to your EKS cluster. The EFS CSI Driver was already installed as an addon via `eksctl.yaml` during cluster creation. Now we need to create the actual file system and make it available to Kubernetes workloads.
 
 This filesystem will be used by Dynamo to store shared model weights and compilation cache across nodes.

--- a/docs/kubernetes/cloud-providers/eks/eks.md
+++ b/docs/kubernetes/cloud-providers/eks/eks.md
@@ -4,8 +4,6 @@
 title: Amazon Elastic Kubernetes Service (EKS)
 ---
 
-# Steps to create an EKS cluster
-
 This guide demonstrates the Dynamo platform on Amazon Elastic Kubernetes Service (EKS).
 
 ## Clone the repository and set working directory

--- a/docs/kubernetes/cloud-providers/gke/gke.md
+++ b/docs/kubernetes/cloud-providers/gke/gke.md
@@ -4,8 +4,6 @@
 title: Google Kubernetes Engine (GKE)
 ---
 
-# Dynamo Deployment on GKE
-
 ## Pre-requisites
 
 ### Install gcloud CLI

--- a/docs/kubernetes/disagg-communication-guide.md
+++ b/docs/kubernetes/disagg-communication-guide.md
@@ -1,11 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Disaggregated Inference Communication Guide
 sidebar-title: Disagg Communication
 subtitle: Best practices for prefill/decode worker communication on Kubernetes
 ---
-
-# Disaggregated Inference Communication Guide
 
 This guide explains how prefill and decode workers communicate in Dynamo's disaggregated inference architecture on Kubernetes. It answers the frequently asked question: **Why can't prefill and decode workers use NVLink to communicate on the same node?**
 

--- a/docs/kubernetes/topology-aware-kv-transfer.md
+++ b/docs/kubernetes/topology-aware-kv-transfer.md
@@ -5,8 +5,6 @@ title: Topology-Aware KV Transfer
 subtitle: Keep disaggregated prefill and decode KV-cache transfers within a selected topology domain
 ---
 
-# Topology-Aware KV Transfer
-
 Topology-aware KV transfer lets a disaggregated Dynamo deployment route decode requests toward workers that share the selected prefill worker's topology domain, such as zone or rack. This reduces slow cross-domain KV-cache transfers when prefill and decode workers exchange KV data over NIXL.
 
 Use this feature when:


### PR DESCRIPTION
## Problem

Fern auto-generates each page's `<h1>` from the `docs/index.yml` nav `page:` value (its docs say to start body content at `##`). 28 nav-referenced pages also carried a body `# H1`, rendering a **duplicate title** on the published site.

## Change

Removed the body `# H1` from **28 pages**, preserving each page's title via frontmatter `title:` (+ `sidebar-title:` where the nav label is shorter). Most of `docs/` already uses no-body-H1, so this just brings the stragglers in line; the diff is minimal (`+title`, `−H1`).

## Why now

The published site's Fern CLI went **3.x → 5.x** (Mar–May 2026); newer Fern emits its own H1 from nav, turning long-standing body H1s (present since v1.0.0) into duplicates. Companion fix for the live versioned trees on the `docs-website` branch: #10427. **Fixing the source here stops the duplicates from regenerating on the next main→Fern sync.**

## Deliberately not touched

- `.zh-CN` language variants (standalone, not in nav — their body H1 is the sole title).
- 2 multi-`#` pages (`benchmarks/benchmarking.md`, `kubernetes/api-reference.md`) — they use `#` for section headings and need a manual `#`→`##` restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Migrated page titles from Markdown H1 headings to YAML frontmatter (title, sidebar-title, subtitle fields) across 30+ documentation files.
  * Removed redundant top-level Markdown headings while preserving all documentation content and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->