### PR TITLE
Multi-node CRIU checkpoint/restore for vLLM (TP16) via snapshot-agent

### DIFF
--- a/components/src/dynamo/common/utils/snapshot.py
+++ b/components/src/dynamo/common/utils/snapshot.py
@@ -48,7 +48,6 @@ class CheckpointConfig:
         if not control_dir:
             return None
 
-        configure_checkpoint_transport_env()
         return cls(control_dir=control_dir)
 
     async def run_lifecycle(
@@ -57,8 +56,9 @@ class CheckpointConfig:
         *quiesce_args: object,
     ) -> bool:
         logger.info("Quiescing model")
-        await quiesce_controller.quiesce(*quiesce_args)
+        await quiesce_controller.quiesce(self.control_dir, *quiesce_args)
 
+        event = None
         try:
             with open(self.ready_file, "w", encoding="utf-8") as ready_file:
                 ready_file.write("ready")
@@ -71,13 +71,15 @@ class CheckpointConfig:
 
             event = await self._wait_for_sentinel()
         finally:
-            self._cleanup_ready_and_sentinels()
+            if event != "restore":
+                self._cleanup_ready_and_sentinels()
 
         if event == "restore":
             logger.info("Restore sentinel detected")
             logger.info("Resuming model after restore")
             await quiesce_controller.resume()
             quiesce_controller.mark_resumed()
+            self._cleanup_ready_and_sentinels()
             return True
 
         logger.info("Snapshot completion sentinel detected")
@@ -106,81 +108,6 @@ class CheckpointConfig:
                 pass
             except OSError:
                 logger.exception("Failed to clean up %s at %s", name, path)
-
-
-def configure_checkpoint_transport_env() -> None:
-    gloo_ifname = os.environ.get("GLOO_SOCKET_IFNAME")
-    if gloo_ifname and gloo_ifname != "lo":
-        logger.warning(
-            "Overriding GLOO_SOCKET_IFNAME=%r with 'lo' for checkpoint mode "
-            "because CRIU cannot restore sockets bound to non-loopback addresses",
-            gloo_ifname,
-        )
-    os.environ["GLOO_SOCKET_IFNAME"] = "lo"
-
-    nccl_ifname = os.environ.get("NCCL_SOCKET_IFNAME")
-    if nccl_ifname and nccl_ifname != "lo":
-        logger.warning(
-            "Overriding NCCL_SOCKET_IFNAME=%r with 'lo' for checkpoint mode "
-            "because CRIU cannot restore sockets bound to non-loopback addresses",
-            nccl_ifname,
-        )
-    os.environ["NCCL_SOCKET_IFNAME"] = "lo"
-
-    nccl_cumem_enable = os.environ.get("NCCL_CUMEM_ENABLE")
-    if nccl_cumem_enable and nccl_cumem_enable != "0":
-        logger.warning(
-            "Overriding NCCL_CUMEM_ENABLE=%r with '0' for checkpoint mode "
-            "because cuda-checkpoint does not support cuMem-backed NCCL allocations",
-            nccl_cumem_enable,
-        )
-    os.environ["NCCL_CUMEM_ENABLE"] = "0"
-
-    nccl_p2p_disable = os.environ.get("NCCL_P2P_DISABLE")
-    if nccl_p2p_disable and nccl_p2p_disable != "0":
-        logger.warning(
-            "Overriding NCCL_P2P_DISABLE=%r with '0' for checkpoint mode "
-            "to keep NCCL on GPU P2P transport when topology allows it",
-            nccl_p2p_disable,
-        )
-    os.environ["NCCL_P2P_DISABLE"] = "0"
-
-    nccl_nvls_enable = os.environ.get("NCCL_NVLS_ENABLE")
-    if nccl_nvls_enable and nccl_nvls_enable != "0":
-        logger.warning(
-            "Overriding NCCL_NVLS_ENABLE=%r with '0' for checkpoint mode "
-            "to avoid NVLS and keep NCCL on the legacy P2P path",
-            nccl_nvls_enable,
-        )
-    os.environ["NCCL_NVLS_ENABLE"] = "0"
-
-    nccl_ib_disable = os.environ.get("NCCL_IB_DISABLE")
-    if nccl_ib_disable and nccl_ib_disable != "1":
-        logger.warning(
-            "Overriding NCCL_IB_DISABLE=%r with '1' for checkpoint mode "
-            "because CRIU and cuda-checkpoint cannot restore InfiniBand state",
-            nccl_ib_disable,
-        )
-    os.environ["NCCL_IB_DISABLE"] = "1"
-
-    nccl_ras_enable = os.environ.get("NCCL_RAS_ENABLE")
-    if nccl_ras_enable and nccl_ras_enable != "0":
-        logger.warning(
-            "Overriding NCCL_RAS_ENABLE=%r with '0' for checkpoint mode "
-            "because NCCL RAS background state is not part of the checkpoint contract",
-            nccl_ras_enable,
-        )
-    os.environ["NCCL_RAS_ENABLE"] = "0"
-
-    torch_nccl_monitoring = os.environ.get("TORCH_NCCL_ENABLE_MONITORING")
-    if torch_nccl_monitoring and torch_nccl_monitoring != "0":
-        logger.warning(
-            "Overriding TORCH_NCCL_ENABLE_MONITORING=%r with '0' for checkpoint mode "
-            "because ProcessGroupNCCL monitoring can terminate restored processes",
-            torch_nccl_monitoring,
-        )
-    os.environ["TORCH_NCCL_ENABLE_MONITORING"] = "0"
-    os.environ.setdefault("TORCH_NCCL_DUMP_ON_TIMEOUT", "0")
 
 
 @dataclass

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -89,11 +89,16 @@ class SGLangEngineQuiesceController:
         from sglang.srt.managers.io_struct import (
             PauseGenerationReqInput,
             ReleaseMemoryOccupationReqInput,
+            SnapshotCheckpointPrepareReqInput,
         )
 
         await self._engine.tokenizer_manager.pause_generation(PauseGenerationReqInput())
         await self._engine.tokenizer_manager.release_memory_occupation(
             ReleaseMemoryOccupationReqInput(tags=tags),
+            None,
+        )
+        await self._engine.tokenizer_manager.snapshot_checkpoint_prepare(
+            SnapshotCheckpointPrepareReqInput(),
             None,
         )
         self._is_quiesced = True
@@ -106,8 +111,13 @@ class SGLangEngineQuiesceController:
         from sglang.srt.managers.io_struct import (
             ContinueGenerationReqInput,
             ResumeMemoryOccupationReqInput,
+            SnapshotCheckpointRestoreReqInput,
         )
 
+        await self._engine.tokenizer_manager.snapshot_checkpoint_restore(
+            SnapshotCheckpointRestoreReqInput(),
+            None,
+        )
         await self._engine.tokenizer_manager.resume_memory_occupation(
             ResumeMemoryOccupationReqInput(tags=tags),
             None,

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -221,6 +221,31 @@ class VllmEngineQuiesceController:
     def __init__(self, engine_client: Any):
         self._engine_client = engine_client
         self._is_quiesced = False
+        self._slept = False
+        self._checkpoint_prepared = False
+
+    def _refresh_rpc_host_env_for_restore(self) -> None:
+        from vllm.utils.network_utils import get_current_ip
+
+        current_ip = get_current_ip()
+        if not current_ip or current_ip == "0.0.0.0":
+            logger.warning(
+                "Snapshot checkpoint restore: could not refresh Dynamo RPC "
+                "host env vars; resolved current_ip=%s",
+                current_ip,
+            )
+            return
+
+        for env_var in ("DYN_TCP_RPC_HOST", "DYN_HTTP_RPC_HOST"):
+            old_host = os.environ.get(env_var)
+            os.environ[env_var] = current_ip
+            logger.info(
+                "Snapshot checkpoint restore: refreshed Dynamo RPC host env "
+                "var %s from %s to %s",
+                env_var,
+                old_host,
+                current_ip,
+            )
 
     @property
     def is_quiesced(self) -> bool:
@@ -230,12 +255,31 @@ class VllmEngineQuiesceController:
         if self._is_quiesced:
             return False
 
-        level = args[0] if args else None
+        control_dir = (
+            str(args[0]) if args and isinstance(args[0], (str, os.PathLike)) else None
+        )
+        level = args[1] if control_dir is not None and len(args) > 1 else None
+        if control_dir is None and args:
+            level = args[0]
         await self._engine_client.pause_generation()
-        if level is None:
+        if control_dir is not None and level is None:
+            logger.info(
+                "Snapshot checkpoint quiesce: paused generation without vLLM memory sleep"
+            )
+        elif level is None:
             await self._engine_client.sleep()
+            self._slept = True
         else:
+            if control_dir is not None:
+                logger.info(
+                    "Snapshot checkpoint quiesce: using explicit vLLM sleep level %s",
+                    level,
+                )
             await self._engine_client.sleep(level)
+            self._slept = True
+        if control_dir is not None:
+            await self._engine_client.snapshot_checkpoint_prepare(control_dir)
+            self._checkpoint_prepared = True
         self._is_quiesced = True
         return True
 
@@ -243,15 +287,22 @@ class VllmEngineQuiesceController:
         if not self._is_quiesced:
             return False
 
-        if tags is None:
-            await self._engine_client.wake_up()
-        else:
-            await self._engine_client.wake_up(tags)
+        if self._checkpoint_prepared:
+            await self._engine_client.snapshot_checkpoint_restore()
+            self._refresh_rpc_host_env_for_restore()
+            self._checkpoint_prepared = False
+        if self._slept:
+            if tags is None:
+                await self._engine_client.wake_up()
+            else:
+                await self._engine_client.wake_up(tags)
         await self._engine_client.resume_generation()
         return True
 
     def mark_resumed(self) -> None:
         self._is_quiesced = False
+        self._slept = False
+        self._checkpoint_prepared = False
 
 
 @dataclass(frozen=True)

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -282,11 +282,9 @@ class InstrumentedScheduler(AsyncScheduler):
 
         base_port = int(os.environ.get(ENV_FPM_PORT, str(DEFAULT_FPM_PORT)))
         port = base_port + dp_rank
-        self._publisher = _FpmPublisherThread(
-            f"tcp://*:{port}",
-            worker_id=self._fpm_worker_id,
-            dp_rank=dp_rank,
-        )
+        self._fpm_endpoint = f"tcp://*:{port}"
+        self._publisher: _FpmPublisherThread | None = None
+        self._start_publisher()
 
         logger.info(
             "InstrumentedScheduler: ZMQ PUB bound on tcp://*:%d "
@@ -297,6 +295,28 @@ class InstrumentedScheduler(AsyncScheduler):
         )
 
         self._bench_init(vllm_config)
+
+    def _start_publisher(self) -> None:
+        if self._publisher is not None:
+            return
+        self._publisher = _FpmPublisherThread(
+            self._fpm_endpoint,
+            worker_id=self._fpm_worker_id,
+            dp_rank=self._fpm_dp_rank,
+        )
+
+    def snapshot_checkpoint_prepare(self) -> None:
+        publisher = self._publisher
+        if publisher is None:
+            return
+        logger.info("InstrumentedScheduler: closing ZMQ PUB for snapshot")
+        publisher.shutdown()
+        self._publisher = None
+
+    def snapshot_checkpoint_restore(self) -> None:
+        if self._publisher is None:
+            logger.info("InstrumentedScheduler: reopening ZMQ PUB after snapshot")
+            self._start_publisher()
 
     @staticmethod
     def _resolve_dp_rank(parallel_config) -> int:
@@ -389,7 +409,10 @@ class InstrumentedScheduler(AsyncScheduler):
                 len(self._bench_active_req_ids),
             )
             self._bench_cleanup_requests()
-        self._publisher.shutdown()
+        publisher = self._publisher
+        if publisher is not None:
+            publisher.shutdown()
+            self._publisher = None
         super().shutdown()
 
     def update_from_output(
@@ -414,7 +437,8 @@ class InstrumentedScheduler(AsyncScheduler):
             metrics = self._extract_metrics(
                 scheduler_output, self._compute_queued(), wall_time
             )
-            self._publisher.publish(metrics)
+            if self._publisher is not None:
+                self._publisher.publish(metrics)
 
             if self._bench_active:
                 self._bench_current_fpms.append(

--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -23,11 +23,12 @@ async def prepare_snapshot_engine(
         return None
 
     if config.headless:
-        raise ValueError(
-            "--headless is incompatible with checkpoint mode "
-            "(DYN_CHECKPOINT_SIGNAL_FILE is set). "
-            "Remove --headless or unset DYN_CHECKPOINT_SIGNAL_FILE."
+        logger.info(
+            "Checkpoint mode enabled for headless vLLM; worker ranks will "
+            "quiesce through the leader scheduler broadcast"
         )
+        config.engine_args.enable_sleep_mode = True
+        return None
 
     logger.info("Checkpoint mode enabled (watcher-driven signals)")
     config.engine_args.enable_sleep_mode = True
@@ -38,7 +39,6 @@ async def prepare_snapshot_engine(
         engine=engine,
         quiesce_controller=VllmEngineQuiesceController(engine[0]),
         checkpoint_config=checkpoint_config,
-        quiesce_args=(None,),
     )
     if not await snapshot_controller.wait_for_restore():
         raise SystemExit(0)

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -29,6 +29,8 @@ def _make_handler() -> _TestWorkerHandler:
         sleep=AsyncMock(),
         wake_up=AsyncMock(),
         resume_generation=AsyncMock(),
+        snapshot_checkpoint_prepare=AsyncMock(),
+        snapshot_checkpoint_restore=AsyncMock(),
     )
     handler.generate_endpoint = SimpleNamespace(
         unregister_endpoint_instance=AsyncMock(),
@@ -67,8 +69,10 @@ async def test_sleep_and_wake_are_idempotent():
 
     handler.engine_client.pause_generation.assert_awaited_once()
     handler.engine_client.sleep.assert_awaited_once_with(2)
+    handler.engine_client.snapshot_checkpoint_prepare.assert_not_awaited()
     handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
 
+    handler.engine_client.snapshot_checkpoint_restore.assert_not_awaited()
     handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()
     handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
@@ -81,6 +85,8 @@ async def test_quiesce_without_level_uses_vllm_default_sleep():
         sleep=AsyncMock(),
         wake_up=AsyncMock(),
         resume_generation=AsyncMock(),
+        snapshot_checkpoint_prepare=AsyncMock(),
+        snapshot_checkpoint_restore=AsyncMock(),
     )
     controller = VllmEngineQuiesceController(engine_client)
 
@@ -89,6 +95,61 @@ async def test_quiesce_without_level_uses_vllm_default_sleep():
     assert changed is True
     engine_client.pause_generation.assert_awaited_once()
     engine_client.sleep.assert_awaited_once_with()
+    engine_client.snapshot_checkpoint_prepare.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_quiesce_prepares_and_restores_checkpoint():
+    engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+        snapshot_checkpoint_prepare=AsyncMock(),
+        snapshot_checkpoint_restore=AsyncMock(),
+    )
+    controller = VllmEngineQuiesceController(engine_client)
+
+    changed = await controller.quiesce("/snapshot-control", 2)
+    resumed = await controller.resume()
+
+    assert changed is True
+    assert resumed is True
+    engine_client.pause_generation.assert_awaited_once()
+    engine_client.sleep.assert_awaited_once_with(2)
+    engine_client.snapshot_checkpoint_prepare.assert_awaited_once_with(
+        "/snapshot-control"
+    )
+    engine_client.snapshot_checkpoint_restore.assert_awaited_once()
+    engine_client.wake_up.assert_awaited_once_with()
+    engine_client.resume_generation.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_quiesce_without_level_skips_memory_sleep():
+    engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+        snapshot_checkpoint_prepare=AsyncMock(),
+        snapshot_checkpoint_restore=AsyncMock(),
+    )
+    controller = VllmEngineQuiesceController(engine_client)
+
+    changed = await controller.quiesce("/snapshot-control")
+    resumed = await controller.resume()
+
+    assert changed is True
+    assert resumed is True
+    engine_client.pause_generation.assert_awaited_once()
+    engine_client.sleep.assert_not_awaited()
+    engine_client.snapshot_checkpoint_prepare.assert_awaited_once_with(
+        "/snapshot-control"
+    )
+    engine_client.snapshot_checkpoint_restore.assert_awaited_once()
+    engine_client.wake_up.assert_not_awaited()
+    engine_client.resume_generation.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -145,19 +145,6 @@ func buildCheckpointJob(
 		activeDeadlineSeconds = &defaultDeadline
 	}
 
-	// Wrap with cuda-checkpoint --launch-job for multi-GPU jobs (TP*PP > 1).
-	// Use checkpoint identity (not container limits) because DRA may have
-	// already removed nvidia.com/gpu from the template.
-	tp := ckpt.Spec.Identity.TensorParallelSize
-	pp := ckpt.Spec.Identity.PipelineParallelSize
-	if tp == 0 {
-		tp = 1
-	}
-	if pp == 0 {
-		pp = 1
-	}
-	wrapLaunchJob := tp*pp > 1
-
 	ttlSecondsAfterFinish := snapshotprotocol.DefaultCheckpointJobTTLSeconds
 
 	return snapshotprotocol.NewCheckpointJob(podTemplate, snapshotprotocol.CheckpointJobOptions{
@@ -168,6 +155,5 @@ func buildCheckpointJob(
 		Name:                  jobName,
 		ActiveDeadlineSeconds: activeDeadlineSeconds,
 		TTLSecondsAfterFinish: &ttlSecondsAfterFinish,
-		WrapLaunchJob:         wrapLaunchJob,
 	})
 }

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -259,7 +259,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 	assert.Equal(t, int32(0), *job.Spec.BackoffLimit)
 	assert.Equal(t, int32(300), *job.Spec.TTLSecondsAfterFinished)
 
-	// Multi-GPU: wrapping decision uses identity.TensorParallelSize, not container GPU limits.
+	// Multi-GPU: the checkpoint job still preserves the workload command.
 	ckpt.Spec.Identity.TensorParallelSize = 2
 	ckpt.Spec.Job.PodTemplateSpec.Spec.Containers[0].Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
@@ -268,11 +268,10 @@ func TestBuildCheckpointJob(t *testing.T) {
 	}
 	job, err = buildCheckpointJob(context.Background(), nil, r.Config, ckpt, defaultCheckpointJobName)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"cuda-checkpoint"}, job.Spec.Template.Spec.Containers[0].Command)
-	assert.Equal(t, []string{"--launch-job", "python3", "-m", "dynamo.vllm"}, job.Spec.Template.Spec.Containers[0].Args)
+	assert.Equal(t, []string{"python3", "-m", "dynamo.vllm"}, job.Spec.Template.Spec.Containers[0].Command)
 }
 
