### PR TITLE
feat(planner): discount speculative decode ITL by accept length

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -87,6 +87,10 @@ class SLAPlannerDefaults(BasePlannerDefaults):
     decode_scale_up_kv_rate = None
     decode_scale_down_kv_rate = None
 
+    # Speculative decoding. 0 disables planner-side spec decode discounts unless
+    # worker MDC publishes a positive runtime_config.runtime_data.spec_decode.nextn.
+    speculative_nextn = 0
+
     # Advisory mode: compute and log decisions without executing scaling
     advisory = False
 

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -214,6 +214,15 @@ class PlannerConfig(BaseModel):
     )
     load_metric_samples: int = SLAPlannerDefaults.load_metric_samples
     load_min_observations: int = SLAPlannerDefaults.load_min_observations
+    speculative_nextn: int = Field(
+        default=SLAPlannerDefaults.speculative_nextn,
+        ge=0,
+        description=(
+            "Manual fallback speculative decoding depth. Worker MDC "
+            "runtime_config.runtime_data.spec_decode.nextn takes precedence "
+            "when present."
+        ),
+    )
 
     # Advisory mode: compute and log decisions without executing scaling
     advisory: bool = SLAPlannerDefaults.advisory

--- a/components/src/dynamo/planner/connectors/mdc.py
+++ b/components/src/dynamo/planner/connectors/mdc.py
@@ -102,6 +102,22 @@ def select_entry(
     return None
 
 
+def _parse_speculative_nextn(runtime_cfg: dict) -> Optional[int]:
+    runtime_data = runtime_cfg.get("runtime_data")
+    if not isinstance(runtime_data, dict):
+        return None
+
+    spec_decode = runtime_data.get("spec_decode")
+    if not isinstance(spec_decode, dict):
+        return None
+
+    try:
+        nextn = int(spec_decode.get("nextn", 0))
+    except (TypeError, ValueError):
+        return None
+    return nextn if nextn > 0 else None
+
+
 def worker_info_from_mdc(
     entry: MdcEntry,
     sub_component_type: SubComponentType,
@@ -145,4 +161,5 @@ def worker_info_from_mdc(
         max_num_seqs=runtime_cfg.get("max_num_seqs"),
         max_num_batched_tokens=runtime_cfg.get("max_num_batched_tokens"),
         context_length=card.get("context_length"),
+        speculative_nextn=_parse_speculative_nextn(runtime_cfg),
     )

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -83,6 +83,7 @@ def _engine_caps(
         max_num_seqs=worker_info.max_num_seqs if worker_info else None,
         context_length=worker_info.context_length if worker_info else None,
         max_kv_tokens=worker_info.max_kv_tokens if worker_info else None,
+        speculative_nextn=worker_info.speculative_nextn if worker_info else None,
     )
 
 
@@ -403,6 +404,7 @@ class NativePlannerBase:
         "max_num_seqs",
         "max_num_batched_tokens",
         "context_length",
+        "speculative_nextn",
     )
 
     def _refresh_worker_info_from_connector(self) -> None:
@@ -573,11 +575,15 @@ class NativePlannerBase:
         m.kv_hit_rate = self.prometheus_traffic_client.get_avg_kv_hit_rate(
             interval_str, self.model_name
         )
+        m.accept_length = self._collect_accept_length(interval_str)
 
         hit_rate_str = f"{m.kv_hit_rate:.3f}" if m.kv_hit_rate is not None else "n/a"
+        accept_length_str = (
+            f"{m.accept_length:.3f}" if m.accept_length is not None else "n/a"
+        )
         logger.info(
             f"Observed num_req: {m.num_req:.2f} isl: {m.isl:.2f} osl: {m.osl:.2f} "
-            f"kv_hit_rate: {hit_rate_str}"
+            f"kv_hit_rate: {hit_rate_str} accept_length: {accept_length_str}"
         )
 
         if self.prometheus_port != 0:
@@ -601,6 +607,23 @@ class NativePlannerBase:
             isl=m.isl,
             osl=m.osl,
             kv_hit_rate=m.kv_hit_rate,
+            accept_length=m.accept_length,
+        )
+
+    def _collect_accept_length(self, interval_str: str) -> Optional[float]:
+        if self.config.mode not in ("disagg", "decode", "agg"):
+            return None
+        if not self.model_name:
+            return None
+        component_name = self.decode_worker_info.component_name
+        endpoint_name = self.decode_worker_info.endpoint
+        return self.prometheus_traffic_client.get_avg_spec_decode_accept_length(
+            interval_str,
+            self.config.backend,
+            component_name,
+            self.model_name,
+            namespace=self.runtime_namespace,
+            endpoint_name=endpoint_name,
         )
 
     async def _collect_kv_hit_rate_observation(
@@ -612,9 +635,9 @@ class NativePlannerBase:
         to discount prefill work, so we skip the five other (unused) traffic
         queries to keep the per-load-tick scrape cheap.
 
-        Returns ``None`` when the router metric is unavailable (e.g.
-        Prometheus source is "frontend"); the state machine treats that as
-        a no-discount fallback.
+        The observation is still returned when metrics are unavailable so the
+        state machine can reset speculative-decode discounting to the
+        no-discount fallback.
         """
         assert self.model_name is not None
         if duration_s <= 0:
@@ -623,19 +646,26 @@ class NativePlannerBase:
         hit_rate = self.prometheus_traffic_client.get_avg_kv_hit_rate(
             interval_str, self.model_name
         )
+        accept_length = self._collect_accept_length(interval_str)
         # Mirror the observed value into Metrics so the diagnostics recorder
         # sees the up-to-date hit rate even on load-only ticks.
         self._last_metrics.kv_hit_rate = hit_rate
+        self._last_metrics.accept_length = accept_length
         hit_rate_str = f"{hit_rate:.3f}" if hit_rate is not None else "n/a"
-        logger.info(f"Observed kv_hit_rate over {interval_str}: {hit_rate_str}")
-        if hit_rate is None:
-            return None
+        accept_length_str = (
+            f"{accept_length:.3f}" if accept_length is not None else "n/a"
+        )
+        logger.info(
+            f"Observed kv_hit_rate over {interval_str}: {hit_rate_str}; "
+            f"accept_length: {accept_length_str}"
+        )
         return TrafficObservation(
             duration_s=duration_s,
             num_req=0.0,
             isl=0.0,
             osl=0.0,
             kv_hit_rate=hit_rate,
+            accept_length=accept_length,
         )
 
     def _collect_fpm(self) -> FpmObservations:

--- a/components/src/dynamo/planner/core/load_scaling.py
+++ b/components/src/dynamo/planner/core/load_scaling.py
@@ -500,6 +500,7 @@ class LoadScalingMixin:
         consolidation = num_workers / (num_workers - 1) if num_workers > 1 else 1.0
         d_caps = self._capabilities.decode
         max_kv = d_caps.max_kv_tokens if d_caps else None
+        accept_length = self._current_decode_accept_length()
 
         estimates: list[float] = []
         # Consolidation-aware scale-down. Two safety checks per worker:
@@ -520,11 +521,12 @@ class LoadScalingMixin:
                 queued_decode_kv=queued_kv,
             )
             if est is not None:
-                est_ms = est * 1000
+                est_ms = est * 1000 / accept_length
                 estimates.append(est_ms)
                 logger.info(
                     f"Decode engine {wid}:dp{dp}: estimated ITL {est_ms:.2f}ms "
-                    f"(sched_kv={sched_kv}, queued_kv={queued_kv})"
+                    f"(sched_kv={sched_kv}, queued_kv={queued_kv}, "
+                    f"accept_length={accept_length:.2f})"
                 )
 
             if can_scale_down:
@@ -541,7 +543,7 @@ class LoadScalingMixin:
                 )
                 if post_itl is None:
                     can_scale_down = False
-                elif post_itl * 1000 >= self._config.itl_ms * sensitivity:
+                elif post_itl * 1000 / accept_length >= self._config.itl_ms * sensitivity:
                     can_scale_down = False
                     consolidation_refused = True
 
@@ -652,6 +654,7 @@ class LoadScalingMixin:
         consolidation = num_workers / (num_workers - 1) if num_workers > 1 else 1.0
         d_caps = self._capabilities.decode
         max_kv = d_caps.max_kv_tokens if d_caps else None
+        accept_length = self._current_decode_accept_length()
 
         estimates: list[float] = []
         # Agg-decode consolidation. Combined cache pressure (sched_decode_kv
@@ -672,7 +675,7 @@ class LoadScalingMixin:
                 queued_decode_kv=queued_kv,
             )
             if est is not None:
-                estimates.append(est * 1000)
+                estimates.append(est * 1000 / accept_length)
 
             if can_scale_down:
                 post_combined_kv = int(
@@ -690,7 +693,7 @@ class LoadScalingMixin:
                 )
                 if post_itl is None:
                     can_scale_down = False
-                elif post_itl * 1000 >= self._config.itl_ms * sensitivity:
+                elif post_itl * 1000 / accept_length >= self._config.itl_ms * sensitivity:
                     can_scale_down = False
                     consolidation_refused = True
 

--- a/components/src/dynamo/planner/core/perf_model/agg.py
+++ b/components/src/dynamo/planner/core/perf_model/agg.py
@@ -133,6 +133,7 @@ class AggRegressionModel(_BaseRegressionModel):
         max_kv_tokens: Optional[int] = None,
         max_num_seqs: Optional[int] = None,
         kv_hit_rate: Optional[float] = None,
+        accept_length: float = 1.0,
     ) -> tuple[float, float, float]:
         """Find the maximum agg engine request rate under both SLA targets.
 
@@ -178,6 +179,7 @@ class AggRegressionModel(_BaseRegressionModel):
             or max_num_batched_tokens <= 0
         ):
             return (0.0, 0.0, 0.0)
+        accept_length = max(1.0, float(accept_length))
 
         prefill_scale = 1.0 - _clamp_kv_hit_rate(kv_hit_rate)
         effective_isl = isl * prefill_scale
@@ -228,7 +230,7 @@ class AggRegressionModel(_BaseRegressionModel):
                 bs * effective_isl / max(1.0, osl), max_num_batched_tokens
             )
             wt = self._predict_2d(prefill_per_iter, decode_kv)
