### PR TITLE
fix(parser): align qwen25 tool-call parsing with SGLang

### DIFF
--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -51,7 +51,7 @@ pub fn find_tool_call_end_position_json(
     config: &JsonParserConfig,
 ) -> usize {
     match parser {
-        "hermes" | "nemotron_deci" => {
+        "hermes" | "nemotron_deci" | "qwen25" => {
             let start_token = config.tool_call_start_tokens.first().map(|s| s.as_str());
             if let Some(end_token) = config.tool_call_end_tokens.first() {
                 let Some(first_end) = chunk.find(end_token.as_str()) else {
@@ -189,6 +189,33 @@ mod tests {
             pos_inc, first_end,
             "should stop at end of first complete call when second is incomplete"
         );
+    }
+
+    // qwen25 aliases the hermes config and must share its jail behavior: two
+    // parallel <tool_call> blocks must be captured as one region, otherwise the
+    // second call's opener leaks into normal_text when split across stream
+    // chunks (e.g. `ol_call>...`). Regression for the qwen25 streaming leak.
+    #[test] // TOOLCALLING.stream.2: qwen25 parallel-call end-position
+    fn test_find_tool_call_end_position_parallel_calls_qwen25() {
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<tool_call>".to_string()],
+            tool_call_end_tokens: vec!["</tool_call>".to_string()],
+            ..Default::default()
+        };
+
+        // Two parallel calls in the qwen2.5 newline-delimited form.
+        let two_calls = concat!(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"NYC\"}}\n</tool_call>\n",
+            "<tool_call>\n{\"name\": \"get_time\", \"arguments\": {\"timezone\": \"EST\"}}\n</tool_call>",
+            "trailing"
+        );
+        let pos = find_tool_call_end_position_json(two_calls, "qwen25", &config);
+        assert!(
+            two_calls[..pos].ends_with("</tool_call>"),
+            "qwen25 should end at last </tool_call>, got: {:?}",
+            &two_calls[..pos]
+        );
+        assert_eq!(&two_calls[pos..], "trailing");
     }
 
     // Bare DeepSeek inner calls (no outer <｜tool▁calls▁begin｜> wrapper) arriving

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -58,7 +58,7 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("gemma-4", ToolCallConfig::gemma4());
         map.insert("default", ToolCallConfig::default());
         map.insert("nemotron_nano", ToolCallConfig::qwen3_coder()); // nemotron nano follows qwen3_coder format
-        map.insert("qwen25", ToolCallConfig::hermes()); // qwen2.5 uses the same <tool_call>...</tool_call> format as hermes
+        map.insert("qwen25", ToolCallConfig::hermes()); // qwen2.5 uses the same <tool_call>...</tool_call> format as hermes; EOF-recovery opt-out is keyed by name in detect_and_parse_tool_call_with_recovery_options
         map
     })
 }
@@ -148,7 +148,10 @@ pub async fn detect_and_parse_tool_call_with_recovery(
     let recovery_config = match &base.parser_config {
         ParserConfig::Json(c) => {
             let mut c = c.clone();
-            c.allow_eof_recovery = true;
+            // qwen25 opts out of EOF recovery so unterminated calls are dropped,
+            // not salvaged. Keyed by name (not a config field) to keep the
+            // exported JsonParserConfig stable for downstream callers.
+            c.allow_eof_recovery = parser_key != "qwen25";
             ParserConfig::Json(c)
         }
         ParserConfig::Xml(c) => {
@@ -170,7 +173,21 @@ pub async fn detect_and_parse_tool_call_with_recovery(
         parser_config: recovery_config,
         structural_tag_builder: None,
     };
-    try_tool_call_parse(message, &cfg, tools).await
+    let (calls, normal_text) = try_tool_call_parse(message, &cfg, tools).await?;
+
+    // An unterminated qwen25 call (open <tool_call>, no close, nothing parsed)
+    // drops its partial markup instead of leaking it. Deliberate non-parity
+    // with SGLang, which surfaces the raw text.
+    if parser_key == "qwen25"
+        && calls.is_empty()
+        && let Some(text) = normal_text.as_deref()
+        && text.contains("<tool_call>")
+        && !text.contains("</tool_call>")
+    {
+        return Ok((calls, Some(String::new())));
+    }
+
+    Ok((calls, normal_text))
 }
 
 /// Deprecated compatibility shim retained for the published `dynamo-parsers`

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.2.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.2.yaml
@@ -7,17 +7,21 @@ cases:
   TOOLCALLING.batch.2.a:
     description: Parallel calls (back-to-back tool_call wrappers)
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
-      "arguments": {"timezone": "EST"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call><tool_call>
+      {"name": "get_time", "arguments": {"timezone": "EST"}}
+      </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -25,7 +29,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -36,20 +40,24 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-          "get_time", "arguments": {"timezone": "EST"}}</tool_call>'
+      sglang: *id001
+  TOOLCALLING.batch.2.b:
+    description: Two back-to-back fence pairs - not applicable to this family
+    reason: Multi-call is covered by 2.a/2.c/2.d; no back-to-back fence pattern for this family.
   TOOLCALLING.batch.2.c:
     description: With surrounding narration
     ref: dynamo
-    model_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-      "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.'
+    model_text: |-
+      Both: <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call><tool_call>
+      {"name": "get_time", "arguments": {"timezone": "EST"}}
+      </tool_call> Done.
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -60,20 +68,21 @@ cases:
         normal_text: 'Both:'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-          "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.'
+      sglang: *id004
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
-      "arguments": {"location": "LA"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call><tool_call>
+      {"name": "get_weather", "arguments": {"location": "LA"}}
+      </tool_call>
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -84,11 +93,4 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-          "get_weather", "arguments": {"location": "LA"}}</tool_call>'
-  TOOLCALLING.batch.2.b:
-    description: Two back-to-back fence pairs — not applicable to this family
-    reason: |-
-      qwen25's multi-call form is exercised by TOOLCALLING.batch.2.a / 2.c / 2.d; no back-to-back fence/wrapper pattern applies to this family's parser syntax.
+      sglang: *id005

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.4.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.4.yaml
@@ -18,7 +18,6 @@ cases:
             type: string
     expected:
       dynamo: &id001
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves <tool_call> tag in normal_text on malformed input (impl-defined recovery)"
         calls: []
         normal_text: <tool_call>not even json</tool_call>
       vllm:
@@ -31,17 +30,12 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
+      dynamo: &id003
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
+      sglang: *id003
   TOOLCALLING.batch.4.c:
     description: Missing name key
     ref: dynamo
@@ -49,13 +43,12 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves <tool_call> tag in normal_text on malformed input (impl-defined recovery)"
+      dynamo: &id004
         calls: []
         normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id003
+      sglang: *id004
   TOOLCALLING.batch.4.d:
     description: Missing </tool_call> close
     ref: dynamo
@@ -63,22 +56,19 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      dynamo:
+        calls: []
+        normal_text: ''
       sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
   TOOLCALLING.batch.4.e:
-    description: Malformed-prefix recovery — n/a for this family's syntax
-    reason: |-
-      TOOLCALLING.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in TOOLCALLING.batch.4.a through 4.d.
+    description: Malformed-prefix recovery - n/a for this family's syntax
+    reason: 'n/a: llama3_json-specific raw-JSON-prefix resync; this family uses a framed grammar (see 4.a-4.d).'
   TOOLCALLING.batch.4.f:
     description: Tool-name XML tag case - n/a for this family's syntax
-    reason: |-
-      TOOLCALLING.batch.4.f is specific to Qwen3-Coder XML syntax, where the model may emit a tool-name tag such as <terminal> inside <tool_call> instead of the required <function=Terminal> opener. This family does not use Qwen3-Coder's <function=...> opener.
+    reason: 'n/a: Qwen3-Coder <function=...> XML syntax, not this family''s format.'

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.5.yaml
@@ -17,15 +17,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      dynamo:
+        calls: []
+        normal_text: ''
       sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
   TOOLCALLING.batch.5.b:
@@ -36,7 +35,6 @@ cases:
     - *id001
     expected:
       dynamo: &id002
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves closing </tool_call> tag plus the JSON body in normal_text when opening <tool_call> marker is missing (impl-defined recovery)"
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
       vllm:
@@ -49,22 +47,28 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id003
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves closing </tool_call> tag plus the JSON body in normal_text when opening <tool_call> marker is missing (impl-defined recovery)"
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id003
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
   TOOLCALLING.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
     ref: dynamo
-    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather",
-      "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York"}}'
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>
+      {"name": "get_weather", "arguments": {"location": "Boston"}}
+      </tool_call><tool_call>
+      {"name": "get_weather", "arguments": {"location": "New York"}}
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
@@ -72,20 +76,19 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
-          "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
-          "New York"}}'
+      sglang: *id003
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
-    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather",
-      "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York'
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>
+      {"name": "get_weather", "arguments": {"location": "Boston"}}
+      </tool_call><tool_call>
+      {"name": "get_weather", "arguments": {"location": "New York
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -93,8 +96,4 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
-          "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
-          "New York'
+      sglang: *id004

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.6.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.6.yaml
@@ -7,52 +7,53 @@ cases:
   TOOLCALLING.batch.6.a:
     description: 'Canonical "arguments": {}'
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_time", "arguments": {}}
+      </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
+      sglang: *id001
   TOOLCALLING.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_time", "arguments": { }}
+      </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>'
+      sglang: *id003
   TOOLCALLING.batch.6.c:
     description: No arguments key
     ref: dynamo
     model_text: '<tool_call>{"name": "get_time"}</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &id002
-        reason: "Dynamo's qwen25 (hermes alias) parser leaves <tool_call> tag in normal_text on minimal/no-body case"
+      dynamo: &id004
         calls: []
         normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id002
+      sglang: *id004

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.7.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.7.yaml
@@ -7,8 +7,10 @@ cases:
   TOOLCALLING.batch.7.a:
     description: Standard scalar types
     ref: dynamo
-    model_text: '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
-      true}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}
+      </tool_call>
     tools:
     - name: book_flight
       parameters:
