### PR TITLE
feat(gms): wire persistent KV into vllm runtime

### DIFF
--- a/components/src/dynamo/common/utils/graceful_shutdown.py
+++ b/components/src/dynamo/common/utils/graceful_shutdown.py
@@ -19,6 +19,11 @@ _GRACE_PERIOD_ENV = "DYN_GRACEFUL_SHUTDOWN_GRACE_PERIOD_SECS"
 _shutdown_started = asyncio.Event()
 
 
+def is_shutdown_in_progress() -> bool:
+    """Return whether this process is already handling graceful shutdown."""
+    return _shutdown_started.is_set()
+
+
 def get_grace_period_seconds() -> float:
     value = os.getenv(_GRACE_PERIOD_ENV)
     if value is None or value == "":

--- a/components/src/dynamo/vllm/engine_monitor.py
+++ b/components/src/dynamo/vllm/engine_monitor.py
@@ -10,6 +10,7 @@ import traceback
 from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.engine.exceptions import EngineDeadError
 
+from dynamo.common.utils.graceful_shutdown import is_shutdown_in_progress
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -110,6 +111,15 @@ class VllmEngineMonitor:
                     await asyncio.sleep(HEALTH_CHECK_INTERVAL)
 
             except EngineDeadError as e:
+                if (
+                    self.shutdown_event and self.shutdown_event.is_set()
+                ) or is_shutdown_in_progress():
+                    logger.info(
+                        "vLLM AsyncLLM health check stopped during graceful shutdown: %s",
+                        e,
+                    )
+                    break
+
                 logger.error(f"Traceback: {traceback.format_exc()}")
                 logger.error(f"vLLM AsyncLLM health check failed: {e}")
                 logger.warning("Initiating Dynamo Runtime shutdown.")

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -32,6 +32,7 @@ from vllm.sampling_params import (
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo._core import Context
+from dynamo.common.gms_failover import release_attached_gms_failover_lock
 from dynamo.common.lora.manager import LoRAInfo, get_lora_manager
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
@@ -237,12 +238,20 @@ class VllmEngineQuiesceController:
     def is_quiesced(self) -> bool:
         return self._is_quiesced
 
-    async def quiesce(self, *args: object) -> bool:
+    async def quiesce(self, *args: object, clear_cache: bool = True) -> bool:
         if self._is_quiesced:
             return False
 
         level = args[0] if args else None
-        await self._engine_client.pause_generation()
+        await self._engine_client.pause_generation(clear_cache=clear_cache)
+        if not clear_cache and level is not None:
+            engine_core = getattr(self._engine_client, "engine_core", None)
+            call_utility_async = getattr(engine_core, "call_utility_async", None)
+            if call_utility_async is not None:
+                await call_utility_async("gms_sleep_no_clear", level, "abort")
+                self._is_quiesced = True
+                return True
+
         if level is None:
             await self._engine_client.sleep()
         else:
@@ -750,15 +759,25 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
                 # Step 2: Abort in-flight requests and wait for them to drain so the
                 # GPU is fully quiesced before unmapping memory.
-                if not await self._quiesce_controller.quiesce(level):
+                handoff = bool(body.get("release_failover_lock") or body.get("handoff"))
+                if not await self._quiesce_controller.quiesce(
+                    level, clear_cache=not handoff
+                ):
                     return {
                         "status": "ok",
                         "message": "Engine already sleeping",
                     }
 
+                lock_released = False
+                if handoff:
+                    lock_released = await release_attached_gms_failover_lock(
+                        self, backend_name="vllm"
+                    )
+
                 return {
                     "status": "ok",
                     "message": f"Engine slept (level={level})",
+                    "failover_lock_released": lock_released,
                 }
             except Exception as e:
                 logger.error(f"Failed to sleep engine: {e}")

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402
 
 import argparse
 import asyncio
@@ -12,7 +13,69 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     from dynamo.vllm.omni.args import OmniConfig
 
+
+def _early_truthy_env(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _maybe_isolate_jit_cache_dirs_by_container() -> dict[str, tuple[str | None, str]]:
+    """Keep runtime JIT/cache locks pod-local and engine-container-local.
+
+    Bulwark primary and shadow containers can compile or materialize FlashInfer
+    artifacts at the same time. Some Kubernetes-mounted filesystems do not
+    reliably support fcntl locks under that contention, so keep these caches in
+    a container-specific tmpfs namespace before vLLM imports FlashInfer.
+    """
+
+    if not _early_truthy_env(
+        "DYN_VLLM_ISOLATE_JIT_CACHE_BY_CONTAINER",
+        default=_early_truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE"),
+    ):
+        return {}
+
+    container = os.environ.get("CONTAINER_NAME") or os.environ.get("ENGINE_ID")
+    if not container:
+        return {}
+
+    base = os.environ.get("DYN_VLLM_JIT_CACHE_BASE", "/dev/shm/dynamo-jit")
+    container_base = os.path.join(base, container)
+    mappings = {
+        "TMPDIR": "tmp",
+        "XDG_CACHE_HOME": "xdg-cache",
+        "VLLM_CACHE_ROOT": "vllm-cache",
+        "TORCHINDUCTOR_CACHE_DIR": "torchinductor-cache",
+        "TRITON_CACHE_DIR": "triton-cache",
+        "CUDA_CACHE_PATH": "cuda-cache",
+        "FLASHINFER_WORKSPACE_BASE": "flashinfer-workspace",
+        "FLASHINFER_CUBIN_DIR": "flashinfer-cubins",
+        "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR": "vllm-flashinfer-autotune",
+        "TILELANG_CACHE_DIR": "tilelang-cache",
+        "TILELANG_TMP_DIR": "tilelang-tmp",
+    }
+
+    changed: dict[str, tuple[str | None, str]] = {}
+    force = _early_truthy_env("DYN_VLLM_FORCE_CONTAINER_JIT_CACHE", default=True)
+    for name, suffix in mappings.items():
+        previous = os.environ.get(name)
+        value = os.path.join(container_base, suffix)
+        if previous == value:
+            continue
+        if previous and not force and not previous.startswith(base):
+            continue
+        os.environ[name] = value
+        changed[name] = (previous, value)
+    return changed
+
+
+_JIT_CACHE_DIR_ENV_CHANGES = _maybe_isolate_jit_cache_dirs_by_container()
+
 import uvloop
+from gpu_memory_service.integrations.vllm.kv_identity import (
+    private_bootstrap_scratch_warmup_enabled,
+)
 from prometheus_client import REGISTRY, CollectorRegistry, multiprocess
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import ZmqEventPublisher
@@ -55,7 +118,181 @@ from .snapshot import prepare_snapshot_engine
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
+if _JIT_CACHE_DIR_ENV_CHANGES:
+    logger.info(
+        "[GMS] Isolated vLLM runtime JIT/cache dirs for container=%s: %s",
+        os.environ.get("CONTAINER_NAME") or os.environ.get("ENGINE_ID"),
+        {name: value for name, (_, value) in _JIT_CACHE_DIR_ENV_CHANGES.items()},
+    )
+GMS_VLLM_WORKER_CLS = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
 shutdown_endpoints: list = []
+
+
+def _truthy_env(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _gms_failover_shadow_member() -> bool:
+    if not (
+        _truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE")
+        or _truthy_env("DYN_VLLM_GMS_SHADOW_MODE")
+    ):
+        return False
+    if _truthy_env("DYN_VLLM_GMS_ACTIVE_LOCK_HELD"):
+        return False
+    if _truthy_env("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"):
+        return True
+    engine_id = os.environ.get("ENGINE_ID", "0")
+    primary_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    return engine_id != primary_id
+
+
+def _gms_private_bootstrap_shadow_member(config: Config) -> bool:
+    engine_args = getattr(config, "engine_args", None)
+    if getattr(engine_args, "load_format", None) != "gms":
+        return False
+    if not getattr(config, "gms_shadow_mode", False):
+        return False
+    if not _truthy_env(
+        "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV",
+        default=_truthy_env("GMS_VLLM_PRIVATE_BOOTSTRAP_KV"),
+    ):
+        return False
+    return _gms_failover_shadow_member()
+
+
+def _maybe_disable_gms_shadow_graphs_before_vllm_config(config: Config) -> bool:
+    if not _gms_private_bootstrap_shadow_member(config):
+        return False
+    if _truthy_env("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_CUDAGRAPH"):
+        return False
+    if private_bootstrap_scratch_warmup_enabled():
+        os.environ["GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED"] = "1"
+        logger.info(
+            "[GMS] Allowing vLLM graph warmup for scratch-backed "
+            "private-bootstrap shadow KV"
+        )
+        return False
+
+    previous = os.environ.get("VLLM_USE_BREAKABLE_CUDAGRAPH")
+    os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "0"
+    logger.info(
+        "[GMS] Disabled vLLM breakable cudagraph for private-bootstrap "
+        "shadow before vLLM config creation (previous=%r)",
+        previous,
+    )
+    return True
+
+
+def _apply_gms_shadow_graph_config(vllm_config: VllmConfig, *, disabled: bool) -> None:
+    if not disabled:
+        return
+
+    from vllm.config import CompilationMode, CUDAGraphMode
+
+    compilation_config = vllm_config.compilation_config
+    previous_mode = getattr(compilation_config, "cudagraph_mode", None)
+    previous_compile_mode = getattr(compilation_config, "mode", None)
+    compilation_config.mode = CompilationMode.NONE
+    compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+    logger.info(
+        "[GMS] Forced private-bootstrap shadow vLLM graph mode to eager: "
+        "compile_mode %s -> %s, cudagraph_mode %s -> %s",
+        previous_compile_mode,
+        compilation_config.mode,
+        previous_mode,
+        compilation_config.cudagraph_mode,
+    )
+
+
+def _is_gms_load_format(engine_args: Any) -> bool:
+    return str(getattr(engine_args, "load_format", "")) == "gms"
+
+
+def _configure_gms_vllm_worker(engine_args: Any) -> None:
+    """Force GMS worker setup early enough for spawned vLLM workers."""
+
+    current = getattr(engine_args, "worker_cls", None)
+    if current not in (None, "auto", GMS_VLLM_WORKER_CLS):
+        logger.warning(
+            "[GMS] Overriding user-provided vLLM worker_cls=%s with %s "
+            "because --load-format=gms requires the GMS worker integration",
+            current,
+            GMS_VLLM_WORKER_CLS,
+        )
+
+    engine_args.worker_cls = GMS_VLLM_WORKER_CLS
+
+    # Import eagerly so model-loader/KV patches fail before vLLM starts worker
+    # processes. Worker subprocesses still resolve the class by string.
+    import gpu_memory_service.integrations.vllm.worker  # noqa: F401
+
+    logger.info("[GMS] vLLM worker_cls configured as %s", GMS_VLLM_WORKER_CLS)
+
+
+def _verify_gms_vllm_worker_config(vllm_config: VllmConfig) -> None:
+    worker_cls = getattr(vllm_config.parallel_config, "worker_cls", None)
+    if worker_cls != GMS_VLLM_WORKER_CLS:
+        raise RuntimeError(
+            "GMS load format requires vLLM worker_cls="
+            f"{GMS_VLLM_WORKER_CLS}, got {worker_cls!r}"
+        )
+    logger.info("[GMS] Final vLLM parallel_config.worker_cls=%s", worker_cls)
+
+
+def _gms_shadow_init_geometry_wait_ms() -> int:
+    names = (
+        "DYN_VLLM_GMS_SHADOW_INIT_GEOMETRY_WAIT_MS",
+        "GMS_VLLM_KV_GEOMETRY_WAIT_MS",
+        "GMS_KV_LEASE_GEOMETRY_WAIT_MS",
+    )
+    wait_ms = 300_000
+    for name in names:
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        try:
+            wait_ms = int(value)
+        except ValueError:
+            logger.warning("Ignoring invalid %s=%r", name, value)
+            continue
+        break
+    return max(wait_ms, 1_800_000)
+
+
+def _maybe_wait_for_gms_primary_kv_before_init(config: Config) -> None:
+    if getattr(config.engine_args, "load_format", None) != "gms":
+        return
+    if not config.gms_shadow_mode:
+        return
+    if not _gms_failover_shadow_member():
+        return
+    if not _truthy_env("DYN_VLLM_GMS_WAIT_FOR_PRIMARY_KV_BEFORE_INIT", default=True):
+        return
+
+    from gpu_memory_service.integrations.vllm.install_vmm_ipc_kv import (
+        _existing_shared_kv_blocks,
+    )
+
+    wait_ms = _gms_shadow_init_geometry_wait_ms()
+    logger.info(
+        "[GMS] Shadow engine waiting up to %d ms for primary KV geometry "
+        "before vLLM engine initialization",
+        wait_ms,
+    )
+    blocks = _existing_shared_kv_blocks(wait_ms=wait_ms)
+    if blocks is None:
+        raise RuntimeError(
+            "Timed out waiting for primary GMS KV geometry before shadow "
+            "vLLM engine initialization"
+        )
+    logger.info(
+        "[GMS] Shadow engine observed primary KV geometry before init: blocks=%d",
+        blocks,
+    )
 
 
 def build_headless_namespace(config: Config) -> argparse.Namespace:
@@ -80,10 +317,8 @@ def run_dynamo_headless(config: Config) -> None:
     """
     # Propagate worker_cls for custom load formats so headless workers use
     # the same model loader and patches as the leader node.
-    if config.engine_args.load_format == "gms":
-        config.engine_args.worker_cls = (
-            "gpu_memory_service.integrations.vllm.worker.GMSWorker"
-        )
+    if _is_gms_load_format(config.engine_args):
+        _configure_gms_vllm_worker(config.engine_args)
 
         if config.gms_shadow_mode:
             from gpu_memory_service.integrations.vllm.utils import (
@@ -91,7 +326,6 @@ def run_dynamo_headless(config: Config) -> None:
                 configure_mx_ports,
             )
 
-            os.environ["DYN_GMS_SCRATCH_KV_ENABLED"] = "1"
             configure_gms_lock_mode(config.engine_args)
             configure_mx_ports(config.engine_args)
 
@@ -153,15 +387,34 @@ async def worker() -> None:
         return
 
     shutdown_event = asyncio.Event()
+    engine_holder: list = []
     runtime, loop = create_runtime(
         discovery_backend=config.discovery_backend,
         request_plane=config.request_plane,
         event_plane=config.event_plane,
     )
 
+    async def cleanup_engine() -> None:
+        if not engine_holder:
+            logger.info("vLLM engine not initialized; skipping cleanup")
+            return
+
+        engine = engine_holder[0]
+        try:
+            engine.shutdown()
+            logger.info("vLLM engine shutdown complete")
+        except Exception as exc:
+            logger.warning("vLLM engine shutdown failed: %s", exc)
+
     # [gluo FIXME] should be after init() below? 'shutdown_endpoints' are populated
     # there
-    install_signal_handlers(loop, runtime, shutdown_endpoints, shutdown_event)
+    install_signal_handlers(
+        loop,
+        runtime,
+        shutdown_endpoints,
+        shutdown_event,
+        cleanup_callback=cleanup_engine,
+    )
 
     # Use WorkerFactory to appropriate initialize worker based on config flags
     factory = WorkerFactory(
@@ -177,6 +430,7 @@ async def worker() -> None:
         shutdown_event,
         shutdown_endpoints,
         snapshot_engine=snapshot_engine,
+        engine_holder=engine_holder,
     )
 
     logger.debug("Worker function completed, exiting...")
@@ -470,8 +724,8 @@ def setup_vllm_engine(
         if "VLLM_LORA_MODULES_LOADING_TIMEOUT" not in os.environ:
             os.environ["VLLM_LORA_MODULES_LOADING_TIMEOUT"] = "600"
 
-    if engine_args.load_format == "gms":
-        engine_args.worker_cls = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
+    if _is_gms_load_format(engine_args):
+        _configure_gms_vllm_worker(engine_args)
 
         if config.gms_shadow_mode:
             from gpu_memory_service.integrations.vllm.utils import (
@@ -479,10 +733,6 @@ def setup_vllm_engine(
                 configure_mx_ports,
             )
 
-            os.environ["DYN_GMS_SCRATCH_KV_ENABLED"] = "1"
-            logger.info(
-                "[GMS] Failover enabled: will use scratch KV for initialization until engine is primary"
-            )
             # ENGINE_ID=0 writes weights, all others import (RO).
             # Prevents deadlock during TP>1 failover.
             configure_gms_lock_mode(engine_args)
@@ -503,6 +753,10 @@ def setup_vllm_engine(
                 f"ModelExpress package required for --load-format={engine_args.load_format}. "
                 "Install with: pip install modelexpress"
             ) from e
+
+    gms_shadow_graphs_disabled = _maybe_disable_gms_shadow_graphs_before_vllm_config(
+        config
+    )
 
     # Load default sampling params from `generation_config.json`
     default_sampling_params = (
@@ -538,6 +792,9 @@ def setup_vllm_engine(
     # Taken from build_async_engine_client_from_engine_args()
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
+    if _is_gms_load_format(engine_args):
+        _verify_gms_vllm_worker_config(vllm_config)
+    _apply_gms_shadow_graph_config(vllm_config, disabled=gms_shadow_graphs_disabled)
 
     # Set up consolidator endpoints if KVBM (DynamoConnector) is enabled
     consolidator_endpoints = None
@@ -577,6 +834,8 @@ def setup_vllm_engine(
     factory = []
     if stat_logger:
         factory.append(stat_logger)
+
+    _maybe_wait_for_gms_primary_kv_before_init(config)
 
     # Time engine initialization
     start_time = time.time()

--- a/components/src/dynamo/vllm/tests/test_vllm_engine_monitor_stats.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine_monitor_stats.py
@@ -7,6 +7,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo.vllm.engine_monitor import VllmEngineMonitor
 
@@ -175,3 +176,31 @@ async def test_periodic_log_stats_malformed_interval(mock_engine):
         await asyncio.wait_for(task, timeout=2.0)
 
     # Task ran without error (used 10s fallback, didn't crash)
+
+
+@pytest.mark.asyncio
+async def test_engine_health_ignores_engine_dead_during_shutdown(mock_engine):
+    shutdown_event = asyncio.Event()
+    monitor = _make_monitor(mock_engine, shutdown_event)
+    mock_engine.check_health.side_effect = EngineDeadError(
+        RuntimeError("engine stopped")
+    )
+
+    with patch(
+        "dynamo.vllm.engine_monitor.is_shutdown_in_progress",
+        return_value=True,
+    ):
+        await asyncio.wait_for(monitor._check_engine_health(), timeout=1.0)
+
+    monitor.runtime.shutdown.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_engine_health_exits_when_shutdown_event_set(mock_engine):
+    shutdown_event = asyncio.Event()
+    shutdown_event.set()
+    monitor = _make_monitor(mock_engine, shutdown_event)
+
+    await asyncio.wait_for(monitor._check_engine_health(), timeout=1.0)
+
+    mock_engine.check_health.assert_not_called()

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -92,6 +92,45 @@ async def test_quiesce_without_level_uses_vllm_default_sleep():
 
 
 @pytest.mark.asyncio
+async def test_quiesce_can_skip_cache_clear():
+    engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+    )
+    controller = VllmEngineQuiesceController(engine_client)
+
+    changed = await controller.quiesce(1, clear_cache=False)
+
+    assert changed is True
+    engine_client.pause_generation.assert_awaited_once_with(clear_cache=False)
+    engine_client.sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_quiesce_uses_no_clear_sleep_utility_when_available():
+    engine_core = SimpleNamespace(call_utility_async=AsyncMock())
+    engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+        engine_core=engine_core,
+    )
+    controller = VllmEngineQuiesceController(engine_client)
+
+    changed = await controller.quiesce(1, clear_cache=False)
+
+    assert changed is True
+    engine_client.pause_generation.assert_awaited_once_with(clear_cache=False)
+    engine_core.call_utility_async.assert_awaited_once_with(
+        "gms_sleep_no_clear", 1, "abort"
+    )
+    engine_client.sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_wake_up_passes_explicit_tags_from_request():
     handler = _make_handler()
     await handler._quiesce_controller.quiesce(1)
@@ -132,3 +171,19 @@ async def test_wake_up_returns_error_for_register_failure():
     handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()
     assert handler._quiesce_controller.is_quiesced is True
+
+
+@pytest.mark.asyncio
+async def test_sleep_with_handoff_releases_failover_lock():
+    handler = _make_handler()
+    lock = SimpleNamespace(release=AsyncMock())
+    handler._gms_failover_lock = lock
+
+    result = await handler.sleep({"level": 1, "release_failover_lock": True})
+
+    assert result["status"] == "ok"
+    assert result["failover_lock_released"] is True
+    handler.engine_client.pause_generation.assert_awaited_once_with(clear_cache=False)
+    handler.engine_client.sleep.assert_awaited_once_with(1)
+    lock.release.assert_awaited_once()
+    assert handler._gms_failover_lock is None

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -4,6 +4,7 @@
 """Unit tests for vLLM backend components."""
 
 import json
+import os
 import re
 import socket
 import sys
@@ -51,6 +52,23 @@ pytestmark = [
 # Create vLLM-specific CLI args fixture
 # This will use monkeypatch to write to argv
 mock_vllm_cli = make_cli_args_fixture("dynamo.vllm")
+
+
+@pytest.fixture(autouse=True)
+def _clear_gms_failover_env_leaks(monkeypatch):
+    for name in (
+        "DYN_VLLM_GMS_ACTIVE_LOCK_HELD",
+        "DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV",
+        "GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    for name in (
+        "DYN_VLLM_GMS_ACTIVE_LOCK_HELD",
+        "DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV",
+        "GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED",
+    ):
+        monkeypatch.delenv(name, raising=False)
 
 
 def test_custom_jinja_template_invalid_path(mock_vllm_cli):
@@ -929,3 +947,706 @@ class TestEmbeddingWorkerFlag:
             ValueError, match="--embedding-worker cannot be combined with multimodal"
         ):
             parse_args()
+
+
+def test_vllm_failover_shape_warmup_payload_covers_serving_shape(monkeypatch):
+    from dynamo.vllm.worker_factory import _vllm_failover_shape_warmup_payload
+
+    monkeypatch.delenv("DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_MAX_TOKENS", raising=False)
+    payload = _vllm_failover_shape_warmup_payload(
+        {"prompt": "Test", "max_tokens": 1, "_HEALTH_CHECK": True}
+    )
+
+    assert "_HEALTH_CHECK" not in payload
+    assert payload["prompt"] != "Test"
+    assert payload["temperature"] == 0.0
+    assert payload["max_tokens"] == 16
+
+
+def test_vllm_failover_shape_warmup_payload_token_mode(monkeypatch):
+    from dynamo.vllm.worker_factory import _vllm_failover_shape_warmup_payload
+
+    monkeypatch.setenv("DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_INPUT_TOKENS", "7")
+    monkeypatch.setenv("DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_MAX_TOKENS", "3")
+
+    payload = _vllm_failover_shape_warmup_payload(
+        {
+            "token_ids": [42],
+            "sampling_options": {"temperature": 1.0},
+            "stop_conditions": {"max_tokens": 1},
+            "_HEALTH_CHECK": True,
+        }
+    )
+
+    assert "_HEALTH_CHECK" not in payload
+    assert payload["token_ids"] == [42] * 7
+    assert payload["sampling_options"]["temperature"] == 0.0
+    assert payload["stop_conditions"]["max_tokens"] == 3
+
+
+def test_gms_shadow_init_geometry_wait_extends_generic_timeout(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("GMS_KV_LEASE_GEOMETRY_WAIT_MS", "300000")
+    monkeypatch.delenv("GMS_VLLM_KV_GEOMETRY_WAIT_MS", raising=False)
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_INIT_GEOMETRY_WAIT_MS", raising=False)
+
+    assert vllm_main._gms_shadow_init_geometry_wait_ms() == 1_800_000
+
+
+def test_vllm_gms_failover_isolates_jit_cache_by_container(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("CONTAINER_NAME", "engine-1")
+    monkeypatch.setenv("TMPDIR", "/dev/shm/dynamo-jit/tmp")
+    monkeypatch.setenv("FLASHINFER_CUBIN_DIR", "/dev/shm/dynamo-jit/flashinfer-cubins")
+
+    changed = vllm_main._maybe_isolate_jit_cache_dirs_by_container()
+
+    assert os.environ["TMPDIR"] == "/dev/shm/dynamo-jit/engine-1/tmp"
+    assert (
+        os.environ["FLASHINFER_CUBIN_DIR"]
+        == "/dev/shm/dynamo-jit/engine-1/flashinfer-cubins"
+    )
+    assert changed["TMPDIR"] == (
+        "/dev/shm/dynamo-jit/tmp",
+        "/dev/shm/dynamo-jit/engine-1/tmp",
+    )
+
+
+def test_vllm_gms_failover_jit_cache_isolation_can_be_disabled(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_ISOLATE_JIT_CACHE_BY_CONTAINER", "0")
+    monkeypatch.setenv("CONTAINER_NAME", "engine-1")
+    monkeypatch.setenv("TMPDIR", "/dev/shm/dynamo-jit/tmp")
+
+    assert vllm_main._maybe_isolate_jit_cache_dirs_by_container() == {}
+    assert os.environ["TMPDIR"] == "/dev/shm/dynamo-jit/tmp"
+
+
+def test_gms_shadow_waits_for_primary_geometry_before_init(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    calls = []
+
+    def fake_existing_blocks(*, wait_ms=0):
+        calls.append(wait_ms)
+        return 123
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("GMS_KV_LEASE_GEOMETRY_WAIT_MS", "300000")
+    monkeypatch.setattr(
+        "gpu_memory_service.integrations.vllm.install_vmm_ipc_kv._existing_shared_kv_blocks",
+        fake_existing_blocks,
+    )
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    vllm_main._maybe_wait_for_gms_primary_kv_before_init(config)
+
+    assert calls == [1_800_000]
+
+
+def test_gms_primary_does_not_wait_for_primary_geometry(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    def fail_if_called(*, wait_ms=0):
+        raise AssertionError("primary must not wait for its own KV geometry")
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setattr(
+        "gpu_memory_service.integrations.vllm.install_vmm_ipc_kv._existing_shared_kv_blocks",
+        fail_if_called,
+    )
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    vllm_main._maybe_wait_for_gms_primary_kv_before_init(config)
+
+
+def test_gms_private_bootstrap_shadow_disables_vllm_graphs(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    assert vllm_main._maybe_disable_gms_shadow_graphs_before_vllm_config(config)
+    assert os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] == "0"
+
+
+def test_gms_private_bootstrap_graph_disable_can_be_overridden(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_CUDAGRAPH", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    assert not vllm_main._maybe_disable_gms_shadow_graphs_before_vllm_config(config)
+    assert "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ
+
+
+def test_gms_private_bootstrap_scratch_warmup_keeps_vllm_graphs(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    monkeypatch.delenv("GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED", raising=False)
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    assert not vllm_main._maybe_disable_gms_shadow_graphs_before_vllm_config(config)
+    assert "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ
+    assert os.environ["GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED"] == "1"
+
+
+def test_gms_private_bootstrap_shadow_forces_eager_vllm_config():
+    from vllm.config import CompilationMode, CUDAGraphMode
+
+    from dynamo.vllm import main as vllm_main
+
+    vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            mode=CompilationMode.VLLM_COMPILE,
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        )
+    )
+
+    vllm_main._apply_gms_shadow_graph_config(vllm_config, disabled=True)
+
+    assert vllm_config.compilation_config.mode == CompilationMode.NONE
+    assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+
+
+def test_gms_forced_private_primary_waits_for_geometry(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    calls = []
+
+    def fake_existing_blocks(*, wait_ms=0):
+        calls.append(wait_ms)
+        return 456
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setattr(
+        "gpu_memory_service.integrations.vllm.install_vmm_ipc_kv._existing_shared_kv_blocks",
+        fake_existing_blocks,
+    )
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    vllm_main._maybe_wait_for_gms_primary_kv_before_init(config)
+
+    assert calls == [1_800_000]
+
+
+@pytest.mark.asyncio
+async def test_gms_preinit_static_primary_uses_shared_kv_when_lock_free(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire(*, timeout=None):
+        events.append(("lock", timeout))
+        return lock
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    config = SimpleNamespace(
+        gms_shadow_mode=True,
+        engine_args=SimpleNamespace(load_format="gms"),
+    )
+
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    got_lock, fence_run = await factory._configure_gms_preinit_failover_role(config)
+
+    assert got_lock is lock
+    assert fence_run is True
+    assert os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] == "1"
+    assert os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] == "0"
+    assert events == [("lock", 0.0), ("fence", "vllm", "engine-0-pre-init")]
+
+
+@pytest.mark.asyncio
+async def test_gms_preinit_static_primary_uses_private_kv_when_lock_held(monkeypatch):
+    from gpu_memory_service.failover_lock.interface import FailoverLockError
+
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire(*, timeout=None):
+        raise FailoverLockError("held")
+
+    config = SimpleNamespace(
+        gms_shadow_mode=True,
+        engine_args=SimpleNamespace(load_format="gms"),
+    )
+
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+
+    got_lock, fence_run = await factory._configure_gms_preinit_failover_role(config)
+
+    assert got_lock is None
+    assert fence_run is False
+    assert os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] == "0"
+    assert os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_gms_preinit_static_shadow_uses_private_kv_without_lock(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fail_acquire(*, timeout=None):
+        raise AssertionError("static shadow should not steal initial active lock")
+
+    config = SimpleNamespace(
+        gms_shadow_mode=True,
+        engine_args=SimpleNamespace(load_format="gms"),
+    )
+
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fail_acquire)
+
+    got_lock, fence_run = await factory._configure_gms_preinit_failover_role(config)
+
+    assert got_lock is None
+    assert fence_run is False
+    assert os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] == "0"
+    assert os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_gms_private_shadow_waits_for_lock_without_startup_sleep(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_promotion_warmup():
+        events.append("warmup")
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            raise AssertionError("private-bootstrap shadow must not sleep at startup")
+
+        async def resume(self, *args, **kwargs):
+            raise AssertionError("private-bootstrap shadow promotes KV directly")
+
+        def mark_resumed(self):
+            raise AssertionError("private-bootstrap shadow promotes KV directly")
+
+    class EngineClient:
+        async def collective_rpc(self, method, *, kwargs=None):
+            events.append(("collective_rpc", method, kwargs))
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(
+        _quiesce_controller=QuiesceController(),
+        engine_client=EngineClient(),
+    )
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", raising=False)
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        Runtime(),
+        config,
+        promotion_warmup=fake_promotion_warmup,
+    )
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        ("health", True),
+        "lock",
+        ("fence", "vllm", "private-bootstrap-shadow"),
+        ("collective_rpc", "wake_up", {"tags": ["kv_pool"]}),
+        "warmup",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gms_private_shadow_can_prepromote_kv_before_lock(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_promotion_warmup():
+        events.append("warmup")
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            raise AssertionError("private-bootstrap shadow must not sleep at startup")
+
+    class EngineClient:
+        async def collective_rpc(self, method, *, kwargs=None):
+            events.append(("collective_rpc", method, kwargs))
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(
+        _quiesce_controller=QuiesceController(),
+        engine_client=EngineClient(),
+    )
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PREPROMOTE_SHADOW_KV", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", raising=False)
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        Runtime(),
+        config,
+        promotion_warmup=fake_promotion_warmup,
+    )
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        ("collective_rpc", "wake_up", {"tags": ["kv_pool"]}),
+        ("health", True),
+        "lock",
+        ("fence", "vllm", "private-bootstrap-shadow"),
+        "warmup",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gms_private_shadow_runs_prelock_scratch_warmup(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_promotion_warmup():
+        events.append("postlock-warmup")
+
+    async def fake_prelock_warmup():
+        events.append("prelock-warmup")
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            raise AssertionError("private-bootstrap shadow must not sleep at startup")
+
+    class EngineClient:
+        async def collective_rpc(self, method, *, kwargs=None):
+            events.append(("collective_rpc", method, kwargs))
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(
+        _quiesce_controller=QuiesceController(),
+        engine_client=EngineClient(),
+    )
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PREPROMOTE_SHADOW_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PREWARM_SHADOW_BEFORE_LOCK", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", raising=False)
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        Runtime(),
+        config,
+        promotion_warmup=fake_promotion_warmup,
+        prelock_warmup=fake_prelock_warmup,
+    )
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        "prelock-warmup",
+        ("collective_rpc", "wake_up", {"tags": ["kv_pool"]}),
+        ("health", True),
+        "lock",
+        ("fence", "vllm", "private-bootstrap-shadow"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gms_primary_does_not_use_private_bootstrap_promotion(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_promotion_warmup():
+        events.append("warmup")
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            raise AssertionError("primary must not quiesce before registration")
+
+    class EngineClient:
+        async def collective_rpc(self, *args, **kwargs):
+            raise AssertionError("primary must not promote private-bootstrap KV")
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(
+        _quiesce_controller=QuiesceController(),
+        engine_client=EngineClient(),
+    )
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.delenv("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", raising=False)
+    monkeypatch.delenv("DYN_VLLM_GMS_ACTIVE_LOCK_HELD", raising=False)
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", raising=False)
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        Runtime(),
+        config,
+        promotion_warmup=fake_promotion_warmup,
+    )
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        "lock",
+        ("fence", "vllm", "active"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gms_shadow_startup_sleep_can_be_forced_for_legacy_path(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            events.append(("quiesce", args, kwargs))
+
+        async def resume(self, *args, **kwargs):
+            events.append("resume")
+
+        def mark_resumed(self):
+            events.append("mark_resumed")
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(_quiesce_controller=QuiesceController())
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(handler, Runtime(), config)
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        ("quiesce", (1,), {"clear_cache": False}),
+        ("health", True),
+        "lock",
+        ("fence", "vllm", "legacy-shadow"),
+        "resume",
+        "mark_resumed",
+    ]

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -16,6 +16,10 @@ from vllm.config import VllmConfig
 from vllm.v1.engine.async_llm import AsyncLLM
 
 from dynamo import prometheus_names
+from dynamo.common.gms_failover import (
+    run_gms_failover_post_lock_fence,
+    run_gms_failover_promotion_warmup,
+)
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.common.utils.prometheus import (
     LLMBackendMetrics,
@@ -51,6 +55,76 @@ logger = logging.getLogger(__name__)
 # have no KV cache / scheduler gauges, so setup_vllm_engine() skips the
 # LLMBackendMetrics registration there.
 EngineSetupResult = tuple[AsyncLLM, VllmConfig, Any, Any, Optional[LLMBackendMetrics]]
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r", name, value)
+        return default
+
+
+def _truthy_env(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _vllm_prelock_shadow_warmup_enabled() -> bool:
+    return _truthy_env("DYN_VLLM_GMS_PREWARM_SHADOW_BEFORE_LOCK")
+
+
+def _vllm_scratch_private_bootstrap_enabled() -> bool:
+    return _truthy_env(
+        "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP",
+        default=_truthy_env("GMS_VLLM_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP"),
+    )
+
+
+def _vllm_failover_shape_warmup_payload(base_payload: dict[str, Any]) -> dict[str, Any]:
+    """Build a small real-request canary that covers post-failover serving JIT."""
+
+    payload = dict(base_payload)
+    payload.pop("_HEALTH_CHECK", None)
+    max_tokens = max(
+        1,
+        _int_env(
+            "DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_MAX_TOKENS",
+            _int_env("DYN_GMS_FAILOVER_SHAPE_WARMUP_MAX_TOKENS", 16),
+        ),
+    )
+    token_count = max(
+        1,
+        _int_env(
+            "DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_INPUT_TOKENS",
+            _int_env("DYN_GMS_FAILOVER_SHAPE_WARMUP_INPUT_TOKENS", 25),
+        ),
+    )
+
+    if "token_ids" in payload:
+        token_ids = payload.get("token_ids") or [1]
+        token_id = int(token_ids[0])
+        payload["token_ids"] = [token_id] * token_count
+        sampling_options = dict(payload.get("sampling_options") or {})
+        sampling_options["temperature"] = 0.0
+        payload["sampling_options"] = sampling_options
+        stop_conditions = dict(payload.get("stop_conditions") or {})
+        stop_conditions["max_tokens"] = max_tokens
+        payload["stop_conditions"] = stop_conditions
+        return payload
+
+    payload["prompt"] = os.environ.get(
+        "DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_PROMPT",
+        "Return one concise deterministic sentence about GMS failover validation.",
+    )
+    payload["temperature"] = 0.0
+    payload["max_tokens"] = max_tokens
+    return payload
 
 
 async def _wait_and_load_benchmark(bench_cfg: dict, vllm_config: VllmConfig) -> dict:
@@ -145,6 +219,7 @@ class WorkerFactory:
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,
         snapshot_engine: Optional[EngineSetupResult] = None,
+        engine_holder: Optional[list] = None,
     ) -> None:
         """Create the appropriate multimodal worker based on config flags."""
 
@@ -172,6 +247,7 @@ class WorkerFactory:
                 shutdown_event,
                 shutdown_endpoints,
                 snapshot_engine=snapshot_engine,
+                engine_holder=engine_holder,
             )
         else:
             # AGGREGATED or DECODE
@@ -181,6 +257,7 @@ class WorkerFactory:
                 shutdown_event,
                 shutdown_endpoints,
                 snapshot_engine=snapshot_engine,
+                engine_holder=engine_holder,
             )
         return
 
@@ -321,34 +398,270 @@ class WorkerFactory:
         finally:
             handler.cleanup()
 
+    @staticmethod
+    def _truthy_env(name: str, *, default: bool = False) -> bool:
+        value = os.environ.get(name)
+        if value is None:
+            return default
+        return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+    @classmethod
+    def _private_bootstrap_requested(cls) -> bool:
+        return cls._truthy_env(
+            "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV",
+            default=cls._truthy_env(
+                "GMS_VLLM_PRIVATE_BOOTSTRAP_KV",
+                default=cls._truthy_env("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV"),
+            ),
+        )
+
+    async def _acquire_failover_lock(self, *, timeout: float | None = None):
+        from gpu_memory_service.failover_lock.flock import FlockFailoverLock
+
+        lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
+        engine_id = os.environ.get("ENGINE_ID", "0")
+        lock = FlockFailoverLock(lock_path)
+        await lock.acquire(engine_id=f"engine-{engine_id}", timeout=timeout)
+        return lock
+
+    async def _configure_gms_preinit_failover_role(
+        self,
+        config: Config,
+    ) -> tuple[Any | None, bool]:
+        """Choose shared vs private-bootstrap KV before vLLM initializes.
+
+        vLLM sizes/profiles memory before the worker handler exists. In a
+        Bulwark pair that uses private-bootstrap shadows, the process that owns
+        the failover lock may initialize against the stable shared KV namespace;
+        all other processes must initialize against member-scoped private KV.
+        This is dynamic: after failover, a restarted ENGINE_ID=0 container is a
+        standby while ENGINE_ID=1 owns the lock.
+        """
+
+        os.environ.pop("DYN_VLLM_GMS_ACTIVE_LOCK_HELD", None)
+        os.environ.pop("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", None)
+
+        if not config.gms_shadow_mode:
+            return None, False
+        if getattr(config.engine_args, "load_format", None) != "gms":
+            return None, False
+        if not self._private_bootstrap_requested():
+            return None, False
+        if not self._truthy_env("DYN_VLLM_GMS_DYNAMIC_PREINIT_ROLE", default=True):
+            return None, False
+
+        engine_id = os.environ.get("ENGINE_ID", "0")
+        primary_engine_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+        is_static_primary = engine_id == primary_engine_id
+
+        if not is_static_primary:
+            os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] = "1"
+            os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] = "0"
+            logger.info(
+                "[GMS] Static shadow engine-%s initializing with private-bootstrap KV",
+                engine_id,
+            )
+            return None, False
+
+        logger.info(
+            "[GMS] Static primary engine-%s attempting active failover lock "
+            "before vLLM engine init",
+            engine_id,
+        )
+        try:
+            lock = await self._acquire_failover_lock(timeout=0.0)
+        except Exception as exc:  # noqa: BLE001 - lock contention is expected.
+            try:
+                from gpu_memory_service.failover_lock.interface import FailoverLockError
+            except ImportError:  # pragma: no cover
+                FailoverLockError = RuntimeError  # type: ignore[assignment]
+
+            if not isinstance(exc, FailoverLockError):
+                raise
+            os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] = "1"
+            os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] = "0"
+            logger.info(
+                "[GMS] Active failover lock is held; static primary engine-%s "
+                "will initialize as private-bootstrap standby",
+                engine_id,
+            )
+            return None, False
+
+        os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] = "1"
+        os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] = "0"
+        await run_gms_failover_post_lock_fence(
+            backend_name="vllm",
+            role=f"engine-{engine_id}-pre-init",
+        )
+        logger.info(
+            "[GMS] Static primary engine-%s owns active lock before vLLM init",
+            engine_id,
+        )
+        return lock, True
+
     async def _maybe_wait_for_failover_lock(
         self,
         handler,
         runtime: DistributedRuntime,
         config: Config,
+        *,
+        lock_already_acquired: bool = False,
+        promotion_warmup: Callable[[], Awaitable[None]] | None = None,
+        prelock_warmup: Callable[[], Awaitable[None]] | None = None,
+        post_lock_fence_already_run: bool = False,
     ) -> None:
         # Shadow mode: lock-driven activation.
-        # Flow: sleep → startup probe passes → block on lock → wake → register.
+        # Default safe flow for GMS shared KV is lock-before-init, because vLLM
+        # warmup writes KV before this handler can quiesce the engine. The legacy
+        # warm-standby path remains behind DYN_VLLM_GMS_LOCK_BEFORE_INIT=0.
         if not config.gms_shadow_mode:
             return
 
-        await handler._quiesce_controller.quiesce(1)
+        if lock_already_acquired:
+            if not post_lock_fence_already_run:
+                await run_gms_failover_post_lock_fence(
+                    backend_name="vllm",
+                    role="pre-init",
+                )
+            if promotion_warmup is not None:
+                logger.info(
+                    "[GMS failover] Skipping promotion warmup for pre-init "
+                    "active lock; warmup is shadow-only"
+                )
+            logger.info(
+                "[Shadow] Failover lock already acquired before engine init; "
+                "registering with discovery"
+            )
+            return
+
+        engine_id = os.environ.get("ENGINE_ID", "0")
+        primary_engine_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+        forced_private_bootstrap = self._truthy_env(
+            "DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"
+        )
+        is_shadow = forced_private_bootstrap or engine_id != primary_engine_id
+        private_bootstrap = self._private_bootstrap_requested() and is_shadow
+
+        if not is_shadow:
+            logger.info(
+                "[Primary] Engine initialized; acquiring active failover lock "
+                "before discovery registration"
+            )
+            lock = await self._acquire_failover_lock()
+            setattr(handler, "_gms_failover_lock", lock)
+            await run_gms_failover_post_lock_fence(
+                backend_name="vllm",
+                role="active",
+            )
+            if promotion_warmup is not None:
+                logger.info(
+                    "[GMS failover] Skipping promotion warmup for active primary; "
+                    "warmup is shadow-only"
+                )
+            logger.info("[Primary] Active lock acquired, registering with discovery")
+            return
+
+        skip_startup_sleep = os.environ.get(
+            "DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP",
+            "1" if private_bootstrap else "0",
+        ).lower() not in {"0", "false", "no", "off"}
+        if skip_startup_sleep:
+            prelock_warmup_ran = False
+            if (
+                private_bootstrap
+                and prelock_warmup is not None
+                and _vllm_prelock_shadow_warmup_enabled()
+            ):
+                if _vllm_scratch_private_bootstrap_enabled():
+                    logger.info(
+                        "[Shadow] Running pre-lock scratch-backed warmup while "
+                        "undiscovered"
+                    )
+                    await prelock_warmup()
+                    prelock_warmup_ran = True
+                    logger.info(
+                        "[Shadow] Pre-lock scratch-backed warmup complete; "
+                        "waiting for active lock"
+                    )
+                else:
+                    logger.warning(
+                        "[Shadow] Skipping pre-lock warmup because scratch-backed "
+                        "private-bootstrap KV is not enabled"
+                    )
+
+            prepromoted_private_bootstrap = False
+            if private_bootstrap and self._truthy_env(
+                "DYN_VLLM_GMS_PREPROMOTE_SHADOW_KV"
+            ):
+                logger.info(
+                    "[Shadow] Pre-promoting private-bootstrap KV while "
+                    "undiscovered; lock still gates serving"
+                )
+                await handler.engine_client.collective_rpc(
+                    "wake_up",
+                    kwargs={"tags": ["kv_pool"]},
+                )
+                prepromoted_private_bootstrap = True
+                logger.info(
+                    "[Shadow] Private-bootstrap KV pre-promotion complete; "
+                    "waiting for active lock"
+                )
+
+            runtime.set_health_status(True)
+            logger.info(
+                "[Shadow] Engine initialized and kept awake but undiscovered; "
+                "startup probe now passing, waiting for lock"
+            )
+
+            lock = await self._acquire_failover_lock()
+            setattr(handler, "_gms_failover_lock", lock)
+            await run_gms_failover_post_lock_fence(
+                backend_name="vllm",
+                role="private-bootstrap-shadow",
+            )
+            if prepromoted_private_bootstrap:
+                logger.info(
+                    "[Shadow] Private-bootstrap KV already promoted before "
+                    "lock; skipping promotion before discovery registration"
+                )
+            else:
+                logger.info(
+                    "[Shadow] Promoting private-bootstrap KV before discovery "
+                    "registration"
+                )
+                await handler.engine_client.collective_rpc(
+                    "wake_up",
+                    kwargs={"tags": ["kv_pool"]},
+                )
+            if promotion_warmup is not None and not prelock_warmup_ran:
+                await promotion_warmup()
+            elif prelock_warmup_ran:
+                logger.info(
+                    "[Shadow] Pre-lock warmup already ran; skipping post-lock "
+                    "promotion warmup"
+                )
+            logger.info("[Shadow] Lock acquired, registering with discovery")
+            return
+
+        await handler._quiesce_controller.quiesce(1, clear_cache=False)
 
         runtime.set_health_status(True)
         logger.info(
             "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
         )
 
-        from gpu_memory_service.failover_lock.flock import FlockFailoverLock
-
-        lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
-        engine_id = os.environ.get("ENGINE_ID", "0")
-        lock = FlockFailoverLock(lock_path)
-        await lock.acquire(engine_id=f"engine-{engine_id}")
+        lock = await self._acquire_failover_lock()
+        setattr(handler, "_gms_failover_lock", lock)
+        await run_gms_failover_post_lock_fence(
+            backend_name="vllm",
+            role="legacy-shadow",
+        )
         logger.info("[Shadow] Lock acquired, waking engine")
 
         await handler._quiesce_controller.resume()
         handler._quiesce_controller.mark_resumed()
+        if promotion_warmup is not None:
+            await promotion_warmup()
         logger.info("[Shadow] Engine awake, registering with discovery")
 
     async def _create_decode_worker(
@@ -358,6 +671,7 @@ class WorkerFactory:
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
         snapshot_engine: Optional[EngineSetupResult] = None,
+        engine_holder: Optional[list] = None,
     ) -> None:
         """
         Instantiate and serve
@@ -395,6 +709,32 @@ class WorkerFactory:
                 ]
             )
 
+        early_failover_lock = None
+        early_failover_fence_run = False
+        (
+            early_failover_lock,
+            early_failover_fence_run,
+        ) = await self._configure_gms_preinit_failover_role(config)
+        lock_before_init = os.environ.get("DYN_VLLM_GMS_LOCK_BEFORE_INIT", "1").lower()
+        if (
+            early_failover_lock is None
+            and config.gms_shadow_mode
+            and lock_before_init not in {"0", "false", "no", "off"}
+        ):
+            logger.info(
+                "[Shadow] Waiting for failover lock before vLLM engine init "
+                "to protect shared GMS KV warmup"
+            )
+            early_failover_lock = await self._acquire_failover_lock()
+            await run_gms_failover_post_lock_fence(
+                backend_name="vllm",
+                role=f"engine-{os.environ.get('ENGINE_ID', '0')}-pre-init",
+            )
+            early_failover_fence_run = True
+            os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] = "1"
+            os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] = "0"
+            logger.info("[Shadow] Failover lock acquired before vLLM engine init")
+
         # Use pre-created engine if provided (checkpoint mode), otherwise create new
         fpm_worker_id = str(generate_endpoint.connection_id())
         if snapshot_engine is not None:
