### PR TITLE
feat(router): add GMS placement index and policy [GMS 17/18]

### DIFF
--- a/components/src/dynamo/common/tests/test_gms_router_policy.py
+++ b/components/src/dynamo/common/tests/test_gms_router_policy.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo import gms_router_policy
+from dynamo.gms_router_policy import (
+    DynamoGmsPlacementPublisher,
+    maybe_fetch_gms_placement,
+)
+
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
+
+def test_router_policy_exposes_no_gms_control_endpoint():
+    assert not hasattr(gms_router_policy, "GMS_CONTROL_ENDPOINT")
+    assert not hasattr(gms_router_policy, "make_gms_control_handler")
+
+
+@pytest.mark.asyncio
+async def test_missing_local_gms_socket_leaves_request_on_vanilla_path():
+    request = {
+        "prompt": "hello",
+        "gms_placement": {
+            "source_nixl_agent_name": "source",
+            "source_nixl_agent_metadata_hex": "00",
+            "hashes": ["00"],
+            "descriptors": [None],
+        },
+    }
+
+    result = await maybe_fetch_gms_placement(request, None)
+
+    assert result is None
+    assert request["prompt"] == "hello"
+    assert "gms_placement" in request
+
+
+def test_router_gms_decode_transfer_arg_defaults_off():
+    from dynamo.router.args import parse_args
+
+    config = parse_args(["--endpoint", "ns.comp.generate"])
+
+    assert config.router_gms_decode_transfer is False
+    assert config.kv_router_kwargs()["router_gms_decode_transfer"] is False
+
+
+def test_router_gms_decode_transfer_arg_can_opt_in():
+    from dynamo.router.args import parse_args
+
+    config = parse_args(
+        ["--endpoint", "ns.comp.generate", "--router-gms-decode-transfer"]
+    )
+
+    assert config.router_gms_decode_transfer is True
+    assert config.kv_router_kwargs()["router_gms_decode_transfer"] is True
+
+
+class _FakeKvPublisher:
+    def __init__(self):
+        self.stored = []
+        self.removed = []
+
+    def publish_gms_placement_stored(self, *args, **kwargs):
+        self.stored.append((args, kwargs))
+
+    def publish_gms_placement_removed(self, *args, **kwargs):
+        self.removed.append((args, kwargs))
+
+
+def test_dynamo_gms_placement_publisher_normalizes_descriptor():
+    fake = _FakeKvPublisher()
+    publisher = DynamoGmsPlacementPublisher(fake, dp_rank=2)
+
+    publisher.publish_stored(
+        bytes.fromhex("aa" * 32),
+        "host_pinned",
+        64,
+        metadata={
+            "source_nixl_agent_name": "agent-a",
+            "source_nixl_agent_metadata_hex": "abcd",
+            "source_nixl_ip": "10.0.0.1",
+            "source_nixl_listen_port": "5555",
+            "gms_descriptor": {
+                "ptr": "1234",
+                "size": "64",
+                "tier": "host",
+                "generation": "7",
+                "ranges": [
+                    {
+                        "ptr": "1234",
+                        "size": "64",
+                        "tier": "host",
+                        "layer": "3",
+                        "offset": "8",
+                    }
+                ],
+            },
+        },
+    )
+
+    assert len(fake.stored) == 1
+    args, kwargs = fake.stored[0]
+    assert args[0] == "agent-a"
+    assert args[1] == "abcd"
+    assert args[2][0]["content_hash_hex"] == "aa" * 32
+    descriptor = args[2][0]["descriptor"]
+    assert descriptor["remote_ptr"] == 1234
+    assert descriptor["generation"] == 7
+    assert descriptor["ranges"][0]["layer"] == 3
+    assert kwargs == {
+        "source_nixl_ip": "10.0.0.1",
+        "source_nixl_listen_port": 5555,
+        "dp_rank": 2,
+    }
+
+
+def test_dynamo_gms_placement_publisher_drops_missing_metadata():
+    fake = _FakeKvPublisher()
+    publisher = DynamoGmsPlacementPublisher(fake)
+
+    publisher.publish_stored(
+        bytes.fromhex("bb" * 32),
+        "host_pinned",
+        64,
+        metadata={"gms_descriptor": {"remote_ptr": 1, "size": 64}},
+    )
+
+    assert fake.stored == []
+
+
+def test_dynamo_gms_placement_publisher_removes_hash():
+    fake = _FakeKvPublisher()
+    publisher = DynamoGmsPlacementPublisher(fake, dp_rank=1)
+
+    publisher.publish_removed(bytes.fromhex("cc" * 32), "host_pinned")
+
+    assert fake.removed == [((["cc" * 32],), {"dp_rank": 1})]

--- a/lib/kv-router/src/indexer/gms_placement.rs
+++ b/lib/kv-router/src/indexer/gms_placement.rs
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! GMS placement metadata index.
+//!
+//! This index is deliberately separate from the radix and lower-tier indexes:
+//! routing overlap still comes from the existing KV event path, while GMS
+//! placement events carry NIXL bootstrap descriptors keyed by the stable GMS
+//! content hash. Routers use this metadata to stamp `gms_placement` onto a
+//! selected request without querying the source worker on the request path.
+
+use std::collections::HashMap;
+
+use dashmap::DashMap;
+use rustc_hash::FxBuildHasher;
+
+use crate::protocols::{
+    ExternalSequenceBlockHash, GmsPlacementBlock, GmsPlacementDescriptor, GmsPlacementEventData,
+    GmsPlacementMatch, GmsPlacementStoreData, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+    RouterEvent, StorageTier, WorkerId, WorkerWithDpRank,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PlacementSource {
+    source_nixl_agent_name: String,
+    source_nixl_agent_metadata_hex: String,
+    source_nixl_ip: Option<String>,
+    source_nixl_listen_port: Option<u16>,
+}
+
+impl PlacementSource {
+    fn from_store(data: &GmsPlacementStoreData) -> Self {
+        Self {
+            source_nixl_agent_name: data.source_nixl_agent_name.clone(),
+            source_nixl_agent_metadata_hex: data.source_nixl_agent_metadata_hex.clone(),
+            source_nixl_ip: data.source_nixl_ip.clone(),
+            source_nixl_listen_port: data.source_nixl_listen_port,
+        }
+    }
+
+    fn into_match(self, descriptors: Vec<Option<GmsPlacementDescriptor>>) -> GmsPlacementMatch {
+        GmsPlacementMatch {
+            source_nixl_agent_name: self.source_nixl_agent_name,
+            source_nixl_agent_metadata_hex: self.source_nixl_agent_metadata_hex,
+            source_nixl_ip: self.source_nixl_ip,
+            source_nixl_listen_port: self.source_nixl_listen_port,
+            descriptors,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PlacementEntry {
+    source: PlacementSource,
+    descriptor: GmsPlacementDescriptor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PlacementKey {
+    worker: WorkerWithDpRank,
+    content_hash_hex: String,
+}
+
+fn normalize_hash(hash: &str) -> Option<String> {
+    let trimmed = hash.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_ascii_lowercase())
+}
+
+#[derive(Default)]
+pub struct GmsPlacementIndex {
+    entries: DashMap<PlacementKey, PlacementEntry, FxBuildHasher>,
+}
+
+impl GmsPlacementIndex {
+    pub fn new() -> Self {
+        Self {
+            entries: DashMap::with_hasher(FxBuildHasher),
+        }
+    }
+
+    pub fn apply_event(&self, event: &RouterEvent) {
+        let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
+        let Some(placement) = event.gms_placement.as_ref() else {
+            if matches!(event.event.data, KvCacheEventData::Cleared) {
+                self.remove_worker_dp_rank(worker);
+            }
+            return;
+        };
+
+        match placement {
+            GmsPlacementEventData::Stored(data) => self.store(worker, data),
+            GmsPlacementEventData::Removed(data) => {
+                for hash in &data.content_hashes_hex {
+                    if let Some(content_hash_hex) = normalize_hash(hash) {
+                        self.entries.remove(&PlacementKey {
+                            worker,
+                            content_hash_hex,
+                        });
+                    }
+                }
+            }
+            GmsPlacementEventData::Cleared => self.remove_worker_dp_rank(worker),
+        }
+    }
+
+    fn store(&self, worker: WorkerWithDpRank, data: &GmsPlacementStoreData) {
+        if data.source_nixl_agent_name.is_empty() {
+            return;
+        }
+        let source = PlacementSource::from_store(data);
+        for block in &data.blocks {
+            if !block.descriptor.sealed.unwrap_or(true) {
+                continue;
+            }
+            let Some(content_hash_hex) = normalize_hash(&block.content_hash_hex) else {
+                continue;
+            };
+            self.entries.insert(
+                PlacementKey {
+                    worker,
+                    content_hash_hex,
+                },
+                PlacementEntry {
+                    source: source.clone(),
+                    descriptor: block.descriptor.clone(),
+                },
+            );
+        }
+    }
+
+    pub fn lookup(
+        &self,
+        worker: WorkerWithDpRank,
+        content_hashes_hex: &[String],
+    ) -> Option<GmsPlacementMatch> {
+        let mut source: Option<PlacementSource> = None;
+        let mut descriptors = Vec::with_capacity(content_hashes_hex.len());
+        let mut hits = 0usize;
+
+        for hash in content_hashes_hex {
+            let Some(content_hash_hex) = normalize_hash(hash) else {
+                descriptors.push(None);
+                continue;
+            };
+            let Some(entry) = self.entries.get(&PlacementKey {
+                worker,
+                content_hash_hex,
+            }) else {
+                descriptors.push(None);
+                continue;
+            };
+
+            match &source {
+                Some(existing) if *existing != entry.source => {
+                    descriptors.push(None);
+                }
+                Some(_) => {
+                    descriptors.push(Some(entry.descriptor.clone()));
+                    hits += 1;
+                }
+                None => {
+                    source = Some(entry.source.clone());
+                    descriptors.push(Some(entry.descriptor.clone()));
+                    hits += 1;
+                }
+            }
+        }
+
+        if hits == 0 {
+            return None;
+        }
+        source.map(|source| source.into_match(descriptors))
+    }
+
+    pub fn remove_worker(&self, worker_id: WorkerId) {
+        self.entries
+            .retain(|key, _| key.worker.worker_id != worker_id);
+    }
+
+    pub fn remove_worker_dp_rank(&self, worker: WorkerWithDpRank) {
+        self.entries.retain(|key, _| key.worker != worker);
+    }
+
+    pub fn dump_events(&self) -> Vec<RouterEvent> {
+        let mut grouped: HashMap<(WorkerWithDpRank, PlacementSource), Vec<GmsPlacementBlock>> =
+            HashMap::new();
+        for entry in self.entries.iter() {
+            grouped
+                .entry((entry.key().worker, entry.value().source.clone()))
+                .or_default()
+                .push(GmsPlacementBlock {
+                    content_hash_hex: entry.key().content_hash_hex.clone(),
+                    descriptor: entry.value().descriptor.clone(),
+                });
+        }
+
+        let mut events = Vec::with_capacity(grouped.len());
+        for (event_id, ((worker, source), blocks)) in grouped.into_iter().enumerate() {
+            events.push(RouterEvent::with_gms_placement(
+                worker.worker_id,
+                KvCacheEvent {
+                    event_id: event_id as u64,
+                    data: KvCacheEventData::Stored(KvCacheStoreData {
+                        parent_hash: None::<ExternalSequenceBlockHash>,
+                        start_position: None,
+                        blocks: Vec::new(),
+                    }),
+                    dp_rank: worker.dp_rank,
+                },
+                StorageTier::External,
+                GmsPlacementEventData::Stored(GmsPlacementStoreData {
+                    source_nixl_agent_name: source.source_nixl_agent_name,
+                    source_nixl_agent_metadata_hex: source.source_nixl_agent_metadata_hex,
+                    source_nixl_ip: source.source_nixl_ip,
+                    source_nixl_listen_port: source.source_nixl_listen_port,
+                    blocks,
+                }),
+            ));
+        }
+        events
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::{GmsPlacementMemoryRegion, GmsPlacementRemoveData};
+
+    fn descriptor(ptr: u64) -> GmsPlacementDescriptor {
+        GmsPlacementDescriptor {
+            remote_ptr: ptr,
+            size: 128,
+            tier: "host".to_string(),
+            ranges: vec![GmsPlacementMemoryRegion {
+                remote_ptr: ptr,
+                size: 128,
+                tier: "host".to_string(),
+                layer: Some(0),
+                offset: Some(0),
+            }],
+            generation: Some(7),
+            sealed: Some(true),
+        }
+    }
+
+    fn placement_event(worker: WorkerWithDpRank, hashes: &[&str]) -> RouterEvent {
+        RouterEvent::with_gms_placement(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id: 1,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    start_position: None,
+                    blocks: Vec::new(),
+                }),
+                dp_rank: worker.dp_rank,
+            },
+            StorageTier::External,
+            GmsPlacementEventData::Stored(GmsPlacementStoreData {
+                source_nixl_agent_name: "src".to_string(),
+                source_nixl_agent_metadata_hex: "abcd".to_string(),
+                source_nixl_ip: Some("10.0.0.1".to_string()),
+                source_nixl_listen_port: Some(5555),
+                blocks: hashes
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, hash)| GmsPlacementBlock {
+                        content_hash_hex: (*hash).to_string(),
+                        descriptor: descriptor(1000 + idx as u64),
+                    })
+                    .collect(),
+            }),
+        )
+    }
+
+    #[test]
+    fn lookup_returns_ordered_descriptors_with_holes() {
+        let index = GmsPlacementIndex::new();
+        let worker = WorkerWithDpRank::new(7, 0);
+        index.apply_event(&placement_event(worker, &["AA", "bb"]));
+
+        let result = index
+            .lookup(
+                worker,
+                &["aa".to_string(), "missing".to_string(), "BB".to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(result.source_nixl_agent_name, "src");
+        assert!(result.descriptors[0].is_some());
+        assert!(result.descriptors[1].is_none());
+        assert!(result.descriptors[2].is_some());
+    }
+
+    #[test]
+    fn remove_event_drops_hash() {
+        let index = GmsPlacementIndex::new();
+        let worker = WorkerWithDpRank::new(7, 0);
+        index.apply_event(&placement_event(worker, &["aa"]));
+        let remove = RouterEvent::with_gms_placement(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id: 2,
+                data: KvCacheEventData::Removed(crate::protocols::KvCacheRemoveData {
+                    block_hashes: Vec::new(),
+                }),
+                dp_rank: worker.dp_rank,
+            },
+            StorageTier::External,
+            GmsPlacementEventData::Removed(GmsPlacementRemoveData {
+                content_hashes_hex: vec!["AA".to_string()],
+            }),
+        );
+        index.apply_event(&remove);
+
+        assert!(index.lookup(worker, &["aa".to_string()]).is_none());
+    }
+
+    #[test]
+    fn ordinary_clear_event_drops_worker_descriptors() {
+        let index = GmsPlacementIndex::new();
+        let worker = WorkerWithDpRank::new(7, 0);
+        index.apply_event(&placement_event(worker, &["aa"]));
+
+        let clear = RouterEvent::new(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id: 2,
+                data: KvCacheEventData::Cleared,
+                dp_rank: worker.dp_rank,
+            },
+        );
+        index.apply_event(&clear);
+
+        assert!(index.lookup(worker, &["aa".to_string()]).is_none());
+    }
+}

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -12,8 +12,8 @@ use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    GetWorkersRequest, KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError,
-    LowerTierIndexer, ThreadPoolIndexer, WorkerKvQueryResponse,
+    GetWorkersRequest, GmsPlacementIndex, KvIndexer, KvIndexerInterface, KvIndexerMetrics,
+    KvRouterError, LowerTierIndexer, ThreadPoolIndexer, WorkerKvQueryResponse,
 };
 use crate::protocols::*;
 