@@ -21,7 +23,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -31,14 +33,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
-          true}}</tool_call>'
+      sglang: *id001
   TOOLCALLING.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}
+      </tool_call>
     tools:
     - name: get_weather
       parameters:
@@ -47,7 +49,7 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
@@ -55,13 +57,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}</tool_call>'
+      sglang: *id002
   TOOLCALLING.batch.7.c:
-    description: Schema mismatch — string value where schema declares integer
+    description: Schema mismatch - string value where schema declares integer
     ref: dynamo
-    model_text: '<tool_call>{"name": "set_temperature", "arguments": {"celsius": "20"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "set_temperature", "arguments": {"celsius": "20"}}
+      </tool_call>
     tools:
     - name: set_temperature
       parameters:
@@ -70,7 +73,7 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
@@ -78,13 +81,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "set_temperature", "arguments": {"celsius": "20"}}</tool_call>'
+      sglang: *id003
   TOOLCALLING.batch.7.d:
     description: Nested object + array
     ref: dynamo
-    model_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}
+      </tool_call>
     tools:
     - name: process_data
       parameters:
@@ -95,7 +99,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -108,14 +112,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>'
+      sglang: *id004
   TOOLCALLING.batch.7.e:
     description: Large / deep JSON-edge argument payload
     ref: dynamo
