### PR TITLE
perf(frontend): optimize chat SSE streaming hot path

### DIFF
--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1663,6 +1663,13 @@ impl<T> From<crate::types::Annotated<T>> for EventConverter<T> {
     }
 }
 
+fn sse_json_data<T: Serialize>(event: Event, data: &T) -> Result<Event, axum::Error> {
+    // serde_json escapes literal LF/CR in string content, so the resulting JSON
+    // is one SSE data line and can avoid Axum json_data's per-write filtering.
+    let json = serde_json::to_string(data).map_err(axum::Error::new)?;
+    Ok(event.data(json))
+}
+
 /// Process streaming response with event conversion for SSE
 ///
 /// This function handles metrics collection, http_queue_guard management, and converts
@@ -1717,7 +1724,7 @@ pub fn process_response_using_event_converter_and_observe_metrics<T: Serialize>(
     let mut event = Event::default();
 
     if let Some(ref data) = annotated.data {
-        event = event.json_data(data)?;
+        event = sse_json_data(event, data)?;
     }
 
     if let Some(ref msg) = annotated.event {
@@ -2844,6 +2851,96 @@ mod tests {
         )
     }
 
+    fn run_chat_stream_event_converter(
+        annotated: crate::types::Annotated<
+            crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse,
+        >,
+    ) -> Result<Option<Event>, axum::Error> {
+        let metrics = Arc::new(Metrics::new());
+        let mut collector = ResponseMetricCollector::new(metrics, "test-model".to_string());
+        let mut http_queue_guard: Option<HttpQueueGuard> = None;
+        process_response_using_event_converter_and_observe_metrics(
+            EventConverter::from(annotated),
+            &mut collector,
+            &mut http_queue_guard,
+        )
+    }
+
+    fn make_chat_stream_annotated(
+        content: &str,
+    ) -> crate::types::Annotated<
+        crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse,
+    > {
+        use dynamo_protocols::types::{
+            ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionStreamResponseDelta,
+            CreateChatCompletionStreamResponse,
+        };
+
+        #[allow(deprecated)]
+        let choice = ChatChoiceStream {
+            index: 0,
+            delta: ChatCompletionStreamResponseDelta {
+                content: Some(ChatCompletionMessageContent::Text(content.to_string())),
+                function_call: None,
+                tool_calls: None,
+                role: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            logprobs: None,
+        };
+
+        crate::types::Annotated {
+            id: Some("test-id".to_string()),
+            data: Some(
+                crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse {
+                    inner: CreateChatCompletionStreamResponse {
+                        id: "test-id".to_string(),
+                        choices: vec![choice],
+                        created: 0,
+                        model: "test-model".to_string(),
+                        system_fingerprint: None,
+                        object: "chat.completion.chunk".to_string(),
+                        usage: None,
+                        service_tier: None,
+                    },
+                    nvext: None,
+                },
+            ),
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    fn extract_sse_data_json(event: Event) -> serde_json::Value {
+        let body = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime")
+            .block_on(async move {
+                use axum::{
+                    body::to_bytes,
+                    response::{IntoResponse, Sse},
+                };
+                let stream = futures::stream::iter(vec![Ok::<Event, axum::Error>(event)]);
+                let response = Sse::new(stream).into_response();
+                let bytes = to_bytes(response.into_body(), 1 << 20)
+                    .await
+                    .expect("body bytes");
+                String::from_utf8(bytes.to_vec()).expect("utf8 body")
+            });
+
+        let data = body
+            .lines()
+            .find_map(|line| line.strip_prefix("data: "))
+            .expect("SSE data line");
+        serde_json::from_str(data).unwrap_or_else(|e| {
+            panic!("failed to parse JSON from SSE data: {e}\nbody: {body}\ndata: {data}")
+        })
+    }
+
     fn error_annotated(
         error: Option<dynamo_runtime::error::DynamoError>,
         comment: Option<Vec<String>>,
@@ -2891,6 +2988,29 @@ mod tests {
     }
 
     #[test]
+    fn test_event_converter_serializes_chat_stream_response_as_json_data() {
+        let event = run_chat_stream_event_converter(make_chat_stream_annotated("hello"))
+            .unwrap()
+            .expect("chat stream response should produce an SSE event");
+
+        let json = extract_sse_data_json(event);
+        assert_eq!(json["id"], "test-id");
+        assert_eq!(json["object"], "chat.completion.chunk");
+        assert_eq!(json["choices"][0]["delta"]["content"], "hello");
+    }
+
+    #[test]
+    fn test_event_converter_json_data_round_trips_escaped_content() {
+        let content = "line1\nline2\r\"quoted\" \\\\ slash 你好 🚀";
+        let event = run_chat_stream_event_converter(make_chat_stream_annotated(content))
+            .unwrap()
+            .expect("chat stream response should produce an SSE event");
+
+        let json = extract_sse_data_json(event);
+        assert_eq!(json["choices"][0]["delta"]["content"], content);
+    }
+
+    #[test]
     fn test_comment_newlines_sanitized() {
         let annotated = crate::types::Annotated::<String> {
             data: Some("test".to_string()),
@@ -2899,7 +3019,14 @@ mod tests {
             comment: Some(vec!["line1\nline2\r\nline3".into()]),
             error: None,
         };
-        assert!(run_event_converter(annotated).is_ok());
+        let event = run_event_converter(annotated)
+            .unwrap()
+            .expect("data event with comment should be returned");
+        let debug = format!("{:?}", event);
+        assert!(
+            debug.contains(": line1 line2  line3\\n"),
+            "comment newlines should be replaced before Event::comment: {debug}"
+        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -63,6 +63,7 @@ use crate::protocols::unified::UnifiedRequest;
 use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 use dynamo_protocols::types::ChatCompletionMessageContent;
+use dynamo_protocols::types::ChatCompletionMessageToolCallChunk;
 use dynamo_protocols::types::ChatCompletionStreamResponseDelta;
 use dynamo_protocols::types::Choice;
 use dynamo_runtime::logging::get_distributed_tracing_context;
@@ -1277,16 +1278,28 @@ pub(super) async fn check_for_backend_error(
     }
 }
 
-/// Serialize `payload` and wrap it as an SSE event with the given name.
-fn make_dispatch_event(
+#[derive(Serialize)]
+struct ToolCallDispatchPayload<'a> {
+    choice_index: u32,
+    tool_call: &'a ChatCompletionMessageToolCallChunk,
+}
+
+#[derive(Serialize)]
+struct ReasoningDispatchPayload<'a> {
+    index: u32,
+    reasoning_content: &'a str,
+}
+
+/// Serialize `payload` and append it as an SSE event with the given name.
+fn push_dispatch_event(
     event_name: &str,
     payload: &impl serde::Serialize,
-) -> Option<Result<Event, axum::Error>> {
+    out: &mut Vec<Result<Event, axum::Error>>,
+) {
     match serde_json::to_string(payload) {
-        Ok(json) => Some(Ok(Event::default().event(event_name).data(json))),
+        Ok(json) => out.push(Ok(Event::default().event(event_name).data(json))),
         Err(e) => {
             tracing::warn!("streaming_{event_name}: failed to serialize: {e}");
-            None
         }
     }
 }
@@ -1351,12 +1364,12 @@ fn is_empty_completion_stream_response(resp: &NvCreateCompletionResponse) -> boo
 fn streaming_tool_dispatch_events(
     response: &crate::types::Annotated<NvCreateChatCompletionStreamResponse>,
     dispatched_ids: &mut HashSet<String>,
-) -> Vec<Result<Event, axum::Error>> {
+    out: &mut Vec<Result<Event, axum::Error>>,
+) {
     let Some(data) = &response.data else {
-        return vec![];
+        return;
     };
 
-    let mut events = vec![];
     for choice in &data.inner.choices {
         let Some(tool_calls) = &choice.delta.tool_calls else {
             continue;
@@ -1374,15 +1387,14 @@ fn streaming_tool_dispatch_events(
                 if !dispatched_ids.insert(id.clone()) {
                     continue;
                 }
-                let payload = serde_json::json!({
-                    "choice_index": choice.index,
-                    "tool_call": chunk,
-                });
-                events.extend(make_dispatch_event("tool_call_dispatch", &payload));
+                let payload = ToolCallDispatchPayload {
+                    choice_index: choice.index,
+                    tool_call: chunk,
+                };
+                push_dispatch_event("tool_call_dispatch", &payload, out);
             }
         }
     }
-    events
 }
 
 /// Accumulates reasoning tokens and emits a single `event: reasoning_dispatch` SSE event
@@ -1394,12 +1406,12 @@ fn streaming_tool_dispatch_events(
 fn accumulate_reasoning_dispatch(
     response: &crate::types::Annotated<NvCreateChatCompletionStreamResponse>,
     buffers: &mut HashMap<u32, String>,
-) -> Vec<Result<Event, axum::Error>> {
+    out: &mut Vec<Result<Event, axum::Error>>,
+) {
     let Some(data) = &response.data else {
-        return vec![];
+        return;
     };
 
-    let mut events = vec![];
     for choice in &data.inner.choices {
         let buffer = buffers.entry(choice.index).or_default();
         let has_reasoning = choice
@@ -1414,15 +1426,14 @@ fn accumulate_reasoning_dispatch(
 
         // Emit when reasoning transitions to None OR when the stream ends (finish_reason).
         if !buffer.is_empty() && (!has_reasoning || choice.finish_reason.is_some()) {
-            let payload = serde_json::json!({
-                "index": choice.index,
-                "reasoning_content": buffer.as_str(),
-            });
-            events.extend(make_dispatch_event("reasoning_dispatch", &payload));
+            let payload = ReasoningDispatchPayload {
+                index: choice.index,
+                reasoning_content: buffer.as_str(),
+            };
+            push_dispatch_event("reasoning_dispatch", &payload, out);
             buffer.clear();
         }
     }
-    events
 }
 
 /// OpenAI Chat Completions Request Handler
@@ -1577,46 +1588,56 @@ async fn chat_completions(
         let mut reasoning_buffer: HashMap<u32, String> = HashMap::new();
         let mut dispatched_tool_ids: HashSet<String> = HashSet::new();
 
-        // flat_map lets us optionally prepend extra SSE events before each regular chunk:
+        // Optionally prepend extra SSE events before each regular chunk:
         //   - `event: tool_call_dispatch`  — complete tool call detected early (tool dispatch)
         //   - `event: reasoning_dispatch`  — complete reasoning block (emitted once)
-        // When both flags are off the flat_map is equivalent to the original map + filter_map.
-        let stream = stream.flat_map(move |response| {
-            // Extract side-channel events before the response is consumed by EventConverter.
-            let mut events: Vec<Result<Event, axum::Error>> = vec![];
-            // Drop empty chunks from multi-byte token assembly.
-            if response.data.as_ref().is_some_and(is_empty_stream_response) {
-                return stream::iter(events);
-            }
-            if tool_dispatch_enabled {
-                events.extend(streaming_tool_dispatch_events(
-                    &response,
-                    &mut dispatched_tool_ids,
-                ));
-            }
-            if reasoning_dispatch_enabled {
-                events.extend(accumulate_reasoning_dispatch(
-                    &response,
-                    &mut reasoning_buffer,
-                ));
-            }
+        let stream = async_stream::stream! {
+            let mut stream = Box::pin(stream);
+            let mut events: Vec<Result<Event, axum::Error>> = Vec::with_capacity(4);
 
-            // Convert to SSE event (this consumes the response).
-            // EventConverter will detect `event: "error"` and convert to SSE error events.
-            let sse_result = process_response_using_event_converter_and_observe_metrics(
-                EventConverter::from(response),
-                &mut response_collector,
-                &mut http_queue_guard,
-            );
+            while let Some(response) = stream.next().await {
+                events.clear();
 
-            // Side-channel events come first, then the regular data event.
-            match sse_result {
-                Ok(Some(ev)) => events.push(Ok(ev)),
-                Ok(None) => {}
-                Err(e) => events.push(Err(e)),
+                // Drop empty chunks from multi-byte token assembly.
+                if response.data.as_ref().is_some_and(is_empty_stream_response) {
+                    continue;
+                }
+                if tool_dispatch_enabled {
+                    streaming_tool_dispatch_events(
+                        &response,
+                        &mut dispatched_tool_ids,
+                        &mut events,
+                    );
+                }
+                if reasoning_dispatch_enabled {
+                    accumulate_reasoning_dispatch(
+                        &response,
+                        &mut reasoning_buffer,
+                        &mut events,
+                    );
+                }
+
+                // Convert to SSE event (this consumes the response).
+                // EventConverter will detect `event: "error"` and convert to SSE error events.
+                let sse_result = process_response_using_event_converter_and_observe_metrics(
+                    EventConverter::from(response),
+                    &mut response_collector,
+                    &mut http_queue_guard,
+                );
+
+                // Side-channel events come first, then the regular data event.
+                match sse_result {
+                    Ok(Some(ev)) => events.push(Ok(ev)),
+                    Ok(None) => {}
+                    Err(e) => events.push(Err(e)),
+                }
+
+                events.reverse();
+                while let Some(event) = events.pop() {
+                    yield event;
+                }
             }
-            stream::iter(events)
-        });
+        };
         let stream = monitor_for_disconnects(stream, ctx, inflight_guard, stream_handle);
 
         let mut sse_stream = Sse::new(stream);
@@ -4192,6 +4213,24 @@ mod tests {
         }
     }
 
+    fn collect_tool_dispatch_events(
+        response: &Annotated<NvCreateChatCompletionStreamResponse>,
+        dispatched_ids: &mut HashSet<String>,
+    ) -> Vec<Result<Event, axum::Error>> {
+        let mut events = Vec::new();
+        streaming_tool_dispatch_events(response, dispatched_ids, &mut events);
+        events
+    }
+
+    fn collect_reasoning_dispatch_events(
+        response: &Annotated<NvCreateChatCompletionStreamResponse>,
+        buffers: &mut HashMap<u32, String>,
+    ) -> Vec<Result<Event, axum::Error>> {
+        let mut events = Vec::new();
+        accumulate_reasoning_dispatch(response, buffers, &mut events);
+        events
+    }
+
     fn make_choice_with_reasoning(
         index: u32,
         reasoning: Option<&str>,
@@ -4255,7 +4294,7 @@ mod tests {
             Some(r#"{"city":"Paris"}"#),
         )]);
 
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert_eq!(events.len(), 1);
 
         let event = events[0].as_ref().unwrap();
@@ -4279,7 +4318,7 @@ mod tests {
             Some(r#"{"city":"Paris"}"#),
         )]);
 
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert!(events.is_empty(), "should not dispatch without id");
     }
 
@@ -4292,7 +4331,7 @@ mod tests {
             Some(r#"{"city":"Paris"}"#),
         )]);
 
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert!(events.is_empty(), "should not dispatch without name");
     }
 
@@ -4305,7 +4344,7 @@ mod tests {
             None, // no arguments
         )]);
 
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert!(events.is_empty(), "should not dispatch without arguments");
     }
 
@@ -4345,7 +4384,7 @@ mod tests {
         };
 
         let response = make_stream_response(vec![choice]);
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert_eq!(events.len(), 2, "should dispatch both tool calls");
 
         // Verify each dispatched event has the correct tool call data
@@ -4367,14 +4406,14 @@ mod tests {
             comment: None,
             error: None,
         };
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert!(events.is_empty());
     }
 
     #[test]
     fn test_tool_dispatch_empty_choices() {
         let response = make_stream_response(vec![]);
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert!(events.is_empty());
     }
 
@@ -4416,7 +4455,7 @@ mod tests {
         };
 
         let response = make_stream_response(vec![choice]);
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert_eq!(
             events.len(),
             1,
@@ -4452,7 +4491,7 @@ mod tests {
         };
 
         let response = make_stream_response(vec![choice]);
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert!(events.is_empty(), "function: None should not dispatch");
     }
 
@@ -4467,7 +4506,7 @@ mod tests {
             Some(""),
         )]);
 
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert_eq!(events.len(), 1, "empty arguments should still dispatch");
 
         let json = extract_sse_data_json(events[0].as_ref().unwrap());
