### PR TITLE
docs(kubernetes): NVLink carries cross-node KV transfer via MNNVL

### DIFF
--- a/docs/kubernetes/disagg-communication-guide.md
+++ b/docs/kubernetes/disagg-communication-guide.md
@@ -10,7 +10,7 @@ This guide explains how prefill and decode workers communicate in Dynamo's disag
 
 ## Summary
 
-- **NVLink cannot be used between Kubernetes pods** due to process isolation and GPU partitioning
+- **NVLink cannot be used between Kubernetes pods on standard nodes** due to process isolation and GPU partitioning (exception: **MNNVL** on GB200/GB300 NVL72 — see table note below)
 - **RDMA (InfiniBand, RoCE, or AWS EFA) is required** for production disaggregated deployments
 - **Without RDMA, expect 200-500x performance degradation** in Time To First Token (TTFT) — observed ~98s TTFT with TCP vs ~200-500ms with RDMA
 - **UCX or libfabric** are the communication layers that NIXL uses to transfer KV cache between workers
@@ -85,10 +85,12 @@ VLLMDecodeWorker:
 
 | Transport | Bandwidth | Latency | Same-Node | Cross-Node | GPU Direct |
 |-----------|-----------|---------|-----------|------------|------------|
-| **NVLink** | 450-900 GB/s | ~µs | ✅ (intra-pod only) | ❌ | ✅ |
+| **NVLink** | 450-900 GB/s | ~µs | ✅ (intra-pod only) | ✅ (via MNNVL) | ✅ |
 | **InfiniBand RDMA** | 20-50 GB/s | ~1 µs | ✅ | ✅ | ✅ (with GPUDirect) |
 | **RoCE RDMA** | 10-25 GB/s | ~2 µs | ✅ | ✅ | ✅ (with GPUDirect) |
 | **TCP** | 1-3 GB/s | ~50 µs | ✅ | ✅ | ❌ (host staging) |
+
+> **MNNVL = Multi-Node NVLink.** On rack-scale NVLink systems (NVIDIA GB200/GB300 NVL72), the NVLink fabric spans nodes, so cross-node KV transfer can use NVLink. On standard nodes (e.g. 8×H100/H200), NVLink stays intra-node and cross-node KV transfer falls back to RDMA.
 
 ### Same-Node Communication
 


### PR DESCRIPTION
## What
Update the transport comparison table in the disaggregated-communication guide: NVLink **Cross-Node** ❌ → **✅ (via MNNVL)**.

## Why
On rack-scale NVLink systems (NVIDIA **GB200/GB300 NVL72/NVL36**), **Multi-Node NVLink (MNNVL)** extends the NVLink fabric across nodes, so prefill↔decode KV-cache transfer can ride NVLink across nodes/pods (UCX `cuda_ipc` transport), not only RDMA. Plain NVLink on standard 8-GPU nodes remains intra-node — hence the `via MNNVL` qualifier.

Verified on a GB300 NVL72 disaggregated run — inter-node UCX/NIXL configs show e.g.:
`inter-node cfg#3 | remote memory write by ucp_put*(multi) from cuda/GPU3 to cuda/dev[0]` over `cuda_ipc/cuda`, alongside RDMA (`rc_mlx5`) for GPU pairs outside the NVLink domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes communication guide regarding NVLink transport capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->