### PR TITLE
feat(gms): integrate TensorRT-LLM GPU memory [GMS 11/18]

### DIFF
--- a/components/src/dynamo/trtllm/__main__.py
+++ b/components/src/dynamo/trtllm/__main__.py
@@ -6,6 +6,7 @@ import os
 if "PYTHONHASHSEED" not in os.environ:
     os.environ["PYTHONHASHSEED"] = "0"
 
+
 if __name__ == "__main__":
     from dynamo.common.snapshot.restore_context import maybe_run_restore_standby_mode
 
@@ -13,6 +14,9 @@ if __name__ == "__main__":
     # write selected restore-time env vars to snapshot-control/restore-context.json
     # and exec `sleep infinity` without initializing CUDA or backend/runtime state.
     maybe_run_restore_standby_mode()
+    from dynamo.trtllm.startup import configure_gms_openmpi_defaults
+
+    configure_gms_openmpi_defaults()
 
     from dynamo.trtllm.main import main
 

--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -134,9 +134,22 @@ async def worker(argv: list[str] | None = None):
     # The drain callback waits for in-flight requests to finish so that GPU
     # memory is not freed while transfers are active (issue #7319).
     engine_holder: list = []
+    publisher_holder: list = []
     drain_callback = None
     if config.disaggregation_mode == DisaggregationMode.PREFILL:
         drain_callback = _make_drain_callback(engine_holder)
+
+    async def cleanup_engine() -> None:
+        if publisher_holder:
+            await publisher_holder[0].cleanup()
+            logging.info("TRT-LLM publisher cleanup complete")
+
+        if not engine_holder:
+            logging.info("TRT-LLM engine not initialized; skipping cleanup")
+            return
+
+        await engine_holder[0].cleanup()
+        logging.info("TRT-LLM engine cleanup complete")
 
     install_signal_handlers(
         loop,
@@ -144,6 +157,7 @@ async def worker(argv: list[str] | None = None):
         shutdown_endpoints,
         shutdown_event,
         drain_callback=drain_callback,
+        cleanup_callback=cleanup_engine,
     )
 
     logging.info(f"Initializing the worker with config: {config}")
@@ -153,6 +167,7 @@ async def worker(argv: list[str] | None = None):
         shutdown_event,
         shutdown_endpoints,
         engine_holder=engine_holder,
+        publisher_holder=publisher_holder,
     )
 
 

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -22,6 +22,7 @@ Event Flow:
 import asyncio
 import concurrent.futures
 import logging
+import struct
 import threading
 import time
 import traceback
@@ -32,11 +33,17 @@ from queue import Queue
 from typing import Any, Awaitable, Callable, Dict, Optional, Union
 
 import msgspec
+import xxhash
 import zmq
 from prometheus_client import CollectorRegistry
 
 from dynamo.common.utils.prometheus import LLMBackendMetrics
-from dynamo.llm import FpmDirectPublisher, KvEventPublisher, WorkerMetricsPublisher
+from dynamo.llm import (
+    FpmDirectPublisher,
+    KvEventPublisher,
+    WorkerMetricsPublisher,
+    compute_block_hash_for_seq,
+)
 from dynamo.trtllm.utils.request_utils import stored_event_cache_salt
 
 logger = logging.getLogger(__name__)
@@ -106,6 +113,66 @@ def _to_signed_i64(value: int | None) -> int | None:
     if value < -(2**63):
         return ((value + 2**63) % 2**64) - 2**63
     return value
+
+
+_XXH3_SEED = 1337
+_UINT64_MASK = (1 << 64) - 1
+# TRT-LLM's PyExecutor/VANILLA path can emit request tokens with an
+# engine-added leading special token even when the router request token_ids did
+# not contain it. Strip only common BOS-style ids before computing router
+# hashes for oversized TRT event blocks.
+_TRT_LEADING_SPECIAL_TOKEN_IDS = {0, 1, 2, 128000, 128001, 128002}
+
+
+def _xxh3_u64(data: bytes, seed: int = _XXH3_SEED) -> int:
+    return xxhash.xxh3_64_intdigest(data, seed=seed & _UINT64_MASK) & _UINT64_MASK
+
+
+def _compute_router_sequence_hashes(local_hashes: list[int]) -> list[int]:
+    if not local_hashes:
+        return []
+
+    sequence_hashes = [int(local_hashes[0]) & _UINT64_MASK]
+    for local_hash in local_hashes[1:]:
+        payload = struct.pack(
+            "<QQ", sequence_hashes[-1], int(local_hash) & _UINT64_MASK
+        )
+        sequence_hashes.append(_xxh3_u64(payload))
+    return sequence_hashes
+
+
+def _strip_trt_leading_special_token(
+    token_ids: list[int], kv_block_size: int
+) -> tuple[list[int], bool]:
+    if len(token_ids) <= kv_block_size or not token_ids:
+        return token_ids, False
+    if token_ids[0] in _TRT_LEADING_SPECIAL_TOKEN_IDS:
+        stripped = token_ids[1:]
+        if len(stripped) >= kv_block_size:
+            return stripped, True
+    return token_ids, False
+
+
+def _split_oversized_trt_block_for_router(
+    token_ids: list[int], kv_block_size: int, lora_name: Optional[str] = None
+) -> tuple[list[int], list[int], list[int], bool]:
+    if kv_block_size <= 0:
+        return [], [], [], False
+
+    normalized_tokens, stripped_special = _strip_trt_leading_special_token(
+        token_ids, kv_block_size
+    )
+    usable_len = len(normalized_tokens) - (len(normalized_tokens) % kv_block_size)
+    if usable_len <= 0:
+        return [], [], [], stripped_special
+
+    full_tokens = normalized_tokens[:usable_len]
+    local_hashes = compute_block_hash_for_seq(
+        [int(token) for token in full_tokens], kv_block_size, lora_name=lora_name
+    )
+    sequence_hashes = _compute_router_sequence_hashes(local_hashes)
+    num_block_tokens = [kv_block_size] * len(sequence_hashes)
+    return full_tokens, num_block_tokens, sequence_hashes, stripped_special
 
 
 class ZmqKvEventPublisher:
@@ -430,11 +497,17 @@ class Publisher:
         # A set to store the block hash of partial block (i.e. block containing less than kv_block_size tokens) hashes.
         # It is used to prevent sending remove event to kv router since partial blocks are not stored.
         self.partial_block_hashes: set[int] = set()
+        # Maps oversized TRT engine block hashes to the synthetic router-visible
+        # sequence hashes we publish for those blocks, so later remove events
+        # evict the same hashes from the router indexer.
+        self.synthetic_block_hashes: dict[int, list[int]] = {}
         self.error_queue: Queue = Queue()
         self._stop_event = threading.Event()
         # Track the last engine event_id per attention-DP rank. TRT-LLM emits
         # independent rank-local sequences before gathering them on rank 0.
         self._last_engine_event_id_by_rank: dict[int, int] = {}
+        self._cleanup_lock = asyncio.Lock()
+        self._cleanup_started = False
 
         # Initialize ZMQ publisher if endpoint is provided (consolidator enabled)
         if zmq_endpoint:
@@ -830,26 +903,59 @@ class Publisher:
             block_mm_infos: list[dict | None] = []
             kv_block_size = self.kv_block_size
             partial_block_hashes = self.partial_block_hashes
+            synthetic_block_hashes = self.synthetic_block_hashes
+            lora_name = data.get("lora_name")
+            synthetic_parent_hash = parent_hash
             for block in data["blocks"]:
                 block_tokens = block["tokens"]
                 token_num_in_block = len(block_tokens)
-                if token_num_in_block > kv_block_size:
-                    logging.error(
-                        f"Block contains {token_num_in_block} tokens, which is greater than kv_block_size {kv_block_size}"
-                    )
-                    return
+                raw_token_ids = [int(t["token_id"]) for t in block_tokens]
                 block_hash = _to_signed_i64(block["block_hash"])
                 if block_hash is None:
                     logging.warning(
                         f"Skipping block with None hash containing {token_num_in_block} tokens"
                     )
                     continue
+
+                if token_num_in_block > kv_block_size:
+                    (
+                        full_tokens,
+                        synthetic_num_block_tokens,
+                        synthetic_hashes,
+                        stripped_special,
+                    ) = _split_oversized_trt_block_for_router(
+                        raw_token_ids, kv_block_size, lora_name
+                    )
+                    if not synthetic_hashes:
+                        logging.debug(
+                            "Skipping oversized TRT KV block with no full router blocks: "
+                            f"token_count={token_num_in_block}, kv_block_size={kv_block_size}"
+                        )
+                        partial_block_hashes.add(block_hash)
+                        continue
+
+                    signed_hashes = [_to_signed_i64(h) for h in synthetic_hashes]
+                    token_ids.extend(full_tokens)
+                    num_block_tokens.extend(synthetic_num_block_tokens)
+                    block_hashes.extend(h for h in signed_hashes if h is not None)
+                    block_mm_infos.extend([None] * len(signed_hashes))
+                    synthetic_block_hashes[block_hash] = [
+                        h for h in signed_hashes if h is not None
+                    ]
+                    synthetic_parent_hash = None
+                    logging.debug(
+                        "Split oversized TRT KV block for router indexing: "
+                        f"engine_hash={block_hash}, token_count={token_num_in_block}, "
+                        f"published_blocks={len(signed_hashes)}, stripped_special={stripped_special}"
+                    )
+                    continue
+
                 if token_num_in_block < kv_block_size:
                     partial_block_hashes.add(block_hash)
                     break
                 num_block_tokens.append(token_num_in_block)
                 block_hashes.append(block_hash)
-                token_ids.extend(int(t["token_id"]) for t in block_tokens)
+                token_ids.extend(raw_token_ids)
 
                 mm_keys = block.get("mm_keys")
                 if mm_keys:
@@ -871,7 +977,12 @@ class Publisher:
                 else:
                     block_mm_infos.append(None)
 
-            lora_name = data.get("lora_name")
+            if not block_hashes:
+                logger.debug(
+                    "Skipping stored KV event %s with no full router blocks", event_id
+                )
+                return
+
             try:
                 cache_salt = stored_event_cache_salt(data)
             except ValueError as error:
@@ -904,7 +1015,7 @@ class Publisher:
                     token_ids,
                     num_block_tokens,
                     block_hashes,
-                    parent_hash,
+                    synthetic_parent_hash,
                     block_mm_infos,
                     attention_dp_rank,
                     lora_name,
@@ -919,7 +1030,7 @@ class Publisher:
                         token_ids,
                         num_block_tokens,
                         block_hashes,
-                        parent_hash,
+                        synthetic_parent_hash,
                         block_mm_infos,
                         lora_name=lora_name,
                         cache_salt=cache_salt,
@@ -936,6 +1047,10 @@ class Publisher:
             for block_hash in data["block_hashes"]:
                 block_hash = _to_signed_i64(block_hash)
                 if block_hash is None:
+                    continue
+                synthetic_hashes = self.synthetic_block_hashes.pop(block_hash, None)
+                if synthetic_hashes:
+                    removed_block_hashes.extend(synthetic_hashes)
                     continue
                 if block_hash in self.partial_block_hashes:
                     self.partial_block_hashes.remove(block_hash)
@@ -999,38 +1114,47 @@ class Publisher:
 
     async def cleanup(self) -> None:
         """Cleanup threads and resources"""
-        self._stop_event.set()
-        # Add timeout to prevent hanging
-        cleanup_timeout = 5.0  # seconds
+        async with self._cleanup_lock:
+            if self._cleanup_started:
+                return
+            self._cleanup_started = True
 
-        if self.publish_stats_thread and self.publish_stats_thread.is_alive():
-            self.publish_stats_thread.stop()
-            self.publish_stats_thread.join(timeout=cleanup_timeout)
-            if self.publish_stats_thread.is_alive():
-                logging.warning("Stats thread did not stop within timeout")
+            self._stop_event.set()
+            # Add timeout to prevent hanging
+            cleanup_timeout = 5.0  # seconds
 
-        if (
-            self.publish_kv_cache_events_thread
-            and self.publish_kv_cache_events_thread.is_alive()
-        ):
-            self.publish_kv_cache_events_thread.stop()
-            self.publish_kv_cache_events_thread.join(timeout=cleanup_timeout)
-            if self.publish_kv_cache_events_thread.is_alive():
-                logging.warning("KV cache events thread did not stop within timeout")
+            thread_warnings = (
+                (self.publish_stats_thread, "Stats thread did not stop within timeout"),
+                (
+                    self.publish_kv_cache_events_thread,
+                    "KV cache events thread did not stop within timeout",
+                ),
+            )
+            live_threads = [
+                (thread, warning)
+                for thread, warning in thread_warnings
+                if thread and thread.is_alive()
+            ]
+            for thread, _warning in live_threads:
+                thread.stop()
+            for thread, warning in live_threads:
+                thread.join(timeout=cleanup_timeout)
+                if thread.is_alive():
+                    logging.warning(warning)
 