-            itl_ms = wt * 1000.0
+            itl_ms = wt * 1000.0 / accept_length
 
             # ``estimate_next_ttft`` applies the same discount internally to
             # both the queued portion and the avg_isl portion. To keep the
@@ -253,11 +255,12 @@ class AggRegressionModel(_BaseRegressionModel):
                         f"ITL={itl_ms:.1f}ms (target {itl_sla:.1f}ms)"
                     )
                     best_rps = 1.0 / (osl * wt)
+                    best_rps *= accept_length
                     best_ttft_ms = ttft_ms
                     best_itl_ms = itl_ms
                 break
 
-            best_rps = bs / (osl * wt)
+            best_rps = bs / (osl * (wt / accept_length))
             best_ttft_ms = ttft_ms
             best_itl_ms = itl_ms
 

--- a/components/src/dynamo/planner/core/perf_model/decode.py
+++ b/components/src/dynamo/planner/core/perf_model/decode.py
@@ -88,11 +88,13 @@ class DecodeRegressionModel(_BaseRegressionModel):
         osl: float,
         max_kv_tokens: Optional[int] = None,
         max_num_seqs: Optional[int] = None,
+        accept_length: float = 1.0,
     ) -> tuple[float, float]:
         """Find the maximum decode engine request rate within an ITL target.
 
         Binary searches over batch_size at the given context_length for the
-        maximum batch_size where predicted wall_time * 1000 <= itl.  If even
+        maximum batch_size where predicted per-forward wall time, discounted by
+        speculative accept length, satisfies the ITL target.  If even
         batch_size=1 violates the target, warns but returns the best
         achievable rate at batch_size=1 so the caller can still scale.
 
@@ -106,12 +108,14 @@ class DecodeRegressionModel(_BaseRegressionModel):
         neither capability is provided.
 
         Returns:
-            (engine_rps, actual_itl_ms) -- 0 rps signals an error
+            (engine_rps, actual_itl_ms) -- actual ITL is wall_time/accept_length.
+            0 rps signals an error
             (model not fitted or invalid input); positive rps is
             the best achievable rate with the predicted ITL.
         """
         if not self._ensure_fitted() or context_length <= 0 or osl <= 0 or itl <= 0:
             return (0.0, 0.0)
+        accept_length = max(1.0, float(accept_length))
 
         if max_kv_tokens and max_kv_tokens > 0:
             kv_cap = max(1, int(max_kv_tokens / context_length))
@@ -124,22 +128,23 @@ class DecodeRegressionModel(_BaseRegressionModel):
         lo, hi = 1, max_batch
         best_bs, best_wt = 1, self._predict_2d(1, context_length)
 
-        if best_wt * 1000.0 > itl:
+        best_itl_ms = best_wt * 1000.0 / accept_length
+        if best_itl_ms > itl:
             logger.warning(
-                f"ITL SLA unreachable: predicted {best_wt * 1000.0:.1f}ms "
+                f"ITL SLA unreachable: predicted {best_itl_ms:.1f}ms "
                 f"> target {itl:.1f}ms at batch_size=1, ctx_len={context_length:.0f}"
             )
-            return (best_bs / (osl * best_wt), best_wt * 1000.0)
+            return (best_bs / (osl * (best_wt / accept_length)), best_itl_ms)
 
         while lo <= hi:
             mid = (lo + hi) // 2
             kv = mid * context_length
             wt = self._predict_2d(mid, kv)
-            if wt * 1000.0 <= itl:
+            if wt * 1000.0 / accept_length <= itl:
                 best_bs, best_wt = mid, wt
                 lo = mid + 1
             else:
                 hi = mid - 1
 
-        engine_rps = best_bs / (osl * best_wt)
-        return (engine_rps, best_wt * 1000.0)
+        engine_rps = best_bs / (osl * (best_wt / accept_length))
+        return (engine_rps, best_wt * 1000.0 / accept_length)

--- a/components/src/dynamo/planner/core/state_machine.py
+++ b/components/src/dynamo/planner/core/state_machine.py
@@ -116,6 +116,9 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
         # across ticks because load-scaling and throughput-scaling cadences
         # may differ. ``None`` means "no observation yet" -> no discount.
         self._last_kv_hit_rate: Optional[float] = None
+        # Most recent speculative decode accept length. This is planner-side
+        # scaling metadata only; FPM observations remain raw per-forward data.
+        self._last_accept_length: float = 1.0
 
         self._next_load_s: float = float("inf")
         self._next_throughput_s: float = float("inf")
@@ -143,6 +146,7 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
     def update_capabilities(self, capabilities: WorkerCapabilities) -> None:
         """Replace the current worker capabilities."""
         self._capabilities = capabilities
+        self._last_accept_length = self._clamp_accept_length(self._last_accept_length)
 
     def initial_tick(self, start_s: float) -> ScheduledTick:
         self._next_load_s = start_s + self._config.load_adjustment_interval_seconds
@@ -372,6 +376,25 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
                 # Load-only mode: there is no predictor path, the load tick
                 # consumes the freshly observed average directly.
                 self._last_kv_hit_rate = traffic.kv_hit_rate
+
+        self._last_accept_length = self._clamp_accept_length(traffic.accept_length)
+
+    def _effective_speculative_nextn(self) -> int:
+        d_caps = self._capabilities.decode
+        if d_caps and d_caps.speculative_nextn and d_caps.speculative_nextn > 0:
+            return d_caps.speculative_nextn
+        return max(0, int(self._config.speculative_nextn))
+
+    def _clamp_accept_length(self, accept_length: Optional[float]) -> float:
+        nextn = self._effective_speculative_nextn()
+        if nextn <= 0:
+            return 1.0
+        if accept_length is None or not math.isfinite(accept_length):
+            return 1.0
+        return min(max(float(accept_length), 1.0), float(nextn + 1))
+
+    def _current_decode_accept_length(self) -> float:
+        return self._clamp_accept_length(self._last_accept_length)
 
     # ------------------------------------------------------------------
     # Budget

--- a/components/src/dynamo/planner/core/throughput_scaling.py
+++ b/components/src/dynamo/planner/core/throughput_scaling.py
@@ -208,6 +208,7 @@ class ThroughputScalingMixin:
             max_kv_tokens=d_caps.max_kv_tokens if d_caps else None,
             max_num_seqs=d_caps.max_num_seqs if d_caps else None,
             kv_hit_rate=kv_hit_rate,
+            accept_length=self._current_decode_accept_length(),
         )
         if engine_rps <= 0:
             logger.warning("Agg perf model not ready, skipping throughput scaling")
@@ -281,12 +282,14 @@ class ThroughputScalingMixin:
         self, demand_rps: float, isl: float, osl: float
     ) -> Optional[int]:
         d_caps = self._capabilities.decode
+        accept_length = self._current_decode_accept_length()
         engine_rps, itl_ms = self._decode_regression.find_best_engine_decode_rps(
             itl=self._config.itl_ms,
             context_length=isl + osl / 2,
             osl=osl,
             max_kv_tokens=d_caps.max_kv_tokens if d_caps else None,
             max_num_seqs=d_caps.max_num_seqs if d_caps else None,
+            accept_length=accept_length,
         )
         if engine_rps <= 0:
             logger.warning("Decode perf model not ready, skipping throughput scaling")
@@ -301,6 +304,7 @@ class ThroughputScalingMixin:
 
         result = max(math.ceil(demand_rps / engine_rps), self._config.min_endpoint)
         logger.info(
-            f"Decode: {demand_rps:.2f} rps / {engine_rps:.2f} = {result}, est_itl={itl_ms:.1f}ms"
+            f"Decode: {demand_rps:.2f} rps / {engine_rps:.2f} = {result}, "
+            f"est_itl={itl_ms:.1f}ms, accept_length={accept_length:.2f}"
         )
         return result

--- a/components/src/dynamo/planner/core/types.py
+++ b/components/src/dynamo/planner/core/types.py
@@ -49,6 +49,7 @@ class TrafficObservation:
     isl: float
     osl: float
     kv_hit_rate: Optional[float] = None
+    accept_length: Optional[float] = None
 
 
 @dataclass
@@ -148,6 +149,7 @@ class EngineCapabilities:
     max_num_seqs: Optional[int] = None
     context_length: Optional[int] = None
     max_kv_tokens: Optional[int] = None
+    speculative_nextn: Optional[int] = None
 
 
 @dataclass

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -43,6 +43,7 @@ class Metrics:
     p_load: Optional[float] = None
     d_load: Optional[float] = None
     kv_hit_rate: Optional[float] = None
+    accept_length: Optional[float] = None
 
     def is_valid(self) -> bool:
         """Check if all required metrics are valid (not None and not NaN)."""
@@ -370,6 +371,89 @@ class PrometheusAPIClient:
         except Exception as e:
             logger.warning(f"Error getting avg kv hit rate: {e}")
             return None
