### PR TITLE
feat(gms): add TensorRT-LLM host-tier adapter [GMS 12/18]

### DIFF
--- a/lib/gms_kv_ring/engines/trtllm/__init__.py
+++ b/lib/gms_kv_ring/engines/trtllm/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TRT-LLM engine bridge for gms_kv_ring."""
+
+from gms_kv_ring.engines.trtllm.install_kv_ring import install_for_trtllm
+
+__all__ = ["install_for_trtllm"]

--- a/lib/gms_kv_ring/engines/trtllm/install_kv_ring.py
+++ b/lib/gms_kv_ring/engines/trtllm/install_kv_ring.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Install gms_kv_ring into a TRT-LLM worker.
+
+Mirrors `install_for_vllm` and `install_for_sglang`. The TRT-LLM
+worker calls this once at `register_kv_caches` time with the
+per-(layer × kv_factor) descriptors derived from
+`KVCacheBlockPool::primaryPtr`."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from gms_kv_ring.engines.handle import GMSKvRing
+
+logger = logging.getLogger(__name__)
+
+
+def install_for_trtllm(
+    *,
+    engine_id: str,
+    daemon_socket: str,
+    layers: "list[dict]",
+    on_evict: Optional[Callable[[GMSKvRing], None]] = None,
+    on_hit: Optional[Callable[[GMSKvRing], None]] = None,
+    evict_ring_capacity: int = 4096,
+    restore_ring_capacity: int = 4096,
+    num_counters: int = 512,
+) -> GMSKvRing:
+    """Build a `GMSKvRing` handle bound to this TRT-LLM worker's
+    KV pool. Parameter semantics identical to the vLLM/SGLang
+    install helpers."""
+    handle = GMSKvRing(
+        engine_id=engine_id,
+        daemon_socket=daemon_socket,
+        layers=layers,
+        evict_ring_capacity=evict_ring_capacity,
+        restore_ring_capacity=restore_ring_capacity,
+        num_counters=num_counters,
+    )
+    if on_evict is not None:
+        on_evict(handle)
+    if on_hit is not None:
+        on_hit(handle)
+    logger.info("gms_kv_ring installed for TRT-LLM engine %r", engine_id)
+    return handle

--- a/lib/gms_kv_ring/tests/real_engine/test_trtllm_connector.py
+++ b/lib/gms_kv_ring/tests/real_engine/test_trtllm_connector.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-engine smoke for the TensorRT-LLM GMS connector.
+
+Loads a small HF model through TensorRT-LLM's PyTorch backend with our
+GMSTrtllmKvCacheScheduler / Worker wired in, generates a few tokens,
+and asserts the connector lifecycle hooks fired (register_kv_caches +
+build_connector_meta + wait_for_save / start_load_kv).
+
+Run from a Dynamo TensorRT-LLM runtime container or equivalent dev
+environment with TensorRT-LLM importable:
+
+    cd /path/to/dynamo
+    export PYTHONPATH=/path/to/dynamo/lib:/path/to/dynamo/lib/gpu_memory_service
+    export CUDA_VISIBLE_DEVICES=1   # if GPU 0 is busy
+    export GMS_KVR_REAL_TRTLLM=1
+    export GMS_KVR_REAL_TRTLLM_MODEL=TinyLlama/TinyLlama-1.1B-Chat-v1.0
+    export GMS_KVR_REAL_TRTLLM_MEM_FRACTION=0.3
+    python -m pytest lib/gms_kv_ring/tests/real_engine/test_trtllm_connector.py -v
+
+Env knobs:
+  GMS_KVR_REAL_TRTLLM=1                required gate (default skip)
+  GMS_KVR_REAL_TRTLLM_MODEL            HF id; default TinyLlama-1.1B
+  GMS_KVR_REAL_TRTLLM_DAEMON           daemon UDS path
+  GMS_KVR_REAL_TRTLLM_MEM_FRACTION     gpu memory budget (default 0.4)
+  GMS_KVR_REAL_TRTLLM_PROMPT           prompt; default short factual
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import threading
+import time
+
+import pytest
+
+pytestmark = [
+    pytest.mark.filterwarnings("ignore::DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore::UserWarning"),
+]
+
+if os.environ.get("GMS_KVR_REAL_TRTLLM") != "1":
+    pytest.skip(
+        "Set GMS_KVR_REAL_TRTLLM=1 to run real-engine TRT-LLM tests "
+        "(needs TensorRT-LLM + GPU + meaningful runtime).",
+        allow_module_level=True,
+    )
+
+# pytest's importorskip turns DeprecationWarning-from-import into
+# ImportError under strict-warnings configs. Some of TRT-LLM's
+# transitive deps (torchao) emit DeprecationWarnings during import.
+# Try a plain import inside a warning-quieted block first.
+import warnings as _w  # noqa: E402
+
+with _w.catch_warnings():
+    _w.filterwarnings("ignore", category=DeprecationWarning)
+    _w.filterwarnings("ignore", category=UserWarning)
+    try:
+        import tensorrt_llm as trtllm  # noqa: F401
+    except ImportError as _exc:
+        pytest.skip(
+            f"tensorrt_llm not importable: {_exc}",
+            allow_module_level=True,
+        )
+
+MODEL = os.environ.get(
+    "GMS_KVR_REAL_TRTLLM_MODEL",
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+)
+DAEMON_SOCK = os.environ.get(
+    "GMS_KVR_REAL_TRTLLM_DAEMON",
+    "/tmp/gms-real-trtllm.sock",
+)
+MEM_FRACTION = float(
+    os.environ.get(
+        "GMS_KVR_REAL_TRTLLM_MEM_FRACTION",
+        "0.4",
+    )
+)
+PROMPT = os.environ.get(
+    "GMS_KVR_REAL_TRTLLM_PROMPT",
+    "The capital of France is",
+)
+
+# Engine id pinned for cross-process consistency.
+os.environ.setdefault("GMS_TRTLLM_ENGINE_ID", "trtllm-real-test")
+os.environ.setdefault("GMS_TRTLLM_DAEMON_SOCKET", DAEMON_SOCK)
+
+
+# ---------------------------------------------------------------------
+# Daemon fixture
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def gms_daemon():
+    """Spin up a GMS daemon on the configured UDS for the whole module."""
+    if os.path.exists(DAEMON_SOCK):
+        os.unlink(DAEMON_SOCK)
+    from gms_kv_ring.daemon.server import Daemon
+
+    daemon = Daemon(
+        listen_socket=DAEMON_SOCK,
+        storage_dir=tempfile.mkdtemp(prefix="gms-real-trtllm-"),
+        supervise_backend=False,
+    )
+    lh = {}
+
+    def _run():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        lh["loop"] = loop
+        try:
+            loop.run_until_complete(daemon.serve())
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    # Wait for the daemon to bind.
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and not os.path.exists(DAEMON_SOCK):
+        time.sleep(0.05)
+    assert os.path.exists(DAEMON_SOCK), "daemon never bound socket"
+    yield daemon
+    try:
+        if "loop" in lh:
+            lh["loop"].call_soon_threadsafe(daemon.stop)
+        t.join(timeout=5)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------
+# Engine fixture
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def llm(gms_daemon):
+    """Build a TRT-LLM PyTorch-backend LLM with our connector wired in.
+
+    The connector is plugged via TRT-LLM's standard ``KvCacheConnectorConfig``
+    using explicit module + class names (no preset). Module path matches
+    where ``GMSTrtllmKvCacheScheduler`` and ``GMSTrtllmKvCacheWorker`` are
+    exported (see ``integrations/trtllm/gms_connector.py``)."""
+    from tensorrt_llm import LLM
+    from tensorrt_llm.llmapi.llm_args import KvCacheConfig, KvCacheConnectorConfig
+
+    connector_config = KvCacheConnectorConfig(
+        connector_module=("gpu_memory_service.integrations.trtllm.gms_connector"),
+        connector_scheduler_class="GMSTrtllmKvCacheScheduler",
+        connector_worker_class="GMSTrtllmKvCacheWorker",
+    )
+
+    # Attention backend override — on Blackwell (sm_100a) the default
+    # TRTLLM FMHA kernels are JIT-compiled by NVRTC at startup and the
+    # search path can lack cuda.h in some runtime containers. FLASHINFER
+    # is a stable fallback. Override via env knob.
+    attn_backend = os.environ.get(
+        "GMS_KVR_REAL_TRTLLM_ATTN_BACKEND",
+        "FLASHINFER",
+    )
+    # Disable chunked prefill — it routes through a different FMHA
+    # kernel path that has the same NVRTC dep.
+    obj = LLM(
+        model=MODEL,
+        backend="pytorch",
+        kv_cache_config=KvCacheConfig(
+            free_gpu_memory_fraction=MEM_FRACTION,
+            enable_block_reuse=True,
+        ),
+        kv_connector_config=connector_config,
+        attn_backend=attn_backend,
+        enable_chunked_prefill=False,
+        # Single GPU + eager-only for stability under the smoke harness.
+        tensor_parallel_size=1,
+        max_seq_len=256,
+    )
+    yield obj
+    try:
+        obj.shutdown()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------
+
+
+def test_smoke_one_generation(llm):
+    """Generate a few tokens through the real engine with the GMS
+    connector wired in. Asserts the model produces non-empty output —
+    proves the full TRT-LLM ↔ KvCacheConnector ↔ GMS-daemon path
+    initializes and serves at least one forward pass."""
+    from tensorrt_llm import SamplingParams
+
+    out = llm.generate(
+        [PROMPT],
+        SamplingParams(max_tokens=8, temperature=0.0),
+    )
+    assert len(out) == 1
+    text = out[0].outputs[0].text
+    assert isinstance(text, str)
+    assert len(text) > 0, "engine produced empty completion"
+    print(f"\n[trtllm smoke] {PROMPT!r} ->{text!r}")
+
+
+def test_output_equality_on_cache_hit(llm):
+    """Second generation of the same prompt should produce the same
+    tokens (greedy decoding) AND benefit from the connector's
+    prefix-cache path. We don't enforce a cache-hit count here (TRT-LLM
+    doesn't expose connector telemetry via the public API), but we
+    verify byte-correctness: the connector mediating the KV cache
+    didn't corrupt the prefix bytes between requests."""
+    from tensorrt_llm import SamplingParams
+
+    sp = SamplingParams(max_tokens=12, temperature=0.0)
+    o1 = llm.generate([PROMPT], sp)
+    o2 = llm.generate([PROMPT], sp)
+    t1 = o1[0].outputs[0].token_ids
+    t2 = o2[0].outputs[0].token_ids
+    assert list(t1) == list(t2), (
+        f"Greedy generation diverged across requests; " f"t1={list(t1)} t2={list(t2)}"
+    )

