### PR TITLE
feat(planner): support MTP accept length scaling

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -95,6 +95,10 @@ class SLAPlannerDefaults(BasePlannerDefaults):
     decode_scale_up_kv_rate = None
     decode_scale_down_kv_rate = None
 
+    # Speculative decoding. 0 disables planner-side spec decode discounts unless
+    # worker MDC publishes a positive runtime_config.runtime_data.spec_decode.nextn.
+    speculative_nextn = 0
+
     # Advisory mode: compute and log decisions without executing scaling
     advisory = False
 

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -613,6 +613,15 @@ class PlannerConfig(BaseModel):
         ),
     )
     load_min_observations: int = SLAPlannerDefaults.load_min_observations
+    speculative_nextn: int = Field(
+        default=SLAPlannerDefaults.speculative_nextn,
+        ge=0,
+        description=(
+            "Manual fallback speculative decoding depth. Worker MDC "
+            "runtime_config.runtime_data.spec_decode.nextn takes precedence "
+            "when present."
+        ),
+    )
 
     # Advisory mode: compute and log decisions without executing scaling
     advisory: bool = SLAPlannerDefaults.advisory

--- a/components/src/dynamo/planner/connectors/mdc.py
+++ b/components/src/dynamo/planner/connectors/mdc.py
@@ -93,6 +93,22 @@ def select_entry(
     return None
 
 
+def _parse_speculative_nextn(runtime_cfg: dict) -> Optional[int]:
+    runtime_data = runtime_cfg.get("runtime_data")
+    if not isinstance(runtime_data, dict):
+        return None
+
+    spec_decode = runtime_data.get("spec_decode")
+    if not isinstance(spec_decode, dict):
+        return None
+
+    try:
+        nextn = int(spec_decode.get("nextn", 0))
+    except (TypeError, ValueError):
+        return None
+    return nextn if nextn > 0 else None
+
+
 def worker_info_from_mdc(
     entry: MdcEntry,
     sub_component_type: SubComponentType,
@@ -139,4 +155,5 @@ def worker_info_from_mdc(
         max_num_seqs=runtime_cfg.get("max_num_seqs"),
         max_num_batched_tokens=runtime_cfg.get("max_num_batched_tokens"),
         context_length=context_length,
+        speculative_nextn=_parse_speculative_nextn(runtime_cfg),
     )

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -738,8 +738,8 @@ class NativePlannerBase:
         queries to keep the per-load-tick scrape cheap.
 
         The observation is still returned when metrics are unavailable so the
-        state machine can reset speculative-decode discounting to the
-        no-discount fallback.
+        state machine can retain last-value runtime metadata without skipping
+        the load tick.
         """
         assert self.model_name is not None
         if duration_s <= 0:

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -85,6 +85,7 @@ def _engine_caps(
         context_length=worker_info.context_length if worker_info else None,
         max_kv_tokens=worker_info.max_kv_tokens if worker_info else None,
         kv_cache_block_size=worker_info.kv_cache_block_size if worker_info else None,
+        speculative_nextn=worker_info.speculative_nextn if worker_info else None,
     )
 
 
@@ -505,6 +506,7 @@ class NativePlannerBase:
         "max_num_seqs",
         "max_num_batched_tokens",
         "context_length",
+        "speculative_nextn",
     )
 
     def _refresh_worker_info_from_connector(self) -> None:
@@ -675,11 +677,15 @@ class NativePlannerBase:
         m.kv_hit_rate = self.prometheus_traffic_client.get_avg_kv_hit_rate(
             interval_str, self.model_name
         )
+        m.accept_length = self._collect_accept_length(interval_str)
 
         hit_rate_str = f"{m.kv_hit_rate:.3f}" if m.kv_hit_rate is not None else "n/a"
+        accept_length_str = (
+            f"{m.accept_length:.3f}" if m.accept_length is not None else "n/a"
+        )
         logger.info(
             f"Observed num_req: {m.num_req:.2f} isl: {m.isl:.2f} osl: {m.osl:.2f} "
-            f"kv_hit_rate: {hit_rate_str}"
+            f"kv_hit_rate: {hit_rate_str} accept_length: {accept_length_str}"
         )
 
         if self.prometheus_port != 0:
@@ -703,6 +709,23 @@ class NativePlannerBase:
             isl=m.isl,
             osl=m.osl,
             kv_hit_rate=m.kv_hit_rate,
+            accept_length=m.accept_length,
+        )
+
+    def _collect_accept_length(self, interval_str: str) -> Optional[float]:
+        if self.config.mode not in ("disagg", "decode", "agg"):
+            return None
+        if not self.model_name:
+            return None
+        component_name = self.decode_worker_info.component_name
+        endpoint_name = self.decode_worker_info.endpoint
+        return self.prometheus_traffic_client.get_avg_spec_decode_accept_length(
+            interval_str,
+            self.config.backend,
+            component_name,
+            self.model_name,
+            namespace=self.runtime_namespace,
+            endpoint_name=endpoint_name,
         )
 
     async def _collect_kv_hit_rate_observation(
@@ -714,9 +737,9 @@ class NativePlannerBase:
         to discount prefill work, so we skip the five other (unused) traffic
         queries to keep the per-load-tick scrape cheap.
 
-        Returns ``None`` when the router metric is unavailable (e.g.
-        Prometheus source is "frontend"); the state machine treats that as
-        a no-discount fallback.
+        The observation is still returned when metrics are unavailable so the
+        state machine can reset speculative-decode discounting to the
+        no-discount fallback.
         """
         assert self.model_name is not None
         if duration_s <= 0:
@@ -725,19 +748,26 @@ class NativePlannerBase:
         hit_rate = self.prometheus_traffic_client.get_avg_kv_hit_rate(
             interval_str, self.model_name
         )
+        accept_length = self._collect_accept_length(interval_str)
         # Mirror the observed value into Metrics so the diagnostics recorder
         # sees the up-to-date hit rate even on load-only ticks.
         self._last_metrics.kv_hit_rate = hit_rate
+        self._last_metrics.accept_length = accept_length
         hit_rate_str = f"{hit_rate:.3f}" if hit_rate is not None else "n/a"
-        logger.info(f"Observed kv_hit_rate over {interval_str}: {hit_rate_str}")
-        if hit_rate is None:
-            return None
+        accept_length_str = (
+            f"{accept_length:.3f}" if accept_length is not None else "n/a"
+        )
+        logger.info(
+            f"Observed kv_hit_rate over {interval_str}: {hit_rate_str}; "
+            f"accept_length: {accept_length_str}"
+        )
         return TrafficObservation(
             duration_s=duration_s,
             num_req=0.0,
             isl=0.0,
             osl=0.0,
             kv_hit_rate=hit_rate,
+            accept_length=accept_length,
         )
 
     def _collect_fpm(self) -> FpmObservations:

--- a/components/src/dynamo/planner/core/load_scaling.py
+++ b/components/src/dynamo/planner/core/load_scaling.py
@@ -502,6 +502,7 @@ class LoadScalingMixin:
         consolidation = num_workers / (num_workers - 1) if num_workers > 1 else 1.0
         d_caps = self._capabilities.decode
         max_kv = d_caps.max_kv_tokens if d_caps else None
+        accept_length = self._current_decode_accept_length()
 
         estimates: list[float] = []
         # Consolidation-aware scale-down. Two safety checks per worker:
@@ -522,11 +523,12 @@ class LoadScalingMixin:
                 include_queued_decode=True,
             )
             if est is not None:
-                est_ms = est * 1000
+                est_ms = est * 1000 / accept_length
                 estimates.append(est_ms)
                 logger.info(
                     f"Decode engine {label}: estimated ITL {est_ms:.2f}ms "
-                    f"(sched_kv={sched_kv}, queued_kv={queued_kv})"
+                    f"(sched_kv={sched_kv}, queued_kv={queued_kv}, "
+                    f"accept_length={accept_length:.2f})"
                 )
 
             if can_scale_down:
@@ -544,7 +546,9 @@ class LoadScalingMixin:
                 )
                 if post_itl is None:
                     can_scale_down = False
-                elif post_itl * 1000 >= self._config.itl_ms * sensitivity:
+                elif (
+                    post_itl * 1000 / accept_length >= self._config.itl_ms * sensitivity
+                ):
                     can_scale_down = False
                     consolidation_refused = True
 
@@ -650,6 +654,7 @@ class LoadScalingMixin:
         consolidation = num_workers / (num_workers - 1) if num_workers > 1 else 1.0
         d_caps = self._capabilities.decode
         max_kv = d_caps.max_kv_tokens if d_caps else None
+        accept_length = self._current_decode_accept_length()
 
         estimates: list[float] = []
         # Agg-decode consolidation. Combined cache pressure (sched_decode_kv
@@ -672,7 +677,7 @@ class LoadScalingMixin:
                 include_queued_decode=True,
             )
             if est is not None:
-                estimates.append(est * 1000)
+                estimates.append(est * 1000 / accept_length)
 
             if can_scale_down:
                 post_combined_kv = int(
@@ -692,7 +697,9 @@ class LoadScalingMixin:
                 )
                 if post_itl is None:
                     can_scale_down = False
-                elif post_itl * 1000 >= self._config.itl_ms * sensitivity:
+                elif (
+                    post_itl * 1000 / accept_length >= self._config.itl_ms * sensitivity
+                ):
                     can_scale_down = False
                     consolidation_refused = True
 

--- a/components/src/dynamo/planner/core/perf_model/agg.py
+++ b/components/src/dynamo/planner/core/perf_model/agg.py
@@ -133,6 +133,7 @@ class AggRegressionModel(_BaseRegressionModel):
         max_kv_tokens: Optional[int] = None,
         max_num_seqs: Optional[int] = None,
         kv_hit_rate: Optional[float] = None,
+        accept_length: float = 1.0,
     ) -> tuple[float, float, float]:
         """Find the maximum agg engine request rate under both SLA targets.
 
@@ -140,8 +141,13 @@ class AggRegressionModel(_BaseRegressionModel):
         where both ITL and TTFT remain within their targets.  Warns if
         even batch_size=1 violates either SLA.
 
-        Request rate is derived via Little's law:
-        ``engine_rps = best_batch_size / (osl * wall_time_per_iter)``.
+        Decode egress rate is derived via Little's law, with speculative
+        accept length reducing the number of decode forwards needed per raw
+        output length:
+        ``decode_rps = best_batch_size * accept_length / (osl * wall_time)``.
+        The final engine RPS is capped by prefill admission capacity so
+        aggregated engines do not claim decode-side speedup that prefill cannot
+        sustain.
 
         ``kv_hit_rate`` discounts only the prefill portion of each
         iteration; decode KV residency uses the full ISL because cache
@@ -178,6 +184,7 @@ class AggRegressionModel(_BaseRegressionModel):
             or max_num_batched_tokens <= 0
         ):
             return (0.0, 0.0, 0.0)
+        accept_length = max(1.0, float(accept_length))
 
         prefill_scale = 1.0 - _clamp_kv_hit_rate(kv_hit_rate)
         effective_isl = isl * prefill_scale
@@ -193,8 +200,11 @@ class AggRegressionModel(_BaseRegressionModel):
         # Concurrency cap
         seq_cap = max_num_seqs if max_num_seqs and max_num_seqs > 0 else kv_cap
 
-        # Prefill/decode balance cap via binary search within [1, min(kv_cap, seq_cap)]
-        # For each candidate x, check: effective_isl / (max_num_batched_tokens - x) <= osl
+        # Prefill/decode balance cap via binary search within [1, min(kv_cap, seq_cap)].
+        # For each candidate x, check that the per-forward prefill work needed
+        # to admit requests at the speculative decode egress rate fits in the
+        # remaining token budget:
+        #   x * accept_length * effective_isl / osl <= max_num_batched_tokens - x
         # Uses ``effective_isl`` (post-cache) because cache reuse shrinks the
         # prefill tokens each new request consumes from the per-iteration
         # budget, raising the admissible batch size.
@@ -204,7 +214,8 @@ class AggRegressionModel(_BaseRegressionModel):
             prefill_budget = max_num_batched_tokens - x
             if prefill_budget <= 0:
                 return False
-            return effective_isl / prefill_budget <= osl
+            required_prefill = x * accept_length * effective_isl / max(1.0, osl)
+            return required_prefill <= prefill_budget
 
         lo, hi = 1, max(1, hard_cap)
         while lo < hi:
@@ -225,10 +236,11 @@ class AggRegressionModel(_BaseRegressionModel):
             # engine actually computes ``effective_isl`` tokens per request
             # because the cached prefix is skipped.
             prefill_per_iter = min(
-                bs * effective_isl / max(1.0, osl), max_num_batched_tokens
+                bs * accept_length * effective_isl / max(1.0, osl),
+                max_num_batched_tokens,
             )
             wt = self._predict_2d(prefill_per_iter, decode_kv)
-            itl_ms = wt * 1000.0
+            itl_ms = wt * 1000.0 / accept_length
 
             # ``estimate_next_ttft`` applies the same discount internally to
             # both the queued portion and the avg_isl portion. To keep the
@@ -236,7 +248,10 @@ class AggRegressionModel(_BaseRegressionModel):
             # queued contribution and forward ``kv_hit_rate`` so the
             # function's own ``(1 - clamp(kv_hit_rate))`` factor scales
             # both sides consistently.
-            raw_prefill_per_iter = min(bs * isl / max(1.0, osl), max_num_batched_tokens)
+            raw_prefill_per_iter = min(
+                bs * accept_length * isl / max(1.0, osl),
+                max_num_batched_tokens,
+            )
             est_ttft = self.estimate_next_ttft(
                 queued_prefill_tokens=int(raw_prefill_per_iter),
                 max_num_batched_tokens=max_num_batched_tokens,
@@ -252,12 +267,26 @@ class AggRegressionModel(_BaseRegressionModel):
                         f"TTFT={ttft_ms:.1f}ms (target {ttft_sla:.1f}ms), "
                         f"ITL={itl_ms:.1f}ms (target {itl_sla:.1f}ms)"
                     )
-                    best_rps = 1.0 / (osl * wt)
+                    decode_rps = accept_length / (osl * wt)
+                    prefill_budget = max(0.0, float(max_num_batched_tokens - 1))
+                    prefill_rps = (
+                        math.inf
+                        if effective_isl <= 0.0
+                        else prefill_budget / (effective_isl * wt)
+                    )
+                    best_rps = min(decode_rps, prefill_rps)
                     best_ttft_ms = ttft_ms
                     best_itl_ms = itl_ms
                 break
 
-            best_rps = bs / (osl * wt)
+            decode_rps = bs * accept_length / (osl * wt)
+            prefill_budget = max(0.0, float(max_num_batched_tokens - bs))
+            prefill_rps = (
+                math.inf
+                if effective_isl <= 0.0
+                else prefill_budget / (effective_isl * wt)
+            )
+            best_rps = min(decode_rps, prefill_rps)
             best_ttft_ms = ttft_ms
             best_itl_ms = itl_ms
 

--- a/components/src/dynamo/planner/core/perf_model/decode.py
+++ b/components/src/dynamo/planner/core/perf_model/decode.py
@@ -88,11 +88,13 @@ class DecodeRegressionModel(_BaseRegressionModel):
         osl: float,
         max_kv_tokens: Optional[int] = None,
         max_num_seqs: Optional[int] = None,
+        accept_length: float = 1.0,
     ) -> tuple[float, float]:
         """Find the maximum decode engine request rate within an ITL target.
 
         Binary searches over batch_size at the given context_length for the
