### PR TITLE
feat(gms): add optional NIXL and Mooncake backends [GMS 15/18]

### DIFF
--- a/lib/gms_kv_ring/daemon/backends_mooncake.py
+++ b/lib/gms_kv_ring/daemon/backends_mooncake.py
@@ -1,0 +1,761 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mooncake-backed storage tier.
+
+ROLE IN THE BACKEND STRATEGY: this is the **optional /
+integration** backend. Use it when an existing Mooncake-store
+fabric is already deployed and a customer wants to integrate
+KV-offload bytes into that fabric. The feature surface here is
+**frozen**: new GMS features (restore-on-hit, async ring,
+`dest_offset` remap, GPU-direct paths) land in `NixlBackend`
+first; this backend gets parity on explicit demand only. For
+PRODUCTION on greenfield deployments use `NixlBackend` (its UCX
+plugin covers RDMA-fabric transfers, OBJ for object storage,
+GDS for GPU-direct file I/O). For DEV use `StorageTier` (Local).
+
+Mooncake (https://github.com/kvcache-ai/Mooncake) is a distributed
+key-value store with:
+  - DRAM pool across nodes (the headline capability — engines on
+    node A can pull from RAM on node B)
+  - Optional SSD offload for cold data
+  - Pluggable transport (TCP or RDMA)
+
+What this backend delivers:
+  - Real demote/promote via `MooncakeDistributedStore.put_from` /
+    `get_into` with a real (external) Mooncake master.
+  - Single-blob layout: [24-byte CRC header | payload] per slot
+    key. Same header format as the Local and NIXL backends, so
+    the CRC contract is identical (single source of truth).
+
+Reconcile after restart: handled via a SIDECAR MANIFEST. Mooncake's
+Python binding doesn't expose a list-keys API, so we can't
+enumerate the master's metadata directly. Instead, the backend
+appends one JSON-lines record per demote to a local file (path
+passed at construction). On restart, we read the manifest and for
+each record verify the key still exists via `is_exist()` — keys
+that the master lost (its own restart, eviction) are silently
+skipped. The manifest is append-only; compaction is a follow-up.
+If `manifest_path` is None (default), reconcile is disabled and
+the backend starts with an empty index — fine for single-process
+test fixtures and ephemeral deployments.
+
+Manifest compaction: the file is append-only and grows over time
+with released-key records. `compact_manifest()` snapshots the
+current in-memory index, atomically rewrites the file with just
+those records, and swaps the append fp. Operators trigger
+explicitly or via the daemon's sweeper; the backend exposes
+manifest size + record-count so a policy can be data-driven.
+
+What's deferred:
+  - Pre-registered host buffer pool. Today demote/promote allocate
+    a fresh staging buffer per call (header + payload bytes). A
+    production version would reuse a per-engine pool to avoid the
+    malloc/memcpy.
+
+Connection model: this backend is a CLIENT of an external Mooncake
+master process. The master is spun up out-of-band (systemd, k8s
+pod, dev script). `master_server_addr` in the constructor points
+at the master's RPC port; `metadata_server` (or
+`enable_http_metadata_server`) handles cluster-wide naming."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import logging
+import os
+import struct
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from gms_kv_ring.daemon.backend import StorageBackend, StorageSlot
+
+logger = logging.getLogger(__name__)
+
+
+# Same header format as Local + NIXL backends — file/key
+# interoperability across backends, single CRC source of truth.
+_MAGIC = 0x47535453  # 'STSG'
+_VERSION = 1
+_HEADER_FMT = "<IIIIQ"  # magic, version, crc, size, _pad
+_HEADER_SIZE = struct.calcsize(_HEADER_FMT)
+
+
+@dataclass
+class _MooncakeSlot(StorageSlot):
+    """Slot record. `mc_key` is the Mooncake-side key used for
+    put_from / get_into. We construct it deterministically from
+    (engine_id, layer, offset) so the key is recoverable from
+    the slot's identity."""
+
+    mc_key: str = ""
+
+
+def _build_key(engine_id: str, layer: int, offset: int) -> str:
+    """Stable, hierarchical Mooncake key. Slashes are typical
+    Mooncake convention for grouping (lets us potentially use
+    `remove_by_regex` for engine-scoped wipes)."""
+    return f"gms/{engine_id}/{int(layer)}/{int(offset)}"
+
+
+class MooncakeBackend(StorageBackend):
+    """Mooncake-backed storage tier. Requires an external master."""
+
+    name = "mooncake"
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """True iff the `mooncake.store` extension imports cleanly.
+        Whether a master is reachable is a separate constructor
+        concern."""
+        from importlib.util import find_spec
+
+        if find_spec("mooncake") is None:
+            return False
+        # The .so modules under mooncake/ link against libibverbs +
+        # cudart. Importing `mooncake.store` lazily checks this.
+        try:
+            import mooncake.store  # noqa: F401
+        except ImportError as exc:
+            logger.debug("mooncake.store import failed: %s", exc)
+            return False
+        return True
+
+    def __init__(
+        self,
+        *,
+        local_hostname: str = "localhost",
+        metadata_server: str = "",
+        master_server_addr: str = "127.0.0.1:50051",
+        global_segment_size: int = 1 << 30,  # 1 GiB
+        local_buffer_size: int = 256 << 20,  # 256 MiB
+        protocol: str = "tcp",
+        rdma_devices: str = "",
+        enable_ssd_offload: bool = False,
+        ssd_offload_path: str = "",
+        manifest_path: Optional[str] = None,
+        sync_manifest: bool = True,
+    ) -> None:
+        """`master_server_addr`: address of the running Mooncake
+        master process (`host:port`).
+        `metadata_server`: HTTP metadata server (e.g.
+        "host:port") OR `"etcd://host:port"`. Pass an empty string
+        to use the master as its own metadata source if the master
+        was launched with `--enable_http_metadata_server`.
+        `protocol`: "tcp" or "rdma". TCP works without IB hardware.
+        `sync_manifest`: when True, fsync each manifest update before
+        returning so a process crash cannot resurrect released keys.
+        """
+        if not self.is_available():
+            raise RuntimeError(
+                "MooncakeBackend requires the `mooncake` Python "
+                "package. Install per Mooncake docs and ensure "
+                "libibverbs.so.1 is on LD_LIBRARY_PATH."
+            )
+        from mooncake.store import MooncakeDistributedStore
+
+        self.local_hostname = local_hostname
+        self.master_server_addr = master_server_addr
+        self.protocol = protocol
+        self._slots: dict[tuple[str, int, int], _MooncakeSlot] = {}
+        self._lock = threading.Lock()
+        self._manifest_lock = threading.Lock()
+        self._sync_manifest = bool(sync_manifest)
+
+        self._mds = MooncakeDistributedStore()
+        # The config-dict overload is cleaner than the positional one.
+        cfg = {
+            "local_hostname": local_hostname,
+            "metadata_server": metadata_server,
+            "global_segment_size": int(global_segment_size),
+            "local_buffer_size": int(local_buffer_size),
+            "protocol": protocol,
+            "rdma_devices": rdma_devices,
+            "master_server_addr": master_server_addr,
+        }
+        if enable_ssd_offload:
+            cfg["enable_ssd_offload"] = True
+            if ssd_offload_path:
+                cfg["ssd_offload_path"] = ssd_offload_path
+        rc = self._mds.setup(cfg)
+        if rc != 0:
+            raise RuntimeError(f"MooncakeBackend setup failed: rc={rc} cfg={cfg!r}")
+
+        # Sidecar manifest for restart-replay. None = disabled (no
+        # reconcile across restarts, ephemeral mode). When set, every
+        # demote appends one JSON line; reconcile replays and filters
+        # via is_exist() so keys the master no longer has are
+        # transparently dropped.
+        self.manifest_path = manifest_path
+        self._manifest_fp = None
+        if manifest_path is not None:
+            os.makedirs(os.path.dirname(os.path.abspath(manifest_path)), exist_ok=True)
+            self._replay_manifest()
+            # Open for append AFTER replay so new records land at EOF.
+            self._manifest_fp = open(manifest_path, "ab", buffering=0)
+
+        logger.info(
+            "MooncakeBackend ready: master=%s protocol=%s " "manifest=%s indexed=%d",
+            master_server_addr,
+            protocol,
+            manifest_path or "<none>",
+            len(self._slots),
+        )
+
+    # ----- manifest replay (restart-replay) -----
+
+    def _replay_manifest(self) -> None:
+        """Read the JSON-lines manifest, dedupe by key (latest wins),
+        verify each surviving key is still in Mooncake, and populate
+        `_slots`. Missing/corrupt lines are skipped with a warning;
+        the manifest is append-only and never rewritten during
+        replay (compaction is a follow-up)."""
+        if not os.path.exists(self.manifest_path):
+            return
+        candidates: dict[tuple[str, int, int], dict] = {}
+        n_records = 0
+        n_bad = 0
+        try:
+            with open(self.manifest_path, "rb") as f:
+                for raw in f:
+                    n_records += 1
+                    try:
+                        rec = json.loads(raw)
+                        key = (
+                            str(rec["eid"]),
+                            int(rec["layer"]),
+                            int(rec["offset"]),
+                        )
+                        if bool(rec.get("deleted", False)):
+                            candidates.pop(key, None)
+                            continue
+                        # Validate required fields up front so a
+                        # truncated line caught later doesn't propagate.
+                        _ = rec["mc_key"]
+                        _ = rec["size"]
+                        _ = rec["crc"]
+                        _ = rec["mtime"]
+                        candidates[key] = rec
+                    except (ValueError, KeyError, TypeError):
+                        n_bad += 1
+                        continue
+        except OSError as exc:
+            logger.warning(
+                "MooncakeBackend: manifest read failed: %s — starting "
+                "with empty index",
+                exc,
+            )
+            return
+
+        # Now verify each candidate is still present in Mooncake.
+        # `is_exist` returns 1 if present, 0 if not, negative on
+        # transport error. We treat anything != 1 as "skip this key."
+        n_surviving = 0
+        n_lost = 0
+        for tkey, rec in candidates.items():
+            mc_key = str(rec["mc_key"])
+            try:
+                rc = self._mds.is_exist(mc_key)
+            except Exception:  # noqa: BLE001
+                rc = -1
+            if rc != 1:
+                n_lost += 1
+                continue
+            self._slots[tkey] = _MooncakeSlot(
+                size=int(rec["size"]),
+                crc=int(rec["crc"]) & 0xFFFFFFFF,
+                mtime=float(rec["mtime"]),
+                mc_key=mc_key,
+            )
+            n_surviving += 1
+        logger.info(
+            "MooncakeBackend manifest replay: records=%d bad=%d "
+            "candidates=%d surviving=%d lost=%d",
+            n_records,
+            n_bad,
+            len(candidates),
+            n_surviving,
+            n_lost,
+        )
+
+    def _write_manifest_record(self, rec: dict) -> None:
+        if self._manifest_fp is None:
+            return
+        try:
+            with self._manifest_lock:
+                self._manifest_fp.write(
+                    (json.dumps(rec) + "\n").encode("utf-8"),
+                )
+                if self._sync_manifest:
+                    os.fsync(self._manifest_fp.fileno())
+        except OSError as exc:
+            logger.warning(
+                "MooncakeBackend: manifest append failed: %s",
+                exc,
+            )
+
+    def _append_manifest(
+        self, slot: _MooncakeSlot, engine_id: str, layer: int, offset: int
+    ) -> None:
+        """Append one durable live-slot record."""
+        rec = {
+            "eid": str(engine_id),
+            "layer": int(layer),
+            "offset": int(offset),
+            "mc_key": slot.mc_key,
+            "size": int(slot.size),
+            "crc": int(slot.crc),
+            "mtime": float(slot.mtime),
+        }
+        self._write_manifest_record(rec)
+
+    def _append_tombstone(self, engine_id: str, layer: int, offset: int) -> None:
+        """Append a deletion record so manifest replay does not
+        resurrect released, pruned, or quota-evicted keys."""
+        self._write_manifest_record(
+            {
+                "eid": str(engine_id),
+                "layer": int(layer),
+                "offset": int(offset),
+                "deleted": True,
+                "mtime": time.time(),
+            }
+        )
+
+    # ----- manifest introspection / compaction -----
+
+    def manifest_size_bytes(self) -> int:
+        """Bytes on disk for the manifest file. 0 if no manifest
+        configured or the file doesn't exist yet."""
+        if self.manifest_path is None:
+            return 0
+        try:
+            return os.path.getsize(self.manifest_path)
+        except OSError:
+            return 0
+
+    def compact_manifest(self) -> int:
+        """Rewrite the manifest to contain only records for slots
+        currently in the in-memory index. Returns the byte savings
+        (old size - new size); negative if compaction grew the file
+        (shouldn't happen but defended against).
+
+        Atomic: writes a temp file in the same directory, fsyncs,
+        then renames over the existing manifest. The append fp is
+        swapped to the new file under the same lock so concurrent
+        demote()'s either land in the new file (preserved) or
+        block briefly during the swap. No-op if manifest disabled.
+
+        Compaction is the right move when the manifest has grown
+        many multiples of the live record count — typical heuristic:
+        compact when size > 4 * live_record_count * avg_record_bytes.
+        Driver lives in operator policy / the sweeper, not here."""
+        if self.manifest_path is None or self._manifest_fp is None:
+            return 0
+        with self._lock, self._manifest_lock:
+            live_items = list(self._slots.items())
+            old_size = self.manifest_size_bytes()
+
+            # Write to a temp file in the SAME directory so the
+            # rename is atomic on POSIX (cross-fs rename would copy).
+            manifest_dir = os.path.dirname(
+                os.path.abspath(self.manifest_path),
+            )
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=".manifest-compact-",
+                suffix=".jsonl",
+                dir=manifest_dir,
+            )
+            try:
+                with os.fdopen(fd, "wb") as out:
+                    for (eid, layer, offset), slot in live_items:
+                        rec = {
+                            "eid": eid,
+                            "layer": int(layer),
+                            "offset": int(offset),
+                            "mc_key": slot.mc_key,
+                            "size": int(slot.size),
+                            "crc": int(slot.crc),
+                            "mtime": float(slot.mtime),
+                        }
+                        out.write(
+                            (json.dumps(rec) + "\n").encode("utf-8"),
+                        )
+                    out.flush()
+                    os.fsync(out.fileno())
+                # Close the old append fp BEFORE the rename so we're
+                # not holding a stale inode. On Linux, rename over an
+                # open file is legal — the open fd keeps pointing at
+                # the old (now-unlinked) inode — but that's exactly
+                # the wrong behavior here.
+                try:
+                    self._manifest_fp.close()
+                except OSError:
+                    pass
+                os.rename(tmp_path, self.manifest_path)
+                tmp_path = None  # rename committed
+                # Reopen for append at the new file.
+                self._manifest_fp = open(
+                    self.manifest_path,
+                    "ab",
+                    buffering=0,
+                )
+            finally:
+                if tmp_path is not None and os.path.exists(tmp_path):
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
+            new_size = self.manifest_size_bytes()
+        savings = old_size - new_size
+        from gms_kv_ring.common import metrics
+
+        metrics.mooncake_manifest_compactions.inc()
+        logger.info(
+            "MooncakeBackend manifest compaction: %d -> %d bytes "
+            "(saved %d), live records=%d",
+            old_size,
+            new_size,
+            savings,
+            len(live_items),
+        )
+        return savings
+
+    def close(self) -> None:
+        """Drop the Mooncake connection. Caller's responsibility to
+        ensure no concurrent operations. Idempotent."""
+        with self._manifest_lock:
+            if self._manifest_fp is not None:
+                try:
+                    if self._sync_manifest:
+                        os.fsync(self._manifest_fp.fileno())
+                    self._manifest_fp.close()
+                except OSError:
+                    pass
+                self._manifest_fp = None
+        if self._mds is not None:
+            try:
+                self._mds.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._mds = None
+
+    # ----- data plane -----
+
+    def demote(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        host_ptr: int,
+        size: int,
+        crc: int,
+    ) -> _MooncakeSlot:
+        """Stage [header | payload] into a contiguous buffer and put
+        it as a single Mooncake key. The header carries the CRC +
+        size; the slot dict mirrors it so promote can verify
+        without a separate metadata round trip."""
+        eid = str(engine_id)
+        key = _build_key(eid, layer, offset)
+        total_size = _HEADER_SIZE + int(size)
+
+        # Staging buffer: header bytes + payload bytes contiguous.
+        # Each demote allocates one; production would reuse a pool.
+        staging = (ctypes.c_ubyte * total_size)()
+        header = struct.pack(
+            _HEADER_FMT,
+            _MAGIC,
+            _VERSION,
+            int(crc) & 0xFFFFFFFF,
+            int(size),
+            0,
+        )
+        ctypes.memmove(
+            ctypes.addressof(staging),
+            header,
+            _HEADER_SIZE,
+        )
+        ctypes.memmove(
+            ctypes.addressof(staging) + _HEADER_SIZE,
+            int(host_ptr),
+            int(size),
+        )
+
+        rc = self._mds.put_from(
+            key,
+            ctypes.addressof(staging),
+            total_size,
+        )
+        if rc != 0:
+            raise RuntimeError(f"MooncakeBackend.demote: put_from rc={rc} key={key!r}")
+
+        slot = _MooncakeSlot(
+            size=int(size),
+            crc=int(crc) & 0xFFFFFFFF,
+            mtime=time.time(),
+            mc_key=key,
+        )
+        with self._lock:
+            self._slots[(eid, int(layer), int(offset))] = slot
+        # Append after the index is committed so an exception in
+        # _append_manifest can't leave the index empty but the
+        # manifest claiming the slot exists.
+        self._append_manifest(slot, eid, layer, offset)
+        return slot
+
+    def promote(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        dest_host_ptr: int,
+        max_size: int,
+    ) -> Optional[int]:
+        """get_into a temp [header | payload] buffer, validate
+        header against the slot, memmove payload into the
+        engine's destination, recompute CRC to detect any
+        in-transit/at-rest corruption."""
+        from gms_kv_ring.common.checksum import crc32_at_ptr
+
+        eid = str(engine_id)
+        with self._lock:
+            slot = self._slots.get((eid, int(layer), int(offset)))
+        if slot is None:
+            return None
+        if slot.size > int(max_size):
+            logger.warning(
+                "MooncakeBackend.promote: slot.size=%d > max_size=%d",
+                slot.size,
+                max_size,
+            )
+            return None
+        total_size = _HEADER_SIZE + int(slot.size)
+
+        staging = (ctypes.c_ubyte * total_size)()
+        rc = self._mds.get_into(
+            slot.mc_key,
+            ctypes.addressof(staging),
+            total_size,
+        )
+        # get_into returns bytes read on success (>= 0) and a
+        # negative error code on failure. We just need not-negative
+        # AND the expected total_size to make it back.
+        if rc < 0:
+            logger.warning(
+                "MooncakeBackend.promote: get_into rc=%d key=%s",
+                rc,
+                slot.mc_key,
+            )
+            return None
+        if rc != total_size:
+            logger.warning(
+                "MooncakeBackend.promote: short read rc=%d expected=%d " "key=%s",
+                rc,
+                total_size,
+                slot.mc_key,
+            )
+            return None
+
+        # Validate header bytes match the slot.
+        hdr_bytes = bytes(
+            ctypes.string_at(
+                ctypes.addressof(staging),
+                _HEADER_SIZE,
+            )
+        )
+        magic, version, file_crc, file_size, _pad = struct.unpack(
+            _HEADER_FMT,
+            hdr_bytes,
+        )
+        if (
+            magic != _MAGIC
+            or version != _VERSION
+            or file_size != slot.size
+            or file_crc != slot.crc
+        ):
+            logger.warning(
+                "MooncakeBackend.promote: header/index mismatch for %s",
+                slot.mc_key,
+            )
+            return None
+
+        # Copy payload portion to the engine's destination.
+        ctypes.memmove(
+            int(dest_host_ptr),
+            ctypes.addressof(staging) + _HEADER_SIZE,
+            int(slot.size),
+        )
+        # Re-CRC at the engine's dest to catch any munging through
+        # the copy path or at-rest bit-flips.
+        actual = crc32_at_ptr(int(dest_host_ptr), int(slot.size))
+        if actual != slot.crc:
+            logger.warning(
+                "MooncakeBackend.promote: CRC mismatch for %s: "
+                "stored=%#x actual=%#x",
+                slot.mc_key,
+                slot.crc,
+                actual,
+            )
+            return None
+        return slot.crc
+
+    # ----- index + lifecycle -----
+
+    def get(self, engine_id, layer, offset) -> Optional[_MooncakeSlot]:
+        with self._lock:
+            return self._slots.get(
+                (str(engine_id), int(layer), int(offset)),
+            )
+
+    def release_slot(self, engine_id, layer, offset) -> bool:
+        eid = str(engine_id)
+        with self._lock:
+            slot = self._slots.pop(
+                (eid, int(layer), int(offset)),
+                None,
+            )
+        if slot is None:
+            return False
+        self._free_resource(slot)
+        self._append_tombstone(eid, layer, offset)
+        return True
+
+    def release_if_current(self, engine_id, layer, offset, expected) -> bool:
+        key = (str(engine_id), int(layer), int(offset))
+        with self._lock:
+            if self._slots.get(key) is not expected:
+                return False
+            slot = self._slots.pop(key)
+        self._free_resource(slot)
+        self._append_tombstone(key[0], key[1], key[2])
+        return True
+
+    def release_engine(self, engine_id) -> int:
+        eid = str(engine_id)
+        with self._lock:
+            keys = [k for k in self._slots if k[0] == eid]
+            to_free = [self._slots.pop(k) for k in keys]
+        for key, slot in zip(keys, to_free):
+            self._free_resource(slot)
+            self._append_tombstone(key[0], key[1], key[2])
+        return len(to_free)
+
+    def _free_resource(self, slot: _MooncakeSlot) -> None:
+        try:
+            self._mds.remove(slot.mc_key)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "MooncakeBackend._free_resource: remove(%s) failed: %s",
+                slot.mc_key,
+                exc,
+            )
+
+    # ----- observability -----
+
+    def n_slots(self) -> int:
+        with self._lock:
+            return len(self._slots)
+
+    def total_bytes(self) -> int:
+        with self._lock:
+            return sum(s.size for s in self._slots.values())
+
+    def bytes_by_engine(self) -> dict[str, int]:
+        out: dict[str, int] = {}
+        with self._lock:
+            for (eid, _l, _o), s in self._slots.items():
+                out[eid] = out.get(eid, 0) + s.size
+        return out
+
+    def stats(self) -> dict:
+        with self._lock:
+            slots = list(self._slots.items())
+        if not slots:
+            return {
+                "n_slots": 0,
+                "total_bytes": 0,
+                "oldest_mtime": 0.0,
+                "newest_mtime": 0.0,
+                "bytes_by_engine": {},
+            }
+        by_eng: dict[str, int] = {}
+        for (eid, _l, _o), s in slots:
+            by_eng[eid] = by_eng.get(eid, 0) + s.size
+        return {
+            "n_slots": len(slots),
+            "total_bytes": sum(s.size for _k, s in slots),
+            "oldest_mtime": min(s.mtime for _k, s in slots),
+            "newest_mtime": max(s.mtime for _k, s in slots),
+            "bytes_by_engine": by_eng,
+        }
+
+    # ----- cleanup (same shape as Local / NIXL) -----
+
+    def prune_older_than(self, max_age_seconds, now=None) -> int:
+        if now is None:
+            now = time.time()
+        threshold = float(now) - float(max_age_seconds)
+        with self._lock:
+            to_remove = [
+                (k, s) for k, s in list(self._slots.items()) if s.mtime < threshold
+            ]
+            for k, _ in to_remove:
+                self._slots.pop(k, None)
+        for key, slot in to_remove:
+            self._free_resource(slot)
+            self._append_tombstone(key[0], key[1], key[2])
+        return len(to_remove)
+
+    def enforce_byte_quota(self, max_bytes) -> int:
+        max_bytes = int(max_bytes)
+        with self._lock:
+            current = sum(s.size for s in self._slots.values())
+            if current <= max_bytes:
+                return 0
+            ordered = sorted(
+                self._slots.items(),
+                key=lambda kv: kv[1].mtime,
+            )
+            to_remove = []
+            for k, s in ordered:
+                if current <= max_bytes:
+                    break
+                to_remove.append((k, s))
+                current -= s.size
+            for k, _ in to_remove:
+                self._slots.pop(k, None)
+        for key, slot in to_remove:
+            self._free_resource(slot)
+            self._append_tombstone(key[0], key[1], key[2])
+        return len(to_remove)
+
+    def enforce_per_engine_byte_quota(
+        self,
+        max_bytes_per_engine,
+    ) -> int:
+        cap = int(max_bytes_per_engine)
+        with self._lock:
+            by_eng: dict[str, list] = {}
+            for k, s in self._slots.items():
+                by_eng.setdefault(k[0], []).append((k, s))
+            to_remove = []
+            for _eid, items in by_eng.items():
+                current = sum(s.size for _, s in items)
+                if current <= cap:
+                    continue
+                items.sort(key=lambda kv: kv[1].mtime)
+                for k, s in items:
+                    if current <= cap:
+                        break
+                    to_remove.append((k, s))
+                    current -= s.size
+            for k, _ in to_remove:
+                self._slots.pop(k, None)
+        for key, slot in to_remove:
+            self._free_resource(slot)
+            self._append_tombstone(key[0], key[1], key[2])
+        return len(to_remove)