-    model_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
-      3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}
+      </tool_call>
     tools:
     - name: process_data
       parameters:
@@ -124,7 +128,7 @@ cases:
           payload:
             type: object
     expected:
-      dynamo:
+      dynamo: &id005
         calls:
         - name: process_data
           arguments:
@@ -147,14 +151,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
-          2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'
+      sglang: *id005
   TOOLCALLING.batch.7.f:
     description: Numeric precision edge preserves integer-like number literal
     ref: https://qwen.readthedocs.io/en/v2.5/framework/function_call.html
-    model_text: '<tool_call>{"name": "set_limit", "arguments": {"count": 9007199254740993}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "set_limit", "arguments": {"count": 9007199254740993}}
+      </tool_call>
     tools:
     - name: set_limit
       parameters:
@@ -163,7 +167,7 @@ cases:
           count:
             type: number
     expected:
-      dynamo:
+      dynamo: &id006
         calls:
         - name: set_limit
           arguments:
@@ -171,7 +175,4 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        reason: SGLang's Qwen2.5 detector requires newline-delimited '<tool_call>\n...\n</tool_call>' blocks; this fixture uses Dynamo's compact inline '<tool_call>{...}</tool_call>' form, so SGLang treats it as normal text.
-        calls: []
-        normal_text: '<tool_call>{"name": "set_limit", "arguments": {"count": 9007199254740993}}</tool_call>'
+      sglang: *id006

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.8.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.8.yaml
@@ -7,9 +7,12 @@ cases:
   TOOLCALLING.batch.8.a:
     description: Narration before tool call only
     ref: dynamo
