### PR TITLE
docs(llm): clarify runtime config ownership

### DIFF
--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -347,6 +347,8 @@ def build_runtime_config(
     engine_args: MockEngineArgs,
 ) -> tuple[int, ModelRuntimeConfig]:
     rc = ModelRuntimeConfig()
+    # Mocker does not enforce a model context limit.
+    rc.context_length = 0
     rc.total_kv_blocks = engine_args.num_gpu_blocks
     rc.max_num_seqs = engine_args.max_num_seqs
     if rc.max_num_seqs is None:

--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -204,7 +204,6 @@ async def launch_workers(args: argparse.Namespace, base_engine_args):
             model_path=args.model_path,
             model_name=args.model_name,
             endpoint_id=args.endpoint,
-            context_length=0,
             extra_engine_args=None,
             mocker_engine_args=worker_engine_args,
             runtime_config=runtime_config,

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -84,6 +84,7 @@ def test_build_runtime_config_uses_normalized_sglang_page_size_alias():
     block_size, runtime_config = CONFIG.build_runtime_config(engine_args)
 
     assert block_size == 16
+    assert runtime_config.context_length == 0
     assert runtime_config.total_kv_blocks == 16384
     assert runtime_config.max_num_seqs == 256
     assert runtime_config.max_num_batched_tokens == 8192