--- a/lib/gms_kv_ring/daemon/backends_nixl.py
+++ b/lib/gms_kv_ring/daemon/backends_nixl.py
@@ -1,0 +1,1405 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NIXL-backed storage tier.
+
+ROLE IN THE BACKEND STRATEGY: this is the **production** backend.
+Today it is the only path that supports GPU-direct storage I/O
+(GDS / GDS_MT plugins), and via its plugin matrix it functionally
+supersedes the Local backend (POSIX plugin = same byte-level
+capabilities) and a subset of Mooncake (UCX for RDMA fabric,
+OBJ/AZURE_BLOB for object stores). New GMS features
+(restore-on-hit, async ring, `dest_offset` remap) land here first;
+Local is for dev/test/CI, and Mooncake is for integrators with
+an existing Mooncake-store deployment (feature-frozen surface;
+new features port on demand only).
+
+NIXL is NVIDIA's unified transport abstraction over UCX, GDS, POSIX,
+GDS_MT, OBJ (S3), AZURE_BLOB and GUSLI plugins. This backend supports
+several plugin modes:
+
+  POSIX (default): local/networked files. Files live under `base_dir`
+    in a `<engine>/<layer>/<offset>.bin` tree. Reconcile walks the
+    filesystem on startup. No manifest needed; the directory is the
+    source of truth.
+
+  GDS / GDS_MT: GPUDirect Storage. Same file layout as POSIX, but
+    the data plane can DMA directly between GPU HBM and the file
+    bypassing CPU staging — when the source is a VRAM_SEG (GPU
+    pointer). Use `demote_from_gpu` / `promote_into_gpu` to take
+    that path; plain `demote` / `promote` still work with a host
+    pointer (then GDS plugin falls back to a CPU-staged path
+    equivalent to POSIX). Requires a GDS-capable filesystem
+    (NVMe with cuFile-enabled mount, BeeGFS, Lustre, etc.) for
+    the actual GPU-direct benefit; on a non-GDS mount the
+    transfer succeeds but routes through host RAM.
+
+  OBJ: S3-compatible object storage. Slots are addressed by string
+    key, not filesystem path. NIXL doesn't expose list-objects via
+    its Python API, so OBJ requires a sidecar JSONL manifest (same
+    shape and replay semantics as the Mooncake backend). Pass
+    `manifest_path` at construction. The bucket is configured via
+    `AWS_DEFAULT_BUCKET` env var or `backend_init_params={"bucket":
+    "..."}`.
+
+File format on disk is bit-identical to `StorageTier` (LocalStorage):
+24-byte CRC32-stamped header + payload. A NIXL-written file can be
+read by a Local backend and vice versa — useful for migration.
+
+Atomic write: like Local, demote writes to a temp file, fsyncs, then
+renames into place. Reconcile (called from the inherited
+`__init__`) ignores any `.tmp-*` leftovers from a crash.
+
+Performance: for the POSIX plugin specifically, NIXL adds agent
+overhead vs raw pread/pwrite — perf parity with the Local backend,
+maybe a hair slower. The architectural win is plugin substitution:
+swapping POSIX for GDS (GPUDirect Storage), OBJ (S3), or GDS_MT
+later is a configuration change, not a code rewrite. NIXL is also
+where the Mooncake-style distributed RAM path lands when we
+introduce a UCX plugin selection.
+
+Concurrency: NIXL agents are thread-safe for concurrent transfers
+on different xfer handles. We hold `self._lock` only for the slot
+index update; the NIXL transfer happens outside the lock.
+
+Optimization deferred: per-transfer register/deregister is paying a
+sys call cost per block. A real production version would
+pre-register a host-buffer pool once and reuse the registration
+across transfers. Same for the file fd: open-on-demote, close-on-
+done is simpler; a per-engine fd cache would be faster."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import struct
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import quote, unquote
+
+from gms_kv_ring.daemon.backend import StorageBackend, StorageSlot
+
+logger = logging.getLogger(__name__)
+
+
+# Same header format as LocalStorageBackend — files are
+# interchangeable between Local and NIXL backends.
+_MAGIC = 0x47535453  # 'STSG' ('GSTS' little-endian)
+_VERSION = 1
+_HEADER_FMT = "<IIIIQ"  # magic, version, crc, size, _pad
+_HEADER_SIZE = struct.calcsize(_HEADER_FMT)
+
+# Transfer polling cadence. Short enough to keep latency low,
+# long enough to avoid spin-burning a core under load.
+_POLL_S = 1e-4
+
+# Plugins that store data in files on a (possibly distributed)
+# filesystem — POSIX semantics for atomic write + reconcile.
+# GDS/GDS_MT use the same file layout; what differs is whether
+# the source register is DRAM_SEG (CPU-staged) or VRAM_SEG (GPU
+# direct), driven by which demote/promote method the caller uses.
+_FILE_PLUGINS = frozenset({"POSIX", "GDS", "GDS_MT"})
+
+
+@dataclass
+class _NixlSlot(StorageSlot):
+    """Slot record for NIXL backend. Same fields as Local — file
+    path is the resource handle. We could attach a cached fd /
+    registration here for repeat-access optimization (deferred)."""
+
+    path: str = ""
+
+
+class NixlBackend(StorageBackend):
+    """NIXL-backed storage tier. POSIX plugin by default."""
+
+    name = "nixl"
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """True iff `nixl` Python binding imports cleanly. Doesn't
+        guarantee a specific plugin works — that's checked at
+        construction time."""
+        from importlib.util import find_spec
+
+        return find_spec("nixl") is not None
+
+    def supports_gpu_direct(self) -> bool:
+        """GPU-direct data plane is available only under the GDS /
+        GDS_MT plugins. POSIX/OBJ go through CPU pinned host."""
+        return self.plugin in ("GDS", "GDS_MT")
+
+    def __init__(
+        self,
+        base_dir: str,
+        *,
+        plugin: str = "POSIX",
+        agent_name: Optional[str] = None,
+        backend_init_params: Optional[dict] = None,
+        manifest_path: Optional[str] = None,
+        bucket: Optional[str] = None,
+        sync_manifest: bool = True,
+    ) -> None:
+        """`base_dir`: filesystem path for POSIX-backed files. Ignored
+        in OBJ mode (objects live in the bucket, not on local disk),
+        but still used as the parent dir for the sidecar manifest by
+        default.
+        `plugin`: NIXL plugin to use. Must be in `get_plugin_list()`.
+        Today: POSIX (files) and OBJ (S3-compatible) are validated;
+        other plugins (GDS, UCX, ...) are accepted but data-plane
+        code paths haven't been exercised.
+        `agent_name`: optional explicit name; default is a uuid.
+        `backend_init_params`: forwarded to `agent.create_backend()`.
+        For OBJ, `bucket` is required either here or via
+        `AWS_DEFAULT_BUCKET` env or the `bucket=` kwarg.
+        `manifest_path`: required for OBJ (no list-objects API).
+        Optional for POSIX (FS walk is the source of truth).
+        `bucket`: convenience kwarg that maps to
+        backend_init_params["bucket"]. Overrides env."""
+        if not self.is_available():
+            raise RuntimeError(
+                "NixlBackend requires the `nixl` Python binding. "
+                "Install per NIXL docs and ensure the desired plugin "
+                "is on LD_LIBRARY_PATH."
+            )
+        from nixl._api import nixl_agent, nixl_agent_config
+
+        self.base_dir = os.path.abspath(base_dir)
+        os.makedirs(self.base_dir, exist_ok=True)
+        self.plugin = plugin
+        self.agent_name = agent_name or f"gms-kvr-nixl-{uuid.uuid4().hex[:8]}"
+        self._slots: dict[tuple[str, int, int], _NixlSlot] = {}
+        self._lock = threading.Lock()
+        self._manifest_lock = threading.Lock()
+        self._sync_manifest = bool(sync_manifest)
+
+        # OBJ-specific config: bucket. Resolve before create_backend
+        # so the error message points at the right knob.
+        init_params = dict(backend_init_params or {})
+        if plugin == "OBJ":
+            if bucket is not None:
+                init_params["bucket"] = bucket
+            if "bucket" not in init_params:
+                env_bucket = os.environ.get("AWS_DEFAULT_BUCKET")
+                if not env_bucket:
+                    raise RuntimeError(
+                        "NixlBackend(plugin='OBJ') requires a bucket. "
+                        "Pass `bucket=` kwarg, set "
+                        "`backend_init_params={'bucket': '...'}`, or "
+                        "set AWS_DEFAULT_BUCKET in the environment."
+                    )
+                init_params["bucket"] = env_bucket
+            if manifest_path is None:
+                raise RuntimeError(
+                    "NixlBackend(plugin='OBJ') requires `manifest_path` "
+                    "because NIXL doesn't expose list-objects — the "
+                    "manifest is the only restart-replay source."
+                )
+
+        # Construct the agent and instantiate the plugin. Constructing
+        # the agent always brings up UCX (used for control); we add
+        # POSIX (or whatever) for the data plane.
+        self._agent = nixl_agent(
+            self.agent_name,
+            nixl_agent_config(backends=[]),
+        )
+        plugins = self._agent.get_plugin_list()
+        if plugin not in plugins:
+            raise RuntimeError(
+                f"NIXL plugin {plugin!r} not in available plugins " f"{plugins!r}"
+            )
+        self._agent.create_backend(plugin, init_params)
+
+        # Sidecar manifest (OBJ requires it; POSIX may also enable it
+        # for cross-backend interop or extra-fast reconcile).
+        self.manifest_path = manifest_path
+        self._manifest_fp = None
+        if manifest_path is not None:
+            os.makedirs(os.path.dirname(os.path.abspath(manifest_path)), exist_ok=True)
+            self._replay_manifest()
+            self._manifest_fp = open(manifest_path, "ab", buffering=0)
+
+        # File-based plugins (POSIX, GDS, GDS_MT) additionally walk
+        # the filesystem. (If manifest was also enabled, FS walk runs
+        # second and merges — manifest entries that point at missing
+        # files get dropped here.)
+        if plugin in _FILE_PLUGINS:
+            self._reconcile_from_disk()
+        logger.info(
+            "NixlBackend ready: plugin=%s base_dir=%s manifest=%s " "indexed=%d",
+            plugin,
+            self.base_dir,
+            manifest_path or "<none>",
+            len(self._slots),
+        )
+
+    # ----- path / reconcile helpers (same shape as Local) -----
+
+    def _path_for(self, engine_id: str, layer: int, offset: int) -> str:
+        safe = quote(str(engine_id), safe="")
+        return os.path.join(
+            self.base_dir,
+            safe,
+            str(int(layer)),
+            f"{int(offset)}.bin",
+        )
+
+    def _reconcile_from_disk(self) -> None:
+        """Walk base_dir and rebuild `_slots` by reading each file's
+        24-byte header. Cleans up torn `.tmp-*` files. Same logic +
+        file format as LocalStorageBackend, so a NIXL backend can
+        adopt files written by Local and vice versa."""
+        n_indexed = n_torn = n_bad = 0
+        seen: set[tuple[str, int, int]] = set()
+        for dirpath, _dirnames, filenames in os.walk(self.base_dir):
+            for fn in filenames:
+                full = os.path.join(dirpath, fn)
+                if fn.startswith(".tmp-"):
+                    try:
+                        os.unlink(full)
+                        n_torn += 1
+                    except OSError:
+                        pass
+                    continue
+                if not fn.endswith(".bin"):
+                    continue
+                rel = os.path.relpath(full, self.base_dir)
+                parts = rel.split(os.sep)
+                if len(parts) != 3:
+                    continue
+                try:
+                    eid = unquote(parts[0])
+                    layer = int(parts[1])
+                    offset = int(parts[2][: -len(".bin")])
+                except ValueError:
+                    continue
+                slot = self._read_header(full)
+                if slot is None:
+                    n_bad += 1
+                    continue
+                key = (eid, layer, offset)
+                self._slots[key] = slot
+                seen.add(key)
+                n_indexed += 1
+        n_missing = 0
+        if self.manifest_path is not None:
+            for key, slot in list(self._slots.items()):
+                if key in seen and os.path.exists(slot.path):
+                    continue
+                self._slots.pop(key, None)
+                n_missing += 1
+        if n_indexed or n_torn or n_bad or n_missing:
+            logger.info(
+                "NixlBackend reconcile: indexed=%d torn=%d bad=%d "
+                "manifest_missing=%d",
+                n_indexed,
+                n_torn,
+                n_bad,
+                n_missing,
+            )
+
+    def _read_header(self, path: str) -> Optional[_NixlSlot]:
+        try:
+            with open(path, "rb") as f:
+                hdr = f.read(_HEADER_SIZE)
+                if len(hdr) != _HEADER_SIZE:
+                    return None
+                magic, version, crc, size, _pad = struct.unpack(
+                    _HEADER_FMT,
+                    hdr,
+                )
+                if magic != _MAGIC or version != _VERSION:
+                    return None
+                f.seek(0, 2)
+                if f.tell() < _HEADER_SIZE + size:
+                    logger.warning(
+                        "NixlBackend reconcile: truncated %s",
+                        path,
+                    )
+                    return None
+            try:
+                mtime = os.path.getmtime(path)
+            except OSError:
+                mtime = time.time()
+            return _NixlSlot(
+                size=int(size),
+                crc=int(crc) & 0xFFFFFFFF,
+                mtime=mtime,
+                path=path,
+            )
+        except OSError as exc:
+            logger.warning("NixlBackend reconcile: %s: %s", path, exc)
+            return None
+
+    # ----- sidecar manifest (used by OBJ, optional for POSIX) -----
+
+    def _replay_manifest(self) -> None:
+        """Read the JSONL manifest. Same shape as MooncakeBackend's:
+        one record per slot, keyed (eid, layer, offset). For OBJ we
+        can't double-check existence via NIXL (no list/head op), so
+        we accept every well-formed record. POSIX additionally runs
+        `_reconcile_from_disk` which drops slots whose files are
+        missing — that's the existence check."""
+        if not os.path.exists(self.manifest_path):
+            return
+        candidates: dict[tuple[str, int, int], dict] = {}
+        n_records = n_bad = 0
+        try:
+            with open(self.manifest_path, "rb") as f:
+                for raw in f:
+                    n_records += 1
+                    try:
+                        rec = json.loads(raw)
+                        key = (
+                            str(rec["eid"]),
+                            int(rec["layer"]),
+                            int(rec["offset"]),
+                        )
+                        if bool(rec.get("deleted", False)):
+                            candidates.pop(key, None)
+                            continue
+                        _ = rec["path"]
+                        _ = rec["size"]
+                        _ = rec["crc"]
+                        _ = rec["mtime"]
+                        candidates[key] = rec
+                    except (ValueError, KeyError, TypeError):
+                        n_bad += 1
+        except OSError as exc:
+            logger.warning(
+                "NixlBackend: manifest read failed: %s",
+                exc,
+            )
+            return
+        for tkey, rec in candidates.items():
+            self._slots[tkey] = _NixlSlot(
+                size=int(rec["size"]),
+                crc=int(rec["crc"]) & 0xFFFFFFFF,
+                mtime=float(rec["mtime"]),
+                path=str(rec["path"]),
+            )
+        logger.info(
+            "NixlBackend manifest replay: records=%d bad=%d " "indexed=%d",
+            n_records,
+            n_bad,
+            len(candidates),
+        )
+
+    def _write_manifest_record(self, rec: dict) -> None:
+        if self._manifest_fp is None:
+            return
+        with self._manifest_lock:
+            self._manifest_fp.write(
+                (json.dumps(rec) + "\n").encode("utf-8"),
+            )
+            if self._sync_manifest:
+                os.fsync(self._manifest_fp.fileno())
+
+    def _append_manifest(
+        self,
+        slot: _NixlSlot,
+        engine_id: str,
+        layer: int,
+        offset: int,
+    ) -> None:
+        """Append one durable live-slot record."""
+        rec = {
+            "eid": str(engine_id),
+            "layer": int(layer),
+            "offset": int(offset),
+            "path": slot.path,
+            "size": int(slot.size),
+            "crc": int(slot.crc),
+            "mtime": float(slot.mtime),
+        }
+        self._write_manifest_record(rec)
+
+    def _append_tombstone(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+    ) -> None:
+        """Append a deletion record so manifest replay does not
+        resurrect released slots. Required for OBJ, which has no delete
+        API in NIXL, and useful for file-plugin manifests too."""
+        self._write_manifest_record(
+            {
+                "eid": str(engine_id),
+                "layer": int(layer),
+                "offset": int(offset),
+                "deleted": True,
+                "mtime": time.time(),
+            }
+        )
+
+    def manifest_size_bytes(self) -> int:
+        if self.manifest_path is None:
+            return 0
+        try:
+            return os.path.getsize(self.manifest_path)
+        except OSError:
+            return 0
+
+    def compact_manifest(self) -> int:
+        """Atomic rewrite-then-rename. Same shape as Mooncake's."""
+        if self.manifest_path is None or self._manifest_fp is None:
+            return 0
+        with self._lock, self._manifest_lock:
+            live = list(self._slots.items())
+            old_size = self.manifest_size_bytes()
+            manifest_dir = os.path.dirname(
+                os.path.abspath(self.manifest_path),
+            )
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=".manifest-compact-",
+                suffix=".jsonl",
+                dir=manifest_dir,
+            )
+            try:
+                with os.fdopen(fd, "wb") as out:
+                    for (eid, layer, offset), slot in live:
+                        rec = {
+                            "eid": eid,
+                            "layer": int(layer),
+                            "offset": int(offset),
+                            "path": slot.path,
+                            "size": int(slot.size),
+                            "crc": int(slot.crc),
+                            "mtime": float(slot.mtime),
+                        }
+                        out.write(
+                            (json.dumps(rec) + "\n").encode("utf-8"),
+                        )
+                    out.flush()
+                    os.fsync(out.fileno())
+                try:
+                    self._manifest_fp.close()
+                except OSError:
+                    pass
+                os.rename(tmp_path, self.manifest_path)
+                tmp_path = None
+                self._manifest_fp = open(
+                    self.manifest_path,
+                    "ab",
+                    buffering=0,
+                )
+            finally:
+                if tmp_path is not None and os.path.exists(tmp_path):
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
+            new_size = self.manifest_size_bytes()
+        savings = old_size - new_size
+        logger.info(
+            "NixlBackend manifest compaction: %d -> %d bytes "
+            "(saved %d), live records=%d",
+            old_size,
+            new_size,
+            savings,
+            len(live),
+        )
+        return savings
+
+    # ----- internal: one NIXL transfer (POSIX or OBJ) -----
+
+    def _do_nixl_xfer_posix(
+        self,
+        direction: str,
+        host_ptr: int,
+        payload_size: int,
+        fd: int,
+        file_offset: int,
+    ) -> None:
+        """POSIX-plugin transfer: source/dest is an open file fd."""
+        self._do_nixl_xfer(
+            direction,
+            host_descs_3tup=[(int(host_ptr), int(payload_size), 0)],
+            storage_descs_3tup=[(int(file_offset), int(payload_size), int(fd))],
+            storage_reg_4tup=[
+                (
+                    int(file_offset),
+                    int(payload_size),
+                    int(fd),
+                    "",
+                )
+            ],
+            storage_mem_type="FILE",
+            host_reg_4tup=[(int(host_ptr), int(payload_size), 0, "")],
+        )
+
+    def _do_nixl_xfer_gds(
+        self,
+        direction: str,
+        gpu_ptr: int,
+        payload_size: int,
+        fd: int,
+        file_offset: int,
+    ) -> None:
+        """GDS-plugin transfer with a VRAM source. Register source as
+        VRAM_SEG so the GDS plugin sees a GPU pointer; destination
+        stays a file fd. On a GDS-capable filesystem this becomes a
+        true GPUDirect Storage DMA bypassing CPU. On non-GDS mounts
+        the transfer succeeds but routes through host RAM (cuFile's
+        compat-mode fallback)."""
+        self._do_nixl_xfer(
+            direction,
+            host_descs_3tup=[(int(gpu_ptr), int(payload_size), 0)],
+            storage_descs_3tup=[(int(file_offset), int(payload_size), int(fd))],
+            storage_reg_4tup=[
+                (
+                    int(file_offset),
+                    int(payload_size),
+                    int(fd),
+                    "",
+                )
+            ],
+            storage_mem_type="FILE",
+            host_reg_4tup=[(int(gpu_ptr), int(payload_size), 0, "")],
+            host_mem_type="VRAM",
+        )
+
+    def _do_nixl_xfer_obj(
+        self,
+        direction: str,
+        host_ptr: int,
+        payload_size: int,
+        obj_key: str,
+    ) -> None:
+        """OBJ-plugin transfer: source/dest is an S3-compatible object
+        addressed by string key. NIXL tuple shape differs from POSIX:
+          register tuple: (0, 0, key_string, "") — key in slot 2
+          xfer descriptor: (0, size, key_string)
+        Per the NIXL Python binding's convention (mirrored from
+        SGLang's hicache_nixl)."""
+        self._do_nixl_xfer(
+            direction,
+            host_descs_3tup=[(int(host_ptr), int(payload_size), 0)],
+            storage_descs_3tup=[(0, int(payload_size), obj_key)],
+            storage_reg_4tup=[(0, 0, obj_key, "")],
+            storage_mem_type="OBJ",
+            host_reg_4tup=[(int(host_ptr), int(payload_size), 0, "")],
+        )
+
+    def _do_nixl_xfer(
+        self,
+        direction: str,
+        host_descs_3tup: list,
+        storage_descs_3tup: list,
+        storage_reg_4tup: list,
+        storage_mem_type: str,
+        host_reg_4tup: list,
+        host_mem_type: str = "DRAM",
+    ) -> None:
+        """Generic NIXL transfer. Tuple shapes are plugin-specific
+        (see _do_nixl_xfer_posix / _do_nixl_xfer_obj /
+        _do_nixl_xfer_gds). `host_mem_type` selects DRAM_SEG (CPU
+        pinned host) or VRAM_SEG (GPU pinned). Blocks until DONE;
+        raises on ERR / timeout."""
+        host_reg = None
+        storage_reg = None
+        xfer = None
+        try:
+            host_reg = self._agent.register_memory(
+                self._agent.get_reg_descs(host_reg_4tup, host_mem_type),
+            )
+            storage_reg = self._agent.register_memory(
+                self._agent.get_reg_descs(
+                    storage_reg_4tup,
+                    storage_mem_type,
+                ),
+            )
+            host_descs = self._agent.get_xfer_descs(
+                host_descs_3tup,
+                host_mem_type,
+            )
+            storage_descs = self._agent.get_xfer_descs(
+                storage_descs_3tup,
+                storage_mem_type,
+            )
+            xfer = self._agent.initialize_xfer(
+                direction,
+                host_descs,
+                storage_descs,
+                self.agent_name,
+            )
+            state = self._agent.transfer(xfer)
+            deadline = time.monotonic() + 60.0
+            while state not in ("DONE", "ERR"):
+                if time.monotonic() > deadline:
+                    raise RuntimeError(f"NIXL {direction} timed out after 60s")
+                state = self._agent.check_xfer_state(xfer)
+                if state not in ("DONE", "ERR"):
+                    time.sleep(_POLL_S)
+            if state == "ERR":
+                raise RuntimeError(f"NIXL {direction} returned ERR state")
+        finally:
+            if xfer is not None:
+                try:
+                    self._agent.release_xfer_handle(xfer)
+                except Exception:
+                    pass  # noqa: BLE001
+            if host_reg is not None:
+                try:
+                    self._agent.deregister_memory(host_reg)
+                except Exception:
+                    pass  # noqa: BLE001
+            if storage_reg is not None:
+                try:
+                    self._agent.deregister_memory(storage_reg)
+                except Exception:
+                    pass  # noqa: BLE001
+
+    # ----- data plane -----
+
+    def _obj_key_for(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+    ) -> str:
+        """Object key for OBJ mode. Hierarchical for grouping;
+        bucket prefix is set in the agent's plugin config."""
+        return f"gms/{engine_id}/{int(layer)}/{int(offset)}"
+
+    def demote(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        host_ptr: int,
+        size: int,
+        crc: int,
+    ) -> _NixlSlot:
+        """Write pinned-host bytes via the selected NIXL plugin.
+
+        POSIX: atomic-rename file write with 24-byte header pwritten
+        at offset 0, payload via NIXL.
+        OBJ: stage [header | payload] in a contiguous buffer, push
+        the whole blob as one object via NIXL. (S3 has no analog
+        to fsync-then-rename; the object becomes visible only on
+        success.)"""
+        key = (str(engine_id), int(layer), int(offset))
+        if self.plugin in _FILE_PLUGINS:
+            final_path = self._path_for(engine_id, layer, offset)
+            os.makedirs(os.path.dirname(final_path), exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=".tmp-",
+                suffix=".bin",
+                dir=os.path.dirname(final_path),
+            )
+            try:
+                header = struct.pack(
+                    _HEADER_FMT,
+                    _MAGIC,
+                    _VERSION,
+                    int(crc) & 0xFFFFFFFF,
+                    int(size),
+                    0,
+                )
+                os.pwrite(fd, header, 0)
+                os.ftruncate(fd, _HEADER_SIZE + int(size))
+                self._do_nixl_xfer_posix(
+                    "WRITE",
+                    host_ptr=host_ptr,
+                    payload_size=int(size),
+                    fd=fd,
+                    file_offset=_HEADER_SIZE,
+                )
+                os.fsync(fd)
+                os.close(fd)
+                fd = -1
+                os.rename(tmp_path, final_path)
+                tmp_path = None
+            finally:
+                if fd >= 0:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+                if tmp_path is not None and os.path.exists(tmp_path):
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
+            slot = _NixlSlot(
+                size=int(size),
+                crc=int(crc) & 0xFFFFFFFF,
+                mtime=time.time(),
+                path=final_path,
+            )
+        elif self.plugin == "OBJ":
+            import ctypes
+
+            obj_key = self._obj_key_for(engine_id, layer, offset)
+            total_size = _HEADER_SIZE + int(size)
+            staging = (ctypes.c_ubyte * total_size)()
+            header = struct.pack(
+                _HEADER_FMT,
+                _MAGIC,
+                _VERSION,
+                int(crc) & 0xFFFFFFFF,
+                int(size),
+                0,
+            )
+            ctypes.memmove(
+                ctypes.addressof(staging),
+                header,
+                _HEADER_SIZE,
+            )
+            ctypes.memmove(
+                ctypes.addressof(staging) + _HEADER_SIZE,
+                int(host_ptr),
+                int(size),
+            )
+            self._do_nixl_xfer_obj(
+                "WRITE",
+                host_ptr=ctypes.addressof(staging),
+                payload_size=total_size,
+                obj_key=obj_key,
+            )
+            slot = _NixlSlot(
+                size=int(size),
+                crc=int(crc) & 0xFFFFFFFF,
+                mtime=time.time(),
+                path=obj_key,
+            )
+        else:
+            raise NotImplementedError(
+                f"NixlBackend.demote: plugin {self.plugin!r} "
+                "data-plane not implemented in this commit. "
+                "POSIX and OBJ are supported."
+            )
+        with self._lock:
+            self._slots[key] = slot
+        self._append_manifest(slot, engine_id, layer, offset)
+        return slot
+
+    def promote(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        dest_host_ptr: int,
+        max_size: int,
+    ) -> Optional[int]:
+        """Read back via the selected NIXL plugin, verify CRC.
+
+        POSIX: pread+validate the 24-byte header, NIXL READ for
+        payload into the engine's dest, re-CRC at dest.
+        OBJ: NIXL READ the whole [header | payload] blob into a
+        staging buffer, validate header, memmove payload to dest,
+        re-CRC at dest."""
+        from gms_kv_ring.common.checksum import crc32_at_ptr
+
+        key = (str(engine_id), int(layer), int(offset))
+        with self._lock:
+            slot = self._slots.get(key)
+        if slot is None:
+            return None
+        if slot.size > int(max_size):
+            logger.warning(
+                "NixlBackend promote: slot.size=%d > max_size=%d",
+                slot.size,
+                max_size,
+            )
+            return None
+
+        if self.plugin in _FILE_PLUGINS:
+            try:
+                fd = os.open(slot.path, os.O_RDONLY)
+            except OSError as exc:
+                logger.warning(
+                    "NixlBackend promote: open(%s) failed: %s",
+                    slot.path,
+                    exc,
+                )
+                return None
+            try:
+                hdr = os.pread(fd, _HEADER_SIZE, 0)
+                if len(hdr) != _HEADER_SIZE:
+                    return None
+                magic, version, file_crc, file_size, _pad = struct.unpack(
+                    _HEADER_FMT, hdr
+                )
+                if (
+                    magic != _MAGIC
+                    or version != _VERSION
+                    or file_size != slot.size
+                    or file_crc != slot.crc
+                ):
+                    logger.warning(
+                        "NixlBackend promote: header/index mismatch " "for %r",
+                        key,
+                    )
+                    return None
+                try:
+                    self._do_nixl_xfer_posix(
+                        "READ",
+                        host_ptr=dest_host_ptr,
+                        payload_size=int(file_size),
+                        fd=fd,
+                        file_offset=_HEADER_SIZE,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "NixlBackend promote: NIXL READ failed: %s",
+                        exc,
+                    )
+                    return None
+            finally:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+        elif self.plugin == "OBJ":
+            import ctypes
+
+            total_size = _HEADER_SIZE + int(slot.size)
+            staging = (ctypes.c_ubyte * total_size)()
+            try:
+                self._do_nixl_xfer_obj(
+                    "READ",
+                    host_ptr=ctypes.addressof(staging),
+                    payload_size=total_size,
+                    obj_key=slot.path,  # OBJ key stored in slot.path
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "NixlBackend promote (OBJ): READ failed: %s",
+                    exc,
+                )
+                return None
+            hdr_bytes = bytes(
+                ctypes.string_at(
+                    ctypes.addressof(staging),
+                    _HEADER_SIZE,
+                )
+            )
+            magic, version, file_crc, file_size, _pad = struct.unpack(
+                _HEADER_FMT,
+                hdr_bytes,
+            )
+            if (
+                magic != _MAGIC
+                or version != _VERSION
+                or file_size != slot.size
+                or file_crc != slot.crc
+            ):
+                logger.warning(
+                    "NixlBackend promote (OBJ): header/index " "mismatch for %r",
+                    key,
+                )
+                return None
+            ctypes.memmove(
+                int(dest_host_ptr),
+                ctypes.addressof(staging) + _HEADER_SIZE,
+                int(slot.size),
+            )
+        else:
+            raise NotImplementedError(
+                f"NixlBackend.promote: plugin {self.plugin!r} " "not implemented"
+            )
+
+        actual = crc32_at_ptr(int(dest_host_ptr), int(slot.size))
+        if actual != slot.crc:
+            logger.warning(
+                "NixlBackend promote: CRC mismatch for %r: " "stored=%#x actual=%#x",
+                key,
+                slot.crc,
+                actual,
+            )
+            return None
+        return slot.crc
+
+    # ----- GPU-direct data plane (GDS only) -----
+
+    @dataclass
+    class _DeferredDemoteHandle:
+        """Opaque token returned by demote_from_gpu_deferred_crc.
+        Caller passes it to commit_deferred_crc once the real CRC
+        is available."""
+
+        engine_id: str
+        layer: int
+        offset: int
+        size: int
+        tmp_path: str
+        final_path: str
+
+    def demote_from_gpu_deferred_crc(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        gpu_ptr: int,
+        size: int,
+    ) -> "NixlBackend._DeferredDemoteHandle":
+        """Like `demote_from_gpu` but with a CRC=0 placeholder and
+        NO commit to the in-memory slot index. The file stays under
+        its `.tmp-*` name; nothing observable changes until
+        `commit_deferred_crc()` patches the real CRC and renames.
+
+        Use this pattern when you want to overlap the GDS transfer
+        with the CRC compute (e.g., on a pinned scratch via async
+        D2H). Without the deferred-commit, a reader racing between
+        the rename and the CRC patch would see CRC=0 in both the
+        header and the slot record, and fail verification.
+
+        Only valid for GDS / GDS_MT plugins."""
+        if self.plugin not in ("GDS", "GDS_MT"):
+            raise NotImplementedError(
+                "demote_from_gpu_deferred_crc requires GDS/GDS_MT; "
+                f"got {self.plugin!r}"
+            )
+        final_path = self._path_for(engine_id, layer, offset)
+        os.makedirs(os.path.dirname(final_path), exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".tmp-",
+            suffix=".bin",
+            dir=os.path.dirname(final_path),
+        )
+        try:
+            # Placeholder header (CRC=0). Real CRC patched later.
+            placeholder = struct.pack(
+                _HEADER_FMT,
+                _MAGIC,
+                _VERSION,
+                0,
+                int(size),
+                0,
+            )
+            os.pwrite(fd, placeholder, 0)
+            os.ftruncate(fd, _HEADER_SIZE + int(size))
+            self._do_nixl_xfer_gds(
+                "WRITE",
+                gpu_ptr=gpu_ptr,
+                payload_size=int(size),
+                fd=fd,
+                file_offset=_HEADER_SIZE,
+            )
+            # IMPORTANT: do NOT fsync, do NOT rename, do NOT add to
+            # _slots. That's the commit step's job.
+            os.close(fd)
+            fd = -1
+        except Exception:
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            raise
+        return NixlBackend._DeferredDemoteHandle(
+            engine_id=str(engine_id),
+            layer=int(layer),
+            offset=int(offset),
+            size=int(size),
+            tmp_path=tmp_path,
+            final_path=final_path,
+        )
+
+    def commit_deferred_crc(
+        self,
+        handle: "NixlBackend._DeferredDemoteHandle",
+        real_crc: int,
+    ) -> _NixlSlot:
+        """Patch the temp file's header with the real CRC, fsync,
+        atomic rename to the final path, and add to the slot index.
+        After this returns the slot is visible to promote/get."""
+        real_header = struct.pack(
+            _HEADER_FMT,
+            _MAGIC,
+            _VERSION,
+            int(real_crc) & 0xFFFFFFFF,
+            int(handle.size),
+            0,
+        )
+        # Open the temp file, patch the header, fsync, close.
+        fd = os.open(handle.tmp_path, os.O_RDWR)
+        try:
+            os.pwrite(fd, real_header, 0)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        # Atomic rename — file becomes visible at final_path NOW.
+        os.rename(handle.tmp_path, handle.final_path)
+        slot = _NixlSlot(
+            size=int(handle.size),
+            crc=int(real_crc) & 0xFFFFFFFF,
+            mtime=time.time(),
+            path=handle.final_path,
+        )
+        with self._lock:
+            self._slots[(handle.engine_id, handle.layer, handle.offset)] = slot
+        self._append_manifest(
+            slot,
+            handle.engine_id,
+            handle.layer,
+            handle.offset,
+        )
+        return slot
+
+    def demote_from_gpu(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        gpu_ptr: int,
+        size: int,
+        crc: int,
+    ) -> _NixlSlot:
+        """GDS-direct demote: source is a GPU pointer (VRAM_SEG),
+        destination is a file on a GDS-capable mount. The NVMe
+        controller DMAs directly to GPU memory via PCIe, bypassing
+        host RAM staging.
+
+        Caller passes the pre-computed CRC over the GPU bytes (the
+        engine has the data on GPU; CRC is up to the engine, possibly
+        computed on GPU via a kernel). On promote_into_gpu we
+        recompute the CRC directly over destination HBM.
+
+        Only valid for GDS/GDS_MT plugins; raises for POSIX/OBJ.
+        On a non-GDS filesystem the NIXL plugin still functions but
+        falls back to cuFile's compat mode (CPU-staged); the data
+        gets through, you just don't get the GPU-direct benefit."""
+        if self.plugin not in ("GDS", "GDS_MT"):
+            raise NotImplementedError(
+                "demote_from_gpu requires plugin in {GDS, GDS_MT}; "
+                f"got {self.plugin!r}"
+            )
+        final_path = self._path_for(engine_id, layer, offset)
+        os.makedirs(os.path.dirname(final_path), exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".tmp-",
+            suffix=".bin",
+            dir=os.path.dirname(final_path),
+        )
+        try:
+            header = struct.pack(
+                _HEADER_FMT,
+                _MAGIC,
+                _VERSION,
+                int(crc) & 0xFFFFFFFF,
+                int(size),
+                0,
+            )
+            # Header: a 24-byte pwrite, far cheaper than a separate
+            # GDS transfer for such a small payload.
+            os.pwrite(fd, header, 0)
+            os.ftruncate(fd, _HEADER_SIZE + int(size))
+            # Payload: VRAM -> FILE via GDS.
+            self._do_nixl_xfer_gds(
+                "WRITE",
+                gpu_ptr=gpu_ptr,
+                payload_size=int(size),
+                fd=fd,
+                file_offset=_HEADER_SIZE,
+            )
+            os.fsync(fd)
+            os.close(fd)
+            fd = -1
+            os.rename(tmp_path, final_path)
+            tmp_path = None
+        finally:
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if tmp_path is not None and os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+        slot = _NixlSlot(
+            size=int(size),
+            crc=int(crc) & 0xFFFFFFFF,
+            mtime=time.time(),
+            path=final_path,
+        )
+        with self._lock:
+            self._slots[(str(engine_id), int(layer), int(offset))] = slot
+        self._append_manifest(slot, engine_id, layer, offset)
+        return slot
+
+    def promote_into_gpu(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        dest_gpu_ptr: int,
+        max_size: int,
+    ) -> Optional[int]:
+        """Symmetric to demote_from_gpu: file -> VRAM via GDS.
+        Returns the verified CRC, or None on any failure.
+
+        CRC verification runs directly over destination HBM. A GDS
+        restore fails closed when the CUDA verifier is unavailable; copying
+        the payload through host memory would violate the GPU-direct contract."""
+
+        if self.plugin not in ("GDS", "GDS_MT"):
+            raise NotImplementedError(
+                "promote_into_gpu requires plugin in {GDS, GDS_MT}; "
+                f"got {self.plugin!r}"
+            )
+        key = (str(engine_id), int(layer), int(offset))
+        with self._lock:
+            slot = self._slots.get(key)
+        if slot is None or slot.size > int(max_size):
+            return None
+
+        try:
+            fd = os.open(slot.path, os.O_RDONLY)
+        except OSError as exc:
+            logger.warning("promote_into_gpu: open(%s): %s", slot.path, exc)
+            return None
+        try:
+            hdr = os.pread(fd, _HEADER_SIZE, 0)
+            if len(hdr) != _HEADER_SIZE:
+                return None
+            magic, version, file_crc, file_size, _pad = struct.unpack(
+                _HEADER_FMT,
+                hdr,
+            )
+            if (
+                magic != _MAGIC
+                or version != _VERSION
+                or file_size != slot.size
+                or file_crc != slot.crc
+            ):
+                return None
+            try:
+                self._do_nixl_xfer_gds(
+                    "READ",
+                    gpu_ptr=dest_gpu_ptr,
+                    payload_size=int(file_size),
+                    fd=fd,
+                    file_offset=_HEADER_SIZE,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "promote_into_gpu: NIXL READ failed: %s",
+                    exc,
+                )
+                return None
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+        try:
+            from gms_kv_ring.common.crc32_gpu import crc32_gpu
+
+            actual = crc32_gpu(int(dest_gpu_ptr), int(slot.size))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("promote_into_gpu: GPU CRC verify failed: %s", exc)
+            return None
+        if actual != slot.crc:
+            logger.warning(
+                "promote_into_gpu: CRC mismatch for %r",
+                key,
+            )
+            return None
+        return slot.crc
+
+    # ----- index + lifecycle -----
+
+    def get(self, engine_id, layer, offset) -> Optional[_NixlSlot]:
+        with self._lock:
+            return self._slots.get(
+                (str(engine_id), int(layer), int(offset)),
+            )
+
+    def _commit_removals_locked(self, items):
+        """Persist tombstones before removing the same indexed slots.
+
+        Caller holds ``_lock``. A manifest failure leaves the in-memory
+        index unchanged, preventing released OBJ entries from resurrecting.
+        """
+        for key, _slot in items:
+            self._append_tombstone(key[0], key[1], key[2])
+        removed = []
+        for key, slot in items:
+            if self._slots.get(key) is slot:
+                self._slots.pop(key)
+                removed.append((key, slot))
+        return removed
+
+    def release_if_current(self, engine_id, layer, offset, expected) -> bool:
+        key = (str(engine_id), int(layer), int(offset))
+        with self._lock:
+            if self._slots.get(key) is not expected:
+                return False
+            removed = self._commit_removals_locked([(key, expected)])
+        self._free_file(removed[0][1])
+        return True
+
+    def release_slot(self, engine_id, layer, offset) -> bool:
+        key = (str(engine_id), int(layer), int(offset))
+        with self._lock:
+            slot = self._slots.get(key)
+            if slot is None:
+                return False
+            removed = self._commit_removals_locked([(key, slot)])
+        self._free_file(removed[0][1])
+        return True
+
+    def release_engine(self, engine_id) -> int:
+        eid = str(engine_id)
+        with self._lock:
+            items = [(key, slot) for key, slot in self._slots.items() if key[0] == eid]
+            removed = self._commit_removals_locked(items)
+        for _key, slot in removed:
+            self._free_file(slot)
+        return len(removed)
+
+    def _free_file(self, slot: _NixlSlot) -> None:
+        """Free the slot's backend resource. POSIX: unlink the file.
+        OBJ: delete the object — NIXL doesn't have a delete op in
+        its Python API, so we log + leak (operator's bucket-side
+        lifecycle policy is expected to GC eventually)."""
+        if self.plugin in _FILE_PLUGINS:
+            try:
+                os.unlink(slot.path)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.warning(
+                    "NixlBackend._free_file: unlink %s failed: %s",
+                    slot.path,
+                    exc,
+                )
+        elif self.plugin == "OBJ":
+            # No NIXL delete API; rely on bucket lifecycle / TTL
+            # policy. We've already dropped the slot from the
+            # in-memory index, so it's invisible to promote — the
+            # leak is bytes on S3, not a correctness issue.
+            logger.debug(
+                "NixlBackend._free_file (OBJ): %s removed from "
+                "index; bytes remain in bucket until lifecycle GC",
+                slot.path,
+            )
+
+    def close(self) -> None:
+        """Close manifest resources. Idempotent."""
+        with self._manifest_lock:
+            if self._manifest_fp is not None:
+                try:
+                    if self._sync_manifest:
+                        os.fsync(self._manifest_fp.fileno())
+                    self._manifest_fp.close()
+                except OSError:
+                    pass
+                self._manifest_fp = None
+
+    # ----- observability -----
+
+    def n_slots(self) -> int:
+        with self._lock:
+            return len(self._slots)
+
+    def total_bytes(self) -> int:
+        with self._lock:
+            return sum(s.size for s in self._slots.values())
+
+    def bytes_by_engine(self) -> dict[str, int]:
+        out: dict[str, int] = {}
+        with self._lock:
+            for (eid, _l, _o), s in self._slots.items():
+                out[eid] = out.get(eid, 0) + s.size
+        return out
+
+    def stats(self) -> dict:
+        with self._lock:
+            slots = list(self._slots.items())
+        if not slots:
+            return {
+                "n_slots": 0,
+                "total_bytes": 0,
+                "oldest_mtime": 0.0,
+                "newest_mtime": 0.0,
+                "bytes_by_engine": {},
+            }
+        by_eng: dict[str, int] = {}
+        for (eid, _l, _o), s in slots:
+            by_eng[eid] = by_eng.get(eid, 0) + s.size
+        return {
+            "n_slots": len(slots),
+            "total_bytes": sum(s.size for _k, s in slots),
+            "oldest_mtime": min(s.mtime for _k, s in slots),
+            "newest_mtime": max(s.mtime for _k, s in slots),
+            "bytes_by_engine": by_eng,
+        }
+
+    # ----- cleanup (same logic shape as Local) -----
+
+    def prune_older_than(self, max_age_seconds, now=None) -> int:
+        if now is None:
+            now = time.time()
+        threshold = float(now) - float(max_age_seconds)
+        with self._lock:
+            to_remove = [
+                (k, s) for k, s in list(self._slots.items()) if s.mtime < threshold
+            ]
+            removed = self._commit_removals_locked(to_remove)
+        for _key, slot in removed:
+            self._free_file(slot)
+        return len(removed)
+
+    def enforce_byte_quota(self, max_bytes) -> int:
+        max_bytes = int(max_bytes)
+        with self._lock:
+            current = sum(s.size for s in self._slots.values())
+            if current <= max_bytes:
+                return 0
+            ordered = sorted(
+                self._slots.items(),
+                key=lambda kv: kv[1].mtime,
+            )
+            to_remove = []
+            for k, s in ordered:
+                if current <= max_bytes:
+                    break
+                to_remove.append((k, s))
+                current -= s.size
+            removed = self._commit_removals_locked(to_remove)
+        for _key, slot in removed:
+            self._free_file(slot)
+        return len(removed)
+
+    def enforce_per_engine_byte_quota(
+        self,
+        max_bytes_per_engine,
+    ) -> int:
+        cap = int(max_bytes_per_engine)
+        with self._lock:
+            by_eng: dict[str, list] = {}
+            for k, s in self._slots.items():
+                by_eng.setdefault(k[0], []).append((k, s))
+            to_remove = []
+            for _eid, items in by_eng.items():
+                current = sum(s.size for _, s in items)
+                if current <= cap:
+                    continue
+                items.sort(key=lambda kv: kv[1].mtime)
+                for k, s in items:
+                    if current <= cap:
+                        break
+                    to_remove.append((k, s))
+                    current -= s.size
+            removed = self._commit_removals_locked(to_remove)
+        for _key, slot in removed:
+            self._free_file(slot)
+        return len(removed)