+
+    @staticmethod
+    def _quote_label_value(value: str) -> str:
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
+    def _engine_metric_filter(
+        self,
+        component_name: Optional[str],
+        model_name: Optional[str],
+        namespace: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+    ) -> str:
+        metric_namespace = namespace or self.dynamo_namespace
+        metric_endpoint = endpoint_name or "generate"
+        filters = [
+            f'{prometheus_names.labels.NAMESPACE}="{self._quote_label_value(metric_namespace)}"',
+            f'{prometheus_names.labels.ENDPOINT}="{self._quote_label_value(metric_endpoint)}"',
+        ]
+        if component_name:
+            filters.append(
+                f'{prometheus_names.labels.COMPONENT}="{self._quote_label_value(component_name)}"'
+            )
+        if model_name:
+            filters.append(
+                f'{prometheus_names.labels.MODEL}="{self._quote_label_value(model_name)}"'
+            )
+        return ",".join(filters)
+
+    def _query_single_value(self, query: str, operation_name: str) -> Optional[float]:
+        try:
+            result = self.prom.custom_query(query=query)
+            if not result:
+                logger.info(f"No prometheus data for {operation_name}")
+                return None
+            value = float(result[0]["value"][1])
+            return value if math.isfinite(value) else None
+        except Exception as e:
+            logger.warning(f"Error getting {operation_name}: {e}")
+            return None
+
+    def get_avg_spec_decode_accept_length(
+        self,
+        interval: str,
+        backend: str,
+        component_name: Optional[str],
+        model_name: Optional[str],
+        namespace: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+    ) -> Optional[float]:
+        """Average spec-decode accept length from worker engine metrics.
+
+        Returns tokens produced per decode forward, including the base token.
+        Missing data returns ``None`` so callers can fall back to no discount.
+        """
+        selector = self._engine_metric_filter(
+            component_name, model_name, namespace, endpoint_name
+        )
+        if backend == "vllm":
+            accepted = (
+                f"sum(rate(vllm:spec_decode_num_accepted_tokens_total"
+                f"{{{selector}}}[{interval}]))"
+            )
+            drafts = (
+                f"sum(rate(vllm:spec_decode_num_drafts_total"
+                f"{{{selector}}}[{interval}]))"
+            )
+            return self._query_single_value(
+                f"1 + ({accepted}) / ({drafts})",
+                "vLLM spec decode accept length",
+            )
+        if backend == "sglang":
+            return self._query_single_value(
+                f"avg(avg_over_time(sglang:spec_accept_length"
+                f"{{{selector}}}[{interval}]))",
+                "SGLang spec decode accept length",
+            )
+        if backend == "trtllm":
+            return self._query_single_value(
+                f"avg(avg_over_time(trtllm_spec_decode_acceptance_length"
+                f"{{{selector}}}[{interval}]))",
+                "TRT-LLM spec decode accept length",
+            )
+        return None
 
     def warn_if_router_not_scraped(self) -> None:
         """Warn if Prometheus is not scraping any dynamo_component_router_* series.

--- a/components/src/dynamo/planner/monitoring/worker_info.py
+++ b/components/src/dynamo/planner/monitoring/worker_info.py
@@ -43,6 +43,7 @@ class WorkerInfo:
     max_num_seqs: Optional[int] = None
     max_num_batched_tokens: Optional[int] = None
     context_length: Optional[int] = None
+    speculative_nextn: Optional[int] = None
 
     @property
     def max_kv_tokens(self) -> Optional[int]:
@@ -64,6 +65,8 @@ class WorkerInfo:
             parts.append(f"max_num_batched_tokens={self.max_num_batched_tokens}")
         if self.context_length is not None:
             parts.append(f"context_length={self.context_length}")
+        if self.speculative_nextn is not None:
+            parts.append(f"speculative_nextn={self.speculative_nextn}")
         return ", ".join(parts)
 
 

--- a/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
@@ -460,6 +460,29 @@ class TestDecodeRegressionModel:
         )
         assert rps > 0 and actual_itl > 0 and actual_itl <= 50.0
 
+    def test_find_best_engine_decode_rps_discounts_itl(self):
+        model = DecodeRegressionModel(
+            max_num_fpm_samples=50, min_observations=3, bucket_count=16
+        )
+        self._train_thpt_model(model)
+        base_rps, base_itl = model.find_best_engine_decode_rps(
+            itl=50.0,
+            context_length=1000.0,
+            osl=150.0,
+            accept_length=1.0,
+            max_num_seqs=1,
+        )
+        spec_rps, spec_itl = model.find_best_engine_decode_rps(
+            itl=50.0,
+            context_length=1000.0,
+            osl=150.0,
+            accept_length=2.0,
+            max_num_seqs=1,
+        )
+
+        assert spec_itl == pytest.approx(base_itl / 2)
+        assert spec_rps == pytest.approx(base_rps * 2)
+
     def test_find_best_engine_decode_rps_zero_context(self):
         model = DecodeRegressionModel(
             max_num_fpm_samples=50, min_observations=3, bucket_count=16
@@ -543,6 +566,31 @@ class TestAggRegressionModel:
             itl_sla=50.0,
         )
         assert thpt > 0 and actual_ttft >= 0 and actual_itl >= 0
+
+    def test_find_best_engine_agg_rps_discounts_itl(self):
+        model = AggRegressionModel(
+            max_num_fpm_samples=50, min_observations=3, bucket_count=16
+        )
+        self._train_agg(model)
+        base_rps, _, base_itl = model.find_best_engine_agg_rps(
+            isl=2048.0,
+            osl=150.0,
+            max_num_batched_tokens=4096,
+            ttft_sla=500.0,
+            itl_sla=50.0,
+            accept_length=1.0,
+        )
+        spec_rps, _, spec_itl = model.find_best_engine_agg_rps(
+            isl=2048.0,
+            osl=150.0,
+            max_num_batched_tokens=4096,
+            ttft_sla=500.0,
+            itl_sla=50.0,
+            accept_length=2.0,
+        )
+
+        assert spec_itl < base_itl
+        assert spec_rps > base_rps
 
     def test_find_best_engine_agg_rps_insufficient_data(self):
         model = AggRegressionModel(
@@ -815,3 +863,19 @@ class TestRefreshWorkerInfoFromConnector:
         planner._refresh_worker_info_from_connector()
         assert planner.prefill_worker_info.max_num_batched_tokens is None
         assert planner.decode_worker_info.max_num_batched_tokens == 4096
+
+    async def test_load_only_accept_length_missing_returns_observation(self):
+        planner = self._make_planner(require_prefill=False, require_decode=True)
+        planner.model_name = "Qwen/Qwen3"
+        planner.decode_worker_info = WorkerInfo(component_name="backend")
+        planner.prometheus_traffic_client = Mock()
+        planner.prometheus_traffic_client.get_avg_kv_hit_rate.return_value = None
+        planner.prometheus_traffic_client.get_avg_spec_decode_accept_length.return_value = (
+            None
+        )
+
+        obs = await planner._collect_kv_hit_rate_observation(duration_s=5)
+
+        assert obs is not None
+        assert obs.kv_hit_rate is None
+        assert obs.accept_length is None

--- a/components/src/dynamo/planner/tests/unit/test_mdc.py
+++ b/components/src/dynamo/planner/tests/unit/test_mdc.py
@@ -117,6 +117,37 @@ class TestWorkerInfoFromMdc:
         assert info.kv_cache_block_size == 16
         assert info.context_length == 8192
 
+    def test_runtime_data_spec_decode_nextn_populates_worker_info(self):
+        entry = MdcEntry(
+            card_json=_card(
+                runtime_data={
+                    "spec_decode": {
+                        "nextn": 2,
+                        "method": "eagle3",
+                        "source": "backend_config",
+                    }
+                }
+            ),
+            component="backend",
+            endpoint="generate",
+        )
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        assert info.speculative_nextn == 2
+
+    @pytest.mark.parametrize(
+        "runtime_data",
+        [
+            {},
+            {"spec_decode": {}},
+            {"spec_decode": {"nextn": 0}},
+            {"spec_decode": {"nextn": "bad"}},
+        ],
+    )
+    def test_invalid_spec_decode_nextn_is_ignored(self, runtime_data):
+        entry = MdcEntry(card_json=_card(runtime_data=runtime_data))
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        assert info.speculative_nextn is None
+
     def test_missing_wrapper_fields_fall_back_to_defaults(self):
         entry = MdcEntry(card_json=_card())
         info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")

--- a/components/src/dynamo/planner/tests/unit/test_planner_config.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_config.py
@@ -109,6 +109,19 @@ def test_max_num_fpm_samples_field():
     assert config.max_num_fpm_samples == 100
 
 
+def test_speculative_nextn_default_and_positive_value():
+    config = PlannerConfig(namespace="test-ns")
+    assert config.speculative_nextn == 0
+
+    config = PlannerConfig(namespace="test-ns", speculative_nextn=3)
+    assert config.speculative_nextn == 3
+
+
+def test_speculative_nextn_rejects_negative_value():
+    with pytest.raises(ValidationError):
+        PlannerConfig(namespace="test-ns", speculative_nextn=-1)
+
+
 def test_agg_mode_supports_throughput_scaling():
     """Agg mode supports throughput-based scaling."""
     config = PlannerConfig(

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -318,6 +318,86 @@ def test_get_avg_request_count_falls_back_to_completed_when_started_missing():
     assert "dynamo_frontend_requests_total" in queries[1]
 
 
+def test_vllm_spec_decode_accept_length_query_derives_from_counters():
+    client = PrometheusAPIClient("http://localhost:9090", "test-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, "2.5"]}]
+
+    result = client.get_avg_spec_decode_accept_length(
+        "60s", "vllm", "backend", "Qwen/Qwen3"
+    )
+
+    assert result == 2.5
+    query = client.prom.custom_query.call_args.kwargs["query"]
+    assert "vllm:spec_decode_num_accepted_tokens_total" in query
+    assert "vllm:spec_decode_num_drafts_total" in query
+    assert 'dynamo_namespace="test-ns"' in query
+    assert 'dynamo_component="backend"' in query
+    assert 'model="Qwen/Qwen3"' in query
+
+
+def test_spec_decode_accept_length_query_can_use_worker_runtime_namespace():
+    client = PrometheusAPIClient("http://localhost:9090", "base-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, "2.5"]}]
+
+    result = client.get_avg_spec_decode_accept_length(
+        "60s",
+        "vllm",
+        "backend",
+        "Qwen/Qwen3",
+        namespace="base-ns-workerhash",
+        endpoint_name="serve",
+    )
+
+    assert result == 2.5
+    query = client.prom.custom_query.call_args.kwargs["query"]
+    assert 'dynamo_namespace="base-ns-workerhash"' in query
+    assert 'dynamo_endpoint="serve"' in query
+
+
+def test_sglang_spec_decode_accept_length_query_uses_gauge():
+    client = PrometheusAPIClient("http://localhost:9090", "test-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, "1.8"]}]
+
+    result = client.get_avg_spec_decode_accept_length(
+        "30s", "sglang", "decode", "model"
+    )
+
+    assert result == 1.8
+    query = client.prom.custom_query.call_args.kwargs["query"]
+    assert "sglang:spec_accept_length" in query
+    assert "avg_over_time" in query
+
+
+def test_trtllm_spec_decode_accept_length_query_uses_gauge():
+    client = PrometheusAPIClient("http://localhost:9090", "test-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, "2.0"]}]
+
+    result = client.get_avg_spec_decode_accept_length(
+        "30s", "trtllm", "tensorrt_llm", "model"
+    )
+
+    assert result == 2.0
+    query = client.prom.custom_query.call_args.kwargs["query"]
+    assert "trtllm_spec_decode_acceptance_length" in query
+    assert "avg_over_time" in query
+
+
+@pytest.mark.parametrize("value", ["NaN", "+Inf", "-Inf"])
+def test_spec_decode_accept_length_returns_none_for_invalid_values(value):
+    client = PrometheusAPIClient("http://localhost:9090", "test-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, value]}]
+
+    assert (
+        client.get_avg_spec_decode_accept_length("30s", "vllm", "backend", "model")
+        is None
+    )
+
+
 # ---------------------------------------------------------------------------
 # Router metrics source tests
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/planner/tests/unit/test_state_machine.py
+++ b/components/src/dynamo/planner/tests/unit/test_state_machine.py
@@ -137,6 +137,58 @@ def _make_agg_core(config=None, caps=None, **config_overrides) -> PlannerStateMa
     return PlannerStateMachine(cfg, caps or _agg_caps())
 
 
+def test_accept_length_clamp_uses_config_fallback_nextn():
+    core = _make_core(speculative_nextn=2)
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=4.5
+        )
+    )
+    assert core._current_decode_accept_length() == 3.0
+
+
+def test_accept_length_clamp_uses_mdc_nextn_before_config():
+    caps = WorkerCapabilities(
+        decode=EngineCapabilities(
+            num_gpu=1, max_num_batched_tokens=2048, speculative_nextn=1
+        )
+    )
+    core = _make_core(caps=caps, speculative_nextn=4)
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=4.5
+        )
+    )
+    assert core._current_decode_accept_length() == 2.0
+
+
+def test_accept_length_forced_to_one_without_spec_decode():
+    core = _make_core()
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=2.0
+        )
+    )
+    assert core._current_decode_accept_length() == 1.0
+
+
+def test_missing_accept_length_resets_to_one():
+    core = _make_core(speculative_nextn=2)
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=2.5
+        )
+    )
+    assert core._current_decode_accept_length() == 2.5
+
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=None
+        )
+    )
+    assert core._current_decode_accept_length() == 1.0
+
+
 def _train_prefill_regression(core: PlannerStateMachine) -> None:
     fpms = [
         _make_fpm(

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -22,10 +22,12 @@ from dynamo.llm import (
     ModelType,
     register_model,
 )
+from dynamo.sglang.runtime_metadata import get_spec_decode_runtime_data
 from dynamo.sglang._compat import get_scheduler_info
 from dynamo.sglang.args import DynamoConfig
 
 SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
+SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 
 
 def _build_media_decoder_and_fetcher():
@@ -298,6 +300,22 @@ async def _get_runtime_config(
 
     if server_args.speculative_algorithm in ("EAGLE", "NEXTN"):
         runtime_config.enable_eagle = True
+
+    spec_decode_runtime_data = get_spec_decode_runtime_data(server_args)
+    if spec_decode_runtime_data is not None:
+        try:
+            runtime_config.set_engine_specific(
+                SPEC_DECODE_RUNTIME_KEY,
+                json.dumps(spec_decode_runtime_data),
+            )
+            logging.info(
+                "Published SGLang spec decode runtime metadata: %s",
+                spec_decode_runtime_data,
+            )
+        except Exception as e:
+            logging.warning(
+                f"Failed to attach SGLang spec decode runtime metadata: {e}"
+            )
 
     mooncake_runtime_data = _get_mooncake_runtime_data(server_args)
     if mooncake_runtime_data is not None:

--- a/components/src/dynamo/sglang/runtime_metadata.py
+++ b/components/src/dynamo/sglang/runtime_metadata.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Optional
+
+
+def get_spec_decode_runtime_data(server_args: Any) -> Optional[dict[str, Any]]:
+    try:
+        nextn = int(getattr(server_args, "speculative_num_steps", 0) or 0)
+    except (TypeError, ValueError):
+        return None
+    if nextn <= 0:
+        return None
+
+    data: dict[str, Any] = {"nextn": nextn, "source": "backend_config"}
+    method = getattr(server_args, "speculative_algorithm", None)
+    if method:
+        data["method"] = str(method)
+    return data

--- a/components/src/dynamo/sglang/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/sglang/tests/test_runtime_metadata.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.sglang.runtime_metadata import get_spec_decode_runtime_data
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_spec_decode_runtime_data_uses_speculative_num_steps():
+    server_args = SimpleNamespace(
+        speculative_num_steps="5",
+        speculative_algorithm="EAGLE",
+    )
+
+    assert get_spec_decode_runtime_data(server_args) == {
+        "nextn": 5,
+        "method": "EAGLE",
+        "source": "backend_config",
+    }
+
+
+@pytest.mark.parametrize(
+    "speculative_num_steps",
+    [None, 0, "bad"],
+)
+def test_spec_decode_runtime_data_ignores_invalid_nextn(speculative_num_steps):
+    server_args = SimpleNamespace(
+        speculative_num_steps=speculative_num_steps,
+        speculative_algorithm="EAGLE",
+    )
+
+    assert get_spec_decode_runtime_data(server_args) is None

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -56,11 +56,12 @@ _KV_EVENTS_MAX_SLEEP_SEC = 0.02
 _KV_EVENTS_BACKOFF_FACTOR = 1.5
 
 # InflightBatchingStats fields the FPM publisher consumes. As of
-# NVIDIA/TensorRT-LLM#13199 (merged 2026-04-27) all 11 fields live nested
-# inside iterationStats["inflightBatchingStats"]. The first-stat schema
-# probe requires the nested dict to be present and to carry every key
-# below; any missing field disables the publisher so we do not emit
-# all-zero snapshots that the Planner would misread as "worker idle".
+# NVIDIA/TensorRT-LLM#13199 (merged 2026-04-27) all 11 scheduler fields live
+# nested inside iterationStats["inflightBatchingStats"]. FPM also requires the
+# top-level gpuForwardTimeMS field for batch-matched wall_time. The first-stat
+# schema probe requires both sets to be present; any missing field disables the
+# publisher so we do not emit all-zero snapshots or overlap-scheduler lifecycle
+# latency that the Planner would misread.
 #
 # Mapping to the Dynamo planner-level fields:
 #   numContextRequests        -> scheduled_num_prefill_requests
@@ -93,6 +94,7 @@ _FPM_REQUIRED_IBS_FIELDS = (
     "numPausedRequests",
     "numPausedKvTokens",
 )
+_FPM_REQUIRED_TOP_LEVEL_FIELDS = ("gpuForwardTimeMS",)
 
 
 def _to_signed_i64(value: int | None) -> int | None:
@@ -416,9 +418,9 @@ class Publisher:
         # 1 s idle heartbeat internally.
         self.fpm_publisher: Optional[FpmDirectPublisher] = None
         # One-shot schema probe gate. The first IterationStats delivered to
-        # handle_stat is checked against _FPM_REQUIRED_STAT_FIELDS; on mismatch
+        # handle_stat is checked against the required FPM schema; on mismatch
         # the publisher is shut down and None'd. Prevents silent planner poison
-        # when running against a TRT-LLM version that predates #13199.
+        # when running against a TRT-LLM version without the FPM fields.
         self._fpm_schema_checked: bool = False
         self.kv_event_publishers: Optional[
             Dict[int, KvEventPublisher]
@@ -587,27 +589,41 @@ class Publisher:
 
     def _check_fpm_schema(self, stat: dict) -> None:
         """One-shot probe: disable FPM publisher if the TRT-LLM IterationStats