@@ -426,6 +766,8 @@ class WorkerFactory:
                 component_gauges,
             ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
         await configure_kv_event_block_size(engine_client, vllm_config)
+        if engine_holder is not None:
+            engine_holder.append(engine_client)
 
         # TODO Hack to get data, move this to registering in TBD
         _, dp_size = get_dp_range_for_worker(vllm_config)
@@ -458,6 +800,8 @@ class WorkerFactory:
             encode_worker_client=encode_worker_client,
         )
         handler.add_temp_dir(prometheus_temp_dir)
+        if early_failover_lock is not None:
+            setattr(handler, "_gms_failover_lock", early_failover_lock)
 
         # Check if kv event consolidator is enabled (port was allocated in setup_vllm_engine)
         consolidator_enabled = False
@@ -519,7 +863,31 @@ class WorkerFactory:
                 "The chat template will be loaded but the /v1/chat/completions endpoint will not be available."
             )
 
-        await self._maybe_wait_for_failover_lock(handler, runtime, config)
+        health_check_payload = VllmHealthCheckPayload(
+            engine_client, use_text_input=config.use_vllm_tokenizer
+        ).to_dict()
+
+        async def promotion_warmup() -> None:
+            await run_gms_failover_promotion_warmup(
+                handler.generate, health_check_payload, backend_name="vllm"
+            )
+
+        shape_warmup_payload = _vllm_failover_shape_warmup_payload(health_check_payload)
+
+        async def prelock_warmup() -> None:
+            await run_gms_failover_promotion_warmup(
+                handler.generate, shape_warmup_payload, backend_name="vllm"
+            )
+
+        await self._maybe_wait_for_failover_lock(
+            handler,
+            runtime,
+            config,
+            lock_already_acquired=early_failover_lock is not None,
+            promotion_warmup=promotion_warmup,
+            prelock_warmup=prelock_warmup,
+            post_lock_fence_already_run=early_failover_fence_run,
+        )
 
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
@@ -548,10 +916,6 @@ class WorkerFactory:
             worker_type=worker_type,
             needs=needs,
         )