-func TestBuildCheckpointJobWrapsWithCudaCheckpointForMultiGPU(t *testing.T) {
+func TestBuildCheckpointJobPreservesCommandForMultiGPU(t *testing.T) {
 	s := checkpointTestScheme()
 	ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhasePending)
 	ckpt.Spec.Identity.TensorParallelSize = 2
@@ -301,8 +300,8 @@ func TestBuildCheckpointJobWrapsWithCudaCheckpointForMultiGPU(t *testing.T) {
 	require.NoError(t, err)
 
 	main := &job.Spec.Template.Spec.Containers[0]
-	assert.Equal(t, []string{"cuda-checkpoint"}, main.Command)
-	assert.Equal(t, []string{"--launch-job", "python3", "-m", "dynamo.vllm"}, main.Args)
+	assert.Equal(t, []string{"python3", "-m", "dynamo.vllm"}, main.Command)
+	assert.Nil(t, main.Args)
 	require.NotNil(t, main.ReadinessProbe)
 	assert.Equal(t, []string{"cat", "/snapshot-control/ready-for-checkpoint"}, main.ReadinessProbe.Exec.Command)
 	assert.Nil(t, main.LivenessProbe)

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -979,7 +980,19 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate base pod spec")
 	}
+	if err := checkpoint.ApplyRestorePodMetadataWithStorageConfig(podLabels, podAnnotations, checkpointInfo, r.Config.Checkpoint.Storage); err != nil {
+		return nil, errors.Wrap(err, "failed to apply checkpoint metadata")
+	}
 	if r.Config.Checkpoint.Enabled {
+		if checkpointInfo != nil && checkpointInfo.Enabled && checkpointInfo.Ready {
+			targets := checkpointInfo.RestoreTargetContainers
+			if len(targets) == 0 {
+				targets = []string{commonconsts.MainContainerName}
+			}
+			if err := snapshotprotocol.ApplyRendezvousMetadataFromPodSpec(podAnnotations, podSpec, targets); err != nil {
+				return nil, errors.Wrap(err, "failed to apply checkpoint rendezvous metadata")
+			}
+		}
 		if err := checkpoint.InjectCheckpointIntoPodSpecWithStorageConfig(
 			ctx,
 			r.Client,
@@ -1004,12 +1017,6 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 	if commonController.IsK8sDiscoveryEnabled(r.Config.Discovery.Backend, podAnnotations) {
 		podLabels[commonconsts.KubeLabelDynamoDiscoveryBackend] = "kubernetes"
 		podLabels[commonconsts.KubeLabelDynamoDiscoveryEnabled] = commonconsts.KubeLabelValueTrue
-	}
-
-	// Restore labels are operator-controlled state. Clear stale values after
-	// metadata merge and only reapply them when checkpoint material is ready.
-	if err := checkpoint.ApplyRestorePodMetadataWithStorageConfig(podLabels, podAnnotations, checkpointInfo, r.Config.Checkpoint.Storage); err != nil {
-		return nil, errors.Wrap(err, "failed to apply checkpoint metadata")
 	}
 
 	if podSpec.ServiceAccountName == "" {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/imdario/mergo"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -1830,8 +1831,38 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 		return nil, fmt.Errorf("failed to generate podSpec for role %s: %w", p.r.Name, err)
 	}
 
+	labels, err := generateLabels(p.component, p.dynamoDeployment, p.componentName, p.discoveryContext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate labels: %w", err)
+	}
+	annotations, err := generateAnnotations(p.component, p.dynamoDeployment, p.componentName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate annotations: %w", err)
+	}
+	if p.isInterPodFailover && p.r.Role != RoleGMS {
+		labels[commonconsts.KubeLabelDynamoFailoverEngineGroupMember] = commonconsts.KubeLabelValueTrue
+	}
+	if p.r.Role == RoleGMS {
+		delete(labels, commonconsts.KubeLabelDynamoDiscoveryBackend)
+		delete(labels, commonconsts.KubeLabelDynamoDiscoveryEnabled)
+	}
+	if p.r.Role != RoleGMS {
+		if err := checkpoint.ApplyRestorePodMetadataWithStorageConfig(labels, annotations, p.checkpointInfo, p.operatorConfig.Checkpoint.Storage); err != nil {
+			return nil, fmt.Errorf("failed to apply checkpoint metadata for role %s: %w", p.r.Name, err)
+		}
+	}
+
 	// GMS weight servers load weights fresh from disk and are not CRIU targets.
 	if p.operatorConfig.Checkpoint.Enabled && p.r.Role != RoleGMS {
+		if p.checkpointInfo != nil && p.checkpointInfo.Enabled && p.checkpointInfo.Ready {
+			targets := p.checkpointInfo.RestoreTargetContainers
+			if len(targets) == 0 {
+				targets = []string{commonconsts.MainContainerName}
+			}
+			if err := snapshotprotocol.ApplyRendezvousMetadataFromPodSpec(annotations, podSpec, targets); err != nil {
+				return nil, fmt.Errorf("failed to apply checkpoint rendezvous metadata for role %s: %w", p.r.Name, err)
+			}
+		}
 		if err := checkpoint.InjectCheckpointIntoPodSpecWithStorageConfig(
 			p.ctx, p.kubeClient, p.dynamoDeployment.Namespace, podSpec, p.checkpointInfo,
 			p.operatorConfig.Checkpoint.Storage,
@@ -1884,39 +1915,12 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 		},
 	}
 
+	clique.Labels = labels
+
 	if !p.usesPCSG {
 		clique.TopologyConstraint = toGroveTopologyConstraint(p.component.TopologyConstraint)
 	}
 
-	labels, err := generateLabels(p.component, p.dynamoDeployment, p.componentName, p.discoveryContext)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate labels: %w", err)
-	}
-	clique.Labels = labels
-	if p.isInterPodFailover && p.r.Role != RoleGMS {
-		clique.Labels[commonconsts.KubeLabelDynamoFailoverEngineGroupMember] = commonconsts.KubeLabelValueTrue
-	}
-	// Strip discovery labels from RoleGMS pods. generateLabels applies them
-	// unconditionally to every role for container-mode Pod reflector filtering
-	// (see #8067), but GMS weight-server pods run gpu_memory_service.cli.server
-	// — not the dynamo runtime — and never register a DynamoWorkerMetadata CR.
-	// Leaving the labels on them would make the Rust discovery daemon include
-	// them in its reflector store for no purpose and wake its debounce loop on
-	// every GMS restart/fast-kill event.
-	if p.r.Role == RoleGMS {
-		delete(clique.Labels, commonconsts.KubeLabelDynamoDiscoveryBackend)
-		delete(clique.Labels, commonconsts.KubeLabelDynamoDiscoveryEnabled)
-	}
-
-	annotations, err := generateAnnotations(p.component, p.dynamoDeployment, p.componentName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate annotations: %w", err)
-	}
-	if p.r.Role != RoleGMS {
-		if err := checkpoint.ApplyRestorePodMetadataWithStorageConfig(labels, annotations, p.checkpointInfo, p.operatorConfig.Checkpoint.Storage); err != nil {
-			return nil, fmt.Errorf("failed to apply checkpoint metadata for role %s: %w", p.r.Name, err)
-		}
-	}
 	annotations = applyRestartAnnotation(annotations, p.componentName, p.restartState, p.existingRestartAnnotations)
 	clique.Annotations = annotations
 

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -91,7 +91,8 @@ RUN gcc -O2 -Wall -Wextra -o /cuda-checkpoint-helper \
     ./cmd/cuda-checkpoint-helper/main.c \
     -I/usr/local/cuda/include \
     -L/usr/local/cuda/lib64/stubs \
-    -lcuda
+    -lcuda \
+    -ldl
 
 # =============================================================================
 # Stage: CRIU Builder - Build CRIU with CUDA plugin
@@ -122,11 +123,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     uuid-dev \
     && rm -rf /var/lib/apt/lists/*
 
+COPY criu-patches /tmp/criu-patches
+
 RUN git init /tmp/criu \
     && cd /tmp/criu \
     && git remote add origin ${CRIU_REPO} \
     && git fetch --depth 1 origin ${CRIU_REF} \
     && git checkout FETCH_HEAD \
+    && for patch in /tmp/criu-patches/*.patch; do git apply "$patch"; done \
     && make -j$(nproc) \
     && make DESTDIR=/criu-install install-criu install-lib install-cuda_plugin
 
@@ -138,6 +142,7 @@ RUN git clone https://github.com/NVIDIA/cuda-checkpoint.git /tmp/cuda-checkpoint
 FROM ${AGENT_BASE_IMAGE} AS agent
 
 ARG TARGETARCH=amd64
+ENV CRIU_LIBS_DIR=/usr/local/lib/criu
 
 RUN if [ "${TARGETARCH}" != "amd64" ]; then \
       echo "ERROR: Dynamo Snapshot requires x86_64 (cuda-checkpoint has no ${TARGETARCH} binary)" >&2; exit 1; \
@@ -195,6 +200,7 @@ FROM ${BASE_IMAGE} AS placeholder
 ARG BASE_IMAGE
 ARG TARGETARCH=amd64
 ENV ORIGINAL_BASE_IMAGE=${BASE_IMAGE}
+ENV CRIU_LIBS_DIR=/usr/local/lib/criu
 
 USER root
 

--- a/deploy/snapshot/cmd/cuda-checkpoint-helper/main.c
+++ b/deploy/snapshot/cmd/cuda-checkpoint-helper/main.c
@@ -1,9 +1,28 @@
 #include <ctype.h>
 #include <cuda.h>
+#include <dlfcn.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+static const CUuuid cuda_checkpoint_export_table_id = {{
+    (char)0x69, (char)0xa2, (char)0x8e, (char)0x9f,
+    (char)0x24, (char)0x49,
+    (char)0x8b, (char)0x47,
+    (char)0xb0, (char)0x30, (char)0xc5, (char)0xda,
+    (char)0x33, (char)0x0e, (char)0xa4, (char)0xe9,
+}};
+
+typedef struct CudaCheckpointExportTable_st
+{
+  size_t struct_size;
+  void* reserved[29];
+  CUresult(CUDAAPI* CreateJobFile)(const char* job_file_path);
+  CUresult(CUDAAPI* SetJobFile)(const char* job_file_path);
+} CudaCheckpointExportTable;
+
+typedef CUresult(CUDAAPI* CuGetExportTableFn)(const void** table, const CUuuid* id);
 
 static int
 print_usage(FILE* stream)
@@ -11,6 +30,7 @@ print_usage(FILE* stream)
   return fprintf(
              stream,
              "Usage:\n"
+             "  cuda-checkpoint-helper --create-job-file <path>\n"
              "  cuda-checkpoint-helper --get-state --pid <pid>\n"
              "  cuda-checkpoint-helper --get-restore-tid --pid <pid>\n"
              "  cuda-checkpoint-helper --action lock|checkpoint|restore|unlock --pid <pid> [--timeout <ms>] "
@@ -36,6 +56,54 @@ print_cuda_error(CUresult status)
   }
 
   fprintf(stderr, "%s: %s\n", name, msg);
+}
+
+static CUresult
+get_checkpoint_export_table(const CudaCheckpointExportTable** table_out)
+{
+  void* handle;
+  void* symbol;
+  const CudaCheckpointExportTable* table = NULL;
+  CUresult status;
+
+  *table_out = NULL;
+
+  handle = dlopen("libcuda.so.1", RTLD_NOW | RTLD_LOCAL);
+  if (handle == NULL) {
+    handle = RTLD_DEFAULT;
+  }
+  symbol = dlsym(handle, "cuGetExportTable");
+  if (symbol == NULL) {
+    return CUDA_ERROR_UNKNOWN;
+  }
+
+  status = ((CuGetExportTableFn)symbol)((const void**)&table, &cuda_checkpoint_export_table_id);
+  if (status != CUDA_SUCCESS) {
+    return status;
+  }
+  if (table == NULL || table->struct_size < sizeof(*table) || table->CreateJobFile == NULL) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  *table_out = table;
+  return CUDA_SUCCESS;
+}
+
+static CUresult
+do_create_job_file(const char* job_file_path)
+{
+  const CudaCheckpointExportTable* table = NULL;
+  CUresult status;
+
+  if (job_file_path == NULL || job_file_path[0] == '\0') {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  status = get_checkpoint_export_table(&table);
+  if (status != CUDA_SUCCESS) {
+    return status;
+  }
+  return table->CreateJobFile(job_file_path);
 }
 
 static int
@@ -269,8 +337,10 @@ main(int argc, char** argv)
 {
   const char* action = NULL;
   const char* device_map = "";
+  const char* job_file_path = NULL;
   int pid = 0;
   int have_pid = 0;
+  int do_create_job_file_flag = 0;
   int do_get_state_flag = 0;
   int do_get_restore_tid_flag = 0;
   unsigned int timeout_ms = 0;
@@ -288,6 +358,14 @@ main(int argc, char** argv)
     }
     if (strcmp(argv[i], "--get-restore-tid") == 0) {
       do_get_restore_tid_flag = 1;
+      continue;
+    }
+    if (strcmp(argv[i], "--create-job-file") == 0) {
+      if (++i >= argc) {
+        return print_usage(stderr);
+      }
+      do_create_job_file_flag = 1;
+      job_file_path = argv[i];
       continue;
     }
     if (strcmp(argv[i], "--action") == 0) {
@@ -323,9 +401,22 @@ main(int argc, char** argv)
     return print_usage(stderr);
   }
 
-  if ((do_get_state_flag + do_get_restore_tid_flag + (action != NULL ? 1 : 0)) != 1) {
+  if ((do_create_job_file_flag + do_get_state_flag + do_get_restore_tid_flag + (action != NULL ? 1 : 0)) != 1) {
     return print_usage(stderr);
   }
+
+  if (do_create_job_file_flag) {
+    if (have_pid || timeout_ms != 0 || device_map[0] != '\0') {
+      return print_usage(stderr);
+    }
+    status = do_create_job_file(job_file_path);
+    if (status != CUDA_SUCCESS) {
+      print_cuda_error(status);
+      return 1;
+    }
+    return 0;
+  }
+
   if (!have_pid) {
     return print_usage(stderr);
   }

--- a/deploy/snapshot/cmd/nsrestore/main.go
+++ b/deploy/snapshot/cmd/nsrestore/main.go
@@ -19,6 +19,8 @@ func main() {
 	checkpointPath := flag.String("checkpoint-path", "", "Path to checkpoint directory")
 	cudaDeviceMap := flag.String("cuda-device-map", "", "CUDA device map for cuda-checkpoint-helper restore")
 	cgroupRoot := flag.String("cgroup-root", "", "CRIU cgroup root remap path")
+	restorePodUID := flag.String("restore-pod-uid", "", "Restore target pod UID for Kubernetes mount remapping")
+	restoreContainerName := flag.String("restore-container-name", "", "Restore target container name for Kubernetes mount remapping")
 	flag.Parse()
 
 	if *checkpointPath == "" {
@@ -26,9 +28,11 @@ func main() {
 	}
 
 	opts := executor.RestoreOptions{
-		CheckpointPath: *checkpointPath,
-		CUDADeviceMap:  *cudaDeviceMap,
-		CgroupRoot:     *cgroupRoot,
+		CheckpointPath:       *checkpointPath,
+		CUDADeviceMap:        *cudaDeviceMap,
+		CgroupRoot:           *cgroupRoot,
+		RestorePodUID:        *restorePodUID,
+		RestoreContainerName: *restoreContainerName,
 	}
 
 	result, err := executor.RestoreInNamespace(context.Background(), opts, log)

--- a/deploy/snapshot/cmd/snapshotctl/checkpoint.go
+++ b/deploy/snapshot/cmd/snapshotctl/checkpoint.go
@@ -21,13 +21,12 @@ import (
 const defaultGeneratedCheckpointIDPrefix = "manual-snapshot"
 
 type checkpointOptions struct {
-	ManifestPath                 string
-	Namespace                    string
-	KubeContext                  string
-	CheckpointID                 string
-	Container                    string
-	DisableCudaCheckpointJobFile bool
-	Timeout                      time.Duration
+	ManifestPath string
+	Namespace    string
+	KubeContext  string
+	CheckpointID string
+	Container    string
+	Timeout      time.Duration
 }
 
 type result struct {
@@ -91,7 +90,6 @@ func runCheckpointFlow(ctx context.Context, opts checkpointOptions) (*result, er
 		ArtifactVersion: snapshotprotocol.DefaultCheckpointArtifactVersion,
 		SeccompProfile:  snapshotprotocol.DefaultSeccompLocalhostProfile,
 		Name:            checkpointJobName,
-		WrapLaunchJob:   !opts.DisableCudaCheckpointJobFile,
 	})
 	if err != nil {
 		return nil, err

--- a/deploy/snapshot/cmd/snapshotctl/main.go
+++ b/deploy/snapshot/cmd/snapshotctl/main.go
@@ -47,7 +47,6 @@ func runCheckpoint(args []string) error {
 	kubeContext := flags.String("kube-context", "", "Kubernetes context override")
 	checkpointID := flags.String("checkpoint-id", "", "Explicit checkpoint ID; defaults to a generated value")
 	container := flags.String("container", "", "Required. Name of the workload container inside the manifest to checkpoint. May be omitted if the manifest already sets the nvidia.com/snapshot-target-containers annotation")
-	disableCudaCheckpointJobFile := flags.Bool("disable-cuda-checkpoint-job-file", false, "Preserve the manifest command instead of wrapping it with cuda-checkpoint --launch-job")
 	timeout := flags.Duration("timeout", 45*time.Minute, "Maximum time to wait for checkpoint completion")
 
 	if err := flags.Parse(args); err != nil {
@@ -62,13 +61,12 @@ func runCheckpoint(args []string) error {
 
 	snapshotctlLog.Info("Running checkpoint", "manifest", *manifest, "namespace", *namespace)
 	result, err := runCheckpointFlow(context.Background(), checkpointOptions{
-		ManifestPath:                 *manifest,
-		Namespace:                    *namespace,
-		KubeContext:                  *kubeContext,
-		CheckpointID:                 *checkpointID,
-		Container:                    *container,
-		DisableCudaCheckpointJobFile: *disableCudaCheckpointJobFile,
-		Timeout:                      *timeout,
+		ManifestPath: *manifest,
+		Namespace:    *namespace,
+		KubeContext:  *kubeContext,
+		CheckpointID: *checkpointID,
+		Container:    *container,
+		Timeout:      *timeout,
 	})
 	if err != nil {
 		return err

--- a/deploy/snapshot/criu-patches/0001-cuda-plugin-nvidia-ext-file.patch
+++ b/deploy/snapshot/criu-patches/0001-cuda-plugin-nvidia-ext-file.patch
@@ -1,0 +1,551 @@
+diff --git a/plugins/cuda/cuda_plugin.c b/plugins/cuda/cuda_plugin.c
+index 9ccb042..65d81e6 100644
+--- a/plugins/cuda/cuda_plugin.c
++++ b/plugins/cuda/cuda_plugin.c
+@@ -11,10 +11,16 @@
+ #include <compel/infect.h>
+ 
+ #include <ctype.h>
++#include <errno.h>
+ #include <fcntl.h>
++#include <limits.h>
+ #include <stdio.h>
++#include <stdint.h>
++#include <string.h>
+ #include <unistd.h>
+ #include <sys/ptrace.h>
++#include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <sys/wait.h>
+ 
+ /* cuda-checkpoint binary should live in your PATH */
+@@ -34,6 +40,12 @@ typedef enum {
+ } cuda_task_state_t;
+ 
+ #define CUDA_CKPT_BUF_SIZE (128)
++#define CUDA_NVIDIA_FD_IMAGE "cuda-nvidia-fd.%x"
++#define CUDA_NVIDIA_FD_IMAGE_VERSION 1
++#define NVIDIA_DEV_MAJOR 195
++#define NVIDIA_CTL_MINOR 255
++#define NVIDIA_MODESET_MINOR 254
++#define CUDA_SETFL_MASK (O_APPEND | O_ASYNC | O_NONBLOCK | O_NDELAY | O_DIRECT | O_NOATIME)
+ 
+ #ifdef LOG_PREFIX
+ #undef LOG_PREFIX
+@@ -54,6 +66,14 @@ struct pid_info {
+ 	struct list_head list;
+ };
+ 
++struct cuda_nvidia_fd_image {
++	uint32_t version;
++	uint32_t major;
++	uint32_t minor;
++	int32_t flags;
++	char path[PATH_MAX];
++};
++
+ /* Used to track which PID's we've paused CUDA operations on so far so we can
+  * release them after we're done with the DUMP
+  */
+@@ -70,22 +90,6 @@ static void dealloc_pid_buffer(struct list_head *pid_buf)
+ 	}
+ }
+ 
+-static int add_pid_to_buf(struct list_head *pid_buf, int pid, cuda_task_state_t state)
+-{
+-	struct pid_info *new = xmalloc(sizeof(*new));
+-
+-	if (new == NULL) {
+-		return -1;
+-	}
+-
+-	new->pid = pid;
+-	new->checkpointed = 0;
+-	new->initial_task_state = state;
+-	list_add_tail(&new->list, pid_buf);
+-
+-	return 0;
+-}
+-
+ static int launch_cuda_checkpoint(const char **args, char *buf, int buf_size)
+ {
+ #define READ  0
+@@ -185,6 +189,286 @@ err:
+ 	return -1;
+ }
+ 
++static bool cuda_all_digits(const char *s)
++{
++	if (!s[0])
++		return false;
++
++	for (; s[0]; s++) {
++		if (!isdigit((unsigned char)s[0]))
++			return false;
++	}
++	return true;
++}
++
++static bool cuda_is_nvidia_device_name(const char *name)
++{
++	if (!strcmp(name, "nvidiactl") || !strcmp(name, "nvidia-modeset") ||
++	    !strcmp(name, "nvidia-uvm") || !strcmp(name, "nvidia-uvm-tools"))
++		return true;
++
++	if (!strncmp(name, "nvidia-cap", strlen("nvidia-cap")))
++		return cuda_all_digits(name + strlen("nvidia-cap"));
++
++	if (!strncmp(name, "nvidia", strlen("nvidia")))
++		return cuda_all_digits(name + strlen("nvidia"));
++
++	return false;
++}
++
++static int cuda_normalize_nvidia_device_path(int fd, const struct stat *st, char *path, size_t path_size)
++{
++	char fd_path[64];
++	char link_path[PATH_MAX];
++	const char *name;
++	ssize_t len;
++	int ret;
++
++	snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", fd);
++	len = readlink(fd_path, link_path, sizeof(link_path) - 1);
++	if (len >= 0) {
++		link_path[len] = '\0';
++		name = strrchr(link_path, '/');
++		name = name ? name + 1 : link_path;
++
++		if (cuda_is_nvidia_device_name(name)) {
++			if (!strncmp(name, "nvidia-cap", strlen("nvidia-cap"))) {
++				ret = snprintf(path, path_size, "/dev/nvidia-caps/%s", name);
++				if (ret < 0 || (size_t)ret >= path_size)
++					return -1;
++			} else {
++				ret = snprintf(path, path_size, "/dev/%s", name);
++				if (ret < 0 || (size_t)ret >= path_size)
++					return -1;
++			}
++			return 0;
++		}
++	}
++
++	if (major(st->st_rdev) != NVIDIA_DEV_MAJOR)
++		return -ENOTSUP;
++
++	switch (minor(st->st_rdev)) {
++	case NVIDIA_CTL_MINOR:
++		name = "nvidiactl";
++		break;
++	case NVIDIA_MODESET_MINOR:
++		name = "nvidia-modeset";
++		break;
++	default:
++		ret = snprintf(path, path_size, "/dev/nvidia%u", minor(st->st_rdev));
++		if (ret < 0 || (size_t)ret >= path_size)
++			return -1;
++		return 0;
++	}
++
++	ret = snprintf(path, path_size, "/dev/%s", name);
++	if (ret < 0 || (size_t)ret >= path_size)
++		return -1;
++	return 0;
++}
++
++static int cuda_read_full(int fd, void *buf, size_t len)
++{
++	char *p = buf;
++
++	while (len > 0) {
++		ssize_t ret = read(fd, p, len);
++		if (ret < 0) {
++			if (errno == EINTR)
++				continue;
++			return -errno;
++		}
++		if (ret == 0)
++			return -EIO;
++		p += ret;
++		len -= ret;
++	}
++	return 0;
++}
++
++static int cuda_write_full(int fd, const void *buf, size_t len)
++{
++	const char *p = buf;
++
++	while (len > 0) {
++		ssize_t ret = write(fd, p, len);
++		if (ret < 0) {
++			if (errno == EINTR)
++				continue;
++			return -errno;
++		}
++		if (ret == 0)
++			return -EIO;
++		p += ret;
++		len -= ret;
++	}
++	return 0;
++}
++
++static int cuda_restore_fd_status_flags(int fd, int flags)
++{
++	int ret;
++	int restored;
++
++	ret = fcntl(fd, F_GETFL, 0);
++	if (ret < 0)
++		return -errno;
++
++	restored = (ret & ~CUDA_SETFL_MASK) | (flags & CUDA_SETFL_MASK);
++	if (fcntl(fd, F_SETFL, restored) < 0)
++		return -errno;
++
++	return 0;
++}
++
++int cuda_plugin_dump_file(int fd, int id)
++{
++	struct cuda_nvidia_fd_image image = {
++		.version = CUDA_NVIDIA_FD_IMAGE_VERSION,
++	};
++	char img_path[PATH_MAX];
++	struct stat st;
++	int ret;
++	int img_fd;
++
++	if (plugin_disabled)
++		return -ENOTSUP;
++
++	if (fstat(fd, &st) < 0) {
++		pr_perror("Unable to stat fd %d", fd);
++		return -1;
++	}
++
++	if (!S_ISCHR(st.st_mode))
++		return -ENOTSUP;
++
++	ret = cuda_normalize_nvidia_device_path(fd, &st, image.path, sizeof(image.path));
++	if (ret == -ENOTSUP)
++		return -ENOTSUP;
++	if (ret < 0)
++		return -1;
++
++	ret = fcntl(fd, F_GETFL, 0);
++	if (ret < 0) {
++		pr_perror("Unable to get status flags for NVIDIA fd %d", fd);
++		return -1;
++	}
++
++	image.flags = ret;
++	image.major = major(st.st_rdev);
++	image.minor = minor(st.st_rdev);
++
++	if (!plugin_added_to_inventory) {
++		if (add_inventory_plugin(CR_PLUGIN_DESC.name)) {
++			pr_err("Failed to add CUDA plugin to inventory image\n");
++			return -1;
++		}
++		plugin_added_to_inventory = true;
++	}
++
++	snprintf(img_path, sizeof(img_path), CUDA_NVIDIA_FD_IMAGE, id);
++	img_fd = openat(criu_get_image_dir(), img_path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
++	if (img_fd < 0) {
++		pr_perror("Unable to open %s", img_path);
++		return -1;
++	}
++
++	ret = cuda_write_full(img_fd, &image, sizeof(image));
++	if (ret < 0) {
++		errno = -ret;
++		pr_perror("Unable to write %s", img_path);
++		close(img_fd);
++		return -1;
++	}
++
++	if (close(img_fd) < 0) {
++		pr_perror("Unable to close %s", img_path);
++		return -1;
++	}
++
++	pr_info("Dumped NVIDIA device fd %d id %#x path %s dev %u:%u flags %#x\n",
++		fd, id, image.path, image.major, image.minor, image.flags);
++	return 0;
++}
++CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__DUMP_EXT_FILE, cuda_plugin_dump_file)
++
++int cuda_plugin_restore_file(int id, bool *retry_needed)
++{
++	struct cuda_nvidia_fd_image image;
++	char img_path[PATH_MAX];
++	int ret;
++	int img_fd;
++	int fd;
++	struct stat restored_st;
++
++	*retry_needed = false;
++
++	if (plugin_disabled)
++		return -ENOTSUP;
++
++	snprintf(img_path, sizeof(img_path), CUDA_NVIDIA_FD_IMAGE, id);
++	img_fd = openat(criu_get_image_dir(), img_path, O_RDONLY);
++	if (img_fd < 0) {
++		if (errno == ENOENT)
++			return -ENOTSUP;
++		pr_perror("Unable to open %s", img_path);
++		return -1;
++	}
++
++	ret = cuda_read_full(img_fd, &image, sizeof(image));
++	close(img_fd);
++	if (ret < 0) {
++		errno = -ret;
++		pr_perror("Unable to read %s", img_path);
++		return -1;
++	}
++
++	if (image.version != CUDA_NVIDIA_FD_IMAGE_VERSION ||
++	    !cuda_is_nvidia_device_name(strrchr(image.path, '/') ? strrchr(image.path, '/') + 1 : image.path)) {
++		pr_err("Invalid NVIDIA fd image %s for id %#x\n", img_path, id);
++		return -1;
++	}
++
++	fd = open(image.path, (image.flags & O_ACCMODE) | O_CLOEXEC);
++	if (fd < 0) {
++		pr_perror("Unable to restore NVIDIA device fd id %#x path %s", id, image.path);
++		return -1;
++	}
++
++	if (fstat(fd, &restored_st) < 0) {
++		pr_perror("Unable to stat restored NVIDIA device fd id %#x path %s", id, image.path);
++		close(fd);
++		return -1;
++	}
++	if (!S_ISCHR(restored_st.st_mode)) {
++		pr_err("Restored NVIDIA fd id %#x path %s is not a character device\n", id, image.path);
++		close(fd);
++		return -1;
++	}
++	if (image.major == NVIDIA_DEV_MAJOR &&
++	    (major(restored_st.st_rdev) != image.major || minor(restored_st.st_rdev) != image.minor)) {
++		pr_err("Restored NVIDIA fd id %#x path %s dev changed from %u:%u to %u:%u\n",
++		       id, image.path, image.major, image.minor,
++		       major(restored_st.st_rdev), minor(restored_st.st_rdev));
++		close(fd);
++		return -1;
++	}
++
++	ret = cuda_restore_fd_status_flags(fd, image.flags);
++	if (ret < 0) {
++		errno = -ret;
++		pr_perror("Unable to restore status flags for NVIDIA device fd id %#x path %s", id, image.path);
++		close(fd);
++		return -1;
++	}
++
++	pr_info("Restored NVIDIA device fd id %#x path %s dev %u:%u flags %#x as fd %d\n",
++		id, image.path, image.major, image.minor, image.flags, fd);
++	return fd;
++}
++CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESTORE_EXT_FILE, cuda_plugin_restore_file)
++
+ /**
+  * Checks if a given flag is supported by the cuda-checkpoint utility
+  *
+@@ -225,37 +509,6 @@ static int get_cuda_restore_tid(int root_pid)
+ 	return atoi(pid_out);
+ }
+ 
+-static cuda_task_state_t get_task_state_enum(const char *state_str)
+-{
+-	if (strncmp(state_str, "running", 7) == 0)
+-		return CUDA_TASK_RUNNING;
+-
+-	if (strncmp(state_str, "locked", 6) == 0)
+-		return CUDA_TASK_LOCKED;
+-
+-	if (strncmp(state_str, "checkpointed", 12) == 0)
+-		return CUDA_TASK_CHECKPOINTED;
+-
+-	pr_err("Unknown CUDA state: %s\n", state_str);
+-	return CUDA_TASK_UNKNOWN;
+-}
+-
+-static cuda_task_state_t get_cuda_state(pid_t pid)
+-{
+-	char pid_buf[16];
+-	char state_str[CUDA_CKPT_BUF_SIZE];
+-	const char *args[] = { CUDA_CHECKPOINT, "--get-state", "--pid", pid_buf, NULL };
+-
+-	snprintf(pid_buf, sizeof(pid_buf), "%d", pid);
+-
+-	if (launch_cuda_checkpoint(args, state_str, sizeof(state_str))) {
+-		pr_err("Failed to launch cuda-checkpoint to retrieve state: %s\n", state_str);
+-		return CUDA_TASK_UNKNOWN;
+-	}
+-
+-	return get_task_state_enum(state_str);
+-}
+-
+ static int cuda_process_checkpoint_action(int pid, const char *action, unsigned int timeout, char *msg_buf,
+ 					  int buf_size)
+ {
+@@ -339,135 +592,23 @@ static int resume_restore_thread(int restore_tid, k_rtsigset_t *save_sigset)
+ 
+ int cuda_plugin_checkpoint_devices(int pid)
+ {
+-	int restore_tid;
+-	char msg_buf[CUDA_CKPT_BUF_SIZE];
+-	int int_ret;
+-	int status;
+-	k_rtsigset_t save_sigset;
+-	struct pid_info *task_info;
+-	bool pid_found = false;
+-
+ 	if (plugin_disabled) {
+ 		return -ENOTSUP;
+ 	}
+ 
+-	restore_tid = get_cuda_restore_tid(pid);
+-
+-	/* We can possibly hit a race with cuInit() where we are past the point of
+-	 * locking the process but at lock time cuInit() hadn't completed in which
+-	 * case cuda-checkpoint will report that we're in an invalid state to
+-	 * checkpoint
+-	 */
+-	if (restore_tid == -1) {
+-		pr_info("No need to checkpoint devices on pid %d\n", pid);
+-		return 0;
+-	}
+-
+-	/* Check if the process is already in a checkpointed state */
+-	list_for_each_entry(task_info, &cuda_pids, list) {
+-		if (task_info->pid == pid) {
+-			if (task_info->initial_task_state == CUDA_TASK_CHECKPOINTED) {
+-				pr_info("pid %d already in a checkpointed state\n", pid);
+-				return 0;
+-			}
+-			pid_found = true;
+-			break;
+-		}
+-	}
+-
+-	if (pid_found == false) {
+-		/* We return an error here. The task should be restored
+-		 * to its original state at cuda_plugin_fini().
+-		 */
+-		pr_err("Failed to track pid %d\n", pid);
+-		return -1;
+-	}
+-
+-	pr_info("Checkpointing CUDA devices on pid %d restore_tid %d\n", pid, restore_tid);
+-	/* We need to resume the checkpoint thread to prepare the mappings for
+-	 * checkpointing
+-	 */
+-	if (resume_restore_thread(restore_tid, &save_sigset)) {
+-		return -1;
+-	}
+-
+-	task_info->checkpointed = 1;
+-	status = cuda_process_checkpoint_action(pid, ACTION_CHECKPOINT, 0, msg_buf, sizeof(msg_buf));
+-	if (status) {
+-		pr_err("CHECKPOINT_DEVICES failed with %s\n", msg_buf);
+-	}
+-
+-	int_ret = interrupt_restore_thread(restore_tid, &save_sigset);
+-	return status != 0 ? -1 : int_ret;
++	pr_info("Dynamo snapshot-agent owns CUDA checkpoint; skipping checkpoint devices on pid %d\n", pid);
++	return 0;
+ }
+ CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__CHECKPOINT_DEVICES, cuda_plugin_checkpoint_devices);
+ 
+ int cuda_plugin_pause_devices(int pid)
+ {
+-	int restore_tid;
+-	char msg_buf[CUDA_CKPT_BUF_SIZE];
+-	cuda_task_state_t task_state;
+-
+ 	if (plugin_disabled) {
+ 		return -ENOTSUP;
+ 	}
+ 
+-	restore_tid = get_cuda_restore_tid(pid);
+-
+-	if (restore_tid == -1) {
+-		pr_info("no need to pause devices on pid %d\n", pid);
+-		return 0;
+-	}
+-
+-	task_state = get_cuda_state(restore_tid);
+-	if (task_state == CUDA_TASK_UNKNOWN) {
+-		pr_err("Failed to get CUDA state for PID %d\n", restore_tid);
+-		return -1;
+-	}
+-
+-	if (!plugin_added_to_inventory) {
+-		if (add_inventory_plugin(CR_PLUGIN_DESC.name)) {
+-			pr_err("Failed to add CUDA plugin to inventory image\n");
+-			return -1;
+-		}
+-		plugin_added_to_inventory = true;
+-	}
+-
+-	if (task_state == CUDA_TASK_LOCKED) {
+-		pr_info("pid %d already in a locked state\n", pid);
+-		/* Leave this PID in a "locked" state at resume_device() */
+-		add_pid_to_buf(&cuda_pids, pid, CUDA_TASK_LOCKED);
+-		return 0;
+-	}
+-
+-	if (task_state == CUDA_TASK_CHECKPOINTED) {
+-		/* We need to skip this PID in cuda_plugin_checkpoint_devices(),
+-		 * and leave it in a "checkpoined" state at resume_device(). */
+-		add_pid_to_buf(&cuda_pids, pid, CUDA_TASK_CHECKPOINTED);
+-		return 0;
+-	}
+-
+-	pr_info("pausing devices on pid %d\n", pid);
+-	int status = cuda_process_checkpoint_action(pid, ACTION_LOCK, opts.timeout * 1000, msg_buf, sizeof(msg_buf));
+-	if (status) {
+-		pr_err("PAUSE_DEVICES failed with %s\n", msg_buf);
+-		if (alarm_timeouted())
+-			goto unlock;
+-		return -1;
+-	}
+-
+-	if (add_pid_to_buf(&cuda_pids, pid, CUDA_TASK_RUNNING)) {
+-		pr_err("unable to track paused pid %d\n", pid);
+-		goto unlock;
+-	}
+-
++	pr_info("Dynamo snapshot-agent owns CUDA checkpoint; skipping pause devices on pid %d\n", pid);
+ 	return 0;
+-unlock:
+-	status = cuda_process_checkpoint_action(pid, ACTION_UNLOCK, 0, msg_buf, sizeof(msg_buf));
+-	if (status) {
+-		pr_err("Failed to unlock process status %s, pid %d may hang\n", msg_buf, pid);
+-	}
+-	return -1;
+ }
+ CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__PAUSE_DEVICES, cuda_plugin_pause_devices)
+ 
+@@ -534,12 +675,8 @@ int cuda_plugin_resume_devices_late(int pid)
+ 		return -ENOTSUP;
+ 	}
+ 
+-	/* RESUME_DEVICES_LATE is used during `criu restore`.
+-	 * Here, we assume that users expect the target process
+-	 * to be in a "running" state after restore, even if it was
+-	 * in a "locked" or "checkpointed" state during `criu dump`.
+-	 */
+-	return resume_device(pid, 1, CUDA_TASK_RUNNING);
++	pr_info("Dynamo snapshot-agent owns CUDA restore; skipping resume devices on pid %d\n", pid);
++	return 0;
+ }
+ CR_PLUGIN_REGISTER_HOOK(CR_PLUGIN_HOOK__RESUME_DEVICES_LATE, cuda_plugin_resume_devices_late)
+ 

