### PR TITLE
fix(parsers): resolve hermes tool-call parity divergences

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -1569,9 +1569,12 @@ mod tests {
         assert!(result.is_ok());
         let response = result.unwrap();
         let choice = &response.inner.choices[0];
+        // hermes preserves the narration before a tool call verbatim (to match
+        // vLLM), so the newline separating "hello" from the <tool_call> opener
+        // is kept rather than trimmed.
         assert_eq!(
             choice.message.content,
-            Some(ChatCompletionMessageContent::Text("hello".to_string()))
+            Some(ChatCompletionMessageContent::Text("hello\n".to_string()))
         );
         assert_eq!(
             choice.finish_reason,

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -1383,17 +1383,22 @@ mod tests {
             "Inner response created should carry forward from real stream chunks, not be 0"
         );
 
-        // Verify accumulated content is returned
+        // The hermes parser drops an unterminated tool-call buffer on stream
+        // finalize rather than leaking it (the call never completed). The
+        // released chunk therefore carries the preserved metadata above but no
+        // leaked `<tool_call>` markup or partial body in its content.
         let content = &inner.inner.choices[0].delta.content;
-        assert!(content.is_some(), "Should have accumulated content");
-        let content = content.as_ref().unwrap();
+        let text = content
+            .as_ref()
+            .map(|c| test_utils::extract_text(c).to_string())
+            .unwrap_or_default();
         assert!(
-            test_utils::extract_text(content).contains("<tool_call>"),
-            "Should contain jail start marker in accumulated content"
+            !text.contains("<tool_call>"),
+            "Partial tool-call markup must not leak into content on stream end; got {text:?}"
         );
         assert!(
-            test_utils::extract_text(content).contains("incomplete_call"),
-            "Should contain accumulated incomplete content"
+            !text.contains("incomplete_call"),
+            "Incomplete tool-call body must not leak into content on stream end; got {text:?}"
         );
     }
 

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -64,6 +64,49 @@ pub struct JsonParserConfig {
     /// trailing marker as leaked text on the next chunk.
     #[serde(default)]
     pub strip_markup_on_recovery: bool,
+
+    /// Keep the narration before a tool call verbatim instead of trimming it,
+    /// to match vLLM. Per-family rather than token-keyed because hermes and
+    /// qwen2.5 share `<tool_call>` but only hermes keeps the space.
+    #[serde(default)]
+    pub preserve_normal_text_whitespace: bool,
+
+    /// Brace-balance a truncated JSON body and retry the parse on the finalize
+    /// path. Default `true` keeps the recovery used by most JSON families;
+    /// hermes sets `false` to drop a malformed body, as vLLM/SGLang do.
+    #[serde(default = "default_true")]
+    pub repair_truncated_body: bool,
+
+    /// Drop a fully-framed wrapper whose body is complete valid JSON but not a
+    /// usable call (no name, or no arguments/parameters) instead of leaking the
+    /// wrapper into normal_text (4.c / 6.c). A non-JSON or truncated body is not
+    /// a complete object, so it is unaffected here. Default `false`.
+    #[serde(default)]
+    pub drop_unusable_json_wrapper: bool,
+
+    /// Suppress an unterminated tool-call buffer on the recovery path: when an
+    /// opener has no closing end-token and no call is recovered, hide the
+    /// dangling markup (empty normal_text) instead of leaking it. Default
+    /// `false`.
+    #[serde(default)]
+    pub drop_partial_markup_on_stream_finalize: bool,
+
+    /// Recover a final unclosed call with a complete body that follows closed
+    /// calls (5.d). Default `false`; hermes leaves it off and drops the trailing
+    /// call, like its per-wrapper peers (kimi/glm/deepseek).
+    #[serde(default)]
+    pub recover_trailing_unclosed_call: bool,
+
+    /// Recover a single call whose body is complete but whose end-token never
+    /// arrived, via EOF recovery. Default `true` keeps the universal recovery;
+    /// hermes sets `false` to drop an unfinished single call (deliberate, not
+    /// vLLM/SGLang parity).
+    #[serde(default = "default_true")]
+    pub recover_unclosed_single_call: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Default for JsonParserConfig {
@@ -78,6 +121,12 @@ impl Default for JsonParserConfig {
             bare_json_mode: false,
             allow_eof_recovery: false,
             strip_markup_on_recovery: false,
+            preserve_normal_text_whitespace: false,
+            repair_truncated_body: true,
+            drop_unusable_json_wrapper: false,
+            drop_partial_markup_on_stream_finalize: false,
+            recover_trailing_unclosed_call: false,
+            recover_unclosed_single_call: true,
         }
     }
 }
@@ -387,6 +436,17 @@ impl ToolCallConfig {
             parser_config: ParserConfig::Json(JsonParserConfig {
                 tool_call_start_tokens: vec!["<tool_call>".to_string()],
                 tool_call_end_tokens: vec!["</tool_call>".to_string()],
+                // Hermes keeps narration verbatim like vLLM, and otherwise
+                // refuses to invent calls from incomplete input: it drops
+                // malformed bodies, unusable wrappers, and any unterminated
+                // call (single, trailing, or mid-stream) rather than recovering
+                // or leaking. See each flag's doc for the cross-impl rationale.
+                preserve_normal_text_whitespace: true,
+                repair_truncated_body: false,
+                drop_unusable_json_wrapper: true,
+                drop_partial_markup_on_stream_finalize: true,
+                recover_trailing_unclosed_call: false,
+                recover_unclosed_single_call: false,
                 ..Default::default()
             }),
             structural_tag_builder: Some(StructuralTagBuilder::TriggeredTags(

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -79,6 +79,51 @@ fn extract_tool_call_content_eof_recovery(input: &str, start_token: &str) -> Opt
     }
 }
 
+/// Return the comma-separated element list of a JSON-array string with its
+/// outer `[` / `]` removed, or the string unchanged if it is not a bracketed
+/// array. Used to flatten head/trailing bodies before re-wrapping them into a
+/// single array, so an empty `[]` or an already-array side can't produce
+/// invalid JSON. `[` and `]` are ASCII, so the slice indices are char-safe.
+fn unwrap_json_array(s: &str) -> &str {
+    let t = s.trim();
+    if t.starts_with('[') && t.ends_with(']') && t.len() >= 2 {
+        t[1..t.len() - 1].trim()
+    } else {
+        t
+    }
+}
+
+/// Multi-call trailing recovery. When the model emits one or more complete
+/// `<start>...<end>` blocks followed by a final `<start>{...}` whose closing
+/// `<end>` marker never arrived (e.g. truncation dropped only the end token),
+/// the regex extractor matches only the closed blocks and the final call is
+/// lost. vLLM and SGLang recover that trailing call when its body is complete
+/// (TOOLCALLING.batch.5.d), so mirror that on the finalize path.
+///
+/// The trailing body MUST parse cleanly with no truncation repair: a trailing
+/// call whose JSON body is itself incomplete (5.e) returns `None` here and is
+/// left dropped, consistent with the no-malformed-body-repair policy. Returns
+/// the verbatim trailing body string when recoverable.
+fn recover_trailing_clean_body(input: &str, start_token: &str, end_token: &str) -> Option<String> {
+    // Scan the region after the last complete end token for a dangling start.
+    let after_last_end = input
+        .rfind(end_token)
+        .map(|p| p + end_token.len())
+        .unwrap_or(0);
+    let tail = &input[after_last_end..];
+    let start_pos = tail.find(start_token)?;
+    let body = tail[start_pos + start_token.len()..].trim();
+    if !body.starts_with('{') && !body.starts_with('[') {
+        return None;
+    }
+    // Validate the body parses as-is (no repair). parse_calls returns
+    // Some(non-empty) only for a recognized, complete tool-call shape.
+    match parse_calls(body) {
+        Ok(Some(calls)) if !calls.is_empty() => Some(body.to_string()),
+        _ => None,
+    }
+}
+
 // Special case for <|python_tag|> . Regex pattern does not work well with it as it has no end token
 // Handles single tool and multiple tool call cases for single start_token like <|python_tag|>
 fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<String> {
@@ -249,19 +294,20 @@ fn recover_leading_complete_objects(json: &str) -> Vec<String> {
     out
 }
 
-fn try_parse_normal_text(input: &str, start_token: &str) -> String {
+fn try_parse_normal_text(input: &str, start_token: &str, preserve_whitespace: bool) -> String {
     // If input contains start token, just take the part before it
     if let Some(idx) = input.find(start_token) {
-        let prefix = &input[..idx];
-        // The mistral family ([TOOL_CALLS]) keeps the boundary space before the
-        // marker to match vLLM; every other JSON family trims it. Keyed on the
-        // family's distinctive start token rather than a config field so the
-        // exported `JsonParserConfig` gains no new public member (downstream
-        // struct-literal constructors stay source-compatible).
-        return if start_token == "[TOOL_CALLS]" {
-            prefix.to_string()
+        let pre = &input[..idx];
+        // Keep the boundary whitespace before the marker verbatim (to match
+        // vLLM) when EITHER the family opted in via
+        // `preserve_normal_text_whitespace` (e.g. hermes; needed because hermes
+        // and qwen2.5 share the `<tool_call>` token but only hermes keeps the
+        // space) OR it is the mistral `[TOOL_CALLS]` family. Every other JSON
+        // family trims both ends.
+        return if preserve_whitespace || start_token == "[TOOL_CALLS]" {
+            pre.to_string()
         } else {
-            prefix.trim().to_string()
+            pre.trim().to_string()
         };
     }
 
@@ -388,6 +434,10 @@ pub fn try_tool_call_parse_basic_json(
     let mut json = trimmed.to_string();
     let mut normal_text = trimmed.to_string();
     let mut found_start_token_with_no_valid_json = false;
+    // True once a complete `<start>...<end>` framed wrapper has been extracted.
+    // Used by the drop-unusable-wrapper path so it only fires on genuinely
+    // framed input, never on bare/no-marker JSON.
+    let mut found_complete_framed_wrapper = false;
 
     // First, check if ANY start token exists in the input. `bare_json_mode`
     // short-circuits this to false so we always take the no-marker branch.
@@ -411,7 +461,11 @@ pub fn try_tool_call_parse_basic_json(
         // Try all combinations of start and end tokens
         'outer: for start_token in tool_call_start_tokens.iter() {
             for end_token in tool_call_end_tokens.iter() {
-                let new_normal_text = try_parse_normal_text(&normal_text, start_token);
+                let new_normal_text = try_parse_normal_text(
+                    &normal_text,
+                    start_token,
+                    config.preserve_normal_text_whitespace,
+                );
 
                 // Process based on token types
                 match (start_token.is_empty(), end_token.is_empty()) {
@@ -440,17 +494,60 @@ pub fn try_tool_call_parse_basic_json(
                     (false, false) => {
                         // Start and end token case
                         let mut result = extract_tool_call_content(&json, start_token, end_token);
+                        // True only when at least one CLOSED `<start>...<end>`
+                        // pair matched. Trailing recovery below keys off this so
+                        // it augments an existing closed call rather than firing
+                        // on the single-unclosed-call path (which the EOF
+                        // recovery fallback already handles).
+                        let had_closed_pair = result.is_some();
+                        if had_closed_pair {
+                            found_complete_framed_wrapper = true;
+                        }
                         // EOF recovery: only when explicitly opted in (finalize
                         // path). Streaming jails leave `allow_eof_recovery=false`
                         // so the parser doesn't claim a complete call before
-                        // the end-token has actually arrived.
+                        // the end-token has actually arrived. `recover_unclosed_
+                        // single_call` lets a family (hermes) DROP an unfinished
+                        // single call instead of recovering it; default `true`
+                        // keeps the universal recovery for the other families.
                         if result.is_none()
                             && config.allow_eof_recovery
+                            && config.recover_unclosed_single_call
                             && json.contains(start_token.as_str())
                         {
                             result = extract_tool_call_content_eof_recovery(&json, start_token);
                         }
-                        if let Some(content) = result {
+                        if let Some(mut content) = result {
+                            // Multi-call trailing recovery (5.d): the regex above
+                            // only matched closed `<start>...<end>` pairs, so a final
+                            // call whose end marker is missing (but body complete) was
+                            // dropped. Recover it on the finalize path to match
+                            // vLLM/SGLang. A trailing call with a truncated body (5.e)
+                            // is not recovered (recover_trailing_clean_body returns
+                            // None), so the complete earlier calls are kept without
+                            // repairing the broken tail.
+                            if config.recover_trailing_unclosed_call
+                                && had_closed_pair
+                                && config.allow_eof_recovery
+                                && !content.is_empty()
+                                && let Some(trailing) =
+                                    recover_trailing_clean_body(&json, start_token, end_token)
+                            {
+                                // Flatten the already-extracted head and the
+                                // recovered trailing body into element lists,
+                                // then re-wrap as one JSON array. Flattening
+                                // both sides avoids invalid JSON when the head
+                                // is an empty `[]` (which would leave a leading
+                                // comma) or when either side is itself an array.
+                                let head_inner = unwrap_json_array(content.trim());
+                                let tail_inner = unwrap_json_array(trailing.trim());
+                                let parts: Vec<&str> = [head_inner, tail_inner]
+                                    .into_iter()
+                                    .filter(|s| !s.is_empty())
+                                    .collect();
+                                content = format!("[{}]", parts.join(","));
+                            }
+
                             // Check if we found a start token but got empty JSON back
                             // This indicates the token was found but no valid JSON followed
                             if content.is_empty() {
@@ -512,13 +609,34 @@ pub fn try_tool_call_parse_basic_json(
     // Truncation recovery: balance unclosed strings/braces (common
     // max_tokens / EOS pattern) and retry the same three parses. Gated on
     // `allow_eof_recovery` so streaming jails don't claim a complete tool
-    // call while the model is still emitting JSON tokens.
+    // call while the model is still emitting JSON tokens. Families that match
+    // vLLM/SGLang's drop-on-malformed-body behavior set
+    // `repair_truncated_body=false` to skip this (e.g. hermes 4.b).
     if config.allow_eof_recovery
+        && config.repair_truncated_body
         && let Some(repaired) = try_repair_truncated_json(json)
         && let Some(calls) = parse_calls(repaired.as_str())?
         && !calls.is_empty()
     {
         return Ok((calls, Some(normal_text)));
+    }
+
+    // Unusable-wrapper drop (opt-in via `drop_unusable_json_wrapper`): a fully
+    // framed wrapper whose body is COMPLETE valid JSON but not a recognized
+    // tool call (missing name or arguments/parameters) is dropped rather than
+    // leaking the wrapper. Matches the cross-family majority on
+    // TOOLCALLING.batch.4.c / 6.c. Restricted to a complete JSON object so
+    // non-JSON bodies (4.a) and truncated bodies (5.c) — documented
+    // all-engine-agree leaks — still fall through to the verbatim return below.
+    // Only the wrapper is dropped: any narration that preceded the marker
+    // (already split into `normal_text`) is preserved.
+    if config.drop_unusable_json_wrapper
+        && found_complete_framed_wrapper
+        && serde_json::from_str::<serde_json::Value>(json)
+            .map(|v| v.is_object())
+            .unwrap_or(false)
+    {
+        return Ok((vec![], Some(normal_text)));
     }
 
     // If we found a start token but no valid JSON, return empty content

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -58,7 +58,17 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("gemma-4", ToolCallConfig::gemma4());
         map.insert("default", ToolCallConfig::default());
         map.insert("nemotron_nano", ToolCallConfig::qwen3_coder()); // nemotron nano follows qwen3_coder format
-        map.insert("qwen25", ToolCallConfig::hermes()); // qwen2.5 uses the same <tool_call>...</tool_call> format as hermes; EOF-recovery opt-out is keyed by name in detect_and_parse_tool_call_with_recovery_options
+        // qwen2.5 uses the same <tool_call> format as hermes but has no
+        // vLLM/SGLang peer, so it opts out of hermes's vendor-alignment flags
+        // while keeping the suppression ones: it still drops and hides any
+        // unterminated call.
+        let mut qwen25 = ToolCallConfig::hermes();
+        if let ParserConfig::Json(ref mut c) = qwen25.parser_config {
+            c.preserve_normal_text_whitespace = false;
+            c.drop_unusable_json_wrapper = false;
+            c.recover_trailing_unclosed_call = false;
+        }
+        map.insert("qwen25", qwen25);
         map
     })
 }
@@ -169,25 +179,67 @@ pub async fn detect_and_parse_tool_call_with_recovery(
         // Other parsers don't have an EOF-recovery flag — pass through.
         other => other.clone(),
     };
+    // If an opted-in family left a tool call unterminated and nothing was
+    // recovered, suppress the dangling buffer (below) but keep any prose before
+    // the opener. We pick the FIRST opener with no following end-token, not
+    // merely the earliest opener, so a closed-but-unusable wrapper before a
+    // later unterminated one can't mask it and leak the whole buffer. Computed
+    // before `recovery_config` is moved into `cfg`.
+    let partial_markup_prefix: Option<String> = if let ParserConfig::Json(c) = &recovery_config
+        && c.drop_partial_markup_on_stream_finalize
+    {
+        // All opener occurrences (every start token, every position), in order.
+        let mut openers: Vec<(usize, usize)> = Vec::new();
+        for t in c.tool_call_start_tokens.iter().filter(|t| !t.is_empty()) {
+            for (pos, _) in message.match_indices(t.as_str()) {
+                openers.push((pos, t.len()));
+            }
+        }
+        openers.sort_by_key(|&(pos, _)| pos);
+        // First opener whose remainder contains no configured end token.
+        let unterminated = openers.into_iter().find_map(|(pos, tok_len)| {
+            let after_opener = &message[pos + tok_len..];
+            let has_end = c
+                .tool_call_end_tokens
+                .iter()
+                .any(|e| !e.is_empty() && after_opener.contains(e.as_str()));
+            if has_end { None } else { Some(pos) }
+        });
+        unterminated.map(|pos| {
+            // Preserve everything before the unclosed opener, honoring the
+            // family's whitespace policy (verbatim for hermes, else trimmed).
+            let pre = &message[..pos];
+            if c.preserve_normal_text_whitespace {
+                pre.to_string()
+            } else {
+                pre.trim().to_string()
+            }
+        })
+    } else {
+        None
+    };
     let cfg = ToolCallConfig {
         parser_config: recovery_config,
         structural_tag_builder: None,
     };
-    let (calls, normal_text) = try_tool_call_parse(message, &cfg, tools).await?;
-
-    // An unterminated qwen25 call (open <tool_call>, no close, nothing parsed)
-    // drops its partial markup instead of leaking it. Deliberate non-parity
-    // with SGLang, which surfaces the raw text.
-    if parser_key == "qwen25"
+    let (calls, content) = try_tool_call_parse(message, &cfg, tools).await?;
+    // Only substitute the prefix when the inner parser is still leaking the
+    // dangling buffer (its content is longer than the prefix). If it already
+    // returned something at least as short (e.g. `drop_unusable_json_wrapper`
+    // emptied a closed-but-unusable wrapper), keep that rather than re-adding
+    // the wrapper markup the prefix would carry. This general suppression also
+    // covers qwen25 (which inherits `drop_partial_markup_on_stream_finalize`),
+    // so no per-name special-case is needed.
+    if let Some(prefix) = partial_markup_prefix
         && calls.is_empty()
-        && let Some(text) = normal_text.as_deref()
-        && text.contains("<tool_call>")
-        && !text.contains("</tool_call>")
+        && content
+            .as_ref()
+            .map(|c| c.len() > prefix.len())
+            .unwrap_or(true)
     {
-        return Ok((calls, Some(String::new())));
+        return Ok((vec![], Some(prefix)));
     }
-
-    Ok((calls, normal_text))
+    Ok((calls, content))
 }
 
 /// Deprecated compatibility shim retained for the published `dynamo-parsers`
@@ -657,7 +709,8 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), None)
             .await
             .unwrap();
-        assert_eq!(content, Some("Hey How are you?".to_string()));
+        // hermes preserves the narration verbatim (trailing space) to match vLLM.
+        assert_eq!(content, Some("Hey How are you? ".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
     }
@@ -807,7 +860,8 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
 "#;
         let config = ToolCallConfig::hermes();
         let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
-        assert_eq!(content, Some("Hey How are you?".to_string()));
+        // hermes preserves the narration verbatim (trailing space) to match vLLM.
+        assert_eq!(content, Some("Hey How are you? ".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -2007,6 +2061,42 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         let args: serde_json::Value =
             serde_json::from_str(&tool_calls[0].function.arguments).unwrap();
         assert_eq!(args["timezone"], "Asia/Shanghai");
+    }
+
+    /// Stream-finalize partial-markup suppression must select the FIRST
+    /// UNCLOSED opener, not merely the earliest opener. Here a closed-but-
+    /// unusable `<tool_call>{...}</tool_call>` (no name key -> not a call)
+    /// precedes a later unterminated `<tool_call>{...`. The earliest opener
+    /// looks "closed" (an end token follows it), so the previous logic skipped
+    /// suppression and leaked the entire dangling buffer. The fix must drop the
+    /// trailing unterminated buffer (its `"name": "later_call"` body must not
+    /// reach normal_text), while no call is recovered.
+    #[tokio::test]
+    async fn test_hermes_stream_finalize_multi_opener_drops_dangling_buffer() {
+        // First wrapper is closed but unusable (no "name"); second is unterminated.
+        let input = concat!(
+            "<tool_call>{\"arguments\": {\"x\": 1}}</tool_call>",
+            "<tool_call>{\"name\": \"later_call\", \"arguments\": {\"loc"
+        );
+
+        let (tool_calls, normal_text) =
+            detect_and_parse_tool_call_with_recovery(input, Some("hermes"), None)
+                .await
+                .expect("Failed to parse");
+
+        assert!(
+            tool_calls.is_empty(),
+            "no call should be recovered (first unusable, second unterminated), got {tool_calls:?}"
+        );
+        let text = normal_text.unwrap_or_default();
+        assert!(
+            !text.contains("later_call"),
+            "dangling unterminated buffer must be dropped, not leaked: {text:?}"
+        );
+        assert!(
+            !text.contains("{\"loc"),
+            "partial argument fragment must not leak: {text:?}"
+        );
     }
 
     /// Alias registration: verifies `deepseek-v4` and `deepseekv4` route to the same parser as `deepseek_v4`. Not a TOOLCALLING.*; covers registry plumbing.

--- a/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.2.yaml
+++ b/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.2.yaml
@@ -53,8 +53,10 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:'
-      vllm:
+        normal_text: 'Both: '
+      vllm: *id004
+      sglang:
+        reason: SGLang trims trailing whitespace from normal_text that precedes hermes tool-call blocks.
         calls:
         - name: get_weather
           arguments:
@@ -62,8 +64,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both: '
-      sglang: *id004
+        normal_text: 'Both:'
   TOOLCALLING.batch.2.d:
     description: Same-name twice
     ref: dynamo

--- a/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.4.yaml
+++ b/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.4.yaml
@@ -30,18 +30,12 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
-      vllm:
+      dynamo: &id_4b
+        reason: Malformed body is dropped (not brace-repaired) and left as content; matches vLLM and SGLang.
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
-      sglang:
-        calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
+      vllm: *id_4b
+      sglang: *id_4b
   TOOLCALLING.batch.4.c:
     description: Missing name key
     ref: dynamo
@@ -50,13 +44,13 @@ cases:
     - *id002
     expected:
       dynamo: &id003
-        reason: "Dynamo's hermes parser leaves <tool_call> tag in normal_text on malformed input (impl-defined recovery)"
-        calls: []
-        normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
-      vllm: *id003
-      sglang:
         calls: []
         normal_text: ''
+      sglang: *id003
+      vllm:
+        reason: vLLM leaks the wrapper; Dynamo and SGLang drop the unusable wrapper (no name key).
+        calls: []
+        normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
   TOOLCALLING.batch.4.d:
     description: Missing </tool_call> close
     ref: dynamo
@@ -64,13 +58,16 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
+        reason: Hermes drops an unfinished single call (no closing </tool_call>) and hides the buffer; vLLM and SGLang recover it (deliberate non-parity).
+        calls: []
+        normal_text: ''
+      vllm: &id004
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id004
       sglang: *id004
   TOOLCALLING.batch.4.e:
     description: Malformed-prefix recovery — n/a for this family's syntax

--- a/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.5.yaml
@@ -17,13 +17,16 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
+      dynamo:
+        reason: Hermes drops an unfinished single call (no closing </tool_call>) and hides the buffer; vLLM and SGLang recover it (deliberate non-parity).
+        calls: []
+        normal_text: ''
+      vllm: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *id001
       sglang: *id001
   TOOLCALLING.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
@@ -45,12 +48,14 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
-        reason: "Dynamo's hermes parser leaves closing </tool_call> tag plus the JSON body in normal_text when opening <tool_call> marker is missing (impl-defined recovery)"
+      dynamo:
+        reason: Hermes drops a tool call truncated mid-argument and hides the buffer; vLLM and SGLang leave the raw buffer (deliberate non-parity).
+        calls: []
+        normal_text: ''
+      vllm: &id005c
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
-      vllm: *id004
-      sglang: *id004
+      sglang: *id005c
   TOOLCALLING.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
     ref: dynamo
@@ -65,7 +70,8 @@ cases:
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm:
+      vllm: &id006
+        reason: vLLM and SGLang recover the unterminated trailing call; hermes drops it, like kimi/glm/deepseek.
         calls:
         - name: get_weather
           arguments:
@@ -74,15 +80,7 @@ cases:
           arguments:
             location: New York
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      sglang:
-        calls:
-        - name: get_weather
-          arguments:
-            location: Boston
-        - name: get_weather
-          arguments:
-            location: New York
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang: *id006
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -98,11 +96,13 @@ cases:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
+        reason: vLLM drops everything and leaks when the trailing call is truncated; hermes keeps the complete leading call, no leak.
         calls: []
         normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
           "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
           "New York'
       sglang:
+        reason: SGLang drops everything and leaks when the trailing call is truncated; hermes keeps the complete leading call, no leak.
         calls: []
         normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
           "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":

--- a/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.6.yaml
+++ b/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.6.yaml
@@ -43,12 +43,15 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
-        reason: "Dynamo's hermes parser leaves <tool_call> tag in normal_text on minimal/no-body case"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        reason: vLLM leaks the wrapper for a name-only body; hermes drops it (no arguments key).
         calls: []
         normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
-      vllm: *id004
       sglang:
+        reason: SGLang coerces a name-only body into an empty-args call; hermes drops it.
         calls:
         - name: get_time
           arguments: {}

--- a/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.8.yaml
+++ b/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.batch.8.yaml
@@ -22,14 +22,15 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
-      vllm:
+        normal_text: 'I will check the weather. '
+      vllm: *id001
+      sglang:
+        reason: SGLang trims trailing whitespace from normal_text that precedes hermes tool-call blocks.
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather. '
-      sglang: *id001
+        normal_text: I will check the weather.
   TOOLCALLING.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -59,14 +60,15 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
-      vllm:
+        normal_text: 'I will check the weather. '
+      vllm: *id004
+      sglang:
+        reason: SGLang trims trailing whitespace from normal_text that precedes hermes tool-call blocks.
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather. '
-      sglang: *id004
+        normal_text: I will check the weather.
   TOOLCALLING.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -83,8 +85,10 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: I will check the weather.
-      vllm:
+        normal_text: 'I will check the weather. '
+      vllm: *id005
+      sglang:
+        reason: SGLang trims trailing whitespace from normal_text that precedes hermes tool-call blocks.
         calls:
         - name: get_weather
           arguments:
@@ -92,5 +96,4 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: 'I will check the weather. '
-      sglang: *id005
+        normal_text: I will check the weather.

--- a/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/hermes/TOOLCALLING.stream.4.yaml
@@ -20,13 +20,16 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
+      dynamo:
+        reason: Hermes drops an unfinished single call and hides the buffer; vLLM and SGLang recover it (deliberate non-parity).
+        calls: []
+        normal_text: ''
+      sglang: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      sglang: *id001
       vllm: *id001
   TOOLCALLING.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
@@ -46,13 +49,15 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
+        normal_text: ''
       sglang:
+        reason: SGLang emits an empty-args call here; hermes drops the incomplete call and hides the buffer.
         calls:
         - name: get_weather
           arguments: {}
         normal_text: ''
       vllm:
+        reason: vLLM emits a partial-args call here; hermes drops the incomplete call and hides the buffer.
         calls:
         - name: get_weather
           arguments: '{"loc'
@@ -78,5 +83,6 @@ cases:
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'
       vllm: *id002
       sglang:
+        reason: No opening <tool_call>, so it was never a framed call; hermes and vLLM pass it through; SGLang strips the trailing close markers.
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}'


### PR DESCRIPTION
#### Overview

Resolves the open `research` cells in the Hermes-3 / Llama-variants row of the parser parity dashboard, aligning Dynamo's hermes tool-call parser with the vLLM and SGLang reference parsers, except where hermes intentionally diverges (documented per case).

Guiding model: hermes consistently suppresses an incomplete tool call. Any `<tool_call>` buffer that never yields a recovered call, because the closing `</tool_call>` never arrived or the body is truncated, is dropped AND its dangling markup is hidden (`calls=[]`, `normal_text=""`). This is deliberate and not always parity: vLLM/SGLang variously recover or leak such buffers, and those are documented as outliers.

Every behavior change is gated behind a per-family config flag, so the other JSON families that share the base parser are unaffected. qwen2.5 reuses the hermes config (no vLLM/SGLang peer) and inherits the same consistent suppression. Each case below shows the actual parity fixture it tests (`before dynamo` = behavior before this PR, `after dynamo` = behavior in this PR).

#### 2.c / 8.a / 8.c / 8.d : Narration whitespace before a tool call

```
model output: I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
before dynamo: calls=[get_weather{location:NYC}], normal_text="I will check the weather."   (trailing space trimmed)
after dynamo:  calls=[get_weather{location:NYC}], normal_text="I will check the weather. "  (kept verbatim)
vllm:   calls=[get_weather{location:NYC}], normal_text="I will check the weather. "  (matches after dynamo)
sglang: calls=[get_weather{location:NYC}], normal_text="I will check the weather."   (trims; documented outlier)
```

#### 4.d / 5.a : Single tool call, complete body, missing closing </tool_call>

```
model output: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}
before dynamo: calls=[get_weather{location:NYC}], normal_text=""   (recovered via EOF recovery)
after dynamo:  calls=[], normal_text=""   (SUPPRESSED: call dropped, dangling buffer hidden)
vllm:   calls=[get_weather{location:NYC}], normal_text=""   (recovers the call; deliberate non-parity divergence)
sglang: calls=[get_weather{location:NYC}], normal_text=""   (recovers the call; deliberate non-parity divergence)
```

#### 5.c : Single tool call, truncated mid-argument (no closing </tool_call>)

```
model output: <tool_call>{"name": "get_weather", "arguments": {"loc
before dynamo: calls=[], normal_text='<tool_call>{"name": "get_weather", "arguments": {"loc'   (raw buffer leaked)
after dynamo:  calls=[], normal_text=""   (SUPPRESSED: dangling buffer hidden)
vllm:   calls=[], normal_text='<tool_call>{"name": "get_weather", "arguments": {"loc'   (leaks raw; deliberate non-parity divergence)
sglang: calls=[], normal_text='<tool_call>{"name": "get_weather", "arguments": {"loc'   (leaks raw; deliberate non-parity divergence)
```

#### 5.d : Multi-call, final call missing only its end marker (body complete)

```
model output: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York"}}
before dynamo: calls=[get_weather{Boston}], normal_text="I'll start by fetching...time!"
after dynamo:  calls=[get_weather{Boston}], normal_text="I'll start by fetching...time!"   (trailing unterminated call dropped, not recovered, not leaked)
vllm:   calls=[get_weather{Boston}, get_weather{New York}], normal_text="...time!"   (recovers trailing; documented outlier)
sglang: calls=[get_weather{Boston}, get_weather{New York}], normal_text="...time!"   (recovers trailing; documented outlier)
```

#### 5.e : Multi-call, final call truncated mid-argument

```
model output: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York
before dynamo: calls=[get_weather{Boston}], normal_text="I'll start by fetching...time!"
after dynamo:  calls=[get_weather{Boston}], normal_text="I'll start by fetching...time!"   (complete leading call kept; truncated trailing dropped, no leak)
vllm:   calls=[], normal_text=<entire raw input incl. tool_call wrappers>   (drops everything and leaks; documented outlier)
sglang: calls=[], normal_text=<entire raw input incl. tool_call wrappers>   (drops everything and leaks; documented outlier)
```

#### 4.b : Malformed JSON body inside complete tags (missing brace)

```
model output: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>
before dynamo: calls=[get_weather{NYC}], normal_text=""   (brace-repaired and recovered)
after dynamo:  calls=[], normal_text='<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'   (closing tag present, not a dangling buffer; left verbatim)
vllm:   calls=[], normal_text=<same verbatim input>   (matches after dynamo)
sglang: calls=[], normal_text=<same verbatim input>   (matches after dynamo)
```

#### 4.c : Complete JSON body missing the name key

```
model output: <tool_call>{"arguments": {"location": "NYC"}}</tool_call>
before dynamo: calls=[], normal_text='<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'   (wrapper leaked)
after dynamo:  calls=[], normal_text=""
vllm:   calls=[], normal_text='<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'   (leaks wrapper; documented outlier)
sglang: calls=[], normal_text=""   (matches after dynamo)
```

#### 6.c : Complete JSON body missing the arguments key

```
model output: <tool_call>{"name": "get_time"}</tool_call>
before dynamo: calls=[], normal_text='<tool_call>{"name": "get_time"}</tool_call>'   (wrapper leaked)
after dynamo:  calls=[], normal_text=""
vllm:   calls=[], normal_text='<tool_call>{"name": "get_time"}</tool_call>'   (leaks wrapper; documented outlier)
sglang: calls=[get_time{arguments:{}}], normal_text=""   (fabricates empty-args call; documented outlier)
```

#### stream.4.a : Streaming, single complete-body call, stream ends with no closing tag

```
model output: chunks ['<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}', '' (finish_reason: stop)]
before dynamo: calls=[get_weather{NYC}], normal_text=""   (recovered)
after dynamo:  calls=[], normal_text=""   (SUPPRESSED: call dropped, dangling buffer hidden)
vllm:   calls=[get_weather{NYC}], normal_text=""   (recovers the call; deliberate non-parity divergence)
sglang: calls=[get_weather{NYC}], normal_text=""   (recovers the call; deliberate non-parity divergence)
```

#### stream.4.b : Streaming, stream ends mid-argument

```
model output: chunks ['<tool_call>{"name": "get_w', 'eather", "arguments": {"loc', '' (finish_reason: stop)]
before dynamo: calls=[], normal_text='<tool_call>{"name": "get_weather", "arguments": {"loc'   (partial buffer leaked)
after dynamo:  calls=[], normal_text=""   (SUPPRESSED: dangling buffer hidden)
vllm:   calls=[get_weather{arguments:'{"loc'}], normal_text=""   (emits raw partial fragment; documented outlier)
sglang: calls=[get_weather{arguments:{}}], normal_text=""   (emits empty-args call; documented outlier)
```

#### stream.4.c : Streaming, inner body with no opening wrapper

```
model output: chunks ['{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>', '' (finish_reason: length)]
before dynamo: calls=[], normal_text='{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call></tool_call></tool_call>'   (passed through as content)
after dynamo:  calls=[], normal_text=<same as before>   (unchanged; no opening <tool_call>, so no dangling-wrapper suppression applies; now documented)
vllm:   calls=[], normal_text=<same pass-through>   (matches after dynamo)
sglang: calls=[], normal_text='{"name": "get_weather", "arguments": {"location": "NYC"}}'   (strips trailing close markers; documented outlier)
```
