### PR TITLE
feat(kvbm): G2/G3 block-state metrics (#10066)

### DIFF
--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
@@ -206,6 +206,7 @@ impl<R: RequestKey> ConnectorSlotManager<R> {
             .unwrap_or(0);
         let kvbm_metrics_clone = kvbm_metrics.clone();
         let cache_stats_clone = cache_stats.clone();
+        let block_manager_metrics = block_manager.clone();
 
         // Spawn a background task to periodically update metrics and log cache hit rates
         let handle = get_current_tokio_handle();
@@ -217,6 +218,14 @@ impl<R: RequestKey> ConnectorSlotManager<R> {
                 let host_rate = cache_stats_clone.host_hit_rate();
                 let disk_rate = cache_stats_clone.disk_hit_rate();
                 kvbm_metrics_clone.update_cache_hit_rates(host_rate, disk_rate, 0.0);
+                // Publish G2 (host) / G3 (disk) block-state gauges (issue #10066).
+                // Tiers are optional; only update when both pools are present and queryable.
+                if let (Some(host_pool), Some(disk_pool)) =
+                    (block_manager_metrics.host(), block_manager_metrics.disk())
+                    && let (Ok(g2), Ok(g3)) = (host_pool.status().await, disk_pool.status().await)
+                {
+                    kvbm_metrics_clone.update_block_states(&g2, &g3);
+                }
                 // Also log cache hit rates periodically
                 cache_stats_clone.maybe_log();
             }

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
@@ -207,24 +207,35 @@ impl<R: RequestKey> ConnectorSlotManager<R> {
         let kvbm_metrics_clone = kvbm_metrics.clone();
         let cache_stats_clone = cache_stats.clone();
         let block_manager_metrics = block_manager.clone();
+        let metrics_cancel = get_current_cancel_token();
 
-        // Spawn a background task to periodically update metrics and log cache hit rates
+        // Spawn a background task to periodically update metrics and log cache hit rates.
+        // It is cancellation-aware (issue #10066 review): the cloned block manager holds
+        // KvBlockManager's drop-driven cancellation owner, so the task must exit on shutdown to
+        // release it, otherwise the block manager progress engines would never shut down.
         let handle = get_current_tokio_handle();
         handle.spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
             loop {
-                interval.tick().await;
+                tokio::select! {
+                    _ = metrics_cancel.cancelled() => break,
+                    _ = interval.tick() => {}
+                }
                 // Update Prometheus metrics
                 let host_rate = cache_stats_clone.host_hit_rate();
                 let disk_rate = cache_stats_clone.disk_hit_rate();
                 kvbm_metrics_clone.update_cache_hit_rates(host_rate, disk_rate, 0.0);
-                // Publish G2 (host) / G3 (disk) block-state gauges (issue #10066).
-                // Tiers are optional; only update when both pools are present and queryable.
-                if let (Some(host_pool), Some(disk_pool)) =
-                    (block_manager_metrics.host(), block_manager_metrics.disk())
-                    && let (Ok(g2), Ok(g3)) = (host_pool.status().await, disk_pool.status().await)
+                // Publish G2 (host) / G3 (disk) block-state gauges (issue #10066). Each tier is
+                // optional and queried independently so a host-only deployment still reports G2.
+                if let Some(host_pool) = block_manager_metrics.host()
+                    && let Ok(g2) = host_pool.status().await
                 {
-                    kvbm_metrics_clone.update_block_states(&g2, &g3);
+                    kvbm_metrics_clone.update_g2_block_states(&g2);
+                }
+                if let Some(disk_pool) = block_manager_metrics.disk()
+                    && let Ok(g3) = disk_pool.status().await
+                {
+                    kvbm_metrics_clone.update_g3_block_states(&g3);
                 }
                 // Also log cache hit rates periodically
                 cache_stats_clone.maybe_log();

--- a/lib/llm/src/block_manager/metrics_kvbm.rs
+++ b/lib/llm/src/block_manager/metrics_kvbm.rs
@@ -297,16 +297,21 @@ impl KvbmMetrics {
         self.object_cache_hit_rate.set(object_rate as f64);
     }
 
-    /// Update G2 (host) / G3 (disk) block-state gauges from pool status snapshots (issue #10066).
+    /// Update the G2 (host tier) block-state gauges from a pool status snapshot (issue #10066).
     /// Total = active + inactive + empty (the pool's fixed capacity); active reads 0 in practice
-    /// for these tiers and is not surfaced as its own gauge. Call from the periodic metrics task in
-    /// slot.rs alongside `update_cache_hit_rates`, passing
-    /// `host_pool.status().await` / `disk_pool.status().await`.
-    pub fn update_block_states(&self, g2: &BlockPoolStatus, g3: &BlockPoolStatus) {
+    /// for this tier and is not surfaced as its own gauge. Updated independently of G3 so a
+    /// host-only deployment still reports G2. Call with `host_pool.status().await`.
+    pub fn update_g2_block_states(&self, g2: &BlockPoolStatus) {
         self.g2_inactive_blocks.set(g2.inactive_blocks as i64);
         self.g2_empty_blocks.set(g2.empty_blocks as i64);
         self.g2_total_blocks
             .set((g2.active_blocks + g2.inactive_blocks + g2.empty_blocks) as i64);
+    }
+
+    /// Update the G3 (disk tier) block-state gauges from a pool status snapshot (issue #10066).
+    /// See [`Self::update_g2_block_states`]; updated independently of G2. Call with
+    /// `disk_pool.status().await`.
+    pub fn update_g3_block_states(&self, g3: &BlockPoolStatus) {
         self.g3_inactive_blocks.set(g3.inactive_blocks as i64);
         self.g3_empty_blocks.set(g3.empty_blocks as i64);
         self.g3_total_blocks

--- a/lib/llm/src/block_manager/metrics_kvbm.rs
+++ b/lib/llm/src/block_manager/metrics_kvbm.rs
@@ -11,11 +11,22 @@ use dynamo_runtime::metrics::prometheus_names::{
     },
     sanitize_prometheus_name,
 };
-use prometheus::{Gauge, IntCounter, Opts, Registry};
+use prometheus::{Gauge, IntCounter, IntGauge, Opts, Registry};
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, thread};
 use tokio::{net::TcpListener, sync::Notify};
 
+use crate::block_manager::pool::BlockPoolStatus;
 use crate::http::service::{RouteDoc, metrics::router};
+
+// Block-state gauge names (issue #10066). The registry prefixes these with `kvbm_`.
+// G2 = host tier pool, G3 = disk tier pool. Total = inactive + empty (active reads 0 in
+// practice for the G2/G3 tiers, so it is not surfaced; see issue #10066).
+const G2_INACTIVE_BLOCKS: &str = "g2_inactive_blocks";
+const G2_EMPTY_BLOCKS: &str = "g2_empty_blocks";
+const G2_TOTAL_BLOCKS: &str = "g2_total_blocks";
+const G3_INACTIVE_BLOCKS: &str = "g3_inactive_blocks";
+const G3_EMPTY_BLOCKS: &str = "g3_empty_blocks";
+const G3_TOTAL_BLOCKS: &str = "g3_total_blocks";
 
 #[derive(Clone, Debug)]
 pub struct KvbmMetrics {
@@ -57,6 +68,16 @@ pub struct KvbmMetrics {
 
     // number of failed object storage write operations (blocks)
     pub object_write_failures: IntCounter,
+
+    // G2 (host tier) block-state gauges (issue #10066)
+    pub g2_inactive_blocks: IntGauge,
+    pub g2_empty_blocks: IntGauge,
+    pub g2_total_blocks: IntGauge,
+
+    // G3 (disk tier) block-state gauges (issue #10066)
+    pub g3_inactive_blocks: IntGauge,
+    pub g3_empty_blocks: IntGauge,
+    pub g3_total_blocks: IntGauge,
 
     shutdown_notify: Option<Arc<Notify>>,
 }
@@ -154,6 +175,27 @@ impl KvbmMetrics {
                 &[],
             )
             .unwrap();
+
+        // block-state gauges (issue #10066)
+        let g2_inactive_blocks = mr
+            .create_intgauge(G2_INACTIVE_BLOCKS, "G2 (host tier) inactive blocks", &[])
+            .unwrap();
+        let g2_empty_blocks = mr
+            .create_intgauge(G2_EMPTY_BLOCKS, "G2 (host tier) empty blocks", &[])
+            .unwrap();
+        let g2_total_blocks = mr
+            .create_intgauge(G2_TOTAL_BLOCKS, "G2 (host tier) total blocks", &[])
+            .unwrap();
+        let g3_inactive_blocks = mr
+            .create_intgauge(G3_INACTIVE_BLOCKS, "G3 (disk tier) inactive blocks", &[])
+            .unwrap();
+        let g3_empty_blocks = mr
+            .create_intgauge(G3_EMPTY_BLOCKS, "G3 (disk tier) empty blocks", &[])
+            .unwrap();
+        let g3_total_blocks = mr
+            .create_intgauge(G3_TOTAL_BLOCKS, "G3 (disk tier) total blocks", &[])
+            .unwrap();
+
         // early return if no endpoint is needed
         if !create_endpoint {
             return Self {
@@ -170,6 +212,12 @@ impl KvbmMetrics {
                 object_cache_hit_rate,
                 object_read_failures,
                 object_write_failures,
+                g2_inactive_blocks,
+                g2_empty_blocks,
+                g2_total_blocks,
+                g3_inactive_blocks,
+                g3_empty_blocks,
+                g3_total_blocks,
                 shutdown_notify: None,
             };
         }
@@ -232,6 +280,12 @@ impl KvbmMetrics {
             object_cache_hit_rate,
             object_read_failures,
             object_write_failures,
+            g2_inactive_blocks,
+            g2_empty_blocks,
+            g2_total_blocks,
+            g3_inactive_blocks,
+            g3_empty_blocks,
+            g3_total_blocks,
             shutdown_notify: Some(notify),
         }
     }
@@ -241,6 +295,22 @@ impl KvbmMetrics {
         self.host_cache_hit_rate.set(host_rate as f64);
         self.disk_cache_hit_rate.set(disk_rate as f64);
         self.object_cache_hit_rate.set(object_rate as f64);
+    }
+
+    /// Update G2 (host) / G3 (disk) block-state gauges from pool status snapshots (issue #10066).
+    /// Total = active + inactive + empty (the pool's fixed capacity); active reads 0 in practice
+    /// for these tiers and is not surfaced as its own gauge. Call from the periodic metrics task in
+    /// slot.rs alongside `update_cache_hit_rates`, passing
+    /// `host_pool.status().await` / `disk_pool.status().await`.
+    pub fn update_block_states(&self, g2: &BlockPoolStatus, g3: &BlockPoolStatus) {
+        self.g2_inactive_blocks.set(g2.inactive_blocks as i64);
+        self.g2_empty_blocks.set(g2.empty_blocks as i64);
+        self.g2_total_blocks
+            .set((g2.active_blocks + g2.inactive_blocks + g2.empty_blocks) as i64);
+        self.g3_inactive_blocks.set(g3.inactive_blocks as i64);
+        self.g3_empty_blocks.set(g3.empty_blocks as i64);
+        self.g3_total_blocks
+            .set((g3.active_blocks + g3.inactive_blocks + g3.empty_blocks) as i64);
     }
     /// Record failed object storage read operations
     pub fn record_object_read_failure(&self, num_blocks: u64) {
@@ -310,6 +380,23 @@ impl KvbmMetricsRegistry {
             .collect();
         let opts = Opts::new(metrics_name, description).const_labels(const_labels);
         let g = Gauge::with_opts(opts)?;
+        self.registry.register(Box::new(g.clone()))?;
+        Ok(g)
+    }
+
+    pub fn create_intgauge(
+        &self,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> anyhow::Result<IntGauge> {
+        let metrics_name = sanitize_prometheus_name(&format!("{}_{}", self.prefix, name))?;
+        let const_labels: HashMap<String, String> = labels
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        let opts = Opts::new(metrics_name, description).const_labels(const_labels);
+        let g = IntGauge::with_opts(opts)?;
         self.registry.register(Box::new(g.clone()))?;
         Ok(g)
     }


### PR DESCRIPTION
## Overview:

Surface KVBM **G2 (host/DRAM)** and **G3 (disk/SSD)** tier block-state counts to Prometheus, as requested in #10066. Operators currently see cache hit rates (`kvbm_host_cache_hit_rate`, `kvbm_disk_cache_hit_rate`) but have no view of how much of each tier holds reusable data vs. sits empty.

## Details:

`BlockPoolStatus` already tracks `active` / `inactive` / `empty` per tier; this PR wires the reusable (`inactive`), free (`empty`), and total (capacity) counts to 6 new gauges, without touching pool internals or block lifecycle.

New gauges (the registry prefixes names with `kvbm_`):
- `kvbm_g2_inactive_blocks`, `kvbm_g2_empty_blocks`, `kvbm_g2_total_blocks`
- `kvbm_g3_inactive_blocks`, `kvbm_g3_empty_blocks`, `kvbm_g3_total_blocks`

Per the issue, `active` is **not** surfaced as its own gauge (it reads 0 in practice for the G2/G3 tiers); `total` = active + inactive + empty, i.e. the pool's fixed capacity.

- `metrics_kvbm.rs`: 6 `IntGauge` fields + names, a `create_intgauge` registry helper, and `update_block_states()` that publishes from `BlockPoolStatus` snapshots.
- `slot.rs`: publishes the gauges from the existing 5-second KVBM metrics task, reading each tier via the async `BlockPoolController::status()`. Tiers are optional, so gauges only update when both the host and disk pools are present.

`cargo build` / `clippy` / `fmt` are clean on both `dynamo-llm` and `kvbm-py3`.

## Where should the reviewer start?

- `lib/llm/src/block_manager/metrics_kvbm.rs` — `update_block_states()` and the gauge registration in `KvbmMetrics::new()`.
- `lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs` — the call site in the periodic metrics task. It uses the **async** `status().await` (not the blocking variant) because it runs inside the tokio task; `status_blocking()` would panic there.

## Related Issues

- Closes #10066


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed block-state metrics tracking, including inactive blocks, empty blocks, and total block counts across host and disk storage tiers
  * Metrics are conditionally published only when both storage pools are available and responding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->