@@ -4494,7 +4533,7 @@ mod tests {
         );
 
         let response = make_stream_response(vec![choice_0, choice_1]);
-        let events = streaming_tool_dispatch_events(&response, &mut HashSet::new());
+        let events = collect_tool_dispatch_events(&response, &mut HashSet::new());
         assert_eq!(events.len(), 2, "should dispatch from both choices");
 
         let json0 = extract_sse_data_json(events[0].as_ref().unwrap());
@@ -4520,11 +4559,11 @@ mod tests {
         let mut dispatched = HashSet::new();
 
         // First call — should dispatch
-        let events = streaming_tool_dispatch_events(&response, &mut dispatched);
+        let events = collect_tool_dispatch_events(&response, &mut dispatched);
         assert_eq!(events.len(), 1);
 
         // Second call with same response — should be deduped
-        let events = streaming_tool_dispatch_events(&response, &mut dispatched);
+        let events = collect_tool_dispatch_events(&response, &mut dispatched);
         assert!(events.is_empty(), "duplicate id should not dispatch twice");
     }
 
@@ -4536,7 +4575,7 @@ mod tests {
 
         // Chunk 1: reasoning token "Let me"
         let r1 = make_stream_response(vec![make_choice_with_reasoning(0, Some("Let me"), None)]);
-        let events = accumulate_reasoning_dispatch(&r1, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r1, &mut buffers);
         assert!(
             events.is_empty(),
             "should not emit yet — still accumulating"
@@ -4545,7 +4584,7 @@ mod tests {
 
         // Chunk 2: reasoning token " think"
         let r2 = make_stream_response(vec![make_choice_with_reasoning(0, Some(" think"), None)]);
-        let events = accumulate_reasoning_dispatch(&r2, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r2, &mut buffers);
         assert!(
             events.is_empty(),
             "should not emit yet — still accumulating"
@@ -4554,7 +4593,7 @@ mod tests {
 
         // Chunk 3: reasoning ends (None), meaning normal content follows
         let r3 = make_stream_response(vec![make_choice_with_reasoning(0, None, None)]);
-        let events = accumulate_reasoning_dispatch(&r3, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r3, &mut buffers);
         assert_eq!(events.len(), 1, "should emit single reasoning_dispatch");
 
         let event = events[0].as_ref().unwrap();
@@ -4580,7 +4619,7 @@ mod tests {
             Some("Thinking..."),
             None,
         )]);
-        accumulate_reasoning_dispatch(&r1, &mut buffers);
+        collect_reasoning_dispatch_events(&r1, &mut buffers);
 
         // Chunk 2: finish_reason=length while still in reasoning (max_tokens hit)
         let r2 = make_stream_response(vec![make_choice_with_reasoning(
@@ -4588,7 +4627,7 @@ mod tests {
             Some(" more"),
             Some(FinishReason::Length),
         )]);
-        let events = accumulate_reasoning_dispatch(&r2, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r2, &mut buffers);
         assert_eq!(events.len(), 1, "should flush on finish_reason");
 
         let json = extract_sse_data_json(events[0].as_ref().unwrap());
@@ -4605,7 +4644,7 @@ mod tests {
             Some("Analysis complete"),
             None,
         )]);
-        accumulate_reasoning_dispatch(&r1, &mut buffers);
+        collect_reasoning_dispatch_events(&r1, &mut buffers);
 
         // Chunk 2: finish_reason=stop while still in reasoning
         let r2 = make_stream_response(vec![make_choice_with_reasoning(
@@ -4613,7 +4652,7 @@ mod tests {
             Some("."),
             Some(FinishReason::Stop),
         )]);
-        let events = accumulate_reasoning_dispatch(&r2, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r2, &mut buffers);
         assert_eq!(events.len(), 1, "should flush on FinishReason::Stop");
 
         let json = extract_sse_data_json(events[0].as_ref().unwrap());
@@ -4626,7 +4665,7 @@ mod tests {
 
         // Chunk with no reasoning content at all
         let r = make_stream_response(vec![make_choice_with_reasoning(0, None, None)]);
-        let events = accumulate_reasoning_dispatch(&r, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r, &mut buffers);
         assert!(events.is_empty(), "no reasoning content = no event");
     }
 
@@ -4636,7 +4675,7 @@ mod tests {
 
         // Chunk with empty string reasoning (treated as no-reasoning)
         let r = make_stream_response(vec![make_choice_with_reasoning(0, Some(""), None)]);
-        let events = accumulate_reasoning_dispatch(&r, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r, &mut buffers);
         assert!(events.is_empty());
         assert!(
             buffers.get(&0).is_none_or(|s| s.is_empty()),
@@ -4654,7 +4693,7 @@ mod tests {
             comment: None,
             error: None,
         };
-        let events = accumulate_reasoning_dispatch(&response, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&response, &mut buffers);
         assert!(events.is_empty());
     }
 
@@ -4662,7 +4701,7 @@ mod tests {
     fn test_reasoning_dispatch_empty_choices() {
         let mut buffers: HashMap<u32, String> = HashMap::new();
         let response = make_stream_response(vec![]);
-        let events = accumulate_reasoning_dispatch(&response, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&response, &mut buffers);
         assert!(events.is_empty());
     }
 
@@ -4675,7 +4714,7 @@ mod tests {
             make_choice_with_reasoning(0, Some("Thinking A"), None),
             make_choice_with_reasoning(1, Some("Thinking B"), None),
         ]);
-        let events = accumulate_reasoning_dispatch(&r1, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r1, &mut buffers);
         assert!(events.is_empty(), "both still accumulating");
         assert_eq!(buffers.get(&0).map(|s| s.as_str()), Some("Thinking A"));
         assert_eq!(buffers.get(&1).map(|s| s.as_str()), Some("Thinking B"));
@@ -4685,7 +4724,7 @@ mod tests {
             make_choice_with_reasoning(0, None, None),
             make_choice_with_reasoning(1, Some(" more"), None),
         ]);
-        let events = accumulate_reasoning_dispatch(&r2, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r2, &mut buffers);
         assert_eq!(events.len(), 1, "only choice 0 should emit");
         let json = extract_sse_data_json(events[0].as_ref().unwrap());
         assert_eq!(json["reasoning_content"], "Thinking A");
@@ -4693,7 +4732,7 @@ mod tests {
 
         // Choice 1 stops reasoning
         let r3 = make_stream_response(vec![make_choice_with_reasoning(1, None, None)]);
-        let events = accumulate_reasoning_dispatch(&r3, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r3, &mut buffers);
         assert_eq!(events.len(), 1, "choice 1 should emit");
         let json = extract_sse_data_json(events[0].as_ref().unwrap());
         assert_eq!(json["reasoning_content"], "Thinking B more");
@@ -4709,20 +4748,20 @@ mod tests {
 
         // First reasoning block
         let r1 = make_stream_response(vec![make_choice_with_reasoning(0, Some("First"), None)]);
-        accumulate_reasoning_dispatch(&r1, &mut buffers);
+        collect_reasoning_dispatch_events(&r1, &mut buffers);
 
         let r2 = make_stream_response(vec![make_choice_with_reasoning(0, None, None)]);
-        let events = accumulate_reasoning_dispatch(&r2, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r2, &mut buffers);
         assert_eq!(events.len(), 1);
         let json = extract_sse_data_json(events[0].as_ref().unwrap());
         assert_eq!(json["reasoning_content"], "First");
 
         // Second reasoning block — buffer was cleared, should accumulate fresh
         let r3 = make_stream_response(vec![make_choice_with_reasoning(0, Some("Second"), None)]);
-        accumulate_reasoning_dispatch(&r3, &mut buffers);
+        collect_reasoning_dispatch_events(&r3, &mut buffers);
 
         let r4 = make_stream_response(vec![make_choice_with_reasoning(0, None, None)]);
-        let events = accumulate_reasoning_dispatch(&r4, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r4, &mut buffers);
         assert_eq!(events.len(), 1);
         let json = extract_sse_data_json(events[0].as_ref().unwrap());
         assert_eq!(
@@ -4741,17 +4780,17 @@ mod tests {
             Some("让我想想 🤔"),
             None,
         )]);
-        accumulate_reasoning_dispatch(&r1, &mut buffers);
+        collect_reasoning_dispatch_events(&r1, &mut buffers);
 
         let r2 = make_stream_response(vec![make_choice_with_reasoning(
             0,
             Some(" 分析完成 ✅"),
             None,
         )]);
-        accumulate_reasoning_dispatch(&r2, &mut buffers);
+        collect_reasoning_dispatch_events(&r2, &mut buffers);
 
         let r3 = make_stream_response(vec![make_choice_with_reasoning(0, None, None)]);
-        let events = accumulate_reasoning_dispatch(&r3, &mut buffers);
+        let events = collect_reasoning_dispatch_events(&r3, &mut buffers);
         assert_eq!(events.len(), 1);
 
         let json = extract_sse_data_json(events[0].as_ref().unwrap());


### PR DESCRIPTION
## Summary

- optimize OpenAI chat streaming SSE by replacing the per-chunk `flat_map -> Vec -> stream::iter` path with one `async_stream` adapter that reuses event storage
- append tool-call and reasoning dispatch events into caller-owned storage while preserving ordering and dedup semantics
- serialize normal SSE JSON with `serde_json::to_string` plus `Event::data` to avoid `Event::json_data` newline/carriage-return filtering overhead

## Validation

- `cargo test -p dynamo-llm http::service::openai`
- `cargo test -p dynamo-llm http::service::metrics`

## Benchmarked Perf

Measured on the agentx trace with frontend+mockers at concurrency 512

| Config | Throughput |
| --- | ---: |
| Baseline frontend | ~318.8 req/s |
| This response-stream optimization PR | 334.36 req/s |

Observed e2e throughput uplift from this PR: **+4.88%**.

## Profiling

- `Event::json_data::IgnoreNewLines`: 6.731% -> 0.000%
- SSE response JSON serialization bucket: 8.287% -> 3.806%
- all `serde_json` serialization bucket: 9.248% -> 4.575%
- SSE body poll subtree: 26.238% -> 21.646%
- old `flat_map`/`flatten` adapter bucket: 24.920% -> 0.000%


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Server-Sent Events JSON serialization for streaming responses, ensuring more reliable data transmission.
  * Enhanced handling of tool-call dispatches and reasoning blocks in OpenAI chat completions streaming.

* **Tests**
  * Expanded test coverage for streaming event behavior and JSON serialization validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
