### PR TITLE
feat(mocker): add MTP burst sampling

### DIFF
--- a/components/src/dynamo/common/configuration/groups/aic_perf_args.py
+++ b/components/src/dynamo/common/configuration/groups/aic_perf_args.py
@@ -34,6 +34,7 @@ class AicPerfConfigBase(ConfigBase):
     aic_attention_dp_size: Optional[int]
     aic_nextn: Optional[int]
     aic_nextn_accept_rates: Optional[str]
+    aic_mtp_seed: int = 42
 
     def aic_perf_kwargs(self) -> dict:
         return {field: getattr(self, field) for field in _AIC_PERF_FIELDS}
@@ -135,7 +136,16 @@ class AicPerfArgGroup(ArgGroup):
             env_var="DYN_AIC_NEXTN_ACCEPT_RATES",
             default=None,
             help=(
-                "[EXPERIMENTAL] Comma-separated per-position accept rates for MTP "
-                "draft tokens (e.g. '0.85,0.3,0,0,0'). Padded to length 5."
+                "[EXPERIMENTAL] Comma-separated conditional accept rates for MTP "
+                "draft tokens. Entry i is P(draft i accepted | all earlier drafts "
+                "were accepted). Values are padded or truncated to --aic-nextn."
             ),
+        )
+        add_argument(
+            g,
+            flag_name="--aic-mtp-seed",
+            env_var="DYN_AIC_MTP_SEED",
+            default=42,
+            help="[EXPERIMENTAL] Base RNG seed for mocker MTP burst sampling.",
+            arg_type=int,
         )

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -88,6 +88,27 @@ def test_aic_perf_moe_env_flows_to_binding_kwargs(monkeypatch) -> None:
     assert config.aic_perf_kwargs()["aic_attention_dp_size"] == 1
 
 
+def test_aic_mtp_cli_documents_conditional_rates_and_seed() -> None:
+    parser = argparse.ArgumentParser()
+    AicPerfArgGroup().add_arguments(parser)
+    args = parser.parse_args(
+        [
+            "--aic-nextn",
+            "3",
+            "--aic-nextn-accept-rates",
+            "1,0.5",
+            "--aic-mtp-seed",
+            "99",
+        ]
+    )
+
+    config = AicPerfConfigBase.from_cli_args(args)
+    assert config.aic_nextn == 3
+    assert config.aic_nextn_accept_rates == "1,0.5"
+    assert config.aic_mtp_seed == 99
+    assert "all earlier drafts were accepted" in parser.format_help()
+
+
 def test_overlap_score_credit_cli_uses_kv_router_config_field() -> None:
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)

--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -374,6 +374,27 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "Corresponds to the 'dp' dimension in AIC CLI output.",
     )
     parser.add_argument(
+        "--aic-nextn",
+        type=int,
+        default=None,
+        help="[EXPERIMENTAL] Number of MTP draft tokens to sample (1-5).",
+    )
+    parser.add_argument(
+        "--aic-nextn-accept-rates",
+        type=str,
+        default=None,
+        help=(
+            "[EXPERIMENTAL] Comma-separated conditional MTP acceptance rates. "
+            "Entry i is P(draft i accepted | all earlier drafts were accepted)."
+        ),
+    )
+    parser.add_argument(
+        "--aic-mtp-seed",
+        type=int,
+        default=42,
+        help="[EXPERIMENTAL] Base RNG seed for mocker MTP burst sampling.",
+    )
+    parser.add_argument(
         "--num-workers",
         type=int,
         default=1,

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -287,6 +287,9 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         aic_moe_tp_size=aic_moe_tp_size,
         aic_moe_ep_size=aic_moe_ep_size,
         aic_attention_dp_size=aic_attention_dp_size,
+        aic_nextn=getattr(args, "aic_nextn", None),
+        aic_nextn_accept_rates=getattr(args, "aic_nextn_accept_rates", None),
+        aic_mtp_seed=getattr(args, "aic_mtp_seed", 42),
         gpu_memory_utilization=getattr(args, "gpu_memory_utilization", None),
         mem_fraction_static=getattr(args, "mem_fraction_static", None),
         free_gpu_memory_fraction=getattr(args, "free_gpu_memory_fraction", None),
@@ -329,12 +332,14 @@ def apply_worker_engine_args_overrides(
     bootstrap_port: int | None = None,
     zmq_kv_events_port: int | None = None,
     zmq_replay_port: int | None = None,
+    aic_mtp_seed: int | None = None,
 ) -> MockEngineArgs:
     return engine_args.with_overrides(
         bootstrap_port=bootstrap_port,
         zmq_kv_events_port=zmq_kv_events_port,
         zmq_replay_port=zmq_replay_port,
         kv_bytes_per_token=kv_bytes_per_token,
+        aic_mtp_seed=aic_mtp_seed,
     )
 
 

--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -154,6 +154,7 @@ async def launch_workers(args: argparse.Namespace, base_engine_args):
         args.bootstrap_ports_list
         or args.zmq_kv_events_ports_list
         or args.zmq_replay_ports_list
+        or base_engine_args.aic_nextn is not None
     )
 
     for worker_id in range(args.num_workers):
@@ -184,6 +185,11 @@ async def launch_workers(args: argparse.Namespace, base_engine_args):
                 zmq_replay_port=(
                     args.zmq_replay_ports_list[worker_id]
                     if args.zmq_replay_ports_list
+                    else None
+                ),
+                aic_mtp_seed=(
+                    (base_engine_args.aic_mtp_seed + worker_id) % (1 << 64)
+                    if base_engine_args.aic_nextn is not None
                     else None
                 ),
             )

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -12,6 +12,7 @@ import pytest
 
 from dynamo.llm import EngineType, EntrypointArgs
 from dynamo.mocker import MockEngineArgs
+from dynamo.mocker.args import parse_args
 
 MODULE_PATH = Path(__file__).resolve().parents[2] / "config.py"
 SPEC = importlib.util.spec_from_file_location("dynamo_mocker_config", MODULE_PATH)
@@ -61,6 +62,9 @@ def make_args(**overrides):
         "aic_moe_tp_size": None,
         "aic_moe_ep_size": None,
         "aic_attention_dp_size": None,
+        "aic_nextn": None,
+        "aic_nextn_accept_rates": None,
+        "aic_mtp_seed": 42,
         "gpu_memory_utilization": None,
         "mem_fraction_static": None,
         "free_gpu_memory_fraction": None,
@@ -339,6 +343,51 @@ def test_aic_backend_override_decouples_from_engine_type():
     engine_args = CONFIG.build_mocker_engine_args(args)
 
     assert engine_args.aic_backend == "trtllm"