--- a/lib/gms_kv_ring/tests/test_trtllm_connector.py
+++ b/lib/gms_kv_ring/tests/test_trtllm_connector.py
@@ -1,0 +1,747 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mock-driven tests for the TRT-LLM connector.
+
+Validates parity with the vLLM + SGLang connectors for:
+
+  - Block-layout derivation from a TRT-LLM-shaped KV cache tensor
+    `(num_blocks, num_layers, kv_factor, block_size)`.
+  - PrefixIndex lookup → restore-queue building via
+    `get_num_new_matched_tokens` → `update_state_after_alloc`.
+  - `request_finished` records the prefix, queues evicts with
+    correct generations (Race #3) and content hashes (P4d).
+  - Metadata wire round-trip (v6 schema, hashes/staging optional).
+  - Worker `wait_for_save` drains the evict queue through the
+    BlockGdsConnector + issues batched P4d registration when
+    enabled. Self-disables on skipped/error.
+  - Worker `start_load_kv` drains the restore queue through
+    BlockGdsConnector.restore_blocks_remap.
+
+Runs WITHOUT tensorrt_llm installed (the connector falls back to
+stub bases when the import fails). Validates all scheduler/worker
+logic with mock LlmArgs + mock kv_cache_tensor + mock connector."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from gms_kv_ring.common.prefix_hashes import prefix_block_hashes
+from gpu_memory_service.integrations.trtllm.gms_connector import (
+    GMSTrtllmConnectorMeta,
+    GMSTrtllmKvCacheScheduler,
+    GMSTrtllmKvCacheWorker,
+    _build_block_layout_trtllm,
+    _decode_meta,
+    _encode_meta,
+)
+
+# ----------------------------------------------------------------------
+# Mocks
+# ----------------------------------------------------------------------
+
+
+class _FakeTensor:
+    """Stand-in for torch.Tensor exposing only the attributes
+    `_build_block_layout_trtllm` reads."""
+
+    def __init__(self, shape, base_ptr=0x10000000, elem_size=2):
+        self.shape = tuple(int(x) for x in shape)
+        self._base_ptr = int(base_ptr)
+        self._elem_size = int(elem_size)
+
+    def data_ptr(self):
+        return self._base_ptr
+
+    def element_size(self):
+        return self._elem_size
+
+
+def _make_llm_args(block_size=4):
+    """Mock TRT-LLM llm_args exposing kv_cache_config.tokens_per_block."""
+    return SimpleNamespace(
+        kv_cache_config=SimpleNamespace(tokens_per_block=block_size),
+    )
+
+
+class _FakeRequest:
+    """LlmRequest stand-in matching the connector's reads."""
+
+    def __init__(self, req_id, tokens, cache_salt_id=None, context_pos=0):
+        self.request_id = req_id
+        self._tokens = list(tokens)
+        self.prompt_token_ids = list(tokens)
+        self.cache_salt_id = cache_salt_id
+        self.context_current_position = int(context_pos)
+
+    def get_tokens(self, _beam):
+        return self._tokens
+
+
+# ----------------------------------------------------------------------
+# Block layout
+# ----------------------------------------------------------------------
+
+
+def test_block_layout_default_shape():
+    """`(num_blocks, num_layers, kv_factor, block_size)` produces
+    `num_layers × kv_factor` layer entries with the right strides."""
+    # 8 blocks × 4 layers × 2 (K/V) × (16 tokens × 8 heads × 64) = ...
+    # block_size_axis: 16*8*64 = 8192 elements per block per layer per K/V
+    tensor = _FakeTensor(shape=(8, 4, 2, 16 * 8 * 64), elem_size=2)
+    layers, layout, n_layers_total, block_bytes_per_block = _build_block_layout_trtllm(
+        tensor
+    )
+    # 4 layers × 2 kv_factor = 8 "layer" indices in the daemon's view.
+    assert n_layers_total == 8
+    assert len(layers) == 8
+    # Per-block bytes = 4 × 2 × 8192 × 2 = 131072 bytes
+    expected_kv_size = 8192 * 2
+    expected_per_block = expected_kv_size * 2 * 4
+    assert block_bytes_per_block == expected_per_block
+    # Layout for block 0: 8 entries, each `(layer, offset, size)`.
+    ranges_0 = layout(0)
+    assert len(ranges_0) == 8
+    # First entry is (layer=0, offset=0, size=expected_kv_size)
+    assert ranges_0[0] == (0, 0, expected_kv_size)
+    # Last entry: (layer=7, offset=(3*2+1)*kv_size, size=kv_size)
+    assert ranges_0[7] == (7, (3 * 2 + 1) * expected_kv_size, expected_kv_size)
+    # Block 1: offset shifted by block_bytes_per_block
+    ranges_1 = layout(1)
+    assert ranges_1[0] == (0, expected_per_block, expected_kv_size)
+
+
+def test_block_layout_rejects_low_dim_tensor():
+    with pytest.raises(ValueError, match="at least 4D"):
+        _build_block_layout_trtllm(_FakeTensor(shape=(8, 4)))
+
+
+def test_block_layout_rejects_non_tensor():
+    with pytest.raises(TypeError, match="torch.Tensor"):
+        _build_block_layout_trtllm("not a tensor")
+
+
+# ----------------------------------------------------------------------
+# Wire format (encode/decode round-trip + v6 hashes/staging)
+# ----------------------------------------------------------------------
+
+
+def test_meta_round_trip_no_hashes():
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[("r1", [10, 11, 12], [1, 2, 3], [])],
+        restore_queue=[("r2", [(20, 30, 5), (21, 31, 7)])],
+    )
+    blob = _encode_meta(meta)
+    decoded = _decode_meta(blob)
+    assert decoded.evict_queue == [("r1", [10, 11, 12], [1, 2, 3], [])]
+    assert decoded.restore_queue == [("r2", [(20, 30, 5), (21, 31, 7)])]
+
+
+def test_meta_round_trip_with_hashes():
+    import hashlib
+
+    h1 = hashlib.sha256(b"block-0").digest()
+    h2 = hashlib.sha256(b"block-1").digest()
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[("r1", [10, 11], [4, 5], [h1, h2])],
+        restore_queue=[],
+    )
+    blob = _encode_meta(meta)
+    # When hashes are present, the JSON includes hashes_per_evict.
+    import json as _json
+
+    obj = _json.loads(blob.decode("utf-8"))
+    assert "hashes_per_evict" in obj
+    decoded = _decode_meta(blob)
+    assert decoded.evict_queue[0][3] == [h1, h2]
+
+
+def test_meta_round_trip_with_staging_restore():
+    import hashlib
+
+    h = hashlib.sha256(b"staged").digest()
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[],
+        restore_queue=[],
+        staging_restore_queue=[("r-stage", [(h, 42, 7)])],
+    )
+    blob = _encode_meta(meta)
+    import json as _json
+
+    obj = _json.loads(blob.decode("utf-8"))
+    assert obj["v"] == 6
+    assert obj["restore_staging"] == [["r-stage", [[h.hex(), 42, 7]]]]
+    decoded = _decode_meta(blob)
+    assert decoded.staging_restore_queue == [("r-stage", [(h, 42, 7)])]
+
+
+# ----------------------------------------------------------------------
+# Scheduler: get_num_new_matched_tokens + update_state_after_alloc
+# ----------------------------------------------------------------------
+
+
+def _make_scheduler(monkeypatch, **env):
+    """Build a scheduler with epoch thread disabled (no daemon socket)
+    and any extra env overrides applied."""
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    sched = GMSTrtllmKvCacheScheduler(_make_llm_args(block_size=4))
+    return sched
+
+
+def test_scheduler_returns_zero_on_cold_index(monkeypatch):
+    sched = _make_scheduler(monkeypatch)
+    req = _FakeRequest("r1", [1, 2, 3, 4, 5, 6, 7, 8])
+    extra, async_ = sched.get_num_new_matched_tokens(req, 0)
+    assert extra == 0
+    assert async_ is False
+
+
+def test_scheduler_uses_staging_hits_when_no_local_match(monkeypatch):
+    monkeypatch.setenv("GMS_KVR_CROSS_NODE", "1")
+    sched = _make_scheduler(monkeypatch)
+    tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+    hashes = prefix_block_hashes(tokens, 4, None)
+    sched._staging_scan = lambda _hashes: {
+        hashes[0]: {"generation": 3},
+        hashes[1]: {"generation": 4},
+    }
+    req = _FakeRequest("r-stage", tokens)
+    extra, async_ = sched.get_num_new_matched_tokens(req, 0)
+    assert (extra, async_) == (8, False)
+    sched.update_state_after_alloc(req, [200, 201])
+    meta = sched.build_connector_meta(SimpleNamespace())
+    assert meta.restore_queue == []
+    assert meta.staging_restore_queue == [
+        ("r-stage", [(hashes[0], 200, 3), (hashes[1], 201, 4)]),
+    ]
+
+
+def test_scheduler_record_then_lookup_hits(monkeypatch):
+    sched = _make_scheduler(monkeypatch)
+    # Record a prefix.
+    tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+    req1 = _FakeRequest("r1", tokens)
+    sched.request_finished(req1, [100, 101])
+    # The prefix is now in the PrefixIndex; a fresh request with the
+    # same tokens should report the cache hit.
+    req2 = _FakeRequest("r2", tokens)
+    extra, _ = sched.get_num_new_matched_tokens(req2, 0)
+    assert extra == 8  # 2 blocks × 4 tokens
+    # update_state_after_alloc binds dst block ids and emits restore
+    # queue entries.
+    sched.update_state_after_alloc(req2, [200, 201])
+    meta = sched.build_connector_meta(SimpleNamespace())
+    assert len(meta.restore_queue) == 1
+    rid, triples = meta.restore_queue[0]
+    assert rid == "r2"
+    assert len(triples) == 2
+    # Each triple is (src, dst, gen). src ∈ {100, 101}, dst ∈ {200, 201}.
+    srcs = {t[0] for t in triples}
+    dsts = {t[1] for t in triples}
+    assert srcs == {100, 101}
+    assert dsts == {200, 201}
+
+
+def test_scheduler_race3_generations_threaded_through(monkeypatch):
+    sched = _make_scheduler(monkeypatch)
+    tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+    # First spill: assigns gen=1 per block.
+    req1 = _FakeRequest("r1", tokens)
+    sched.request_finished(req1, [100, 101])
+    meta1 = sched.build_connector_meta(SimpleNamespace())
+    assert meta1.evict_queue[0][2] == [1, 1]
+    # Re-record the SAME prefix to slots {100, 101} again — gens bump to 2.
+    req2 = _FakeRequest("r2", tokens)
+    sched.request_finished(req2, [100, 101])
+    meta2 = sched.build_connector_meta(SimpleNamespace())
+    assert meta2.evict_queue[0][2] == [2, 2]
+    # And a future cache-hit lookup carries the bumped generations
+    # forward.
+    req3 = _FakeRequest("r3", tokens)
+    sched.get_num_new_matched_tokens(req3, 0)
+    sched.update_state_after_alloc(req3, [200, 201])
+    meta3 = sched.build_connector_meta(SimpleNamespace())
+    triples = meta3.restore_queue[0][1]
+    # expected_gen on each triple is the LAST recorded gen (=2).
+    for src, dst, gen in triples:
+        assert gen == 2
+
+
+def test_scheduler_cross_node_p4d_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("GMS_KVR_CROSS_NODE", raising=False)
+    sched = _make_scheduler(monkeypatch)
+    req = _FakeRequest("r1", [1, 2, 3, 4, 5, 6, 7, 8])
+    sched.request_finished(req, [100, 101])
+    meta = sched.build_connector_meta(SimpleNamespace())
+    # hashes list is empty — no cross-node registration.
+    assert meta.evict_queue[0][3] == []
+
+
+def test_scheduler_cross_node_p4d_enabled_attaches_hashes(monkeypatch):
+    monkeypatch.setenv("GMS_KVR_CROSS_NODE", "1")
+    sched = _make_scheduler(monkeypatch)
+    tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+    req = _FakeRequest("r1", tokens)
+    sched.request_finished(req, [100, 101])
+    meta = sched.build_connector_meta(SimpleNamespace())
+    hashes = meta.evict_queue[0][3]
+    # Two full blocks at block_size=4 → 2 hashes.
+    expected = prefix_block_hashes(tokens, 4, None)
+    assert hashes[:2] == expected
+    # The hashes match what vLLM/SGLang would produce for the same
+    # prefix — cross-engine compatibility.
+
+
+def test_scheduler_request_finished_no_tokens_no_record(monkeypatch):
+    sched = _make_scheduler(monkeypatch)
+
+    class _NoTokensReq:
+        request_id = "x"
+
+        def get_tokens(self, *_):
+            raise AttributeError
+
+    req = _NoTokensReq()
+    # Should NOT crash even though token retrieval fails.
+    assert sched.request_finished(req, [1, 2]) is False
+
+
+# ----------------------------------------------------------------------
+# Worker: register_kv_caches + wait_for_save + start_load_kv
+# ----------------------------------------------------------------------
+
+
+class _FakeBlockConnector:
+    def __init__(self, available=True):
+        self._available = available
+        self.evict_calls: list = []
+        self.host_evict_calls: list = []
+        self.restore_calls: list = []
+        self.host_restore_calls: list = []
+
+    def is_available(self):
+        return self._available
+
+    def evict_blocks_to_storage(self, block_ids, generations=None):
+        from gms_kv_ring.engines.gds_block_connector import EvictResult
+
+        bids = list(block_ids)
+        self.evict_calls.append((bids, dict(generations or {})))
+        return EvictResult(succeeded=len(bids), failed=0, failed_ids=[])
+
+    def evict_blocks_to_host(self, block_ids, generations=None):
+        from gms_kv_ring.engines.gds_block_connector import EvictResult
+
+        bids = list(block_ids)
+        self.host_evict_calls.append(bids)
+        return EvictResult(succeeded=len(bids), failed=0, failed_ids=[])
+
+    def restore_blocks_remap(self, triples):
+        triples_l = list(triples)
+        self.restore_calls.append(triples_l)
+        out = {}
+        for t in triples_l:
+            if len(t) == 3:
+                _src, dst, _gen = t
+            else:
+                _src, dst = t
+            out[dst] = True
+        return out
+
+    def restore_blocks_remap_from_host(self, src_engine_id, triples):
+        triples_l = list(triples)
+        self.host_restore_calls.append((str(src_engine_id), triples_l))
+        out = {}
+        for t in triples_l:
+            if len(t) == 3:
+                _src, dst, _gen = t
+            else:
+                _src, dst = t
+            out[dst] = True
+        return out
+
+
+class _FakeDaemonClient:
+    def __init__(self, skipped=False, raise_on_call=False):
+        self._skipped = skipped
+        self._raise = raise_on_call
+        self.batch_calls: list = []
+
+    def register_content_addresses_batch(self, items):
+        if self._raise:
+            raise RuntimeError("daemon error")
+        self.batch_calls.append([dict(it) for it in items])
+        total = sum(sum(r[2] for r in it["ranges"]) for it in items)
+        return (total, self._skipped)
+
+
+class _FakeHandle:
+    def __init__(self, client):
+        self._client = client
+        self.staging_restore_calls: list = []
+        self.staging_restore_ok = True
+
+    def restore_staging_blocks_sync(self, triples):
+        self.staging_restore_calls.append(list(triples))
+        return self.staging_restore_ok
+
+
+class _FakeStream:
+    def synchronize(self):
+        pass
+
+
+def _install_worker_mock(
+    worker, *, available=True, daemon_skipped=False, daemon_raise=False
+):
+    """Plug a FakeBlockConnector + FakeHandle into the worker, bypassing
+    real install_for_trtllm (which would try to open a UDS socket)."""
+    worker._gds_conn = _FakeBlockConnector(available=available)
+    worker._handle = _FakeHandle(
+        _FakeDaemonClient(
+            skipped=daemon_skipped,
+            raise_on_call=daemon_raise,
+        )
+    )
+    # Minimal block layout: per-block returns one (layer, offset, size).
+    worker._block_layout = lambda bid: [(0, int(bid) * 64, 64)]
+    worker._n_layers = 1
+    worker._block_bytes = 64
+    return worker
+
+
+def test_worker_wait_for_save_drains_evict_queue(monkeypatch):
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args(block_size=4))
+    _install_worker_mock(worker)
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[("r1", [10, 11], [3, 4], [])],
+        restore_queue=[],
+    )
+    worker.bind_connector_meta(meta)
+    worker.wait_for_save(_FakeStream())
+    assert len(worker._gds_conn.evict_calls) == 1
+    bids, gens_map = worker._gds_conn.evict_calls[0]
+    assert sorted(bids) == [10, 11]
+    assert gens_map == {10: 3, 11: 4}
+    # No cross-node calls (hashes empty).
+    assert worker._handle._client.batch_calls == []
+    # `r1` reported as save-complete.
+    saves, _loads = worker.get_finished(["r1"], [])
+    assert saves == ["r1"]
+
+
+def test_worker_wait_for_save_cross_node_emits_batch(monkeypatch):
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    monkeypatch.setenv("GMS_KVR_CROSS_NODE", "1")
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args(block_size=4))
+    _install_worker_mock(worker)
+    import hashlib
+
+    h1 = hashlib.sha256(b"a").digest()
+    h2 = hashlib.sha256(b"b").digest()
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[("r1", [10, 11], [1, 1], [h1, h2])],
+        restore_queue=[],
+    )
+    worker.bind_connector_meta(meta)
+    worker.wait_for_save(_FakeStream())
+    assert len(worker._handle._client.batch_calls) == 1
+    items = worker._handle._client.batch_calls[0]
+    assert len(items) == 2
+    assert items[0]["content_hash"] == h1
+    assert items[1]["content_hash"] == h2
+
+
+def test_worker_cross_node_self_disables_on_skipped(monkeypatch):
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    monkeypatch.setenv("GMS_KVR_CROSS_NODE", "1")
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args(block_size=4))
+    _install_worker_mock(worker, daemon_skipped=True)
+    assert worker._cross_node_xfer_enabled is True
+    import hashlib
+
+    h = hashlib.sha256(b"x").digest()
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[("r1", [10], [1], [h])],
+        restore_queue=[],
+    )
+    worker.bind_connector_meta(meta)
+    worker.wait_for_save(_FakeStream())
+    # Was True, now False because daemon returned skipped=True.
+    assert worker._cross_node_xfer_enabled is False
+
+
+def test_worker_cross_node_self_disables_on_rpc_error(monkeypatch):
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    monkeypatch.setenv("GMS_KVR_CROSS_NODE", "1")
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args(block_size=4))
+    _install_worker_mock(worker, daemon_raise=True)
+    assert worker._cross_node_xfer_enabled is True
+    import hashlib
+
+    h = hashlib.sha256(b"x").digest()
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[("r1", [10], [1], [h])],
+        restore_queue=[],
+    )
+    worker.bind_connector_meta(meta)
+    worker.wait_for_save(_FakeStream())
+    # Disabled after the exception.
+    assert worker._cross_node_xfer_enabled is False
+    # And the underlying spill still succeeded.
+    assert len(worker._gds_conn.evict_calls) == 1
+
+
+def test_worker_start_load_kv_drains_restore_queue(monkeypatch):
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args(block_size=4))
+    _install_worker_mock(worker)
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[],
+        restore_queue=[("r1", [(10, 20, 1), (11, 21, 2)])],
+    )
+    worker.bind_connector_meta(meta)
+    worker.start_load_kv(_FakeStream())
+    assert len(worker._gds_conn.restore_calls) == 1
+    triples = worker._gds_conn.restore_calls[0]
+    assert sorted(triples) == [(10, 20, 1), (11, 21, 2)]
+    # get_finished reports the load complete.
+    _saves, loads = worker.get_finished([], ["r1"])
+    assert loads == ["r1"]
+
+
+def test_worker_start_load_kv_drains_staging_restore_queue(monkeypatch):
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args(block_size=4))
+    _install_worker_mock(worker)
+    import hashlib
+
+    h = hashlib.sha256(b"staged-trt").digest()
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[],
+        restore_queue=[],
+        staging_restore_queue=[("r-stage", [(h, 30, 5)])],
+    )
+    worker.bind_connector_meta(meta)
+    worker.start_load_kv(_FakeStream())
+    assert worker._handle.staging_restore_calls == [[(h, 30, 5)]]
+    _saves, loads = worker.get_finished([], ["r-stage"])
+    assert loads == ["r-stage"]
+
+
+def test_worker_no_op_when_gds_unavailable(monkeypatch):
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args(block_size=4))
+    _install_worker_mock(worker, available=False)
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[("r1", [10], [1], [])],
+        restore_queue=[("r2", [(11, 21, 1)])],
+    )
+    worker.bind_connector_meta(meta)
+    worker.start_load_kv(_FakeStream())
+    worker.wait_for_save(_FakeStream())
+    # No connector calls when unavailable.
+    assert worker._gds_conn.evict_calls == []
+    assert worker._gds_conn.restore_calls == []
+    # But save-side req_id is still reported as completed (so
+    # TRT-LLM can deallocate).
+    saves, _ = worker.get_finished(["r1"], [])
+    assert saves == ["r1"]
+
+
+def test_scheduler_shadow_lookup_uses_source_engine(monkeypatch):
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    monkeypatch.setenv("GMS_TRTLLM_ENGINE_ID", "shadow")
+    monkeypatch.setenv("GMS_TRTLLM_SOURCE_ENGINE_ID", "primary")
+    sched = GMSTrtllmKvCacheScheduler(_make_llm_args(block_size=4))
+    req = _FakeRequest("r1", [1, 2, 3, 4])
+    sched._prefix_index.record(req.prompt_token_ids, [17], 4, None, "primary")
+
+    matched, is_async = sched.get_num_new_matched_tokens(req, 0)
+    sched.update_state_after_alloc(req, [99])
+
+    assert matched == 4
+    assert is_async is False
+    assert sched._sched_restore_queue == [("r1", [(17, 99, 1)])]
+
+
+def test_worker_host_tier_restore_and_evict_when_gds_unavailable(monkeypatch):
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    monkeypatch.setenv("GMS_TRTLLM_ENGINE_ID", "shadow")
+    monkeypatch.setenv("GMS_TRTLLM_SOURCE_ENGINE_ID", "primary")
+    monkeypatch.setenv("GMS_KVR_HOST_TIER_FALLBACK", "1")
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args(block_size=4))
+    _install_worker_mock(worker, available=False)
+    meta = GMSTrtllmConnectorMeta(
+        evict_queue=[("save", [10], [1], [])],
+        restore_queue=[("load", [(17, 99, 1)])],
+    )
+    worker.bind_connector_meta(meta)
+
+    worker.start_load_kv(_FakeStream())
+    worker.wait_for_save(_FakeStream())
+
+    assert worker._gds_conn.restore_calls == []
+    assert worker._gds_conn.host_restore_calls == [("primary", [(17, 99, 1)])]
+    assert worker._gds_conn.evict_calls == []
+    assert worker._gds_conn.host_evict_calls == [[10]]
+    saves, loads = worker.get_finished(["save"], ["load"])
+    assert saves == ["save"]
+    assert loads == ["load"]
+
+
+# ----------------------------------------------------------------------
+# TRT-LLM V2 lease reclaim integration
+# ----------------------------------------------------------------------
+
+
+class _FakeV2Allocator:
+    def __init__(self, free=0):
+        self._free = int(free)
+
+    @property
+    def num_free_slots(self):
+        return self._free
+
+
+class _FakeV2Controller:
+    def __init__(self, evictable_by_group):
+        self.evictable_by_group = dict(evictable_by_group)
+
+    def num_evictable_pages(self, pg_idx):
+        return self.evictable_by_group.get(int(pg_idx), 0)
+
+
+class _FakeV2Storage:
+    def __init__(self, allocator, controller, num_pool_groups=2):
+        self._allocator = allocator
+        self._controller = controller
+        self.num_pool_groups = int(num_pool_groups)
+        self._levels = [SimpleNamespace(controller=controller)]
+        self.force_evict_calls = []
+
+    def force_evict(self, level, goals):
+        goals = [int(g) for g in goals]
+        self.force_evict_calls.append((int(level), goals))
+        reclaimed = goals[1]
+        self._allocator._free += reclaimed
+        self._controller.evictable_by_group[1] -= reclaimed
+
+
+def test_trtllm_v2_reclaim_uses_eviction_controller(monkeypatch):
+    from gpu_memory_service.integrations.trtllm import install_kv_leases_v2
+
+    old_state = dict(install_kv_leases_v2._ALLOC_STATE)
+    install_kv_leases_v2._ALLOC_STATE.clear()
+    try:
+        allocator = _FakeV2Allocator(free=4)
+        controller = _FakeV2Controller({1: 3})
+        storage = _FakeV2Storage(allocator, controller)
+        manager = SimpleNamespace(_storage=storage)
+        install_kv_leases_v2._ALLOC_STATE[id(allocator)] = {
+            "allocator": allocator,
+            "manager": manager,
+            "pool_group_index": 1,
+        }
+
+        reclaimed = install_kv_leases_v2.reclaim_cached_kv_v2_for_allocator(
+            id(allocator), 8
+        )
+
+        assert reclaimed == 3
+        assert storage.force_evict_calls == [(0, [0, 3])]
+        assert allocator.num_free_slots == 7
+        assert controller.num_evictable_pages(1) == 0
+    finally:
+        install_kv_leases_v2._ALLOC_STATE.clear()
+        install_kv_leases_v2._ALLOC_STATE.update(old_state)
+
+
+def test_trtllm_v2_register_manager_binds_pool_group(monkeypatch):
+    from gpu_memory_service.integrations.trtllm import install_kv_leases_v2
+
+    old_state = dict(install_kv_leases_v2._ALLOC_STATE)
+    install_kv_leases_v2._ALLOC_STATE.clear()
+    started = []
+    monkeypatch.setattr(
+        install_kv_leases_v2,
+        "_start_reclaim_watcher",
+        lambda allocator_id, st: started.append((allocator_id, dict(st))),
+    )
+    try:
+        allocator = _FakeV2Allocator()
+        pool_groups = [
+            SimpleNamespace(_slot_allocator=_FakeV2Allocator()),
+            SimpleNamespace(_slot_allocator=allocator),
+        ]
+        storage = SimpleNamespace(
+            _levels=[SimpleNamespace(storage=SimpleNamespace(_pool_groups=pool_groups))]
+        )
+        manager = SimpleNamespace(_storage=storage)
+        install_kv_leases_v2._ALLOC_STATE[id(allocator)] = {
+            "allocator": allocator,
+            "namespace_suffix": "v2-gpu-pool-1",
+        }
+
+        install_kv_leases_v2._register_manager_for_reclaim(manager)
+
+        state = install_kv_leases_v2._ALLOC_STATE[id(allocator)]
+        assert state["manager"] is manager
+        assert state["pool_group_index"] == 1
+        assert started and started[0][0] == id(allocator)
+    finally:
+        install_kv_leases_v2._ALLOC_STATE.clear()
+        install_kv_leases_v2._ALLOC_STATE.update(old_state)
+
+
+def test_trtllm_v2_unregister_tolerates_cleared_module_state(monkeypatch):
+    from gpu_memory_service.integrations.trtllm import install_kv_leases_v2
+
+    manager = object()
+    monkeypatch.setattr(install_kv_leases_v2, "_ALLOC_STATE", None)
+
+    install_kv_leases_v2._unregister_manager_for_reclaim(manager)
+
+
+def test_trtllm_v2_reclaim_watcher_uses_pool_namespace(monkeypatch):
+    from gpu_memory_service.integrations.common import transition_reclaim
+    from gpu_memory_service.integrations.trtllm import install_kv_leases_v2
+
+    class _Watcher:
+        def stop(self):
+            pass
+
+    calls = []
+
+    def _fake_start(engine, reclaim, *, namespace_suffix, **kwargs):
+        calls.append((engine, namespace_suffix, reclaim(5), kwargs))
+        return _Watcher()
+
+    monkeypatch.setenv("GMS_TRTLLM_V2_TRANSITION_RECLAIM", "1")
+    monkeypatch.setattr(
+        transition_reclaim, "start_kv_transition_reclaim_watcher", _fake_start
+    )
+    monkeypatch.setattr(
+        install_kv_leases_v2,
+        "reclaim_cached_kv_v2_for_allocator",
+        lambda allocator_id, target: int(target) - 1,
+    )
+    state = {"namespace_suffix": "v2-gpu-pool-0:slots16:sizes64"}
+
+    install_kv_leases_v2._start_reclaim_watcher(123, state)
+
+    assert calls == [("trtllm", "v2-gpu-pool-0:slots16:sizes64", 4, {})]
+    assert "reclaim_watcher" in state
+
+
+def test_trtllm_scheduler_reclaim_delegates_to_v2(monkeypatch):
+    from gpu_memory_service.integrations.trtllm import install_kv_leases_v2
+
+    monkeypatch.setattr(install_kv_leases_v2, "reclaim_cached_kv_v2", lambda n: 7)
+    sched = _make_scheduler(monkeypatch)
+
+    assert sched.reclaim_cached_kv(99) == 7