--- a/components/src/dynamo/planner/connectors/mdc.py
+++ b/components/src/dynamo/planner/connectors/mdc.py
@@ -125,6 +125,9 @@ def worker_info_from_mdc(
             model_name = None
 
     k8s_name = k8s_name_override if k8s_name_override is not None else defaults.k8s_name
+    context_length = runtime_cfg.get("context_length")
+    if context_length is None:
+        context_length = card.get("architectural_max_context_length")
 
     return WorkerInfo(
         k8s_name=k8s_name,
@@ -135,5 +138,5 @@ def worker_info_from_mdc(
         kv_cache_block_size=card.get("kv_cache_block_size"),
         max_num_seqs=runtime_cfg.get("max_num_seqs"),
         max_num_batched_tokens=runtime_cfg.get("max_num_batched_tokens"),
-        context_length=card.get("context_length"),
+        context_length=context_length,
     )

--- a/components/src/dynamo/planner/tests/unit/test_mdc.py
+++ b/components/src/dynamo/planner/tests/unit/test_mdc.py
@@ -79,11 +79,12 @@ def _card(worker_type: str = "decode", **runtime_config_overrides) -> dict:
         "model_type": 2,  # Completions
         "worker_type": worker_type,
         "kv_cache_block_size": 16,
-        "context_length": 8192,
+        "architectural_max_context_length": 32768,
         "runtime_config": {
             "total_kv_blocks": 1024,
             "max_num_seqs": 256,
             "max_num_batched_tokens": 8192,
+            "context_length": 8192,
             **runtime_config_overrides,
         },
     }
@@ -173,7 +174,7 @@ class TestWorkerInfoFromMdc:
         assert info.total_kv_blocks is None
         # Non-runtime_config fields still populate
         assert info.kv_cache_block_size == 16
-        assert info.context_length == 8192
+        assert info.context_length == 32768
 
     def test_non_dict_runtime_config_treated_as_missing(self):
         card = _card()
@@ -183,13 +184,17 @@ class TestWorkerInfoFromMdc:
         assert info.max_num_batched_tokens is None
         assert info.total_kv_blocks is None
         assert info.max_num_seqs is None
+        assert info.context_length == 32768
+
+    def test_runtime_context_zero_does_not_fall_back(self):
+        entry = MdcEntry(card_json=_card(context_length=0))
+        info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
+        assert info.context_length == 0
 
     def test_empty_card_json(self):
         entry = MdcEntry(card_json={})
         info = worker_info_from_mdc(entry, SubComponentType.DECODE, backend="vllm")
-        # Component/endpoint/k8s_name from defaults
         assert info.component_name == "backend"
-        # Runtime fields all None
         assert info.max_num_batched_tokens is None
         assert info.model_name is None
 

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -103,7 +103,6 @@ async def _register_model_with_runtime_config(
             endpoint,
             server_args.model_path,
             server_args.served_model_name,
-            context_length=server_args.context_length,
             kv_cache_block_size=server_args.page_size,
             runtime_config=runtime_config,
             custom_template_path=dynamo_args.custom_jinja_template,
@@ -272,6 +271,7 @@ async def _get_runtime_config(
         ModelRuntimeConfig with extracted values, or None if extraction fails.
     """
     runtime_config = ModelRuntimeConfig()
+    runtime_config.context_length = server_args.context_length
     # set reasoning parser and tool call parser
     runtime_config.reasoning_parser = dynamo_args.dyn_reasoning_parser
     runtime_config.tool_call_parser = dynamo_args.dyn_tool_call_parser

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -520,6 +520,7 @@ async def init_llm_worker(
         # So for now, we just set the parsers from the config
         # TODO: fix this once we have a better way to get total_kv_blocks
         runtime_config = ModelRuntimeConfig()
+        runtime_config.context_length = config.max_seq_len
 
         # Set values from config that are available immediately
         # Note: We populate max_num_seqs and max_num_batched_tokens from config
@@ -703,7 +704,6 @@ async def init_llm_worker(
             endpoint,
             config.model,
             config.served_model_name,
-            context_length=config.max_seq_len,
             kv_cache_block_size=config.kv_block_size,
             runtime_config=runtime_config,
             custom_template_path=config.custom_jinja_template,

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1552,6 +1552,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             }
 
                             runtime_config = ModelRuntimeConfig()
+                            runtime_config.context_length = self.model_max_len
                             runtime_config.tool_call_parser = (
                                 self.config.dyn_tool_call_parser
                             )

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -674,6 +674,7 @@ async def register_vllm_model(
             (list of alternative AND-sets).
     """
     runtime_config = ModelRuntimeConfig()
+    runtime_config.context_length = vllm_config.model_config.max_model_len
 
     # Get runtime configuration from vLLM engine
     logging.info(
@@ -753,7 +754,6 @@ async def register_vllm_model(
         generate_endpoint,
         config.model,
         config.served_model_name,
-        context_length=vllm_config.model_config.max_model_len,
         kv_cache_block_size=runtime_values["kv_event_block_size"],
         runtime_config=runtime_config,
         custom_template_path=config.custom_jinja_template,

--- a/examples/backends/tritonserver/src/tritonworker.py
+++ b/examples/backends/tritonserver/src/tritonworker.py
@@ -12,13 +12,7 @@ import uvloop
 from google.protobuf import text_format
 from tritonclient.utils import triton_to_np_dtype
 
-from dynamo.llm import (
-    ModelInput,
-    ModelRuntimeConfig,
-    ModelType,
-    WorkerType,
-    register_model,
-)
+from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -146,9 +140,6 @@ async def triton_worker(runtime: DistributedRuntime, args: argparse.Namespace):
         "triton_model_config": triton_model_config.SerializeToString(),
     }
 
-    runtime_config = ModelRuntimeConfig()
-    runtime_config.set_tensor_model_config(model_config)
-
     logger.info("Attempting to register model with Dynamo runtime...")
     # Use register_model for tensor-based models (skips HuggingFace downloads)
     await register_model(
@@ -156,8 +147,8 @@ async def triton_worker(runtime: DistributedRuntime, args: argparse.Namespace):
         ModelType.TensorBased,
         endpoint,
         model_name,  # model_path (used as display name for tensor-based models)
-        runtime_config=runtime_config,
         worker_type=WorkerType.Aggregated,
+        tensor_model_config=model_config,
     )
     logger.info(
         f"✓ Successfully registered model '{model_name}' with endpoint triton/tritonserver/generate"

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1178,6 +1178,7 @@ async fn build_local_model(
     };
 
     let rt_cfg = ModelRuntimeConfig {
+        context_length: engine_config.context_length,
         total_kv_blocks: engine_config.total_kv_blocks,
         max_num_seqs: engine_config.max_num_seqs,
         max_num_batched_tokens: engine_config.max_num_batched_tokens,
@@ -1198,7 +1199,6 @@ async fn build_local_model(
     let mut builder = LocalModelBuilder::default();
     builder
         .model_name(served_name)
-        .context_length(engine_config.context_length)
         .kv_cache_block_size(engine_config.kv_cache_block_size)
         .custom_template_path(config.custom_jinja_template.clone())
         .runtime_config(rt_cfg);
@@ -1392,6 +1392,7 @@ mod tests {
         };
         let engine_config = EngineConfig {
             model: "nvidia/Kimi-K2.5-NVFP4".to_string(),
+            context_length: Some(32_768),
             total_kv_blocks: Some(100),
             max_num_seqs: Some(16),
             max_num_batched_tokens: Some(8192),
@@ -1406,6 +1407,7 @@ mod tests {
         let local_model = build_local_model(&config, &engine_config).await.unwrap();
         let runtime_config = local_model.runtime_config();
 
+        assert_eq!(runtime_config.context_length, Some(32_768));
         assert_eq!(runtime_config.total_kv_blocks, Some(100));
         assert_eq!(runtime_config.max_num_seqs, Some(16));
         assert_eq!(runtime_config.max_num_batched_tokens, Some(8192));

--- a/lib/bindings/python/examples/cli/cli.py
+++ b/lib/bindings/python/examples/cli/cli.py
@@ -24,7 +24,13 @@ from pathlib import Path
 
 import uvloop
 
-from dynamo.llm import EngineType, EntrypointArgs, make_engine, run_input
+from dynamo.llm import (
+    EngineType,
+    EntrypointArgs,
+    ModelRuntimeConfig,
+    make_engine,
+    run_input,
+)
 from dynamo.runtime import DistributedRuntime
 
 
@@ -136,7 +142,9 @@ async def run():
     if flags.model_name is not None:
         entrypoint_kwargs["model_name"] = flags.model_name
     if flags.context_length is not None:
-        entrypoint_kwargs["context_length"] = flags.context_length
+        runtime_config = ModelRuntimeConfig()
+        runtime_config.context_length = flags.context_length
+        entrypoint_kwargs["runtime_config"] = runtime_config
     if flags.template_file is not None:
         entrypoint_kwargs["template_file"] = flags.template_file
     if flags.kv_cache_block_size is not None:

--- a/lib/bindings/python/rust/kserve_grpc.rs
+++ b/lib/bindings/python/rust/kserve_grpc.rs
@@ -9,9 +9,12 @@ use llm_rs::model_type::{ModelInput, ModelType};
 use pyo3::prelude::*;
 
 use crate::{
-    CancellationToken, DistributedRuntime, engine::*, llm::local_model::ModelRuntimeConfig,
+    CancellationToken, DistributedRuntime,
+    engine::*,
+    llm::local_model::{ModelRuntimeConfig, parse_tensor_model_config},
     to_pyerr,
 };
+use pyo3::types::PyDict;
 
 pub use dynamo_llm::grpc::service::kserve;
 
@@ -67,22 +70,25 @@ impl KserveGrpcService {
             .map_err(to_pyerr)
     }
 
-    #[pyo3(signature = (model, checksum, engine, runtime_config=None))]
+    #[pyo3(signature = (model, checksum, engine, *, runtime_config=None, tensor_model_config=None))]
     pub fn add_tensor_model(
         &self,
         model: String,
         checksum: String,
         engine: PythonAsyncEngine,
         runtime_config: Option<ModelRuntimeConfig>,
+        tensor_model_config: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<()> {
-        // If runtime_config is provided, create and save a ModelDeploymentCard
-        // so the ModelConfig endpoint can return model configuration
-        if let Some(runtime_config) = runtime_config {
-            runtime_config.validate_config()?;
+        let tensor_model_config = parse_tensor_model_config(tensor_model_config)?;
+        if runtime_config.is_some() || tensor_model_config.is_some() {
             let mut card = RsModelDeploymentCard::with_name_only(&model);
             card.model_type = ModelType::TensorBased;
             card.model_input = ModelInput::Tensor;
-            card.runtime_config = runtime_config.inner;
+            if let Some(runtime_config) = runtime_config {
+                runtime_config.validate_config()?;
+                card.runtime_config = runtime_config.inner;
+            }
+            card.tensor_model_config = tensor_model_config;
 
             self.inner
                 .model_manager()

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -40,7 +40,7 @@ use dynamo_llm::{self as llm_rs};
 
 use crate::llm::entrypoint::RouterConfig as PyRouterConfig;
 
-use crate::llm::local_model::{ModelRuntimeConfig, RoutingConstraints};
+use crate::llm::local_model::{ModelRuntimeConfig, RoutingConstraints, parse_tensor_model_config};
 use crate::llm::preprocessor::{MediaDecoder, MediaFetcher};
 
 #[pyclass(eq, eq_int)]
@@ -332,7 +332,7 @@ fn resolve_routing_image_token_id(model_id: &str, model_dir: &str) -> Option<u32
 /// For LoRA mode, both `lora_name` and `base_model_path` must be provided together.
 /// Providing only one of them will result in an error.
 #[pyfunction]
-#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, worker_type=None, needs=None, self_host_metadata=None))]
+#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, worker_type=None, needs=None, self_host_metadata=None, *, tensor_model_config=None))]
 #[allow(clippy::too_many_arguments)]
 fn register_model<'p>(
     py: Python<'p>,
@@ -341,7 +341,6 @@ fn register_model<'p>(
     endpoint: Endpoint,
     model_path: &str,
     model_name: Option<&str>,
-    context_length: Option<u32>,
     kv_cache_block_size: Option<u32>,
     router_config: Option<PyRouterConfig>,
     runtime_config: Option<ModelRuntimeConfig>,
@@ -354,6 +353,7 @@ fn register_model<'p>(
     worker_type: Option<WorkerType>,
     needs: Option<Vec<Vec<WorkerType>>>,
     self_host_metadata: Option<bool>,
+    tensor_model_config: Option<&Bound<'p, PyDict>>,
 ) -> PyResult<Bound<'p, PyAny>> {
     // Every worker registers with an explicit `worker_type`. Reject `None`
     // outright — a missing role would produce a card whose readiness math
@@ -415,6 +415,12 @@ fn register_model<'p>(
     let is_realtime = model_type.inner.supports_realtime();
 
     let model_type_obj = model_type.inner;
+    let tensor_model_config = parse_tensor_model_config(tensor_model_config)?;
+    if tensor_model_config.is_some() && !is_tensor_based {
+        return Err(PyValueError::new_err(
+            "tensor_model_config is only valid for TensorBased models",
+        ));
+    }
 
     // Model-serving-readiness fields on the MDC. `worker_type` is required
     // (see the check above). Non-Aggregated workers must declare their peers
@@ -497,6 +503,8 @@ fn register_model<'p>(
     }
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let runtime_config = runtime_config.unwrap_or_default();
+
         // For TensorBased, Images, Videos, and Realtime models, skip
         // HuggingFace downloads and register directly. These model types
         // handle model loading internally; no tokenizer extraction is
@@ -510,9 +518,8 @@ fn register_model<'p>(
             card.needs = needs_value.clone();
             card.user_data = user_data_json;
 
-            if let Some(cfg) = runtime_config {
-                card.runtime_config = cfg.inner;
-            }
+            card.runtime_config = runtime_config.inner;
+            card.tensor_model_config = tensor_model_config;
             card.router_config = explicit_router_config.clone();
 
             // Register the Model Deployment Card via discovery interface
@@ -553,10 +560,9 @@ fn register_model<'p>(
             .source_path(source_path.clone().into())
             // --served_model_name
             .model_name(model_name.clone())
-            .context_length(context_length)
             .kv_cache_block_size(kv_cache_block_size)
             .router_config(explicit_router_config.clone())
-            .runtime_config(runtime_config.unwrap_or_default().inner)
+            .runtime_config(runtime_config.inner)
             .user_data(user_data_json)
             .custom_template_path(custom_template_path_owned)
             .media_decoder(media_decoder.map(|m| m.inner))

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -437,7 +437,6 @@ pub(crate) struct EntrypointArgs {
     model_path: Option<PathBuf>,
     model_name: Option<String>,
     endpoint_id: Option<EndpointId>,
-    context_length: Option<u32>,
     template_file: Option<PathBuf>,
     router_config: Option<RouterConfig>,
     kv_cache_block_size: Option<u32>,
@@ -463,14 +462,13 @@ pub(crate) struct EntrypointArgs {
 impl EntrypointArgs {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, mocker_engine_args=None, runtime_config=None, namespace=None, namespace_prefix=None, is_prefill=false, is_decode=false, migration_limit=0, migration_max_seq_len=None, chat_engine_factory=None, aic_perf_config=None))]
+    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, mocker_engine_args=None, runtime_config=None, namespace=None, namespace_prefix=None, is_prefill=false, is_decode=false, migration_limit=0, migration_max_seq_len=None, chat_engine_factory=None, aic_perf_config=None))]
     pub fn new(
         py: Python<'_>,
         engine_type: EngineType,
         model_path: Option<PathBuf>,
         model_name: Option<String>, // e.g. "dyn://namespace.component.endpoint"
         endpoint_id: Option<String>,
-        context_length: Option<u32>,
         template_file: Option<PathBuf>,
         router_config: Option<RouterConfig>,
         kv_cache_block_size: Option<u32>,
@@ -524,7 +522,6 @@ impl EntrypointArgs {
             model_path,
             model_name,
             endpoint_id: endpoint_id_obj,
-            context_length,
             template_file,
             router_config,
             kv_cache_block_size,
@@ -571,7 +568,6 @@ pub fn make_engine<'p>(
                 .or_else(|| args.model_path.clone().map(|p| p.display().to_string())),
         )
         .endpoint_id(args.endpoint_id.clone())
-        .context_length(args.context_length)
         .request_template(args.template_file.clone())
         .kv_cache_block_size(args.kv_cache_block_size)
         .router_config(args.router_config.clone().map(|rc| rc.into()))

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -12,6 +12,7 @@ use llm_rs::local_model::runtime_config::ModelRuntimeConfig as RsModelRuntimeCon
 use llm_rs::local_model::runtime_config::StructuralTagMode as RsStructuralTagMode;
 use llm_rs::local_model::runtime_config::StructuralTagSchemaMode as RsStructuralTagSchemaMode;
 use llm_rs::local_model::runtime_config::StructuralTagScope as RsStructuralTagScope;
+use llm_rs::protocols::tensor::TensorModelConfig;
 use pyo3::exceptions::PyValueError;
 
 fn validate_model_runtime_config(config: &RsModelRuntimeConfig) -> PyResult<()> {
@@ -72,6 +73,20 @@ impl ModelRuntimeConfig {
     }
 }
 
+pub(crate) fn parse_tensor_model_config(
+    tensor_model_config: Option<&Bound<'_, PyDict>>,
+) -> PyResult<Option<TensorModelConfig>> {
+    tensor_model_config
+        .map(|config| {
+            pythonize::depythonize(config).map_err(|err| {
+                PyErr::new::<PyException, _>(format!(
+                    "Failed to convert tensor_model_config: {err}"
+                ))
+            })
+        })
+        .transpose()
+}
+
 #[pymethods]
 impl ModelRuntimeConfig {
     #[new]
@@ -86,6 +101,11 @@ impl ModelRuntimeConfig {
     #[setter]
     fn set_total_kv_blocks(&mut self, total_kv_blocks: u64) {
         self.inner.total_kv_blocks = Some(total_kv_blocks);
+    }
+
+    #[setter]
+    fn set_context_length(&mut self, context_length: Option<u32>) {
+        self.inner.context_length = context_length;
     }
 
     #[setter]
@@ -159,30 +179,14 @@ impl ModelRuntimeConfig {
         Ok(())
     }
 
-    fn set_tensor_model_config(
-        &mut self,
-        _py: Python<'_>,
-        tensor_model_config: &Bound<'_, PyDict>,
-    ) -> PyResult<()> {
-        let tensor_model_config = pythonize::depythonize(tensor_model_config).map_err(|err| {
-            PyErr::new::<PyException, _>(format!("Failed to convert tensor_model_config: {}", err))
-        })?;
-        self.inner.tensor_model_config = Some(tensor_model_config);
-        Ok(())
-    }
-
-    fn get_tensor_model_config(&self, _py: Python<'_>) -> PyResult<Option<PyObject>> {
-        if let Some(tensor_model_config) = &self.inner.tensor_model_config {
-            let py_obj = pythonize::pythonize(_py, tensor_model_config).map_err(to_pyerr)?;
-            Ok(Some(py_obj.unbind()))
-        } else {
-            Ok(None)
-        }
-    }
-
     #[getter]
     fn total_kv_blocks(&self) -> Option<u64> {
         self.inner.total_kv_blocks
+    }
+
+    #[getter]
+    fn context_length(&self) -> Option<u32> {
+        self.inner.context_length
     }
 
     #[getter]

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -717,6 +717,7 @@ class ModelRuntimeConfig:
     A model runtime configuration is a collection of runtime information
     """
 
+    context_length: int | None
     total_kv_blocks: int | None
     max_num_seqs: int | None
     max_num_batched_tokens: int | None
@@ -734,7 +735,6 @@ class ModelRuntimeConfig:
     kv_transfer_domain: str | None
     kv_transfer_enforcement: str | None
     kv_transfer_preferred_weight: float | None
-    tensor_model_config: Any | None
     bootstrap_host: str | None
     bootstrap_port: int | None
 
@@ -766,14 +766,6 @@ class ModelRuntimeConfig:
             bootstrap_port: int | None = None,
         ) -> None:
         """Set the disaggregated endpoint for the model"""
-        ...
-
-    def set_tensor_model_config(self, tensor_model_config: Dict[str, Any]) -> None:
-        """Set the tensor model configuration from a dictionary."""
-        ...
-
-    def get_tensor_model_config(self) -> Any | None:
-        """Get the tensor model configuration."""
         ...
 
 class RoutingConstraints:
@@ -1375,7 +1367,9 @@ class KserveGrpcService:
         model: str,
         checksum: str,
         engine: PythonAsyncEngine,
-        runtime_config: Optional[ModelRuntimeConfig],
+        *,
+        runtime_config: Optional[ModelRuntimeConfig] = None,
+        tensor_model_config: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Register a tensor-based model with the service.
@@ -1384,6 +1378,8 @@ class KserveGrpcService:
             model: The model name
             checksum: The model checksum
             engine: The async engine to handle requests
+            runtime_config: Optional runtime-resolved worker metadata
+            tensor_model_config: Optional tensor protocol model metadata
         """
         ...
 
@@ -2120,10 +2116,10 @@ async def register_model(
     model_name: Optional[str] = None,
     *,
     worker_type: WorkerType,
-    context_length: Optional[int] = None,
     kv_cache_block_size: Optional[int] = None,
     router_mode: Optional[RouterMode] = None,
     runtime_config: Optional[ModelRuntimeConfig] = None,
+    tensor_model_config: Optional[Dict[str, Any]] = None,
     user_data: Optional[Dict[str, Any]] = None,
     custom_template_path: Optional[str] = None,
     media_decoder: Optional[MediaDecoder] = None,
@@ -2142,7 +2138,7 @@ async def register_model(
 
     For TensorBased models (using ModelInput.Tensor), HuggingFace downloads are skipped
     and a minimal model card is registered directly. Use model_path as the display name
-    for these models.
+    for these models. Pass tensor protocol metadata through `tensor_model_config`.
 
     Model serving readiness:
         `worker_type` and `needs` describe the worker's processing stage and
@@ -2778,7 +2774,6 @@ class EntrypointArgs:
         model_path: Optional[str] = None,
         model_name: Optional[str] = None,
         endpoint_id: Optional[str] = None,
-        context_length: Optional[int] = None,
         template_file: Optional[str] = None,
         router_config: Optional[RouterConfig] = None,
         kv_cache_block_size: Optional[int] = None,
@@ -2806,7 +2801,6 @@ class EntrypointArgs:
             model_path: Path to the model directory on disk
             model_name: Model name or dynamo endpoint (e.g. 'dyn://namespace.component.endpoint')
             endpoint_id: Optional endpoint ID
-            context_length: Optional context length override
             template_file: Optional path to a prompt template file
             router_config: Optional router configuration
             kv_cache_block_size: Optional KV cache block size

--- a/lib/bindings/python/tests/test_kserve_grpc.py
+++ b/lib/bindings/python/tests/test_kserve_grpc.py
@@ -65,6 +65,7 @@ def tensor_service(runtime):
         model_name: str,
         *,
         runtime_config: Optional[ModelRuntimeConfig] = None,
+        tensor_model_config: Optional[dict[str, Any]] = None,
         checksum: str = "dummy-mdcsum",
     ) -> AsyncIterator[Tuple[str, int]]:
         host = "127.0.0.1"
@@ -74,7 +75,11 @@ def tensor_service(runtime):
         tensor_model_service = KserveGrpcService(port=port, host=host)
 
         tensor_model_service.add_tensor_model(
-            model_name, checksum, engine, runtime_config=runtime_config
+            model_name,
+            checksum,
+            engine,
+            runtime_config=runtime_config,
+            tensor_model_config=tensor_model_config,
         )
 
         async def _serve():
@@ -94,8 +99,8 @@ def tensor_service(runtime):
 
 @pytest.mark.asyncio
 @pytest.mark.forked
-async def test_model_config_uses_runtime_config(tensor_service):
-    """Ensure tensor runtime_config is returned via the ModelConfig endpoint."""
+async def test_model_config_uses_tensor_model_config(tensor_service):
+    """Ensure tensor metadata is returned via the ModelConfig endpoint."""
     import tritonclient.grpc as grpcclient
 
     model_name = "tensor-config-model"
@@ -109,10 +114,7 @@ async def test_model_config_uses_runtime_config(tensor_service):
             {"name": "results", "data_type": "Bytes", "shape": [-1]},
         ],
     }
-    runtime_config = ModelRuntimeConfig()
-    runtime_config.set_tensor_model_config(tensor_config)
-
-    async with tensor_service(model_name, runtime_config=runtime_config) as (
+    async with tensor_service(model_name, tensor_model_config=tensor_config) as (
         host,
         port,
     ):
@@ -140,12 +142,12 @@ async def test_model_config_uses_runtime_config(tensor_service):
 
 @pytest.mark.asyncio
 @pytest.mark.forked
-async def test_model_config_missing_runtime_config_errors(tensor_service):
-    """ModelConfig should return NOT_FOUND when no tensor runtime_config is saved."""
+async def test_model_config_missing_tensor_config_errors(tensor_service):
+    """ModelConfig should return NOT_FOUND when no tensor metadata is saved."""
     model_name = "tensor-config-missing"
     import tritonclient.grpc as grpcclient
 
-    async with tensor_service(model_name, runtime_config=None) as (host, port):
+    async with tensor_service(model_name) as (host, port):
         client = grpcclient.InferenceServerClient(url=f"{host}:{port}")
         try:
             with pytest.raises(InferenceServerException) as excinfo:

--- a/lib/bindings/python/tests/test_tensor.py
+++ b/lib/bindings/python/tests/test_tensor.py
@@ -8,13 +8,7 @@ import os
 import pytest
 import uvloop
 
-from dynamo.llm import (
-    ModelInput,
-    ModelRuntimeConfig,
-    ModelType,
-    WorkerType,
-    register_model,
-)
+from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
 from dynamo.runtime import DistributedRuntime
 
 TEST_END_TO_END = os.environ.get("TEST_END_TO_END", 0)
@@ -39,19 +33,14 @@ async def test_register(runtime: DistributedRuntime):
         ],
         "outputs": [{"name": "output_text", "data_type": "Bytes", "shape": [-1]}],
     }
-    runtime_config = ModelRuntimeConfig()
-    runtime_config.set_tensor_model_config(model_config)
-
-    assert model_config == runtime_config.get_tensor_model_config()
-
     # Use register_model for tensor-based backends (skips HuggingFace downloads)
     await register_model(
         ModelInput.Tensor,
         ModelType.TensorBased,
         endpoint,
         "tensor",  # model_path (used as display name for tensor-based models)
-        runtime_config=runtime_config,
         worker_type=WorkerType.Aggregated,
+        tensor_model_config=model_config,
     )
 
     if TEST_END_TO_END:

--- a/lib/llm/src/grpc/service/kserve.rs
+++ b/lib/llm/src/grpc/service/kserve.rs
@@ -11,7 +11,6 @@ use crate::http::service::Metrics;
 use crate::http::service::service_v2 as http_service;
 
 use crate::discovery::ModelManager;
-use crate::local_model::runtime_config::ModelRuntimeConfig;
 use crate::protocols::tensor::TensorModelConfig;
 use crate::protocols::tensor::{NvCreateTensorRequest, NvCreateTensorResponse};
 use crate::request_template::RequestTemplate;
@@ -300,8 +299,10 @@ enum Config {
 }
 
 impl Config {
-    fn from_runtime_config(runtime_config: &ModelRuntimeConfig) -> Result<Config, anyhow::Error> {
-        if let Some(tensor_model_config) = runtime_config.tensor_model_config.as_ref() {
+    fn from_tensor_model_config(
+        tensor_model_config: Option<&TensorModelConfig>,
+    ) -> Result<Config, anyhow::Error> {
+        if let Some(tensor_model_config) = tensor_model_config {
             if let Some(triton_model_config) = tensor_model_config.triton_model_config.as_ref() {
                 let model_config = ModelConfig::decode(triton_model_config.as_slice())?;
                 Ok(Config::Triton(model_config))
@@ -576,12 +577,13 @@ impl GrpcInferenceService for KserveService {
             .find(|card| request_model_name == &card.display_name)
         {
             if card.model_type.supports_tensor() {
-                let config = Config::from_runtime_config(&card.runtime_config).map_err(|e| {
-                    Status::invalid_argument(format!(
-                        "Model '{}' has type Tensor but: {}",
-                        request_model_name, e
-                    ))
-                })?;
+                let config = Config::from_tensor_model_config(card.tensor_model_config.as_ref())
+                    .map_err(|e| {
+                        Status::invalid_argument(format!(
+                            "Model '{}' has type Tensor but: {}",
+                            request_model_name, e
+                        ))
+                    })?;
                 match config {
                     Config::Triton(model_config) => {
                         return Ok(Response::new(ModelMetadataResponse {
@@ -695,12 +697,13 @@ impl GrpcInferenceService for KserveService {
             .find(|card| request_model_name == &card.display_name)
         {
             if card.model_type.supports_tensor() {
-                let config = Config::from_runtime_config(&card.runtime_config).map_err(|e| {
-                    Status::invalid_argument(format!(
-                        "Model '{}' has type Tensor but: {}",
-                        request_model_name, e
-                    ))
-                })?;
+                let config = Config::from_tensor_model_config(card.tensor_model_config.as_ref())
+                    .map_err(|e| {
+                        Status::invalid_argument(format!(
+                            "Model '{}' has type Tensor but: {}",
+                            request_model_name, e
+                        ))
+                    })?;
                 match config {
                     Config::Triton(model_config) => {
                         return Ok(Response::new(ModelConfigResponse {

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -518,7 +518,7 @@ fn build_model_context_map(state: &service_v2::State) -> std::collections::HashM
         .manager()
         .get_model_cards()
         .iter()
-        .map(|c| (c.display_name.clone(), c.context_length))
+        .map(|c| (c.display_name.clone(), c.effective_context_length()))
         .collect()
 }
 

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1002,7 +1002,7 @@ impl Metrics {
 
         self.model_context_length
             .with_label_values(&[&card.display_name])
-            .set(card.context_length as i64);
+            .set(card.effective_context_length() as i64);
 
         self.model_kv_cache_block_size
             .with_label_values(&[&card.display_name])

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2280,7 +2280,7 @@ async fn list_models_openai(
     let cards = state.manager().get_model_cards();
     let card_map: HashMap<String, u32> = cards
         .iter()
-        .map(|c| (c.display_name.clone(), c.context_length))
+        .map(|c| (c.display_name.clone(), c.effective_context_length()))
         .collect();
 
     // Env var overrides (take precedence over MDC values)
@@ -2439,7 +2439,7 @@ async fn get_model_openai(
     let context_length = cards
         .iter()
         .find(|c| c.display_name == model_id)
-        .map(|c| c.context_length as u64);
+        .map(|c| c.effective_context_length() as u64);
     let context_window: Option<u64> = std::env::var("DYN_CONTEXT_WINDOW")
         .ok()
         .and_then(|v| v.parse().ok())

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -54,7 +54,6 @@ pub struct LocalModelBuilder {
     source_path: Option<PathBuf>,
     model_name: Option<String>,
     endpoint_id: Option<EndpointId>,
-    context_length: Option<u32>,
     template_file: Option<PathBuf>,
     router_config: Option<RouterConfig>,
     kv_cache_block_size: u32,
@@ -90,7 +89,6 @@ impl Default for LocalModelBuilder {
             source_path: Default::default(),
             model_name: Default::default(),
             endpoint_id: Default::default(),
-            context_length: Default::default(),
             template_file: Default::default(),
             router_config: Default::default(),
             migration_limit: Default::default(),
@@ -131,11 +129,6 @@ impl LocalModelBuilder {
 
     pub fn endpoint_id(&mut self, endpoint_id: Option<EndpointId>) -> &mut Self {
         self.endpoint_id = endpoint_id;
-        self
-    }
-
-    pub fn context_length(&mut self, context_length: Option<u32>) -> &mut Self {
-        self.context_length = context_length;
         self
     }
 
@@ -331,11 +324,6 @@ impl LocalModelBuilder {
         card.set_name(self.model_name.as_deref().unwrap_or(&alt));
 
         card.kv_cache_block_size = self.kv_cache_block_size;
-
-        // Override max number of tokens in context. We usually only do this to limit kv cache allocation.
-        if let Some(context_length) = self.context_length {
-            card.context_length = context_length;
-        }
 
         card.migration_limit = self.migration_limit;
         card.user_data = self.user_data.take();

--- a/lib/llm/src/local_model/CLAUDE.md
+++ b/lib/llm/src/local_model/CLAUDE.md
@@ -1,8 +1,10 @@
 # Local Model Metadata
 
 `ModelRuntimeConfig` is intended for facts resolved authoritatively after an
-engine starts, such as effective limits, capacity, data-parallel placement, and
-resolved service endpoints.
+engine starts. `context_length` is the effective limit enforced by the running
+engine; the static model maximum belongs in
+`ModelDeploymentCard::architectural_max_context_length`. Tensor model
+configuration is model metadata and belongs at the top level of the card.
 
 Some existing fields do not yet follow this ownership boundary. In particular,
 declarative model, frontend, routing, worker-placement, and deployment policy

--- a/lib/llm/src/local_model/CLAUDE.md
+++ b/lib/llm/src/local_model/CLAUDE.md
@@ -1,0 +1,11 @@
+# Local Model Metadata
+
+`ModelRuntimeConfig` is intended for facts resolved authoritatively after an
+engine starts, such as effective limits, capacity, data-parallel placement, and
+resolved service endpoints.
+
+Some existing fields do not yet follow this ownership boundary. In particular,
+declarative model, frontend, routing, worker-placement, and deployment policy
+should generally live in dedicated metadata rather than being added to runtime
+config. Preserve current behavior when working in this area, and avoid adding
+more statically known configuration to `ModelRuntimeConfig`.

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -56,6 +56,30 @@ pub struct DisaggregatedEndpoint {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Validate)]
 #[validate(schema(function = "validate_model_runtime_config"))]
+/// Runtime-resolved metadata published by a worker after its engine starts.
+///
+/// NOTE: This type is intended for facts that can only be known authoritatively at
+/// runtime, such as effective engine limits, capacity, data-parallel placement, and
+/// resolved service endpoints. Declarative model, frontend, routing, and deployment
+/// policy should live in dedicated metadata instead of accumulating here.
+///
+/// TODO(metadata ownership): Refine this boundary without changing behavior until the
+/// corresponding producers and consumers can migrate together.
+///
+/// - Move `ModelDeploymentCard::context_length` here as the effective engine serving
+///   limit. Preserve any static architectural maximum separately in model metadata.
+/// - Move and rename `ModelDeploymentCard::kv_cache_block_size` to
+///   `kv_event_block_size`. This is the router/KV-event hashing granularity, not
+///   necessarily the engine's physical KV block size; preserve the current fallback
+///   value of 16 during the migration.
+/// - Move frontend policy out: tool/reasoning parsers, structural-tag settings, and
+///   tool filtering behavior.
+/// - Move worker identity and placement metadata out: local-indexer availability,
+///   taints, stable routing identity, topology domains, and KV-transfer policy.
+/// - Move tensor model configuration to model metadata and speculative-decoding
+///   capability to engine metadata.
+/// - Audit `runtime_data` and retain only extensions that are genuinely resolved at
+///   runtime.
 pub struct ModelRuntimeConfig {
     pub total_kv_blocks: Option<u64>,
 

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -9,7 +9,6 @@ use std::{
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use validator::{Validate, ValidationError};
 
-use crate::protocols::tensor;
 use dynamo_kv_router::protocols::KvTransferEnforcement;
 
 /// Re-export from parsers crate so that `ModelRuntimeConfig` can use it
@@ -59,28 +58,14 @@ pub struct DisaggregatedEndpoint {
 /// Runtime-resolved metadata published by a worker after its engine starts.
 ///
 /// NOTE: This type is intended for facts that can only be known authoritatively at
-/// runtime, such as effective engine limits, capacity, data-parallel placement, and
-/// resolved service endpoints. Declarative model, frontend, routing, and deployment
-/// policy should live in dedicated metadata instead of accumulating here.
-///
-/// TODO(metadata ownership): Refine this boundary without changing behavior until the
-/// corresponding producers and consumers can migrate together.
-///
-/// - Move `ModelDeploymentCard::context_length` here as the effective engine serving
-///   limit. Preserve any static architectural maximum separately in model metadata.
-/// - Move and rename `ModelDeploymentCard::kv_cache_block_size` to
-///   `kv_event_block_size`. This is the router/KV-event hashing granularity, not
-///   necessarily the engine's physical KV block size; preserve the current fallback
-///   value of 16 during the migration.
-/// - Move frontend policy out: tool/reasoning parsers, structural-tag settings, and
-///   tool filtering behavior.
-/// - Move worker identity and placement metadata out: local-indexer availability,
-///   taints, stable routing identity, topology domains, and KV-transfer policy.
-/// - Move tensor model configuration to model metadata and speculative-decoding
-///   capability to engine metadata.
-/// - Audit `runtime_data` and retain only extensions that are genuinely resolved at
-///   runtime.
+/// runtime, such as the effective engine context limit, capacity, data-parallel
+/// placement, and resolved service endpoints. Some legacy fields do not yet follow
+/// this ownership boundary; avoid adding declarative model metadata here.
 pub struct ModelRuntimeConfig {
+    /// Effective context limit enforced by the running engine.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<u32>,
+
     pub total_kv_blocks: Option<u64>,
 
     pub max_num_seqs: Option<u64>,
@@ -122,16 +107,6 @@ pub struct ModelRuntimeConfig {
     /// Mapping of engine-specific runtime configs
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub runtime_data: HashMap<String, serde_json::Value>,
-
-    // Provide tensor model config in the case where the model type is Tensor.
-    // Currently use JSON object for convinence, the programmatic way is to
-    // define the model config struct as part of the tensor protocol and
-    // import it here.
-    // [gluo TODO] switch to ModelConfig if desired and workout a way to
-    // prepare it in a convinent way, the protobuf library used by tonic
-    // doesn't provide JSON parsing.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tensor_model_config: Option<tensor::TensorModelConfig>,
 
     /// Bootstrap endpoint for disaggregated serving (prefill workers publish this)
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -204,6 +179,7 @@ const fn default_eagle() -> bool {
 impl Default for ModelRuntimeConfig {
     fn default() -> Self {
         Self {
+            context_length: None,
             total_kv_blocks: None,
             max_num_seqs: None,
             max_num_batched_tokens: None,
@@ -217,7 +193,6 @@ impl Default for ModelRuntimeConfig {
             data_parallel_size: default_data_parallel_size(),
             enable_local_indexer: true,
             runtime_data: HashMap::new(),
-            tensor_model_config: None,
             disaggregated_endpoint: None,
             enable_eagle: false,
             taints: HashSet::new(),
@@ -501,6 +476,7 @@ mod tests {
         let cfg = ModelRuntimeConfig::default();
         let json = serde_json::to_string(&cfg).unwrap();
         assert!(!json.contains("stable_routing_id"));
+        assert!(!json.contains("context_length"));
     }
 
     #[test]

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -20,6 +20,7 @@ use crate::common::checked_file::CheckedFile;
 use crate::entrypoint::RouterConfig;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 use crate::model_type::{ModelInput, ModelType};
+use crate::protocols::tensor::TensorModelConfig;
 use anyhow::{Context, Result};
 use derive_builder::Builder;
 use dynamo_runtime::{slug::Slug, storage::kv};
@@ -671,8 +672,10 @@ pub struct ModelDeploymentCard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_context: Option<Vec<PromptContextMixin>>,
 
-    /// Max context (in number of tokens) this model can handle
-    pub context_length: u32,
+    /// Architectural context maximum derived from model or tokenizer metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub architectural_max_context_length: Option<u32>,
 
     /// Size of a KV cache block.
     /// Passed to the engine, KV router, and trace replay hash path.
@@ -724,6 +727,11 @@ pub struct ModelDeploymentCard {
 
     #[serde(default)]
     pub runtime_config: ModelRuntimeConfig,
+
+    /// Tensor model configuration for tensor-serving protocols.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub tensor_model_config: Option<TensorModelConfig>,
 
     /// Media decoding configuration
     #[serde(default)]
@@ -816,6 +824,14 @@ impl ModelDeploymentCard {
         &self.slug
     }
 
+    /// Effective serving context: runtime engine limit, then architectural maximum.
+    pub fn effective_context_length(&self) -> u32 {
+        self.runtime_config
+            .context_length
+            .or(self.architectural_max_context_length)
+            .unwrap_or(0)
+    }
+
     /// Serialize the model deployment card to a JSON string
     pub fn to_json(&self) -> Result<String, anyhow::Error> {
         Ok(serde_json::to_string(self)?)
@@ -872,7 +888,7 @@ impl ModelDeploymentCard {
                     // fine. If the debug representation changes that only happens in a new release.
                     bytes_to_hash.extend(format!("{prompt_context_vec:?}").as_bytes());
                 }
-                bytes_to_hash.extend(self.context_length.to_be_bytes());
+                bytes_to_hash.extend(self.effective_context_length().to_be_bytes());
                 bytes_to_hash.extend(self.kv_cache_block_size.to_be_bytes());
 
                 // Topology fields participate in the checksum so that a rolling
@@ -1408,7 +1424,7 @@ impl ModelDeploymentCard {
         let local_path = local_path.as_ref();
 
         // This is usually the right choice
-        let context_length =
+        let architectural_max_context_length =
             crate::file_json_field(&local_path.join("config.json"), "max_position_embeddings")
                 // But sometimes this is
                 .or_else(|_| {
@@ -1417,8 +1433,8 @@ impl ModelDeploymentCard {
                         "model_max_length",
                     )
                 })
-                // If neither of those are present let the engine default it
-                .unwrap_or(0);
+                .ok()
+                .filter(|context_length| *context_length > 0);
 
         let is_mistral_model = is_exclusively_mistral_model(local_path);
 
@@ -1473,7 +1489,7 @@ impl ModelDeploymentCard {
             prompt_formatter,
             chat_template_file,
             prompt_context: None, // TODO - auto-detect prompt context
-            context_length,
+            architectural_max_context_length,
             kv_cache_block_size: 0, // set later
             migration_limit: 0,
             model_type: Default::default(),  // set later
@@ -1483,6 +1499,7 @@ impl ModelDeploymentCard {
             lora: None,
             user_data: None,
             runtime_config: ModelRuntimeConfig::default(),
+            tensor_model_config: None,
             media_decoder: None,
             media_fetcher: None,
             router_config: None,
@@ -2353,6 +2370,48 @@ mod tests {
         );
         assert!(slug.path().join("special_tokens_map.json").exists());
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod ownership_tests {
+    use super::*;
+
+    #[test]
+    fn effective_context_prefers_runtime_then_architecture_then_unknown() {
+        let mut card = ModelDeploymentCard::with_name_only("model");
+        assert_eq!(card.effective_context_length(), 0);
+
+        card.architectural_max_context_length = Some(32_768);
+        assert_eq!(card.effective_context_length(), 32_768);
+
+        card.runtime_config.context_length = Some(8_192);
+        assert_eq!(card.effective_context_length(), 8_192);
+
+        card.runtime_config.context_length = Some(0);
+        assert_eq!(card.effective_context_length(), 0);
+    }
+
+    #[test]
+    fn tensor_config_serializes_at_card_top_level() {
+        let mut card = ModelDeploymentCard::with_name_only("tensor");
+        card.tensor_model_config = Some(TensorModelConfig {
+            name: "tensor".to_string(),
+            ..Default::default()
+        });
+
+        let value = serde_json::to_value(&card).unwrap();
+        assert_eq!(value["tensor_model_config"]["name"], "tensor");
+        assert!(value["runtime_config"].get("tensor_model_config").is_none());
+
+        let parsed: ModelDeploymentCard = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            parsed
+                .tensor_model_config
+                .as_ref()
+                .map(|config| config.name.as_str()),
+            Some("tensor")
+        );
     }
 }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -427,12 +427,12 @@ impl OpenAIPreprocessor {
             }
         };
 
+        let context_length = mdc.effective_context_length();
+
         let media_loader = match mdc.media_decoder {
             Some(media_decoder) => Some(MediaLoader::new(media_decoder, mdc.media_fetcher)?),
             None => None,
         };
-
-        let context_length = mdc.context_length;
 
         #[cfg(feature = "mm-routing")]
         let (image_token_counter, routing_image_token_id, bos_token_string) =

--- a/lib/llm/tests/kserve_service.rs
+++ b/lib/llm/tests/kserve_service.rs
@@ -25,7 +25,6 @@ pub mod kserve_test {
     pub mod inference {
         tonic::include_proto!("inference");
     }
-    use dynamo_llm::local_model::runtime_config::ModelRuntimeConfig;
     use dynamo_llm::model_card::ModelDeploymentCard;
     use dynamo_llm::model_type::{ModelInput, ModelType};
     use dynamo_llm::protocols::tensor;
@@ -1166,25 +1165,22 @@ pub mod kserve_test {
         let mut card = ModelDeploymentCard::with_name_only("tensor");
         card.model_type = ModelType::TensorBased;
         card.model_input = ModelInput::Tensor;
-        card.runtime_config = ModelRuntimeConfig {
-            tensor_model_config: Some(tensor::TensorModelConfig {
-                name: "tensor".to_string(),
-                inputs: vec![tensor::TensorMetadata {
-                    name: "input".to_string(),
-                    data_type: tensor::DataType::Int32,
-                    shape: vec![3],
-                    parameters: Default::default(),
-                }],
-                outputs: vec![tensor::TensorMetadata {
-                    name: "output".to_string(),
-                    data_type: tensor::DataType::Bool,
-                    shape: vec![-1],
-                    parameters: Default::default(),
-                }],
-                triton_model_config: None,
-            }),
-            ..Default::default()
-        };
+        card.tensor_model_config = Some(tensor::TensorModelConfig {
+            name: "tensor".to_string(),
+            inputs: vec![tensor::TensorMetadata {
+                name: "input".to_string(),
+                data_type: tensor::DataType::Int32,
+                shape: vec![3],
+                parameters: Default::default(),
+            }],
+            outputs: vec![tensor::TensorMetadata {
+                name: "output".to_string(),
+                data_type: tensor::DataType::Bool,
+                shape: vec![-1],
+                parameters: Default::default(),
+            }],
+            triton_model_config: None,
+        });
         let tensor = Arc::new(TensorEngine {});
         service_with_engines
             .0
@@ -1268,13 +1264,10 @@ pub mod kserve_test {
         let mut card = ModelDeploymentCard::with_name_only(model_name);
         card.model_type = ModelType::TensorBased;
         card.model_input = ModelInput::Tensor;
-        card.runtime_config = ModelRuntimeConfig {
-            tensor_model_config: Some(tensor::TensorModelConfig {
-                triton_model_config: Some(buf.clone()),
-                ..Default::default()
-            }),
+        card.tensor_model_config = Some(tensor::TensorModelConfig {
+            triton_model_config: Some(buf.clone()),
             ..Default::default()
-        };
+        });
         let tensor = Arc::new(TensorEngine {});
         service_with_engines
             .0
@@ -1318,25 +1311,22 @@ pub mod kserve_test {
         let mut card = ModelDeploymentCard::with_name_only("tensor");
         card.model_type = ModelType::TensorBased;
         card.model_input = ModelInput::Tensor;
-        card.runtime_config = ModelRuntimeConfig {
-            tensor_model_config: Some(tensor::TensorModelConfig {
-                name: "tensor".to_string(),
-                inputs: vec![tensor::TensorMetadata {
-                    name: "input".to_string(),
-                    data_type: tensor::DataType::Int32,
-                    shape: vec![1],
-                    parameters: Default::default(),
-                }],
-                outputs: vec![tensor::TensorMetadata {
-                    name: "output".to_string(),
-                    data_type: tensor::DataType::Bool,
-                    shape: vec![-1],
-                    parameters: Default::default(),
-                }],
-                triton_model_config: Some(buf.clone()),
-            }),
-            ..Default::default()
-        };
+        card.tensor_model_config = Some(tensor::TensorModelConfig {
+            name: "tensor".to_string(),
+            inputs: vec![tensor::TensorMetadata {
+                name: "input".to_string(),
+                data_type: tensor::DataType::Int32,
+                shape: vec![1],
+                parameters: Default::default(),
+            }],
+            outputs: vec![tensor::TensorMetadata {
+                name: "output".to_string(),
+                data_type: tensor::DataType::Bool,
+                shape: vec![-1],
+                parameters: Default::default(),
+            }],
+            triton_model_config: Some(buf.clone()),
+        });
         let _ = service_with_engines
             .0
             .model_manager()
@@ -1368,13 +1358,10 @@ pub mod kserve_test {
         let mut card = ModelDeploymentCard::with_name_only(model_name);
         card.model_type = ModelType::TensorBased;
         card.model_input = ModelInput::Tensor;
-        card.runtime_config = ModelRuntimeConfig {
-            tensor_model_config: Some(tensor::TensorModelConfig {
-                triton_model_config: Some(vec![1, 2, 3, 4, 5]),
-                ..Default::default()
-            }),
+        card.tensor_model_config = Some(tensor::TensorModelConfig {
+            triton_model_config: Some(vec![1, 2, 3, 4, 5]),
             ..Default::default()
-        };
+        });
         let _ = service_with_engines
             .0
             .model_manager()
@@ -1484,25 +1471,22 @@ pub mod kserve_test {
         let mut card = ModelDeploymentCard::with_name_only("tensor");
         card.model_type = ModelType::TensorBased;
         card.model_input = ModelInput::Tensor;
-        card.runtime_config = ModelRuntimeConfig {
-            tensor_model_config: Some(tensor::TensorModelConfig {
-                name: "tensor".to_string(),
-                inputs: vec![tensor::TensorMetadata {
-                    name: "input".to_string(),
-                    data_type: tensor::DataType::Bytes,
-                    shape: vec![1],
-                    parameters: Default::default(),
-                }],
-                outputs: vec![tensor::TensorMetadata {
-                    name: "output".to_string(),
-                    data_type: tensor::DataType::Bool,
-                    shape: vec![-1],
-                    parameters: Default::default(),
-                }],
-                triton_model_config: None,
-            }),
-            ..Default::default()
-        };
+        card.tensor_model_config = Some(tensor::TensorModelConfig {
+            name: "tensor".to_string(),
+            inputs: vec![tensor::TensorMetadata {
+                name: "input".to_string(),
+                data_type: tensor::DataType::Bytes,
+                shape: vec![1],
+                parameters: Default::default(),
+            }],
+            outputs: vec![tensor::TensorMetadata {
+                name: "output".to_string(),
+                data_type: tensor::DataType::Bool,
+                shape: vec![-1],
+                parameters: Default::default(),
+            }],
+            triton_model_config: None,
+        });
         let _ = service_with_engines
             .0
             .model_manager()
@@ -1871,25 +1855,22 @@ pub mod kserve_test {
         let mut tensor_card = ModelDeploymentCard::with_name_only("test_tensor_model");
         tensor_card.model_type = ModelType::TensorBased;
         tensor_card.model_input = ModelInput::Tensor;
-        tensor_card.runtime_config = ModelRuntimeConfig {
-            tensor_model_config: Some(tensor::TensorModelConfig {
-                name: "test_tensor_model".to_string(),
-                inputs: vec![tensor::TensorMetadata {
-                    name: "input".to_string(),
-                    data_type: tensor::DataType::Int32,
-                    shape: vec![1],
-                    parameters: Default::default(),
-                }],
-                outputs: vec![tensor::TensorMetadata {
-                    name: "output".to_string(),
-                    data_type: tensor::DataType::Int32,
-                    shape: vec![1],
-                    parameters: Default::default(),
-                }],
-                triton_model_config: None,
-            }),
-            ..Default::default()
-        };
+        tensor_card.tensor_model_config = Some(tensor::TensorModelConfig {
+            name: "test_tensor_model".to_string(),
+            inputs: vec![tensor::TensorMetadata {
+                name: "input".to_string(),
+                data_type: tensor::DataType::Int32,
+                shape: vec![1],
+                parameters: Default::default(),
+            }],
+            outputs: vec![tensor::TensorMetadata {
+                name: "output".to_string(),
+                data_type: tensor::DataType::Int32,
+                shape: vec![1],
+                parameters: Default::default(),
+            }],
+            triton_model_config: None,
+        });
         manager
             .add_tensor_model(
                 "test_tensor_model",
@@ -2016,25 +1997,22 @@ pub mod kserve_test {
         let mut card = ModelDeploymentCard::with_name_only("tensor");
         card.model_type = ModelType::TensorBased;
         card.model_input = ModelInput::Tensor;
-        card.runtime_config = ModelRuntimeConfig {
-            tensor_model_config: Some(tensor::TensorModelConfig {
-                name: "tensor".to_string(),
-                inputs: vec![tensor::TensorMetadata {
-                    name: "input".to_string(),
-                    data_type: tensor::DataType::Int32,
-                    shape: vec![1],
-                    parameters: Default::default(),
-                }],
-                outputs: vec![tensor::TensorMetadata {
-                    name: "output".to_string(),
-                    data_type: tensor::DataType::Bool,
-                    shape: vec![-1],
-                    parameters: Default::default(),
-                }],
-                triton_model_config: None,
-            }),
-            ..Default::default()
-        };
+        card.tensor_model_config = Some(tensor::TensorModelConfig {
+            name: "tensor".to_string(),
+            inputs: vec![tensor::TensorMetadata {
+                name: "input".to_string(),
+                data_type: tensor::DataType::Int32,
+                shape: vec![1],
+                parameters: Default::default(),
+            }],
+            outputs: vec![tensor::TensorMetadata {
+                name: "output".to_string(),
+                data_type: tensor::DataType::Bool,
+                shape: vec![-1],
+                parameters: Default::default(),
+            }],
+            triton_model_config: None,
+        });
         let tensor = Arc::new(TensorEngine {});
         service
             .model_manager()

--- a/lib/llm/tests/model_card.rs
+++ b/lib/llm/tests/model_card.rs
@@ -9,12 +9,15 @@ const HF_PATH: &str = "tests/data/sample-models/TinyLlama_v1.1";
 #[tokio::test]
 async fn test_model_info_from_hf_like_local_repo() {
     let mdc = ModelDeploymentCard::load_from_disk(HF_PATH, None).unwrap();
-    let info = mdc.model_info.unwrap().get_model_info().unwrap();
+    let info = mdc.model_info.as_ref().unwrap().get_model_info().unwrap();
     assert_eq!(info.model_type(), "llama");
     assert_eq!(info.bos_token_id(), Some(1));
     assert_eq!(info.eos_token_ids(), vec![2]);
     assert_eq!(info.max_position_embeddings(), Some(2048));
     assert_eq!(info.vocab_size(), Some(32000));
+    assert_eq!(mdc.architectural_max_context_length, Some(2048));
+    assert_eq!(mdc.runtime_config.context_length, None);
+    assert_eq!(mdc.effective_context_length(), 2048);
 }
 
 #[tokio::test]

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -714,7 +714,7 @@ mod context_length_validation {
     async fn test_prompt_exceeding_context_length_returns_400() {
         let mut mdc = ModelDeploymentCard::load_from_disk(MODEL_PATH, None).unwrap();
         // Set a very small context length so even a short prompt exceeds it
-        mdc.context_length = 5;
+        mdc.runtime_config.context_length = Some(5);
 
         let preprocessor = OpenAIPreprocessor::new(mdc).unwrap();
         let request = make_chat_request(
@@ -748,7 +748,7 @@ mod context_length_validation {
     async fn test_prompt_exactly_at_context_length_returns_400() {
         let mut mdc = ModelDeploymentCard::load_from_disk(MODEL_PATH, None).unwrap();
         // First, preprocess with a large context_length to discover the token count
-        mdc.context_length = 131072;
+        mdc.runtime_config.context_length = Some(131072);
         let preprocessor = OpenAIPreprocessor::new(mdc.clone()).unwrap();
         let request = make_chat_request(
             r#"[{"role": "user", "content": "What is deep learning?"}]"#,
@@ -761,7 +761,7 @@ mod context_length_validation {
         let token_count = preprocessed.token_ids.len() as u32;
 
         // Now set context_length to exactly the token count — no room for output
-        mdc.context_length = token_count;
+        mdc.runtime_config.context_length = Some(token_count);
         let preprocessor = OpenAIPreprocessor::new(mdc).unwrap();
         let request = make_chat_request(
             r#"[{"role": "user", "content": "What is deep learning?"}]"#,
@@ -782,7 +782,8 @@ mod context_length_validation {
     async fn test_context_length_zero_skips_validation() {
         let mut mdc = ModelDeploymentCard::load_from_disk(MODEL_PATH, None).unwrap();
         // context_length = 0 means unconfigured, should skip validation
-        mdc.context_length = 0;
+        mdc.runtime_config.context_length = None;
+        mdc.architectural_max_context_length = None;
 
         let preprocessor = OpenAIPreprocessor::new(mdc).unwrap();
         let request = make_chat_request(

--- a/tests/frontend/grpc/echo_tensor_worker.py
+++ b/tests/frontend/grpc/echo_tensor_worker.py
@@ -9,13 +9,7 @@
 import tritonclient.grpc.model_config_pb2 as mc
 import uvloop
 
-from dynamo.llm import (
-    ModelInput,
-    ModelRuntimeConfig,
-    ModelType,
-    WorkerType,
-    register_model,
-)
+from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 
@@ -47,25 +41,14 @@ async def echo_tensor_worker(runtime: DistributedRuntime):
         "outputs": [],
         "triton_model_config": triton_model_config.SerializeToString(),
     }
-    runtime_config = ModelRuntimeConfig()
-    runtime_config.set_tensor_model_config(model_config)
-
-    # Internally the bytes string will be converted to List of int
-    retrieved_model_config = runtime_config.get_tensor_model_config()
-    assert retrieved_model_config is not None
-    retrieved_model_config["triton_model_config"] = bytes(
-        retrieved_model_config["triton_model_config"]
-    )
-    assert model_config == retrieved_model_config
-
     # Use register_model for tensor-based backends (skips HuggingFace downloads)
     await register_model(
         ModelInput.Tensor,
         ModelType.TensorBased,
         endpoint,
         "echo",  # model_path (used as display name for tensor-based models)
-        runtime_config=runtime_config,
         worker_type=WorkerType.Aggregated,
+        tensor_model_config=model_config,
     )
 
     await endpoint.serve_endpoint(generate)

--- a/tests/frontend/http_status_propagation_worker.py
+++ b/tests/frontend/http_status_propagation_worker.py
@@ -10,7 +10,7 @@ import asyncio
 
 import uvloop
 
-from dynamo.llm import ModelInput, ModelType, register_model
+from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
 from dynamo.runtime import DistributedRuntime
 from tests.frontend.test_http_status_propagation import (
     ENDPOINT_PATH,
@@ -45,6 +45,7 @@ async def main():
         endpoint,
         QWEN,
         model_name=MODEL_NAME,
+        worker_type=WorkerType.Aggregated,
     )
     await endpoint.serve_endpoint(generate)
 


### PR DESCRIPTION
Document the intended runtime-only ownership boundary for `ModelRuntimeConfig`. Record the planned field moves while explicitly preserving current behavior until producers and consumers migrate together.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified runtime configuration ownership and boundaries; guidance on where context limits and tensor metadata belong.
* **New Features**
  * Exposed optional model context-length in runtime config for bindings.
  * Added support for passing tensor model metadata via a dedicated tensor config parameter.
* **Refactor**
  * Model context-length is now derived consistently from an effective value; API responses advertising model context windows use this effective value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->