### PR TITLE
fix(frontend): set HTTP status worker type

### DIFF
--- a/tests/frontend/http_status_propagation_worker.py
+++ b/tests/frontend/http_status_propagation_worker.py
@@ -10,7 +10,7 @@ import asyncio
 
 import uvloop
 
-from dynamo.llm import ModelInput, ModelType, register_model
+from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
 from dynamo.runtime import DistributedRuntime
 from tests.frontend.test_http_status_propagation import (
     ENDPOINT_PATH,
@@ -45,6 +45,7 @@ async def main():
         endpoint,
         QWEN,
         model_name=MODEL_NAME,
+        worker_type=WorkerType.Aggregated,
     )
     await endpoint.serve_endpoint(generate)
 


### PR DESCRIPTION
#### Overview:

Fix the HTTP status propagation test worker added by #10364 to pass the now-required `worker_type` argument to `register_model`.

#### Details:

- Import `WorkerType` in `tests/frontend/http_status_propagation_worker.py`.
- Register the self-contained HTTP status propagation worker as `WorkerType.Aggregated`.
- This mirrors the follow-up made for `tests/frontend/realtime_echo_worker.py` in #10447 and covers the additional worker introduced by #10364.

#### Where should the reviewer start?

`tests/frontend/http_status_propagation_worker.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #10364.
- Relates to #10447.
- Relates to full CI failures in `dynamo-runtime / test / sequential cuda13.0` for amd64 and arm64.

#### Testing:

- `pre-commit run ruff --files tests/frontend/http_status_propagation_worker.py tests/frontend/test_http_status_propagation.py`
- `pre-commit run black --files tests/frontend/http_status_propagation_worker.py tests/frontend/test_http_status_propagation.py`
- `pytest -q tests/frontend/test_http_status_propagation.py`
- Commit hook passed: isort, black, flake8, codespell, ruff, pytest marker report, and other configured hooks.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for HTTP status propagation validation with explicit worker type configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->