### PR TITLE
docs(agents): add minimal repository instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+- Keep changes focused and reviewable.
+- Use Conventional Commit PR titles: `type(scope): summary`. Accepted types:
+  `feat`, `fix`, `docs`, `test`, `ci`, `refactor`, `perf`, `chore`, `revert`,
+  `style`, and `build`.
+- PR descriptions must include `Summary` and `Validation`.
+- Sign every commit with DCO: `git commit -s`.


### PR DESCRIPTION
## Summary

- Add a minimal root-level `AGENTS.md` for repository-wide agent defaults.
- Keep the file intentionally short: scoped `AGENTS.md` or `CLAUDE.md` files remain the source of detailed local guidance.
- Capture only the core expectations: focused changes, Conventional Commit PR titles, Summary/Validation PR descriptions, and DCO signed commits.

## Validation

- `git diff --check -- AGENTS.md`
- `pre-commit run --files AGENTS.md`
- Commit hooks during `git commit -s -m "docs/agents: add minimal repository instructions"`

## Related Issues

- [x] Confirmed: no related issue