### PR TITLE
fix(frontend): set realtime echo worker type

### DIFF
--- a/tests/frontend/realtime_echo_worker.py
+++ b/tests/frontend/realtime_echo_worker.py
@@ -17,7 +17,7 @@ import uuid
 
 import uvloop
 
-from dynamo.llm import ModelInput, ModelType, register_model
+from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
 from dynamo.runtime import DistributedRuntime
 from tests.frontend.test_realtime_python_bridge import ENDPOINT_PATH, MODEL_NAME
 
@@ -127,6 +127,7 @@ async def main() -> None:
         endpoint,
         MODEL_NAME,
         model_name=MODEL_NAME,
+        worker_type=WorkerType.Aggregated,
     )
     await endpoint.serve_bidirectional_endpoint(_python_realtime_echo)
 


### PR DESCRIPTION
#### Overview:

Fix the realtime echo worker test fixture to pass the now-required `worker_type` argument to `register_model`.

#### Details:

- Import `WorkerType` in `tests/frontend/realtime_echo_worker.py`.
- Register the self-contained realtime echo worker as `WorkerType.Aggregated`.

#### Where should the reviewer start?

`tests/frontend/realtime_echo_worker.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to full CI failure in `dynamo-runtime / test / sequential cuda13.0`.

#### Testing:

- `pre-commit run ruff --files tests/frontend/realtime_echo_worker.py`
- `pre-commit run black --files tests/frontend/realtime_echo_worker.py`
- `git commit -s -m "fix(frontend): set realtime echo worker type"` (pre-commit hook passed: isort, black, flake8, codespell, ruff, pytest marker report, and other configured hooks)
- `pytest -q tests/frontend/test_realtime_python_bridge.py` (attempted locally after installing pytest/test plugins; blocked by local source/binding mismatch: `ImportError: cannot import name run_slot_tracker from dynamo._core`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to properly specify configuration when registering the realtime text model component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->