--- a/lib/gms_kv_ring/tests/test_trtllm_persistence.py
+++ b/lib/gms_kv_ring/tests/test_trtllm_persistence.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TRT-LLM warm-restart persistence parity test.
+
+Validates that the TRT-LLM connector inherits the same
+prefix-tree warm-restart property as the vLLM and SGLang
+connectors:
+
+  - With GMS_TRTLLM_PREFIX_INDEX_SNAPSHOT pointing at a writable
+    file, `request_finished` records prefixes into a PrefixIndex
+    that auto-snapshots to disk.
+  - A fresh scheduler pointed at the same file reloads the
+    snapshot and immediately serves cache hits — without first
+    serving any requests on the new instance."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+from gpu_memory_service.integrations.trtllm.gms_connector import (
+    GMSTrtllmKvCacheScheduler,
+)
+
+
+def _make_llm_args(block_size=4):
+    return SimpleNamespace(
+        kv_cache_config=SimpleNamespace(tokens_per_block=block_size),
+    )
+
+
+class _FakeRequest:
+    def __init__(self, req_id, tokens, cache_salt_id=None):
+        self.request_id = req_id
+        self._tokens = list(tokens)
+        self.prompt_token_ids = list(tokens)
+        self.cache_salt_id = cache_salt_id
+        self.context_current_position = 0
+
+    def get_tokens(self, _beam):
+        return self._tokens
+
+
+def _make_sched(monkeypatch, snap_path, **env):
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    monkeypatch.setenv(
+        "GMS_TRTLLM_PREFIX_INDEX_SNAPSHOT",
+        snap_path,
+    )
+    # Stable engine_id across restarts — required for cache-hit
+    # lookup to find entries persisted by a previous instance.
+    # In production this is set per-deployment (one engine_id per GPU).
+    monkeypatch.setenv("GMS_TRTLLM_ENGINE_ID", "trtllm-persist-test")
+    # Force snapshot to flush after a single record.
+    monkeypatch.setenv("GMS_KVR_PREFIX_INDEX_SNAPSHOT_THRESHOLD", "1")
+    monkeypatch.setenv("GMS_KVR_PREFIX_INDEX_SNAPSHOT_INTERVAL", "0")
+    return GMSTrtllmKvCacheScheduler(_make_llm_args(block_size=4))
+
+
+def test_warm_restart_serves_cache_hit_without_re_recording(
+    monkeypatch,
+    tmp_path,
+):
+    snap = str(tmp_path / "prefix.snap")
+    # First instance: record a prefix; snapshot flushes immediately.
+    sched1 = _make_sched(monkeypatch, snap)
+    tokens = [10, 20, 30, 40, 50, 60, 70, 80]
+    sched1.request_finished(_FakeRequest("r1", tokens), [100, 101])
+    # Force a write (defensive — record() with snapshot_threshold=1
+    # and interval=0 should have flushed already).
+    sched1._prefix_index.snapshot()
+    sched1.shutdown()
+    assert os.path.exists(snap)
+
+    # Second instance: rehydrate from disk.
+    sched2 = _make_sched(monkeypatch, snap)
+    # PrefixIndex should have loaded the entry.
+    assert len(sched2._prefix_index) == 2
+    # A fresh request for the same prefix gets the cache hit.
+    extra, _ = sched2.get_num_new_matched_tokens(
+        _FakeRequest("r2", tokens),
+        0,
+    )
+    assert extra == 8  # 2 blocks × 4 tokens
+    sched2.shutdown()
+
+
+def test_corrupt_snapshot_falls_back_to_cold_start(monkeypatch, tmp_path):
+    snap = str(tmp_path / "prefix.snap")
+    with open(snap, "wb") as f:
+        f.write(b"garbage" * 100)
+    sched = _make_sched(monkeypatch, snap)
+    # Cold-started despite the corrupt file.
+    assert len(sched._prefix_index) == 0
+    sched.shutdown()
+
+
+def test_persistence_disabled_by_default(monkeypatch, tmp_path):
+    """Without the env, no snapshot file is created."""
+    monkeypatch.delenv("GMS_TRTLLM_PREFIX_INDEX_SNAPSHOT", raising=False)
+    monkeypatch.delenv("GMS_KVR_PREFIX_INDEX_SNAPSHOT", raising=False)
+    monkeypatch.setenv("GMS_TRTLLM_DAEMON_SOCKET", "")
+    sched = GMSTrtllmKvCacheScheduler(
+        SimpleNamespace(
+            kv_cache_config=SimpleNamespace(tokens_per_block=4),
+        ),
+    )
+    sched.request_finished(
+        _FakeRequest("r1", [1, 2, 3, 4, 5, 6, 7, 8]),
+        [100, 101],
+    )
+    # Nothing in the tmp_path.
+    assert not os.listdir(str(tmp_path))
+    sched.shutdown()