-        # Shutdown ZMQ publisher if it exists
-        if self.zmq_kv_event_publisher:
-            self.zmq_kv_event_publisher.shutdown()
+            # Shutdown ZMQ publisher if it exists
+            if self.zmq_kv_event_publisher:
+                self.zmq_kv_event_publisher.shutdown()
 
-        # Shutdown FpmDirectPublisher (stops the per-rank serialization tasks
-        # and the event-plane publisher task on the Rust side). PyO3 surfaces
-        # shutdown failures as PyRuntimeError; narrower catch keeps real
-        # programming errors visible.
-        if self.fpm_publisher is not None:
-            try:
-                self.fpm_publisher.shutdown()
-            except RuntimeError as e:
-                logging.warning(f"FpmDirectPublisher shutdown failed: {e}")
+            # Shutdown FpmDirectPublisher (stops the per-rank serialization tasks
+            # and the event-plane publisher task on the Rust side). PyO3 surfaces
+            # shutdown failures as PyRuntimeError; narrower catch keeps real
+            # programming errors visible.
+            if self.fpm_publisher is not None:
+                try:
+                    self.fpm_publisher.shutdown()
+                except RuntimeError as e:
+                    logging.warning(f"FpmDirectPublisher shutdown failed: {e}")
 
     def update_max_window_size(self, event: dict) -> None:
         if "window_size" in event:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -35,7 +35,12 @@ from tensorrt_llm.scheduling_params import SchedulingParams
 
 from dynamo._core import Client, Context
 from dynamo.common.backend import logprobs as _shared_logprobs
+from dynamo.common.gms_failover import release_attached_gms_failover_lock
 from dynamo.common.utils.structural_tag import serialize_structural_tag
+from dynamo.gms_router_policy import (
+    maybe_fetch_gms_placement,
+    resolve_env_gms_daemon_socket,
+)
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.logits_processing.examples import HelloWorldLogitsProcessor
@@ -65,10 +70,24 @@ configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
 
+def _gms_kv_managed() -> bool:
+    """True when GMS owns the KV cache (V2 persistent pool + block leases).
+
+    In that mode the KV must persist across pause and write ownership is handled
+    by V2 KV leases, so the engine performs no local KV sleep/wake.
+    """
+    try:
+        from gpu_memory_service.integrations.trtllm.model_loader import gms_enabled
+    except ImportError:
+        return False
+    return gms_enabled()
+
+
 class TRTLLMEnginePauseController:
     """Adapts TRT-LLM sleep/wake to the standard pause controller interface.
 
-    Two memory domains: KV cache via TRT-LLM collective_rpc, weights via GMS.
+    KV cache: under GMS, the GMS-owned persistent V2 pool (leases arbitrate
+    writes); otherwise TRT-LLM collective_rpc sleep/wake. Weights: always GMS.
     """
 
     def __init__(self, engine: TensorRTLLMEngine):
@@ -90,7 +109,14 @@ class TRTLLMEnginePauseController:
         tags = tags or ["kv_cache", "weights"]
         if "kv_cache" in tags:
             self._pending_resume_tags.add("kv_cache")
-            self._collective_rpc("sleep", ["kv_cache"])
+            # Under GMS the KV cache is the GMS-owned persistent V2 pool: it must
+            # SURVIVE pause so the shadow can reattach it, and write ownership is
+            # arbitrated by V2 KV block leases — not by the engine's local
+            # torch-memory-saver sleep. The collective_rpc("sleep") path *frees*
+            # the KV, which is both wrong under GMS and unavailable on the
+            # single-process executor (no _collective_rpc). Skip it under GMS.
+            if not _gms_kv_managed():
+                self._collective_rpc("sleep", ["kv_cache"])
         if "weights" in tags:
             self._pending_resume_tags.add("weights")
             self._release_gms_weights()
@@ -108,7 +134,10 @@ class TRTLLMEnginePauseController:
             self._restore_gms_weights()
             self._pending_resume_tags.discard("weights")
         if "kv_cache" in resume_tags:
-            self._collective_rpc("wakeup", ["kv_cache"])
+            # Symmetric with pause(): GMS V2 KV persists across pause and is
+            # reattached via leases, so there is no engine-side wakeup to do.
+            if not _gms_kv_managed():
+                self._collective_rpc("wakeup", ["kv_cache"])
             self._pending_resume_tags.discard("kv_cache")
         return True
 
@@ -120,12 +149,20 @@ class TRTLLMEnginePauseController:
         """Call TRT-LLM collective_rpc for KV cache sleep/wake."""
         rpc = getattr(self._engine.llm, "_collective_rpc", None)
         if rpc is None:
-            logger.warning(
-                "TRT-LLM does not expose _collective_rpc; skipping %s", method
+            raise RuntimeError(
+                f"TRT-LLM does not expose _collective_rpc; cannot {method} KV cache"
             )
-            return
 
-        rpc(method, args=(rpc_tags,), kwargs={}, non_block=False)
+        try:
+            rpc(method, args=(rpc_tags,), kwargs={}, non_block=False)
+        except NotImplementedError as exc:
+            message = str(exc)
+            if "MPI collective_rpc only supports model_world_size == 1" in message:
+                raise RuntimeError(
+                    "TRT-LLM MPI executor does not support "
+                    f"collective_rpc({method}) for multi-rank KV cache control"
+                ) from exc
+            raise
 
     @staticmethod
     def _release_gms_weights() -> None:
@@ -350,16 +387,45 @@ class HandlerBase(BaseGenerativeHandler):
                 }
 
             try:
-                await self._set_reject_new_requests(True)
+                timeout_s = float(body.get("timeout_s", 30.0))
 
                 if self.generate_endpoint is not None:
                     await self.generate_endpoint.unregister_endpoint_instance()
 
-                timeout_s = float(body.get("timeout_s", 30.0))
+                if body.get("handoff"):
+                    settle_ms = float(
+                        body.get(
+                            "handoff_settle_ms",
+                            os.environ.get("DYN_TRTLLM_HANDOFF_ROUTE_SETTLE_MS", "250"),
+                        )
+                    )
+                    if settle_ms > 0:
+                        await asyncio.sleep(settle_ms / 1000.0)
+                    await self._set_reject_new_requests(True)
+                    lock_released = await release_attached_gms_failover_lock(
+                        self, backend_name="trtllm"
+                    )
+                    return {
+                        "status": "ok",
+                        "message": "Failover handoff released",
+                        "failover_lock_released": lock_released,
+                    }
+
+                await self._set_reject_new_requests(True)
                 await self._wait_for_inflight_requests(timeout_s)
                 await self._pause_controller.pause(tags)
 
-                return {"status": "ok", "message": "Memory released"}
+                lock_released = False
+                if body.get("release_failover_lock"):
+                    lock_released = await release_attached_gms_failover_lock(
+                        self, backend_name="trtllm"
+                    )
+
+                return {
+                    "status": "ok",
+                    "message": "Memory released",
+                    "failover_lock_released": lock_released,
+                }
             except Exception as exc:
                 logger.error("release_memory_occupation failed: %s", exc)
                 # Rollback: TRT-LLM has no pause_generation(), so we
@@ -967,6 +1033,16 @@ class HandlerBase(BaseGenerativeHandler):
 
         # Normalize OpenAI format to TRT-LLM internal format
         self._normalize_request_format(request)
+
+        await maybe_fetch_gms_placement(
+            request,
+            resolve_env_gms_daemon_socket(
+                "GMS_TRTLLM_DAEMON_SOCKET",
+                default_when_cross_node="/tmp/gms.sock",
+            ),
+            logger=logging.getLogger(__name__),
+            request_id=context.id(),
+        )
 
         # Setup disaggregated params based on PREFILL/DECODE mode
         (

--- a/components/src/dynamo/trtllm/startup.py
+++ b/components/src/dynamo/trtllm/startup.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Startup helpers for the Dynamo TensorRT-LLM backend."""
+
+import logging
+import os
+
+
+def configure_gms_openmpi_defaults() -> None:
+    """Keep TRT-LLM's local mpi4py pool off UCX unless explicitly configured."""
+
+    defaults = {
+        "OMPI_MCA_pml": "ob1",
+        "OMPI_MCA_btl": "self,vader,tcp",
+        "OMPI_MCA_coll_hcoll_enable": "0",
+    }
+    applied = []
+    for key, value in defaults.items():
+        if key not in os.environ:
+            os.environ[key] = value
+            applied.append(f"{key}={value}")
+
+    if applied:
+        logging.info("Configured TRT-LLM GMS OpenMPI defaults: %s", ", ".join(applied))

--- a/components/src/dynamo/trtllm/tests/test_trtllm_entrypoint.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_entrypoint.py
@@ -13,10 +13,17 @@ def test_trtllm_entrypoint_checks_snapshot_standby_before_main_import():
         "maybe_run_restore_standby_mode"
     )
     standby_call = "maybe_run_restore_standby_mode()"
+    startup_import = "from dynamo.trtllm.startup import configure_gms_openmpi_defaults"
+    startup_call = "configure_gms_openmpi_defaults()"
     main_import = "from dynamo.trtllm.main import main"
 
     assert standby_import in source
     assert standby_call in source
     assert main_import in source
+    assert startup_import in source
+    assert startup_call in source
     assert source.index(standby_import) < source.index(main_import)
     assert source.index(standby_call) < source.index(main_import)
+    assert source.index(standby_call) < source.index(startup_import)
+    assert source.index(startup_import) < source.index(startup_call)
+    assert source.index(startup_call) < source.index(main_import)

--- a/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
@@ -320,9 +320,12 @@ def _build_publisher_stub(monkeypatch, *, attention_dp_size: int, fpm_enabled: b
     pub.publish_kv_cache_events_thread = None
     pub.publish_stats_thread = None
     pub.partial_block_hashes = set()
+    pub.synthetic_block_hashes = {}
     pub.error_queue = queue.Queue()
     pub._stop_event = threading.Event()
     pub._last_engine_event_id_by_rank = {}
+    pub._cleanup_lock = asyncio.Lock()
+    pub._cleanup_started = False
 
     fake_fpm_cls = MagicMock()
     monkeypatch.setattr(publisher_mod, "FpmDirectPublisher", fake_fpm_cls)
@@ -375,6 +378,7 @@ def _publisher_for_kv_event_test():
     pub._last_engine_event_id_by_rank = {}
     pub.processing_initial_created_events = False
     pub.partial_block_hashes = set()
+    pub.synthetic_block_hashes = {}
     pub.kv_block_size = 4
     pub.max_window_size = None
     return pub
@@ -586,6 +590,7 @@ def test_partial_only_removed_event_does_not_publish_empty_batch():
     pub.should_drop_event = MagicMock(return_value=False)
     pub.processing_initial_created_events = True
     pub.partial_block_hashes = {123}
+    pub.synthetic_block_hashes = {}
     pub.zmq_kv_event_publisher = None
     pub.kv_event_publishers = {0: kv_event_publisher}
 
@@ -763,3 +768,160 @@ def test_invoke_handler_matches_publisher_keyword_set():
         "wall_time_secs",
     }
     assert set(fpm.publish.call_args.kwargs.keys()) == expected_kwargs