-    model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    model_text: |-
+      I will check the weather. <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,7 +20,7 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -25,18 +28,18 @@ cases:
         normal_text: I will check the weather.
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+      sglang: *id001
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Let me know if you need
-      more.'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
@@ -44,19 +47,18 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Let me know if you
-          need more.'
+      sglang: *id003
   TOOLCALLING.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
-    model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
-      Let me know if you need more.'
+    model_text: |-
+      I will check the weather. <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -64,19 +66,20 @@ cases:
         normal_text: I will check the weather.
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
-          Let me know if you need more.'
+      sglang: *id004
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
-    model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
-      Then check LA weather. <tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>'
+    model_text: |-
+      I will check the weather. <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call> Then check LA weather. <tool_call>
+      {"name": "get_weather", "arguments": {"location": "LA"}}
+      </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -87,7 +90,4 @@ cases:
         normal_text: I will check the weather.
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
-          Then check LA weather. <tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>'
+      sglang: *id005

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.batch.yaml
@@ -7,9 +7,12 @@ mode: batch
 cases:
   TOOLCALLING.batch.1:
     description: Single tool call (happy path)
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,7 +20,7 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -25,21 +28,19 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+      sglang: *id001
   TOOLCALLING.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &id002
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id002
+      sglang: *id003
   TOOLCALLING.batch.9.a:
     description: Empty model text
     model_text: ''
@@ -81,12 +82,16 @@ cases:
         normal_text: '   '
   TOOLCALLING.batch.10:
     description: Duplicate calls (same name twice)
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
-      "arguments": {"location": "LA"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "get_weather", "arguments": {"location": "NYC"}}
+      </tool_call><tool_call>
+      {"name": "get_weather", "arguments": {"location": "LA"}}
+      </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo:
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -97,22 +102,14 @@ cases:
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
-          "get_weather", "arguments": {"location": "LA"}}</tool_call>'
-  TOOLCALLING.batch.30:
-    description: Separator-character case not applicable
-    reason: |-
-      This case is not applicable to qwen25 because it wraps each JSON object in <tool_call>, not a delimiter-separated call body.
-  TOOLCALLING.batch.31:
-    description: Multi-call separator-character case not applicable
-    reason: |-
-      This case is not applicable to qwen25 because it wraps each JSON object in <tool_call>, not a delimiter-separated call body.
+      sglang: *id004
   TOOLCALLING.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
-    model_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location": "NYC"}}</tool_call>'
+    model_text: |-
+      <tool_call>
+      {"name": "unknown_tool", "arguments": {"location": "NYC"}}
+      </tool_call>
     tools:
     - name: get_weather
       parameters:
@@ -121,19 +118,24 @@ cases:
           location:
             type: string
     expected:
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
       dynamo:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-      vllm:
-        unavailable: vLLM has no parser for family='qwen25'
       sglang:
+        reason: SGLang drops tool calls whose name is absent from the supplied tools; Dynamo forwards the call regardless.
         calls: []
-        normal_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location": "NYC"}}</tool_call>'
-        reason: SGLang treats the unknown qwen25 tool call as ordinary content rather than forwarding it by default.
+        normal_text: ''
   TOOLCALLING.batch.13.c:
     description: Mixed known and unknown calls not applicable
-    reason: |-
-      This case is not applicable to qwen25 because vLLM has no peer parser and SGLang treats this family as ordinary content.
+    reason: 'n/a: no vLLM peer; SGLang treats unknown calls as content.'
+  TOOLCALLING.batch.30:
+    description: Separator-character case not applicable
+    reason: 'n/a: this family wraps each call in <tool_call>, not a delimiter-separated body.'
+  TOOLCALLING.batch.31:
+    description: Multi-call separator-character case not applicable
+    reason: 'n/a: this family wraps each call in <tool_call>, not a delimiter-separated body.'

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.stream.1.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.stream.1.yaml
@@ -9,10 +9,13 @@ cases:
     description: Complete tool-call payload delivered in one content chunk
     ref: derived from TOOLCALLING.batch.1
     chunks:
-    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    - delta_text: |-
+        <tool_call>
+        {"name": "get_weather", "arguments": {"location": "NYC"}}
+        </tool_call>
     - delta_text: ''
       finish_reason: tool_calls
-    tools: &id001
+    tools: &id002
     - name: get_weather
       parameters:
         type: object