@@ -207,6 +207,8 @@ pub struct LocalKvIndexer {
     indexer: KvIndexer,
     /// Lazily-created exact lower-tier indexes partitioned by storage tier.
     lower_tier_indexers: Arc<Mutex<HashMap<StorageTier, Arc<ThreadPoolIndexer<LowerTierIndexer>>>>>,
+    /// GMS placement metadata learned from the same KV event stream.
+    gms_placement_index: Arc<GmsPlacementIndex>,
     /// Circular buffer of recent events
     pub(super) event_buffer: Mutex<VecDeque<RouterEvent>>,
     /// Coordinates single-flight tree dumps and the cached recovery snapshot.
@@ -236,6 +238,7 @@ impl LocalKvIndexer {
             indexer: KvIndexer::new(token, kv_block_size, metrics.clone()),
             metrics,
             lower_tier_indexers: Arc::new(Mutex::new(HashMap::new())),
+            gms_placement_index: Arc::new(GmsPlacementIndex::new()),
             event_buffer: Mutex::new(VecDeque::with_capacity(max_buffer_size)),
             recovery_cache: Arc::new(RecoverySnapshotCache::new()),
             max_buffer_size,
@@ -552,6 +555,7 @@ impl LocalKvIndexer {
         last_event_id: u64,
     ) -> tokio::task::JoinHandle<BuildTaskResult> {
         let indexer = self.indexer.clone();
+        let gms_placement_index = self.gms_placement_index.clone();
         let recovery_cache = self.recovery_cache.clone();
         #[cfg(test)]
         let build_delay = *self.dump_build_delay.lock().unwrap();
@@ -564,7 +568,8 @@ impl LocalKvIndexer {
                 tokio::time::sleep(delay).await;
             }
 
-            let build_output = Self::build_fresh_dump(indexer, last_event_id).await;
+            let build_output =
+                Self::build_fresh_dump(indexer, gms_placement_index, last_event_id).await;
             let notify = build.notify.clone();
             let result = recovery_cache.finish_build(&build, build_output).await;
 
@@ -573,9 +578,14 @@ impl LocalKvIndexer {
         })
     }
 
-    async fn build_fresh_dump(indexer: KvIndexer, last_event_id: u64) -> FreshDumpOutput {
+    async fn build_fresh_dump(
+        indexer: KvIndexer,
+        gms_placement_index: Arc<GmsPlacementIndex>,
+        last_event_id: u64,
+    ) -> FreshDumpOutput {
         match indexer.dump_events().await {
-            Ok(events) => {
+            Ok(mut events) => {
+                events.extend(gms_placement_index.dump_events());
                 let represented_blocks = events
                     .iter()
                     .map(|event| match &event.event.data {
@@ -666,6 +676,7 @@ impl LocalKvIndexer {
     }
 
     async fn apply_event_by_tier(&self, event: &RouterEvent) -> Result<(), KvRouterError> {
+        self.gms_placement_index.apply_event(event);
         match &event.event.data {
             KvCacheEventData::Cleared => {
                 self.apply_event_to_primary(event.clone()).await?;
@@ -732,6 +743,7 @@ impl KvIndexerInterface for LocalKvIndexer {
     }
 
     async fn remove_worker(&self, worker: WorkerId) {
+        self.gms_placement_index.remove_worker(worker);
         for indexer in self.all_lower_tier_indexers() {
             indexer.remove_worker(worker).await;
         }
@@ -739,6 +751,8 @@ impl KvIndexerInterface for LocalKvIndexer {
     }
 
     async fn remove_worker_dp_rank(&self, worker: WorkerId, dp_rank: DpRank) {
+        self.gms_placement_index
+            .remove_worker_dp_rank(WorkerWithDpRank::new(worker, dp_rank));
         for indexer in self.all_lower_tier_indexers() {
             KvIndexerInterface::remove_worker_dp_rank(&*indexer, worker, dp_rank).await;
         }
@@ -769,6 +783,8 @@ impl KvIndexerInterface for LocalKvIndexer {
                 }
             }
         }
+
+        events.extend(self.gms_placement_index.dump_events());
 
         Ok(events)
     }

--- a/lib/kv-router/src/indexer/lower_tier_indexers.rs
+++ b/lib/kv-router/src/indexer/lower_tier_indexers.rs
@@ -21,7 +21,7 @@ use crate::indexer::{
     KvIndexerMetrics, LowerTierContinuation, LowerTierIndexer, LowerTierMatchDetails, MatchDetails,
     ThreadPoolIndexer, WireTieredMatchDetails,
 };
-use crate::protocols::{LocalBlockHash, StorageTier};
+use crate::protocols::{GmsPlacementMatch, LocalBlockHash, StorageTier, WorkerWithDpRank};
 
 /// Holds one per-tier [`ThreadPoolIndexer<LowerTierIndexer>`] for every
 /// non-device [`StorageTier`] that has received at least one event.
@@ -119,6 +119,7 @@ impl LowerTierIndexers {
 pub struct TieredMatchDetails {
     pub device: MatchDetails,
     pub lower_tier: HashMap<StorageTier, LowerTierMatchDetails>,
+    pub gms_placements: HashMap<WorkerWithDpRank, GmsPlacementMatch>,
 }
 
 impl From<&TieredMatchDetails> for WireTieredMatchDetails {
@@ -129,6 +130,11 @@ impl From<&TieredMatchDetails> for WireTieredMatchDetails {
                 .lower_tier
                 .iter()
                 .map(|(tier, details)| (*tier, details.into()))
+                .collect(),
+            gms_placements: d
+                .gms_placements
+                .iter()
+                .map(|(worker, placement)| (*worker, placement.clone()))
                 .collect(),
         }
     }
@@ -153,6 +159,7 @@ impl From<WireTieredMatchDetails> for TieredMatchDetails {
                 ..Default::default()
             },
             lower_tier,
+            gms_placements: w.gms_placements.into_iter().collect(),
         }
     }
 }

--- a/lib/kv-router/src/indexer/mod.rs
+++ b/lib/kv-router/src/indexer/mod.rs
@@ -58,6 +58,7 @@ fn warn_on_unit_block_size(indexer_type: &'static str, kv_block_size: u32) {
         );
     }
 }
+mod gms_placement;
 mod kv_indexer;
 mod local;
 mod lower_tier;
@@ -80,6 +81,7 @@ mod tests;
 
 // Re-export everything that was public in the old single-file module.
 pub use branch_sharded::*;
+pub use gms_placement::*;
 pub use kv_indexer::*;
 pub use local::*;
 pub use lower_tier::*;

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -158,6 +158,10 @@ pub struct IndexerQueryRequest {
     pub model_name: String,
     /// Block hashes to find matches for in the radix tree.
     pub block_hashes: Vec<LocalBlockHash>,
+    /// Stable GMS content hashes for the same request prefix, used only to
+    /// attach already-indexed placement metadata to the query response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gms_content_hashes_hex: Option<Vec<String>>,
     /// When true, the server skips the lower-tier walk and returns only the
     /// device-tier overlap. Older clients that omit this field default to
     /// `false`, preserving the full tiered response.
@@ -233,6 +237,8 @@ impl From<WireLowerTierMatchDetails> for super::lower_tier::LowerTierMatchDetail
 pub struct WireTieredMatchDetails {
     pub device: WireOverlapScores,
     pub lower_tier: Vec<(StorageTier, WireLowerTierMatchDetails)>,
+    #[serde(default)]
+    pub gms_placements: Vec<(WorkerWithDpRank, GmsPlacementMatch)>,
 }
 
 /// Response from a served KV indexer query.

--- a/lib/kv-router/src/scheduling/overlap.rs
+++ b/lib/kv-router/src/scheduling/overlap.rs
@@ -416,6 +416,7 @@ mod tests {
                 (StorageTier::Disk, disk),
                 (StorageTier::External, external),
             ]),
+            gms_placements: HashMap::new(),
         };
         let config = KvRouterConfig {
             host_cache_hit_weight: 0.5,
@@ -452,6 +453,7 @@ mod tests {
                 (StorageTier::HostPinned, host),
                 (StorageTier::External, external),
             ]),
+            gms_placements: HashMap::new(),
         };
         let config = KvRouterConfig {
             overlap_score_credit: 0.5,

--- a/lib/kv-router/src/scheduling/overlap_refresh.rs
+++ b/lib/kv-router/src/scheduling/overlap_refresh.rs
@@ -217,6 +217,7 @@ mod tests {
                     ..Default::default()
                 },
                 lower_tier: HashMap::new(),
+                gms_placements: HashMap::new(),
             })
         }
     }

--- a/lib/kv-router/src/services/indexer/backend.rs
+++ b/lib/kv-router/src/services/indexer/backend.rs
@@ -168,6 +168,7 @@ impl Indexer {
                 Ok(TieredMatchDetails {
                     device,
                     lower_tier: lt,
+                    gms_placements: Default::default(),
                 })
             }
             Indexer::Concurrent {
@@ -180,6 +181,7 @@ impl Indexer {
                 Ok(TieredMatchDetails {
                     device,
                     lower_tier: lt,
+                    gms_placements: Default::default(),
                 })
             }
         }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Instant,
+};
 
 use anyhow::Result;
 use dynamo_kv_router::{
@@ -10,9 +14,9 @@ use dynamo_kv_router::{
     indexer::{KvRouterError, RoutingDecisionHashes},
     protocols::KV_EVENT_SUBJECT,
     protocols::{
-        BlockExtraInfo, BlockHashOptions, DpRank, LocalBlockHash, PrefillLoadHint, RouterEvent,
-        RouterRequest, RouterResponse, RoutingConstraints, TokensWithHashes, WorkerConfigLike,
-        WorkerId, WorkerWithDpRank, compute_block_hash_for_seq,
+        BlockExtraInfo, BlockHashOptions, DpRank, GmsPlacementMatch, LocalBlockHash,
+        PrefillLoadHint, RouterEvent, RouterRequest, RouterResponse, RoutingConstraints,
+        TokensWithHashes, WorkerConfigLike, WorkerId, WorkerWithDpRank, compute_block_hash_for_seq,
     },
     scheduling::{
         CacheHitEstimates, OverlapAnalysis, OverloadedWorkerProvider, ScheduleMode,
@@ -33,6 +37,7 @@ use dynamo_runtime::{
     traits::DistributedRuntimeProvider,
 };
 use futures::stream;
+use sha2::{Digest, Sha256};
 use tracing::Instrument;
 use validator::Validate;
 
@@ -60,12 +65,13 @@ pub use prefill_router::PrefillRouter;
 pub use push_router::{DirectRoutingRouter, KvPushRouter};
 
 use crate::{
-    discovery::RuntimeConfigWatch,
+    discovery::{RuntimeConfigWatch, WORKER_TYPE_DECODE},
     kv_router::{
         scheduler::{DefaultWorkerSelector, KvScheduler, PotentialLoad},
         sequence::{SequenceError, SequenceRequest},
     },
     local_model::runtime_config::ModelRuntimeConfig,
+    protocols::common::preprocessor::{GmsBlockDescriptor, GmsMemoryRegion, GmsPlacementInfo},
 };
 use route_lookup::{TieredLookupResult, query_tiered_matches, split_retained_block_hashes};
 
@@ -76,6 +82,8 @@ pub enum FindBestMatchOutcome {
         effective_overlap_blocks: f64,
         cached_tokens: usize,
         routing_hashes: Option<RoutingDecisionHashes>,
+        gms_transfer: Option<GmsTransferDecision>,
+        gms_placement: Option<Box<GmsPlacementInfo>>,
     },
     QueueRejected {
         rejection: scheduling::QueueRejection,
@@ -126,6 +134,136 @@ pub const RADIX_STATE_FILE: &str = "radix-state";
 
 // for worker-local kvindexer query
 pub const WORKER_KV_INDEXER_BUFFER_SIZE: usize = 1024; // store 1024 most recent events in worker buffer
+
+#[derive(Debug, Clone, Copy)]
+pub struct GmsTransferDecision {
+    pub source_worker: WorkerWithDpRank,
+    pub destination_worker: WorkerWithDpRank,
+    pub source_overlap_blocks: f64,
+    pub source_load_blocks: usize,
+    pub destination_load_blocks: usize,
+}
+
+type GmsTransferCandidate = GmsTransferDecision;
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn gms_prefix_block_hashes_hex(
+    tokens: &[u32],
+    block_size: u32,
+    cache_salt: Option<&str>,
+) -> Vec<String> {
+    if block_size == 0 {
+        return Vec::new();
+    }
+    let block_size = block_size as usize;
+    let full_blocks = tokens.len() / block_size;
+    if full_blocks == 0 {
+        return Vec::new();
+    }
+
+    let salt = cache_salt.unwrap_or("").as_bytes();
+    let mut hasher = Sha256::new();
+    hasher.update(b"GMSKVRv1\0");
+    hasher.update((salt.len() as u32).to_be_bytes());
+    hasher.update(salt);
+    hasher.update((block_size as u32).to_be_bytes());
+
+    let mut hashes = Vec::with_capacity(full_blocks);
+    for block in tokens.chunks_exact(block_size) {
+        for token in block {
+            hasher.update((*token as u64).to_be_bytes());
+        }
+        let digest = hasher.clone().finalize();
+        hashes.push(hex_encode(&digest));
+    }
+
+    hashes
+}
+
+fn gms_worker_load_score(load: &PotentialLoad, block_size: u32) -> usize {
+    let block_size = block_size.max(1) as usize;
+    load.potential_decode_blocks + load.potential_prefill_tokens.div_ceil(block_size)
+}
+
+fn gms_decode_transfer_allowed(
+    worker_type: &str,
+    kv_router_config: &KvRouterConfig,
+    router_config_override: Option<&RouterConfigOverride>,
+) -> bool {
+    let overlap_score_credit = router_config_override
+        .and_then(|config| config.overlap_score_credit)
+        .unwrap_or(kv_router_config.overlap_score_credit);
+
+    kv_router_config.router_gms_decode_transfer
+        && worker_type == WORKER_TYPE_DECODE
+        && overlap_score_credit > 0.0
+        && kv_router_config.assume_kv_reuse(router_config_override)
+        && kv_router_config.track_prefill_tokens(router_config_override)
+}
+
+fn choose_gms_transfer_candidate(
+    cache_hit_estimates: &CacheHitEstimates,
+    potential_loads: &[PotentialLoad],
+    block_size: u32,
+    eligible_workers: &HashSet<WorkerWithDpRank>,
+    pinned_worker: Option<WorkerWithDpRank>,
+    allowed_worker_ids: Option<&HashSet<WorkerId>>,
+) -> Option<GmsTransferCandidate> {
+    if pinned_worker.is_some() || eligible_workers.len() < 2 {
+        return None;
+    }
+
+    let is_allowed = |worker: WorkerWithDpRank| {
+        allowed_worker_ids.is_none_or(|ids| ids.contains(&worker.worker_id))
+    };
+
+    let (&source_worker, &source_overlap_blocks) = cache_hit_estimates
+        .effective_overlap_blocks
+        .iter()
+        .filter(|(worker, overlap)| {
+            **overlap > 0.0 && eligible_workers.contains(worker) && is_allowed(**worker)
+        })
+        .max_by(|(_, left), (_, right)| left.total_cmp(right))?;
+
+    let load_for_worker: HashMap<WorkerWithDpRank, &PotentialLoad> = potential_loads
+        .iter()
+        .map(|load| (WorkerWithDpRank::new(load.worker_id, load.dp_rank), load))
+        .collect();
+    let source_load = *load_for_worker.get(&source_worker)?;
+    let source_load_blocks = gms_worker_load_score(source_load, block_size);
+
+    let destination_load = potential_loads
+        .iter()
+        .filter(|load| {
+            let worker = WorkerWithDpRank::new(load.worker_id, load.dp_rank);
+            eligible_workers.contains(&worker) && is_allowed(worker)
+        })
+        .min_by_key(|load| gms_worker_load_score(load, block_size))?;
+    let destination_worker =
+        WorkerWithDpRank::new(destination_load.worker_id, destination_load.dp_rank);
+    let destination_load_blocks = gms_worker_load_score(destination_load, block_size);
+
+    if destination_worker == source_worker || source_load_blocks <= destination_load_blocks {
+        return None;
+    }
+
+    Some(GmsTransferCandidate {
+        source_worker,
+        destination_worker,
+        source_overlap_blocks,
+        source_load_blocks,
+        destination_load_blocks,
+    })
+}
+
+fn cached_tokens_from_effective_overlap(block_size: u32, effective_overlap_blocks: f64) -> usize {
+    (effective_overlap_blocks * block_size as f64)
+        .round()
+        .max(0.0) as usize
+}
 
 fn map_scheduler_error(error: scheduling::KvSchedulerError) -> anyhow::Error {
     if !error.is_overload() {
@@ -394,6 +532,79 @@ where
         cache_hit_for_worker(cache_hit_estimates, worker)
     }
 
+    fn gms_eligible_workers(&self) -> HashSet<WorkerWithDpRank> {
+        let configs = self.workers_with_configs.borrow();
+        let mut workers = HashSet::new();
+        for (worker_id, config) in configs.iter() {
+            let Some(runtime) = config.gms_runtime_config() else {
+                continue;
+            };
+            if !runtime.control_enabled {
+                continue;
+            }
+            for dp_rank_offset in 0..config.data_parallel_size.max(1) {
+                workers.insert(WorkerWithDpRank::new(
+                    *worker_id,
+                    config.data_parallel_start_rank + dp_rank_offset,
+                ));
+            }
+        }
+        workers
+    }
+
+    fn gms_placement_from_indexed_match(
+        &self,
+        hashes: Vec<String>,
+        placement: GmsPlacementMatch,
+    ) -> Option<GmsPlacementInfo> {
+        if hashes.is_empty() || placement.source_nixl_agent_name.is_empty() {
+            return None;
+        }
+        if placement.descriptors.len() != hashes.len() {
+            tracing::debug!(
+                expected = hashes.len(),
+                actual = placement.descriptors.len(),
+                "GMS placement index returned descriptor count mismatch"
+            );
+            return None;
+        }
+        if placement.descriptors.iter().all(Option::is_none) {
+            return None;
+        }
+
+        Some(GmsPlacementInfo {
+            source_nixl_agent_name: placement.source_nixl_agent_name,
+            source_nixl_agent_metadata_hex: placement.source_nixl_agent_metadata_hex,
+            source_nixl_ip: placement.source_nixl_ip,
+            source_nixl_listen_port: placement.source_nixl_listen_port,
+            descriptors: placement
+                .descriptors
+                .into_iter()
+                .map(|descriptor| {
+                    descriptor.map(|descriptor| GmsBlockDescriptor {
+                        remote_ptr: descriptor.remote_ptr,
+                        size: descriptor.size,
+                        tier: descriptor.tier,
+                        ranges: descriptor
+                            .ranges
+                            .into_iter()
+                            .map(|region| GmsMemoryRegion {
+                                remote_ptr: region.remote_ptr,
+                                size: region.size,
+                                tier: region.tier,
+                                layer: region.layer,
+                                offset: region.offset,
+                            })
+                            .collect(),
+                        generation: descriptor.generation,
+                        sealed: descriptor.sealed,
+                    })
+                })
+                .collect(),
+            hashes,
+        })
+    }
+
     pub async fn record_routing_decision(
         &self,
         mut tokens_with_hashes: TokensWithHashes,
@@ -569,6 +780,19 @@ where
         let supports_overlap_refresh = self.scheduler.supports_overlap_refresh();
         let retain_block_hashes = supports_overlap_refresh || return_routing_hashes;
 
+        // GMS decode-to-decode transfer uses the same KV event/indexer plane as
+        // normal routing. When enabled, include stable GMS content hashes in
+        // the index query so local and served-indexer modes can attach any
+        // already-published NIXL descriptors to the tiered match result.
+        let allow_gms_decode_transfer = gms_decode_transfer_allowed(
+            self.scheduler.worker_type(),
+            &self.kv_router_config,
+            router_config_override,
+        );
+        let gms_content_hashes =
+            (update_states && pinned_worker.is_none() && allow_gms_decode_transfer)
+                .then(|| gms_prefix_block_hashes_hex(tokens, self.block_size, None));
+
         let TieredLookupResult {
             tiered_matches,
             shared_cache_hits,
@@ -583,6 +807,7 @@ where
             block_hashes,
             cache_namespace.as_deref(),
             retain_block_hashes,
+            gms_content_hashes.as_deref(),
         )
         .await?;
 
@@ -596,11 +821,77 @@ where
             })
             .unwrap_or((None, None));
 
+        // Keep the GMS-only placement inputs across the scheduler await without
+        // retaining the full indexer response. The unified scheduler still owns
+        // admission and queueing; GMS only supplies an optional pinned worker.
+        let gms_lookup = (update_states && pinned_worker.is_none() && allow_gms_decode_transfer)
+            .then(|| {
+                (
+                    cache_hit_estimates_from_tiered_matches(
+                        &self.kv_router_config,
+                        self.block_size,
+                        &tiered_matches,
+                    ),
+                    tiered_matches.gms_placements.clone(),
+                )
+            });
+
         let overlap =
             OverlapAnalysis::new(&self.kv_router_config, self.block_size, &tiered_matches)
                 .signals();
         drop(tiered_matches);
         let find_matches_elapsed = start.elapsed();
+
+        // Reference GMS decode-to-decode policy: when the worker holding the
+        // best KV prefix is busier than another GMS-backed worker, route the
+        // request to the least busy GMS-backed worker and attach placement
+        // metadata so that worker can pull the prefix from the source daemon.
+        // Keep this aligned with vanilla Dynamo UX: only agg-like main decode
+        // routing enables it. Disaggregated prefill/decode routing disables KV
+        // reuse/overlap scoring through router overrides and should not trigger
+        // decode-to-decode GMS movement.
+        let track_prefill_tokens = self
+            .kv_router_config
+            .track_prefill_tokens(router_config_override);
+        let gms_candidate = if let Some((cache_hit_estimates, gms_placements)) = &gms_lookup {
+            let potential_loads = self.scheduler.get_potential_loads(
+                maybe_seq_hashes.clone(),
+                isl_tokens,
+                cache_hit_estimates
+                    .cached_tokens
+                    .clone()
+                    .into_iter()
+                    .collect(),
+                track_prefill_tokens,
+            );
+            let eligible_workers = self.gms_eligible_workers();
+            choose_gms_transfer_candidate(
+                cache_hit_estimates,
+                &potential_loads,
+                self.block_size,
+                &eligible_workers,
+                pinned_worker,
+                allowed_worker_ids.as_ref(),
+            )
+            .and_then(|candidate| {
+                let overlap_blocks = candidate.source_overlap_blocks.floor().max(0.0) as usize;
+                let hashes: Vec<String> = gms_content_hashes
+                    .as_ref()
+                    .map(|hashes| hashes.iter().take(overlap_blocks).cloned().collect())
+                    .unwrap_or_default();
+                gms_placements
+                    .get(&candidate.source_worker)
+                    .cloned()
+                    .and_then(|placement| self.gms_placement_from_indexed_match(hashes, placement))
+                    .map(|placement| (candidate, Box::new(placement)))
+            })
+        } else {
+            None
+        };
+        let scheduler_pinned_worker = gms_candidate
+            .as_ref()
+            .map(|(candidate, _)| candidate.destination_worker)
+            .or(pinned_worker);
 
         // Capture shared cache info for metrics before moving into schedule().
         // Clone the hits so we can compute `hits_beyond(overlap_blocks)` after
@@ -632,7 +923,7 @@ where
                 policy_class,
                 session_id,
                 expected_output_tokens,
-                pinned_worker,
+                pinned_worker: scheduler_pinned_worker,
                 allowed_worker_ids,
                 routing_constraints,
                 shared_cache_hits,
@@ -646,6 +937,42 @@ where
             }
             Err(error) => return Err(map_scheduler_error(error)),
         };
+
+        let mut selected_cache_hit = WorkerCacheHitEstimate {
+            effective_overlap_blocks: response.effective_overlap_blocks,
+        };
+        let mut selected_cached_tokens = response.cached_tokens;
+        let mut gms_transfer = None;
+        let mut gms_placement = None;
+        if let Some((candidate, placement)) = gms_candidate
+            && candidate.destination_worker == response.best_worker
+        {
+            selected_cache_hit = WorkerCacheHitEstimate {
+                effective_overlap_blocks: candidate.source_overlap_blocks,
+            };
+            selected_cached_tokens = cached_tokens_from_effective_overlap(
+                self.block_size,
+                candidate.source_overlap_blocks,
+            );
+            gms_transfer = Some(GmsTransferDecision {
+                source_worker: candidate.source_worker,
+                destination_worker: candidate.destination_worker,
+                source_overlap_blocks: candidate.source_overlap_blocks,
+                source_load_blocks: candidate.source_load_blocks,
+                destination_load_blocks: candidate.destination_load_blocks,
+            });
+            gms_placement = Some(placement);
+            tracing::info!(
+                source_worker_id = candidate.source_worker.worker_id,
+                source_dp_rank = candidate.source_worker.dp_rank,
+                destination_worker_id = candidate.destination_worker.worker_id,
+                destination_dp_rank = candidate.destination_worker.dp_rank,
+                source_overlap_blocks = candidate.source_overlap_blocks,
+                source_load_blocks = candidate.source_load_blocks,
+                destination_load_blocks = candidate.destination_load_blocks,
+                "GMS router policy selected decode-to-decode KV transfer"
+            );
+        }
         let total_elapsed = start.elapsed();
         let routing_hashes = routing_block_hashes.map(RoutingDecisionHashes::from_local_hashes);
 
@@ -668,7 +995,7 @@ where
                 m.shared_cache_hit_rate
                     .observe(hits.total_hits as f64 / num_blocks as f64);
             }
-            let beyond = hits.hits_beyond(response.effective_overlap_blocks.round() as u32);
+            let beyond = hits.hits_beyond(selected_cache_hit.rounded_overlap_blocks());
             m.shared_cache_beyond_blocks.observe(beyond as f64);
         }
 
