### PR TITLE
chore(planner): remove unused direct router metrics client

### DIFF
--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -13,16 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import logging
 import math
 import typing
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, Optional
 
-import aiohttp
 from prometheus_api_client import PrometheusConnect
-from prometheus_client.parser import text_string_to_metric_families
 from pydantic import BaseModel, ValidationError
 
 from dynamo import prometheus_names
@@ -74,24 +71,6 @@ class Metrics:
             self.request_duration,
         ]
         return all(v is not None and not math.isnan(v) for v in required)
-
-
-@dataclass
-class CachedLoadMetrics:
-    """Container for load metrics used by load-based scaling.
-
-    Attributes:
-        recent:              Most recent per-worker metrics (from the latest sample).
-                             Keyed by worker_id -> {metric_name: value}.
-        per_worker_averaged: Per-worker metrics averaged over time (not across workers).
-                             Keyed by worker_id -> {metric_name: value}.
-        cluster_averaged:    Metrics averaged over time and all workers.
-                             Flat dict {metric_name: value}.
-    """
-
-    recent: dict[str, dict[str, float]] = field(default_factory=dict)
-    per_worker_averaged: dict[str, dict[str, float]] = field(default_factory=dict)
-    cluster_averaged: dict[str, float] = field(default_factory=dict)
 
 
 class FrontendMetric(BaseModel):
