### PR TITLE
feat(router): wire GMS decode-to-decode orchestration [GMS 18/18]

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -39,6 +39,7 @@ _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "router_track_output_blocks",
     "router_assume_kv_reuse",
     "router_track_prefill_tokens",
+    "router_gms_decode_transfer",
     "router_prefill_load_model",
     "router_snapshot_threshold",
     "router_reset_states",
@@ -122,6 +123,7 @@ class KvRouterConfigBase(ConfigBase):
     router_track_output_blocks: bool
     router_assume_kv_reuse: bool
     router_track_prefill_tokens: bool
+    router_gms_decode_transfer: bool
     router_prefill_load_model: str
     router_snapshot_threshold: int
     router_reset_states: bool
@@ -341,6 +343,18 @@ class KvRouterArgGroup(ArgGroup):
                 "KV Router: Include prompt-side prefill tokens in active load accounting. "
                 "Use --no-router-track-prefill-tokens to ignore prompt tokens in router "
                 "prefill-token load, queue pressure, and active_prefill_tokens metrics."
+            ),
+        )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--router-gms-decode-transfer",
+            env_var="DYN_ROUTER_GMS_DECODE_TRANSFER",
+            default=False,
+            dest="router_gms_decode_transfer",
+            help=(
+                "[EXPERIMENTAL] KV Router: Enable GMS decode-to-decode KV transfer "
+                "orchestration for GMS-capable aggregated decode workers. Disabled "
+                "by default so vanilla Dynamo routing behavior is unchanged."
             ),
         )
         add_argument(

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -357,6 +357,78 @@ def test_load_aware_frontend_implies_kv_router_mode() -> None:
     assert config.router_assume_kv_reuse is False
 
 
+def test_bulwark_gateway_endpoint_requires_private_namespace() -> None:
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        ["--bulwark-gateway-endpoint", "dyn://public.backend.generate"]
+    )
+    config = FrontendConfig.from_cli_args(args)
+
+    with pytest.raises(ValueError, match="requires --namespace"):
+        config.validate()
+
+
+def test_bulwark_gateway_endpoint_rejects_non_endpoint_path() -> None:
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--bulwark-gateway-endpoint",
+            "public.backend.generate",
+            "--namespace",
+            "private-workers",
+        ]
+    )
+    config = FrontendConfig.from_cli_args(args)
+
+    with pytest.raises(ValueError, match="dyn://"):
+        config.validate()
+
+
+def test_bulwark_gateway_endpoint_validates() -> None:
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--bulwark-gateway-endpoint",
+            "dyn://public.backend.generate",
+            "--namespace-prefix",
+            "private-workers",
+        ]
+    )
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.bulwark_gateway_endpoint == "dyn://public.backend.generate"
+    assert config.namespace_prefix == "private-workers"
+
+
+def test_bulwark_gateway_exact_namespace_uses_worker_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DYN_NAMESPACE_WORKER_SUFFIX", "replica-a")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--bulwark-gateway-endpoint",
+            "dyn://public.backend.generate",
+            "--namespace",
+            "private-workers",
+        ]
+    )
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.namespace == "private-workers-replica-a"
+    assert config.namespace_prefix is None
+
+
 def test_frontend_admission_control_defaults_to_none(monkeypatch) -> None:
     """Default --admission-control is 'none': busy thresholds are cleared
     even though the underlying threshold flags have non-None defaults."""

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -213,6 +213,7 @@ async def worker(runtime: DistributedRuntime):
         f"router_track_output_blocks={config.router_track_output_blocks}, "
         f"router_assume_kv_reuse={config.router_assume_kv_reuse}, "
         f"router_track_prefill_tokens={config.router_track_prefill_tokens}, "
+        f"router_gms_decode_transfer={config.router_gms_decode_transfer}, "
         f"router_ttl_secs={config.router_ttl_secs}"
     )
 

