### PR TITLE
feat(gms): integrate vLLM and SGLang GPU memory [GMS 05/18]

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -111,6 +111,7 @@ core:
   - 'components/src/dynamo/frontend/**'
   - 'components/src/dynamo/common/**'
   - 'components/src/dynamo/gpu_memory_service/**'
+  - 'components/src/dynamo/gms_router_policy.py'
   # TODO(will): Move TokenSpeed to a dedicated framework filter once CI has
   # TokenSpeed Docker images and backend-specific build/test jobs.
   - 'components/src/dynamo/tokenspeed/**'
@@ -228,6 +229,7 @@ frontend:
   - 'components/src/dynamo/frontend/**'
   - 'components/src/dynamo/common/**'
   - 'deploy/inference-gateway/**'
+  - 'components/src/dynamo/gms_router_policy.py'
   - 'container/templates/frontend.Dockerfile'
   - '!**/*.md'
   - '!**/*.rst'

--- a/components/src/dynamo/common/rank_liveness.py
+++ b/components/src/dynamo/common/rank_liveness.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ZMQ-based cross-rank liveness watcher for fast detection of a non-leader rank's
+death in a multi-node tensor-parallel cohort.
+
+Motivation
+----------
+When a rank>0 worker on another node dies, the leader (rank 0) only learns via the
+engine's NCCL collective timeout — 600s by default, ~20s even when tuned down — and
+in-flight requests stall for that whole window. The flock-based GMS failover only
+covers rank-0 death (the OS releases the flock on the leader's exit); it does not see
+a remote worker die.
+
+This module adds a *GPU-independent* liveness channel. Each worker rank holds a ZMQ
+connection to a leader-side monitor and sends a heartbeat on a plain CPU thread. When
+the worker process dies, its heartbeats stop and the monitor fires within one
+heartbeat-timeout (sub-second), letting the leader proactively fence + release the GMS
+failover lock so the warm shadow takes over immediately — instead of waiting out the
+NCCL timeout.
+
+Two properties make this better than both the NFS-flock idea and the NCCL timeout:
+  * The heartbeat runs on a CPU thread, so it keeps beating even while the GPU is busy
+    in a long legitimate collective (warmup, load spike) — it does NOT false-positive
+    the way an aggressive NCCL/engine watchdog does during init.
+  * A peer process exit drops the heartbeat promptly, so a *crash* is detected in
+    ~one interval rather than ~one collective-timeout.
+
+It does NOT replace the NCCL/engine watchdog: a rank that is hung-but-alive with its
+heartbeat thread still running is invisible here (only a timeout catches a true hang).
+This is the crash detector; the (dynamically-lowered) engine watchdog stays the hang
+detector.
+
+Reuses pyzmq, already a dependency of both vLLM and SGLang. Engine-agnostic: the
+leader supplies an ``on_rank_lost`` callback that wires into the existing failover
+trigger (fence children + release the failover lock).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Callable, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Defaults: ~750ms detection (timeout) with a 250ms heartbeat. Well under the ~20s
+# tuned NCCL window, and the CPU-thread heartbeat is immune to GPU-collective stalls.
+DEFAULT_HEARTBEAT_MS = 250
+DEFAULT_TIMEOUT_MS = 750
+DEFAULT_LIVENESS_PORT = 29555
+DEFAULT_STARTUP_GRACE_MS = 30_000
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; using %d", name, raw, default)
+        return default
+
+
+def liveness_enabled() -> bool:
+    val = os.environ.get("DYN_GMS_RANK_LIVENESS")
+    if val is None:
+        return False
+    return val.lower() in {"1", "true", "yes", "on"}
+
+
+def heartbeat_ms() -> int:
+    return max(20, _int_env("DYN_GMS_RANK_LIVENESS_HEARTBEAT_MS", DEFAULT_HEARTBEAT_MS))
+
+
+def timeout_ms() -> int:
+    return max(
+        heartbeat_ms() * 2,
+        _int_env("DYN_GMS_RANK_LIVENESS_TIMEOUT_MS", DEFAULT_TIMEOUT_MS),
+    )
+
+
+def startup_grace_ms() -> int:
+    return max(
+        timeout_ms(),
+        _int_env("DYN_GMS_RANK_LIVENESS_STARTUP_GRACE_MS", DEFAULT_STARTUP_GRACE_MS),
+    )
+
+
+def liveness_port() -> int:
+    return _int_env("DYN_GMS_RANK_LIVENESS_PORT", DEFAULT_LIVENESS_PORT)
+
+
+def leader_bind_addr() -> str:
+    return os.environ.get(
+        "DYN_GMS_RANK_LIVENESS_BIND_ADDR", f"tcp://*:{liveness_port()}"
+    )
+
+
+def leader_connect_addr(leader_host: str) -> str:
+    template = os.environ.get("DYN_GMS_RANK_LIVENESS_CONNECT_ADDR")
+    if template:
+        return template.format(leader_host=leader_host)
+    return f"tcp://{leader_host}:{liveness_port()}"
+
+
+class RankLivenessClient:
+    """Runs on a worker rank (rank>0). Holds a DEALER connection to the leader and
+    heartbeats on a daemon thread. On process death the socket drops and the leader's
+    monitor fires within one timeout window."""
+
+    def __init__(
+        self,
+        leader_host: str,
+        rank: int,
+        *,
+        interval_ms: Optional[int] = None,
+        connect_addr: Optional[str] = None,
+    ):
+        self._leader_host = leader_host
+        self._rank = int(rank)
+        self._interval = (interval_ms or heartbeat_ms()) / 1000.0
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._connect_addr = connect_addr or leader_connect_addr(leader_host)
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name=f"gms-rank-liveness-client-{self._rank}", daemon=True
+        )
+        self._thread.start()
+        logger.info(
+            "[GMS liveness] rank %d heartbeating leader %s every %dms",
+            self._rank,
+            self._connect_addr,
+            int(self._interval * 1000),
+        )
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=0.5)
+            self._thread = None
+
+    def _run(self) -> None:
+        import zmq
+
+        ctx = zmq.Context.instance()
+        sock = ctx.socket(zmq.DEALER)
+        # Identity = rank, so the leader maps heartbeats -> rank with no correlation.
+        sock.setsockopt(zmq.IDENTITY, f"rank-{self._rank}".encode())
+        sock.setsockopt(zmq.LINGER, 0)
+        # ZMTP-level heartbeats make ZMQ itself notice a dead peer quickly too.
+        sock.setsockopt(zmq.HEARTBEAT_IVL, int(self._interval * 1000))
+        sock.setsockopt(zmq.HEARTBEAT_TIMEOUT, int(self._interval * 1000) * 3)
+        sock.connect(self._connect_addr)
+        try:
+            while not self._stop.is_set():
+                try:
+                    sock.send(b"hb", flags=zmq.NOBLOCK)
+                except zmq.ZMQError:
+                    logger.debug(
+                        "[GMS liveness] rank %d heartbeat send failed",
+                        self._rank,
+                        exc_info=True,
+                    )
+                self._stop.wait(self._interval)
+        finally:
+            sock.close(0)
+
+
+class RankLivenessMonitor:
+    """Monitor non-leader ranks and report the first lost rank exactly once.
+
+    When ``expected_ranks`` is provided, ranks that never register are reported after
+    the startup grace period. Omitting it preserves the legacy behavior: only ranks
+    observed at least once are armed. ``bind_addr`` allows each colocated replica to
+    use its own endpoint.
+    """
+
+    def __init__(
+        self,
+        on_rank_lost: Callable[[int, str], None],
+        *,
+        bind_addr: Optional[str] = None,
+        timeout_ms_override: Optional[int] = None,
+        expected_ranks: Optional[Iterable[int]] = None,
+        startup_grace_ms_override: Optional[int] = None,
+    ):
+        self._on_rank_lost = on_rank_lost
+        self._bind_addr = bind_addr or leader_bind_addr()
+        timeout_value = (
+            timeout_ms() if timeout_ms_override is None else max(1, timeout_ms_override)
+        )
+        self._timeout = timeout_value / 1000.0
+        self._expected_ranks = (
+            None
+            if expected_ranks is None
+            else frozenset(int(rank) for rank in expected_ranks)
+        )
+        grace_value = (
+            startup_grace_ms()
+            if startup_grace_ms_override is None
+            else max(0, startup_grace_ms_override)
+        )
+        self._startup_grace = grace_value / 1000.0
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._fired = False
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="gms-rank-liveness-monitor", daemon=True
+        )
+        self._thread.start()
+        logger.info(
+            "[GMS liveness] leader monitor bound %s (timeout %dms)",
+            self._bind_addr,
+            int(self._timeout * 1000),
+        )
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=0.5)
+            self._thread = None
+
+    def _run(self) -> None:
+        import zmq
+
+        ctx = zmq.Context.instance()
+        sock = ctx.socket(zmq.ROUTER)
+        sock.setsockopt(zmq.LINGER, 0)
+        sock.setsockopt(zmq.HEARTBEAT_IVL, int(self._timeout * 1000 / 3))
+        sock.setsockopt(zmq.HEARTBEAT_TIMEOUT, int(self._timeout * 1000))
+        sock.bind(self._bind_addr)
+        poller = zmq.Poller()
+        poller.register(sock, zmq.POLLIN)
+
+        last_seen: dict[int, float] = {}
+        started = time.monotonic()
+        poll_ms = max(10, int(self._timeout * 1000 / 5))
+        try:
+            while not self._stop.is_set():
+                events = dict(poller.poll(poll_ms))
+                now = time.monotonic()
+                if sock in events:
+                    while True:
+                        try:
+                            frames = sock.recv_multipart(flags=zmq.NOBLOCK)
+                        except zmq.Again:
+                            break
+                        if len(frames) < 2 or frames[-1] != b"hb":
+                            continue
+                        rank = self._rank_of(frames[0])
+                        if rank is None:
+                            continue
+                        if (
+                            self._expected_ranks is not None
+                            and rank not in self._expected_ranks
+                        ):
+                            logger.debug(
+                                "[GMS liveness] ignoring unexpected rank %d", rank
+                            )
+                            continue
+                        if rank not in last_seen:
+                            logger.info("[GMS liveness] rank %d registered", rank)
+                        last_seen[rank] = now
+
+                if (
+                    self._expected_ranks is not None
+                    and now - started > self._startup_grace
+                ):
+                    missing = sorted(self._expected_ranks.difference(last_seen))
+                    if missing:
+                        self._fire(missing[0], "startup-timeout")
+                        return
+
+                for rank, seen in list(last_seen.items()):
+                    if now - seen > self._timeout:
+                        logger.warning(
+                            "[GMS liveness] rank %d silent for %.0fms (>%.0fms)",
+                            rank,
+                            (now - seen) * 1000,
+                            self._timeout * 1000,
+                        )
+                        self._fire(rank, "liveness-timeout")
+                        return
+        finally:
+            sock.close(0)
+
+    def _fire(self, rank: int, reason: str) -> bool:
+        if self._fired:
+            return False
+        self._fired = True
+        logger.warning("[GMS liveness] rank %d lost (%s)", rank, reason)
+        try:
+            self._on_rank_lost(rank, reason)
+        except Exception:
+            logger.exception("[GMS liveness] on_rank_lost callback failed")
+        return True
+
+    @staticmethod
+    def _rank_of(identity: bytes) -> Optional[int]:
+        try:
+            text = identity.decode()
+        except Exception:
+            return None
+        if text.startswith("rank-"):
+            try:
+                return int(text[len("rank-") :])
+            except ValueError:
+                return None
+        return None

--- a/components/src/dynamo/common/tests/test_rank_liveness.py
+++ b/components/src/dynamo/common/tests/test_rank_liveness.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+
+import pytest
+
+from dynamo.common import rank_liveness as rl
+
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
+
+def _endpoint() -> str:
+    return f"inproc://gms-rank-liveness-{uuid.uuid4().hex}"
+
+
+def _wait(event: threading.Event, timeout: float = 1.0) -> None:
+    assert event.wait(timeout), "liveness callback did not fire"
+
+
+def test_endpoint_overrides_support_replica_scoping(monkeypatch):
+    monkeypatch.setenv(
+        "DYN_GMS_RANK_LIVENESS_BIND_ADDR",
+        "tcp://127.0.0.1:31001",
+    )
+    monkeypatch.setenv(
+        "DYN_GMS_RANK_LIVENESS_CONNECT_ADDR",
+        "tcp://{leader_host}:31001",
+    )
+
+    assert rl.leader_bind_addr() == "tcp://127.0.0.1:31001"
+    assert rl.leader_connect_addr("replica-a") == "tcp://replica-a:31001"
+
+
+def test_fire_is_exactly_once_even_if_callback_raises():
+    calls: list[tuple[int, str]] = []
+
+    def callback(rank: int, reason: str) -> None:
+        calls.append((rank, reason))
+        raise RuntimeError("expected test error")
+
+    monitor = rl.RankLivenessMonitor(callback)
+
+    assert monitor._fire(1, "first") is True
+    assert monitor._fire(2, "second") is False
+    assert calls == [(1, "first")]
+
+
+def test_expected_rank_that_never_registers_fires_startup_timeout():
+    endpoint = _endpoint()
+    fired = threading.Event()
+    calls: list[tuple[int, str]] = []
+    monitor = rl.RankLivenessMonitor(
+        lambda rank, reason: (calls.append((rank, reason)), fired.set()),
+        bind_addr=endpoint,
+        timeout_ms_override=100,
+        expected_ranks={1},
+        startup_grace_ms_override=40,
+    )
+
+    monitor.start()
+    try:
+        _wait(fired)
+        assert calls == [(1, "startup-timeout")]
+    finally:
+        monitor.stop()
+
+
+def test_legacy_monitor_does_not_require_unseen_ranks():
+    fired = threading.Event()
+    monitor = rl.RankLivenessMonitor(
+        lambda _rank, _reason: fired.set(),
+        bind_addr=_endpoint(),
+        timeout_ms_override=40,
+    )
+
+    monitor.start()
+    try:
+        time.sleep(0.12)
+        assert not fired.is_set()
+    finally:
+        monitor.stop()
+
+
+def test_registered_rank_silence_fires_liveness_timeout():
+    endpoint = _endpoint()
+    fired = threading.Event()
+    calls: list[tuple[int, str]] = []
+    monitor = rl.RankLivenessMonitor(
+        lambda rank, reason: (calls.append((rank, reason)), fired.set()),
+        bind_addr=endpoint,
+        timeout_ms_override=80,
+        expected_ranks={1},
+        startup_grace_ms_override=500,
+    )
+    client = rl.RankLivenessClient(
+        "unused",
+        1,
+        interval_ms=20,
+        connect_addr=endpoint,
+    )
+
+    monitor.start()
+    time.sleep(0.03)
+    client.start()
+    try:
+        time.sleep(0.12)
+        client.stop()
+        _wait(fired)
+        assert calls == [(1, "liveness-timeout")]
+    finally:
+        client.stop()
+        monitor.stop()
+
+
+def test_unexpected_multipart_identity_does_not_arm_monitor():
+    import zmq
+
+    endpoint = _endpoint()
+    fired = threading.Event()
+    calls: list[tuple[int, str]] = []
+    monitor = rl.RankLivenessMonitor(
+        lambda rank, reason: (calls.append((rank, reason)), fired.set()),
+        bind_addr=endpoint,
+        timeout_ms_override=100,
+        expected_ranks={1},
+        startup_grace_ms_override=80,
+    )
+    socket = zmq.Context.instance().socket(zmq.DEALER)
+    socket.setsockopt(zmq.IDENTITY, b"rank-9")
+    socket.setsockopt(zmq.LINGER, 0)
+
+    monitor.start()
+    time.sleep(0.03)
+    socket.connect(endpoint)
+    try:
+        socket.send(b"hb")
+        _wait(fired)
+        assert calls == [(1, "startup-timeout")]
+    finally:
+        socket.close(0)
+        monitor.stop()

--- a/components/src/dynamo/gms_router_policy.py
+++ b/components/src/dynamo/gms_router_policy.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for router-orchestrated GMS KV placement metadata.
+
+The router stays transport-agnostic. It learns source placement descriptors from
+the existing KV event/indexer plane and stamps optional ``gms_placement`` onto
+the request for the destination worker. Worker-local GMS daemon sockets remain
+private to the worker process; the router does not open a GMS side channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+_LOG = logging.getLogger(__name__)
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").lower() not in ("", "0", "false", "no", "off")
+
+
+def resolve_vllm_gms_daemon_socket(vllm_config: Any) -> str | None:
+    """Return the vLLM GMS KV daemon socket when the GMS connector is active."""
+
+    kv_cfg = getattr(vllm_config, "kv_transfer_config", None)
+    if kv_cfg is None:
+        return None
+
+    extra = getattr(kv_cfg, "kv_connector_extra_config", None) or {}
+    socket_path = extra.get("gms_daemon_socket")
+    if socket_path:
+        return str(socket_path)
+
+    connector = str(getattr(kv_cfg, "kv_connector", ""))
+    module_path = str(getattr(kv_cfg, "kv_connector_module_path", ""))
+    if "GMSKVCacheConnector" not in connector and "gds_connector" not in module_path:
+        return None
+
+    try:
+        from gpu_memory_service.common.utils import get_socket_path
+
+        return str(get_socket_path(0, "kv_cache"))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def resolve_env_gms_daemon_socket(
+    env_name: str,
+    default_when_cross_node: str | None = None,
+) -> str | None:
+    socket_path = os.environ.get(env_name)
+    if socket_path:
+        return socket_path
+    if default_when_cross_node and _truthy(os.environ.get("GMS_KVR_CROSS_NODE")):
+        return default_when_cross_node
+    return None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_gms_descriptor(
+    descriptor: dict[str, Any],
+    *,
+    tier: str,
+    bytes_size: int,
+) -> dict[str, Any] | None:
+    remote_ptr = _optional_int(descriptor.get("remote_ptr", descriptor.get("ptr")))
+    size = _optional_int(descriptor.get("size", bytes_size))
+    if remote_ptr is None or size is None or size <= 0:
+        return None
+
+    descriptor_tier = str(descriptor.get("tier") or tier or "external")
+    ranges_raw = descriptor.get("ranges")
+    if not isinstance(ranges_raw, list) or not ranges_raw:
+        ranges_raw = [descriptor]
+
+    ranges: list[dict[str, Any]] = []
+    for item in ranges_raw:
+        if not isinstance(item, dict):
+            continue
+        range_ptr = _optional_int(item.get("remote_ptr", item.get("ptr", remote_ptr)))
+        range_size = _optional_int(item.get("size", size))
+        if range_ptr is None or range_size is None or range_size <= 0:
+            continue
+        region: dict[str, Any] = {
+            "remote_ptr": range_ptr,
+            "size": range_size,
+            "tier": str(item.get("tier") or descriptor_tier),
+        }
+        layer = _optional_int(item.get("layer"))
+        if layer is not None:
+            region["layer"] = layer
+        offset = _optional_int(item.get("offset"))
+        if offset is not None:
+            region["offset"] = offset
+        ranges.append(region)
+
+    if not ranges:
+        return None
+
+    normalized: dict[str, Any] = {
+        "remote_ptr": remote_ptr,
+        "size": size,
+        "tier": descriptor_tier,
+        "ranges": ranges,
+        "sealed": bool(descriptor.get("sealed", True)),
+    }
+    generation = _optional_int(descriptor.get("generation"))
+    if generation is not None:
+        normalized["generation"] = generation
+    return normalized
+
+
+class DynamoGmsPlacementPublisher:
+    """Publish GMS placements through Dynamo's existing KV event plane."""
+
+    def __init__(
+        self,
+        kv_publisher: Any,
+        *,
+        logger: logging.Logger | None = None,
+        dp_rank: int | None = None,
+    ) -> None:
+        self._kv_publisher = kv_publisher
+        self._logger = logger or _LOG
+        self._dp_rank = dp_rank
+        self._closed = False
+
+    def publish_stored(
+        self,
+        content_hash: bytes,
+        tier: str,
+        bytes_size: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        if self._closed:
+            return
+        metadata = metadata or {}
+        descriptor = metadata.get("gms_descriptor") or metadata.get("descriptor")
+        if not isinstance(descriptor, dict):
+            self._logger.debug("Skipping GMS placement without descriptor")
+            return
+        source_name = str(metadata.get("source_nixl_agent_name") or "")
+        source_metadata = str(
+            metadata.get("source_nixl_agent_metadata_hex")
+            or metadata.get("source_agent_metadata_hex")
+            or ""
+        )
+        if not source_name or not source_metadata:
+            self._logger.debug("Skipping GMS placement without NIXL source metadata")
+            return
+
+        normalized = _normalize_gms_descriptor(
+            descriptor,
+            tier=tier,
+            bytes_size=bytes_size,
+        )
+        if normalized is None:
+            self._logger.debug("Skipping malformed GMS placement descriptor")
+            return
+
+        kwargs: dict[str, Any] = {
+            "source_nixl_ip": metadata.get("source_nixl_ip"),
+            "source_nixl_listen_port": _optional_int(
+                metadata.get("source_nixl_listen_port"),
+            ),
+        }
+        if self._dp_rank is not None:
+            kwargs["dp_rank"] = self._dp_rank
+
+        self._kv_publisher.publish_gms_placement_stored(
+            source_name,
+            source_metadata,
+            [{"content_hash_hex": content_hash.hex(), "descriptor": normalized}],
+            **kwargs,
+        )
+
+    def publish_removed(self, content_hash: bytes, tier: str) -> None:
+        if self._closed:
+            return
+        kwargs: dict[str, Any] = {}
+        if self._dp_rank is not None:
+            kwargs["dp_rank"] = self._dp_rank
+        self._kv_publisher.publish_gms_placement_removed(
+            [content_hash.hex()],
+            **kwargs,
+        )
+
+    def close(self) -> None:
+        self._closed = True
+
+
+def _fetch_gms_placement_sync(
+    *,
+    placement: dict[str, Any],
+    local_daemon_socket: str,
+    timeout_s: float,
+    batch_size: int,
+) -> dict[str, int] | None:
+    source_nixl_name = str(placement.get("source_nixl_agent_name") or "")
+    if not source_nixl_name:
+        return None
+
+    from gms_kv_ring.daemon.client import DaemonClient
+
+    metadata_hex = str(
+        placement.get("source_nixl_agent_metadata_hex")
+        or placement.get("source_agent_metadata_hex")
+        or ""
+    )
+    hashes_hex = placement.get("hashes") or []
+    descriptors = placement.get("descriptors") or []
+    if not metadata_hex or not isinstance(hashes_hex, list):
+        return None
+    if not isinstance(descriptors, list) or len(hashes_hex) != len(descriptors):
+        return None
+
+    hashes: list[bytes] = []
+    for value in hashes_hex:
+        if not isinstance(value, str):
+            return None
+        try:
+            hashes.append(bytes.fromhex(value))
+        except ValueError:
+            return None
+    if not hashes or all(descriptor is None for descriptor in descriptors):
+        return None
+
+    with DaemonClient(
+        local_daemon_socket,
+        connect_timeout=min(5.0, max(0.5, timeout_s)),
+        op_timeout=max(timeout_s + 5.0, timeout_s),
+    ) as client:
+        result = client.read_bootstrap_into_staging(
+            source_nixl_name=source_nixl_name,
+            source_agent_metadata_hex=metadata_hex,
+            hashes=hashes,
+            descriptors=descriptors,
+            timeout_s=timeout_s,
+            batch_size=batch_size,
+        )
+    return result
+
+
+async def maybe_fetch_gms_placement(
+    request: dict[str, Any],
+    local_daemon_socket: str | None,
+    *,
+    logger: logging.Logger | None = None,
+    request_id: str | None = None,
+) -> dict[str, int] | None:
+    """Fetch router-selected remote KV into the local daemon staging tier.
+
+    Placements use in-band source NIXL metadata and descriptors.
+    """
+
+    placement = request.get("gms_placement")
+    if not isinstance(placement, dict) or not local_daemon_socket:
+        return None
+
+    log = logger or _LOG
+    try:
+        timeout_s = float(os.environ.get("DYNAMO_GMS_ROUTER_FETCH_TIMEOUT_S", "30.0"))
+    except ValueError:
+        timeout_s = 30.0
+    try:
+        batch_size = int(os.environ.get("DYNAMO_GMS_ROUTER_FETCH_BATCH_SIZE", "0"))
+    except ValueError:
+        batch_size = 0
+
+    try:
+        result = await asyncio.to_thread(
+            _fetch_gms_placement_sync,
+            placement=placement,
+            local_daemon_socket=local_daemon_socket,
+            timeout_s=timeout_s,
+            batch_size=batch_size,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.debug(
+            "GMS router placement fetch failed for request %s: %s",
+            request_id or "",
+            exc,
+            exc_info=True,
+        )
+        return None
+
+    if result and result.get("failed", 0):
+        log.warning(
+            "GMS router placement fetch had failures for request %s: %s",
+            request_id or "",
+            result,
+        )
+    elif result:
+        log.debug(
+            "GMS router placement fetch completed for request %s: %s",
+            request_id or "",
+            result,
+        )
+    return result

--- a/components/src/dynamo/sglang/failover_watchdog.py
+++ b/components/src/dynamo/sglang/failover_watchdog.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast failover fencing for SGLang subprocess crashes."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+import os
+import signal
+import threading
+import time
+from typing import Any, Iterable
+
+from dynamo.common.gms_failover import release_attached_gms_failover_lock
+
+logger = logging.getLogger(__name__)
+
+
+def _truthy_env(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _watchdog_enabled() -> bool:
+    return _truthy_env("DYN_SGLANG_GMS_FAILOVER_CHILD_WATCHDOG", default=True)
+
+
+def _poll_interval_s() -> float:
+    raw = os.environ.get("DYN_SGLANG_GMS_FAILOVER_CHILD_WATCHDOG_POLL_MS", "5")
+    try:
+        return max(0.01, float(raw) / 1000.0)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid DYN_SGLANG_GMS_FAILOVER_CHILD_WATCHDOG_POLL_MS=%r",
+            raw,
+        )
+        return 0.05
+
+
+def _process_alive(proc: Any) -> bool:
+    is_alive = getattr(proc, "is_alive", None)
+    if callable(is_alive):
+        try:
+            return bool(is_alive())
+        except Exception:
+            logger.debug("SGLang process liveness check failed", exc_info=True)
+            return True
+
+    pid = getattr(proc, "pid", None)
+    if not pid:
+        return False
+    return _pid_running(int(pid))
+
+
+def _process_failed(proc: Any) -> bool:
+    if _process_alive(proc):
+        return False
+    exitcode = getattr(proc, "exitcode", None)
+    return exitcode != 0
+
+
+def _pid_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+    try:
+        with open(f"/proc/{pid}/stat", "r", encoding="utf-8") as stat_file:
+            parts = stat_file.read().split()
+        return len(parts) < 3 or parts[2] != "Z"
+    except OSError:
+        return True
+
+
+def _terminate_pid(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    except PermissionError:
+        logger.warning("[GMS failover] cannot SIGKILL SGLang child pid=%s", pid)
+
+
+def _child_pids(engine: Any) -> list[int]:
+    get_all_child_pids = getattr(engine, "get_all_child_pids", None)
+    if callable(get_all_child_pids):
+        try:
+            return [int(pid) for pid in get_all_child_pids() if pid]
+        except Exception:
+            logger.debug("SGLang get_all_child_pids failed", exc_info=True)
+
+    result = getattr(engine, "_scheduler_init_result", None)
+    return [int(pid) for pid in getattr(result, "all_child_pids", []) if pid]
+
+
+def _watchdog_processes(engine: Any) -> tuple[list[Any], list[str]]:
+    tokenizer_manager = getattr(engine, "tokenizer_manager", None)
+    watchdog = getattr(tokenizer_manager, "_subprocess_watchdog", None)
+    processes = list(getattr(watchdog, "_processes", []) or [])
+    names = list(getattr(watchdog, "_names", []) or [])
+    if processes and len(names) != len(processes):
+        names = [f"process_{idx}" for idx in range(len(processes))]
+    return processes, names
+
+
+def _failed_watchdog_child(engine: Any) -> tuple[str, Any] | None:
+    processes, names = _watchdog_processes(engine)
+    for proc, name in zip(processes, names):
+        if _process_failed(proc):
+            return str(name), proc
+    return None
+
+
+def _scheduler_dead(engine: Any) -> bool:
+    # Historical test helper name. Any failed SGLang child is fatal for serving
+    # and must fence all children before the old endpoint can linger in discovery.
+    if _failed_watchdog_child(engine) is not None:
+        return True
+
+    pids = _child_pids(engine)
+    return bool(pids) and any(not _pid_running(pid) for pid in pids)
+
+
+def _fence_children(engine: Any, *, wait_s: float = 0.25) -> None:
+    pids = _child_pids(engine)
+    for pid in pids:
+        if _pid_running(pid):
+            _terminate_pid(pid)
+
+    deadline = time.monotonic() + wait_s
+    while time.monotonic() < deadline:
+        if all(not _pid_running(pid) for pid in pids):
+            return
+        time.sleep(0.01)
+
+    alive = [pid for pid in pids if _pid_running(pid)]
+    if alive:
+        logger.warning(
+            "[GMS failover] SGLang child fence timed out; still-running pids=%s",
+            alive,
+        )
+
+
+class SGLangGmsFailoverChildWatchdog:
+    """Release active ownership promptly after fenced SGLang child failure."""
+
+    def __init__(
+        self, target: Any, engine: Any, loop: asyncio.AbstractEventLoop
+    ) -> None:
+        self._target = target
+        self._engine = engine
+        self._loop = loop
+        self._stop = threading.Event()
+        self._released = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._install_subprocess_watchdog_hook()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="sglang-gms-failover-child-watchdog",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=0.2)
+            self._thread = None
+
+    def _run(self) -> None:
+        interval = _poll_interval_s()
+        while not self._stop.wait(interval):
+            if (
+                self._released.is_set()
+                or getattr(self._target, "_gms_failover_lock", None) is None
+            ):
+                return
+            failed = _failed_watchdog_child(self._engine)
+            if failed is None and not _scheduler_dead(self._engine):
+                continue
+
+            name = failed[0] if failed is not None else "pid"
+            self._trigger_failure(f"detected SGLang child failure name={name}")
+            return
+
+    def _install_subprocess_watchdog_hook(self) -> None:
+        tokenizer_manager = getattr(self._engine, "tokenizer_manager", None)
+        watchdog = getattr(tokenizer_manager, "_subprocess_watchdog", None)
+        check_processes = getattr(watchdog, "_check_processes", None)
+        if not callable(check_processes) or getattr(
+            watchdog, "_dynamo_gms_failover_hooked", False
+        ):
+            return
+
+        def patched_check_processes() -> bool:
+            failed = _failed_watchdog_child(self._engine)
+            if failed is not None:
+                self._trigger_failure(
+                    f"SGLang subprocess watchdog detected child failure name={failed[0]}"
+                )
+            return check_processes()
+
+        setattr(watchdog, "_check_processes", patched_check_processes)
+        setattr(watchdog, "_dynamo_gms_failover_hooked", True)
+        logger.info("[GMS failover] hooked SGLang subprocess watchdog")
+
+    def _trigger_failure(self, reason: str) -> None:
+        if (
+            self._released.is_set()
+            or getattr(self._target, "_gms_failover_lock", None) is None
+        ):
+            return
+
+        logger.warning(
+            "[GMS failover] %s; fencing children before releasing active lock",
+            reason,
+        )
+        _fence_children(self._engine)
+        self._released.set()
+        future = asyncio.run_coroutine_threadsafe(
+            self._release_after_fence(), self._loop
+        )
+        try:
+            future.result(timeout=0.25)
+        except concurrent.futures.TimeoutError:
+            logger.warning(
+                "[GMS failover] SGLang child watchdog release did not finish before shutdown"
+            )
+        except RuntimeError:
+            logger.debug(
+                "[GMS failover] SGLang child watchdog release could not be scheduled",
+                exc_info=True,
+            )
+        except Exception:
+            logger.debug(
+                "[GMS failover] SGLang child watchdog release failed", exc_info=True
+            )
+
+    async def _release_after_fence(self) -> None:
+        endpoint = getattr(self._target, "generate_endpoint", None)
+        unregister = getattr(endpoint, "unregister_endpoint_instance", None)
+        if callable(unregister):
+            try:
+                await unregister()
+            except Exception:
+                logger.debug(
+                    "[GMS failover] SGLang child watchdog endpoint unregister failed",
+                    exc_info=True,
+                )
+
+        await release_attached_gms_failover_lock(self._target, backend_name="sglang")
+        shutdown_event = getattr(self._target, "shutdown_event", None)
+        if shutdown_event is not None:
+            shutdown_event.set()
+
+
+def maybe_start_gms_failover_child_watchdog(
+    target: Any,
+    engine: Any,
+    *,
+    loop: asyncio.AbstractEventLoop | None = None,
+) -> SGLangGmsFailoverChildWatchdog | None:
+    if not _truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE") or not _watchdog_enabled():
+        return None
+    if getattr(target, "_gms_failover_lock", None) is None:
+        return None
+
+    loop = loop or asyncio.get_running_loop()
+    watchdog = SGLangGmsFailoverChildWatchdog(target, engine, loop)
+    setattr(target, "_gms_failover_child_watchdog", watchdog)
+    watchdog.start()
+    logger.info("[GMS failover] started SGLang child watchdog")
+    return watchdog
+
+
+def maybe_start_rank_liveness(
+    target: Any,
+    engine: Any,
+    *,
+    node_rank: int,
+    leader_host: str | None,
+    loop: asyncio.AbstractEventLoop | None = None,
+    expected_ranks: Iterable[int] | None = None,
+):
+    """Start the cross-node ZMQ rank-liveness channel for SGLang.
+
+    Worker nodes (node_rank>=1) heartbeat the leader. The leader (node_rank==0)
+    monitors those heartbeats and, on a worker going silent (process death),
+    reuses the child watchdog's fence+release path — so a remote rank crash is
+    detected in ~one heartbeat-timeout instead of via the NCCL collective timeout.
+    Local detection (child watchdog) and pure hangs (engine/NCCL watchdog) are
+    unaffected; this only adds the fast cross-node *crash* path.
+    """
+    from dynamo.common import rank_liveness as rl
+
+    if not rl.liveness_enabled() or not _truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE"):
+        return None
+
+    if node_rank >= 1:
+        if not leader_host:
+            logger.warning(
+                "[GMS liveness] no leader host for worker rank %d; skipping", node_rank
+            )
+            return None
+        client = rl.RankLivenessClient(leader_host, node_rank)
+        if target is not None:
+            setattr(target, "_gms_rank_liveness_client", client)
+        client.start()
+        return client
+
+    # Leader side: trigger failover when a worker rank dies.
+    loop = loop or asyncio.get_running_loop()
+
+    def on_rank_lost(rank: int, reason: str) -> None:
+        watchdog = getattr(target, "_gms_failover_child_watchdog", None)
+        if watchdog is not None:
+            watchdog._trigger_failure(
+                f"cross-node rank {rank} liveness lost ({reason})"
+            )
+            return
+        logger.warning(
+            "[GMS liveness] rank %d lost (%s); fencing + releasing lock directly",
+            rank,
+            reason,
+        )
+        try:
+            _fence_children(engine)
+        except Exception:
+            logger.debug("[GMS liveness] fence on rank loss failed", exc_info=True)
+        asyncio.run_coroutine_threadsafe(
+            release_attached_gms_failover_lock(target, backend_name="sglang"), loop
+        )
+
+    monitor = rl.RankLivenessMonitor(on_rank_lost, expected_ranks=expected_ranks)
+    setattr(target, "_gms_rank_liveness_monitor", monitor)
+    monitor.start()
+    return monitor

--- a/components/src/dynamo/sglang/failover_watchdog.py
+++ b/components/src/dynamo/sglang/failover_watchdog.py
@@ -89,6 +89,17 @@ def _terminate_pid(pid: int) -> None:
         logger.warning("[GMS failover] cannot SIGKILL SGLang child pid=%s", pid)
 
 
+def _request_owner_shutdown() -> None:
+    """Close the failed request plane after its ownership handoff is complete.
+
+    The TP children are already fenced, so graceful draining cannot complete;
+    SIGTERM would add the normal five-second grace period and then wait on
+    handlers whose engine no longer exists.  This kills only the Dynamo/SGLang
+    engine process.  The GMS sidecars continue owning weights and KV memory.
+    """
+    os.kill(os.getpid(), signal.SIGKILL)
+
+
 def _child_pids(engine: Any) -> list[int]:
     get_all_child_pids = getattr(engine, "get_all_child_pids", None)
     if callable(get_all_child_pids):
@@ -210,6 +221,12 @@ class SGLangGmsFailoverChildWatchdog:
                 self._trigger_failure(
                     f"SGLang subprocess watchdog detected child failure name={failed[0]}"
                 )
+                # The GMS watchdog already fenced every child, unregistered the
+                # endpoint, released ownership, and requested shutdown.  Do not
+                # call SGLang's original failure path: it sends SIGQUIT, whose
+                # crash-diagnostics handler intentionally sleeps for five seconds
+                # before closing the request-plane stream.
+                return True
             return check_processes()
 
         setattr(watchdog, "_check_processes", patched_check_processes)
@@ -264,6 +281,10 @@ class SGLangGmsFailoverChildWatchdog:
         shutdown_event = getattr(self._target, "shutdown_event", None)
         if shutdown_event is not None:
             shutdown_event.set()
+        logger.info(
+            "[GMS failover] sglang controlled handoff complete; closing request plane"
+        )
+        _request_owner_shutdown()
 
 
 def maybe_start_gms_failover_child_watchdog(

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -11,10 +11,19 @@ import sglang as sgl
 from sglang.srt.observability.trace import set_global_trace_level
 
 from dynamo.common.constants import DisaggregationMode
+from dynamo.common.gms_failover import (
+    acquire_gms_failover_lock_before_init,
+    prepare_gms_failover,
+    run_gms_failover_promotion_warmup,
+)
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.llm import ModelInput, ModelType, WorkerType
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
+from dynamo.sglang.failover_watchdog import (
+    maybe_start_gms_failover_child_watchdog,
+    maybe_start_rank_liveness,
+)
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangHealthCheckPayload,
@@ -27,6 +36,108 @@ from dynamo.sglang.publisher import (
 )
 from dynamo.sglang.register import register_model_with_readiness_gate
 from dynamo.sglang.request_handlers import DecodeWorkerHandler, PrefillWorkerHandler
+from dynamo.sglang.request_handlers.handler_base import SGLangEnginePauseController
+
+
+def _truthy_env(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _private_bootstrap_shadow_prewarm_enabled() -> bool:
+    return _truthy_env("DYN_SGLANG_GMS_SHADOW_PREWARM", default=False)
+
+
+def _is_private_bootstrap_shadow() -> bool:
+    if not _truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE"):
+        return False
+    if not _truthy_env("DYN_SGLANG_GMS_PRIVATE_BOOTSTRAP_KV"):
+        return False
+    engine_id = os.environ.get("ENGINE_ID", "0")
+    primary_engine_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    return engine_id != primary_engine_id
+
+
+def _rank_liveness_leader_host(server_args) -> Optional[str]:
+    """Leader host that worker nodes heartbeat — derived from --dist-init-addr."""
+    addr = getattr(server_args, "dist_init_addr", None)
+    if not addr:
+        return None
+    # "host:port" or "[ipv6]:port" -> host
+    return addr.rsplit(":", 1)[0].strip("[]")
+
+
+class _NonLeaderFailoverController:
+    """Rank-local failover controller for SGLang non-leader nodes."""
+
+    def __init__(self, engine: sgl.Engine) -> None:
+        self._delegate = (
+            SGLangEnginePauseController(engine)
+            if getattr(engine, "tokenizer_manager", None) is not None
+            else None
+        )
+        self._is_quiesced = False
+
+    async def quiesce(self, tags: Optional[list[str]] = None) -> bool:
+        # The delegate only handles quiesce when it actually implements it (the
+        # leader rank's request handler). A standby whose delegate has no quiesce
+        # (e.g. a DecodeWorkerHandler) falls through to the lock-only path.
+        if self._delegate is not None and hasattr(self._delegate, "quiesce"):
+            return await self._delegate.quiesce(tags)
+        if self._is_quiesced:
+            return False
+        logging.info(
+            "[GMS failover] sglang rank has no quiesce-capable handler; "
+            "using lock-only quiesce"
+        )
+        self._is_quiesced = True
+        return True
+
+    async def resume(self, tags: Optional[list[str]] = None) -> bool:
+        if self._delegate is not None and hasattr(self._delegate, "resume"):
+            return await self._delegate.resume(tags)
+        if not self._is_quiesced:
+            return False
+        self._is_quiesced = False
+        return True
+
+    def mark_resumed(self) -> None:
+        if self._delegate is not None and hasattr(self._delegate, "mark_resumed"):
+            self._delegate.mark_resumed()
+        self._is_quiesced = False
+
+
+class _NonLeaderFailoverOwner:
+    """Failover owner for SGLang multinode ranks that do not publish endpoints."""
+
+    def __init__(self, engine: sgl.Engine) -> None:
+        self._quiesce_controller = _NonLeaderFailoverController(engine)
+
+
+async def _prepare_non_leader_failover(
+    engine: sgl.Engine,
+    runtime: DistributedRuntime,
+    early_failover_activation,
+) -> _NonLeaderFailoverOwner | None:
+    owner = _NonLeaderFailoverOwner(engine)
+    if early_failover_activation is not None and early_failover_activation.enabled:
+        early_failover_activation.attach_to(owner)
+        maybe_start_gms_failover_child_watchdog(owner, engine)
+        return owner
+
+    failover_activation = await prepare_gms_failover(
+        owner,
+        runtime,
+        backend_name="sglang",
+        promotion_warmup=None,
+    )
+    if not failover_activation.enabled:
+        return None
+    failover_activation.attach_to(owner)
+    maybe_start_gms_failover_child_watchdog(owner, engine)
+    return owner
 
 
 async def _warmup_prefill_engine(engine: sgl.Engine, server_args) -> None:
@@ -60,6 +171,13 @@ async def init_decode(
     clear_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.clear_kv_blocks"
     )
+
+    early_failover_activation = None
+    lock_before_init = os.environ.get("DYN_SGLANG_GMS_LOCK_BEFORE_INIT", "1").lower()
+    if lock_before_init not in {"0", "false", "no", "off"}:
+        early_failover_activation = await acquire_gms_failover_lock_before_init(
+            backend_name="sglang"
+        )
 
     # Use pre-created engine if provided (snapshot mode)
     if snapshot_engine is not None:
@@ -104,6 +222,20 @@ async def init_decode(
     logging.debug(f"SGLang model load time: {load_time:.2f}s")
 
     if server_args.node_rank >= 1:
+        non_leader_failover_owner = await _prepare_non_leader_failover(
+            engine, runtime, early_failover_activation
+        )
+        # Heartbeat the leader over ZMQ so a crash of this worker node is detected
+        # in ~one heartbeat-timeout instead of via the NCCL collective timeout.
+        maybe_start_rank_liveness(
+            non_leader_failover_owner,
+            engine,
+            node_rank=server_args.node_rank,
+            leader_host=_rank_liveness_leader_host(server_args),
+        )
+        # Keep the owner alive for the non-leader loop. Its attached lock fd is
+        # the local primary/shadow fencing token.
+        _ = non_leader_failover_owner
         await handle_non_leader_node(engine, publisher, metrics_task)
         return
 
@@ -127,6 +259,52 @@ async def init_decode(
         health_check_payload = SglangHealthCheckPayload(
             engine, use_text_input=dynamo_args.use_sglang_tokenizer
         ).to_dict()
+
+    async def promotion_warmup() -> None:
+        await run_gms_failover_promotion_warmup(
+            handler.generate, health_check_payload, backend_name="sglang"
+        )
+
+    if early_failover_activation is not None and early_failover_activation.enabled:
+        early_failover_activation.attach_to(handler)
+        await promotion_warmup()
+    else:
+        shadow_prewarmed = False
+        if (
+            _private_bootstrap_shadow_prewarm_enabled()
+            and _is_private_bootstrap_shadow()
+        ):
+            logging.info(
+                "[GMS failover] sglang private-bootstrap shadow prewarm starting"
+            )
+            await promotion_warmup()
+            shadow_prewarmed = True
+            logging.info(
+                "[GMS failover] sglang private-bootstrap shadow prewarm complete"
+            )
+        # Give the serving handler a quiesce-capable failover controller so a
+        # shadow can quiesce (pause/release memory) before discovery; without it
+        # gms_failover falls back to the raw handler, which has no quiesce.
+        if getattr(handler, "_quiesce_controller", None) is None:
+            handler._quiesce_controller = SGLangEnginePauseController(engine)
+        failover_activation = await prepare_gms_failover(
+            handler,
+            runtime,
+            backend_name="sglang",
+            promotion_warmup=None if shadow_prewarmed else promotion_warmup,
+        )
+        failover_activation.attach_to(handler)
+    maybe_start_gms_failover_child_watchdog(handler, engine)
+    # Leader side of the cross-node liveness channel: watch worker heartbeats and,
+    # on a worker crash, reuse the fence+release path to fail over to the warm shadow.
+    if server_args.nnodes and server_args.nnodes > 1:
+        maybe_start_rank_liveness(
+            handler,
+            engine,
+            node_rank=0,
+            leader_host=None,
+            expected_ranks=range(1, server_args.nnodes),
+        )
 
     logging.info(f"Registering model with endpoint types: {dynamo_args.endpoint_types}")
     if dynamo_args.custom_jinja_template and "chat" not in dynamo_args.endpoint_types:

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -131,6 +131,7 @@ async def _prepare_non_leader_failover(
         owner,
         runtime,
         backend_name="sglang",
+        tags=["kv_cache"],
         promotion_warmup=None,
     )
     if not failover_activation.enabled:
@@ -291,6 +292,10 @@ async def init_decode(
             handler,
             runtime,
             backend_name="sglang",
+            # GMS weights are immutable, shared, and already coexist mapped in
+            # primary and shadow during prewarm.  Quiesce only the private KV
+            # namespace so promotion does not remap weights on the hot path.
+            tags=["kv_cache"],
             promotion_warmup=None if shadow_prewarmed else promotion_warmup,
         )
         failover_activation.attach_to(handler)

--- a/components/src/dynamo/sglang/pause.py
+++ b/components/src/dynamo/sglang/pause.py
@@ -56,6 +56,12 @@ class SGLangEnginePauseController:
         self._is_paused = True
         return True
 
+    async def quiesce(self, tags: list[str] | None = None) -> bool:
+        # GMS failover quiesce == pause: release the engine's memory occupation
+        # (compute/activation) while the GMS-owned KV pool persists, so a shadow
+        # coexists out-of-discovery until it is promoted.
+        return await self.pause(tags)
+
     async def resume(self, tags: list[str] | None = None) -> bool:
         if not self._is_paused and not self._generation_paused:
             return False

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -374,6 +374,10 @@ async def _get_runtime_config(
         dynamo_args.enable_local_indexer and not is_decode_worker
     )
 
+    if os.environ.get("GMS_SGLANG_DAEMON_SOCKET"):
+        runtime_config.set_gms_placement_enabled()
+        logging.info("Publishing GMS placement capability to discovery")
+
     start_dp_rank, end_dp_rank = model_card_dp_rank_bounds(server_args)
     registered_dp_size = end_dp_rank - start_dp_rank
     runtime_config.data_parallel_start_rank = start_dp_rank

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -27,6 +27,7 @@ from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 
 from dynamo._core import Context
 from dynamo.common.constants import DisaggregationMode
+from dynamo.common.gms_failover import release_attached_gms_failover_lock
 from dynamo.common.lora.manager import get_lora_manager
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.common.utils.input_params import InputParamManager
@@ -736,12 +737,28 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
 
             unregistered = False
             try:
-                # Stop new requests and drain in-flight work before releasing memory.
+                # Stop new requests before memory or ownership transitions.
                 if self.generate_endpoint is not None:
                     await self.generate_endpoint.unregister_endpoint_instance()
                     unregistered = True
 
+                if body.get("handoff"):
+                    lock_released = await release_attached_gms_failover_lock(
+                        self, backend_name="sglang"
+                    )
+                    return {
+                        "status": "ok",
+                        "message": "Failover handoff released",
+                        "failover_lock_released": lock_released,
+                    }
+
                 await self._pause_controller.pause(tags)
+
+                lock_released = False
+                if body.get("release_failover_lock"):
+                    lock_released = await release_attached_gms_failover_lock(
+                        self, backend_name="sglang"
+                    )
 
                 return {
                     "status": "ok",
@@ -750,6 +767,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
                         if tags is not None
                         else "Memory released"
                     ),
+                    "failover_lock_released": lock_released,
                 }
             except Exception as e:
                 logging.error(f"Failed to release memory occupation: {e}")
@@ -1005,6 +1023,9 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
 
     def cleanup(self) -> None:
         """Cleanup resources. Override in subclasses as needed."""
+        watchdog = getattr(self, "_gms_failover_child_watchdog", None)
+        if watchdog is not None:
+            watchdog.stop()
         if self.publisher is not None:
             self.publisher.cleanup()
 

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -15,6 +15,10 @@ from dynamo.common.constants import DisaggregationMode
 from dynamo.common.metadata_upload import MetadataUploader
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.utils.engine_response import normalize_finish_reason
+from dynamo.gms_router_policy import (
+    maybe_fetch_gms_placement,
+    resolve_env_gms_daemon_socket,
+)
 from dynamo.sglang._compat import (
     filter_supported_async_generate_kwargs,
     require_reasoning_kwargs,
@@ -357,6 +361,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         lora_path = self._resolve_lora(request)
         if lora_path:
             logging.debug(f"Request {context.id()} will use LoRA adapter: {lora_path}")
+
+        await maybe_fetch_gms_placement(
+            request,
+            resolve_env_gms_daemon_socket("GMS_SGLANG_DAEMON_SOCKET"),
+            logger=logging.getLogger(__name__),
+            request_id=context.id(),
+        )
 
         if self.serving_mode == DisaggregationMode.DECODE:
             raise_if_unextracted_multimodal(request)

--- a/components/src/dynamo/sglang/tests/test_sglang_failover.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_failover.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+def _install_sglang_test_compat_modules() -> None:
+    if "sglang.srt.observability.trace" not in sys.modules:
+        observability_module = sys.modules.setdefault(
+            "sglang.srt.observability",
+            types.ModuleType("sglang.srt.observability"),
+        )
+        trace_module = types.ModuleType("sglang.srt.observability.trace")
+        trace_module.set_global_trace_level = lambda *_args, **_kwargs: None
+        setattr(observability_module, "trace", trace_module)
+        sys.modules["sglang.srt.observability.trace"] = trace_module
+
+    if "dynamo.sglang.register" not in sys.modules:
+        register_module = types.ModuleType("dynamo.sglang.register")
+
+        async def register_model_with_readiness_gate(*_args, **_kwargs):
+            return True
+
+        register_module.register_model_with_readiness_gate = (
+            register_model_with_readiness_gate
+        )
+        sys.modules["dynamo.sglang.register"] = register_module
+
+
+_install_sglang_test_compat_modules()
+import dynamo.sglang.init_llm as init_llm
+from dynamo.sglang.failover_watchdog import (
+    _scheduler_dead,
+    maybe_start_gms_failover_child_watchdog,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _FakeEndpoint:
+    def connection_id(self):
+        return 1234
+
+
+class _FakeRuntime:
+    def endpoint(self, name):
+        return _FakeEndpoint()
+
+
+class _FakePublisher:
+    def __init__(self):
+        self.component_gauges = SimpleNamespace(set_model_load_time=lambda value: None)
+
+
+@pytest.mark.asyncio
+async def test_non_leader_decode_prepares_failover_before_publisher_loop(monkeypatch):
+    events = []
+
+    async def fake_prepare(engine, runtime, early_failover_activation):
+        events.append("prepare")
+        return object()
+
+    async def fake_setup_sgl_metrics(engine, config, generate_endpoint):
+        metrics_task = asyncio.create_task(asyncio.Event().wait())
+        return _FakePublisher(), metrics_task, []
+
+    async def fake_handle_non_leader_node(engine, publisher, metrics_task):
+        events.append("handle_non_leader")
+        metrics_task.cancel()
+
+    monkeypatch.setattr(init_llm, "_prepare_non_leader_failover", fake_prepare)
+    monkeypatch.setattr(init_llm, "setup_sgl_metrics", fake_setup_sgl_metrics)
+    monkeypatch.setattr(init_llm, "handle_non_leader_node", fake_handle_non_leader_node)
+
+    server_args = SimpleNamespace(
+        node_rank=1,
+        enable_forward_pass_metrics=False,
+        enable_trace=False,
+    )
+    dynamo_args = SimpleNamespace(
+        namespace="test-ns",
+        component="backend",
+        endpoint="generate",
+        sglang_trace_level=0,
+    )
+    config = SimpleNamespace(server_args=server_args, dynamo_args=dynamo_args)
+    engine = SimpleNamespace()
+
+    await init_llm.init_decode(
+        _FakeRuntime(),
+        config,
+        asyncio.Event(),
+        [],
+        snapshot_engine=engine,
+    )
+
+    assert events == ["prepare", "handle_non_leader"]
+
+
+@pytest.mark.asyncio
+async def test_non_leader_failover_controller_allows_missing_tokenizer_manager(
+    monkeypatch,
+):
+    monkeypatch.delenv("DYN_GMS_FAILOVER_SHADOW_MODE", raising=False)
+    controller = init_llm._NonLeaderFailoverController(SimpleNamespace())
+
+    assert await controller.quiesce(["kv_cache"]) is True
+    assert await controller.quiesce(["kv_cache"]) is False
+    assert await controller.resume(["kv_cache"]) is True
+    assert await controller.resume(["kv_cache"]) is False
+
+
+@pytest.mark.asyncio
+async def test_prepare_non_leader_failover_attaches_lock_owner(monkeypatch):
+    calls = []
+
+    class FakeActivation:
+        enabled = True
+
+        def attach_to(self, owner):
+            owner.lock_attached = True
+
+    async def fake_prepare(owner, runtime, **kwargs):
+        calls.append((owner, runtime, kwargs))
+        return FakeActivation()
+
+    monkeypatch.setattr(init_llm, "prepare_gms_failover", fake_prepare)
+
+    engine = SimpleNamespace(tokenizer_manager=SimpleNamespace())
+    runtime = object()
+    owner = await init_llm._prepare_non_leader_failover(engine, runtime, None)
+
+    assert owner is calls[0][0]
+    assert owner.lock_attached is True
+    assert calls[0][1] is runtime
+    assert calls[0][2] == {"backend_name": "sglang", "promotion_warmup": None}
+
+
+def test_sglang_failover_watchdog_detects_dead_scheduler_process():
+    class Proc:
+        pid = 123
+        exitcode = -9
+
+        def is_alive(self):
+            return False
+
+    watchdog = SimpleNamespace(_processes=[Proc()], _names=["scheduler_0"])
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(_subprocess_watchdog=watchdog)
+    )
+
+    assert _scheduler_dead(engine) is True
+
+
+def test_sglang_failover_watchdog_detects_dead_detokenizer_process():
+    class Proc:
+        pid = 124
+        exitcode = -9
+
+        def is_alive(self):
+            return False
+
+    watchdog = SimpleNamespace(_processes=[Proc()], _names=["detokenizer"])
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(_subprocess_watchdog=watchdog)
+    )
+
+    assert _scheduler_dead(engine) is True
+
+
+@pytest.mark.asyncio
+async def test_sglang_failover_watchdog_releases_lock_after_fence(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "1")
+    monkeypatch.setenv("DYN_SGLANG_GMS_FAILOVER_CHILD_WATCHDOG_POLL_MS", "10")
+    released = asyncio.Event()
+    unregistered = asyncio.Event()
+
+    class Lock:
+        async def release(self):
+            released.set()
+
+    class Endpoint:
+        async def unregister_endpoint_instance(self):
+            unregistered.set()
+
+    class Proc:
+        pid = 456
+        exitcode = -9
+
+        def is_alive(self):
+            return False
+
+    target = SimpleNamespace(
+        _gms_failover_lock=Lock(),
+        generate_endpoint=Endpoint(),
+        shutdown_event=asyncio.Event(),
+    )
+    engine = SimpleNamespace(
+        get_all_child_pids=lambda: [],
+        tokenizer_manager=SimpleNamespace(
+            _subprocess_watchdog=SimpleNamespace(
+                _processes=[Proc()], _names=["scheduler_0"]
+            )
+        ),
+    )
+
+    watchdog = maybe_start_gms_failover_child_watchdog(target, engine)
+    try:
+        await asyncio.wait_for(released.wait(), timeout=1.0)
+        await asyncio.wait_for(unregistered.wait(), timeout=1.0)
+        assert target._gms_failover_lock is None
+        assert target.shutdown_event.is_set()
+    finally:
+        assert watchdog is not None
+        watchdog.stop()
+
+
+@pytest.mark.asyncio
+async def test_sglang_failover_watchdog_hooks_subprocess_watchdog(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "1")
+    released = asyncio.Event()
+
+    class Lock:
+        async def release(self):
+            released.set()
+
+    class Proc:
+        pid = 789
+        exitcode = -9
+
+        def is_alive(self):
+            return False
+
+    class SGLangWatchdog:
+        def __init__(self):
+            self._processes = [Proc()]
+            self._names = ["detokenizer"]
+            self.original_called = False
+
+        def _check_processes(self):
+            self.original_called = True
+            return True
+
+    sglang_watchdog = SGLangWatchdog()
+    target = SimpleNamespace(_gms_failover_lock=Lock(), shutdown_event=asyncio.Event())
+    engine = SimpleNamespace(
+        get_all_child_pids=lambda: [],
+        tokenizer_manager=SimpleNamespace(_subprocess_watchdog=sglang_watchdog),
+    )
+
+    watchdog = maybe_start_gms_failover_child_watchdog(target, engine)
+    try:
+        assert getattr(sglang_watchdog, "_dynamo_gms_failover_hooked") is True
+        assert sglang_watchdog._check_processes() is True
+        await asyncio.wait_for(released.wait(), timeout=1.0)
+        assert sglang_watchdog.original_called is True
+        assert target._gms_failover_lock is None
+        assert target.shutdown_event.is_set()
+    finally:
+        assert watchdog is not None
+        watchdog.stop()

--- a/components/src/dynamo/sglang/tests/test_sglang_failover.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_failover.py
@@ -11,16 +11,6 @@ import pytest
 
 
 def _install_sglang_test_compat_modules() -> None:
-    if "sglang.srt.observability.trace" not in sys.modules:
-        observability_module = sys.modules.setdefault(
-            "sglang.srt.observability",
-            types.ModuleType("sglang.srt.observability"),
-        )
-        trace_module = types.ModuleType("sglang.srt.observability.trace")
-        trace_module.set_global_trace_level = lambda *_args, **_kwargs: None
-        setattr(observability_module, "trace", trace_module)
-        sys.modules["sglang.srt.observability.trace"] = trace_module
-
     if "dynamo.sglang.register" not in sys.modules:
         register_module = types.ModuleType("dynamo.sglang.register")
 

--- a/components/src/dynamo/sglang/tests/test_sglang_failover.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_failover.py
@@ -31,9 +31,26 @@ def _install_sglang_test_compat_modules() -> None:
             register_model_with_readiness_gate
         )
         sys.modules["dynamo.sglang.register"] = register_module
+    if "sglang.srt.observability.trace" not in sys.modules:
+        try:
+            __import__("sglang.srt.observability.trace")
+        except ImportError:
+            observability = sys.modules.setdefault(
+                "sglang.srt.observability",
+                types.ModuleType("sglang.srt.observability"),
+            )
+            trace = types.ModuleType("sglang.srt.observability.trace")
+
+            def set_global_trace_level(*_args, **_kwargs):
+                return None
+
+            trace.set_global_trace_level = set_global_trace_level
+            observability.trace = trace
+            sys.modules["sglang.srt.observability.trace"] = trace
 
 
 _install_sglang_test_compat_modules()
+import dynamo.sglang.failover_watchdog as failover_watchdog
 import dynamo.sglang.init_llm as init_llm
 from dynamo.sglang.failover_watchdog import (
     _scheduler_dead,
@@ -144,7 +161,11 @@ async def test_prepare_non_leader_failover_attaches_lock_owner(monkeypatch):
     assert owner is calls[0][0]
     assert owner.lock_attached is True
     assert calls[0][1] is runtime
-    assert calls[0][2] == {"backend_name": "sglang", "promotion_warmup": None}
+    assert calls[0][2] == {
+        "backend_name": "sglang",
+        "tags": ["kv_cache"],
+        "promotion_warmup": None,
+    }
 
 
 def test_sglang_failover_watchdog_detects_dead_scheduler_process():
@@ -183,6 +204,10 @@ def test_sglang_failover_watchdog_detects_dead_detokenizer_process():
 async def test_sglang_failover_watchdog_releases_lock_after_fence(monkeypatch):
     monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "1")
     monkeypatch.setenv("DYN_SGLANG_GMS_FAILOVER_CHILD_WATCHDOG_POLL_MS", "10")
+    shutdown_requested = asyncio.Event()
+    monkeypatch.setattr(
+        failover_watchdog, "_request_owner_shutdown", shutdown_requested.set
+    )
     released = asyncio.Event()
     unregistered = asyncio.Event()
 
@@ -221,6 +246,7 @@ async def test_sglang_failover_watchdog_releases_lock_after_fence(monkeypatch):
         await asyncio.wait_for(unregistered.wait(), timeout=1.0)
         assert target._gms_failover_lock is None
         assert target.shutdown_event.is_set()
+        assert shutdown_requested.is_set()
     finally:
         assert watchdog is not None
         watchdog.stop()
@@ -229,6 +255,7 @@ async def test_sglang_failover_watchdog_releases_lock_after_fence(monkeypatch):
 @pytest.mark.asyncio
 async def test_sglang_failover_watchdog_hooks_subprocess_watchdog(monkeypatch):
     monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "1")
+    monkeypatch.setattr(failover_watchdog, "_request_owner_shutdown", lambda: None)
     released = asyncio.Event()
 
     class Lock:
@@ -264,7 +291,7 @@ async def test_sglang_failover_watchdog_hooks_subprocess_watchdog(monkeypatch):
         assert getattr(sglang_watchdog, "_dynamo_gms_failover_hooked") is True
         assert sglang_watchdog._check_processes() is True
         await asyncio.wait_for(released.wait(), timeout=1.0)
-        assert sglang_watchdog.original_called is True
+        assert sglang_watchdog.original_called is False
         assert target._gms_failover_lock is None
         assert target.shutdown_event.is_set()
     finally:

--- a/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
@@ -51,11 +51,15 @@ class _FakeManager:
         self.granted_lock_type = GrantedLockType(lock_type.value)
         self.is_unmapped = False
 
-    def reallocate_all_handles(self, *, tag: str) -> None:
-        self.calls.append(("reallocate_all_handles", tag))
-
     def remap_all_vas(self) -> None:
         self.calls.append("remap_all_vas")
+        self.is_unmapped = False
+
+    def prepare_scratch_for_reallocation(self) -> None:
+        self.calls.append("prepare_scratch_for_reallocation")
+
+    def remap_persistent_vas(self, engine_id: str, *, shared: bool) -> None:
+        self.calls.append(("remap_persistent_vas", engine_id, shared))
         self.is_unmapped = False
 
 
@@ -71,30 +75,92 @@ def build_impl(monkeypatch, tmp_path):
         *,
         weights_lock: GrantedLockType = GrantedLockType.RW,
         kv_cache_lock: GrantedLockType = GrantedLockType.RW,
+        private_bootstrap: bool = False,
+        allocation_engine_id: str = "sglang-test",
+        promotion_engine_id: str = "sglang-test",
+        allocation_shared: bool = True,
+        shared_kv_enabled: bool = True,
     ):
         weights = _FakeManager(granted_lock_type=weights_lock)
         kv_cache = _FakeManager(granted_lock_type=kv_cache_lock)
         pool_calls: list[tuple[str, torch.device]] = []
+        retarget_calls: list[tuple[str, str, bool]] = []
+        release_calls: list[str] = []
+        persistent_allocator_calls: list[tuple[str, int, str, str, bool, bool]] = []
 
         @contextmanager
         def fake_use_mem_pool(tag: str, device: torch.device):
             pool_calls.append((tag, device))
             yield
 
+        @contextmanager
+        def fake_use_persistent_pool(tag: str, device: torch.device):
+            pool_calls.append((tag, device))
+            yield
+
+        monkeypatch.setattr(
+            gms_memory_saver,
+            "allocation_engine_id",
+            lambda device: allocation_engine_id,
+        )
+        monkeypatch.setattr(
+            gms_memory_saver, "promotion_engine_id", lambda device: promotion_engine_id
+        )
+        monkeypatch.setattr(
+            gms_memory_saver,
+            "private_bootstrap_kv_enabled",
+            lambda: private_bootstrap,
+        )
+        monkeypatch.setattr(
+            gms_memory_saver, "allocation_shared", lambda: allocation_shared
+        )
+        monkeypatch.setattr(
+            gms_memory_saver, "shared_kv_enabled", lambda: shared_kv_enabled
+        )
         monkeypatch.setattr(
             gms_memory_saver,
             "get_or_create_gms_client_memory_manager",
-            lambda socket_path, device, mode, tag: {
-                "weights": weights,
-                "kv_cache": kv_cache,
-            }[tag],
+            lambda socket_path, device, mode, tag: weights,
+        )
+
+        def fake_get_or_create_persistent_allocator(
+            socket_path, device, engine_id, tag, *, shared, defer_physical=False
+        ):
+            persistent_allocator_calls.append(
+                (socket_path, device, engine_id, tag, shared, defer_physical)
+            )
+            return kv_cache
+
+        monkeypatch.setattr(
+            gms_memory_saver,
+            "get_or_create_persistent_allocator",
+            fake_get_or_create_persistent_allocator,
+        )
+        monkeypatch.setattr(
+            gms_memory_saver,
+            "retarget_persistent_allocator",
+            lambda tag, engine_id, shared: retarget_calls.append(
+                (tag, engine_id, shared)
+            ),
+        )
+        monkeypatch.setattr(
+            gms_memory_saver,
+            "release_private_bootstrap_kv_pool",
+            lambda manager, engine_id, logger=None: release_calls.append(engine_id)
+            or 1,
         )
         monkeypatch.setattr(gms_memory_saver, "gms_use_mem_pool", fake_use_mem_pool)
+        monkeypatch.setattr(
+            gms_memory_saver, "gms_use_persistent_pool", fake_use_persistent_pool
+        )
         return (
             GMSMemorySaverImpl(device_index=0, mode=None),
             weights,
             kv_cache,
             pool_calls,
+            retarget_calls,
+            release_calls,
+            persistent_allocator_calls,
         )
 
     return build
@@ -105,7 +171,11 @@ def build_impl(monkeypatch, tmp_path):
     [
         ("weights", GrantedLockType.RW, [("weights", torch.device("cuda", 0))]),
         ("weights", GrantedLockType.RO, []),
-        ("kv_cache", GrantedLockType.RW, [("kv_cache", torch.device("cuda", 0))]),
+        (
+            "kv_cache",
+            GrantedLockType.RW,
+            [("kv_pool:cuda0", torch.device("cuda", 0))],
+        ),
         ("cuda_graph", GrantedLockType.RW, []),
     ],
 )
@@ -115,7 +185,7 @@ def test_region_uses_gms_pool_only_for_rw_managed_tags(
     weights_lock,
     expected_pool_calls,
 ):
-    impl, _, _, pool_calls = build_impl(
+    impl, _, _, pool_calls, _, _, _ = build_impl(
         weights_lock=weights_lock,
         kv_cache_lock=GrantedLockType.RW,
     )
@@ -127,7 +197,7 @@ def test_region_uses_gms_pool_only_for_rw_managed_tags(
 
 
 def test_pause_resume_routes_only_managed_tags(build_impl):
-    impl, weights, kv_cache, _ = build_impl(
+    impl, weights, kv_cache, _, _, _, _ = build_impl(
         weights_lock=GrantedLockType.RO,
         kv_cache_lock=GrantedLockType.RW,
     )
@@ -147,17 +217,50 @@ def test_pause_resume_routes_only_managed_tags(build_impl):
     assert kv_cache.calls == [
         "unmap_all_vas",
         "abort",
-        ("connect", RequestedLockType.RW, None),
-        ("reallocate_all_handles", "kv_cache"),
-        "remap_all_vas",
+        ("connect", RequestedLockType.RW_PERSISTENT, None),
+        ("remap_persistent_vas", "sglang-test", True),
     ]
 
 
-@pytest.mark.parametrize("tag", ["weights", "kv_cache"])
-def test_region_requires_rw_allocator(build_impl, tag):
-    impl, _, _, _ = build_impl()
+def test_region_requires_rw_allocator(build_impl):
+    impl, _, _, _, _, _, _ = build_impl()
+    tag = "weights"
     impl.allocators[tag].abort()
 
-    with pytest.raises(RuntimeError, match=rf"requires '{tag}' to be RW"):
+    with pytest.raises(RuntimeError, match=rf"requires {tag!r} to be RW"):
         with impl.region(tag, enable_cpu_backup=False):
             pass
+
+
+def test_private_bootstrap_kv_resume_promotes_to_shared_namespace(build_impl):
+    (
+        impl,
+        _,
+        kv_cache,
+        _,
+        retarget_calls,
+        release_calls,
+        persistent_allocator_calls,
+    ) = build_impl(
+        private_bootstrap=True,
+        allocation_engine_id="sglang-test|bootstrap=1",
+        promotion_engine_id="sglang-test",
+        allocation_shared=False,
+        shared_kv_enabled=True,
+    )
+
+    impl.pause("kv_cache")
+    impl.resume("kv_cache")
+
+    assert kv_cache.calls == [
+        "unmap_all_vas",
+        "abort",
+        ("connect", RequestedLockType.RW_PERSISTENT, None),
+        "prepare_scratch_for_reallocation",
+        ("remap_persistent_vas", "sglang-test", True),
+    ]
+    assert persistent_allocator_calls[-1][4:] == (False, True)
+    assert retarget_calls == [("kv_pool:cuda0", "sglang-test", True)]
+    assert release_calls == ["sglang-test|bootstrap=1"]
+    assert impl._kv_engine_id == "sglang-test"
+    assert impl._kv_private_bootstrap is False

--- a/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
@@ -322,3 +322,36 @@ async def test_clear_kv_blocks_reports_flush_exception(handler):
     chunks = [chunk async for chunk in handler.clear_kv_blocks({})]
 
     assert chunks == [{"status": "error", "message": "flush crashed"}]
+
+
+@pytest.mark.asyncio
+async def test_release_memory_occupation_with_handoff_releases_failover_lock(handler):
+    lock = SimpleNamespace(release=AsyncMock())
+    handler._gms_failover_lock = lock
+
+    result = await handler.release_memory_occupation({"release_failover_lock": True})
+
+    assert result["status"] == "ok"
+    assert result["failover_lock_released"] is True
+    lock.release.assert_awaited_once()
+    assert handler._gms_failover_lock is None
+
+
+@pytest.mark.asyncio
+async def test_fast_handoff_releases_lock_without_memory_release(handler):
+    lock = SimpleNamespace(release=AsyncMock())
+    handler._gms_failover_lock = lock
+
+    result = await handler.release_memory_occupation({"handoff": True})
+
+    assert result == {
+        "status": "ok",
+        "message": "Failover handoff released",
+        "failover_lock_released": True,
+    }
+    handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
+    lock.release.assert_awaited_once()
+    assert handler._gms_failover_lock is None
+    assert handler._pause_controller.is_paused is False
+    handler.engine.tokenizer_manager.pause_generation.assert_not_awaited()
+    handler.engine.tokenizer_manager.release_memory_occupation.assert_not_awaited()

--- a/components/src/dynamo/vllm/engine_monitor.py
+++ b/components/src/dynamo/vllm/engine_monitor.py
@@ -12,6 +12,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo.common.engine_monitor import EngineHealthMonitorConfig
+from dynamo.common.utils.graceful_shutdown import is_shutdown_in_progress
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -116,6 +117,15 @@ class VllmEngineMonitor:
                     await asyncio.sleep(self.health_config.interval)
 
             except (EngineDeadError, asyncio.TimeoutError) as e:
+                if (
+                    self.shutdown_event and self.shutdown_event.is_set()
+                ) or is_shutdown_in_progress():
+                    logger.info(
+                        "vLLM AsyncLLM health check stopped during graceful shutdown: %s",
+                        e,
+                    )
+                    break
+
                 logger.error(f"Traceback: {traceback.format_exc()}")
                 logger.error(f"vLLM AsyncLLM health check failed: {e}")
                 logger.warning("Initiating Dynamo Runtime shutdown.")

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -44,6 +44,7 @@ from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo._core import Context
 from dynamo.common.backend import logprobs as _shared_logprobs
+from dynamo.common.gms_failover import release_attached_gms_failover_lock
 from dynamo.common.lora.manager import LoRAInfo, get_lora_manager
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
@@ -65,6 +66,10 @@ from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.common.utils.time_section import time_and_log_code_section
+from dynamo.gms_router_policy import (
+    maybe_fetch_gms_placement,
+    resolve_vllm_gms_daemon_socket,
+)
 from dynamo.llm import (
     KvEventPublisher,
     ModelInput,
@@ -305,13 +310,23 @@ class VllmEnginePauseController:
     def needs_resume_recovery(self) -> bool:
         return self._generation_paused
 
-    async def pause(self, *args: object) -> bool:
+    async def pause(self, *args: object, clear_cache: bool = True) -> bool:
         if self._is_paused or self._generation_paused:
             return False
 
         level = args[0] if args else None
-        await self._engine_client.pause_generation()
+        await self._engine_client.pause_generation(clear_cache=clear_cache)
         self._generation_paused = True
+        # GMS failover no-clear sleep path: keep KV cache contents and let the
+        # GMS engine-core hook perform the unmap so the pages survive for remap.
+        if not clear_cache and level is not None:
+            engine_core = getattr(self._engine_client, "engine_core", None)
+            call_utility_async = getattr(engine_core, "call_utility_async", None)
+            if call_utility_async is not None:
+                await call_utility_async("gms_sleep_no_clear", level, "abort")
+                self._is_paused = True
+                return True
+
         try:
             if level is None:
                 await self._engine_client.sleep()
@@ -1135,16 +1150,28 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     )
 
                 # Step 2: Abort in-flight requests and wait for them to drain so
-                # generation is fully paused before unmapping memory.
-                if not await self._pause_controller.pause(level):
+                # generation is fully paused before unmapping memory. On a
+                # failover handoff, keep the KV cache (no clear) so the GMS
+                # pages survive for remap by the standby.
+                handoff = bool(body.get("release_failover_lock") or body.get("handoff"))
+                if not await self._pause_controller.pause(
+                    level, clear_cache=not handoff
+                ):
                     return {
                         "status": "ok",
                         "message": "Engine already sleeping",
                     }
 
+                lock_released = False
+                if handoff:
+                    lock_released = await release_attached_gms_failover_lock(
+                        self, backend_name="vllm"
+                    )
+
                 return {
                     "status": "ok",
                     "message": f"Engine slept (level={level})",
+                    "failover_lock_released": lock_released,
                 }
             except Exception as e:
                 logger.error(f"Failed to sleep engine: {e}")
@@ -2797,6 +2824,12 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             return
 
         request = prepared_input.request
+        await maybe_fetch_gms_placement(
+            request,
+            resolve_vllm_gms_daemon_socket(self.engine_client.vllm_config),
+            logger=logger,
+            request_id=request_id,
+        )
         multi_modal_data = prepared_input.multi_modal_data
         mm_processor_kwargs = prepared_input.mm_processor_kwargs
         pre_rendered = prepared_input.pre_rendered_prompt

--- a/components/src/dynamo/vllm/headless.py
+++ b/components/src/dynamo/vllm/headless.py
@@ -20,9 +20,25 @@ so secondary nodes run neither this headless mode nor the backend at all.
 from __future__ import annotations
 
 import argparse
-import os
+import logging
 
 from .args import Config
+
+logger = logging.getLogger(__name__)
+GMS_VLLM_WORKER_CLS = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
+
+
+def _configure_gms_vllm_worker(engine_args) -> None:
+    current = getattr(engine_args, "worker_cls", None)
+    if current not in (None, "auto", GMS_VLLM_WORKER_CLS):
+        logger.warning(
+            "[GMS] Overriding user-provided vLLM worker_cls=%s with %s because "
+            "--load-format=gms requires the GMS worker integration",
+            current,
+            GMS_VLLM_WORKER_CLS,
+        )
+    engine_args.worker_cls = GMS_VLLM_WORKER_CLS
+    import gpu_memory_service.integrations.vllm.worker  # noqa: F401
 
 
 def build_headless_namespace(config: Config) -> argparse.Namespace:
@@ -46,11 +62,9 @@ def run_dynamo_headless(config: Config) -> None:
     no Dynamo endpoints. Bypasses DistributedRuntime entirely (no NATS/etcd).
     """
     # Propagate worker_cls for custom load formats so headless workers use
-    # the same model loader settings as the leader node.
+    # the same model loader and patches as the leader node.
     if config.engine_args.load_format == "gms":
-        config.engine_args.worker_cls = (
-            "gpu_memory_service.integrations.vllm.worker.GMSWorker"
-        )
+        _configure_gms_vllm_worker(config.engine_args)
 
         if config.gms_shadow_mode:
             from gpu_memory_service.integrations.vllm.utils import (
@@ -58,12 +72,14 @@ def run_dynamo_headless(config: Config) -> None:
                 configure_mx_ports,
             )
 
-            os.environ["DYN_GMS_SCRATCH_KV_ENABLED"] = "1"
             configure_gms_lock_mode(config.engine_args)
             configure_mx_ports(config.engine_args)
 
     # ModelExpress uses vLLM's plugin path with --load-format=modelexpress.
     # Dynamo does not set a custom worker class here.
+
+    # Detect failed secondary ranks before the NCCL collective timeout.
+    _maybe_start_vllm_rank_liveness_client(config)
 
     # Keep the upstream CLI import local so tests that only exercise
     # build_headless_namespace() do not pull in vLLM's full CLI import graph.
@@ -71,3 +87,18 @@ def run_dynamo_headless(config: Config) -> None:
 
     args = build_headless_namespace(config)
     run_headless(args)
+
+
+def _maybe_start_vllm_rank_liveness_client(config: Config) -> None:
+    """Start the worker-side ZMQ rank-liveness channel for headless nodes."""
+    from dynamo.common import rank_liveness as rl
+
+    if not rl.liveness_enabled() or not config.gms_shadow_mode:
+        return
+    engine_args = config.engine_args
+    node_rank = int(getattr(engine_args, "node_rank", 0) or 0)
+    leader_host = getattr(engine_args, "master_addr", None)
+    nnodes = int(getattr(engine_args, "nnodes", 1) or 1)
+    if nnodes <= 1 or node_rank < 1 or not leader_host:
+        return
+    rl.RankLivenessClient(leader_host, node_rank).start()

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402
 
 import asyncio
 import json
@@ -13,7 +14,69 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     from dynamo.vllm.omni.args import OmniConfig
 
+
+def _early_truthy_env(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _maybe_isolate_jit_cache_dirs_by_container() -> dict[str, tuple[str | None, str]]:
+    """Keep runtime JIT/cache locks pod-local and engine-container-local.
+
+    Bulwark primary and shadow containers can compile or materialize FlashInfer
+    artifacts at the same time. Some Kubernetes-mounted filesystems do not
+    reliably support fcntl locks under that contention, so keep these caches in
+    a container-specific tmpfs namespace before vLLM imports FlashInfer.
+    """
+
+    if not _early_truthy_env(
+        "DYN_VLLM_ISOLATE_JIT_CACHE_BY_CONTAINER",
+        default=_early_truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE"),
+    ):
+        return {}
+
+    container = os.environ.get("CONTAINER_NAME") or os.environ.get("ENGINE_ID")
+    if not container:
+        return {}
+
+    base = os.environ.get("DYN_VLLM_JIT_CACHE_BASE", "/dev/shm/dynamo-jit")
+    container_base = os.path.join(base, container)
+    mappings = {
+        "TMPDIR": "tmp",
+        "XDG_CACHE_HOME": "xdg-cache",
+        "VLLM_CACHE_ROOT": "vllm-cache",
+        "TORCHINDUCTOR_CACHE_DIR": "torchinductor-cache",
+        "TRITON_CACHE_DIR": "triton-cache",
+        "CUDA_CACHE_PATH": "cuda-cache",
+        "FLASHINFER_WORKSPACE_BASE": "flashinfer-workspace",
+        "FLASHINFER_CUBIN_DIR": "flashinfer-cubins",
+        "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR": "vllm-flashinfer-autotune",
+        "TILELANG_CACHE_DIR": "tilelang-cache",
+        "TILELANG_TMP_DIR": "tilelang-tmp",
+    }
+
+    changed: dict[str, tuple[str | None, str]] = {}
+    force = _early_truthy_env("DYN_VLLM_FORCE_CONTAINER_JIT_CACHE", default=True)
+    for name, suffix in mappings.items():
+        previous = os.environ.get(name)
+        value = os.path.join(container_base, suffix)
+        if previous == value:
+            continue
+        if previous and not force and not previous.startswith(base):
+            continue
+        os.environ[name] = value
+        changed[name] = (previous, value)
+    return changed
+
+
+_JIT_CACHE_DIR_ENV_CHANGES = _maybe_isolate_jit_cache_dirs_by_container()
+
 import uvloop
+from gpu_memory_service.integrations.vllm.kv_identity import (
+    private_bootstrap_scratch_warmup_enabled,
+)
 from huggingface_hub import try_to_load_from_cache
 from huggingface_hub.utils import HFValidationError
 from prometheus_client import REGISTRY, CollectorRegistry, multiprocess
@@ -36,6 +99,7 @@ from dynamo.common.utils.prometheus import (
 )
 from dynamo.common.utils.runtime import create_runtime
 from dynamo.common.utils.topology import apply_topology_config
+from dynamo.gms_router_policy import resolve_vllm_gms_daemon_socket
 from dynamo.llm import (
     KvEventPublisher,
     ModelInput,
@@ -67,6 +131,13 @@ from .snapshot import prepare_snapshot_engine
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
+if _JIT_CACHE_DIR_ENV_CHANGES:
+    logger.info(
+        "[GMS] Isolated vLLM runtime JIT/cache dirs for container=%s: %s",
+        os.environ.get("CONTAINER_NAME") or os.environ.get("ENGINE_ID"),
+        {name: value for name, (_, value) in _JIT_CACHE_DIR_ENV_CHANGES.items()},
+    )
+GMS_VLLM_WORKER_CLS = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
 shutdown_endpoints: list = []
 SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 MX_LOAD_FORMATS = {"modelexpress", "mx"}
@@ -107,6 +178,173 @@ def _register_model_source_path(config: Config, vllm_config: VllmConfig) -> str:
     if getattr(vllm_config.model_config, "model_weights", ""):
         return vllm_config.model_config.model
     return config.model
+
+
+def _truthy_env(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _gms_failover_shadow_member() -> bool:
+    if not (
+        _truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE")
+        or _truthy_env("DYN_VLLM_GMS_SHADOW_MODE")
+    ):
+        return False
+    if _truthy_env("DYN_VLLM_GMS_ACTIVE_LOCK_HELD"):
+        return False
+    if _truthy_env("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"):
+        return True
+    engine_id = os.environ.get("ENGINE_ID", "0")
+    primary_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    return engine_id != primary_id
+
+
+def _gms_private_bootstrap_shadow_member(config: Config) -> bool:
+    engine_args = getattr(config, "engine_args", None)
+    if getattr(engine_args, "load_format", None) != "gms":
+        return False
+    if not getattr(config, "gms_shadow_mode", False):
+        return False
+    if not _truthy_env(
+        "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV",
+        default=_truthy_env("GMS_VLLM_PRIVATE_BOOTSTRAP_KV"),
+    ):
+        return False
+    return _gms_failover_shadow_member()
+
+
+def _maybe_disable_gms_shadow_graphs_before_vllm_config(config: Config) -> bool:
+    if not _gms_private_bootstrap_shadow_member(config):
+        return False
+    if _truthy_env("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_CUDAGRAPH"):
+        return False
+    if private_bootstrap_scratch_warmup_enabled():
+        os.environ["GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED"] = "1"
+        logger.info(
+            "[GMS] Allowing vLLM graph warmup for scratch-backed "
+            "private-bootstrap shadow KV"
+        )
+        return False
+
+    previous = os.environ.get("VLLM_USE_BREAKABLE_CUDAGRAPH")
+    os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "0"
+    logger.info(
+        "[GMS] Disabled vLLM breakable cudagraph for private-bootstrap "
+        "shadow before vLLM config creation (previous=%r)",
+        previous,
+    )
+    return True
+
+
+def _apply_gms_shadow_graph_config(vllm_config: VllmConfig, *, disabled: bool) -> None:
+    if not disabled:
+        return
+
+    from vllm.config import CompilationMode, CUDAGraphMode
+
+    compilation_config = vllm_config.compilation_config
+    previous_mode = getattr(compilation_config, "cudagraph_mode", None)
+    previous_compile_mode = getattr(compilation_config, "mode", None)
+    compilation_config.mode = CompilationMode.NONE
+    compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+    logger.info(
+        "[GMS] Forced private-bootstrap shadow vLLM graph mode to eager: "
+        "compile_mode %s -> %s, cudagraph_mode %s -> %s",
+        previous_compile_mode,
+        compilation_config.mode,
+        previous_mode,
+        compilation_config.cudagraph_mode,
+    )
+
+
+def _is_gms_load_format(engine_args: Any) -> bool:
+    return str(getattr(engine_args, "load_format", "")) == "gms"
+
+
+def _configure_gms_vllm_worker(engine_args: Any) -> None:
+    """Force GMS worker setup early enough for spawned vLLM workers."""
+
+    current = getattr(engine_args, "worker_cls", None)
+    if current not in (None, "auto", GMS_VLLM_WORKER_CLS):
+        logger.warning(
+            "[GMS] Overriding user-provided vLLM worker_cls=%s with %s "
+            "because --load-format=gms requires the GMS worker integration",
+            current,
+            GMS_VLLM_WORKER_CLS,
+        )
+
+    engine_args.worker_cls = GMS_VLLM_WORKER_CLS
+
+    # Import eagerly so model-loader/KV patches fail before vLLM starts worker
+    # processes. Worker subprocesses still resolve the class by string.
+    import gpu_memory_service.integrations.vllm.worker  # noqa: F401
+
+    logger.info("[GMS] vLLM worker_cls configured as %s", GMS_VLLM_WORKER_CLS)
+
+
+def _verify_gms_vllm_worker_config(vllm_config: VllmConfig) -> None:
+    worker_cls = getattr(vllm_config.parallel_config, "worker_cls", None)
+    if worker_cls != GMS_VLLM_WORKER_CLS:
+        raise RuntimeError(
+            "GMS load format requires vLLM worker_cls="
+            f"{GMS_VLLM_WORKER_CLS}, got {worker_cls!r}"
+        )
+    logger.info("[GMS] Final vLLM parallel_config.worker_cls=%s", worker_cls)
+
+
+def _gms_shadow_init_geometry_wait_ms() -> int:
+    names = (
+        "DYN_VLLM_GMS_SHADOW_INIT_GEOMETRY_WAIT_MS",
+        "GMS_VLLM_KV_GEOMETRY_WAIT_MS",
+        "GMS_KV_LEASE_GEOMETRY_WAIT_MS",
+    )
+    wait_ms = 300_000
+    for name in names:
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        try:
+            wait_ms = int(value)
+        except ValueError:
+            logger.warning("Ignoring invalid %s=%r", name, value)
+            continue
+        break
+    return max(wait_ms, 0)
+
+
+def _maybe_wait_for_gms_primary_kv_before_init(config: Config) -> None:
+    if getattr(config.engine_args, "load_format", None) != "gms":
+        return
+    if not config.gms_shadow_mode:
+        return
+    if not _gms_failover_shadow_member():
+        return
+    if not _truthy_env("DYN_VLLM_GMS_WAIT_FOR_PRIMARY_KV_BEFORE_INIT", default=True):
+        return
+
+    from gpu_memory_service.integrations.vllm.install_vmm_ipc_kv import (
+        _existing_shared_kv_blocks,
+    )
+
+    wait_ms = _gms_shadow_init_geometry_wait_ms()
+    logger.info(
+        "[GMS] Shadow engine waiting up to %d ms for primary KV geometry "
+        "before vLLM engine initialization",
+        wait_ms,
+    )
+    blocks = _existing_shared_kv_blocks(wait_ms=wait_ms)
+    if blocks is None:
+        raise RuntimeError(
+            "Timed out waiting for primary GMS KV geometry before shadow "
+            "vLLM engine initialization"
+        )
+    logger.info(
+        "[GMS] Shadow engine observed primary KV geometry before init: blocks=%d",
+        blocks,
+    )
 
 
 async def worker(argv: list[str] | None = None) -> None:
@@ -159,15 +397,34 @@ async def worker(argv: list[str] | None = None) -> None:
         return
 
     shutdown_event = asyncio.Event()
+    engine_holder: list = []
     runtime, loop = create_runtime(
         discovery_backend=config.discovery_backend,
         request_plane=config.request_plane,
         event_plane=config.event_plane,
     )
 
+    async def cleanup_engine() -> None:
+        if not engine_holder:
+            logger.info("vLLM engine not initialized; skipping cleanup")
+            return
+
+        engine = engine_holder[0]
+        try:
+            engine.shutdown()
+            logger.info("vLLM engine shutdown complete")
+        except Exception as exc:
+            logger.warning("vLLM engine shutdown failed: %s", exc)
+
     # [gluo FIXME] should be after init() below? 'shutdown_endpoints' are populated
     # there
-    install_signal_handlers(loop, runtime, shutdown_endpoints, shutdown_event)
+    install_signal_handlers(
+        loop,
+        runtime,
+        shutdown_endpoints,
+        shutdown_event,
+        cleanup_callback=cleanup_engine,
+    )
 
     # Use WorkerFactory to appropriate initialize worker based on config flags
     factory = WorkerFactory(
@@ -183,6 +440,7 @@ async def worker(argv: list[str] | None = None) -> None:
         shutdown_event,
         shutdown_endpoints,
         snapshot_engine=snapshot_engine,
+        engine_holder=engine_holder,
     )
 
     logger.debug("Worker function completed, exiting...")
@@ -531,8 +789,8 @@ def setup_vllm_engine(
         if "VLLM_LORA_MODULES_LOADING_TIMEOUT" not in os.environ:
             os.environ["VLLM_LORA_MODULES_LOADING_TIMEOUT"] = "600"
 
-    if engine_args.load_format == "gms":
-        engine_args.worker_cls = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
+    if _is_gms_load_format(engine_args):
+        _configure_gms_vllm_worker(engine_args)
 
         if config.gms_shadow_mode:
             from gpu_memory_service.integrations.vllm.utils import (
@@ -540,14 +798,28 @@ def setup_vllm_engine(
                 configure_mx_ports,
             )
 
-            os.environ["DYN_GMS_SCRATCH_KV_ENABLED"] = "1"
-            logger.info(
-                "[GMS] Failover enabled: will use scratch KV for initialization until engine is primary"
-            )
             # ENGINE_ID=0 writes weights, all others import (RO).
             # Prevents deadlock during TP>1 failover.
             configure_gms_lock_mode(engine_args)
             configure_mx_ports(engine_args)
+
+    if engine_args.load_format in ("mx-source", "mx-target"):
+        try:
+            from modelexpress import register_modelexpress_loaders
+
+            if config.model_express_url:
+                os.environ["MODEL_EXPRESS_URL"] = config.model_express_url
+            register_modelexpress_loaders()
+            engine_args.worker_cls = "modelexpress.vllm_worker.ModelExpressWorker"
+        except ImportError as e:
+            raise ImportError(
+                f"ModelExpress package required for --load-format={engine_args.load_format}. "
+                "Install with: pip install modelexpress"
+            ) from e
+
+    gms_shadow_graphs_disabled = _maybe_disable_gms_shadow_graphs_before_vllm_config(
+        config
+    )
 
     # Must happen before create_engine_config() so vLLM sees ec_transfer_config.
     configure_multimodal_embedding_cache(
@@ -562,6 +834,9 @@ def setup_vllm_engine(
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
     default_sampling_params = vllm_config.model_config.get_diff_sampling_param()
+    if _is_gms_load_format(engine_args):
+        _verify_gms_vllm_worker_config(vllm_config)
+    _apply_gms_shadow_graph_config(vllm_config, disabled=gms_shadow_graphs_disabled)
 
     # Set up consolidator endpoints if KVBM (DynamoConnector) is enabled
     consolidator_endpoints = None
@@ -601,6 +876,8 @@ def setup_vllm_engine(
     factory = []
     if stat_logger:
         factory.append(stat_logger)
+
+    _maybe_wait_for_gms_primary_kv_before_init(config)
 
     # Time engine initialization
     start_time = time.time()
@@ -725,6 +1002,10 @@ async def register_vllm_model(
             SPEC_DECODE_RUNTIME_KEY, json.dumps(spec_decode)
         )
         logging.info("Published vLLM spec decode runtime metadata: %s", spec_decode)
+
+    if resolve_vllm_gms_daemon_socket(vllm_config):
+        runtime_config.set_gms_placement_enabled()
+        logging.info("Publishing GMS placement capability to discovery")
 
     runtime_config.data_parallel_start_rank = dp_range[0]
     runtime_config.data_parallel_size = dp_range[1]

--- a/components/src/dynamo/vllm/tests/test_vllm_engine_monitor_stats.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine_monitor_stats.py
@@ -7,6 +7,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo.common.engine_monitor import EngineHealthMonitorConfig
 from dynamo.vllm.engine_monitor import VllmEngineMonitor
@@ -193,3 +194,31 @@ async def test_run_health_check_times_out(mock_engine):
 
     with pytest.raises(asyncio.TimeoutError):
         await monitor._run_health_check()
+
+
+@pytest.mark.asyncio
+async def test_engine_health_ignores_engine_dead_during_shutdown(mock_engine):
+    shutdown_event = asyncio.Event()
+    monitor = _make_monitor(mock_engine, shutdown_event)
+    mock_engine.check_health.side_effect = EngineDeadError(
+        RuntimeError("engine stopped")
+    )
+
+    with patch(
+        "dynamo.vllm.engine_monitor.is_shutdown_in_progress",
+        return_value=True,
+    ):
+        await asyncio.wait_for(monitor._check_engine_health(), timeout=1.0)
+
+    monitor.runtime.shutdown.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_engine_health_exits_when_shutdown_event_set(mock_engine):
+    shutdown_event = asyncio.Event()
+    shutdown_event.set()
+    monitor = _make_monitor(mock_engine, shutdown_event)
+
+    await asyncio.wait_for(monitor._check_engine_health(), timeout=1.0)
+
+    mock_engine.check_health.assert_not_called()

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -99,6 +99,45 @@ async def test_pause_without_level_uses_vllm_default_sleep():
 
 
 @pytest.mark.asyncio
+async def test_quiesce_can_skip_cache_clear():
+    engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+    )
+    controller = VllmEnginePauseController(engine_client)
+
+    changed = await controller.pause(1, clear_cache=False)
+
+    assert changed is True
+    engine_client.pause_generation.assert_awaited_once_with(clear_cache=False)
+    engine_client.sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_quiesce_uses_no_clear_sleep_utility_when_available():
+    engine_core = SimpleNamespace(call_utility_async=AsyncMock())
+    engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+        engine_core=engine_core,
+    )
+    controller = VllmEnginePauseController(engine_client)
+
+    changed = await controller.pause(1, clear_cache=False)
+
+    assert changed is True
+    engine_client.pause_generation.assert_awaited_once_with(clear_cache=False)
+    engine_core.call_utility_async.assert_awaited_once_with(
+        "gms_sleep_no_clear", 1, "abort"
+    )
+    engine_client.sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_wake_up_passes_explicit_tags_from_request():
     handler = _make_handler()
     await handler._pause_controller.pause(1)
@@ -181,3 +220,19 @@ async def test_wake_up_returns_error_for_register_failure():
     handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()
     assert handler._pause_controller.is_paused is True
+
+
+@pytest.mark.asyncio
+async def test_sleep_with_handoff_releases_failover_lock():
+    handler = _make_handler()
+    lock = SimpleNamespace(release=AsyncMock())
+    handler._gms_failover_lock = lock
+
+    result = await handler.sleep({"level": 1, "release_failover_lock": True})
+
+    assert result["status"] == "ok"
+    assert result["failover_lock_released"] is True
+    handler.engine_client.pause_generation.assert_awaited_once_with(clear_cache=False)
+    handler.engine_client.sleep.assert_awaited_once_with(1)
+    lock.release.assert_awaited_once()
+    assert handler._gms_failover_lock is None

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -73,6 +73,23 @@ def _load_vllm_main() -> ModuleType:
     return importlib.import_module("dynamo.vllm.main")
 
 
+@pytest.fixture(autouse=True)
+def _clear_gms_failover_env_leaks(monkeypatch):
+    for name in (
+        "DYN_VLLM_GMS_ACTIVE_LOCK_HELD",
+        "DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV",
+        "GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    for name in (
+        "DYN_VLLM_GMS_ACTIVE_LOCK_HELD",
+        "DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV",
+        "GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
 def test_custom_jinja_template_invalid_path(mock_vllm_cli):
     """Test that invalid file path raises FileNotFoundError."""
     invalid_path = "/nonexistent/path/to/template.jinja"
@@ -1508,3 +1525,714 @@ async def test_generate_text_mode_applies_nvext_cache_salt():
 
     assert chunks
     assert captured["prompt"]["cache_salt"] == "dynamo-cache-salt:tenant-a"
+
+
+def test_vllm_failover_shape_warmup_payload_covers_serving_shape(monkeypatch):
+    from dynamo.vllm.worker_factory import _vllm_failover_shape_warmup_payload
+
+    monkeypatch.delenv("DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_MAX_TOKENS", raising=False)
+    payload = _vllm_failover_shape_warmup_payload(
+        {"prompt": "Test", "max_tokens": 1, "_HEALTH_CHECK": True}
+    )
+
+    assert "_HEALTH_CHECK" not in payload
+    assert payload["prompt"] != "Test"
+    assert payload["temperature"] == 0.0
+    assert payload["max_tokens"] == 16
+
+
+def test_vllm_failover_shape_warmup_payload_token_mode(monkeypatch):
+    from dynamo.vllm.worker_factory import _vllm_failover_shape_warmup_payload
+
+    monkeypatch.setenv("DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_INPUT_TOKENS", "7")
+    monkeypatch.setenv("DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_MAX_TOKENS", "3")
+
+    payload = _vllm_failover_shape_warmup_payload(
+        {
+            "token_ids": [42],
+            "sampling_options": {"temperature": 1.0},
+            "stop_conditions": {"max_tokens": 1},
+            "_HEALTH_CHECK": True,
+        }
+    )
+
+    assert "_HEALTH_CHECK" not in payload
+    assert payload["token_ids"] == [42] * 7
+    assert payload["sampling_options"]["temperature"] == 0.0
+    assert payload["stop_conditions"]["max_tokens"] == 3
+
+
+def test_gms_shadow_init_geometry_wait_honors_generic_timeout(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("GMS_KV_LEASE_GEOMETRY_WAIT_MS", "300000")
+    monkeypatch.delenv("GMS_VLLM_KV_GEOMETRY_WAIT_MS", raising=False)
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_INIT_GEOMETRY_WAIT_MS", raising=False)
+
+    assert vllm_main._gms_shadow_init_geometry_wait_ms() == 300_000
+
+
+def test_gms_shadow_init_geometry_wait_clamps_negative_timeout(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_INIT_GEOMETRY_WAIT_MS", "-1")
+
+    assert vllm_main._gms_shadow_init_geometry_wait_ms() == 0
+
+
+def test_vllm_gms_failover_isolates_jit_cache_by_container(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("CONTAINER_NAME", "engine-1")
+    monkeypatch.setenv("TMPDIR", "/dev/shm/dynamo-jit/tmp")
+    monkeypatch.setenv("FLASHINFER_CUBIN_DIR", "/dev/shm/dynamo-jit/flashinfer-cubins")
+
+    changed = vllm_main._maybe_isolate_jit_cache_dirs_by_container()
+
+    assert os.environ["TMPDIR"] == "/dev/shm/dynamo-jit/engine-1/tmp"
+    assert (
+        os.environ["FLASHINFER_CUBIN_DIR"]
+        == "/dev/shm/dynamo-jit/engine-1/flashinfer-cubins"
+    )
+    assert changed["TMPDIR"] == (
+        "/dev/shm/dynamo-jit/tmp",
+        "/dev/shm/dynamo-jit/engine-1/tmp",
+    )
+
+
+def test_vllm_gms_failover_jit_cache_isolation_can_be_disabled(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_ISOLATE_JIT_CACHE_BY_CONTAINER", "0")
+    monkeypatch.setenv("CONTAINER_NAME", "engine-1")
+    monkeypatch.setenv("TMPDIR", "/dev/shm/dynamo-jit/tmp")
+
+    assert vllm_main._maybe_isolate_jit_cache_dirs_by_container() == {}
+    assert os.environ["TMPDIR"] == "/dev/shm/dynamo-jit/tmp"
+
+
+def test_gms_shadow_waits_for_primary_geometry_before_init(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    calls = []
+
+    def fake_existing_blocks(*, wait_ms=0):
+        calls.append(wait_ms)
+        return 123
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("GMS_KV_LEASE_GEOMETRY_WAIT_MS", "300000")
+    monkeypatch.setattr(
+        "gpu_memory_service.integrations.vllm.install_vmm_ipc_kv._existing_shared_kv_blocks",
+        fake_existing_blocks,
+    )
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    vllm_main._maybe_wait_for_gms_primary_kv_before_init(config)
+
+    assert calls == [300_000]
+
+
+def test_gms_primary_does_not_wait_for_primary_geometry(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    def fail_if_called(*, wait_ms=0):
+        raise AssertionError("primary must not wait for its own KV geometry")
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setattr(
+        "gpu_memory_service.integrations.vllm.install_vmm_ipc_kv._existing_shared_kv_blocks",
+        fail_if_called,
+    )
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    vllm_main._maybe_wait_for_gms_primary_kv_before_init(config)
+
+
+def test_gms_private_bootstrap_shadow_disables_vllm_graphs(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    assert vllm_main._maybe_disable_gms_shadow_graphs_before_vllm_config(config)
+    assert os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] == "0"
+
+
+def test_gms_private_bootstrap_graph_disable_can_be_overridden(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_CUDAGRAPH", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    assert not vllm_main._maybe_disable_gms_shadow_graphs_before_vllm_config(config)
+    assert "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ
+
+
+def test_gms_private_bootstrap_scratch_warmup_keeps_vllm_graphs(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    monkeypatch.delenv("GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED", raising=False)
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    assert not vllm_main._maybe_disable_gms_shadow_graphs_before_vllm_config(config)
+    assert "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ
+    assert os.environ["GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED"] == "1"
+
+
+def test_gms_private_bootstrap_shadow_forces_eager_vllm_config():
+    from vllm.config import CompilationMode, CUDAGraphMode
+
+    from dynamo.vllm import main as vllm_main
+
+    vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            mode=CompilationMode.VLLM_COMPILE,
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        )
+    )
+
+    vllm_main._apply_gms_shadow_graph_config(vllm_config, disabled=True)
+
+    assert vllm_config.compilation_config.mode == CompilationMode.NONE
+    assert vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+
+
+def test_gms_forced_private_primary_waits_for_geometry(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    calls = []
+
+    def fake_existing_blocks(*, wait_ms=0):
+        calls.append(wait_ms)
+        return 456
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setattr(
+        "gpu_memory_service.integrations.vllm.install_vmm_ipc_kv._existing_shared_kv_blocks",
+        fake_existing_blocks,
+    )
+
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(load_format="gms"),
+        gms_shadow_mode=True,
+    )
+
+    vllm_main._maybe_wait_for_gms_primary_kv_before_init(config)
+
+    assert calls == [300_000]
+
+
+@pytest.mark.asyncio
+async def test_gms_preinit_static_primary_uses_shared_kv_when_lock_free(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire(*, timeout=None):
+        events.append(("lock", timeout))
+        return lock
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    config = SimpleNamespace(
+        gms_shadow_mode=True,
+        engine_args=SimpleNamespace(load_format="gms"),
+    )
+
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    got_lock, fence_run = await factory._configure_gms_preinit_failover_role(config)
+
+    assert got_lock is lock
+    assert fence_run is True
+    assert os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] == "1"
+    assert os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] == "0"
+    assert events == [("lock", 0.0), ("fence", "vllm", "engine-0-pre-init")]
+
+
+@pytest.mark.asyncio
+async def test_gms_preinit_static_primary_uses_private_kv_when_lock_held(monkeypatch):
+    from gpu_memory_service.failover_lock.interface import FailoverLockError
+
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire(*, timeout=None):
+        raise FailoverLockError("held")
+
+    config = SimpleNamespace(
+        gms_shadow_mode=True,
+        engine_args=SimpleNamespace(load_format="gms"),
+    )
+
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+
+    got_lock, fence_run = await factory._configure_gms_preinit_failover_role(config)
+
+    assert got_lock is None
+    assert fence_run is False
+    assert os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] == "0"
+    assert os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_gms_preinit_static_shadow_uses_private_kv_without_lock(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fail_acquire(*, timeout=None):
+        raise AssertionError("static shadow should not steal initial active lock")
+
+    config = SimpleNamespace(
+        gms_shadow_mode=True,
+        engine_args=SimpleNamespace(load_format="gms"),
+    )
+
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fail_acquire)
+
+    got_lock, fence_run = await factory._configure_gms_preinit_failover_role(config)
+
+    assert got_lock is None
+    assert fence_run is False
+    assert os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] == "0"
+    assert os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_gms_private_shadow_waits_for_lock_without_startup_sleep(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_promotion_warmup():
+        events.append("warmup")
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            raise AssertionError("private-bootstrap shadow must not sleep at startup")
+
+        async def resume(self, *args, **kwargs):
+            raise AssertionError("private-bootstrap shadow promotes KV directly")
+
+        def mark_resumed(self):
+            raise AssertionError("private-bootstrap shadow promotes KV directly")
+
+    class EngineClient:
+        async def collective_rpc(self, method, *, kwargs=None):
+            events.append(("collective_rpc", method, kwargs))
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(
+        _quiesce_controller=QuiesceController(),
+        engine_client=EngineClient(),
+    )
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", raising=False)
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        Runtime(),
+        config,
+        promotion_warmup=fake_promotion_warmup,
+    )
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        ("health", True),
+        "lock",
+        ("fence", "vllm", "private-bootstrap-shadow"),
+        ("collective_rpc", "wake_up", {"tags": ["kv_pool"]}),
+        "warmup",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gms_private_shadow_can_prepromote_kv_before_lock(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_promotion_warmup():
+        events.append("warmup")
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            raise AssertionError("private-bootstrap shadow must not sleep at startup")
+
+    class EngineClient:
+        async def collective_rpc(self, method, *, kwargs=None):
+            events.append(("collective_rpc", method, kwargs))
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(
+        _quiesce_controller=QuiesceController(),
+        engine_client=EngineClient(),
+    )
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PREPROMOTE_SHADOW_KV", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", raising=False)
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        Runtime(),
+        config,
+        promotion_warmup=fake_promotion_warmup,
+    )
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        ("collective_rpc", "wake_up", {"tags": ["kv_pool"]}),
+        ("health", True),
+        "lock",
+        ("fence", "vllm", "private-bootstrap-shadow"),
+        "warmup",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gms_private_shadow_runs_prelock_scratch_warmup(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_promotion_warmup():
+        events.append("postlock-warmup")
+
+    async def fake_prelock_warmup():
+        events.append("prelock-warmup")
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            raise AssertionError("private-bootstrap shadow must not sleep at startup")
+
+    class EngineClient:
+        async def collective_rpc(self, method, *, kwargs=None):
+            events.append(("collective_rpc", method, kwargs))
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(
+        _quiesce_controller=QuiesceController(),
+        engine_client=EngineClient(),
+    )
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PREPROMOTE_SHADOW_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PREWARM_SHADOW_BEFORE_LOCK", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", raising=False)
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        Runtime(),
+        config,
+        promotion_warmup=fake_promotion_warmup,
+        prelock_warmup=fake_prelock_warmup,
+    )
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        "prelock-warmup",
+        ("collective_rpc", "wake_up", {"tags": ["kv_pool"]}),
+        ("health", True),
+        "lock",
+        ("fence", "vllm", "private-bootstrap-shadow"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gms_primary_does_not_use_private_bootstrap_promotion(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_promotion_warmup():
+        events.append("warmup")
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class QuiesceController:
+        async def quiesce(self, *args, **kwargs):
+            raise AssertionError("primary must not quiesce before registration")
+
+    class EngineClient:
+        async def collective_rpc(self, *args, **kwargs):
+            raise AssertionError("primary must not promote private-bootstrap KV")
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(
+        _quiesce_controller=QuiesceController(),
+        engine_client=EngineClient(),
+    )
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.delenv("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", raising=False)
+    monkeypatch.delenv("DYN_VLLM_GMS_ACTIVE_LOCK_HELD", raising=False)
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.delenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", raising=False)
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(
+        handler,
+        Runtime(),
+        config,
+        promotion_warmup=fake_promotion_warmup,
+    )
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        "lock",
+        ("fence", "vllm", "active"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gms_shadow_startup_sleep_can_be_forced_for_legacy_path(monkeypatch):
+    from dynamo.vllm.worker_factory import WorkerFactory
+
+    events = []
+    lock = object()
+    factory = WorkerFactory(
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_acquire():
+        events.append("lock")
+        return lock
+
+    async def fake_post_lock_fence(*, backend_name, role):
+        events.append(("fence", backend_name, role))
+
+    class PauseController:
+        async def pause(self, *args, **kwargs):
+            events.append(("pause", args, kwargs))
+
+        async def resume(self, *args, **kwargs):
+            events.append("resume")
+
+        def mark_resumed(self):
+            events.append("mark_resumed")
+
+    class Runtime:
+        def set_health_status(self, status):
+            events.append(("health", status))
+
+    handler = SimpleNamespace(_pause_controller=PauseController())
+    config = SimpleNamespace(gms_shadow_mode=True)
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP", "0")
+    monkeypatch.setattr(factory, "_acquire_failover_lock", fake_acquire)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.run_gms_failover_post_lock_fence",
+        fake_post_lock_fence,
+    )
+
+    await factory._maybe_wait_for_failover_lock(handler, Runtime(), config)
+
+    assert getattr(handler, "_gms_failover_lock") is lock
+    assert events == [
+        ("pause", (1,), {"clear_cache": False}),
+        ("health", True),
+        "lock",
+        ("fence", "vllm", "legacy-shadow"),
+        "resume",
+        "mark_resumed",
+    ]

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -16,6 +16,11 @@ from vllm.config import VllmConfig
 from vllm.v1.engine.async_llm import AsyncLLM
 
 from dynamo import prometheus_names
+from dynamo.common.gms_failover import (
+    release_attached_gms_failover_lock,
+    run_gms_failover_post_lock_fence,
+    run_gms_failover_promotion_warmup,
+)
 from dynamo.common.rl import first_endpoint_response, register_rl_routes
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.common.utils.prometheus import (
@@ -52,6 +57,76 @@ logger = logging.getLogger(__name__)
 # have no KV cache / scheduler gauges, so setup_vllm_engine() skips the
 # LLMBackendMetrics registration there.
 EngineSetupResult = tuple[AsyncLLM, VllmConfig, Any, Any, Optional[LLMBackendMetrics]]
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r", name, value)
+        return default
+
+
+def _truthy_env(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _vllm_prelock_shadow_warmup_enabled() -> bool:
+    return _truthy_env("DYN_VLLM_GMS_PREWARM_SHADOW_BEFORE_LOCK")
+
+
+def _vllm_scratch_private_bootstrap_enabled() -> bool:
+    return _truthy_env(
+        "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP",
+        default=_truthy_env("GMS_VLLM_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP"),
+    )
+
+
+def _vllm_failover_shape_warmup_payload(base_payload: dict[str, Any]) -> dict[str, Any]:
+    """Build a small real-request canary that covers post-failover serving JIT."""
+
+    payload = dict(base_payload)
+    payload.pop("_HEALTH_CHECK", None)
+    max_tokens = max(
+        1,
+        _int_env(
+            "DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_MAX_TOKENS",
+            _int_env("DYN_GMS_FAILOVER_SHAPE_WARMUP_MAX_TOKENS", 16),
+        ),
+    )
+    token_count = max(
+        1,
+        _int_env(
+            "DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_INPUT_TOKENS",
+            _int_env("DYN_GMS_FAILOVER_SHAPE_WARMUP_INPUT_TOKENS", 25),
+        ),
+    )
+
+    if "token_ids" in payload:
+        token_ids = payload.get("token_ids") or [1]
+        token_id = int(token_ids[0])
+        payload["token_ids"] = [token_id] * token_count
+        sampling_options = dict(payload.get("sampling_options") or {})
+        sampling_options["temperature"] = 0.0
+        payload["sampling_options"] = sampling_options
+        stop_conditions = dict(payload.get("stop_conditions") or {})
+        stop_conditions["max_tokens"] = max_tokens
+        payload["stop_conditions"] = stop_conditions
+        return payload
+
+    payload["prompt"] = os.environ.get(
+        "DYN_VLLM_GMS_FAILOVER_SHAPE_WARMUP_PROMPT",
+        "Return one concise deterministic sentence about GMS failover validation.",
+    )
+    payload["temperature"] = 0.0
+    payload["max_tokens"] = max_tokens
+    return payload
 
 
 async def _wait_and_load_benchmark(bench_cfg: dict, vllm_config: VllmConfig) -> dict:
@@ -146,6 +221,7 @@ class WorkerFactory:
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,
         snapshot_engine: Optional[EngineSetupResult] = None,
+        engine_holder: Optional[list] = None,
     ) -> None:
         """Create the appropriate multimodal worker based on config flags."""
 
@@ -173,6 +249,7 @@ class WorkerFactory:
                 shutdown_event,
                 shutdown_endpoints,
                 snapshot_engine=snapshot_engine,
+                engine_holder=engine_holder,
             )
         else:
             # AGGREGATED or DECODE
@@ -182,6 +259,7 @@ class WorkerFactory:
                 shutdown_event,
                 shutdown_endpoints,
                 snapshot_engine=snapshot_engine,
+                engine_holder=engine_holder,
             )
         return
 
@@ -341,34 +419,318 @@ class WorkerFactory:
         finally:
             handler.cleanup()
 
+    @staticmethod
+    def _truthy_env(name: str, *, default: bool = False) -> bool:
+        value = os.environ.get(name)
+        if value is None:
+            return default
+        return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+    @classmethod
+    def _private_bootstrap_requested(cls) -> bool:
+        return cls._truthy_env(
+            "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV",
+            default=cls._truthy_env(
+                "GMS_VLLM_PRIVATE_BOOTSTRAP_KV",
+                default=cls._truthy_env("DYN_GMS_FAILOVER_PRIVATE_BOOTSTRAP_KV"),
+            ),
+        )
+
+    async def _acquire_failover_lock(self, *, timeout: float | None = None):
+        from gpu_memory_service.failover_lock.flock import FlockFailoverLock
+
+        lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
+        engine_id = os.environ.get("ENGINE_ID", "0")
+        lock = FlockFailoverLock(lock_path)
+        await lock.acquire(engine_id=f"engine-{engine_id}", timeout=timeout)
+        return lock
+
+    def _maybe_start_rank_liveness_monitor(self, handler, config: Config):
+        """Leader side of the cross-node ZMQ rank-liveness channel.
+
+        Only the rank-0 leader runs worker_factory (headless workers bypass it),
+        so reaching here means we are the active leader. On a worker node going
+        silent (process death), release the failover lock so the warm shadow
+        promotes in ~one heartbeat-timeout, then signal a graceful shutdown of the
+        now-broken leader — instead of waiting out the NCCL collective timeout.
+        """
+        import signal
+
+        from dynamo.common import rank_liveness as rl
+
+        if not rl.liveness_enabled() or not getattr(config, "gms_shadow_mode", False):
+            return None
+        nnodes = int(getattr(config.engine_args, "nnodes", 1) or 1)
+        if nnodes <= 1:
+            return None
+
+        loop = asyncio.get_running_loop()
+
+        def on_rank_lost(rank: int, reason: str) -> None:
+            logger.warning(
+                "[GMS liveness] vLLM worker rank %d lost (%s); releasing lock + "
+                "shutting down broken leader for fast shadow promotion",
+                rank,
+                reason,
+            )
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    release_attached_gms_failover_lock(handler, backend_name="vllm"),
+                    loop,
+                )
+            except Exception:
+                logger.debug(
+                    "[GMS liveness] lock release on rank loss failed", exc_info=True
+                )
+            # The cohort is broken (a TP rank is gone); bring the leader down so it
+            # stops holding the GPU/KV and the shadow (now lock holder) serves.
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        monitor = rl.RankLivenessMonitor(on_rank_lost, expected_ranks=range(1, nnodes))
+        setattr(handler, "_gms_rank_liveness_monitor", monitor)
+        monitor.start()
+        logger.info("[GMS liveness] started vLLM leader rank-liveness monitor")
+        return monitor
+
+    async def _configure_gms_preinit_failover_role(
+        self,
+        config: Config,
+    ) -> tuple[Any | None, bool]:
+        """Choose shared vs private-bootstrap KV before vLLM initializes.
+
+        vLLM sizes/profiles memory before the worker handler exists. In a
+        Bulwark pair that uses private-bootstrap shadows, the process that owns
+        the failover lock may initialize against the stable shared KV namespace;
+        all other processes must initialize against member-scoped private KV.
+        This is dynamic: after failover, a restarted ENGINE_ID=0 container is a
+        standby while ENGINE_ID=1 owns the lock.
+        """
+
+        os.environ.pop("DYN_VLLM_GMS_ACTIVE_LOCK_HELD", None)
+        os.environ.pop("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", None)
+
+        if not config.gms_shadow_mode:
+            return None, False
+        if getattr(config.engine_args, "load_format", None) != "gms":
+            return None, False
+        if not self._private_bootstrap_requested():
+            return None, False
+        if not self._truthy_env("DYN_VLLM_GMS_DYNAMIC_PREINIT_ROLE", default=True):
+            return None, False
+
+        engine_id = os.environ.get("ENGINE_ID", "0")
+        primary_engine_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+        is_static_primary = engine_id == primary_engine_id
+
+        if not is_static_primary:
+            os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] = "1"
+            os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] = "0"
+            logger.info(
+                "[GMS] Static shadow engine-%s initializing with private-bootstrap KV",
+                engine_id,
+            )
+            return None, False
+
+        logger.info(
+            "[GMS] Static primary engine-%s attempting active failover lock "
+            "before vLLM engine init",
+            engine_id,
+        )
+        try:
+            lock = await self._acquire_failover_lock(timeout=0.0)
+        except Exception as exc:  # noqa: BLE001 - lock contention is expected.
+            try:
+                from gpu_memory_service.failover_lock.interface import FailoverLockError
+            except ImportError:  # pragma: no cover
+                FailoverLockError = RuntimeError  # type: ignore[assignment]
+
+            if not isinstance(exc, FailoverLockError):
+                raise
+            os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] = "1"
+            os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] = "0"
+            logger.info(
+                "[GMS] Active failover lock is held; static primary engine-%s "
+                "will initialize as private-bootstrap standby",
+                engine_id,
+            )
+            return None, False
+
+        os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] = "1"
+        os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] = "0"
+        await run_gms_failover_post_lock_fence(
+            backend_name="vllm",
+            role=f"engine-{engine_id}-pre-init",
+        )
+        logger.info(
+            "[GMS] Static primary engine-%s owns active lock before vLLM init",
+            engine_id,
+        )
+        return lock, True
+
     async def _maybe_wait_for_failover_lock(
         self,
         handler,
         runtime: DistributedRuntime,
         config: Config,
+        *,
+        lock_already_acquired: bool = False,
+        promotion_warmup: Callable[[], Awaitable[None]] | None = None,
+        prelock_warmup: Callable[[], Awaitable[None]] | None = None,
+        post_lock_fence_already_run: bool = False,
     ) -> None:
         # Shadow mode: lock-driven activation.
-        # Flow: sleep → startup probe passes → block on lock → wake → register.
+        # Default safe flow for GMS shared KV is lock-before-init, because vLLM
+        # warmup writes KV before this handler can quiesce the engine. The legacy
+        # warm-standby path remains behind DYN_VLLM_GMS_LOCK_BEFORE_INIT=0.
         if not config.gms_shadow_mode:
             return
 
-        await handler._pause_controller.pause(1)
+        if lock_already_acquired:
+            if not post_lock_fence_already_run:
+                await run_gms_failover_post_lock_fence(
+                    backend_name="vllm",
+                    role="pre-init",
+                )
+            if promotion_warmup is not None:
+                logger.info(
+                    "[GMS failover] Skipping promotion warmup for pre-init "
+                    "active lock; warmup is shadow-only"
+                )
+            logger.info(
+                "[Shadow] Failover lock already acquired before engine init; "
+                "registering with discovery"
+            )
+            return
+
+        engine_id = os.environ.get("ENGINE_ID", "0")
+        primary_engine_id = os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+        forced_private_bootstrap = self._truthy_env(
+            "DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"
+        )
+        is_shadow = forced_private_bootstrap or engine_id != primary_engine_id
+        private_bootstrap = self._private_bootstrap_requested() and is_shadow
+
+        if not is_shadow:
+            logger.info(
+                "[Primary] Engine initialized; acquiring active failover lock "
+                "before discovery registration"
+            )
+            lock = await self._acquire_failover_lock()
+            setattr(handler, "_gms_failover_lock", lock)
+            await run_gms_failover_post_lock_fence(
+                backend_name="vllm",
+                role="active",
+            )
+            if promotion_warmup is not None:
+                logger.info(
+                    "[GMS failover] Skipping promotion warmup for active primary; "
+                    "warmup is shadow-only"
+                )
+            self._maybe_start_rank_liveness_monitor(handler, config)
+            logger.info("[Primary] Active lock acquired, registering with discovery")
+            return
+
+        skip_startup_sleep = os.environ.get(
+            "DYN_VLLM_GMS_SHADOW_SKIP_STARTUP_SLEEP",
+            "1" if private_bootstrap else "0",
+        ).lower() not in {"0", "false", "no", "off"}
+        if skip_startup_sleep:
+            prelock_warmup_ran = False
+            if (
+                private_bootstrap
+                and prelock_warmup is not None
+                and _vllm_prelock_shadow_warmup_enabled()
+            ):
+                if _vllm_scratch_private_bootstrap_enabled():
+                    logger.info(
+                        "[Shadow] Running pre-lock scratch-backed warmup while "
+                        "undiscovered"
+                    )
+                    await prelock_warmup()
+                    prelock_warmup_ran = True
+                    logger.info(
+                        "[Shadow] Pre-lock scratch-backed warmup complete; "
+                        "waiting for active lock"
+                    )
+                else:
+                    logger.warning(
+                        "[Shadow] Skipping pre-lock warmup because scratch-backed "
+                        "private-bootstrap KV is not enabled"
+                    )
+
+            prepromoted_private_bootstrap = False
+            if private_bootstrap and self._truthy_env(
+                "DYN_VLLM_GMS_PREPROMOTE_SHADOW_KV"
+            ):
+                logger.info(
+                    "[Shadow] Pre-promoting private-bootstrap KV while "
+                    "undiscovered; lock still gates serving"
+                )
+                await handler.engine_client.collective_rpc(
+                    "wake_up",
+                    kwargs={"tags": ["kv_pool"]},
+                )
+                prepromoted_private_bootstrap = True
+                logger.info(
+                    "[Shadow] Private-bootstrap KV pre-promotion complete; "
+                    "waiting for active lock"
+                )
+
+            runtime.set_health_status(True)
+            logger.info(
+                "[Shadow] Engine initialized and kept awake but undiscovered; "
+                "startup probe now passing, waiting for lock"
+            )
+
+            lock = await self._acquire_failover_lock()
+            setattr(handler, "_gms_failover_lock", lock)
+            await run_gms_failover_post_lock_fence(
+                backend_name="vllm",
+                role="private-bootstrap-shadow",
+            )
+            if prepromoted_private_bootstrap:
+                logger.info(
+                    "[Shadow] Private-bootstrap KV already promoted before "
+                    "lock; skipping promotion before discovery registration"
+                )
+            else:
+                logger.info(
+                    "[Shadow] Promoting private-bootstrap KV before discovery "
+                    "registration"
+                )
+                await handler.engine_client.collective_rpc(
+                    "wake_up",
+                    kwargs={"tags": ["kv_pool"]},
+                )
+            if promotion_warmup is not None and not prelock_warmup_ran:
+                await promotion_warmup()
+            elif prelock_warmup_ran:
+                logger.info(
+                    "[Shadow] Pre-lock warmup already ran; skipping post-lock "
+                    "promotion warmup"
+                )
+            logger.info("[Shadow] Lock acquired, registering with discovery")
+            return
+
+        await handler._pause_controller.pause(1, clear_cache=False)
 
         runtime.set_health_status(True)
         logger.info(
             "[Shadow] Engine sleeping, startup probe now passing, waiting for lock"
         )
 
-        from gpu_memory_service.failover_lock.flock import FlockFailoverLock
-
-        lock_path = os.environ.get("FAILOVER_LOCK_PATH", "/shared/failover.lock")
-        engine_id = os.environ.get("ENGINE_ID", "0")
-        lock = FlockFailoverLock(lock_path)
-        await lock.acquire(engine_id=f"engine-{engine_id}")
+        lock = await self._acquire_failover_lock()
+        setattr(handler, "_gms_failover_lock", lock)
+        await run_gms_failover_post_lock_fence(
+            backend_name="vllm",
+            role="legacy-shadow",
+        )
         logger.info("[Shadow] Lock acquired, waking engine")
 
         await handler._pause_controller.resume()
         handler._pause_controller.mark_resumed()
+        if promotion_warmup is not None:
+            await promotion_warmup()
         logger.info("[Shadow] Engine awake, registering with discovery")
 
     async def _create_decode_worker(
@@ -378,6 +740,7 @@ class WorkerFactory:
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
         snapshot_engine: Optional[EngineSetupResult] = None,
+        engine_holder: Optional[list] = None,
     ) -> None:
         """
         Instantiate and serve
@@ -422,6 +785,32 @@ class WorkerFactory:
                 ]
             )
 
+        early_failover_lock = None
+        early_failover_fence_run = False
+        (
+            early_failover_lock,
+            early_failover_fence_run,
+        ) = await self._configure_gms_preinit_failover_role(config)
+        lock_before_init = os.environ.get("DYN_VLLM_GMS_LOCK_BEFORE_INIT", "1").lower()
+        if (
+            early_failover_lock is None
+            and config.gms_shadow_mode
+            and lock_before_init not in {"0", "false", "no", "off"}
+        ):
+            logger.info(
+                "[Shadow] Waiting for failover lock before vLLM engine init "
+                "to protect shared GMS KV warmup"
+            )
+            early_failover_lock = await self._acquire_failover_lock()
+            await run_gms_failover_post_lock_fence(
+                backend_name="vllm",
+                role=f"engine-{os.environ.get('ENGINE_ID', '0')}-pre-init",
+            )
+            early_failover_fence_run = True
+            os.environ["DYN_VLLM_GMS_ACTIVE_LOCK_HELD"] = "1"
+            os.environ["DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV"] = "0"
+            logger.info("[Shadow] Failover lock acquired before vLLM engine init")
+
         # Use pre-created engine if provided (checkpoint mode), otherwise create new
         fpm_worker_id = str(generate_endpoint.connection_id())
         if snapshot_engine is not None:
@@ -453,6 +842,8 @@ class WorkerFactory:
                 component_gauges,
             ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
         await configure_kv_event_block_size(engine_client, vllm_config)
+        if engine_holder is not None:
+            engine_holder.append(engine_client)
 
         # TODO Hack to get data, move this to registering in TBD
         _, dp_size = get_dp_range_for_worker(vllm_config)
@@ -485,6 +876,8 @@ class WorkerFactory:
             encode_worker_client=encode_worker_client,
         )
         handler.add_temp_dir(prometheus_temp_dir)
+        if early_failover_lock is not None:
+            setattr(handler, "_gms_failover_lock", early_failover_lock)
 
         # Check if kv event consolidator is enabled (port was allocated in setup_vllm_engine)
         consolidator_enabled = False
@@ -546,7 +939,31 @@ class WorkerFactory:
                 "The chat template will be loaded but the /v1/chat/completions endpoint will not be available."
             )
 
-        await self._maybe_wait_for_failover_lock(handler, runtime, config)
+        health_check_payload = VllmHealthCheckPayload(
+            engine_client, use_text_input=config.use_vllm_tokenizer
+        ).to_dict()
+
+        async def promotion_warmup() -> None:
+            await run_gms_failover_promotion_warmup(
+                handler.generate, health_check_payload, backend_name="vllm"
+            )
+
+        shape_warmup_payload = _vllm_failover_shape_warmup_payload(health_check_payload)
+
+        async def prelock_warmup() -> None:
+            await run_gms_failover_promotion_warmup(
+                handler.generate, shape_warmup_payload, backend_name="vllm"
+            )
+
+        await self._maybe_wait_for_failover_lock(
+            handler,
+            runtime,
+            config,
+            lock_already_acquired=early_failover_lock is not None,
+            promotion_warmup=promotion_warmup,
+            prelock_warmup=prelock_warmup,
+            post_lock_fence_already_run=early_failover_fence_run,
+        )
 
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
@@ -581,10 +998,6 @@ class WorkerFactory:
             worker_type=worker_type,
             needs=needs,
         )
-
-        health_check_payload = VllmHealthCheckPayload(
-            engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"
@@ -667,6 +1080,7 @@ class WorkerFactory:
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
         snapshot_engine: Optional[EngineSetupResult] = None,
+        engine_holder: Optional[list] = None,
     ) -> None:
         """
         Instantiate and serve
@@ -707,6 +1121,8 @@ class WorkerFactory:
                 _component_gauges,
             ) = self.setup_vllm_engine(config, fpm_worker_id=fpm_worker_id)
         await configure_kv_event_block_size(engine_client, vllm_config)
+        if engine_holder is not None:
+            engine_holder.append(engine_client)
 
         encode_worker_client = await self._maybe_get_encode_worker_client(
             runtime, config
@@ -775,7 +1191,18 @@ class WorkerFactory:
             runtime, handler, lora_enabled=config.engine_args.enable_lora
         )
 
-        await self._maybe_wait_for_failover_lock(handler, runtime, config)
+        health_check_payload = VllmPrefillHealthCheckPayload(
+            engine_client, use_text_input=config.use_vllm_tokenizer
+        ).to_dict()
+
+        async def promotion_warmup() -> None:
+            await run_gms_failover_promotion_warmup(
+                handler.generate, health_check_payload, backend_name="vllm"
+            )
+
+        await self._maybe_wait_for_failover_lock(
+            handler, runtime, config, promotion_warmup=promotion_warmup
+        )
 
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
@@ -816,10 +1243,6 @@ class WorkerFactory:
             worker_type=WorkerType.Prefill,
             needs=[prefill_needs_set],
         )
-
-        health_check_payload = VllmPrefillHealthCheckPayload(
-            engine_client, use_text_input=config.use_vllm_tokenizer
-        ).to_dict()
 
         prefill_metrics_labels = [
             (

--- a/lib/gpu_memory_service/common/serving_timeout.py
+++ b/lib/gpu_memory_service/common/serving_timeout.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tighten the NCCL/collective watchdog timeout once a replica is serving traffic.
+
+During startup a collective can legitimately take many seconds — model load, warmup,
+CUDA-graph capture, the first cross-node all-reduce, load spikes — so the process-group
+timeout must be GENEROUS or it false-positives and aborts a *healthy* rank. (Observed:
+a 20s timeout killed a healthy SGLang primary during warmup.)
+
+Once the replica is serving steady traffic, individual TP/PP collectives are sub-second,
+so a much lower timeout (default 5s) gives fast HANG detection without false positives.
+This module lowers the timeout via ``_set_pg_timeout`` once the engine is past warmup.
+
+Applied from a precise post-warmup hook in each rank's worker process — never on a timer:
+  * vLLM:   ``GMSWorker.compile_or_warm_up_model`` (the last init step, per rank)
+  * SGLang: ``Scheduler.run_event_loop`` entry (model load + capture happen earlier, in
+            ``Scheduler.__init__``) — see integrations/sglang/patches.py
+So a tight 2-3s serving timeout can never fire during warmup.
+
+Pairs with the ZMQ rank-liveness watcher (dynamo.common.rank_liveness): that catches
+*crashes* in ~one heartbeat; this catches *hangs* within the serving timeout.
+
+Config:
+  DYN_GMS_SERVING_NCCL_TIMEOUT_S        serving timeout in seconds (default 5; <=0 disables)
+
+NOTE on failover latency: the serving timeout governs DETECTION. How fast the process then
+*dies* (releasing the failover flock) is governed by TORCH_NCCL_WAIT_TIMEOUT_DUMP_MILSEC —
+the monitoring thread waits that long for the flight-recorder dump to coordinate before
+aborting. Default 60000ms; measured ~69s exit at the default vs ~5.5s with it set to 1000.
+Set TORCH_NCCL_WAIT_TIMEOUT_DUMP_MILSEC=1000 (and TORCH_NCCL_ASYNC_ERROR_HANDLING=1) for
+prompt failover. This module warns once if it is left high.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_applied = False
+_warned = False
+
+
+def serving_timeout_s() -> float:
+    raw = os.environ.get("DYN_GMS_SERVING_NCCL_TIMEOUT_S", "5")
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid DYN_GMS_SERVING_NCCL_TIMEOUT_S=%r; using 5", raw)
+        return 5.0
+
+
+def enabled() -> bool:
+    return serving_timeout_s() > 0
+
+
+def _warn_if_slow_teardown() -> None:
+    global _warned
+    if _warned:
+        return
+    _warned = True
+    try:
+        dump_wait = int(os.environ.get("TORCH_NCCL_WAIT_TIMEOUT_DUMP_MILSEC", "60000"))
+    except ValueError:
+        dump_wait = 60000
+    if dump_wait > 5000:
+        logger.warning(
+            "[GMS serving-timeout] TORCH_NCCL_WAIT_TIMEOUT_DUMP_MILSEC=%dms: after a "
+            "%.1fs hang detection the process may wait this long before aborting, "
+            "delaying failover (flock release). Set it to ~1000 for prompt failover.",
+            dump_wait,
+            serving_timeout_s(),
+        )
+
+
+def apply_serving_collective_timeout(seconds: float | None = None) -> bool:
+    """Lower the watchdog timeout on the default PG and every tracked PG. Returns
+    True if applied to at least one group. No-op (returns False) if torch.distributed
+    is unavailable / not yet initialized, so it is safe to call early or repeatedly."""
+    global _applied
+    seconds = serving_timeout_s() if seconds is None else seconds
+    if seconds <= 0 or _applied:
+        return False
+    try:
+        import torch.distributed as dist
+        from torch.distributed import distributed_c10d as c10d
+    except Exception:
+        return False
+    if not dist.is_available() or not dist.is_initialized():
+        return False
+
+    set_fn = getattr(c10d, "_set_pg_timeout", None)
+    if set_fn is None:
+        logger.warning(
+            "[GMS serving-timeout] this torch has no _set_pg_timeout; cannot tighten"
+        )
+        return False
+
+    td = datetime.timedelta(seconds=seconds)
+    applied = 0
+    try:
+        set_fn(td, None)  # default / world group
+        applied += 1
+    except Exception:
+        logger.debug("[GMS serving-timeout] set on default group failed", exc_info=True)
+    # Cover TP/PP sub-groups: each forward-pass collective runs on its own PG whose
+    # ProcessGroupNCCL watchdog uses that PG's own timeout.
+    try:
+        world = getattr(c10d, "_world", None)
+        pg_map = getattr(world, "pg_map", {}) if world is not None else {}
+        for pg in list(pg_map.keys()):
+            try:
+                set_fn(td, pg)
+                applied += 1
+            except Exception:
+                logger.debug(
+                    "[GMS serving-timeout] set on a sub-PG failed", exc_info=True
+                )
+    except Exception:
+        logger.debug("[GMS serving-timeout] iterating PGs failed", exc_info=True)
+
+    if applied:
+        _applied = True
+        _warn_if_slow_teardown()
+        logger.info(
+            "[GMS serving-timeout] tightened collective watchdog to %.1fs on %d PG(s)",
+            seconds,
+            applied,
+        )
+    return applied > 0
+
+
+def tighten_now() -> bool:
+    """Apply the serving timeout immediately. Called from each engine's precise
+    post-warmup hook (vLLM GMSWorker / SGLang Scheduler.run_event_loop)."""
+    return apply_serving_collective_timeout()

--- a/lib/gpu_memory_service/integrations/sglang/__init__.py
+++ b/lib/gpu_memory_service/integrations/sglang/__init__.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Type
 
 if TYPE_CHECKING:
@@ -30,6 +31,22 @@ _gms_initialized = False
 def is_gms_active() -> bool:
     """Return True if setup_gms() has been called successfully."""
     return _gms_initialized
+
+
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def configure_shared_failover_env() -> None:
+    if not (
+        _truthy_env("GMS_SGLANG_SHARED_KV")
+        and _truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE")
+    ):
+        return
+    os.environ.setdefault("SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK", "0")
+    logger.info(
+        "[GMS] Disabled SGLang TP memory imbalance check for shared-GMS failover"
+    )
 
 
 def setup_gms(server_args) -> Type["GMSModelLoader"]:
@@ -57,7 +74,20 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
             "Cannot use --enable-draft-weights-cpu-backup with --load-format gms."
         )
 
+    # GMS uses SGLang's torch_memory_saver regions as the allocation hook for
+    # weights and KV. Force the adapter on for --load-format gms so allocations
+    # are captured even when users did not pass --enable-memory-saver.
     server_args.enable_memory_saver = True
+
+    configure_shared_failover_env()
+
+    # The post-ready collective-timeout tightening for SGLang is applied PRECISELY,
+    # not via a grace delay: patches.patch_serving_collective_timeout_for_gms wraps
+    # Scheduler.run_event_loop (entered only AFTER model load + CUDA-graph capture in
+    # Scheduler.__init__), so a tight 2-3s serving timeout can never fire during warmup.
+    # That patch is installed at GMSModelLoader import time (model_loader.py), which
+    # runs in every rank's scheduler process. Nothing to arm here.
+
     # Resolve lock mode and RO reconnect timeout from model_loader_extra_config
     # before patches fire.
     global _gms_lock_mode
@@ -76,6 +106,14 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
 
     _gms_lock_mode = get_gms_lock_mode(extra)
     _gms_ro_connect_timeout_ms = get_gms_ro_connect_timeout_ms(extra)
+
+    from gpu_memory_service.integrations.sglang import (
+        install_kv_leases,
+        install_vmm_ipc_kv,
+    )
+
+    install_vmm_ipc_kv.install_lazy()
+    install_kv_leases.install()
 
     # Import triggers patches at module level
     from gpu_memory_service.integrations.sglang.model_loader import GMSModelLoader

--- a/lib/gpu_memory_service/integrations/sglang/install_kv_leases.py
+++ b/lib/gpu_memory_service/integrations/sglang/install_kv_leases.py
@@ -1,0 +1,419 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang token/page allocator integration for GMS KV block leases."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from gpu_memory_service.integrations.common.kv_lease_client import (
+    GMSKVLeaseClient,
+    KVLease,
+    KVLeaseClient,
+    kv_leases_enabled,
+    log_lease_pressure,
+    resolve_lease_device,
+)
+
+logger = logging.getLogger(__name__)
+
+_patched = False
+_factory: Callable[[object, int], KVLeaseClient] | None = None
+_STATE: dict[int, dict[str, object]] = {}
+
+
+def install(factory: Callable[[object, int], KVLeaseClient] | None = None) -> bool:
+    global _patched, _factory
+    if factory is not None:
+        _factory = factory
+    if _patched:
+        return False
+    if _factory is None and not kv_leases_enabled("sglang"):
+        return False
+
+    try:
+        import torch
+        from sglang.srt.mem_cache import allocator as alloc_mod
+        from sglang.srt.utils import get_num_new_pages
+    except Exception:  # noqa: BLE001
+        logger.debug("[GMS-KVLease] SGLang allocator not importable", exc_info=True)
+        return False
+
+    Base = alloc_mod.BaseTokenToKVPoolAllocator
+    Token = alloc_mod.TokenToKVPoolAllocator
+    Paged = alloc_mod.PagedTokenToKVPoolAllocator
+
+    orig_base_init = Base.__init__
+    orig_token_alloc = Token.alloc
+    orig_token_free = Token.free
+    orig_token_clear = Token.clear
+    orig_token_available = Token.available_size
+    orig_paged_alloc = Paged.alloc
+    orig_paged_alloc_extend = Paged.alloc_extend
+    orig_paged_alloc_decode = Paged.alloc_decode
+    orig_paged_free = Paged.free
+    orig_paged_clear = Paged.clear
+    orig_base_available = Base.available_size
+
+    def _make_client(self, total_pages: int) -> KVLeaseClient:
+        if _factory is not None:
+            return _factory(self, total_pages)
+        device_idx = resolve_lease_device("GMS_SGLANG_KV_LEASE_DEVICE")
+        suffix = (
+            f"{self.__class__.__name__}:size{int(self.size)}:page{int(self.page_size)}"
+        )
+        return GMSKVLeaseClient.from_env(
+            "sglang",
+            device_idx,
+            total_blocks=total_pages + 1,
+            namespace_suffix=suffix,
+            reserved_blocks=[0],
+        )
+
+    def _state(self) -> dict[str, object] | None:
+        return _STATE.get(id(self))
+
+    def _safe_free_count(client: KVLeaseClient) -> int:
+        try:
+            return int(client.free_count())
+        except Exception:  # noqa: BLE001
+            logger.debug("[GMS-KVLease] SGLang free-count read failed", exc_info=True)
+            return -1
+
+    def _pages_to_list(pages) -> list[int]:
+        if pages is None:
+            return []
+        if hasattr(pages, "numel") and int(pages.numel()) == 0:
+            return []
+        return [int(x) for x in pages.detach().cpu().tolist()]
+
+    def _page_tensor(self, pages: list[int]):
+        return torch.tensor(
+            pages,
+            dtype=self.free_pages.dtype,
+            device=self.free_pages.device,
+        )
+
+    def _prepend_pages(self, pages: list[int]) -> None:
+        if not pages:
+            return
+        self.free_pages = torch.cat((_page_tensor(self, pages), self.free_pages))
+
+    def _deprioritize_pages(self, pages: list[int]) -> None:
+        if not pages:
+            return
+        page_tensor = _page_tensor(self, pages)
+        move_mask = torch.isin(self.free_pages, page_tensor)
+        moved = self.free_pages[move_mask]
+        if moved.numel() == 0:
+            return
+        self.free_pages = torch.cat((self.free_pages[~move_mask], moved))
+
+    def _max_lease_attempts(num_pages: int, local_free: int) -> int:
+        if num_pages <= 0:
+            return 1
+        return max(1, min(8, (int(local_free) + int(num_pages) - 1) // int(num_pages)))
+
+    def _record_leases(st: dict[str, object], leases: list[KVLease]) -> None:
+        lease_map = st["leases_by_page"]
+        assert isinstance(lease_map, dict)
+        for lease in leases:
+            lease_map[int(lease.block_id)] = lease
+
+    def _lease_pages(
+        self,
+        pages: list[int],
+        *,
+        local_free: int,
+        operation: str,
+    ) -> bool:
+        st = _state(self)
+        if st is None:
+            return False
+        client = st["client"]
+        assert isinstance(client, GMSKVLeaseClient) or hasattr(client, "acquire")
+        if not pages:
+            return True
+        try:
+            leases = client.acquire(
+                len(pages),
+                preferred_blocks=pages,
+                strict_preferred=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log_lease_pressure(
+                logger,
+                f"sglang:{getattr(client, 'namespace', '?')}:acquire-error",
+                "[GMS-KVLease] SGLang lease acquire failed",
+                namespace=getattr(client, "namespace", "?"),
+                owner_id=getattr(client, "owner_id", "?"),
+                operation=operation,
+                requested=len(pages),
+                local_free=local_free,
+                shared_free=_safe_free_count(client),
+                preferred_count=len(pages),
+                error=type(exc).__name__,
+            )
+            logger.debug("[GMS-KVLease] SGLang lease acquire failed", exc_info=True)
+            return False
+        if len(leases) != len(pages):
+            log_lease_pressure(
+                logger,
+                f"sglang:{getattr(client, 'namespace', '?')}:acquire-short",
+                "[GMS-KVLease] SGLang lease acquire returned fewer pages than requested",
+                namespace=getattr(client, "namespace", "?"),
+                owner_id=getattr(client, "owner_id", "?"),
+                operation=operation,
+                requested=len(pages),
+                returned=len(leases),
+                shared_free=_safe_free_count(client),
+                preferred_count=len(pages),
+            )
+            client.release(leases)
+            return False
+        _record_leases(st, leases)
+        return True
+
+    def _release_indices(self, free_index) -> None:
+        st = _state(self)
+        if st is None or free_index.numel() == 0:
+            return
+        if int(self.page_size) == 1:
+            pages_tensor = free_index
+        else:
+            pages_tensor = torch.unique(free_index // int(self.page_size))
+        pages = [int(x) for x in pages_tensor.detach().cpu().tolist() if int(x) > 0]
+        lease_map = st["leases_by_page"]
+        client = st["client"]
+        assert isinstance(lease_map, dict)
+        missing_pages = [page for page in pages if page not in lease_map]
+        leases = [lease_map.pop(page) for page in pages if page in lease_map]
+        if missing_pages:
+            log_lease_pressure(
+                logger,
+                f"sglang:{getattr(client, 'namespace', '?')}:missing-release",
+                "[GMS-KVLease] SGLang releasing pages without matching leases",
+                namespace=getattr(client, "namespace", "?"),
+                owner_id=getattr(client, "owner_id", "?"),
+                missing_count=len(missing_pages),
+                first_missing_page=missing_pages[0],
+                active_leases=len(lease_map),
+            )
+        client.release(leases)
+
+    def patched_base_init(self, *args, **kwargs):
+        orig_base_init(self, *args, **kwargs)
+        total_pages = int(self.size // self.page_size)
+        client = _make_client(self, total_pages)
+        _STATE[id(self)] = {"client": client, "leases_by_page": {}}
+        logger.info(
+            "[GMS-KVLease] SGLang allocator leases enabled namespace=%s owner=%s pages=%d",
+            getattr(client, "namespace", "?"),
+            getattr(client, "owner_id", "?"),
+            total_pages,
+        )
+
+    def patched_token_available(self):
+        return orig_token_available(self)
+
+    def patched_base_available(self):
+        return orig_base_available(self)
+
+    def patched_token_alloc(self, need_size: int):
+        st = _state(self)
+        if st is None:
+            return orig_token_alloc(self, need_size)
+        local_free = len(self.free_pages)
+        for _attempt in range(_max_lease_attempts(int(need_size), local_free)):
+            out = orig_token_alloc(self, need_size)
+            if out is None:
+                return None
+            pages = _pages_to_list(out)
+            if _lease_pages(
+                self,
+                pages,
+                local_free=local_free,
+                operation="token_alloc",
+            ):
+                return out
+            _prepend_pages(self, pages)
+            _deprioritize_pages(self, pages)
+        return None
+
+    def patched_token_free(self, free_index):
+        _release_indices(self, free_index)
+        return orig_token_free(self, free_index)
+
+    def patched_token_clear(self):
+        st = _state(self)
+        if st is not None:
+            lease_map = st["leases_by_page"]
+            client = st["client"]
+            assert isinstance(lease_map, dict)
+            outstanding = list(lease_map.values())
+            if outstanding:
+                logger.info(
+                    "[GMS-KVLease] SGLang allocator clear releases %d outstanding leases namespace=%s owner=%s",
+                    len(outstanding),
+                    getattr(client, "namespace", "?"),
+                    getattr(client, "owner_id", "?"),
+                )
+            client.release(outstanding)
+            lease_map.clear()
+        return orig_token_clear(self)
+
+    def patched_paged_alloc(self, need_size: int):
+        st = _state(self)
+        if st is None:
+            return orig_paged_alloc(self, need_size)
+        num_pages = int(need_size) // int(self.page_size)
+        local_free = len(self.free_pages)
+        for _attempt in range(_max_lease_attempts(num_pages, local_free)):
+            out = orig_paged_alloc(self, need_size)
+            if out is None:
+                return None
+            pages = _pages_to_list(torch.unique(out // int(self.page_size)))
+            if _lease_pages(
+                self,
+                pages,
+                local_free=local_free,
+                operation="paged_alloc",
+            ):
+                return out
+            _prepend_pages(self, pages)
+            _deprioritize_pages(self, pages)
+        return None
+
+    def patched_paged_alloc_extend(
+        self,
+        prefix_lens,
+        prefix_lens_cpu,
+        seq_lens,
+        seq_lens_cpu,
+        last_loc,
+        extend_num_tokens: int,
+        num_new_pages: int | None = None,
+    ):
+        st = _state(self)
+        if st is None:
+            return orig_paged_alloc_extend(
+                self,
+                prefix_lens,
+                prefix_lens_cpu,
+                seq_lens,
+                seq_lens_cpu,
+                last_loc,
+                extend_num_tokens,
+                num_new_pages=num_new_pages,
+            )
+        premerge_pages = extend_num_tokens // int(self.page_size) + len(prefix_lens) + 1
+        if self.need_sort and premerge_pages > len(self.free_pages):
+            self.merge_and_sort_free()
+        if num_new_pages is None:
+            num_new_pages = get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=int(self.page_size),
+                prefix_lens=prefix_lens_cpu,
+            )
+        local_free = len(self.free_pages)
+        for _attempt in range(_max_lease_attempts(int(num_new_pages), local_free)):
+            new_pages = self.free_pages[: int(num_new_pages)].clone()
+            out = orig_paged_alloc_extend(
+                self,
+                prefix_lens,
+                prefix_lens_cpu,
+                seq_lens,
+                seq_lens_cpu,
+                last_loc,
+                extend_num_tokens,
+                num_new_pages=int(num_new_pages),
+            )
+            if out is None:
+                return None
+            pages = _pages_to_list(new_pages)
+            if _lease_pages(
+                self,
+                pages,
+                local_free=local_free,
+                operation="paged_alloc_extend",
+            ):
+                return out
+            _prepend_pages(self, pages)
+            _deprioritize_pages(self, pages)
+        return None
+
+    def patched_paged_alloc_decode(self, seq_lens, seq_lens_cpu, last_loc):
+        st = _state(self)
+        if st is None:
+            return orig_paged_alloc_decode(self, seq_lens, seq_lens_cpu, last_loc)
+        if self.need_sort and len(seq_lens) > len(self.free_pages):
+            self.merge_and_sort_free()
+        num_new_pages = get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=int(self.page_size),
+            decode=True,
+        )
+        local_free = len(self.free_pages)
+        for _attempt in range(_max_lease_attempts(int(num_new_pages), local_free)):
+            new_pages = self.free_pages[: int(num_new_pages)].clone()
+            out = orig_paged_alloc_decode(self, seq_lens, seq_lens_cpu, last_loc)
+            if out is None:
+                return None
+            pages = _pages_to_list(new_pages)
+            if _lease_pages(
+                self,
+                pages,
+                local_free=local_free,
+                operation="paged_alloc_decode",
+            ):
+                return out
+            _prepend_pages(self, pages)
+            _deprioritize_pages(self, pages)
+        return None
+
+    def patched_paged_free(self, free_index):
+        _release_indices(self, free_index)
+        return orig_paged_free(self, free_index)
+
+    def patched_paged_clear(self):
+        st = _state(self)
+        if st is not None:
+            lease_map = st["leases_by_page"]
+            client = st["client"]
+            assert isinstance(lease_map, dict)
+            outstanding = list(lease_map.values())
+            if outstanding:
+                logger.info(
+                    "[GMS-KVLease] SGLang allocator clear releases %d outstanding leases namespace=%s owner=%s",
+                    len(outstanding),
+                    getattr(client, "namespace", "?"),
+                    getattr(client, "owner_id", "?"),
+                )
+            client.release(outstanding)
+            lease_map.clear()
+        return orig_paged_clear(self)
+
+    Base.__init__ = patched_base_init  # type: ignore[method-assign]
+    Base.available_size = patched_base_available  # type: ignore[method-assign]
+    Token.alloc = patched_token_alloc  # type: ignore[method-assign]
+    Token.free = patched_token_free  # type: ignore[method-assign]
+    Token.clear = patched_token_clear  # type: ignore[method-assign]
+    Token.available_size = patched_token_available  # type: ignore[method-assign]
+    Paged.alloc = patched_paged_alloc  # type: ignore[method-assign]
+    Paged.alloc_extend = patched_paged_alloc_extend  # type: ignore[method-assign]
+    Paged.alloc_decode = patched_paged_alloc_decode  # type: ignore[method-assign]
+    Paged.free = patched_paged_free  # type: ignore[method-assign]
+    Paged.clear = patched_paged_clear  # type: ignore[method-assign]
+
+    _patched = True
+    logger.info("[GMS-KVLease] patched SGLang token/page allocators")
+    return True
+
+
+if kv_leases_enabled("sglang"):
+    try:
+        install()
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-KVLease] SGLang auto-install failed")

--- a/lib/gpu_memory_service/integrations/sglang/install_vmm_ipc_kv.py
+++ b/lib/gpu_memory_service/integrations/sglang/install_vmm_ipc_kv.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Install hook: route SGLang's MHATokenToKVPool / MLATokenToKVPool
+allocation through GMS-owned VMM-IPC persistent allocations.
+
+SGLang allocates its KV pool inside ``MHATokenToKVPool.__init__`` (and
+the MLA variant), which constructs ``self.kv_buffer`` as a list of
+per-layer CUDA tensors. Current SGLang versions already wrap those
+allocations with ``memory_saver_adapter.region("kv_cache")``. This hook
+therefore only ensures the persistent allocator exists before vanilla init;
+the memory saver adapter owns the single mempool allocation scope.
+
+Gates:
+  GMS_SGLANG_VMM_IPC_KV=0           optional test/debug disable
+  GMS_SGLANG_VMM_IPC_SOCKET=<path>  daemon UDS (default: derived from device)
+  GMS_SGLANG_VMM_IPC_ENGINE_ID=<id> identifier for (engine_id, tag) keying
+                                    (default: derived stable Dynamo id)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+from gpu_memory_service.integrations.common.kv_lease_client import resolve_lease_device
+from gpu_memory_service.integrations.common.utils import (
+    env_enabled_by_default,
+    get_gms_persistent_kv_socket,
+)
+from gpu_memory_service.integrations.sglang.kv_identity import (
+    allocation_engine_id,
+    allocation_shared,
+    allocator_tag,
+    private_bootstrap_kv_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+_INSTALLED = False
+_LAZY_HOOK_INSTALLED = False
+
+
+def _is_enabled() -> bool:
+    return env_enabled_by_default("GMS_SGLANG_VMM_IPC_KV", default=True)
+
+
+def _resolve_socket(device: int) -> str:
+    return get_gms_persistent_kv_socket(device, "GMS_SGLANG_VMM_IPC_SOCKET")
+
+
+def _engine_id(device: int = 0) -> str:
+    return allocation_engine_id(device)
+
+
+def _device_index_from_value(value) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return int(value)
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if ":" in raw:
+            raw = raw.rsplit(":", 1)[1]
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+    index = getattr(value, "index", None)
+    if index is not None and not callable(index):
+        try:
+            return int(index)
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_kv_pool_device(args, kwargs) -> int:
+    candidates = [kwargs.get("device")]
+    if len(args) > 6:
+        candidates.append(args[6])
+    for candidate in candidates:
+        index = _device_index_from_value(candidate)
+        if index is not None:
+            return index
+    return int(resolve_lease_device("GMS_SGLANG_KV_LEASE_DEVICE"))
+
+
+def _wrap_init(cls, name: str) -> None:
+    """Wrap ``cls.__init__`` so it runs inside a persistent pool scope."""
+    from gpu_memory_service.client.torch.allocator import (
+        get_or_create_persistent_allocator,
+    )
+
+    original_init = cls.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        logger.debug("[GMS-VMM-IPC] %s init in pid=%d", name, os.getpid())
+        # The device is one of the constructor args on current SGLang,
+        # but may be passed positionally as plain "cuda". In that case
+        # SGLang has already set the rank-local current device.
+        device = _resolve_kv_pool_device(args, kwargs)
+        socket = _resolve_socket(device)
+        engine_id = _engine_id(device)
+        try:
+            get_or_create_persistent_allocator(
+                socket,
+                device,
+                engine_id,
+                tag=allocator_tag(device),
+                shared=allocation_shared(),
+                defer_physical=private_bootstrap_kv_enabled(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                f"GMS SGLang persistent KV allocator registration failed for {name}"
+            ) from exc
+        logger.info(
+            "[GMS-VMM-IPC] %s using registered GMS persistent KV "
+            "allocator (engine_id=%s, device=%d)",
+            name,
+            engine_id,
+            device,
+        )
+        return original_init(self, *args, **kwargs)
+
+    cls.__init__ = _patched_init  # type: ignore[method-assign]
+    logger.debug("[GMS-VMM-IPC] patched %s init in pid=%d", name, os.getpid())
+
+
+def install() -> bool:
+    global _INSTALLED
+    if _INSTALLED:
+        return False
+    if not _is_enabled():
+        logger.debug(
+            "[GMS-VMM-IPC] GMS_SGLANG_VMM_IPC_KV not set; skipping install",
+        )
+        return False
+
+    try:
+        from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, MLATokenToKVPool
+    except ImportError:
+        logger.warning(
+            "[GMS-VMM-IPC] sglang.srt.mem_cache.memory_pool not importable; "
+            "cannot install VMM-IPC KV hook",
+        )
+        return False
+
+    _wrap_init(MHATokenToKVPool, "MHATokenToKVPool")
+    _wrap_init(MLATokenToKVPool, "MLATokenToKVPool")
+    _INSTALLED = True
+    logger.info(
+        "[GMS-VMM-IPC install] patched MHATokenToKVPool.__init__ and "
+        "MLATokenToKVPool.__init__",
+    )
+    return True
+
+
+def install_lazy() -> None:
+    """Register a sys.meta_path finder that calls install() AFTER the
+    target SGLang module's body has finished executing.
+
+    We wrap the real Loader's exec_module so the patch lands once the
+    target module has fully initialized — otherwise the module body's
+    own ``__init__`` definition would overwrite our patch."""
+    global _LAZY_HOOK_INSTALLED
+    if _LAZY_HOOK_INSTALLED:
+        return
+    if not _is_enabled():
+        return
+
+    target_name = "sglang.srt.mem_cache.memory_pool"
+
+    class _PatchAfterLoad:
+        def __init__(self, real_loader):
+            self._real = real_loader
+
+        def create_module(self, spec):
+            if hasattr(self._real, "create_module"):
+                return self._real.create_module(spec)
+            return None
+
+        def exec_module(self, module):
+            self._real.exec_module(module)
+            # Module body has run; classes are defined. Now patch.
+            try:
+                install()
+            except Exception:  # noqa: BLE001
+                logger.exception("[GMS-VMM-IPC] SGLang post-load install raised")
+                raise
+
+    class _Finder:
+        def find_spec(self, name, path=None, target_pkg=None):
+            if name != target_name:
+                return None
+            # Find the real spec via the OTHER finders.
+            for finder in sys.meta_path:
+                if finder is self:
+                    continue
+                if hasattr(finder, "find_spec"):
+                    spec = finder.find_spec(name, path, target_pkg)
+                    if spec is not None and spec.loader is not None:
+                        # Self-uninstall: only need to fire once.
+                        try:
+                            sys.meta_path.remove(self)
+                        except ValueError:
+                            pass
+                        spec.loader = _PatchAfterLoad(spec.loader)
+                        return spec
+            return None
+
+    sys.meta_path.insert(0, _Finder())
+    _LAZY_HOOK_INSTALLED = True
+
+
+# Eager install only if SGLang's memory_pool is already loaded.
+if _is_enabled() and "sglang.srt.mem_cache.memory_pool" in sys.modules:
+    try:
+        install()
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-VMM-IPC] SGLang auto-install raised")
+        raise

--- a/lib/gpu_memory_service/integrations/sglang/kv_identity.py
+++ b/lib/gpu_memory_service/integrations/sglang/kv_identity.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistent KV identity helpers for the SGLang GMS integration."""
+
+from __future__ import annotations
+
+import os
+
+from gpu_memory_service.integrations.common.utils import (
+    env_enabled_by_default,
+    get_gms_persistent_kv_engine_id,
+)
+
+
+def truthy_env(name: str, *, default: bool = False) -> bool:
+    return env_enabled_by_default(name, default=default)
+
+
+def shared_kv_enabled() -> bool:
+    return truthy_env(
+        "GMS_SGLANG_SHARED_KV",
+        default=truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE", default=False),
+    )
+
+
+def private_bootstrap_kv_enabled() -> bool:
+    requested = truthy_env(
+        "DYN_SGLANG_GMS_PRIVATE_BOOTSTRAP_KV",
+        default=truthy_env("GMS_SGLANG_PRIVATE_BOOTSTRAP_KV", default=False),
+    )
+    if not requested:
+        return False
+    if not truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE", default=False):
+        return True
+    return _member_id() != _primary_member_id()
+
+
+def stable_engine_id(device: int) -> str:
+    return get_gms_persistent_kv_engine_id(
+        "sglang", device, "GMS_SGLANG_VMM_IPC_ENGINE_ID"
+    )
+
+
+def allocator_tag(device: int) -> str:
+    """Process-local Torch allocator tag for this device's KV pool."""
+    return f"kv_pool:cuda{int(device)}"
+
+
+def _member_id() -> str:
+    for name in ("ENGINE_ID", "DYN_WORKER_ID", "HOSTNAME"):
+        value = os.environ.get(name)
+        if value:
+            return value
+    return str(os.getpid())
+
+
+def _primary_member_id() -> str:
+    return os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+
+
+def allocation_engine_id(device: int) -> str:
+    engine_id = stable_engine_id(device)
+    if private_bootstrap_kv_enabled():
+        return f"{engine_id}|bootstrap={_member_id()}"
+    return engine_id
+
+
+def allocation_shared() -> bool:
+    return shared_kv_enabled() and not private_bootstrap_kv_enabled()
+
+
+def promotion_engine_id(device: int) -> str:
+    return stable_engine_id(device)
+
+
+def release_private_bootstrap_kv_pool(manager, engine_id: str, *, logger=None) -> int:
+    try:
+        allocations = list(manager.list_persistent(engine_id=engine_id))
+    except Exception:  # noqa: BLE001
+        if logger is not None:
+            logger.warning(
+                "[GMS] Failed to list private SGLang KV bootstrap allocations for %s",
+                engine_id,
+                exc_info=True,
+            )
+        return 0
+
+    released = 0
+    for allocation in allocations:
+        tag = getattr(allocation, "tag", "")
+        if not tag.startswith("kv_pool"):
+            continue
+        try:
+            if manager.release_persistent(engine_id, tag):
+                released += 1
+        except Exception:  # noqa: BLE001
+            if logger is not None:
+                logger.warning(
+                    "[GMS] Failed to release private SGLang KV bootstrap allocation %s/%s",
+                    engine_id,
+                    tag,
+                    exc_info=True,
+                )
+
+    if released and logger is not None:
+        logger.info(
+            "[GMS] Released %d private SGLang KV bootstrap allocations for %s",
+            released,
+            engine_id,
+        )
+    return released

--- a/lib/gpu_memory_service/integrations/sglang/memory_saver.py
+++ b/lib/gpu_memory_service/integrations/sglang/memory_saver.py
@@ -5,7 +5,7 @@
 
 SGLang with GMS owns exactly two memory classes:
 1. "weights" via the shared RO/RW publish flow
-2. "kv_cache" via the RW failover flow
+2. "kv_cache" via the GMS-owned persistent KV pool
 
 Unsupported release/resume tags stay no-ops with a warning so the generic
 SGLang memory-control API can still pass broader tag sets without reintroducing
@@ -24,38 +24,64 @@ from typing import Optional
 import torch
 from gpu_memory_service.client.torch.allocator import (
     get_or_create_gms_client_memory_manager,
+    get_or_create_persistent_allocator,
     gms_use_mem_pool,
+    gms_use_persistent_pool,
+    retarget_persistent_allocator,
 )
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
-from gpu_memory_service.common.utils import GMS_TAGS, get_socket_path
-from gpu_memory_service.integrations.common.utils import finalize_gms_write
+from gpu_memory_service.common.utils import get_socket_path
+from gpu_memory_service.integrations.common.utils import (
+    finalize_gms_write,
+    get_gms_persistent_kv_socket,
+)
+from gpu_memory_service.integrations.sglang.kv_identity import (
+    allocation_engine_id,
+    allocation_shared,
+    allocator_tag,
+    private_bootstrap_kv_enabled,
+    promotion_engine_id,
+    release_private_bootstrap_kv_pool,
+    shared_kv_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
-# Published weights must come back RO, while KV cache always resumes in a fresh
-# RW epoch so the restored engine can rebuild mutable cache state.
-_TAG_LOCK_TYPES = {"weights": RequestedLockType.RO, "kv_cache": RequestedLockType.RW}
+# Published weights come back RO. KV cache is backed by persistent HBM and
+# remaps by reclaiming the same (engine_id, allocation-tag) keys.
+_MEMORY_SAVER_TAGS = ("weights", "kv_cache")
+_TAG_LOCK_TYPES = {
+    "weights": RequestedLockType.RO,
+    "kv_pool": RequestedLockType.RW_PERSISTENT,
+}
 
 
 def _pause_resume_tags(tag: Optional[str]) -> tuple[str, ...]:
     if tag is None:
-        return GMS_TAGS
+        return ("weights", "kv_pool")
+    if tag == "kv_cache":
+        return ("kv_pool",)
     if tag in _TAG_LOCK_TYPES:
         return (tag,)
     logger.warning(
         "[GMS] Ignoring unsupported torch_memory_saver tag %r; supported tags are %s",
         tag,
-        list(GMS_TAGS),
+        list(_MEMORY_SAVER_TAGS),
     )
     return ()
 
 
 def get_gms_memory_saver_impl() -> Optional["GMSMemorySaverImpl"]:
-    """Get the GMS memory saver impl from the torch_memory_saver singleton."""
+    """Get or lazily initialize the GMS impl from torch_memory_saver."""
     try:
         import torch_memory_saver
 
-        return torch_memory_saver.torch_memory_saver.gms_impl
+        singleton = torch_memory_saver.torch_memory_saver
+        impl = getattr(singleton, "gms_impl", None)
+        if impl is None and hasattr(singleton, "_ensure_initialized"):
+            singleton._ensure_initialized()
+            impl = getattr(singleton, "gms_impl", None)
+        return impl
     except (ImportError, AttributeError):
         return None
 
@@ -70,20 +96,31 @@ class GMSMemorySaverImpl:
         ro_connect_timeout_ms=None,
     ):
         self._device = torch.device("cuda", device_index)
+        self._device_index = device_index
+        self._kv_engine_id = allocation_engine_id(device_index)
+        self._kv_tag = allocator_tag(device_index)
+        self._kv_promote_engine_id = promotion_engine_id(device_index)
+        self._kv_private_bootstrap = private_bootstrap_kv_enabled()
+        self._kv_shared = allocation_shared()
         self.imported_weights_bytes = 0
         self.preloaded_weights_bytes = 0
         self.ro_connect_timeout_ms = ro_connect_timeout_ms
         requested_mode = mode or RequestedLockType.RW_OR_RO
         self.allocators = {
-            tag: get_or_create_gms_client_memory_manager(
-                get_socket_path(device_index, tag),
+            "weights": get_or_create_gms_client_memory_manager(
+                get_socket_path(device_index, "weights"),
                 device_index,
-                # weights follow the configured publish/import mode; kv_cache is
-                # always mutable and therefore always needs an RW session.
-                mode=requested_mode if tag == "weights" else RequestedLockType.RW,
-                tag=tag,
-            )
-            for tag in GMS_TAGS
+                mode=requested_mode,
+                tag="weights",
+            ),
+            "kv_pool": get_or_create_persistent_allocator(
+                get_gms_persistent_kv_socket(device_index, "GMS_SGLANG_VMM_IPC_SOCKET"),
+                device_index,
+                self._kv_engine_id,
+                tag=self._kv_tag,
+                shared=self._kv_shared,
+                defer_physical=self._kv_private_bootstrap,
+            ),
         }
 
         logger.info(
@@ -101,20 +138,22 @@ class GMSMemorySaverImpl:
                 "SGLang with GMS does not support CPU backup for allocations."
             )
 
-        if tag not in _TAG_LOCK_TYPES:
+        if tag == "kv_cache":
+            with gms_use_persistent_pool(self._kv_tag, self._device):
+                yield
+            return
+
+        if tag != "weights":
             logger.warning(
                 "[GMS] Ignoring unsupported torch_memory_saver region tag %r; "
                 "supported tags are %s",
                 tag,
-                list(GMS_TAGS),
+                list(_MEMORY_SAVER_TAGS),
             )
             yield
             return
 
-        if (
-            tag == "weights"
-            and self.allocators["weights"].granted_lock_type == GrantedLockType.RO
-        ):
+        if self.allocators["weights"].granted_lock_type == GrantedLockType.RO:
             # Imported weights are already mapped and immutable in RO mode, so
             # there is no allocator swap to install for this region.
             yield
@@ -177,11 +216,37 @@ class GMSMemorySaverImpl:
             self.allocators[target_tag].connect(
                 _TAG_LOCK_TYPES[target_tag], timeout_ms=timeout_ms
             )
-            if target_tag == "kv_cache":
-                # KV cache resumes into a new RW layout epoch, so the handles
-                # must be re-created before the VA range is mapped again.
-                self.allocators[target_tag].reallocate_all_handles(tag=target_tag)
-            self.allocators[target_tag].remap_all_vas()
+            if target_tag == "kv_pool":
+                target_engine_id = self._kv_engine_id
+                target_shared = self._kv_shared
+                if self._kv_private_bootstrap:
+                    target_engine_id = self._kv_promote_engine_id
+                    target_shared = shared_kv_enabled()
+
+                if self._kv_private_bootstrap:
+                    self.allocators[target_tag].prepare_scratch_for_reallocation()
+
+                self.allocators[target_tag].remap_persistent_vas(
+                    target_engine_id,
+                    shared=target_shared,
+                )
+                if target_engine_id != self._kv_engine_id:
+                    retarget_persistent_allocator(
+                        self._kv_tag, target_engine_id, shared=target_shared
+                    )
+                    release_private_bootstrap_kv_pool(
+                        self.allocators[target_tag], self._kv_engine_id, logger=logger
+                    )
+                    logger.info(
+                        "[GMS] Promoted SGLang KV namespace %s -> %s",
+                        self._kv_engine_id,
+                        target_engine_id,
+                    )
+                    self._kv_engine_id = target_engine_id
+                    self._kv_shared = target_shared
+                    self._kv_private_bootstrap = False
+            else:
+                self.allocators[target_tag].remap_all_vas()
 
     def finalize_write_mode(self, model: torch.nn.Module) -> None:
         """Finalize write mode: register tensors, commit, and switch to read."""

--- a/lib/gpu_memory_service/integrations/sglang/model_loader.py
+++ b/lib/gpu_memory_service/integrations/sglang/model_loader.py
@@ -28,6 +28,8 @@ from gpu_memory_service.integrations.sglang.memory_saver import (
 )
 from gpu_memory_service.integrations.sglang.patches import (
     patch_model_runner,
+    patch_serving_collective_timeout_for_gms,
+    patch_shared_kv_pool_geometry,
     patch_static_state_for_gms,
     patch_torch_memory_saver,
 )
@@ -42,7 +44,9 @@ logger = logging.getLogger(__name__)
 patch_empty_cache()
 patch_torch_memory_saver()
 patch_model_runner()
+patch_shared_kv_pool_geometry()
 patch_static_state_for_gms()
+patch_serving_collective_timeout_for_gms()
 logger.info("[GMS] Applied patches")
 
 

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 from contextlib import contextmanager
 from typing import Optional
 
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 _torch_memory_saver_patched = False
 _model_runner_patched = False
 _static_state_patched = False
+_kv_pool_geometry_patched = False
 
 
 def patch_torch_memory_saver() -> None:
@@ -243,17 +245,190 @@ def patch_model_runner() -> None:
     logger.info("[GMS] Patched ModelRunner.init_memory_pool")
 
 
+def patch_shared_kv_pool_geometry() -> None:
+    """Make shared-GMS SGLang workers agree on KV page geometry.
+
+    SGLang sizes KV from a local free-memory profile. With GMS shared KV,
+    the first worker owns the persistent physical pool and later workers
+    reattach to it. Later workers must therefore use the first worker's page
+    count instead of their smaller post-attach free-memory profile.
+    """
+    global _kv_pool_geometry_patched
+    if _kv_pool_geometry_patched:
+        return
+
+    try:
+        from gpu_memory_service.integrations.common.kv_lease_client import (
+            kv_leases_enabled,
+            resolve_kv_lease_namespace_total_blocks,
+            resolve_lease_device,
+        )
+        from sglang.srt.model_executor import model_runner_kv_cache_mixin as mixin
+        from sglang.srt.model_executor.pool_configurator import (
+            create_memory_pool_configurator,
+        )
+    except ImportError:
+        logger.warning("[GMS] Could not import SGLang KV geometry hooks", exc_info=True)
+        return
+
+    if hasattr(
+        mixin.ModelRunnerKVCacheMixin,
+        "_gms_shared_kv_pool_geometry_patched",
+    ):
+        _kv_pool_geometry_patched = True
+        return
+
+    original_resolve = mixin.ModelRunnerKVCacheMixin._resolve_memory_pool_config
+
+    def patched_resolve_memory_pool_config(self, pre_model_load_memory):
+        config = original_resolve(self, pre_model_load_memory)
+
+        shared_kv = os.environ.get("GMS_SGLANG_SHARED_KV", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        if not shared_kv or not kv_leases_enabled("sglang"):
+            return config
+
+        page_size = int(self.server_args.page_size)
+        proposed_pages = int(config.max_total_num_tokens) // page_size
+        if proposed_pages <= 0:
+            return config
+
+        device_idx = _resolve_shared_kv_geometry_device(self, resolve_lease_device)
+        model_id = (
+            getattr(self.server_args, "served_model_name", None)
+            or getattr(self.server_args, "model_path", None)
+            or "model"
+        )
+        dynamo_namespace = (
+            os.environ.get("DYN_NAMESPACE")
+            or os.environ.get("DYN_PARENT_DGD_K8S_NAME")
+            or "default"
+        )
+        suffix = (
+            f"shared:{dynamo_namespace}:{self.__class__.__name__}:"
+            f"model{model_id}:page{page_size}"
+        )
+        namespace, total_blocks = resolve_kv_lease_namespace_total_blocks(
+            "sglang",
+            device_idx,
+            total_blocks=proposed_pages + 1,
+            namespace_suffix=suffix,
+            reserved_blocks=[0],
+        )
+        target_pages = int(total_blocks) - 1
+        if target_pages == proposed_pages:
+            return config
+
+        target_tokens = target_pages * page_size
+        configurator = create_memory_pool_configurator(self)
+        adjusted = configurator.calculate_pool_sizes_from_max_tokens(
+            target_tokens,
+            page_size,
+        )
+        adjusted.max_running_requests = self._resolve_max_num_reqs(
+            adjusted.max_total_num_tokens
+        )
+        adjusted.mem_fraction_static = self.server_args.mem_fraction_static
+        logger.info(
+            "[GMS] Adjusted SGLang shared KV geometry from %d pages to %d "
+            "pages (namespace=%s)",
+            proposed_pages,
+            target_pages,
+            namespace,
+        )
+        return adjusted
+
+    mixin.ModelRunnerKVCacheMixin._resolve_memory_pool_config = (
+        patched_resolve_memory_pool_config
+    )
+    mixin.ModelRunnerKVCacheMixin._gms_shared_kv_pool_geometry_patched = True
+    _kv_pool_geometry_patched = True
+    logger.info("[GMS] Patched SGLang shared KV pool geometry")
+
+
+def _resolve_shared_kv_geometry_device(runner, resolve_lease_device_fn) -> int:
+    explicit = os.environ.get("GMS_SGLANG_KV_LEASE_DEVICE")
+    if explicit is not None:
+        try:
+            return int(explicit)
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid GMS_SGLANG_KV_LEASE_DEVICE=%r for SGLang KV geometry",
+                explicit,
+            )
+
+    gpu_id = getattr(runner, "gpu_id", None)
+    if gpu_id is not None:
+        try:
+            return int(gpu_id)
+        except (TypeError, ValueError):
+            logger.debug("Unable to parse SGLang runner.gpu_id=%r", gpu_id)
+
+    return int(resolve_lease_device_fn("GMS_SGLANG_KV_LEASE_DEVICE"))
+
+
+_serving_timeout_patched = False
+
+
+def patch_serving_collective_timeout_for_gms() -> None:
+    """Tighten the NCCL collective watchdog to the serving timeout once SGLang is past
+    warmup. Model load + CUDA-graph capture (the heavy/slow collectives) happen in
+    ``Scheduler.__init__``, BEFORE ``run_event_loop``; wrapping ``run_event_loop`` entry
+    therefore applies the low serving timeout only after warmup, in every rank's
+    scheduler process — the precise post-warmup hook for SGLang, analogous to vLLM's
+    ``GMSWorker.compile_or_warm_up_model``. No grace-delay heuristic, so a tight 2-3s
+    serving timeout can never fire during warmup. No-op unless
+    DYN_GMS_SERVING_NCCL_TIMEOUT_S>0 (checked inside ``tighten_now``).
+    """
+    global _serving_timeout_patched
+    if _serving_timeout_patched:
+        return
+    try:
+        from sglang.srt.managers.scheduler import Scheduler
+    except ImportError:
+        logger.debug(
+            "[GMS] Could not import SGLang Scheduler, skipping serving-timeout patch"
+        )
+        return
+    if getattr(Scheduler, "_gms_serving_timeout_patched", False):
+        _serving_timeout_patched = True
+        return
+
+    original_run_event_loop = Scheduler.run_event_loop
+
+    def patched_run_event_loop(self, *args, **kwargs):
+        # First (and only) entry == post-warmup, pre-traffic: tighten now.
+        try:
+            from gpu_memory_service.common.serving_timeout import tighten_now
+
+            tighten_now()
+        except Exception:
+            logger.debug("[GMS serving-timeout] sglang tighten failed", exc_info=True)
+        return original_run_event_loop(self, *args, **kwargs)
+
+    Scheduler.run_event_loop = patched_run_event_loop
+    Scheduler._gms_serving_timeout_patched = True
+    _serving_timeout_patched = True
+    logger.info(
+        "[GMS serving-timeout] patched SGLang Scheduler.run_event_loop "
+        "(post-warmup collective-timeout tighten)"
+    )
+
+
 def patch_static_state_for_gms() -> None:
     """No-op SGLang's _export/_import_static_state when using GMS.
 
-    SGLang's release_memory_occupation clones every named buffer via
-    buffer.detach().clone() through the default CUDA allocator, then restores
-    them during resume_memory_occupation.
-    This patch must run inside the scheduler child process (which uses
-    multiprocessing spawn).  It is triggered by the GMSModelLoader import
-    in model_loader.py, which executes at module level in the child.
+    SGLang's release_memory_occupation clones every named buffer through the
+    default CUDA allocator, then restores them during resume_memory_occupation.
+    GMS preserves the same VAs across unmap/remap, so this static-state backup
+    is unnecessary and can fail after VMM remap. This patch must run inside the
+    scheduler child process, where the weight updater module is imported.
     """
-    import os
+    import importlib
 
     global _static_state_patched
     logger.info(
@@ -264,26 +439,48 @@ def patch_static_state_for_gms() -> None:
     if _static_state_patched:
         return
 
-    try:
-        from sglang.srt.managers import scheduler_update_weights_mixin as _mixin
+    def _export_noop(model):
+        """NO-OP: GMS preserves buffers via VA-stable unmap/remap."""
+        return dict(buffers=[])
 
-        def _export_noop(model):
-            """NO-OP: GMS preserves buffers via VA-stable unmap/remap."""
-            return dict(buffers=[])
+    def _import_noop(model, static_params):
+        """NO-OP: GMS preserves buffers via VA-stable unmap/remap."""
+        pass
 
-        def _import_noop(model, static_params):
-            """NO-OP: GMS preserves buffers via VA-stable unmap/remap."""
-            pass
+    module_names = (
+        "sglang.srt.managers.scheduler_components.weight_updater",
+        "sglang.srt.managers.scheduler_update_weights_mixin",
+    )
+    patched_modules: list[str] = []
+    for module_name in module_names:
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            logger.debug(
+                "[GMS] %s unavailable; static-state patch skipped", module_name
+            )
+            continue
 
-        _mixin._export_static_state = _export_noop
-        _mixin._import_static_state = _import_noop
+        if not hasattr(module, "_export_static_state") or not hasattr(
+            module, "_import_static_state"
+        ):
+            logger.debug(
+                "[GMS] %s has no static-state helpers; patch skipped",
+                module_name,
+            )
+            continue
+
+        module._export_static_state = _export_noop
+        module._import_static_state = _import_noop
+        patched_modules.append(module_name)
+
+    if patched_modules:
         _static_state_patched = True
         logger.info(
-            "[GMS] Patched _export/_import_static_state -> no-op (pid=%d)",
+            "[GMS] Patched SGLang static-state helpers -> no-op modules=%s pid=%d",
+            patched_modules,
             os.getpid(),
         )
-    except Exception:
-        logger.warning(
-            "[GMS] Could not patch scheduler_update_weights_mixin: ",
-            exc_info=True,
-        )
+        return
+
+    logger.info("[GMS] no SGLang static-state helper module available to patch")

--- a/lib/gpu_memory_service/integrations/vllm/install_kv_leases.py
+++ b/lib/gpu_memory_service/integrations/vllm/install_kv_leases.py
@@ -79,8 +79,55 @@ def _fallback_preferred_candidate_limit(num_blocks: int) -> int:
     return max(num_blocks, min(max(num_blocks * 4, 256), 4096))
 
 
+def install_gms_engine_core_sleep() -> bool:
+    """Install the no-clear sleep utility in this EngineCore process.
+
+    Multi-process/TP vLLM spawns EngineCoreProc without importing GMSWorker, so
+    this must run from the scheduler-process bootstrap as well as the worker
+    import path.
+    """
+    try:
+        from concurrent.futures import Future
+
+        from vllm.v1.engine.core import EngineCore
+    except Exception:
+        logger.debug("[GMS] EngineCore sleep utility patch skipped", exc_info=True)
+        return False
+
+    if hasattr(EngineCore, "gms_sleep_no_clear"):
+        return False
+
+    def gms_sleep_no_clear(self, level: int = 1, mode: str = "abort"):
+        pause_future = self.pause_scheduler(mode=mode, clear_cache=False)
+        if level < 1:
+            return pause_future
+
+        model_executor = self.model_executor
+        if pause_future is None:
+            model_executor.sleep(level)
+            return None
+
+        future = Future()
+
+        def pause_complete(completed):
+            try:
+                completed.result()
+                future.set_result(model_executor.sleep(level))
+            except Exception as exc:  # noqa: BLE001
+                future.set_exception(exc)
+
+        logger.info("[GMS] Waiting for in-flight requests before no-clear sleep")
+        pause_future.add_done_callback(pause_complete)
+        return future
+
+    EngineCore.gms_sleep_no_clear = gms_sleep_no_clear
+    logger.info("[GMS] Installed EngineCore.gms_sleep_no_clear utility")
+    return True
+
+
 def _install_engine_core_process_hooks() -> None:
-    """Install scheduler-process GMS KV hooks before BlockPool creation."""
+    """Install scheduler-process GMS hooks before EngineCore construction."""
+    install_gms_engine_core_sleep()
     try:
         install()
     except Exception:  # noqa: BLE001

--- a/lib/gpu_memory_service/integrations/vllm/install_kv_leases.py
+++ b/lib/gpu_memory_service/integrations/vllm/install_kv_leases.py
@@ -1,0 +1,417 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""vLLM BlockPool integration for GMS KV block leases."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Callable
+
+from gpu_memory_service.integrations.common.kv_lease_client import (
+    GMSKVLeaseClient,
+    KVLease,
+    KVLeaseClient,
+    kv_leases_enabled,
+    log_lease_pressure,
+    resolve_lease_device,
+)
+
+logger = logging.getLogger(__name__)
+
+_patched = False
+_factory: Callable[[int], KVLeaseClient] | None = None
+_engine_core_hook_patched = False
+_original_run_engine_core = None
+
+
+class GMSKVLeaseUnavailable(ValueError):
+    """Shared KV leases were temporarily unavailable for this allocation."""
+
+
+def _preferred_block_ids(free_block_queue, limit: int) -> list[int]:
+    """Return a bounded prefix of local free block IDs without walking
+    vLLM's entire free list. The real queue is a linked list; unit-test
+    fakes may only expose get_all_free_blocks().
+    """
+    if limit <= 0:
+        return []
+    out: list[int] = []
+    head = getattr(free_block_queue, "fake_free_list_head", None)
+    block = getattr(head, "next_free_block", None) if head is not None else None
+    while block is not None and getattr(block, "next_free_block", None) is not None:
+        if not getattr(block, "is_null", False):
+            out.append(int(block.block_id))
+            if len(out) >= limit:
+                return out
+        block = getattr(block, "next_free_block", None)
+
+    get_all = getattr(free_block_queue, "get_all_free_blocks", None)
+    if get_all is None:
+        return out
+    for block in get_all():
+        if getattr(block, "is_null", False):
+            continue
+        block_id = int(block.block_id)
+        if block_id in out:
+            continue
+        out.append(block_id)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _preferred_candidate_limit(num_blocks: int) -> int:
+    configured = os.environ.get("GMS_VLLM_KV_LEASE_PREFERRED_CANDIDATES")
+    if configured:
+        try:
+            return max(num_blocks, int(configured))
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid GMS_VLLM_KV_LEASE_PREFERRED_CANDIDATES=%r",
+                configured,
+            )
+    return num_blocks
+
+
+def _fallback_preferred_candidate_limit(num_blocks: int) -> int:
+    return max(num_blocks, min(max(num_blocks * 4, 256), 4096))
+
+
+def _install_engine_core_process_hooks() -> None:
+    """Install scheduler-process GMS KV hooks before BlockPool creation."""
+    try:
+        install()
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-KVLease] EngineCore BlockPool lease install failed")
+        raise
+
+    try:
+        from gpu_memory_service.integrations.vllm.install_vmm_ipc_kv import (
+            install_geometry_patch,
+        )
+
+        install_geometry_patch()
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-KVLease] EngineCore geometry patch install failed")
+        raise
+
+
+def run_engine_core_with_gms_kv_leases(*args, **kwargs):
+    """Picklable wrapper for vLLM EngineCore subprocess bootstrap.
+
+    vLLM builds BlockPool in the EngineCore scheduler process, not in the CUDA
+    worker process that imports GMSWorker. The wrapper keeps the integration
+    local to GMS while making spawned/forked EngineCore processes install the
+    lease and geometry patches before scheduler construction.
+    """
+    global _original_run_engine_core
+
+    original = _original_run_engine_core
+    if original is None:
+        from vllm.v1.engine.core import EngineCoreProc
+
+        original = EngineCoreProc.run_engine_core
+        if getattr(original, "_gms_kv_lease_engine_core_wrapper", False):
+            raise RuntimeError("GMS EngineCore KV lease wrapper recursion detected")
+        _original_run_engine_core = original
+
+    _install_engine_core_process_hooks()
+    return original(*args, **kwargs)
+
+
+def install_engine_core_hook() -> bool:
+    """Patch vLLM's EngineCore process target so scheduler KV leases install.
+
+    The target must be a module-level function so it remains valid when vLLM
+    uses a spawn multiprocessing context. Forked children reuse the saved
+    original; spawned children resolve the original after importing vLLM.
+    """
+    global _engine_core_hook_patched, _original_run_engine_core
+    if _engine_core_hook_patched:
+        return False
+    if not kv_leases_enabled("vllm"):
+        return False
+
+    try:
+        from vllm.v1.engine.core import EngineCoreProc
+    except Exception:  # noqa: BLE001
+        logger.debug("[GMS-KVLease] EngineCoreProc not importable", exc_info=True)
+        return False
+
+    current = EngineCoreProc.run_engine_core
+    if getattr(current, "_gms_kv_lease_engine_core_wrapper", False):
+        _engine_core_hook_patched = True
+        return False
+
+    _original_run_engine_core = current
+    run_engine_core_with_gms_kv_leases._gms_kv_lease_engine_core_wrapper = True
+    EngineCoreProc.run_engine_core = staticmethod(run_engine_core_with_gms_kv_leases)
+    _engine_core_hook_patched = True
+    logger.info("[GMS-KVLease] patched vLLM EngineCore process bootstrap")
+    return True
+
+
+def install(factory: Callable[[int], KVLeaseClient] | None = None) -> bool:
+    """Patch vLLM's BlockPool so block allocation is lease-gated."""
+
+    global _patched, _factory
+    if factory is not None:
+        _factory = factory
+    if _patched:
+        return False
+    if _factory is None and not kv_leases_enabled("vllm"):
+        return False
+
+    try:
+        from vllm.v1.core.block_pool import BlockPool
+    except Exception:  # noqa: BLE001
+        logger.debug("[GMS-KVLease] vLLM BlockPool not importable", exc_info=True)
+        return False
+
+    orig_init = BlockPool.__init__
+    orig_get_new_blocks = BlockPool.get_new_blocks
+    orig_free_blocks = BlockPool.free_blocks
+    orig_get_num_free_blocks = BlockPool.get_num_free_blocks
+
+    def _make_client(total_blocks: int) -> KVLeaseClient:
+        if _factory is not None:
+            return _factory(total_blocks)
+        device = resolve_lease_device("GMS_VLLM_KV_LEASE_DEVICE")
+        return GMSKVLeaseClient.from_env(
+            "vllm",
+            device,
+            total_blocks=total_blocks,
+            namespace_suffix="block-pool",
+            reserved_blocks=[0],
+        )
+
+    def patched_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        client = _make_client(int(self.num_gpu_blocks))
+        self._gms_kv_lease_client = client
+        self._gms_kv_leases_by_block: dict[int, KVLease] = {}
+        logger.info(
+            "[GMS-KVLease] vLLM BlockPool leases enabled namespace=%s owner=%s blocks=%d",
+            getattr(client, "namespace", "?"),
+            getattr(client, "owner_id", "?"),
+            self.num_gpu_blocks,
+        )
+
+    def patched_get_num_free_blocks(self) -> int:
+        client = getattr(self, "_gms_kv_lease_client", None)
+        if client is None:
+            return orig_get_num_free_blocks(self)
+        return min(orig_get_num_free_blocks(self), int(client.free_count()))
+
+    def patched_get_new_blocks(self, num_blocks: int):
+        client = getattr(self, "_gms_kv_lease_client", None)
+        if client is None:
+            return orig_get_new_blocks(self, num_blocks)
+        local_free = orig_get_num_free_blocks(self)
+        if num_blocks > local_free:
+            log_lease_pressure(
+                logger,
+                f"vllm:{getattr(client, 'namespace', '?')}:local-exhausted",
+                "[GMS-KVLease] vLLM allocation blocked by local free blocks",
+                namespace=getattr(client, "namespace", "?"),
+                owner_id=getattr(client, "owner_id", "?"),
+                requested=int(num_blocks),
+                local_free=local_free,
+                active_leases=len(getattr(self, "_gms_kv_leases_by_block", {})),
+            )
+            raise GMSKVLeaseUnavailable(
+                f"Cannot get {num_blocks} free blocks from the local pool"
+            )
+
+        preferred = _preferred_block_ids(
+            self.free_block_queue,
+            _preferred_candidate_limit(int(num_blocks)),
+        )
+
+        def acquire_with_preferred(
+            candidates: list[int], *, strict: bool = False
+        ) -> list[KVLease]:
+            leases = client.acquire(
+                int(num_blocks),
+                preferred_blocks=candidates,
+                strict_preferred=strict,
+            )
+            if len(leases) != num_blocks:
+                client.release(leases)
+                raise GMSKVLeaseUnavailable(
+                    f"GMS returned {len(leases)} leases, expected {num_blocks}"
+                )
+            return leases
+
+        try:
+            leases = acquire_with_preferred(preferred, strict=False)
+        except Exception as exc:  # noqa: BLE001
+            fallback_limit = _fallback_preferred_candidate_limit(int(num_blocks))
+            if fallback_limit <= len(preferred):
+                refresh = getattr(client, "refresh_free_count", None)
+                if refresh is not None:
+                    try:
+                        refresh()
+                    except Exception:  # noqa: BLE001
+                        logger.debug(
+                            "[GMS-KVLease] free-count refresh failed after acquire error",
+                            exc_info=True,
+                        )
+                raise GMSKVLeaseUnavailable(
+                    f"Cannot get {num_blocks} leased free blocks from the pool"
+                ) from exc
+
+            fallback_preferred = _preferred_block_ids(
+                self.free_block_queue,
+                fallback_limit,
+            )
+            try:
+                leases = acquire_with_preferred(fallback_preferred, strict=False)
+                preferred = fallback_preferred
+            except Exception as fallback_exc:  # noqa: BLE001
+                refresh = getattr(client, "refresh_free_count", None)
+                if refresh is not None:
+                    try:
+                        refresh()
+                    except Exception:  # noqa: BLE001
+                        logger.debug(
+                            "[GMS-KVLease] free-count refresh failed after acquire error",
+                            exc_info=True,
+                        )
+                raise GMSKVLeaseUnavailable(
+                    f"Cannot get {num_blocks} leased free blocks from the pool"
+                ) from fallback_exc
+
+        lease_block_ids = [int(lease.block_id) for lease in leases]
+        try:
+            if lease_block_ids == preferred[:num_blocks] and hasattr(
+                self.free_block_queue, "popleft_n"
+            ):
+                ret = self.free_block_queue.popleft_n(num_blocks)
+            else:
+                ret = []
+                for block_id in lease_block_ids:
+                    block = self.blocks[block_id]
+                    self.free_block_queue.remove(block)
+                    ret.append(block)
+        except Exception:
+            client.release(leases)
+            raise
+
+        for block, lease in zip(ret, leases):
+            if self.enable_caching:
+                self._maybe_evict_cached_block(block)
+            assert block.ref_cnt == 0
+            block.ref_cnt += 1
+            self._gms_kv_leases_by_block[int(block.block_id)] = lease
+            if self.metrics_collector:
+                self.metrics_collector.on_block_allocated(block)
+        return ret
+
+    def patched_free_blocks(self, ordered_blocks, prepend: bool = False):
+        client = getattr(self, "_gms_kv_lease_client", None)
+        if client is None:
+            return orig_free_blocks(self, ordered_blocks, prepend=prepend)
+
+        blocks_list = list(ordered_blocks)
+        for block in blocks_list:
+            block.ref_cnt -= 1
+
+        free_blocks = [
+            block for block in blocks_list if block.ref_cnt == 0 and not block.is_null
+        ]
+        leases = []
+        missing_lease_blocks = []
+        for block in free_blocks:
+            if self.enable_caching:
+                self._maybe_evict_cached_block(block)
+            lease = self._gms_kv_leases_by_block.pop(int(block.block_id), None)
+            if lease is not None:
+                leases.append(lease)
+            else:
+                missing_lease_blocks.append(int(block.block_id))
+        if missing_lease_blocks:
+            log_lease_pressure(
+                logger,
+                f"vllm:{getattr(client, 'namespace', '?')}:missing-release",
+                "[GMS-KVLease] vLLM releasing blocks without matching leases",
+                namespace=getattr(client, "namespace", "?"),
+                owner_id=getattr(client, "owner_id", "?"),
+                missing_count=len(missing_lease_blocks),
+                first_missing_block=missing_lease_blocks[0],
+                active_leases=len(getattr(self, "_gms_kv_leases_by_block", {})),
+            )
+        client.release(leases)
+        if prepend:
+            self.free_block_queue.prepend_n(free_blocks)
+        else:
+            self.free_block_queue.append_n(free_blocks)
+
+    try:
+        from vllm.v1.core.kv_cache_manager import KVCacheManager
+    except Exception:  # noqa: BLE001
+        KVCacheManager = None  # type: ignore[assignment]
+
+    if KVCacheManager is not None:
+        orig_allocate_slots = KVCacheManager.allocate_slots
+
+        def patched_allocate_slots(self, *args, **kwargs):
+            try:
+                return orig_allocate_slots(self, *args, **kwargs)
+            except GMSKVLeaseUnavailable:
+                num_new_computed_tokens = (
+                    args[2]
+                    if len(args) > 2
+                    else kwargs.get("num_new_computed_tokens", 0)
+                )
+                new_computed_blocks = (
+                    args[3] if len(args) > 3 else kwargs.get("new_computed_blocks")
+                )
+                num_external_computed_tokens = (
+                    args[5]
+                    if len(args) > 5
+                    else kwargs.get("num_external_computed_tokens", 0)
+                )
+                if new_computed_blocks is None:
+                    has_new_computed_blocks = False
+                else:
+                    groups = getattr(new_computed_blocks, "blocks", ())
+                    has_new_computed_blocks = any(len(group) > 0 for group in groups)
+                safe_to_backpressure = (
+                    int(num_new_computed_tokens or 0) == 0
+                    and not has_new_computed_blocks
+                    and int(num_external_computed_tokens or 0) == 0
+                )
+                if not safe_to_backpressure:
+                    raise
+                log_lease_pressure(
+                    logger,
+                    "vllm:allocate-slots-backpressure",
+                    "[GMS-KVLease] vLLM scheduler backpressured by shared leases",
+                    requested_tokens=int(num_new_computed_tokens or 0),
+                    external_tokens=int(num_external_computed_tokens or 0),
+                )
+                logger.debug(
+                    "[GMS-KVLease] vLLM allocation backpressured by shared leases",
+                    exc_info=True,
+                )
+                return None
+
+        KVCacheManager.allocate_slots = patched_allocate_slots  # type: ignore[method-assign]
+
+    BlockPool.__init__ = patched_init  # type: ignore[method-assign]
+    BlockPool.get_new_blocks = patched_get_new_blocks  # type: ignore[method-assign]
+    BlockPool.free_blocks = patched_free_blocks  # type: ignore[method-assign]
+    BlockPool.get_num_free_blocks = patched_get_num_free_blocks  # type: ignore[method-assign]
+    _patched = True
+    logger.info("[GMS-KVLease] patched vLLM BlockPool")
+    return True
+
+
+if kv_leases_enabled("vllm"):
+    try:
+        install()
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-KVLease] vLLM auto-install failed")

--- a/lib/gpu_memory_service/integrations/vllm/install_vmm_ipc_kv.py
+++ b/lib/gpu_memory_service/integrations/vllm/install_vmm_ipc_kv.py
@@ -1,0 +1,668 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Install hook: route vLLM's KV-cache allocation through GMS-owned
+VMM-IPC persistent allocations.
+
+Engine code (typically the vLLM worker) imports this module BEFORE
+the model is loaded. The installer monkey-patches the V1 KV cache
+allocation path (``Worker._allocate_kv_cache_tensors`` /
+``GPUWorker._initialize_kv_caches`` depending on vLLM version) so
+the per-layer ``torch.empty`` / ``torch.zeros`` calls allocate from
+a GMS persistent pool instead of the default ``cudaMalloc`` pool.
+
+Effect:
+  - daemon owns the KV pool's physical pages (cuMemCreate),
+  - engine has its own VA into the same pages,
+  - daemon can read/write directly via its va_daemon → no D2D copy
+    on evict/restore,
+  - engine restart with the same engine_id re-attaches to the SAME
+    physical pages → KV survives without recompute.
+
+Gates:
+  GMS_VLLM_VMM_IPC_KV=0            optional test/debug disable
+  GMS_VLLM_VMM_IPC_SOCKET=<path>   daemon UDS (default: derived from device)
+  GMS_VLLM_VMM_IPC_ENGINE_ID=<id>  identifier for (engine_id, tag) keying
+                                   (default: derived stable Dynamo id)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import sys
+import time
+from collections import Counter
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+from gpu_memory_service.integrations.common.utils import (
+    env_enabled_by_default,
+    get_gms_persistent_kv_socket,
+)
+from gpu_memory_service.integrations.vllm.kv_identity import (
+    allocation_engine_id,
+    allocation_shared,
+    private_bootstrap_kv_enabled,
+    use_existing_shared_geometry,
+)
+
+logger = logging.getLogger(__name__)
+
+_INSTALLED = False
+_LAZY_HOOK_INSTALLED = False
+_GEOMETRY_PATCH_INSTALLED = False
+_KV_CACHE_PROFILING: ContextVar[bool] = ContextVar(
+    "gms_vllm_kv_cache_profiling", default=False
+)
+
+
+@contextmanager
+def _private_bootstrap_kv_zeros_as_empty(enabled: bool):
+    """Avoid touching reserve-only private-bootstrap KV pages.
+
+    vLLM allocates KV buffers with ``torch.zeros``. In private-bootstrap mode
+    the GMS allocator only reserves the final VAs until the shadow is promoted,
+    so zero-filling those tensors launches a CUDA kernel against unbacked VAs
+    and poisons the context. During this narrow allocation window, replace
+    int8 zero allocations with ``torch.empty`` so vLLM can build tensor views
+    without writing to KV. Scheduler-driven block zeroing runs later after
+    promotion, when the shared persistent backing is attached.
+    """
+    if not enabled:
+        yield
+        return
+
+    import torch
+
+    original_zeros = torch.zeros
+    replacements = 0
+
+    def zeros_as_empty(*args, **kwargs):
+        nonlocal replacements
+        if kwargs.get("dtype") is torch.int8:
+            replacements += 1
+            return torch.empty(*args, **kwargs)
+        return original_zeros(*args, **kwargs)
+
+    torch.zeros = zeros_as_empty
+    try:
+        yield
+    finally:
+        torch.zeros = original_zeros
+        if replacements:
+            logger.info(
+                "[GMS-VMM-IPC] allocated %d private-bootstrap KV tensors "
+                "with torch.empty to avoid reserve-only zero-fill",
+                replacements,
+            )
+
+
+def _is_enabled() -> bool:
+    return env_enabled_by_default("GMS_VLLM_VMM_IPC_KV", default=True)
+
+
+def _resolve_socket(device: int) -> str:
+    return get_gms_persistent_kv_socket(device, "GMS_VLLM_VMM_IPC_SOCKET")
+
+
+def _engine_id(device: int = 0) -> str:
+    return allocation_engine_id(device)
+
+
+def _current_cuda_device() -> int:
+    import torch
+
+    return int(torch.cuda.current_device())
+
+
+def _device_index(device) -> int:
+    if isinstance(device, int):
+        return int(device)
+    index = getattr(device, "index", None)
+    if index is not None:
+        return int(index)
+    try:
+        return _current_cuda_device()
+    except Exception:
+        logger.debug(
+            "[GMS-VMM-IPC] Failed to resolve current CUDA device; using cuda:0",
+            exc_info=True,
+        )
+        return 0
+
+
+def _int_env_value(name: str, value: str | None, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r for GMS KV geometry", name, value)
+        return default
+
+
+def _shared_kv_enabled() -> bool:
+    return allocation_shared()
+
+
+def _install_kv_leases() -> bool:
+    try:
+        from gpu_memory_service.integrations.vllm.install_kv_leases import (
+            install as install_kv_leases,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[GMS-VMM-IPC] vLLM KV lease installer unavailable", exc_info=True)
+        return False
+    try:
+        return bool(install_kv_leases())
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-VMM-IPC] vLLM KV lease install failed")
+        raise
+
+
+def _defer_physical_enabled() -> bool:
+    return private_bootstrap_kv_enabled()
+
+
+def _semantic_kv_tensor_tag(index: int, kv_cache_tensor) -> str:
+    shared_by = tuple(
+        sorted(str(layer) for layer in getattr(kv_cache_tensor, "shared_by", ()) or ())
+    )
+    if shared_by:
+        key = "\0".join(shared_by)
+    else:
+        key = f"anonymous:{index}:{getattr(kv_cache_tensor, 'size', '')}"
+    digest = hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
+    return f"kv_pool:v2:{digest}"
+
+
+def _semantic_kv_tensor_tag_plan(kv_cache_config) -> list[str]:
+    base_tags = [
+        _semantic_kv_tensor_tag(index, kv_cache_tensor)
+        for index, kv_cache_tensor in enumerate(
+            getattr(kv_cache_config, "kv_cache_tensors", ()) or ()
+        )
+    ]
+    counts = Counter(base_tags)
+    seen: dict[str, int] = {}
+    planned_tags: list[str] = []
+    for base_tag in base_tags:
+        if counts[base_tag] == 1:
+            planned_tags.append(base_tag)
+            continue
+        duplicate_index = seen.get(base_tag, 0)
+        seen[base_tag] = duplicate_index + 1
+        planned_tags.append(f"{base_tag}:dup{duplicate_index}")
+    return planned_tags
+
+
+def _geometry_device() -> int:
+    for name in ("GMS_VLLM_KV_LEASE_DEVICE", "LOCAL_RANK"):
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except ValueError:
+            logger.warning("Ignoring invalid %s=%r for GMS KV geometry", name, value)
+    return 0
+
+
+def _existing_shared_kv_blocks(*, wait_ms: int = 0) -> int | None:
+    if not use_existing_shared_geometry():
+        return None
+    if env_enabled_by_default("GMS_KV_LEASE_SHM_RESET", default=False):
+        return None
+
+    from gpu_memory_service.integrations.common.kv_lease_client import (
+        kv_leases_enabled,
+        read_any_kv_lease_namespace_total_blocks,
+        read_kv_lease_namespace_total_blocks,
+    )
+
+    if not kv_leases_enabled("vllm"):
+        return None
+
+    device = _geometry_device()
+    deadline = time.monotonic() + max(0, wait_ms) / 1000.0
+    logged_wait = False
+    while True:
+        namespace, total_blocks = read_kv_lease_namespace_total_blocks(
+            "vllm",
+            device,
+            namespace_suffix="block-pool",
+        )
+        if total_blocks is None:
+            namespace, total_blocks = read_any_kv_lease_namespace_total_blocks("vllm")
+        if total_blocks is not None:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        if not logged_wait:
+            logger.info(
+                "[GMS-VMM-IPC] Waiting up to %d ms for existing KV lease "
+                "namespace geometry",
+                wait_ms,
+            )
+            logged_wait = True
+        time.sleep(min(0.05, remaining))
+
+    logger.info(
+        "[GMS-VMM-IPC] Reusing existing KV lease namespace geometry: "
+        "namespace=%s blocks=%d",
+        namespace,
+        total_blocks,
+    )
+    return int(total_blocks)
+
+
+def _available_memory_exhausted(available_memory) -> bool:
+    try:
+        if isinstance(available_memory, (int, float)):
+            values = [available_memory]
+        else:
+            values = list(available_memory)
+    except TypeError:
+        return False
+    if not values:
+        return False
+    try:
+        return min(int(value) for value in values) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _geometry_wait_ms(available_memory) -> int:
+    private_bootstrap = private_bootstrap_kv_enabled()
+    if not private_bootstrap and not _available_memory_exhausted(available_memory):
+        return 0
+    name = "GMS_VLLM_KV_GEOMETRY_WAIT_MS"
+    value = os.environ.get(name)
+    if value is not None:
+        return max(0, _int_env_value(name, value, 300_000))
+
+    if value is None:
+        name = "GMS_KV_LEASE_GEOMETRY_WAIT_MS"
+        value = os.environ.get(name)
+    wait_ms = max(0, _int_env_value(name, value, 300_000))
+    if private_bootstrap:
+        # A private-bootstrap shadow must attach to the primary's published KV
+        # geometry. Falling back to vLLM sizing before the primary has published
+        # can observe negative available HBM and fail even though the shared KV
+        # pool is about to become attachable.
+        return max(wait_ms, 1_800_000)
+    return wait_ms
+
+
+def _wrap_get_kv_cache_configs(original):
+    if getattr(original, "_gms_geometry_patched", False):
+        return original
+
+    def _patched_get_kv_cache_configs(vllm_config, kv_cache_specs, available_memory):
+        existing_blocks = _existing_shared_kv_blocks(
+            wait_ms=_geometry_wait_ms(available_memory)
+        )
+        if existing_blocks is None:
+            return original(vllm_config, kv_cache_specs, available_memory)
+
+        cache_config = getattr(vllm_config, "cache_config", None)
+        if cache_config is None:
+            return original(vllm_config, kv_cache_specs, available_memory)
+
+        previous_override = getattr(cache_config, "num_gpu_blocks_override", None)
+        if previous_override is not None and int(previous_override) != existing_blocks:
+            logger.warning(
+                "[GMS-VMM-IPC] Existing shared KV pool has %d blocks; "
+                "temporarily replacing num_gpu_blocks_override=%s during attach",
+                existing_blocks,
+                previous_override,
+            )
+
+        cache_config.num_gpu_blocks_override = existing_blocks
+        try:
+            return original(vllm_config, kv_cache_specs, available_memory)
+        finally:
+            cache_config.num_gpu_blocks_override = previous_override
+
+    _patched_get_kv_cache_configs._gms_geometry_patched = True
+    _patched_get_kv_cache_configs._gms_geometry_original = original
+    return _patched_get_kv_cache_configs
+
+
+def install_geometry_patch() -> bool:
+    """Patch vLLM KV sizing to reuse existing GMS shared-KV geometry.
+
+    VMM-IPC reattach already works once vLLM reaches tensor allocation. The
+    missing piece is earlier: vLLM profiles currently free HBM before it builds
+    KVCacheConfig. A shadow/restarted engine can therefore fail or shrink its KV
+    block count before it reaches the GMS persistent allocation path. When the
+    primary has already initialized the shared lease namespace, its header is
+    the authoritative logical block count for subsequent attachers.
+
+    vLLM imports ``get_kv_cache_configs`` into ``vllm.v1.engine.core`` by value,
+    so patching only ``kv_cache_utils`` is not enough if engine core is imported
+    after the first GMS hook. Keep this function idempotent while still updating
+    the late-bound engine-core alias whenever it becomes available.
+    """
+    global _GEOMETRY_PATCH_INSTALLED
+    if not _is_enabled():
+        return False
+
+    try:
+        from vllm.v1.core import kv_cache_utils
+    except ImportError:
+        logger.debug(
+            "[GMS-VMM-IPC] vLLM KV cache utils unavailable; geometry patch skipped"
+        )
+        return False
+
+    changed = False
+    current = kv_cache_utils.get_kv_cache_configs
+    if getattr(current, "_gms_geometry_patched", False):
+        patched = current
+    else:
+        patched = _wrap_get_kv_cache_configs(current)
+        kv_cache_utils.get_kv_cache_configs = patched
+        _GEOMETRY_PATCH_INSTALLED = True
+        changed = True
+
+    engine_core = sys.modules.get("vllm.v1.engine.core")
+    if engine_core is not None and hasattr(engine_core, "get_kv_cache_configs"):
+        if getattr(engine_core, "get_kv_cache_configs") is not patched:
+            engine_core.get_kv_cache_configs = patched
+            changed = True
+
+    if changed:
+        logger.info("[GMS-VMM-IPC] patched vLLM KV cache geometry attach path")
+    return changed
+
+
+def install() -> bool:
+    """Monkey-patch vLLM's KV-cache tensor allocation. Returns True iff
+    a patch was actually installed. Safe to call multiple times; idempotent."""
+    global _INSTALLED
+    if not _is_enabled():
+        logger.debug(
+            "[GMS-VMM-IPC] GMS_VLLM_VMM_IPC_KV not set; skipping install",
+        )
+        return False
+    install_geometry_patch()
+    _install_kv_leases()
+    if _INSTALLED:
+        return False
+
+    # vLLM has two model-runner code paths:
+    #   V1: GPUModelRunner.initialize_kv_cache_tensors → _allocate_kv_cache_tensors
+    #       (in vllm.v1.worker.gpu_model_runner)
+    #   V2: gpu.attn_utils._allocate_kv_cache (module-level function called
+    #       from vllm.v1.worker.gpu.model_runner.GPUModelRunner.initialize_kv_cache)
+    # Patch BOTH so we don't depend on VLLM_USE_V2_MODEL_RUNNER.
+
+    from gpu_memory_service.client.torch.allocator import (
+        clear_persistent_allocator_tag_plan,
+        get_or_create_persistent_allocator,
+        gms_use_persistent_pool,
+        set_persistent_allocator_tag_plan,
+    )
+
+    # ---- V2 patch: module-level _allocate_kv_cache ----
+    try:
+        from vllm.v1.worker.gpu import attn_utils as _gpu_attn_utils
+
+        if hasattr(_gpu_attn_utils, "_allocate_kv_cache"):
+            _orig_v2_alloc = _gpu_attn_utils._allocate_kv_cache
+            if getattr(_orig_v2_alloc, "_gms_vmm_ipc_patched", False):
+                _orig_v2_alloc = getattr(
+                    _orig_v2_alloc, "_gms_original", _orig_v2_alloc
+                )
+
+            def _patched_v2_allocate_kv_cache(
+                kv_cache_config, shared_layers=None, device=None, *args, **kwargs
+            ):
+                # Current vLLM passes (kv_cache_config, shared_layers, device).
+                # Older snapshots passed (kv_cache_config, device). Keep both
+                # shapes working so this integration can ride upstream churn.
+                if device is None:
+                    alloc_device = shared_layers
+                    original_args = (kv_cache_config, shared_layers, *args)
+                else:
+                    alloc_device = device
+                    original_args = (kv_cache_config, shared_layers, device, *args)
+
+                if _KV_CACHE_PROFILING.get():
+                    logger.debug(
+                        "[GMS-VMM-IPC] bypassing persistent pool for vLLM "
+                        "profiling KV allocation"
+                    )
+                    return _orig_v2_alloc(*original_args, **kwargs)
+
+                dev_idx = _device_index(alloc_device)
+                socket = _resolve_socket(dev_idx)
+                engine_id = _engine_id(dev_idx)
+                logger.debug(
+                    "[GMS-VMM-IPC] V2 allocation pid=%d device=%d",
+                    os.getpid(),
+                    dev_idx,
+                )
+                try:
+                    shared_kv = _shared_kv_enabled()
+                    defer_physical = _defer_physical_enabled()
+                    get_or_create_persistent_allocator(
+                        socket,
+                        dev_idx,
+                        engine_id,
+                        tag="kv_pool",
+                        shared=shared_kv,
+                        defer_physical=defer_physical,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    raise RuntimeError(
+                        "GMS vLLM persistent KV allocator registration failed"
+                    ) from exc
+                tag_plan = _semantic_kv_tensor_tag_plan(kv_cache_config)
+                if tag_plan:
+                    set_persistent_allocator_tag_plan("kv_pool", tag_plan)
+                logger.debug(
+                    "[GMS-VMM-IPC] V2 persistent pool engine_id=%s device=%d "
+                    "defer_physical=%s semantic_tags=%d",
+                    engine_id,
+                    dev_idx,
+                    defer_physical,
+                    len(tag_plan),
+                )
+                try:
+                    with gms_use_persistent_pool("kv_pool", dev_idx):
+                        with _private_bootstrap_kv_zeros_as_empty(defer_physical):
+                            return _orig_v2_alloc(*original_args, **kwargs)
+                finally:
+                    if tag_plan:
+                        clear_persistent_allocator_tag_plan("kv_pool")
+
+            _patched_v2_allocate_kv_cache._gms_vmm_ipc_patched = True
+            _patched_v2_allocate_kv_cache._gms_original = _orig_v2_alloc
+            _gpu_attn_utils._allocate_kv_cache = _patched_v2_allocate_kv_cache  # type: ignore[assignment]
+            logger.debug(
+                "[GMS-VMM-IPC] patched V2 allocation in pid=%d",
+                os.getpid(),
+            )
+    except ImportError:
+        pass
+
+    # ---- V1 patch: GPUModelRunner.initialize_kv_cache_tensors ----
+    try:
+        from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+    except ImportError:
+        logger.warning(
+            "[GMS-VMM-IPC] vLLM v1 GPUModelRunner not importable; V1 install skipped",
+        )
+        _INSTALLED = True  # V2 may have succeeded
+        return True
+
+    if not hasattr(GPUModelRunner, "initialize_kv_cache_tensors"):
+        logger.warning(
+            "[GMS-VMM-IPC] vLLM GPUModelRunner.initialize_kv_cache_tensors "
+            "not found; V1 install skipped",
+        )
+        _INSTALLED = True
+        return True
+
+    if hasattr(GPUModelRunner, "initialize_kv_cache"):
+        original_initialize_kv_cache = GPUModelRunner.initialize_kv_cache
+        if not getattr(original_initialize_kv_cache, "_gms_profiling_guard", False):
+
+            def _patched_initialize_kv_cache(self, *args, **kwargs):
+                is_profiling = bool(kwargs.get("is_profiling", False))
+                if len(args) >= 2:
+                    is_profiling = bool(args[1])
+                if not is_profiling:
+                    return original_initialize_kv_cache(self, *args, **kwargs)
+                token = _KV_CACHE_PROFILING.set(True)
+                try:
+                    return original_initialize_kv_cache(self, *args, **kwargs)
+                finally:
+                    _KV_CACHE_PROFILING.reset(token)
+
+            _patched_initialize_kv_cache._gms_profiling_guard = True
+            _patched_initialize_kv_cache._gms_original = original_initialize_kv_cache
+            GPUModelRunner.initialize_kv_cache = _patched_initialize_kv_cache  # type: ignore[assignment]
+
+    original = GPUModelRunner.initialize_kv_cache_tensors
+
+    def _patched_initialize_kv_cache_tensors(self, *args, **kwargs):
+        logger.debug(
+            "[GMS-VMM-IPC] V1 allocation in pid=%d",
+            os.getpid(),
+        )
+        if _KV_CACHE_PROFILING.get():
+            logger.debug(
+                "[GMS-VMM-IPC] bypassing persistent pool for vLLM profiling "
+                "KV tensor initialization"
+            )
+            return original(self, *args, **kwargs)
+
+        device = _device_index(getattr(self, "device", 0))
+        socket = _resolve_socket(device)
+        engine_id = _engine_id(device)
+        try:
+            shared_kv = _shared_kv_enabled()
+            defer_physical = _defer_physical_enabled()
+            get_or_create_persistent_allocator(
+                socket,
+                device,
+                engine_id,
+                tag="kv_pool",
+                shared=shared_kv,
+                defer_physical=defer_physical,
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                "GMS vLLM persistent KV allocator registration failed"
+            ) from exc
+        logger.info(
+            "[GMS-VMM-IPC] Allocating vLLM KV-cache through GMS "
+            "persistent pool (engine_id=%s, device=%d)",
+            engine_id,
+            device,
+        )
+        kv_cache_config = args[0] if args else kwargs.get("kv_cache_config")
+        tag_plan = _semantic_kv_tensor_tag_plan(kv_cache_config)
+        if tag_plan:
+            set_persistent_allocator_tag_plan("kv_pool", tag_plan)
+        logger.debug(
+            "[GMS-VMM-IPC] V1 persistent pool engine_id=%s device=%d "
+            "defer_physical=%s semantic_tags=%d",
+            engine_id,
+            device,
+            defer_physical,
+            len(tag_plan),
+        )
+        try:
+            with gms_use_persistent_pool("kv_pool", device):
+                with _private_bootstrap_kv_zeros_as_empty(defer_physical):
+                    return original(self, *args, **kwargs)
+        finally:
+            if tag_plan:
+                clear_persistent_allocator_tag_plan("kv_pool")
+
+    GPUModelRunner.initialize_kv_cache_tensors = _patched_initialize_kv_cache_tensors  # type: ignore[assignment]
+    _INSTALLED = True
+    logger.info(
+        "[GMS-VMM-IPC install] patched GPUModelRunner.initialize_kv_cache_tensors",
+    )
+    return True
+
+
+def install_lazy() -> None:
+    """Register a sys.meta_path finder that calls install() the first
+    time `vllm.v1.worker.gpu_model_runner` is loaded. Designed for use
+    from a .pth file (Python startup): avoids eagerly importing vLLM,
+    which would interfere with pytest's assertion rewriter and other
+    startup-sensitive consumers (e.g. anyio)."""
+    global _LAZY_HOOK_INSTALLED
+    if _LAZY_HOOK_INSTALLED:
+        return
+    if not _is_enabled():
+        return
+
+    targets = {
+        "vllm.v1.core.block_pool",  # Scheduler-side KV lease publication
+        "vllm.v1.engine.core",  # KV sizing call-site imports get_kv_cache_configs by value
+        "vllm.v1.worker.gpu_model_runner",  # V1 path
+        "vllm.v1.worker.gpu.attn_utils",  # V2 path
+    }
+
+    class _PatchAfterLoad:
+        def __init__(self, real_loader):
+            self._real = real_loader
+
+        def create_module(self, spec):
+            if hasattr(self._real, "create_module"):
+                return self._real.create_module(spec)
+            return None
+
+        def exec_module(self, module):
+            self._real.exec_module(module)
+            try:
+                install()
+            except Exception:  # noqa: BLE001
+                logger.exception("[GMS-VMM-IPC] post-load install raised")
+                raise
+
+    class _Finder:
+        def find_spec(self, name, path=None, target_pkg=None):
+            if name not in targets:
+                return None
+            for finder in sys.meta_path:
+                if finder is self:
+                    continue
+                if hasattr(finder, "find_spec"):
+                    spec = finder.find_spec(name, path, target_pkg)
+                    if spec is not None and spec.loader is not None:
+                        try:
+                            sys.meta_path.remove(self)
+                        except ValueError:
+                            pass
+                        spec.loader = _PatchAfterLoad(spec.loader)
+                        return spec
+            return None
+
+    sys.meta_path.insert(0, _Finder())
+    _LAZY_HOOK_INSTALLED = True
+    logger.debug(
+        "[GMS-VMM-IPC] lazy hook armed; will install on first import of %s",
+        sorted(targets),
+    )
+
+
+# Eager install (when this module is imported AFTER vllm — e.g. tests
+# that import vllm first then enable the hook). The .pth file calls
+# install_lazy() instead to avoid eagerly importing vllm.
+if _is_enabled() and "vllm.v1.worker.gpu_model_runner" in sys.modules:
+    try:
+        install()
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-VMM-IPC] Auto-install raised")
+        raise

--- a/lib/gpu_memory_service/integrations/vllm/kv_identity.py
+++ b/lib/gpu_memory_service/integrations/vllm/kv_identity.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistent KV identity helpers for the vLLM GMS integration."""
+
+from __future__ import annotations
+
+import os
+
+from gpu_memory_service.integrations.common.utils import (
+    env_enabled_by_default,
+    get_gms_persistent_kv_engine_id,
+)
+
+
+def truthy_env(name: str, *, default: bool = False) -> bool:
+    return env_enabled_by_default(name, default=default)
+
+
+def shared_kv_enabled() -> bool:
+    return truthy_env(
+        "GMS_VLLM_SHARED_KV",
+        default=truthy_env("DYN_VLLM_GMS_SHADOW_MODE", default=False),
+    )
+
+
+def private_bootstrap_kv_enabled() -> bool:
+    """True when this process must initialize on member-scoped KV.
+
+    In Bulwark failover the static primary id is only a bootstrap preference.
+    After failover, the restarted primary container may be a standby while the
+    promoted shadow owns the active lock, so the worker factory can override the
+    static id with a dynamic pre-init role decision.
+    """
+    requested = truthy_env(
+        "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV",
+        default=truthy_env("GMS_VLLM_PRIVATE_BOOTSTRAP_KV", default=False),
+    )
+    if not requested:
+        return False
+    if truthy_env("DYN_VLLM_GMS_ACTIVE_LOCK_HELD", default=False):
+        return False
+    if truthy_env("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", default=False):
+        return True
+    if not truthy_env("DYN_GMS_FAILOVER_SHADOW_MODE", default=False):
+        return True
+    return _member_id() != _primary_member_id()
+
+
+def private_bootstrap_scratch_warmup_enabled() -> bool:
+    """True when private-bootstrap KV may be touched before promotion.
+
+    This mode keeps the final KV virtual layout but backs the deferred private
+    namespace with a small aliased scratch allocation. It is only safe for
+    discarded shadow warmup traffic; real serving still requires promotion to
+    the shared persistent KV namespace.
+    """
+    if not private_bootstrap_kv_enabled():
+        return False
+    return truthy_env(
+        "DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP",
+        default=truthy_env("GMS_VLLM_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP"),
+    )
+
+
+def stable_engine_id(device: int) -> str:
+    return get_gms_persistent_kv_engine_id("vllm", device, "GMS_VLLM_VMM_IPC_ENGINE_ID")
+
+
+def _member_id() -> str:
+    for name in ("ENGINE_ID", "DYN_WORKER_ID", "HOSTNAME"):
+        value = os.environ.get(name)
+        if value:
+            return value
+    return str(os.getpid())
+
+
+def _primary_member_id() -> str:
+    return os.environ.get("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+
+
+def allocation_engine_id(device: int) -> str:
+    engine_id = stable_engine_id(device)
+    if private_bootstrap_kv_enabled():
+        return f"{engine_id}|bootstrap={_member_id()}"
+    return engine_id
+
+
+def allocation_shared() -> bool:
+    return shared_kv_enabled() and not private_bootstrap_kv_enabled()
+
+
+def promotion_engine_id(device: int) -> str:
+    return stable_engine_id(device)
+
+
+def use_existing_shared_geometry() -> bool:
+    return shared_kv_enabled() or private_bootstrap_kv_enabled()
+
+
+def release_private_bootstrap_kv_pool(manager, engine_id: str, *, logger=None) -> int:
+    """Release stale private bootstrap KV allocations after promotion.
+
+    Private bootstrap namespaces are only used to let a shadow initialize
+    without writing into the active shared KV pool. Once the worker remaps to
+    the stable shared namespace, keeping the private ``kv_pool#*`` allocations
+    resident wastes HBM and can prevent a replacement Bulwark pair from
+    bootstrapping.
+    """
+    try:
+        allocations = list(manager.list_persistent(engine_id=engine_id))
+    except Exception:  # noqa: BLE001
+        if logger is not None:
+            logger.warning(
+                "[GMS] Failed to list private vLLM KV bootstrap allocations for %s",
+                engine_id,
+                exc_info=True,
+            )
+        return 0
+
+    released = 0
+    for allocation in allocations:
+        tag = getattr(allocation, "tag", "")
+        if not tag.startswith("kv_pool"):
+            continue
+        try:
+            if manager.release_persistent(engine_id, tag):
+                released += 1
+        except Exception:  # noqa: BLE001
+            if logger is not None:
+                logger.warning(
+                    "[GMS] Failed to release private vLLM KV bootstrap allocation %s/%s",
+                    engine_id,
+                    tag,
+                    exc_info=True,
+                )
+
+    if released and logger is not None:
+        logger.info(
+            "[GMS] Released %d private vLLM KV bootstrap allocations for %s",
+            released,
+            engine_id,
+        )
+    return released

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -10,12 +10,14 @@ processes import from GMS metadata (RO).
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 from typing import TYPE_CHECKING
 
 import torch
 from gpu_memory_service.client.torch.allocator import (
+    get_gms_client_memory_manager,
     get_or_create_gms_client_memory_manager,
     gms_use_mem_pool,
 )
@@ -147,6 +149,59 @@ def abort_pending_gms_write() -> bool:
     return True
 
 
+def patch_vllm_worker_memory_accounting() -> None:
+    """Avoid double-counting RW GMS weights in vLLM KV memory profiling.
+
+    Spawned vLLM worker processes always import the GMS model loader for
+    ``--load-format gms``, but they may not instantiate ``GMSWorker`` in every
+    executor path. Patch the base GPU worker here so the accounting fix follows
+    the load-format path that is guaranteed to be present in child workers.
+    """
+    try:
+        from vllm.v1.worker.gpu_worker import Worker
+    except Exception:
+        logger.debug(
+            "[GMS] vLLM GPU Worker unavailable for memory patch", exc_info=True
+        )
+        return
+
+    original = Worker.determine_available_memory
+    if getattr(original, "_gms_weight_accounting_patched", False):
+        return
+
+    def patched_determine_available_memory(self, *args, **kwargs):
+        manager = get_gms_client_memory_manager("weights")
+        model_runner = getattr(self, "model_runner", None)
+        if (
+            manager is None
+            or manager.granted_lock_type != GrantedLockType.RW
+            or model_runner is None
+            or not hasattr(model_runner, "model_memory_usage")
+        ):
+            return original(self, *args, **kwargs)
+
+        old_usage = int(getattr(model_runner, "model_memory_usage") or 0)
+        if old_usage <= 0:
+            return original(self, *args, **kwargs)
+
+        logger.info(
+            "[GMS] Suppressing %.2f GiB RW GMS weight bytes from vLLM "
+            "weights_memory during KV profiling; cudaMemGetInfo already "
+            "accounts for them as non-torch memory",
+            old_usage / (1 << 30),
+        )
+        model_runner.model_memory_usage = 0
+        try:
+            return original(self, *args, **kwargs)
+        finally:
+            model_runner.model_memory_usage = old_usage
+
+    patched_determine_available_memory._gms_weight_accounting_patched = True
+    patched_determine_available_memory._gms_original = original
+    Worker.determine_available_memory = patched_determine_available_memory
+    logger.info("[GMS] Patched vLLM Worker.determine_available_memory")
+
+
 # =============================================================================
 # MX (ModelExpress) Integration — Optional P2P weight transfer
 #
@@ -192,6 +247,7 @@ def get_mx_load_context(
 
 def register_gms_loader(load_format: str = "gms") -> None:
     """Register the GMS model loader with vLLM's loader registry."""
+    patch_vllm_worker_memory_accounting()
     from vllm.model_executor.model_loader import register_model_loader
     from vllm.model_executor.model_loader.base_loader import BaseModelLoader
     from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
@@ -218,6 +274,10 @@ def register_gms_loader(load_format: str = "gms") -> None:
             self.default_loader.load_weights(model, model_config)
 
         def load_model(self, vllm_config, model_config, prefix="") -> torch.nn.Module:
+            # Spawned vLLM workers can import the loader while gpu_worker is still
+            # in a circular import. Retry here, after worker initialization and
+            # before KV memory profiling.
+            patch_vllm_worker_memory_accounting()
             device = torch.cuda.current_device()
             extra = getattr(self.load_config, "model_loader_extra_config", {}) or {}
             mode = get_gms_lock_mode(extra)
@@ -259,8 +319,25 @@ def _load_read_mode(
     global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
 
     try:
+        target_device = torch.device("cuda", device_index)
+
+        logger.info("[GMS] Read mode: creating meta model")
         model = _create_meta_model(vllm_config, model_config)
+
+        logger.info("[GMS] Read mode: materializing tensors")
         materialize_module_from_gms(gms_client, model, device_index=device_index)
+
+        _refresh_fused_moe_router_tensors_after_gms_materialization(model)
+        _process_fused_moe_kernels_after_gms_materialization(
+            model,
+            model_config,
+            target_device,
+        )
+        _process_mla_weights_after_gms_materialization(
+            model,
+            model_config,
+            target_device,
+        )
 
         # MX: register materialized tensors (available for P2P transfer)
         mx_ctx = get_mx_load_context(vllm_config, model_config)
@@ -276,8 +353,240 @@ def _load_read_mode(
         )
         return model.eval()
     except Exception:
-        gms_client.close()
+        logger.exception("[GMS] Read mode failed while importing weights")
+        gms_client.close(best_effort=True)
         raise
+
+
+def _is_mla_post_load_module(module: torch.nn.Module) -> bool:
+    return (
+        hasattr(module, "kv_b_proj")
+        and hasattr(module, "kv_lora_rank")
+        and hasattr(module, "num_heads")
+        and callable(getattr(module, "process_weights_after_loading", None))
+    )
+
+
+def _call_with_supported_kwargs(factory, **kwargs):
+    signature = inspect.signature(factory)
+    supported_kwargs = {
+        name: value for name, value in kwargs.items() if name in signature.parameters
+    }
+    return factory(**supported_kwargs)
+
+
+def _is_meta_tensor(value) -> bool:
+    return isinstance(value, torch.Tensor) and value.is_meta
+
+
+def _refresh_fused_moe_router_tensors_after_gms_materialization(
+    model: torch.nn.Module,
+) -> None:
+    """Refresh vLLM FusedMoE tensor references captured from a meta model.
+
+    Some MoE constructors keep non-owning references to gate tensors in the
+    FusedMoE layer and router. GMS RO mode materializes the owning gate
+    parameters/buffers after construction, so these cached references must be
+    rebound before vLLM's profile run executes routing kernels.
+    """
+
+    refreshed: list[str] = []
+    stale_meta: list[str] = []
+
+    for name, module in model.named_modules():
+        gate = getattr(module, "gate", None)
+        experts = getattr(module, "experts", None)
+        if gate is None or experts is None:
+            continue
+
+        e_score_correction_bias = getattr(gate, "e_score_correction_bias", None)
+        hash_indices_table = getattr(gate, "tid2eid", None)
+        router = getattr(experts, "router", None)
+
+        changed = False
+        if hasattr(experts, "e_score_correction_bias"):
+            if _is_meta_tensor(getattr(experts, "e_score_correction_bias", None)):
+                stale_meta.append(f"{name}.experts.e_score_correction_bias")
+            experts.e_score_correction_bias = e_score_correction_bias
+            changed = True
+        if hasattr(experts, "hash_indices_table"):
+            if _is_meta_tensor(getattr(experts, "hash_indices_table", None)):
+                stale_meta.append(f"{name}.experts.hash_indices_table")
+            experts.hash_indices_table = hash_indices_table
+            changed = True
+        if router is not None and hasattr(router, "e_score_correction_bias"):
+            if _is_meta_tensor(getattr(router, "e_score_correction_bias", None)):
+                stale_meta.append(f"{name}.experts.router.e_score_correction_bias")
+            router.e_score_correction_bias = e_score_correction_bias
+            changed = True
+        if router is not None and hasattr(router, "_hash_indices_table"):
+            if _is_meta_tensor(getattr(router, "_hash_indices_table", None)):
+                stale_meta.append(f"{name}.experts.router._hash_indices_table")
+            router._hash_indices_table = hash_indices_table
+            changed = True
+
+        runner = getattr(experts, "runner", None)
+        if runner is not None and getattr(runner, "router", None) is not router:
+            runner.router = router
+            changed = True
+
+        if changed:
+            refreshed.append(name)
+
+    if refreshed:
+        logger.info(
+            "[GMS] Read mode: refreshed %d FusedMoE router tensor references: %s",
+            len(refreshed),
+            refreshed[:8],
+        )
+    if stale_meta:
+        logger.info(
+            "[GMS] Read mode: replaced stale meta FusedMoE router tensors: %s",
+            stale_meta[:16],
+        )
+
+
+def _make_fused_moe_kernel(module: torch.nn.Module, quant_method) -> bool:
+    experts_cls = getattr(quant_method, "experts_cls", None)
+    if experts_cls is None:
+        return False
+
+    quant_config = quant_method.get_fused_moe_quant_config(module)
+    if quant_config is None:
+        return False
+    quant_method.moe_quant_config = quant_config
+
+    routing_tables = None
+    maybe_routing_tables = getattr(module, "_maybe_init_expert_routing_tables", None)
+    if callable(maybe_routing_tables):
+        routing_tables = maybe_routing_tables()
+    shared_experts = getattr(module, "shared_experts", None)
+
+    if hasattr(quant_method, "fp8_backend"):
+        from vllm.model_executor.layers.fused_moe.oracle.fp8 import make_fp8_moe_kernel
+
+        quant_method.moe_kernel = _call_with_supported_kwargs(
+            make_fp8_moe_kernel,
+            moe_quant_config=quant_config,
+            moe_config=module.moe_config,
+            fp8_backend=quant_method.fp8_backend,
+            experts_cls=experts_cls,
+            routing_tables=routing_tables,
+            shared_experts=shared_experts,
+            layer=module,
+        )
+        return True
+
+    if hasattr(quant_method, "mxfp4_backend"):
+        from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+            make_mxfp4_moe_kernel,
+        )
+
+        quant_method.moe_kernel = _call_with_supported_kwargs(
+            make_mxfp4_moe_kernel,
+            moe_quant_config=quant_config,
+            moe_config=module.moe_config,
+            mxfp4_backend=quant_method.mxfp4_backend,
+            experts_cls=experts_cls,
+            routing_tables=routing_tables,
+            shared_experts=shared_experts,
+            layer=module,
+        )
+        return True
+
+    if hasattr(quant_method, "nvfp4_backend"):
+        from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+            make_nvfp4_moe_kernel,
+        )
+
+        quant_method.moe_kernel = _call_with_supported_kwargs(
+            make_nvfp4_moe_kernel,
+            moe_quant_config=quant_config,
+            moe_config=module.moe_config,
+            experts_cls=experts_cls,
+            routing_tables=routing_tables,
+            shared_experts=shared_experts,
+            layer=module,
+        )
+        return True
+
+    if hasattr(quant_method, "unquantized_backend"):
+        from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+            make_unquantized_moe_kernel,
+        )
+
+        quant_method.moe_kernel = _call_with_supported_kwargs(
+            make_unquantized_moe_kernel,
+            quant_config=quant_config,
+            moe_config=module.moe_config,
+            backend=quant_method.unquantized_backend,
+            experts_cls=experts_cls,
+            routing_tables=routing_tables,
+            shared_experts=shared_experts,
+            layer=module,
+        )
+        return True
+
+    return False
+
+
+def _process_fused_moe_kernels_after_gms_materialization(
+    model: torch.nn.Module,
+    model_config,
+    target_device: torch.device,
+) -> None:
+    """Rebuild vLLM MoE runtime kernels around imported GMS weights."""
+    from vllm.utils.torch_utils import set_default_torch_dtype
+
+    rebuilt: list[str] = []
+    with set_default_torch_dtype(model_config.dtype):
+        with target_device:
+            for name, module in model.named_modules():
+                quant_method = getattr(module, "quant_method", None)
+                if quant_method is None:
+                    continue
+                if getattr(quant_method, "moe_kernel", None) is not None:
+                    continue
+                if not callable(
+                    getattr(quant_method, "get_fused_moe_quant_config", None)
+                ):
+                    continue
+                if not hasattr(module, "moe_config"):
+                    continue
+                if _make_fused_moe_kernel(module, quant_method):
+                    rebuilt.append(name)
+
+    if rebuilt:
+        logger.info(
+            "[GMS] Read mode: rebuilt %d FusedMoE kernels: %s",
+            len(rebuilt),
+            rebuilt[:8],
+        )
+
+
+def _process_mla_weights_after_gms_materialization(
+    model: torch.nn.Module,
+    model_config,
+    target_device: torch.device,
+) -> None:
+    """Rebuild derived MLA projection tensors skipped from GMS metadata."""
+    from vllm.utils.torch_utils import set_default_torch_dtype
+
+    processed: list[str] = []
+    with set_default_torch_dtype(model_config.dtype):
+        with target_device:
+            for name, module in model.named_modules():
+                if not _is_mla_post_load_module(module):
+                    continue
+                module.process_weights_after_loading(model_config.dtype)
+                processed.append(name)
+
+    if processed:
+        logger.info(
+            "[GMS] Read mode: rebuilt %d MLA post-load modules: %s",
+            len(processed),
+            processed[:8],
+        )
 
 
 def _load_write_mode(
@@ -348,10 +657,7 @@ def _load_write_mode(
 
 def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
     """Create model on meta device for RO mode materialization."""
-    from vllm.model_executor.model_loader.utils import (
-        initialize_model,
-        process_weights_after_loading,
-    )
+    from vllm.model_executor.model_loader.utils import initialize_model
     from vllm.utils.torch_utils import set_default_torch_dtype
 
     setup_meta_tensor_workaround()
@@ -361,9 +667,10 @@ def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
         with meta_device:
             model = initialize_model(vllm_config=vllm_config, model_config=model_config)
 
-    try:
-        process_weights_after_loading(model, model_config, meta_device)
-    except Exception as e:
-        logger.debug("[GMS] Post-processing on meta tensors: %s", e)
+    # Do not run vLLM post-load hooks on the RO meta model. Some DSV4
+    # quantization and attention hooks initialize CUDA runtime state even when
+    # tensors are still meta. GMS imports the writer's final parameter metadata
+    # first, then rebuilds supported derived runtime state on the target CUDA
+    # device in _load_read_mode().
 
     return model

--- a/lib/gpu_memory_service/integrations/vllm/patches.py
+++ b/lib/gpu_memory_service/integrations/vllm/patches.py
@@ -5,9 +5,6 @@
 
 Patches:
   - MemorySnapshot.measure: adds GMS-committed bytes to free_memory in RO mode.
-  - request_memory: bypasses the free>=requested check during deferred-KV init.
-  - NixlConnector.register_kv_caches: defers registration during the scratch
-    phase and stashes the dict for replay at wake.
 
 The torch.cuda.empty_cache patch lives in integrations/common/patches.py.
 """
@@ -18,22 +15,15 @@ import logging
 
 from gpu_memory_service.client.torch.allocator import get_gms_client_memory_manager
 from gpu_memory_service.common.locks import GrantedLockType
-from gpu_memory_service.common.utils import is_scratch_kv_enabled
+from gpu_memory_service.integrations.vllm.kv_identity import allocation_engine_id
 
 logger = logging.getLogger(__name__)
 
 _memory_snapshot_patched = False
-_request_memory_patched = False
-_register_kv_caches_patched = False
-
-
-# =============================================================================
-# Core GMS patch (always applied)
-# =============================================================================
 
 
 def patch_memory_snapshot() -> None:
-    """Add committed GMS bytes to MemorySnapshot.free_memory"""
+    """Add committed GMS bytes to MemorySnapshot.free_memory."""
     global _memory_snapshot_patched
 
     if _memory_snapshot_patched:
@@ -53,14 +43,33 @@ def patch_memory_snapshot() -> None:
         manager = get_gms_client_memory_manager("weights")
         assert manager is not None, "GMS client is not initialized"
 
+        committed_bytes = 0
         if manager.granted_lock_type == GrantedLockType.RO:
             allocations = manager.list_handles()
-            committed_bytes = sum(alloc.aligned_size for alloc in allocations)
+            committed_bytes += sum(alloc.aligned_size for alloc in allocations)
         else:
-            # NOTE: by design, we want to assume we have the whole GPU when writing
-            # weights for the first time, so we don't make an adjustment.
-            committed_bytes = 0
-            logger.info("[GMS] RW mode - skipping committed memory adjustment")
+            # In write mode the engine should account for the weights it loaded.
+            logger.info("[GMS] RW mode - skipping committed weight memory adjustment")
+
+        kv_manager = get_gms_client_memory_manager("kv_pool")
+        if kv_manager is not None and kv_manager.is_connected:
+            try:
+                device = getattr(self.device_, "index", None)
+                if device is None:
+                    device = kv_manager.device
+                engine_id = allocation_engine_id(int(device))
+                persistent = kv_manager.list_persistent(engine_id=engine_id)
+                kv_bytes = sum(alloc.aligned_size for alloc in persistent)
+                committed_bytes += kv_bytes
+                if kv_bytes > 0:
+                    logger.info(
+                        "[GMS Patch] Accounting for %.2f GiB existing persistent KV",
+                        kv_bytes / (1 << 30),
+                    )
+            except Exception as exc:
+                logger.debug(
+                    "[GMS Patch] Persistent KV memory accounting skipped: %s", exc
+                )
 
         original_free = self.free_memory
         self.free_memory += committed_bytes
@@ -76,112 +85,3 @@ def patch_memory_snapshot() -> None:
     MemorySnapshot.measure = patched_measure
     _memory_snapshot_patched = True
     logger.info("[GMS Patch] Patched MemorySnapshot.measure")
-
-
-# =============================================================================
-# Shadow mode patches
-# =============================================================================
-
-
-def patch_request_memory() -> None:
-    """Bypass free >= requested check (shadow shares GPU with active engine)."""
-    global _request_memory_patched
-
-    if _request_memory_patched:
-        return
-
-    try:
-        from vllm.v1.worker import utils as worker_utils
-    except ImportError:
-        logger.debug("[GMS Patch] vllm.v1.worker.utils not available")
-        return
-
-    def patched_request_memory(init_snapshot, cache_config):
-        requested_memory = int(
-            init_snapshot.total_memory * cache_config.gpu_memory_utilization
-        )
-        logger.info(
-            "[GMS Patch] Shadow mode: bypassing memory check "
-            "(requested=%.2f GiB, free=%.2f GiB)",
-            requested_memory / (1 << 30),
-            init_snapshot.free_memory / (1 << 30),
-        )
-        return requested_memory
-
-    worker_utils.request_memory = patched_request_memory
-    _request_memory_patched = True
-    logger.info("[GMS Patch] Patched request_memory for shadow mode")
-
-
-def patch_register_kv_caches() -> None:
-    """Defer NixlConnector.register_kv_caches while KV backing is scratch-aliased.
-
-    Registering NIXL MRs over scratch would pin a soon-stale page into the NIC;
-    sleep tears down scratch and wake remaps real backing at the same VAs.
-    Stash the dict during the scratch phase and let GMSWorker.wake_up replay
-    it after remap.
-    """
-    global _register_kv_caches_patched
-
-    if _register_kv_caches_patched:
-        return
-
-    try:
-        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
-            NixlConnector,
-        )
-    except ImportError:
-        logger.debug("[GMS Patch] NixlConnector not available")
-        return
-
-    original_register = NixlConnector.register_kv_caches
-
-    def patched_register_kv_caches(self, kv_caches):
-        from gpu_memory_service.client.torch.allocator import (
-            get_gms_client_memory_manager,
-            is_scratch,
-        )
-
-        # Fail closed on lookup errors: falling through to original_register
-        # would pin an MR onto a scratch page that sleep is about to free,
-        # exactly the bug this patch exists to prevent.
-        try:
-            kv_mgr = get_gms_client_memory_manager("kv_cache")
-            has_deferred = kv_mgr is not None and is_scratch(kv_mgr)
-        except (LookupError, AttributeError, RuntimeError) as exc:
-            logger.warning(
-                "[GMS Patch] Cannot determine deferred-KV state — "
-                "raising to avoid pinning a stale scratch MR: %s",
-                exc,
-                exc_info=True,
-            )
-            raise
-
-        if has_deferred:
-            self._scratch_kv_pending = kv_caches
-            logger.info(
-                "[GMS Patch] Deferring NIXL KV cache registration "
-                "(stashed %d layers for wake replay)",
-                len(kv_caches),
-            )
-            return
-        return original_register(self, kv_caches)
-
-    NixlConnector.register_kv_caches = patched_register_kv_caches
-    _register_kv_caches_patched = True
-    logger.info("[GMS Patch] Patched NixlConnector.register_kv_caches")
-
-
-# =============================================================================
-# Patch application helper
-# =============================================================================
-
-
-def apply_scratch_kv_patches() -> None:
-    """Apply scratch-KV monkey-patches. No-ops when scratch KV is disabled."""
-    if not is_scratch_kv_enabled():
-        return
-
-    patch_request_memory()
-    patch_register_kv_caches()
-    logger.info("[GMS Patch] applied")

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -24,20 +24,37 @@ from gpu_memory_service.client.memory_manager import StaleMemoryLayoutError
 from gpu_memory_service.client.torch.allocator import (
     get_gms_client_memory_manager,
     get_or_create_gms_client_memory_manager,
-    get_or_create_scratch_manager,
-    gms_use_mem_pool,
-    is_scratch,
+    get_or_create_persistent_allocator,
+    gms_use_persistent_pool,
+    retarget_persistent_allocator,
 )
-from gpu_memory_service.common.locks import RequestedLockType
-from gpu_memory_service.common.utils import (
-    GMS_TAGS,
-    get_socket_path,
-    is_scratch_kv_enabled,
-)
+from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
+from gpu_memory_service.common.utils import get_socket_path, is_scratch_kv_enabled
 from gpu_memory_service.integrations.common import patch_empty_cache
 from gpu_memory_service.integrations.common.utils import (
+    env_enabled_by_default,
     get_gms_lock_mode,
+    get_gms_persistent_kv_socket,
     get_gms_ro_connect_timeout_ms,
+)
+from gpu_memory_service.integrations.vllm.install_kv_leases import (
+    install as install_kv_leases,
+)
+from gpu_memory_service.integrations.vllm.install_kv_leases import (
+    install_engine_core_hook,
+)
+from gpu_memory_service.integrations.vllm.install_vmm_ipc_kv import (
+    install as install_vmm_ipc_kv,
+)
+from gpu_memory_service.integrations.vllm.kv_identity import (
+    allocation_engine_id,
+    allocation_shared,
+    private_bootstrap_kv_enabled,
+    private_bootstrap_scratch_warmup_enabled,
+    promotion_engine_id,
+    release_private_bootstrap_kv_pool,
+    shared_kv_enabled,
+    stable_engine_id,
 )
 from gpu_memory_service.integrations.vllm.model_loader import (
     abort_pending_gms_write,
@@ -47,12 +64,10 @@ from gpu_memory_service.integrations.vllm.model_loader import (
     publish_pending_gms_write,
     register_gms_loader,
 )
-from gpu_memory_service.integrations.vllm.patches import (
-    apply_scratch_kv_patches,
-    patch_memory_snapshot,
-)
+from gpu_memory_service.integrations.vllm.patches import patch_memory_snapshot
 
 logger = logging.getLogger(__name__)
+
 
 # Trigger model loader registration and utility patches on import
 register_gms_loader()
@@ -60,9 +75,13 @@ register_gms_loader()
 # Apply core utility patches (always needed for GMS)
 patch_empty_cache()
 patch_memory_snapshot()
+install_kv_leases()
+install_engine_core_hook()
+install_vmm_ipc_kv()
 
-# Apply scratch-KV patches when DYN_GMS_SCRATCH_KV_ENABLED is set
-apply_scratch_kv_patches()
+# Register the KV-cache GDS-direct connector under the short name so
+# users can wire it via vLLM's standard --kv-transfer-config flag.
+# Opt-in: the connector is only constructed if the user names it.
 
 logger.info("[GMS] Worker module loaded - model loader registered, all patches applied")
 
@@ -82,6 +101,54 @@ if os.environ.get("MX_ENABLED", "0") == "1":
             "Install with: pip install modelexpress"
         ) from e
 
+
+def _install_gms_engine_core_sleep() -> None:
+    """Install a GMS-only sleep utility that skips prefix-cache clearing.
+
+    Bulwark startup quiesce has no user traffic to discard, and vLLM can have
+    initialized internal KV blocks that make reset_prefix_cache() fail before
+    the engine ever serves. This utility keeps the scheduler pause semantics
+    but delegates directly to model_executor.sleep(level).
+    """
+    try:
+        from concurrent.futures import Future
+
+        from vllm.v1.engine.core import EngineCore
+    except Exception:
+        logger.debug("[GMS] EngineCore sleep utility patch skipped", exc_info=True)
+        return
+
+    if hasattr(EngineCore, "gms_sleep_no_clear"):
+        return
+
+    def gms_sleep_no_clear(self, level: int = 1, mode: str = "abort"):
+        pause_future = self.pause_scheduler(mode=mode, clear_cache=False)
+        if level < 1:
+            return pause_future
+
+        model_executor = self.model_executor
+        if pause_future is None:
+            model_executor.sleep(level)
+            return None
+
+        future = Future()
+
+        def pause_complete(f):
+            try:
+                f.result()
+                future.set_result(model_executor.sleep(level))
+            except Exception as exc:  # noqa: BLE001
+                future.set_exception(exc)
+
+        logger.info("[GMS] Waiting for in-flight requests before no-clear sleep")
+        pause_future.add_done_callback(pause_complete)
+        return future
+
+    EngineCore.gms_sleep_no_clear = gms_sleep_no_clear
+    logger.info("[GMS] Installed EngineCore.gms_sleep_no_clear utility")
+
+
+_install_gms_engine_core_sleep()
 
 # Import Worker after patches are applied
 from vllm.v1.worker.gpu_worker import Worker  # noqa: E402
@@ -125,8 +192,161 @@ def _get_dp_adjusted_local_rank(local_rank: int, parallel_config) -> int:
     return adjusted_local_rank
 
 
+def _bootstrap_memory_utilization_cap() -> float:
+    for name in (
+        "DYN_VLLM_GMS_BOOTSTRAP_GPU_MEMORY_UTILIZATION",
+        "GMS_VLLM_BOOTSTRAP_GPU_MEMORY_UTILIZATION",
+    ):
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        try:
+            cap = float(value)
+        except ValueError:
+            logger.warning("Ignoring invalid %s=%r", name, value)
+            continue
+        if cap > 0:
+            return min(cap, 1.0)
+    return 0.05
+
+
+def _existing_shared_kv_blocks(device: int) -> Optional[int]:
+    if os.environ.get("GMS_KV_LEASE_SHM_RESET", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return None
+    try:
+        from gpu_memory_service.integrations.common.kv_lease_client import (
+            kv_leases_enabled,
+            read_any_kv_lease_namespace_total_blocks,
+            read_kv_lease_namespace_total_blocks,
+        )
+
+        if not kv_leases_enabled("vllm"):
+            return None
+        namespace, total_blocks = read_kv_lease_namespace_total_blocks(
+            "vllm",
+            device,
+            namespace_suffix="block-pool",
+        )
+        if total_blocks is None:
+            namespace, total_blocks = read_any_kv_lease_namespace_total_blocks("vllm")
+        if total_blocks is not None:
+            logger.debug(
+                "[GMS] Found existing vLLM KV lease geometry for startup cap: "
+                "namespace_or_path=%s blocks=%d device=%d",
+                namespace,
+                int(total_blocks),
+                device,
+            )
+    except Exception:
+        logger.debug(
+            "[GMS] Failed to inspect existing vLLM KV lease geometry",
+            exc_info=True,
+        )
+        return None
+    if total_blocks is None:
+        return None
+    return int(total_blocks)
+
+
+def _maybe_cap_private_bootstrap_memory(vllm_config, device: int) -> None:
+    """Reduce vLLM's startup memory target for a standby attach.
+
+    Large-model Bulwark shadows start while the active engine already owns most
+    HBM. vLLM checks ``gpu_memory_utilization`` before it reaches the GMS
+    persistent KV allocation path, so a standby can fail even though it will
+    later attach to the existing shared KV geometry. Private bootstrap is only
+    enabled for non-primary shadows, so cap even if the primary has not yet
+    published lease geometry.
+    """
+    if not private_bootstrap_kv_enabled():
+        return
+    existing_blocks = _existing_shared_kv_blocks(device)
+
+    cache_config = getattr(vllm_config, "cache_config", None)
+    if cache_config is None:
+        return
+    current = getattr(cache_config, "gpu_memory_utilization", None)
+    if current is None:
+        return
+
+    cap = _bootstrap_memory_utilization_cap()
+    try:
+        current_value = float(current)
+    except (TypeError, ValueError):
+        return
+    if current_value <= cap:
+        return
+
+    cache_config.gpu_memory_utilization = cap
+    if existing_blocks is None:
+        logger.info(
+            "[GMS] Capping private-bootstrap gpu_memory_utilization for "
+            "cuda:%d from %.4f to %.4f for startup; shared KV geometry "
+            "is not published yet",
+            device,
+            current_value,
+            cap,
+        )
+    else:
+        logger.info(
+            "[GMS] Existing shared KV geometry detected for cuda:%d "
+            "(%d blocks); capping private-bootstrap gpu_memory_utilization "
+            "from %.4f to %.4f for startup",
+            device,
+            existing_blocks,
+            current_value,
+            cap,
+        )
+
+
 class GMSWorker(Worker):
     """vLLM Worker subclass with GMS integration."""
+
+    def _determine_available_memory_with_gms_weight_accounting(self) -> int:
+        """Avoid double-counting RW GMS weights during vLLM KV profiling.
+
+        RW GMS weight allocations are visible to cudaMemGetInfo, but not to
+        PyTorch's reserved-memory counters. vLLM therefore observes them as
+        non-torch memory growth during profiling. Passing the same bytes as
+        model_memory_usage would count them twice and can produce negative KV
+        capacity on large models.
+        """
+        manager = get_gms_client_memory_manager("weights")
+        model_runner = getattr(self, "model_runner", None)
+        if (
+            manager is None
+            or manager.granted_lock_type != GrantedLockType.RW
+            or model_runner is None
+            or not hasattr(model_runner, "model_memory_usage")
+        ):
+            return super().determine_available_memory()
+
+        old_usage = int(getattr(model_runner, "model_memory_usage") or 0)
+        if old_usage <= 0:
+            return super().determine_available_memory()
+
+        logger.info(
+            "[GMS] Suppressing %.2f GiB RW GMS weight bytes from vLLM "
+            "weights_memory during KV profiling; cudaMemGetInfo already "
+            "accounts for them as non-torch memory",
+            old_usage / (1 << 30),
+        )
+        model_runner.model_memory_usage = 0
+        try:
+            return super().determine_available_memory()
+        finally:
+            model_runner.model_memory_usage = old_usage
+
+    def _private_bootstrap_kv_active(self) -> bool:
+        return bool(
+            getattr(self, "_gms_kv_private_bootstrap", False)
+            or private_bootstrap_kv_enabled()
+        )
 
     def init_device(self) -> None:
         """Initialize device with early GMS connection.
@@ -140,6 +360,17 @@ class GMSWorker(Worker):
         # Worker will apply the same DP adjustment during super().init_device().
         device = _get_dp_adjusted_local_rank(self.local_rank, self.parallel_config)
         current_platform.set_device(torch.device(f"cuda:{device}"))
+        self._gms_kv_private_bootstrap = private_bootstrap_kv_enabled()
+        self._gms_kv_scratch_warmup = private_bootstrap_scratch_warmup_enabled()
+        if self._gms_kv_scratch_warmup:
+            os.environ["GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED"] = "1"
+            logger.info(
+                "[GMS] Enabling scratch-backed private-bootstrap KV warmup "
+                "for cuda:%d",
+                device,
+            )
+        self._gms_deferred_private_bootstrap_warmup = False
+        _maybe_cap_private_bootstrap_memory(self.vllm_config, device)
 
         # Establish weights GMS connection (so MemorySnapshot can query committed bytes).
         # Lock type is determined by model_loader_extra_config, set upstream by
@@ -155,22 +386,28 @@ class GMSWorker(Worker):
             mode=mode,
             tag="weights",
         )
+
+        if env_enabled_by_default("GMS_VLLM_VMM_IPC_KV", default=True):
+            socket = get_gms_persistent_kv_socket(device, "GMS_VLLM_VMM_IPC_SOCKET")
+            engine_id = allocation_engine_id(device)
+            get_or_create_persistent_allocator(
+                socket,
+                device,
+                engine_id,
+                tag="kv_pool",
+                shared=allocation_shared(),
+                defer_physical=private_bootstrap_kv_enabled(),
+            )
+
         # Parent will set device again (harmless) and do memory checks
         super().init_device()
 
     @torch.inference_mode()
     def determine_available_memory(self) -> int:
-        """
-        Determine actual available memory for the engine.
+        """Profile memory, then publish a pending first-writer layout.
 
-        During a failover scenario, this function may be called while there is an active engine colocated on the same device.
-        We want our assessment to ignore the kv cache allocation of the active engine if there is one.
-
-        A first writer defers its GMS commit until profiling completes here:
-        waiting RO consumers (snapshot saver, peer engines) would otherwise
-        attach to the device mid-profile and perturb vLLM's memory accounting.
-        On failure the pending write is released and the error propagates;
-        the GMS server also clears an uncommitted layout if this process dies.
+        Publication is delayed until profiling completes so waiting RO
+        consumers cannot attach mid-profile and perturb vLLM's accounting.
         """
         try:
             available = self._determine_available_memory_before_gms_publish()
@@ -184,17 +421,41 @@ class GMSWorker(Worker):
         return available
 
     def _determine_available_memory_before_gms_publish(self) -> int:
+        """Profile without touching reserve-only private-bootstrap KV."""
+        if not self._private_bootstrap_kv_active():
+            return self._determine_available_memory_with_scratch_accounting()
+        if private_bootstrap_scratch_warmup_enabled():
+            logger.info(
+                "[GMS] Allowing vLLM CUDA graph memory profiling for "
+                "scratch-backed private-bootstrap shadow KV"
+            )
+            return self._determine_available_memory_with_scratch_accounting()
+
+        from vllm.config import CUDAGraphMode
+
+        compilation_config = self.vllm_config.compilation_config
+        saved_mode = compilation_config.cudagraph_mode
+        if saved_mode == CUDAGraphMode.NONE:
+            return self._determine_available_memory_with_scratch_accounting()
+
+        logger.info(
+            "[GMS] Deferring vLLM CUDA graph memory profiling for "
+            "private-bootstrap shadow until KV promotion"
+        )
+        compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+        try:
+            return self._determine_available_memory_with_scratch_accounting()
+        finally:
+            compilation_config.cudagraph_mode = saved_mode
+
+    def _determine_available_memory_with_scratch_accounting(self) -> int:
         if not is_scratch_kv_enabled():
-            return super().determine_available_memory()
+            return self._determine_available_memory_with_gms_weight_accounting()
 
         import vllm.envs as envs
         from vllm.config import CUDAGraphMode
         from vllm.platforms import current_platform
 
-        # A pending first writer's GMS MemPool and private rebound
-        # allocations are both visible in PyTorch's absolute peak. An RO
-        # import's GMS mappings are not, so only those imported bytes need
-        # adding below.
         has_pending_write = has_pending_gms_write()
 
         torch.cuda.reset_peak_memory_stats()
@@ -244,45 +505,108 @@ class GMSWorker(Worker):
         )
         logger.info(msg)
         print(msg, flush=True)
-
         return int(projected_available)
 
-    def initialize_from_config(self, kv_cache_config) -> None:
-        """Allocate KV cache backing.
-
-        In scratch-KV mode the tensors are allocated over scratch-aliased
-        backing client-side; wake_up drops scratch backing and installs fresh
-        server backing via the standard reallocate+remap path. With
-        enable_sleep_mode the manager connects RW at init and allocates real
-        backing immediately.
+    def _maybe_tighten_serving_collective_timeout(self) -> None:
+        """Post-warmup hook: the engine is fully initialized in this rank's worker
+        process, so lower the NCCL collective watchdog to the (low) serving timeout
+        for fast hang detection. Only ever called after warmup actually ran, so it
+        cannot fire during init/warmup. No-op unless DYN_GMS_SERVING_NCCL_TIMEOUT_S>0.
         """
+        try:
+            from gpu_memory_service.common.serving_timeout import (
+                apply_serving_collective_timeout,
+            )
+
+            apply_serving_collective_timeout()
+        except Exception:
+            logger.debug("[GMS serving-timeout] vLLM tighten failed", exc_info=True)
+
+    def compile_or_warm_up_model(self):
+        """Defer warmup/cudagraph capture while private-bootstrap KV is VA-only."""
+        if not self._private_bootstrap_kv_active():
+            result = super().compile_or_warm_up_model()
+            self._maybe_tighten_serving_collective_timeout()
+            return result
+        if private_bootstrap_scratch_warmup_enabled():
+            logger.info(
+                "[GMS] Running vLLM warmup and CUDA graph capture on "
+                "scratch-backed private-bootstrap shadow KV"
+            )
+            result = super().compile_or_warm_up_model()
+            self._maybe_tighten_serving_collective_timeout()
+            return result
+
+        from vllm.v1.worker.worker_base import CompilationTimes
+
+        self._gms_deferred_private_bootstrap_warmup = True
+        logger.info(
+            "[GMS] Deferring vLLM warmup and CUDA graph capture for "
+            "private-bootstrap shadow until KV promotion"
+        )
+        return CompilationTimes(language_model=0.0, encoder=0.0)
+
+    def _run_deferred_private_bootstrap_warmup(self) -> None:
+        if not getattr(self, "_gms_deferred_private_bootstrap_warmup", False):
+            return
+
+        if not env_enabled_by_default(
+            "GMS_VLLM_RUN_DEFERRED_PRIVATE_BOOTSTRAP_WARMUP", default=False
+        ):
+            logger.info(
+                "[GMS] Skipping deferred vLLM warmup and CUDA graph capture "
+                "after private-bootstrap KV promotion"
+            )
+            self._gms_deferred_private_bootstrap_warmup = False
+            return
+
+        logger.info(
+            "[GMS] Running deferred vLLM warmup and CUDA graph capture after "
+            "private-bootstrap KV promotion"
+        )
+        self._gms_deferred_private_bootstrap_warmup = False
+        try:
+            super().compile_or_warm_up_model()
+        except Exception:
+            self._gms_deferred_private_bootstrap_warmup = True
+            raise
+        # Deferred warmup just completed (shadow promoted + about to serve): tighten.
+        self._maybe_tighten_serving_collective_timeout()
+
+    def initialize_from_config(self, kv_cache_config) -> None:
+        """Allocate persistent KV backing after publishing pending weights."""
         # EngineCore can skip determine_available_memory for models with no
         # KV cache. Publish before connector setup, allocation, or warm-up.
         publish_pending_gms_write()
 
         from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized
 
+        self.cache_config.num_gpu_blocks = kv_cache_config.num_blocks
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
 
         device = self.local_rank
-        socket = get_socket_path(device, "kv_cache")
-        if is_scratch_kv_enabled():
-            # Client-local scratch only — no GMS server session at init.
-            # wake_up will connect RW and allocate fresh server backing.
-            get_or_create_scratch_manager(socket, device, tag="kv_cache")
-            with gms_use_mem_pool("kv_cache", torch.device(f"cuda:{device}")):
-                self.model_runner.initialize_kv_cache(kv_cache_config)
-        elif self.vllm_config.model_config.enable_sleep_mode:
-            get_or_create_gms_client_memory_manager(
-                socket,
-                device,
-                mode=RequestedLockType.RW,
-                tag="kv_cache",
-            )
-            with gms_use_mem_pool("kv_cache", torch.device(f"cuda:{device}")):
-                self.model_runner.initialize_kv_cache(kv_cache_config)
-        else:
-            self.model_runner.initialize_kv_cache(kv_cache_config)
+        socket = get_gms_persistent_kv_socket(device, "GMS_VLLM_VMM_IPC_SOCKET")
+        engine_id = allocation_engine_id(device)
+        self._gms_kv_engine_id = engine_id
+        self._gms_kv_promote_engine_id = promotion_engine_id(device)
+        self._gms_kv_private_bootstrap = private_bootstrap_kv_enabled()
+        get_or_create_persistent_allocator(
+            socket,
+            device,
+            engine_id,
+            tag="kv_pool",
+            shared=allocation_shared(),
+            defer_physical=self._gms_kv_private_bootstrap,
+        )
+        self.model_runner.initialize_kv_cache(kv_cache_config)
+
+        if self.model_config.enable_return_routed_experts:
+            self.model_runner.init_routed_experts_capturer()
+
+        if kv_cache_config.needs_kv_cache_zeroing and hasattr(
+            self.model_runner, "_init_kv_zero_meta"
+        ):
+            self.model_runner._init_kv_zero_meta()
 
     def load_model(self, *args, **kwargs) -> None:
         """Load model with corrected memory accounting.
@@ -329,11 +653,8 @@ class GMSWorker(Worker):
         """vLLM sleep implementation with GMS integration.
 
         Skips super().sleep() (which copies GPU buffers to CPU and segfaults
-        on unmapped GMS memory). For both managers: unmap_all_vas + abort.
-        Symmetric for regular and deferred-KV — unmap_all_vas walks both
-        _mappings and _scratch_mappings, releasing physical and preserving VA
-        reservations. Wake reconnects and rebuilds via the standard
-        prepare_scratch_for_reallocation → reallocate → remap pipeline.
+        on unmapped GMS memory). We unmap weights plus the persistent KV pool;
+        GMS keeps the underlying physical KV pages alive for reconnect.
         """
         free_bytes_before = torch.cuda.mem_get_info()[0]
 
@@ -342,7 +663,7 @@ class GMSWorker(Worker):
         if mx_ctx is not None:
             pause_serving(mx_ctx)
 
-        for tag in ("weights", "kv_cache"):
+        for tag in ("weights", "kv_pool"):
             manager = get_gms_client_memory_manager(tag)
             assert manager is not None, f"GMS {tag} client is not initialized"
             assert not manager.is_unmapped, f"GMS {tag} is already unmapped"
@@ -361,10 +682,37 @@ class GMSWorker(Worker):
             used_bytes / (1 << 30),
         )
 
+    def _reset_fp8_kv_scales_without_zeroing(self) -> None:
+        """Reset quantized-KV scale tensors without modifying KV contents."""
+        cache_config = getattr(self, "cache_config", None)
+        cache_dtype = getattr(cache_config, "cache_dtype", "")
+        if not str(cache_dtype).startswith("fp8"):
+            return
+
+        model_runner = getattr(self, "model_runner", None)
+        compilation_config = getattr(model_runner, "compilation_config", None)
+        attn_layers = getattr(compilation_config, "static_forward_context", {}) or {}
+        reset_count = 0
+        for module in attn_layers.values():
+            for attr in ("_k_scale", "k_scale", "_v_scale", "v_scale"):
+                if not hasattr(module, attr):
+                    continue
+                param = getattr(module, attr)
+                if isinstance(param, torch.Tensor):
+                    param.fill_(1.0)
+                    reset_count += 1
+        logger.info(
+            "[GMS] Reset vLLM FP8 KV scale tensors without zeroing KV: count=%d",
+            reset_count,
+        )
+
     def wake_up(self, tags: Optional[List[str]] = None) -> None:
         """vLLM wake implementation with GMS integration."""
+        requested_tags = tags
         if tags is None:
-            tags = list(GMS_TAGS)
+            tags = ["weights", "kv_pool"]
+        elif "kv_cache" in tags and "kv_pool" not in tags:
+            tags = list(tags) + ["kv_pool"]
 
         if "weights" in tags:
             weights_manager = get_gms_client_memory_manager("weights")
@@ -400,67 +748,121 @@ class GMSWorker(Worker):
             if mx_ctx is not None:
                 resume_serving(mx_ctx, self.model_runner.model)
 
-        if "kv_cache" in tags:
-            kv_cache_manager = get_gms_client_memory_manager("kv_cache")
-            assert (
-                kv_cache_manager is not None
-            ), "GMS kv_cache client is not initialized"
-            # Capture scratch state BEFORE the flip so we know whether to
-            # move bookkeeping and whether to replay the deferred NIXL
-            # registration.
-            was_scratch = is_scratch(kv_cache_manager)
-            assert kv_cache_manager.is_unmapped, "GMS kv_cache is not unmapped"
-            kv_cache_manager.connect(RequestedLockType.RW)
-            if was_scratch:
-                # Move scratch bookkeeping from _scratch_mappings into _mappings
-                # as preserved-VA records and flip subsequent allocations on
-                # this mempool to server-backed create_mapping.
-                kv_cache_manager.prepare_scratch_for_reallocation()
-            kv_cache_manager.reallocate_all_handles(tag="kv_cache")
-            kv_cache_manager.remap_all_vas()
-            self.model_runner.post_kv_cache_wake_up()
-            if was_scratch:
-                self._register_kv_caches_with_nixl()
+        promoted_private_bootstrap = False
+        if "kv_pool" in tags:
+            kv_manager = get_gms_client_memory_manager("kv_pool")
+            assert kv_manager is not None, "GMS persistent KV client is not initialized"
+            private_bootstrap = bool(getattr(self, "_gms_kv_private_bootstrap", False))
+            logger.info(
+                "[GMS] vLLM KV wake_up start: private_bootstrap=%s "
+                "is_unmapped=%s mappings=%d scratch_mappings=%d",
+                private_bootstrap,
+                kv_manager.is_unmapped,
+                len(kv_manager.mappings),
+                len(getattr(kv_manager, "_scratch_mappings", {})),
+            )
+            if private_bootstrap and not kv_manager.is_unmapped:
+                migrated = kv_manager.prepare_deferred_scratch_for_persistent_remap()
+                logger.info(
+                    "[GMS] vLLM KV wake_up prepared private-bootstrap VAs: "
+                    "migrated=%d is_unmapped=%s mappings=%d scratch_mappings=%d",
+                    migrated,
+                    kv_manager.is_unmapped,
+                    len(kv_manager.mappings),
+                    len(getattr(kv_manager, "_scratch_mappings", {})),
+                )
+            else:
+                assert kv_manager.is_unmapped, "GMS persistent KV is not unmapped"
+            engine_id = getattr(
+                self,
+                "_gms_kv_engine_id",
+                stable_engine_id(self.local_rank),
+            )
+            target_engine_id = engine_id
+            target_shared = shared_kv_enabled()
+            if private_bootstrap:
+                target_engine_id = getattr(
+                    self, "_gms_kv_promote_engine_id", stable_engine_id(self.local_rank)
+                )
+                target_shared = True
 
-    def _register_kv_caches_with_nixl(self) -> None:
-        """Fire the NixlConnector KV-cache registration after deferred KV swap.
+            logger.info(
+                "[GMS] vLLM KV wake_up connecting: engine_id=%s "
+                "target_engine_id=%s target_shared=%s",
+                engine_id,
+                target_engine_id,
+                target_shared,
+            )
+            kv_manager.connect(RequestedLockType.RW_PERSISTENT)
+            if (
+                private_bootstrap
+                and kv_manager.is_unmapped
+                and getattr(kv_manager, "_scratch_mappings", {})
+            ):
+                migrated = kv_manager.prepare_scratch_for_reallocation()
+                logger.info(
+                    "[GMS] vLLM KV wake_up prepared scratch VAs after connect: "
+                    "migrated=%d",
+                    migrated,
+                )
+            logger.info(
+                "[GMS] vLLM KV wake_up remap begin: target_engine_id=%s "
+                "sync_mode=%s",
+                target_engine_id,
+                "batched" if private_bootstrap else "per_mapping",
+            )
+            kv_manager.remap_persistent_vas(
+                target_engine_id,
+                shared=target_shared,
+                synchronize_per_mapping=not private_bootstrap,
+                validate_after_remap=not private_bootstrap,
+            )
+            logger.info("[GMS] vLLM KV wake_up remap done")
+            if target_engine_id != engine_id:
+                logger.info(
+                    "[GMS] vLLM KV wake_up retargeting allocator: %s -> %s",
+                    engine_id,
+                    target_engine_id,
+                )
+                retarget_persistent_allocator(
+                    "kv_pool", target_engine_id, shared=target_shared
+                )
+                release_private_bootstrap_kv_pool(kv_manager, engine_id, logger=logger)
+                self._gms_kv_engine_id = target_engine_id
+                promoted_private_bootstrap = private_bootstrap
+                self._gms_kv_private_bootstrap = False
+                logger.info(
+                    "[GMS] Promoted vLLM KV namespace %s -> %s",
+                    engine_id,
+                    target_engine_id,
+                )
 
-        During scratch phase the patches.patch_register_kv_caches gate intercepts
-        register_kv_caches(dict) and stashes the dict on the connector as
-        self._scratch_kv_pending. We replay that here, NOT
-        self.model_runner.kv_caches — the latter is the list-of-tensors view
-        set by vLLM, and NixlConnector.register_kv_caches does kv_caches.values()
-        which requires the dict form.
+        if (
+            requested_tags is None
+            or "kv_cache" in requested_tags
+            or "kv_pool" in requested_tags
+        ):
+            if promoted_private_bootstrap:
+                logger.info(
+                    "[GMS] Skipping vLLM post_kv_cache_wake_up after "
+                    "private-bootstrap promotion to preserve shared KV"
+                )
+                self._reset_fp8_kv_scales_without_zeroing()
+            else:
+                logger.info("[GMS] vLLM post_kv_cache_wake_up begin")
+                self.model_runner.post_kv_cache_wake_up()
+                logger.info("[GMS] vLLM post_kv_cache_wake_up done")
 
-        Imports from the package root (vllm.distributed.kv_transfer) — the
-        kv_connector.v1.base re-exports were unreliable across vLLM versions
-        and a silent ImportError here would make this a no-op, leaving
-        NixlConnectorWorker.kv_topo=None and crashing on the first
-        scheduler tick.
-        """
-        from vllm.distributed.kv_transfer import (
-            get_kv_transfer_group,
-            has_kv_transfer_group,
-        )
+                # Reinitialize FP8 KV scales if needed for vLLM versions whose
+                # post-wake hook does not already do it.
+                if self.cache_config.cache_dtype.startswith("fp8") and hasattr(
+                    self.model_runner, "init_fp8_kv_scales"
+                ):
+                    logger.info("[GMS] vLLM init_fp8_kv_scales begin")
+                    self.model_runner.init_fp8_kv_scales()
+                    logger.info("[GMS] vLLM init_fp8_kv_scales done")
 
-        if not has_kv_transfer_group():
-            return
-        group = get_kv_transfer_group()
-        pending = getattr(group, "_scratch_kv_pending", None)
-        if not pending:
-            # Nothing was stashed — either no deferred registration, or a
-            # non-NixlConnector connector that didn't hit the patched path.
-            return
-        group.register_kv_caches(pending)
-        # Drop the stash so a second call is a no-op.
-        try:
-            delattr(group, "_scratch_kv_pending")
-        except AttributeError:
-            pass
-        logger.info(
-            "[GMS] Registered %d kv_cache tensors with KV transfer group",
-            len(pending),
-        )
+            self._run_deferred_private_bootstrap_warmup()
 
     def _maybe_get_memory_pool_context(self, tag: str):
         """Route tag-scoped runtime allocations to the right allocator.
@@ -476,5 +878,7 @@ class GMSWorker(Worker):
             logger.debug("[GMS] Skipping CuMemAllocator for weights")
             return nullcontext()
         if tag == "kv_cache":
-            return gms_use_mem_pool("kv_cache", torch.device("cuda", self.local_rank))
+            return gms_use_persistent_pool(
+                "kv_pool", torch.device("cuda", self.local_rank)
+            )
         return super()._maybe_get_memory_pool_context(tag)

--- a/lib/gpu_memory_service/tests/test_serving_timeout.py
+++ b/lib/gpu_memory_service/tests/test_serving_timeout.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from gpu_memory_service.common import serving_timeout
+
+pytestmark = pytest.mark.pre_merge
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch):
+    monkeypatch.setattr(serving_timeout, "_applied", False)
+    monkeypatch.setattr(serving_timeout, "_warned", False)
+    monkeypatch.setenv("TORCH_NCCL_WAIT_TIMEOUT_DUMP_MILSEC", "1000")
+
+
+def test_invalid_timeout_uses_default(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_SERVING_NCCL_TIMEOUT_S", "invalid")
+
+    assert serving_timeout.serving_timeout_s() == 5.0
+
+
+def test_disabled_timeout_is_noop(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_SERVING_NCCL_TIMEOUT_S", "0")
+
+    assert serving_timeout.tighten_now() is False
+    assert serving_timeout._applied is False
+
+
+def test_uninitialized_distributed_is_noop(monkeypatch):
+    import torch.distributed as dist
+
+    monkeypatch.setattr(dist, "is_available", lambda: True)
+    monkeypatch.setattr(dist, "is_initialized", lambda: False)
+
+    assert serving_timeout.apply_serving_collective_timeout(3.0) is False
+    assert serving_timeout._applied is False
+
+
+def test_applies_default_and_tracked_process_groups(monkeypatch):
+    import torch.distributed as dist
+    from torch.distributed import distributed_c10d as c10d
+
+    group_a = object()
+    group_b = object()
+    calls: list[tuple[datetime.timedelta, object | None]] = []
+
+    monkeypatch.setattr(dist, "is_available", lambda: True)
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        c10d,
+        "_set_pg_timeout",
+        lambda timeout, group: calls.append((timeout, group)),
+    )
+    monkeypatch.setattr(
+        c10d,
+        "_world",
+        SimpleNamespace(pg_map={group_a: object(), group_b: object()}),
+    )
+
+    assert serving_timeout.apply_serving_collective_timeout(2.5) is True
+    assert calls == [
+        (datetime.timedelta(seconds=2.5), None),
+        (datetime.timedelta(seconds=2.5), group_a),
+        (datetime.timedelta(seconds=2.5), group_b),
+    ]
+    assert serving_timeout._applied is True
+
+    assert serving_timeout.apply_serving_collective_timeout(1.0) is False
+    assert len(calls) == 3
+
+
+def test_missing_private_timeout_api_is_noop(monkeypatch):
+    import torch.distributed as dist
+    from torch.distributed import distributed_c10d as c10d
+
+    monkeypatch.setattr(dist, "is_available", lambda: True)
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    monkeypatch.delattr(c10d, "_set_pg_timeout", raising=False)
+
+    assert serving_timeout.apply_serving_collective_timeout(2.0) is False
+    assert serving_timeout._applied is False

--- a/lib/gpu_memory_service/tests/test_sglang_static_state_patch.py
+++ b/lib/gpu_memory_service/tests/test_sglang_static_state_patch.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import types
+
+import gpu_memory_service.integrations.sglang as sglang_gms
+import pytest
+from gpu_memory_service.integrations.sglang import patches
+
+pytestmark = pytest.mark.pre_merge
+
+
+def test_patch_static_state_for_gms_targets_current_weight_updater(monkeypatch):
+    module_name = "sglang.srt.managers.scheduler_components.weight_updater"
+    module = types.ModuleType(module_name)
+    module._export_static_state = lambda model: {"buffers": [("x", object())]}
+
+    def _import_static_state(model, static_params):
+        raise AssertionError("original import should be replaced")
+
+    module._import_static_state = _import_static_state
+    monkeypatch.setitem(sys.modules, module_name, module)
+    monkeypatch.setattr(patches, "_static_state_patched", False)
+
+    patches.patch_static_state_for_gms()
+
+    assert module._export_static_state(object()) == {"buffers": []}
+    assert module._import_static_state(object(), {"buffers": [("x", object())]}) is None
+    assert patches._static_state_patched is True
+
+
+def test_configure_shared_failover_env_disables_sglang_tp_memory_check(monkeypatch):
+    monkeypatch.setenv("GMS_SGLANG_SHARED_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.delenv("SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK", raising=False)
+
+    sglang_gms.configure_shared_failover_env()
+
+    assert os.environ["SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK"] == "0"
+
+
+def test_configure_shared_failover_env_preserves_explicit_sglang_tp_memory_check(
+    monkeypatch,
+):
+    monkeypatch.setenv("GMS_SGLANG_SHARED_KV", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK", "1")
+
+    sglang_gms.configure_shared_failover_env()
+
+    assert os.environ["SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK"] == "1"

--- a/lib/gpu_memory_service/tests/test_vllm_engine_core_hooks.py
+++ b/lib/gpu_memory_service/tests/test_vllm_engine_core_hooks.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from gpu_memory_service.integrations.vllm.install_kv_leases import (
+    install_gms_engine_core_sleep,
+)
+
+
+def test_sleep_utility_is_visible_on_spawned_engine_core_proc():
+    from vllm.v1.engine.core import EngineCore, EngineCoreProc
+
+    original = EngineCore.__dict__.get("gms_sleep_no_clear")
+    if original is not None:
+        delattr(EngineCore, "gms_sleep_no_clear")
+    try:
+        assert install_gms_engine_core_sleep()
+        assert "gms_sleep_no_clear" in EngineCore.__dict__
+        assert hasattr(EngineCoreProc, "gms_sleep_no_clear")
+        assert not install_gms_engine_core_sleep()
+    finally:
+        if hasattr(EngineCore, "gms_sleep_no_clear"):
+            delattr(EngineCore, "gms_sleep_no_clear")
+        if original is not None:
+            EngineCore.gms_sleep_no_clear = original

--- a/lib/gpu_memory_service/tests/test_vllm_gms_worker_memory_accounting.py
+++ b/lib/gpu_memory_service/tests/test_vllm_gms_worker_memory_accounting.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+from gpu_memory_service.common.locks import GrantedLockType
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+def _make_worker(worker_module, usage: int):
+    worker = object.__new__(worker_module.GMSWorker)
+    worker.model_runner = SimpleNamespace(model_memory_usage=usage)
+    return worker
+
+
+def test_vllm_gms_rw_weight_memory_not_double_counted(monkeypatch):
+    from gpu_memory_service.integrations.vllm import worker as worker_module
+
+    calls = []
+    worker = _make_worker(worker_module, 1234)
+    monkeypatch.setattr(
+        worker_module,
+        "get_gms_client_memory_manager",
+        lambda tag: SimpleNamespace(granted_lock_type=GrantedLockType.RW),
+    )
+
+    def fake_determine_available_memory(self):
+        calls.append(self.model_runner.model_memory_usage)
+        return 5678
+
+    monkeypatch.setattr(
+        worker_module.Worker,
+        "determine_available_memory",
+        fake_determine_available_memory,
+    )
+
+    assert worker._determine_available_memory_with_gms_weight_accounting() == 5678
+    assert calls == [0]
+    assert worker.model_runner.model_memory_usage == 1234
+
+
+def test_vllm_gms_ro_weight_memory_preserved(monkeypatch):
+    from gpu_memory_service.integrations.vllm import worker as worker_module
+
+    calls = []
+    worker = _make_worker(worker_module, 1234)
+    monkeypatch.setattr(
+        worker_module,
+        "get_gms_client_memory_manager",
+        lambda tag: SimpleNamespace(granted_lock_type=GrantedLockType.RO),
+    )
+
+    def fake_determine_available_memory(self):
+        calls.append(self.model_runner.model_memory_usage)
+        return 5678
+
+    monkeypatch.setattr(
+        worker_module.Worker,
+        "determine_available_memory",
+        fake_determine_available_memory,
+    )
+
+    assert worker._determine_available_memory_with_gms_weight_accounting() == 5678
+    assert calls == [1234]
+    assert worker.model_runner.model_memory_usage == 1234
+
+
+def test_vllm_gms_model_loader_patches_base_worker_memory_accounting(monkeypatch):
+    from gpu_memory_service.integrations.vllm import model_loader
+    from vllm.v1.worker.gpu_worker import Worker
+
+    original = Worker.determine_available_memory
+    calls = []
+
+    def fake_determine_available_memory(self):
+        calls.append(self.model_runner.model_memory_usage)
+        return 42
+
+    monkeypatch.setattr(
+        Worker, "determine_available_memory", fake_determine_available_memory
+    )
+    monkeypatch.setattr(
+        model_loader,
+        "get_gms_client_memory_manager",
+        lambda tag: SimpleNamespace(granted_lock_type=GrantedLockType.RW),
+    )
+
+    model_loader.patch_vllm_worker_memory_accounting()
+    worker = SimpleNamespace(model_runner=SimpleNamespace(model_memory_usage=99))
+
+    try:
+        assert Worker.determine_available_memory(worker) == 42
+        assert calls == [0]
+        assert worker.model_runner.model_memory_usage == 99
+    finally:
+        Worker.determine_available_memory = original
+
+
+def test_vllm_gms_model_loader_base_worker_patch_preserves_ro(monkeypatch):
+    from gpu_memory_service.integrations.vllm import model_loader
+    from vllm.v1.worker.gpu_worker import Worker
+
+    original = Worker.determine_available_memory
+    calls = []
+
+    def fake_determine_available_memory(self):
+        calls.append(self.model_runner.model_memory_usage)
+        return 42
+
+    monkeypatch.setattr(
+        Worker, "determine_available_memory", fake_determine_available_memory
+    )
+    monkeypatch.setattr(
+        model_loader,
+        "get_gms_client_memory_manager",
+        lambda tag: SimpleNamespace(granted_lock_type=GrantedLockType.RO),
+    )
+
+    model_loader.patch_vllm_worker_memory_accounting()
+    worker = SimpleNamespace(model_runner=SimpleNamespace(model_memory_usage=99))
+
+    try:
+        assert Worker.determine_available_memory(worker) == 42
+        assert calls == [99]
+        assert worker.model_runner.model_memory_usage == 99
+    finally:
+        Worker.determine_available_memory = original

--- a/lib/gpu_memory_service/tests/test_vllm_kv_identity.py
+++ b/lib/gpu_memory_service/tests/test_vllm_kv_identity.py
@@ -1,0 +1,538 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+from gpu_memory_service.integrations.vllm import install_vmm_ipc_kv, kv_identity
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_dynamic_gms_role_env(monkeypatch):
+    for name in (
+        "DYN_VLLM_GMS_ACTIVE_LOCK_HELD",
+        "DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV",
+        "GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    for name in (
+        "DYN_VLLM_GMS_ACTIVE_LOCK_HELD",
+        "DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV",
+        "GMS_PERSISTENT_DEFER_PHYSICAL_SCRATCH_BACKED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_v2_semantic_kv_tags_follow_layer_identity():
+    tensor_a = SimpleNamespace(
+        shared_by=["model.layers.1.self_attn", "model.layers.0.self_attn"], size=123
+    )
+    tensor_b = SimpleNamespace(shared_by=["model.layers.0.mla"], size=456)
+    same_a_different_order = SimpleNamespace(
+        shared_by=["model.layers.0.self_attn", "model.layers.1.self_attn"],
+        size=789,
+    )
+
+    tag_a, tag_b = install_vmm_ipc_kv._semantic_kv_tensor_tag_plan(
+        SimpleNamespace(kv_cache_tensors=[tensor_a, tensor_b])
+    )
+    tag_b2, tag_a2 = install_vmm_ipc_kv._semantic_kv_tensor_tag_plan(
+        SimpleNamespace(kv_cache_tensors=[tensor_b, same_a_different_order])
+    )
+
+    assert tag_a.startswith("kv_pool:v2:")
+    assert tag_b.startswith("kv_pool:v2:")
+    assert tag_a == tag_a2
+    assert tag_b == tag_b2
+    assert tag_a != tag_b
+
+
+def test_semantic_kv_tags_disambiguate_duplicate_layer_identity():
+    tensor_a = SimpleNamespace(shared_by=["model.layers.0.self_attn"], size=123)
+    tensor_b = SimpleNamespace(shared_by=["model.layers.0.self_attn"], size=123)
+
+    tag_a, tag_b = install_vmm_ipc_kv._semantic_kv_tensor_tag_plan(
+        SimpleNamespace(kv_cache_tensors=[tensor_a, tensor_b])
+    )
+
+    assert tag_a.startswith("kv_pool:v2:")
+    assert tag_b.startswith("kv_pool:v2:")
+    assert tag_a != tag_b
+    assert tag_a.endswith(":dup0")
+    assert tag_b.endswith(":dup1")
+
+
+def test_private_bootstrap_kv_zeros_as_empty_only_rewrites_int8(monkeypatch):
+    import sys
+    from types import SimpleNamespace
+
+    int8_marker = object()
+    fp16_marker = object()
+    calls = []
+
+    def fake_zeros(*args, **kwargs):
+        calls.append(("zeros", args, dict(kwargs)))
+        return ("zeros", kwargs.get("dtype"))
+
+    def fake_empty(*args, **kwargs):
+        calls.append(("empty", args, dict(kwargs)))
+        return ("empty", kwargs.get("dtype"))
+
+    fake_torch = SimpleNamespace(
+        int8=int8_marker,
+        float16=fp16_marker,
+        zeros=fake_zeros,
+        empty=fake_empty,
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    with install_vmm_ipc_kv._private_bootstrap_kv_zeros_as_empty(True):
+        assert fake_torch.zeros((16,), dtype=int8_marker, device="cuda") == (
+            "empty",
+            int8_marker,
+        )
+        assert fake_torch.zeros((16,), dtype=fp16_marker) == (
+            "zeros",
+            fp16_marker,
+        )
+
+    assert fake_torch.zeros is fake_zeros
+    assert calls[0][0] == "empty"
+    assert calls[1][0] == "zeros"
+
+    calls.clear()
+    with install_vmm_ipc_kv._private_bootstrap_kv_zeros_as_empty(False):
+        assert fake_torch.zeros((16,), dtype=int8_marker) == ("zeros", int8_marker)
+    assert calls == [("zeros", ((16,),), {"dtype": int8_marker})]
+
+
+def test_v1_profiling_kv_tensors_bypass_persistent_pool(monkeypatch):
+    import sys
+    import types
+    from contextlib import contextmanager
+
+    from gpu_memory_service.client.torch import allocator as torch_allocator
+
+    class FakeGPUModelRunner:
+        device = 0
+
+        def initialize_kv_cache(self, kv_cache_config, is_profiling=False):
+            return self.initialize_kv_cache_tensors(kv_cache_config, [16])
+
+        def initialize_kv_cache_tensors(self, _kv_cache_config, _kernel_block_sizes):
+            return "original"
+
+    calls = []
+
+    def fake_get_or_create(*args, **kwargs):
+        calls.append(("register", args, kwargs))
+        return object()
+
+    @contextmanager
+    def fake_pool(tag, device):
+        calls.append(("pool", tag, device))
+        yield
+
+    monkeypatch.setattr(install_vmm_ipc_kv, "_INSTALLED", False)
+    monkeypatch.setattr(install_vmm_ipc_kv, "_install_kv_leases", lambda: False)
+    monkeypatch.setattr(
+        install_vmm_ipc_kv, "_resolve_socket", lambda device: f"sock-{device}"
+    )
+    monkeypatch.setattr(
+        install_vmm_ipc_kv, "_engine_id", lambda device=0: f"engine-{device}"
+    )
+    monkeypatch.setattr(install_vmm_ipc_kv, "_shared_kv_enabled", lambda: True)
+    monkeypatch.setattr(install_vmm_ipc_kv, "_defer_physical_enabled", lambda: False)
+    monkeypatch.setattr(
+        torch_allocator, "get_or_create_persistent_allocator", fake_get_or_create
+    )
+    monkeypatch.setattr(torch_allocator, "gms_use_persistent_pool", fake_pool)
+    monkeypatch.setattr(
+        torch_allocator,
+        "set_persistent_allocator_tag_plan",
+        lambda tag, plan: calls.append(("plan", tag, tuple(plan))),
+    )
+    monkeypatch.setattr(
+        torch_allocator,
+        "clear_persistent_allocator_tag_plan",
+        lambda tag: calls.append(("clear", tag)),
+    )
+
+    vllm_mod = types.ModuleType("vllm")
+    v1_mod = types.ModuleType("vllm.v1")
+    core_pkg = types.ModuleType("vllm.v1.core")
+    kv_cache_utils = types.ModuleType("vllm.v1.core.kv_cache_utils")
+    kv_cache_utils.get_kv_cache_configs = lambda *args, **kwargs: None
+    worker_pkg = types.ModuleType("vllm.v1.worker")
+    gpu_pkg = types.ModuleType("vllm.v1.worker.gpu")
+    attn_utils = types.ModuleType("vllm.v1.worker.gpu.attn_utils")
+    attn_utils._allocate_kv_cache = lambda *args, **kwargs: "v2"
+    gpu_pkg.attn_utils = attn_utils
+    gpu_model_runner = types.ModuleType("vllm.v1.worker.gpu_model_runner")
+    gpu_model_runner.GPUModelRunner = FakeGPUModelRunner
+
+    for name, module in {
+        "vllm": vllm_mod,
+        "vllm.v1": v1_mod,
+        "vllm.v1.core": core_pkg,
+        "vllm.v1.core.kv_cache_utils": kv_cache_utils,
+        "vllm.v1.worker": worker_pkg,
+        "vllm.v1.worker.gpu": gpu_pkg,
+        "vllm.v1.worker.gpu.attn_utils": attn_utils,
+        "vllm.v1.worker.gpu_model_runner": gpu_model_runner,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    assert install_vmm_ipc_kv.install()
+
+    cfg = SimpleNamespace(
+        kv_cache_tensors=[SimpleNamespace(shared_by=["layer.0"], size=128)]
+    )
+    runner = FakeGPUModelRunner()
+
+    assert runner.initialize_kv_cache(cfg, is_profiling=True) == "original"
+    assert calls == []
+
+    assert runner.initialize_kv_cache(cfg) == "original"
+    assert calls[0][0] == "register"
+    assert calls[1][0] == "plan"
+    assert calls[2][0] == "pool"
+    assert calls[3][0] == "clear"
+
+
+def test_default_shared_shadow_uses_stable_shared_id(monkeypatch):
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_NAMESPACE", "ns")
+    monkeypatch.setenv("DYN_COMPONENT", "worker")
+    monkeypatch.delenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", raising=False)
+    monkeypatch.delenv("GMS_VLLM_PRIVATE_BOOTSTRAP_KV", raising=False)
+    monkeypatch.delenv("GMS_VLLM_VMM_IPC_ENGINE_ID", raising=False)
+
+    stable = kv_identity.stable_engine_id(0)
+
+    assert kv_identity.shared_kv_enabled()
+    assert not kv_identity.private_bootstrap_kv_enabled()
+    assert kv_identity.allocation_engine_id(0) == stable
+    assert kv_identity.promotion_engine_id(0) == stable
+    assert kv_identity.allocation_shared()
+    assert kv_identity.use_existing_shared_geometry()
+
+
+def test_private_bootstrap_uses_member_scoped_init_id(monkeypatch):
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("GMS_VLLM_VMM_IPC_ENGINE_ID", "shared-engine")
+    monkeypatch.setenv("ENGINE_ID", "shadow-1")
+
+    assert kv_identity.private_bootstrap_kv_enabled()
+    assert kv_identity.stable_engine_id(0) == "shared-engine"
+    assert kv_identity.allocation_engine_id(0) == "shared-engine|bootstrap=shadow-1"
+    assert kv_identity.promotion_engine_id(0) == "shared-engine"
+    assert not kv_identity.allocation_shared()
+    assert kv_identity.use_existing_shared_geometry()
+
+
+def test_private_bootstrap_is_shadow_only_in_failover(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("GMS_VLLM_VMM_IPC_ENGINE_ID", "shared-engine")
+    monkeypatch.delenv("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", raising=False)
+    monkeypatch.delenv("DYN_VLLM_GMS_ACTIVE_LOCK_HELD", raising=False)
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "0")
+
+    assert not kv_identity.private_bootstrap_kv_enabled()
+    assert kv_identity.allocation_engine_id(0) == "shared-engine"
+    assert kv_identity.allocation_shared()
+
+    monkeypatch.setenv("ENGINE_ID", "1")
+
+    assert kv_identity.private_bootstrap_kv_enabled()
+    assert kv_identity.allocation_engine_id(0) == "shared-engine|bootstrap=1"
+    assert not kv_identity.allocation_shared()
+
+
+def test_dynamic_preinit_role_overrides_static_primary(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("GMS_VLLM_VMM_IPC_ENGINE_ID", "shared-engine")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", "1")
+
+    assert kv_identity.private_bootstrap_kv_enabled()
+    assert kv_identity.allocation_engine_id(0) == "shared-engine|bootstrap=0"
+    assert not kv_identity.allocation_shared()
+
+
+def test_dynamic_preinit_lock_holder_uses_shared_kv(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("GMS_VLLM_VMM_IPC_ENGINE_ID", "shared-engine")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_ACTIVE_LOCK_HELD", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_FORCE_PRIVATE_BOOTSTRAP_KV", "1")
+
+    assert not kv_identity.private_bootstrap_kv_enabled()
+    assert kv_identity.allocation_engine_id(0) == "shared-engine"
+    assert kv_identity.allocation_shared()
+
+
+def test_private_bootstrap_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "0")
+    monkeypatch.setenv("GMS_VLLM_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("GMS_VLLM_VMM_IPC_ENGINE_ID", "shared-engine")
+
+    assert not kv_identity.private_bootstrap_kv_enabled()
+    assert kv_identity.allocation_engine_id(0) == "shared-engine"
+    assert kv_identity.allocation_shared()
+
+
+def test_private_bootstrap_scratch_warmup_requires_private_bootstrap(monkeypatch):
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "0")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP", "1")
+
+    assert not kv_identity.private_bootstrap_kv_enabled()
+    assert not kv_identity.private_bootstrap_scratch_warmup_enabled()
+
+
+def test_private_bootstrap_scratch_warmup_is_shadow_only(monkeypatch):
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_SCRATCH_WARMUP", "1")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "0")
+
+    assert not kv_identity.private_bootstrap_scratch_warmup_enabled()
+
+    monkeypatch.setenv("ENGINE_ID", "1")
+
+    assert kv_identity.private_bootstrap_kv_enabled()
+    assert kv_identity.private_bootstrap_scratch_warmup_enabled()
+
+
+def test_vllm_v2_device_index_uses_current_cuda_device_for_unindexed_cuda(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from gpu_memory_service.integrations.vllm import install_vmm_ipc_kv
+
+    monkeypatch.setattr(install_vmm_ipc_kv, "_current_cuda_device", lambda: 3)
+
+    assert install_vmm_ipc_kv._device_index(SimpleNamespace(index=None)) == 3
+
+
+def test_private_bootstrap_caps_startup_memory_for_existing_shared_geometry(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from gpu_memory_service.integrations.vllm import worker
+
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_BOOTSTRAP_GPU_MEMORY_UTILIZATION", "0.125")
+    monkeypatch.setattr(worker, "_existing_shared_kv_blocks", lambda device: 1024)
+
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(gpu_memory_utilization=0.7)
+    )
+
+    worker._maybe_cap_private_bootstrap_memory(vllm_config, 0)
+
+    assert vllm_config.cache_config.gpu_memory_utilization == 0.125
+
+
+def test_existing_shared_kv_blocks_falls_back_to_any_rank_geometry(monkeypatch):
+    from gpu_memory_service.integrations.vllm import worker
+
+    monkeypatch.setenv("GMS_KV_LEASES", "1")
+    monkeypatch.setattr(
+        "gpu_memory_service.integrations.common.kv_lease_client.read_kv_lease_namespace_total_blocks",
+        lambda engine, device, *, namespace_suffix="kv": ("vllm:gpu7:block-pool", None),
+    )
+    monkeypatch.setattr(
+        "gpu_memory_service.integrations.common.kv_lease_client.read_any_kv_lease_namespace_total_blocks",
+        lambda engine: ("/pod/gms-kv-lease-rank0.shm", 2048),
+    )
+
+    assert worker._existing_shared_kv_blocks(7) == 2048
+
+
+def test_private_bootstrap_caps_startup_memory_before_geometry(monkeypatch):
+    from types import SimpleNamespace
+
+    from gpu_memory_service.integrations.vllm import worker
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_BOOTSTRAP_GPU_MEMORY_UTILIZATION", "0.125")
+    monkeypatch.setattr(worker, "_existing_shared_kv_blocks", lambda device: None)
+
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(gpu_memory_utilization=0.7)
+    )
+
+    worker._maybe_cap_private_bootstrap_memory(vllm_config, 0)
+
+    assert vllm_config.cache_config.gpu_memory_utilization == 0.125
+
+
+def test_private_bootstrap_memory_cap_ignores_first_primary(monkeypatch):
+    from types import SimpleNamespace
+
+    from gpu_memory_service.integrations.vllm import worker
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "0")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setattr(worker, "_existing_shared_kv_blocks", lambda device: None)
+
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(gpu_memory_utilization=0.7)
+    )
+
+    worker._maybe_cap_private_bootstrap_memory(vllm_config, 0)
+
+    assert vllm_config.cache_config.gpu_memory_utilization == 0.7
+
+
+def test_vllm_geometry_reader_uses_block_pool_lease_namespace(monkeypatch):
+    from gpu_memory_service.integrations.vllm import install_vmm_ipc_kv
+
+    calls = []
+
+    def fake_read(engine, device, *, namespace_suffix="kv"):
+        calls.append((engine, device, namespace_suffix))
+        if namespace_suffix == "block-pool":
+            return "vllm:gpu2:block-pool", 123
+        return "vllm:gpu2:kv", None
+
+    monkeypatch.setenv("GMS_KV_LEASES", "1")
+    monkeypatch.setenv("GMS_VLLM_SHARED_KV", "1")
+    monkeypatch.setenv("LOCAL_RANK", "2")
+    monkeypatch.setattr(
+        "gpu_memory_service.integrations.common.kv_lease_client.read_kv_lease_namespace_total_blocks",
+        fake_read,
+    )
+
+    assert install_vmm_ipc_kv._existing_shared_kv_blocks() == 123
+    assert calls == [("vllm", 2, "block-pool")]
+
+
+def test_private_bootstrap_geometry_wait_extends_generic_timeout(monkeypatch):
+    from gpu_memory_service.integrations.vllm import install_vmm_ipc_kv
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("GMS_KV_LEASE_GEOMETRY_WAIT_MS", "300000")
+    monkeypatch.delenv("GMS_VLLM_KV_GEOMETRY_WAIT_MS", raising=False)
+
+    assert install_vmm_ipc_kv._geometry_wait_ms(-1) == 1_800_000
+
+
+def test_private_bootstrap_geometry_wait_honors_vllm_specific_timeout(monkeypatch):
+    from gpu_memory_service.integrations.vllm import install_vmm_ipc_kv
+
+    monkeypatch.setenv("DYN_GMS_FAILOVER_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_GMS_FAILOVER_PRIMARY_ENGINE_ID", "0")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("DYN_VLLM_GMS_SHADOW_MODE", "true")
+    monkeypatch.setenv("DYN_VLLM_GMS_PRIVATE_BOOTSTRAP_KV", "1")
+    monkeypatch.setenv("GMS_KV_LEASE_GEOMETRY_WAIT_MS", "300000")
+    monkeypatch.setenv("GMS_VLLM_KV_GEOMETRY_WAIT_MS", "42")
+
+    assert install_vmm_ipc_kv._geometry_wait_ms(-1) == 42
+
+
+def test_vllm_geometry_patch_updates_late_engine_core_alias(monkeypatch):
+    import sys
+    import types
+
+    from gpu_memory_service.integrations.vllm import install_vmm_ipc_kv
+
+    def original(_vllm_config, _kv_cache_specs, _available_memory):
+        return "original"
+
+    vllm_mod = types.ModuleType("vllm")
+    v1_mod = types.ModuleType("vllm.v1")
+    core_pkg = types.ModuleType("vllm.v1.core")
+    kv_cache_utils = types.ModuleType("vllm.v1.core.kv_cache_utils")
+    kv_cache_utils.get_kv_cache_configs = original
+    core_pkg.kv_cache_utils = kv_cache_utils
+
+    monkeypatch.setitem(sys.modules, "vllm", vllm_mod)
+    monkeypatch.setitem(sys.modules, "vllm.v1", v1_mod)
+    monkeypatch.setitem(sys.modules, "vllm.v1.core", core_pkg)
+    monkeypatch.setitem(sys.modules, "vllm.v1.core.kv_cache_utils", kv_cache_utils)
+    monkeypatch.delitem(sys.modules, "vllm.v1.engine.core", raising=False)
+    monkeypatch.setattr(install_vmm_ipc_kv, "_GEOMETRY_PATCH_INSTALLED", False)
+
+    assert install_vmm_ipc_kv.install_geometry_patch()
+    patched = kv_cache_utils.get_kv_cache_configs
+    assert getattr(patched, "_gms_geometry_patched", False)
+
+    engine_core = types.ModuleType("vllm.v1.engine.core")
+    engine_core.get_kv_cache_configs = original
+    monkeypatch.setitem(sys.modules, "vllm.v1.engine.core", engine_core)
+
+    assert install_vmm_ipc_kv.install_geometry_patch()
+    assert engine_core.get_kv_cache_configs is patched
+
+
+def test_release_private_bootstrap_kv_pool_releases_only_kv_tags():
+    from types import SimpleNamespace
+
+    from gpu_memory_service.integrations.vllm.kv_identity import (
+        release_private_bootstrap_kv_pool,
+    )
+
+    class FakeManager:
+        def __init__(self):
+            self.released = []
+
+        def list_persistent(self, engine_id=None):
+            assert engine_id == "stable|bootstrap=1"
+            return [
+                SimpleNamespace(tag="kv_pool#0"),
+                SimpleNamespace(tag="kv_pool#1"),
+                SimpleNamespace(tag="weights#0"),
+            ]
+
+        def release_persistent(self, engine_id, tag):
+            self.released.append((engine_id, tag))
+            return True
+
+    manager = FakeManager()
+
+    released = release_private_bootstrap_kv_pool(manager, "stable|bootstrap=1")
+
+    assert released == 2
+    assert manager.released == [
+        ("stable|bootstrap=1", "kv_pool#0"),
+        ("stable|bootstrap=1", "kv_pool#1"),
+    ]

--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -24,6 +24,31 @@ from tests.utils.port_utils import allocate_ports, deallocate_ports
 logger = logging.getLogger(__name__)
 
 
+def _tp_size() -> int:
+    """Tensor-parallel size for the failover scenario (GMS_TEST_TP_SIZE, default 1).
+
+    TP=N runs each engine across devices 0..N-1; the GMS weights + kv_cache
+    daemons are started on each of those devices. The engine's own collective
+    (vLLM mp executor / sglang tp schedulers) applies
+    pause/resume across all ranks, so failover stays group-atomic without the
+    harness coordinating per-rank.
+    """
+    return max(1, int(os.environ.get("GMS_TEST_TP_SIZE", "1")))
+
+
+def _tp_visible_devices() -> str:
+    tp = _tp_size()
+    inherited = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if inherited:
+        devices = [device.strip() for device in inherited.split(",") if device.strip()]
+        if len(devices) < tp:
+            raise ValueError(
+                f"GMS_TEST_TP_SIZE={tp} exceeds CUDA_VISIBLE_DEVICES={inherited!r}"
+            )
+        return ",".join(devices[:tp])
+    return ",".join(str(i) for i in range(tp))
+
+
 class GMSProcessManager:
     """Start the shared GMS daemons and frontend for one test scenario."""
 
@@ -49,14 +74,19 @@ class GMSProcessManager:
     def __enter__(self):
         stack = ExitStack()
         try:
+            tp = _tp_size()
             if "weights" in self._tags:
                 self.weights_gms = stack.enter_context(
                     GMSServer(device=0, tag="weights")
                 )
+                for d in range(1, tp):
+                    stack.enter_context(GMSServer(device=d, tag="weights"))
             if "kv_cache" in self._tags:
                 self.kv_cache_gms = stack.enter_context(
                     GMSServer(device=0, tag="kv_cache")
                 )
+                for d in range(1, tp):
+                    stack.enter_context(GMSServer(device=d, tag="kv_cache"))
             frontend = stack.enter_context(
                 DynamoFrontendProcess(
                     self._request,
@@ -160,7 +190,7 @@ class GMSEngineProcess(EngineProcess, ABC):
                 (f"http://localhost:{frontend_port}/v1/models", check_models_api),
                 (f"http://localhost:{frontend_port}/health", check_health_generate),
             ],
-            timeout=300,
+            timeout=1200,
             display_output=True,
             terminate_all_matching_process_names=False,
             stragglers=[],
@@ -262,7 +292,10 @@ class VLLMWithGMSProcess(GMSEngineProcess):
             raise
 
     def env_updates(self) -> dict[str, str]:
-        return {"VLLM_NIXL_SIDE_CHANNEL_PORT": str(self.nixl_port)}
+        return {
+            "VLLM_NIXL_SIDE_CHANNEL_PORT": str(self.nixl_port),
+            "CUDA_VISIBLE_DEVICES": _tp_visible_devices(),
+        }
 
     def command(self) -> list[str]:
         kv_events_cfg = json.dumps(
@@ -286,9 +319,17 @@ class VLLMWithGMSProcess(GMSEngineProcess):
             "--max-num-seqs",
             "1",
             "--gpu-memory-utilization",
-            "0.8",
+            # Env-configurable: shadow engines start while a prior engine's
+            # GMS-persistent KV pool is still resident, so vLLM's startup
+            # free-memory preflight (free >= util*total) needs headroom for a
+            # second/third coexisting allocation. Default 0.8 matches upstream;
+            # the failover repro lowers it so the preflight passes and the
+            # geometry patch reattaches the shared pool.
+            os.environ.get("VLLM_GMS_GPU_MEM_UTIL", "0.8"),
             "--kv-events-config",
             kv_events_cfg,
+            "--tensor-parallel-size",
+            str(_tp_size()),
         ]
         extra_config = self.model_loader_extra_config()
         if extra_config is not None:
@@ -437,6 +478,8 @@ class SGLangWithGMSProcess(GMSEngineProcess):
             "0.8",
             "--port",
             str(self.serve_port),
+            "--tp-size",
+            str(_tp_size()),
         ]
         extra_config = self.model_loader_extra_config()
         if extra_config is not None:
@@ -449,7 +492,10 @@ class SGLangWithGMSProcess(GMSEngineProcess):
         return command
 
     def env_updates(self) -> dict[str, str]:
-        return {"NVCC_PREPEND_FLAGS": "-ccbin /usr/bin/g++"}
+        return {
+            "NVCC_PREPEND_FLAGS": "-ccbin /usr/bin/g++",
+            "CUDA_VISIBLE_DEVICES": _tp_visible_devices(),
+        }
 
     def pause_payload(self) -> dict:
         return {}

--- a/tests/gpu_memory_service/conftest.py
+++ b/tests/gpu_memory_service/conftest.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 
 # Per-GPU threshold: absorbs small driver baseline residue, catches any real
 # leak (the bug that motivated the subprocess refactor was ~2.4 GiB).
-_LEAK_THRESHOLD_MIB = 100
+_LEAK_THRESHOLD_MIB = int(
+    __import__("os").environ.get("GMS_TEST_LEAK_THRESHOLD_MIB", "100")
+)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/gpu_memory_service/flow_assertions.py
+++ b/tests/gpu_memory_service/flow_assertions.py
@@ -84,12 +84,23 @@ def wait_for_active_layout(
     *,
     expected_weights_hash: str | None = None,
     min_weight_ro_sessions: int = 0,
-    timeout: float = 30.0,
+    timeout: float = float(
+        __import__("os").environ.get("GMS_TEST_ACTIVE_LAYOUT_TIMEOUT", "30")
+    ),
 ):
     deadline = time.monotonic() + timeout
     while True:
         weights_state = weights_gms.get_runtime_state()
         kv_state = kv_cache_gms.get_runtime_state()
+        logger.warning(
+            "[DBG active-layout] weights=%s ro_sess=%s w_alloc=%s w_hash=%s | kv=%s kv_alloc=%s",
+            getattr(weights_state, "state", None),
+            getattr(weights_state, "ro_session_count", None),
+            getattr(weights_state, "allocation_count", None),
+            bool(getattr(weights_state, "memory_layout_hash", None)),
+            getattr(kv_state, "state", None),
+            getattr(kv_state, "allocation_count", None),
+        )
         if (
             weights_state.state == ServerState.RO
             and weights_state.ro_session_count >= min_weight_ro_sessions
@@ -114,7 +125,9 @@ def wait_for_paused_layout(
     weights_state_before_pause,
     *,
     require_no_ro_sessions: bool = False,
-    timeout: float = 30.0,
+    timeout: float = float(
+        __import__("os").environ.get("GMS_TEST_ACTIVE_LAYOUT_TIMEOUT", "30")
+    ),
 ):
     deadline = time.monotonic() + timeout
     while True:
@@ -142,7 +155,9 @@ def wait_for_resumed_layout(
     weights_state_before_pause,
     *,
     min_weight_ro_sessions: int = 0,
-    timeout: float = 30.0,
+    timeout: float = float(
+        __import__("os").environ.get("GMS_TEST_ACTIVE_LAYOUT_TIMEOUT", "30")
+    ),
 ):
     deadline = time.monotonic() + timeout
     while True:
@@ -198,7 +213,9 @@ def wait_for_weights_state(
     *,
     min_ro_sessions: int = 0,
     expected_hash: str | None = None,
-    timeout: float = 30.0,
+    timeout: float = float(
+        __import__("os").environ.get("GMS_TEST_ACTIVE_LAYOUT_TIMEOUT", "30")
+    ),
 ):
     """Poll until the weights GMS daemon reaches *expected_state*."""
     deadline = time.monotonic() + timeout

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -124,38 +124,26 @@ def _resume_shadow_after_primary_failover(
     kv_cache_gms,
     primary: ManagedProcess,
 ):
+    # Pre-activation failover model: the shadow begins taking over as soon as a
+    # crash is detected, and may go live BEFORE the primary fully dies. Primary
+    # and shadow coexist on the shared GMS-owned KV pool; per KV segment only one
+    # engine holds the RW lock, so the shadow writes the segments the primary has
+    # released and acquires the remainder once the primary is gone. The handoff
+    # therefore must NOT be required to block on a single whole-pool RW lock.
     resume_timeout_s = 300
-    expected_kv_kinds_while_blocked = [
-        "rw_connected",
-        "rw_aborted",
-        "allocations_cleared",
-    ] * 3 + ["rw_connected", "allocation_oom"]
 
     with ThreadPoolExecutor(max_workers=1) as executor:
         resume_future = executor.submit(shadow.resume, resume_timeout_s)
-        deadline = time.monotonic() + 10.0
-        while time.monotonic() < deadline:
-            if resume_future.done():
-                break
-            time.sleep(0.2)
-        assert not resume_future.done(), (
-            "Shadow resume completed before the primary died; "
-            "KV cache RW handoff did not block as expected"
-        )
 
+        # KV must remain RW-owned throughout the overlap window (never EMPTY):
+        # the persistent pool survives the crash and is continuously claimed.
         kv_with_primary = kv_cache_gms.get_runtime_state()
         assert kv_with_primary.state == ServerState.RW
         assert kv_with_primary.allocation_count > 0
 
         _kill_process_group(primary)
 
-        _wait_for_blocked_resume_layout(
-            kv_cache_gms,
-            resume_future,
-            kv_with_primary.allocation_count,
-            expected_kv_kinds_while_blocked,
-        )
-
+        # After the primary is gone the shadow must fully reacquire the KV pool.
         deadline = time.monotonic() + 30.0
         while time.monotonic() < deadline:
             kv_after_primary_kill = kv_cache_gms.get_runtime_state()
@@ -168,7 +156,13 @@ def _resume_shadow_after_primary_failover(
         else:
             raise TimeoutError("shadow did not reacquire KV cache after failover")
 
-        return resume_future.result(timeout=resume_timeout_s)
+        result = resume_future.result(timeout=resume_timeout_s)
+        kv_with_shadow = kv_cache_gms.get_runtime_state()
+        assert kv_with_shadow.state == ServerState.RW
+        assert (
+            kv_with_shadow.allocation_count == kv_with_primary.allocation_count
+        ), "failover changed the committed shared KV allocation count"
+        return result
 
 
 def _run_shadow_failover_test(
@@ -233,19 +227,14 @@ def _run_shadow_failover_test(
             min_weight_ro_sessions=1,
         )
 
-        # The final KV history should show the full handoff:
-        # shadow A paused -> shadow B paused -> primary layout ->
-        # primary abort/clear -> shadow A reconnects -> shadow A sees OOM.
+        # Weights are still published exactly once across the whole handoff.
         weights_events_after_resume = weights_gms.get_event_history().events
         assert_weights_published_once(weights_events_after_resume)
 
-        kv_events_after_resume = kv_cache_gms.get_event_history().events
-        assert_kv_history(
-            kv_events_after_resume,
-            cleared_layouts=3,
-            suffix=["rw_connected", "allocation_oom"],
-        )
+        # The helper asserted that takeover preserved the committed shared KV
+        # allocation count and returned only after the shadow held RW ownership.
 
+        # The reported result: the shadow serves real tokens after the crash.
         assert_completion_ok(
             frontend_port,
             "Post failover",


### PR DESCRIPTION
## Summary

Connect vLLM and SGLang to GMS-owned GPU KV blocks without requiring patches to either upstream inference engine.

## Scope

Adds Dynamo-side allocation and lifecycle adapters for vLLM and SGLang. TensorRT-LLM is intentionally deferred until after their E2E coverage.

## Stack

Position **5/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-01-core-persistent-kv`.

Parent: #10450  
Tracking: #10452 #10453

## Review migration

This existing PR is updated in place so its comments and reviews remain attached. Line comments may appear outdated where code moved during the rebase; they remain visible and should be dispositioned against the current diff. Previous approvals should be revalidated.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

The reproducible local and Kubernetes recipes for both engines are introduced in position 10.