--- a/deploy/snapshot/criu-patches/0002-ghost-dev-shm-posix-semaphores.patch
+++ b/deploy/snapshot/criu-patches/0002-ghost-dev-shm-posix-semaphores.patch
@@ -1,0 +1,32 @@
+diff --git a/criu/files-reg.c b/criu/files-reg.c
+index 7d3f3fe82..eaa7c6508 100644
+--- a/criu/files-reg.c
++++ b/criu/files-reg.c
+@@ -1295,6 +1295,14 @@ static inline bool nfs_silly_rename(char *rpath, const struct fd_parms *parms)
+ 	return (parms->fs_type == NFS_SUPER_MAGIC) && is_sillyrename_name(rpath);
+ }
+ 
++static inline bool is_dev_shm_posix_sem(char *rpath, const struct fd_parms *parms)
++{
++	if (parms->fs_type != TMPFS_MAGIC)
++		return false;
++
++	return !strncmp(rpath, "./dev/shm/sem.", sizeof("./dev/shm/sem.") - 1);
++}
++
+ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms, int lfd, u32 id, struct ns_id *nsid)
+ {
+ 	char *rpath = link->name;
+@@ -1369,6 +1377,12 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms,
+ 		return 0;
+ 	}
+ 
++	if (is_dev_shm_posix_sem(rpath, parms)) {
++		link_strip_deleted(link);
++		pr_info("Dumping /dev/shm POSIX semaphore as ghost remap for restore portability\n");
++		return dump_ghost_remap(rpath + 1, ost, lfd, id, nsid);
++	}
++
+ 	if (ost->st_nlink == 0) {
+ 		/*
+ 		 * Unpleasant, but easy case. File is completely invisible

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -585,6 +586,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		NSRestorePath:               w.config.Restore.NSRestorePath,
 		PodName:                     pod.Name,
 		PodNamespace:                pod.Namespace,
+		PodUID:                      string(pod.UID),
 		ContainerName:               containerName,
 		Clientset:                   w.clientset,
 	}
@@ -604,6 +606,30 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 			return fmt.Errorf("restore failed and placeholder could not be killed: %w", killErr)
 		}
 		return nil
+	}
+
+	rendezvousConfig, err := restoreRendezvousConfig(pod, containerName, checkpointID)
+	if err != nil {
+		log.Error(err, "Failed to build rendezvous file")
+		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
+		if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
+			return statusErr
+		}
+		if killErr := snapshotruntime.SendSignalToPID(log, placeholderHostPID, syscall.SIGKILL, "restore rendezvous failed"); killErr != nil {
+			log.Error(killErr, "Failed to kill placeholder after rendezvous failure")
+		}
+		return fmt.Errorf("failed to build rendezvous file: %w", err)
+	}
+	if err := snapshotruntime.WriteRendezvousFile(placeholderHostPID, rendezvousConfig); err != nil {
+		log.Error(err, "Failed to write rendezvous file")
+		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
+		if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
+			return statusErr
+		}
+		if killErr := snapshotruntime.SendSignalToPID(log, placeholderHostPID, syscall.SIGKILL, "restore rendezvous failed"); killErr != nil {
+			log.Error(killErr, "Failed to kill placeholder after rendezvous failure")
+		}
+		return fmt.Errorf("failed to write rendezvous file: %w", err)
 	}
 
 	// Any PID inside the container mount namespace reaches the control
@@ -635,6 +661,158 @@ func (w *NodeController) tryAcquire(podKey string) bool {
 	}
 	w.inFlight[podKey] = struct{}{}
 	return true
+}
+
+func restoreRendezvousConfig(pod *corev1.Pod, containerName string, checkpointID string) (snapshotruntime.RendezvousConfig, error) {
+	host := pod.Status.PodIP
+	port := 29500
+	env := map[string]string{}
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		if container.Name != containerName {
+			continue
+		}
+		env = containerEnvMap(pod, container)
+		args := containerCommandAndArgs(container)
+		if parsedHost := flagValue(args, "--master-addr"); parsedHost != "" {
+			host = parsedHost
+		}
+		if parsedPort := flagValue(args, "--master-port"); parsedPort != "" {
+			parsedPort = expandEnvReferences(parsedPort, env)
+			n, err := strconv.Atoi(parsedPort)
+			if err != nil || n <= 0 {
+				return snapshotruntime.RendezvousConfig{}, fmt.Errorf("invalid --master-port value %q", parsedPort)
+			}
+			port = n
+		}
+		break
+	}
+	if annotatedHost := strings.TrimSpace(pod.Annotations[snapshotprotocol.RendezvousHostAnnotation]); annotatedHost != "" {
+		host = annotatedHost
+	}
+	if annotatedPort := strings.TrimSpace(pod.Annotations[snapshotprotocol.RendezvousPortAnnotation]); annotatedPort != "" {
+		annotatedPort = expandEnvReferences(annotatedPort, env)
+		n, err := strconv.Atoi(annotatedPort)
+		if err != nil || n <= 0 {
+			return snapshotruntime.RendezvousConfig{}, fmt.Errorf("invalid %s value %q", snapshotprotocol.RendezvousPortAnnotation, annotatedPort)
+		}
+		port = n
+	}
+	host = expandEnvReferences(host, env)
+	if hasUnresolvedEnvReference(host) {
+		return snapshotruntime.RendezvousConfig{}, fmt.Errorf("rendezvous host %q still contains unresolved env references", host)
+	}
+	return snapshotruntime.RendezvousConfig{
+		RestoreID: checkpointID,
+		Store: snapshotruntime.RendezvousStore{
+			Host:       host,
+			Port:       port,
+			MasterRank: 0,
+		},
+	}, nil
+}
+
+func flagValue(args []string, name string) string {
+	prefix := name + "="
+	for i, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return strings.TrimPrefix(arg, prefix)
+		}
+		if arg == name && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func containerCommandAndArgs(container *corev1.Container) []string {
+	if container == nil {
+		return nil
+	}
+	args := make([]string, 0, len(container.Command)+len(container.Args))
+	for _, arg := range container.Command {
+		args = append(args, strings.Fields(arg)...)
+	}
+	for _, arg := range container.Args {
+		args = append(args, strings.Fields(arg)...)
+	}
+	return args
+}
+
+func containerEnvMap(pod *corev1.Pod, container *corev1.Container) map[string]string {
+	env := map[string]string{}
+	if pod != nil {
+		env["POD_NAME"] = pod.Name
+		env["POD_NAMESPACE"] = pod.Namespace
+		env["POD_IP"] = pod.Status.PodIP
+	}
+	if container == nil {
+		return env
+	}
+	for _, e := range container.Env {
+		if e.Value != "" {
+			env[e.Name] = e.Value
+			continue
+		}
+		if e.ValueFrom == nil || e.ValueFrom.FieldRef == nil || pod == nil {
+			continue
+		}
+		switch e.ValueFrom.FieldRef.FieldPath {
+		case "metadata.name":
+			env[e.Name] = pod.Name
+		case "metadata.namespace":
+			env[e.Name] = pod.Namespace
+		case "status.podIP":
+			env[e.Name] = pod.Status.PodIP
+		}
+	}
+	return env
+}
+
+func expandEnvReferences(value string, env map[string]string) string {
+	value = expandDelimitedEnvReferences(value, "$(", ")", env)
+	return expandDelimitedEnvReferences(value, "${", "}", env)
+}
+
+func expandDelimitedEnvReferences(value, prefix, suffix string, env map[string]string) string {
+	for {
+		start := strings.Index(value, prefix)
+		if start < 0 {
+			return value
+		}
+		end := strings.Index(value[start+len(prefix):], suffix)
+		if end < 0 {
+			return value
+		}
+		end += start + len(prefix)
+		name := value[start+len(prefix) : end]
+		if !isSimpleEnvName(name) {
+			return value[:end+len(suffix)] + expandDelimitedEnvReferences(value[end+len(suffix):], prefix, suffix, env)
+		}
+		replacement, ok := env[name]
+		if !ok {
+			return value[:end+len(suffix)] + expandDelimitedEnvReferences(value[end+len(suffix):], prefix, suffix, env)
+		}
+		value = value[:start] + replacement + value[end+len(suffix):]
+	}
+}
+
+func isSimpleEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	first := name[0]
+	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+}
+
+func hasUnresolvedEnvReference(value string) bool {
+	return strings.Contains(value, "$(") || strings.Contains(value, "${")
 }
 
 func (w *NodeController) release(podKey string) {

--- a/deploy/snapshot/internal/criu/devices.go
+++ b/deploy/snapshot/internal/criu/devices.go
@@ -1,0 +1,102 @@
+package criu
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const nvidiaDevicePrefix = "dev["
+
+func dumpNVIDIAExternalDevices(rootFS string) ([]string, error) {
+	patterns := []string{
+		filepath.Join(rootFS, "dev", "nvidia*"),
+		filepath.Join(rootFS, "dev", "nvidia-caps", "nvidia-cap*"),
+	}
+
+	seen := map[string]struct{}{}
+	var external []string
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to glob NVIDIA device pattern %s: %w", pattern, err)
+		}
+		for _, path := range matches {
+			info, err := os.Lstat(path)
+			if err != nil {
+				continue
+			}
+			if info.Mode()&os.ModeCharDevice == 0 {
+				continue
+			}
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok {
+				continue
+			}
+
+			name := filepath.Base(path)
+			spec := fmt.Sprintf("dev[%d/%d]:%s", unix.Major(uint64(stat.Rdev)), unix.Minor(uint64(stat.Rdev)), name)
+			if _, ok := seen[spec]; ok {
+				continue
+			}
+			seen[spec] = struct{}{}
+			external = append(external, spec)
+		}
+	}
+
+	sort.Strings(external)
+	return external, nil
+}
+
+func restoreNVIDIAExternalDevices(dumpExternal []string) []string {
+	var external []string
+	for _, spec := range dumpExternal {
+		name, ok := parseDumpExternalDeviceName(spec)
+		if !ok || !isNVIDIADeviceName(name) {
+			continue
+		}
+
+		devicePath := filepath.Join("/dev", name)
+		if strings.HasPrefix(name, "nvidia-cap") {
+			devicePath = filepath.Join("/dev/nvidia-caps", name)
+		}
+		external = append(external, fmt.Sprintf("dev[%s]:%s", name, devicePath))
+	}
+
+	sort.Strings(external)
+	return external
+}
+
+func parseDumpExternalDeviceName(spec string) (string, bool) {
+	if !strings.HasPrefix(spec, nvidiaDevicePrefix) {
+		return "", false
+	}
+	_, name, ok := strings.Cut(spec, "]:")
+	if !ok || name == "" || strings.Contains(name, "/") {
+		return "", false
+	}
+	return name, true
+}
+
+func isNVIDIADeviceName(name string) bool {
+	if name == "nvidiactl" || name == "nvidia-uvm" || name == "nvidia-uvm-tools" || name == "nvidia-modeset" {
+		return true
+	}
+	if strings.HasPrefix(name, "nvidia-cap") {
+		return true
+	}
+	if !strings.HasPrefix(name, "nvidia") {
+		return false
+	}
+	for _, r := range strings.TrimPrefix(name, "nvidia") {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return len(name) > len("nvidia")
+}

--- a/deploy/snapshot/internal/criu/dump.go
+++ b/deploy/snapshot/internal/criu/dump.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	dumpLogFilename  = "dump.log"
+	DumpLogFilename  = "dump.log"
 	criuConfFilename = "criu.conf"
 )
 
@@ -44,9 +44,17 @@ func BuildDumpOptions(
 	criuOpts := &criurpc.CriuOpts{
 		Pid:     proto.Int32(int32(state.PID)),
 		Root:    proto.String(state.RootFS),
-		LogFile: proto.String(dumpLogFilename),
+		LogFile: proto.String(DumpLogFilename),
 		// Always externalize network namespace
 		External: []string{fmt.Sprintf("net[%d]:extNetNs", state.NetNSInode)},
+	}
+	nvidiaExternal, err := dumpNVIDIAExternalDevices(state.RootFS)
+	if err != nil {
+		return nil, err
+	}
+	criuOpts.External = append(criuOpts.External, nvidiaExternal...)
+	if len(nvidiaExternal) > 0 {
+		log.Info("Externalized NVIDIA device files for CRIU dump", "external", nvidiaExternal)
 	}
 	criuOpts.ExtMnt = toExtMountMaps(externalized)
 	criuOpts.SkipMnt = skipped
@@ -113,7 +121,7 @@ func ExecuteDump(
 		log.Error(err, "CRIU dump failed",
 			"duration", dumpDuration,
 			"checkpoint_dir", checkpointDir,
-			"dump_log_path", fmt.Sprintf("%s/%s", checkpointDir, dumpLogFilename),
+			"dump_log_path", fmt.Sprintf("%s/%s", checkpointDir, DumpLogFilename),
 		)
 		return 0, fmt.Errorf("CRIU dump failed: %w", err)
 	}

--- a/deploy/snapshot/internal/criu/restore.go
+++ b/deploy/snapshot/internal/criu/restore.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"syscall"
 
 	criulib "github.com/checkpoint-restore/go-criu/v8"
 	criurpc "github.com/checkpoint-restore/go-criu/v8/rpc"
@@ -19,9 +21,43 @@ import (
 const RestoreLogFilename = "restore.log"
 
 const (
-	netNsPath        = "/proc/1/ns/net"
-	placeholderFDDir = "/proc/1/fd"
+	netNsPath                = "/proc/1/ns/net"
+	placeholderFDDir         = "/proc/1/fd"
+	hostMountPath            = "/host"
+	hostRunRoot              = "/host/run"
+	hostContainerdRunRoot    = "/host/run/containerd"
+	hostRunNetnsRoot         = "/host/run/netns"
+	snapshotControlMountPath = "/snapshot-control"
 )
+
+var kubeletPodsRoot = "/host/var/lib/kubelet/pods"
+var findHostRunNetnsTarget = findCurrentHostRunNetnsTarget
+var restoreHostRunScratchRoot = "/tmp/dynamo-criu-restore-host-run"
+
+// RestoreMountContext identifies restore-time Kubernetes mounts that CRIU
+// must remap from checkpoint-time pod paths.
+type RestoreMountContext struct {
+	PodUID        string
+	ContainerName string
+}
+
+type restoreExtMountStats struct {
+	remappedSnapshotControl int
+	remappedKubeletVolumes  int
+	remappedHostNetns       int
+	remappedHostRunParent   int
+	hostNetnsTarget         string
+	hostRunScratchTarget    string
+}
+
+type restoreExternalMount struct {
+	source                  string
+	target                  string
+	remappedSnapshotControl bool
+	remappedKubeletVolume   bool
+	remappedHostNetns       bool
+	remappedHostRunParent   bool
+}
 
 // ExecuteRestore opens the image/work directory FDs, configures inherited
 // resources, and calls go-criu Restore. Returns the namespace-relative PID.
@@ -83,18 +119,47 @@ func ExecuteRestore(
 
 // BuildRestoreOpts assembles CriuOpts for a CRIU restore from the checkpoint manifest.
 // ImagesDirFd and WorkDirFd are left unset — ExecuteRestore opens them at restore time.
-func BuildRestoreOpts(m *types.CheckpointManifest, checkpointPath string, cgroupRoot string, log logr.Logger) (*criurpc.CriuOpts, error) {
-	extMounts, err := buildRestoreExtMounts(m)
+func BuildRestoreOpts(m *types.CheckpointManifest, checkpointPath string, cgroupRoot string, mountCtx RestoreMountContext, log logr.Logger) (*criurpc.CriuOpts, error) {
+	extMounts, stats, err := buildRestoreExtMounts(m, mountCtx)
 	if err != nil {
 		return nil, err
 	}
 	log.V(1).Info("Generated external mount map set", "ext_mount_count", len(extMounts))
+	if stats.remappedSnapshotControl > 0 {
+		log.Info("Remapped snapshot-control external mounts for CRIU restore",
+			"count", stats.remappedSnapshotControl,
+			"restore_pod_uid", mountCtx.PodUID,
+			"restore_container", mountCtx.ContainerName,
+		)
+	}
+	if stats.remappedKubeletVolumes > 0 {
+		log.Info("Remapped kubelet pod volume external mounts for CRIU restore",
+			"count", stats.remappedKubeletVolumes,
+			"restore_pod_uid", mountCtx.PodUID,
+		)
+	}
+	if stats.remappedHostNetns > 0 {
+		log.Info("Remapped host netns external mounts for CRIU restore",
+			"count", stats.remappedHostNetns,
+			"target", stats.hostNetnsTarget,
+		)
+	}
+	if stats.remappedHostRunParent > 0 {
+		log.Info("Remapped host run parent external mount for CRIU restore",
+			"count", stats.remappedHostRunParent,
+			"target", stats.hostRunScratchTarget,
+		)
+	}
 
 	settings := m.CRIUDump.CRIU
 	criuOpts := &criurpc.CriuOpts{
-		LogFile: proto.String(RestoreLogFilename),
-		Root:    proto.String("/"),
-		ExtMnt:  extMounts,
+		LogFile:  proto.String(RestoreLogFilename),
+		Root:     proto.String("/"),
+		ExtMnt:   extMounts,
+		External: restoreNVIDIAExternalDevices(m.CRIUDump.External),
+	}
+	if len(criuOpts.External) > 0 {
+		log.Info("Mapped external NVIDIA devices for CRIU restore", "external", criuOpts.External)
 	}
 	if err := applyCommonSettings(criuOpts, &settings); err != nil {
 		return nil, err
@@ -120,19 +185,402 @@ func BuildRestoreOpts(m *types.CheckpointManifest, checkpointPath string, cgroup
 	return criuOpts, nil
 }
 
-func buildRestoreExtMounts(m *types.CheckpointManifest) ([]*criurpc.ExtMountMap, error) {
+func buildRestoreExtMounts(m *types.CheckpointManifest, mountCtx RestoreMountContext) ([]*criurpc.ExtMountMap, restoreExtMountStats, error) {
 	if len(m.CRIUDump.ExtMnt) == 0 {
-		return nil, fmt.Errorf("checkpoint manifest is missing criuDump.extMnt")
+		return nil, restoreExtMountStats{}, fmt.Errorf("checkpoint manifest is missing criuDump.extMnt")
 	}
 
 	restoreMap := map[string]string{"/": "."}
+	snapshotControlTarget := resolveSnapshotControlExternalTarget(mountCtx)
+	stats := restoreExtMountStats{
+		hostNetnsTarget:      findHostRunNetnsTarget(),
+		hostRunScratchTarget: restoreHostRunScratchRoot,
+	}
 	for _, val := range m.CRIUDump.ExtMnt {
 		if val == "" || val == "/" {
 			continue
 		}
-		restoreMap[val] = val
+		mount := resolveRestoreExternalMount(val, mountCtx, snapshotControlTarget, stats.hostNetnsTarget)
+		if mount.remappedSnapshotControl {
+			stats.remappedSnapshotControl++
+		}
+		if mount.remappedKubeletVolume {
+			stats.remappedKubeletVolumes++
+		}
+		if mount.remappedHostNetns {
+			stats.remappedHostNetns++
+		}
+		if mount.remappedHostRunParent {
+			stats.remappedHostRunParent++
+		}
+		restoreMap[mount.source] = mount.target
 	}
-	return toExtMountMaps(restoreMap), nil
+	return toExtMountMaps(restoreMap), stats, nil
+}
+
+func PrepareRestoreMountpoints(m *types.CheckpointManifest, mountCtx RestoreMountContext, log logr.Logger) error {
+	mountpoints := remappedRestoreMountpoints(m, mountCtx)
+	if len(mountpoints) == 0 {
+		return nil
+	}
+	if _, ok := mountpoints[restoreHostRunScratchRoot]; ok {
+		if err := os.RemoveAll(restoreHostRunScratchRoot); err != nil {
+			return fmt.Errorf("failed to reset restore host-run scratch tree %s: %w", restoreHostRunScratchRoot, err)
+		}
+	}
+
+	if err := remountHost(false); err != nil {
+		return fmt.Errorf("failed to remount %s read-write for restore mountpoint preparation: %w", hostMountPath, err)
+	}
+	prepared, prepareErr := createRestoreMountpoints(mountpoints)
+	remountErr := remountHost(true)
+	if remountErr != nil {
+		log.Error(remountErr, "Failed to remount host root read-only after restore mountpoint preparation")
+	}
+	if prepareErr != nil {
+		return prepareErr
+	}
+	if prepared > 0 {
+		log.Info("Prepared remapped external mountpoints for CRIU restore",
+			"count", prepared,
+			"restore_pod_uid", mountCtx.PodUID,
+			"restore_container", mountCtx.ContainerName,
+		)
+	}
+	return remountErr
+}
+
+func remappedRestoreMountpoints(m *types.CheckpointManifest, mountCtx RestoreMountContext) map[string]string {
+	mountpoints := map[string]string{}
+	if m == nil || len(m.CRIUDump.ExtMnt) == 0 {
+		return mountpoints
+	}
+
+	snapshotControlTarget := resolveSnapshotControlExternalTarget(mountCtx)
+	hostNetnsTarget := findHostRunNetnsTarget()
+	hostRunParentSeen := false
+	var hostRunMounts []restoreExternalMount
+	var kubeletMounts []restoreExternalMount
+	var containerdRootfsMounts []string
+	for _, val := range m.CRIUDump.ExtMnt {
+		if val == "" || val == "/" {
+			continue
+		}
+		mount := resolveRestoreExternalMount(val, mountCtx, snapshotControlTarget, hostNetnsTarget)
+		cleanPath := filepath.Clean(mount.source)
+		if cleanPath == hostRunRoot {
+			hostRunParentSeen = true
+		}
+		if strings.HasPrefix(cleanPath, hostRunRoot+string(os.PathSeparator)) {
+			hostRunMounts = append(hostRunMounts, mount)
+		}
+		if strings.HasPrefix(cleanPath, filepath.Clean(kubeletPodsRoot)+string(os.PathSeparator)) {
+			kubeletMounts = append(kubeletMounts, mount)
+		}
+		if isHostContainerdRootfsMountpoint(cleanPath) {
+			containerdRootfsMounts = append(containerdRootfsMounts, cleanPath)
+		}
+		if strings.HasPrefix(cleanPath, hostMountPath+string(os.PathSeparator)) &&
+			cleanPath != hostRunRoot &&
+			!isHostRunNetnsMountpoint(cleanPath) &&
+			(mount.target != mount.source || isHostContainerdMountpoint(cleanPath)) {
+			mountpoints[cleanPath] = mount.target
+		}
+	}
+	if hostRunParentSeen {
+		mountpoints[restoreHostRunScratchRoot] = hostRunRoot
+		addHostRunScratchMountpoints(mountpoints, hostRunMounts)
+	}
+	addNestedRootfsMountpoints(mountpoints, containerdRootfsMounts, kubeletMounts)
+	addNestedRootfsMountpoints(mountpoints, containerdRootfsMounts, nonContainerdHostRunMounts(hostRunMounts))
+	return mountpoints
+}
+
+func resolveRestoreExternalMount(path string, mountCtx RestoreMountContext, snapshotControlTarget string, hostNetnsTarget string) restoreExternalMount {
+	mount := restoreExternalMount{source: path, target: path}
+	if remappedTarget, ok := remapSnapshotControlExternalMount(path, snapshotControlTarget); ok {
+		mount.target = remappedTarget
+		mount.remappedSnapshotControl = remappedTarget != path
+	}
+	if remappedTarget, ok := remapKubeletPodVolumeExternalMount(path, mountCtx); ok {
+		mount.target = remappedTarget
+		mount.remappedKubeletVolume = remappedTarget != path
+	}
+	if remappedTarget, ok := remapHostRunNetnsExternalMount(path, hostNetnsTarget); ok {
+		mount.target = remappedTarget
+		mount.remappedHostNetns = remappedTarget != path
+	}
+	if remappedTarget, ok := remapHostRunExternalMount(path, restoreHostRunScratchRoot); ok {
+		mount.target = remappedTarget
+		mount.remappedHostRunParent = remappedTarget != path
+	}
+	return mount
+}
+
+func addHostRunScratchMountpoints(mountpoints map[string]string, mounts []restoreExternalMount) {
+	for _, mount := range mounts {
+		cleanPath := filepath.Clean(mount.source)
+		rel, ok := strings.CutPrefix(cleanPath, hostRunRoot+string(os.PathSeparator))
+		if !ok {
+			continue
+		}
+		mountpoints[filepath.Join(restoreHostRunScratchRoot, rel)] = mount.target
+	}
+}
+
+func addNestedRootfsMountpoints(mountpoints map[string]string, rootfsMounts []string, mounts []restoreExternalMount) {
+	for _, rootfs := range rootfsMounts {
+		for _, mount := range mounts {
+			rel, ok := rootfsRelativeExternalMountPath(mount.source)
+			if !ok {
+				continue
+			}
+			mountpoints[filepath.Join(rootfs, rel)] = mount.target
+		}
+	}
+}
+
+func nonContainerdHostRunMounts(mounts []restoreExternalMount) []restoreExternalMount {
+	filtered := make([]restoreExternalMount, 0, len(mounts))
+	for _, mount := range mounts {
+		if !isHostContainerdMountpoint(mount.source) {
+			filtered = append(filtered, mount)
+		}
+	}
+	return filtered
+}
+
+func rootfsRelativeExternalMountPath(path string) (string, bool) {
+	cleanPath := filepath.Clean(path)
+	if rel, ok := strings.CutPrefix(cleanPath, hostMountPath+string(os.PathSeparator)); ok {
+		return rel, true
+	}
+	if strings.HasPrefix(cleanPath, string(os.PathSeparator)) {
+		return strings.TrimPrefix(cleanPath, string(os.PathSeparator)), true
+	}
+	return "", false
+}
+
+func createRestoreMountpoints(mountpoints map[string]string) (int, error) {
+	paths := make([]string, 0, len(mountpoints))
+	for path := range mountpoints {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	prepared := 0
+	for _, path := range paths {
+		target := mountpoints[path]
+		info, err := os.Stat(target)
+		if err != nil {
+			if isHostContainerdMountpoint(path) {
+				if err := os.MkdirAll(path, 0755); err != nil {
+					return prepared, fmt.Errorf("failed to create restore mountpoint directory %s: %w", path, err)
+				}
+				prepared++
+			}
+			continue
+		}
+		if info.IsDir() {
+			if err := os.MkdirAll(path, 0755); err != nil {
+				return prepared, fmt.Errorf("failed to create restore mountpoint directory %s: %w", path, err)
+			}
+			prepared++
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return prepared, fmt.Errorf("failed to create restore mountpoint parent %s: %w", filepath.Dir(path), err)
+		}
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, info.Mode().Perm())
+		if err != nil {
+			return prepared, fmt.Errorf("failed to create restore mountpoint file %s: %w", path, err)
+		}
+		if err := f.Close(); err != nil {
+			return prepared, fmt.Errorf("failed to close restore mountpoint file %s: %w", path, err)
+		}
+		prepared++
+	}
+	return prepared, nil
+}
+
+func remountHost(readOnly bool) error {
+	flags := uintptr(syscall.MS_REMOUNT | syscall.MS_BIND)
+	if readOnly {
+		flags |= syscall.MS_RDONLY
+	}
+	return syscall.Mount(hostMountPath, hostMountPath, "", flags, "")
+}
+
+func isHostContainerdMountpoint(path string) bool {
+	return strings.HasPrefix(filepath.Clean(path), hostContainerdRunRoot+string(os.PathSeparator))
+}
+
+func isHostContainerdRootfsMountpoint(path string) bool {
+	cleanPath := filepath.Clean(path)
+	return strings.HasPrefix(cleanPath, hostContainerdRunRoot+string(os.PathSeparator)) &&
+		strings.HasSuffix(cleanPath, string(os.PathSeparator)+"rootfs")
+}
+
+func isHostRunNetnsMountpoint(path string) bool {
+	return strings.HasPrefix(filepath.Clean(path), hostRunNetnsRoot+string(os.PathSeparator))
+}
+
+func resolveSnapshotControlExternalTarget(mountCtx RestoreMountContext) string {
+	const fallback = snapshotControlMountPath
+	podUID := strings.TrimSpace(mountCtx.PodUID)
+	containerName := strings.TrimSpace(mountCtx.ContainerName)
+	if podUID == "" || containerName == "" {
+		return fallback
+	}
+
+	matches, err := filepath.Glob(filepath.Join(
+		kubeletPodsRoot,
+		podUID,
+		"volume-subpaths",
+		"snapshot-control",
+		containerName,
+		"*",
+	))
+	if err != nil || len(matches) == 0 {
+		return fallback
+	}
+	sort.Strings(matches)
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		if err == nil && info.IsDir() {
+			return match
+		}
+	}
+	return fallback
+}
+
+func remapSnapshotControlExternalMount(path string, target string) (string, bool) {
+	cleanPath := filepath.Clean(path)
+	if cleanPath == snapshotControlMountPath {
+		return cleanPath, false
+	}
+	if strings.Contains(cleanPath, "/volume-subpaths/snapshot-control/") {
+		return target, true
+	}
+	if strings.HasPrefix(cleanPath, "/host/run/containerd/io.containerd.runtime.v2.task/") &&
+		strings.HasSuffix(cleanPath, "/rootfs/snapshot-control") {
+		return target, true
+	}
+	return "", false
+}
+
+func remapKubeletPodVolumeExternalMount(path string, mountCtx RestoreMountContext) (string, bool) {
+	podUID := strings.TrimSpace(mountCtx.PodUID)
+	if podUID == "" {
+		return "", false
+	}
+	cleanPath := filepath.Clean(path)
+	rel, ok := strings.CutPrefix(cleanPath, filepath.Clean(kubeletPodsRoot)+string(os.PathSeparator))
+	if !ok {
+		return "", false
+	}
+
+	parts := strings.Split(rel, string(os.PathSeparator))
+	if len(parts) < 3 {
+		return "", false
+	}
+
+	switch parts[1] {
+	case "volumes":
+		return remapKubeletPodVolume(parts, podUID)
+	case "volume-subpaths":
+		return remapKubeletPodVolumeSubpath(parts, podUID, mountCtx.ContainerName)
+	default:
+		return "", false
+	}
+}
+
+func remapKubeletPodVolume(parts []string, podUID string) (string, bool) {
+	if len(parts) < 4 {
+		return "", false
+	}
+	targetParts := append([]string{kubeletPodsRoot, podUID, "volumes"}, parts[2:]...)
+	target := filepath.Join(targetParts...)
+	if _, err := os.Stat(target); err == nil {
+		return target, true
+	}
+
+	plugin := parts[2]
+	volumeName := parts[3]
+	if plugin != "kubernetes.io~projected" || !strings.HasPrefix(volumeName, "kube-api-access-") {
+		return "", false
+	}
+
+	matches, err := filepath.Glob(filepath.Join(kubeletPodsRoot, podUID, "volumes", plugin, "kube-api-access-*"))
+	if err != nil || len(matches) == 0 {
+		return "", false
+	}
+	sort.Strings(matches)
+	for _, match := range matches {
+		target := filepath.Join(append([]string{match}, parts[4:]...)...)
+		if _, err := os.Stat(target); err == nil {
+			return target, true
+		}
+	}
+	return "", false
+}
+
+func remapKubeletPodVolumeSubpath(parts []string, podUID string, containerName string) (string, bool) {
+	if len(parts) < 5 {
+		return "", false
+	}
+	if strings.TrimSpace(containerName) == "" {
+		containerName = parts[3]
+	}
+	targetParts := append([]string{kubeletPodsRoot, podUID, "volume-subpaths", parts[2], containerName}, parts[4:]...)
+	target := filepath.Join(targetParts...)
+	if _, err := os.Stat(target); err == nil {
+		return target, true
+	}
+
+	matches, err := filepath.Glob(filepath.Join(kubeletPodsRoot, podUID, "volume-subpaths", parts[2], containerName, "*"))
+	if err != nil || len(matches) != 1 {
+		return "", false
+	}
+	target = filepath.Join(append([]string{matches[0]}, parts[5:]...)...)
+	if _, err := os.Stat(target); err == nil {
+		return target, true
+	}
+	return "", false
+}
+
+func remapHostRunNetnsExternalMount(path string, target string) (string, bool) {
+	if target != "" && isHostRunNetnsMountpoint(path) {
+		return target, true
+	}
+	return "", false
+}
+
+func remapHostRunExternalMount(path string, target string) (string, bool) {
+	if filepath.Clean(path) == hostRunRoot {
+		return target, true
+	}
+	return "", false
+}
+
+func findCurrentHostRunNetnsTarget() string {
+	netInfo, err := os.Stat(netNsPath)
+	if err != nil {
+		return ""
+	}
+
+	matches, err := filepath.Glob(filepath.Join(hostRunNetnsRoot, "*"))
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	sort.Strings(matches)
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		if err == nil && os.SameFile(netInfo, info) {
+			return match
+		}
+	}
+	return ""
 }
 
 func registerInheritFDs(c *criulib.Criu, stdioFDs []string, log logr.Logger) []*os.File {

--- a/deploy/snapshot/internal/criu/util_test.go
+++ b/deploy/snapshot/internal/criu/util_test.go
@@ -1,6 +1,8 @@
 package criu
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	criurpc "github.com/checkpoint-restore/go-criu/v8/rpc"
@@ -123,9 +125,21 @@ func TestBuildRestoreExtMounts(t *testing.T) {
 				},
 			},
 		}
-		mounts, err := buildRestoreExtMounts(m)
+		mounts, stats, err := buildRestoreExtMounts(m, RestoreMountContext{})
 		if err != nil {
 			t.Fatalf("buildRestoreExtMounts: %v", err)
+		}
+		if stats.remappedSnapshotControl != 0 {
+			t.Fatalf("remapped snapshot-control mounts = %d, want 0", stats.remappedSnapshotControl)
+		}
+		if stats.remappedKubeletVolumes != 0 {
+			t.Fatalf("remapped kubelet volume mounts = %d, want 0", stats.remappedKubeletVolumes)
+		}
+		if stats.remappedHostNetns != 0 {
+			t.Fatalf("remapped host netns mounts = %d, want 0", stats.remappedHostNetns)
+		}
+		if stats.remappedHostRunParent != 0 {
+			t.Fatalf("remapped host run parent mounts = %d, want 0", stats.remappedHostRunParent)
 		}
 
 		// Should contain value→value self-mappings plus "/" → "."
@@ -155,9 +169,21 @@ func TestBuildRestoreExtMounts(t *testing.T) {
 				},
 			},
 		}
-		mounts, err := buildRestoreExtMounts(m)
+		mounts, stats, err := buildRestoreExtMounts(m, RestoreMountContext{})
 		if err != nil {
 			t.Fatalf("buildRestoreExtMounts: %v", err)
+		}
+		if stats.remappedSnapshotControl != 0 {
+			t.Fatalf("remapped snapshot-control mounts = %d, want 0", stats.remappedSnapshotControl)
+		}
+		if stats.remappedKubeletVolumes != 0 {
+			t.Fatalf("remapped kubelet volume mounts = %d, want 0", stats.remappedKubeletVolumes)
+		}
+		if stats.remappedHostNetns != 0 {
+			t.Fatalf("remapped host netns mounts = %d, want 0", stats.remappedHostNetns)
+		}
+		if stats.remappedHostRunParent != 0 {
+			t.Fatalf("remapped host run parent mounts = %d, want 0", stats.remappedHostRunParent)
 		}
 
 		mountMap := make(map[string]string, len(mounts))
@@ -182,9 +208,345 @@ func TestBuildRestoreExtMounts(t *testing.T) {
 		m := &types.CheckpointManifest{
 			CRIUDump: types.CRIUDumpManifest{},
 		}
-		_, err := buildRestoreExtMounts(m)
+		_, _, err := buildRestoreExtMounts(m, RestoreMountContext{})
 		if err == nil {
 			t.Error("expected error for empty ExtMnt")
 		}
 	})
+
+	t.Run("snapshot-control host mounts remap to live control mount", func(t *testing.T) {
+		m := &types.CheckpointManifest{
+			CRIUDump: types.CRIUDumpManifest{
+				ExtMnt: map[string]string{
+					"/snapshot-control": "/snapshot-control",
+					"/source-subpath":   "/host/var/lib/kubelet/pods/source-pod/volume-subpaths/snapshot-control/main/2",
+					"/source-rootfs":    "/host/run/containerd/io.containerd.runtime.v2.task/k8s.io/source-container/rootfs/snapshot-control",
+				},
+			},
+		}
+		mounts, stats, err := buildRestoreExtMounts(m, RestoreMountContext{})
+		if err != nil {
+			t.Fatalf("buildRestoreExtMounts: %v", err)
+		}
+		if stats.remappedSnapshotControl != 2 {
+			t.Fatalf("remapped snapshot-control mounts = %d, want 2", stats.remappedSnapshotControl)
+		}
+		if stats.remappedKubeletVolumes != 0 {
+			t.Fatalf("remapped kubelet volume mounts = %d, want 0", stats.remappedKubeletVolumes)
+		}
+		if stats.remappedHostNetns != 0 {
+			t.Fatalf("remapped host netns mounts = %d, want 0", stats.remappedHostNetns)
+		}
+		if stats.remappedHostRunParent != 0 {
+			t.Fatalf("remapped host run parent mounts = %d, want 0", stats.remappedHostRunParent)
+		}
+
+		mountMap := make(map[string]string, len(mounts))
+		for _, em := range mounts {
+			mountMap[em.GetKey()] = em.GetVal()
+		}
+		if mountMap["/host/var/lib/kubelet/pods/source-pod/volume-subpaths/snapshot-control/main/2"] != "/snapshot-control" {
+			t.Errorf("snapshot-control subPath remap: got %q", mountMap["/host/var/lib/kubelet/pods/source-pod/volume-subpaths/snapshot-control/main/2"])
+		}
+		if mountMap["/host/run/containerd/io.containerd.runtime.v2.task/k8s.io/source-container/rootfs/snapshot-control"] != "/snapshot-control" {
+			t.Errorf("snapshot-control rootfs remap: got %q", mountMap["/host/run/containerd/io.containerd.runtime.v2.task/k8s.io/source-container/rootfs/snapshot-control"])
+		}
+	})
+
+	t.Run("kubelet pod volume mounts remap to restore pod UID", func(t *testing.T) {
+		oldKubeletPodsRoot := kubeletPodsRoot
+		kubeletPodsRoot = t.TempDir()
+		t.Cleanup(func() {
+			kubeletPodsRoot = oldKubeletPodsRoot
+		})
+
+		targetCSIPath := kubeletPodsRoot + "/target-pod/volumes/kubernetes.io~csi/pvc-abc/mount"
+		targetProjectedPath := kubeletPodsRoot + "/target-pod/volumes/kubernetes.io~projected/kube-api-access-live"
+		targetSubpath := kubeletPodsRoot + "/target-pod/volume-subpaths/config/main/7"
+		for _, path := range []string{targetCSIPath, targetProjectedPath, targetSubpath} {
+			if err := os.MkdirAll(path, 0755); err != nil {
+				t.Fatalf("mkdir target kubelet volume path %s: %v", path, err)
+			}
+		}
+		sourceCSIPath := kubeletPodsRoot + "/source-pod/volumes/kubernetes.io~csi/pvc-abc/mount"
+		sourceProjectedPath := kubeletPodsRoot + "/source-pod/volumes/kubernetes.io~projected/kube-api-access-old"
+		sourceSubpath := kubeletPodsRoot + "/source-pod/volume-subpaths/config/main/2"
+		m := &types.CheckpointManifest{
+			CRIUDump: types.CRIUDumpManifest{
+				ExtMnt: map[string]string{
+					"/checkpoints": sourceCSIPath,
+					"/api-access":  sourceProjectedPath,
+					"/config":      sourceSubpath,
+				},
+			},
+		}
+		mounts, stats, err := buildRestoreExtMounts(m, RestoreMountContext{PodUID: "target-pod", ContainerName: "main"})
+		if err != nil {
+			t.Fatalf("buildRestoreExtMounts: %v", err)
+		}
+		if stats.remappedSnapshotControl != 0 {
+			t.Fatalf("remapped snapshot-control mounts = %d, want 0", stats.remappedSnapshotControl)
+		}
+		if stats.remappedKubeletVolumes != 3 {
+			t.Fatalf("remapped kubelet volume mounts = %d, want 3", stats.remappedKubeletVolumes)
+		}
+		if stats.remappedHostNetns != 0 {
+			t.Fatalf("remapped host netns mounts = %d, want 0", stats.remappedHostNetns)
+		}
+		if stats.remappedHostRunParent != 0 {
+			t.Fatalf("remapped host run parent mounts = %d, want 0", stats.remappedHostRunParent)
+		}
+
+		mountMap := make(map[string]string, len(mounts))
+		for _, em := range mounts {
+			mountMap[em.GetKey()] = em.GetVal()
+		}
+		if mountMap[sourceCSIPath] != targetCSIPath {
+			t.Errorf("kubelet CSI volume remap: got %q, want %q", mountMap[sourceCSIPath], targetCSIPath)
+		}
+		if mountMap[sourceProjectedPath] != targetProjectedPath {
+			t.Errorf("kubelet projected volume remap: got %q, want %q", mountMap[sourceProjectedPath], targetProjectedPath)
+		}
+		if mountMap[sourceSubpath] != targetSubpath {
+			t.Errorf("kubelet subpath remap: got %q, want %q", mountMap[sourceSubpath], targetSubpath)
+		}
+	})
+
+	t.Run("host netns mounts remap to live restore namespace", func(t *testing.T) {
+		oldFindHostRunNetnsTarget := findHostRunNetnsTarget
+		findHostRunNetnsTarget = func() string {
+			return "/host/run/netns/cni-live"
+		}
+		t.Cleanup(func() {
+			findHostRunNetnsTarget = oldFindHostRunNetnsTarget
+		})
+
+		netnsPath := "/host/run/netns/cni-source"
+		m := &types.CheckpointManifest{
+			CRIUDump: types.CRIUDumpManifest{
+				ExtMnt: map[string]string{
+					"/netns": netnsPath,
+				},
+			},
+		}
+		mounts, stats, err := buildRestoreExtMounts(m, RestoreMountContext{})
+		if err != nil {
+			t.Fatalf("buildRestoreExtMounts: %v", err)
+		}
+		if stats.remappedSnapshotControl != 0 {
+			t.Fatalf("remapped snapshot-control mounts = %d, want 0", stats.remappedSnapshotControl)
+		}
+		if stats.remappedKubeletVolumes != 0 {
+			t.Fatalf("remapped kubelet volume mounts = %d, want 0", stats.remappedKubeletVolumes)
+		}
+		if stats.remappedHostNetns != 1 {
+			t.Fatalf("remapped host netns mounts = %d, want 1", stats.remappedHostNetns)
+		}
+		if stats.remappedHostRunParent != 0 {
+			t.Fatalf("remapped host run parent mounts = %d, want 0", stats.remappedHostRunParent)
+		}
+
+		mountMap := make(map[string]string, len(mounts))
+		for _, em := range mounts {
+			mountMap[em.GetKey()] = em.GetVal()
+		}
+		if mountMap[netnsPath] != "/host/run/netns/cni-live" {
+			t.Errorf("host netns remap: got %q, want %q", mountMap[netnsPath], "/host/run/netns/cni-live")
+		}
+	})
+
+	t.Run("host run parent remaps to scratch tree", func(t *testing.T) {
+		oldFindHostRunNetnsTarget := findHostRunNetnsTarget
+		oldScratchRoot := restoreHostRunScratchRoot
+		findHostRunNetnsTarget = func() string {
+			return "/host/run/netns/cni-live"
+		}
+		restoreHostRunScratchRoot = filepath.Join(t.TempDir(), "host-run")
+		t.Cleanup(func() {
+			findHostRunNetnsTarget = oldFindHostRunNetnsTarget
+			restoreHostRunScratchRoot = oldScratchRoot
+		})
+
+		netnsPath := "/host/run/netns/cni-source"
+		shmPath := "/host/run/nvidia/driver/dev/shm"
+		m := &types.CheckpointManifest{
+			CRIUDump: types.CRIUDumpManifest{
+				ExtMnt: map[string]string{
+					"/host-run":   hostRunRoot,
+					"/driver-shm": shmPath,
+					"/netns":      netnsPath,
+				},
+			},
+		}
+		mounts, stats, err := buildRestoreExtMounts(m, RestoreMountContext{})
+		if err != nil {
+			t.Fatalf("buildRestoreExtMounts: %v", err)
+		}
+		if stats.remappedHostRunParent != 1 {
+			t.Fatalf("remapped host run parent mounts = %d, want 1", stats.remappedHostRunParent)
+		}
+		if stats.remappedHostNetns != 1 {
+			t.Fatalf("remapped host netns mounts = %d, want 1", stats.remappedHostNetns)
+		}
+		if stats.hostNetnsTarget != "/host/run/netns/cni-live" {
+			t.Fatalf("host netns target = %q, want live netns", stats.hostNetnsTarget)
+		}
+		if stats.hostRunScratchTarget != restoreHostRunScratchRoot {
+			t.Fatalf("host run scratch target = %q, want %q", stats.hostRunScratchTarget, restoreHostRunScratchRoot)
+		}
+
+		mountMap := make(map[string]string, len(mounts))
+		for _, em := range mounts {
+			mountMap[em.GetKey()] = em.GetVal()
+		}
+		if mountMap[hostRunRoot] != restoreHostRunScratchRoot {
+			t.Errorf("host run remap: got %q, want %q", mountMap[hostRunRoot], restoreHostRunScratchRoot)
+		}
+		if mountMap[netnsPath] != "/host/run/netns/cni-live" {
+			t.Errorf("host netns remap: got %q, want live netns", mountMap[netnsPath])
+		}
+
+		mountpoints := remappedRestoreMountpoints(m, RestoreMountContext{})
+		if mountpoints[restoreHostRunScratchRoot] != hostRunRoot {
+			t.Fatalf("scratch root target = %q, want %q", mountpoints[restoreHostRunScratchRoot], hostRunRoot)
+		}
+		if mountpoints[filepath.Join(restoreHostRunScratchRoot, "netns", "cni-source")] != "/host/run/netns/cni-live" {
+			t.Fatalf("scratch netns mountpoint target = %q, want live netns", mountpoints[filepath.Join(restoreHostRunScratchRoot, "netns", "cni-source")])
+		}
+		if mountpoints[filepath.Join(restoreHostRunScratchRoot, "nvidia", "driver", "dev", "shm")] != shmPath {
+			t.Fatalf("scratch shm mountpoint target = %q, want %q", mountpoints[filepath.Join(restoreHostRunScratchRoot, "nvidia", "driver", "dev", "shm")], shmPath)
+		}
+		if _, ok := mountpoints[netnsPath]; ok {
+			t.Fatal("real host netns mountpoint should not be prepared")
+		}
+		if _, ok := mountpoints[hostRunRoot]; ok {
+			t.Fatal("real host run parent should not be prepared")
+		}
+	})
+}
+
+func TestRestoreNVIDIAExternalDevices(t *testing.T) {
+	external := restoreNVIDIAExternalDevices([]string{
+		"net[12345]:extNetNs",
+		"dev[195/255]:nvidiactl",
+		"dev[195/0]:nvidia0",
+		"dev[510/1]:nvidia-cap1",
+		"dev[1/3]:null",
+		"dev[195/1]:nvidia-frontend",
+	})
+
+	got := map[string]struct{}{}
+	for _, entry := range external {
+		got[entry] = struct{}{}
+	}
+
+	want := []string{
+		"dev[nvidia0]:/dev/nvidia0",
+		"dev[nvidia-cap1]:/dev/nvidia-caps/nvidia-cap1",
+		"dev[nvidiactl]:/dev/nvidiactl",
+	}
+	for _, entry := range want {
+		if _, ok := got[entry]; !ok {
+			t.Errorf("missing restore external device %q from %v", entry, external)
+		}
+	}
+	if _, ok := got["dev[null]:/dev/null"]; ok {
+		t.Errorf("non-NVIDIA device should not be restored: %v", external)
+	}
+	if _, ok := got["dev[nvidia-frontend]:/dev/nvidia-frontend"]; ok {
+		t.Errorf("unknown NVIDIA-like name should not be restored: %v", external)
+	}
+}
+
+func TestRemappedRestoreMountpointsIncludesHostContainerdOnly(t *testing.T) {
+	containerdPath := "/host/run/containerd/io.containerd.runtime.v2.task/k8s.io/source/rootfs"
+	netnsPath := "/host/run/netns/cni-source"
+	m := &types.CheckpointManifest{
+		CRIUDump: types.CRIUDumpManifest{
+			ExtMnt: map[string]string{
+				"/rootfs":       containerdPath,
+				"/netns":        netnsPath,
+				"/etc/hostname": "/etc/hostname",
+			},
+		},
+	}
+
+	mountpoints := remappedRestoreMountpoints(m, RestoreMountContext{})
+	if mountpoints[containerdPath] != containerdPath {
+		t.Fatalf("containerd mountpoint missing: got %q", mountpoints[containerdPath])
+	}
+	if _, ok := mountpoints[netnsPath]; ok {
+		t.Fatal("netns mountpoint should not be prepared")
+	}
+	if _, ok := mountpoints["/etc/hostname"]; ok {
+		t.Fatal("non-host containerd mountpoint should not be prepared")
+	}
+}
+
+func TestRemappedRestoreMountpointsIncludesNestedRootfsChildren(t *testing.T) {
+	oldFindHostRunNetnsTarget := findHostRunNetnsTarget
+	findHostRunNetnsTarget = func() string {
+		return "/host/run/netns/cni-live"
+	}
+	t.Cleanup(func() {
+		findHostRunNetnsTarget = oldFindHostRunNetnsTarget
+	})
+
+	rootfsPath := "/host/run/containerd/io.containerd.runtime.v2.task/k8s.io/source/rootfs"
+	kubeletPath := "/host/var/lib/kubelet/pods/source-pod/volumes/kubernetes.io~csi/pvc-abc/mount"
+	netnsPath := "/host/run/netns/cni-source"
+	m := &types.CheckpointManifest{
+		CRIUDump: types.CRIUDumpManifest{
+			ExtMnt: map[string]string{
+				"/checkpoints": kubeletPath,
+				"/netns":       netnsPath,
+				"/rootfs":      rootfsPath,
+			},
+		},
+	}
+
+	mountpoints := remappedRestoreMountpoints(m, RestoreMountContext{})
+	nestedKubeletPath := filepath.Join(rootfsPath, "var/lib/kubelet/pods/source-pod/volumes/kubernetes.io~csi/pvc-abc/mount")
+	if mountpoints[nestedKubeletPath] != kubeletPath {
+		t.Fatalf("nested kubelet mountpoint target = %q, want %q", mountpoints[nestedKubeletPath], kubeletPath)
+	}
+	nestedNetnsPath := filepath.Join(rootfsPath, "run/netns/cni-source")
+	if mountpoints[nestedNetnsPath] != "/host/run/netns/cni-live" {
+		t.Fatalf("nested netns mountpoint target = %q, want live netns", mountpoints[nestedNetnsPath])
+	}
+	if _, ok := mountpoints[netnsPath]; ok {
+		t.Fatal("real host netns mountpoint should not be prepared")
+	}
+}
+
+func TestCreateRestoreMountpoints(t *testing.T) {
+	root := t.TempDir()
+	targetDir := filepath.Join(root, "target-dir")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	targetFile := filepath.Join(root, "target-file")
+	if err := os.WriteFile(targetFile, []byte("x"), 0644); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+
+	sourceDir := filepath.Join(root, "old", "dir")
+	sourceFile := filepath.Join(root, "old", "file")
+	prepared, err := createRestoreMountpoints(map[string]string{
+		sourceDir:                             targetDir,
+		sourceFile:                            targetFile,
+		filepath.Join(root, "missing-target"): filepath.Join(root, "does-not-exist"),
+	})
+	if err != nil {
+		t.Fatalf("createRestoreMountpoints: %v", err)
+	}
+	if prepared != 2 {
+		t.Fatalf("prepared = %d, want 2", prepared)
+	}
+	if info, err := os.Stat(sourceDir); err != nil || !info.IsDir() {
+		t.Fatalf("source dir was not created: info=%v err=%v", info, err)
+	}
+	if info, err := os.Stat(sourceFile); err != nil || info.IsDir() {
+		t.Fatalf("source file was not created: info=%v err=%v", info, err)
+	}
 }

--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -20,6 +21,8 @@ import (
 const (
 	nvidiaGPUResource  = "nvidia.com/gpu"
 	nvidiaGPUDRADriver = "gpu.nvidia.com"
+
+	cudaStateProbeTimeout = 10 * time.Second
 )
 
 var podResourcesSocketPath = "/var/lib/kubelet/pod-resources/kubelet.sock"
@@ -145,22 +148,29 @@ func DiscoverGPUUUIDs(ctx context.Context, clientset kubernetes.Interface, podNa
 
 // FilterProcesses returns the subset of candidate PIDs that hold actual CUDA contexts.
 // Uses --get-restore-tid (the same technique as the CRIU CUDA plugin) instead of
-// --get-state, because --get-state incorrectly matches coordinator processes like
-// cuda-checkpoint --launch-job that share a /proc namespace with CUDA processes but
-// don't hold CUDA contexts themselves.
+// --get-state, because --get-state incorrectly matches coordinator processes
+// that share a /proc namespace with CUDA processes but don't hold CUDA
+// contexts themselves.
 func FilterProcesses(ctx context.Context, allPIDs []int, log logr.Logger) []int {
 	cudaPIDs := make([]int, 0, len(allPIDs))
 	for _, pid := range allPIDs {
 		if pid <= 0 {
 			continue
 		}
-		cmd := exec.CommandContext(ctx, cudaCheckpointHelperBinary, "--get-restore-tid", "--pid", strconv.Itoa(pid))
+		probeCtx, cancel := context.WithTimeout(ctx, cudaStateProbeTimeout)
+		cmd := exec.CommandContext(probeCtx, cudaCheckpointHelperBinary, "--get-restore-tid", "--pid", strconv.Itoa(pid))
 		output, err := cmd.CombinedOutput()
+		cancel()
 		if err != nil {
 			if ctx.Err() != nil {
 				break
 			}
-			log.V(1).Info("CUDA restore-tid probe negative", "pid", pid)
+			if state, ok := getCheckpointState(ctx, pid, log); ok && (state == "checkpointed" || state == "locked") {
+				log.V(1).Info("CUDA restore-tid probe negative but process is checkpoint-managed", "pid", pid, "state", state)
+				cudaPIDs = append(cudaPIDs, pid)
+				continue
+			}
+			log.V(1).Info("CUDA restore-tid probe negative", "pid", pid, "error", err, "output", strings.TrimSpace(string(output)))
 			continue
 		}
 		tid := strings.TrimSpace(string(output))
@@ -168,6 +178,20 @@ func FilterProcesses(ctx context.Context, allPIDs []int, log logr.Logger) []int 
 		cudaPIDs = append(cudaPIDs, pid)
 	}
 	return cudaPIDs
+}
+
+func getCheckpointState(ctx context.Context, pid int, log logr.Logger) (string, bool) {
+	probeCtx, cancel := context.WithTimeout(ctx, cudaStateProbeTimeout)
+	defer cancel()
+
+	state, err := getState(probeCtx, pid)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.V(1).Info("CUDA state probe failed", "pid", pid, "error", err)
+		}
+		return "", false
+	}
+	return state, true
 }
 
 // BuildDeviceMap creates a cuda-checkpoint-helper --device-map value from source and target GPU UUID lists.
@@ -226,14 +250,33 @@ func LockAndCheckpointProcessTree(ctx context.Context, cudaPIDs []int, log logr.
 	var timings CheckpointPhaseTimings
 
 	start := time.Now()
-	for _, pid := range cudaPIDs {
-		if err := lock(ctx, pid, log); err != nil {
+	checkpointPIDs := append([]int(nil), cudaPIDs...)
+	slices.Reverse(checkpointPIDs)
+	log.V(1).Info("Locking CUDA process tree", "pids", checkpointPIDs)
+	for _, pid := range checkpointPIDs {
+		if state, ok := getCheckpointState(ctx, pid, log); ok {
+			if state == "checkpointed" {
+				log.V(1).Info("CUDA process already checkpointed", "pid", pid)
+				continue
+			}
+			if state == "locked" {
+				log.V(1).Info("CUDA process already locked", "pid", pid)
+			} else if err := lock(ctx, pid, log); err != nil {
+				timings.TotalDuration = time.Since(start)
+				return timings, err
+			}
+		} else if err := lock(ctx, pid, log); err != nil {
 			timings.TotalDuration = time.Since(start)
 			return timings, err
 		}
 	}
 
-	for _, pid := range cudaPIDs {
+	log.V(1).Info("Checkpointing locked CUDA process tree", "pids", checkpointPIDs)
+	for _, pid := range checkpointPIDs {
+		if state, ok := getCheckpointState(ctx, pid, log); ok && state == "checkpointed" {
+			log.V(1).Info("CUDA process already checkpointed", "pid", pid)
+			continue
+		}
 		if err := checkpoint(ctx, pid, log); err != nil {
 			timings.TotalDuration = time.Since(start)
 			return timings, err

--- a/deploy/snapshot/internal/cuda/cuda_test.go
+++ b/deploy/snapshot/internal/cuda/cuda_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -76,6 +77,68 @@ func TestBuildDeviceMap(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestLockAndCheckpointProcessTreeLocksAllPIDsBeforeCheckpointing(t *testing.T) {
+	dir := t.TempDir()
+	actionsPath := filepath.Join(dir, "actions")
+	helperPath := filepath.Join(dir, "cuda-checkpoint-helper")
+	script := `#!/bin/sh
+if [ "$1" = "--get-state" ]; then
+  echo running
+  exit 0
+fi
+
+action=""
+pid=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --action)
+      action="$2"
+      shift 2
+      ;;
+    --pid)
+      pid="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s:%s\n' "$action" "$pid" >> "$HELPER_ACTIONS_PATH"
+`
+	if err := os.WriteFile(helperPath, []byte(script), 0700); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	t.Setenv("HELPER_ACTIONS_PATH", actionsPath)
+
+	previousHelper := cudaCheckpointHelperBinary
+	cudaCheckpointHelperBinary = helperPath
+	t.Cleanup(func() {
+		cudaCheckpointHelperBinary = previousHelper
+	})
+
+	if _, err := LockAndCheckpointProcessTree(context.Background(), []int{101, 102, 103}, logr.Discard()); err != nil {
+		t.Fatalf("LockAndCheckpointProcessTree: %v", err)
+	}
+
+	data, err := os.ReadFile(actionsPath)
+	if err != nil {
+		t.Fatalf("read helper actions: %v", err)
+	}
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{
+		"lock:103",
+		"lock:102",
+		"lock:101",
+		"checkpoint:103",
+		"checkpoint:102",
+		"checkpoint:101",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("helper actions = %q, want %q", got, want)
 	}
 }
 

--- a/deploy/snapshot/internal/cuda/shim.go
+++ b/deploy/snapshot/internal/cuda/shim.go
@@ -1,9 +1,13 @@
 package cuda
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -14,13 +18,16 @@ import (
 )
 
 const (
-	cudaCheckpointHelperBinary = "/usr/local/bin/cuda-checkpoint-helper"
-
 	actionLock       = "lock"
 	actionCheckpoint = "checkpoint"
 	actionRestore    = "restore"
 	actionUnlock     = "unlock"
+
+	cudaShortActionTimeout = 2 * time.Minute
+	cudaLongActionTimeout  = 10 * time.Minute
 )
+
+var cudaCheckpointHelperBinary = "/usr/local/bin/cuda-checkpoint-helper"
 
 func lock(ctx context.Context, pid int, log logr.Logger) error {
 	return runAction(ctx, pid, actionLock, "", log)
@@ -53,10 +60,22 @@ func getState(ctx context.Context, pid int) (string, error) {
 
 func runAction(ctx context.Context, pid int, action, deviceMap string, log logr.Logger) error {
 	args := []string{"--action", action, "--pid", strconv.Itoa(pid)}
+	timeout := cudaShortActionTimeout
+	if action == actionCheckpoint || action == actionRestore {
+		timeout = cudaLongActionTimeout
+	}
+	if action == actionLock {
+		args = append(args, "--timeout", strconv.FormatInt(timeout.Milliseconds(), 10))
+	}
 	if action == actionRestore && deviceMap != "" {
 		args = append(args, "--device-map", deviceMap)
 	}
-	cmd := exec.CommandContext(ctx, cudaCheckpointHelperBinary, args...)
+	actionCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cmd := exec.Command(cudaCheckpointHelperBinary, args...)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
 	details := snapshotruntime.ProcessDetails{
 		ObservedPID:   pid,
 		OutermostPID:  pid,
@@ -67,9 +86,38 @@ func runAction(ctx context.Context, pid int, action, deviceMap string, log logr.
 		details = process
 	}
 	start := time.Now()
-	output, err := cmd.CombinedOutput()
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("cuda-checkpoint-helper %v failed to start for pid %d: %w", args, pid, err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	var err error
+	timedOut := false
+	select {
+	case err = <-done:
+	case <-actionCtx.Done():
+		timedOut = actionCtx.Err() == context.DeadlineExceeded
+		if timedOut {
+			logCudaTimeoutDiagnostics(ctx, pid, cmd.Process.Pid, action, details, log)
+		}
+		if killErr := cmd.Process.Kill(); killErr != nil {
+			log.Error(killErr, "Failed to kill timed out cuda-checkpoint-helper", "pid", pid, "helper_pid", cmd.Process.Pid, "action", action)
+		}
+		select {
+		case err = <-done:
+		case <-time.After(5 * time.Second):
+			err = fmt.Errorf("cuda-checkpoint-helper did not exit after kill")
+		}
+		if timedOut && err == nil {
+			err = context.DeadlineExceeded
+		}
+	}
 	duration := time.Since(start)
-	out := strings.TrimSpace(string(output))
+	out := strings.TrimSpace(output.String())
 	if err != nil {
 		log.Error(err, "cuda-checkpoint-helper command failed",
 			"pid", pid,
@@ -78,8 +126,13 @@ func runAction(ctx context.Context, pid int, action, deviceMap string, log logr.
 			"cmdline", details.Cmdline,
 			"action", action,
 			"duration", duration,
+			"timeout", timeout,
+			"timed_out", timedOut,
 			"output", out,
 		)
+		if timedOut {
+			return fmt.Errorf("cuda-checkpoint-helper %v timed out for pid %d after %s (output: %s)", args, pid, timeout, out)
+		}
 		return fmt.Errorf("cuda-checkpoint-helper %v failed for pid %d after %s: %w (output: %s)", args, pid, duration, err, out)
 	}
 	log.V(1).Info("cuda-checkpoint-helper command succeeded",
@@ -89,7 +142,192 @@ func runAction(ctx context.Context, pid int, action, deviceMap string, log logr.
 		"cmdline", details.Cmdline,
 		"action", action,
 		"duration", duration,
+		"timeout", timeout,
 		"output", out,
 	)
 	return nil
+}
+
+func logCudaTimeoutDiagnostics(ctx context.Context, targetPID, helperPID int, action string, details snapshotruntime.ProcessDetails, log logr.Logger) {
+	log.Info("cuda-checkpoint-helper timeout diagnostics started",
+		"pid", targetPID,
+		"helper_pid", helperPID,
+		"outermost_pid", details.OutermostPID,
+		"innermost_pid", details.InnermostPID,
+		"cmdline", details.Cmdline,
+		"action", action,
+	)
+
+	logProcessDiagnostics("target", targetPID, log)
+	if helperPID > 0 {
+		logProcessDiagnostics("helper", helperPID, log)
+	}
+
+	nvidiaSmiCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(nvidiaSmiCtx, "nvidia-smi", "pmon", "-c", "1")
+	output, err := cmd.CombinedOutput()
+	nvidiaSmiError := ""
+	if err != nil {
+		nvidiaSmiError = err.Error()
+	}
+	log.Info("cuda-checkpoint-helper timeout nvidia-smi pmon",
+		"error", nvidiaSmiError,
+		"output", trimForLog(string(output), 12000),
+	)
+}
+
+func logProcessDiagnostics(label string, pid int, log logr.Logger) {
+	status := readProcFile(pid, "status", 12000)
+	threadsTotal, threads := collectThreadDiagnostics(pid, 128)
+	fdTotal, fdMatches := collectFDDiagnostics(pid, 128)
+	mapMatches := collectMapsDiagnostics(pid, 160)
+
+	log.Info("cuda-checkpoint-helper timeout process diagnostics",
+		"label", label,
+		"pid", pid,
+		"cmdline", readProcFile(pid, "cmdline", 4000),
+		"comm", readProcFile(pid, "comm", 1000),
+		"wchan", readProcFile(pid, "wchan", 1000),
+		"stack", readProcFile(pid, "stack", 12000),
+		"status", status,
+		"thread_count", threadsTotal,
+		"threads", strings.Join(threads, "\n"),
+		"fd_count", fdTotal,
+		"cuda_relevant_fds", strings.Join(fdMatches, "\n"),
+		"cuda_relevant_maps", strings.Join(mapMatches, "\n"),
+	)
+}
+
+func collectThreadDiagnostics(pid int, limit int) (int, []string) {
+	taskDir := filepath.Join("/proc", strconv.Itoa(pid), "task")
+	entries, err := os.ReadDir(taskDir)
+	if err != nil {
+		return 0, []string{fmt.Sprintf("failed to read %s: %v", taskDir, err)}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	threads := make([]string, 0, min(len(entries), limit))
+	for _, entry := range entries {
+		if len(threads) >= limit {
+			break
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		tid := entry.Name()
+		threadPath := filepath.Join(taskDir, tid)
+		status := readFile(filepath.Join(threadPath, "status"), 4000)
+		threads = append(threads, fmt.Sprintf(
+			"tid=%s comm=%q state=%q wchan=%q",
+			tid,
+			readFile(filepath.Join(threadPath, "comm"), 1000),
+			statusValue(status, "State:"),
+			readFile(filepath.Join(threadPath, "wchan"), 1000),
+		))
+	}
+	if len(entries) > limit {
+		threads = append(threads, fmt.Sprintf("... truncated %d additional threads", len(entries)-limit))
+	}
+	return len(entries), threads
+}
+
+func collectFDDiagnostics(pid int, limit int) (int, []string) {
+	fdDir := filepath.Join("/proc", strconv.Itoa(pid), "fd")
+	entries, err := os.ReadDir(fdDir)
+	if err != nil {
+		return 0, []string{fmt.Sprintf("failed to read %s: %v", fdDir, err)}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	matches := make([]string, 0)
+	for _, entry := range entries {
+		if len(matches) >= limit {
+			break
+		}
+		target, err := os.Readlink(filepath.Join(fdDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		if isCudaRelevant(target) {
+			matches = append(matches, fmt.Sprintf("%s -> %s", entry.Name(), target))
+		}
+	}
+	return len(entries), matches
+}
+
+func collectMapsDiagnostics(pid int, limit int) []string {
+	mapsPath := filepath.Join("/proc", strconv.Itoa(pid), "maps")
+	data := readFile(mapsPath, 1_000_000)
+	if strings.HasPrefix(data, "failed to read ") {
+		return []string{data}
+	}
+
+	matches := make([]string, 0)
+	for _, line := range strings.Split(data, "\n") {
+		if len(matches) >= limit {
+			break
+		}
+		if isCudaRelevant(line) {
+			matches = append(matches, line)
+		}
+	}
+	return matches
+}
+
+func readProcFile(pid int, name string, limit int) string {
+	path := filepath.Join("/proc", strconv.Itoa(pid), name)
+	if name == "cmdline" {
+		return strings.ReplaceAll(readFile(path, limit), "\x00", " ")
+	}
+	return readFile(path, limit)
+}
+
+func readFile(path string, limit int) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("failed to read %s: %v", path, err)
+	}
+	return trimForLog(string(data), limit)
+}
+
+func trimForLog(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if limit > 0 && len(value) > limit {
+		return value[:limit] + "\n... truncated"
+	}
+	return value
+}
+
+func statusValue(status string, key string) string {
+	for _, line := range strings.Split(status, "\n") {
+		if strings.HasPrefix(line, key) {
+			return strings.TrimSpace(strings.TrimPrefix(line, key))
+		}
+	}
+	return ""
+}
+
+func isCudaRelevant(value string) bool {
+	lower := strings.ToLower(value)
+	relevantTerms := []string{
+		"cuda",
+		"nvidia",
+		"uvm",
+		"nccl",
+		"/dev/shm",
+		"memfd:",
+		"anon_inode",
+		"socket:",
+	}
+	for _, term := range relevantTerms {
+		if strings.Contains(lower, term) {
+			return true
+		}
+	}
+	return false
 }

--- a/deploy/snapshot/internal/cuda/shim_test.go
+++ b/deploy/snapshot/internal/cuda/shim_test.go
@@ -1,0 +1,49 @@
+package cuda
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestLockPassesDriverTimeout(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	helperPath := filepath.Join(dir, "cuda-checkpoint-helper")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$HELPER_ARGS_PATH\"\n"
+	if err := os.WriteFile(helperPath, []byte(script), 0700); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	t.Setenv("HELPER_ARGS_PATH", argsPath)
+
+	previousHelper := cudaCheckpointHelperBinary
+	cudaCheckpointHelperBinary = helperPath
+	t.Cleanup(func() {
+		cudaCheckpointHelperBinary = previousHelper
+	})
+
+	if err := lock(context.Background(), os.Getpid(), logr.Discard()); err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read helper args: %v", err)
+	}
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{
+		"--action",
+		"lock",
+		"--pid",
+		strconv.Itoa(os.Getpid()),
+		"--timeout",
+		strconv.FormatInt(cudaShortActionTimeout.Milliseconds(), 10),
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("helper args = %q, want %q", got, want)
+	}
+}

--- a/deploy/snapshot/internal/executor/checkpoint.go
+++ b/deploy/snapshot/internal/executor/checkpoint.go
@@ -5,6 +5,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,6 +89,7 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	// Phase 3: Capture — CRIU dump, rootfs diff
 	captureTimings, err := captureCheckpoint(ctx, criuOpts, &cfg.CRIU, data, state, tmpDir, log)
 	if err != nil {
+		preserveFailedCheckpointArtifacts(tmpDir, finalDir, log)
 		return err
 	}
 	phaseTimings.CUDADuration = captureTimings.CUDADuration
@@ -260,6 +262,7 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 		}
 		timings.CUDADuration = cudaTimings.TotalDuration
 	}
+	writeNVIDIAOpenFDDiagnostic(state, checkpointDir, log)
 
 	criuDumpDuration, err := criu.ExecuteDump(criuOpts, checkpointDir, criuSettings, log)
 	if err != nil {
@@ -282,4 +285,55 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 	}
 
 	return timings, nil
+}
+
+func preserveFailedCheckpointArtifacts(tmpDir, finalDir string, log logr.Logger) {
+	failureDir := filepath.Join(filepath.Dir(finalDir), "failed", filepath.Base(tmpDir))
+	preserved := 0
+	err := filepath.WalkDir(tmpDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		name := entry.Name()
+		if name != criu.DumpLogFilename &&
+			name != "criu.conf" &&
+			!strings.HasSuffix(name, ".log") &&
+			!strings.HasPrefix(name, "cuda-nvidia-fd.") {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(tmpDir, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(failureDir, rel)
+		if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, content, info.Mode().Perm()); err != nil {
+			return err
+		}
+		preserved++
+		return nil
+	})
+	if err != nil {
+		log.Error(err, "Failed to preserve checkpoint failure artifacts", "source_dir", tmpDir, "failure_dir", failureDir)
+		return
+	}
+	log.Info("Preserved checkpoint failure artifacts", "source_dir", tmpDir, "failure_dir", failureDir, "count", preserved)
 }

--- a/deploy/snapshot/internal/executor/nsrestore.go
+++ b/deploy/snapshot/internal/executor/nsrestore.go
@@ -17,9 +17,11 @@ import (
 
 // RestoreOptions holds configuration for an in-namespace restore.
 type RestoreOptions struct {
-	CheckpointPath string
-	CUDADeviceMap  string
-	CgroupRoot     string
+	CheckpointPath       string
+	CUDADeviceMap        string
+	CgroupRoot           string
+	RestorePodUID        string
+	RestoreContainerName string
 }
 
 type RestoreInNamespaceResult struct {
@@ -53,7 +55,10 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 
 	// Phase 1: Configure — build CRIU opts from manifest
 	configureStart := time.Now()
-	criuOpts, err := criu.BuildRestoreOpts(m, opts.CheckpointPath, opts.CgroupRoot, log)
+	criuOpts, err := criu.BuildRestoreOpts(m, opts.CheckpointPath, opts.CgroupRoot, criu.RestoreMountContext{
+		PodUID:        opts.RestorePodUID,
+		ContainerName: opts.RestoreContainerName,
+	}, log)
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +103,13 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 
 	if err := snapshotruntime.ApplyDeletedFiles(opts.CheckpointPath, "/", log); err != nil {
 		log.Error(err, "Failed to apply deleted files")
+	}
+
+	if err := criu.PrepareRestoreMountpoints(m, criu.RestoreMountContext{
+		PodUID:        opts.RestorePodUID,
+		ContainerName: opts.RestoreContainerName,
+	}, log); err != nil {
+		return nil, 0, fmt.Errorf("failed to prepare restore mountpoints: %w", err)
 	}
 
 	// Unmount placeholder's /dev/shm so CRIU can recreate tmpfs with checkpointed content

--- a/deploy/snapshot/internal/executor/nvidia_fds.go
+++ b/deploy/snapshot/internal/executor/nvidia_fds.go
@@ -1,0 +1,181 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	snapshotruntime "github.com/ai-dynamo/dynamo/deploy/snapshot/internal/runtime"
+	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
+)
+
+const nvidiaOpenFDLogFilename = "nvidia-open-fds.log"
+
+type nvidiaOpenFD struct {
+	HostPID       int
+	InnermostPID  int
+	NamespacePIDs []int
+	CUDAPID       bool
+	Cmdline       string
+	FD            int
+	Target        string
+	Major         int64
+	Minor         int64
+	FDInfo        string
+}
+
+func writeNVIDIAOpenFDDiagnostic(state *types.CheckpointContainerSnapshot, checkpointDir string, log logr.Logger) {
+	if state == nil || state.PID <= 0 {
+		return
+	}
+
+	pids := snapshotruntime.ProcessTreePIDs(state.PID)
+	fds := collectNVIDIAOpenFDs(snapshotruntime.HostProcPath, pids, state.CUDAHostPIDs)
+	sort.Slice(fds, func(i, j int) bool {
+		if fds[i].HostPID == fds[j].HostPID {
+			return fds[i].FD < fds[j].FD
+		}
+		return fds[i].HostPID < fds[j].HostPID
+	})
+
+	path := filepath.Join(checkpointDir, nvidiaOpenFDLogFilename)
+	if err := os.WriteFile(path, []byte(formatNVIDIAOpenFDs(state, pids, fds)), 0644); err != nil {
+		log.Error(err, "Failed to write NVIDIA open FD diagnostic", "path", path)
+		return
+	}
+	log.Info("Captured NVIDIA open FD diagnostic before CRIU dump", "count", len(fds), "path", path)
+}
+
+func collectNVIDIAOpenFDs(procRoot string, pids []int, cudaHostPIDs []int) []nvidiaOpenFD {
+	cudaPID := make(map[int]bool, len(cudaHostPIDs))
+	for _, pid := range cudaHostPIDs {
+		cudaPID[pid] = true
+	}
+
+	var out []nvidiaOpenFD
+	for _, pid := range pids {
+		fdDir := filepath.Join(procRoot, strconv.Itoa(pid), "fd")
+		entries, err := os.ReadDir(fdDir)
+		if err != nil {
+			continue
+		}
+		process := snapshotruntime.ReadProcessDetailsOrDefault(procRoot, pid)
+		for _, entry := range entries {
+			fd, err := strconv.Atoi(entry.Name())
+			if err != nil {
+				continue
+			}
+			fdPath := filepath.Join(fdDir, entry.Name())
+			target, err := os.Readlink(fdPath)
+			if err != nil {
+				continue
+			}
+
+			major, minor := statDeviceMajorMinor(fdPath)
+			if !isNVIDIAFD(target, major) {
+				continue
+			}
+			out = append(out, nvidiaOpenFD{
+				HostPID:       pid,
+				InnermostPID:  process.InnermostPID,
+				NamespacePIDs: append([]int(nil), process.NamespacePIDs...),
+				CUDAPID:       cudaPID[pid],
+				Cmdline:       process.Cmdline,
+				FD:            fd,
+				Target:        target,
+				Major:         major,
+				Minor:         minor,
+				FDInfo:        readFDInfo(procRoot, pid, fd),
+			})
+		}
+	}
+	return out
+}
+
+func statDeviceMajorMinor(path string) (int64, int64) {
+	var stat unix.Stat_t
+	if err := unix.Stat(path, &stat); err != nil {
+		return -1, -1
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFCHR {
+		return -1, -1
+	}
+	return int64(unix.Major(uint64(stat.Rdev))), int64(unix.Minor(uint64(stat.Rdev)))
+}
+
+func isNVIDIAFD(target string, major int64) bool {
+	if strings.Contains(target, "nvidia") {
+		return true
+	}
+	return major == 195
+}
+
+func readFDInfo(procRoot string, pid int, fd int) string {
+	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "fdinfo", strconv.Itoa(fd)))
+	if err != nil {
+		return ""
+	}
+	var fields []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "pos:") ||
+			strings.HasPrefix(line, "flags:") ||
+			strings.HasPrefix(line, "mnt_id:") {
+			fields = append(fields, strings.Join(strings.Fields(line), "="))
+		}
+	}
+	return strings.Join(fields, ";")
+}
+
+func formatNVIDIAOpenFDs(state *types.CheckpointContainerSnapshot, pids []int, fds []nvidiaOpenFD) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "phase=post_cuda_checkpoint_pre_criu_dump")
+	if state != nil {
+		fmt.Fprintf(&b, "root_host_pid=%d\n", state.PID)
+		fmt.Fprintf(&b, "cuda_host_pids=%s\n", formatIntSlice(state.CUDAHostPIDs))
+		fmt.Fprintf(&b, "cuda_namespace_pids=%s\n", formatIntSlice(state.CUDANSPIDs))
+	}
+	fmt.Fprintf(&b, "process_tree_host_pids=%s\n", formatIntSlice(pids))
+	fmt.Fprintf(&b, "count=%d\n", len(fds))
+	fmt.Fprintln(&b, "host_pid\tinnermost_pid\tnspid\tcuda_pid\tfd\ttarget\tmajor\tminor\tfdinfo\tcmdline")
+	for _, fd := range fds {
+		fmt.Fprintf(
+			&b,
+			"%d\t%d\t%s\t%t\t%d\t%s\t%d\t%d\t%s\t%s\n",
+			fd.HostPID,
+			fd.InnermostPID,
+			formatIntSlice(fd.NamespacePIDs),
+			fd.CUDAPID,
+			fd.FD,
+			sanitizeDiagnosticField(fd.Target),
+			fd.Major,
+			fd.Minor,
+			sanitizeDiagnosticField(fd.FDInfo),
+			sanitizeDiagnosticField(fd.Cmdline),
+		)
+	}
+	return b.String()
+}
+
+func formatIntSlice(values []int) string {
+	if len(values) == 0 {
+		return ""
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, strconv.Itoa(value))
+	}
+	return strings.Join(out, ",")
+}
+
+func sanitizeDiagnosticField(value string) string {
+	value = strings.ReplaceAll(value, "\t", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return value
+}

--- a/deploy/snapshot/internal/executor/nvidia_fds_test.go
+++ b/deploy/snapshot/internal/executor/nvidia_fds_test.go
@@ -1,0 +1,85 @@
+package executor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCollectNVIDIAOpenFDs(t *testing.T) {
+	procRoot := t.TempDir()
+	pid := 101
+	procDir := filepath.Join(procRoot, "101")
+	fdDir := filepath.Join(procDir, "fd")
+	fdInfoDir := filepath.Join(procDir, "fdinfo")
+	if err := os.MkdirAll(fdDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(fdDir): %v", err)
+	}
+	if err := os.MkdirAll(fdInfoDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(fdInfoDir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(procDir, "status"), []byte("Name:\tpython3\nPPid:\t1\nNSpid:\t101 7\n"), 0644); err != nil {
+		t.Fatalf("WriteFile(status): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(procDir, "cmdline"), []byte("python3\x00-m\x00dynamo.vllm\x00"), 0644); err != nil {
+		t.Fatalf("WriteFile(cmdline): %v", err)
+	}
+	if err := os.Symlink("/dev/nvidiactl", filepath.Join(fdDir, "10")); err != nil {
+		t.Fatalf("Symlink(nvidia): %v", err)
+	}
+	if err := os.Symlink("/tmp/regular", filepath.Join(fdDir, "11")); err != nil {
+		t.Fatalf("Symlink(regular): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fdInfoDir, "10"), []byte("pos:\t0\nflags:\t0100002\nmnt_id:\t123\nino:\t99\n"), 0644); err != nil {
+		t.Fatalf("WriteFile(fdinfo): %v", err)
+	}
+
+	fds := collectNVIDIAOpenFDs(procRoot, []int{pid}, []int{pid})
+	if len(fds) != 1 {
+		t.Fatalf("len(fds) = %d, want 1: %#v", len(fds), fds)
+	}
+	if fds[0].HostPID != pid || fds[0].InnermostPID != 7 || !fds[0].CUDAPID || fds[0].FD != 10 {
+		t.Fatalf("unexpected fd entry: %#v", fds[0])
+	}
+	if got := formatIntSlice(fds[0].NamespacePIDs); got != "101,7" {
+		t.Fatalf("NamespacePIDs = %q, want 101,7", got)
+	}
+	if fds[0].Target != "/dev/nvidiactl" {
+		t.Fatalf("target = %q, want /dev/nvidiactl", fds[0].Target)
+	}
+	if fds[0].FDInfo != "pos:=0;flags:=0100002;mnt_id:=123" {
+		t.Fatalf("FDInfo = %q, want selected fdinfo fields", fds[0].FDInfo)
+	}
+	if !strings.Contains(fds[0].Cmdline, "dynamo.vllm") {
+		t.Fatalf("cmdline = %q, want dynamo.vllm", fds[0].Cmdline)
+	}
+}
+
+func TestFormatNVIDIAOpenFDs(t *testing.T) {
+	got := formatNVIDIAOpenFDs(nil, []int{101}, []nvidiaOpenFD{
+		{
+			HostPID:       101,
+			InnermostPID:  7,
+			NamespacePIDs: []int{101, 7},
+			CUDAPID:       true,
+			Cmdline:       "python3 -m dynamo.vllm",
+			FD:            10,
+			Target:        "/dev/nvidiactl",
+			Major:         195,
+			Minor:         255,
+			FDInfo:        "pos:=0;flags:=0100002;mnt_id:=123",
+		},
+	})
+	for _, want := range []string{
+		"phase=post_cuda_checkpoint_pre_criu_dump",
+		"process_tree_host_pids=101",
+		"count=1",
+		"host_pid\tinnermost_pid\tnspid\tcuda_pid\tfd\ttarget\tmajor\tminor\tfdinfo\tcmdline",
+		"101\t7\t101,7\ttrue\t10\t/dev/nvidiactl\t195\t255\tpos:=0;flags:=0100002;mnt_id:=123\tpython3 -m dynamo.vllm",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/deploy/snapshot/internal/executor/restore.go
+++ b/deploy/snapshot/internal/executor/restore.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -31,6 +32,7 @@ type RestoreRequest struct {
 	NSRestorePath               string
 	PodName                     string
 	PodNamespace                string
+	PodUID                      string
 	ContainerName               string
 	Clientset                   kubernetes.Interface
 }
@@ -59,6 +61,19 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 		return 0, err
 	}
 	hostInspectDuration := time.Since(hostInspectStart)
+
+	m, err := types.ReadManifest(snap.CheckpointPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read checkpoint manifest for restore preflight: %w", err)
+	}
+	if err := prepareKubeletMountpointsForRestore(
+		log,
+		req,
+		m,
+		filepath.Join(snapshotruntime.HostProcPath, "1", "root"),
+	); err != nil {
+		return 0, err
+	}
 
 	// Phase 2: Execute — nsrestore handles rootfs, CRIU restore, and CUDA restore inside namespace
 	result, err := execNSRestore(ctx, log, req, snap)
@@ -183,6 +198,153 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 	}, nil
 }
 
+func prepareKubeletMountpointsForRestore(log logr.Logger, req RestoreRequest, m *types.CheckpointManifest, hostRoot string) error {
+	if m == nil || strings.TrimSpace(req.PodUID) == "" || len(m.CRIUDump.ExtMnt) == 0 {
+		return nil
+	}
+
+	prepared := 0
+	for _, val := range m.CRIUDump.ExtMnt {
+		sourcePath, targetPath, ok := kubeletMountpointPaths(val, req.PodUID, req.ContainerName, hostRoot)
+		if !ok || sourcePath == targetPath {
+			continue
+		}
+		info, err := os.Stat(targetPath)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			if err := os.MkdirAll(sourcePath, 0755); err != nil {
+				return fmt.Errorf("failed to create checkpoint-time kubelet mountpoint %s: %w", sourcePath, err)
+			}
+			prepared++
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(sourcePath), 0755); err != nil {
+			return fmt.Errorf("failed to create checkpoint-time kubelet mountpoint parent %s: %w", filepath.Dir(sourcePath), err)
+		}
+		f, err := os.OpenFile(sourcePath, os.O_CREATE|os.O_WRONLY, info.Mode().Perm())
+		if err != nil {
+			return fmt.Errorf("failed to create checkpoint-time kubelet mountpoint file %s: %w", sourcePath, err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("failed to close checkpoint-time kubelet mountpoint file %s: %w", sourcePath, err)
+		}
+		prepared++
+	}
+	if prepared > 0 {
+		log.Info("Prepared checkpoint-time kubelet mountpoints for CRIU restore",
+			"count", prepared,
+			"restore_pod_uid", req.PodUID,
+		)
+	}
+	return nil
+}
+
+func kubeletMountpointPaths(path string, restorePodUID string, restoreContainerName string, hostRoot string) (string, string, bool) {
+	restorePodUID = strings.TrimSpace(restorePodUID)
+	if restorePodUID == "" {
+		return "", "", false
+	}
+	cleanPath := filepath.Clean(path)
+	rel, ok := strings.CutPrefix(cleanPath, "/host/var/lib/kubelet/pods"+string(os.PathSeparator))
+	if !ok {
+		return "", "", false
+	}
+	parts := strings.Split(rel, string(os.PathSeparator))
+	if len(parts) < 3 {
+		return "", "", false
+	}
+
+	sourceParts := append([]string{hostRoot, "var", "lib", "kubelet", "pods"}, parts...)
+	sourcePath := filepath.Join(sourceParts...)
+	switch parts[1] {
+	case "volumes":
+		targetPath, ok := kubeletVolumeTargetPath(parts, restorePodUID, hostRoot)
+		return sourcePath, targetPath, ok
+	case "volume-subpaths":
+		targetPath, ok := kubeletVolumeSubpathTargetPath(parts, restorePodUID, restoreContainerName, hostRoot)
+		return sourcePath, targetPath, ok
+	default:
+		return "", "", false
+	}
+}
+
+func kubeletVolumeTargetPath(parts []string, restorePodUID string, hostRoot string) (string, bool) {
+	if len(parts) < 4 {
+		return "", false
+	}
+	targetParts := append([]string{hostRoot, "var", "lib", "kubelet", "pods", restorePodUID, "volumes"}, parts[2:]...)
+	targetPath := filepath.Join(targetParts...)
+	if _, err := os.Stat(targetPath); err == nil {
+		return targetPath, true
+	}
+	if parts[2] != "kubernetes.io~projected" || !strings.HasPrefix(parts[3], "kube-api-access-") {
+		return targetPath, true
+	}
+
+	matches, err := filepath.Glob(filepath.Join(
+		hostRoot,
+		"var",
+		"lib",
+		"kubelet",
+		"pods",
+		restorePodUID,
+		"volumes",
+		parts[2],
+		"kube-api-access-*",
+	))
+	if err != nil || len(matches) == 0 {
+		return "", false
+	}
+	sort.Strings(matches)
+	for _, match := range matches {
+		targetPath := filepath.Join(append([]string{match}, parts[4:]...)...)
+		if _, err := os.Stat(targetPath); err == nil {
+			return targetPath, true
+		}
+	}
+	return "", false
+}
+
+func kubeletVolumeSubpathTargetPath(parts []string, restorePodUID string, restoreContainerName string, hostRoot string) (string, bool) {
+	if len(parts) < 5 {
+		return "", false
+	}
+	if strings.TrimSpace(restoreContainerName) == "" {
+		restoreContainerName = parts[3]
+	}
+	targetParts := append(
+		[]string{hostRoot, "var", "lib", "kubelet", "pods", restorePodUID, "volume-subpaths", parts[2], restoreContainerName},
+		parts[4:]...,
+	)
+	targetPath := filepath.Join(targetParts...)
+	if _, err := os.Stat(targetPath); err == nil {
+		return targetPath, true
+	}
+
+	matches, err := filepath.Glob(filepath.Join(
+		hostRoot,
+		"var",
+		"lib",
+		"kubelet",
+		"pods",
+		restorePodUID,
+		"volume-subpaths",
+		parts[2],
+		restoreContainerName,
+		"*",
+	))
+	if err != nil || len(matches) != 1 {
+		return "", false
+	}
+	targetPath = filepath.Join(append([]string{matches[0]}, parts[5:]...)...)
+	if _, err := os.Stat(targetPath); err == nil {
+		return targetPath, true
+	}
+	return "", false
+}
+
 // execNSRestore launches the nsrestore binary inside the placeholder container's
 // namespaces via nsenter and parses the restored PID from stdout JSON.
 func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, snap *types.RestoreContainerSnapshot) (*RestoreInNamespaceResult, error) {
@@ -206,6 +368,12 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 	}
 	if snap.CgroupRoot != "" {
 		args = append(args, "--cgroup-root", snap.CgroupRoot)
+	}
+	if req.PodUID != "" {
+		args = append(args, "--restore-pod-uid", req.PodUID)
+	}
+	if req.ContainerName != "" {
+		args = append(args, "--restore-container-name", req.ContainerName)
 	}
 
 	cmd := exec.CommandContext(ctx, "nsenter", args...)

--- a/deploy/snapshot/internal/executor/restore_test.go
+++ b/deploy/snapshot/internal/executor/restore_test.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -28,5 +30,49 @@ func TestExecNSRestoreRejectsRelativeContainerCheckpointLocation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "absolute") {
 		t.Fatalf("expected absolute-path validation error, got: %v", err)
+	}
+}
+
+func TestPrepareKubeletMountpointsForRestore(t *testing.T) {
+	hostRoot := t.TempDir()
+	targetCSIPath := filepath.Join(hostRoot, "var", "lib", "kubelet", "pods", "target-pod", "volumes", "kubernetes.io~csi", "pvc-abc", "mount")
+	targetProjectedPath := filepath.Join(hostRoot, "var", "lib", "kubelet", "pods", "target-pod", "volumes", "kubernetes.io~projected", "kube-api-access-live")
+	targetSubpath := filepath.Join(hostRoot, "var", "lib", "kubelet", "pods", "target-pod", "volume-subpaths", "config", "main", "7")
+	for _, path := range []string{targetCSIPath, targetProjectedPath, targetSubpath} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatalf("mkdir target path %s: %v", path, err)
+		}
+	}
+
+	m := &types.CheckpointManifest{
+		CRIUDump: types.CRIUDumpManifest{
+			ExtMnt: map[string]string{
+				"/checkpoints": "/host/var/lib/kubelet/pods/source-pod/volumes/kubernetes.io~csi/pvc-abc/mount",
+				"/projected":   "/host/var/lib/kubelet/pods/source-pod/volumes/kubernetes.io~projected/kube-api-access-old",
+				"/subpath":     "/host/var/lib/kubelet/pods/source-pod/volume-subpaths/config/main/2",
+			},
+		},
+	}
+	err := prepareKubeletMountpointsForRestore(
+		testr.New(t),
+		RestoreRequest{PodUID: "target-pod", ContainerName: "main"},
+		m,
+		hostRoot,
+	)
+	if err != nil {
+		t.Fatalf("prepareKubeletMountpointsForRestore: %v", err)
+	}
+
+	sourceCSIPath := filepath.Join(hostRoot, "var", "lib", "kubelet", "pods", "source-pod", "volumes", "kubernetes.io~csi", "pvc-abc", "mount")
+	if info, err := os.Stat(sourceCSIPath); err != nil || !info.IsDir() {
+		t.Fatalf("source CSI mountpoint was not created: info=%v err=%v", info, err)
+	}
+	sourceProjectedPath := filepath.Join(hostRoot, "var", "lib", "kubelet", "pods", "source-pod", "volumes", "kubernetes.io~projected", "kube-api-access-old")
+	if info, err := os.Stat(sourceProjectedPath); err != nil || !info.IsDir() {
+		t.Fatalf("source projected mountpoint was not created: info=%v err=%v", info, err)
+	}
+	sourceSubpath := filepath.Join(hostRoot, "var", "lib", "kubelet", "pods", "source-pod", "volume-subpaths", "config", "main", "2")
+	if info, err := os.Stat(sourceSubpath); err != nil || !info.IsDir() {
+		t.Fatalf("source subpath mountpoint was not created: info=%v err=%v", info, err)
 	}
 }

--- a/deploy/snapshot/internal/runtime/control.go
+++ b/deploy/snapshot/internal/runtime/control.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -32,15 +33,48 @@ func WriteControlSentinel(hostPID int, name string) error {
 	return writeSentinelInDir(dir, name)
 }
 
+type RendezvousConfig struct {
+	RestoreID string          `json:"restore_id,omitempty"`
+	Store     RendezvousStore `json:"store"`
+}
+
+type RendezvousStore struct {
+	Host       string `json:"host"`
+	Port       int    `json:"port"`
+	MasterRank int    `json:"master_rank"`
+}
+
+func WriteRendezvousFile(hostPID int, config RendezvousConfig) error {
+	if hostPID <= 0 {
+		return fmt.Errorf("invalid host PID %d for rendezvous file", hostPID)
+	}
+	if config.Store.Host == "" {
+		return fmt.Errorf("rendezvous store host is empty")
+	}
+	if config.Store.Port <= 0 {
+		return fmt.Errorf("invalid rendezvous store port %d", config.Store.Port)
+	}
+	dir := filepath.Join(HostProcPath, strconv.Itoa(hostPID), "root", snapshotprotocol.SnapshotControlMountPath)
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal rendezvous file: %w", err)
+	}
+	return writeFileInDir(dir, snapshotprotocol.TorchC10dRendezvousFile, append(data, '\n'))
+}
+
 func writeSentinelInDir(dir, name string) error {
+	return writeFileInDir(dir, name, []byte("done\n"))
+}
+
+func writeFileInDir(dir, name string, data []byte) error {
 	tmpPath := filepath.Join(dir, "."+name+".tmp")
 	finalPath := filepath.Join(dir, name)
-	if err := os.WriteFile(tmpPath, []byte("done\n"), 0o644); err != nil {
-		return fmt.Errorf("write temp sentinel %s: %w", tmpPath, err)
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write temp file %s: %w", tmpPath, err)
 	}
 	if err := os.Rename(tmpPath, finalPath); err != nil {
 		_ = os.Remove(tmpPath)
-		return fmt.Errorf("rename sentinel %s -> %s: %w", tmpPath, finalPath, err)
+		return fmt.Errorf("rename file %s -> %s: %w", tmpPath, finalPath, err)
 	}
 	return nil
 }

--- a/deploy/snapshot/protocol/checkpoint.go
+++ b/deploy/snapshot/protocol/checkpoint.go
@@ -21,7 +21,6 @@ type CheckpointJobOptions struct {
 	Name                  string
 	ActiveDeadlineSeconds *int64
 	TTLSecondsAfterFinish *int32
-	WrapLaunchJob         bool
 }
 
 type CheckpointObservationPhase string
@@ -97,16 +96,6 @@ func NewCheckpointJob(podTemplate *corev1.PodTemplateSpec, opts CheckpointJobOpt
 	}
 	targetContainer.LivenessProbe = nil
 	targetContainer.StartupProbe = nil
-
-	if opts.WrapLaunchJob {
-		if len(targetContainer.Command) == 0 {
-			return nil, fmt.Errorf("checkpoint job requires container.command when cuda-checkpoint launch-job wrapping is enabled")
-		}
-		targetContainer.Command, targetContainer.Args = wrapWithCudaCheckpointLaunchJob(
-			targetContainer.Command,
-			targetContainer.Args,
-		)
-	}
 
 	return &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{APIVersion: "batch/v1", Kind: "Job"},
@@ -201,18 +190,4 @@ func EnsureLocalhostSeccompProfile(podSpec *corev1.PodSpec, profile string) {
 		Type:             corev1.SeccompProfileTypeLocalhost,
 		LocalhostProfile: &profile,
 	}
-}
-
-// wrapWithCudaCheckpointLaunchJob rewrites the container's entrypoint so the
-// workload is launched under `cuda-checkpoint --launch-job`, required for
-// multi-GPU checkpoints. The original command and args are preserved as-is
-// (including shell-form entrypoints): workload-to-agent signaling now uses
-// file sentinels in the snapshot-control volume, so an intervening shell at
-// PID 1 is no longer an issue.
-func wrapWithCudaCheckpointLaunchJob(command []string, args []string) ([]string, []string) {
-	wrappedArgs := make([]string, 0, len(command)+len(args)+1)
-	wrappedArgs = append(wrappedArgs, "--launch-job")
-	wrappedArgs = append(wrappedArgs, command...)
-	wrappedArgs = append(wrappedArgs, args...)
-	return []string{"cuda-checkpoint"}, wrappedArgs
 }

--- a/deploy/snapshot/protocol/checkpoint_job_test.go
+++ b/deploy/snapshot/protocol/checkpoint_job_test.go
@@ -49,7 +49,6 @@ func TestNewCheckpointJob(t *testing.T) {
 		Name:                  "test-job",
 		ActiveDeadlineSeconds: ptr.To(int64(60)),
 		TTLSecondsAfterFinish: ptr.To(int32(300)),
-		WrapLaunchJob:         true,
 	})
 	if err != nil {
 		t.Fatalf("expected checkpoint job, got error: %v", err)
@@ -96,12 +95,11 @@ func TestNewCheckpointJob(t *testing.T) {
 	if job.Spec.Template.Spec.SecurityContext == nil || job.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", job.Spec.Template.Spec.SecurityContext)
 	}
-	if len(main.Command) != 1 || main.Command[0] != "cuda-checkpoint" {
-		t.Fatalf("expected cuda-checkpoint wrapper command: %#v", main.Command)
+	if strings.Join(main.Command, "|") != "python3|-m|dynamo.vllm" {
+		t.Fatalf("expected workload command to be preserved, got %#v", main.Command)
 	}
-	expectedArgs := []string{"--launch-job", "python3", "-m", "dynamo.vllm", "--model", "Qwen"}
-	if strings.Join(main.Args, "|") != strings.Join(expectedArgs, "|") {
-		t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, main.Args)
+	if strings.Join(main.Args, "|") != "--model|Qwen" {
+		t.Fatalf("expected workload args to be preserved, got %#v", main.Args)
 	}
 	if job.Spec.BackoffLimit == nil || *job.Spec.BackoffLimit != 0 {
 		t.Fatalf("expected backoffLimit 0, got %#v", job.Spec.BackoffLimit)
@@ -114,7 +112,7 @@ func TestNewCheckpointJob(t *testing.T) {
 	}
 }
 
-func TestNewCheckpointJobWrapsTargetContainer(t *testing.T) {
+func TestNewCheckpointJobShapesOnlyTargetContainer(t *testing.T) {
 	job, err := NewCheckpointJob(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{TargetContainersAnnotation: "worker"},
@@ -131,19 +129,17 @@ func TestNewCheckpointJobWrapsTargetContainer(t *testing.T) {
 		ArtifactVersion:       "2",
 		Name:                  "test-job",
 		TTLSecondsAfterFinish: ptr.To(int32(300)),
-		WrapLaunchJob:         true,
 	})
 	if err != nil {
 		t.Fatalf("expected checkpoint job, got error: %v", err)
 	}
 
 	worker := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "worker")
-	if len(worker.Command) != 1 || worker.Command[0] != "cuda-checkpoint" {
-		t.Fatalf("expected target container to be wrapped, got %#v", worker.Command)
+	if strings.Join(worker.Command, "|") != "python3|-m|dynamo.vllm" {
+		t.Fatalf("expected target command to be preserved, got %#v", worker.Command)
 	}
-	expectedArgs := []string{"--launch-job", "python3", "-m", "dynamo.vllm", "--model", "Qwen"}
-	if strings.Join(worker.Args, "|") != strings.Join(expectedArgs, "|") {
-		t.Fatalf("expected launch-job args %#v, got %#v", expectedArgs, worker.Args)
+	if strings.Join(worker.Args, "|") != "--model|Qwen" {
+		t.Fatalf("expected target args to be preserved, got %#v", worker.Args)
 	}
 
 	sidecar := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, "sidecar")

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -36,6 +36,8 @@ const (
 
 	CheckpointStorageTypeAnnotation     = "nvidia.com/snapshot-storage-type"
 	CheckpointStorageBasePathAnnotation = "nvidia.com/snapshot-storage-base-path"
+	RendezvousHostAnnotation            = "nvidia.com/snapshot-rendezvous-host"
+	RendezvousPortAnnotation            = "nvidia.com/snapshot-rendezvous-port"
 	CheckpointVolumeName                = "checkpoint-storage"
 	DefaultCheckpointArtifactVersion    = "1"
 	DefaultCheckpointJobTTLSeconds      = int32(300)
@@ -189,6 +191,8 @@ func ApplyRestoreTargetMetadata(labels map[string]string, annotations map[string
 	delete(labels, CheckpointIDLabel)
 	delete(annotations, CheckpointArtifactVersionAnnotation)
 	delete(annotations, CheckpointStatusAnnotation)
+	delete(annotations, RendezvousHostAnnotation)
+	delete(annotations, RendezvousPortAnnotation)
 	clearRestoreStatusKeys(annotations)
 
 	if !enabled {

--- a/deploy/snapshot/protocol/control_volume.go
+++ b/deploy/snapshot/protocol/control_volume.go
@@ -27,6 +27,22 @@ const (
 	// mount path to the workload.
 	SnapshotControlDirEnv = "DYN_SNAPSHOT_CONTROL_DIR"
 
+	// TorchC10dRendezvousFileEnv points PyTorch at the post-restore c10d
+	// rendezvous file in the snapshot-control volume.
+	TorchC10dRendezvousFileEnv = "TORCH_C10D_RENDEZVOUS_FILE"
+
+	// CudaCheckpointJobFileEnv points CUDA at the per-container job file
+	// used to coordinate multi-process CUDA IPC checkpoint metadata.
+	CudaCheckpointJobFileEnv = "CUDA_CHECKPOINT_JOB_FILE"
+
+	// TorchC10dRendezvousFile is written before restore-complete so restored
+	// processes can recreate TCPStore/Gloo state with fresh pod addresses.
+	TorchC10dRendezvousFile = "rendezvous.json"
+
+	// CudaCheckpointJobFile is created before CUDA initialization in the
+	// checkpoint source process and inherited by worker processes.
+	CudaCheckpointJobFile = "cuda-checkpoint-job-file"
+
 	// SnapshotCompleteFile is written by the snapshot agent inside the
 	// control volume when a checkpoint has completed successfully.
 	SnapshotCompleteFile = "snapshot-complete"
@@ -92,17 +108,36 @@ func EnsureControlVolume(podSpec *corev1.PodSpec, container *corev1.Container) {
 		})
 	}
 
-	hasEnv := false
+	hasControlEnv := false
+	hasRendezvousEnv := false
+	hasCudaJobFileEnv := false
 	for _, e := range container.Env {
 		if e.Name == SnapshotControlDirEnv {
-			hasEnv = true
-			break
+			hasControlEnv = true
+		}
+		if e.Name == TorchC10dRendezvousFileEnv {
+			hasRendezvousEnv = true
+		}
+		if e.Name == CudaCheckpointJobFileEnv {
+			hasCudaJobFileEnv = true
 		}
 	}
-	if !hasEnv {
+	if !hasControlEnv {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  SnapshotControlDirEnv,
 			Value: SnapshotControlMountPath,
+		})
+	}
+	if !hasRendezvousEnv {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  TorchC10dRendezvousFileEnv,
+			Value: SnapshotControlMountPath + "/" + TorchC10dRendezvousFile,
+		})
+	}
+	if !hasCudaJobFileEnv {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  CudaCheckpointJobFileEnv,
+			Value: SnapshotControlMountPath + "/" + CudaCheckpointJobFile,
 		})
 	}
 }

--- a/deploy/snapshot/protocol/control_volume_test.go
+++ b/deploy/snapshot/protocol/control_volume_test.go
@@ -24,9 +24,9 @@ func TestEnsureControlVolume(t *testing.T) {
 		if c.VolumeMounts[0].SubPath != "main" {
 			t.Fatalf("expected subPath=%q, got %q", "main", c.VolumeMounts[0].SubPath)
 		}
-		if len(c.Env) != 1 || c.Env[0].Name != SnapshotControlDirEnv || c.Env[0].Value != SnapshotControlMountPath {
-			t.Fatalf("expected env %s=%s, got %#v", SnapshotControlDirEnv, SnapshotControlMountPath, c.Env)
-		}
+		assertEnv(t, c.Env, SnapshotControlDirEnv, SnapshotControlMountPath)
+		assertEnv(t, c.Env, TorchC10dRendezvousFileEnv, SnapshotControlMountPath+"/"+TorchC10dRendezvousFile)
+		assertEnv(t, c.Env, CudaCheckpointJobFileEnv, SnapshotControlMountPath+"/"+CudaCheckpointJobFile)
 	})
 
 	t.Run("per-container subPath isolates multi-container pods", func(t *testing.T) {
@@ -53,7 +53,7 @@ func TestEnsureControlVolume(t *testing.T) {
 		EnsureControlVolume(ps, &ps.Containers[0])
 		EnsureControlVolume(ps, &ps.Containers[0])
 		c := ps.Containers[0]
-		if len(ps.Volumes) != 1 || len(c.VolumeMounts) != 1 || len(c.Env) != 1 {
+		if len(ps.Volumes) != 1 || len(c.VolumeMounts) != 1 || len(c.Env) != 3 {
 			t.Fatalf("expected single volume/mount/env after two calls, got volumes=%d mounts=%d env=%d", len(ps.Volumes), len(c.VolumeMounts), len(c.Env))
 		}
 	})
@@ -89,8 +89,21 @@ func TestEnsureControlVolume(t *testing.T) {
 		}
 		EnsureControlVolume(ps, &ps.Containers[0])
 		c := ps.Containers[0]
-		if len(ps.Volumes) != 2 || len(c.VolumeMounts) != 2 || len(c.Env) != 2 {
+		if len(ps.Volumes) != 2 || len(c.VolumeMounts) != 2 || len(c.Env) != 4 {
 			t.Fatalf("expected existing + control entries, got volumes=%#v mounts=%#v env=%#v", ps.Volumes, c.VolumeMounts, c.Env)
 		}
 	})
+}
+
+func assertEnv(t *testing.T, env []corev1.EnvVar, name, value string) {
+	t.Helper()
+	for _, e := range env {
+		if e.Name == name {
+			if e.Value != value {
+				t.Fatalf("expected env %s=%s, got %s", name, value, e.Value)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing env %s in %#v", name, env)
 }

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,6 +42,13 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) (*corev1.Pod, error) {
 		pod.Annotations = map[string]string{}
 	}
 	ApplyRestoreTargetMetadata(pod.Labels, pod.Annotations, true, opts.CheckpointID, opts.ArtifactVersion)
+	targets, err := TargetContainersFromAnnotations(pod.Annotations, 1, 0)
+	if err != nil {
+		return nil, err
+	}
+	if err := ApplyRendezvousMetadataFromPodSpec(pod.Annotations, &pod.Spec, targets); err != nil {
+		return nil, err
+	}
 	if err := PrepareRestorePodSpec(&pod.Spec, pod.Annotations, opts.Storage, opts.SeccompProfile, true); err != nil {
 		return nil, err
 	}
@@ -90,6 +98,77 @@ func PrepareRestorePodSpec(
 		}
 	}
 	return nil
+}
+
+func ApplyRendezvousMetadataFromPodSpec(
+	annotations map[string]string,
+	podSpec *corev1.PodSpec,
+	targets []string,
+) error {
+	if annotations == nil || podSpec == nil {
+		return nil
+	}
+	delete(annotations, RendezvousHostAnnotation)
+	delete(annotations, RendezvousPortAnnotation)
+
+	targetSet := map[string]struct{}{}
+	for _, target := range targets {
+		target = strings.TrimSpace(target)
+		if target != "" {
+			targetSet[target] = struct{}{}
+		}
+	}
+	for i := range podSpec.Containers {
+		container := &podSpec.Containers[i]
+		if len(targetSet) > 0 {
+			if _, ok := targetSet[container.Name]; !ok {
+				continue
+			}
+		}
+		args := containerCommandAndArgs(container)
+		host := flagValue(args, "--master-addr")
+		if host == "" {
+			continue
+		}
+		port := flagValue(args, "--master-port")
+		if port == "" {
+			port = "29500"
+		}
+		if n, err := strconv.Atoi(port); err != nil || n <= 0 {
+			return fmt.Errorf("invalid %s value %q on container %q", RendezvousPortAnnotation, port, container.Name)
+		}
+		annotations[RendezvousHostAnnotation] = host
+		annotations[RendezvousPortAnnotation] = port
+		return nil
+	}
+	return nil
+}
+
+func containerCommandAndArgs(container *corev1.Container) []string {
+	if container == nil {
+		return nil
+	}
+	args := make([]string, 0, len(container.Command)+len(container.Args))
+	for _, arg := range container.Command {
+		args = append(args, strings.Fields(arg)...)
+	}
+	for _, arg := range container.Args {
+		args = append(args, strings.Fields(arg)...)
+	}
+	return args
+}
+
+func flagValue(args []string, name string) string {
+	prefix := name + "="
+	for i, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return strings.TrimPrefix(arg, prefix)
+		}
+		if arg == name && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
 }
 
 // ensureRestoreStartupProbe reuses the workload's probe when possible and

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -129,6 +129,49 @@ func TestNewRestorePod(t *testing.T) {
 	}
 }
 
+func TestNewRestorePodPreservesRendezvousMetadata(t *testing.T) {
+	restorePod, err := NewRestorePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker",
+			Annotations: map[string]string{
+				TargetContainersAnnotation: "main",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "main",
+				Command: []string{"python3", "-m", "dynamo.vllm"},
+				Args: []string{
+					"--model",
+					"Qwen",
+					"--master-addr=$(LWS_LEADER_ADDRESS)",
+					"--master-port",
+					"29517",
+				},
+			}},
+		},
+	}, PodOptions{
+		Namespace:       "test-ns",
+		CheckpointID:    "hash",
+		ArtifactVersion: "2",
+		SeccompProfile:  DefaultSeccompLocalhostProfile,
+	})
+	if err != nil {
+		t.Fatalf("NewRestorePod returned error: %v", err)
+	}
+
+	if restorePod.Annotations[RendezvousHostAnnotation] != "$(LWS_LEADER_ADDRESS)" {
+		t.Fatalf("expected rendezvous host annotation, got %#v", restorePod.Annotations)
+	}
+	if restorePod.Annotations[RendezvousPortAnnotation] != "29517" {
+		t.Fatalf("expected rendezvous port annotation, got %#v", restorePod.Annotations)
+	}
+	main := restorePod.Spec.Containers[0]
+	if len(main.Command) != 2 || main.Command[0] != "sleep" || main.Command[1] != "infinity" {
+		t.Fatalf("expected placeholder command, got %#v", main.Command)
+	}
+}
+
 func TestNewRestorePodShapesMultipleTargets(t *testing.T) {
 	restorePod, err := NewRestorePod(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/lib/runtime/src/pipeline/network/manager.rs
+++ b/lib/runtime/src/pipeline/network/manager.rs
@@ -140,8 +140,7 @@ impl NetworkConfig {
         Self {
             // HTTP server configuration
             // If DYN_HTTP_RPC_PORT is set, use that port; otherwise None means OS will assign a free port
-            http_host: std::env::var("DYN_HTTP_RPC_HOST")
-                .unwrap_or_else(|_| crate::utils::get_http_rpc_host_from_env()),
+            http_host: crate::utils::get_http_rpc_host_from_env(),
             http_port: std::env::var("DYN_HTTP_RPC_PORT")
                 .ok()
                 .and_then(|p| p.parse().ok()),
@@ -150,8 +149,7 @@ impl NetworkConfig {
 
             // TCP server configuration
             // If DYN_TCP_RPC_PORT is set, use that port; otherwise None means OS will assign a free port
-            tcp_host: std::env::var("DYN_TCP_RPC_HOST")
-                .unwrap_or_else(|_| crate::utils::get_tcp_rpc_host_from_env()),
+            tcp_host: crate::utils::get_tcp_rpc_host_from_env(),
             tcp_port: std::env::var("DYN_TCP_RPC_PORT")
                 .ok()
                 .and_then(|p| p.parse().ok()),

--- a/lib/runtime/src/utils/ip_resolver.rs
+++ b/lib/runtime/src/utils/ip_resolver.rs
@@ -4,7 +4,7 @@
 //! IP resolution utilities for getting local IP addresses with fallback support
 
 use crate::pipeline::network::tcp::server::{DefaultIpResolver, IpResolver};
-use local_ip_address::Error;
+use local_ip_address::{Error, list_afinet_netifas};
 use std::net::IpAddr;
 
 fn resolve_local_ip_with_resolver<R: IpResolver>(resolver: R) -> IpAddr {
@@ -27,6 +27,81 @@ fn format_ip_for_url(addr: IpAddr) -> String {
         IpAddr::V6(_) => format!("[{}]", addr),
         IpAddr::V4(_) => addr.to_string(),
     }
+}
+
+fn parse_env_host_ip(host: &str) -> Option<IpAddr> {
+    let host = host.trim();
+    if host.is_empty() {
+        return None;
+    }
+    let host = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host);
+    host.parse().ok()
+}
+
+fn current_interface_ips() -> Option<Vec<IpAddr>> {
+    match list_afinet_netifas() {
+        Ok(interfaces) => Some(interfaces.into_iter().map(|(_, ip)| ip).collect()),
+        Err(err) => {
+            tracing::warn!(
+                %err,
+                "Could not list local interfaces while validating RPC host env var"
+            );
+            None
+        }
+    }
+}
+
+fn select_rpc_host_from_value<F>(
+    env_var: &str,
+    configured_host: String,
+    local_ips: Option<&[IpAddr]>,
+    fallback: F,
+) -> String
+where
+    F: FnOnce() -> String,
+{
+    if configured_host.trim().is_empty() {
+        let resolved_host = fallback();
+        tracing::warn!(
+            env_var = %env_var,
+            resolved_host = %resolved_host,
+            "Ignoring empty RPC host env var"
+        );
+        return resolved_host;
+    }
+
+    let Some(configured_ip) = parse_env_host_ip(&configured_host) else {
+        return configured_host;
+    };
+
+    if let Some(local_ips) = local_ips {
+        if !local_ips.contains(&configured_ip) {
+            let resolved_host = fallback();
+            tracing::warn!(
+                env_var = %env_var,
+                configured_host = %configured_host,
+                resolved_host = %resolved_host,
+                "Ignoring RPC host env var because it is not assigned to this network namespace"
+            );
+            return resolved_host;
+        }
+    }
+
+    configured_host
+}
+
+fn get_rpc_host_from_env<F>(env_var: &str, fallback: F) -> String
+where
+    F: FnOnce() -> String,
+{
+    let Ok(configured_host) = std::env::var(env_var) else {
+        return fallback();
+    };
+    let local_ips = current_interface_ips();
+    select_rpc_host_from_value(env_var, configured_host, local_ips.as_deref(), fallback)
 }
 
 /// Get the local IP address for advertising endpoints, using IpResolver with fallback to 127.0.0.1
@@ -74,7 +149,7 @@ pub fn get_http_rpc_host() -> String {
 /// # Returns
 /// A string representation of the HTTP RPC host address
 pub fn get_http_rpc_host_from_env() -> String {
-    std::env::var("DYN_HTTP_RPC_HOST").unwrap_or_else(|_| get_http_rpc_host())
+    get_rpc_host_from_env("DYN_HTTP_RPC_HOST", get_http_rpc_host)
 }
 
 /// Get the TCP RPC host from environment variable or resolve local IP as fallback
@@ -85,7 +160,7 @@ pub fn get_http_rpc_host_from_env() -> String {
 /// # Returns
 /// A string representation of the TCP RPC host address
 pub fn get_tcp_rpc_host_from_env() -> String {
-    std::env::var("DYN_TCP_RPC_HOST").unwrap_or_else(|_| get_http_rpc_host())
+    get_rpc_host_from_env("DYN_TCP_RPC_HOST", get_http_rpc_host)
 }
 
 #[cfg(test)]
@@ -155,11 +230,11 @@ mod tests {
     fn test_get_http_rpc_host_from_env_with_env_var() {
         // Set environment variable
         unsafe {
-            std::env::set_var("DYN_HTTP_RPC_HOST", "10.0.0.1");
+            std::env::set_var("DYN_HTTP_RPC_HOST", "127.0.0.1");
         }
 
         let result = get_http_rpc_host_from_env();
-        assert_eq!(result, "10.0.0.1");
+        assert_eq!(result, "127.0.0.1");
 
         // Clean up
         unsafe {
@@ -206,5 +281,49 @@ mod tests {
         // IPv4 should NOT be bracketed
         assert!(!result.contains('['), "IPv4 should not contain '['");
         assert_eq!(result, "10.0.0.1");
+    }
+
+    #[test]
+    fn test_stale_rpc_host_env_ip_falls_back_to_resolved_ip() {
+        let result = select_rpc_host_from_value(
+            "DYN_TCP_RPC_HOST",
+            "10.0.0.1".to_string(),
+            Some(&[IpAddr::from([10, 0, 0, 2])]),
+            || "10.0.0.2".to_string(),
+        );
+        assert_eq!(result, "10.0.0.2");
+    }
+
+    #[test]
+    fn test_current_rpc_host_env_ip_is_used() {
+        let result = select_rpc_host_from_value(
+            "DYN_TCP_RPC_HOST",
+            "10.0.0.2".to_string(),
+            Some(&[IpAddr::from([10, 0, 0, 2])]),
+            || "10.0.0.3".to_string(),
+        );
+        assert_eq!(result, "10.0.0.2");
+    }
+
+    #[test]
+    fn test_rpc_host_env_hostname_is_used() {
+        let result = select_rpc_host_from_value(
+            "DYN_TCP_RPC_HOST",
+            "rank-0.default.svc.cluster.local".to_string(),
+            Some(&[IpAddr::from([10, 0, 0, 2])]),
+            || "10.0.0.2".to_string(),
+        );
+        assert_eq!(result, "rank-0.default.svc.cluster.local");
+    }
+
+    #[test]
+    fn test_stale_bracketed_ipv6_rpc_host_env_ip_falls_back_to_resolved_ip() {
+        let result = select_rpc_host_from_value(
+            "DYN_TCP_RPC_HOST",
+            "[fd00::1]".to_string(),
+            Some(&[IpAddr::from([0xfd00, 0, 0, 0, 0, 0, 0, 2])]),
+            || "[fd00::2]".to_string(),
+        );
+        assert_eq!(result, "[fd00::2]");
     }
 }


### PR DESCRIPTION
## Summary

Adds end-to-end support for CRIU checkpoint/restore of a **multi-node vLLM** process tree and validates it at **TP16 (2 nodes × 8 GPUs)**. The checkpointed process tree is restored on new hardware (new pod IPs) and re-rendezvouses without an external KV store.

Validated run: `mncriu16-2x8-nullremap-20260605t162630z` — checkpoint, external restore on both nodes, and coherent post-restore inference (`/v1/chat/completions` → `Paris`).

## Changes

**snapshot-agent (`deploy/snapshot`)**
- CRIU dump/restore: externalize NVIDIA device files, capture open NVIDIA FDs.
- Vendored CRIU patches `0001` (cuda-plugin nvidia ext-file) and `0002` (dev/shm POSIX semaphores); `Dockerfile` applies them when building CRIU.
- cuda checkpoint helper/shim run `cuda-checkpoint` per-process (no `--launch-job`).
- executor/protocol/control-volume: armed restore flow, per-node checkpoint ids, post-restore rendezvous via the snapshot control dir.

**dynamo runtime/handlers**
- vLLM handlers refresh PodIP-derived `DYN_TCP_RPC_HOST`/`DYN_HTTP_RPC_HOST` on restore; snapshot prepare/restore hooks.
- `lib/runtime` ip_resolver + network manager for restore-time IP refresh.

**operator**
- checkpoint_job + deployment controller wiring for the checkpoint CRD.

## Companion changes in other repos
- **PyTorch** `schwinns/quiesce-resume-hooks`: `CheckpointRendezvousStore` (c10d file-based re-rendezvous).
- **NCCL** fork `schwinns/nccl` branch `schwinns/quiesce-criu-checkpoint-restore`: checkpoint shim accepts ncclUniqueIds directly + transport hardening.
- **vLLM** fork `galletas1712/vllm` branch `schwinns/quiesce-criu-rerendezvous`: PyNCCL/Gloo teardown + replay, RPC host refresh.
- **CRIU** fork `galletas1712/criu` branch `schwinns/quiesce-criu-cuda-shm`: the two vendored patches as source commits.

## Status
Draft — opening to back up the work and for review. Several companion images were built from dirty trees; authoritative provenance is recorded in the run worklog.