-        maximum batch_size where predicted wall_time * 1000 <= itl.  If even
+        maximum batch_size where predicted per-forward wall time, discounted by
+        speculative accept length, satisfies the ITL target.  If even
         batch_size=1 violates the target, warns but returns the best
         achievable rate at batch_size=1 so the caller can still scale.
 
@@ -106,12 +108,14 @@ class DecodeRegressionModel(_BaseRegressionModel):
         neither capability is provided.
 
         Returns:
-            (engine_rps, actual_itl_ms) -- 0 rps signals an error
+            (engine_rps, actual_itl_ms) -- actual ITL is wall_time/accept_length.
+            0 rps signals an error
             (model not fitted or invalid input); positive rps is
             the best achievable rate with the predicted ITL.
         """
         if not self._ensure_fitted() or context_length <= 0 or osl <= 0 or itl <= 0:
             return (0.0, 0.0)
+        accept_length = max(1.0, float(accept_length))
 
         if max_kv_tokens and max_kv_tokens > 0:
             kv_cap = max(1, int(max_kv_tokens / context_length))
@@ -124,22 +128,23 @@ class DecodeRegressionModel(_BaseRegressionModel):
         lo, hi = 1, max_batch
         best_bs, best_wt = 1, self._predict_2d(1, context_length)
 
-        if best_wt * 1000.0 > itl:
+        best_itl_ms = best_wt * 1000.0 / accept_length
+        if best_itl_ms > itl:
             logger.warning(
-                f"ITL SLA unreachable: predicted {best_wt * 1000.0:.1f}ms "
+                f"ITL SLA unreachable: predicted {best_itl_ms:.1f}ms "
                 f"> target {itl:.1f}ms at batch_size=1, ctx_len={context_length:.0f}"
             )
-            return (best_bs / (osl * best_wt), best_wt * 1000.0)
+            return (best_bs / (osl * (best_wt / accept_length)), best_itl_ms)
 
         while lo <= hi:
             mid = (lo + hi) // 2
             kv = mid * context_length
             wt = self._predict_2d(mid, kv)
-            if wt * 1000.0 <= itl:
+            if wt * 1000.0 / accept_length <= itl:
                 best_bs, best_wt = mid, wt
                 lo = mid + 1
             else:
                 hi = mid - 1
 
-        engine_rps = best_bs / (osl * best_wt)
-        return (engine_rps, best_wt * 1000.0)
+        engine_rps = best_bs / (osl * (best_wt / accept_length))
+        return (engine_rps, best_wt * 1000.0 / accept_length)

--- a/components/src/dynamo/planner/core/perf_model/rust_adapter.py
+++ b/components/src/dynamo/planner/core/perf_model/rust_adapter.py
@@ -597,19 +597,16 @@ class PlannerEnginePerfModel:
         if self._worker_type != "prefill" and osl <= 0:
             return None
         accept_length = max(1.0, float(accept_length))
-        discount_decode = self._worker_type != "prefill"
-        query_itl_sla_ms = itl_sla_ms
-        if discount_decode and query_itl_sla_ms is not None:
-            query_itl_sla_ms *= accept_length
         try:
             request = EngineCapacityRequest(
                 isl=int(math.ceil(isl)),
                 osl=max(1, int(math.ceil(osl))),
                 ttft_sla_ms=ttft_sla_ms,
-                itl_sla_ms=query_itl_sla_ms,
+                itl_sla_ms=itl_sla_ms,
                 e2e_latency_sla_ms=e2e_latency_sla_ms,
                 kv_hit_rate=kv_hit_rate,
                 optimization_target=OptimizationTarget.Throughput,
+                accept_length=accept_length,
             )
             result = self._rust_model.find_engine_capacity_rps(request)
         except _RUST_SHIM_FALLBACK_EXCEPTIONS as e:
@@ -618,20 +615,7 @@ class PlannerEnginePerfModel:
         if result is None:
             return None
         rps = result.rps
-        if self._worker_type == "decode":
-            rps *= accept_length
-        elif self._worker_type == "aggregated":
-            rps = self._cap_aggregated_spec_decode_rps(
-                raw_rps=result.rps,
-                raw_itl_ms=result.itl_ms,
-                isl=isl,
-                osl=osl,
-                kv_hit_rate=kv_hit_rate,
-                accept_length=accept_length,
-            )
         itl_ms = result.itl_ms
-        if discount_decode and itl_ms is not None:
-            itl_ms /= accept_length
         return PlannerEngineCapacity(
             rps=rps,
             ttft_ms=result.ttft_ms,
@@ -639,49 +623,6 @@ class PlannerEnginePerfModel:
             e2e_latency_ms=result.e2e_latency_ms,
             eligible=result.eligible,
         )
-
-    def _cap_aggregated_spec_decode_rps(
-        self,
-        *,
-        raw_rps: float,
-        raw_itl_ms: Optional[float],
-        isl: float,
-        osl: float,
-        kv_hit_rate: Optional[float],
-        accept_length: float,
-    ) -> float:
-        """Apply speculative decode speedup without exceeding prefill admission.
-
-        The Rust capacity search returns an aggregated-engine RPS for raw OSL.
-        Speculative decoding reduces decode forwards per request, but an agg
-        worker can only realize that extra decode egress if its per-forward
-        prefill budget can admit the matching requests.  Infer the raw decode
-        batch from ``rps = batch / (osl * forward_wall_s)`` and cap the
-        discounted decode RPS by the prefill tokens left in the same forward.
-        """
-        if accept_length <= 1.0:
-            return raw_rps
-        if raw_itl_ms is None or raw_itl_ms <= 0.0 or osl <= 0.0:
-            return raw_rps
-
-        values = self._limit_values()
-        if values is None:
-            return raw_rps
-        max_num_batched_tokens, _max_num_seqs, _max_kv_tokens = values
-
-        forward_wall_s = raw_itl_ms / 1000.0
-        if forward_wall_s <= 0.0:
-            return raw_rps
-
-        decode_rps = raw_rps * accept_length
-        inferred_batch = raw_rps * float(osl) * forward_wall_s
-        prefill_budget = max(0.0, float(max_num_batched_tokens) - inferred_batch)
-        effective_isl = float(isl) * (1.0 - _clamp_kv_hit_rate(kv_hit_rate))
-        if effective_isl <= 0.0:
-            return decode_rps
-
-        prefill_rps = prefill_budget / (effective_isl * forward_wall_s)
-        return max(0.0, min(decode_rps, prefill_rps))
 
     # ------------------------------------------------------------------
     # Readiness and moving-average accessors used by load scaling and query

--- a/components/src/dynamo/planner/core/perf_model/rust_adapter.py
+++ b/components/src/dynamo/planner/core/perf_model/rust_adapter.py
@@ -60,6 +60,7 @@ _RUST_SHIM_FALLBACK_EXCEPTIONS = (RuntimeError, ValueError, TypeError)
 DEFAULT_MAX_NUM_BATCHED_TOKENS = 8192
 DEFAULT_MAX_NUM_SEQS = 512
 DEFAULT_MAX_KV_TOKENS = 2_000_000
+RAW_AIC_NEXTN_ACCEPT_RATES = "0,0,0,0,0"
 
 
 @dataclass(frozen=True)
@@ -117,7 +118,9 @@ class PlannerEnginePerfModel:
         self._config = config
         self._capabilities = capabilities
         self._rust_model: Optional[Any] = None
+        self._rust_model_key: Optional[tuple[Any, ...]] = None
         self._pending_iterations: list[list[ForwardPassMetrics]] = []
+        self._retained_iterations: list[list[ForwardPassMetrics]] = []
         self._avg_isl = _MovingAverage(config.max_num_fpm_samples)
         self._avg_decode_length = _MovingAverage(config.max_num_fpm_samples)
 
@@ -131,12 +134,18 @@ class PlannerEnginePerfModel:
         self._capabilities = capabilities
         if self._rust_model is None:
             self._init_rust_model()
+            return
+        if self._model_key() != self._rust_model_key:
+            self._rust_model = None
+            self._rust_model_key = None
+            self._init_rust_model()
 
     def _init_rust_model(self) -> None:
         if not _RUST_SHIM_AVAILABLE or RustEnginePerfModel is None:
             logger.debug("Rust engine perf shim unavailable")
             return
 
+        model_key = self._model_key()
         limits = self._build_limits()
         if limits is None:
             logger.debug(
@@ -160,9 +169,12 @@ class PlannerEnginePerfModel:
                 diagnostics.get("source", "unknown"),
                 diagnostics.get("readiness", "unknown"),
             )
+            self._rust_model_key = model_key
             if self._pending_iterations:
                 self._rust_model.tune_with_fpms(self._pending_iterations)
                 self._pending_iterations.clear()
+            elif self._retained_iterations:
+                self._rust_model.tune_with_fpms(self._retained_iterations)
         except _RUST_SHIM_FALLBACK_EXCEPTIONS as e:
             logger.warning(
                 "Failed to initialize Rust engine perf model for %s; "
@@ -171,6 +183,7 @@ class PlannerEnginePerfModel:
                 e,
             )
             self._rust_model = None
+            self._rust_model_key = None
 
     def _rust_diagnostics(self) -> dict[str, Any]:
         if self._rust_model is None:
@@ -246,6 +259,10 @@ class PlannerEnginePerfModel:
         pick = self._pick_for_worker(spec)
         if pick is None:
             return None
+        extra = {"nextn_accept_rates": RAW_AIC_NEXTN_ACCEPT_RATES}
+        nextn = self._effective_speculative_nextn()
+        if self._worker_type != "prefill" and nextn > 0:
+            extra["nextn"] = str(nextn)
         return AicEngineConfig(
             model_name=spec.hf_id,
             backend=spec.backend,
@@ -266,7 +283,60 @@ class PlannerEnginePerfModel:
             moe_dtype=spec.moe_dtype,
             activation_dtype=spec.activation_dtype,
             kv_cache_dtype=spec.kv_cache_dtype,
+            extra=extra,
         )
+
+    def _model_key(self) -> Optional[tuple[Any, ...]]:
+        values = self._limit_values()
+        if values is None:
+            return None
+        spec = self._config.aic_perf_model
+        pick = self._pick_for_worker(spec) if spec is not None else None
+        aic_key = None
+        if spec is not None and pick is not None:
+            aic_extra: tuple[tuple[str, str], ...] = (
+                ("nextn_accept_rates", RAW_AIC_NEXTN_ACCEPT_RATES),
+            )
+            nextn = self._effective_speculative_nextn()
+            if self._worker_type != "prefill" and nextn > 0:
+                aic_extra = (
+                    ("nextn", str(nextn)),
+                    ("nextn_accept_rates", RAW_AIC_NEXTN_ACCEPT_RATES),
+                )
+            aic_key = (
+                spec.hf_id,
+                spec.backend,
+                spec.system,
+                spec.backend_version,
+                spec.model_arch,
+                spec.weight_dtype,
+                spec.moe_dtype,
+                spec.activation_dtype,
+                spec.kv_cache_dtype,
+                pick.tp,
+                pick.pp,
+                pick.moe_tp,
+                pick.moe_ep,
+                pick.dp,
+                self._capabilities.kv_cache_block_size
+                if self._capabilities is not None
+                else None,
+                aic_extra,
+            )
+        return (
+            self._worker_type,
+            values,
+            self._config.max_num_fpm_samples,
+            self._config.load_min_observations,
+            self._config.fpm_sample_bucket_size,
+            aic_key,
+        )
+
+    def _effective_speculative_nextn(self) -> int:
+        caps = self._capabilities
+        if caps is not None and caps.speculative_nextn and caps.speculative_nextn > 0:
+            return int(caps.speculative_nextn)
+        return max(0, int(self._config.speculative_nextn or 0))
 
     def _pick_for_worker(
         self, spec: AICPerfModelSpec
@@ -324,6 +394,7 @@ class PlannerEnginePerfModel:
     def _tune(self, iterations: list[list[ForwardPassMetrics]]) -> None:
         if not iterations:
             return
+        self._remember_iterations(iterations)
         if self._rust_model is not None:
             try:
                 self._rust_model.tune_with_fpms(iterations)
@@ -335,6 +406,13 @@ class PlannerEnginePerfModel:
                 self._pending_iterations = self._pending_iterations[
                     -self._config.max_num_fpm_samples :
                 ]
+
+    def _remember_iterations(self, iterations: list[list[ForwardPassMetrics]]) -> None:
+        self._retained_iterations.extend(iterations)
+        if len(self._retained_iterations) > self._config.max_num_fpm_samples:
+            self._retained_iterations = self._retained_iterations[
+                -self._config.max_num_fpm_samples :
+            ]
 
     def _is_supported_fpm(self, fpm: ForwardPassMetrics) -> bool:
         if fpm.version != FPM_VERSION:
@@ -505,6 +583,7 @@ class PlannerEnginePerfModel:
         itl_sla_ms: Optional[float] = None,
         e2e_latency_sla_ms: Optional[float] = None,
         kv_hit_rate: Optional[float] = None,
+        accept_length: float = 1.0,
     ) -> Optional[PlannerEngineCapacity]:
         """Estimate sustainable single-engine RPS for one request shape.
 
@@ -517,12 +596,17 @@ class PlannerEnginePerfModel:
             return None
         if self._worker_type != "prefill" and osl <= 0:
             return None