+
+
+# ---------------------------------------------------------------------------
+# KV event normalization
+# ---------------------------------------------------------------------------
+
+
+def _build_kv_event_publisher_stub():
+    """Minimal Publisher instance for direct _handle_kv_event tests."""
+    import threading
+
+    from dynamo.trtllm import publisher as publisher_mod
+
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub.worker_id = "worker-abc"
+    pub.kv_block_size = 32
+    pub.max_window_size = None
+    pub.processing_initial_created_events = True
+    pub.kv_event_publishers = None
+    pub.zmq_kv_event_publisher = MagicMock()
+    pub.partial_block_hashes = set()
+    pub.synthetic_block_hashes = {}
+    pub._last_engine_event_id_by_rank = {}
+    pub._stop_event = threading.Event()
+    return pub, publisher_mod
+
+
+def _token_block(token_ids, block_hash):
+    return {
+        "block_hash": block_hash,
+        "tokens": [{"token_id": token_id} for token_id in token_ids],
+    }
+
+
+def _stored_event(event_id, token_ids, block_hash=0xF00D):
+    return {
+        "event_id": event_id,
+        "attention_dp_rank": 0,
+        "data": {
+            "type": "stored",
+            "parent_hash": None,
+            "blocks": [_token_block(token_ids, block_hash)],
+        },
+    }
+
+
+def test_oversized_trt_block_splits_into_router_hashes():
+    pub, publisher_mod = _build_kv_event_publisher_stub()
+    request_tokens = list(range(100, 164))
+    engine_tokens = [1] + request_tokens
+
+    pub._handle_kv_event(_stored_event(1, engine_tokens))
+
+    expected_local_hashes = publisher_mod.compute_block_hash_for_seq(
+        request_tokens, pub.kv_block_size
+    )
+    expected_sequence_hashes = [
+        publisher_mod._to_signed_i64(h)
+        for h in publisher_mod._compute_router_sequence_hashes(expected_local_hashes)
+    ]
+    pub.zmq_kv_event_publisher.publish_stored.assert_called_once_with(
+        request_tokens,
+        [32, 32],
+        expected_sequence_hashes,
+        None,
+        [None, None],
+        0,
+        None,
+        None,
+    )
+
+
+def test_oversized_trt_block_remove_uses_synthetic_router_hashes():
+    pub, publisher_mod = _build_kv_event_publisher_stub()
+    request_tokens = list(range(200, 264))
+    engine_hash = 0xABCDEF
+
+    pub._handle_kv_event(_stored_event(1, [1] + request_tokens, engine_hash))
+    expected_hashes = list(
+        pub.synthetic_block_hashes[publisher_mod._to_signed_i64(engine_hash)]
+    )
+
+    pub._handle_kv_event(
+        {
+            "event_id": 2,
+            "attention_dp_rank": 0,
+            "data": {"type": "removed", "block_hashes": [engine_hash]},
+        }
+    )
+
+    pub.zmq_kv_event_publisher.publish_removed.assert_called_once_with(
+        expected_hashes, 0
+    )
+    assert pub.synthetic_block_hashes == {}
+
+
+def test_oversized_trt_block_drops_trailing_partial_router_block():
+    pub, _publisher_mod = _build_kv_event_publisher_stub()
+    request_tokens = list(range(300, 370))
+
+    pub._handle_kv_event(_stored_event(1, [1] + request_tokens))
+
+    call = pub.zmq_kv_event_publisher.publish_stored.call_args
+    assert call.args[0] == request_tokens[:64]
+    assert call.args[1] == [32, 32]
+    assert len(call.args[2]) == 2
+
+
+class _FakeManagedThread:
+    def __init__(self, name: str, events: list[str], peers: list["_FakeManagedThread"]):
+        self.name = name
+        self.events = events
+        self.peers = peers
+        self._alive = True
+        self.stopped = False
+
+    def is_alive(self):
+        return self._alive
+
+    def stop(self):
+        self.events.append(f"stop:{self.name}")
+        self.stopped = True
+
+    def join(self, timeout=None):
+        assert all(peer.stopped for peer in self.peers)
+        self.events.append(f"join:{self.name}")
+        self._alive = False
+
+
+def test_publisher_cleanup_stops_threads_before_join_and_is_idempotent():
+    from dynamo.trtllm.publisher import Publisher
+
+    async def run_cleanup():
+        events: list[str] = []
+        threads: list[_FakeManagedThread] = []
+        stats_thread = _FakeManagedThread("stats", events, threads)
+        kv_thread = _FakeManagedThread("kv", events, threads)
+        threads.extend([stats_thread, kv_thread])
+
+        pub = Publisher.__new__(Publisher)
+        pub._cleanup_lock = asyncio.Lock()
+        pub._cleanup_started = False
+        pub._stop_event = threading.Event()
+        pub.publish_stats_thread = stats_thread
+        pub.publish_kv_cache_events_thread = kv_thread
+        pub.zmq_kv_event_publisher = MagicMock()
+        pub.fpm_publisher = MagicMock()
+
+        await pub.cleanup()
+        await pub.cleanup()
+
+        assert events == ["stop:stats", "stop:kv", "join:stats", "join:kv"]
+        assert pub._stop_event.is_set()
+        pub.zmq_kv_event_publisher.shutdown.assert_called_once()
+        pub.fpm_publisher.shutdown.assert_called_once()
+
+    asyncio.run(run_cleanup())

--- a/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
@@ -166,6 +166,33 @@ async def test_mark_request_finished_is_idempotent():
     assert handler._inflight_requests == 0
 
 
+@pytest.mark.asyncio
+async def test_trtllm_quiesce_fails_when_collective_rpc_missing():
+    controller = TRTLLMEnginePauseController(SimpleNamespace(llm=SimpleNamespace()))
+
+    with pytest.raises(RuntimeError, match="_collective_rpc"):
+        await controller.pause(["kv_cache"])
+
+    assert controller.is_paused is False
+
+
+@pytest.mark.asyncio
+async def test_trtllm_quiesce_fails_closed_for_unsupported_multi_rank_rpc():
+    def collective_rpc(*args, **kwargs):
+        raise NotImplementedError(
+            "MPI collective_rpc only supports model_world_size == 1"
+        )
+
+    controller = TRTLLMEnginePauseController(
+        SimpleNamespace(llm=SimpleNamespace(_collective_rpc=collective_rpc))
+    )
+
+    with pytest.raises(RuntimeError, match="multi-rank KV cache control"):
+        await controller.pause(["kv_cache"])
+
+    assert controller.is_paused is False
+
+
 # ---------------------------------------------------------------------------
 # release_memory_occupation
 # ---------------------------------------------------------------------------
@@ -310,3 +337,37 @@ async def test_generate_locally_rejected_when_sleeping():
 
     assert len(chunks) == 1
     assert "error" in str(chunks[0].get("finish_reason", ""))
+
+
+@pytest.mark.asyncio
+async def test_release_memory_occupation_with_handoff_releases_failover_lock():
+    handler = _make_handler()
+    lock = SimpleNamespace(release=AsyncMock())
+    handler._gms_failover_lock = lock
+
+    result = await handler.release_memory_occupation({"release_failover_lock": True})
+
+    assert result["status"] == "ok"
+    assert result["failover_lock_released"] is True
+    lock.release.assert_awaited_once()
+    assert handler._gms_failover_lock is None
+
+
+@pytest.mark.asyncio
+async def test_fast_handoff_releases_lock_without_memory_release():
+    handler = _make_handler()
+    lock = SimpleNamespace(release=AsyncMock())
+    handler._gms_failover_lock = lock
+
+    result = await handler.release_memory_occupation({"handoff": True})
+
+    assert result == {
+        "status": "ok",
+        "message": "Failover handoff released",
+        "failover_lock_released": True,
+    }
+    handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
+    handler._pause_controller.pause.assert_not_called()
+    assert handler._reject_new_requests is True
+    lock.release.assert_awaited_once()
+    assert handler._gms_failover_lock is None

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -4,6 +4,7 @@
 """Unit tests for TRTLLM backend components."""
 
 import asyncio
+import os
 import re
 import warnings
 from pathlib import Path
@@ -21,6 +22,7 @@ if not torch.cuda.is_available():
 
 from dynamo.trtllm.args import Config, parse_args
 from dynamo.trtllm.constants import DisaggregationMode, Modality
+from dynamo.trtllm.startup import configure_gms_openmpi_defaults
 from dynamo.trtllm.tests.conftest import make_cli_args_fixture
 from dynamo.trtllm.utils.trtllm_utils import deep_update, warn_override_collisions
 from dynamo.trtllm.workers.llm_worker import init_llm_worker
