### PR TITLE
feat(router): add GMS placement protocol [GMS 16/18]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,6 +2491,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.4",
+ "bincode 1.3.3",
  "chrono",
  "criterion",
  "dashmap",

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -234,7 +234,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, durable_kv_events=false, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_snapshot_threshold=1000000, router_reset_states=false, router_ttl_secs=120.0, router_queue_threshold=Some(16.0), router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, *, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, router_policy_config=None))]
+    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, durable_kv_events=false, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_snapshot_threshold=1000000, router_reset_states=false, router_ttl_secs=120.0, router_queue_threshold=Some(16.0), router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, *, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, router_policy_config=None, router_gms_decode_transfer=false))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: Option<f64>,
@@ -264,6 +264,7 @@ impl KvRouterConfig {
         overlap_score_credit_decay: f64,
         mut prefill_load_scale: f64,
         router_policy_config: Option<String>,
+        router_gms_decode_transfer: bool,
     ) -> PyResult<Self> {
         if let Some(value) = overlap_score_weight {
             apply_deprecated_overlap_score_weight(
@@ -287,6 +288,7 @@ impl KvRouterConfig {
             router_track_output_blocks,
             router_assume_kv_reuse,
             router_track_prefill_tokens,
+            router_gms_decode_transfer,
             router_prefill_load_model: router_prefill_load_model
                 .parse::<RsRouterPrefillLoadModel>()
                 .map_err(PyValueError::new_err)?,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1802,6 +1802,7 @@ class KvRouterConfig:
         overlap_score_credit_decay: float = 0.0,
         prefill_load_scale: float = 1.0,
         router_policy_config: Optional[str] = None,
+        router_gms_decode_transfer: bool = False,
     ) -> None:
         """
         Create a KV router configuration.
@@ -1826,6 +1827,7 @@ class KvRouterConfig:
             router_assume_kv_reuse: Assume KV cache reuse when tracking active blocks (default: True).
                 When True, computes actual block hashes. When False, generates random hashes.
             router_track_prefill_tokens: Include prompt-side prefill tokens in active load accounting (default: True).
+            router_gms_decode_transfer: Enable experimental GMS decode-to-decode transfer orchestration (default: False).
             router_prefill_load_model: Prompt-side prefill load model (default: "none").
                 "none" keeps static prompt load accounting.
                 "aic" decays the oldest active prefill request using AIC-predicted duration.

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -72,6 +72,7 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }
 dynamo-tokens = { workspace = true }
+bincode = { version = "1" }
 tower = { version = "0.5", features = ["util"] }
 
 [[bench]]

--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -680,6 +680,7 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
             let shard_event = RouterEvent {
                 worker_id: event.worker_id,
                 storage_tier: event.storage_tier,
+                gms_placement: None,
                 event: KvCacheEvent {
                     event_id: event.event.event_id,
                     dp_rank: event.event.dp_rank,
@@ -699,6 +700,7 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
                 let broadcast_event = RouterEvent {
                     worker_id: event.worker_id,
                     storage_tier: event.storage_tier,
+                    gms_placement: None,
                     event: KvCacheEvent {
                         event_id: event.event.event_id,
                         dp_rank: event.event.dp_rank,

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -536,6 +536,7 @@ impl ConcurrentRadixTree {
                 let event = RouterEvent {
                     worker_id: worker.worker_id,
                     storage_tier: crate::protocols::StorageTier::Device,
+                    gms_placement: None,
                     event: KvCacheEvent {
                         event_id,
                         data: KvCacheEventData::Stored(KvCacheStoreData {

--- a/lib/kv-router/src/indexer/positional.rs
+++ b/lib/kv-router/src/indexer/positional.rs
@@ -543,6 +543,7 @@ impl PositionalIndexer {
                 events.push(RouterEvent {
                     worker_id: worker.worker_id,
                     storage_tier: crate::protocols::StorageTier::Device,
+                    gms_placement: None,
                     event: KvCacheEvent {
                         event_id,
                         data: KvCacheEventData::Stored(KvCacheStoreData {

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -411,11 +411,29 @@ impl Placement {
 pub struct PlacementEvent {
     pub placement: Placement,
     pub event: KvCacheEvent,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gms_placement: Option<GmsPlacementEventData>,
 }
 
 impl PlacementEvent {
     pub fn new(placement: Placement, event: KvCacheEvent) -> Self {
-        Self { placement, event }
+        Self {
+            placement,
+            event,
+            gms_placement: None,
+        }
+    }
+
+    pub fn with_gms_placement(
+        placement: Placement,
+        event: KvCacheEvent,
+        gms_placement: GmsPlacementEventData,
+    ) -> Self {
+        Self {
+            placement,
+            event,
+            gms_placement: Some(gms_placement),
+        }
     }
 
     pub fn local_gpu(worker_id: WorkerId, event: KvCacheEvent) -> Self {
@@ -426,11 +444,10 @@ impl PlacementEvent {
         let PlacementOwner::LocalWorker(worker) = self.placement.owner else {
             return None;
         };
-        Some(RouterEvent::with_storage_tier(
-            worker.worker_id,
-            self.event,
-            self.placement.tier,
-        ))
+        let mut event =
+            RouterEvent::with_storage_tier(worker.worker_id, self.event, self.placement.tier);
+        event.gms_placement = self.gms_placement;
+        Some(event)
     }
 }
 
@@ -830,6 +847,72 @@ pub struct KvCacheRemoveData {
     pub block_hashes: Vec<ExternalSequenceBlockHash>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GmsPlacementMemoryRegion {
+    pub remote_ptr: u64,
+    pub size: u64,
+    pub tier: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layer: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GmsPlacementDescriptor {
+    pub remote_ptr: u64,
+    pub size: u64,
+    pub tier: String,
+    #[serde(default)]
+    pub ranges: Vec<GmsPlacementMemoryRegion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sealed: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GmsPlacementBlock {
+    /// Stable GMS content hash for the full prefix ending at this block.
+    pub content_hash_hex: String,
+    pub descriptor: GmsPlacementDescriptor,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GmsPlacementStoreData {
+    pub source_nixl_agent_name: String,
+    pub source_nixl_agent_metadata_hex: String,
+    #[serde(default)]
+    pub source_nixl_ip: Option<String>,
+    #[serde(default)]
+    pub source_nixl_listen_port: Option<u16>,
+    pub blocks: Vec<GmsPlacementBlock>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GmsPlacementRemoveData {
+    pub content_hashes_hex: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GmsPlacementMatch {
+    pub source_nixl_agent_name: String,
+    pub source_nixl_agent_metadata_hex: String,
+    #[serde(default)]
+    pub source_nixl_ip: Option<String>,
+    #[serde(default)]
+    pub source_nixl_listen_port: Option<u16>,
+    pub descriptors: Vec<Option<GmsPlacementDescriptor>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum GmsPlacementEventData {
+    Stored(GmsPlacementStoreData),
+    Removed(GmsPlacementRemoveData),
+    Cleared,
+}
+
 impl Serialize for LocalBlockHash {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -895,6 +978,17 @@ pub struct RouterEvent {
     pub storage_tier: StorageTier,
     /// The cache event associated with the worker.
     pub event: KvCacheEvent,
+    /// Optional GMS placement metadata published on the KV event plane.
+    ///
+    /// This is orthogonal to `event.data`: ordinary radix indexes keep using
+    /// `KvCacheEventData`, while GMS-aware routers can learn the NIXL
+    /// bootstrap descriptors needed to build request-local `gms_placement`
+    /// without querying the source worker on each request. Keep this field last
+    /// so older positional MessagePack payloads deserialize with the default.
+    /// Always serialize the `None` value for bincode-backed snapshots, where
+    /// skipped positional fields are not recoverable.
+    #[serde(default)]
+    pub gms_placement: Option<GmsPlacementEventData>,
 }
 
 impl RouterEvent {
@@ -920,6 +1014,21 @@ impl RouterEvent {
         Self {
             worker_id,
             storage_tier,
+            gms_placement: None,
+            event,
+        }
+    }
+
+    pub fn with_gms_placement(
+        worker_id: WorkerId,
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+        gms_placement: GmsPlacementEventData,
+    ) -> Self {
+        Self {
+            worker_id,
+            storage_tier,
+            gms_placement: Some(gms_placement),
             event,
         }
     }
@@ -1234,6 +1343,82 @@ mod tests {
         } else {
             panic!("Expected KvCacheEventData::Stored");
         }
+    }
+
+    #[test]
+    fn router_event_msgpack_accepts_legacy_three_field_payload() {
+        let worker_id = 7;
+        let kv_cache_event = KvCacheEvent {
+            event_id: 11,
+            data: KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(99)],
+            }),
+            dp_rank: 2,
+        };
+        let payload =
+            rmp_serde::to_vec(&(worker_id, StorageTier::Device, kv_cache_event.clone())).unwrap();
+
+        let router_event: RouterEvent = rmp_serde::from_slice(&payload).unwrap();
+
+        assert_eq!(router_event.worker_id, worker_id);
+        assert_eq!(router_event.storage_tier, StorageTier::Device);
+        assert_eq!(router_event.event, kv_cache_event);
+        assert_eq!(router_event.gms_placement, None);
+    }
+
+    #[test]
+    fn router_event_bincode_round_trips_none_gms_placement_snapshot() {
+        let events = vec![RouterEvent::new(
+            7,
+            KvCacheEvent {
+                event_id: 11,
+                data: KvCacheEventData::Removed(KvCacheRemoveData {
+                    block_hashes: vec![ExternalSequenceBlockHash(99)],
+                }),
+                dp_rank: 2,
+            },
+        )];
+
+        let payload = bincode::serialize(&events).unwrap();
+        let decoded: Vec<RouterEvent> = bincode::deserialize(&payload).unwrap();
+
+        assert_eq!(decoded, events);
+        assert_eq!(decoded[0].gms_placement, None);
+    }
+
+    #[test]
+    fn router_event_msgpack_round_trips_gms_placement_tail_field() {
+        let router_event = RouterEvent::with_gms_placement(
+            7,
+            KvCacheEvent {
+                event_id: 11,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    start_position: None,
+                    blocks: Vec::new(),
+                }),
+                dp_rank: 2,
+            },
+            StorageTier::External,
+            GmsPlacementEventData::Stored(GmsPlacementStoreData {
+                source_nixl_agent_name: "agent-a".to_string(),
+                source_nixl_agent_metadata_hex: "00".to_string(),
+                source_nixl_ip: None,
+                source_nixl_listen_port: None,
+                blocks: Vec::new(),
+            }),
+        );
+        let payload = rmp_serde::to_vec(&router_event).unwrap();
+
+        let decoded: RouterEvent = rmp_serde::from_slice(&payload).unwrap();
+
+        assert_eq!(decoded, router_event);
+    }
+
+    #[test]
+    fn test_overlap_scores_default() {
+        let overlap_scores: OverlapScores = Default::default();
+        assert!(overlap_scores.scores.is_empty());
     }
 
     #[rstest]

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -395,6 +395,7 @@ struct KvRouterConfigSerde {
     router_track_output_blocks: bool,
     router_assume_kv_reuse: bool,
     router_track_prefill_tokens: bool,
+    router_gms_decode_transfer: bool,
     router_prefill_load_model: RouterPrefillLoadModel,
     router_snapshot_threshold: Option<u32>,
     router_reset_states: bool,
@@ -430,6 +431,7 @@ impl Default for KvRouterConfigSerde {
             router_track_output_blocks: config.router_track_output_blocks,
             router_assume_kv_reuse: config.router_assume_kv_reuse,
             router_track_prefill_tokens: config.router_track_prefill_tokens,
+            router_gms_decode_transfer: config.router_gms_decode_transfer,
             router_prefill_load_model: config.router_prefill_load_model,
             router_snapshot_threshold: config.router_snapshot_threshold,
             router_reset_states: config.router_reset_states,
@@ -507,6 +509,12 @@ pub struct KvRouterConfig {
     /// and potential prefill-token load calculations.
     #[serde(default = "default_track_prefill_tokens")]
     pub router_track_prefill_tokens: bool,
+
+    /// Whether the router may orchestrate GMS decode-to-decode KV transfer.
+    /// Default is false so GMS transfer policy remains an explicit opt-in and
+    /// vanilla Dynamo routing behavior is unchanged.
+    #[serde(default)]
+    pub router_gms_decode_transfer: bool,
 
     /// Optional model for estimating effective prompt-side prefill load over time.
     pub router_prefill_load_model: RouterPrefillLoadModel,
@@ -604,6 +612,7 @@ impl Default for KvRouterConfig {
             router_track_output_blocks: false,
             router_assume_kv_reuse: true,
             router_track_prefill_tokens: default_track_prefill_tokens(),
+            router_gms_decode_transfer: false,
             router_prefill_load_model: RouterPrefillLoadModel::default(),
             router_snapshot_threshold: Some(1000000),
             router_reset_states: false,
@@ -653,6 +662,7 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
             router_track_output_blocks: compat.router_track_output_blocks,
             router_assume_kv_reuse: compat.router_assume_kv_reuse,
             router_track_prefill_tokens: compat.router_track_prefill_tokens,
+            router_gms_decode_transfer: compat.router_gms_decode_transfer,
             router_prefill_load_model: compat.router_prefill_load_model,
             router_snapshot_threshold: compat.router_snapshot_threshold,
             router_reset_states: compat.router_reset_states,
@@ -928,6 +938,13 @@ mod tests {
 
         let out_of_range = config_from_values(&[("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", "1.5")]);
         assert!(out_of_range.validate_config().is_err());
+    }
+
+    #[test]
+    fn router_gms_decode_transfer_is_disabled_by_default() {
+        let cfg = KvRouterConfig::default();
+
+        assert!(!cfg.router_gms_decode_transfer);
     }
 
     #[test]

--- a/lib/llm/src/kv_router/publisher/batching.rs
+++ b/lib/llm/src/kv_router/publisher/batching.rs
@@ -96,6 +96,7 @@ impl BatchingState {
                     data: KvCacheEventData::Removed(filtered),
                     dp_rank,
                 },
+                None,
             )
             .await;
             emitted = true;
@@ -112,6 +113,7 @@ impl BatchingState {
                     data: KvCacheEventData::Stored(data),
                     dp_rank,
                 },
+                None,
             )
             .await;
             emitted = true;

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -17,7 +17,7 @@ use crate::kv_router::metrics::kv_publisher_metrics;
 use super::DEFAULT_MAX_BATCH_BLOCKS;
 use super::batching::BatchingState;
 use super::dedup::EventDedupFilter;
-use super::sinks::{JetStreamPublisher, emit};
+use super::sinks::{JetStreamPublisher, emit, emit_router_event};
 
 pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 'static>(
     publisher: P,
@@ -71,12 +71,37 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                 last_raw_input_id = Some(raw_event_id);
 
                 let storage_tier = placement_event.placement.tier;
+                let gms_placement = placement_event.gms_placement;
                 let event = placement_event.event;
                 tracing::trace!(
                     "Event processor for worker_id {} processing event: {:?}",
                     worker_id,
                     event.data
                 );
+
+                if let Some(gms_placement) = gms_placement {
+                    batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                    let dp_rank = event.dp_rank;
+                    emit_router_event(
+                        &publisher,
+                        &local_indexer,
+                        RouterEvent::with_gms_placement(
+                            worker_id,
+                            KvCacheEvent {
+                                event_id: batching_state.next_publish_id,
+                                data: event.data,
+                                dp_rank,
+                            },
+                            storage_tier,
+                            gms_placement,
+                        ),
+                    )
+                    .await;
+                    batching_state.next_publish_id += 1;
+                    batching_state.last_dp_rank = dp_rank;
+                    batching_state.last_storage_tier = storage_tier;
+                    continue;
+                }
 
                 let dp_rank_changed =
                     batching_state.has_pending() && event.dp_rank != batching_state.last_dp_rank;
@@ -128,6 +153,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                                 data: KvCacheEventData::Cleared,
                                 dp_rank: event.dp_rank,
                             },
+                            None,
                         )
                         .await;
                         batching_state.next_publish_id += 1;

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -358,6 +358,41 @@ impl KvEventPublisher {
         }
     }
 
+    pub fn publish_gms_placement(
+        &self,
+        gms_placement: GmsPlacementEventData,
+        storage_tier: StorageTier,
+        dp_rank: DpRank,
+    ) -> Result<(), mpsc::error::SendError<KvCacheEvent>> {
+        let event_data = match &gms_placement {
+            GmsPlacementEventData::Stored(_) => KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: None,
+                start_position: None,
+                blocks: Vec::new(),
+            }),
+            GmsPlacementEventData::Removed(_) => KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: Vec::new(),
+            }),
+            GmsPlacementEventData::Cleared => KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: Vec::new(),
+            }),
+        };
+        let event = KvCacheEvent {
+            event_id: self.next_event_id(),
+            data: event_data,
+            dp_rank,
+        };
+        let placement_event = PlacementEvent::with_gms_placement(
+            Placement::local_worker(self.worker_id, dp_rank, storage_tier),
+            event,
+            gms_placement,
+        );
+        match self.tx.send(placement_event) {
+            Ok(()) => Ok(()),
+            Err(err) => Err(mpsc::error::SendError(err.0.event)),
+        }
+    }
+
     pub fn next_event_id(&self) -> u64 {
         self.next_event_id.fetch_add(1, Ordering::SeqCst)
     }

--- a/lib/llm/src/kv_router/publisher/sinks.rs
+++ b/lib/llm/src/kv_router/publisher/sinks.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 
 use dynamo_kv_router::RouterEventSink;
 use dynamo_kv_router::indexer::LocalKvIndexer;
-use dynamo_kv_router::protocols::{KvCacheEvent, RouterEvent, StorageTier};
+use dynamo_kv_router::protocols::{GmsPlacementEventData, KvCacheEvent, RouterEvent, StorageTier};
 use dynamo_runtime::transports::event_plane::EventPublisher;
 use dynamo_runtime::transports::nats::NatsQueue;
 
@@ -30,20 +30,41 @@ impl RouterEventSink for JetStreamPublisher {
     }
 }
 
+pub(super) async fn emit_router_event<P: RouterEventSink>(
+    publisher: &P,
+    local_indexer: &Option<Arc<LocalKvIndexer>>,
+    router_event: RouterEvent,
+) {
+    if let Some(indexer) = local_indexer
+        && let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await
+    {
+        tracing::warn!(
+            worker_id = router_event.worker_id,
+            error = %e,
+            "Failed to apply event to local indexer"
+        );
+    }
+    if let Err(e) = publisher.publish_event(&router_event).await {
+        tracing::error!(
+            worker_id = router_event.worker_id,
+            error = %e,
+            "Failed to publish event"
+        );
+    }
+}
+
 pub(super) async fn emit<P: RouterEventSink>(
     publisher: &P,
     local_indexer: &Option<Arc<LocalKvIndexer>>,
     worker_id: u64,
     storage_tier: StorageTier,
     event: KvCacheEvent,
+    _gms_placement: Option<GmsPlacementEventData>,
 ) {
-    let router_event = RouterEvent::with_storage_tier(worker_id, event, storage_tier);
-    if let Some(indexer) = local_indexer
-        && let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await
-    {
-        tracing::warn!(worker_id, error = %e, "Failed to apply event to local indexer");
-    }
-    if let Err(e) = publisher.publish_event(&router_event).await {
-        tracing::error!(worker_id, error = %e, "Failed to publish event");
-    }
+    emit_router_event(
+        publisher,
+        local_indexer,
+        RouterEvent::with_storage_tier(worker_id, event, storage_tier),
+    )
+    .await;
 }

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -950,6 +950,85 @@ mod tests_startup_helpers {
         token.cancel();
     }
 
+    #[tokio::test]
+    async fn test_gms_cleared_does_not_clear_normal_local_indexer() {
+        let (component, published) = MockComponent::new();
+
+        let token = CancellationToken::new();
+        let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
+        let local_indexer = Arc::new(LocalKvIndexer::new(token.clone(), 4, metrics, 100));
+
+        let store_event = KvCacheEvent {
+            event_id: 1,
+            data: KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: None,
+                start_position: None,
+                blocks: vec![KvCacheStoredBlockData {
+                    block_hash: ExternalSequenceBlockHash(100),
+                    tokens_hash: LocalBlockHash(200),
+                    mm_extra_info: None,
+                }],
+            }),
+            dp_rank: 0,
+        };
+
+        let gms_clear_event = KvCacheEvent {
+            event_id: 2,
+            data: KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: Vec::new(),
+            }),
+            dp_rank: 0,
+        };
+
+        let (tx, rx) = mpsc::unbounded_channel::<PlacementEvent>();
+        tx.send(local_gpu_event(1, store_event)).unwrap();
+        tx.send(PlacementEvent::with_gms_placement(
+            Placement::local_worker(1, 0, StorageTier::External),
+            gms_clear_event,
+            GmsPlacementEventData::Cleared,
+        ))
+        .unwrap();
+        drop(tx);
+
+        let handle = tokio::spawn(start_event_processor(
+            component,
+            1,
+            token.clone(),
+            rx,
+            Some(local_indexer.clone()),
+            Some(10_000),
+        ));
+
+        tokio::time::timeout(tokio::time::Duration::from_secs(1), handle)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let mut found = false;
+        for _ in 0..20 {
+            let scores = local_indexer
+                .find_matches(vec![LocalBlockHash(200)])
+                .await
+                .unwrap();
+            if !scores.scores.is_empty() {
+                found = true;
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        }
+        assert!(found, "GMS clear should not clear ordinary KV index state");
+
+        let published = published.lock().unwrap();
+        assert_eq!(
+            published.len(),
+            2,
+            "expected 2 published events, found {}",
+            published.len()
+        );
+
+        token.cancel();
+    }
+
     //--------------------------------------------------------------------
     // Test that local indexer failure doesn't break NATS publishing
     //--------------------------------------------------------------------
@@ -1868,6 +1947,83 @@ mod event_processor_tests {
             Placement::local_worker(1, event.dp_rank, StorageTier::HostPinned),
             event,
         )
+    }
+
+    fn gms_store_event(content_hash_hex: &str) -> GmsPlacementEventData {
+        GmsPlacementEventData::Stored(GmsPlacementStoreData {
+            source_nixl_agent_name: "agent-a".to_string(),
+            source_nixl_agent_metadata_hex: "00".to_string(),
+            source_nixl_ip: None,
+            source_nixl_listen_port: None,
+            blocks: vec![GmsPlacementBlock {
+                content_hash_hex: content_hash_hex.to_string(),
+                descriptor: GmsPlacementDescriptor {
+                    remote_ptr: 0x1000,
+                    size: 4096,
+                    tier: "device".to_string(),
+                    ranges: Vec::new(),
+                    generation: Some(3),
+                    sealed: Some(true),
+                },
+            }],
+        })
+    }
+
+    #[tokio::test]
+    async fn test_run_event_processor_loop_preserves_gms_placement() {
+        let (tx, rx) = mpsc::unbounded_channel::<PlacementEvent>();
+        let publisher = MockPublisher::new();
+        let publisher_clone = publisher.clone();
+        let cancellation_token = CancellationToken::new();
+
+        let handle = tokio::spawn(async move {
+            run_event_processor_loop(
+                publisher_clone,
+                1,
+                cancellation_token,
+                rx,
+                None,
+                Some(100),
+                DEFAULT_MAX_BATCH_BLOCKS,
+            )
+            .await
+        });
+
+        tx.send(local_gpu_event(KvCacheEvent {
+            event_id: 1,
+            data: KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(10)],
+            }),
+            dp_rank: 0,
+        }))
+        .unwrap();
+
+        let gms_placement = gms_store_event("abc123");
+        tx.send(PlacementEvent::with_gms_placement(
+            Placement::local_worker(1, 0, StorageTier::External),
+            KvCacheEvent {
+                event_id: 2,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    start_position: None,
+                    blocks: Vec::new(),
+                }),
+                dp_rank: 0,
+            },
+            gms_placement.clone(),
+        ))
+        .unwrap();
+
+        drop(tx);
+        handle.await.unwrap();
+
+        let events = publisher.get_events();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0].event.data, KvCacheEventData::Removed(_)));
+        assert_eq!(events[0].gms_placement, None);
+        assert_eq!(events[1].storage_tier, StorageTier::External);
+        assert_eq!(events[1].event.event_id, 2);
+        assert_eq!(events[1].gms_placement, Some(gms_placement));
     }
 
     /// Test that pushing N removed events results in batched output


### PR DESCRIPTION
## Summary

Define the placement events and protocol types needed for the router to reason about GMS-resident KV content and decode-to-decode transfer.

## Scope

Adds protocol surfaces and compatibility wiring only; indexing policy and publication/orchestration are separate follow-up PRs.

## Stack

Position **16/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-08-2-2-host-tier-transport-backends`.

Parent: #10450  
Tracking: #10457

## Review migration

This existing PR is updated in place so its comments and reviews remain attached. Line comments may appear outdated where code moved during the rebase; they remain visible and should be dispositioned against the current diff. Previous approvals should be revalidated.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

Passed `cargo check -p dynamo-kv-router -p dynamo-llm --all-targets` at this stack boundary before the exact latest-main rebase.