--- a/lib/gms_kv_ring/daemon/transport/nixl_transport.py
+++ b/lib/gms_kv_ring/daemon/transport/nixl_transport.py
@@ -1,0 +1,911 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NIXL-backed cross-node KV transport.
+
+Each daemon owns a `NixlTransport` that wraps a NIXL agent with the
+UCX backend. The agent:
+
+  - Listens for inbound transfers (`enable_listen_thread=True`).
+  - Registers a staging-tier buffer pool with NIXL for RDMA targeting.
+  - Issues outbound `WRITE` transfers to peer agents.
+  - Drains notification messages on a background thread; each notif
+    carries `{reservation_id, content_hash}` and triggers the
+    receiver-side `StagingTier.commit_or_reject` path.
+
+Single-host loopback works via UCX-over-SHM (no hardware needed).
+Cross-host production uses UCX-over-InfiniBand or UCX-over-RoCE.
+
+Wire protocol (per transfer):
+
+  1. Router commands sender via UDS: `transfer_block(target, hash, payload_bytes_or_ptr)`.
+  2. Sender → reserves a sender-side memory slot, copies bytes in,
+     registers if not already, calls `NixlTransport.send(peer, hash, src_ptr, size)`.
+  3. NixlTransport.send:
+        a. Allocates receiver-side reservation via the existing UDS
+           control channel (peer's `staging_tier_reserve` op). Receiver
+           pre-allocates a staging-tier slot and replies with
+           `(reservation_id, dst_ptr)`.
+        b. `initialize_xfer("WRITE", local_descs, remote_descs,
+                            peer_name, notif_msg={hash, reservation_id})`.
+        c. `transfer(handle)`. On completion, receiver's notif arrives.
+  4. Receiver's notif drain thread:
+        a. Decodes notif → (reservation_id, content_hash).
+        b. Reads bytes from staging-tier dst buffer (already populated
+           by the NIXL WRITE) and calls
+           `staging_tier.commit_or_reject(reservation_id, payload)`.
+        c. StagingTier verifies hash (I-9) and transitions to READY
+           or CORRUPT.
+
+Why pre-reservation: NIXL needs both sides' descriptors before the
+WRITE. The sender can't write into staging without the receiver having
+allocated and registered the destination buffer first. This adds one
+UDS round-trip (the pre-reserve RPC) on top of the RDMA transfer; for
+typical block sizes (~MB) the overhead is amortized.
+
+Invariants enforced here:
+
+  - I-8 (atomic reservation): the receiver's `staging_tier_reserve`
+    RPC goes through `StagingTier.reserve_or_wait`; concurrent
+    transfers for the same hash coalesce as waiters in the staging tier.
+  - I-9 (hash-on-receive): the receiver's commit path verifies the
+    payload hash before transitioning to READY.
+
+Failure modes:
+
+  - Peer unreachable / metadata exchange failed → `TransportClosed`
+    from `add_peer`; caller can retry or fall back.
+  - Transfer fails → sender's `transfer()` returns non-DONE status;
+    sender calls `staging_tier_fail_reservation` RPC to release the
+    receiver-side reservation; waiters get notified of failure.
+  - Receiver agent dies mid-transfer → metadata invalidation; sender
+    sees ERROR on next `transfer()`; reservation stale-times out on
+    receiver if it restarts before the sender retries.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import struct
+import threading
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+# ---- Exception types --------------------------------------------------------
+
+
+class TransportNotAvailable(RuntimeError):
+    """NIXL or its UCX plugin is not importable / not constructible."""
+
+
+class TransportClosed(RuntimeError):
+    """Operation attempted on a closed transport, or peer is unreachable."""
+
+
+# ---- Public API -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PeerHandle:
+    """Identifies a peer NIXL agent reachable from this transport.
+
+    `nixl_name` is the agent's identity in NIXL (returned by
+    `add_remote_agent`). `ip_addr` + `port` are the listen endpoint
+    used for metadata exchange (NIXL's own listen thread)."""
+
+    nixl_name: str
+    ip_addr: str
+    port: int
+
+
+@dataclass
+class _AsyncSend:
+    """One in-flight NIXL send tracked by the completion loop.
+
+    `handle` is the opaque NIXL xfer handle. `on_complete` is invoked
+    with `(success: bool, error_msg: str)` from the completion thread
+    once NIXL reports DONE/ERR or `deadline_monotonic` passes. After
+    `on_complete` runs, the NIXL handle is released."""
+
+    handle: object
+    peer_name: str
+    reservation_id: str
+    deadline_monotonic: float
+    on_complete: object = None
+
+
+_BATCH_NOTIF_MAGIC = b"BNTF"  # 4-byte prefix for multi-record notifs
+
+
+def _encode_batch_notif(records: "list[tuple[str, bytes]]") -> bytes:
+    """Multi-record notif carried by a single NIXL xfer covering N
+    block WRITEs (the per-request-batched path that matches Dynamo's
+    one-xfer-per-request shape). One transfer, one notif, N records.
+
+    Layout:
+        [4: "BNTF" magic]
+        [4 LE: n_records]
+        for each record:
+            [4 LE: rid_len][rid_len: reservation_id utf-8][32: content_hash]
+
+    For a single-block legacy path, `_encode_notif` (no magic prefix)
+    is still used; `_decode_batch_notif` handles both."""
+    parts: list[bytes] = [_BATCH_NOTIF_MAGIC, struct.pack("<I", len(records))]
+    for rid, content_hash in records:
+        if len(content_hash) != 32:
+            raise ValueError(
+                f"content_hash must be 32 bytes, got {len(content_hash)}",
+            )
+        rid_b = rid.encode("utf-8")
+        parts.append(struct.pack("<I", len(rid_b)))
+        parts.append(rid_b)
+        parts.append(content_hash)
+    return b"".join(parts)
+
+
+def _decode_batch_notif(msg: bytes) -> "list[tuple[str, bytes]]":
+    """Decode either the batch format (with BNTF magic) or the legacy
+    single-record format. Returns a list of (reservation_id,
+    content_hash) tuples — length 1 for the legacy format, ≥1 for
+    batched."""
+    if len(msg) >= 4 and msg[:4] == _BATCH_NOTIF_MAGIC:
+        if len(msg) < 8:
+            raise ValueError("batch notif truncated")
+        n = struct.unpack_from("<I", msg, 4)[0]
+        out: list[tuple[str, bytes]] = []
+        pos = 8
+        for _ in range(n):
+            if pos + 4 > len(msg):
+                raise ValueError("batch notif truncated mid-record")
+            rid_len = struct.unpack_from("<I", msg, pos)[0]
+            pos += 4
+            if pos + rid_len + 32 > len(msg):
+                raise ValueError("batch notif truncated mid-record body")
+            rid = msg[pos : pos + rid_len].decode("utf-8")
+            pos += rid_len
+            content_hash = msg[pos : pos + 32]
+            pos += 32
+            out.append((rid, content_hash))
+        return out
+    # Legacy single-record fallback.
+    rid, h = _decode_notif(msg)
+    return [(rid, h)]
+
+
+def _encode_notif(reservation_id: str, content_hash: bytes) -> bytes:
+    """Wire format for inbound transfer notifications (legacy
+    single-record). See `_encode_batch_notif` for the modern
+    per-request multi-record format.
+
+    Layout:
+        [4 LE: rid_len][rid_len: reservation_id utf-8][32: content_hash]
+    """
+    rid_bytes = reservation_id.encode("utf-8")
+    if len(content_hash) != 32:
+        raise ValueError(
+            f"content_hash must be 32 bytes, got {len(content_hash)}",
+        )
+    return struct.pack("<I", len(rid_bytes)) + rid_bytes + content_hash
+
+
+def _decode_notif(msg: bytes) -> tuple[str, bytes]:
+    if len(msg) < 4:
+        raise ValueError(f"notif too short ({len(msg)} bytes)")
+    rid_len = struct.unpack("<I", msg[:4])[0]
+    expected = 4 + rid_len + 32
+    if len(msg) != expected:
+        raise ValueError(
+            f"notif length mismatch: got {len(msg)}, expected {expected}",
+        )
+    rid = msg[4 : 4 + rid_len].decode("utf-8")
+    h = msg[4 + rid_len : 4 + rid_len + 32]
+    return rid, h
+
+
+class NixlTransport:
+    """Per-daemon NIXL agent + connection manager + notif drain.
+
+    Lifecycle: construct, `add_peer()` for each known peer, `send()`
+    to push bytes; `close()` to tear down."""
+
+    def __init__(
+        self,
+        agent_name: str,
+        listen_port: int,
+        *,
+        ucx_backend: str = "UCX",
+        notif_poll_interval_s: float = 0.005,
+        on_inbound_notif=None,
+    ) -> None:
+        """`on_inbound_notif(peer_name, reservation_id, content_hash)` is
+        invoked on the drain thread when a remote agent finishes
+        WRITE-ing to one of our registered slots. The caller (Daemon)
+        wires this to `StagingTier.commit_or_reject` via a closure
+        that knows how to read the destination bytes."""
+        try:
+            from nixl._api import nixl_agent, nixl_agent_config
+        except ImportError as exc:
+            raise TransportNotAvailable(
+                f"pynixl not importable: {exc}",
+            ) from exc
+
+        self._agent_name = agent_name
+        self._listen_port = int(listen_port)
+        backend = os.environ.get("GMS_KVR_NIXL_BACKEND") or ucx_backend
+        self._ucx_backend = backend
+        self._on_inbound_notif = on_inbound_notif
+
+        try:
+            cfg = nixl_agent_config(
+                enable_prog_thread=True,
+                enable_listen_thread=True,
+                listen_port=self._listen_port,
+                backends=[backend],
+            )
+            self._agent = nixl_agent(agent_name, cfg)
+        except Exception as exc:
+            raise TransportNotAvailable(
+                f"failed to construct nixl_agent: {exc}",
+            ) from exc
+
+        # Peer registry: nixl_name → PeerHandle. Populated by add_peer.
+        self._peers: dict[str, PeerHandle] = {}
+        # Memory registrations: list of ctypes-managed buffers (held
+        # so refcount keeps them alive). NIXL's internal registration
+        # is by (ptr, size); we just remember what we've registered to
+        # avoid double-registration.
+        self._registered: set[tuple[int, int]] = set()
+
+        # Notif drain thread. All state the thread reads (stop event,
+        # poll interval, callback) MUST be initialized before .start()
+        # — otherwise the thread can race ahead and AttributeError.
+        self._stop = threading.Event()
+        self._poll_s = float(notif_poll_interval_s)
+        self._lock = threading.Lock()  # guards _peers, _registered
+        self._closed = False
+        # Async-send tracking: (handle_id → _AsyncSend record). The
+        # background completion loop polls each pending xfer, releases
+        # its NIXL handle on DONE/ERR, and fires `on_complete`. This is
+        # what removes the synchronous waiter that previously stalled
+        # `send()` under bidirectional load.
+        self._async_lock = threading.Lock()
+        self._async_pending: dict[int, "_AsyncSend"] = {}
+        self._notif_thread = threading.Thread(
+            target=self._notif_loop,
+            name=f"nixl-notif-{agent_name}",
+            daemon=True,
+        )
+        self._notif_thread.start()
+        self._completion_thread = threading.Thread(
+            target=self._completion_loop,
+            name=f"nixl-completion-{agent_name}",
+            daemon=True,
+        )
+        self._completion_thread.start()
+
+    # ----- peer registration -----
+
+    def add_peer(self, ip_addr: str, port: int, label: str = "") -> PeerHandle:
+        """Fetch the remote agent's metadata over its listen socket and
+        register it locally. Returns the PeerHandle for later send()
+        calls. Idempotent: re-adding the same peer is a no-op.
+
+        `label` is an optional NIXL-side label for metadata fetch
+        bookkeeping; can be empty for the common case."""
+        if self._closed:
+            raise TransportClosed("transport is closed")
+        # NIXL fetch_remote_metadata takes the remote agent's nixl
+        # name as the first argument. The first connect doesn't know
+        # it, so we use the empty-string form which negotiates via
+        # the listen socket.
+        try:
+            self._agent.fetch_remote_metadata(
+                remote_agent="",
+                ip_addr=ip_addr,
+                port=int(port),
+                label=label,
+            )
+        except Exception as exc:
+            raise TransportClosed(
+                f"fetch_remote_metadata({ip_addr}:{port}) failed: {exc}",
+            ) from exc
+
+        # After fetch, the new remote agent name appears in the
+        # agent's local registry. We don't have a clean API to list
+        # them, so the caller must pass us the expected name; for now
+        # we assume the convention that nixl_name == f"gms-{port}" or
+        # similar agreed at construction. This is brittle; cleaner
+        # alternative is to send_local_metadata from peer with a
+        # pre-arranged name. Documented as future work.
+        # Workaround: poll for the new peer's name by checking
+        # check_remote_metadata against a placeholder. For now we
+        # rely on the caller passing it.
+        raise NotImplementedError(
+            "add_peer: name resolution is pending — use add_peer_by_name "
+            "with the known agent_name in this build",
+        )
+
+    def add_peer_by_name(
+        self,
+        nixl_name: str,
+        ip_addr: str,
+        port: int,
+        label: str = "",
+    ) -> PeerHandle:
+        """Same as add_peer but the caller already knows the peer's
+        NIXL agent name (out-of-band: e.g., daemon socket exchanges
+        it before transport setup). This is the production path until
+        we wire up an agent-name discovery RPC."""
+        if self._closed:
+            raise TransportClosed("transport is closed")
+        with self._lock:
+            existing = self._peers.get(nixl_name)
+            if existing is not None:
+                return existing
+        try:
+            # send_local_metadata pushes OUR metadata to peer's listen
+            # socket. The peer registers us. Then we fetch theirs.
+            self._agent.send_local_metadata(ip_addr=ip_addr, port=int(port))
+            self._agent.fetch_remote_metadata(
+                remote_agent=nixl_name,
+                ip_addr=ip_addr,
+                port=int(port),
+                label=label,
+            )
+        except Exception as exc:
+            raise TransportClosed(
+                f"metadata exchange with {nixl_name}@{ip_addr}:{port} "
+                f"failed: {exc}",
+            ) from exc
+        handle = PeerHandle(
+            nixl_name=nixl_name,
+            ip_addr=ip_addr,
+            port=int(port),
+        )
+        with self._lock:
+            self._peers[nixl_name] = handle
+        return handle
+
+    def add_peer_inproc(
+        self,
+        peer_transport: "NixlTransport",
+    ) -> PeerHandle:
+        """Loopback (same-process) metadata exchange path. Avoids the
+        listen-thread metadata roundtrip by snapshotting the peer's
+        metadata directly. Bidirectional: registers `self` on `peer`
+        AND `peer` on `self`. Intended for tests and single-host
+        multi-GPU deployments where both transports live in the same
+        Python process. Production cross-host deployments use
+        `add_peer_by_name` over the listen socket."""
+        if self._closed:
+            raise TransportClosed("transport is closed")
+        with self._lock:
+            existing = self._peers.get(peer_transport._agent_name)
+            if existing is not None:
+                return existing
+        # NIXL metadata is point-in-time — must be captured AFTER
+        # any register_memory calls on the peer that we want to be
+        # visible. Caller is responsible for the ordering.
+        peer_md = peer_transport._agent.get_agent_metadata()
+        my_md = self._agent.get_agent_metadata()
+        peer_transport._agent.add_remote_agent(my_md)
+        self._agent.add_remote_agent(peer_md)
+        handle = PeerHandle(
+            nixl_name=peer_transport._agent_name,
+            ip_addr="inproc",
+            port=peer_transport._listen_port,
+        )
+        with self._lock:
+            self._peers[peer_transport._agent_name] = handle
+        # Also register US on peer (symmetric) so peer can issue notifs back.
+        with peer_transport._lock:
+            if self._agent_name not in peer_transport._peers:
+                peer_transport._peers[self._agent_name] = PeerHandle(
+                    nixl_name=self._agent_name,
+                    ip_addr="inproc",
+                    port=self._listen_port,
+                )
+        return handle
+
+    def remove_peer(self, nixl_name: str) -> bool:
+        if self._closed:
+            return False
+        with self._lock:
+            handle = self._peers.pop(nixl_name, None)
+        if handle is None:
+            return False
+        try:
+            self._agent.remove_remote_agent(nixl_name)
+        except Exception:
+            logger.exception(
+                "[NixlTransport] remove_remote_agent(%s) failed",
+                nixl_name,
+            )
+        return True
+
+    def add_peer_from_metadata(
+        self,
+        nixl_name: str,
+        metadata: bytes,
+    ) -> PeerHandle:
+        """Register a peer from an in-band NIXL metadata blob.
+
+        Router-orchestrated decode-to-decode placement does not expose the
+        source daemon's UDS path to the destination worker. Instead, the
+        source worker returns a fresh metadata blob through Dynamo's request
+        plane. The destination daemon registers that blob locally and can then
+        issue NIXL READs against the source agent.
+        """
+        if self._closed:
+            raise TransportClosed("transport is closed")
+        peer_name = str(nixl_name)
+        if not peer_name:
+            raise TransportClosed("peer NIXL agent name is empty")
+        with self._lock:
+            existing = self._peers.get(peer_name)
+        metadata_bytes = bytes(metadata or b"")
+        if not metadata_bytes:
+            raise TransportClosed(
+                f"metadata for peer {peer_name!r} is empty",
+            )
+        try:
+            self._agent.add_remote_agent(metadata_bytes)
+        except Exception as exc:
+            if existing is None:
+                raise TransportClosed(
+                    f"add_remote_agent({peer_name}) failed: {exc}",
+                ) from exc
+            try:
+                self._agent.remove_remote_agent(peer_name)
+                self._agent.add_remote_agent(metadata_bytes)
+            except Exception as refresh_exc:
+                logger.debug(
+                    "[NixlTransport] peer metadata refresh for %s failed; "
+                    "using existing metadata: %s",
+                    peer_name,
+                    refresh_exc,
+                )
+                return existing
+        handle = PeerHandle(nixl_name=peer_name, ip_addr="metadata", port=0)
+        with self._lock:
+            self._peers[peer_name] = handle
+        return handle
+
+    # ----- memory registration -----
+
+    def register_buffer(self, ptr: int, size: int, label: str = "") -> None:
+        """Register a host-pinned buffer with NIXL so peers can RDMA
+        into / out of it. Idempotent for the same (ptr, size) pair."""
+        if self._closed:
+            raise TransportClosed("transport is closed")
+        key = (int(ptr), int(size))
+        with self._lock:
+            if key in self._registered:
+                return
+        try:
+            self._agent.register_memory(
+                [(int(ptr), int(size), 0, label or f"buf@{ptr:x}")],
+                mem_type="DRAM",
+            )
+        except Exception as exc:
+            raise TransportClosed(
+                f"register_memory({ptr:x}, {size}) failed: {exc}",
+            ) from exc
+        with self._lock:
+            self._registered.add(key)
+
+    # ----- outbound transfer -----
+
+    def send(
+        self,
+        peer: PeerHandle,
+        local_ptr: int,
+        size: int,
+        remote_ptr: int,
+        reservation_id: str,
+        content_hash: bytes,
+        timeout_s: float = 30.0,
+    ) -> None:
+        """Push `size` bytes from local memory at `local_ptr` to peer's
+        memory at `remote_ptr` via NIXL UCX. Sender's `local_ptr` must
+        already be `register_buffer`-ed. Receiver-side preconditions:
+        peer has reserved a staging slot, registered the destination
+        buffer with NIXL, and given us `remote_ptr` out-of-band.
+
+        On successful WRITE completion, NIXL delivers a notif to the
+        peer carrying `(reservation_id, content_hash)`. The peer's
+        notif drain calls into its StagingTier.commit_or_reject.
+
+        Raises TransportClosed on metadata-resolution failure;
+        TimeoutError on timeout; RuntimeError on transfer-level
+        failures."""
+        if self._closed:
+            raise TransportClosed("transport is closed")
+
+        # Build local + remote descriptor lists. Each is a single
+        # contiguous range for the typical case.
+        local_descs = self._agent.get_xfer_descs(
+            [(int(local_ptr), int(size), 0)],
+            mem_type="DRAM",
+        )
+        remote_descs = self._agent.get_xfer_descs(
+            [(int(remote_ptr), int(size), 0)],
+            mem_type="DRAM",
+        )
+        # Confirm peer's descriptor metadata is reachable; gives a
+        # cleaner error message than initialize_xfer's
+        # NIXL_ERR_NOT_FOUND when metadata exchange is incomplete.
+        if not self._agent.check_remote_metadata(peer.nixl_name, remote_descs):
+            raise TransportClosed(
+                f"remote metadata for {peer.nixl_name} doesn't cover "
+                f"ptr={remote_ptr:x} size={size}"
+            )
+
+        notif = _encode_notif(reservation_id, content_hash)
+        try:
+            handle = self._agent.initialize_xfer(
+                "WRITE",
+                local_descs,
+                remote_descs,
+                peer.nixl_name,
+                notif_msg=notif,
+            )
+        except Exception as exc:
+            raise TransportClosed(
+                f"initialize_xfer to {peer.nixl_name} failed: {exc}",
+            ) from exc
+
+        try:
+            status = self._agent.transfer(handle)
+            # NIXL returns "DONE" immediately if synchronous; otherwise
+            # we poll. Either way `release_xfer_handle` is required.
+            deadline = time.monotonic() + float(timeout_s)
+            while status not in ("DONE", "ERR"):
+                if time.monotonic() > deadline:
+                    raise TimeoutError(
+                        f"transfer to {peer.nixl_name} did not "
+                        f"complete within {timeout_s}s",
+                    )
+                time.sleep(0.001)
+                status = self._agent.transfer(handle)
+            if status == "ERR":
+                raise RuntimeError(
+                    f"transfer to {peer.nixl_name} reported ERR",
+                )
+        finally:
+            try:
+                self._agent.release_xfer_handle(handle)
+            except Exception:
+                logger.exception(
+                    "[NixlTransport] release_xfer_handle failed",
+                )
+
+    def read_batch(
+        self,
+        source_nixl_name: str,
+        items: "list[tuple[int, int, int]]",
+        timeout_s: float = 30.0,
+    ) -> None:
+        """Pull one or more remote regions into local registered memory.
+
+        ``items`` entries are ``(local_ptr, size, remote_ptr)``. The local
+        pointers must lie inside a buffer registered on this agent, and the
+        remote pointers must be covered by the source agent metadata previously
+        registered with :meth:`add_peer_from_metadata`.
+        """
+        if self._closed:
+            raise TransportClosed("transport is closed")
+        if not items:
+            raise ValueError("read_batch: items must be non-empty")
+        peer_name = str(source_nixl_name)
+        if not peer_name:
+            raise TransportClosed("source NIXL agent name is empty")
+
+        local_descs = self._agent.get_xfer_descs(
+            [(int(lp), int(sz), 0) for (lp, sz, _rp) in items],
+            mem_type="DRAM",
+        )
+        remote_descs = self._agent.get_xfer_descs(
+            [(int(rp), int(sz), 0) for (_lp, sz, rp) in items],
+            mem_type="DRAM",
+        )
+        if not self._agent.check_remote_metadata(peer_name, remote_descs):
+            raise TransportClosed(
+                f"remote metadata for {peer_name} doesn't cover one or more "
+                f"of {len(items)} READ regions"
+            )
+
+        try:
+            handle = self._agent.initialize_xfer(
+                "READ",
+                local_descs,
+                remote_descs,
+                peer_name,
+            )
+        except Exception as exc:
+            raise TransportClosed(
+                f"initialize_xfer READ from {peer_name} failed: {exc}",
+            ) from exc
+
+        try:
+            status = self._agent.transfer(handle)
+            deadline = time.monotonic() + float(timeout_s)
+            while status not in ("DONE", "ERR"):
+                if time.monotonic() > deadline:
+                    raise TimeoutError(
+                        f"READ from {peer_name} did not complete within "
+                        f"{timeout_s}s",
+                    )
+                time.sleep(0.001)
+                status = self._agent.transfer(handle)
+            if status == "ERR":
+                raise RuntimeError(f"READ from {peer_name} reported ERR")
+        finally:
+            try:
+                self._agent.release_xfer_handle(handle)
+            except Exception:
+                logger.exception(
+                    "[NixlTransport] release_xfer_handle failed",
+                )
+
+    def _completion_loop(self) -> None:
+        """Poll outstanding async sends; release handles + fire
+        callbacks when they reach DONE/ERR or the deadline passes."""
+        while not self._stop.is_set():
+            try:
+                with self._async_lock:
+                    items = list(self._async_pending.items())
+                if not items:
+                    time.sleep(self._poll_s)
+                    continue
+                for hid, rec in items:
+                    try:
+                        status = self._agent.transfer(rec.handle)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "[NixlTransport async] transfer() poll for "
+                            "rid=%s peer=%s raised: %s — treating as ERR",
+                            rec.reservation_id,
+                            rec.peer_name,
+                            exc,
+                        )
+                        status = "ERR"
+                    now = time.monotonic()
+                    if status == "DONE":
+                        self._finalize_async(hid, rec, True, "")
+                    elif status == "ERR":
+                        self._finalize_async(
+                            hid,
+                            rec,
+                            False,
+                            f"transfer to {rec.peer_name} reported ERR",
+                        )
+                    elif now > rec.deadline_monotonic:
+                        self._finalize_async(
+                            hid,
+                            rec,
+                            False,
+                            f"transfer to {rec.peer_name} timed out",
+                        )
+                time.sleep(self._poll_s)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "[NixlTransport async] completion loop iteration "
+                    "raised; continuing",
+                )
+                time.sleep(self._poll_s)
+
+    def send_async_batch(
+        self,
+        peer: PeerHandle,
+        items: "list[tuple[int, int, int, str, bytes]]",
+        timeout_s: float = 30.0,
+        on_complete=None,
+    ) -> int:
+        """Submit ONE NIXL xfer covering N WRITEs in a single
+        operation — the per-request batched path matching Dynamo's
+        one-xfer-per-request shape.
+
+        `items` is a list of `(local_ptr, size, remote_ptr,
+        reservation_id, content_hash)` tuples. NIXL builds one
+        multi-region xfer; the notif carries all N (rid, hash)
+        records. Receiver's notif drain decodes them and processes
+        each.
+
+        This eliminates the per-WRITE concurrency limit: instead of
+        N concurrent WRITEs (which UCX-TCP can't reliably handle), we
+        issue ONE multi-region WRITE. Bytes for different blocks
+        cannot mix because they're one xfer with deterministic
+        descriptor ordering.
+
+        Returns the synthetic handle id for tracking.
+        """
+        if self._closed:
+            raise TransportClosed("transport is closed")
+        if not items:
+            raise ValueError("send_async_batch: items must be non-empty")
+        local_descs = self._agent.get_xfer_descs(
+            [(int(lp), int(sz), 0) for (lp, sz, _rp, _rid, _h) in items],
+            mem_type="DRAM",
+        )
+        remote_descs = self._agent.get_xfer_descs(
+            [(int(rp), int(sz), 0) for (_lp, sz, rp, _rid, _h) in items],
+            mem_type="DRAM",
+        )
+        if not self._agent.check_remote_metadata(peer.nixl_name, remote_descs):
+            raise TransportClosed(
+                f"remote metadata for {peer.nixl_name} doesn't cover one or "
+                f"more of {len(items)} remote regions"
+            )
+        records = [(rid, h) for (_lp, _sz, _rp, rid, h) in items]
+        notif = _encode_batch_notif(records)
+        try:
+            handle = self._agent.initialize_xfer(
+                "WRITE",
+                local_descs,
+                remote_descs,
+                peer.nixl_name,
+                notif_msg=notif,
+            )
+        except Exception as exc:
+            raise TransportClosed(
+                f"initialize_xfer (batch, n={len(items)}) to "
+                f"{peer.nixl_name} failed: {exc}",
+            ) from exc
+        try:
+            self._agent.transfer(handle)
+        except Exception as exc:
+            try:
+                self._agent.release_xfer_handle(handle)
+            except Exception:
+                pass
+            raise TransportClosed(
+                f"transfer() submission (batch) to {peer.nixl_name} " f"failed: {exc}",
+            ) from exc
+        rec = _AsyncSend(
+            handle=handle,
+            peer_name=peer.nixl_name,
+            reservation_id=f"batch:{len(items)}",
+            deadline_monotonic=time.monotonic() + float(timeout_s),
+            on_complete=on_complete,
+        )
+        hid = id(handle)
+        with self._async_lock:
+            self._async_pending[hid] = rec
+        return hid
+
+    def _finalize_async(
+        self,
+        hid: int,
+        rec: _AsyncSend,
+        success: bool,
+        err_msg: str,
+    ) -> None:
+        with self._async_lock:
+            if hid not in self._async_pending:
+                return  # already finalized
+            del self._async_pending[hid]
+        try:
+            self._agent.release_xfer_handle(rec.handle)
+        except Exception:
+            logger.exception(
+                "[NixlTransport async] release_xfer_handle failed for rid=%s",
+                rec.reservation_id,
+            )
+        if rec.on_complete is not None:
+            try:
+                rec.on_complete(success, err_msg)
+            except Exception:
+                logger.exception(
+                    "[NixlTransport async] on_complete callback raised " "for rid=%s",
+                    rec.reservation_id,
+                )
+
+    # ----- inbound notification drain -----
+
+    def _notif_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                notifs = self._agent.get_new_notifs()
+            except Exception:
+                logger.exception(
+                    "[NixlTransport] get_new_notifs failed; sleeping",
+                )
+                self._stop.wait(self._poll_s)
+                continue
+            if not notifs:
+                self._stop.wait(self._poll_s)
+                continue
+            for peer_name, msgs in notifs.items():
+                pn = peer_name.decode() if isinstance(peer_name, bytes) else peer_name
+                for msg in msgs:
+                    try:
+                        records = _decode_batch_notif(msg)
+                    except Exception:
+                        logger.exception(
+                            "[NixlTransport] notif decode failed (peer=%s, %d bytes)",
+                            pn,
+                            len(msg),
+                        )
+                        continue
+                    cb = self._on_inbound_notif
+                    if cb is None:
+                        logger.warning(
+                            "[NixlTransport] received notif but no callback "
+                            "registered; dropping %d record(s)",
+                            len(records),
+                        )
+                        continue
+                    for rid, content_hash in records:
+                        try:
+                            cb(pn, rid, content_hash)
+                        except Exception:
+                            logger.exception(
+                                "[NixlTransport] inbound notif callback raised",
+                            )
+
+    # ----- lifecycle -----
+
+    def agent_name(self) -> str:
+        return self._agent_name
+
+    def listen_port(self) -> int:
+        return self._listen_port
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._stop.set()
+        try:
+            self._completion_thread.join(timeout=2.0)
+        except Exception:
+            pass
+        # If shutdown raced with submitted async transfers, release any
+        # handles the completion loop did not get to finalize.
+        try:
+            with self._async_lock:
+                pending = list(self._async_pending.items())
+                self._async_pending.clear()
+            for _hid, rec in pending:
+                try:
+                    self._agent.release_xfer_handle(rec.handle)
+                except Exception:
+                    logger.exception(
+                        "[NixlTransport] close() release_xfer_handle failed "
+                        "for rid=%s",
+                        rec.reservation_id,
+                    )
+                if rec.on_complete is not None:
+                    try:
+                        rec.on_complete(False, "transport closed")
+                    except Exception:
+                        logger.exception(
+                            "[NixlTransport] close() on_complete callback "
+                            "raised for rid=%s",
+                            rec.reservation_id,
+                        )
+        except Exception:
+            logger.exception("[NixlTransport] close() async cleanup")
+        try:
+            self._notif_thread.join(timeout=2.0)
+        except Exception:
+            pass
+        # NIXL agent cleans up its own state when garbage-collected;
+        # we drop the reference here. UCX backend teardown happens
+        # via NIXL's internal lifecycle.
+        try:
+            with self._lock:
+                for name in list(self._peers.keys()):
+                    try:
+                        self._agent.remove_remote_agent(name)
+                    except Exception:
+                        pass
+                self._peers.clear()
+        except Exception:
+            logger.exception("[NixlTransport] close() peer cleanup")
+        self._agent = None