@@ -406,6 +408,78 @@ async def test_init_llm_worker_engine_args_with_extra_engine_args(
         assert config.max_seq_len == 32768
         assert config.max_num_tokens == 32768
         assert config.max_batch_size == 512
+
+
+def test_configure_gms_openmpi_defaults_sets_safe_local_transport(monkeypatch):
+    for key in ("OMPI_MCA_pml", "OMPI_MCA_btl", "OMPI_MCA_coll_hcoll_enable"):
+        monkeypatch.delenv(key, raising=False)
+
+    configure_gms_openmpi_defaults()
+
+    assert os.environ["OMPI_MCA_pml"] == "ob1"
+    assert os.environ["OMPI_MCA_btl"] == "self,vader,tcp"
+    assert os.environ["OMPI_MCA_coll_hcoll_enable"] == "0"
+
+
+def test_configure_gms_openmpi_defaults_preserves_user_overrides(monkeypatch):
+    monkeypatch.setenv("OMPI_MCA_pml", "ucx")
+    monkeypatch.setenv("OMPI_MCA_btl", "self,tcp")
+    monkeypatch.setenv("OMPI_MCA_coll_hcoll_enable", "1")
+
+    configure_gms_openmpi_defaults()
+
+    assert os.environ["OMPI_MCA_pml"] == "ucx"
+    assert os.environ["OMPI_MCA_btl"] == "self,tcp"
+    assert os.environ["OMPI_MCA_coll_hcoll_enable"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_init_llm_worker_gms_forces_trtllm_v2_kv_manager(monkeypatch):
+    """GMS uses TRT-LLM KVCacheManagerV2 and avoids V1 fallback triggers."""
+    monkeypatch.delenv("DYN_TRTLLM_MAX_NUM_TOKENS", raising=False)
+    monkeypatch.delenv("DYN_TRTLLM_MAX_BATCH_SIZE", raising=False)
+
+    config = parse_args(["--model", "fake-model", "--load-format", "gms"])
+
+    with (
+        mock.patch("gpu_memory_service.integrations.trtllm.setup_gms") as setup_gms,
+        mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.nixl_connect.Connector"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.dump_config"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.LLMBackendMetrics"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.get_llm_engine",
+            side_effect=_mock_get_llm_engine,
+        ),
+    ):
+        with pytest.raises(EngineArgsCaptured) as exc_info:
+            await init_llm_worker(
+                runtime=mock.MagicMock(),
+                config=config,
+                shutdown_event=asyncio.Event(),
+            )
+
+    setup_gms.assert_called_once()
+    engine_args = exc_info.value.engine_args
+    kv_cache_config = engine_args["kv_cache_config"]
+    assert kv_cache_config["use_kv_cache_manager_v2"] is True
+    assert kv_cache_config["event_buffer_max_size"] == 0
+    assert engine_args["kv_connector_config"] is None
+
+
+@pytest.mark.asyncio
+async def test_init_llm_worker_gms_rejects_kv_connector():
+    """TRT-LLM GMS is V2-only, and V2 cannot use kv_connector_config."""
+    config = parse_args(
+        ["--model", "fake-model", "--load-format", "gms", "--connector", "kvbm"]
+    )
+
+    with pytest.raises(ValueError, match="cannot be combined with --connector"):
+        await init_llm_worker(
+            runtime=mock.MagicMock(),
+            config=config,
+            shutdown_event=asyncio.Event(),
+        )
 
 
 class MultimodalProcessorInstantiated(Exception):

--- a/components/src/dynamo/trtllm/workers/__init__.py
+++ b/components/src/dynamo/trtllm/workers/__init__.py
@@ -35,6 +35,7 @@ async def init_worker(
     shutdown_event: asyncio.Event,
     shutdown_endpoints: Optional[list] = None,
     engine_holder: Optional[list] = None,
+    publisher_holder: Optional[list] = None,
 ) -> None:
     """Initialize the appropriate worker based on modality.
 
@@ -49,6 +50,8 @@ async def init_worker(
         engine_holder: Optional mutable list; when provided, init_llm_worker will
             append the TensorRTLLMEngine instance so that the drain callback
             (installed earlier by main.py) can access it at signal time.
+        publisher_holder: Optional mutable list; when provided, init_llm_worker
+            appends the Publisher so signal cleanup can stop it before engine teardown.
     """
     logging.info(f"Initializing worker with modality={config.modality}")
 
@@ -82,6 +85,7 @@ async def init_worker(
         shutdown_event,
         shutdown_endpoints,
         engine_holder=engine_holder,
+        publisher_holder=publisher_holder,
     )
 
 

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -36,6 +36,11 @@ from transformers import AutoConfig
 import dynamo.nixl_connect as nixl_connect
 from dynamo import prometheus_names
 from dynamo.common.config_dump import dump_config
+from dynamo.common.gms_failover import (
+    acquire_gms_failover_lock_before_init,
+    prepare_gms_failover,
+    run_gms_failover_promotion_warmup,
+)
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.common.utils.prometheus import (
     LLMBackendMetrics,
@@ -44,6 +49,7 @@ from dynamo.common.utils.prometheus import (
 )
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.common.utils.topology import apply_topology_config
+from dynamo.gms_router_policy import resolve_env_gms_daemon_socket
 from dynamo.llm import (
     KvEventPublisher,
     MediaDecoder,
@@ -61,10 +67,12 @@ from dynamo.trtllm.engine import Backend, get_llm_engine
 from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
 from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor
 from dynamo.trtllm.publisher import DYNAMO_COMPONENT_REGISTRY, get_publisher
+from dynamo.trtllm.request_handlers.handler_base import TRTLLMEnginePauseController
 from dynamo.trtllm.request_handlers.handlers import (
     RequestHandlerConfig,
     RequestHandlerFactory,
 )
+from dynamo.trtllm.startup import configure_gms_openmpi_defaults
 from dynamo.trtllm.utils.trtllm_utils import deep_update, get_spec_decode_runtime_data
 
 # Default buffer size for kv cache events.
@@ -133,6 +141,78 @@ def _sync_config_from_engine_args(config: Config, engine_args: dict) -> None:
             setattr(config, field_name, engine_args[field_name])
 
 
+def _kv_cache_config_as_dict(kv_cache_config: object) -> dict[str, object]:
+    if isinstance(kv_cache_config, KvCacheConfig):
+        return kv_cache_config.model_dump(exclude_none=True)
+    if isinstance(kv_cache_config, dict):
+        return dict(kv_cache_config)
+    raise TypeError(
+        "kv_cache_config must be a TensorRT-LLM KvCacheConfig or dict, "
+        f"got {type(kv_cache_config).__name__}"
+    )
+
+
+# KVCacheManagerV2 (which --load-format gms forces on) auto-provisions a HOST_MEM KV offload
+# tier sized ~= the full GPU KV quota (tens of GB) whenever host_cache_size is left unset, then
+# registers it to CUDA with a single cuMemHostRegister(addr, size, PORTABLE|DEVICEMAP). On Linux
+# kernels outside the engine's chunked-registration allowlist (6.11/6.12/6.13) that one call pins
+# the whole multi-GB range page-by-page and stalls executor init for many minutes (effectively a
+# hang). GMS keeps the failover KV pool GPU-resident, so the host tier only needs to be large
+# enough for the V2 suspend/resume scheduler — default it small so init stays fast, and keep the
+# active KV on the GPU via free_gpu_memory_fraction (raise it if high-concurrency KV would
+# otherwise spill onto this DEVICEMAP host tier and crawl over PCIe).
+_GMS_V2_DEFAULT_HOST_CACHE_BYTES = 512 * 1024 * 1024  # 512 MiB
+
+
+def _configure_gms_v2_kv_cache(arg_map: dict[str, object]) -> None:
+    """Force the supported TRT-LLM GMS path onto KVCacheManagerV2.
+
+    TRT-LLM V2 is the only GMS KV path we support here. The older connector
+    manager and event-buffer paths force TRT-LLM back to the V1 manager, so keep
+    them disabled instead of silently losing V2 lease semantics.
+    """
+
+    if arg_map.get("kv_connector_config") is not None:
+        raise ValueError(
+            "--load-format gms requires TRT-LLM KVCacheManagerV2, but "
+            "KVCacheManagerV2 does not support kv_connector_config. "
+            "Disable --connector or use a non-GMS TRT-LLM path."
+        )
+
+    cache_transceiver_config = arg_map.get("cache_transceiver_config")
+    if cache_transceiver_config not in (None, {}):
+        raise ValueError(
+            "--load-format gms requires TRT-LLM KVCacheManagerV2, but "
+            "KVCacheManagerV2 does not support cache_transceiver_config. "
+            "GMS TRT-LLM is currently aggregated-mode only."
+        )
+
+    max_beam_width = int(arg_map.get("max_beam_width") or 1)
+    if max_beam_width != 1:
+        raise ValueError(
+            "--load-format gms requires TRT-LLM KVCacheManagerV2, which "
+            f"supports only max_beam_width=1; got {max_beam_width}."
+        )
+
+    kv_cache_config = _kv_cache_config_as_dict(arg_map["kv_cache_config"])
+    kv_cache_config["use_kv_cache_manager_v2"] = True
+    # TRT-LLM falls back to KVCacheManager V1 when event_buffer_max_size > 0.
+    # Dynamo can still publish worker metrics; KV-event support for GMS/TRT V2
+    # needs a dedicated V2 event path.
+    if kv_cache_config.get("event_buffer_max_size"):
+        logging.warning(
+            "Ignoring kv_cache_config.event_buffer_max_size=%s for TRT-LLM "
+            "GMS because KVCacheManagerV2 would otherwise fall back to V1.",
+            kv_cache_config["event_buffer_max_size"],
+        )
+    kv_cache_config["event_buffer_max_size"] = 0
+    # Cap the V2 host offload tier so its cuMemHostRegister(DEVICEMAP) stays fast (see
+    # _GMS_V2_DEFAULT_HOST_CACHE_BYTES). Respect an explicit operator value if one was given.
+    if not kv_cache_config.get("host_cache_size"):
+        kv_cache_config["host_cache_size"] = _GMS_V2_DEFAULT_HOST_CACHE_BYTES
+    arg_map["kv_cache_config"] = kv_cache_config
+
+
 def _register_memory_routes(runtime, handler) -> None:
     runtime.register_engine_route(
         "control/release_memory_occupation",
@@ -154,6 +234,7 @@ async def init_llm_worker(
     shutdown_event: asyncio.Event,
     shutdown_endpoints: Optional[list] = None,
     engine_holder: Optional[list] = None,
+    publisher_holder: Optional[list] = None,
 ) -> None:
     """Initialize and run the LLM worker.
 
@@ -166,6 +247,8 @@ async def init_llm_worker(
         shutdown_endpoints: Optional list to populate with endpoints for graceful shutdown.
         engine_holder: Optional mutable list; when provided, the TensorRTLLMEngine
             is appended so that the drain callback can reference it at shutdown time.
+        publisher_holder: Optional mutable list; when provided, the Publisher is
+            appended so signal cleanup can stop polling threads before engine teardown.
     """
 
     encode_client = None
@@ -217,6 +300,11 @@ async def init_llm_worker(
         sys.exit(1)
 
     if config.load_format == "gms":
+        if kv_connector_config is not None:
+            raise ValueError(
+                "--load-format gms targets TRT-LLM KVCacheManagerV2 and cannot "
+                "be combined with --connector. Use --connector none."
+            )
         try:
             from gpu_memory_service.integrations.trtllm import setup_gms
         except ImportError as exc:
@@ -224,9 +312,11 @@ async def init_llm_worker(
                 "gpu-memory-service is required for --load-format gms. "
                 "Install or update the package."
             ) from exc
+        configure_gms_openmpi_defaults()
         setup_gms(model_loader_extra_config)
         logging.info(
-            "TRT-LLM GMS integration enabled (extra=%s)", model_loader_extra_config
+            "TRT-LLM GMS integration enabled in KVCacheManagerV2 mode (extra=%s)",
+            model_loader_extra_config,
         )
 
     # Resolve load_format for engine args. GMS patches are active regardless;
@@ -250,6 +340,7 @@ async def init_llm_worker(
         "moe_expert_parallel_size": config.expert_parallel_size,
         "enable_attention_dp": config.enable_attention_dp,
         "backend": Backend.PYTORCH,
+        "dtype": config.torch_dtype,
         "kv_cache_config": kv_cache_config,
         "gpus_per_node": gpus_per_node,
         "max_num_tokens": config.max_num_tokens,
@@ -263,6 +354,14 @@ async def init_llm_worker(
         "enable_iter_perf_stats": config.publish_events_and_metrics,
         "kv_connector_config": kv_connector_config,
     }
+
+    attn_backend_explicit = os.environ.get(
+        "DYN_TRTLLM_ATTN_BACKEND"
+    ) is not None or any(
+        arg == "--attn-backend" or arg.startswith("--attn-backend=") for arg in sys.argv
+    )
+    if attn_backend_explicit:
+        arg_map["attn_backend"] = config.attn_backend
 
     arg_map["load_format"] = engine_load_format
 
@@ -298,6 +397,9 @@ async def init_llm_worker(
             logging.error(f"Failed to parse override_engine_args as JSON: {e}")
             sys.exit(1)
 
+    if config.load_format == "gms":
+        _configure_gms_v2_kv_cache(arg_map)
+
     _sync_config_from_engine_args(config, arg_map)
 
     event_buffer_max_size = 0
@@ -317,17 +419,27 @@ async def init_llm_worker(
                 f"got {type(current_kv_config).__name__}"
             )
 
-        # Preserve a user-specified event_buffer_max_size from YAML/overrides;
-        # only apply the default when it is unset or zero (TRTLLM's disabled value).
-        existing = current_kv_config.get("event_buffer_max_size")
-        if existing:
-            logging.info(
-                f"Using existing event_buffer_max_size={existing} from kv_cache_config"
-            )
+        if config.load_format == "gms":
+            if current_kv_config.get("event_buffer_max_size"):
+                logging.warning(
+                    "Ignoring kv_cache_config.event_buffer_max_size=%s for "
+                    "TRT-LLM GMS because KVCacheManagerV2 would otherwise "
+                    "fall back to V1.",
+                    current_kv_config["event_buffer_max_size"],
+                )
+            current_kv_config["event_buffer_max_size"] = 0
         else:
-            current_kv_config[
-                "event_buffer_max_size"
-            ] = DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
+            # Preserve a user-specified event_buffer_max_size from YAML/overrides;
+            # only apply the default when it is unset or zero (TRTLLM's disabled value).
+            existing = current_kv_config.get("event_buffer_max_size")
+            if existing:
+                logging.info(
+                    f"Using existing event_buffer_max_size={existing} from kv_cache_config"
+                )
+            else:
+                current_kv_config[
+                    "event_buffer_max_size"
+                ] = DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
         event_buffer_max_size = int(current_kv_config["event_buffer_max_size"])
 
         # Only pytorch backend is supported for now to publish events and metrics.
@@ -500,6 +612,13 @@ async def init_llm_worker(
         component_name=config.component,
     )
 
+    early_failover_activation = None
+    lock_before_init = os.environ.get("DYN_TRTLLM_GMS_LOCK_BEFORE_INIT", "1").lower()
+    if lock_before_init not in {"0", "false", "no", "off"}:
+        early_failover_activation = await acquire_gms_failover_lock_before_init(
+            backend_name="trtllm"
+        )
+
     async with get_llm_engine(
         engine_args,
         config.disaggregation_mode,
@@ -564,6 +683,13 @@ async def init_llm_worker(
             config.enable_local_indexer
             and config.disaggregation_mode != DisaggregationMode.DECODE
         )
+        gms_daemon_socket = resolve_env_gms_daemon_socket(
+            "GMS_TRTLLM_DAEMON_SOCKET",
+            default_when_cross_node="/tmp/gms.sock",
+        )
+        if gms_daemon_socket:
+            runtime_config.set_gms_placement_enabled()
+            logging.info("Publishing GMS placement capability to discovery")
         # Set data_parallel_size for attention DP mode
         # This enables the router's scheduler to correctly iterate over all dp_ranks
         # Need to name ADP as `data_parallel_size` for parity with other frameworks
@@ -691,6 +817,20 @@ async def init_llm_worker(
             media_fetcher.allow_direct_ip(allow_internal)
             media_fetcher.allow_direct_port(allow_internal)
 
+        health_check_payload = TrtllmHealthCheckPayload(
+            tokenizer=tokenizer,
+            disaggregation_mode=config.disaggregation_mode,
+        ).to_dict()
+
+        if early_failover_activation is not None and early_failover_activation.enabled:
+            failover_activation = early_failover_activation
+        else:
+            failover_activation = await prepare_gms_failover(
+                TRTLLMEnginePauseController(engine),
+                runtime,
+                backend_name="trtllm",
+            )
+
         # Register the model with runtime config for every disaggregation
         # role, including ENCODE. Encode workers get their own bucket in the
         # WorkerSet via `worker_type` in the ws_key.
@@ -738,11 +878,6 @@ async def init_llm_worker(
             needs=needs,
         )
 
-        health_check_payload = TrtllmHealthCheckPayload(
-            tokenizer=tokenizer,
-            disaggregation_mode=config.disaggregation_mode,
-        ).to_dict()
-
         if config.publish_events_and_metrics:
             # Initialize and pass in the publisher to the request handler to
             # publish events and metrics.
@@ -789,32 +924,52 @@ async def init_llm_worker(
                 enable_local_indexer=config.enable_local_indexer,
                 metrics_collector=metrics_collector,
             ) as publisher:
-                handler_config.publisher = publisher
-                handler = RequestHandlerFactory().get_request_handler(handler_config)
-                if config.load_format == "gms":
-                    _register_memory_routes(runtime, handler)
-
-                encoder_cache = getattr(handler, "_encoder_cache", None)
-                if encoder_cache is not None:
-                    register_embedding_cache_metrics(
-                        endpoint=endpoint,
-                        cache=encoder_cache,
-                        model_name=model_name_for_metrics,
-                        component_name=config.component,
+                if publisher_holder is not None:
+                    publisher_holder.append(publisher)
+                try:
+                    handler_config.publisher = publisher
+                    handler = RequestHandlerFactory().get_request_handler(
+                        handler_config
                     )
-                await endpoint.serve_endpoint(
-                    handler.generate,
-                    metrics_labels=metrics_labels,
-                    health_check_payload=health_check_payload,
-                )
+                    failover_activation.attach_to(handler)
+                    if config.load_format == "gms":
+                        _register_memory_routes(runtime, handler)
+                    if failover_activation.enabled:
+                        await run_gms_failover_promotion_warmup(
+                            handler.generate,
+                            health_check_payload,
+                            backend_name="trtllm",
+                        )
+
+                    encoder_cache = getattr(handler, "_encoder_cache", None)
+                    if encoder_cache is not None:
+                        register_embedding_cache_metrics(
+                            endpoint=endpoint,
+                            cache=encoder_cache,
+                            model_name=model_name_for_metrics,
+                            component_name=config.component,
+                        )
+                    await endpoint.serve_endpoint(
+                        handler.generate,
+                        metrics_labels=metrics_labels,
+                        health_check_payload=health_check_payload,
+                    )
+                finally:
+                    if publisher_holder is not None and publisher in publisher_holder:
+                        publisher_holder.remove(publisher)
 
             # Shutdown consolidator publisher if it was created
             if consolidator_publisher:
                 consolidator_publisher.shutdown()
         else:
             handler = RequestHandlerFactory().get_request_handler(handler_config)
+            failover_activation.attach_to(handler)
             if config.load_format == "gms":
                 _register_memory_routes(runtime, handler)
+            if failover_activation.enabled:
+                await run_gms_failover_promotion_warmup(
+                    handler.generate, health_check_payload, backend_name="trtllm"
+                )
             await endpoint.serve_endpoint(
                 handler.generate, health_check_payload=health_check_payload
             )

--- a/lib/gpu_memory_service/README.md
+++ b/lib/gpu_memory_service/README.md
@@ -529,9 +529,9 @@ class GMSClientMemoryManager:
 
 ---
 
-## Framework Integration (vLLM / SGLang)
+## Framework Integration (vLLM / SGLang / TensorRT-LLM)
 
-GMS provides pre-built integrations for vLLM and SGLang. Enable GMS by passing `--load-format gms` when launching an engine.
+GMS provides pre-built integrations for vLLM, SGLang, and TensorRT-LLM. Enable GMS by passing `--load-format gms` when launching an engine.
 
 ### How It Works
 
@@ -579,12 +579,40 @@ The integration patches `torch_memory_saver` to route both weight and KV-cache o
 - Other tags are not supported in GMS mode
 - The `--enable-memory-saver` flag is required to activate the memory saver pathway
 
+#### TensorRT-LLM
+
+```bash
+python -m dynamo.trtllm \
+  --model <model> \
+  --load-format gms
+```
+
+**KV management is KVCacheManager V2 only.** TensorRT-LLM + GMS is supported on
+the V2 KV path exclusively; the legacy V1 KV connector is **not** supported and
+is never used. When `--load-format gms` is set, the worker:
+
+- Loads model weights through GMS (the `weights` tag), identical to vLLM/SGLang.
+- **Forces `use_kv_cache_manager_v2=True`** and sets `event_buffer_max_size=0`
+  (`_configure_gms_v2_kv_cache`). The V1 connector manager and event-buffer
+  paths silently fall back to the V1 manager, so they are kept disabled.
+- **Rejects `--connector` / `kv_connector_config`** in GMS mode (V2 cannot use a
+  KV connector). Passing one is a hard error, not a silent V1 fallback.
+- Coordinates KV cache access through **V2 slot leases** (`install_kv_leases_v2`)
+  rather than a `kv_cache` daemon allocation. The TRT-LLM integration does not
+  connect to the `kv_cache` GMS socket; a generic operator deployment may still
+  render an idle `kv_cache` server container. Enable leases with
+  `GMS_KV_LEASES=1` (or `GMS_TRTLLM_KV_LEASES=1`).
+
+> For TensorRT-LLM, GMS KV management means KVCacheManager V2 plus slot leases;
+> the V1 connector is unsupported.
+
 ### Shadow Engine Failover (Pause / Resume)
 
-Both integrations support releasing and reclaiming GPU memory for shadow engine patterns. The API names differ by framework:
+All integrations support releasing and reclaiming GPU memory for shadow engine patterns. The API names differ by framework:
 
 - **vLLM**: `sleep` / `wake_up` (via `/engine/control/sleep` and `/engine/control/wake_up` HTTP endpoints)
 - **SGLang**: `release_memory_occupation` / `resume_memory_occupation` (via the corresponding HTTP endpoints)
+- **TensorRT-LLM**: `release_memory_occupation` / `resume_memory_occupation` (weights via GMS; KV via V2 slot leases — see above)
 
 Under the hood, pausing calls `unmap_all_vas()` + `abort()` to release GPU memory while preserving VA reservations. Resuming is tag-specific:
 

--- a/lib/gpu_memory_service/integrations/trtllm/__init__.py
+++ b/lib/gpu_memory_service/integrations/trtllm/__init__.py
@@ -3,14 +3,9 @@
 
 """GPU Memory Service integration for TensorRT-LLM.
 
-Usage:
-    import json
-    from gpu_memory_service.integrations.trtllm import setup_gms
-
-    if config.load_format == "gms":
-        raw = config.model_loader_extra_config
-        extra = json.loads(raw) if isinstance(raw, str) else (raw or None)
-        setup_gms(extra)
+The supported TRT-LLM path is KVCacheManagerV2. GMS owns model weights and
+coordinates V2 KV slot leases from Python; the legacy V1 connector hook that
+required a patched TRT-LLM wheel is intentionally not part of this runtime path.
 """
 
 from __future__ import annotations
@@ -22,27 +17,381 @@ from gpu_memory_service.integrations.common import patch_empty_cache
 from gpu_memory_service.integrations.common.utils import (
     get_gms_lock_mode as _resolve_lock_mode,
 )
-from gpu_memory_service.integrations.trtllm.model_loader import (
-    get_gms_lock_mode,
-    patch_model_loader,
-    set_gms_enabled,
-    set_gms_lock_mode,
-)
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["setup_gms", "get_gms_lock_mode"]
+__all__ = [
+    "setup_gms",
+    "get_gms_lock_mode",
+]
 
 
-def setup_gms(model_loader_extra_config: dict[str, Any] | None = None) -> None:
-    """Set up GMS integration for TensorRT-LLM. Call once before creating the engine."""
+def get_gms_lock_mode():
+    from gpu_memory_service.integrations.trtllm.model_loader import (
+        get_gms_lock_mode as _get_gms_lock_mode,
+    )
+
+    return _get_gms_lock_mode()
+
+
+def setup_gms(
+    model_loader_extra_config: dict[str, Any] | None = None,
+    *,
+    _patch_mpi_workers: bool = True,
+) -> None:
+    """Set up GMS integration for TensorRT-LLM. Call once before creating the engine.
+
+    For TP>1 the engine spawns one MPI worker per rank (MpiPoolSession); those
+    workers are fresh processes that do not import this module. ``_patch_mpi_workers``
+    (internal) installs a hook so each spawned worker also runs ``setup_gms`` —
+    the worker initializer passes ``_patch_mpi_workers=False`` to avoid re-patching.
+    """
     extra = model_loader_extra_config or {}
     lock_mode = _resolve_lock_mode(extra)
+
+    from gpu_memory_service.integrations.trtllm.model_loader import (
+        patch_model_loader,
+        set_gms_enabled,
+        set_gms_lock_mode,
+    )
 
     set_gms_enabled(True)
     set_gms_lock_mode(lock_mode)
 
     patch_empty_cache()
+    from gpu_memory_service.integrations.trtllm.remote_code_cache import (
+        patch_remote_code_cache,
+    )
+
+    patch_remote_code_cache()
     patch_model_loader()
 
+    from gpu_memory_service.integrations.trtllm import install_kv_leases_v2
+
+    install_kv_leases_v2.install()
+
+    # Under GMS the custom IPC-workspace all-reduce strategies (AUTO/ONESHOT/TWOSHOT)
+    # share buffers across ranks via CUDA/VMM IPC, which conflicts with GMS-managed
+    # GPU memory and faults (CUDA 700) in the spawned MPI rank workers. NCCL all-reduce
+    # uses its own buffers (no custom workspace), so force it for every AllReduce.
+    _force_nccl_allreduce()
+
+    # Multi-node: AllReduce.__init__ under the AUTO strategy probes multi-node-NVLink
+    # support via pynvml.nvmlDeviceGetNvLinkCapability, which raises NVMLError on this
+    # hardware and crashes model construction. MNNVL is only ever used on aarch64 + real
+    # NVL domains anyway, so neutralize the probe (return False) to make AllReduce robust
+    # even if the force-NCCL patch above did not bind (e.g. import-order at sitecustomize).
+    _patch_disable_mnnvl()
+
+    # Fast HANG detection (matches vllm/sglang). TRT-LLM uses an MPI/C++ NCCL communicator
+    # (not torch.distributed PGs) for the executor, so the torch _set_pg_timeout path is a
+    # no-op here — but TRT-LLM ships its own PyExecutor HangDetector. Lower its (fixed 300s)
+    # timeout to the serving value; on_detected already does _handle_errors + shutdown which
+    # releases the failover flock so the shadow takes over. Keep the torch-PG tighten too for
+    # any config that runs the TorchDist (torch.distributed) communicator.
+    _patch_hang_detector_timeout()
+    _patch_serving_collective_timeout()
+
+    # CUDA graphs + GMS: the V2 KV lease acquire is a cross-rank flock/shared-mmap round-trip
+    # that diverges TP ranks during cuda-graph capture warmup -> captured NCCL all-reduce
+    # deadlocks. Bypass leases for the (transient) warmup allocations so capture matches the
+    # no-GMS path; real per-request leases (failover) are untouched.
+    _patch_warmup_lease_bypass()
+
+    # TP>1 spawns rank workers via MpiPoolSession; those fresh processes must also
+    # run setup_gms or weights/KV bypass GMS. Opt-in (still being hardened: running
+    # the GMS patches inside the spawned ranks currently triggers a CUDA illegal
+    # access during V2 KV executor init — see GMS_TRTLLM_MPI_WORKER_SETUP notes).
+    import os as _os
+
+    if _patch_mpi_workers and _os.environ.get(
+        "GMS_TRTLLM_MPI_WORKER_SETUP", ""
+    ).strip().lower() not in ("", "0", "false", "no", "off"):
+        _install_mpi_worker_gms(extra)
+
     logger.info("[GMS] TensorRT-LLM integration enabled (mode=%s)", lock_mode)
+
+
+def _force_nccl_allreduce() -> None:
+    """Force every TRT-LLM AllReduce module to the NCCL strategy under GMS.
+
+    The custom IPC-workspace strategies (AUTO/ONESHOT/TWOSHOT/MNNVL) share a
+    workspace buffer across TP ranks via CUDA/VMM IPC; that handle is invalid in a
+    Comm-spawned MPI rank whose GPU memory is GMS-managed -> CUDA 700 illegal access
+    during the autotuner warmup. NCCL all-reduce uses NCCL's own buffers (no custom
+    workspace), so it is safe with GMS. ``self.strategy`` is read per forward, so
+    setting it post-init is sufficient.
+    """
+    try:
+        from tensorrt_llm._torch.distributed import ops as _ops
+        from tensorrt_llm.functional import AllReduceStrategy
+    except Exception:  # pragma: no cover - import shape varies by version
+        logger.debug("[GMS] could not import AllReduce to force NCCL", exc_info=True)
+        return
+    cls = getattr(_ops, "AllReduce", None)
+    if cls is None or getattr(cls, "_gms_nccl_forced", False):
+        return
+    orig_init = cls.__init__
+
+    def patched_init(self, *args, **kwargs):
+        # Force NCCL as the strategy ARGUMENT, before the original __init__ runs. This
+        # both avoids the custom IPC workspace (which faults against GMS memory) AND
+        # skips the AUTO/MNNVL branch in __init__ whose multi-node NVLink probe
+        # (MnnvlMemory.supports_mnnvl -> pynvml.nvmlDeviceGetNvLinkCapability) raises
+        # NVMLError_InvalidArgument on this hardware and crashes model construction.
+        # Signature: __init__(self, mapping, strategy=AUTO, dtype=None).
+        if len(args) >= 2:
+            args = (args[0], AllReduceStrategy.NCCL) + tuple(args[2:])
+        else:
+            kwargs["strategy"] = AllReduceStrategy.NCCL
+        orig_init(self, *args, **kwargs)
+        try:
+            self.strategy = AllReduceStrategy.NCCL
+        except Exception:  # pragma: no cover
+            logger.debug("[GMS] failed to force NCCL on AllReduce", exc_info=True)
+
+    cls.__init__ = patched_init
+    cls._gms_nccl_forced = True
+    logger.info(
+        "[GMS] forced AllReduce strategy=NCCL (custom IPC all-reduce conflicts with GMS memory)"
+    )
+
+
+def _patch_disable_mnnvl() -> None:
+    """Make TRT-LLM's multi-node-NVLink (MNNVL) support probe a safe no-op.
+
+    ``AllReduce.__init__`` (AUTO strategy) calls ``MNNVLAllReduce.is_mnnvl`` ->
+    ``MnnvlMemory.supports_mnnvl`` -> ``support_nvlink`` ->
+    ``pynvml.nvmlDeviceGetNvLinkCapability``, which raises ``NVMLError_InvalidArgument``
+    on this driver/GPU and crashes model construction in multi-node runs. MNNVL is only
+    actually selected on aarch64 with a real NVLink domain, so forcing the probe to False
+    is behaviorally safe and prevents the crash regardless of the all-reduce strategy.
+    """
+    try:
+        from tensorrt_llm import _mnnvl_utils as _mn
+    except Exception:  # pragma: no cover - import shape varies by version
+        logger.debug(
+            "[GMS] could not import _mnnvl_utils to disable MNNVL", exc_info=True
+        )
+        return
+    cls = getattr(_mn, "MnnvlMemory", None)
+    if cls is None or getattr(cls, "_gms_mnnvl_disabled", False):
+        return
+
+    def _supports_mnnvl(*_a, **_k):
+        return False
+
+    try:
+        cls.supports_mnnvl = staticmethod(_supports_mnnvl)
+    except Exception:  # pragma: no cover
+        logger.debug("[GMS] failed to patch supports_mnnvl", exc_info=True)
+        return
+    cls._gms_mnnvl_disabled = True
+    logger.info(
+        "[GMS] disabled MNNVL probe (avoids nvml NvLink-capability crash, multi-node)"
+    )
+
+
+def _patch_warmup_lease_bypass() -> None:
+    """Make CUDA-graph capture work under GMS by allocating warmup KV slots locally.
+
+    PyExecutor warmup (which includes CUDA-graph capture) calls
+    PyTorchModelEngine.warmup; wrap it to set install_kv_leases_v2's warmup-bypass flag for
+    the duration, so the patched V2 SlotAllocator skips the cross-rank GMS lease acquire and
+    falls back to the engine's local allocator. That keeps warmup batch construction
+    deterministic and identical on every TP rank (like the no-GMS path), preventing the
+    rank-divergence -> captured-all-reduce deadlock. Per-request leases (failover) unaffected.
+    """
+    try:
+        from gpu_memory_service.integrations.trtllm import install_kv_leases_v2 as _kv
+        from tensorrt_llm._torch.pyexecutor.model_engine import PyTorchModelEngine
+    except Exception:  # pragma: no cover - import shape varies by version
+        logger.debug(
+            "[GMS] could not import PyTorchModelEngine for warmup bypass", exc_info=True
+        )
+        return
+    if getattr(PyTorchModelEngine, "_gms_warmup_bypass_patched", False):
+        return
+    orig_warmup = PyTorchModelEngine.warmup
+
+    def patched_warmup(self, *args, **kwargs):
+        _kv.set_warmup_bypass(True)
+        try:
+            return orig_warmup(self, *args, **kwargs)
+        finally:
+            _kv.set_warmup_bypass(False)
+
+    PyTorchModelEngine.warmup = patched_warmup
+    PyTorchModelEngine._gms_warmup_bypass_patched = True
+    logger.info(
+        "[GMS] patched PyTorchModelEngine.warmup -> local KV alloc during cuda-graph capture"
+    )
+
+
+def _patch_hang_detector_timeout() -> None:
+    """Lower TRT-LLM's native PyExecutor HangDetector timeout to the serving timeout.
+
+    TRT-LLM's executor runs on an MPI/C++ NCCL communicator, not torch.distributed process
+    groups, so ``_set_pg_timeout`` (the vllm/sglang serving-timeout mechanism) cannot tighten
+    anything here. TRT-LLM instead ships ``HangDetector`` (pyexecutor/hang_detector.py): the
+    executor loop ``checkpoint()``s every iteration and, if no checkpoint lands within
+    ``timeout`` seconds (a stuck collective on a dead/hung rank), fires ``on_detected`` which
+    runs ``_handle_errors`` + sets the shutdown event — the process exits, the failover flock
+    releases, and the shadow takes over. The timeout defaults to 300s and is not plumbed from
+    any config, so override it to the (low) serving timeout. The detector is constructed AFTER
+    warmup in ``PyExecutor.__init__`` and only times the serving loop (idle iterations
+    checkpoint too), so a small value is warmup-safe and won't false-positive.
+    """
+    try:
+        from gpu_memory_service.common.serving_timeout import enabled, serving_timeout_s
+    except Exception:  # pragma: no cover
+        return
+    if not enabled():
+        return
+    try:
+        from tensorrt_llm._torch.pyexecutor import hang_detector as _hd
+    except Exception:  # pragma: no cover - import shape varies by version
+        logger.debug(
+            "[GMS serving-timeout] could not import HangDetector", exc_info=True
+        )
+        return
+    cls = getattr(_hd, "HangDetector", None)
+    if cls is None or getattr(cls, "_gms_timeout_patched", False):
+        return
+    secs = max(1, int(serving_timeout_s()))
+    orig_init = cls.__init__
+
+    def patched_init(self, timeout=None, on_detected=None):
+        # Force the serving timeout regardless of the caller's default (300s).
+        orig_init(self, timeout=secs, on_detected=on_detected)
+
+    cls.__init__ = patched_init
+    cls._gms_timeout_patched = True
+    logger.info(
+        "[GMS] patched TRT-LLM HangDetector timeout -> %ds (fast serving hang detection)",
+        secs,
+    )
+
+
+def _patch_serving_collective_timeout() -> None:
+    """Lower the collective watchdog to the serving timeout once a rank is past warmup.
+
+    TRT-LLM's PyExecutor runs warmup (model_engine.warmup + CUDA-graph capture) inside
+    ``__init__`` and then calls ``start_worker()`` as the final init step to spin up the
+    executor loop thread. So wrapping ``start_worker`` gives a precise PER-RANK post-warmup
+    hook (mirrors vllm's compile_or_warm_up_model / sglang's run_event_loop): the tight
+    serving timeout can never fire during the generous-timeout warmup phase. The tighten
+    is a no-op if torch.distributed isn't initialized, so it is safe regardless of backend.
+    """
+    try:
+        from gpu_memory_service.common.serving_timeout import enabled, tighten_now
+    except Exception:  # pragma: no cover
+        return
+    if not enabled():
+        return
+    try:
+        from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+    except Exception:  # pragma: no cover - import shape varies by version
+        logger.debug("[GMS serving-timeout] could not import PyExecutor", exc_info=True)
+        return
+    if getattr(PyExecutor, "_gms_serving_timeout_patched", False):
+        return
+    orig_start_worker = PyExecutor.start_worker
+
+    def patched_start_worker(self, *args, **kwargs):
+        result = orig_start_worker(self, *args, **kwargs)
+        try:
+            tighten_now()
+        except Exception:  # pragma: no cover
+            logger.debug("[GMS serving-timeout] trtllm tighten failed", exc_info=True)
+        return result
+
+    PyExecutor.start_worker = patched_start_worker
+    PyExecutor._gms_serving_timeout_patched = True
+    logger.info(
+        "[GMS] patched PyExecutor.start_worker to tighten serving NCCL timeout post-warmup"
+    )
+
+
+def _gms_worker_initializer(model_loader_extra_config: dict[str, Any] | None) -> None:
+    """Run in each MPI-spawned TRT-LLM rank worker before it builds the engine."""
+    # Re-apply the GMS patches in the worker process; do not re-patch the pool
+    # (the worker does not spawn sub-workers).
+    setup_gms(model_loader_extra_config, _patch_mpi_workers=False)
+
+
+def _install_mpi_worker_gms(model_loader_extra_config: dict[str, Any] | None) -> None:
+    """Make TP>1 MPI workers run the GMS integration.
+
+    TRT-LLM's ``MpiPoolSession._start_mpi_pool`` creates the worker pool with a
+    filtered env (only ``TRTLLM*``/``TLLM*``/``CUDA_*``) and no initializer, so the
+    spawned rank workers — which actually own the GPUs and load weights/allocate KV —
+    never run ``setup_gms``; their weights+KV then bypass the GMS pool. Wrap pool
+    creation to (a) also propagate ``GMS*`` env and (b) run ``setup_gms`` in each
+    worker via an initializer.
+    """
+    try:
+        from tensorrt_llm.llmapi import mpi_session as _mpi
+    except Exception:  # pragma: no cover - TRT-LLM not importable
+        return
+    cls = getattr(_mpi, "MpiPoolSession", None)
+    if cls is None or getattr(cls, "_gms_worker_init_patched", False):
+        return
+
+    import os as _os
+    import sys as _sys
+
+    from mpi4py.futures import MPIPoolExecutor
+
+    def _start_mpi_pool(self) -> None:
+        assert not self.mpi_pool, "MPI session already started"
+        # Spawned rank workers must inherit not just GMS/TRTLLM config but the full
+        # toolchain env they need to load/JIT (CUDA, driver, the compiler+linker
+        # search paths for flashinfer's runtime JIT, HF cache, the failover lock).
+        # Without LIBRARY_PATH/PATH the flashinfer JIT link fails (-lcudart/-lcuda);
+        # without LD_LIBRARY_PATH the driver/OMPI libs are missing.
+        # DYN_GMS_* carries the serving-timeout config; TORCH_NCCL_* carries the NCCL
+        # watchdog/teardown knobs — both must reach the spawned ranks where the engine runs.
+        _prefixes = (
+            "TRTLLM",
+            "TLLM",
+            "GMS",
+            "CUDA",
+            "NCCL",
+            "HF_",
+            "OMPI_",
+            "MPI",
+            "DYN_GMS",
+            "TORCH_NCCL",
+        )
+        _exact = {
+            "CUDA_HOME",
+            "CUDA_PATH",
+            "LIBRARY_PATH",
+            "LD_LIBRARY_PATH",
+            "PATH",
+            "CPATH",
+            "CC",
+            "CXX",
+            "TRITON_LIBCUDA_PATH",
+            "PYTHONPATH",
+            "FAILOVER_LOCK_PATH",
+            "HOME",
+            "TLLM_WORKER_USE_SINGLE_PROCESS",
+        }
+        env = {
+            k: v
+            for k, v in _os.environ.items()
+            if k.startswith(_prefixes) or k in _exact
+        }
+        self.mpi_pool = MPIPoolExecutor(
+            max_workers=self.n_workers,
+            path=_sys.path,
+            env=env,
+            initializer=_gms_worker_initializer,
+            initargs=(model_loader_extra_config or {},),
+        )
+
+    cls._start_mpi_pool = _start_mpi_pool
+    cls._gms_worker_init_patched = True
+    logger.info("[GMS] patched MpiPoolSession: propagate GMS env + init workers (TP>1)")

--- a/lib/gpu_memory_service/integrations/trtllm/install_kv_leases_v2.py
+++ b/lib/gpu_memory_service/integrations/trtllm/install_kv_leases_v2.py
@@ -1,0 +1,500 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT-LLM KVCacheManager V2 SlotAllocator lease integration."""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import os
+import threading
+from typing import Callable
+
+from gpu_memory_service.integrations.common.kv_lease_client import (
+    GMSKVLeaseClient,
+    KVLeaseClient,
+    kv_leases_enabled,
+    log_lease_pressure,
+    resolve_lease_device,
+)
+
+logger = logging.getLogger(__name__)
+
+_patched = False
+_factory: Callable[[object, int, str], KVLeaseClient] | None = None
+_ALLOC_STATE: dict[int, dict[str, object]] = {}
+_GROUP_ORDINALS = itertools.count()
+_RECLAIM_LOCK = threading.RLock()
+
+# During CUDA-graph capture warmup the executor allocates/releases dummy KV slots. Those
+# slots are transient (released immediately after capture) and never need a failover lease,
+# but the per-slot GMS lease acquire is a cross-rank flock + shared-mmap round-trip that can
+# return different results on each TP rank -> the ranks build different warmup batches -> one
+# rank enters the captured NCCL all-reduce while the other skips it -> collective deadlock
+# (both ranks spin at 100% CPU, capture never finishes). When this flag is set, the patched
+# allocator falls back to the engine's LOCAL allocator (identical/deterministic on every rank,
+# exactly like the no-GMS path), so capture proceeds. Real per-request leases (and thus the
+# pause/resume failover path) are unaffected — only warmup-phase allocations are bypassed.
+_warmup_bypass = False
+
+
+def set_warmup_bypass(value: bool) -> None:
+    """Toggle local-only KV slot allocation for the CUDA-graph/warmup phase."""
+    global _warmup_bypass
+    _warmup_bypass = bool(value)
+
+
+def _env_enabled(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _v2_transition_reclaim_enabled() -> bool:
+    """Gate V2 proactive reclaim behind host-tier mirroring/fallback.
+
+    Reclaiming a TRT-LLM V2 GPU page is only useful for shadow transition when
+    the same cached KV has already been mirrored into the GMS CPU host tier.
+    Keep this opt-in via the existing CPU-tier knobs, with an explicit TRT V2
+    override for tests and controlled rollouts.
+    """
+
+    explicit = os.environ.get("GMS_TRTLLM_V2_TRANSITION_RECLAIM")
+    if explicit is None:
+        explicit = os.environ.get("GMS_TRTLLM_TRANSITION_RECLAIM")
+    if explicit is not None:
+        return explicit.strip().lower() not in ("", "0", "false", "no", "off")
+    return _env_enabled("GMS_KVR_HOST_TIER_FALLBACK") or _env_enabled(
+        "GMS_KVR_HOST_TIER_MIRROR"
+    )
+
+
+def reclaim_cached_kv_v2_for_allocator(allocator_id: int, target_blocks: int) -> int:
+    """Free evictable TRT-LLM V2 GPU pages for one leased pool group.
+
+    This intentionally uses TRT-LLM V2's own eviction controller. Active decode
+    pages are locked/held by the manager and are not in the evictable queue, so
+    the operation only drops reusable cached pages. Slot release then flows
+    through our patched ``SlotAllocator.release`` path, which releases the
+    matching GMS lease and gives the shadow owner headroom.
+    """
+
+    target = max(0, int(target_blocks))
+    if target <= 0:
+        return 0
+    with _RECLAIM_LOCK:
+        st = _ALLOC_STATE.get(int(allocator_id))
+        if st is None:
+            return 0
+        manager = st.get("manager")
+        allocator = st.get("allocator")
+        pool_group_index = st.get("pool_group_index")
+        if manager is None or allocator is None or pool_group_index is None:
+            return 0
+        try:
+            pg_idx = int(pool_group_index)
+            storage = getattr(manager, "_storage")
+            gpu_level = 0
+            levels = getattr(storage, "_levels")
+            controller = levels[gpu_level].controller
+            evictable = int(controller.num_evictable_pages(pg_idx))
+            to_evict = min(target, evictable)
+            if to_evict <= 0:
+                return 0
+
+            before_free = int(getattr(allocator, "num_free_slots"))
+            goals = [0] * int(storage.num_pool_groups)
+            goals[pg_idx] = to_evict
+            storage.force_evict(gpu_level, goals)
+            after_free = int(getattr(allocator, "num_free_slots"))
+            reclaimed = max(0, after_free - before_free)
+            return reclaimed if reclaimed > 0 else to_evict
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[GMS-KVLease] TRT-LLM V2 reclaim failed",
+                exc_info=True,
+            )
+            return 0
+
+
+def reclaim_cached_kv_v2(target_blocks: int) -> int:
+    """Best-effort aggregate V2 reclaim across registered GPU pool groups."""
+
+    remaining = max(0, int(target_blocks))
+    reclaimed = 0
+    for allocator_id in list(_ALLOC_STATE):
+        if remaining <= 0:
+            break
+        n = reclaim_cached_kv_v2_for_allocator(allocator_id, remaining)
+        reclaimed += int(n)
+        remaining -= int(n)
+    return reclaimed
+
+
+def _start_reclaim_watcher(allocator_id: int, st: dict[str, object]) -> None:
+    if st.get("reclaim_watcher") is not None:
+        return
+    if not _v2_transition_reclaim_enabled():
+        return
+    suffix = st.get("namespace_suffix")
+    if not suffix:
+        return
+    try:
+        from gpu_memory_service.integrations.common.transition_reclaim import (
+            start_kv_transition_reclaim_watcher,
+        )
+
+        watcher = start_kv_transition_reclaim_watcher(
+            "trtllm",
+            lambda target: reclaim_cached_kv_v2_for_allocator(allocator_id, target),
+            namespace_suffix=str(suffix),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "[GMS-KVLease] TRT-LLM V2 transition reclaim watcher not started",
+            exc_info=True,
+        )
+        return
+    if watcher is not None:
+        st["reclaim_watcher"] = watcher
+
+
+def _register_manager_for_reclaim(manager: object) -> None:
+    """Bind TRT-LLM V2 KVCacheManager storage to leased pool groups."""
+
+    try:
+        storage = getattr(manager, "_storage")
+        gpu_storage = getattr(storage, "_levels")[0].storage
+        pool_groups = getattr(gpu_storage, "_pool_groups")
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "[GMS-KVLease] TRT-LLM V2 manager has no GPU pool groups",
+            exc_info=True,
+        )
+        return
+    for pg_idx, group in enumerate(pool_groups):
+        allocator = getattr(group, "_slot_allocator", None)
+        if allocator is None:
+            continue
+        st = _ALLOC_STATE.get(id(allocator))
+        if st is None:
+            continue
+        st["manager"] = manager
+        st["pool_group_index"] = int(pg_idx)
+        _start_reclaim_watcher(id(allocator), st)
+
+
+def _unregister_manager_for_reclaim(manager: object) -> None:
+    # Module globals may already be cleared while KVCacheManager.__del__ runs
+    # during interpreter shutdown.
+    alloc_state = _ALLOC_STATE
+    if alloc_state is None:
+        return
+    for st in list(alloc_state.values()):
+        if st.get("manager") is not manager:
+            continue
+        watcher = st.pop("reclaim_watcher", None)
+        if watcher is not None:
+            try:
+                watcher.stop()
+            except Exception:  # noqa: BLE001
+                pass
+        st.pop("manager", None)
+        st.pop("pool_group_index", None)
+
+
+def install(factory: Callable[[object, int, str], KVLeaseClient] | None = None) -> bool:
+    global _patched, _factory
+    if factory is not None:
+        _factory = factory
+    if _patched:
+        return False
+    if _factory is None and not kv_leases_enabled("trtllm"):
+        return False
+
+    try:
+        from tensorrt_llm.runtime.kv_cache_manager_v2._storage import _core
+    except Exception:  # noqa: BLE001
+        logger.debug("[GMS-KVLease] TRT-LLM V2 storage not importable", exc_info=True)
+        return False
+    try:
+        from tensorrt_llm.runtime.kv_cache_manager_v2._core._kv_cache_manager import (
+            KVCacheManager,
+        )
+    except Exception:  # noqa: BLE001
+        KVCacheManager = None
+        logger.debug(
+            "[GMS-KVLease] TRT-LLM V2 KVCacheManager not importable; "
+            "lease patch will run without transition reclaim",
+            exc_info=True,
+        )
+
+    GpuPoolGroup = _core.GpuPoolGroup
+    SlotAllocator = _core.SlotAllocator
+    Slot = _core.Slot
+    SlotId = _core.SlotId
+    CachedCudaEvent = _core.CachedCudaEvent
+    OutOfPagesError = _core.OutOfPagesError
+
+    orig_gpu_group_init = GpuPoolGroup.__init__
+    orig_allocate = SlotAllocator.allocate
+    orig_allocate_multiple = SlotAllocator.allocate_multiple
+    orig_release = SlotAllocator.release
+    if KVCacheManager is not None:
+        orig_manager_init = KVCacheManager.__init__
+        orig_manager_shutdown = KVCacheManager.shutdown
+
+    def _make_client(group, total_slots: int, suffix: str) -> KVLeaseClient:
+        if _factory is not None:
+            return _factory(group, total_slots, suffix)
+        # The lease MUST bind the same GPU the V2 pool is allocated on. Under the
+        # MPI proxy executor each TP rank is a Comm-spawned worker; the
+        # LOCAL_RANK / OMPI_COMM_WORLD_LOCAL_RANK env heuristic is unreliable there
+        # (all spawned ranks can report 0 -> every rank binds gpu0 -> the non-zero
+        # ranks touch gpu0 memory from their own context => CUDA 700). The V2 pool
+        # is created on the worker's *current* CUDA device, so resolve from that;
+        # an explicit GMS_TRTLLM_KV_LEASE_DEVICE still overrides for tests.
+        device = None
+        _explicit = os.environ.get("GMS_TRTLLM_KV_LEASE_DEVICE")
+        if _explicit is not None:
+            try:
+                device = int(_explicit)
+            except ValueError:
+                device = None
+        if device is None:
+            try:
+                import torch
+
+                if torch.cuda.is_available():
+                    device = int(torch.cuda.current_device())
+            except Exception:  # noqa: BLE001
+                device = None
+        if device is None:
+            device = resolve_lease_device(
+                "GMS_TRTLLM_KV_LEASE_DEVICE",
+                fallback_env_names=("LOCAL_RANK", "OMPI_COMM_WORLD_LOCAL_RANK"),
+            )
+        return GMSKVLeaseClient.from_env(
+            "trtllm",
+            device,
+            total_blocks=total_slots,
+            namespace_suffix=suffix,
+        )
+
+    def patched_gpu_group_init(self, num_slots, slot_size_list, shared_phys_mem_pool):
+        orig_gpu_group_init(self, num_slots, slot_size_list, shared_phys_mem_pool)
+        ordinal = next(_GROUP_ORDINALS)
+        suffix = (
+            f"v2-gpu-pool-{ordinal}:slots{int(num_slots)}:"
+            f"sizes{','.join(str(int(x)) for x in slot_size_list)}"
+        )
+        client = _make_client(self, int(num_slots), suffix)
+        _ALLOC_STATE[id(self._slot_allocator)] = {
+            "allocator": self._slot_allocator,
+            "client": client,
+            "leases_by_slot": {},
+            "namespace_suffix": suffix,
+        }
+        logger.info(
+            "[GMS-KVLease] TRT-LLM V2 GPU pool leases enabled namespace=%s owner=%s slots=%d",
+            getattr(client, "namespace", "?"),
+            getattr(client, "owner_id", "?"),
+            int(num_slots),
+        )
+
+    def _state(allocator) -> dict[str, object] | None:
+        return _ALLOC_STATE.get(id(allocator))
+
+    def _capacity(allocator) -> int:
+        return min(int(allocator.num_slots), int(allocator._target_capacity))
+
+    def _safe_free_count(client: KVLeaseClient) -> int:
+        try:
+            return int(client.free_count())
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[GMS-KVLease] TRT-LLM V2 free-count read failed", exc_info=True
+            )
+            return -1
+
+    def _preferred_slots(allocator, limit: int | None = None) -> list[int]:
+        allocator._scrub_events()
+        preferred: list[int] = []
+        seen: set[int] = set()
+
+        def add(slot_id: int) -> bool:
+            if slot_id in seen:
+                return False
+            preferred.append(slot_id)
+            seen.add(slot_id)
+            return limit is not None and len(preferred) >= int(limit)
+
+        for slot in allocator._recycled_slots:
+            if add(int(slot.slot_id)):
+                return preferred
+        for slot_id in range(int(allocator._num_active_slots), _capacity(allocator)):
+            if add(int(slot_id)):
+                return preferred
+        return preferred
+
+    def _take_local_slot(allocator, slot_id: int):
+        allocator._scrub_events()
+        for idx, slot in enumerate(list(allocator._recycled_slots)):
+            if int(slot.slot_id) != int(slot_id):
+                continue
+            del allocator._recycled_slots[idx]
+            if idx < allocator._num_ready_recycled_slots:
+                allocator._num_ready_recycled_slots -= 1
+            allocator._occupied_mask.set(slot.slot_id)
+            return slot
+        if int(allocator._num_active_slots) <= slot_id < _capacity(allocator):
+            for skipped in range(int(allocator._num_active_slots), slot_id):
+                allocator._recycled_slots.append(
+                    Slot(SlotId(skipped), CachedCudaEvent.NULL)
+                )
+                allocator._num_ready_recycled_slots += 1
+            slot = Slot(SlotId(slot_id), CachedCudaEvent.NULL)
+            allocator._num_active_slots = slot_id + 1
+            allocator._occupied_mask.set(slot.slot_id)
+            return slot
+        raise OutOfPagesError(f"No local free slot compatible with GMS lease {slot_id}")
+
+    def patched_allocate(self):
+        st = _state(self)
+        if st is None or _warmup_bypass:
+            return orig_allocate(self)
+        client = st["client"]
+        if self.num_free_slots == 0:
+            log_lease_pressure(
+                logger,
+                f"trtllm:{getattr(client, 'namespace', '?')}:local-exhausted",
+                "[GMS-KVLease] TRT-LLM V2 allocation blocked by local free slots",
+                namespace=getattr(client, "namespace", "?"),
+                owner_id=getattr(client, "owner_id", "?"),
+                active_slots=int(getattr(self, "_num_active_slots", 0)),
+                capacity=_capacity(self),
+                active_leases=len(st["leases_by_slot"]),
+            )
+            raise OutOfPagesError("No free slots")
+
+        def acquire_with_preferred(limit: int | None) -> tuple[list[object], list[int]]:
+            preferred = _preferred_slots(self, limit=limit)
+            leases = client.acquire(
+                1,
+                preferred_blocks=preferred,
+                strict_preferred=True,
+            )
+            return leases, preferred
+
+        try:
+            leases, preferred = acquire_with_preferred(1)
+        except Exception as exc:  # noqa: BLE001
+            try:
+                leases, preferred = acquire_with_preferred(None)
+            except Exception as fallback_exc:  # noqa: BLE001
+                log_lease_pressure(
+                    logger,
+                    f"trtllm:{getattr(client, 'namespace', '?')}:acquire-error",
+                    "[GMS-KVLease] TRT-LLM V2 lease acquire failed",
+                    namespace=getattr(client, "namespace", "?"),
+                    owner_id=getattr(client, "owner_id", "?"),
+                    local_free=int(self.num_free_slots),
+                    shared_free=_safe_free_count(client),
+                    preferred_count=len(_preferred_slots(self, limit=16)),
+                    error=type(fallback_exc).__name__,
+                )
+                raise OutOfPagesError("No GMS-leased slot available") from exc
+        if len(leases) != 1:
+            log_lease_pressure(
+                logger,
+                f"trtllm:{getattr(client, 'namespace', '?')}:acquire-short",
+                "[GMS-KVLease] TRT-LLM V2 lease acquire returned unexpected count",
+                namespace=getattr(client, "namespace", "?"),
+                owner_id=getattr(client, "owner_id", "?"),
+                requested=1,
+                returned=len(leases),
+                shared_free=_safe_free_count(client),
+                preferred_count=len(preferred),
+            )
+            client.release(leases)
+            raise OutOfPagesError("No GMS-leased slot available")
+        lease = leases[0]
+        try:
+            slot = _take_local_slot(self, int(lease.block_id))
+        except Exception:
+            client.release(leases)
+            raise
+        lease_map = st["leases_by_slot"]
+        assert isinstance(lease_map, dict)
+        lease_map[int(slot.slot_id)] = lease
+        return slot
+
+    def patched_allocate_multiple(self, num_slots: int):
+        st = _state(self)
+        if st is None or _warmup_bypass:
+            return orig_allocate_multiple(self, num_slots)
+        if self.num_free_slots < num_slots:
+            raise OutOfPagesError("Not enough free slots")
+        allocated = []
+        try:
+            for _ in range(int(num_slots)):
+                allocated.append(patched_allocate(self))
+        except Exception:
+            for slot in allocated:
+                patched_release(self, slot)
+            raise
+        return allocated
+
+    def patched_release(self, slot):
+        st = _state(self)
+        if st is None or _warmup_bypass:
+            return orig_release(self, slot)
+        slot_id = int(slot.slot_id)
+        orig_release(self, slot)
+        lease_map = st["leases_by_slot"]
+        assert isinstance(lease_map, dict)
+        lease = lease_map.pop(slot_id, None)
+        if lease is not None:
+            st["client"].release([lease])
+        else:
+            client = st["client"]
+            log_lease_pressure(
+                logger,
+                f"trtllm:{getattr(client, 'namespace', '?')}:missing-release",
+                "[GMS-KVLease] TRT-LLM V2 releasing slot without matching lease",
+                namespace=getattr(client, "namespace", "?"),
+                owner_id=getattr(client, "owner_id", "?"),
+                slot_id=slot_id,
+                active_leases=len(lease_map),
+            )
+
+    if KVCacheManager is not None:
+
+        def patched_manager_init(self, config):
+            orig_manager_init(self, config)
+            _register_manager_for_reclaim(self)
+
+        def patched_manager_shutdown(self):
+            _unregister_manager_for_reclaim(self)
+            return orig_manager_shutdown(self)
+
+    GpuPoolGroup.__init__ = patched_gpu_group_init  # type: ignore[method-assign]
+    SlotAllocator.allocate = patched_allocate  # type: ignore[method-assign]
+    SlotAllocator.allocate_multiple = patched_allocate_multiple  # type: ignore[method-assign]
+    SlotAllocator.release = patched_release  # type: ignore[method-assign]
+    if KVCacheManager is not None:
+        KVCacheManager.__init__ = patched_manager_init  # type: ignore[method-assign]
+        KVCacheManager.shutdown = patched_manager_shutdown  # type: ignore[method-assign]
+
+    _patched = True
+    logger.info("[GMS-KVLease] patched TRT-LLM V2 GPU SlotAllocator")
+    return True
+
+
+if kv_leases_enabled("trtllm"):
+    try:
+        install()
+    except Exception:  # noqa: BLE001
+        logger.exception("[GMS-KVLease] TRT-LLM V2 auto-install failed")

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -43,6 +43,10 @@ def set_gms_enabled(enabled: bool) -> None:
     _gms_enabled = enabled
 
 
+def gms_enabled() -> bool:
+    return _gms_enabled
+
+
 def set_gms_lock_mode(mode: RequestedLockType) -> None:
     global _gms_lock_mode
     _gms_lock_mode = mode

--- a/lib/gpu_memory_service/integrations/trtllm/remote_code_cache.py
+++ b/lib/gpu_memory_service/integrations/trtllm/remote_code_cache.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TRT-LLM remote-code cache compatibility for GMS deployments.
+
+TRT-LLM serializes Hugging Face remote-code config loading with a global
+``_remote_code.lock`` under ``HF_MODULES_CACHE``. In Kubernetes recipes that
+mount the HF cache from a RWX PVC, that path can be backed by a filesystem that
+does not support POSIX file locks and returns ENOLCK. GMS only needs the model
+weights to stay shared; the generated remote-code module cache can be local to
+the pod.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+import filelock
+
+logger = logging.getLogger(__name__)
+
+_patched = False
+
+
+def patch_remote_code_cache() -> None:
+    """Move TRT-LLM/HF remote-code cache locking to pod-local storage."""
+    global _patched
+    if _patched:
+        return
+
+    cache_dir = Path(
+        os.environ.get("GMS_TRTLLM_REMOTE_CODE_CACHE_DIR", "")
+        or Path(tempfile.gettempdir()) / "trtllm-hf-modules-cache"
+    )
+    lock_dir = Path(os.environ.get("GMS_TRTLLM_CONFIG_LOCK_DIR", "") or cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    lock_dir.mkdir(parents=True, exist_ok=True)
+
+    os.environ["HF_MODULES_CACHE"] = str(cache_dir)
+
+    _patch_transformers_constant("transformers.utils.hub", cache_dir)
+    _patch_transformers_constant("transformers.dynamic_module_utils", cache_dir)
+
+    try:
+        import tensorrt_llm._torch.model_config as model_config
+    except Exception as exc:  # pragma: no cover - depends on optional TRT-LLM.
+        logger.debug("[GMS] TRT-LLM model_config unavailable: %s", exc)
+        return
+
+    model_config.HF_MODULES_CACHE = str(cache_dir)
+    model_config.config_file_lock = _make_local_config_file_lock(lock_dir)
+    _patched = True
+    logger.info(
+        "[GMS] Patched TRT-LLM remote-code cache: cache=%s lock=%s",
+        cache_dir,
+        lock_dir,
+    )
+
+
+def _patch_transformers_constant(module_name: str, cache_dir: Path) -> None:
+    try:
+        module = __import__(module_name, fromlist=["HF_MODULES_CACHE"])
+    except Exception:  # pragma: no cover - optional import path.
+        return
+    if hasattr(module, "HF_MODULES_CACHE"):
+        module.HF_MODULES_CACHE = str(cache_dir)
+
+
+def _make_local_config_file_lock(lock_dir: Path):
+    @contextlib.contextmanager
+    def local_config_file_lock(timeout: int = 10) -> Iterator[None]:
+        lock_path = lock_dir / "_remote_code.lock"
+        lock = filelock.FileLock(str(lock_path), timeout=timeout)
+        yielded = False
+        try:
+            with lock:
+                yielded = True
+                yield
+        except filelock.Timeout:
+            logger.warning(
+                "[GMS] TRT-LLM remote-code lock timed out at %s; proceeding unlocked",
+                lock_path,
+            )
+            yield
+        except (OSError, PermissionError) as exc:
+            if yielded:
+                logger.warning(
+                    "[GMS] TRT-LLM remote-code lock release failed at %s: %s",
+                    lock_path,
+                    exc,
+                )
+                return
+            logger.warning(
+                "[GMS] TRT-LLM remote-code lock unavailable at %s: %s; proceeding unlocked",
+                lock_path,
+                exc,
+            )
+            yield
+
+    return local_config_file_lock

--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -29,7 +29,7 @@ def _tp_size() -> int:
 
     TP=N runs each engine across devices 0..N-1; the GMS weights + kv_cache
     daemons are started on each of those devices. The engine's own collective
-    (vLLM mp executor / sglang tp schedulers) applies
+    (vLLM mp executor / sglang tp schedulers / trtllm MPI proxy) applies
     pause/resume across all ranks, so failover stays group-atomic without the
     harness coordinating per-rank.
     """
@@ -361,7 +361,11 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
     TRTLLM_GMS_MAX_SEQ_LEN = os.environ.get("TRTLLM_GMS_MAX_SEQ_LEN", "256")
     TRTLLM_GMS_MAX_NUM_TOKENS = os.environ.get("TRTLLM_GMS_MAX_NUM_TOKENS", "256")
     TRTLLM_GMS_OVERRIDE_ENGINE_ARGS = os.environ.get(
-        "TRTLLM_GMS_OVERRIDE_ENGINE_ARGS", ""
+        # TRT-LLM 1.3.0rc18's TRTLLM-GEN Blackwell kernel emits both
+        # .maxntid and .reqntid under CUDA 13. FlashInfer avoids that upstream
+        # JIT bug while exercising the same GMS allocation and failover paths.
+        "TRTLLM_GMS_OVERRIDE_ENGINE_ARGS",
+        '{"attn_backend":"FLASHINFER"}',
     )
 
     def __init__(
@@ -390,8 +394,16 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
 
     def env_updates(self) -> dict[str, str]:
         env = {
-            "CUDA_VISIBLE_DEVICES": os.environ.get("CUDA_VISIBLE_DEVICES", "0"),
-            "TLLM_WORKER_USE_SINGLE_PROCESS": "1",
+            "CUDA_VISIBLE_DEVICES": os.environ.get(
+                "CUDA_VISIBLE_DEVICES", _tp_visible_devices()
+            ),
+            # Single-process executor (GenerationExecutorWorker) has no
+            # collective_rpc, which GMS pause/resume (release_memory_occupation)
+            # requires. The MPI proxy executor implements collective_rpc and
+            # supports model_world_size==1, so the failover repro sets this to 0.
+            "TLLM_WORKER_USE_SINGLE_PROCESS": os.environ.get(
+                "TLLM_WORKER_USE_SINGLE_PROCESS", "1"
+            ),
             "MPI4PY_MPIABI": "openmpi",
             "OMPI_MCA_coll_ucc_enable": "0",
         }
@@ -410,7 +422,9 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
             "--model",
             self.TRTLLM_GMS_MODEL_NAME,
             "--gpus-per-node",
-            "1",
+            str(_tp_size()),
+            "--tensor-parallel-size",
+            str(_tp_size()),
             "--load-format",
             "gms",
             "--free-gpu-memory-fraction",

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -291,7 +291,6 @@ def _trtllm_pause(
     return ws
 
 
-@pytest.mark.skip(reason="Nightly CI failure: https://linear.app/nvidia/issue/OPS-4450")
 @pytest.mark.trtllm
 @pytest.mark.e2e
 @pytest.mark.gpu_1
@@ -300,7 +299,14 @@ def _trtllm_pause(
 def test_gms_shadow_engine_failover_trtllm(
     request, runtime_services_dynamic_ports, predownload_models
 ):
-    """Weights-only shadow failover for TRT-LLM (no KV cache GMS)."""
+    """Shadow failover for TRT-LLM.
+
+    TRT-LLM's only supported GMS KV path is KVCacheManagerV2 (the worker forces
+    ``use_kv_cache_manager_v2=True`` and rejects the legacy V1 connector). GMS
+    owns the model weights via the weights daemon; V2 KV slot leases coordinate
+    the KV handoff host-side (no kv_cache GMS daemon, so ``tags=("weights",)``).
+    The shadow pre-activates (resume immediately on primary kill, no KV block).
+    Requires GMS_KV_LEASES=1 for the V2 slot-lease integration to install."""
     with GMSProcessManager(request, TRTLLMWithGMSProcess, tags=("weights",)) as manager:
         frontend_port = manager.frontend_port
         weights_gms = manager.weights_gms


### PR DESCRIPTION
## Summary

Add the TensorRT-LLM-specific hooks required to consume GMS-owned KV memory after the patch-free vLLM and SGLang path is independently reviewable.

## Scope

Contains the Dynamo integration plus the minimal TensorRT-LLM compatibility patch surface. No host-tier adapter or test recipes are included here.

## Stack

Position **11/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-09-4-router-event-plane-gms-d2d-e2e`.

Parent: #10450  
Tracking: #10453

## Review migration

This existing PR is updated in place so its comments and reviews remain attached. Line comments may appear outdated where code moved during the rebase; they remain visible and should be dispositioned against the current diff. Previous approvals should be revalidated.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

TensorRT-LLM host-tier coverage follows in position 12 and reproducible E2E coverage in position 13.