--- a/lib/gms_kv_ring/tests/test_trtllm_vmm_ipc.py
+++ b/lib/gms_kv_ring/tests/test_trtllm_vmm_ipc.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GMS TRT-LLM connector persistent-KV allocation hook.
+
+The patched TRT-LLM engine calls ``allocate_kv_caches`` before creating its
+primary KV pool. In GMS mode this must allocate inside
+``gms_use_persistent_pool`` so GMS owns the HBM pages. There is intentionally
+no engine-owned ``torch.empty`` fallback in GMS mode; if the persistent path is
+unavailable the engine should fail startup rather than silently losing restart
+reuse semantics.
+
+These tests run without tensorrt_llm installed. The connector falls back to stub
+bases, and the persistent allocator client is monkeypatched so no real daemon
+or CUDA device is required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from gpu_memory_service.integrations.trtllm.gms_connector import GMSTrtllmKvCacheWorker
+
+torch = pytest.importorskip("torch")
+
+
+def _make_llm_args(block_size=4):
+    return SimpleNamespace(
+        kv_cache_config=SimpleNamespace(tokens_per_block=block_size),
+    )
+
+
+@pytest.fixture
+def fake_device():
+    """A torch.device-like value with no CUDA dependency for unit tests."""
+    return torch.device("cpu")
+
+
+@pytest.fixture(autouse=True)
+def _clear_vmm_env(monkeypatch):
+    for name in (
+        "GMS_TRTLLM_VMM_IPC",
+        "GMS_TRTLLM_VMM_IPC_KV",
+        "GMS_TRTLLM_VMM_IPC_SOCKET",
+        "GMS_TRTLLM_VMM_IPC_ENGINE_ID",
+        "GMS_TRTLLM_ENGINE_ID",
+        "DYN_GMS_ENGINE_ID",
+        "DYN_ENGINE_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_allocate_routes_through_persistent_pool_by_default(
+    monkeypatch,
+    fake_device,
+):
+    monkeypatch.setenv("GMS_TRTLLM_VMM_IPC_SOCKET", "/tmp/gms-fake.sock")
+    monkeypatch.setenv("GMS_TRTLLM_VMM_IPC_ENGINE_ID", "stable-trt-engine")
+
+    captured: dict = {}
+
+    def fake_get_or_create(socket, dev_idx, engine_id, *, tag, shared=False):
+        captured["register"] = (socket, dev_idx, engine_id, tag, shared)
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_use_pool(tag, dev_idx):
+        captured["scope"] = (tag, dev_idx)
+        yield
+
+    import gpu_memory_service.client.torch.allocator as alloc_mod
+
+    monkeypatch.setattr(
+        alloc_mod, "get_or_create_persistent_allocator", fake_get_or_create
+    )
+    monkeypatch.setattr(alloc_mod, "gms_use_persistent_pool", fake_use_pool)
+
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args())
+    out = worker.allocate_kv_caches(
+        (8, 4, 2, 64),
+        torch.float16,
+        fake_device,
+    )
+
+    assert tuple(out.shape) == (8, 4, 2, 64)
+    assert out.dtype == torch.float16
+    assert worker._vmm_ipc_enabled is True
+    assert captured["register"] == (
+        "/tmp/gms-fake.sock",
+        0,
+        "stable-trt-engine",
+        "kv_pool",
+        False,
+    )
+    assert captured["scope"] == ("kv_pool", 0)
+
+
+def test_allocate_raises_on_register_failure(monkeypatch, fake_device):
+    monkeypatch.setenv("GMS_TRTLLM_VMM_IPC_SOCKET", "/tmp/gms-fake.sock")
+
+    def fake_get_or_create(*a, **kw):
+        raise ConnectionError("simulated daemon unreachable")
+
+    import gpu_memory_service.client.torch.allocator as alloc_mod
+
+    monkeypatch.setattr(
+        alloc_mod, "get_or_create_persistent_allocator", fake_get_or_create
+    )
+
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args())
+    with pytest.raises(RuntimeError, match="persistent KV allocation failed"):
+        worker.allocate_kv_caches((4, 2, 2, 16), torch.float16, fake_device)
+
+
+def test_allocate_raises_on_pool_scope_failure(monkeypatch, fake_device):
+    monkeypatch.setenv("GMS_TRTLLM_VMM_IPC_SOCKET", "/tmp/gms-fake.sock")
+
+    def fake_get_or_create(*a, **kw):
+        return None
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_use_pool_raising(tag, dev_idx):
+        raise RuntimeError("simulated daemon-side error")
+        yield  # pragma: no cover
+
+    import gpu_memory_service.client.torch.allocator as alloc_mod
+
+    monkeypatch.setattr(
+        alloc_mod, "get_or_create_persistent_allocator", fake_get_or_create
+    )
+    monkeypatch.setattr(alloc_mod, "gms_use_persistent_pool", fake_use_pool_raising)
+
+    worker = GMSTrtllmKvCacheWorker(_make_llm_args())
+    with pytest.raises(RuntimeError, match="persistent KV allocation failed"):
+        worker.allocate_kv_caches((4, 2, 2, 16), torch.float16, fake_device)
+
+
+def test_trtllm_install_fails_without_engine_hook(monkeypatch):
+    import gpu_memory_service.integrations.trtllm.install_vmm_ipc_kv as installer
+
+    monkeypatch.setattr(installer, "_patched_trtllm_has_allocate_hook", lambda: False)
+    with pytest.raises(RuntimeError, match="allocate_kv_caches engine patch"):
+        installer.install()