--- a/lib/gms_kv_ring/scripts/gds_preflight.sh
+++ b/lib/gms_kv_ring/scripts/gds_preflight.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# gds_preflight.sh — validate GMS NIXL GDS-direct path on a host
+# before exercising the restore-on-hit production tests.
+#
+# Runs 4 gates in order; stops at the first failure with a clear
+# diagnosis. Only if all gates pass does it run the env-gated
+# real-GDS test that exercises promote_storage_to_hbm with
+# `dest_offset != offset` — the path GMSKVCacheConnectorV1's
+# restore-on-hit rides on.
+#
+# REQUIRED ENV:
+#   GMS_KVR_NIXL_GDS_PATH  Writable directory on a cuFile-capable
+#                          filesystem (NVMe-w/-cuFile, BeeGFS,
+#                          Lustre, etc.). Will create + delete a
+#                          handful of small files there during the
+#                          test run.
+#
+# OPTIONAL ENV:
+#   GMS_GDS_TEST_TIMEOUT_S Per-test timeout for pytest (default: 120).
+#
+# OUTPUT: structured PASS/FAIL per gate, final summary. Exit 0
+# only if every gate passed AND the env-gated test passed.
+
+set -eu
+
+# ---------- helpers ----------
+
+red()    { printf '\033[31m%s\033[0m' "$*"; }
+green()  { printf '\033[32m%s\033[0m' "$*"; }
+yellow() { printf '\033[33m%s\033[0m' "$*"; }
+bold()   { printf '\033[1m%s\033[0m'  "$*"; }
+
+gate() {
+    local n="$1" ; shift
+    local title="$1" ; shift
+    printf '\n%s %s — %s\n' "$(bold "[gate $n]")" "$(bold "$title")" "$*"
+}
+pass() { printf '  %s %s\n' "$(green PASS)" "$*"; }
+fail() { printf '  %s %s\n' "$(red FAIL)" "$*"; exit 1; }
+info() { printf '  %s %s\n' "$(yellow info)" "$*"; }
+
+# ---------- gate 0: required env vars ----------
+
+gate 0 "environment" "resolve Python, repository root, and GDS path"
+
+GMS_DYNAMO_ROOT="${GMS_DYNAMO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+GMS_PYTHON="${GMS_PYTHON:-${PYTHON:-python}}"
+GMS_PYTHON="$(command -v "$GMS_PYTHON")" || fail "Python executable not found"
+: "${GMS_KVR_NIXL_GDS_PATH:?Set GMS_KVR_NIXL_GDS_PATH to a cuFile-capable mount}"
+
+[[ -d "$GMS_DYNAMO_ROOT/lib/gms_kv_ring" ]] || fail "no $GMS_DYNAMO_ROOT/lib/gms_kv_ring"
+[[ -d "$GMS_KVR_NIXL_GDS_PATH" ]] || fail "$GMS_KVR_NIXL_GDS_PATH is not a directory"
+[[ -w "$GMS_KVR_NIXL_GDS_PATH" ]] || fail "$GMS_KVR_NIXL_GDS_PATH is not writable by $(whoami)"
+
+pass "python:      $GMS_PYTHON"
+pass "dynamo root: $GMS_DYNAMO_ROOT"
+pass "GDS path:    $GMS_KVR_NIXL_GDS_PATH (writable)"
+
+# Use repository sources while preserving caller-provided loader paths.
+# We do not re-export PATH-style libraries here because that is
+# host-specific. Supply any extra loader paths via LD_LIBRARY_PATH
+# before running this script.
+export PYTHONPATH="$GMS_DYNAMO_ROOT/lib"
+export GMS_KVR_NIXL_GDS_PATH
+
+# ---------- gate 1: libcufile is loadable ----------
+
+gate 1 "libcufile" "cuFile driver library must be loadable"
+
+# Try unversioned soname first (system install), then versioned
+# soname (.so.0 — what NVIDIA CUDA wheels ship). If only the
+# versioned form resolves, print the LD_LIBRARY_PATH extension the
+# user should set so subsequent gates find it.
+"$GMS_PYTHON" - <<'PY' || fail "libcufile is not loadable. Add the directory containing libcufile.so to LD_LIBRARY_PATH and re-run."
+import ctypes, sys
+
+attempts = [
+    "libcufile.so",      # unversioned (system install or dev pkg)
+    "libcufile.so.0",    # soname'd, what CUDA wheels ship
+]
+last_err = None
+loaded_via = None
+for name in attempts:
+    try:
+        ctypes.CDLL(name)
+        loaded_via = name
+        break
+    except OSError as e:
+        last_err = e
+
+if loaded_via is None:
+    print("    dlopen failed for", attempts, ":", last_err, file=sys.stderr)
+    print("    set LD_LIBRARY_PATH to the directory containing libcufile.so and re-run", file=sys.stderr)
+    sys.exit(2)
+
+print(f"    loaded {loaded_via} via dlopen")
+PY
+pass "libcufile resolves via dynamic loader"
+
+# ---------- gate 2: NIXL has the GDS plugin ----------
+
+gate 2 "NIXL plugins" "NIXL agent must enumerate the GDS plugin"
+
+"$GMS_PYTHON" - <<'PY' || fail "NIXL is loadable but the 'GDS' plugin is NOT in available_plugins. Install nixl-cu12 with GDS support, or re-build NIXL with --enable-gds. The current host's NIXL is built without GDS."
+import sys
+try:
+    from nixl._api import nixl_agent
+except Exception as e:
+    print("    cannot import nixl:", e, file=sys.stderr)
+    sys.exit(2)
+agent = nixl_agent("gms-preflight-probe")
+plugins = list(agent.get_plugin_list())
+print(f"    NIXL plugins available: {plugins}")
+if "GDS" not in plugins and "GDS_MT" not in plugins:
+    print("    GDS / GDS_MT plugin missing", file=sys.stderr)
+    sys.exit(3)
+PY
+pass "NIXL GDS plugin available"
+
+# ---------- gate 3: GMS NIXL backend constructs with the GDS plugin ----------
+
+gate 3 "NixlBackend(plugin=GDS)" "construct NixlBackend on the candidate path"
+
+"$GMS_PYTHON" - <<PY || fail "NixlBackend failed to construct with plugin=GDS on $GMS_KVR_NIXL_GDS_PATH. Likely causes: the mount is not cuFile-capable (try \`cufile_sample_001\` against it), filesystem is read-only at the path, or cuFile JSON config is missing."
+import os, sys
+from gms_kv_ring.daemon.backends_nixl import NixlBackend
+base = os.environ["GMS_KVR_NIXL_GDS_PATH"]
+try:
+    nb = NixlBackend(base, plugin="GDS")
+    print("    NixlBackend(plugin=GDS) constructed; name=", nb.name)
+    nb.release_engine("__preflight__")
+except Exception as e:
+    print("    construction raised:", repr(e), file=sys.stderr)
+    sys.exit(2)
+PY
+pass "NixlBackend constructs on the candidate path"
+
+# ---------- gate 4: real-GDS round-trip + dest_offset test ----------
+
+gate 4 "pytest" "exercise the GDS data plane end-to-end"
+
+TIMEOUT="${GMS_GDS_TEST_TIMEOUT_S:-120}"
+
+cd "$GMS_DYNAMO_ROOT/lib/gms_kv_ring"
+
+info "running: pytest -v tests/test_backend_nixl.py::test_nixl_gds_round_trip_real_mount"
+timeout "$TIMEOUT" "$GMS_PYTHON" -m pytest -v --tb=short \
+    tests/test_backend_nixl.py::test_nixl_gds_round_trip_real_mount \
+    || fail "single-block GDS round-trip failed — restore-on-hit cannot land on this host."
+pass "single-block GDS demote+promote round-trip"
+
+info "running: pytest -v tests/test_backend_nixl.py::test_nixl_gds_promote_to_hbm_with_separate_dest_offset"
+timeout "$TIMEOUT" "$GMS_PYTHON" -m pytest -v --tb=short \
+    tests/test_backend_nixl.py::test_nixl_gds_promote_to_hbm_with_separate_dest_offset \
+    || fail "promote_storage_to_hbm with dest_offset != offset failed — restore-on-hit's cross-block-id remap is broken on this host."
+pass "promote_storage_to_hbm dest_offset remap"
+
+# ---------- summary ----------
+
+printf '\n%s %s\n' "$(green ALL GATES PASSED)" "— GMS restore-on-hit validation succeeded."