@@ -20,37 +23,36 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      sglang: *id001
   TOOLCALLING.stream.1.b:
     description: Complete tool call split across parser-significant boundaries
     ref: derived from TOOLCALLING.batch.1
     chunks:
-    - delta_text: <tool_call>
+    - delta_text: |
+        <tool_call>
     - delta_text: '{"name": "get_weather", '
     - delta_text: '"arguments": {"location": "NYC"}}'
-    - delta_text: </tool_call>
+    - delta_text: |2-
+
+        </tool_call>
     - delta_text: ''
       finish_reason: tool_calls
-    tools: *id001
+    tools: *id002
     expected:
-      dynamo:
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      sglang: *id003

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.stream.2.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.stream.2.yaml
@@ -9,23 +9,21 @@ cases:
     description: Multiple tool calls split across multiple content chunks
     ref: derived from TOOLCALLING.batch.2.a
     chunks:
-    - delta_text: <tool_cal
-    - delta_text: l>{"nam
+    - delta_text: |-
+        <tool_call>
+        {"nam
     - delta_text: 'e": "get_weat'
-    - delta_text: her",
-    - delta_text: ' "arguments": {"l'
-    - delta_text: oca
-    - delta_text: 'tion": "N'
-    - delta_text: YC"}}</
-    - delta_text: tool_call><to
-    - delta_text: ol_ca
-    - delta_text: 'll>{"name": "get_'
-    - delta_text: tim
-    - delta_text: e", "argu
-    - delta_text: 'ments":'
-    - delta_text: ' {"timezone":'
-    - delta_text: ' "EST'
-    - delta_text: '"}}</tool_call>'
+    - delta_text: 'her", "arguments": {"location": "NYC"}}'
+    - delta_text: |2-
+
+        </tool_call><to
+    - delta_text: |-
+        ol_call>
+        {"name": "get_time"
+    - delta_text: ', "arguments": {"timezone": "EST"}}'
+    - delta_text: |2-
+
+        </tool_call>
     - delta_text: ''
       finish_reason: tool_calls
     tools:
@@ -42,15 +40,15 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo:
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'ol_call>{"name": "get_time", "arguments": {"timezone": "EST"}}</tool_call>'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}<tool_call>{"name": "get_time",
-          "arguments": {"timezone": "EST"}}'
-      vllm:
-        unavailable: vLLM has no parser for family='qwen25'
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang: *id001

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.stream.3.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.stream.3.yaml
@@ -11,14 +11,17 @@ cases:
     chunks:
     - delta_text: <t
     - delta_text: ool
-    - delta_text: _call
-    - delta_text: '>{"name": "'
+    - delta_text: |-
+        _call>
+        {"name": "
     - delta_text: get_weather", "argu
     - delta_text: me
     - delta_text: nts
     - delta_text: '": {"'
     - delta_text: 'location": '
-    - delta_text: '"NYC"}}</tool_call>'
+    - delta_text: |-
+        "NYC"}}
+        </tool_call>
     - delta_text: ''
       finish_reason: tool_calls
     tools:
@@ -29,14 +32,12 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      sglang: *id001

--- a/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen25/TOOLCALLING.stream.4.yaml
@@ -20,17 +20,16 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
   TOOLCALLING.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from TOOLCALLING.batch.5.c
@@ -47,12 +46,16 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
-      sglang: *id001
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        reason: 'Incomplete call (open <tool_call>, no close): Dynamo suppresses to empty, SGLang keeps raw. Non-parity by
+          design.'
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
   TOOLCALLING.stream.4.c:
     description: Stream reaches length after a valid inner tool-call body without the required outer wrapper, followed by
       repeated close markers
@@ -75,5 +78,6 @@ cases:
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
+        reason: 'Orphan </tool_call> markers with no opener: SGLang strips them, Dynamo keeps them (impl-defined recovery).'
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'


### PR DESCRIPTION
## Overview

Makes Dynamo's qwen2.5 tool-call output agree with SGLang on the parity dashboard, with a few deliberate exceptions. Changes: fixtures now use the spec newline `<tool_call>` form the model actually emits (SGLang only parses that); a streaming jail leak on parallel calls is fixed; and qwen2.5 now suppresses incomplete (unterminated) tool calls, emitting empty content rather than leaking the partial markup, for consistent suppression across the hermes parser family. The suppression deliberately diverges from SGLang (which surfaces the raw partial text) and is documented as non-parity. Two more cases (orphan close-markers, and an unknown tool name) stay divergent by design and are documented. All scoped by parser name so the shared hermes parser is untouched. vLLM has no qwen2.5 parser (n/a throughout).

## Case 1: Well-formed call, newline format (`batch.1`; same for parallel / narration / unicode / nested / bigint and `stream.1.a/1.b/3`)

```
model output: <tool_call>\n{"name": "get_weather", "arguments": {"location": "NYC"}}\n</tool_call>
before dynamo: calls=[get_weather{location: NYC}], normal_text=""
after dynamo: calls=[get_weather{location: NYC}], normal_text=""
vllm: n/a (no qwen25 parser)
sglang: calls=[get_weather{location: NYC}], normal_text=""
```
Fixture previously used a compact one-line form the model never emits; the spec newline form is what lets SGLang parse it (it returned 0 calls plus raw echo before).

## Case 2: Parallel calls, opener split across stream chunks (`stream.2`)

```
model output: <tool_call>\n{...get_weather...NYC...}\n</tool_call><tool_call>\n{...get_time...EST...}\n</tool_call>  (streamed; 2nd opener split as "</tool_call><to" + "ol_call>")
before dynamo: calls=[get_weather{NYC}], normal_text="ol_call>{\"name\": \"get_time\", \"arguments\": {\"timezone\": \"EST\"}}</tool_call>"
after dynamo: calls=[get_weather{NYC}, get_time{EST}], normal_text=""
vllm: n/a (no qwen25 parser)
sglang: calls=[get_weather{NYC}, get_time{EST}], normal_text=""
```
The streaming jail recognized the parallel-call pattern for `hermes` but not its `qwen25` alias, so the second call's split opener leaked into text.

## Case 3: Malformed JSON body, complete wrapper (`batch.4.b`)

```
model output: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>
before dynamo: calls=[get_weather{NYC}], normal_text=""  (leniently recovered)
after dynamo: calls=[], normal_text='<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
vllm: n/a (no qwen25 parser)
sglang: calls=[], normal_text='<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
```
Wrapper is complete (`<tool_call>...</tool_call>`) but the JSON is malformed; dropped and the raw text kept, which matches SGLang.

## Case 4: Incomplete (unterminated) call, no close marker, suppressed (`batch.5.a`; also `batch.4.d`, `batch.5.c`, `stream.4.a`, `stream.4.b`)

```
model output: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}
before dynamo: calls=[get_weather{NYC}], normal_text=""  (EOF-recovered)
after dynamo: calls=[], normal_text=""  (suppressed: opener with no close, nothing recovered)
vllm: n/a (no qwen25 parser)
sglang: calls=[], normal_text='<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'  (keeps raw, non-parity by design)
```
Covers every "opening `<tool_call>` with no matching close" case, both complete-body (`4.d`/`5.a`/`stream.4.a`) and truncated-body (`5.c`/`stream.4.b`). Dynamo deliberately suppresses (empty `normal_text`) for consistent suppression across the hermes family; SGLang keeps the raw partial markup, so each case carries a `reason:` documenting the intentional non-parity. Scoped to qwen2.5 by parser name; hermes keeps its lenient recovery.

## Case 5: Orphan close-markers, no opener, documented divergence (`stream.4.c`)

```
model output: {"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>
before dynamo: calls=[], normal_text='{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
after dynamo: calls=[], normal_text='{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
vllm: n/a (no qwen25 parser)
sglang: calls=[], normal_text='{"name": "get_weather", "arguments": {"location": "NYC"}}'
```
Impl-defined recovery: SGLang strips the dangling close-markers, Dynamo keeps them. Documented as non-parity, not aligned.

## Case 6: Unknown tool name, absent from supplied tools, documented divergence (`batch.13`)

```
model output: <tool_call>\n{"name": "unknown_tool", "arguments": {"location": "NYC"}}\n</tool_call>
before dynamo: calls=[unknown_tool{location: NYC}], normal_text=""
after dynamo: calls=[unknown_tool{location: NYC}], normal_text=""
vllm: n/a (no qwen25 parser)
sglang: calls=[], normal_text=""  (drops the call: name not in supplied tools)
```
Migrated to the spec newline form like the rest of the family. SGLang drops tool calls whose name is absent from the supplied tools; Dynamo forwards the call regardless. Documented as non-parity.