+        accept_length = max(1.0, float(accept_length))
+        discount_decode = self._worker_type != "prefill"
+        query_itl_sla_ms = itl_sla_ms
+        if discount_decode and query_itl_sla_ms is not None:
+            query_itl_sla_ms *= accept_length
         try:
             request = EngineCapacityRequest(
                 isl=int(math.ceil(isl)),
                 osl=max(1, int(math.ceil(osl))),
                 ttft_sla_ms=ttft_sla_ms,
-                itl_sla_ms=itl_sla_ms,
+                itl_sla_ms=query_itl_sla_ms,
                 e2e_latency_sla_ms=e2e_latency_sla_ms,
                 kv_hit_rate=kv_hit_rate,
                 optimization_target=OptimizationTarget.Throughput,
@@ -533,13 +617,71 @@ class PlannerEnginePerfModel:
             return None
         if result is None:
             return None
+        rps = result.rps
+        if self._worker_type == "decode":
+            rps *= accept_length
+        elif self._worker_type == "aggregated":
+            rps = self._cap_aggregated_spec_decode_rps(
+                raw_rps=result.rps,
+                raw_itl_ms=result.itl_ms,
+                isl=isl,
+                osl=osl,
+                kv_hit_rate=kv_hit_rate,
+                accept_length=accept_length,
+            )
+        itl_ms = result.itl_ms
+        if discount_decode and itl_ms is not None:
+            itl_ms /= accept_length
         return PlannerEngineCapacity(
-            rps=result.rps,
+            rps=rps,
             ttft_ms=result.ttft_ms,
-            itl_ms=result.itl_ms,
+            itl_ms=itl_ms,
             e2e_latency_ms=result.e2e_latency_ms,
             eligible=result.eligible,
         )
+
+    def _cap_aggregated_spec_decode_rps(
+        self,
+        *,
+        raw_rps: float,
+        raw_itl_ms: Optional[float],
+        isl: float,
+        osl: float,
+        kv_hit_rate: Optional[float],
+        accept_length: float,
+    ) -> float:
+        """Apply speculative decode speedup without exceeding prefill admission.
+
+        The Rust capacity search returns an aggregated-engine RPS for raw OSL.
+        Speculative decoding reduces decode forwards per request, but an agg
+        worker can only realize that extra decode egress if its per-forward
+        prefill budget can admit the matching requests.  Infer the raw decode
+        batch from ``rps = batch / (osl * forward_wall_s)`` and cap the
+        discounted decode RPS by the prefill tokens left in the same forward.
+        """
+        if accept_length <= 1.0:
+            return raw_rps
+        if raw_itl_ms is None or raw_itl_ms <= 0.0 or osl <= 0.0:
+            return raw_rps
+
+        values = self._limit_values()
+        if values is None:
+            return raw_rps
+        max_num_batched_tokens, _max_num_seqs, _max_kv_tokens = values
+
+        forward_wall_s = raw_itl_ms / 1000.0
+        if forward_wall_s <= 0.0:
+            return raw_rps
+
+        decode_rps = raw_rps * accept_length
+        inferred_batch = raw_rps * float(osl) * forward_wall_s
+        prefill_budget = max(0.0, float(max_num_batched_tokens) - inferred_batch)
+        effective_isl = float(isl) * (1.0 - _clamp_kv_hit_rate(kv_hit_rate))
+        if effective_isl <= 0.0:
+            return decode_rps
+
+        prefill_rps = prefill_budget / (effective_isl * forward_wall_s)
+        return max(0.0, min(decode_rps, prefill_rps))
 
     # ------------------------------------------------------------------
     # Readiness and moving-average accessors used by load scaling and query

--- a/components/src/dynamo/planner/core/perf_model/rust_adapter.py
+++ b/components/src/dynamo/planner/core/perf_model/rust_adapter.py
@@ -597,17 +597,19 @@ class PlannerEnginePerfModel:
         if self._worker_type != "prefill" and osl <= 0:
             return None
         accept_length = max(1.0, float(accept_length))
+        request_kwargs: dict[str, Any] = {
+            "isl": int(math.ceil(isl)),
+            "osl": max(1, int(math.ceil(osl))),
+            "ttft_sla_ms": ttft_sla_ms,
+            "itl_sla_ms": itl_sla_ms,
+            "e2e_latency_sla_ms": e2e_latency_sla_ms,
+            "kv_hit_rate": kv_hit_rate,
+            "optimization_target": OptimizationTarget.Throughput,
+        }
+        if self._worker_type != "prefill":
+            request_kwargs["accept_length"] = accept_length
         try:
-            request = EngineCapacityRequest(
-                isl=int(math.ceil(isl)),
-                osl=max(1, int(math.ceil(osl))),
-                ttft_sla_ms=ttft_sla_ms,
-                itl_sla_ms=itl_sla_ms,
-                e2e_latency_sla_ms=e2e_latency_sla_ms,
-                kv_hit_rate=kv_hit_rate,
-                optimization_target=OptimizationTarget.Throughput,
-                accept_length=accept_length,
-            )
+            request = EngineCapacityRequest(**request_kwargs)
             result = self._rust_model.find_engine_capacity_rps(request)
         except _RUST_SHIM_FALLBACK_EXCEPTIONS as e:
             logger.warning("Rust capacity query failed: %s", e)

--- a/components/src/dynamo/planner/core/state_machine.py
+++ b/components/src/dynamo/planner/core/state_machine.py
@@ -95,9 +95,6 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
             self._num_req_predictor = predictor_cls(config)
             self._isl_predictor = predictor_cls(config)
             self._osl_predictor = predictor_cls(config)
-            # KV hit rate has no good offline-trace proxy, so it is NOT warmed
-            # via ``warm_load_predictors``; it learns only from live observations.
-            self._kv_hit_rate_predictor = predictor_cls(config)
 
         self._num_p_workers: int = 0
         self._num_d_workers: int = 0
@@ -109,13 +106,13 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
         self._throughput_lower_bound_p: int = 1
         self._throughput_lower_bound_d: int = 1
 
-        # Most recent observed KV hit rate from the router. Used by load-scaling
-        # to discount queued/avg prefill tokens in ``estimate_next_ttft``. Sticky
-        # across ticks because load-scaling and throughput-scaling cadences
-        # may differ. ``None`` means "no observation yet" -> no discount.
+        # Most recent observed KV hit rate from the router. Runtime metadata like
+        # this is intentionally last-value only, not fed through the traffic load
+        # predictor. ``None`` means "no observation yet" -> no discount.
         self._last_kv_hit_rate: Optional[float] = None
-        # Most recent speculative decode accept length. This is planner-side
-        # scaling metadata only; FPM observations remain raw per-forward data.
+        # Most recent speculative decode accept length. This uses last-value
+        # semantics as runtime metadata; FPM observations remain raw per-forward
+        # data and cold start/no observation falls back to 1.0.
         self._last_accept_length: float = 1.0
 
         self._next_load_s: float = float("inf")
@@ -379,18 +376,9 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
             self._isl_predictor.add_data_point(traffic.isl)
             self._osl_predictor.add_data_point(traffic.osl)
         if traffic.kv_hit_rate is not None and not math.isnan(traffic.kv_hit_rate):
-            if self._config.enable_throughput_scaling:
-                # Mixed mode: feed the predictor; ``_last_kv_hit_rate`` will be
-                # overwritten with the predicted value inside
-                # ``_advance_throughput`` so load scaling consumes the smoothed
-                # forecast (not the raw per-window observation).
-                self._kv_hit_rate_predictor.add_data_point(traffic.kv_hit_rate)
-            else:
-                # Load-only mode: there is no predictor path, the load tick
-                # consumes the freshly observed average directly.
-                self._last_kv_hit_rate = traffic.kv_hit_rate
+            self._last_kv_hit_rate = traffic.kv_hit_rate
 
-        self._last_accept_length = self._clamp_accept_length(traffic.accept_length)
+        self._observe_accept_length(traffic.accept_length)
 
     def _effective_speculative_nextn(self) -> int:
         d_caps = self._capabilities.decode
@@ -405,6 +393,11 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
         if accept_length is None or not math.isfinite(accept_length):
             return 1.0
         return min(max(float(accept_length), 1.0), float(nextn + 1))
+
+    def _observe_accept_length(self, accept_length: Optional[float]) -> None:
+        if accept_length is None or not math.isfinite(accept_length):
+            return
+        self._last_accept_length = self._clamp_accept_length(accept_length)
 
     def _current_decode_accept_length(self) -> float:
         return self._clamp_accept_length(self._last_accept_length)

--- a/components/src/dynamo/planner/core/state_machine.py
+++ b/components/src/dynamo/planner/core/state_machine.py
@@ -114,6 +114,9 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
         # across ticks because load-scaling and throughput-scaling cadences
         # may differ. ``None`` means "no observation yet" -> no discount.
         self._last_kv_hit_rate: Optional[float] = None
+        # Most recent speculative decode accept length. This is planner-side
+        # scaling metadata only; FPM observations remain raw per-forward data.
+        self._last_accept_length: float = 1.0
 
         self._next_load_s: float = float("inf")
         self._next_throughput_s: float = float("inf")
@@ -141,6 +144,7 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
     def update_capabilities(self, capabilities: WorkerCapabilities) -> None:
         """Replace the current worker capabilities."""
         self._capabilities = capabilities
+        self._last_accept_length = self._clamp_accept_length(self._last_accept_length)
         if self._is_easy:
             return
         if self._is_agg and hasattr(self, "_agg_regression"):
@@ -385,6 +389,25 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
                 # Load-only mode: there is no predictor path, the load tick
                 # consumes the freshly observed average directly.
                 self._last_kv_hit_rate = traffic.kv_hit_rate
+
+        self._last_accept_length = self._clamp_accept_length(traffic.accept_length)
+
+    def _effective_speculative_nextn(self) -> int:
+        d_caps = self._capabilities.decode
+        if d_caps and d_caps.speculative_nextn and d_caps.speculative_nextn > 0:
+            return d_caps.speculative_nextn
+        return max(0, int(self._config.speculative_nextn))
+
+    def _clamp_accept_length(self, accept_length: Optional[float]) -> float:
+        nextn = self._effective_speculative_nextn()
+        if nextn <= 0:
+            return 1.0
+        if accept_length is None or not math.isfinite(accept_length):
+            return 1.0
+        return min(max(float(accept_length), 1.0), float(nextn + 1))
+
+    def _current_decode_accept_length(self) -> float:
+        return self._clamp_accept_length(self._last_accept_length)
 
     # ------------------------------------------------------------------
     # Budget

--- a/components/src/dynamo/planner/core/throughput_scaling.py
+++ b/components/src/dynamo/planner/core/throughput_scaling.py
@@ -200,6 +200,7 @@ class ThroughputScalingMixin:
             ttft_sla_ms=self._config.ttft_ms,
             itl_sla_ms=self._config.itl_ms,
             kv_hit_rate=kv_hit_rate,
+            accept_length=self._current_decode_accept_length(),
         )
         engine_rps = capacity.rps if capacity is not None else 0.0
         if engine_rps <= 0:
@@ -277,10 +278,12 @@ class ThroughputScalingMixin:
     def _compute_decode_replicas(
         self, demand_rps: float, isl: float, osl: float
     ) -> Optional[int]:
+        accept_length = self._current_decode_accept_length()
         capacity = self._decode_regression.find_engine_capacity_rps(
             isl=isl,
             osl=osl,
             itl_sla_ms=self._config.itl_ms,
+            accept_length=accept_length,
         )
         engine_rps = capacity.rps if capacity is not None else 0.0
         if engine_rps <= 0:
@@ -297,6 +300,7 @@ class ThroughputScalingMixin:
 
         result = max(math.ceil(demand_rps / engine_rps), self._config.min_endpoint)
         logger.info(
-            f"Decode: {demand_rps:.2f} rps / {engine_rps:.2f} = {result}, est_itl={itl_ms:.1f}ms"
+            f"Decode: {demand_rps:.2f} rps / {engine_rps:.2f} = {result}, "
+            f"est_itl={itl_ms:.1f}ms, accept_length={accept_length:.2f}"
         )
         return result

--- a/components/src/dynamo/planner/core/throughput_scaling.py
+++ b/components/src/dynamo/planner/core/throughput_scaling.py
@@ -32,7 +32,7 @@ class ThroughputScalingMixin:
     _diag_throughput_reason: Optional[str]
     _diag_throughput_reason_prefill: Optional[str]
     _diag_throughput_reason_decode: Optional[str]
-    # Sticky value consumed by the load-scaling path between throughput ticks.
+    # Last-value runtime metadata consumed by throughput/load scaling.
     _last_kv_hit_rate: Optional[float]
 
     def _advance_throughput(
@@ -53,12 +53,6 @@ class ThroughputScalingMixin:
         demand_rps = next_num_req / traffic.duration_s
 
         predicted_hit_rate = self._predict_kv_hit_rate()
-        # Promote the predicted value to the sticky field so subsequent
-        # load-scaling ticks (between throughput ticks) discount prefill work
-        # using the smoothed forecast rather than the raw last-window
-        # observation.
-        if predicted_hit_rate is not None and not math.isnan(predicted_hit_rate):
-            self._last_kv_hit_rate = predicted_hit_rate
         mode = self._config.mode
 
         if mode == "agg":
@@ -91,21 +85,17 @@ class ThroughputScalingMixin:
             return None, None, None
 
     def _predict_kv_hit_rate(self) -> Optional[float]:
-        """Predict next-interval KV hit rate.
+        """Return the latest observed KV hit rate.
 
-        Returns ``None`` if the predictor isn't ready (cold start: no live
-        observations yet, no trace-based warmup) -- the caller treats that
-        as a 0.0 discount, preserving pre-change throughput-scaling behavior.
+        KV hit rate is engine/router runtime metadata, not traffic shape. Keep
+        it as a last-value signal instead of running it through the configured
+        traffic predictor.
         """
-        try:
-            predicted = self._kv_hit_rate_predictor.predict_next()
-        except Exception as e:
-            logger.warning(f"Failed to predict kv_hit_rate: {e}")
-            self._diag_predicted_kv_hit_rate = None
-            return None
-        self._diag_predicted_kv_hit_rate = predicted
-        logger.info(f"Predicted kv_hit_rate={predicted:.3f}")
-        return predicted
+        value = self._last_kv_hit_rate
+        self._diag_predicted_kv_hit_rate = value
+        if value is not None:
+            logger.info(f"Using last observed kv_hit_rate={value:.3f}")
+        return value
 
     def _throughput_single(
         self,

--- a/components/src/dynamo/planner/core/types.py
+++ b/components/src/dynamo/planner/core/types.py
@@ -49,6 +49,7 @@ class TrafficObservation:
     isl: float
     osl: float
     kv_hit_rate: Optional[float] = None
+    accept_length: Optional[float] = None
 
 
 @dataclass
@@ -197,6 +198,7 @@ class EngineCapabilities:
     context_length: Optional[int] = None
     max_kv_tokens: Optional[int] = None
     kv_cache_block_size: Optional[int] = None
+    speculative_nextn: Optional[int] = None
 
 
 @dataclass

--- a/components/src/dynamo/planner/core/types.py
+++ b/components/src/dynamo/planner/core/types.py
@@ -107,7 +107,8 @@ class TickDiagnostics:
     estimated_ttft_ms: Optional[float] = None
     estimated_itl_ms: Optional[float] = None
 
-    # Throughput-scaling: predicted next-interval traffic
+    # Throughput-scaling: predicted next-interval traffic and last-value
+    # runtime metadata used by throughput decisions.
     predicted_num_req: Optional[float] = None
     predicted_isl: Optional[float] = None
     predicted_osl: Optional[float] = None

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -59,6 +59,7 @@ class Metrics:
     p_load: Optional[float] = None
     d_load: Optional[float] = None
     kv_hit_rate: Optional[float] = None
+    accept_length: Optional[float] = None
 
     def is_valid(self) -> bool:
         """Check if all required metrics are valid (not None and not NaN)."""
@@ -384,6 +385,89 @@ class PrometheusAPIClient:
         except Exception as e:
             logger.warning(f"Error getting avg kv hit rate: {e}")
             return None
+
+    @staticmethod
+    def _quote_label_value(value: str) -> str:
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
+    def _engine_metric_filter(
+        self,
+        component_name: Optional[str],
+        model_name: Optional[str],
+        namespace: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+    ) -> str:
+        metric_namespace = namespace or self.dynamo_namespace
+        metric_endpoint = endpoint_name or "generate"
+        filters = [
+            f'{prometheus_names.labels.NAMESPACE}="{self._quote_label_value(metric_namespace)}"',
+            f'{prometheus_names.labels.ENDPOINT}="{self._quote_label_value(metric_endpoint)}"',
+        ]
+        if component_name:
+            filters.append(
+                f'{prometheus_names.labels.COMPONENT}="{self._quote_label_value(component_name)}"'
+            )
+        if model_name:
+            filters.append(
+                f'{prometheus_names.labels.MODEL}="{self._quote_label_value(model_name)}"'
+            )
+        return ",".join(filters)
+
+    def _query_single_value(self, query: str, operation_name: str) -> Optional[float]:
+        try:
+            result = self.prom.custom_query(query=query)
+            if not result:
+                logger.info(f"No prometheus data for {operation_name}")
+                return None
+            value = float(result[0]["value"][1])
+            return value if math.isfinite(value) else None
+        except Exception as e:
+            logger.warning(f"Error getting {operation_name}: {e}")
+            return None
+
+    def get_avg_spec_decode_accept_length(
+        self,
+        interval: str,
+        backend: str,
+        component_name: Optional[str],
+        model_name: Optional[str],
+        namespace: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+    ) -> Optional[float]:
+        """Average spec-decode accept length from worker engine metrics.
+
+        Returns tokens produced per decode forward, including the base token.
+        Missing data returns ``None`` so callers can fall back to no discount.
+        """
+        selector = self._engine_metric_filter(
+            component_name, model_name, namespace, endpoint_name
+        )
+        if backend == "vllm":
+            accepted = (
+                f"sum(rate(vllm:spec_decode_num_accepted_tokens_total"
+                f"{{{selector}}}[{interval}]))"
+            )
+            drafts = (
+                f"sum(rate(vllm:spec_decode_num_drafts_total"
+                f"{{{selector}}}[{interval}]))"
+            )
+            return self._query_single_value(
+                f"1 + ({accepted}) / ({drafts})",
+                "vLLM spec decode accept length",
+            )
+        if backend == "sglang":
+            return self._query_single_value(
+                f"avg(avg_over_time(sglang:spec_accept_length"
+                f"{{{selector}}}[{interval}]))",
+                "SGLang spec decode accept length",
+            )
+        if backend == "trtllm":
+            return self._query_single_value(
+                f"avg(avg_over_time(trtllm_spec_decode_acceptance_length"
+                f"{{{selector}}}[{interval}]))",
+                "TRT-LLM spec decode accept length",
+            )
+        return None
 
     def warn_if_router_not_scraped(self) -> None:
         """Warn if Prometheus is not scraping any dynamo_component_router_* series.