--- a/lib/gms_kv_ring/tests/test_backend.py
+++ b/lib/gms_kv_ring/tests/test_backend.py
@@ -3,6 +3,8 @@
 
 """Tests for the StorageBackend abstraction layer:
   - StorageTier still satisfies the StorageBackend ABC
+  - NixlBackend / MooncakeBackend skeletons: is_available + import
+    cleanly even when their runtime deps are absent
   - BackendSupervisor: catches Python exceptions, restarts on
     persistent failure, tracks metrics, marks dead on max_restarts
 
@@ -67,6 +69,44 @@ def test_storage_release_does_not_delete_replacement(tmp_path):
     assert dst.raw == second_bytes
 
 
+def test_nixl_backend_is_available_returns_bool_without_raising():
+    """is_available probes for the binding lazily. Calling it on a
+    machine without nixl installed must return False, not raise."""
+    from gms_kv_ring.daemon.backends_nixl import NixlBackend
+
+    result = NixlBackend.is_available()
+    assert isinstance(result, bool)
+
+
+def test_mooncake_backend_is_available_returns_bool_without_raising():
+    from gms_kv_ring.daemon.backends_mooncake import MooncakeBackend
+
+    result = MooncakeBackend.is_available()
+    assert isinstance(result, bool)
+
+
+def test_nixl_backend_init_raises_when_dep_missing():
+    """If `nixl` isn't importable, constructing the backend must
+    raise a clear RuntimeError pointing to the install path —
+    rather than failing later in a confusing way."""
+    from gms_kv_ring.daemon.backends_nixl import NixlBackend
+
+    if NixlBackend.is_available():
+        pytest.skip("nixl is installed; can't test missing-dep path")
+    with pytest.raises(RuntimeError, match="nixl"):
+        NixlBackend("/tmp/x", plugin="POSIX")
+
+
+def test_mooncake_backend_init_raises_when_dep_missing():
+    from gms_kv_ring.daemon.backends_mooncake import MooncakeBackend
+
+    if MooncakeBackend.is_available():
+        pytest.skip("mooncake is installed; can't test missing-dep path")
+    with pytest.raises(RuntimeError, match="mooncake"):
+        MooncakeBackend(master_server_addr="127.0.0.1:50051")
+
+
+# ---------------------------------------------------------------------------
 # BackendSupervisor
 # ---------------------------------------------------------------------------
 

--- a/lib/gms_kv_ring/tests/test_backend_hermetic_contracts.py
+++ b/lib/gms_kv_ring/tests/test_backend_hermetic_contracts.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hermetic adapter contracts for optional storage and transport runtimes.
+
+These tests validate our descriptor, framing, integrity, and cleanup logic with
+in-memory doubles. Hardware/service-backed tests remain separate live gates.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import sys
+import threading
+import types
+import zlib
+
+import pytest
+
+
+class _MemoryMooncakeStore:
+    def __init__(self):
+        self.data = {}
+        self.config = None
+        self.closed = False
+
+    def setup(self, config):
+        self.config = config
+        return 0
+
+    def put_from(self, key, ptr, size):
+        self.data[key] = bytes(ctypes.string_at(ptr, size))
+        return 0
+
+    def get_into(self, key, ptr, size):
+        payload = self.data.get(key)
+        if payload is None:
+            return -1
+        ctypes.memmove(ptr, payload, min(size, len(payload)))
+        return len(payload)
+
+    def remove(self, key):
+        self.data.pop(key, None)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def mooncake_backend(monkeypatch):
+    from gms_kv_ring.daemon.backends_mooncake import MooncakeBackend
+
+    package = types.ModuleType("mooncake")
+    store_module = types.ModuleType("mooncake.store")
+    store_module.MooncakeDistributedStore = _MemoryMooncakeStore
+    monkeypatch.setitem(sys.modules, "mooncake", package)
+    monkeypatch.setitem(sys.modules, "mooncake.store", store_module)
+    monkeypatch.setattr(MooncakeBackend, "is_available", classmethod(lambda cls: True))
+    backend = MooncakeBackend(
+        local_hostname="contract-client",
+        metadata_server="http://metadata.invalid",
+        master_server_addr="master.invalid:50051",
+        protocol="tcp",
+    )
+    yield backend
+    backend.close()
+
+
+def test_mooncake_adapter_round_trip_integrity_and_release(mooncake_backend):
+    payload = bytes((i * 29) & 0xFF for i in range(2048))
+    source = (ctypes.c_ubyte * len(payload)).from_buffer_copy(payload)
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    slot = mooncake_backend.demote(
+        "engine", 3, 4096, ctypes.addressof(source), len(payload), crc
+    )
+    destination = (ctypes.c_ubyte * len(payload))()
+    assert (
+        mooncake_backend.promote(
+            "engine", 3, 4096, ctypes.addressof(destination), len(payload)
+        )
+        == crc
+    )
+    assert bytes(destination) == payload
+
+    stored = bytearray(mooncake_backend._mds.data[slot.mc_key])
+    stored[-1] ^= 0xFF
+    mooncake_backend._mds.data[slot.mc_key] = bytes(stored)
+    assert (
+        mooncake_backend.promote(
+            "engine", 3, 4096, ctypes.addressof(destination), len(payload)
+        )
+        is None
+    )
+    assert mooncake_backend.release_slot("engine", 3, 4096)
+    assert slot.mc_key not in mooncake_backend._mds.data
+
+
+class _DescriptorAgent:
+    def __init__(self, states=("DONE",)):
+        self.states = list(states)
+        self.registrations = []
+        self.deregistered = []
+        self.released = []
+        self.initialized = []
+
+    def get_reg_descs(self, descs, mem_type):
+        return ("reg", mem_type, descs)
+
+    def register_memory(self, desc):
+        token = ("registered", len(self.registrations))
+        self.registrations.append(desc)
+        return token
+
+    def get_xfer_descs(self, descs, mem_type):
+        return ("xfer", mem_type, descs)
+
+    def initialize_xfer(self, direction, local, remote, agent_name):
+        handle = object()
+        self.initialized.append((direction, local, remote, agent_name, handle))
+        return handle
+
+    def transfer(self, handle):
+        return self.states.pop(0) if self.states else "DONE"
+
+    def check_xfer_state(self, handle):
+        return self.states.pop(0) if self.states else "DONE"
+
+    def release_xfer_handle(self, handle):
+        self.released.append(handle)
+
+    def deregister_memory(self, token):
+        self.deregistered.append(token)
+
+
+def _nixl_backend(agent):
+    from gms_kv_ring.daemon.backends_nixl import NixlBackend
+
+    backend = object.__new__(NixlBackend)
+    backend._agent = agent
+    backend.agent_name = "contract-agent"
+    return backend
+
+
+@pytest.mark.parametrize(
+    ("method", "args", "host_type", "storage_type"),
+    [
+        ("_do_nixl_xfer_posix", ("WRITE", 0x1000, 64, 7, 24), "DRAM", "FILE"),
+        ("_do_nixl_xfer_obj", ("WRITE", 0x1000, 64, "object-key"), "DRAM", "OBJ"),
+        ("_do_nixl_xfer_gds", ("READ", 0x2000, 64, 7, 24), "VRAM", "FILE"),
+    ],
+)
+def test_nixl_plugin_descriptor_contracts(method, args, host_type, storage_type):
+    agent = _DescriptorAgent(states=("IN_PROGRESS", "DONE"))
+    getattr(_nixl_backend(agent), method)(*args)
+
+    _direction, local, remote, name, handle = agent.initialized[0]
+    assert local[1] == host_type
+    assert remote[1] == storage_type
+    assert name == "contract-agent"
+    assert agent.released == [handle]
+    assert len(agent.deregistered) == 2
+
+
+def test_nixl_transfer_error_still_releases_every_resource():
+    agent = _DescriptorAgent(states=("ERR",))
+    with pytest.raises(RuntimeError, match="returned ERR"):
+        _nixl_backend(agent)._do_nixl_xfer_obj("WRITE", 0x1000, 64, "key")
+    assert len(agent.released) == 1
+    assert len(agent.deregistered) == 2
+
+
+class _TransportAgent:
+    def __init__(self, states=("IN_PROGRESS", "DONE"), metadata=True):
+        self.states = list(states)
+        self.metadata = metadata
+        self.initialized = []
+        self.released = []
+
+    def get_xfer_descs(self, descs, mem_type):
+        return (mem_type, descs)
+
+    def check_remote_metadata(self, peer, descs):
+        return self.metadata
+
+    def initialize_xfer(self, direction, local, remote, peer, **kwargs):
+        handle = object()
+        self.initialized.append((direction, local, remote, peer, kwargs, handle))
+        return handle
+
+    def transfer(self, handle):
+        return self.states.pop(0) if self.states else "DONE"
+
+    def release_xfer_handle(self, handle):
+        self.released.append(handle)
+
+
+def _transport(agent):
+    from gms_kv_ring.daemon.transport.nixl_transport import NixlTransport
+
+    transport = object.__new__(NixlTransport)
+    transport._closed = False
+    transport._agent = agent
+    transport._async_lock = threading.Lock()
+    transport._async_pending = {}
+    return transport
+
+
+def test_ucx_transport_write_and_read_contracts():
+    from gms_kv_ring.daemon.transport.nixl_transport import PeerHandle, _decode_notif
+
+    agent = _TransportAgent()
+    transport = _transport(agent)
+    peer = PeerHandle("peer", "127.0.0.1", 1234)
+    content_hash = b"h" * 32
+    transport.send(peer, 0x1000, 64, 0x2000, "reservation", content_hash)
+    direction, local, remote, name, kwargs, write_handle = agent.initialized[0]
+    assert (direction, local[0], remote[0], name) == ("WRITE", "DRAM", "DRAM", "peer")
+    assert _decode_notif(kwargs["notif_msg"]) == ("reservation", content_hash)
+    assert agent.released == [write_handle]
+
+    transport.read_batch("peer", [(0x3000, 32, 0x4000)])
+    direction, _local, _remote, name, kwargs, read_handle = agent.initialized[1]
+    assert (direction, name, kwargs) == ("READ", "peer", {})
+    assert agent.released == [write_handle, read_handle]
+
+
+def test_ucx_transport_rejects_uncovered_remote_memory():
+    from gms_kv_ring.daemon.transport.nixl_transport import PeerHandle, TransportClosed
+
+    transport = _transport(_TransportAgent(metadata=False))
+    with pytest.raises(TransportClosed, match="doesn't cover"):
+        transport.send(PeerHandle("peer", "host", 1), 1, 8, 2, "rid", b"x" * 32)

--- a/lib/gms_kv_ring/tests/test_backend_mooncake.py
+++ b/lib/gms_kv_ring/tests/test_backend_mooncake.py
@@ -1,0 +1,902 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-Mooncake tests for MooncakeBackend.
+
+These spin up an actual `mooncake_master` subprocess + connect a
+client to it. The whole module skips if:
+  - `mooncake.store` isn't importable on this Python install
+  - the `mooncake_master` binary isn't on disk
+  - the master subprocess can't bind a port
+
+Memory note `21-mooncake-unified-pool-layout-bug.md` flags one
+Mooncake xfail on TRT-LLM warm_hit; that's the engine-side
+unified-pool path, NOT the storage put_from/get_into path we
+exercise here. Worth re-checking if these tests ever start
+flaking.
+
+Covered: setup, demote, promote, CRC mismatch detection,
+multi-block put/get, release_slot, release_engine."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import socket
+import subprocess
+import time
+import uuid
+import zlib
+
+import pytest
+from gms_kv_ring.daemon.backends_mooncake import MooncakeBackend
+
+if not MooncakeBackend.is_available():
+    pytest.skip(
+        "mooncake.store not importable in this environment",
+        allow_module_level=True,
+    )
+
+# Locate the master binary. Skip if missing.
+_MOONCAKE_PKG = os.path.dirname(__import__("mooncake").__file__)
+_MASTER_BIN = os.path.join(_MOONCAKE_PKG, "mooncake_master")
+if not os.access(_MASTER_BIN, os.X_OK):
+    pytest.skip(
+        f"mooncake_master not executable at {_MASTER_BIN}",
+        allow_module_level=True,
+    )
+
+
+def _free_port() -> int:
+    """OS-assigned free port. Closes immediately; small TOCTOU
+    window before the master claims it — fine for tests."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture(scope="module")
+def mooncake_master(tmp_path_factory):
+    """Spawn a Mooncake master process with an HTTP metadata
+    server. Yields (master_rpc_addr, metadata_addr). Cleans up at
+    module teardown."""
+    rpc_port = _free_port()
+    meta_port = _free_port()
+    root_fs = tmp_path_factory.mktemp("mooncake-storage")
+    os.environ["GMS_TEST_MOONCAKE_ROOT_FS"] = str(root_fs)
+    # Keep the test offload client small; Mooncake defaults can reserve
+    # more than a GiB of process memory for the local-disk path. These
+    # must be visible to the in-process client, not just the master.
+    os.environ.setdefault(
+        "MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES",
+        str(128 << 20),
+    )
+    os.environ.setdefault(
+        "MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES",
+        str(128 << 20),
+    )
+    os.environ.setdefault("MOONCAKE_OFFLOAD_ENABLE_EVICTION", "true")
+    env = os.environ.copy()
+    # The active runtime environment owns LD_LIBRARY_PATH for libibverbs,
+    # CUDA runtime, libcurl, and liblzma. Avoid hardcoded paths here so
+    # the fixture validates the packaged runtime environment.
+    proc = subprocess.Popen(
+        [
+            _MASTER_BIN,
+            f"--rpc_port={rpc_port}",
+            "--enable_http_metadata_server",
+            f"--http_metadata_server_port={meta_port}",
+            "--http_metadata_server_host=127.0.0.1",
+            "--enable_offload=true",
+            f"--root_fs_dir={root_fs}",
+            "--cluster_id=gms_test",
+            f"--global_file_segment_size={64 << 20}",
+            "--logtostderr",
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        # Wait for the RPC port to accept connections.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                stderr = proc.stderr.read().decode("utf-8", "replace")
+                pytest.skip(
+                    f"mooncake_master exited rc={proc.returncode}; "
+                    f"stderr={stderr[:500]!r}"
+                )
+            try:
+                s = socket.create_connection(
+                    ("127.0.0.1", rpc_port),
+                    timeout=0.5,
+                )
+                s.close()
+                break
+            except OSError:
+                time.sleep(0.05)
+        else:
+            proc.terminate()
+            proc.wait(timeout=2)
+            pytest.skip("mooncake_master never bound the rpc_port")
+        yield (
+            f"127.0.0.1:{rpc_port}",
+            f"127.0.0.1:{meta_port}",
+        )
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+def _make_backend(mooncake_master):
+    master_addr, meta_addr = mooncake_master
+    # Mooncake's HTTP metadata server needs the full URL form,
+    # not just host:port — the C client builds GET requests like
+    # `{metadata_server}?key=...` so the path matters.
+    return MooncakeBackend(
+        local_hostname=f"test-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,  # 64 MiB
+        local_buffer_size=16 << 20,  # 16 MiB
+        protocol="tcp",
+        rdma_devices="",
+    )
+
+
+def _make_backend_with_ssd_offload(mooncake_master, ssd_path):
+    master_addr, meta_addr = mooncake_master
+    os.makedirs(ssd_path, exist_ok=True)
+    return MooncakeBackend(
+        local_hostname=f"ssd-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+        enable_ssd_offload=True,
+        ssd_offload_path=str(ssd_path),
+    )
+
+
+def _pinned(payload: bytes):
+    buf = (ctypes.c_ubyte * len(payload)).from_buffer_copy(payload)
+    return ctypes.addressof(buf), buf
+
+
+def test_mooncake_backend_demote_promote_round_trip(mooncake_master):
+    """Put a payload, get it back, verify bytes + CRC."""
+    nb = _make_backend(mooncake_master)
+    try:
+        payload = bytes((i * 23 & 0xFF) for i in range(4096))
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+        src_addr, _src_buf = _pinned(payload)
+
+        slot = nb.demote("eng-A", 0, 0, host_ptr=src_addr, size=len(payload), crc=crc)
+        assert slot.size == len(payload)
+        assert slot.crc == crc
+        assert slot.mc_key == "gms/eng-A/0/0"
+
+        dst = (ctypes.c_ubyte * len(payload))()
+        verified = nb.promote(
+            "eng-A",
+            0,
+            0,
+            dest_host_ptr=ctypes.addressof(dst),
+            max_size=len(payload),
+        )
+        assert verified == crc
+        assert bytes(dst) == payload
+    finally:
+        nb.release_engine("eng-A")
+        nb.close()
+
+
+def test_mooncake_backend_multiple_blocks(mooncake_master):
+    """Several blocks in flight, all round-trippable."""
+    nb = _make_backend(mooncake_master)
+    try:
+        payloads = [bytes((i * (k + 1) & 0xFF) for i in range(1024)) for k in range(4)]
+        for k, p in enumerate(payloads):
+            addr, _ = _pinned(p)
+            nb.demote(
+                "eng-B",
+                0,
+                k * 1024,
+                host_ptr=addr,
+                size=len(p),
+                crc=zlib.crc32(p) & 0xFFFFFFFF,
+            )
+        assert nb.n_slots() == 4
+
+        for k, p in enumerate(payloads):
+            dst = (ctypes.c_ubyte * len(p))()
+            v = nb.promote(
+                "eng-B",
+                0,
+                k * 1024,
+                dest_host_ptr=ctypes.addressof(dst),
+                max_size=len(p),
+            )
+            assert v == zlib.crc32(p) & 0xFFFFFFFF
+            assert bytes(dst) == p
+    finally:
+        nb.release_engine("eng-B")
+        nb.close()
+
+
+def test_mooncake_backend_release_slot_removes_key(mooncake_master):
+    """release_slot drops the index entry AND removes the key from
+    Mooncake — a subsequent promote returns None (slot unknown)."""
+    nb = _make_backend(mooncake_master)
+    try:
+        payload = b"x" * 512
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+        addr, _b = _pinned(payload)
+        nb.demote("eng-C", 0, 0, addr, len(payload), crc)
+        assert nb.release_slot("eng-C", 0, 0) is True
+        assert nb.get("eng-C", 0, 0) is None
+        # Promote on a released slot returns None.
+        dst = (ctypes.c_ubyte * len(payload))()
+        assert (
+            nb.promote(
+                "eng-C",
+                0,
+                0,
+                ctypes.addressof(dst),
+                len(payload),
+            )
+            is None
+        )
+    finally:
+        nb.close()
+
+
+def test_mooncake_backend_release_engine(mooncake_master):
+    """release_engine drops every slot for one engine, leaves others
+    alone."""
+    nb = _make_backend(mooncake_master)
+    try:
+        addr_a, _ba = _pinned(b"a" * 256)
+        addr_b, _bb = _pinned(b"b" * 256)
+        nb.demote("eng-X", 0, 0, addr_a, 256, 1)
+        nb.demote("eng-X", 0, 256, addr_a, 256, 2)
+        nb.demote("eng-Y", 0, 0, addr_b, 256, 3)
+
+        n = nb.release_engine("eng-X")
+        assert n == 2
+        assert nb.get("eng-X", 0, 0) is None
+        assert nb.get("eng-Y", 0, 0) is not None
+    finally:
+        nb.release_engine("eng-Y")
+        nb.close()
+
+
+def test_mooncake_backend_ssd_offload_local_path_round_trip(
+    mooncake_master,
+    tmp_path,
+):
+    """Enable Mooncake's SSD offload knob against a local folder.
+
+    Small payloads may remain in Mooncake's DRAM pool, so this validates
+    configuration and data correctness rather than forcing eviction.
+    """
+    nb = _make_backend_with_ssd_offload(
+        mooncake_master,
+        tmp_path / "mooncake-ssd",
+    )
+    try:
+        root_fs = os.environ["GMS_TEST_MOONCAKE_ROOT_FS"]
+
+        def files_under(path):
+            out = set()
+            for dirpath, _dirnames, filenames in os.walk(path):
+                for filename in filenames:
+                    out.add(os.path.relpath(os.path.join(dirpath, filename), path))
+            return out
+
+        before_files = files_under(root_fs)
+        payload = bytes((i * 29 & 0xFF) for i in range(4096))
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+        addr, _b = _pinned(payload)
+        nb.demote("eng-SSD", 0, 0, addr, len(payload), crc)
+
+        deadline = time.monotonic() + 3.0
+        new_files = set()
+        while time.monotonic() < deadline:
+            new_files = files_under(root_fs) - before_files
+            if new_files:
+                break
+            time.sleep(0.05)
+        assert new_files, "Mooncake local-disk offload produced no files"
+
+        dst = (ctypes.c_ubyte * len(payload))()
+        verified = nb.promote(
+            "eng-SSD",
+            0,
+            0,
+            ctypes.addressof(dst),
+            len(payload),
+        )
+        assert verified == crc
+        assert bytes(dst) == payload
+    finally:
+        nb.release_engine("eng-SSD")
+        nb.close()
+
+
+def test_mooncake_backend_manifest_tombstone_replay(tmp_path):
+    """Manifest tombstones must win even if the backing store says
+    the old key still exists. This is a pure replay-state test."""
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text(
+        '{"eid":"eng-T","layer":0,"offset":0,'
+        '"mc_key":"gms/eng-T/0/0","size":256,'
+        '"crc":1,"mtime":1700000000.0}\n'
+        '{"eid":"eng-T","layer":0,"offset":0,'
+        '"deleted":true,"mtime":1700000001.0}\n'
+    )
+
+    class FakeStore:
+        def is_exist(self, _key):
+            return 1
+
+    nb = MooncakeBackend.__new__(MooncakeBackend)
+    nb.manifest_path = str(manifest)
+    nb._slots = {}
+    nb._mds = FakeStore()
+    nb._replay_manifest()
+    assert nb._slots == {}
+
+
+def test_mooncake_backend_manifest_quota_tombstone_replay(
+    mooncake_master,
+    tmp_path,
+):
+    master_addr, meta_addr = mooncake_master
+    manifest = str(tmp_path / "manifest.jsonl")
+    payload = b"q" * 512
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    addr, _b = _pinned(payload)
+
+    nb1 = MooncakeBackend(
+        local_hostname=f"quota-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+        manifest_path=manifest,
+    )
+    try:
+        for off in (0, 512, 1024):
+            nb1.demote("eng-Q", 0, off, addr, len(payload), crc)
+        nb1._slots[("eng-Q", 0, 0)].mtime = 1.0
+        nb1._slots[("eng-Q", 0, 512)].mtime = 2.0
+        nb1._slots[("eng-Q", 0, 1024)].mtime = 3.0
+        assert nb1.enforce_byte_quota(512) == 2
+
+        nb2 = MooncakeBackend(
+            local_hostname=f"quota-r-{uuid.uuid4().hex[:6]}",
+            metadata_server=f"http://{meta_addr}/metadata",
+            master_server_addr=master_addr,
+            global_segment_size=64 << 20,
+            local_buffer_size=16 << 20,
+            protocol="tcp",
+            rdma_devices="",
+            manifest_path=manifest,
+        )
+        try:
+            assert nb2.n_slots() == 1
+            assert nb2.get("eng-Q", 0, 0) is None
+            assert nb2.get("eng-Q", 0, 512) is None
+            assert nb2.get("eng-Q", 0, 1024) is not None
+        finally:
+            nb2.close()
+    finally:
+        nb1.release_engine("eng-Q")
+        nb1.close()
+
+
+def test_mooncake_backend_with_supervisor(mooncake_master):
+    """MooncakeBackend works behind BackendSupervisor — exercises
+    the supervisor's exception-isolation path on a real transport."""
+    from gms_kv_ring.daemon.supervisor import BackendSupervisor
+
+    master_addr, meta_addr = mooncake_master
+    nb = _make_backend(mooncake_master)
+    sup = BackendSupervisor(nb, factory=lambda: _make_backend(mooncake_master))
+    try:
+        payload = b"sup" * 64
+        addr, _b = _pinned(payload)
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+        slot = sup.demote("eng-S", 0, 0, addr, len(payload), crc)
+        assert slot is not None
+        assert sup.n_slots() == 1
+    finally:
+        sup.release_engine("eng-S")
+        nb.close()
+
+
+def test_mooncake_backend_manifest_filters_lost_keys(mooncake_master):
+    """If the manifest references keys Mooncake no longer has,
+    replay must skip them and start with an empty index.
+
+    This validates the important partial-loss restart behavior without
+    relying on any specific persistence mode: a stale manifest record
+    must not become a phantom slot returned to the engine.
+    """
+    import tempfile
+
+    master_addr, meta_addr = mooncake_master
+    with tempfile.TemporaryDirectory() as td:
+        manifest = os.path.join(td, "manifest.jsonl")
+        payload = b"L" * 256
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+        nb1 = MooncakeBackend(
+            local_hostname=f"d1-{uuid.uuid4().hex[:6]}",
+            metadata_server=f"http://{meta_addr}/metadata",
+            master_server_addr=master_addr,
+            global_segment_size=64 << 20,
+            local_buffer_size=16 << 20,
+            protocol="tcp",
+            rdma_devices="",
+            manifest_path=manifest,
+        )
+        addr, _b = _pinned(payload)
+        nb1.demote("eng-D", 0, 0, addr, len(payload), crc)
+        nb1.demote("eng-D", 0, 1024, addr, len(payload), crc)
+        # Simulate backing-store loss while leaving live records in
+        # the manifest: remove Mooncake objects directly, without
+        # calling release_slot/release_engine, so no tombstones are
+        # written. Replay must use is_exist() to filter these records.
+        nb1._free_resource(nb1.get("eng-D", 0, 0))
+        nb1._free_resource(nb1.get("eng-D", 0, 1024))
+        nb1.close()
+        del nb1
+
+        nb2 = MooncakeBackend(
+            local_hostname=f"d2-{uuid.uuid4().hex[:6]}",
+            metadata_server=f"http://{meta_addr}/metadata",
+            master_server_addr=master_addr,
+            global_segment_size=64 << 20,
+            local_buffer_size=16 << 20,
+            protocol="tcp",
+            rdma_devices="",
+            manifest_path=manifest,
+        )
+        try:
+            # Manifest had 2 records but Mooncake lost both segments.
+            # Reconcile must report 0 surviving — engine will fall
+            # to cold compute for any block referenced post-restart.
+            assert nb2.n_slots() == 0, (
+                f"is_exist filter should drop lost keys; got "
+                f"{nb2.n_slots()} phantom slots"
+            )
+        finally:
+            nb2.close()
+
+
+def test_mooncake_backend_manifest_replay_within_session(mooncake_master, tmp_path):
+    """A working version of the round-trip semantics: ONE client
+    writes the manifest. Then a SECOND client opens the same
+    manifest WHILE the first is still alive (i.e., the data is
+    still in client #1's DRAM segment). is_exist returns 1 for
+    keys that are reachable cluster-wide, so reconcile picks them
+    up.
+
+    This isn't the kill-and-restart story (which needs SSD
+    offload), but it exercises the manifest read + is_exist
+    filter path with real-Mooncake."""
+    master_addr, meta_addr = mooncake_master
+    manifest = str(tmp_path / "manifest.jsonl")
+
+    payload = b"S" * 256
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    nb1 = MooncakeBackend(
+        local_hostname=f"keep-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+        manifest_path=manifest,
+    )
+    try:
+        addr, _b = _pinned(payload)
+        nb1.demote("eng-S", 0, 0, addr, len(payload), crc)
+        nb1.demote("eng-S", 0, 1024, addr, len(payload), crc)
+        # NB1 is still alive — its DRAM segment still holds the keys.
+        nb2 = MooncakeBackend(
+            local_hostname=f"reader-{uuid.uuid4().hex[:6]}",
+            metadata_server=f"http://{meta_addr}/metadata",
+            master_server_addr=master_addr,
+            global_segment_size=64 << 20,
+            local_buffer_size=16 << 20,
+            protocol="tcp",
+            rdma_devices="",
+            manifest_path=manifest,
+        )
+        try:
+            # Reconcile saw 2 records, both still in Mooncake.
+            assert nb2.n_slots() == 2, (
+                f"reconcile should see 2 surviving keys; got " f"{nb2.n_slots()}"
+            )
+        finally:
+            nb2.close()
+    finally:
+        nb1.release_engine("eng-S")
+        nb1.close()
+
+
+def test_mooncake_backend_manifest_skips_corrupt_lines(mooncake_master, tmp_path):
+    """If a manifest line is malformed JSON (truncated write
+    on crash, disk corruption), reconcile must skip it cleanly and
+    pick up the rest."""
+    master_addr, meta_addr = mooncake_master
+    manifest = str(tmp_path / "manifest.jsonl")
+    # Pre-seed the manifest with one bad line + one good (but the
+    # good key won't be in Mooncake — that's fine, we're testing
+    # the parse path, not the is_exist path).
+    with open(manifest, "wb") as f:
+        f.write(b"{ this is not valid json\n")
+        f.write(
+            b'{"eid":"e","layer":0,"offset":0,"mc_key":"gms/e/0/0",'
+            b'"size":256,"crc":1,"mtime":1700000000.0}\n'
+        )
+
+    nb = MooncakeBackend(
+        local_hostname=f"c1-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+        manifest_path=manifest,
+    )
+    try:
+        # Bad line skipped silently; the good line's key isn't in
+        # Mooncake so it's filtered too — net: 0 slots indexed.
+        assert nb.n_slots() == 0
+    finally:
+        nb.close()
+
+
+def test_mooncake_backend_no_manifest_means_no_reconcile(
+    mooncake_master,
+    tmp_path,
+):
+    """Without a manifest_path, a fresh backend starts empty even
+    if there were earlier puts on the same master — that's the
+    documented ephemeral behavior."""
+    master_addr, meta_addr = mooncake_master
+    payload = b"N" * 128
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    nb1 = MooncakeBackend(
+        local_hostname=f"e1-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+        # No manifest_path.
+    )
+    addr, _b = _pinned(payload)
+    nb1.demote("eng-N", 0, 0, addr, len(payload), crc)
+    # Release before close so we don't leak in the master.
+    nb1.release_engine("eng-N")
+    nb1.close()
+    del nb1
+
+    nb2 = MooncakeBackend(
+        local_hostname=f"e2-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+    )
+    try:
+        assert nb2.n_slots() == 0
+    finally:
+        nb2.close()
+
+
+def test_mooncake_backend_manifest_compaction_shrinks_file(
+    mooncake_master,
+    tmp_path,
+):
+    """Demote many slots, release most, compact: the manifest
+    shrinks to just the surviving records. Replay on a new backend
+    sees only the surviving slots."""
+    from gms_kv_ring.common import metrics
+
+    master_addr, meta_addr = mooncake_master
+    manifest = str(tmp_path / "manifest.jsonl")
+    payload = b"K" * 256
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    nb = MooncakeBackend(
+        local_hostname=f"comp-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+        manifest_path=manifest,
+    )
+    try:
+        # 20 demotes, then release 18 — manifest has 20 records but
+        # only 2 are live.
+        addr, _b = _pinned(payload)
+        for off in range(0, 20 * 1024, 1024):
+            nb.demote("eng-C", 0, off, addr, len(payload), crc)
+        for off in range(0, 18 * 1024, 1024):
+            nb.release_slot("eng-C", 0, off)
+        assert nb.n_slots() == 2
+
+        size_before = nb.manifest_size_bytes()
+        before_metric = metrics.mooncake_manifest_compactions.get()
+        savings = nb.compact_manifest()
+        size_after = nb.manifest_size_bytes()
+        after_metric = metrics.mooncake_manifest_compactions.get()
+
+        assert savings > 0, (
+            f"compaction should free bytes; got savings={savings} "
+            f"(before={size_before} after={size_after})"
+        )
+        assert size_after < size_before
+        assert after_metric == before_metric + 1
+        # New file has exactly 2 records (one per surviving slot).
+        with open(manifest, "rb") as f:
+            lines = f.read().splitlines()
+        assert len(lines) == 2
+
+        # Demote after compaction still works (append fp was swapped).
+        nb.demote("eng-C", 0, 99_000, addr, len(payload), crc)
+        with open(manifest, "rb") as f:
+            lines = f.read().splitlines()
+        assert len(lines) == 3
+    finally:
+        nb.release_engine("eng-C")
+        nb.close()
+
+
+def test_mooncake_backend_compaction_then_replay(mooncake_master, tmp_path):
+    """End-to-end: write 5 records, compact, drop the backend,
+    open a second backend on the same manifest. Reconcile sees
+    exactly the post-compaction set (with is_exist filtering)."""
+    master_addr, meta_addr = mooncake_master
+    manifest = str(tmp_path / "manifest.jsonl")
+    payload = b"R" * 128
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    nb1 = MooncakeBackend(
+        local_hostname=f"keep-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+        manifest_path=manifest,
+    )
+    try:
+        addr, _b = _pinned(payload)
+        for k in range(5):
+            nb1.demote("eng-X", 0, k * 1024, addr, len(payload), crc)
+        for k in (1, 3):
+            nb1.release_slot("eng-X", 0, k * 1024)
+        assert nb1.n_slots() == 3
+        nb1.compact_manifest()
+
+        # While nb1 is still alive (segment owner), open a second
+        # backend on the same manifest. is_exist will return 1 for
+        # nb1's live keys.
+        nb2 = MooncakeBackend(
+            local_hostname=f"r-{uuid.uuid4().hex[:6]}",
+            metadata_server=f"http://{meta_addr}/metadata",
+            master_server_addr=master_addr,
+            global_segment_size=64 << 20,
+            local_buffer_size=16 << 20,
+            protocol="tcp",
+            rdma_devices="",
+            manifest_path=manifest,
+        )
+        try:
+            assert nb2.n_slots() == 3
+            # And it's exactly the right 3 (offsets 0, 2, 4).
+            assert nb2.get("eng-X", 0, 0) is not None
+            assert nb2.get("eng-X", 0, 1024) is None
+            assert nb2.get("eng-X", 0, 2 * 1024) is not None
+            assert nb2.get("eng-X", 0, 3 * 1024) is None
+            assert nb2.get("eng-X", 0, 4 * 1024) is not None
+        finally:
+            nb2.close()
+    finally:
+        nb1.release_engine("eng-X")
+        nb1.close()
+
+
+def test_mooncake_backend_sweeper_auto_compaction(mooncake_master, tmp_path):
+    """End-to-end auto-trigger: a sweeper with
+    `compact_manifest_at_bytes` set runs against a MooncakeBackend
+    whose manifest has grown past that threshold. The sweeper
+    invokes compact_manifest() on the next tick; the file shrinks;
+    `sweeper.compactions_run` increments."""
+    import threading
+
+    from gms_kv_ring.daemon.storage_tier import StorageSweeper
+
+    master_addr, meta_addr = mooncake_master
+    manifest = str(tmp_path / "manifest.jsonl")
+    payload = b"S" * 256
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    nb = MooncakeBackend(
+        local_hostname=f"sw-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+        manifest_path=manifest,
+    )
+    try:
+        # Bloat the manifest: 30 demotes + 28 releases. 30 records on
+        # disk, 2 live in memory.
+        addr, _b = _pinned(payload)
+        for off in range(0, 30 * 1024, 1024):
+            nb.demote("eng-W", 0, off, addr, len(payload), crc)
+        for off in range(0, 28 * 1024, 1024):
+            nb.release_slot("eng-W", 0, off)
+        assert nb.n_slots() == 2
+
+        size_before = nb.manifest_size_bytes()
+        # Set threshold below current size so the next sweep fires.
+        threshold = size_before // 2
+
+        compacted = threading.Event()
+
+        def on_sweep(_ttl, _per_eng, _quota):
+            # Fires every sweep; we only signal once the sweeper has
+            # actually compacted.
+            if sweeper.compactions_run > 0:
+                compacted.set()
+
+        sweeper = StorageSweeper(
+            nb,
+            interval_s=0.05,
+            compact_manifest_at_bytes=threshold,
+            on_sweep=on_sweep,
+        )
+        sweeper.start()
+        try:
+            assert compacted.wait(timeout=3.0), (
+                f"sweeper should auto-compact within 3s; "
+                f"compactions_run={sweeper.compactions_run}"
+            )
+        finally:
+            sweeper.stop()
+
+        size_after = nb.manifest_size_bytes()
+        assert size_after < size_before
+        assert sweeper.last_compaction_savings > 0
+        # Manifest now has only 2 live records.
+        with open(manifest, "rb") as f:
+            lines = f.read().splitlines()
+        assert len(lines) == 2
+    finally:
+        nb.release_engine("eng-W")
+        nb.close()
+
+
+def test_mooncake_backend_sweeper_skips_compaction_below_threshold(
+    mooncake_master,
+    tmp_path,
+):
+    """If the manifest is below the threshold, the sweeper must
+    NOT compact — extra fsyncs and locking are wasted work
+    otherwise."""
+    import threading
+
+    from gms_kv_ring.daemon.storage_tier import StorageSweeper
+
+    master_addr, meta_addr = mooncake_master
+    manifest = str(tmp_path / "manifest.jsonl")
+    payload = b"B" * 64
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    nb = MooncakeBackend(
+        local_hostname=f"sw2-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+        manifest_path=manifest,
+    )
+    try:
+        addr, _b = _pinned(payload)
+        nb.demote("eng-Q", 0, 0, addr, len(payload), crc)
+        size = nb.manifest_size_bytes()
+        assert size > 0
+
+        ran = threading.Event()
+
+        def on_sweep(*_):
+            ran.set()
+
+        # Threshold MUCH larger than current size → never fires.
+        sweeper = StorageSweeper(
+            nb,
+            interval_s=0.05,
+            compact_manifest_at_bytes=size * 100,
+            on_sweep=on_sweep,
+        )
+        sweeper.start()
+        try:
+            # Wait for at least one sweep iteration to happen.
+            assert ran.wait(timeout=2.0)
+            # Sweeper should have run but never compacted.
+            assert sweeper.sweeps_run >= 1
+            assert sweeper.compactions_run == 0
+        finally:
+            sweeper.stop()
+    finally:
+        nb.release_engine("eng-Q")
+        nb.close()
+
+
+def test_mooncake_backend_compaction_noop_without_manifest(mooncake_master):
+    """compact_manifest is a no-op when manifest is disabled — must
+    not raise."""
+    master_addr, meta_addr = mooncake_master
+    nb = MooncakeBackend(
+        local_hostname=f"n-{uuid.uuid4().hex[:6]}",
+        metadata_server=f"http://{meta_addr}/metadata",
+        master_server_addr=master_addr,
+        global_segment_size=64 << 20,
+        local_buffer_size=16 << 20,
+        protocol="tcp",
+        rdma_devices="",
+    )
+    try:
+        assert nb.compact_manifest() == 0
+        assert nb.manifest_size_bytes() == 0
+    finally:
+        nb.close()
+
+
+def test_mooncake_backend_stats_includes_bytes_by_engine(mooncake_master):
+    nb = _make_backend(mooncake_master)
+    try:
+        addr_a, _ba = _pinned(b"a" * 1024)
+        nb.demote("eng-1", 0, 0, addr_a, 1024, zlib.crc32(b"a" * 1024) & 0xFFFFFFFF)
+        nb.demote("eng-2", 0, 0, addr_a, 1024, zlib.crc32(b"a" * 1024) & 0xFFFFFFFF)
+        nb.demote("eng-2", 0, 1024, addr_a, 1024, zlib.crc32(b"a" * 1024) & 0xFFFFFFFF)
+        s = nb.stats()
+        assert s["n_slots"] == 3
+        assert s["bytes_by_engine"] == {"eng-1": 1024, "eng-2": 2048}
+    finally:
+        nb.release_engine("eng-1")
+        nb.release_engine("eng-2")
+        nb.close()

--- a/lib/gms_kv_ring/tests/test_backend_nixl.py
+++ b/lib/gms_kv_ring/tests/test_backend_nixl.py
@@ -1,0 +1,715 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-NIXL tests for NixlBackend (POSIX plugin).
+
+These tests exercise the actual `nixl_agent` data plane:
+register memory → initialize_xfer → transfer → poll → release.
+The whole suite is skipped on machines without `nixl` importable
+so the gms_kv_ring suite still passes on a bare host.
+
+Covered:
+  - End-to-end round trip: demote pinned host bytes → file →
+    promote → verify byte equality and CRC
+  - CRC mismatch detected if the file is tampered after demote
+  - Reconcile reads back files written by a previous instance
+  - Cleanup primitives (TTL prune, LRU quota, per-engine quota)
+    behave the same as the Local backend
+  - Cross-backend compatibility: a file written by `StorageTier`
+    is readable by `NixlBackend` (same 24-byte CRC header)
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import time
+import zlib
+
+import pytest
+from gms_kv_ring.daemon.backends_nixl import NixlBackend
+
+if not NixlBackend.is_available():
+    pytest.skip(
+        "nixl not importable in this environment",
+        allow_module_level=True,
+    )
+
+
+def _pinned(payload: bytes) -> tuple[int, "ctypes.Array"]:
+    """Allocate a ctypes buffer holding `payload`, return (addr, buf).
+    Caller MUST keep the buf reference alive for the test's duration."""
+    buf = (ctypes.c_ubyte * len(payload)).from_buffer_copy(payload)
+    return ctypes.addressof(buf), buf
+
+
+def test_nixl_backend_demote_promote_round_trip(tmp_path):
+    """Write a payload via NIXL, read it back, verify bytes + CRC."""
+    nb = NixlBackend(str(tmp_path / "store"), plugin="POSIX")
+    payload = bytes((i * 31 & 0xFF) for i in range(4096))
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    src_addr, _src_buf = _pinned(payload)
+
+    slot = nb.demote("eng-A", 0, 0, host_ptr=src_addr, size=len(payload), crc=crc)
+    assert slot.size == len(payload)
+    assert slot.crc == crc
+    assert os.path.exists(slot.path)
+
+    dst_buf = (ctypes.c_ubyte * len(payload))()
+    dst_addr = ctypes.addressof(dst_buf)
+    verified = nb.promote("eng-A", 0, 0, dest_host_ptr=dst_addr, max_size=len(payload))
+    assert verified == crc
+    assert bytes(dst_buf) == payload
+
+
+def test_nixl_backend_promote_detects_byte_corruption(tmp_path):
+    """If someone tampers with the file after demote, promote must
+    detect the CRC mismatch and return None — engine must not get
+    corrupted data."""
+    nb = NixlBackend(str(tmp_path / "store"), plugin="POSIX")
+    payload = b"hello, world" * 200
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    src_addr, _src_buf = _pinned(payload)
+    slot = nb.demote("eng", 0, 0, src_addr, len(payload), crc)
+
+    # Flip a byte well inside the payload (past the 24-byte header).
+    with open(slot.path, "r+b") as f:
+        f.seek(100)
+        b = f.read(1)
+        f.seek(100)
+        f.write(bytes([b[0] ^ 0xA5]))
+
+    dst_buf = (ctypes.c_ubyte * len(payload))()
+    assert (
+        nb.promote(
+            "eng",
+            0,
+            0,
+            ctypes.addressof(dst_buf),
+            len(payload),
+        )
+        is None
+    ), "CRC mismatch must surface as promote failure"
+
+
+def test_nixl_backend_reconciles_index_on_startup(tmp_path):
+    """Write some files via instance #1, drop the instance,
+    instance #2 picks them up from disk via reconcile."""
+    storage_dir = str(tmp_path / "store")
+    nb1 = NixlBackend(storage_dir, plugin="POSIX")
+    payload = b"r" * 1024
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    src_addr, _src_buf = _pinned(payload)
+    for off in (0, 1024, 2048):
+        nb1.demote("eng", 0, off, src_addr, len(payload), crc)
+    assert nb1.n_slots() == 3
+    del nb1
+
+    nb2 = NixlBackend(storage_dir, plugin="POSIX")
+    assert nb2.n_slots() == 3
+    # Promote still works post-reconcile.
+    dst = (ctypes.c_ubyte * len(payload))()
+    assert (
+        nb2.promote(
+            "eng",
+            0,
+            0,
+            ctypes.addressof(dst),
+            len(payload),
+        )
+        == crc
+    )
+
+
+def test_nixl_backend_files_interoperable_with_local(tmp_path):
+    """File format is shared: a file written by StorageTier (Local)
+    must be readable by NixlBackend. This lets operators migrate
+    backends without re-spilling."""
+    from gms_kv_ring.daemon.storage_tier import StorageTier
+
+    storage_dir = str(tmp_path / "store")
+    payload = bytes((i * 17 & 0xFF) for i in range(2048))
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    src_addr, _src_buf = _pinned(payload)
+
+    # Write with Local.
+    local = StorageTier(storage_dir)
+    local.demote("eng", 0, 0, src_addr, len(payload), crc)
+    del local
+
+    # Read with NIXL.
+    nb = NixlBackend(storage_dir, plugin="POSIX")
+    assert nb.n_slots() == 1
+    dst = (ctypes.c_ubyte * len(payload))()
+    assert (
+        nb.promote(
+            "eng",
+            0,
+            0,
+            ctypes.addressof(dst),
+            len(payload),
+        )
+        == crc
+    )
+    assert bytes(dst) == payload
+
+
+def test_nixl_backend_release_slot_unlinks(tmp_path):
+    nb = NixlBackend(str(tmp_path / "store"), plugin="POSIX")
+    payload = b"x" * 512
+    src_addr, _src_buf = _pinned(payload)
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    slot = nb.demote("eng", 0, 0, src_addr, len(payload), crc)
+    assert os.path.exists(slot.path)
+    assert nb.release_slot("eng", 0, 0) is True
+    assert not os.path.exists(slot.path)
+    assert nb.n_slots() == 0
+
+
+def test_nixl_release_keeps_slot_when_tombstone_fails(tmp_path, monkeypatch):
+    manifest = str(tmp_path / "manifest.jsonl")
+    nb = NixlBackend(str(tmp_path / "store"), plugin="POSIX", manifest_path=manifest)
+    payload = b"durable" * 128
+    src_addr, _src_buf = _pinned(payload)
+    slot = nb.demote("eng", 0, 0, src_addr, len(payload), zlib.crc32(payload))
+
+    def fail_tombstone(*_args):
+        raise OSError("manifest fsync failed")
+
+    monkeypatch.setattr(nb, "_append_tombstone", fail_tombstone)
+    with pytest.raises(OSError, match="manifest fsync"):
+        nb.release_slot("eng", 0, 0)
+    assert nb.get("eng", 0, 0) is slot
+    assert os.path.exists(slot.path)
+    nb.close()
+
+
+def test_nixl_backend_manifest_tombstone_prevents_release_resurrection(tmp_path):
+    storage_dir = str(tmp_path / "store")
+    manifest = str(tmp_path / "manifest.jsonl")
+    payload = b"m" * 512
+    src_addr, _src_buf = _pinned(payload)
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    nb1 = NixlBackend(storage_dir, plugin="POSIX", manifest_path=manifest)
+    nb1.demote("eng-M", 0, 0, src_addr, len(payload), crc)
+    assert nb1.release_slot("eng-M", 0, 0) is True
+    nb1.close()
+
+    nb2 = NixlBackend(storage_dir, plugin="POSIX", manifest_path=manifest)
+    try:
+        assert nb2.n_slots() == 0
+        assert nb2.get("eng-M", 0, 0) is None
+    finally:
+        nb2.close()
+
+
+def test_nixl_backend_manifest_drops_missing_file_records(tmp_path):
+    storage_dir = str(tmp_path / "store")
+    manifest = tmp_path / "manifest.jsonl"
+    missing_path = tmp_path / "store" / "eng" / "0" / "0.bin"
+    manifest.write_text(
+        '{"eid":"eng","layer":0,"offset":0,'
+        f'"path":"{missing_path}","size":512,'
+        '"crc":1,"mtime":1700000000.0}\n'
+    )
+
+    nb = NixlBackend(storage_dir, plugin="POSIX", manifest_path=str(manifest))
+    try:
+        assert nb.n_slots() == 0
+        assert nb.get("eng", 0, 0) is None
+    finally:
+        nb.close()
+
+
+def test_nixl_backend_manifest_records_quota_tombstones(tmp_path):
+    storage_dir = str(tmp_path / "store")
+    manifest = str(tmp_path / "manifest.jsonl")
+    payload = b"q" * 512
+    src_addr, _src_buf = _pinned(payload)
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    nb1 = NixlBackend(storage_dir, plugin="POSIX", manifest_path=manifest)
+    for off in (0, 512, 1024):
+        nb1.demote("eng-Q", 0, off, src_addr, len(payload), crc)
+    nb1._slots[("eng-Q", 0, 0)].mtime = 1.0
+    nb1._slots[("eng-Q", 0, 512)].mtime = 2.0
+    nb1._slots[("eng-Q", 0, 1024)].mtime = 3.0
+    assert nb1.enforce_byte_quota(512) == 2
+    nb1.close()
+
+    nb2 = NixlBackend(storage_dir, plugin="POSIX", manifest_path=manifest)
+    try:
+        assert nb2.n_slots() == 1
+        assert nb2.get("eng-Q", 0, 0) is None
+        assert nb2.get("eng-Q", 0, 512) is None
+        assert nb2.get("eng-Q", 0, 1024) is not None
+    finally:
+        nb2.release_engine("eng-Q")
+        nb2.close()
+
+
+def test_nixl_backend_cleanup_primitives(tmp_path):
+    """TTL + global + per-engine quota all work on the NIXL backend
+    with the same semantics as Local."""
+    nb = NixlBackend(str(tmp_path / "store"), plugin="POSIX")
+    payload = b"y" * 1024
+    src_addr, _src_buf = _pinned(payload)
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    # Four slots for engine A.
+    for off in (0, 1024, 2048, 3072):
+        nb.demote("A", 0, off, src_addr, len(payload), crc)
+    # Backdate two of them.
+    nb._slots[("A", 0, 0)].mtime = 100.0
+    nb._slots[("A", 0, 1024)].mtime = 200.0
+    nb._slots[("A", 0, 2048)].mtime = 300.0
+    nb._slots[("A", 0, 3072)].mtime = 400.0
+
+    # Global quota at 2KB → 2 evictions (oldest first).
+    n = nb.enforce_byte_quota(2048)
+    assert n == 2
+    assert nb.get("A", 0, 0) is None
+    assert nb.get("A", 0, 1024) is None
+    assert nb.get("A", 0, 2048) is not None
+    assert nb.get("A", 0, 3072) is not None
+
+    # TTL prune: reset surviving slots to "now" so they're fresh,
+    # add an ancient one, prune. (Backdated mtimes from the quota
+    # step were absolute values — relative to time.time() they're
+    # ancient, so we re-fresh them here to isolate the TTL test.)
+    now = time.time()
+    nb._slots[("A", 0, 2048)].mtime = now
+    nb._slots[("A", 0, 3072)].mtime = now
+    nb.demote("A", 0, 4096, src_addr, len(payload), crc)
+    nb._slots[("A", 0, 4096)].mtime = 1.0  # ancient
+    n_pruned = nb.prune_older_than(max_age_seconds=60.0)
+    assert n_pruned == 1, f"only the ancient slot should be pruned; got {n_pruned}"
+    assert nb.get("A", 0, 4096) is None
+    assert nb.get("A", 0, 2048) is not None
+    assert nb.get("A", 0, 3072) is not None
+
+
+def test_nixl_backend_with_supervisor(tmp_path):
+    """NixlBackend works behind BackendSupervisor exactly like the
+    Local backend — the supervisor cares about the protocol, not the
+    transport."""
+    from gms_kv_ring.daemon.supervisor import BackendSupervisor
+
+    nb = NixlBackend(str(tmp_path / "store"), plugin="POSIX")
+    sup = BackendSupervisor(
+        nb,
+        factory=lambda: NixlBackend(
+            str(tmp_path / "store"),
+            plugin="POSIX",
+        ),
+    )
+    payload = b"z" * 256
+    src_addr, _src_buf = _pinned(payload)
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    slot = sup.demote("eng", 0, 0, src_addr, len(payload), crc)
+    assert slot is not None
+    assert sup.n_slots() == 1
+
+
+def test_nixl_backend_rejects_unknown_plugin(tmp_path):
+    """Specifying a plugin NIXL doesn't have must raise at
+    construction with a clear list of what IS available."""
+    with pytest.raises(RuntimeError, match="not in available plugins"):
+        NixlBackend(
+            str(tmp_path / "store"),
+            plugin="NOT_A_REAL_PLUGIN",
+        )
+
+
+# ---------------------------------------------------------------------------
+# OBJ plugin (S3-compatible object storage)
+# ---------------------------------------------------------------------------
+
+
+def test_nixl_obj_rejects_construction_without_bucket(tmp_path, monkeypatch):
+    """OBJ plugin REQUIRES a bucket. Without one (no kwarg, no env)
+    the constructor must raise a clear error pointing at the three
+    knobs operators can set."""
+    monkeypatch.delenv("AWS_DEFAULT_BUCKET", raising=False)
+    with pytest.raises(RuntimeError, match="bucket"):
+        NixlBackend(
+            str(tmp_path / "store"),
+            plugin="OBJ",
+            manifest_path=str(tmp_path / "m.jsonl"),
+        )
+
+
+def test_nixl_obj_rejects_construction_without_manifest(
+    tmp_path,
+    monkeypatch,
+):
+    """OBJ has no list-objects API → restart-replay needs a
+    manifest. Constructing without one must fail loudly."""
+    monkeypatch.setenv("AWS_DEFAULT_BUCKET", "test-bucket")
+    with pytest.raises(RuntimeError, match="manifest_path"):
+        NixlBackend(
+            str(tmp_path / "store"),
+            plugin="OBJ",
+            # missing manifest_path
+        )
+
+
+def test_nixl_obj_picks_up_bucket_from_env(tmp_path, monkeypatch):
+    """If AWS_DEFAULT_BUCKET is set in the env AND we don't pass an
+    explicit bucket, construction proceeds. (We can't test the full
+    construction here without a live S3 endpoint — NIXL will try to
+    talk to it and fail. We test up to the point where it'd try.)
+
+    Concretely: validate the error message changes from 'bucket'
+    (our pre-flight) to a NIXL-side error when env is set."""
+    monkeypatch.setenv("AWS_DEFAULT_BUCKET", "test-bucket")
+    try:
+        NixlBackend(
+            str(tmp_path / "store"),
+            plugin="OBJ",
+            manifest_path=str(tmp_path / "m.jsonl"),
+        )
+    except RuntimeError as exc:
+        # NIXL error from the actual OBJ backend trying to connect
+        # to S3 is fine — what we care about is NOT seeing our
+        # pre-flight bucket check fail.
+        assert "bucket" not in str(exc).lower(), (
+            f"expected bucket pre-flight to pass with env set; " f"got error: {exc}"
+        )
+    except Exception:  # noqa: BLE001
+        # NIXL plugin-level errors (no S3 endpoint, etc.) — also fine.
+        pass
+
+
+def test_nixl_obj_explicit_bucket_overrides_env(tmp_path, monkeypatch):
+    """An explicit `bucket=` kwarg overrides AWS_DEFAULT_BUCKET.
+    Verify by checking that without env BUT WITH the kwarg, our
+    pre-flight passes."""
+    monkeypatch.delenv("AWS_DEFAULT_BUCKET", raising=False)
+    try:
+        NixlBackend(
+            str(tmp_path / "store"),
+            plugin="OBJ",
+            bucket="explicit-bucket-xyz",
+            manifest_path=str(tmp_path / "m.jsonl"),
+        )
+    except RuntimeError as exc:
+        assert "bucket" not in str(exc).lower(), (
+            f"explicit bucket kwarg should satisfy pre-flight; " f"got: {exc}"
+        )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# GDS plugin (GPUDirect Storage)
+# ---------------------------------------------------------------------------
+
+
+def test_nixl_gds_construction_succeeds(tmp_path):
+    """GDS plugin instantiates without errors on any host where
+    NIXL is installed — the plugin's libcufile dependency comes
+    along with the NIXL Python install. Actual GDS data plane
+    requires a cuFile-enabled mount; we test construction here,
+    data plane separately env-gated."""
+    try:
+        nb = NixlBackend(str(tmp_path / "store"), plugin="GDS")
+    except Exception as exc:  # noqa: BLE001
+        if exc.__class__.__name__ == "nixlBackendError":
+            pytest.skip(f"NIXL GDS backend unavailable: {exc}")
+        raise
+    assert nb.plugin == "GDS"
+    # File-walk reconcile runs (same shape as POSIX); empty dir → 0.
+    assert nb.n_slots() == 0
+
+
+def test_nixl_gds_demote_from_gpu_rejects_wrong_plugin(tmp_path):
+    """demote_from_gpu / promote_into_gpu only work for GDS plugins
+    — POSIX/OBJ raise immediately with a clear error. Same for the
+    deferred-CRC pair."""
+    nb = NixlBackend(str(tmp_path / "store"), plugin="POSIX")
+    with pytest.raises(NotImplementedError, match="GDS"):
+        nb.demote_from_gpu("eng", 0, 0, gpu_ptr=0, size=0, crc=0)
+    with pytest.raises(NotImplementedError, match="GDS"):
+        nb.promote_into_gpu("eng", 0, 0, dest_gpu_ptr=0, max_size=0)
+    with pytest.raises(NotImplementedError, match="GDS"):
+        nb.demote_from_gpu_deferred_crc(
+            "eng",
+            0,
+            0,
+            gpu_ptr=0,
+            size=0,
+        )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("GMS_KVR_TEST_GDS_FAILS_LOUDLY"),
+    reason="Triggering cuFile registration failure leaves the "
+    "process-global cuFile state in a way that breaks later "
+    "tests (Mooncake master fixture in the same process "
+    "starts dumping core). Opt in via "
+    "GMS_KVR_TEST_GDS_FAILS_LOUDLY=1 when investigating GDS "
+    "configuration; not safe to run in the default suite.",
+)
+def test_nixl_gds_demote_from_gpu_fails_loudly_on_non_gds_mount(
+    tmp_path,
+):
+    """On a non-GDS mount (the typical test path), cuFile's
+    `file register` step fails — we want this to propagate as a
+    clear NIXL_ERR_BACKEND, not silently route through a slower
+    fallback path that masks the configuration error.
+
+    This test documents the runtime contract: if your storage
+    isn't GDS-capable, GDS demote fails fast.
+
+    CAVEAT: triggering this failure once leaves cuFile in a state
+    where other CUDA libraries (Mooncake's transfer engine) abort
+    when initialized later in the same process. We've reproduced
+    this with the Mooncake master fixture — the master subprocess
+    is fine, but any in-process cuFile-touching code that runs
+    after this test crashes. So the test is opt-in only."""
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    nb = NixlBackend(str(tmp_path / "store"), plugin="GDS")
+    t = torch.zeros(1024, dtype=torch.uint8, device="cuda")
+    import zlib
+
+    crc = zlib.crc32(b"\x00" * 1024) & 0xFFFFFFFF
+    with pytest.raises(Exception):
+        nb.demote_from_gpu(
+            "eng",
+            0,
+            0,
+            gpu_ptr=int(t.data_ptr()),
+            size=1024,
+            crc=crc,
+        )
+
+
+# Real GDS data-plane tests need a cuFile-enabled mount
+# (NVMe with proper kernel/driver, BeeGFS, Lustre, etc.). Gate
+# on an env var pointing to such a path.
+_GDS_PATH = os.environ.get("GMS_KVR_NIXL_GDS_PATH")
+_GDS_AVAILABLE = bool(_GDS_PATH) and os.path.isdir(_GDS_PATH or "/")
+
+
+@pytest.mark.skipif(
+    not _GDS_AVAILABLE,
+    reason="Set GMS_KVR_NIXL_GDS_PATH to a cuFile-capable directory "
+    "to exercise real GDS data-plane tests",
+)
+def test_nixl_gds_round_trip_real_mount():
+    """End-to-end GPU-direct write+read on a real GDS-capable
+    mount. Skipped without the env var."""
+    import zlib
+
+    import torch
+
+    nb = NixlBackend(_GDS_PATH, plugin="GDS")
+    try:
+        payload_bytes = bytes((i * 53 & 0xFF) for i in range(4096))
+        crc = zlib.crc32(payload_bytes) & 0xFFFFFFFF
+        src_t = torch.frombuffer(
+            bytearray(payload_bytes),
+            dtype=torch.uint8,
+        ).cuda()
+        nb.demote_from_gpu(
+            "eng-GDS",
+            0,
+            0,
+            gpu_ptr=int(src_t.data_ptr()),
+            size=len(payload_bytes),
+            crc=crc,
+        )
+        dst_t = torch.zeros(
+            len(payload_bytes),
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        verified = nb.promote_into_gpu(
+            "eng-GDS",
+            0,
+            0,
+            dest_gpu_ptr=int(dst_t.data_ptr()),
+            max_size=len(payload_bytes),
+        )
+        assert verified == crc
+        assert torch.equal(src_t, dst_t)
+    finally:
+        nb.release_engine("eng-GDS")
+
+
+@pytest.mark.skipif(
+    not _GDS_AVAILABLE,
+    reason="Set GMS_KVR_NIXL_GDS_PATH to exercise the daemon's "
+    "promote_storage_to_hbm dest_offset path against real GDS",
+)
+def test_nixl_gds_promote_to_hbm_with_separate_dest_offset(tmp_path):
+    """End-to-end check that the daemon's `dest_offset` plumbing
+    works against a real GDS mount.
+
+    The connector's restore-on-hit path issues
+    `promote_storage_to_hbm(layer, src_offset, size,
+    dest_offset=dst_offset)` with src_offset != dst_offset. The
+    backend's `promote_into_gpu` already separates the storage key
+    from the dest GPU pointer (see daemon/server.py:1048), but the
+    fake-backend tests don't exercise the real cuFile write into
+    an arbitrary dest VA. This test does.
+    """
+    import asyncio
+    import os
+    import threading
+    import time
+
+    import torch
+    from gms_kv_ring.daemon.server import Daemon
+    from gms_kv_ring.engines.handle import GMSKvRing
+
+    backend = NixlBackend(_GDS_PATH, plugin="GDS")
+    sock = str(tmp_path / "gds-remap.sock")
+
+    daemon = Daemon(
+        sock,
+        storage_backend=backend,
+        supervise_backend=False,
+    )
+    holder = {}
+
+    def _runner():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        holder["loop"] = loop
+        try:
+            loop.run_until_complete(daemon.serve())
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not os.path.exists(sock):
+        time.sleep(0.02)
+
+    try:
+        block_bytes = 4096
+        n_blocks = 4
+        dev = torch.zeros(
+            n_blocks * block_bytes,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        torch.cuda.synchronize()
+        base = int(dev.data_ptr())
+        h = GMSKvRing(
+            engine_id="eng-GDS-remap",
+            daemon_socket=sock,
+            layers=[
+                {
+                    "layer_idx": 0,
+                    "va": base,
+                    "size": n_blocks * block_bytes,
+                    "stride": block_bytes,
+                }
+            ],
+        )
+        try:
+            # Demote block 1: src_offset = 1 * 4096.
+            src_offset = 1 * block_bytes
+            payload = bytes((i * 37 & 0xFF) for i in range(block_bytes))
+            src_tensor = torch.frombuffer(
+                bytearray(payload),
+                dtype=torch.uint8,
+            ).cuda()
+            dev[src_offset : src_offset + block_bytes].copy_(src_tensor)
+            torch.cuda.synchronize()
+            assert h.demote_hbm_to_storage(0, src_offset, block_bytes)
+
+            # Zero the destination region so the restore must
+            # actually write bytes there.
+            dev.zero_()
+            torch.cuda.synchronize()
+
+            # Promote with dest_offset != offset: storage key uses
+            # src_offset, HBM dest uses 3 * block_bytes.
+            dst_offset = 3 * block_bytes
+            ok = h.promote_storage_to_hbm(
+                0,
+                src_offset,
+                block_bytes,
+                dest_offset=dst_offset,
+            )
+            assert ok is True
+
+            got_at_dst = bytes(
+                dev[dst_offset : dst_offset + block_bytes].cpu().numpy().tobytes()
+            )
+            assert got_at_dst == payload
+            # Source region must NOT have been touched (it's the
+            # cuFile READ destination that matters, not the
+            # original demote source).
+            got_at_src = bytes(
+                dev[src_offset : src_offset + block_bytes].cpu().numpy().tobytes()
+            )
+            assert got_at_src == b"\x00" * block_bytes
+        finally:
+            h.close()
+    finally:
+        holder["loop"].call_soon_threadsafe(daemon.stop)
+        t.join(timeout=3)
+        backend.release_engine("eng-GDS-remap")
+
+
+# Real OBJ data-plane tests need an S3-compatible endpoint
+# (MinIO / AWS / Azure Blob). Gate on a runtime env var.
+
+_OBJ_BUCKET = os.environ.get("GMS_KVR_NIXL_OBJ_BUCKET")
+_OBJ_AVAILABLE = bool(_OBJ_BUCKET) and bool(os.environ.get("AWS_ACCESS_KEY_ID"))
+
+
+@pytest.mark.skipif(
+    not _OBJ_AVAILABLE,
+    reason="Set GMS_KVR_NIXL_OBJ_BUCKET + AWS_* env to exercise S3 "
+    "data-plane tests against a real endpoint",
+)
+def test_nixl_obj_demote_promote_round_trip(tmp_path):
+    """End-to-end against a real S3-compatible bucket: demote a
+    payload, promote it back, verify bytes + CRC. Skipped without
+    a configured bucket — the bucket env var is what gates this."""
+    manifest = str(tmp_path / "m.jsonl")
+    nb = NixlBackend(
+        str(tmp_path / "store"),
+        plugin="OBJ",
+        bucket=_OBJ_BUCKET,
+        manifest_path=manifest,
+    )
+    try:
+        import zlib
+
+        payload = bytes((i * 47 & 0xFF) for i in range(2048))
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+        src_addr, _src_buf = _pinned(payload)
+        slot = nb.demote(
+            "eng-OBJ",
+            0,
+            0,
+            src_addr,
+            len(payload),
+            crc,
+        )
+        assert slot.size == len(payload)
+
+        dst_buf = (ctypes.c_ubyte * len(payload))()
+        verified = nb.promote(
+            "eng-OBJ",
+            0,
+            0,
+            ctypes.addressof(dst_buf),
+            len(payload),
+        )
+        assert verified == crc
+        assert bytes(dst_buf) == payload
+    finally:
+        nb.release_engine("eng-OBJ")

--- a/lib/gms_kv_ring/tests/test_crc32_gpu.py
+++ b/lib/gms_kv_ring/tests/test_crc32_gpu.py
@@ -116,3 +116,43 @@ def test_crc32_gpu_detects_device_corruption():
     assert crc32_gpu(int(tensor.data_ptr()), len(payload)) == expected
     tensor[len(payload) // 2] ^= 0x80
     assert crc32_gpu(int(tensor.data_ptr()), len(payload)) != expected
+
+
+def test_gds_promote_verifies_destination_in_hbm(tmp_path):
+    """The backend's GDS promotion path consumes the device verifier result."""
+    import struct
+    import threading
+    import time
+
+    from gms_kv_ring.daemon.backends_nixl import (
+        _HEADER_FMT,
+        _MAGIC,
+        _VERSION,
+        NixlBackend,
+        _NixlSlot,
+    )
+
+    payload = bytearray((i * 37 & 0xFF) for i in range(4097))
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    path = tmp_path / "slot.bin"
+    path.write_bytes(
+        struct.pack(_HEADER_FMT, _MAGIC, _VERSION, crc, len(payload), 0) + payload
+    )
+    backend = object.__new__(NixlBackend)
+    backend.plugin = "GDS"
+    backend._lock = threading.Lock()
+    backend._slots = {
+        ("eng", 0, 0): _NixlSlot(len(payload), crc, time.time(), str(path))
+    }
+    backend._do_nixl_xfer_gds = lambda *args, **kwargs: None
+
+    destination = torch.frombuffer(payload, dtype=torch.uint8).cuda()
+    assert (
+        backend.promote_into_gpu("eng", 0, 0, destination.data_ptr(), len(payload))
+        == crc
+    )
+    destination[3] ^= 1
+    assert (
+        backend.promote_into_gpu("eng", 0, 0, destination.data_ptr(), len(payload))
+        is None
+    )

--- a/lib/gms_kv_ring/tests/test_nixl_transport.py
+++ b/lib/gms_kv_ring/tests/test_nixl_transport.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end NIXL transport tests (Phase 3 of cross-node design).
+
+Two NIXL transports in the same process, each with its own agent +
+listen port, exchange bytes via UCX-over-SHM (the local transport
+UCX picks when peers are on the same host). Receiver-side notif
+drain invokes a callback that bridges into StagingTier
+(reserve+commit), exercising the full inbound path including I-9
+hash verification.
+
+Skipped if pynixl isn't installed or UCX backend can't initialize."""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import os
+import subprocess
+import sys
+import threading
+
+import pytest
+
+# Skip the whole module if NIXL isn't available in this Python environment.
+nixl = pytest.importorskip("nixl")
+
+# Even with NIXL installed, the agent-to-agent transfer in the pytest
+# harness shows flaky notif-delivery latency (single-host UCX-over-SHM
+# loopback works <100ms in a standalone Python process but variably
+# 1-5s under pytest's threading + capture machinery). The transport
+# code is exercised by the standalone smoke harness (see
+# `docs/CROSS_NODE_DESIGN.md` and the `_smoke*.py` files in the
+# transport module docstring). For routine PR runs we env-gate this
+# module the same way `test_backend_nixl.py` gates its real-GDS
+# tests — opt-in via env var; failure modes are debugged by hand.
+if not os.environ.get("GMS_KVR_TEST_NIXL_TRANSPORT"):
+    pytest.skip(
+        "Set GMS_KVR_TEST_NIXL_TRANSPORT=1 to run NIXL transport tests. "
+        "Skipped by default because pytest's threading model triggers "
+        "variable UCX-loopback notif-delivery latency.",
+        allow_module_level=True,
+    )
+
+
+def _probe_ucx_loopback() -> None:
+    """Contain native UCX capability failures in a sacrificial process."""
+    probe = r"""
+import ctypes, hashlib, socket
+from gms_kv_ring.daemon.transport import NixlTransport
+
+def port():
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    value = sock.getsockname()[1]
+    sock.close()
+    return value
+
+a = b = None
+try:
+    a = NixlTransport("probe-a", port())
+    b = NixlTransport("probe-b", port())
+    src = (ctypes.c_ubyte * 4096)(*[(i & 0xff) for i in range(4096)])
+    dst = (ctypes.c_ubyte * 4096)()
+    a.register_buffer(ctypes.addressof(src), 4096)
+    b.register_buffer(ctypes.addressof(dst), 4096)
+    peer = a.add_peer_inproc(b)
+    payload = bytes(src)
+    a.send(peer, ctypes.addressof(src), 4096, ctypes.addressof(dst),
+           "probe", hashlib.sha256(payload).digest(), timeout_s=5)
+    assert bytes(dst) == payload
+finally:
+    if a is not None:
+        a.close()
+    if b is not None:
+        b.close()
+"""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=os.environ.copy(),
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip(
+            "NIXL/UCX loopback capability probe timed out after 20s",
+            allow_module_level=True,
+        )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()[-500:]
+        if result.returncode < 0:
+            reason = f"crashed with signal {-result.returncode}"
+        else:
+            reason = f"failed with exit code {result.returncode}"
+        pytest.skip(
+            f"NIXL/UCX loopback capability probe {reason}: {detail}",
+            allow_module_level=True,
+        )
+
+
+_probe_ucx_loopback()
+
+# NIXL listen sockets aren't released cleanly on agent destruction, so
+# every test needs unique ports across the run. Module-level counter.
+_PORT_BASE = 0x5000 + (os.getpid() % 100) * 100
+_port_lock = threading.Lock()
+_next_port = [_PORT_BASE]
+
+
+def _next_pair():
+    with _port_lock:
+        a, b = _next_port[0], _next_port[0] + 1
+        _next_port[0] += 2
+        return a, b
+
+
+def _hash(data: bytes) -> bytes:
+    return hashlib.sha256(data).digest()
+
+
+def _alloc_aligned(size: int):
+    """Allocate a host buffer and return (ptr_int, ctypes_array). The
+    array must be kept alive by the caller so refcount keeps the
+    backing storage."""
+    buf = (ctypes.c_ubyte * size)()
+    return ctypes.addressof(buf), buf
+
+
+def _make_transport(name: str, port: int, on_inbound=None):
+    from gms_kv_ring.daemon.transport import NixlTransport, TransportNotAvailable
+
+    try:
+        return NixlTransport(
+            agent_name=name,
+            listen_port=port,
+            on_inbound_notif=on_inbound,
+        )
+    except TransportNotAvailable as exc:
+        pytest.skip(f"NIXL transport not available: {exc}")
+
+
+@pytest.fixture
+def transports():
+    """Yield two NIXL transports A and B; clean up at teardown.
+    Uses unique ports per test invocation."""
+    port_a, port_b = _next_pair()
+    a = _make_transport(f"agent_a_{port_a}", port_a)
+    b = _make_transport(f"agent_b_{port_b}", port_b)
+    yield (a, b, port_a, port_b)
+    try:
+        a.close()
+    finally:
+        b.close()
+
+
+# ----- bare loopback transfer (no StagingTier) ------------------------------
+
+
+def test_loopback_write_and_notif(transports):
+    a, b, port_a, port_b = transports
+
+    src_ptr, _src_buf = _alloc_aligned(4096)
+    dst_ptr, _dst_buf = _alloc_aligned(4096)
+    payload = bytes((i & 0xFF) for i in range(64)) + b"\x00" * (4096 - 64)
+    ctypes.memmove(src_ptr, payload, len(payload))
+
+    a.register_buffer(src_ptr, 4096, label="src")
+    b.register_buffer(dst_ptr, 4096, label="dst")
+
+    # In-process loopback metadata exchange (memory must be registered
+    # FIRST). add_peer_inproc handles both directions.
+    peer_b = a.add_peer_inproc(b)
+
+    received: list[tuple[str, str, bytes]] = []
+    drained = threading.Event()
+
+    def on_inbound(peer_name, rid, h):
+        received.append((peer_name, rid, h))
+        drained.set()
+
+    b._on_inbound_notif = on_inbound  # override (test convenience)
+
+    payload_hash = _hash(payload)
+    a.send(
+        peer=peer_b,
+        local_ptr=src_ptr,
+        size=len(payload),
+        remote_ptr=dst_ptr,
+        reservation_id="rsv-001",
+        content_hash=payload_hash,
+        timeout_s=5.0,
+    )
+
+    # Wait up to 3s for notif to be drained
+    assert drained.wait(timeout=3.0), "notif never delivered"
+    assert len(received) == 1
+    sender_name, rid, h = received[0]
+    assert sender_name == a.agent_name()
+    assert rid == "rsv-001"
+    assert h == payload_hash
+
+    # Verify the bytes actually landed in B's destination buffer
+    dst_view = (ctypes.c_ubyte * len(payload)).from_address(dst_ptr)
+    assert bytes(dst_view) == payload
+
+
+# ----- staging-tier integration ---------------------------------------------
+
+
+def test_transport_to_staging_tier_round_trip(transports):
+    """The full intended path: sender pushes bytes; receiver's notif
+    callback reads dest bytes and calls StagingTier.commit_or_reject,
+    transitioning the slot to READY."""
+    from gms_kv_ring.daemon.staging_tier import (
+        Reservation,
+        StagingTier,
+        _BytearrayAllocator,
+    )
+
+    a, b, port_a, port_b = transports
+
+    # Receiver-side staging tier (manages its own buffer pool, but for
+    # this test we pre-allocate the dst buffer outside it via ctypes
+    # — staging_tier just bookkeeps the reservation state machine).
+    staging = StagingTier(
+        capacity_bytes=1 << 20,
+        allocator=_BytearrayAllocator(),
+    )
+
+    src_ptr, _src_buf = _alloc_aligned(4096)
+    dst_ptr, _dst_buf = _alloc_aligned(4096)
+    payload = b"cross-node round trip payload" * 4  # 116 bytes
+    ctypes.memmove(src_ptr, payload, len(payload))
+
+    a.register_buffer(src_ptr, 4096, label="src")
+    b.register_buffer(dst_ptr, 4096, label="dst")
+
+    peer_b = a.add_peer_inproc(b)
+
+    # Pre-reserve a staging slot on B (the receiver) so we know its
+    # reservation_id when sending. In production this is mediated by
+    # a UDS pre-reserve RPC; here we call directly.
+    payload_hash = _hash(payload)
+    reservation = staging.reserve_or_wait(payload_hash, source_daemon="a")
+    assert isinstance(reservation, Reservation)
+
+    commit_done = threading.Event()
+    commit_result = []
+
+    def on_inbound(peer_name, rid, h):
+        # Read the bytes from the dst buffer (NIXL WRITE landed here).
+        dst_view = (ctypes.c_ubyte * len(payload)).from_address(dst_ptr)
+        bytes_received = bytes(dst_view)
+        result = staging.commit_or_reject(rid, bytes_received)
+        commit_result.append(result)
+        commit_done.set()
+
+    b._on_inbound_notif = on_inbound
+
+    a.send(
+        peer=peer_b,
+        local_ptr=src_ptr,
+        size=len(payload),
+        remote_ptr=dst_ptr,
+        reservation_id=reservation.reservation_id,
+        content_hash=payload_hash,
+        timeout_s=5.0,
+    )
+
+    # Notif delivery latency varies — fast in production-tuned envs,
+    # surprisingly slow under pytest's threading + capture machinery.
+    # Generous timeout for the integration test; flake-resistant.
+    assert commit_done.wait(timeout=10.0)
+    from gms_kv_ring.daemon.staging_tier import CommitOk
+
+    assert len(commit_result) == 1
+    assert isinstance(commit_result[0], CommitOk), commit_result[0]
+
+    # Slot is now READY in the receiver's staging tier
+    hit = staging.scan([payload_hash])
+    assert payload_hash in hit
+    assert hit[payload_hash].bytes_size == len(payload)
+
+
+# ----- I-9 hash mismatch via wire corruption --------------------------------
+
+
+def test_hash_mismatch_caught_at_commit(transports):
+    """If we lie about the content_hash (advertise wrong hash), the
+    receiver's StagingTier.commit_or_reject rejects via I-9."""
+    from gms_kv_ring.daemon.staging_tier import (
+        CommitCorrupt,
+        Reservation,
+        StagingTier,
+        _BytearrayAllocator,
+    )
+
+    a, b, port_a, port_b = transports
+
+    staging = StagingTier(
+        capacity_bytes=1 << 20,
+        allocator=_BytearrayAllocator(),
+    )
+
+    src_ptr, _src_buf = _alloc_aligned(4096)
+    dst_ptr, _dst_buf = _alloc_aligned(4096)
+    actual_payload = b"true bytes" * 8
+    advertised_hash = _hash(b"different content")  # wrong hash on purpose
+    ctypes.memmove(src_ptr, actual_payload, len(actual_payload))
+
+    a.register_buffer(src_ptr, 4096, label="src")
+    b.register_buffer(dst_ptr, 4096, label="dst")
+
+    peer_b = a.add_peer_inproc(b)
+
+    reservation = staging.reserve_or_wait(advertised_hash, source_daemon="a")
+    assert isinstance(reservation, Reservation)
+
+    commit_done = threading.Event()
+    commit_result = []
+
+    def on_inbound(peer_name, rid, h):
+        dst_view = (ctypes.c_ubyte * len(actual_payload)).from_address(dst_ptr)
+        result = staging.commit_or_reject(rid, bytes(dst_view))
+        commit_result.append(result)
+        commit_done.set()
+
+    b._on_inbound_notif = on_inbound
+
+    a.send(
+        peer=peer_b,
+        local_ptr=src_ptr,
+        size=len(actual_payload),
+        remote_ptr=dst_ptr,
+        reservation_id=reservation.reservation_id,
+        content_hash=advertised_hash,
+        timeout_s=5.0,
+    )
+
+    assert commit_done.wait(timeout=10.0)
+    assert isinstance(commit_result[0], CommitCorrupt)
+    assert "hash mismatch" in commit_result[0].reason
+    # Slot is dropped; subsequent scan empty.
+    assert staging.scan([advertised_hash]) == {}

--- a/lib/gms_kv_ring/tests/test_nixl_transport_lifecycle.py
+++ b/lib/gms_kv_ring/tests/test_nixl_transport_lifecycle.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lifecycle tests for the NIXL transport wrapper.
+
+These do not instantiate pynixl. They exercise shutdown bookkeeping with a
+fake agent so the behavior is covered in ordinary unit-test runs.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from gms_kv_ring.daemon.transport.nixl_transport import (
+    NixlTransport,
+    PeerHandle,
+    _AsyncSend,
+)
+
+
+class _FakeThread:
+    def __init__(self) -> None:
+        self.join_calls: list[float | None] = []
+
+    def join(self, timeout=None):
+        self.join_calls.append(timeout)
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.released: list[object] = []
+        self.removed: list[str] = []
+
+    def release_xfer_handle(self, handle):
+        self.released.append(handle)
+
+    def remove_remote_agent(self, name: str):
+        self.removed.append(name)
+
+
+def test_close_joins_completion_thread_and_releases_pending_async_handles():
+    transport = object.__new__(NixlTransport)
+    transport._closed = False
+    transport._stop = threading.Event()
+    transport._completion_thread = _FakeThread()
+    transport._notif_thread = _FakeThread()
+    transport._async_lock = threading.Lock()
+    transport._lock = threading.Lock()
+    agent = _FakeAgent()
+    transport._agent = agent
+    transport._peers = {
+        "peer-a": PeerHandle("peer-a", "127.0.0.1", 48101),
+    }
+
+    callback_results: list[tuple[bool, str]] = []
+    handle = object()
+    transport._async_pending = {
+        id(handle): _AsyncSend(
+            handle=handle,
+            peer_name="peer-a",
+            reservation_id="rid-1",
+            deadline_monotonic=0.0,
+            on_complete=lambda ok, err: callback_results.append((ok, err)),
+        ),
+    }
+
+    transport.close()
+
+    assert transport._closed is True
+    assert transport._stop.is_set()
+    assert transport._completion_thread.join_calls == [2.0]
+    assert transport._notif_thread.join_calls == [2.0]
+    assert transport._async_pending == {}
+    assert agent.released == [handle]
+    assert callback_results == [(False, "transport closed")]
+    assert agent.removed == ["peer-a"]
+    assert transport._peers == {}
+    assert transport._agent is None
+
+    transport.close()
+    assert agent.released == [handle]
+    assert agent.removed == ["peer-a"]


### PR DESCRIPTION
## Summary

Provide optional peer-to-peer implementations for the common host-tier transfer contracts after core behavior and all engine E2E recipes are reviewable.

## Scope

Adds NIXL and Mooncake backends behind the common interface. Neither backend is required for the core GMS lifecycle.

## Stack

Position **15/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-10-public-docs`.

Parent: #10450  
Tracking: #10455

## Review migration

This existing PR is updated in place so its comments and reviews remain attached. Line comments may appear outdated where code moved during the rebase; they remain visible and should be dispositioned against the current diff. Previous approvals should be revalidated.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

Backend-specific coverage supplements, but does not replace, the engine-neutral E2E recipes in positions 10 and 13.