@@ -685,10 +1012,12 @@ where
 
         Ok(FindBestMatchOutcome::Routed {
             worker: response.best_worker,
-            overlap_blocks: response.effective_overlap_blocks.round() as u32,
-            effective_overlap_blocks: response.effective_overlap_blocks,
-            cached_tokens: response.cached_tokens,
+            overlap_blocks: selected_cache_hit.rounded_overlap_blocks(),
+            effective_overlap_blocks: selected_cache_hit.effective_overlap_blocks,
+            cached_tokens: selected_cached_tokens,
             routing_hashes,
+            gms_transfer,
+            gms_placement,
         })
     }
 
@@ -1205,8 +1534,183 @@ mod tests {
     use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
     use tokio::sync::watch;
 
+    use crate::discovery::{WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
     use crate::kv_router::scheduler::KvSchedulerError;
     use crate::local_model::runtime_config::ModelRuntimeConfig;
+
+    #[test]
+    fn gms_prefix_block_hashes_match_shared_contract() {
+        assert_eq!(
+            gms_prefix_block_hashes_hex(&[11, 12, 21, 22], 2, None),
+            vec![
+                "27633adc838d290bfe4130a375197a136e5645f3ff1bd0d5904da56154fbbba1".to_string(),
+                "bd4400b4f97544846c8f83979d2907c784d6715516ba7bbf3e9fbbfc68f2f723".to_string(),
+            ]
+        );
+        assert_eq!(
+            gms_prefix_block_hashes_hex(&[11, 12, 21, 22], 2, Some("salt")),
+            vec![
+                "acd28c255e6db179ed1d9b959db9aa5b2b9f649a8895f9035fad787cabb036cf".to_string(),
+                "8b35efff2c76c7bd0081b968c92f47555874da0312630d9682f5bc0ca5a1ec89".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn gms_decode_transfer_gate_skips_by_default() {
+        let config = KvRouterConfig::default();
+
+        assert!(!gms_decode_transfer_allowed(
+            WORKER_TYPE_DECODE,
+            &config,
+            None
+        ));
+    }
+
+    #[test]
+    fn gms_decode_transfer_gate_allows_explicitly_enabled_aggregated_decode() {
+        let config = KvRouterConfig {
+            router_gms_decode_transfer: true,
+            ..Default::default()
+        };
+
+        assert!(gms_decode_transfer_allowed(
+            WORKER_TYPE_DECODE,
+            &config,
+            None
+        ));
+    }
+
+    #[test]
+    fn gms_decode_transfer_gate_skips_disaggregated_decode_override() {
+        let config = KvRouterConfig {
+            router_gms_decode_transfer: true,
+            ..Default::default()
+        };
+        let disaggregated_decode_override = RouterConfigOverride {
+            overlap_score_credit: Some(0.0),
+            assume_kv_reuse: Some(false),
+            track_prefill_tokens: Some(false),
+            ..Default::default()
+        };
+
+        assert!(!gms_decode_transfer_allowed(
+            WORKER_TYPE_DECODE,
+            &config,
+            Some(&disaggregated_decode_override)
+        ));
+    }
+
+    #[test]
+    fn gms_decode_transfer_gate_skips_prefill_router() {
+        let config = KvRouterConfig {
+            router_gms_decode_transfer: true,
+            ..Default::default()
+        };
+
+        assert!(!gms_decode_transfer_allowed(
+            WORKER_TYPE_PREFILL,
+            &config,
+            None
+        ));
+    }
+
+    #[test]
+    fn gms_decode_transfer_gate_skips_when_overlap_scoring_is_disabled() {
+        let config = KvRouterConfig {
+            overlap_score_credit: 0.0,
+            router_gms_decode_transfer: true,
+            ..Default::default()
+        };
+
+        assert!(!gms_decode_transfer_allowed(
+            WORKER_TYPE_DECODE,
+            &config,
+            None
+        ));
+    }
+
+    #[test]
+    fn gms_transfer_policy_targets_least_busy_worker() {
+        let source = WorkerWithDpRank::new(0, 0);
+        let destination = WorkerWithDpRank::new(1, 0);
+        let cache_hit_estimates = CacheHitEstimates {
+            effective_overlap_blocks: [(source, 4.0)].into_iter().collect(),
+            cached_tokens: Default::default(),
+        };
+        let loads = vec![
+            PotentialLoad {
+                worker_id: source.worker_id,
+                dp_rank: source.dp_rank,
+                potential_prefill_tokens: 32,
+                potential_decode_blocks: 6,
+                active_requests: 0,
+            },
+            PotentialLoad {
+                worker_id: destination.worker_id,
+                dp_rank: destination.dp_rank,
+                potential_prefill_tokens: 0,
+                potential_decode_blocks: 1,
+                active_requests: 0,
+            },
+        ];
+        let eligible_workers = HashSet::from([source, destination]);
+
+        let candidate = choose_gms_transfer_candidate(
+            &cache_hit_estimates,
+            &loads,
+            16,
+            &eligible_workers,
+            None,
+            None,
+        )
+        .expect("expected GMS transfer candidate");
+
+        assert_eq!(candidate.source_worker, source);
+        assert_eq!(candidate.destination_worker, destination);
+        assert_eq!(candidate.source_overlap_blocks, 4.0);
+        assert_eq!(candidate.source_load_blocks, 8);
+        assert_eq!(candidate.destination_load_blocks, 1);
+    }
+
+    #[test]
+    fn gms_transfer_policy_skips_when_source_is_not_busier() {
+        let source = WorkerWithDpRank::new(0, 0);
+        let destination = WorkerWithDpRank::new(1, 0);
+        let cache_hit_estimates = CacheHitEstimates {
+            effective_overlap_blocks: [(source, 4.0)].into_iter().collect(),
+            cached_tokens: Default::default(),
+        };
+        let loads = vec![
+            PotentialLoad {
+                worker_id: source.worker_id,
+                dp_rank: source.dp_rank,
+                potential_prefill_tokens: 0,
+                potential_decode_blocks: 1,
+                active_requests: 0,
+            },
+            PotentialLoad {
+                worker_id: destination.worker_id,
+                dp_rank: destination.dp_rank,
+                potential_prefill_tokens: 0,
+                potential_decode_blocks: 4,
+                active_requests: 0,
+            },
+        ];
+        let eligible_workers = HashSet::from([source, destination]);
+
+        assert!(
+            choose_gms_transfer_candidate(
+                &cache_hit_estimates,
+                &loads,
+                16,
+                &eligible_workers,
+                None,
+                None,
+            )
+            .is_none()
+        );
+    }
 
     #[test]
     fn weighted_cache_hit_estimates_include_lower_tiers() {
@@ -1229,6 +1733,7 @@ mod tests {
                 (StorageTier::HostPinned, host_match_details),
                 (StorageTier::Disk, disk_match_details),
             ]),
+            gms_placements: Default::default(),
         };
 
         let estimates = cache_hit_estimates_from_tiered_matches(

--- a/lib/llm/src/kv_router/indexer/lookup.rs
+++ b/lib/llm/src/kv_router/indexer/lookup.rs
@@ -1,13 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use dynamo_kv_router::{
     ConcurrentRadixTreeCompressed,
     indexer::{
-        KvIndexer, KvRouterError, LowerTierIndexers, MatchDetails, ThreadPoolIndexer,
-        TieredMatchProvider, query_lower_tiers,
+        GmsPlacementIndex, KvIndexer, KvRouterError, LowerTierIndexers, MatchDetails,
+        ThreadPoolIndexer, TieredMatchProvider, query_lower_tiers,
     },
-    protocols::{LocalBlockHash, OverlapScores},
+    protocols::{LocalBlockHash, OverlapScores, WorkerWithDpRank},
 };
 use dynamo_runtime::pipeline::async_trait;
 
@@ -51,6 +53,7 @@ pub(super) struct LookupPipeline<'a> {
     primary: PrimaryLookup<'a>,
     lower_tier: Option<&'a LowerTierIndexers>,
     side: Option<&'a SideIndexer>,
+    gms_placement: Option<&'a GmsPlacementIndex>,
 }
 
 impl Indexer {
@@ -60,21 +63,25 @@ impl Indexer {
                 primary,
                 lower_tier,
                 approx,
+                gms_placement,
                 ..
             } => LookupPipeline {
                 primary: PrimaryLookup::KvIndexer(primary),
                 lower_tier: Some(lower_tier),
                 side: approx.as_ref(),
+                gms_placement: Some(gms_placement),
             },
             Self::Concurrent {
                 primary,
                 lower_tier,
                 approx,
+                gms_placement,
                 ..
             } => LookupPipeline {
                 primary: PrimaryLookup::Concurrent(primary.as_ref()),
                 lower_tier: Some(lower_tier),
                 side: approx.as_ref(),
+                gms_placement: Some(gms_placement),
             },
             Self::Remote {
                 primary, approx, ..
@@ -82,11 +89,13 @@ impl Indexer {
                 primary: PrimaryLookup::Remote(primary.as_ref()),
                 lower_tier: None,
                 side: approx.as_ref(),
+                gms_placement: None,
             },
             Self::None => LookupPipeline {
                 primary: PrimaryLookup::None,
                 lower_tier: None,
                 side: None,
+                gms_placement: None,
             },
         }
     }
@@ -115,7 +124,7 @@ impl Indexer {
         sequence: Vec<LocalBlockHash>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
         self.lookup_pipeline()
-            .find_matches_by_tier(HashInput::Owned(sequence))
+            .find_matches_by_tier(HashInput::Owned(sequence), None)
             .await
     }
 
@@ -124,16 +133,27 @@ impl Indexer {
         sequence: &[LocalBlockHash],
     ) -> Result<TieredMatchDetails, KvRouterError> {
         self.lookup_pipeline()
-            .find_matches_by_tier(HashInput::Borrowed(sequence))
+            .find_matches_by_tier(HashInput::Borrowed(sequence), None)
             .await
     }
 
-    pub(crate) async fn find_primary_matches_by_tier(
+    pub(crate) async fn find_matches_by_tier_with_gms_placements(
         &self,
         sequence: Vec<LocalBlockHash>,
+        gms_content_hashes_hex: Option<&[String]>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
         self.lookup_pipeline()
-            .find_primary_matches_by_tier(HashInput::Owned(sequence))
+            .find_matches_by_tier(HashInput::Owned(sequence), gms_content_hashes_hex)
+            .await
+    }
+
+    pub(crate) async fn find_primary_matches_by_tier_with_gms_placements(
+        &self,
+        sequence: Vec<LocalBlockHash>,
+        gms_content_hashes_hex: Option<&[String]>,
+    ) -> Result<TieredMatchDetails, KvRouterError> {
+        self.lookup_pipeline()
+            .find_primary_matches_by_tier(HashInput::Owned(sequence), gms_content_hashes_hex)
             .await
     }
 }
@@ -169,9 +189,42 @@ impl<'a> LookupPipeline<'a> {
         self.primary.find_match_details(sequence).await
     }
 
+    fn attach_gms_placements(
+        &self,
+        tiered: &mut TieredMatchDetails,
+        content_hashes_hex: Option<&[String]>,
+    ) {
+        let (Some(gms_placement), Some(content_hashes_hex)) =
+            (self.gms_placement, content_hashes_hex)
+        else {
+            return;
+        };
+        if content_hashes_hex.is_empty() {
+            return;
+        }
+
+        let mut workers: HashSet<WorkerWithDpRank> = tiered
+            .device
+            .overlap_scores
+            .scores
+            .keys()
+            .copied()
+            .collect();
+        for details in tiered.lower_tier.values() {
+            workers.extend(details.hits.keys().copied());
+        }
+
+        for worker in workers {
+            if let Some(placement) = gms_placement.lookup(worker, content_hashes_hex) {
+                tiered.gms_placements.insert(worker, placement);
+            }
+        }
+    }
+
     async fn find_matches_by_tier(
         &self,
         sequence: HashInput<'_>,
+        gms_content_hashes_hex: Option<&[String]>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
         match self.primary {
             PrimaryLookup::KvIndexer(_) | PrimaryLookup::Concurrent(_) => {
@@ -187,15 +240,22 @@ impl<'a> LookupPipeline<'a> {
                 let lt = query_lower_tiers(lower_tier, sequence.as_slice(), &primary_device);
                 let device = merge_side_or_warn(self.side, primary_device, sequence).await;
 
-                Ok(TieredMatchDetails {
+                let mut tiered = TieredMatchDetails {
                     device,
                     lower_tier: lt,
-                })
+                    gms_placements: Default::default(),
+                };
+                self.attach_gms_placements(&mut tiered, gms_content_hashes_hex);
+                Ok(tiered)
             }
             PrimaryLookup::Remote(primary) => {
                 let Some(side) = self.side else {
                     return primary
-                        .find_matches_by_tier(sequence.into_owned_at_boundary(), false)
+                        .find_matches_by_tier(
+                            sequence.into_owned_at_boundary(),
+                            false,
+                            gms_content_hashes_hex,
+                        )
                         .await
                         .map_err(|e| {
                             tracing::warn!(error = %e, "Remote indexer tiered query failed");
@@ -203,7 +263,11 @@ impl<'a> LookupPipeline<'a> {
                         });
                 };
                 let mut tiered = primary
-                    .find_matches_by_tier(sequence.clone_for_boundary(), false)
+                    .find_matches_by_tier(
+                        sequence.clone_for_boundary(),
+                        false,
+                        gms_content_hashes_hex,
+                    )
                     .await
                     .map_err(|e| {
                         tracing::warn!(error = %e, "Remote indexer tiered query failed");
@@ -219,6 +283,7 @@ impl<'a> LookupPipeline<'a> {
     async fn find_primary_matches_by_tier(
         &self,
         sequence: HashInput<'_>,
+        gms_content_hashes_hex: Option<&[String]>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
         match self.primary {
             PrimaryLookup::KvIndexer(_) | PrimaryLookup::Concurrent(_) => {
@@ -227,13 +292,20 @@ impl<'a> LookupPipeline<'a> {
                 };
                 let device = self.primary.find_match_details_retained(&sequence).await?;
                 let lt = query_lower_tiers(lower_tier, sequence.as_slice(), &device);
-                Ok(TieredMatchDetails {
+                let mut tiered = TieredMatchDetails {
                     device,
                     lower_tier: lt,
-                })
+                    gms_placements: Default::default(),
+                };
+                self.attach_gms_placements(&mut tiered, gms_content_hashes_hex);
+                Ok(tiered)
             }
             PrimaryLookup::Remote(primary) => primary
-                .find_matches_by_tier(sequence.into_owned_at_boundary(), false)
+                .find_matches_by_tier(
+                    sequence.into_owned_at_boundary(),
+                    false,
+                    gms_content_hashes_hex,
+                )
                 .await
                 .map_err(|e| {
                     tracing::warn!(error = %e, "Remote indexer tiered query failed");
@@ -260,7 +332,7 @@ impl<'a> PrimaryLookup<'a> {
                 .find_match_details_impl(sequence.as_slice(), false),
             Self::Remote(primary) => {
                 let tiered = primary
-                    .find_matches_by_tier(sequence.into_owned_at_boundary(), true)
+                    .find_matches_by_tier(sequence.into_owned_at_boundary(), true, None)
                     .await
                     .map_err(|e| {
                         tracing::warn!(error = %e, "Remote indexer query failed");
@@ -289,7 +361,7 @@ impl<'a> PrimaryLookup<'a> {
                 .find_match_details_impl(sequence.as_slice(), false),
             Self::Remote(primary) => {
                 let tiered = primary
-                    .find_matches_by_tier(sequence.clone_for_boundary(), true)
+                    .find_matches_by_tier(sequence.clone_for_boundary(), true, None)
                     .await
                     .map_err(|e| {
                         tracing::warn!(error = %e, "Remote indexer query failed");

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -9,10 +9,10 @@ use dynamo_kv_router::{
     approx::PruneConfig,
     config::KvRouterConfig,
     indexer::{
-        KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError, LowerTierIndexers,
-        ThreadPoolIndexer,
+        GmsPlacementIndex, KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError,
+        LowerTierIndexers, ThreadPoolIndexer,
     },
-    protocols::{DpRank, RouterEvent, WorkerId},
+    protocols::{DpRank, RouterEvent, WorkerId, WorkerWithDpRank},
 };
 
 // Re-export tiered-match types so internal callers (`indexer::TieredMatchDetails`)
@@ -50,12 +50,14 @@ pub enum Indexer {
     KvIndexer {
         primary: KvIndexer,
         lower_tier: LowerTierIndexers,
+        gms_placement: Arc<GmsPlacementIndex>,
         approx: Option<SideIndexer>,
         primary_records_routing_decisions: bool,
     },
     Concurrent {
         primary: Arc<ThreadPoolIndexer<ConcurrentRadixTreeCompressed>>,
         lower_tier: LowerTierIndexers,
+        gms_placement: Arc<GmsPlacementIndex>,
         approx: Option<SideIndexer>,
         primary_records_routing_decisions: bool,
     },
@@ -130,6 +132,7 @@ impl Indexer {
                         block_size,
                         Some(kv_indexer_metrics),
                     ),
+                    gms_placement: Arc::new(GmsPlacementIndex::new()),
                     approx: None,
                     primary_records_routing_decisions: true,
                 });
@@ -148,6 +151,7 @@ impl Indexer {
                     block_size,
                     Some(kv_indexer_metrics),
                 ),
+                gms_placement: Arc::new(GmsPlacementIndex::new()),
                 approx: None,
                 primary_records_routing_decisions: true,
             });
@@ -169,6 +173,7 @@ impl Indexer {
                     block_size,
                     Some(kv_indexer_metrics),
                 ),
+                gms_placement: Arc::new(GmsPlacementIndex::new()),
                 approx,
                 primary_records_routing_decisions: false,
             });
@@ -189,6 +194,7 @@ impl Indexer {
                 block_size,
                 Some(kv_indexer_metrics),
             ),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
             approx,
             primary_records_routing_decisions: false,
         })
@@ -196,8 +202,24 @@ impl Indexer {
 
     pub(crate) async fn dump_events(&self) -> Result<Vec<RouterEvent>, KvRouterError> {
         match self {
-            Self::KvIndexer { primary, .. } => primary.dump_events().await,
-            Self::Concurrent { primary, .. } => primary.dump_events().await,
+            Self::KvIndexer {
+                primary,
+                gms_placement,
+                ..
+            } => {
+                let mut events = primary.dump_events().await?;
+                events.extend(gms_placement.dump_events());
+                Ok(events)
+            }
+            Self::Concurrent {
+                primary,
+                gms_placement,
+                ..
+            } => {
+                let mut events = primary.dump_events().await?;
+                events.extend(gms_placement.dump_events());
+                Ok(events)
+            }
             Self::Remote { .. } => Ok(Vec::new()),
             Self::None => {
                 panic!(
@@ -212,51 +234,59 @@ impl Indexer {
             Self::KvIndexer {
                 primary,
                 lower_tier,
+                gms_placement,
                 ..
-            } => match &event.event.data {
-                dynamo_kv_router::protocols::KvCacheEventData::Cleared => {
-                    if let Err(e) = primary.event_sender().send(event.clone()).await {
-                        tracing::warn!("Failed to send event to indexer: {e}");
-                    }
+            } => {
+                gms_placement.apply_event(&event);
+                match &event.event.data {
+                    dynamo_kv_router::protocols::KvCacheEventData::Cleared => {
+                        if let Err(e) = primary.event_sender().send(event.clone()).await {
+                            tracing::warn!("Failed to send event to indexer: {e}");
+                        }
 
-                    for indexer in lower_tier.all() {
-                        indexer.apply_event(event.clone()).await;
+                        for indexer in lower_tier.all() {
+                            indexer.apply_event(event.clone()).await;
+                        }
+                    }
+                    _ if event.storage_tier.is_gpu() => {
+                        if let Err(e) = primary.event_sender().send(event).await {
+                            tracing::warn!("Failed to send event to indexer: {e}");
+                        }
+                    }
+                    _ => {
+                        lower_tier
+                            .get_or_create(event.storage_tier)
+                            .apply_event(event)
+                            .await;
                     }
                 }
-                _ if event.storage_tier.is_gpu() => {
-                    if let Err(e) = primary.event_sender().send(event).await {
-                        tracing::warn!("Failed to send event to indexer: {e}");
-                    }
-                }
-                _ => {
-                    lower_tier
-                        .get_or_create(event.storage_tier)
-                        .apply_event(event)
-                        .await;
-                }
-            },
+            }
             Self::Concurrent {
                 primary,
                 lower_tier,
+                gms_placement,
                 ..
-            } => match &event.event.data {
-                dynamo_kv_router::protocols::KvCacheEventData::Cleared => {
-                    primary.apply_event(event.clone()).await;
+            } => {
+                gms_placement.apply_event(&event);
+                match &event.event.data {
+                    dynamo_kv_router::protocols::KvCacheEventData::Cleared => {
+                        primary.apply_event(event.clone()).await;
 
-                    for indexer in lower_tier.all() {
-                        indexer.apply_event(event.clone()).await;
+                        for indexer in lower_tier.all() {
+                            indexer.apply_event(event.clone()).await;
+                        }
+                    }
+                    _ if event.storage_tier.is_gpu() => {
+                        primary.apply_event(event).await;
+                    }
+                    _ => {
+                        lower_tier
+                            .get_or_create(event.storage_tier)
+                            .apply_event(event)
+                            .await;
                     }
                 }
-                _ if event.storage_tier.is_gpu() => {
-                    primary.apply_event(event).await;
-                }
-                _ => {
-                    lower_tier
-                        .get_or_create(event.storage_tier)
-                        .apply_event(event)
-                        .await;
-                }
-            },
+            }
             Self::Remote { .. } | Self::None => {}
         }
     }
@@ -266,9 +296,11 @@ impl Indexer {
             Self::KvIndexer {
                 primary,
                 lower_tier,
+                gms_placement,
                 approx,
                 ..
             } => {
+                gms_placement.remove_worker(worker_id);
                 for indexer in lower_tier.all() {
                     indexer.remove_worker(worker_id).await;
                 }
@@ -282,9 +314,11 @@ impl Indexer {
             Self::Concurrent {
                 primary,
                 lower_tier,
+                gms_placement,
                 approx,
                 ..
             } => {
+                gms_placement.remove_worker(worker_id);
                 for indexer in lower_tier.all() {
                     indexer.remove_worker(worker_id).await;
                 }
@@ -303,13 +337,16 @@ impl Indexer {
     }
 
     pub(crate) async fn remove_worker_dp_rank(&self, worker_id: WorkerId, dp_rank: DpRank) {
+        let worker = WorkerWithDpRank::new(worker_id, dp_rank);
         match self {
             Self::KvIndexer {
                 primary,
                 lower_tier,
+                gms_placement,
                 approx,
                 ..
             } => {
+                gms_placement.remove_worker_dp_rank(worker);
                 for indexer in lower_tier.all() {
                     KvIndexerInterface::remove_worker_dp_rank(&*indexer, worker_id, dp_rank).await;
                 }
@@ -321,9 +358,11 @@ impl Indexer {
             Self::Concurrent {
                 primary,
                 lower_tier,
+                gms_placement,
                 approx,
                 ..
             } => {
+                gms_placement.remove_worker_dp_rank(worker);
                 for indexer in lower_tier.all() {
                     KvIndexerInterface::remove_worker_dp_rank(&*indexer, worker_id, dp_rank).await;
                 }
@@ -428,7 +467,10 @@ mod tests {
     use dynamo_kv_router::{
         ConcurrentRadixTreeCompressed, ThreadPoolIndexer,
         approx::PruneConfig,
-        indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics, RoutingDecisionHashes},
+        indexer::{
+            GmsPlacementIndex, KvIndexer, KvIndexerInterface, KvIndexerMetrics,
+            RoutingDecisionHashes,
+        },
         protocols::{
             BlockHashOptions, LocalBlockHash, StorageTier, TokensWithHashes, WorkerWithDpRank,
             compute_block_hash_for_seq, compute_seq_hash_for_block,
@@ -443,6 +485,7 @@ mod tests {
                 Arc::new(KvIndexerMetrics::new_unregistered()),
             ),
             lower_tier: LowerTierIndexers::new(1, 4),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
             approx: None,
             primary_records_routing_decisions: false,
         }
@@ -456,6 +499,7 @@ mod tests {
                 4,
             )),
             lower_tier: LowerTierIndexers::new(2, 4),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
             approx: None,
             primary_records_routing_decisions: false,
         }
@@ -472,6 +516,7 @@ mod tests {
                 },
             )),
             lower_tier: LowerTierIndexers::new(2, 4),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
             approx: None,
             primary_records_routing_decisions: true,
         }
@@ -788,6 +833,7 @@ mod tests {
         let indexer = Indexer::Concurrent {
             primary,
             lower_tier: LowerTierIndexers::new(2, 4),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
             approx: Some(super::SideIndexer::Concurrent(side)),
             primary_records_routing_decisions: false,
         };
@@ -919,6 +965,7 @@ mod tests {
         let indexer = Indexer::Concurrent {
             primary,
             lower_tier: LowerTierIndexers::new(2, 4),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
             approx: Some(super::SideIndexer::Concurrent(side)),
             primary_records_routing_decisions: false,
         };

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -699,7 +699,9 @@ impl WorkerQueryClient {
 mod tests {
     use super::*;
     use crate::kv_router::{Indexer, indexer::LowerTierIndexers};
-    use dynamo_kv_router::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
+    use dynamo_kv_router::indexer::{
+        GmsPlacementIndex, KvIndexer, KvIndexerInterface, KvIndexerMetrics,
+    };
     use dynamo_kv_router::protocols::{
         ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
         KvCacheStoredBlockData, LocalBlockHash, RouterEvent,
@@ -840,6 +842,7 @@ mod tests {
             Indexer::KvIndexer {
                 primary: kv_indexer,
                 lower_tier: LowerTierIndexers::new(1, 4),
+                gms_placement: Arc::new(GmsPlacementIndex::new()),
                 approx: None,
                 primary_records_routing_decisions: false,
             },

--- a/lib/llm/src/kv_router/indexer/remote.rs
+++ b/lib/llm/src/kv_router/indexer/remote.rs
@@ -89,6 +89,7 @@ impl RemoteIndexer {
         &self,
         block_hashes: Vec<LocalBlockHash>,
         device_only: bool,
+        gms_content_hashes_hex: Option<&[String]>,
     ) -> Result<TieredMatchDetails> {
         self.validate_topology_if_ready().await.inspect_err(|_| {
             self.metrics.increment_query_failures();
@@ -97,6 +98,7 @@ impl RemoteIndexer {
         let request = IndexerQueryRequest {
             model_name: self.model_name.clone(),
             block_hashes,
+            gms_content_hashes_hex: gms_content_hashes_hex.map(|hashes| hashes.to_vec()),
             device_only,
         };
         let mut stream: ManyOut<IndexerQueryResponse> = self
@@ -449,10 +451,14 @@ impl AsyncEngine<SingleIn<IndexerQueryRequest>, ManyOut<IndexerQueryResponse>, a
                         .map(|device| TieredMatchDetails {
                             device,
                             lower_tier: HashMap::new(),
+                            gms_placements: Default::default(),
                         })
                 } else {
                     indexer
-                        .find_primary_matches_by_tier(request.block_hashes)
+                        .find_primary_matches_by_tier_with_gms_placements(
+                            request.block_hashes,
+                            request.gms_content_hashes_hex.as_deref(),
+                        )
                         .await
                 };
                 match result {
@@ -533,9 +539,14 @@ mod tests {
     use std::time::Duration;
 
     use dynamo_kv_router::indexer::{
-        KvIndexer, KvIndexerInterface, KvIndexerMetrics, pruning::PruneConfig,
+        GmsPlacementIndex, KvIndexer, KvIndexerInterface, KvIndexerMetrics, pruning::PruneConfig,
     };
-    use dynamo_kv_router::protocols::{StorageTier, WorkerWithDpRank, compute_seq_hash_for_block};
+    use dynamo_kv_router::protocols::{
+        ExternalSequenceBlockHash, GmsPlacementBlock, GmsPlacementDescriptor,
+        GmsPlacementEventData, GmsPlacementMemoryRegion, GmsPlacementStoreData, KvCacheEvent,
+        KvCacheEventData, KvCacheStoreData, RouterEvent, StorageTier, WorkerWithDpRank,
+        compute_seq_hash_for_block,
+    };
     use tokio_util::sync::CancellationToken;
 
     #[tokio::test]
@@ -548,6 +559,7 @@ mod tests {
         let request = SingleIn::new(IndexerQueryRequest {
             model_name: "model-b".to_string(),
             block_hashes: vec![LocalBlockHash(1)],
+            gms_content_hashes_hex: None,
             device_only: false,
         });
 
@@ -584,6 +596,7 @@ mod tests {
                 Arc::new(KvIndexerMetrics::new_unregistered()),
             ),
             lower_tier: LowerTierIndexers::new(1, 4),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
             approx: Some(SideIndexer::KvIndexer(side)),
             primary_records_routing_decisions: false,
         };
@@ -607,6 +620,7 @@ mod tests {
             .generate(SingleIn::new(IndexerQueryRequest {
                 model_name: "m".to_string(),
                 block_hashes,
+                gms_content_hashes_hex: None,
                 device_only: false,
             }))
             .await
@@ -636,6 +650,7 @@ mod tests {
                 Arc::new(KvIndexerMetrics::new_unregistered()),
             ),
             lower_tier: LowerTierIndexers::new(1, 4),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
             approx: None,
             primary_records_routing_decisions: false,
         };
@@ -674,6 +689,7 @@ mod tests {
             .generate(SingleIn::new(IndexerQueryRequest {
                 model_name: "m".to_string(),
                 block_hashes: vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)],
+                gms_content_hashes_hex: None,
                 device_only: false,
             }))
             .await
@@ -722,6 +738,94 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn query_engine_returns_gms_placements_from_event_plane() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let indexer = Indexer::KvIndexer {
+            primary: KvIndexer::new(
+                CancellationToken::new(),
+                4,
+                Arc::new(KvIndexerMetrics::new_unregistered()),
+            ),
+            lower_tier: LowerTierIndexers::new(1, 4),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
+            approx: None,
+            primary_records_routing_decisions: false,
+        };
+
+        indexer
+            .apply_event(store_event(7, 0, 1, &[], &[11], StorageTier::Device))
+            .await;
+        indexer
+            .apply_event(RouterEvent::with_gms_placement(
+                worker.worker_id,
+                KvCacheEvent {
+                    event_id: 2,
+                    data: KvCacheEventData::Stored(KvCacheStoreData {
+                        parent_hash: None::<ExternalSequenceBlockHash>,
+                        start_position: None,
+                        blocks: Vec::new(),
+                    }),
+                    dp_rank: worker.dp_rank,
+                },
+                StorageTier::External,
+                GmsPlacementEventData::Stored(GmsPlacementStoreData {
+                    source_nixl_agent_name: "agent-a".to_string(),
+                    source_nixl_agent_metadata_hex: "abcd".to_string(),
+                    source_nixl_ip: Some("10.0.0.1".to_string()),
+                    source_nixl_listen_port: Some(5555),
+                    blocks: vec![GmsPlacementBlock {
+                        content_hash_hex: "aa".to_string(),
+                        descriptor: GmsPlacementDescriptor {
+                            remote_ptr: 1234,
+                            size: 64,
+                            tier: "host".to_string(),
+                            ranges: vec![GmsPlacementMemoryRegion {
+                                remote_ptr: 1234,
+                                size: 64,
+                                tier: "host".to_string(),
+                                layer: Some(0),
+                                offset: Some(0),
+                            }],
+                            generation: Some(9),
+                            sealed: Some(true),
+                        },
+                    }],
+                }),
+            ))
+            .await;
+
+        let Indexer::KvIndexer { primary, .. } = &indexer else {
+            unreachable!()
+        };
+        let _ = primary.flush().await;
+
+        let bindings = Arc::new(RwLock::new(HashMap::from([("m".to_string(), indexer)])));
+        let engine = ServedIndexerQueryEngine { bindings };
+        let mut stream = engine
+            .generate(SingleIn::new(IndexerQueryRequest {
+                model_name: "m".to_string(),
+                block_hashes: vec![LocalBlockHash(11)],
+                gms_content_hashes_hex: Some(vec!["AA".to_string()]),
+                device_only: false,
+            }))
+            .await
+            .unwrap();
+
+        let Some(IndexerQueryResponse::TieredScores(wire)) = stream.next().await else {
+            panic!("expected TieredScores response");
+        };
+        let (_, placement) = wire
+            .gms_placements
+            .iter()
+            .find(|(candidate, _)| *candidate == worker)
+            .expect("GMS placement should be attached to served-indexer response");
+
+        assert_eq!(placement.source_nixl_agent_name, "agent-a");
+        assert_eq!(placement.descriptors.len(), 1);
+        assert_eq!(placement.descriptors[0].as_ref().unwrap().remote_ptr, 1234);
+    }
+
     /// `device_only=true` must skip the lower-tier walk: the response carries
     /// the device overlap but no per-tier entries, even when the underlying
     /// indexer holds host-pinned data.
@@ -735,6 +839,7 @@ mod tests {
                 Arc::new(KvIndexerMetrics::new_unregistered()),
             ),
             lower_tier: LowerTierIndexers::new(1, 4),
+            gms_placement: Arc::new(GmsPlacementIndex::new()),
             approx: None,
             primary_records_routing_decisions: false,
         };
@@ -772,6 +877,7 @@ mod tests {
             .generate(SingleIn::new(IndexerQueryRequest {
                 model_name: "m".to_string(),
                 block_hashes: vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)],
+                gms_content_hashes_hex: None,
                 device_only: true,
             }))
             .await

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -304,6 +304,9 @@ impl KvPushRouter {
 
         let (mut backend_input, context) = request.into_parts();
         backend_input.routing_mut().dp_rank = Some(selection.dp_rank);
+        if backend_input.gms_placement.is_none() {
+            backend_input.gms_placement = selection.gms_placement.map(|placement| *placement);
+        }
         let updated_request = context.map(|_| backend_input);
         guard.record_prefill_start();
 

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -16,7 +16,10 @@ use crate::{
     preprocessor::PreprocessedRequest,
     protocols::{
         TokenIdType,
-        common::{preprocessor::RoutingHints, timing::RequestPhase},
+        common::{
+            preprocessor::{GmsPlacementInfo, RoutingHints},
+            timing::RequestPhase,
+        },
     },
 };
 
@@ -27,6 +30,9 @@ pub(super) struct WorkerSelection {
     pub(super) effective_overlap_blocks: f64,
     pub(super) cached_tokens: usize,
     pub(super) routing_hashes: Option<RoutingDecisionHashes>,
+    /// Optional GMS placement metadata that lets the selected worker fetch KV
+    /// from a busier peer selected by the router's reference policy.
+    pub(super) gms_placement: Option<Box<GmsPlacementInfo>>,
     pub(super) scheduler_tracked: bool,
 }
 
@@ -102,15 +108,33 @@ impl KvPushRouter {
                 effective_overlap_blocks,
                 cached_tokens,
                 routing_hashes,
-            } => Ok(WorkerSelection {
-                instance_id: worker.worker_id,
-                dp_rank: worker.dp_rank,
-                overlap_amount: overlap_blocks,
-                effective_overlap_blocks,
-                cached_tokens,
-                routing_hashes,
-                scheduler_tracked: args.scheduler_tracked,
-            }),
+                gms_transfer,
+                gms_placement,
+            } => {
+                if let Some(transfer) = gms_transfer {
+                    tracing::debug!(
+                        request_id = %args.context_id,
+                        source_worker_id = transfer.source_worker.worker_id,
+                        source_dp_rank = transfer.source_worker.dp_rank,
+                        destination_worker_id = transfer.destination_worker.worker_id,
+                        destination_dp_rank = transfer.destination_worker.dp_rank,
+                        source_overlap_blocks = transfer.source_overlap_blocks,
+                        source_load_blocks = transfer.source_load_blocks,
+                        destination_load_blocks = transfer.destination_load_blocks,
+                        "Routing request with GMS KV transfer placement"
+                    );
+                }
+                Ok(WorkerSelection {
+                    instance_id: worker.worker_id,
+                    dp_rank: worker.dp_rank,
+                    overlap_amount: overlap_blocks,
+                    effective_overlap_blocks,
+                    cached_tokens,
+                    routing_hashes,
+                    gms_placement,
+                    scheduler_tracked: args.scheduler_tracked,
+                })
+            }
             FindBestMatchOutcome::QueueRejected { rejection } => Err(rejection.into()),
         }
     }

--- a/lib/llm/src/kv_router/route_lookup.rs
+++ b/lib/llm/src/kv_router/route_lookup.rs
@@ -41,6 +41,7 @@ pub(super) fn split_retained_block_hashes(
     (None, Some(block_hashes))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn query_tiered_matches(
     indexer: &Indexer,
     shared_cache: Option<&dyn SharedKvCache>,
@@ -49,6 +50,7 @@ pub(super) async fn query_tiered_matches(
     block_hashes: Vec<LocalBlockHash>,
     cache_namespace: Option<&str>,
     retain_block_hashes: bool,
+    gms_content_hashes_hex: Option<&[String]>,
 ) -> Result<TieredLookupResult, KvRouterError> {
     if retain_block_hashes {
         let (tiered_matches, shared_cache_hits, indexer_duration, shared_cache_duration) =
@@ -59,6 +61,7 @@ pub(super) async fn query_tiered_matches(
                 block_size,
                 &block_hashes,
                 cache_namespace,
+                gms_content_hashes_hex,
             )
             .await?;
 
@@ -78,6 +81,7 @@ pub(super) async fn query_tiered_matches(
         block_size,
         block_hashes,
         cache_namespace,
+        gms_content_hashes_hex,
     )
     .await?;
 
@@ -97,6 +101,7 @@ async fn query_retained(
     block_size: u32,
     block_hashes: &[LocalBlockHash],
     cache_namespace: Option<&str>,
+    gms_content_hashes_hex: Option<&[String]>,
 ) -> Result<
     (
         TieredMatchDetails,
@@ -106,18 +111,25 @@ async fn query_retained(
     ),
     KvRouterError,
 > {
+    let indexer_fut = async move {
+        if let Some(gms_content_hashes_hex) = gms_content_hashes_hex {
+            indexer
+                .find_matches_by_tier_with_gms_placements(
+                    block_hashes.to_vec(),
+                    Some(gms_content_hashes_hex),
+                )
+                .await
+        } else {
+            indexer.find_matches_by_tier_ref(block_hashes).await
+        }
+    }
+    .instrument(tracing::info_span!("kv_router.find_matches"));
+
     let Some(shared_cache) = shared_cache else {
         let t = Instant::now();
-        let tiered = indexer
-            .find_matches_by_tier_ref(block_hashes)
-            .instrument(tracing::info_span!("kv_router.find_matches"))
-            .await?;
+        let tiered = indexer_fut.await?;
         return Ok((tiered, None, t.elapsed(), None));
     };
-
-    let indexer_fut = indexer
-        .find_matches_by_tier_ref(block_hashes)
-        .instrument(tracing::info_span!("kv_router.find_matches"));
     join_indexer_and_shared_cache(
         indexer_fut,
         shared_cache,
@@ -135,6 +147,7 @@ async fn query_owned(
     block_size: u32,
     block_hashes: Vec<LocalBlockHash>,
     cache_namespace: Option<&str>,
+    gms_content_hashes_hex: Option<&[String]>,
 ) -> Result<
     (
         TieredMatchDetails,
@@ -144,18 +157,25 @@ async fn query_owned(
     ),
     KvRouterError,
 > {
+    let indexer_fut = async move {
+        if let Some(gms_content_hashes_hex) = gms_content_hashes_hex {
+            indexer
+                .find_matches_by_tier_with_gms_placements(
+                    block_hashes,
+                    Some(gms_content_hashes_hex),
+                )
+                .await
+        } else {
+            indexer.find_matches_by_tier(block_hashes).await
+        }
+    }
+    .instrument(tracing::info_span!("kv_router.find_matches"));
+
     let Some(shared_cache) = shared_cache else {
         let t = Instant::now();
-        let tiered = indexer
-            .find_matches_by_tier(block_hashes)
-            .instrument(tracing::info_span!("kv_router.find_matches"))
-            .await?;
+        let tiered = indexer_fut.await?;
         return Ok((tiered, None, t.elapsed(), None));
     };
-
-    let indexer_fut = indexer
-        .find_matches_by_tier(block_hashes)
-        .instrument(tracing::info_span!("kv_router.find_matches"));
     join_indexer_and_shared_cache(
         indexer_fut,
         shared_cache,


### PR DESCRIPTION
## Summary

Maintain an index of GMS KV placement and use it in routing policy without coupling the router to a storage backend.

## Scope

Adds the placement indexer and policy. Worker publication and decode-to-decode orchestration remain in the final PR.

## Stack

Position **17/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-09-1-router-event-plane-gms-d2d-protocol`.

Parent: #10450  
Tracking: #10457

## Review migration

This existing PR is updated in place so its comments and reviews remain attached. Line comments may appear outdated where code moved during the rebase; they remain visible and should be dispositioned against the current diff. Previous approvals should be revalidated.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

Passed `cargo check -p dynamo-kv-router -p dynamo-llm --all-targets` at this stack boundary before the exact latest-main rebase.