+
+
+def test_build_mocker_engine_args_propagates_mtp_configuration():
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(
+            aic_perf_model=True,
+            aic_system="h200_sxm",
+            model_path="/models/mock",
+            num_gpu_blocks=128,
+            aic_nextn=3,
+            aic_nextn_accept_rates="1,0.5",
+            aic_mtp_seed=99,
+        )
+    )
+
+    assert engine_args.aic_nextn == 3
+    assert engine_args.aic_nextn_accept_rates == "1,0.5,0"
+    assert engine_args.aic_mtp_seed == 99
+
+
+def test_worker_override_offsets_mtp_seed():
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(aic_nextn=1, aic_mtp_seed=2**64 - 1)
+    )
+
+    worker_args = CONFIG.apply_worker_engine_args_overrides(engine_args, aic_mtp_seed=0)
+
+    assert worker_args.aic_mtp_seed == 0
+
+
+def test_mocker_cli_accepts_mtp_configuration():
+    args = parse_args(
+        [
+            "--aic-nextn",
+            "3",
+            "--aic-nextn-accept-rates",
+            "1,0.5",
+            "--aic-mtp-seed",
+            "99",
+        ]
+    )
+
+    assert args.aic_nextn == 3
+    assert args.aic_nextn_accept_rates == "1,0.5"
+    assert args.aic_mtp_seed == 99
 
 
 def test_replay_engine_args_compute_kv_bytes_for_g3_before_validation(monkeypatch):

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -443,6 +443,8 @@ def _run_planner_replay(
                     moe_ep_size=ref_args.aic_moe_ep_size,
                     attention_dp_size=ref_args.aic_attention_dp_size,
                     nextn=d_args.aic_nextn,
+                    # Model the full verification round; real conditional rates
+                    # are consumed only by the mocker's burst sampler.
                     nextn_accept_rates=(
                         ",".join(["0"] * d_args.aic_nextn)
                         if d_args.aic_nextn is not None

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -395,7 +395,24 @@ def _run_planner_replay(
     # feed the throughput regression (its decode formula is quadratic in
     # utilization ratio, causing negative regression coefficients).
     if not adapter._is_easy_mode():
-        ref_args = extra_engine_args or prefill_engine_args or MockEngineArgs()
+        ref_args = (
+            extra_engine_args
+            or (
+                decode_engine_args
+                if decode_engine_args is not None
+                and decode_engine_args.aic_backend is not None
+                else None
+            )
+            or prefill_engine_args
+            or decode_engine_args
+            or MockEngineArgs()
+        )
+        p_args = (
+            extra_engine_args if planner_config.mode == "agg" else prefill_engine_args
+        ) or ref_args
+        d_args = (
+            extra_engine_args if planner_config.mode == "agg" else decode_engine_args
+        ) or ref_args
         aic_backend = ref_args.aic_backend
         if (
             aic_backend is None
@@ -425,6 +442,12 @@ def _run_planner_replay(
                     moe_tp_size=ref_args.aic_moe_tp_size,
                     moe_ep_size=ref_args.aic_moe_ep_size,
                     attention_dp_size=ref_args.aic_attention_dp_size,
+                    nextn=d_args.aic_nextn,
+                    nextn_accept_rates=(
+                        ",".join(["0"] * d_args.aic_nextn)
+                        if d_args.aic_nextn is not None
+                        else None
+                    ),
                 )
             except (
                 ImportError,
@@ -446,16 +469,6 @@ def _run_planner_replay(
             # predict_* can raise on unsupported model/system combos or
             # numerical edge cases; log and fall back in those cases.
             if aic_session is not None:
-                p_args = (
-                    extra_engine_args
-                    if planner_config.mode == "agg"
-                    else prefill_engine_args
-                ) or ref_args
-                d_args = (
-                    extra_engine_args
-                    if planner_config.mode == "agg"
-                    else decode_engine_args
-                ) or ref_args
                 try:
                     prefill_fpms = _generate_aic_prefill_fpms(
                         aic_session, p_args, benchmark_granularity

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -750,7 +750,7 @@ async fn select_engine(
                 let moe_ep_size = mocker_args.aic_moe_ep_size;
                 let attention_dp_size = mocker_args.aic_attention_dp_size;
                 let nextn = mocker_args.aic_nextn;
-                let nextn_accept_rates = mocker_args.aic_nextn_accept_rates.as_deref();
+                let undiscounted_accept_rates = mocker_args.undiscounted_aic_accept_rates();
                 match Python::with_gil(|py| {
                     create_aic_callback(
                         py,
@@ -763,7 +763,7 @@ async fn select_engine(
                         moe_ep_size,
                         attention_dp_size,
                         nextn,
-                        nextn_accept_rates,
+                        undiscounted_accept_rates.as_deref(),
                     )
                 }) {
                     Ok(callback) => {

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -171,7 +171,7 @@ impl MockEngineArgs {
 #[pymethods]
 impl MockEngineArgs {
     #[new]
-    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
+    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=42, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         engine_type: &str,
@@ -197,6 +197,7 @@ impl MockEngineArgs {
         aic_attention_dp_size: Option<usize>,
         aic_nextn: Option<usize>,
         aic_nextn_accept_rates: Option<String>,
+        aic_mtp_seed: u64,
         gpu_memory_utilization: Option<f64>,
         mem_fraction_static: Option<f64>,
         free_gpu_memory_fraction: Option<f64>,
@@ -256,6 +257,7 @@ impl MockEngineArgs {
             .aic_attention_dp_size(aic_attention_dp_size)
             .aic_nextn(aic_nextn)
             .aic_nextn_accept_rates(aic_nextn_accept_rates)
+            .aic_mtp_seed(aic_mtp_seed)
             .gpu_memory_utilization(gpu_memory_utilization)
             .mem_fraction_static(mem_fraction_static)
             .free_gpu_memory_fraction(free_gpu_memory_fraction)
@@ -535,6 +537,16 @@ impl MockEngineArgs {
     }
 
     #[getter]
+    fn aic_mtp_seed(&self) -> u64 {
+        self.inner.aic_mtp_seed
+    }
+
+    #[setter]
+    fn set_aic_mtp_seed(&mut self, value: u64) {
+        self.inner.aic_mtp_seed = value;
+    }
+
+    #[getter]
     fn gpu_memory_utilization(&self) -> Option<f64> {
         self.inner.gpu_memory_utilization
     }
@@ -618,7 +630,7 @@ impl MockEngineArgs {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (bootstrap_port=None, zmq_kv_events_port=None, zmq_replay_port=None, kv_bytes_per_token=None, num_gpu_blocks=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_prefix_caching=None, worker_type=None))]
+    #[pyo3(signature = (bootstrap_port=None, zmq_kv_events_port=None, zmq_replay_port=None, kv_bytes_per_token=None, num_gpu_blocks=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_prefix_caching=None, worker_type=None))]
     fn with_overrides(
         &self,
         bootstrap_port: Option<u16>,
@@ -636,6 +648,7 @@ impl MockEngineArgs {
         aic_attention_dp_size: Option<usize>,
         aic_nextn: Option<usize>,
         aic_nextn_accept_rates: Option<String>,
+        aic_mtp_seed: Option<u64>,
         gpu_memory_utilization: Option<f64>,
         mem_fraction_static: Option<f64>,
         free_gpu_memory_fraction: Option<f64>,
@@ -689,6 +702,9 @@ impl MockEngineArgs {
         }
         if let Some(rates) = aic_nextn_accept_rates {
             inner.aic_nextn_accept_rates = Some(rates);
+        }
+        if let Some(seed) = aic_mtp_seed {
+            inner.aic_mtp_seed = seed;
         }
         if let Some(gpu_memory_utilization) = gpu_memory_utilization {
             inner.gpu_memory_utilization = Some(gpu_memory_utilization);
@@ -1255,7 +1271,7 @@ fn materialize_replay_mocker_args(
         let moe_ep_size = args.aic_moe_ep_size;
         let attention_dp_size = args.aic_attention_dp_size;
         let nextn = args.aic_nextn;
-        let nextn_accept_rates = args.aic_nextn_accept_rates.clone();
+        let undiscounted_accept_rates = args.undiscounted_aic_accept_rates();
         // AIC-backed config may intentionally omit num_gpu_blocks. Estimate it
         // here, after candidate TP/backend/model overrides have been applied.
         if !extra_args.num_gpu_blocks_explicit() {
@@ -1295,7 +1311,7 @@ fn materialize_replay_mocker_args(
             moe_ep_size,
             attention_dp_size,
             nextn,
-            nextn_accept_rates.as_deref(),
+            undiscounted_accept_rates.as_deref(),
         )
         .map_err(|e| {
             PyException::new_err(format!(

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1836,6 +1836,7 @@ class MockEngineArgs:
         aic_attention_dp_size: Optional[int] = None,
         aic_nextn: Optional[int] = None,
         aic_nextn_accept_rates: Optional[str] = None,
+        aic_mtp_seed: int = 42,
         gpu_memory_utilization: Optional[float] = None,
         mem_fraction_static: Optional[float] = None,
         free_gpu_memory_fraction: Optional[float] = None,
@@ -1990,6 +1991,12 @@ class MockEngineArgs:
     def aic_nextn_accept_rates(self, value: Optional[str]) -> None: ...
 
     @property
+    def aic_mtp_seed(self) -> int: ...
+
+    @aic_mtp_seed.setter
+    def aic_mtp_seed(self, value: int) -> None: ...
+
+    @property
     def gpu_memory_utilization(self) -> Optional[float]: ...
 
     @gpu_memory_utilization.setter
@@ -2034,6 +2041,7 @@ class MockEngineArgs:
         aic_attention_dp_size: Optional[int] = None,
         aic_nextn: Optional[int] = None,
         aic_nextn_accept_rates: Optional[str] = None,
+        aic_mtp_seed: Optional[int] = None,
         gpu_memory_utilization: Optional[float] = None,
         mem_fraction_static: Optional[float] = None,
         free_gpu_memory_fraction: Optional[float] = None,

--- a/lib/mocker/src/common/mod.rs
+++ b/lib/mocker/src/common/mod.rs
@@ -10,4 +10,5 @@ pub mod perf_model;
 pub mod protocols;
 pub mod running_mean;
 pub mod sequence;
+pub(crate) mod speculative;
 pub mod utils;

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -272,11 +272,11 @@ impl FromStr for PreemptionMode {
     type Err = String;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
+        match value.to_ascii_lowercase().as_str() {
             "lifo" => Ok(Self::Lifo),
             "fifo" => Ok(Self::Fifo),
-            other => Err(format!(
-                "Invalid preemption_mode: '{other}'. Must be 'lifo' or 'fifo'."
+            _ => Err(format!(
+                "Invalid preemption_mode: '{value}'. Must be 'lifo' or 'fifo'."
             )),
         }
     }
@@ -300,12 +300,12 @@ impl FromStr for EngineType {
     type Err = String;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
+        match value.to_ascii_lowercase().as_str() {
             "vllm" => Ok(Self::Vllm),
             "sglang" => Ok(Self::Sglang),
             "trtllm" => Ok(Self::Trtllm),
-            other => Err(format!(
-                "Invalid engine_type '{other}'. Must be 'vllm', 'sglang', or 'trtllm'."
+            _ => Err(format!(
+                "Invalid engine_type '{value}'. Must be 'vllm', 'sglang', or 'trtllm'."
             )),
         }
     }
@@ -342,12 +342,12 @@ impl FromStr for WorkerType {
     type Err = String;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
+        match value.to_ascii_lowercase().as_str() {
             "aggregated" => Ok(Self::Aggregated),
             "prefill" => Ok(Self::Prefill),
             "decode" => Ok(Self::Decode),
-            other => Err(format!(
-                "Invalid worker_type '{other}'. Must be 'aggregated', 'prefill', or 'decode'."
+            _ => Err(format!(
+                "Invalid worker_type '{value}'. Must be 'aggregated', 'prefill', or 'decode'."
             )),
         }
     }
@@ -1288,6 +1288,24 @@ mod tests {
         assert_eq!(restored.worker_type, WorkerType::Decode);
         assert_eq!(restored.max_num_seqs, None);
         assert_eq!(restored.max_num_batched_tokens, None);
+    }
+
+    #[test]
+    fn test_mock_engine_args_accepts_legacy_enum_case_and_writes_lowercase() {
+        let args = MockEngineArgs::from_json_str(
+            &json!({
+                "engine_type": "Vllm",
+                "worker_type": "Aggregated",
+                "preemption_mode": "Lifo",
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let serialized = serde_json::to_value(args).unwrap();
+        assert_eq!(serialized["engine_type"], "vllm");
+        assert_eq!(serialized["worker_type"], "aggregated");
+        assert_eq!(serialized["preemption_mode"], "lifo");
     }
 
     #[test]

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -259,6 +259,7 @@ pub struct OutputSignal {
 
 /// Preemption policy for evicting decode requests under memory pressure
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
 pub enum PreemptionMode {
     /// Evict the newest request (matches vLLM v1 default)
     #[default]
@@ -283,6 +284,7 @@ impl FromStr for PreemptionMode {
 
 /// Engine type for selecting scheduling and KV cache simulation behavior
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
 pub enum EngineType {
     /// vLLM-style scheduling with hash-based block KV cache
     #[default]
@@ -325,6 +327,7 @@ pub enum SchedulingPolicy {
 
 /// Worker type for disaggregated serving configurations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
 pub enum WorkerType {
     /// Standard aggregated worker handling both prefill and decode
     #[default]
@@ -484,6 +487,7 @@ struct MockEngineArgsSerde {
     aic_attention_dp_size: OptionalConfigValue<usize>,
     aic_nextn: OptionalConfigValue<usize>,
     aic_nextn_accept_rates: OptionalConfigValue<String>,
+    aic_mtp_seed: OptionalConfigValue<u64>,
     gpu_memory_utilization: OptionalConfigValue<f64>,
     mem_fraction_static: OptionalConfigValue<f64>,
     free_gpu_memory_fraction: OptionalConfigValue<f64>,
@@ -644,20 +648,22 @@ pub struct MockEngineArgs {
     #[builder(default = "None")]
     pub aic_attention_dp_size: Option<usize>,
 
-    /// MTP/Eagle speculative-decoding draft-token count (1..=5). When set,
-    /// AIC's perf model applies the spec-dec speedup to decode latency.
-    /// Validated here so the mocker/replay JSON path shares the same 1..=5
-    /// contract as `AicPerfConfig` (omit to disable spec dec).
-    #[serde(skip)]
+    /// MTP/Eagle speculative-decoding draft-token count (1..=5).
+    /// The mocker samples accepted drafts while AIC supplies undiscounted
+    /// verification-round latency.
     #[builder(default = "None")]
     #[validate(range(min = 1, max = 5))]
     pub aic_nextn: Option<usize>,
 
-    /// Per-position accept rates for MTP draft tokens, comma-separated
-    /// (e.g. "0.85,0.3,0,0,0"). Padded to length 5 by the Python layer.
-    #[serde(skip)]
+    /// Conditional acceptance rates for draft tokens, comma-separated.
+    /// Entry i is P(draft i accepted | every earlier draft was accepted).
     #[builder(default = "None")]
     pub aic_nextn_accept_rates: Option<String>,
+
+    /// Base RNG seed for MTP burst sampling. Worker rank is added with
+    /// wrapping arithmetic before constructing each worker-local sampler.
+    #[builder(default = "42")]
+    pub aic_mtp_seed: u64,
 
     /// GPU memory fraction for AIC KV capacity estimation with vLLM.
     #[builder(default = "None")]
@@ -826,6 +832,23 @@ fn validate_mock_engine_args(args: &MockEngineArgs) -> Result<(), ValidationErro
         ));
     }
 
+    if args.aic_nextn.is_some() && args.decode_speedup_ratio != 1.0 {
+        return Err(mock_engine_args_validation_error(
+            "mtp_decode_speedup_conflict",
+            format!(
+                "aic_nextn requires decode_speedup_ratio=1.0 because MTP output acceleration is modeled by burst sampling, got {}",
+                args.decode_speedup_ratio
+            ),
+        ));
+    }
+
+    if args.aic_nextn.is_none() && args.aic_nextn_accept_rates.is_some() {
+        return Err(mock_engine_args_validation_error(
+            "mtp_rates_without_nextn",
+            "aic_nextn_accept_rates requires aic_nextn".to_string(),
+        ));
+    }
+
     if let Some(policy) = args
         .trtllm
         .as_ref()
@@ -988,6 +1011,9 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         if let Some(aic_nextn_accept_rates) = compat.aic_nextn_accept_rates.into_nullable() {
             builder = builder.aic_nextn_accept_rates(aic_nextn_accept_rates);
         }
+        if let Some(aic_mtp_seed) = compat.aic_mtp_seed.into_non_null("aic_mtp_seed")? {
+            builder = builder.aic_mtp_seed(aic_mtp_seed);
+        }
         if let Some(gpu_memory_utilization) = compat.gpu_memory_utilization.into_nullable() {
             builder = builder.gpu_memory_utilization(gpu_memory_utilization);
         }
@@ -1141,9 +1167,17 @@ impl MockEngineArgs {
         }
     }
 
-    fn validate_config(&self) -> anyhow::Result<()> {
+    fn validate_config(&mut self) -> anyhow::Result<()> {
         self.validate()
             .map_err(|error| anyhow::anyhow!("Failed to validate MockEngineArgs: {error}"))?;
+        if let Some(nextn) = self.aic_nextn {
+            let rates = crate::common::speculative::normalize_conditional_accept_rates(
+                nextn,
+                self.aic_nextn_accept_rates.as_deref(),
+            )?;
+            self.aic_nextn_accept_rates =
+                Some(crate::common::speculative::format_accept_rates(&rates));
+        }
         Ok(())
     }
 
@@ -1166,6 +1200,10 @@ impl MockEngineArgs {
 
     pub fn needs_kv_publisher(&self) -> bool {
         self.enable_prefix_caching && !self.is_decode()
+    }
+
+    pub fn undiscounted_aic_accept_rates(&self) -> Option<String> {
+        crate::common::speculative::undiscounted_aic_accept_rates(self.aic_nextn)
     }
 
     /// Create MockEngineArgs from a JSON file containing extra engine arguments
@@ -1391,7 +1429,7 @@ mod tests {
     #[test]
     fn test_normalized_rejects_out_of_range_aic_nextn() {
         // The mocker/replay JSON path must share AicPerfConfig's 1..=5 contract.
-        for bad in [0_usize, 6] {
+        for bad in [0_usize, 6, usize::MAX] {
             let err = MockEngineArgs::builder()
                 .aic_nextn(Some(bad))
                 .build()
@@ -1409,6 +1447,81 @@ mod tests {
             .unwrap()
             .normalized()
             .expect("in-range aic_nextn should validate");
+    }
+
+    #[test]
+    fn test_mtp_defaults_and_json_round_trip() {
+        let args = MockEngineArgs::builder()
+            .aic_nextn(Some(3))
+            .build()
+            .unwrap()
+            .normalized()
+            .unwrap();
+        assert_eq!(args.aic_nextn_accept_rates.as_deref(), Some("0.85,0.3,0"));
+        assert_eq!(args.aic_mtp_seed, 42);
+        assert_eq!(
+            args.undiscounted_aic_accept_rates().as_deref(),
+            Some("0,0,0")
+        );
+
+        let json = serde_json::to_string(&args).unwrap();
+        let round_trip = MockEngineArgs::from_json_str(&json).unwrap();
+        assert_eq!(round_trip.aic_nextn, Some(3));
+        assert_eq!(
+            round_trip.aic_nextn_accept_rates.as_deref(),
+            Some("0.85,0.3,0")
+        );
+        assert_eq!(round_trip.aic_mtp_seed, 42);
+    }
+
+    #[test]
+    fn test_mtp_rates_are_validated_before_normalization() {
+        for rates in ["nan", "inf", "-0.1", "1.1", "bad"] {
+            let err = MockEngineArgs::builder()
+                .aic_nextn(Some(1))
+                .aic_nextn_accept_rates(Some(rates.to_string()))
+                .build()
+                .unwrap()
+                .normalized()
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("aic_nextn_accept_rates"),
+                "unexpected error for rates={rates:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mtp_rates_are_padded_and_truncated_to_nextn() {
+        let padded = MockEngineArgs::builder()
+            .aic_nextn(Some(3))
+            .aic_nextn_accept_rates(Some("1,0.5".to_string()))
+            .build()
+            .unwrap()
+            .normalized()
+            .unwrap();
+        assert_eq!(padded.aic_nextn_accept_rates.as_deref(), Some("1,0.5,0"));
+
+        let truncated = MockEngineArgs::builder()
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("1,0.5,0.25".to_string()))
+            .build()
+            .unwrap()
+            .normalized()
+            .unwrap();
+        assert_eq!(truncated.aic_nextn_accept_rates.as_deref(), Some("1,0.5"));
+    }
+
+    #[test]
+    fn test_mtp_rejects_decode_speedup_ratio() {
+        let err = MockEngineArgs::builder()
+            .aic_nextn(Some(1))
+            .decode_speedup_ratio(2.0)
+            .build()
+            .unwrap()
+            .normalized()
+            .unwrap_err();
+        assert!(err.to_string().contains("decode_speedup_ratio=1.0"));
     }
 
     #[test]

--- a/lib/mocker/src/common/speculative.rs
+++ b/lib/mocker/src/common/speculative.rs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+const DEFAULT_CONDITIONAL_ACCEPT_RATES: [f64; 5] = [0.85, 0.3, 0.0, 0.0, 0.0];
+
+pub(crate) fn normalize_conditional_accept_rates(
+    nextn: usize,
+    rates: Option<&str>,
+) -> anyhow::Result<Vec<f64>> {
+    anyhow::ensure!(
+        (1..=5).contains(&nextn),
+        "aic_nextn must be in 1..=5, got {nextn}"
+    );
+    let mut parsed = match rates.map(str::trim).filter(|rates| !rates.is_empty()) {
+        Some(rates) => rates
+            .split(',')
+            .map(|rate| {
+                rate.trim().parse::<f64>().map_err(|error| {
+                    anyhow::anyhow!("invalid aic_nextn_accept_rates value {rate:?}: {error}")
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?,
+        None => DEFAULT_CONDITIONAL_ACCEPT_RATES.to_vec(),
+    };
+
+    for (index, rate) in parsed.iter().copied().enumerate() {
+        anyhow::ensure!(
+            rate.is_finite() && (0.0..=1.0).contains(&rate),
+            "aic_nextn_accept_rates[{index}] must be finite and in [0, 1], got {rate}"
+        );
+    }
+
+    parsed.resize(nextn, 0.0);
+    parsed.truncate(nextn);
+    Ok(parsed)
+}
+
+pub(crate) fn format_accept_rates(rates: &[f64]) -> String {
+    rates
+        .iter()
+        .map(|rate| rate.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+pub(crate) fn undiscounted_aic_accept_rates(nextn: Option<usize>) -> Option<String> {
+    nextn.map(|nextn| vec!["0"; nextn].join(","))
+}
+
+pub(crate) struct SpeculativeDecodeSampler {
+    conditional_accept_rates: Vec<f64>,
+    rng: StdRng,
+}
+
+impl SpeculativeDecodeSampler {
+    pub(crate) fn new(conditional_accept_rates: Vec<f64>, seed: u64) -> Self {
+        Self {
+            conditional_accept_rates,
+            rng: StdRng::seed_from_u64(seed),
+        }
+    }
+
+    pub(crate) fn sample_output_tokens(&mut self, remaining_output_tokens: usize) -> usize {
+        if remaining_output_tokens == 0 {
+            return 0;
+        }
+
+        let mut output_tokens = 1;
+        for rate in &self.conditional_accept_rates {
+            if !self.rng.random_bool(*rate) {
+                break;
+            }
+            output_tokens += 1;
+        }
+        output_tokens.min(remaining_output_tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_and_one_rates_are_exact() {
+        let mut zero = SpeculativeDecodeSampler::new(vec![0.0, 1.0], 42);
+        assert_eq!(zero.sample_output_tokens(10), 1);
+
+        let mut one = SpeculativeDecodeSampler::new(vec![1.0, 1.0], 42);
+        assert_eq!(one.sample_output_tokens(10), 3);
+    }
+
+    #[test]
+    fn sampling_stops_at_first_rejection() {
+        let mut sampler = SpeculativeDecodeSampler::new(vec![1.0, 0.0, 1.0], 42);
+        assert_eq!(sampler.sample_output_tokens(10), 2);
+    }
+
+    #[test]
+    fn sampling_clamps_to_remaining_output() {
+        let mut sampler = SpeculativeDecodeSampler::new(vec![1.0, 1.0], 42);
+        assert_eq!(sampler.sample_output_tokens(2), 2);
+        assert_eq!(sampler.sample_output_tokens(0), 0);
+    }
+
+    #[test]
+    fn equal_seeds_produce_equal_streams() {
+        let rates = vec![0.8, 0.6, 0.4];
+        let mut left = SpeculativeDecodeSampler::new(rates.clone(), 123);
+        let mut right = SpeculativeDecodeSampler::new(rates, 123);
+        let left_samples: Vec<_> = (0..100).map(|_| left.sample_output_tokens(10)).collect();
+        let right_samples: Vec<_> = (0..100).map(|_| right.sample_output_tokens(10)).collect();
+        assert_eq!(left_samples, right_samples);
+    }
+
+    #[test]
+    fn worker_seed_offsets_produce_distinct_streams() {
+        let rates = vec![0.8, 0.6, 0.4];
+        let mut left = SpeculativeDecodeSampler::new(rates.clone(), 42);
+        let mut right = SpeculativeDecodeSampler::new(rates, 43);
+        let left_samples: Vec<_> = (0..100).map(|_| left.sample_output_tokens(10)).collect();
+        let right_samples: Vec<_> = (0..100).map(|_| right.sample_output_tokens(10)).collect();
+        assert_ne!(left_samples, right_samples);
+    }
+
+    #[test]
+    fn empirical_mean_matches_conditional_expectation() {
+        let rates = vec![0.7, 0.5, 0.2];
+        let expected = 1.0 + 0.7 + 0.7 * 0.5 + 0.7 * 0.5 * 0.2;
+        let mut sampler = SpeculativeDecodeSampler::new(rates, 42);
+        let samples = 200_000;
+        let mean = (0..samples)
+            .map(|_| sampler.sample_output_tokens(10) as f64)
+            .sum::<f64>()
+            / samples as f64;
+        assert!(
+            (mean - expected).abs() < 0.01,
+            "mean={mean}, expected={expected}"
+        );
+    }
+
+    #[test]
+    fn rates_are_validated_then_padded_or_truncated() {
+        assert_eq!(
+            normalize_conditional_accept_rates(3, Some("1, 0.5")).unwrap(),
+            vec![1.0, 0.5, 0.0]
+        );
+        assert_eq!(
+            normalize_conditional_accept_rates(2, Some("1,0.5,0.25")).unwrap(),
+            vec![1.0, 0.5]
+        );
+        for rates in ["nan", "inf", "-0.1", "1.1", "not-a-rate"] {
+            assert!(normalize_conditional_accept_rates(1, Some(rates)).is_err());
+        }
+    }
+}

--- a/lib/mocker/src/common/speculative.rs
+++ b/lib/mocker/src/common/speculative.rs
@@ -34,7 +34,6 @@ pub(crate) fn normalize_conditional_accept_rates(
     }
 
     parsed.resize(nextn, 0.0);
-    parsed.truncate(nextn);
     Ok(parsed)
 }
 

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -127,6 +127,20 @@ enum G1AllocationAttempt {
     },
 }
 
+pub struct DecodeBlockReservation {
+    blocks: Vec<MutableBlock<G1>>,
+}
+
+impl DecodeBlockReservation {
+    fn take(&mut self) -> Option<MutableBlock<G1>> {
+        self.blocks.pop()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.blocks.len()
+    }
+}
+
 #[derive(Clone)]
 struct RegisteredBlockInfo {
     seq_hash: SequenceHash,
@@ -668,6 +682,7 @@ impl KvManager {
                 plhs,
                 token_ids.as_deref(),
                 parent.as_ref(),
+                None,
             ),
             MoveBlock::Deref(hashes) => {
                 self.process_deref(hashes);
@@ -683,6 +698,44 @@ impl KvManager {
                     token_ids.clone(),
                 );
                 1
+            }
+        }
+    }
+
+    pub fn reserve_decode_blocks(&mut self, count: usize) -> Option<DecodeBlockReservation> {
+        let (blocks, evicted_plhs) = self.block_manager.allocate_blocks_with_evictions(count)?;
+        if self.should_block_on_g1_offload(&evicted_plhs) {
+            self.handle_evictions_with_source_slots(evicted_plhs, blocks);
+            return None;
+        }
+
+        self.handle_evictions(evicted_plhs);
+        Some(DecodeBlockReservation { blocks })
+    }
+
+    pub fn process_decode_signal(
+        &mut self,
+        event: &MoveBlock,
+        reservation: &mut DecodeBlockReservation,
+    ) {
+        match event {
+            MoveBlock::Use(blocks, local_hashes, plhs, token_ids, parent) => {
+                let allocated = self.process_use(
+                    blocks,
+                    local_hashes,
+                    plhs,
+                    token_ids.as_deref(),
+                    parent.as_ref(),
+                    Some(reservation),
+                );
+                assert_eq!(
+                    allocated,
+                    blocks.len(),
+                    "reserved decode allocation must be infallible"
+                );
+            }
+            _ => {
+                self.process(event);
             }
         }
     }
@@ -830,6 +883,7 @@ impl KvManager {
         plhs: &[PositionalLineageHash],
         token_ids: Option<&[Vec<u32>]>,
         parent: Option<&UniqueBlock>,
+        mut reservation: Option<&mut DecodeBlockReservation>,
     ) -> usize {
         // Upstream invariant: caller must supply exactly one PLH per FullBlock in
         // `blocks`.
@@ -896,7 +950,21 @@ impl KvManager {
                                 .push(immutable);
                             UseOutcome::InactiveHit
                         } else {
-                            let Some(allocation) = self.allocate_one_g1_slot() else {
+                            let allocation = reservation
+                                .as_deref_mut()
+                                .and_then(DecodeBlockReservation::take)
+                                .map(|mutable| G1AllocationAttempt::Allocated {
+                                    mutable,
+                                    evicted_plhs: Vec::new(),
+                                })
+                                .or_else(|| {
+                                    if reservation.is_some() {
+                                        None
+                                    } else {
+                                        self.allocate_one_g1_slot()
+                                    }
+                                });
+                            let Some(allocation) = allocation else {
                                 break; // capacity exhausted; scheduler will preempt
                             };
                             let mutable = match allocation {
@@ -955,7 +1023,21 @@ impl KvManager {
                     if self.active_partial.contains_key(uuid) {
                         UseOutcome::ActiveHit
                     } else {
-                        let Some(allocation) = self.allocate_one_g1_slot() else {
+                        let allocation = reservation
+                            .as_deref_mut()
+                            .and_then(DecodeBlockReservation::take)
+                            .map(|mutable| G1AllocationAttempt::Allocated {
+                                mutable,
+                                evicted_plhs: Vec::new(),
+                            })
+                            .or_else(|| {
+                                if reservation.is_some() {
+                                    None
+                                } else {
+                                    self.allocate_one_g1_slot()
+                                }
+                            });
+                        let Some(allocation) = allocation else {
                             break;
                         };
                         let mutable = match allocation {
@@ -1474,6 +1556,25 @@ mod tests {
         deref_full(&mut mgr, 1);
         // Use with same PLH reuses the inactive block.
         assert_eq!(use_full(&mut mgr, 2, p), 1);
+    }
+
+    #[test]
+    fn failed_decode_reservation_preserves_inactive_cache() {
+        let (mut mgr, sink) = make_mgr_capturing(2, 16);
+        let first = plh(100);
+        let second = plh(200);
+        use_full(&mut mgr, 1, first);
+        use_full(&mut mgr, 2, second);
+        deref_full(&mut mgr, 1);
+        deref_full(&mut mgr, 2);
+        assert_eq!(mgr.num_inactive_blocks(), 2);
+        sink.events.lock().unwrap().clear();
+
+        assert!(mgr.reserve_decode_blocks(3).is_none());
+        assert_eq!(mgr.num_inactive_blocks(), 2);
+        assert!(sink.events.lock().unwrap().is_empty());
+        assert_eq!(use_full(&mut mgr, 3, first), 1);
+        assert_eq!(use_full(&mut mgr, 4, second), 1);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -5,6 +5,7 @@
 //! operations and KV event publishing.
 
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
@@ -40,6 +41,22 @@ pub struct SglangKvManager {
     /// block hash so router events reflect logical block visibility, not
     /// transient slot ownership.
     block_hash_refcounts: HashMap<ExternalSequenceBlockHash, usize>,
+}
+
+pub struct DecodeTokenReservation {
+    indices: VecDeque<usize>,
+}
+
+impl DecodeTokenReservation {
+    pub fn take(&mut self) -> usize {
+        self.indices
+            .pop_front()
+            .expect("reserved decode token allocation must be infallible")
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.indices.len()
+    }
 }
 
 impl SglangKvManager {
@@ -176,10 +193,32 @@ impl SglangKvManager {
     pub fn allocate_decode_token(&mut self, last_idx: Option<usize>) -> Option<usize> {
         let indices = self.cache.token_pool.allocate(1)?;
         let idx = indices[0];
+        self.publish_decode_token(idx, last_idx);
+        Some(idx)
+    }
+
+    pub fn reserve_decode_tokens(&mut self, count: usize) -> Option<DecodeTokenReservation> {
+        self.cache
+            .token_pool
+            .allocate(count)
+            .map(|indices| DecodeTokenReservation {
+                indices: indices.into(),
+            })
+    }
+
+    pub fn publish_decode_token(&mut self, idx: usize, last_idx: Option<usize>) {
         let parent_hash = last_idx.and_then(|i| self.idx_to_block_hash.get(&i).copied());
         self.publish_stored_event(&[], &[idx], parent_hash);
         self.log_trace("allocation", 1);
-        Some(idx)
+    }
+
+    pub fn release_decode_reservation(&mut self, reservation: DecodeTokenReservation) {
+        let indices = reservation.indices.into_iter().collect::<Vec<_>>();
+        if indices.is_empty() {
+            return;
+        }
+        self.cache.token_pool.free(&indices);
+        self.log_trace("release_unpublished", indices.len());
     }
 
     /// Free a request without caching (e.g., aborted request).

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -168,7 +168,7 @@ impl TrafficAccumulator {
                 self.total_ttft_ms += ttft_ms;
                 self.ttft_count += 1;
             }
-            if mean_itl_ms > 0.0 {
+            if output_tokens > 1 && mean_itl_ms.is_finite() && mean_itl_ms >= 0.0 {
                 self.total_itl_ms += mean_itl_ms;
                 self.itl_count += 1;
             }
@@ -300,5 +300,14 @@ mod tests {
         assert_eq!(stats.avg_isl, 0.0);
         assert_eq!(stats.avg_osl, 0.0);
         assert_eq!(stats.avg_kv_hit_rate, 0.0);
+    }
+
+    #[test]
+    fn traffic_accumulator_retains_zero_millisecond_itl_samples() {
+        let mut acc = TrafficAccumulator::new();
+        acc.on_request(10, 3, Some((1.0, 0.0)));
+        acc.on_request(10, 3, Some((1.0, 10.0)));
+        let stats = acc.drain(1_000.0);
+        assert_eq!(stats.avg_itl_ms, 5.0);
     }
 }

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -1044,4 +1044,59 @@ mod tests {
             "expected second request to wait for completion plus delay"
         );
     }
+
+    #[test]
+    fn test_mtp_artifacts_emit_ordered_same_timestamp_bursts() {
+        let args = MockEngineArgs::builder()
+            .block_size(2)
+            .num_gpu_blocks(32)
+            .max_num_batched_tokens(None)
+            .max_num_seqs(None)
+            .enable_prefix_caching(false)
+            .speedup_ratio(1000.0)
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("1,1".to_string()))
+            .build()
+            .unwrap();
+        let trace = Trace {
+            block_size: 2,
+            sessions: vec![SessionTrace {
+                session_id: "mtp-session".to_string(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![TurnTrace {
+                    input_length: 4,
+                    max_output_tokens: 5,
+                    hash_ids: vec![1, 2],
+                    delay_after_previous_ms: 0.0,
+                }],
+            }],
+        };
+
+        let artifacts = generate_trace_worker_artifacts(args, trace).unwrap();
+        assert_eq!(artifacts.output_signals.len(), 5);
+        assert_eq!(
+            artifacts.output_signals[0].timestamp_us,
+            artifacts.output_signals[1].timestamp_us
+        );
+        assert_eq!(
+            artifacts.output_signals[1].timestamp_us,
+            artifacts.output_signals[2].timestamp_us
+        );
+        assert!(
+            artifacts.output_signals[2].timestamp_us < artifacts.output_signals[3].timestamp_us
+        );
+        assert_eq!(
+            artifacts.output_signals[3].timestamp_us,
+            artifacts.output_signals[4].timestamp_us
+        );
+        assert_eq!(
+            artifacts
+                .output_signals
+                .iter()
+                .filter(|output| output.signal.completed)
+                .count(),
+            1
+        );
+        assert!(artifacts.output_signals.last().unwrap().signal.completed);
+    }
 }

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -168,7 +168,7 @@ impl OfflineWorkerState {
                 let mut core = if capture_kv_events {
                     crate::scheduler::VllmCore::new_with_kv_capture(args, worker_idx as u64)
                 } else {
-                    crate::scheduler::VllmCore::new(args)
+                    crate::scheduler::VllmCore::new_with_worker_id(args, worker_idx as u64)
                 };
                 #[cfg(feature = "kvbm-offload")]
                 if let Err(e) = core.init_offload_offline() {
@@ -185,7 +185,10 @@ impl OfflineWorkerState {
                         worker_idx as u64,
                     ))
                 } else {
-                    EngineCore::Sglang(crate::scheduler::SglangCore::new(args))
+                    EngineCore::Sglang(crate::scheduler::SglangCore::new_with_worker_id(
+                        args,
+                        worker_idx as u64,
+                    ))
                 }
             }
         };

--- a/lib/mocker/src/scheduler/sglang/config.rs
+++ b/lib/mocker/src/scheduler/sglang/config.rs
@@ -39,6 +39,7 @@ pub(super) struct SglangConfig {
     pub(super) total_kv_tokens: usize,
     pub(super) kv_bytes_per_token: Option<usize>,
     pub(super) kv_transfer_bandwidth: Option<f64>,
+    pub(super) speculative_max_tokens: Option<usize>,
 }
 
 impl SglangConfig {
@@ -87,6 +88,7 @@ impl SglangConfig {
             total_kv_tokens: args.num_gpu_blocks * args.block_size,
             kv_bytes_per_token: args.kv_bytes_per_token,
             kv_transfer_bandwidth: args.kv_transfer_bandwidth,
+            speculative_max_tokens: args.aic_nextn.map(|nextn| nextn + 1),
         }
     }
 }

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -8,11 +8,12 @@ use dynamo_kv_router::protocols::WorkerId;
 use uuid::Uuid;
 
 use crate::common::protocols::{DirectRequest, KvEventPublishers, MockEngineArgs, WorkerType};
+use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
 use crate::kv_manager::SglangKvManager;
 use crate::replay::TraceCollector;
 
 use super::config::SglangConfig;
-use super::decode::{cache_materialized_prefix, simulate_decode_step};
+use super::decode::{cache_materialized_prefix, simulate_decode_step_with_sampler};
 use super::policy::apply_schedule_policy;
 use super::prefill::get_new_batch_prefill;
 use super::request::SglangRequest;
@@ -28,12 +29,17 @@ pub(crate) struct SglangCore {
     pub(super) running: Vec<SglangRequest>,
     pub(super) new_token_ratio: f64,
     pub(super) kv_manager: SglangKvManager,
+    speculative_sampler: Option<SpeculativeDecodeSampler>,
     kv_event_buffer: Option<CapturedRouterEventBuffer>,
 }
 
 impl SglangCore {
     pub(crate) fn new(args: MockEngineArgs) -> Self {
-        Self::new_internal(args, 0, None, KvEventPublishers::default())
+        Self::new_internal(args, 0, 0, None, KvEventPublishers::default())
+    }
+
+    pub(crate) fn new_with_worker_id(args: MockEngineArgs, worker_id: WorkerId) -> Self {
+        Self::new_internal(args, 0, worker_id, None, KvEventPublishers::default())
     }
 
     pub(crate) fn new_with_kv_capture(args: MockEngineArgs, worker_id: WorkerId) -> Self {
@@ -41,6 +47,7 @@ impl SglangCore {
         Self::new_internal(
             args,
             0,
+            worker_id,
             Some(buffer),
             KvEventPublishers::new(Some(sink), None),
         )
@@ -51,18 +58,25 @@ impl SglangCore {
         dp_rank: u32,
         kv_event_publishers: KvEventPublishers,
     ) -> Self {
-        Self::new_internal(args, dp_rank, None, kv_event_publishers)
+        Self::new_internal(args, dp_rank, u64::from(dp_rank), None, kv_event_publishers)
     }
 
     fn new_internal(
         args: MockEngineArgs,
         dp_rank: u32,
+        worker_id: WorkerId,
         kv_event_buffer: Option<CapturedRouterEventBuffer>,
         kv_event_publishers: KvEventPublishers,
     ) -> Self {
         let args = args.normalized().expect("invalid MockEngineArgs");
         let config = SglangConfig::from_args(&args);
         let total_tokens = args.num_gpu_blocks * args.block_size;
+        let speculative_sampler = args.aic_nextn.map(|nextn| {
+            let rates =
+                normalize_conditional_accept_rates(nextn, args.aic_nextn_accept_rates.as_deref())
+                    .expect("normalized MTP acceptance rates");
+            SpeculativeDecodeSampler::new(rates, args.aic_mtp_seed.wrapping_add(worker_id))
+        });
 
         Self {
             config,
@@ -76,6 +90,7 @@ impl SglangCore {
                 kv_event_publishers,
                 dp_rank,
             ),
+            speculative_sampler,
             kv_event_buffer,
         }
     }
@@ -167,10 +182,11 @@ impl SglangCore {
             .collect();
 
         let decode_start_ms = now_ms + prefill_time.as_secs_f64() * 1000.0;
-        let mut decode = simulate_decode_step(
+        let mut decode = simulate_decode_step_with_sampler(
             &mut self.running,
             &mut self.kv_manager,
             &self.config,
+            self.speculative_sampler.as_mut(),
             decode_start_ms,
             true,
         );

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -4,6 +4,7 @@
 use std::time::Duration;
 
 use crate::common::protocols::OutputSignal;
+use crate::common::speculative::SpeculativeDecodeSampler;
 use crate::common::utils::compute_prefill_handoff_delay_ms;
 use crate::kv_manager::SglangKvManager;
 
@@ -22,7 +23,8 @@ fn decode_capacity_state(
     running: &[SglangRequest],
     kv_manager: &SglangKvManager,
     config: &SglangConfig,
-) -> (usize, usize) {
+    max_burst: usize,
+) -> (usize, usize, usize) {
     let actual_available =
         kv_manager.cache().available_tokens() + kv_manager.cache().evictable_size;
     let reserved_tokens = running
@@ -33,18 +35,14 @@ fn decode_capacity_state(
     let page_growth_needed = running
         .iter()
         .map(|req| {
-            if req.current_sequence_len() + 1 > req.allocated_tokens {
-                config.block_size
-            } else {
-                0
-            }
+            let burst = max_burst.min(req.remaining_output_tokens());
+            let target =
+                super::config::ceil_to_block(req.current_sequence_len() + burst, config.block_size);
+            target.saturating_sub(req.allocated_tokens)
         })
         .sum();
 
-    (
-        actual_available,
-        logical_available.saturating_sub(page_growth_needed),
-    )
+    (actual_available, logical_available, page_growth_needed)
 }
 
 pub(super) fn cache_materialized_prefix(
@@ -72,17 +70,31 @@ pub(super) fn cache_materialized_prefix(
     req.debug_assert_invariants(config.block_size);
 }
 
+#[cfg(test)]
 pub(super) fn check_decode_mem(
     running: &mut Vec<SglangRequest>,
     kv_manager: &mut SglangKvManager,
     config: &SglangConfig,
 ) -> Vec<SglangRequest> {
+    check_decode_mem_for_burst(running, kv_manager, config, 1)
+}
+
+fn check_decode_mem_for_burst(
+    running: &mut Vec<SglangRequest>,
+    kv_manager: &mut SglangKvManager,
+    config: &SglangConfig,
+    max_burst: usize,
+) -> Vec<SglangRequest> {
     let mut retracted = Vec::new();
 
     loop {
-        let (actual_available, logical_available_after_growth) =
-            decode_capacity_state(running, kv_manager, config);
-        if actual_available >= running.len() && logical_available_after_growth > 0 {
+        let (actual_available, logical_available, page_growth_needed) =
+            decode_capacity_state(running, kv_manager, config, max_burst);
+        let needed = running
+            .iter()
+            .map(|req| max_burst.min(req.remaining_output_tokens()))
+            .sum::<usize>();
+        if actual_available >= needed && logical_available >= page_growth_needed {
             break;
         }
         if running.len() <= 1 {
@@ -97,7 +109,7 @@ pub(super) fn check_decode_mem(
             break;
         };
 
-        let mut req = running.swap_remove(idx);
+        let mut req = running.remove(idx);
         kv_manager.free_indices(&req.kv_indices[req.cached_tokens..]);
         if let Some(last_node) = req.last_node.take() {
             kv_manager.free_request(last_node);
@@ -108,7 +120,10 @@ pub(super) fn check_decode_mem(
     }
 
     let available = kv_manager.cache().token_pool.available();
-    let needed = running.len();
+    let needed = running
+        .iter()
+        .map(|req| max_burst.min(req.remaining_output_tokens()))
+        .sum::<usize>();
     if available < needed {
         kv_manager.evict(needed - available);
     }
@@ -124,6 +139,7 @@ pub(super) fn check_decode_mem(
     retracted
 }
 
+#[cfg(test)]
 pub(super) fn simulate_decode_step(
     running: &mut Vec<SglangRequest>,
     kv_manager: &mut SglangKvManager,
@@ -131,8 +147,42 @@ pub(super) fn simulate_decode_step(
     current_time_ms: f64,
     apply_speedup: bool,
 ) -> DecodeResult {
+    simulate_decode_step_with_sampler(
+        running,
+        kv_manager,
+        config,
+        None,
+        current_time_ms,
+        apply_speedup,
+    )
+}
+
+pub(super) fn simulate_decode_step_with_sampler(
+    running: &mut Vec<SglangRequest>,
+    kv_manager: &mut SglangKvManager,
+    config: &SglangConfig,
+    mut sampler: Option<&mut SpeculativeDecodeSampler>,
+    current_time_ms: f64,
+    apply_speedup: bool,
+) -> DecodeResult {
     if running.is_empty() {
         return DecodeResult {
+            end_ms: current_time_ms,
+            ..DecodeResult::default()
+        };
+    }
+
+    let max_burst = if config.worker_type == crate::common::protocols::WorkerType::Prefill {
+        1
+    } else {
+        config.speculative_max_tokens.unwrap_or(1)
+    };
+    let retracted = check_decode_mem_for_burst(running, kv_manager, config, max_burst);
+    let retracted_any = !retracted.is_empty();
+    if running.is_empty() {
+        return DecodeResult {
+            requests: retracted,
+            retracted_any,
             end_ms: current_time_ms,
             ..DecodeResult::default()
         };
@@ -158,73 +208,107 @@ pub(super) fn simulate_decode_step(
         unscaled_time
     };
 
-    let retracted = check_decode_mem(running, kv_manager, config);
-    let retracted_any = !retracted.is_empty();
-    let mut output_signals = Vec::with_capacity(running.len());
+    let reserved_tokens = running
+        .iter()
+        .map(|req| max_burst.min(req.remaining_output_tokens()))
+        .sum();
+    let Some(mut reservation) = kv_manager.reserve_decode_tokens(reserved_tokens) else {
+        tracing::warn!(
+            reserved_tokens,
+            "Failed to reserve speculative decode tokens after capacity preflight"
+        );
+        return DecodeResult {
+            requests: retracted,
+            retracted_any,
+            end_ms: current_time_ms,
+            ..DecodeResult::default()
+        };
+    };
+
+    let sampled_bursts = running
+        .iter()
+        .map(|req| {
+            let remaining = req.remaining_output_tokens();
+            if config.worker_type == crate::common::protocols::WorkerType::Prefill {
+                remaining.min(1)
+            } else if let Some(sampler) = sampler.as_deref_mut() {
+                sampler.sample_output_tokens(remaining)
+            } else {
+                remaining.min(1)
+            }
+        })
+        .collect::<Vec<_>>();
+    let mut output_signals = Vec::with_capacity(sampled_bursts.iter().copied().sum::<usize>());
     let mut completed_indices = Vec::new();
 
-    for (idx, req) in running.iter_mut().enumerate() {
-        if kv_manager.cache().token_pool.available() == 0 {
-            kv_manager.evict(1);
-        }
+    for (idx, (req, burst)) in running
+        .iter_mut()
+        .zip(sampled_bursts.into_iter())
+        .enumerate()
+    {
+        for _ in 0..burst {
+            let crossing_page_boundary = req.current_sequence_len() + 1 > req.allocated_tokens;
+            let last_idx = req.kv_indices.last().copied();
+            let new_idx = reservation.take();
+            kv_manager.publish_decode_token(new_idx, last_idx);
 
-        let crossing_page_boundary = req.current_sequence_len() + 1 > req.allocated_tokens;
-        let last_idx = req.kv_indices.last().copied();
-        let Some(new_idx) = kv_manager.allocate_decode_token(last_idx) else {
-            tracing::warn!(uuid = %req.uuid, "Failed to allocate decode token, skipping output");
-            continue;
-        };
-
-        req.kv_indices.push(new_idx);
-        if crossing_page_boundary {
-            req.allocated_tokens += config.block_size;
-        }
-        req.append_output_token(req.next_output_token());
-        req.debug_assert_invariants(config.block_size);
-
-        let is_complete = req.output_len() >= req.max_output_tokens;
-        output_signals.push(OutputSignal {
-            uuid: req.uuid,
-            completed: is_complete,
-            rejected: false,
-            handoff_delay_ms: compute_prefill_handoff_delay_ms(
-                config.worker_type,
-                is_complete,
-                req.prompt_len(),
-                config.kv_transfer_bandwidth,
-                config.kv_bytes_per_token,
-            ),
-        });
-
-        if is_complete {
-            let sequence = req.sequence_tokens();
-            let tokens_to_cache = floor_to_block(sequence.len(), config.block_size);
-            if req.kv_indices.len() > tokens_to_cache {
-                kv_manager.free_indices(&req.kv_indices[tokens_to_cache..]);
+            req.kv_indices.push(new_idx);
+            if crossing_page_boundary {
+                req.allocated_tokens += config.block_size;
             }
+            req.append_output_token(req.next_output_token());
+            req.debug_assert_invariants(config.block_size);
 
-            if let Some(last_node) = req.last_node.take() {
-                if tokens_to_cache > 0 {
-                    kv_manager.cache_finished_req(
-                        &sequence[..tokens_to_cache],
-                        &req.kv_indices[..tokens_to_cache],
-                        last_node,
-                    );
-                } else {
-                    kv_manager.free_request(last_node);
+            let is_complete = req.output_len() >= req.max_output_tokens;
+            output_signals.push(OutputSignal {
+                uuid: req.uuid,
+                completed: is_complete,
+                rejected: false,
+                handoff_delay_ms: compute_prefill_handoff_delay_ms(
+                    config.worker_type,
+                    is_complete,
+                    req.prompt_len(),
+                    config.kv_transfer_bandwidth,
+                    config.kv_bytes_per_token,
+                ),
+            });
+
+            if is_complete {
+                let sequence = req.sequence_tokens();
+                let tokens_to_cache = floor_to_block(sequence.len(), config.block_size);
+                if req.kv_indices.len() > tokens_to_cache {
+                    kv_manager.free_indices(&req.kv_indices[tokens_to_cache..]);
                 }
+
+                if let Some(last_node) = req.last_node.take() {
+                    if tokens_to_cache > 0 {
+                        kv_manager.cache_finished_req(
+                            &sequence[..tokens_to_cache],
+                            &req.kv_indices[..tokens_to_cache],
+                            last_node,
+                        );
+                    } else {
+                        kv_manager.free_request(last_node);
+                    }
+                }
+
+                completed_indices.push(idx);
+                break;
             }
 
-            completed_indices.push(idx);
-            continue;
+            cache_materialized_prefix(req, kv_manager, config);
+            req.debug_assert_invariants(config.block_size);
         }
-
-        cache_materialized_prefix(req, kv_manager, config);
-        req.debug_assert_invariants(config.block_size);
     }
 
+    debug_assert_eq!(
+        reservation.len(),
+        reserved_tokens.saturating_sub(output_signals.len())
+    );
+    kv_manager.release_decode_reservation(reservation);
+
     for &idx in completed_indices.iter().rev() {
-        running.swap_remove(idx);
+        running.remove(idx);
     }
 
     DecodeResult {

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -530,6 +530,80 @@ mod core_behavior {
     }
 
     #[test]
+    fn test_mtp_batch_applies_request_bursts_in_stable_order() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Sglang)
+            .num_gpu_blocks(32)
+            .block_size(4)
+            .speedup_ratio(0.0)
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("1,1".to_string()))
+            .sglang(Some(SglangArgs {
+                page_size: Some(4),
+                chunked_prefill_size: Some(16),
+                ..Default::default()
+            }))
+            .build()
+            .unwrap();
+        let mut core = SglangCore::new(args);
+        let short = Uuid::from_u128(101);
+        let long = Uuid::from_u128(102);
+        let longer = Uuid::from_u128(103);
+        for (uuid, tokens, max_output_tokens) in [
+            (short, vec![1, 2, 3, 4], 5),
+            (long, vec![5, 6, 7, 8], 8),
+            (longer, vec![9, 10, 11, 12], 8),
+        ] {
+            core.receive(DirectRequest {
+                tokens,
+                max_output_tokens,
+                uuid: Some(uuid),
+                dp_rank: 0,
+                arrival_timestamp_ms: None,
+            });
+        }
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let first = core.execute_pass(&mut collector, 0.0);
+        assert_eq!(first.output_signals.len(), 9);
+        let second = core.execute_pass(&mut collector, first.end_ms);
+        let ordered = second
+            .output_signals
+            .iter()
+            .map(|signal| (signal.uuid, signal.completed))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ordered,
+            vec![
+                (short, false),
+                (short, true),
+                (long, false),
+                (long, false),
+                (long, false),
+                (longer, false),
+                (longer, false),
+                (longer, false),
+            ]
+        );
+        assert_eq!(core.running.len(), 2);
+        assert_eq!(core.running[0].uuid, long);
+        assert_eq!(core.running[0].output_len(), 6);
+        assert_eq!(core.running[1].uuid, longer);
+        assert_eq!(core.running[1].output_len(), 6);
+        assert_eq!(second.fpm.unwrap().num_decode_requests, 3);
+
+        let third = core.execute_pass(&mut collector, second.end_ms);
+        assert_eq!(
+            third
+                .output_signals
+                .iter()
+                .map(|signal| signal.uuid)
+                .collect::<Vec<_>>(),
+            vec![long, long, longer, longer],
+        );
+    }
+
+    #[test]
     fn test_sglang_pass_visibility_is_pass_end() {
         let mut core = SglangCore::new_with_kv_capture(test_args(32, 4, 4), ROUTER_TEST_WORKER_ID);
         core.receive(direct_request(vec![1, 2, 3, 4], 1));
@@ -830,6 +904,70 @@ mod router_events {
             }
         }
 
+        assert!(saw_remove);
+        harness.assert_no_event_errors();
+        harness.assert_no_event_warnings();
+        harness.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_mtp_lifecycle_drains_with_clean_router_events() {
+        let harness = RouterIndexerHarness::new(4, ROUTER_TEST_WORKER_ID);
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Sglang)
+            .num_gpu_blocks(5)
+            .block_size(4)
+            .max_num_batched_tokens(Some(8))
+            .max_num_seqs(Some(4))
+            .speedup_ratio(0.0)
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("0,1".to_string()))
+            .sglang(Some(SglangArgs {
+                page_size: Some(4),
+                chunked_prefill_size: Some(4),
+                ..Default::default()
+            }))
+            .build()
+            .unwrap();
+        let mut core = SglangCore::new_with_kv_capture(args, ROUTER_TEST_WORKER_ID);
+        let requests = [
+            direct_request(vec![1, 2, 3, 4, 5, 6], 7),
+            direct_request(vec![9, 10, 11, 12], 5),
+        ];
+        let expected_tokens = requests
+            .iter()
+            .map(|request| request.max_output_tokens)
+            .sum::<usize>();
+        for request in requests {
+            core.receive(request);
+        }
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let mut now_ms = 0.0;
+        let mut output_tokens = 0;
+        let mut saw_remove = false;
+        for _ in 0..100 {
+            if core.is_empty() {
+                break;
+            }
+            let pass = core.execute_pass(&mut collector, now_ms);
+            now_ms = pass.end_ms.max(now_ms + 1.0);
+            output_tokens += pass.output_signals.len();
+            saw_remove |= removed_event_count(&pass.kv_events) > 0;
+            harness.apply_events(pass.kv_events).await;
+        }
+
+        assert!(
+            core.is_empty(),
+            "scheduler did not drain: waiting={}, running={}, outputs={output_tokens}, available={}, evictable={}",
+            core.waiting.len(),
+            core.running.len(),
+            core.kv_manager.cache().available_tokens(),
+            core.kv_manager.cache().evictable_size,
+        );
+        assert_eq!(output_tokens, expected_tokens);
+        assert!(core.waiting.is_empty());
+        assert!(core.running.is_empty());
         assert!(saw_remove);
         harness.assert_no_event_errors();
         harness.assert_no_event_warnings();

--- a/lib/mocker/src/scheduler/trtllm/tests.rs
+++ b/lib/mocker/src/scheduler/trtllm/tests.rs
@@ -113,6 +113,8 @@ fn preemption_inducing_workload_never_preempts() {
         .enable_chunked_prefill(true)
         .enable_prefix_caching(false)
         .speedup_ratio(0.0)
+        .aic_nextn(Some(2))
+        .aic_nextn_accept_rates(Some("1,1".to_string()))
         .build()
         .unwrap();
     let mut core = VllmCore::new(args);

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -21,6 +21,7 @@ use crate::common::protocols::{
     WorkerType,
 };
 use crate::common::sequence::ActiveSequence;
+use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
 use crate::common::utils::compute_prefill_handoff_delay_ms;
 use crate::kv_manager::KvManager;
 #[cfg(feature = "kvbm-offload")]
@@ -355,6 +356,7 @@ pub(crate) struct VllmCore {
     dp_rank: u32,
     pub(super) state: SchedulerState,
     pub(super) kv_manager: KvManager,
+    speculative_sampler: Option<SpeculativeDecodeSampler>,
     kv_event_buffer: Option<CapturedRouterEventBuffer>,
 
     /// Requests parked on pending G2→G1 swap-ins. Populated by the
@@ -371,7 +373,11 @@ pub(crate) struct VllmCore {
 
 impl VllmCore {
     pub(crate) fn new(args: MockEngineArgs) -> Self {
-        Self::new_internal(args, 0, None, KvEventPublishers::default())
+        Self::new_internal(args, 0, 0, None, KvEventPublishers::default())
+    }
+
+    pub(crate) fn new_with_worker_id(args: MockEngineArgs, worker_id: WorkerId) -> Self {
+        Self::new_internal(args, 0, worker_id, None, KvEventPublishers::default())
     }
 
     pub(crate) fn new_with_kv_capture(args: MockEngineArgs, worker_id: WorkerId) -> Self {
@@ -379,6 +385,7 @@ impl VllmCore {
         Self::new_internal(
             args,
             0,
+            worker_id,
             Some(buffer),
             KvEventPublishers::new(Some(sink), None),
         )
@@ -389,16 +396,23 @@ impl VllmCore {
         dp_rank: u32,
         kv_event_publishers: KvEventPublishers,
     ) -> Self {
-        Self::new_internal(args, dp_rank, None, kv_event_publishers)
+        Self::new_internal(args, dp_rank, u64::from(dp_rank), None, kv_event_publishers)
     }
 
     fn new_internal(
         args: MockEngineArgs,
         dp_rank: u32,
+        worker_id: WorkerId,
         kv_event_buffer: Option<CapturedRouterEventBuffer>,
         kv_event_publishers: KvEventPublishers,
     ) -> Self {
         let args = args.normalized().expect("invalid MockEngineArgs");
+        let speculative_sampler = args.aic_nextn.map(|nextn| {
+            let rates =
+                normalize_conditional_accept_rates(nextn, args.aic_nextn_accept_rates.as_deref())
+                    .expect("normalized MTP acceptance rates");
+            SpeculativeDecodeSampler::new(rates, args.aic_mtp_seed.wrapping_add(worker_id))
+        });
         Self {
             kv_manager: KvManager::new_with_event_sink(
                 args.num_gpu_blocks,
@@ -409,6 +423,7 @@ impl VllmCore {
             args,
             dp_rank,
             state: SchedulerState::default(),
+            speculative_sampler,
             kv_event_buffer,
             #[cfg(feature = "kvbm-offload")]
             requests_awaiting_swap_in: Vec::new(),
@@ -1229,6 +1244,10 @@ impl VllmCore {
             return (Duration::ZERO, Vec::new());
         }
 
+        if self.speculative_sampler.is_some() {
+            return self.emit_speculative_ready_tokens(ready, collector, decode_start_ms);
+        }
+
         // For prefill workers, the first decode token is produced as part of
         // the prefill forward pass — no separate decode iteration needed.
         let (decode_time, decode_end_ms) = if self.args.worker_type == WorkerType::Prefill {
@@ -1315,6 +1334,203 @@ impl VllmCore {
                 self.state.compact_running();
             }
             return (Duration::ZERO, output_signals);
+        }
+
+        if running_changed {
+            self.state.compact_running();
+        }
+        (decode_time, output_signals)
+    }
+
+    fn emit_speculative_ready_tokens(
+        &mut self,
+        mut ready: Vec<Uuid>,
+        collector: Option<&mut TraceCollector>,
+        decode_start_ms: f64,
+    ) -> (Duration, Vec<OutputSignal>) {
+        let max_burst = if self.args.worker_type == WorkerType::Prefill {
+            1
+        } else {
+            self.args
+                .aic_nextn
+                .expect("speculative sampler requires nextn")
+                + 1
+        };
+        let mut running_changed = false;
+        let mut reservation = loop {
+            let required_blocks = ready
+                .iter()
+                .filter_map(|uuid| self.state.requests.get(uuid))
+                .map(|request| {
+                    let remaining = request
+                        .sequence
+                        .max_output_tokens()
+                        .saturating_sub(request.sequence.generated_tokens());
+                    let burst = max_burst.min(remaining);
+                    let current_blocks = request.sequence.len().div_ceil(self.args.block_size);
+                    let target_blocks =
+                        (request.sequence.len() + burst).div_ceil(self.args.block_size);
+                    target_blocks.saturating_sub(current_blocks)
+                })
+                .sum();
+
+            if let Some(reservation) = self.kv_manager.reserve_decode_blocks(required_blocks) {
+                break reservation;
+            }
+
+            let Some(preempted) = self.policy_preempt() else {
+                if running_changed {
+                    self.state.compact_running();
+                }
+                return (Duration::ZERO, Vec::new());
+            };
+            running_changed = true;
+            for signal in preempted.signals {
+                self.kv_manager.process(&signal);
+            }
+
+            ready.clear();
+            for uuid in self.state.running.iter().copied() {
+                let Some(request) = self.state.requests.get(&uuid) else {
+                    continue;
+                };
+                if request.num_computed_tokens == request.sequence.len()
+                    && request.sequence.generated_tokens() < request.sequence.max_output_tokens()
+                {
+                    ready.push(uuid);
+                }
+            }
+            if ready.is_empty() {
+                self.state.compact_running();
+                return (Duration::ZERO, Vec::new());
+            }
+        };
+
+        let total_length = ready
+            .iter()
+            .filter_map(|uuid| self.state.requests.get(uuid))
+            .map(|request| request.sequence.len())
+            .sum::<usize>();
+        let (decode_time, decode_end_ms) = if self.args.worker_type == WorkerType::Prefill {
+            (Duration::ZERO, decode_start_ms)
+        } else {
+            let active_kv_tokens = self
+                .kv_manager
+                .num_active_blocks()
+                .saturating_sub(reservation.len())
+                * self.args.block_size;
+            let total_kv_tokens = self.args.num_gpu_blocks * self.args.block_size;
+            let context_length = total_length / ready.len();
+            let decode_ms = self.args.perf_model.predict_decode_time(
+                ready.len(),
+                active_kv_tokens,
+                context_length,
+                total_kv_tokens,
+            );
+            let duration = scale_decode_time(decode_ms, &self.args);
+            (duration, decode_start_ms + duration.as_secs_f64() * 1000.0)
+        };
+
+        let sampled_bursts = {
+            let sampler = self
+                .speculative_sampler
+                .as_mut()
+                .expect("speculative sampler checked above");
+            ready
+                .iter()
+                .map(|uuid| {
+                    let request = self
+                        .state
+                        .requests
+                        .get(uuid)
+                        .expect("ready request must remain active");
+                    let remaining = request
+                        .sequence
+                        .max_output_tokens()
+                        .saturating_sub(request.sequence.generated_tokens());
+                    let burst = if self.args.worker_type == WorkerType::Prefill {
+                        remaining.min(1)
+                    } else {
+                        sampler.sample_output_tokens(remaining)
+                    };
+                    (*uuid, burst)
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut output_signals =
+            Vec::with_capacity(sampled_bursts.iter().map(|(_, burst)| *burst).sum());
+        for (uuid, burst) in sampled_bursts {
+            let mut completed = false;
+            for _ in 0..burst {
+                let signals = {
+                    let request = self
+                        .state
+                        .requests
+                        .get_mut(&uuid)
+                        .expect("sampled request must remain active");
+                    request.sequence.generate()
+                };
+                for signal in &signals {
+                    self.kv_manager
+                        .process_decode_signal(signal, &mut reservation);
+                }
+
+                let (is_complete, prompt_tokens) = {
+                    let request = self
+                        .state
+                        .requests
+                        .get_mut(&uuid)
+                        .expect("sampled request must remain active");
+                    let is_complete =
+                        request.sequence.generated_tokens() >= request.sequence.max_output_tokens();
+                    if !is_complete {
+                        request.sequence.commit_allocation(request.sequence.len());
+                    }
+                    (is_complete, request.sequence.num_input_tokens())
+                };
+                output_signals.push(OutputSignal {
+                    uuid,
+                    completed: is_complete,
+                    rejected: false,
+                    handoff_delay_ms: compute_prefill_handoff_delay_ms(
+                        self.args.worker_type,
+                        is_complete,
+                        prompt_tokens,
+                        self.args.kv_transfer_bandwidth,
+                        self.args.kv_bytes_per_token,
+                    ),
+                });
+                if is_complete {
+                    completed = true;
+                    break;
+                }
+            }
+
+            if completed {
+                self.state.complete(&uuid);
+                running_changed = true;
+                continue;
+            }
+
+            let request = self
+                .state
+                .requests
+                .get_mut(&uuid)
+                .expect("nonterminal sampled request must remain active");
+            request.num_computed_tokens = request.sequence.len().saturating_sub(1);
+            request.debug_assert_progress(uuid);
+            debug_assert_eq!(
+                request.sequence.len() - request.num_computed_tokens,
+                1,
+                "nonterminal speculative decode must leave exactly one dangling token"
+            );
+        }
+
+        if let Some(collector) = collector {
+            for signal in &output_signals {
+                collector.on_token(signal.uuid, decode_end_ms);
+            }
         }
 
         if running_changed {

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -421,6 +421,103 @@ mod core_behavior {
         assert!(core.state.running.is_empty());
         assert_eq!(core.kv_manager.num_active_blocks(), 0);
     }
+
+    #[test]
+    fn test_mtp_batch_applies_request_bursts_in_stable_order() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(16)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_prefix_caching(false)
+            .speedup_ratio(0.0)
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("1,1".to_string()))
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let short = Uuid::from_u128(1);
+        let long = Uuid::from_u128(2);
+        core.receive(DirectRequest {
+            tokens: (0..4).collect(),
+            max_output_tokens: 5,
+            uuid: Some(short),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+        });
+        core.receive(DirectRequest {
+            tokens: (100..104).collect(),
+            max_output_tokens: 8,
+            uuid: Some(long),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+        });
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let first = core.execute_pass(&mut collector, 0.0);
+        assert_eq!(first.output_signals.len(), 6);
+        let pass = core.execute_pass(&mut collector, first.end_ms);
+        let ordered = pass
+            .output_signals
+            .iter()
+            .map(|signal| (signal.uuid, signal.completed))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ordered,
+            vec![
+                (short, false),
+                (short, true),
+                (long, false),
+                (long, false),
+                (long, false),
+            ]
+        );
+
+        let request = core.state.requests.get(&long).unwrap();
+        assert_eq!(request.sequence.generated_tokens(), 6);
+        assert_eq!(request.sequence.len() - request.num_computed_tokens, 1);
+        assert_eq!(
+            pass.fpm.unwrap().num_decode_requests,
+            2,
+            "FPM counts requests participating in the forward pass, not emitted tokens"
+        );
+    }
+
+    #[test]
+    fn test_mtp_releases_unused_block_reservations() {
+        let args = MockEngineArgs::builder()
+            .block_size(2)
+            .num_gpu_blocks(8)
+            .max_num_batched_tokens(Some(8))
+            .max_num_seqs(Some(2))
+            .enable_prefix_caching(false)
+            .speedup_ratio(0.0)
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("0,1".to_string()))
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let uuid = Uuid::from_u128(3);
+        core.receive(DirectRequest {
+            tokens: (0..3).collect(),
+            max_output_tokens: 5,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+        });
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let pass = core.execute_pass(&mut collector, 0.0);
+        assert_eq!(pass.output_signals.len(), 1);
+        assert_eq!(
+            core.kv_manager.num_active_blocks(),
+            2,
+            "the block reserved only for rejected drafts must return through RAII"
+        );
+        let request = core.state.requests.get(&uuid).unwrap();
+        assert_eq!(request.sequence.generated_tokens(), 1);
+        assert_eq!(request.sequence.len() - request.num_computed_tokens, 1);
+    }
 }
 
 mod router_events {
@@ -530,6 +627,64 @@ mod router_events {
         harness.assert_no_event_warnings();
         harness.shutdown();
     }
+
+    #[tokio::test]
+    async fn test_mtp_preemption_recompute_drains_with_clean_events() {
+        let harness = RouterIndexerHarness::new(4, ROUTER_TEST_WORKER_ID);
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(6)
+            .max_num_batched_tokens(Some(12))
+            .max_num_seqs(Some(3))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(true)
+            .preemption_mode(PreemptionMode::Lifo)
+            .speedup_ratio(0.0)
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("0,1".to_string()))
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new_with_kv_capture(args, ROUTER_TEST_WORKER_ID);
+        let requests = [
+            (Uuid::from_u128(61), 0u32..8u32),
+            (Uuid::from_u128(62), 100u32..108u32),
+            (Uuid::from_u128(63), 200u32..212u32),
+        ];
+        for (uuid, tokens) in requests {
+            core.receive(DirectRequest {
+                tokens: tokens.collect(),
+                max_output_tokens: 7,
+                uuid: Some(uuid),
+                dp_rank: 0,
+                arrival_timestamp_ms: None,
+            });
+        }
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let mut now_ms = 0.0;
+        let mut output_tokens = 0;
+        let mut saw_remove = false;
+        for _ in 0..200 {
+            if core.is_empty() {
+                break;
+            }
+            let pass = core.execute_pass(&mut collector, now_ms);
+            now_ms = pass.end_ms.max(now_ms + 1.0);
+            output_tokens += pass.output_signals.len();
+            saw_remove |= removed_event_count(&pass.kv_events) > 0;
+            harness.apply_events(pass.kv_events).await;
+        }
+
+        assert!(core.is_empty());
+        assert_eq!(output_tokens, 21);
+        assert!(core.state.waiting.is_empty());
+        assert!(core.state.running.is_empty());
+        assert_eq!(core.kv_manager.num_active_blocks(), 0);
+        assert!(saw_remove);
+        harness.assert_no_event_errors();
+        harness.assert_no_event_warnings();
+        harness.shutdown();
+    }
 }
 
 mod live_scheduler {
@@ -630,6 +785,40 @@ mod live_scheduler {
         // mocker's protocol does not emit router `Removed` events on
         // request completion.
         harness.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_scheduler_mtp_lifecycle_drains_small_blocks() {
+        let (output_tx, mut output_rx) = mpsc::unbounded_channel::<Vec<OutputSignal>>();
+        let args = MockEngineArgs::builder()
+            .num_gpu_blocks(128)
+            .block_size(4)
+            .max_num_batched_tokens(Some(64))
+            .max_num_seqs(Some(16))
+            .speedup_ratio(1000.0)
+            .enable_prefix_caching(false)
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("1,1".to_string()))
+            .build()
+            .unwrap();
+        let scheduler = Scheduler::new(
+            args,
+            0,
+            Some(output_tx),
+            KvEventPublishers::default(),
+            None,
+            FpmPublisher::default(),
+        );
+
+        crate::scheduler::test_utils::assert_scheduler_completes_all(
+            &scheduler,
+            &mut output_rx,
+            24,
+            5,
+            7,
+            false,
+        )
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Model MTP decode rounds with conditional acceptance sampling and atomic burst reservations across mocker engines. Keep AIC timing undiscounted while propagating configuration through live and replay paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added speculative decoding (MTP) support with new configuration options: `--aic-nextn`, `--aic-nextn-accept-rates`, and `--aic-mtp-seed` for enhanced token prediction and sampling control.
  * Introduced conditional acceptance-rate configuration for speculative decoding strategies.

* **Bug Fixes**
  * Fixed ITL sample validation to properly include zero-millisecond inter-token latency measurements.

* **Tests**
  * Expanded test coverage for speculative decoding functionality, configuration propagation, and burst-based token planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->