--- a/lib/bench/kv_router/common/replay.rs
+++ b/lib/bench/kv_router/common/replay.rs
@@ -24,10 +24,18 @@ pub fn process_mooncake_trace(
     let trace = Trace::from_mooncake(std::path::Path::new(path), block_size as usize)?
         .expand_hash_prefix_depth(trace_length_factor)
         .duplicate_hash_space(trace_duplication_factor);
-    Ok(trace.partition_by_session(SessionPartitionSpec::Random {
+    let partitions = trace.partition_by_session(SessionPartitionSpec::Random {
         num_partitions: num_workers,
         seed,
-    }))
+    });
+    let non_empty = partitions
+        .into_iter()
+        .filter(|trace| !trace.sessions.is_empty())
+        .collect::<Vec<_>>();
+    if non_empty.is_empty() {
+        anyhow::bail!("mooncake trace produced no non-empty worker partitions");
+    }
+    Ok(non_empty)
 }
 
 pub fn maybe_rescale_ready_span(

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1028,6 +1028,58 @@ impl KvEventPublisher {
         })
     }
 
+    #[pyo3(signature = (source_nixl_agent_name, source_nixl_agent_metadata_hex, blocks, source_nixl_ip=None, source_nixl_listen_port=None, dp_rank=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn publish_gms_placement_stored(
+        &self,
+        py: Python,
+        source_nixl_agent_name: String,
+        source_nixl_agent_metadata_hex: String,
+        blocks: Bound<PyAny>,
+        source_nixl_ip: Option<String>,
+        source_nixl_listen_port: Option<u16>,
+        dp_rank: Option<DpRank>,
+    ) -> PyResult<()> {
+        let blocks: Vec<GmsPlacementBlock> = depythonize(&blocks).map_err(to_pyerr)?;
+        let inner = self.inner.clone();
+        let dp_rank = dp_rank.unwrap_or(self.dp_rank);
+        py.allow_threads(|| {
+            inner
+                .publish_gms_placement(
+                    GmsPlacementEventData::Stored(GmsPlacementStoreData {
+                        source_nixl_agent_name,
+                        source_nixl_agent_metadata_hex,
+                        source_nixl_ip,
+                        source_nixl_listen_port,
+                        blocks,
+                    }),
+                    StorageTier::External,
+                    dp_rank,
+                )
+                .map_err(to_pyerr)
+        })
+    }
+
+    #[pyo3(signature = (content_hashes_hex, dp_rank=None))]
+    fn publish_gms_placement_removed(
+        &self,
+        py: Python,
+        content_hashes_hex: Vec<String>,
+        dp_rank: Option<DpRank>,
+    ) -> PyResult<()> {
+        let inner = self.inner.clone();
+        let dp_rank = dp_rank.unwrap_or(self.dp_rank);
+        py.allow_threads(|| {
+            inner
+                .publish_gms_placement(
+                    GmsPlacementEventData::Removed(GmsPlacementRemoveData { content_hashes_hex }),
+                    StorageTier::External,
+                    dp_rank,
+                )
+                .map_err(to_pyerr)
+        })
+    }
+
     fn shutdown(&mut self) {
         // If no other Arc clones exist, shut down eagerly.
         // Otherwise the Drop impl handles cleanup when the last reference is freed.

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1142,6 +1142,26 @@ class KvEventPublisher:
         """
         ...
 
+    def publish_gms_placement_stored(
+        self,
+        source_nixl_agent_name: str,
+        source_nixl_agent_metadata_hex: str,
+        blocks: List[Dict[str, Any]],
+        source_nixl_ip: Optional[str] = None,
+        source_nixl_listen_port: Optional[int] = None,
+        dp_rank: Optional[int] = None,
+    ) -> None:
+        """Publish GMS placement descriptors through the KV event plane."""
+        ...
+
+    def publish_gms_placement_removed(
+        self,
+        content_hashes_hex: List[str],
+        dp_rank: Optional[int] = None,
+    ) -> None:
+        """Remove GMS placement descriptors from the router's event-plane index."""
+        ...
+
     def shutdown(self) -> None:
         """
         Shuts down the event publisher, stopping any background tasks.


### PR DESCRIPTION
## Summary

Complete the train by publishing worker placement state to the router and using it to orchestrate decode-to-decode KV transfer.

## Scope

Adds worker publication, router consumption, and final D2D orchestration on top of the protocol and indexer from positions 16-17.

## Stack

Position **18/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-09-2-router-event-plane-gms-d2d-indexer`.

Parent: #10450  
Tracking: #10457 #10458

## Review migration

This existing PR is updated in place so its comments and reviews remain attached. Line comments may appear outdated where code moved during the rebase; they remain visible and should be dispositioned against the current diff. Previous approvals should be revalidated.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

The final tree is whitespace-clean and preserves the validated reordered functionality, with only the documented compatibility-hunk move and unused-constant removal.