@@ -446,181 +425,3 @@ def parse_frontend_metric_containers(
             logger.error(f"Error parsing frontend metric container: {e}")
             continue
     return metrics_containers
-
-
-# Metric names for per-worker load metrics (gauge-type, queried directly from router)
-_WORKER_METRIC_NAMES = {
-    "active_prefill_tokens": f"{prometheus_names.name_prefix.FRONTEND}_{prometheus_names.frontend_service.WORKER_ACTIVE_PREFILL_TOKENS}",
-    "active_decode_blocks": f"{prometheus_names.name_prefix.FRONTEND}_{prometheus_names.frontend_service.WORKER_ACTIVE_DECODE_BLOCKS}",
-    "last_ttft": f"{prometheus_names.name_prefix.FRONTEND}_{prometheus_names.frontend_service.WORKER_LAST_TIME_TO_FIRST_TOKEN_SECONDS}",
-    "last_isl": f"{prometheus_names.name_prefix.FRONTEND}_{prometheus_names.frontend_service.WORKER_LAST_INPUT_SEQUENCE_TOKENS}",
-    "last_itl": f"{prometheus_names.name_prefix.FRONTEND}_{prometheus_names.frontend_service.WORKER_LAST_INTER_TOKEN_LATENCY_SECONDS}",
-}
-
-
-class DirectRouterMetricsClient:
-    """Query router's /metrics endpoint directly for real-time per-worker metrics.
-
-    Runs a continuous background sampling loop that collects metrics at
-    evenly-spaced intervals (interval / num_samples). At decision time,
-    the load-based loop reads the buffer via get_recent_and_averaged_metrics().
-    """
-
-    def __init__(self, router_metrics_url: str, dynamo_namespace: str):
-        self.router_metrics_url = router_metrics_url
-        self.dynamo_namespace = dynamo_namespace
-        self._sample_buffer: list[dict[str, dict[str, dict[str, float]]]] = []
-        self._num_samples: int = 10
-
-    def _parse_prometheus_text(
-        self, text: str
-    ) -> dict[str, dict[str, dict[str, float]]]:
-        """Parse Prometheus text exposition format and extract per-worker metrics.
-
-        Uses prometheus_client.parser to parse the text exposition format.
-        Groups results by worker_type label (prefill/decode) so callers
-        can access only the workers they care about.
-
-        Args:
-            text: Raw Prometheus text from /metrics endpoint
-
-        Returns:
-            {"prefill": {worker_id: {metric: float, ...}},
-             "decode":  {worker_id: {metric: float, ...}}}
-        """
-        target_metrics = set(_WORKER_METRIC_NAMES.values())
-        reverse_map = {v: k for k, v in _WORKER_METRIC_NAMES.items()}
-        result: dict[str, dict[str, dict[str, float]]] = {}
-
-        for family in text_string_to_metric_families(text):
-            if family.name not in target_metrics:
-                continue
-
-            field_name = reverse_map[family.name]
-
-            for sample in family.samples:
-                labels = sample.labels
-                worker_type = labels.get("worker_type", "unknown")
-                worker_id = labels.get("worker_id", "unknown")
-                value = sample.value
-
-                if worker_type not in result:
-                    result[worker_type] = {}
-                if worker_id not in result[worker_type]:
-                    result[worker_type][worker_id] = {}
-                result[worker_type][worker_id][field_name] = value
-
-        return result
-
-    async def _fetch_and_parse(self) -> dict[str, dict[str, dict[str, float]]]:
-        """Fetch /metrics from router and parse into per-worker metrics."""
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    self.router_metrics_url, timeout=aiohttp.ClientTimeout(total=2)
-                ) as response:
-                    text = await response.text()
-            return self._parse_prometheus_text(text)
-        except Exception as e:
-            logger.warning(f"Failed to fetch router metrics: {e}")
-            return {}
-
-    async def run_sampling_loop(self, num_samples: int, interval: float) -> None:
-        """Background coroutine: continuously sample at evenly-spaced intervals.
-
-        Runs alongside the load-based loop via asyncio.gather().
-        sample_interval = interval / num_samples (e.g., 5s / 10 = 0.5s)
-        Keeps only the last num_samples in the buffer (rolling window).
-        """
-        self._num_samples = num_samples
-        sample_interval = interval / num_samples
-        while True:
-            metrics = await self._fetch_and_parse()
-            if metrics:
-                self._sample_buffer.append(metrics)
-                if len(self._sample_buffer) > num_samples:
-                    self._sample_buffer.pop(0)
-            await asyncio.sleep(sample_interval)
-
-    def get_recent_and_averaged_metrics(
-        self, worker_type: str
-    ) -> typing.Optional[
-        tuple[
-            dict[str, dict[str, float]],
-            dict[str, dict[str, float]],
-            dict[str, float],
-        ]
-    ]:
-        """Return recent, per-worker time-averaged, and cluster-averaged metrics.
-
-        Called by the load-based loop at decision time. Non-blocking.
-
-        Args:
-            worker_type: "prefill" or "decode" — only workers matching
-                         the worker_type label are included.
-
-        Returns:
-            A tuple of (recent, per_worker_averaged, cluster_averaged):
-            - recent:              {worker_id: {metric: float}} from the latest sample
-            - per_worker_averaged: {worker_id: {metric: float}} averaged over time per worker
-            - cluster_averaged:    {metric: float} averaged over all samples and all workers
-            Returns None if the sample buffer is empty.
-        """
-        if not self._sample_buffer:
-            return None
-
-        # --- Recent: last sample only ---
-        latest_sample = self._sample_buffer[-1]
-        recent: dict[str, dict[str, float]] = {}
-        for worker_id, metrics in latest_sample.get(worker_type, {}).items():
-            recent[worker_id] = dict(metrics)
-
-        # --- Per-worker averaged: across time, grouped by worker_id ---
-        pw_sums: dict[str, dict[str, float]] = {}
-        pw_counts: dict[str, dict[str, int]] = {}
-
-        for sample in self._sample_buffer:
-            typed_workers = sample.get(worker_type, {})
-            for worker_id, metrics in typed_workers.items():
-                if worker_id not in pw_sums:
-                    pw_sums[worker_id] = {}
-                    pw_counts[worker_id] = {}
-                for metric_name, value in metrics.items():
-                    pw_sums[worker_id][metric_name] = (
-                        pw_sums[worker_id].get(metric_name, 0.0) + value
-                    )
-                    pw_counts[worker_id][metric_name] = (
-                        pw_counts[worker_id].get(metric_name, 0) + 1
-                    )
-
-        if not pw_sums and not recent:
-            return None
-
-        per_worker_averaged: dict[str, dict[str, float]] = {}
-        for worker_id in pw_sums:
-            per_worker_averaged[worker_id] = {}
-            for metric_name in pw_sums[worker_id]:
-                per_worker_averaged[worker_id][metric_name] = (
-                    pw_sums[worker_id][metric_name] / pw_counts[worker_id][metric_name]
-                )
-
-        # --- Cluster averaged: across time AND worker_id ---
-        cluster_sums: dict[str, float] = {}
-        cluster_counts: dict[str, int] = {}
-        for worker_id in pw_sums:
-            for metric_name in pw_sums[worker_id]:
-                cluster_sums[metric_name] = (
-                    cluster_sums.get(metric_name, 0.0) + pw_sums[worker_id][metric_name]
-                )
-                cluster_counts[metric_name] = (
-                    cluster_counts.get(metric_name, 0)
-                    + pw_counts[worker_id][metric_name]
-                )
-
-        cluster_averaged: dict[str, float] = {}
-        for metric_name in cluster_sums:
-            cluster_averaged[metric_name] = (
-                cluster_sums[metric_name] / cluster_counts[metric_name]
-            )
-
-        return recent, per_worker_averaged, cluster_averaged


### PR DESCRIPTION
## Summary
- remove unused `DirectRouterMetricsClient` direct router scrape implementation
- remove unused `CachedLoadMetrics` container and dead per-worker metric mapping
- clean up imports that only supported the removed code

## Verification
- `uv run --no-project --with ruff ruff check components/src/dynamo/planner/monitoring/traffic_metrics.py`
- `PYTHONPATH=components/src:lib/bindings/python/src uv run --no-project --with prometheus-api-client --with prometheus-client --with pydantic python -m py_compile components/src/dynamo/planner/monitoring/traffic_metrics.py`

Focused planner pytest was attempted but could not collect locally because this worktree lacks the compiled `dynamo._core` extension; adding the published runtime via uv was not possible because `ai-dynamo-runtime==1.3.0` was unavailable in the configured indexes.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->