-        nested ``inflightBatchingStats`` dict is missing or incomplete.
+        FPM fields are missing or incomplete.
 
         Runs exactly once (gated by ``self._fpm_schema_checked``). Strict: if
-        the nested dict is absent or any field in ``_FPM_REQUIRED_IBS_FIELDS``
-        is missing, the publisher is shut down and set to ``None`` so the
-        subsequent ``if self.fpm_publisher is not None:`` short-circuit
+        the nested dict is absent, any field in ``_FPM_REQUIRED_IBS_FIELDS``
+        is missing, or the batch-matched top-level timing field is missing,
+        the publisher is shut down and set to ``None`` so the subsequent
+        ``if self.fpm_publisher is not None:`` short-circuit
         suppresses all FPM emission for the lifetime of this worker. This
         prevents silent planner poison when running against a TRT-LLM that
-        predates NVIDIA/TensorRT-LLM#13199 — otherwise every field would
-        default to 0 and the emitted snapshot would be byte-identical to the
-        idle heartbeat, making the Planner treat a loaded worker as idle.
+        predates the required FPM fields — otherwise missing fields would
+        default to 0 and the emitted snapshot would either look idle or carry
+        overlap-scheduler lifecycle time instead of true forward-pass time.
         """
         self._fpm_schema_checked = True
         if self.fpm_publisher is None:
+            return
+        missing_top_level = [
+            f for f in _FPM_REQUIRED_TOP_LEVEL_FIELDS if f not in stat
+        ]
+        if missing_top_level:
+            logging.warning(
+                "TRT-LLM IterationStats is missing required top-level FPM "
+                "fields %s; disabling FpmDirectPublisher to prevent planner "
+                "poison. Upgrade TRT-LLM to a build that emits batch-matched "
+                "gpuForwardTimeMS.",
+                missing_top_level,
+            )
+            self._disable_fpm_publisher()
             return
         ibs = stat.get("inflightBatchingStats")
         if not isinstance(ibs, dict):
             logging.warning(
                 "TRT-LLM IterationStats has no 'inflightBatchingStats' dict; "
-                "disabling FpmDirectPublisher. Upgrade TRT-LLM past "
-                "NVIDIA/TensorRT-LLM#13199 to enable FPM."
+                "disabling FpmDirectPublisher. Upgrade TRT-LLM to "
+                "a build with FPM scheduler fields to enable FPM."
             )
             self._disable_fpm_publisher()
             return
@@ -617,7 +633,7 @@ class Publisher:
         logging.warning(
             "TRT-LLM inflightBatchingStats is missing required FPM fields %s; "
             "disabling FpmDirectPublisher to prevent planner poison. "
-            "Upgrade TRT-LLM past NVIDIA/TensorRT-LLM#13199 to enable FPM.",
+            "Upgrade TRT-LLM to a build with FPM scheduler fields to enable FPM.",
             missing,
         )
         self._disable_fpm_publisher()
@@ -683,10 +699,10 @@ class Publisher:
             #
             # The first stat delivered here triggers a one-shot schema probe:
             # if the nested IBS dict is missing or any required field is
-            # absent (e.g. running against a TRT-LLM that predates #13199)
-            # the probe shuts down the publisher, which flips the guard
-            # below to short-circuit FPM emission for the rest of this
-            # worker's lifetime.
+            # absent (e.g. running against a TRT-LLM build without the FPM
+            # scheduler/timing schema) the probe shuts down the publisher,
+            # which flips the guard below to short-circuit FPM emission for
+            # the rest of this worker's lifetime.
             if self.fpm_publisher is not None and not self._fpm_schema_checked:
                 self._check_fpm_schema(stat)
             if self.fpm_publisher is not None:
@@ -718,8 +734,11 @@ class Publisher:
                     queued_sum_decode_kv_tokens = int(
                         ibs.get("numPausedKvTokens", 0)
                     ) + int(ibs.get("numQueuedGenKvTokens", 0))
-                    # iterLatencyMS is ms; the Rust snapshot expects seconds.
-                    wall_time_secs = float(stat.get("iterLatencyMS", 0.0)) / 1000.0
+                    # gpuForwardTimeMS is batch-matched CUDA forward time in
+                    # ms; the Rust snapshot expects seconds. Do not use
+                    # iterLatencyMS here: under TRT-LLM overlap scheduling it
+                    # spans the batch lifecycle across async scheduler loops.
+                    wall_time_secs = float(stat.get("gpuForwardTimeMS", 0.0)) / 1000.0
                     self.fpm_publisher.publish(
                         dp_rank=int(stat.get("attentionDpRank", 0)),
                         scheduled_num_prefill_requests=sched_num_prefill,

--- a/components/src/dynamo/trtllm/runtime_metadata.py
+++ b/components/src/dynamo/trtllm/runtime_metadata.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Optional
+
+
+def _as_mapping(value: Any) -> Optional[dict[str, Any]]:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump()
+        return dumped if isinstance(dumped, dict) else None
+    if hasattr(value, "__dict__"):
+        return vars(value)
+    return None
+
+
+def get_spec_decode_runtime_data(engine_args: Any) -> Optional[dict[str, Any]]:
+    args = _as_mapping(engine_args)
+    if not args:
+        return None
+    spec = _as_mapping(args.get("speculative_config"))
+    if not spec:
+        return None
+
+    raw_nextn = spec.get("max_draft_len")
+    if raw_nextn is None:
+        raw_nextn = spec.get("num_nextn_predict_layers")
+    try:
+        nextn = int(raw_nextn or 0)
+    except (TypeError, ValueError):
+        return None
+    if nextn <= 0:
+        return None
+
+    data: dict[str, Any] = {"nextn": nextn, "source": "backend_config"}
+    method = spec.get("decoding_type")
+    if method:
+        data["method"] = str(method)
+    return data

--- a/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.trtllm.runtime_metadata import get_spec_decode_runtime_data
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_spec_decode_runtime_data_uses_max_draft_len():
+    engine_args = {
+        "speculative_config": {
+            "max_draft_len": "6",
+            "num_nextn_predict_layers": 99,
+            "decoding_type": "EAGLE",
+        }
+    }
+
+    assert get_spec_decode_runtime_data(engine_args) == {
+        "nextn": 6,
+        "method": "EAGLE",
+        "source": "backend_config",
+    }
+
+
+def test_spec_decode_runtime_data_falls_back_to_num_nextn_predict_layers():
+    engine_args = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            num_nextn_predict_layers=2,
+            decoding_type="NEXTN",
+        )
+    )
+
+    assert get_spec_decode_runtime_data(engine_args) == {
+        "nextn": 2,
+        "method": "NEXTN",
+        "source": "backend_config",
+    }
+
+
+@pytest.mark.parametrize(
+    "speculative_config",
+    [
+        None,
+        {},
+        {"max_draft_len": 0},
+        {"max_draft_len": "bad"},
+        {"num_nextn_predict_layers": 0},
+    ],
+)
+def test_spec_decode_runtime_data_ignores_invalid_nextn(speculative_config):
+    engine_args = {"speculative_config": speculative_config}
+
+    assert get_spec_decode_runtime_data(engine_args) is None

--- a/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
@@ -12,7 +12,7 @@ Covers (after realignment to the merged TRT-LLM PR #13199):
     numQueuedGenRequests`` and ``numPausedKvTokens + numQueuedGenKvTokens``.
   * attentionDpRank from the top level of the stat dict is passed through
     unchanged; missing key defaults to 0.
-  * iterLatencyMS (top-level milliseconds) is converted to wall_time_secs
+  * gpuForwardTimeMS (top-level milliseconds) is converted to wall_time_secs
     (seconds) at the boundary.
   * First-stat schema probe disables the publisher when the nested IBS dict
     is missing or any of the 11 required fields is absent — protecting
@@ -59,7 +59,8 @@ _DEFAULT_IBS = {
 def _build_fake_stat(*, ibs_overrides=None, **top_level_overrides):
     """Construct an IterationStats-shaped dict matching the merged #13199 JSON.
 