--- a/components/src/dynamo/planner/monitoring/worker_info.py
+++ b/components/src/dynamo/planner/monitoring/worker_info.py
@@ -177,8 +177,7 @@ def resolve_worker_info(
             logger.info(f"Using model name from config: {model_name}")
         else:
             raise ValueError(
-                "Could not determine model name. "
-                "Please set model_name in the config."
+                "Could not determine model name. Please set model_name in the config."
             )
 
     prefill_info.model_name = model_name

--- a/components/src/dynamo/planner/monitoring/worker_info.py
+++ b/components/src/dynamo/planner/monitoring/worker_info.py
@@ -43,6 +43,7 @@ class WorkerInfo:
     max_num_seqs: Optional[int] = None
     max_num_batched_tokens: Optional[int] = None
     context_length: Optional[int] = None
+    speculative_nextn: Optional[int] = None
 
     @property
     def max_kv_tokens(self) -> Optional[int]:
@@ -64,6 +65,8 @@ class WorkerInfo:
             parts.append(f"max_num_batched_tokens={self.max_num_batched_tokens}")
         if self.context_length is not None:
             parts.append(f"context_length={self.context_length}")
+        if self.speculative_nextn is not None:
+            parts.append(f"speculative_nextn={self.speculative_nextn}")
         return ", ".join(parts)
 
 

--- a/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
@@ -773,12 +773,10 @@ class TestRefreshWorkerInfoFromConnector:
         # Bypass Prometheus registration (Gauge+Enum double-register across
         # tests). KubernetesConnector.__init__ loads ~/.kube/config and reads
         # DYN_PARENT_DGD_K8S_NAME; stub both so this runs in plain pytest envs.
-        with patch(
-            "dynamo.planner.core.base.PlannerPrometheusMetrics"
-        ) as mock_metrics, patch(
-            "dynamo.planner.connectors.kubernetes.KubernetesAPI"
-        ), patch.dict(
-            os.environ, {"DYN_PARENT_DGD_K8S_NAME": "test-graph"}
+        with (
+            patch("dynamo.planner.core.base.PlannerPrometheusMetrics") as mock_metrics,
+            patch("dynamo.planner.connectors.kubernetes.KubernetesAPI"),
+            patch.dict(os.environ, {"DYN_PARENT_DGD_K8S_NAME": "test-graph"}),
         ):
             mock_metrics.return_value = Mock()
             config = PlannerConfig.model_construct(

--- a/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
@@ -481,6 +481,29 @@ class TestDecodeRegressionModel:
         )
         assert rps > 0 and actual_itl > 0 and actual_itl <= 50.0
 
+    def test_find_best_engine_decode_rps_discounts_itl(self):
+        model = DecodeRegressionModel(
+            max_num_fpm_samples=50, min_observations=3, bucket_count=16
+        )
+        self._train_thpt_model(model)
+        base_rps, base_itl = model.find_best_engine_decode_rps(
+            itl=50.0,
+            context_length=1000.0,
+            osl=150.0,
+            accept_length=1.0,
+            max_num_seqs=1,
+        )
+        spec_rps, spec_itl = model.find_best_engine_decode_rps(
+            itl=50.0,
+            context_length=1000.0,
+            osl=150.0,
+            accept_length=2.0,
+            max_num_seqs=1,
+        )
+
+        assert spec_itl == pytest.approx(base_itl / 2)
+        assert spec_rps == pytest.approx(base_rps * 2)
+
     def test_find_best_engine_decode_rps_zero_context(self):
         model = DecodeRegressionModel(
             max_num_fpm_samples=50, min_observations=3, bucket_count=16
@@ -564,6 +587,60 @@ class TestAggRegressionModel:
             itl_sla=50.0,
         )
         assert thpt > 0 and actual_ttft >= 0 and actual_itl >= 0
+
+    def test_find_best_engine_agg_rps_discounts_itl(self):
+        model = AggRegressionModel(
+            max_num_fpm_samples=50, min_observations=3, bucket_count=16
+        )
+        self._train_agg(model)
+        base_rps, _, base_itl = model.find_best_engine_agg_rps(
+            isl=2048.0,
+            osl=150.0,
+            max_num_batched_tokens=4096,
+            ttft_sla=500.0,
+            itl_sla=50.0,
+            accept_length=1.0,
+        )
+        spec_rps, _, spec_itl = model.find_best_engine_agg_rps(
+            isl=2048.0,
+            osl=150.0,
+            max_num_batched_tokens=4096,
+            ttft_sla=500.0,
+            itl_sla=50.0,
+            accept_length=2.0,
+        )
+
+        assert spec_itl < base_itl
+        assert spec_rps > base_rps
+
+    def test_find_best_engine_agg_rps_caps_spec_decode_by_prefill_admission(
+        self, monkeypatch
+    ):
+        model = AggRegressionModel(
+            max_num_fpm_samples=50, min_observations=3, bucket_count=16
+        )
+        monkeypatch.setattr(model, "_ensure_fitted", lambda: True)
+        monkeypatch.setattr(model, "_predict_2d", lambda _prefill, _decode: 0.05)
+        monkeypatch.setattr(
+            model,
+            "estimate_next_ttft",
+            lambda **_kwargs: 0.0,
+        )
+
+        rps, _ttft, itl = model.find_best_engine_agg_rps(
+            isl=100.0,
+            osl=100.0,
+            max_num_batched_tokens=1000,
+            ttft_sla=10_000.0,
+            itl_sla=10_000.0,
+            accept_length=2.0,
+        )
+
+        # Without the stricter agg cap, the old raw balance could choose
+        # batch=500 and report 200 rps. Spec decode doubles decode egress, so
+        # steady-state prefill admission requires a smaller sustainable batch.
+        assert rps == pytest.approx(133.2)
+        assert itl == pytest.approx(25.0)
 
     def test_find_best_engine_agg_rps_insufficient_data(self):
         model = AggRegressionModel(
@@ -835,3 +912,19 @@ class TestRefreshWorkerInfoFromConnector:
         planner._refresh_worker_info_from_connector()
         assert planner.prefill_worker_info.max_num_batched_tokens is None
         assert planner.decode_worker_info.max_num_batched_tokens == 4096
+
+    async def test_load_only_accept_length_missing_returns_observation(self):
+        planner = self._make_planner(require_prefill=False, require_decode=True)
+        planner.model_name = "Qwen/Qwen3"
+        planner.decode_worker_info = WorkerInfo(component_name="backend")
+        planner.prometheus_traffic_client = Mock()
+        planner.prometheus_traffic_client.get_avg_kv_hit_rate.return_value = None
+        planner.prometheus_traffic_client.get_avg_spec_decode_accept_length.return_value = (
+            None
+        )
+
+        obs = await planner._collect_kv_hit_rate_observation(duration_s=5)
+
+        assert obs is not None
+        assert obs.kv_hit_rate is None
+        assert obs.accept_length is None

--- a/components/src/dynamo/planner/tests/unit/test_mdc.py
+++ b/components/src/dynamo/planner/tests/unit/test_mdc.py
@@ -107,6 +107,37 @@ class TestWorkerInfoFromMdc:
         assert info.kv_cache_block_size == 16
         assert info.context_length == 8192
 
+    def test_runtime_data_spec_decode_nextn_populates_worker_info(self):
+        entry = MdcEntry(
+            card_json=_card(
+                runtime_data={
+                    "spec_decode": {
+                        "nextn": 2,
+                        "method": "eagle3",
+                        "source": "backend_config",
+                    }
+                }
+            ),
+            component="backend",
+            endpoint="generate",
+        )
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        assert info.speculative_nextn == 2
+
+    @pytest.mark.parametrize(
+        "runtime_data",
+        [
+            {},
+            {"spec_decode": {}},
+            {"spec_decode": {"nextn": 0}},
+            {"spec_decode": {"nextn": "bad"}},
+        ],
+    )
+    def test_invalid_spec_decode_nextn_is_ignored(self, runtime_data):
+        entry = MdcEntry(card_json=_card(runtime_data=runtime_data))
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        assert info.speculative_nextn is None
+
     def test_missing_wrapper_fields_fall_back_to_defaults(self):
         entry = MdcEntry(card_json=_card())
         info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")

--- a/components/src/dynamo/planner/tests/unit/test_planner_config.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_config.py
@@ -110,6 +110,19 @@ def test_max_num_fpm_samples_field():
     assert config.max_num_fpm_samples == 100
 
 
+def test_speculative_nextn_default_and_positive_value():
+    config = PlannerConfig(namespace="test-ns")
+    assert config.speculative_nextn == 0
+
+    config = PlannerConfig(namespace="test-ns", speculative_nextn=3)
+    assert config.speculative_nextn == 3
+
+
+def test_speculative_nextn_rejects_negative_value():
+    with pytest.raises(ValidationError):
+        PlannerConfig(namespace="test-ns", speculative_nextn=-1)
+
+
 def test_agg_mode_supports_throughput_scaling():
     """Agg mode supports throughput-based scaling."""
     config = PlannerConfig(

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -318,6 +318,86 @@ def test_get_avg_request_count_falls_back_to_completed_when_started_missing():
     assert "dynamo_frontend_requests_total" in queries[1]
 
 
+def test_vllm_spec_decode_accept_length_query_derives_from_counters():
+    client = PrometheusAPIClient("http://localhost:9090", "test-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, "2.5"]}]
+
+    result = client.get_avg_spec_decode_accept_length(
+        "60s", "vllm", "backend", "Qwen/Qwen3"
+    )
+
+    assert result == 2.5
+    query = client.prom.custom_query.call_args.kwargs["query"]
+    assert "vllm:spec_decode_num_accepted_tokens_total" in query
+    assert "vllm:spec_decode_num_drafts_total" in query
+    assert 'dynamo_namespace="test-ns"' in query
+    assert 'dynamo_component="backend"' in query
+    assert 'model="Qwen/Qwen3"' in query
+
+
+def test_spec_decode_accept_length_query_can_use_worker_runtime_namespace():
+    client = PrometheusAPIClient("http://localhost:9090", "base-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, "2.5"]}]
+
+    result = client.get_avg_spec_decode_accept_length(
+        "60s",
+        "vllm",
+        "backend",
+        "Qwen/Qwen3",
+        namespace="base-ns-workerhash",
+        endpoint_name="serve",
+    )
+
+    assert result == 2.5
+    query = client.prom.custom_query.call_args.kwargs["query"]
+    assert 'dynamo_namespace="base-ns-workerhash"' in query
+    assert 'dynamo_endpoint="serve"' in query
+
+
+def test_sglang_spec_decode_accept_length_query_uses_gauge():
+    client = PrometheusAPIClient("http://localhost:9090", "test-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, "1.8"]}]
+
+    result = client.get_avg_spec_decode_accept_length(
+        "30s", "sglang", "decode", "model"
+    )
+
+    assert result == 1.8
+    query = client.prom.custom_query.call_args.kwargs["query"]
+    assert "sglang:spec_accept_length" in query
+    assert "avg_over_time" in query
+
+
+def test_trtllm_spec_decode_accept_length_query_uses_gauge():
+    client = PrometheusAPIClient("http://localhost:9090", "test-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, "2.0"]}]
+
+    result = client.get_avg_spec_decode_accept_length(
+        "30s", "trtllm", "tensorrt_llm", "model"
+    )
+
+    assert result == 2.0
+    query = client.prom.custom_query.call_args.kwargs["query"]
+    assert "trtllm_spec_decode_acceptance_length" in query
+    assert "avg_over_time" in query
+
+
+@pytest.mark.parametrize("value", ["NaN", "+Inf", "-Inf"])
+def test_spec_decode_accept_length_returns_none_for_invalid_values(value):
+    client = PrometheusAPIClient("http://localhost:9090", "test-ns")
+    client.prom = MagicMock()
+    client.prom.custom_query.return_value = [{"value": [0, value]}]
+
+    assert (
+        client.get_avg_spec_decode_accept_length("30s", "vllm", "backend", "model")
+        is None
+    )
+
+
 # ---------------------------------------------------------------------------
 # Router metrics source tests
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/planner/tests/unit/test_rust_perf_adapter.py
+++ b/components/src/dynamo/planner/tests/unit/test_rust_perf_adapter.py
@@ -391,7 +391,7 @@ def test_capacity_request_passes_kv_hit_rate(monkeypatch):
     assert fake.capacity_requests[0].kwargs["kv_hit_rate"] == 0.4
 
 
-def test_decode_capacity_applies_accept_length_to_rps_and_itl(monkeypatch):
+def test_decode_capacity_passes_accept_length_to_rust(monkeypatch):
     fake = _FakeRustModel(
         diagnostics={
             "source": "aic",
@@ -400,7 +400,7 @@ def test_decode_capacity_applies_accept_length_to_rps_and_itl(monkeypatch):
             "correction_ready_buckets": 0,
             "last_warning": None,
         },
-        capacity=_FakeCapacity(rps=100.0, itl_ms=50.0),
+        capacity=_FakeCapacity(rps=200.0, itl_ms=25.0),
     )
     _install_fake_rust(monkeypatch, fake)
     model = PlannerEnginePerfModel(
@@ -416,13 +416,14 @@ def test_decode_capacity_applies_accept_length_to_rps_and_itl(monkeypatch):
         accept_length=2.0,
     )
 
-    assert fake.capacity_requests[0].kwargs["itl_sla_ms"] == 60.0
+    assert fake.capacity_requests[0].kwargs["itl_sla_ms"] == 30.0
+    assert fake.capacity_requests[0].kwargs["accept_length"] == 2.0
     assert capacity is not None
     assert capacity.rps == 200.0
     assert capacity.itl_ms == 25.0
 
 
-def test_agg_capacity_caps_spec_decode_rps_by_prefill_admission(monkeypatch):
+def test_agg_capacity_passes_accept_length_to_rust(monkeypatch):
     fake = _FakeRustModel(
         diagnostics={
             "source": "aic",
@@ -431,7 +432,7 @@ def test_agg_capacity_caps_spec_decode_rps_by_prefill_admission(monkeypatch):
             "correction_ready_buckets": 0,
             "last_warning": None,
         },
-        capacity=_FakeCapacity(rps=100.0, ttft_ms=10.0, itl_ms=50.0),
+        capacity=_FakeCapacity(rps=100.0, ttft_ms=10.0, itl_ms=25.0),
     )
     _install_fake_rust(monkeypatch, fake)
     model = PlannerEnginePerfModel(
@@ -453,11 +454,9 @@ def test_agg_capacity_caps_spec_decode_rps_by_prefill_admission(monkeypatch):
         accept_length=2.0,
     )
 
-    assert fake.capacity_requests[0].kwargs["itl_sla_ms"] == 60.0
+    assert fake.capacity_requests[0].kwargs["itl_sla_ms"] == 30.0
+    assert fake.capacity_requests[0].kwargs["accept_length"] == 2.0
     assert capacity is not None
-    # Raw rps=100 and raw itl=50ms imply batch=500. Doubling decode egress
-    # would report 200 rps, but only 500 prefill tokens remain per forward:
-    # 500 / (100 ISL * 0.050s) = 100 rps.
     assert capacity.rps == 100.0
     assert capacity.itl_ms == 25.0
 

--- a/components/src/dynamo/planner/tests/unit/test_rust_perf_adapter.py
+++ b/components/src/dynamo/planner/tests/unit/test_rust_perf_adapter.py
@@ -87,6 +87,23 @@ class _FakeRustModel:
         return self._capacity
 
 
+class _FakeCapacity:
+    def __init__(
+        self,
+        *,
+        rps,
+        itl_ms=None,
+        ttft_ms=None,
+        e2e_latency_ms=None,
+        eligible=True,
+    ):
+        self.rps = rps
+        self.itl_ms = itl_ms
+        self.ttft_ms = ttft_ms
+        self.e2e_latency_ms = e2e_latency_ms
+        self.eligible = eligible
+
+
 def _install_fake_rust(monkeypatch, fake_model: _FakeRustModel) -> None:
     _FakeRustFactory.next_model = fake_model
     _FakeRustFactory.last_kwargs = None
@@ -99,7 +116,12 @@ def _install_fake_rust(monkeypatch, fake_model: _FakeRustModel) -> None:
     monkeypatch.setattr(rust_adapter, "RustEnginePerfModel", _FakeRustFactory)
 
 
-def _config(*, dp: int = 1, min_observations: int = 5) -> PlannerConfig:
+def _config(
+    *,
+    dp: int = 1,
+    min_observations: int = 5,
+    speculative_nextn: int = 0,
+) -> PlannerConfig:
     pick = PickedParallelConfig(dp=dp)
     return PlannerConfig.model_construct(
         aic_perf_model=AICPerfModelSpec.model_construct(
@@ -114,15 +136,17 @@ def _config(*, dp: int = 1, min_observations: int = 5) -> PlannerConfig:
         fpm_sample_bucket_size=16,
         ttft_ms=500.0,
         itl_ms=50.0,
+        speculative_nextn=speculative_nextn,
     )
 
 
-def _caps() -> EngineCapabilities:
+def _caps(*, speculative_nextn: int | None = None) -> EngineCapabilities:
     return EngineCapabilities(
         max_num_batched_tokens=1024,
         max_num_seqs=128,
         max_kv_tokens=100_000,
         kv_cache_block_size=16,
+        speculative_nextn=speculative_nextn,
     )
 
 
@@ -143,6 +167,23 @@ def _prefill_fpm(
         queued_requests=QueuedRequestMetrics(
             num_prefill_requests=1 if queued_tokens else 0,
             sum_prefill_tokens=queued_tokens,
+        ),
+    )
+
+
+def _decode_fpm(
+    *,
+    requests: int = 1,
+    kv_tokens: int = 128,
+    wall_time: float = 0.01,
+) -> ForwardPassMetrics:
+    return ForwardPassMetrics(
+        worker_id="w0",
+        dp_rank=0,
+        wall_time=wall_time,
+        scheduled_requests=ScheduledRequestMetrics(
+            num_decode_requests=requests,
+            sum_decode_kv_tokens=kv_tokens,
         ),
     )
 
@@ -195,6 +236,86 @@ def test_missing_capability_fields_use_rust_shim_defaults(monkeypatch):
         "max_num_seqs": rust_adapter.DEFAULT_MAX_NUM_SEQS,
         "max_kv_tokens": rust_adapter.DEFAULT_MAX_KV_TOKENS,
     }
+
+
+@pytest.mark.parametrize(
+    ("capability_nextn", "config_nextn", "expected_nextn"),
+    [
+        (3, 5, "3"),
+        (None, 4, "4"),
+    ],
+)
+def test_aic_config_requests_raw_spec_decode_iteration_time(
+    monkeypatch,
+    capability_nextn,
+    config_nextn,
+    expected_nextn,
+):
+    fake = _FakeRustModel(
+        diagnostics={
+            "source": "aic",
+            "readiness": "ready",
+            "retained_observations": 0,
+            "correction_ready_buckets": 0,
+            "last_warning": None,
+        }
+    )
+    _install_fake_rust(monkeypatch, fake)
+
+    PlannerEnginePerfModel(
+        worker_type="decode",
+        config=_config(speculative_nextn=config_nextn),
+        capabilities=_caps(speculative_nextn=capability_nextn),
+    )
+
+    assert _FakeRustFactory.last_kwargs is not None
+    aic_config = _FakeRustFactory.last_kwargs["aic_config"]
+    assert aic_config.kwargs["extra"] == {
+        "nextn": expected_nextn,
+        "nextn_accept_rates": rust_adapter.RAW_AIC_NEXTN_ACCEPT_RATES,
+    }
+
+
+def test_capability_nextn_update_rebuilds_aic_model_and_replays_fpms(monkeypatch):
+    first = _FakeRustModel(
+        diagnostics={
+            "source": "aic",
+            "readiness": "ready",
+            "retained_observations": 0,
+            "correction_ready_buckets": 0,
+            "last_warning": None,
+        }
+    )
+    _install_fake_rust(monkeypatch, first)
+    model = PlannerEnginePerfModel(
+        worker_type="decode",
+        config=_config(),
+        capabilities=_caps(),
+    )
+    fpm = _decode_fpm(requests=2, kv_tokens=256, wall_time=0.02)
+    model.add_observations({("w0", 0): fpm})
+    assert first.tuned_iterations == [[fpm]]
+
+    second = _FakeRustModel(
+        diagnostics={
+            "source": "aic",
+            "readiness": "ready",
+            "retained_observations": 0,
+            "correction_ready_buckets": 0,
+            "last_warning": None,
+        }
+    )
+    _FakeRustFactory.next_model = second
+
+    model.update_capabilities(_caps(speculative_nextn=3))
+
+    assert _FakeRustFactory.last_kwargs is not None
+    aic_config = _FakeRustFactory.last_kwargs["aic_config"]
+    assert aic_config.kwargs["extra"] == {
+        "nextn": "3",
+        "nextn_accept_rates": rust_adapter.RAW_AIC_NEXTN_ACCEPT_RATES,
+    }
+    assert second.tuned_iterations == [[fpm]]
 
 
 def test_rust_none_result_remains_unavailable(monkeypatch):
@@ -268,6 +389,77 @@ def test_capacity_request_passes_kv_hit_rate(monkeypatch):
     assert model.find_engine_capacity_rps(isl=1000, osl=100, kv_hit_rate=0.4) is None
     assert fake.capacity_requests
     assert fake.capacity_requests[0].kwargs["kv_hit_rate"] == 0.4
+
+
+def test_decode_capacity_applies_accept_length_to_rps_and_itl(monkeypatch):
+    fake = _FakeRustModel(
+        diagnostics={
+            "source": "aic",
+            "readiness": "ready",
+            "retained_observations": 0,
+            "correction_ready_buckets": 0,
+            "last_warning": None,
+        },
+        capacity=_FakeCapacity(rps=100.0, itl_ms=50.0),
+    )
+    _install_fake_rust(monkeypatch, fake)
+    model = PlannerEnginePerfModel(
+        worker_type="decode",
+        config=_config(min_observations=1),
+        capabilities=_caps(),
+    )
+
+    capacity = model.find_engine_capacity_rps(
+        isl=1000,
+        osl=100,
+        itl_sla_ms=30.0,
+        accept_length=2.0,
+    )
+
+    assert fake.capacity_requests[0].kwargs["itl_sla_ms"] == 60.0
+    assert capacity is not None
+    assert capacity.rps == 200.0
+    assert capacity.itl_ms == 25.0
+
+
+def test_agg_capacity_caps_spec_decode_rps_by_prefill_admission(monkeypatch):
+    fake = _FakeRustModel(
+        diagnostics={
+            "source": "aic",
+            "readiness": "ready",
+            "retained_observations": 0,
+            "correction_ready_buckets": 0,
+            "last_warning": None,
+        },
+        capacity=_FakeCapacity(rps=100.0, ttft_ms=10.0, itl_ms=50.0),
+    )
+    _install_fake_rust(monkeypatch, fake)
+    model = PlannerEnginePerfModel(
+        worker_type="aggregated",
+        config=_config(min_observations=1),
+        capabilities=EngineCapabilities(
+            max_num_batched_tokens=1000,
+            max_num_seqs=1000,
+            max_kv_tokens=100_000,
+            kv_cache_block_size=16,
+        ),
+    )
+
+    capacity = model.find_engine_capacity_rps(
+        isl=100,
+        osl=100,
+        ttft_sla_ms=1000.0,
+        itl_sla_ms=30.0,
+        accept_length=2.0,
+    )
+
+    assert fake.capacity_requests[0].kwargs["itl_sla_ms"] == 60.0
+    assert capacity is not None
+    # Raw rps=100 and raw itl=50ms imply batch=500. Doubling decode egress
+    # would report 200 rps, but only 500 prefill tokens remain per forward:
+    # 500 / (100 ISL * 0.050s) = 100 rps.
+    assert capacity.rps == 100.0
+    assert capacity.itl_ms == 25.0
 
 
 def test_adapter_does_not_expose_legacy_prediction_passthroughs():

--- a/components/src/dynamo/planner/tests/unit/test_rust_perf_adapter.py
+++ b/components/src/dynamo/planner/tests/unit/test_rust_perf_adapter.py
@@ -391,6 +391,36 @@ def test_capacity_request_passes_kv_hit_rate(monkeypatch):
     assert fake.capacity_requests[0].kwargs["kv_hit_rate"] == 0.4
 
 
+def test_prefill_capacity_does_not_pass_accept_length(monkeypatch):
+    fake = _FakeRustModel(
+        diagnostics={
+            "source": "aic",
+            "readiness": "ready",
+            "retained_observations": 0,
+            "correction_ready_buckets": 0,
+            "last_warning": None,
+        },
+        capacity=_FakeCapacity(rps=10.0, ttft_ms=100.0),
+    )
+    _install_fake_rust(monkeypatch, fake)
+    model = PlannerEnginePerfModel(
+        worker_type="prefill",
+        config=_config(min_observations=1),
+        capabilities=_caps(),
+    )
+
+    capacity = model.find_engine_capacity_rps(
+        isl=1000,
+        osl=100,
+        ttft_sla_ms=500.0,
+        accept_length=2.0,
+    )
+
+    assert "accept_length" not in fake.capacity_requests[0].kwargs
+    assert capacity is not None
+    assert capacity.rps == 10.0
+
+
 def test_decode_capacity_passes_accept_length_to_rust(monkeypatch):
     fake = _FakeRustModel(
         diagnostics={

--- a/components/src/dynamo/planner/tests/unit/test_state_machine.py
+++ b/components/src/dynamo/planner/tests/unit/test_state_machine.py
@@ -137,6 +137,58 @@ def _make_agg_core(config=None, caps=None, **config_overrides) -> PlannerStateMa
     return PlannerStateMachine(cfg, caps or _agg_caps())
 
 
+def test_accept_length_clamp_uses_config_fallback_nextn():
+    core = _make_core(speculative_nextn=2)
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=4.5
+        )
+    )
+    assert core._current_decode_accept_length() == 3.0
+
+
+def test_accept_length_clamp_uses_mdc_nextn_before_config():
+    caps = WorkerCapabilities(
+        decode=EngineCapabilities(
+            num_gpu=1, max_num_batched_tokens=2048, speculative_nextn=1
+        )
+    )
+    core = _make_core(caps=caps, speculative_nextn=4)
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=4.5
+        )
+    )
+    assert core._current_decode_accept_length() == 2.0
+
+
+def test_accept_length_forced_to_one_without_spec_decode():
+    core = _make_core()
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=2.0
+        )
+    )
+    assert core._current_decode_accept_length() == 1.0
+
+
+def test_missing_accept_length_resets_to_one():
+    core = _make_core(speculative_nextn=2)
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=2.5
+        )
+    )
+    assert core._current_decode_accept_length() == 2.5
+
+    core._observe_traffic(
+        TrafficObservation(
+            duration_s=60, num_req=1, isl=1000, osl=150, accept_length=None
+        )
+    )
+    assert core._current_decode_accept_length() == 1.0
+
+
 def _train_prefill_regression(core: PlannerStateMachine) -> None:
     fpms = [
         _make_fpm(

--- a/components/src/dynamo/planner/tests/unit/test_state_machine.py
+++ b/components/src/dynamo/planner/tests/unit/test_state_machine.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     pytest.skip("forward_pass_metrics not available", allow_module_level=True)
 from dynamo.planner.config.planner_config import PlannerConfig
+from dynamo.planner.core.perf_model.rust_adapter import PlannerEngineCapacity
 from dynamo.planner.core.state_machine import PlannerStateMachine
 from dynamo.planner.core.types import (
     EngineCapabilities,
@@ -172,7 +173,7 @@ def test_accept_length_forced_to_one_without_spec_decode():
     assert core._current_decode_accept_length() == 1.0
 
 
-def test_missing_accept_length_resets_to_one():
+def test_missing_accept_length_keeps_last_value():
     core = _make_core(speculative_nextn=2)
     core._observe_traffic(
         TrafficObservation(
@@ -186,7 +187,7 @@ def test_missing_accept_length_resets_to_one():
             duration_s=60, num_req=1, isl=1000, osl=150, accept_length=None
         )
     )
-    assert core._current_decode_accept_length() == 1.0
+    assert core._current_decode_accept_length() == 2.5
 
 
 def _train_prefill_regression(core: PlannerStateMachine) -> None:
@@ -816,8 +817,8 @@ class TestKvHitRatePlumbing:
         assert core._num_req_predictor.data_buffer == []
         assert core._isl_predictor.data_buffer == []
         assert core._osl_predictor.data_buffer == []
-        # kv predictor also untouched in load-only mode (no prediction needed)
-        assert core._kv_hit_rate_predictor.data_buffer == []
+        assert not hasattr(core, "_kv_hit_rate_predictor")
+        assert core._last_kv_hit_rate == 0.4
 
     def test_load_only_none_kv_hit_rate_leaves_last_value_unchanged(self):
         core = _make_core(enable_throughput_scaling=False)
@@ -848,10 +849,9 @@ class TestKvHitRatePlumbing:
         )
         assert core._last_kv_hit_rate == 0.5
 
-    def test_mixed_mode_observe_traffic_feeds_predictor_only(self):
-        """In mixed mode the raw observation feeds the predictor; the sticky
-        ``_last_kv_hit_rate`` is *not* updated until ``_advance_throughput``
-        promotes the predicted value to it."""
+    def test_mixed_mode_observe_traffic_updates_last_kv_hit_rate(self):
+        """KV hit rate uses last-value semantics even when traffic shape uses
+        configured predictors."""
         core = _make_core()  # both load + throughput scaling enabled
         assert core._last_kv_hit_rate is None
         core._observe_traffic(
@@ -859,21 +859,25 @@ class TestKvHitRatePlumbing:
                 duration_s=60, num_req=100, isl=1000, osl=150, kv_hit_rate=0.3
             )
         )
-        # Predictor saw the observation
-        assert len(core._kv_hit_rate_predictor.data_buffer) == 1
-        # Sticky value is *not* set from the raw observation in mixed mode
-        assert core._last_kv_hit_rate is None
+        assert not hasattr(core, "_kv_hit_rate_predictor")
+        assert core._last_kv_hit_rate == 0.3
 
-    def test_mixed_mode_advance_throughput_promotes_predicted_value(self):
-        """After a throughput tick fires, ``_last_kv_hit_rate`` should hold
-        the predicted value (used by all subsequent load ticks until the
-        next throughput tick)."""
+    def test_kv_hit_rate_ignores_configured_load_predictor(self):
+        core = _make_core(load_predictor="arima")
+        core._observe_traffic(
+            TrafficObservation(
+                duration_s=60, num_req=100, isl=1000, osl=150, kv_hit_rate=0.35
+            )
+        )
+        assert not hasattr(core, "_kv_hit_rate_predictor")
+        assert core._last_kv_hit_rate == 0.35
+
+    def test_mixed_mode_advance_throughput_uses_last_kv_hit_rate(self):
+        """Throughput scaling uses the most recent observed hit rate directly."""
         core = _make_core(
             mode="prefill", enable_load_scaling=True, enable_throughput_scaling=True
         )
         _train_prefill_regression(core)
-        # ConstantPredictor returns the last observed value once min_data_points=1.
-        # Feed a known value and run a throughput tick.
         traffic = TrafficObservation(
             duration_s=60, num_req=100, isl=1000, osl=150, kv_hit_rate=0.6
         )
@@ -883,7 +887,6 @@ class TestKvHitRatePlumbing:
             worker_counts=WorkerCounts(ready_num_prefill=1),
         )
         core.on_tick(_tick_for(tick_input), tick_input)
-        # Constant predictor returns 0.6, which is then promoted to sticky
         assert core._last_kv_hit_rate == pytest.approx(0.6)
 
     def test_load_only_scheduler_sets_need_traffic_on_load_tick(self):
@@ -933,8 +936,7 @@ class TestKvHitRatePlumbing:
         assert core._last_kv_hit_rate == 0.7
 
     def test_warm_load_predictors_skips_kv_hit_rate(self):
-        """kv_hit_rate has no good offline-trace proxy, so it must not
-        receive warmup data (only live observations feed it)."""
+        """kv_hit_rate is runtime metadata, so warmup traces must not set it."""
         core = _make_core()
         observations = [
             TrafficObservation(
@@ -947,8 +949,8 @@ class TestKvHitRatePlumbing:
         assert len(core._num_req_predictor.data_buffer) == 3
         assert len(core._isl_predictor.data_buffer) == 3
         assert len(core._osl_predictor.data_buffer) == 3
-        # kv_hit_rate predictor stayed cold
-        assert core._kv_hit_rate_predictor.data_buffer == []
+        assert not hasattr(core, "_kv_hit_rate_predictor")
+        assert core._last_kv_hit_rate is None
 
     def test_throughput_diagnostics_include_predicted_kv_hit_rate(self):
         core = _make_core(
@@ -968,23 +970,44 @@ class TestKvHitRatePlumbing:
             worker_counts=WorkerCounts(ready_num_prefill=1),
         )
         effects = core.on_tick(_tick_for(tick), tick)
-        # ConstantPredictor predicts the last value it saw
+        # The API field is named "predicted" for compatibility; kv_hit_rate uses
+        # last-value semantics.
         assert effects.diagnostics.predicted_kv_hit_rate == 0.4
 
-    def test_high_predicted_hit_rate_reduces_prefill_replicas(self):
-        """With the same demand + regression, a high predicted hit rate
+    def test_high_last_observed_hit_rate_reduces_prefill_replicas(self, monkeypatch):
+        """With the same demand + regression, a high last-observed hit rate
         should yield fewer (or at worst equal) prefill replicas than no
         reuse."""
         core_base = _make_core(
             mode="prefill", enable_load_scaling=False, enable_throughput_scaling=True
         )
-        _train_prefill_regression(core_base)
         core_hit = _make_core(
             mode="prefill", enable_load_scaling=False, enable_throughput_scaling=True
         )
-        _train_prefill_regression(core_hit)
+        base_hit_rates: list[float | None] = []
+        cached_hit_rates: list[float | None] = []
 
-        # Feed several observations so the (constant) predictor locks in.
+        def _capacity_for(hit_rates: list[float | None]):
+            def _capacity(**kwargs) -> PlannerEngineCapacity:
+                hit_rate = kwargs.get("kv_hit_rate")
+                hit_rates.append(hit_rate)
+                rps = 5.0 if (hit_rate or 0.0) >= 0.8 else 1.0
+                return PlannerEngineCapacity(rps=rps, ttft_ms=100.0)
+
+            return _capacity
+
+        monkeypatch.setattr(
+            core_base._prefill_regression,
+            "find_engine_capacity_rps",
+            _capacity_for(base_hit_rates),
+        )
+        monkeypatch.setattr(
+            core_hit._prefill_regression,
+            "find_engine_capacity_rps",
+            _capacity_for(cached_hit_rates),
+        )
+
+        # Feed observations so last-value runtime metadata is available.
         traffic_base = TrafficObservation(
             duration_s=60, num_req=500, isl=4000, osl=150, kv_hit_rate=0.0
         )
@@ -1008,6 +1031,8 @@ class TestKvHitRatePlumbing:
         effects_hit = core_hit.on_tick(_tick_for(tick_hit), tick_hit)
         assert effects_base.scale_to is not None
         assert effects_hit.scale_to is not None
+        assert base_hit_rates == [0.0]
+        assert cached_hit_rates == [0.8]
         assert effects_hit.scale_to.num_prefill <= effects_base.scale_to.num_prefill
 
 

--- a/components/src/dynamo/sglang/capacity.py
+++ b/components/src/dynamo/sglang/capacity.py
@@ -82,3 +82,18 @@ def kv_metrics_block_values(kv_metrics: Any, page_size: int | None) -> tuple[int
         tokens_to_kv_blocks(kv_metrics.kv_active_blocks, page_size),
         tokens_to_kv_blocks(kv_metrics.kv_total_blocks, page_size),
     )
+
+
+def get_spec_decode_runtime_data(server_args: Any) -> dict[str, Any] | None:
+    try:
+        nextn = int(getattr(server_args, "speculative_num_steps", 0) or 0)
+    except (TypeError, ValueError):
+        return None
+    if nextn <= 0:
+        return None
+
+    data: dict[str, Any] = {"nextn": nextn, "source": "backend_config"}
+    method = getattr(server_args, "speculative_algorithm", None)
+    if method:
+        data["method"] = str(method)
+    return data

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -27,9 +27,14 @@ from dynamo.llm import (
 from dynamo.sglang._compat import get_scheduler_info
 from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_group_id
 from dynamo.sglang.args import DynamoConfig
-from dynamo.sglang.capacity import model_card_dp_rank_bounds, runtime_capacity
+from dynamo.sglang.capacity import (
+    get_spec_decode_runtime_data,
+    model_card_dp_rank_bounds,
+    runtime_capacity,
+)
 
 SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
+SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 
 
 def _build_media_decoder_and_fetcher():
@@ -339,6 +344,22 @@ async def _get_runtime_config(
 
     if server_args.speculative_algorithm in ("EAGLE", "NEXTN"):
         runtime_config.enable_eagle = True
+
+    spec_decode_runtime_data = get_spec_decode_runtime_data(server_args)
+    if spec_decode_runtime_data is not None:
+        try:
+            runtime_config.set_engine_specific(
+                SPEC_DECODE_RUNTIME_KEY,
+                json.dumps(spec_decode_runtime_data),
+            )
+            logging.info(
+                "Published SGLang spec decode runtime metadata: %s",
+                spec_decode_runtime_data,
+            )
+        except Exception as e:
+            logging.warning(
+                f"Failed to attach SGLang spec decode runtime metadata: {e}"
+            )
 
     mooncake_runtime_data = _get_mooncake_runtime_data(server_args)
     if mooncake_runtime_data is not None:

--- a/components/src/dynamo/sglang/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/sglang/tests/test_runtime_metadata.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.sglang.capacity import get_spec_decode_runtime_data
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_spec_decode_runtime_data_uses_speculative_num_steps():
+    server_args = SimpleNamespace(
+        speculative_num_steps="5",
+        speculative_algorithm="EAGLE",
+    )
+
+    assert get_spec_decode_runtime_data(server_args) == {
+        "nextn": 5,
+        "method": "EAGLE",
+        "source": "backend_config",
+    }
+
+
+@pytest.mark.parametrize(
+    "speculative_num_steps",
+    [None, 0, "bad"],
+)
+def test_spec_decode_runtime_data_ignores_invalid_nextn(speculative_num_steps):
+    server_args = SimpleNamespace(
+        speculative_num_steps=speculative_num_steps,
+        speculative_algorithm="EAGLE",
+    )
+
+    assert get_spec_decode_runtime_data(server_args) is None

--- a/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.trtllm.utils.trtllm_utils import get_spec_decode_runtime_data
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_spec_decode_runtime_data_uses_max_draft_len():
+    engine_args = {
+        "speculative_config": {
+            "max_draft_len": "6",
+            "num_nextn_predict_layers": 99,
+            "decoding_type": "EAGLE",
+        }
+    }
+
+    assert get_spec_decode_runtime_data(engine_args) == {
+        "nextn": 6,
+        "method": "EAGLE",
+        "source": "backend_config",
+    }
+
+
+def test_spec_decode_runtime_data_falls_back_to_num_nextn_predict_layers():
+    engine_args = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            num_nextn_predict_layers=2,
+            decoding_type="NEXTN",
+        )
+    )
+
+    assert get_spec_decode_runtime_data(engine_args) == {
+        "nextn": 2,
+        "method": "NEXTN",
+        "source": "backend_config",
+    }
+
+
+@pytest.mark.parametrize(
+    "speculative_config",
+    [
+        None,
+        {},
+        {"max_draft_len": 0},
+        {"max_draft_len": "bad"},
+        {"num_nextn_predict_layers": 0},
+    ],
+)
+def test_spec_decode_runtime_data_ignores_invalid_nextn(speculative_config):
+    engine_args = {"speculative_config": speculative_config}
+
+    assert get_spec_decode_runtime_data(engine_args) is None

--- a/components/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -39,3 +39,41 @@ def warn_override_collisions(
                     old_val,
                     new_val,
                 )
+
+
+def _as_mapping(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump()
+        return dumped if isinstance(dumped, dict) else None
+    if hasattr(value, "__dict__"):
+        return vars(value)
+    return None
+
+
+def get_spec_decode_runtime_data(engine_args: Any) -> dict[str, Any] | None:
+    args = _as_mapping(engine_args)
+    if not args:
+        return None
+    spec = _as_mapping(args.get("speculative_config"))
+    if not spec:
+        return None
+
+    raw_nextn = spec.get("max_draft_len")
+    if raw_nextn is None:
+        raw_nextn = spec.get("num_nextn_predict_layers")
+    try:
+        nextn = int(raw_nextn or 0)
+    except (TypeError, ValueError):
+        return None
+    if nextn <= 0:
+        return None
+
+    data: dict[str, Any] = {"nextn": nextn, "source": "backend_config"}
+    method = spec.get("decoding_type")
+    if method:
+        data["method"] = str(method)
+    return data

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -65,10 +65,11 @@ from dynamo.trtllm.request_handlers.handlers import (
     RequestHandlerConfig,
     RequestHandlerFactory,
 )
-from dynamo.trtllm.utils.trtllm_utils import deep_update
+from dynamo.trtllm.utils.trtllm_utils import deep_update, get_spec_decode_runtime_data
 
 # Default buffer size for kv cache events.
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 100_000
+SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 
 
 def build_kv_connector_config(config: Config):
@@ -558,6 +559,17 @@ async def init_llm_worker(
 
         # Set topology and KV transfer policy for topology-aware routing
         apply_topology_config(runtime_config)
+
+        spec_decode_runtime_data = get_spec_decode_runtime_data(engine_args)
+        if spec_decode_runtime_data is not None:
+            runtime_config.set_engine_specific(
+                SPEC_DECODE_RUNTIME_KEY,
+                json.dumps(spec_decode_runtime_data),
+            )
+            logging.info(
+                "Published TRT-LLM spec decode runtime metadata: %s",
+                spec_decode_runtime_data,
+            )
 
         logging.info(f"Set runtime config max_num_seqs: {runtime_config.max_num_seqs}")
         logging.info(

--- a/components/src/dynamo/vllm/capacity.py
+++ b/components/src/dynamo/vllm/capacity.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -38,3 +40,53 @@ def per_rank_kv_blocks(
         )
 
     return per_rank
+
+
+def get_metrics_model_name(config: Any) -> str:
+    return str(
+        getattr(config, "served_model_name", None) or getattr(config, "model", "")
+    )
+
+
+def _as_mapping(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump()
+        return dumped if isinstance(dumped, dict) else None
+    if hasattr(value, "__dict__"):
+        return vars(value)
+    return None
+
+
+def get_spec_decode_runtime_data(
+    config: Any, vllm_config: Any
+) -> dict[str, Any] | None:
+    spec_config = getattr(vllm_config, "speculative_config", None)
+    if spec_config is None:
+        engine_args = getattr(config, "engine_args", None)
+        spec_config = getattr(engine_args, "speculative_config", None)
+    spec = _as_mapping(spec_config)
+    if not spec:
+        return None
+
+    try:
+        nextn = int(spec.get("num_speculative_tokens") or 0)
+    except (TypeError, ValueError):
+        return None
+    if nextn <= 0:
+        return None
+
+    data: dict[str, Any] = {"nextn": nextn, "source": "backend_config"}
+    method = spec.get("method")
+    if method:
+        data["method"] = str(method)
+    return data

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -3,6 +3,7 @@
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import tempfile
@@ -46,7 +47,11 @@ from dynamo.vllm.worker_factory import WorkerFactory
 from . import envs
 from .args import Config, _uses_dynamo_connector, configure_rl_logprobs_mode, parse_args
 from .cache_info import get_configured_kv_event_block_size
-from .capacity import per_rank_kv_blocks
+from .capacity import (
+    get_metrics_model_name,
+    get_spec_decode_runtime_data,
+    per_rank_kv_blocks,
+)
 from .constants import DisaggregationMode
 from .handlers import get_dp_range_for_worker
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
@@ -56,6 +61,7 @@ from .snapshot import prepare_snapshot_engine
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 shutdown_endpoints: list = []
+SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 
 
 def build_headless_namespace(config: Config) -> argparse.Namespace:
@@ -206,6 +212,7 @@ def setup_metrics_collection(
         injected into engine metrics to align Python metrics with Rust auto-labels.
         Additional labels can be provided via inject_labels parameter.
     """
+    metrics_model_name = get_metrics_model_name(config)
     if config.engine_args.disable_log_stats is False:
         # Register the dedicated dynamo_component registry callback
         # IMPORTANT: We do NOT use MultiProcessCollector for DYNAMO_COMPONENT_REGISTRY
@@ -239,7 +246,7 @@ def setup_metrics_collection(
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
-                    model_name=config.model,
+                    model_name=metrics_model_name,
                 )
             except ValueError as e:
                 # Conflict: metrics already in REGISTRY, MultiProcessCollector tries to add same metrics from .db files
@@ -259,7 +266,7 @@ def setup_metrics_collection(
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
-                    model_name=config.model,
+                    model_name=metrics_model_name,
                 )
                 # Multiproc registry has .db file metrics (lmcache, possibly vllm duplicates)
                 register_engine_metrics_callback(
@@ -269,7 +276,7 @@ def setup_metrics_collection(
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
-                    model_name=config.model,
+                    model_name=metrics_model_name,
                 )
         else:
             if multiproc_dir:
@@ -285,7 +292,7 @@ def setup_metrics_collection(
                 namespace_name=config.namespace,
                 component_name=config.component,
                 endpoint_name=config.endpoint,
-                model_name=config.model,
+                model_name=metrics_model_name,
             )
 
 
@@ -726,6 +733,13 @@ async def register_vllm_model(
     stream_interval = getattr(config.engine_args, "stream_interval", None)
     if stream_interval is not None:
         runtime_config.set_engine_specific("stream_interval", str(stream_interval))
+
+    spec_decode = get_spec_decode_runtime_data(config, vllm_config)
+    if spec_decode is not None:
+        runtime_config.set_engine_specific(
+            SPEC_DECODE_RUNTIME_KEY, json.dumps(spec_decode)
+        )
+        logging.info("Published vLLM spec decode runtime metadata: %s", spec_decode)
 
     runtime_config.data_parallel_start_rank = dp_range[0]
     runtime_config.data_parallel_size = dp_range[1]

--- a/components/src/dynamo/vllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/vllm/tests/test_runtime_metadata.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.vllm.capacity import get_metrics_model_name, get_spec_decode_runtime_data
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_spec_decode_runtime_data_uses_vllm_speculative_config():
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(
+            speculative_config={"num_speculative_tokens": 99, "method": "ignored"}
+        )
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(num_speculative_tokens=3, method="eagle")
+    )
+
+    assert get_spec_decode_runtime_data(config, vllm_config) == {
+        "nextn": 3,
+        "method": "eagle",
+        "source": "backend_config",
+    }
+
+
+def test_metrics_model_name_prefers_served_model_name():
+    config = SimpleNamespace(model="meta-llama/Llama-3.1-8B", served_model_name="llama")
+
+    assert get_metrics_model_name(config) == "llama"
+
+
+def test_metrics_model_name_falls_back_to_model():
+    config = SimpleNamespace(model="meta-llama/Llama-3.1-8B", served_model_name=None)
+
+    assert get_metrics_model_name(config) == "meta-llama/Llama-3.1-8B"
+
+
+def test_spec_decode_runtime_data_falls_back_to_engine_args_json():
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(
+            speculative_config='{"num_speculative_tokens": "4", "method": "ngram"}'
+        )
+    )
+    vllm_config = SimpleNamespace(speculative_config=None)
+
+    assert get_spec_decode_runtime_data(config, vllm_config) == {
+        "nextn": 4,
+        "method": "ngram",
+        "source": "backend_config",
+    }
+
+
+@pytest.mark.parametrize(
+    "speculative_config",
+    [None, {}, {"num_speculative_tokens": 0}, {"num_speculative_tokens": "bad"}],
+)
+def test_spec_decode_runtime_data_ignores_invalid_nextn(speculative_config):
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(speculative_config=speculative_config)
+    )
+    vllm_config = SimpleNamespace(speculative_config=None)
+
+    assert get_spec_decode_runtime_data(config, vllm_config) is None

--- a/docs/components/planner/planner-guide.md
+++ b/docs/components/planner/planner-guide.md
@@ -139,10 +139,12 @@ features:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `load_predictor` | string | `arima` | Prediction method: `constant`, `arima`, `kalman`, or `prophet`. |
-| `load_predictor_log1p` | bool | `false` | Apply log1p transform to load data before prediction. |
+| `load_predictor` | string | `arima` | Prediction method for request count, ISL, and OSL: `constant`, `arima`, `kalman`, or `prophet`. Runtime metadata such as KV hit rate and speculative decode accept length uses the latest valid observation instead. |
+| `load_predictor_log1p` | bool | `false` | Apply log1p transform to predicted request count, ISL, and OSL data. |
 | `prophet_window_size` | int | `50` | Window size (seconds) for Prophet predictor. |
 | `load_predictor_warmup_trace` | string | `null` | Path to a warmup trace file for bootstrapping predictions. |
+
+KV hit rate and speculative decode accept length are runtime engine/router signals, not traffic shape. The planner stores the latest valid observation for each signal and reuses it until a newer valid value arrives. On cold start, missing KV hit rate means no prefix-cache discount, and missing accept length means `1.0`.
 
 ### Kalman Filter Settings
 

--- a/docs/components/planner/planner-guide.zh-CN.md
+++ b/docs/components/planner/planner-guide.zh-CN.md
@@ -139,10 +139,12 @@ features:
 
 | 字段 | 类型 | 默认值 | 说明 |
 |-------|------|---------|-------------|
-| `load_predictor` | string | `arima` | 预测方法：`constant`、`arima`、`kalman` 或 `prophet`。 |
-| `load_predictor_log1p` | bool | `false` | 在预测前对负载数据应用 log1p 变换。 |
+| `load_predictor` | string | `arima` | 用于 request count、ISL 和 OSL 的预测方法：`constant`、`arima`、`kalman` 或 `prophet`。KV hit rate 和 speculative decode accept length 等运行时元数据会使用最新的有效观测值。 |
+| `load_predictor_log1p` | bool | `false` | 对被预测的 request count、ISL 和 OSL 数据应用 log1p 变换。 |
 | `prophet_window_size` | int | `50` | Prophet predictor 的窗口大小（秒）。 |
 | `load_predictor_warmup_trace` | string | `null` | 用于引导预测的 warmup trace 文件路径。 |
+
+KV hit rate 和 speculative decode accept length 是引擎/Router 运行时信号，不是流量形状。Planner 会保存每个信号最新的有效观测值，并在新的有效值到达前复用它。冷启动时，缺失的 KV hit rate 表示不做 prefix-cache discount，缺失的 accept length 表示 `1.0`。
 
 ### Kalman Filter 设置
 

--- a/docs/design-docs/planner-design.md
+++ b/docs/design-docs/planner-design.md
@@ -46,7 +46,7 @@ The correction factors are applied as multipliers to the next scaling decision. 
 
 ### Step 3: Load Prediction
 
-The planner forecasts three values for the next interval:
+The planner forecasts three traffic-shape values for the next interval:
 
 - `next_num_req`: Number of requests
 - `next_isl`: Average input sequence length
@@ -64,6 +64,12 @@ Four predictor implementations are available:
 
 
 All predictors support warm-starting from trace files (`--load-predictor-warmup-trace`).
+
+Runtime metadata that describes engine/router behavior is not forecast with
+these predictors. KV hit rate and speculative decode accept length use
+last-value semantics: the planner stores the latest valid Prometheus
+observation and reuses it until a newer valid value arrives. Cold start falls
+back to no KV hit-rate discount and accept length `1.0`.
 
 ### Step 4: Replica Calculation
 
@@ -242,4 +248,3 @@ In aggregated mode (`--mode agg`), engines handle both prefill and decode via ch
 | `exceptions.py`              | Custom exception hierarchy                            |
 | `defaults.py`                | Default configs, backend name mappings                |
 | `planner_argparse.py`        | CLI argument definitions                              |
-

--- a/lib/bindings/python/rust/llm/engine_perf.rs
+++ b/lib/bindings/python/rust/llm/engine_perf.rs
@@ -196,6 +196,7 @@ impl EngineCapacityRequest {
         e2e_latency_sla_ms=None,
         kv_hit_rate=None,
         optimization_target=OptimizationTarget::Throughput,
+        accept_length=1.0,
     ))]
     fn new(
         isl: u32,
@@ -205,7 +206,13 @@ impl EngineCapacityRequest {
         e2e_latency_sla_ms: Option<f64>,
         kv_hit_rate: Option<f64>,
         optimization_target: OptimizationTarget,
+        accept_length: f64,
     ) -> PyResult<Self> {
+        if !accept_length.is_finite() {
+            return Err(PyValueError::new_err(format!(
+                "accept_length must be finite, got {accept_length}"
+            )));
+        }
         Ok(Self {
             inner: rs_engine_perf::EngineCapacityRequest {
                 isl,
@@ -213,6 +220,7 @@ impl EngineCapacityRequest {
                 ttft_sla: ttft_sla_ms.map(ms_to_duration).transpose()?,
                 itl_sla: itl_sla_ms.map(ms_to_duration).transpose()?,
                 e2e_latency_sla: e2e_latency_sla_ms.map(ms_to_duration).transpose()?,
+                accept_length: accept_length.max(1.0),
                 kv_hit_rate,
                 optimization_target: optimization_target.into(),
             },

--- a/lib/bindings/python/tests/test_engine_perf_model.py
+++ b/lib/bindings/python/tests/test_engine_perf_model.py
@@ -108,6 +108,11 @@ def test_capacity_request_rejects_non_finite_sla() -> None:
         EngineCapacityRequest(isl=100, osl=10, ttft_sla_ms=float("nan"))
 
 
+def test_capacity_request_rejects_non_finite_accept_length() -> None:
+    with pytest.raises(ValueError, match="accept_length must be finite"):
+        EngineCapacityRequest(isl=100, osl=10, accept_length=float("nan"))
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/lib/mocker/src/common/engine_perf.rs
+++ b/lib/mocker/src/common/engine_perf.rs
@@ -25,6 +25,9 @@ use crate::common::protocols::{ForwardPassSnapshot, MockEngineArgs, WorkerType};
 const DEFAULT_AIC_SYSTEM: &str = "h200_sxm";
 const MAX_CAPACITY_SEARCH_CANDIDATES: u32 = 128;
 const MAX_KV_HIT_RATE_DISCOUNT: f64 = 0.95;
+const AIC_NEXTN_KEY: &str = "nextn";
+const AIC_NEXTN_ACCEPT_RATES_KEY: &str = "nextn_accept_rates";
+const RAW_AIC_NEXTN_ACCEPT_RATES: &str = "0,0,0,0,0";
 
 /// Engine limits needed by planner/router-level queries.
 ///
@@ -95,6 +98,18 @@ impl AicEngineConfig {
             extra: self.extra,
         })
     }
+}
+
+fn aic_config_for_raw_iteration_time(mut config: EngineConfig) -> EngineConfig {
+    config.extra.insert(
+        AIC_NEXTN_ACCEPT_RATES_KEY.to_string(),
+        RAW_AIC_NEXTN_ACCEPT_RATES.to_string(),
+    );
+    config
+}
+
+fn aic_engine_config_for_raw_iteration_time(config: AicEngineConfig) -> Result<EngineConfig> {
+    Ok(aic_config_for_raw_iteration_time(config.into_aic_config()?))
 }
 
 impl EnginePerfLimits {
@@ -333,7 +348,7 @@ impl EnginePerfModel {
         let options = resolve_options(inputs.options, &limits);
         let load_averages = AggLoadAverages::new(options.max_observations);
         let aic_config = match inputs.aic_config {
-            Some(config) => Some(config.into_aic_config()?),
+            Some(config) => Some(aic_engine_config_for_raw_iteration_time(config)?),
             None => inputs
                 .engine_args
                 .as_ref()
@@ -387,7 +402,7 @@ impl EnginePerfModel {
         limits: EnginePerfLimits,
         options: Option<ForwardPassPerfOptions>,
     ) -> Result<Self> {
-        let aic_config = aic_config.into_aic_config()?;
+        let aic_config = aic_engine_config_for_raw_iteration_time(aic_config)?;
         let attention_dp_size = aic_config.attention_dp_size.unwrap_or(1).max(1) as usize;
         limits.validate().context("invalid engine perf limits")?;
         let resolved_options = resolve_options(options, &limits);
@@ -990,7 +1005,15 @@ pub fn aic_config_from_mock_engine_args(args: &MockEngineArgs) -> Result<Option<
     let Some(model_name) = args.aic_model_path.clone() else {
         bail!("aic_model_path is required when aic_backend is set");
     };
-    Ok(Some(EngineConfig {
+    let mut extra = BTreeMap::new();
+    if let Some(nextn) = args.aic_nextn {
+        extra.insert(AIC_NEXTN_KEY.to_string(), nextn.to_string());
+    }
+    extra.insert(
+        AIC_NEXTN_ACCEPT_RATES_KEY.to_string(),
+        RAW_AIC_NEXTN_ACCEPT_RATES.to_string(),
+    );
+    Ok(Some(aic_config_for_raw_iteration_time(EngineConfig {
         schema_version: ENGINE_CONFIG_SCHEMA_VERSION,
         model_name,
         model_arch: None,
@@ -1019,8 +1042,8 @@ pub fn aic_config_from_mock_engine_args(args: &MockEngineArgs) -> Result<Option<
         activation_dtype: None,
         kv_cache_dtype: None,
         kv_block_size: Some(to_u32(args.block_size, "block_size")?),
-        extra: BTreeMap::new(),
-    }))
+        extra,
+    })))
 }
 
 fn resolve_worker_type(
@@ -1445,6 +1468,63 @@ mod tests {
             extra: extra.clone(),
         };
         assert_eq!(config.into_aic_config().unwrap().extra, extra);
+    }
+
+    #[test]
+    fn raw_iteration_time_aic_config_forces_zero_accept_rates() {
+        let mut extra = BTreeMap::new();
+        extra.insert(AIC_NEXTN_KEY.to_string(), "3".to_string());
+        extra.insert(
+            AIC_NEXTN_ACCEPT_RATES_KEY.to_string(),
+            "0.85,0.3,0,0,0".to_string(),
+        );
+        let config = AicEngineConfig {
+            model_name: "model".to_string(),
+            model_arch: Some("arch".to_string()),
+            system_name: "h200_sxm".to_string(),
+            backend: "vllm".to_string(),
+            backend_version: None,
+            tp_size: 1,
+            pp_size: 1,
+            moe_tp_size: None,
+            moe_ep_size: None,
+            attention_dp_size: Some(1),
+            weight_dtype: None,
+            moe_dtype: None,
+            activation_dtype: None,
+            kv_cache_dtype: None,
+            kv_block_size: None,
+            extra,
+        };
+
+        let config = aic_engine_config_for_raw_iteration_time(config).unwrap();
+
+        assert_eq!(config.extra.get(AIC_NEXTN_KEY), Some(&"3".to_string()));
+        assert_eq!(
+            config.extra.get(AIC_NEXTN_ACCEPT_RATES_KEY),
+            Some(&RAW_AIC_NEXTN_ACCEPT_RATES.to_string())
+        );
+    }
+
+    #[test]
+    fn mock_engine_args_aic_config_forces_zero_accept_rates() {
+        let args = MockEngineArgs::builder()
+            .aic_backend(Some("vllm".to_string()))
+            .aic_model_path(Some("model".to_string()))
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("0.85,0.3,0,0,0".to_string()))
+            .build()
+            .unwrap()
+            .normalized()
+            .unwrap();
+
+        let config = aic_config_from_mock_engine_args(&args).unwrap().unwrap();
+
+        assert_eq!(config.extra.get(AIC_NEXTN_KEY), Some(&"2".to_string()));
+        assert_eq!(
+            config.extra.get(AIC_NEXTN_ACCEPT_RATES_KEY),
+            Some(&RAW_AIC_NEXTN_ACCEPT_RATES.to_string())
+        );
     }
 
     #[test]

--- a/lib/mocker/src/common/engine_perf.rs
+++ b/lib/mocker/src/common/engine_perf.rs
@@ -163,6 +163,12 @@ pub struct EngineCapacityRequest {
     pub ttft_sla: Option<Duration>,
     pub itl_sla: Option<Duration>,
     pub e2e_latency_sla: Option<Duration>,
+    /// Average accepted tokens per decode forward, including the base token.
+    ///
+    /// Values below one or non-finite values are treated as one so existing raw
+    /// decode capacity requests keep their historical behavior.
+    #[serde(default = "default_accept_length")]
+    pub accept_length: f64,
     /// Prefix-cache hit rate used to discount prefill compute only.
     ///
     /// Decode context/KV residency still uses the raw `isl`, because prefix
@@ -684,6 +690,7 @@ impl EnginePerfModel {
         if request.osl == 0 {
             return Ok(None);
         }
+        let accept_length = normalized_accept_length(request.accept_length);
         let context_length = decode_context_length(request);
         let max_batch = self.decode_max_batch(context_length);
         if max_batch == 0 {
@@ -691,9 +698,14 @@ impl EnginePerfModel {
         }
         let mut best = None;
         for batch_size in capacity_batch_sizes(max_batch) {
-            let Some(itl) = self.decode_time_for_batch(batch_size, context_length)? else {
+            let Some(forward_wall_time) = self.decode_time_for_batch(batch_size, context_length)?
+            else {
                 return Ok(None);
             };
+            if forward_wall_time.is_zero() {
+                continue;
+            }
+            let itl = div_duration_by_f64(forward_wall_time, accept_length, "decode ITL")?;
             if itl.is_zero() {
                 continue;
             }
@@ -718,6 +730,7 @@ impl EnginePerfModel {
         }
 
         let prefill_isl = effective_prefill_isl(request)?;
+        let accept_length = normalized_accept_length(request.accept_length);
         let context_length = decode_context_length(request);
         let kv_cap = self.decode_max_batch(context_length);
         let hard_cap = cmp::min(
@@ -735,18 +748,25 @@ impl EnginePerfModel {
                 request.osl,
                 batch_size,
                 self.limits.max_num_batched_tokens,
-            ) {
+                accept_length,
+            )? {
                 continue;
             }
 
             let decode_kv = batch_size.saturating_mul(context_length);
             let prefill_per_iter = cmp::min(
                 self.limits.max_num_batched_tokens,
-                ceil_div_u32(batch_size.saturating_mul(prefill_isl), request.osl.max(1)),
+                aggregate_prefill_per_iter(prefill_isl, request.osl, batch_size, accept_length)?,
             );
-            let Some(itl) = self.mixed_time(prefill_per_iter, batch_size, decode_kv)? else {
+            let Some(forward_wall_time) =
+                self.mixed_time(prefill_per_iter, batch_size, decode_kv)?
+            else {
                 return Ok(None);
             };
+            if forward_wall_time.is_zero() {
+                continue;
+            }
+            let itl = div_duration_by_f64(forward_wall_time, accept_length, "aggregate ITL")?;
             if itl.is_zero() {
                 continue;
             }
@@ -1201,6 +1221,18 @@ fn effective_prefill_isl(request: &EngineCapacityRequest) -> Result<u32> {
     Ok(tokens.max(1))
 }
 
+fn default_accept_length() -> f64 {
+    1.0
+}
+
+fn normalized_accept_length(value: f64) -> f64 {
+    if value.is_finite() && value > 1.0 {
+        value
+    } else {
+        1.0
+    }
+}
+
 fn clamp_kv_hit_rate(kv_hit_rate: Option<f64>) -> f64 {
     let Some(value) = kv_hit_rate else {
         return 0.0;
@@ -1216,9 +1248,26 @@ fn prefill_decode_balanced(
     osl: u32,
     batch_size: u32,
     max_num_batched_tokens: u32,
-) -> bool {
+    accept_length: f64,
+) -> Result<bool> {
     let prefill_budget = max_num_batched_tokens.saturating_sub(batch_size);
-    prefill_budget > 0 && isl <= osl.saturating_mul(prefill_budget)
+    if prefill_budget == 0 {
+        return Ok(false);
+    }
+    Ok(aggregate_prefill_per_iter(isl, osl, batch_size, accept_length)? <= prefill_budget)
+}
+
+fn aggregate_prefill_per_iter(
+    isl: u32,
+    osl: u32,
+    batch_size: u32,
+    accept_length: f64,
+) -> Result<u32> {
+    ceil_positive_f64_to_u32(
+        f64::from(batch_size) * normalized_accept_length(accept_length) * f64::from(isl)
+            / f64::from(osl.max(1)),
+        "aggregate prefill per iteration",
+    )
 }
 
 fn capacity_batch_sizes(max_batch: u32) -> Vec<u32> {
@@ -1234,13 +1283,6 @@ fn capacity_batch_sizes(max_batch: u32) -> Vec<u32> {
     (0..MAX_CAPACITY_SEARCH_CANDIDATES)
         .map(|index| 1 + ((u64::from(index) * span) / denominator) as u32)
         .collect()
-}
-
-fn ceil_div_u32(numerator: u32, denominator: u32) -> u32 {
-    if denominator == 0 {
-        return 0;
-    }
-    numerator / denominator + u32::from(numerator % denominator != 0)
 }
 
 fn sla_ok(value: Option<Duration>, sla: Option<Duration>) -> bool {
@@ -1294,6 +1336,15 @@ fn select_capacity(
 fn checked_add_duration(lhs: Duration, rhs: Duration, context: &str) -> Result<Duration> {
     lhs.checked_add(rhs)
         .ok_or_else(|| anyhow!("{context} overflow"))
+}
+
+fn div_duration_by_f64(duration: Duration, divisor: f64, context: &str) -> Result<Duration> {
+    ensure!(
+        divisor.is_finite() && divisor > 0.0,
+        "{context} divisor must be a positive finite value, got {divisor}"
+    );
+    Duration::try_from_secs_f64(duration.as_secs_f64() / divisor)
+        .with_context(|| format!("{context} overflow dividing {duration:?} by {divisor}"))
 }
 
 fn mul_duration(duration: Duration, factor: u64) -> Result<Duration> {
@@ -1900,12 +1951,99 @@ mod tests {
                 ttft_sla: None,
                 itl_sla: None,
                 e2e_latency_sla: None,
+                accept_length: 1.0,
                 kv_hit_rate: None,
                 optimization_target: OptimizationTarget::Latency,
             })
             .unwrap()
             .unwrap();
         assert!(capacity.ttft.unwrap().as_secs_f64() > 0.08);
+    }
+
+    #[test]
+    fn decode_capacity_accept_length_discounts_itl_and_rps() {
+        let mut model =
+            EnginePerfModel::from_regression(WorkerType::Decode, limits(), Some(fast_options()))
+                .unwrap();
+        model
+            .tune_with_fpms(&vec![
+                vec![decode_observation(1, 100, 0.010)],
+                vec![decode_observation(2, 200, 0.020)],
+            ])
+            .unwrap();
+
+        let base = model
+            .find_engine_capacity_rps(EngineCapacityRequest {
+                isl: 100,
+                osl: 10,
+                ttft_sla: None,
+                itl_sla: None,
+                e2e_latency_sla: None,
+                accept_length: 1.0,
+                kv_hit_rate: None,
+                optimization_target: OptimizationTarget::Throughput,
+            })
+            .unwrap()
+            .unwrap();
+        let spec = model
+            .find_engine_capacity_rps(EngineCapacityRequest {
+                isl: 100,
+                osl: 10,
+                ttft_sla: None,
+                itl_sla: None,
+                e2e_latency_sla: None,
+                accept_length: 2.0,
+                kv_hit_rate: None,
+                optimization_target: OptimizationTarget::Throughput,
+            })
+            .unwrap()
+            .unwrap();
+
+        assert!(spec.rps > base.rps);
+        assert!(spec.itl.unwrap() < base.itl.unwrap());
+    }
+
+    #[test]
+    fn aggregated_capacity_accept_length_tightens_prefill_balance() {
+        assert!(prefill_decode_balanced(100, 100, 33, 100, 2.0).unwrap());
+        assert!(!prefill_decode_balanced(100, 100, 34, 100, 2.0).unwrap());
+        assert_eq!(aggregate_prefill_per_iter(100, 100, 33, 2.0).unwrap(), 66);
+
+        let small_limits = EnginePerfLimits {
+            max_num_batched_tokens: 100,
+            max_num_seqs: 100,
+            max_kv_tokens: 1_000_000,
+        };
+        let mut model = EnginePerfModel::from_regression(
+            WorkerType::Aggregated,
+            small_limits,
+            Some(fast_options()),
+        )
+        .unwrap();
+        model
+            .tune_with_fpms(&vec![
+                vec![mixed_observation(10, 1, 150, 0.010)],
+                vec![mixed_observation(50, 1, 150, 0.050)],
+                vec![mixed_observation(100, 1, 150, 0.100)],
+            ])
+            .unwrap();
+
+        let capacity = model
+            .find_engine_capacity_rps(EngineCapacityRequest {
+                isl: 100,
+                osl: 100,
+                ttft_sla: None,
+                itl_sla: None,
+                e2e_latency_sla: None,
+                accept_length: 2.0,
+                kv_hit_rate: None,
+                optimization_target: OptimizationTarget::Throughput,
+            })
+            .unwrap()
+            .unwrap();
+
+        let inferred_batch = capacity.rps * 100.0 * capacity.itl.unwrap().as_secs_f64();
+        assert!(inferred_batch <= 34.0);
     }
 
     #[test]
@@ -1935,6 +2073,7 @@ mod tests {
                 ttft_sla: None,
                 itl_sla: None,
                 e2e_latency_sla: None,
+                accept_length: 1.0,
                 kv_hit_rate: None,
                 optimization_target: OptimizationTarget::Throughput,
             })
@@ -1970,6 +2109,7 @@ mod tests {
                 ttft_sla: None,
                 itl_sla: None,
                 e2e_latency_sla: None,
+                accept_length: 1.0,
                 kv_hit_rate: None,
                 optimization_target: OptimizationTarget::Throughput,
             })
@@ -2009,6 +2149,7 @@ mod tests {
                 ttft_sla: None,
                 itl_sla: None,
                 e2e_latency_sla: None,
+                accept_length: 1.0,
                 kv_hit_rate: Some(0.0),
                 optimization_target: OptimizationTarget::Throughput,
             })
@@ -2021,6 +2162,7 @@ mod tests {
                 ttft_sla: None,
                 itl_sla: None,
                 e2e_latency_sla: None,
+                accept_length: 1.0,
                 kv_hit_rate: Some(0.5),
                 optimization_target: OptimizationTarget::Throughput,
             })
@@ -2069,6 +2211,7 @@ mod tests {
             ttft_sla: None,
             itl_sla: None,
             e2e_latency_sla: None,
+            accept_length: 1.0,
             kv_hit_rate: Some(0.9),
             optimization_target: OptimizationTarget::Throughput,
         };
@@ -2108,6 +2251,7 @@ mod tests {
                 ttft_sla: None,
                 itl_sla: None,
                 e2e_latency_sla: None,
+                accept_length: 1.0,
                 kv_hit_rate: None,
                 optimization_target: OptimizationTarget::Throughput,
             })
@@ -2134,6 +2278,7 @@ mod tests {
                 ttft_sla: None,
                 itl_sla: Some(Duration::from_secs(1)),
                 e2e_latency_sla: None,
+                accept_length: 1.0,
                 kv_hit_rate: None,
                 optimization_target: OptimizationTarget::Throughput,
             })
@@ -2157,6 +2302,7 @@ mod tests {
                 ttft_sla: Some(Duration::from_secs(1)),
                 itl_sla: None,
                 e2e_latency_sla: None,
+                accept_length: 1.0,
                 kv_hit_rate: None,
                 optimization_target: OptimizationTarget::Throughput,
             })
@@ -2183,6 +2329,7 @@ mod tests {
                 ttft_sla: None,
                 itl_sla: Some(Duration::from_secs_f64(1.0)),
                 e2e_latency_sla: None,
+                accept_length: 1.0,
                 kv_hit_rate: None,
                 optimization_target: OptimizationTarget::Throughput,
             })


### PR DESCRIPTION
## Summary
- publish backend spec decode metadata in MDC `runtime_config.runtime_data["spec_decode"]` for vLLM, SGLang, and TRT-LLM
- add planner `speculative_nextn` fallback and prefer MDC `spec_decode.nextn` when present
- scrape/clamp speculative accept length from backend worker Prometheus metrics and discount decode ITL without changing raw OSL/KV/context estimates
- request raw AIC iteration time by forcing spec-decode acceptance rates to all zeros while carrying effective `nextn` into AIC metadata
- rebuild/replay planner AIC perf models when capabilities that affect AIC config change, so later MDC `nextn` updates keep tuning consistent
- apply accept-length ITL discount to load-based decode/agg checks and throughput-based decode/agg capacity queries
- cap aggregated throughput by prefill admission so decode-side speculative speedup cannot overstate agg engine RPS

## Agentic review follow-ups included
- reset accept length back to `1.0` on load-only ticks when the accept-length scrape is missing
- query worker metrics using the runtime namespace and decode endpoint instead of hardcoded defaults
- align vLLM metric label injection with served model names so planner Prometheus filters match MDC display names
- keep aggregated capacity conservative by applying accept length to decode egress while bounding final RPS by raw prefill admission capacity
- force all AIC engine-perf queries to use `nextn_accept_rates=0,0,0,0,0` so planner-owned accept-length discount is not applied twice
- retain recent FPM iterations and replay them when capability updates require rebuilding the Rust perf model
- fold short backend metadata helpers into existing lightweight capacity/utils modules instead of adding new `runtime_metadata.py` files

## Validation
- `uv run --no-project --with maturin maturin develop --uv --features aic-forward-pass`
- `uv run --no-project --with ruff ruff check <modified files>`
- `uvx ruff check components/src/dynamo/planner/core/perf_model/rust_adapter.py components/src/dynamo/planner/tests/unit/test_rust_perf_adapter.py`
- `uvx ruff check components/src/dynamo/vllm/capacity.py components/src/dynamo/sglang/capacity.py components/src/dynamo/trtllm/utils/trtllm_utils.py components/src/dynamo/vllm/main.py components/src/dynamo/sglang/register.py components/src/dynamo/trtllm/workers/llm_worker.py components/src/dynamo/vllm/tests/test_runtime_metadata.py components/src/dynamo/sglang/tests/test_runtime_metadata.py components/src/dynamo/trtllm/tests/test_runtime_metadata.py`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- focused planner/backend pytest suite: `211 passed`
- `PYTHONPATH=/tmp/dynamo-spec-decode-pr/components/src:/tmp/dynamo-spec-decode-pr/lib/bindings/python/src uv run --no-project --with pytest==8.4.1 --with pytest-benchmark --with pytest-asyncio --with pydantic --with aiohttp --with kubernetes --with prometheus-client --with msgspec --with pyzmq --with numpy --with pandas --with pmdarima --with filterpy --with prophet pytest components/src/dynamo/planner/tests/unit/test_rust_perf_adapter.py -q` (`11 passed`)
- `PYTHONPATH=/tmp/dynamo-spec-decode-pr/components/src:/tmp/dynamo-spec-decode-pr/lib/bindings/python/src uv run --no-project --with pytest==8.4.1 --with pytest-benchmark --with pytest-asyncio --with pydantic pytest components/src/dynamo/vllm/tests/test_runtime_metadata.py components/src/dynamo/sglang/tests/test_runtime_metadata.py components/src/dynamo/trtllm/tests/test_runtime_metadata.py -q` (`24 passed`)
- `cargo test -p dynamo-mocker --features aic-forward-pass aic_config_forces_zero_accept_rates` (`2 passed`)
- `cargo test -p dynamo-mocker --features aic-forward-pass tune_with_fpms_accepts_multiple_attention_dp_ranks` (`1 passed`)

## Notes
- FPM and replay behavior are intentionally unchanged.
- TRT-LLM accept-length metric support is best-effort; missing or invalid Prometheus data falls back to `1.0`.
- `aiconfigurator-core` does not consume `nextn`/`nextn_accept_rates` extras at the current pinned revision; the shim still writes them to make raw-iteration-time semantics explicit if/when core starts consuming them.