### PR TITLE
fix(parsers): resolve mistral tool-call parity divergences

### DIFF
--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -766,6 +766,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_jailed_stream_mistral_parser_repeated_close_markers() {
+        // Framed Mistral call immediately followed by consecutive [/TOOL_CALLS]
+        // close markers. The jail must consume through ALL adjacent closers so
+        // none leak into trailing content. Regression for the streaming
+        // end-position only advancing past the first close marker.
+        // Input: "[TOOL_CALLS][{...}][/TOOL_CALLS][/TOOL_CALLS]" + " All set."
+        let chunks = vec![
+            create_mock_response_chunk("[TOOL_CALLS]".to_string(), 0),
+            create_mock_response_chunk("[{\"name\": \"get_time\", ".to_string(), 0),
+            create_mock_response_chunk("\"arguments\": {\"timezone\": \"UTC\"}}]".to_string(), 0),
+            create_mock_response_chunk("[/TOOL_CALLS][/TOOL_CALLS]".to_string(), 0),
+            create_mock_response_chunk(" All set.".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+
+        let jail = JailedStream::builder().tool_call_parser("mistral").build();
+
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        // Exactly one tool call; no [/TOOL_CALLS] marker leaks into content.
+        let reconstructed = test_utils::reconstruct_content(&results);
+        assert!(
+            !reconstructed.contains("[/TOOL_CALLS]"),
+            "repeated close markers must not leak into normal_text, got: {reconstructed:?}"
+        );
+        assert_eq!(
+            reconstructed.trim(),
+            "All set.",
+            "only the trailing prose should remain as content"
+        );
+        let tool_calls: Vec<_> = results
+            .iter()
+            .filter(|r| {
+                r.data
+                    .as_ref()
+                    .and_then(|d| d.inner.choices.first())
+                    .and_then(|c| c.delta.tool_calls.as_ref())
+                    .is_some_and(|tc| !tc.is_empty())
+            })
+            .collect();
+        assert_eq!(tool_calls.len(), 1, "should emit exactly one tool call");
+        test_utils::assert_tool_call(
+            tool_calls[0],
+            "get_time",
+            serde_json::json!({"timezone": "UTC"}),
+        );
+    }
+
+    #[tokio::test]
     async fn test_jailed_stream_phi4_parser() {
         // Tests Phi4 format tool call parsing with functools[ pattern
         // Input: "I'll analyze this data. " + "functools[{\"name\": \"analyze_data\", \"arguments\": {\"dataset\": \"sales_data\"}}]" + " Analysis complete."

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -215,10 +215,54 @@ pub(crate) fn try_repair_truncated_json(s: &str) -> Option<String> {
     Some(repaired)
 }
 
+/// Recover the complete leading tool-call objects from an unterminated mistral
+/// JSON array body (e.g. `[{...complete...}, {...truncated`). Parses top-level
+/// `{...}` objects left-to-right with a streaming deserializer and stops at the
+/// first incomplete one, keeping every complete leading call and dropping the
+/// truncated tail. Unlike `try_repair_truncated_json`, it performs no
+/// brace-balancing fabrication, so a half-emitted trailing call is discarded
+/// rather than invented. Returns the verbatim byte spans of the complete
+/// objects (empty when none completed).
+fn recover_leading_complete_objects(json: &str) -> Vec<String> {
+    let trimmed = json.trim();
+    let body = trimmed.strip_prefix('[').unwrap_or(trimmed);
+    let mut out: Vec<String> = Vec::new();
+    let mut remaining = body.trim_start();
+    while !remaining.is_empty() {
+        let mut stream = serde_json::Deserializer::from_str(remaining).into_iter::<Box<RawValue>>();
+        match stream.next() {
+            Some(Ok(rv)) => {
+                let raw = rv.get();
+                if raw.is_empty() || !raw.trim_start().starts_with('{') {
+                    break;
+                }
+                out.push(raw.to_string());
+                remaining = remaining[raw.len()..].trim_start();
+                match remaining.strip_prefix(',') {
+                    Some(rest) => remaining = rest.trim_start(),
+                    None => break,
+                }
+            }
+            _ => break,
+        }
+    }
+    out
+}
+
 fn try_parse_normal_text(input: &str, start_token: &str) -> String {
     // If input contains start token, just take the part before it
     if let Some(idx) = input.find(start_token) {
-        return input[..idx].trim().to_string();
+        let prefix = &input[..idx];
+        // The mistral family ([TOOL_CALLS]) keeps the boundary space before the
+        // marker to match vLLM; every other JSON family trims it. Keyed on the
+        // family's distinctive start token rather than a config field so the
+        // exported `JsonParserConfig` gains no new public member (downstream
+        // struct-literal constructors stay source-compatible).
+        return if start_token == "[TOOL_CALLS]" {
+            prefix.to_string()
+        } else {
+            prefix.trim().to_string()
+        };
     }
 
     // No start token found, return empty string
@@ -436,6 +480,33 @@ pub fn try_tool_call_parse_basic_json(
     // through to truncation recovery.
     if let Some(calls) = parse_calls(json)? {
         return Ok((calls, Some(normal_text)));
+    }
+
+    // mistral optional-close form: an unterminated call (a `[TOOL_CALLS]`
+    // opener with no `[/TOOL_CALLS]` close) whose JSON array did not parse
+    // cleanly above. Recover only the complete leading objects, dropping the
+    // truncated tail with no brace-balancing fabrication; if nothing complete
+    // remains, suppress entirely so the raw `[TOOL_CALLS]...` markup never
+    // leaks into normal_text (consistent incomplete-call handling, matching
+    // hermes). Gated on `allow_eof_recovery` so it only runs at finalize /
+    // batch, never mid-stream, and scoped to mistral via its start token so
+    // other JSON families keep their existing recovery.
+    if config.allow_eof_recovery
+        && config
+            .tool_call_start_tokens
+            .iter()
+            .any(|t| t == "[TOOL_CALLS]")
+        && trimmed.contains("[TOOL_CALLS]")
+        && !trimmed.contains("[/TOOL_CALLS]")
+    {
+        let recovered = recover_leading_complete_objects(json);
+        if !recovered.is_empty()
+            && let Some(calls) = parse_calls(&format!("[{}]", recovered.join(",")))?
+            && !calls.is_empty()
+        {
+            return Ok((calls, Some(normal_text)));
+        }
+        return Ok((vec![], Some(normal_text)));
     }
 
     // Truncation recovery: balance unclosed strings/braces (common

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -270,6 +270,64 @@ pub fn find_tool_call_end_position(chunk: &str, parser_str: Option<&str>) -> Opt
                 } else {
                     parser_key
                 };
+                // mistral's `[/TOOL_CALLS]` close marker is optional, so the
+                // streaming jail can't simply split at the JSON array `]`: if a
+                // `[/TOOL_CALLS]` arrives in a later chunk it would be stranded
+                // as leaked normal_text (TOOLCALLING.stream.1.b / .2 / .3). But
+                // it also can't just wait for the marker, because the bare
+                // `[TOOL_CALLS][...]` form is frequently followed by ordinary
+                // trailing prose that must still stream as content. Decide based
+                // on what trails the JSON body. Guarded to mistral so phi4
+                // (empty end token) and the marker-required families
+                // (hermes / nemotron_deci) keep their existing behavior.
+                // Only the framed form (an explicit `[TOOL_CALLS]` opener) can
+                // strand a later `[/TOOL_CALLS]`; the bare `[{...}]` form keeps
+                // the normal immediate-split behavior so trailing prose still
+                // streams as its own chunk.
+                let has_open_marker = json_config
+                    .tool_call_start_tokens
+                    .iter()
+                    .any(|t| !t.is_empty() && chunk.contains(t.as_str()));
+                if effective_parser == "mistral"
+                    && has_open_marker
+                    && let Some(marker) = json_config
+                        .tool_call_end_tokens
+                        .iter()
+                        .find(|t| !t.is_empty())
+                {
+                    // Full close marker already present: consume through it so
+                    // it is part of the jailed region, never leaked. Advance
+                    // past any consecutive close markers separated only by
+                    // whitespace (e.g. `[/TOOL_CALLS][/TOOL_CALLS]`) so a
+                    // repeated marker isn't stranded as trailing normal_text.
+                    // Mirrors the consecutive-block loop in the hermes branch of
+                    // `find_tool_call_end_position_json`.
+                    if let Some(pos) = chunk.find(marker.as_str()) {
+                        let mut cursor = pos + marker.len();
+                        loop {
+                            let rest = &chunk[cursor..];
+                            let trimmed = rest.trim_start();
+                            if !trimmed.starts_with(marker.as_str()) {
+                                break;
+                            }
+                            let trim_offset = rest.len() - trimmed.len();
+                            cursor += trim_offset + marker.len();
+                        }
+                        return Some(cursor);
+                    }
+                    let json_end =
+                        find_tool_call_end_position_json(chunk, effective_parser, json_config);
+                    let tail = chunk.get(json_end..).unwrap_or("").trim_start();
+                    // Tail empty, or a partial `[/TOOL_CALLS]` still arriving:
+                    // keep the jail open so the marker is consumed once complete
+                    // (or the call is recovered by `finalize()` if the stream
+                    // ends here). Real non-marker prose: split at the JSON body
+                    // end so the trailing content streams normally.
+                    if tail.is_empty() || marker.starts_with(tail) {
+                        return None;
+                    }
+                    return Some(json_end);
+                }
                 Some(find_tool_call_end_position_json(
                     chunk,
                     effective_parser,
@@ -924,7 +982,8 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         let input = r#"Hey How are you? [TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
         let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
-        assert_eq!(content, Some("Hey How are you?".to_string()));
+        // mistral preserves the boundary space before `[TOOL_CALLS]` (matches vLLM).
+        assert_eq!(content, Some("Hey How are you? ".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -977,7 +1036,8 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         let input = r#"Hey How are you? [TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
         let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
-        assert_eq!(content, Some("Hey How are you?".to_string()));
+        // mistral preserves the boundary space before `[TOOL_CALLS]` (matches vLLM).
+        assert_eq!(content, Some("Hey How are you? ".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
         let (name, args) = extract_name_and_args(result[0].clone());

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.2.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.2.yaml
@@ -38,6 +38,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -55,7 +56,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:'
+        normal_text: 'Both: '
       vllm:
         calls:
         - name: get_weather
@@ -68,6 +69,7 @@ cases:
       sglang:
         calls: []
         normal_text: 'Both:'
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -90,6 +92,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.2.b:
     description: Two back-to-back fence pairs — not applicable to this family
     reason: |-

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.4.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.4.yaml
@@ -75,6 +75,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.4.e:
     description: Malformed-prefix recovery — n/a for this family's syntax
     reason: |-

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.5.yaml
@@ -48,12 +48,12 @@ cases:
     - *id002
     expected:
       dynamo:
-        reason: "Dynamo's mistral parser leaves [TOOL_CALLS] in normal_text on missing/orphan end marker (impl-defined recovery)"
         calls: []
-        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
+        normal_text: ''
       vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"loc'
+        reason: vLLM leaves the truncated post-marker JSON body in content; Dynamo suppresses the unterminated [TOOL_CALLS] call and emits empty content.
       sglang:
         calls: []
         normal_text: ''
@@ -91,14 +91,13 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
-        - name: get_weather
-          arguments:
-            location: New York
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments":
           {"location": "New York'
+        reason: vLLM leaves the raw truncated body in content; Dynamo recovers the complete leading call (Boston) and drops the truncated trailing call without fabricating it.
       sglang:
         calls: []
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+        reason: SGLang emits no call and keeps the narration prefix; Dynamo recovers the complete leading call (Boston) and drops the truncated trailing call.

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.6.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.6.yaml
@@ -24,6 +24,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -40,6 +41,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.6.c:
     description: No arguments key
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L514
@@ -55,4 +57,5 @@ cases:
         - name: get_time
           arguments: {}
         normal_text: ''
+        reason: vLLM's mistral_tool_parser fabricates an empty arguments object {} when the 'arguments' key is absent; Dynamo and SGLang drop the call because the required key is missing
       sglang: *id004

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.7.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.7.yaml
@@ -33,6 +33,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -55,6 +56,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -77,6 +79,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.d:
     description: Nested object + array
     ref: dynamo
@@ -106,6 +109,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.e:
     description: Large / deep JSON-edge argument payload
     ref: dynamo
@@ -164,6 +168,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.7.f:
     description: Numeric precision edge preserves integer-like number literal
     ref: inferhub live capture on nvidia/mistralai/mixtral-8x22b-instruct-v01

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.8.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.8.yaml
@@ -22,7 +22,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather. '
       vllm:
         calls:
         - name: get_weather
@@ -32,6 +32,7 @@ cases:
       sglang:
         calls: []
         normal_text: I will check the weather.
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -50,6 +51,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858
@@ -63,7 +65,7 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather. '
       vllm:
         calls:
         - name: get_weather
@@ -73,6 +75,7 @@ cases:
       sglang:
         calls: []
         normal_text: I will check the weather.
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -81,10 +84,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id003
+      dynamo:
         calls: []
-        normal_text: I will check the weather.
+        normal_text: 'I will check the weather. '
       vllm:
         error: 'ValueError: Only one BOT token should have been outputted'
         reason: vLLM mistral_tool_parser raises ValueError on two consecutive [TOOL_CALLS] envelopes
-      sglang: *id003
+      sglang:
+        calls: []
+        normal_text: I will check the weather.
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits; it also trims the boundary whitespace Dynamo now preserves.

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.yaml
@@ -156,6 +156,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.30.c:
     description: Mistral wrapper marker `[TOOL_CALLS]...[/TOOL_CALLS]` text inside one argument string value
     ref: dynamo
@@ -183,6 +184,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.31.a:
     description: Multi-call JSON array with call separator `,` inside the first argument string
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L2736
@@ -264,6 +266,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   TOOLCALLING.batch.13.a:
     description: Unknown-only call under default behavior
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_unknown_tool_name.py#L29

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.1.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.1.yaml
@@ -44,13 +44,20 @@ cases:
       finish_reason: tool_calls
     tools: *id001
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: SGLang's Mistral detector emits no tool call when the [TOOL_CALLS] payload is split across streaming chunks; Dynamo buffers the fragments and recovers the call.
+      vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: '[/TOOL_CALLS]'
-      sglang:
-        calls: []
-        normal_text: ''
-      vllm: *id002
+        reason: vLLM's streaming Mistral parser leaks the trailing [/TOOL_CALLS] close marker into content; Dynamo now keeps the jail open until the marker arrives and consumes it, so normal_text is empty.

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.2.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.2.yaml
@@ -49,10 +49,12 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: '[/TOOL_CALLS]'
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang's Mistral detector emits no tool call when the [TOOL_CALLS] payload is split across streaming chunks; Dynamo buffers the fragments and recovers the calls.
       vllm:
         calls: []
         normal_text: '[TOOL_CAL'
+        reason: vLLM leaks the partial start marker prefix into content when [TOOL_CALLS] is split across chunks and emits no call; Dynamo buffers the marker fragments and recovers the calls with empty normal_text.

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.3.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.3.yaml
@@ -36,10 +36,12 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: '[/TOOL_CALLS]'
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang's Mistral detector emits no tool call when the [TOOL_CALLS] payload is split across streaming chunks; Dynamo buffers the fragments and recovers the call.
       vllm:
         calls: []
         normal_text: '[TOOL_CALL'
+        reason: vLLM leaks the partial start marker prefix into content when [TOOL_CALLS] is split across chunks and emits no call; Dynamo buffers the marker fragments and recovers the call with empty normal_text.

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.4.yaml
@@ -48,7 +48,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
@@ -57,6 +57,7 @@ cases:
         - name: get_weather
           arguments: '{"loc'
         normal_text: ''
+        reason: vLLM emits a malformed partial call with the incomplete argument fragment as arguments; Dynamo suppresses the unterminated call and emits empty content.
   TOOLCALLING.stream.4.c:
     description: Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by
       repeated close markers
@@ -80,3 +81,4 @@ cases:
       sglang:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}[/TOOL_CALLS[/TOOL_CALLS[/TOOL_CALLS'
+        reason: SGLang strips the trailing ] from each orphan [/TOOL_CALLS] close marker (leaving bracket fragments); Dynamo and vLLM keep the bare body and markers verbatim when the [TOOL_CALLS] opener is absent.


### PR DESCRIPTION
## Overview

Drives the Mistral parser-parity row on the M2 dashboard to zero unclassified divergences. Mistral tool calls are `[TOOL_CALLS][ ...json... ][/TOOL_CALLS]`, where the closing marker is optional. Three divergences are real Dynamo bugs fixed here in code (Mistral-only, no other family touched); the rest are cases where Dynamo is already correct and a peer engine differs, now recorded with a `reason:`. Each case below shows the raw model output and the per-engine result.

## Code fixes

### streaming close-marker leak

`stream.1.b` - complete call streamed, `[/TOOL_CALLS]` in its own chunk
```
model output: [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]
before dynamo: calls=[get_weather(location=NYC)]  text="[/TOOL_CALLS]"
after dynamo:  calls=[get_weather(location=NYC)]  text=""
vllm:          calls=[get_weather(location=NYC)]  text="[/TOOL_CALLS]"
sglang:        calls=[]  text=""
```

`stream.2` - multi-call streamed character-by-character
```
model output: [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]
before dynamo: calls=[get_weather(location=NYC), get_time(timezone=EST)]  text="[/TOOL_CALLS]"
after dynamo:  calls=[get_weather(location=NYC), get_time(timezone=EST)]  text=""
vllm:          calls=[]  text="[TOOL_CAL"
sglang:        calls=[]  text=""
```

`stream.3` - single call streamed character-by-character
```
model output: [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]
before dynamo: calls=[get_weather(location=NYC)]  text="[/TOOL_CALLS]"
after dynamo:  calls=[get_weather(location=NYC)]  text=""
vllm:          calls=[]  text="[TOOL_CALL"
sglang:        calls=[]  text=""
```

### keep the boundary space before the marker

`batch.2.c`
```
model output: Both: [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS] Done.
before dynamo: calls=[get_weather(location=NYC), get_time(timezone=EST)]  text="Both:"
after dynamo:  calls=[get_weather(location=NYC), get_time(timezone=EST)]  text="Both: "
vllm:          calls=[get_weather(location=NYC), get_time(timezone=EST)]  text="Both: "
sglang:        calls=[]  text="Both:"
```

`batch.8.a` (and `8.c`, sandwich)
```
model output: I will check the weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]
before dynamo: calls=[get_weather(location=NYC)]  text="I will check the weather."
after dynamo:  calls=[get_weather(location=NYC)]  text="I will check the weather. "
vllm:          calls=[get_weather(location=NYC)]  text="I will check the weather. "
sglang:        calls=[]  text="I will check the weather."
```

`batch.8.d` - two back-to-back envelopes
```
model output: I will check the weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS] Then check LA weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "LA"}}][/TOOL_CALLS]
before dynamo: calls=[]  text="I will check the weather."
after dynamo:  calls=[]  text="I will check the weather. "
vllm:          error: ValueError: Only one BOT token should have been outputted
sglang:        calls=[]  text="I will check the weather."
```

### incomplete or unterminated call suppression

Consistent handling of an unterminated `[TOOL_CALLS]` (opener present, no `[/TOOL_CALLS]` close) whose JSON did not parse cleanly: recover only the complete leading calls (no brace-balancing fabrication) and suppress the truncated tail rather than leaking raw markup. Matches hermes incomplete-call handling.

`batch.5.e` - multi-call, trailing call truncated mid-value
```
model output: I'll start by fetching the weather for both Boston and New York at the same time![TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York
before dynamo: calls=[get_weather(location=Boston), get_weather(location=New York)]  text="I'll start ... at the same time!"
after dynamo:  calls=[get_weather(location=Boston)]  text="I'll start ... at the same time!"
vllm:          calls=[]  text="[{...Boston...}, {...New York"  reason=vLLM leaves the raw truncated body; Dynamo keeps the complete leading call and drops the truncated tail without fabricating it
sglang:        calls=[]  text="I'll start ... at the same time!"  reason=SGLang emits no call and keeps narration; Dynamo keeps the complete leading call
```

`batch.5.c` - single call truncated mid-arguments (no close marker)
```
model output: [TOOL_CALLS][{"name": "get_weather", "arguments": {"loc
before dynamo: calls=[]  text='[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
after dynamo:  calls=[]  text=''
vllm:          calls=[]  text='[{"name": "get_weather", "arguments": {"loc'  reason=vLLM leaves the truncated body in content; Dynamo suppresses the unterminated call
sglang:        calls=[]  text=''
```

`stream.4.b` - stream ends mid-arguments (finish_reason=stop)
```
model output: [TOOL_CALLS][{"name": "get_weather", "arguments": {"loc
before dynamo: calls=[]  text='[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
after dynamo:  calls=[]  text=''
vllm:          calls=[get_weather(arguments='{"loc')]  text=""  reason=vLLM emits a malformed partial call; Dynamo suppresses the unterminated call
sglang:        calls=[]  text=""
```

## Documented divergences (no Dynamo change)

SGLang format mismatch - `batch.2.a, 2.d, 4.d, 6.a, 6.b, 7.a-7.e, 8.b, 30.b, 30.c, 31.b` (representative `7.a`)
```
model output: [TOOL_CALLS][{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}][/TOOL_CALLS]
before dynamo: calls=[book_flight(destination=Paris, passengers=2, first_class=true)]  text=""
after dynamo:  calls=[book_flight(destination=Paris, passengers=2, first_class=true)]  text=""
vllm:          calls=[book_flight(destination=Paris, passengers=2, first_class=true)]  text=""
sglang:        calls=[]  text=""  reason=SGLang accepts only the spaced "[TOOL_CALLS] [...]" form, not the bracket-close form Dynamo emits
```

`batch.6.c` - no `arguments` key
```
model output: [TOOL_CALLS][{"name": "get_time"}][/TOOL_CALLS]
before dynamo: calls=[]  text=""
after dynamo:  calls=[]  text=""
vllm:          calls=[get_time({})]  text=""  reason=vLLM fabricates empty args; Dynamo and SGLang drop the call
sglang:        calls=[]  text=""
```

`stream.4.c` - bare body, no opener, repeated closers (finish_reason=length)
```
model output: [{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]
before dynamo: calls=[]  text='[{...}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]'
after dynamo:  calls=[]  text='[{...}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]'
vllm:          calls=[]  text='[{...}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]'
sglang:        calls=[]  text='[{...}[/TOOL_CALLS[/TOOL_CALLS[/TOOL_CALLS'  reason=SGLang strips the trailing ] from each orphan close marker
```