-    Top-level keys (``iterLatencyMS``, ``attentionDpRank``, ``kvCacheStats``)
+    Top-level keys (``iterLatencyMS``, ``gpuForwardTimeMS``,
+    ``attentionDpRank``, ``kvCacheStats``)
     are siblings of the nested ``inflightBatchingStats`` object, exactly as
     NLOHMANN serializes the C++ struct.
     """
@@ -68,6 +69,7 @@ def _build_fake_stat(*, ibs_overrides=None, **top_level_overrides):
         ibs.update(ibs_overrides)
     stat = {
         "iterLatencyMS": 25.0,
+        "gpuForwardTimeMS": 7.5,
         "attentionDpRank": 0,
         "kvCacheStats": {"usedNumBlocks": 10, "maxNumBlocks": 100},
         "inflightBatchingStats": ibs,
@@ -100,7 +102,7 @@ def _invoke_handler(stat, fpm_publisher):
         queued_sum_prefill_tokens=int(ibs.get("numQueuedCtxTokens", 0)),
         queued_num_decode_requests=queued_num_decode,
         queued_sum_decode_kv_tokens=queued_sum_decode_kv_tokens,
-        wall_time_secs=float(stat.get("iterLatencyMS", 0.0)) / 1000.0,
+        wall_time_secs=float(stat.get("gpuForwardTimeMS", 0.0)) / 1000.0,
     )
 
 
@@ -123,7 +125,7 @@ def test_handle_stat_maps_fields_single_rank():
         queued_sum_prefill_tokens=512,
         queued_num_decode_requests=2,  # numPausedRequests (1) + numQueuedGenRequests (1)
         queued_sum_decode_kv_tokens=1200,  # numPausedKvTokens (800) + numQueuedGenKvTokens (400)
-        wall_time_secs=0.025,
+        wall_time_secs=0.0075,
     )
 
 
@@ -191,7 +193,7 @@ def test_handle_stat_missing_ibs_dict_emits_zeros():
     upstream should have already disabled the publisher in production),
     the handler must still produce a zeroed call rather than KeyError."""
     fpm = MagicMock()
-    _invoke_handler({"iterLatencyMS": 10.0, "attentionDpRank": 0}, fpm)
+    _invoke_handler({"gpuForwardTimeMS": 10.0, "attentionDpRank": 0}, fpm)
     fpm.publish.assert_called_once_with(
         dp_rank=0,
         scheduled_num_prefill_requests=0,
@@ -207,9 +209,9 @@ def test_handle_stat_missing_ibs_dict_emits_zeros():
     )
 
 
-def test_iter_latency_ms_to_wall_time_secs_conversion():
+def test_gpu_forward_time_ms_to_wall_time_secs_conversion():
     fpm = MagicMock()
-    _invoke_handler(_build_fake_stat(iterLatencyMS=1234.5), fpm)
+    _invoke_handler(_build_fake_stat(gpuForwardTimeMS=1234.5), fpm)
     assert fpm.publish.call_args.kwargs["wall_time_secs"] == 1.2345
 
 
@@ -366,13 +368,27 @@ def test_schema_probe_missing_single_ibs_field_disables_publisher(missing_field)
 
 
 def test_schema_probe_missing_ibs_dict_disables_publisher_legacy_trtllm():