-
-        health_check_payload = VllmHealthCheckPayload(
-            engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"
@@ -626,6 +990,7 @@ class WorkerFactory:
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
         snapshot_engine: Optional[EngineSetupResult] = None,
+        engine_holder: Optional[list] = None,
     ) -> None:
         """
         Instantiate and serve
@@ -661,6 +1026,8 @@ class WorkerFactory:
                 _component_gauges,
             ) = self.setup_vllm_engine(config, fpm_worker_id=fpm_worker_id)
         await configure_kv_event_block_size(engine_client, vllm_config)
+        if engine_holder is not None:
+            engine_holder.append(engine_client)
 
         encode_worker_client = await self._maybe_get_encode_worker_client(
             runtime, config
@@ -727,7 +1094,18 @@ class WorkerFactory:
         # Register engine routes
         self.register_engine_routes(runtime, handler)
 
-        await self._maybe_wait_for_failover_lock(handler, runtime, config)
+        health_check_payload = VllmPrefillHealthCheckPayload(
+            engine_client, use_text_input=config.use_vllm_tokenizer
+        ).to_dict()
+
+        async def promotion_warmup() -> None:
+            await run_gms_failover_promotion_warmup(
+                handler.generate, health_check_payload, backend_name="vllm"
+            )
+
+        await self._maybe_wait_for_failover_lock(
+            handler, runtime, config, promotion_warmup=promotion_warmup
+        )
 
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
@@ -755,10 +1133,6 @@ class WorkerFactory:
             worker_type=WorkerType.Prefill,
             needs=[[WorkerType.Decode]],
         )
-
-        health_check_payload = VllmPrefillHealthCheckPayload(
-            engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
 
         prefill_metrics_labels = [
             (


### PR DESCRIPTION
Stacked PR in the GMS-managed KV review train.

Base: `review/gms-v2-latehost-03-2-vllm-gms-integration-package`
Head: `review/gms-v2-latehost-03-3-vllm-runtime-wiring`

Refs #10452 #10450

This PR is intentionally scoped to one commit in the train so reviewers can inspect the GMS KV ownership, engine integration, Bulwark, host-tier, router, and docs work incrementally.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->