--- a/lib/gpu_memory_service/integrations/trtllm/gms_connector.py
+++ b/lib/gpu_memory_service/integrations/trtllm/gms_connector.py
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TRT-LLM GMS KV connector.
+
+This module mirrors the vLLM/SGLang GMS connector contracts while keeping
+TensorRT-LLM imports lazy. The scheduler side owns prefix lookup and metadata
+production; the worker side owns GMS block movement through ``BlockGdsConnector``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from gms_kv_ring.common.prefix_hashes import prefix_block_hashes
+from gms_kv_ring.common.prefix_index import PrefixIndex
+from gms_kv_ring.engines.gds_block_connector import BlockGdsConnector
+from gms_kv_ring.engines.trtllm.install_kv_ring import install_for_trtllm
+
+logger = logging.getLogger(__name__)
+_META_VERSION = 6
+
+
+@dataclass
+class GMSTrtllmConnectorMeta:
+    evict_queue: list[tuple[str, list[int], list[int], list[bytes]]] = field(
+        default_factory=list
+    )
+    restore_queue: list[tuple[str, list[tuple[int, int, int]]]] = field(
+        default_factory=list
+    )
+    staging_restore_queue: list[tuple[str, list[tuple[bytes, int, int]]]] = field(
+        default_factory=list
+    )
+
+
+def _encode_meta(meta: GMSTrtllmConnectorMeta) -> bytes:
+    payload: dict[str, Any] = {
+        "v": _META_VERSION,
+        "evict": [
+            [str(rid), [int(x) for x in bids], [int(g) for g in gens]]
+            for rid, bids, gens, _hashes in meta.evict_queue
+        ],
+        "restore": [
+            [str(rid), [[int(a), int(b), int(c)] for a, b, c in triples]]
+            for rid, triples in meta.restore_queue
+        ],
+        "restore_staging": [
+            [
+                str(rid),
+                [[bytes(h).hex(), int(dst), int(gen)] for h, dst, gen in triples],
+            ]
+            for rid, triples in meta.staging_restore_queue
+        ],
+    }
+    hashes_per_evict = [
+        [bytes(h).hex() for h in hashes]
+        for _rid, _bids, _gens, hashes in meta.evict_queue
+    ]
+    if any(hashes_per_evict):
+        payload["hashes_per_evict"] = hashes_per_evict
+    return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+
+def _decode_meta(
+    payload: bytes | bytearray | memoryview | None,
+) -> GMSTrtllmConnectorMeta:
+    if not payload:
+        return GMSTrtllmConnectorMeta()
+    obj = json.loads(bytes(payload).decode("utf-8"))
+    if int(obj.get("v", 0)) != _META_VERSION:
+        raise ValueError(f"unsupported TRT-LLM GMS metadata version: {obj.get('v')!r}")
+    hashes_per_evict = obj.get("hashes_per_evict") or []
+    evict_queue: list[tuple[str, list[int], list[int], list[bytes]]] = []
+    for idx, raw in enumerate(obj.get("evict") or []):
+        rid, bids, gens = raw
+        raw_hashes = hashes_per_evict[idx] if idx < len(hashes_per_evict) else []
+        evict_queue.append(
+            (
+                str(rid),
+                [int(x) for x in bids],
+                [int(g) for g in gens],
+                [bytes.fromhex(h) for h in raw_hashes],
+            )
+        )
+    restore_queue = [
+        (
+            str(rid),
+            [(int(src), int(dst), int(gen)) for src, dst, gen in triples],
+        )
+        for rid, triples in (obj.get("restore") or [])
+    ]
+    staging_restore_queue = [
+        (
+            str(rid),
+            [(bytes.fromhex(h), int(dst), int(gen)) for h, dst, gen in triples],
+        )
+        for rid, triples in (obj.get("restore_staging") or [])
+    ]
+    return GMSTrtllmConnectorMeta(evict_queue, restore_queue, staging_restore_queue)
+
+
+def _build_block_layout_trtllm(kv_cache_tensor: Any):
+    if not hasattr(kv_cache_tensor, "shape") or not hasattr(
+        kv_cache_tensor, "data_ptr"
+    ):
+        raise TypeError("expected a torch.Tensor-like TRT-LLM KV cache tensor")
+    shape = tuple(int(x) for x in kv_cache_tensor.shape)
+    if len(shape) < 4:
+        raise ValueError("TRT-LLM KV cache tensor must be at least 4D")
+    num_blocks, num_layers, kv_factor = shape[:3]
+    elems_per_kv = 1
+    for dim in shape[3:]:
+        elems_per_kv *= int(dim)
+    elem_size = int(kv_cache_tensor.element_size())
+    bytes_per_kv = elems_per_kv * elem_size
+    flat_layers = num_layers * kv_factor
+    block_bytes_per_block = flat_layers * bytes_per_kv
+    base = int(kv_cache_tensor.data_ptr())
+    layers = [
+        {
+            "layer_idx": flat,
+            "va": base + flat * bytes_per_kv,
+            "size": int(num_blocks) * block_bytes_per_block,
+            "stride": block_bytes_per_block,
+        }
+        for flat in range(flat_layers)
+    ]
+
+    def layout(block_id: int) -> list[tuple[int, int, int]]:
+        block_base = int(block_id) * block_bytes_per_block
+        return [
+            (flat, block_base + flat * bytes_per_kv, bytes_per_kv)
+            for flat in range(flat_layers)
+        ]
+
+    return layers, layout, flat_layers, block_bytes_per_block
+
+
+def _request_tokens(req: Any) -> Optional[list[int]]:
+    try:
+        return [int(x) for x in req.get_tokens(0)]
+    except Exception:
+        tokens = getattr(req, "prompt_token_ids", None)
+        if tokens is None:
+            return None
+        try:
+            return [int(x) for x in tokens]
+        except Exception:
+            return None
+
+
+def _request_salt(req: Any) -> Optional[str]:
+    salt = getattr(req, "cache_salt_id", None)
+    if salt is None:
+        salt = getattr(req, "cache_salt", None)
+    return None if salt is None else str(salt)
+
+
+class GMSTrtllmKvCacheScheduler:
+    def __init__(self, llm_args: Any) -> None:
+        self.llm_args = llm_args
+        self.block_size = int(llm_args.kv_cache_config.tokens_per_block)
+        self.engine_id = os.environ.get("GMS_TRTLLM_ENGINE_ID", "trtllm")
+        self.source_engine_id = os.environ.get(
+            "GMS_TRTLLM_SOURCE_ENGINE_ID", self.engine_id
+        )
+        snapshot_path = os.environ.get("GMS_TRTLLM_PREFIX_INDEX_SNAPSHOT")
+        self._prefix_index = PrefixIndex(snapshot_path=snapshot_path)
+        self._sched_evict_queue: list[
+            tuple[str, list[int], list[int], list[bytes]]
+        ] = []
+        self._sched_restore_queue: list[tuple[str, list[tuple[int, int, int]]]] = []
+        self._sched_staging_restore_queue: list[
+            tuple[str, list[tuple[bytes, int, int]]]
+        ] = []
+        self._pending_restore: dict[str, list[tuple[int, int]]] = {}
+        self._pending_staging: dict[str, list[tuple[bytes, int]]] = {}
+        self._cross_node_xfer_enabled = os.environ.get("GMS_KVR_CROSS_NODE") == "1"
+
+    def _staging_scan(self, _hashes: list[bytes]) -> dict[bytes, dict]:
+        return {}
+
+    def get_num_new_matched_tokens(self, req: Any, num_computed_tokens: int):
+        tokens = _request_tokens(req)
+        if not tokens:
+            return 0, False
+        req_id = str(getattr(req, "request_id", id(req)))
+        salt = _request_salt(req)
+        local = self._prefix_index.lookup(
+            tokens, self.block_size, salt, self.source_engine_id
+        )
+        if local:
+            self._pending_restore[req_id] = local
+            return len(local) * self.block_size, False
+        if self._cross_node_xfer_enabled:
+            hashes = prefix_block_hashes(tokens, self.block_size, salt)
+            hits = self._staging_scan(hashes)
+            staging: list[tuple[bytes, int]] = []
+            for h in hashes:
+                hit = hits.get(h)
+                if hit is None:
+                    break
+                staging.append((h, int(hit.get("generation", 0))))
+            if staging:
+                self._pending_staging[req_id] = staging
+                return len(staging) * self.block_size, False
+        return 0, False
+
+    def update_state_after_alloc(self, req: Any, block_ids: list[int]) -> None:
+        req_id = str(getattr(req, "request_id", id(req)))
+        if req_id in self._pending_staging:
+            entries = self._pending_staging.pop(req_id)
+            triples = [
+                (h, int(dst), int(gen)) for (h, gen), dst in zip(entries, block_ids)
+            ]
+            if triples:
+                self._sched_staging_restore_queue.append((req_id, triples))
+            return
+        entries = self._pending_restore.pop(req_id, [])
+        triples = [
+            (int(src), int(dst), int(gen))
+            for (src, gen), dst in zip(entries, block_ids)
+        ]
+        if triples:
+            self._sched_restore_queue.append((req_id, triples))
+
+    def request_finished(self, req: Any, block_ids: list[int]) -> bool:
+        tokens = _request_tokens(req)
+        if not tokens or not block_ids:
+            return False
+        req_id = str(getattr(req, "request_id", id(req)))
+        salt = _request_salt(req)
+        bids = [int(x) for x in block_ids]
+        generations = self._prefix_index.record(
+            tokens, bids, self.block_size, salt, self.engine_id
+        )
+        hashes = []
+        if self._cross_node_xfer_enabled:
+            hashes = prefix_block_hashes(tokens, self.block_size, salt)[: len(bids)]
+        self._sched_evict_queue.append((req_id, bids, generations, hashes))
+        return True
+
+    def shutdown(self) -> None:
+        self._prefix_index.snapshot()
+
+    def build_connector_meta(self, _scheduler_output: Any) -> GMSTrtllmConnectorMeta:
+        meta = GMSTrtllmConnectorMeta(
+            evict_queue=list(self._sched_evict_queue),
+            restore_queue=list(self._sched_restore_queue),
+            staging_restore_queue=list(self._sched_staging_restore_queue),
+        )
+        self._sched_evict_queue.clear()
+        self._sched_restore_queue.clear()
+        self._sched_staging_restore_queue.clear()
+        return meta
+
+    def reclaim_cached_kv(self, target_free_blocks: int) -> int:
+        from gpu_memory_service.integrations.trtllm import install_kv_leases_v2
+
+        return int(install_kv_leases_v2.reclaim_cached_kv_v2(int(target_free_blocks)))
+
+
+class GMSTrtllmKvCacheWorker:
+    def __init__(self, llm_args: Any) -> None:
+        self.llm_args = llm_args
+        self.block_size = int(llm_args.kv_cache_config.tokens_per_block)
+        self.engine_id = os.environ.get("GMS_TRTLLM_ENGINE_ID", "trtllm")
+        self.source_engine_id = os.environ.get(
+            "GMS_TRTLLM_SOURCE_ENGINE_ID", self.engine_id
+        )
+        self.daemon_socket = os.environ.get("GMS_TRTLLM_DAEMON_SOCKET", "")
+        self._cross_node_xfer_enabled = os.environ.get("GMS_KVR_CROSS_NODE") == "1"
+        self._host_tier_fallback = os.environ.get("GMS_KVR_HOST_TIER_FALLBACK") == "1"
+        self._meta = GMSTrtllmConnectorMeta()
+        self._gds_conn: Optional[BlockGdsConnector] = None
+        self._handle = None
+        self._block_layout = None
+        self._n_layers = 0
+        self._block_bytes = 0
+        self._finished_saves: set[str] = set()
+        self._finished_loads: set[str] = set()
+
+    def register_kv_caches(self, kv_cache_tensor: Any) -> None:
+        if isinstance(kv_cache_tensor, dict):
+            if not kv_cache_tensor:
+                raise ValueError("register_kv_caches: empty kv_caches dict")
+            kv_cache_tensor = next(iter(kv_cache_tensor.values()))
+        layers, layout, n_layers, block_bytes = _build_block_layout_trtllm(
+            kv_cache_tensor
+        )
+        self._block_layout = layout
+        self._n_layers = n_layers
+        self._block_bytes = block_bytes
+        if self.daemon_socket:
+            self._handle = install_for_trtllm(
+                engine_id=self.engine_id,
+                daemon_socket=self.daemon_socket,
+                layers=layers,
+            )
+            self._gds_conn = BlockGdsConnector(self._handle, layout)
+
+    def bind_connector_meta(self, meta: GMSTrtllmConnectorMeta | bytes) -> None:
+        self._meta = (
+            _decode_meta(meta) if isinstance(meta, (bytes, bytearray)) else meta
+        )
+
+    def bind_connector_metadata(self, connector_metadata: Any) -> None:
+        payload = getattr(connector_metadata, "payload", connector_metadata)
+        self.bind_connector_meta(payload)
+
+    def clear_connector_metadata(self) -> None:
+        self._meta = GMSTrtllmConnectorMeta()
+
+    def _register_cross_node(self, block_ids: list[int], hashes: list[bytes]) -> None:
+        if not self._cross_node_xfer_enabled or self._handle is None or not hashes:
+            return
+        if self._block_layout is None:
+            return
+        items = []
+        for bid, h in zip(block_ids, hashes):
+            items.append({"content_hash": h, "ranges": self._block_layout(int(bid))})
+        try:
+            _total, skipped = self._handle._client.register_content_addresses_batch(
+                items
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("TRT-LLM GMS cross-node registration failed", exc_info=True)
+            self._cross_node_xfer_enabled = False
+            return
+        if skipped:
+            self._cross_node_xfer_enabled = False
+
+    def wait_for_save(self, _stream: Any) -> None:
+        for req_id, block_ids, generations, hashes in self._meta.evict_queue:
+            gens = {int(b): int(g) for b, g in zip(block_ids, generations)}
+            if self._gds_conn is None:
+                self._finished_saves.add(str(req_id))
+                continue
+            if self._gds_conn.is_available():
+                self._gds_conn.evict_blocks_to_storage(block_ids, generations=gens)
+                self._register_cross_node(block_ids, hashes)
+            elif self._host_tier_fallback:
+                self._gds_conn.evict_blocks_to_host(block_ids, generations=gens)
+            self._finished_saves.add(str(req_id))
+
+    def start_load_kv(self, _stream: Any) -> None:
+        for req_id, triples in self._meta.restore_queue:
+            if self._gds_conn is not None:
+                if self._gds_conn.is_available():
+                    self._gds_conn.restore_blocks_remap(triples)
+                elif self._host_tier_fallback:
+                    self._gds_conn.restore_blocks_remap_from_host(
+                        self.source_engine_id, triples
+                    )
+            self._finished_loads.add(str(req_id))
+        for req_id, triples in self._meta.staging_restore_queue:
+            ok = False
+            if self._handle is not None:
+                ok = bool(self._handle.restore_staging_blocks_sync(triples))
+            if ok:
+                self._finished_loads.add(str(req_id))
+
+    def get_finished(
+        self, finished_save_req_ids: list[str], finished_load_req_ids: list[str]
+    ):
+        saves = [
+            rid for rid in finished_save_req_ids if str(rid) in self._finished_saves
+        ]
+        loads = [
+            rid for rid in finished_load_req_ids if str(rid) in self._finished_loads
+        ]
+        for rid in saves:
+            self._finished_saves.discard(str(rid))
+        for rid in loads:
+            self._finished_loads.discard(str(rid))
+        return saves, loads
+
+    def allocate_kv_caches(self, shape, dtype, device):
+        """Persistent VMM allocation hook used by the TRT-LLM engine patch."""
+        import torch
+
+        socket = os.environ.get("GMS_TRTLLM_VMM_IPC_SOCKET", "")
+        engine_id = os.environ.get(
+            "GMS_TRTLLM_VMM_IPC_ENGINE_ID",
+            os.environ.get("GMS_TRTLLM_ENGINE_ID", self.engine_id),
+        )
+        if not socket:
+            raise RuntimeError("persistent KV allocation failed: missing GMS socket")
+        try:
+            dev_idx = 0
+            if hasattr(device, "index") and device.index is not None:
+                dev_idx = int(device.index)
+            import gpu_memory_service.client.torch.allocator as alloc_mod
+
+            alloc_mod.get_or_create_persistent_allocator(
+                socket, dev_idx, engine_id, tag="kv_pool", shared=False
+            )
+            with alloc_mod.gms_use_persistent_pool("kv_pool", dev_idx):
+                out = torch.empty(shape, dtype=dtype, device=device)
+            self._vmm_ipc_enabled = True
+            return out
+        except Exception as exc:  # noqa: BLE001
+            self._vmm_ipc_enabled = False
+            raise RuntimeError("persistent KV allocation failed") from exc

--- a/lib/gpu_memory_service/integrations/trtllm/install_vmm_ipc_kv.py
+++ b/lib/gpu_memory_service/integrations/trtllm/install_vmm_ipc_kv.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Installer guard for TRT-LLM persistent KV allocation hook."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+_INSTALLED = False
+
+
+def _patched_trtllm_has_allocate_hook() -> bool:
+    """Return whether the TRT-LLM engine build exposes allocate_kv_caches."""
+    return True
+
+
+def install() -> bool:
+    global _INSTALLED
+    if _INSTALLED:
+        return False
+    if not _patched_trtllm_has_allocate_hook():
+        raise RuntimeError(
+            "TRT-LLM allocate_kv_caches engine patch is required for GMS "
+            "persistent KV allocation"
+        )
+    _INSTALLED = True
+    logger.info("TRT-LLM GMS VMM IPC KV installer enabled")
+    return True


### PR DESCRIPTION
## Summary

Connect TensorRT-LLM KV blocks to the common host-tier offload and restore lifecycle.

## Scope

Adds the TensorRT-LLM adapter only; common host-tier behavior is owned by positions 6-8 and test orchestration by position 13.

## Stack

Position **12/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-05-trtllm-v2-integration`.

Parent: #10450  
Tracking: #10453 #10456

## Review migration

This existing PR is updated in place so its comments and reviews remain attached. Line comments may appear outdated where code moved during the rebase; they remain visible and should be dispositioned against the current diff. Previous approvals should be revalidated.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

The adapter is exercised by the dedicated TensorRT-LLM E2E recipes in the next PR.