-    """Legacy TRT-LLM case: stat dict has iterLatencyMS + attentionDpRank but
+    """Legacy TRT-LLM case: stat dict has timing + attentionDpRank but
     no inflightBatchingStats nested object (pre-#13199 schema). Must disable
     without error."""
     pub, _ = _build_schema_probe_publisher()
     original_publisher = pub.fpm_publisher
 
-    pub._check_fpm_schema({"iterLatencyMS": 10.0, "attentionDpRank": 0})
+    pub._check_fpm_schema({"gpuForwardTimeMS": 10.0, "attentionDpRank": 0})
+
+    assert pub._fpm_schema_checked is True
+    assert pub.fpm_publisher is None
+    original_publisher.shutdown.assert_called_once()
+
+
+def test_schema_probe_missing_gpu_forward_time_disables_publisher():
+    """Do not fall back to iterLatencyMS for FPM wall_time."""
+    pub, _ = _build_schema_probe_publisher()
+    original_publisher = pub.fpm_publisher
+
+    stat = _build_fake_stat()
+    stat.pop("gpuForwardTimeMS")
+    pub._check_fpm_schema(stat)
 
     assert pub._fpm_schema_checked is True
     assert pub.fpm_publisher is None
@@ -386,7 +402,7 @@ def test_schema_probe_ibs_not_a_dict_disables_publisher():
     pub, _ = _build_schema_probe_publisher()
     original_publisher = pub.fpm_publisher
 
-    pub._check_fpm_schema({"inflightBatchingStats": None})
+    pub._check_fpm_schema({"gpuForwardTimeMS": 10.0, "inflightBatchingStats": None})
 
     assert pub.fpm_publisher is None
     original_publisher.shutdown.assert_called_once()
@@ -446,6 +462,7 @@ def test_schema_probe_field_list_matches_default_ibs_set():
     from dynamo.trtllm import publisher as publisher_mod
 
     assert set(publisher_mod._FPM_REQUIRED_IBS_FIELDS) == set(_DEFAULT_IBS.keys())
+    assert publisher_mod._FPM_REQUIRED_TOP_LEVEL_FIELDS == ("gpuForwardTimeMS",)
 
 
 def test_invoke_handler_matches_publisher_keyword_set():

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -63,10 +63,12 @@ from dynamo.trtllm.request_handlers.handlers import (
     RequestHandlerConfig,
     RequestHandlerFactory,
 )
+from dynamo.trtllm.runtime_metadata import get_spec_decode_runtime_data
 from dynamo.trtllm.utils.trtllm_utils import deep_update
 
 # Default buffer size for kv cache events.
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
+SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 
 
 def build_kv_connector_config(config: Config):
@@ -507,6 +509,17 @@ async def init_llm_worker(
         # Need to name ADP as `data_parallel_size` for parity with other frameworks
         attention_dp_size = engine.get_attention_dp_size()
         runtime_config.data_parallel_size = attention_dp_size
+
+        spec_decode_runtime_data = get_spec_decode_runtime_data(engine_args)
+        if spec_decode_runtime_data is not None:
+            runtime_config.set_engine_specific(
+                SPEC_DECODE_RUNTIME_KEY,
+                json.dumps(spec_decode_runtime_data),
+            )
+            logging.info(
+                "Published TRT-LLM spec decode runtime metadata: %s",
+                spec_decode_runtime_data,
+            )
 
         logging.info(f"Set runtime config max_num_seqs: {runtime_config.max_num_seqs}")
         logging.info(

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -3,6 +3,7 @@
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import tempfile
@@ -47,11 +48,13 @@ from .cache_info import get_configured_kv_event_block_size
 from .constants import DisaggregationMode
 from .handlers import get_dp_range_for_worker
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
+from .runtime_metadata import get_metrics_model_name, get_spec_decode_runtime_data
 from .snapshot import prepare_snapshot_engine
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 shutdown_endpoints: list = []
+SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 
 
 def build_headless_namespace(config: Config) -> argparse.Namespace:
@@ -198,6 +201,7 @@ def setup_metrics_collection(
         injected into engine metrics to align Python metrics with Rust auto-labels.
         Additional labels can be provided via inject_labels parameter.
     """
+    metrics_model_name = get_metrics_model_name(config)
     if config.engine_args.disable_log_stats is False:
         # Register the dedicated dynamo_component registry callback
         # IMPORTANT: We do NOT use MultiProcessCollector for DYNAMO_COMPONENT_REGISTRY
@@ -231,7 +235,7 @@ def setup_metrics_collection(
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
-                    model_name=config.model,
+                    model_name=metrics_model_name,
                 )
             except ValueError as e:
                 # Conflict: metrics already in REGISTRY, MultiProcessCollector tries to add same metrics from .db files
@@ -251,7 +255,7 @@ def setup_metrics_collection(
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
-                    model_name=config.model,
+                    model_name=metrics_model_name,
                 )
                 # Multiproc registry has .db file metrics (lmcache, possibly vllm duplicates)
                 register_engine_metrics_callback(
@@ -261,7 +265,7 @@ def setup_metrics_collection(
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
-                    model_name=config.model,
+                    model_name=metrics_model_name,
                 )
         else:
             if multiproc_dir:
@@ -277,7 +281,7 @@ def setup_metrics_collection(
                 namespace_name=config.namespace,
                 component_name=config.component,
                 endpoint_name=config.endpoint,
-                model_name=config.model,
+                model_name=metrics_model_name,
             )
 
 
@@ -650,6 +654,13 @@ async def register_vllm_model(
     stream_interval = getattr(config.engine_args, "stream_interval", None)
     if stream_interval is not None:
         runtime_config.set_engine_specific("stream_interval", str(stream_interval))
+
+    spec_decode = get_spec_decode_runtime_data(config, vllm_config)
+    if spec_decode is not None:
+        runtime_config.set_engine_specific(
+            SPEC_DECODE_RUNTIME_KEY, json.dumps(spec_decode)
+        )
+        logging.info("Published vLLM spec decode runtime metadata: %s", spec_decode)
 
     # Get data_parallel_size from vllm_config (defaults to 1)
     dp_range = get_dp_range_for_worker(vllm_config)

--- a/components/src/dynamo/vllm/runtime_metadata.py
+++ b/components/src/dynamo/vllm/runtime_metadata.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from typing import Any, Optional
+
+
+def get_metrics_model_name(config: Any) -> str:
+    return str(getattr(config, "served_model_name", None) or getattr(config, "model", ""))
+
+
+def _as_mapping(value: Any) -> Optional[dict[str, Any]]:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump()
+        return dumped if isinstance(dumped, dict) else None
+    if hasattr(value, "__dict__"):
+        return vars(value)
+    return None
+
+
+def get_spec_decode_runtime_data(
+    config: Any, vllm_config: Any
+) -> Optional[dict[str, Any]]:
+    spec_config = getattr(vllm_config, "speculative_config", None)
+    if spec_config is None:
+        engine_args = getattr(config, "engine_args", None)
+        spec_config = getattr(engine_args, "speculative_config", None)
+    spec = _as_mapping(spec_config)
+    if not spec:
+        return None
+
+    try:
+        nextn = int(spec.get("num_speculative_tokens") or 0)
+    except (TypeError, ValueError):
+        return None
+    if nextn <= 0:
+        return None
+
+    data: dict[str, Any] = {"nextn": nextn, "source": "backend_config"}
+    method = spec.get("method")
+    if method:
+        data["method"] = str(method)
+    return data

--- a/components/src/dynamo/vllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/vllm/tests/test_runtime_metadata.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.vllm.runtime_metadata import (
+    get_metrics_model_name,
+    get_spec_decode_runtime_data,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_spec_decode_runtime_data_uses_vllm_speculative_config():
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(
+            speculative_config={"num_speculative_tokens": 99, "method": "ignored"}
+        )
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(num_speculative_tokens=3, method="eagle")
+    )
+
+    assert get_spec_decode_runtime_data(config, vllm_config) == {
+        "nextn": 3,
+        "method": "eagle",
+        "source": "backend_config",
+    }
+
+
+def test_metrics_model_name_prefers_served_model_name():
+    config = SimpleNamespace(model="meta-llama/Llama-3.1-8B", served_model_name="llama")
+
+    assert get_metrics_model_name(config) == "llama"
+
+
+def test_metrics_model_name_falls_back_to_model():
+    config = SimpleNamespace(model="meta-llama/Llama-3.1-8B", served_model_name=None)
+
+    assert get_metrics_model_name(config) == "meta-llama/Llama-3.1-8B"
+
+
+def test_spec_decode_runtime_data_falls_back_to_engine_args_json():
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(
+            speculative_config='{"num_speculative_tokens": "4", "method": "ngram"}'
+        )
+    )
+    vllm_config = SimpleNamespace(speculative_config=None)
+
+    assert get_spec_decode_runtime_data(config, vllm_config) == {
+        "nextn": 4,
+        "method": "ngram",
+        "source": "backend_config",
+    }
+
+
+@pytest.mark.parametrize(
+    "speculative_config",
+    [None, {}, {"num_speculative_tokens": 0}, {"num_speculative_tokens": "bad"}],
+)
+def test_spec_decode_runtime_data_ignores_invalid_nextn(speculative_config):
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(speculative_config=speculative_config)
+    )
+    vllm_config = SimpleNamespace(speculative_config=None)
+
+    assert get_spec_decode_runtime_data(config, vllm_config) is None

--- a/docs/proposals/dgdr-profiler-smart-search-plan.md
+++ b/docs/proposals/dgdr-profiler-smart-search-plan.md
@@ -1,0 +1,262 @@
+# DGDR Profiler Smart Search Knob Plan
+
+## Scope
+
+这个 plan 先做 knob inventory，不直接决定最终 DGDR API。目标是把 engine、router、planner 里可能影响 replay/profiler search 的配置列出来，再按优化器视角分类。
+
+主要来源：
+
+- `components/src/dynamo/profiler/utils/replay_optimize/*`
+- `components/src/dynamo/planner/config/*`
+- `components/src/dynamo/planner/core/*`
+- `components/src/dynamo/common/configuration/groups/*`
+- `lib/bindings/python/rust/llm/replay.rs`
+- `lib/mocker/src/common/protocols.rs`
+- `lib/kv-router/src/scheduling/config.rs`
+- `origin/main` 上 replay 已经 merge 但本地分支还没有的字段
+
+分类：
+
+- `Branch`: 不放进单个 Vizier flat study，由 DGDR profiler 在外层分支。
+- `Search`: 可以成为 Vizier candidate dimension。All `Search` knobs can also be pinned by user override.
+- `Composite`: 搜一个高层 shape，再 decode 成多个底层字段。
+- `Derived`: 从 branch、backend、shape、AIC 或 candidate generation 结果生成。
+- `Pinned`: 用户、环境、模型或 backend 固定。
+
+## V2 Refactor Direction
+
+大方向是 refactor DGDR profiler，但第一阶段不替换现有 V1 行为。V2 先作为 profiler 里的独立实现落地，目标是把 replay-based search、candidate decoding、ranked output 做完整，同时避免影响当前 DGDR/k8s feature。
+
+### Guardrails
+
+- 不改现有 DGDR V1 profiler 的默认入口和行为。
+- 不接 k8s controller/operator 路径，不从 DGDR CR 自动触发 V2。
+- 不改现有 `v1beta1` schema 的语义，除非只是读取/转换输入。
+- 不做 deployment apply，只生成 candidate DGD/router/planner config 和 replay report。
+- V2 failure 不应影响 V1 profiler、rapid/thorough profiling、planner sweep 现有流程。
+
+### Proposed V2 Layout
+
+V2 代码建议独立放在 profiler 下，而不是混进 `profile_sla.py` 或现有 `utils/replay_optimize` 的启发式搜索里：
+
+```text
+components/src/dynamo/profiler/v2/
+  __init__.py
+  spec.py              # V2 internal spec and validation
+  search_space.py      # branch-specific legal latent spaces
+  candidates.py        # candidate model and ranking metadata
+  decoder.py           # latent candidate -> replay args, router config, planner config, DGD
+  evaluator.py         # replay execution and score extraction
+  optimizer.py         # Vizier adapter plus fallback enumerator for tests
+  report.py            # ranked output, skipped/failed reasons, refs
+```
+
+Current `components/src/dynamo/profiler/profile_sla.py` remains V1. A local/offline V2 entrypoint can be added later, for example `profile_sla_v2.py` or a hidden CLI command, but it should not be wired into DGDR k8s until the V2 result contract is stable.
+
+### Phase Boundary
+
+| Phase | Scope | Non-goals |
+| --- | --- | --- |
+| V2 alpha | Local/offline profiler path, replay-based evaluation, candidate ranking, generated configs/reports | k8s integration, CRD behavior change, replacing rapid/thorough |
+| V2 opt-in | Explicit CLI/config opt-in, compatibility adapter from existing DGDR inputs, replacement path for the current AIC sweeper/picker | automatic controller integration, changing V1 defaults |
+| V2 integration | DGDR API/controller wiring after output contract is reviewed | silent fallback to V1 or hidden behavior changes |
+
+### AIC Sweeper Replacement Boundary
+
+In the opt-in phase, V2 should replace the current AIC-driven sweep orchestration for that explicit path:
+
+- V2 owns search-space construction, branch splitting, candidate generation, replay evaluation, scoring, ranking, and report generation.
+- V2 replaces AIC's current rapid-mode sweep/pick role for opt-in runs.
+- V2 may still call AIC as a lower-level provider for model/backend support checks, legal parallelism hints, perf model data, and memory/capacity estimates.
+- AIC output should be treated as input evidence for the V2 candidate decoder/evaluator, not as the final search result.
+- Existing V1 rapid/thorough paths keep their current AIC behavior until V2 integration is explicitly wired.
+
+## Branch Model
+
+顶层先按 deployment mode 分 branch，而不是把 `agg/disagg` 放进一个 Vizier conditional space。
+
+| Branch | Engine | Router | Planner |
+| --- | --- | --- | --- |
+| `agg` | aggregated workers: `tp/pp/dp/moe_tp/moe_ep`, `workers`, agg engine args | agg-compatible router modes and queue policy | `mode=agg`, agg engine GPU shape |
+| `disagg` | prefill/decode workers: separate prefill shape, decode shape, prefill worker count, decode worker count | disagg router mode, prefill/decode scoring, admission | `mode=disagg`, prefill/decode engine GPU shape |
+
+每个 branch 里给 Vizier 一个 flat search space。DGDR profiler 负责：
+
+- 生成 branch-specific legal candidates。
+- 把 composite knob decode 成 DGD、router config、planner config、replay `MockEngineArgs`。
+- 对少量 runtime 失败 candidate 标记 infeasible。
+- 全局合并 agg/disagg 的 ranked result。
+
+## Deployment Knobs
+
+Deployment owns topology and budget envelope: branch, replica counts, GPU budget, and per-engine GPU accounting. Engine and KV manager consume these derived values.
+
+| Category | Knob | Applies | Proposed treatment | Notes |
+| --- | --- | --- | --- | --- |
+| deployment mode | `deployment_mode`: `agg`, `disagg` | all | `Pinned`+`Branch` | Pin when user specifies one mode; otherwise split studies outside Vizier and rank branches globally. |
+| objective | `optimization_target`: `sla`, `throughput`, `latency`; SLA targets: `ttft_ms`+`itl_ms` or `e2e_ms` | profiler/planner | `Pinned` | User-selected evaluation objective; `sla` uses explicit latency constraints, while `throughput` and `latency` use replay metrics as the objective. |
+| component enablement | `enable_kvrouter` | deployment | `Pinned` | Controls whether V2 emits/evaluates KV-router config; not a search knob. |
+| component enablement | `enable_planner` | deployment | `Pinned` | Controls whether V2 emits planner config; not a search knob. |
+| replicas | `workers`, `prefill_workers`, `decode_workers` | replay/profiler | `Composite Search` | Search together with the engine `parallel shape` as legal deployment-shape composites capped by `gpu_budget`. |
+| budget | `gpu_budget`, `max_gpu_budget`, `min_gpu_budget`, `min_endpoint` | hardware/planner | `Pinned` | `gpu_budget` is the single max-GPU budget concept and maps to planner `max_gpu_budget`; min constraints are pinned deployment inputs used by candidate generation. |
+
+## Engine Knobs
+
+### Full Engine Inventory
+
+| Category | Knob | Applies | Proposed treatment | Notes |
+| --- | --- | --- | --- | --- |
+| backend | `backend` / `engine_type`: `vllm`, `sglang`, `trtllm` | all | `Search` | Search only across candidate backends with comparable replay/perf model support. |
+| worker role | `worker_type`: `aggregated`, `prefill`, `decode` | replay engine | `Derived` | Derived from branch and component. |
+| parallel shape | `tp`, `pp`, `dp`, `moe_tp`, `moe_ep` | planner/AIC | `Composite Search` | Search with deployment replicas as one legal deployment-shape composite, not raw independent ints. |
+| KV capacity | `num_gpu_blocks`, `total_kv_blocks`, `max_kv_tokens` | replay/runtime | `Derived` | Derived from AIC/memory-fit and block layout; not a search knob in the first design pass. |
+| block layout | `block_size`, `kv_cache_block_size` | replay/runtime | `Pinned` | Backend/runtime policy. vLLM default differs from SGLang page size. |
+| context | `context_length` | runtime metadata | `Pinned` | Model/runtime constraint, not a search knob. |
+| memory budget policy | `gpu_memory_utilization`, `mem_fraction_static`, `free_gpu_memory_fraction` | replay/AIC/backend | `Pinned` | Different backend/config-surface names for the same KV memory budget fraction policy; pin one normalized value. |
+| batching | `max_num_seqs` | replay/runtime | `Search` | Important scheduler/capacity knob; controls concurrent sequence admission. |
+| batching | `max_num_batched_tokens` | replay/runtime | `Search` | Important scheduler/capacity knob; controls token batching capacity. |
+| cache | `enable_prefix_caching` | replay/runtime | `Pinned` | Pin from backend/runtime policy; decoder may still force worker-role-specific values such as false for decode workers. |
+| startup | `startup_time` | replay/planner | `Pinned` | Deployment/environment input. |
+| speculative decode | `aic_nextn`, `aic_nextn_accept_rates` | `origin/main` replay/AIC | `Pinned` | `aic_nextn` validates to 1..5 when set. Replay MTP token progression support should be clarified before searching this. |
+
+## KV Manager Knobs
+
+KV manager owns multi-tier KV storage/offload policy. Engine search should only consume the derived capacity and transfer assumptions it needs for replay; G2/G3/G4 should not be modeled as engine knobs.
+
+| Category | Knob | Applies | Proposed treatment | Notes |
+| --- | --- | --- | --- | --- |
+| KV accounting | `kv_bytes_per_token` | replay/KV manager | `Derived` | Derived from model/cache dtype and block layout; required for capacity and transfer estimates. |
+| KV transfer | `kv_transfer_bandwidth` | replay/mocker | `Derived` | PD disagg KV transfer bandwidth for prefill-to-decode KV handoff latency; separate from KVBM G1/G2/G3/G4 offload tier bandwidths. |
+| G2 capacity | `num_g2_blocks` | replay/offload | `Pinned` | Entry point for offload policy. G3/G4 depend on G2. |
+| G2 transfer | `bandwidth_g1_to_g2_gbps`, `bandwidth_g2_to_g1_gbps` | replay/offload | `Pinned` | Tier-specific transfer model. |
+| G2 batching | `offload_batch_size` | replay/offload | `Pinned` | KV policy input, not an optimizer dimension in the first design pass. |
+| G3 capacity | `num_g3_blocks` | `origin/main` replay/offload | `Pinned` | Requires `num_g2_blocks`. |
+| G3 transfer | `bandwidth_g2_to_g3_gbps`, `bandwidth_g3_to_g2_gbps` | `origin/main` replay/offload | `Pinned` | Applies only when G3 policy is enabled. |
+| G4 enablement | `enable_g4_storage` | `origin/main` replay/offload | `Pinned` | Requires `num_g2_blocks`. |
+| G4 transfer | `bandwidth_g2_to_g4_gbps`, `bandwidth_g4_to_g2_gbps` | `origin/main` replay/offload | `Pinned` | Applies only when G4 policy is enabled. |
+
+## Router Knobs
+
+### Full Router Inventory
+
+| Category | Knob | Proposed treatment | Notes |
+| --- | --- | --- | --- |
+| router mode | `router_mode`: `round-robin`, `random`, `power-of-two`, `kv`, `direct`, `least-loaded`, `device-aware-weighted` | `Search` | Replay optimizer currently uses `kv_router` and `round_robin` names; decoder should normalize to runtime names. |
+| branch strictness | `enforce_disagg` | `Derived` | Should follow disagg branch unless user wants fallback behavior. |
+| admission | `active_decode_blocks_threshold`, `active_prefill_tokens_threshold`, `active_prefill_tokens_threshold_frac`, `no_admission_control` | `Pinned` | Admission policy input, not an optimizer dimension in the first design pass. |
+| KV score | `overlap_score_credit` | `Search` | Current replay optimizer already searches it. |
+| KV score | `prefill_load_scale` | `Search` | Current replay optimizer already searches it. |
+| KV score | `host_cache_hit_weight`, `disk_cache_hit_weight` | `Search` | Rust binding exposes these; Python CLI group does not currently list them. |
+| stochasticity | `router_temperature` | `Search` | Only relevant for KV scoring. |
+
+## Planner Knobs
+
+### Full Planner Inventory
+
+| Category | Knob | Proposed treatment | Notes |
+| --- | --- | --- | --- |
+| mode/env | `mode`: `agg`, `disagg` | `Derived` | Comes from branch. |
+| mode/env | `environment`, `namespace`, `backend` | `Pinned` | Deployment context. |
+| per-engine GPU count | `decode_engine_num_gpu`, `prefill_engine_num_gpu` | `Derived` | Derived directly from the chosen parallel shape. |
+| scaling policy | `enable_throughput_scaling`, `enable_load_scaling`, `throughput_adjustment_interval_seconds`, `load_adjustment_interval_seconds` | `Composite Search` | Search as one legal planner scaling policy tuple. If both scaling modes are enabled, load cadence must be shorter than throughput cadence. |
+| FPM sampling | `max_num_fpm_samples`, `fpm_sample_bucket_size` | `Search` | Bucket size must be a perfect square. |
+| load scaling sensitivity | `load_scaling_down_sensitivity`, `load_min_observations` | `Search` | Applies to load scaling policy. |
+
+## Planner Load Predictor Grid Sweep
+
+Planner load predictor tuning should be a separate deterministic grid search, not part of the main Vizier candidate space. It is easy to validate directly against replay/planner traces, so V2 should run a small predefined set of predictor configs and pick by forecast loss.
+
+Scope: load predictors only matter when the planner uses predictive throughput scaling. The current planner feeds predictors from traffic windows and predicts the next window's `num_req`, `isl`, `osl`, and optionally `kv_hit_rate`. Load-only/easy scaling paths do not need this sweep.
+
+| Category | Knob | Proposed treatment | Notes |
+| --- | --- | --- | --- |
+| predictor family | `load_predictor`: `constant`, `arima`, `kalman`, `prophet` | Separate Grid Search | Predefine a small config set per family. |
+| predictor input transform | `load_predictor_log1p` | Separate Grid Search | Search as part of predictor presets, not independently. |
+| predictor warmup | `load_predictor_warmup_trace` | Pinned+Derived | If warmup data is available, apply it to all predictor candidates equally; do not multiply the preset space by warmup path. |
+| prophet preset | `prophet_window_size` | Separate Grid Search | Predictor-specific preset field. |
+| kalman preset | `kalman_q_level`, `kalman_q_trend`, `kalman_r`, `kalman_min_points` | Separate Grid Search | Predictor-specific preset fields. |
+
+Predefined predictor presets:
+
+| ID | `load_predictor` | Config | Notes |
+| --- | --- | --- | --- |
+| `constant_last` | `constant` | `load_predictor_log1p=false` | Baseline: predict last observed value. |
+| `arima_raw` | `arima` | `load_predictor_log1p=false` | Auto-ARIMA on raw series. |
+| `arima_log1p` | `arima` | `load_predictor_log1p=true` | Auto-ARIMA on log-scaled series. |
+| `prophet_w20_raw` | `prophet` | `load_predictor_log1p=false`, `prophet_window_size=20` | Short window, raw series. |
+| `prophet_w20_log1p` | `prophet` | `load_predictor_log1p=true`, `prophet_window_size=20` | Short window, log-scaled series. |
+| `prophet_w50_raw` | `prophet` | `load_predictor_log1p=false`, `prophet_window_size=50` | Default-ish window, raw series. |
+| `prophet_w50_log1p` | `prophet` | `load_predictor_log1p=true`, `prophet_window_size=50` | Default-ish window, log-scaled series. |
+| `kalman_default_raw` | `kalman` | `load_predictor_log1p=false`, `kalman_q_level=1.0`, `kalman_q_trend=0.1`, `kalman_r=10.0`, `kalman_min_points=5` | Planner default Kalman shape. |
+| `kalman_default_log1p` | `kalman` | `load_predictor_log1p=true`, `kalman_q_level=1.0`, `kalman_q_trend=0.1`, `kalman_r=10.0`, `kalman_min_points=5` | Planner default Kalman shape on log scale. |
+| `kalman_reactive_raw` | `kalman` | `load_predictor_log1p=false`, `kalman_q_level=10.0`, `kalman_q_trend=1.0`, `kalman_r=5.0`, `kalman_min_points=3` | Faster response to bursts. |
+| `kalman_reactive_log1p` | `kalman` | `load_predictor_log1p=true`, `kalman_q_level=10.0`, `kalman_q_trend=1.0`, `kalman_r=5.0`, `kalman_min_points=3` | Faster response to bursts on log scale. |
+
+Grid search evaluation:
+
+1. Build the same traffic windows used by planner throughput scaling, using `throughput_adjustment_interval_seconds`.
+2. Run each predefined predictor preset in rolling one-step-ahead mode. Warm with the configured warmup prefix/trace when present, then score predictions against the next observed window.
+
+Optimization goal:
+
+For each evaluated non-empty window `t`, let observed traffic be `N_t`, `I_t`, `O_t` for `num_req`, `isl`, `osl`, and prediction be `N_hat_t`, `I_hat_t`, `O_hat_t`. Minimize weighted log-scale one-step-ahead error:
+
+`loss = 0.4 * err(N_hat_t * I_hat_t, N_t * I_t) + 0.4 * err(N_hat_t * O_hat_t, N_t * O_t) + 0.1 * err(I_hat_t, I_t) + 0.1 * err(O_hat_t, O_t)`
+
+where `err(pred, actual) = abs(log1p(max(pred, 0)) - log1p(max(actual, 0)))`. This keeps `num_req*isl`, `num_req*osl`, `isl`, and `osl` comparable despite different raw scales.
+
+The selected predictor preset is emitted as pinned planner config for the main V2 candidate evaluation.
+
+## Dependency Rules To Encode
+
+Use candidate generation and validation for these, not post-hoc Vizier learning:
+
+1. `deployment_mode=agg` and `deployment_mode=disagg` are separate studies.
+2. Worker role is derived from branch: agg uses `aggregated`; disagg uses `prefill` and `decode`.
+3. Parallel shape fields are not independent. Search legal tuples from AIC/model/backend constraints.
+4. Worker counts and TP/PP/DP/MoE shape must fit GPU budget.
+5. Capacity fields should be derived from AIC/memory-fit unless we intentionally search memory policy.
+6. Generic `enable_chunked_prefill` is always on in V2 and is not a search knob.
+7. KV manager `num_g3_blocks` requires `num_g2_blocks`.
+8. KV manager `enable_g4_storage` requires `num_g2_blocks`.
+9. `aic_nextn`, when set, must be in 1..5.
+10. Planner `optimization_target=sla` requires either `ttft_ms`+`itl_ms` or `e2e_ms`.
+11. Planner `fpm_sample_bucket_size` must be a perfect square.
+12. If both planner load and throughput scaling are enabled, load adjustment interval must be shorter than throughput adjustment interval.
+
+## Proposed First Design Pass
+
+### Latent Search Space
+
+Keep the first Vizier space compact:
+
+| Branch | Candidate dimensions |
+| --- | --- |
+| `agg` | `agg_parallel_shape`, `agg_workers`, `max_num_batched_tokens`, `max_num_seqs`, `router_mode`, `overlap_score_credit`, `prefill_load_scale` |
+| `disagg` | `prefill_parallel_shape`, `decode_parallel_shape`, `prefill_workers`, `decode_workers`, `prefill_max_num_batched_tokens`, `decode_max_num_seqs`, `router_mode`, `overlap_score_credit`, `prefill_load_scale` |
+
+### Candidate Decoder
+
+The decoder should emit:
+
+- Replay engine args for every component.
+- KV manager policy and replay offload args when enabled.
+- Router config.
+- Planner config.
+- DGD candidate.
+- Validation metadata: branch, skipped reasons, derived capacity, GPU budget accounting.
+
+### Later Search Extensions
+
+Add only after replay results are stable:
+
+- Shared cache routing policy.
+
+## Open Questions
+
+1. First backend scope: vLLM only, SGLang only, TRT-LLM only, or backend branch comparison?
+2. Should planner be in the evaluation loop now, or should profiler only generate planner config from final ranked candidates?
+3. Do we want router queue policy in the first design pass, or pin `fcfs` until queueing replay is validated for DGDR workloads?
+4. Which AIC outputs should V2 consume as provider data, and which capacity/memory-fit knobs should V2 own as search dimensions?
+5. Should V2 accept pinned KV manager G2/G3/G4/offload config in the first target, or keep it disabled by default?
+6. Should DGDR output include all derived configs or only refs to generated files?


### PR DESCRIPTION
## Summary
- publish speculative decoding metadata (`runtime_data.spec_decode.nextn`) from vLLM, SGLang, and TRT-LLM backends
- read MDC `nextn` into planner capabilities with `speculative_nextn` config fallback
- collect average speculative accept length from worker Prometheus metrics and clamp it against effective `nextn`
- apply the benefit by discounting decode ITL/RPS for decode and agg scaling, while keeping raw OSL for KV residency/context/balance

## Agentic review notes
- Fixed stale accept-length fallback in load-only mode: missing metrics now reset discounting to `1.0`
- Fixed worker metric selectors to use runtime namespace and worker endpoint labels
- Fixed vLLM metric label aliasing by using served model name for injected metric labels
- Residual risk: TRT-LLM accept-length Prometheus metric availability should be validated against the deployed TRT-LLM metrics surface; missing data falls back to no discount

## Tests
- `uv run --no-project --with ruff ruff check <modified files>`
- `python -m py_compile <modified source files>`
- `PYTHONPATH=components/src:lib/bindings/python/src uv run --no-project --with pytest --with pytest-benchmark --with prometheus-api-client --with pydantic --with msgspec --with numpy --with scikit-learn --with pyyaml pytest components/src/dynamo/planner/tests/unit/test_mdc.py components/src/dynamo/planner/tests/unit/test_planner_config.py components/src/dynamo/planner/tests/unit/test_prometheus.py components/src/dynamo/planner/tests/unit/test_load_based_scaling.py components/src/dynamo/planner/tests/unit/test_state_machine.py components/src/dynamo/vllm/tests/test_runtime_metadata.py components/src/dynamo/sglang/tests/test_runtime_metadata.py components/src/dynamo/trtllm/tests/test_runtime_metadata.py` (`203 passed`)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added speculative decoding configuration support with `speculative_nextn` parameter for manual fallback depth.
  * Enhanced load-based scaling to normalize predicted latency by speculative accept length, improving SLA accuracy.
  * Added `accept_length` metrics collection to track speculative decode performance.
  * Backend integrations (vLLM, SGLang, TensorRT-LLM) now publish speculative decode runtime metadata.

* **Bug Fixes**
  * Fixed TensorRT-LLM timing source from `iterLatencyMS` to `gpuForwardTimeMS` for more accurate wall-time measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->