### PR TITLE
docs: add v1.3.0-dev.1 to support matrix and release artifacts

### DIFF
--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -202,7 +202,7 @@ For backend version pins, see the version-pins table above and the [GitHub Relea
 
 **Pre-Release and Experimental Git Tags**
 
-- **v1.3.0-dev.1**: **Images:** full runtime matrix -- `vllm-runtime` (cuda12/cuda13/efa), `tensorrtllm-runtime` (cuda13/efa), `sglang-runtime` (cuda12/cuda13/efa), plus `dynamo-frontend`, `dynamo-planner`, `kubernetes-operator`, `snapshot-agent`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime`, `kvbm` on [pypi.nvidia.com](https://pypi.nvidia.com/). **Crates:** on [crates.io](https://crates.io/) at `1.3.0-dev.1`. **Helm:** `dynamo-platform` at `1.3.0-dev.1` (see [below](#v130-dev1)).
+- **v1.3.0-dev.1**: **Images:** full runtime matrix -- `vllm-runtime` (cuda12/cuda13/efa), `tensorrtllm-runtime` (cuda13/efa), `sglang-runtime` (cuda12/cuda13/efa), plus `dynamo-frontend`, `dynamo-planner`, `kubernetes-operator`, `snapshot-agent`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime`, `kvbm` on [pypi.nvidia.com](https://pypi.nvidia.com/). **Crates:** on [crates.io](https://crates.io/) at `1.3.0-dev.1`. **Helm:** `dynamo-platform`, `snapshot` at `1.3.0-dev.1` (see [below](#v130-dev1)).
 - **v1.2.0-deepseek-v4-dev.3**: **Images:** `vllm-runtime:*-deepseek-v4-cuda13-dev.3`, `sglang-runtime:*-deepseek-v4-cuda12-dev.3`, `sglang-runtime:*-deepseek-v4-cuda13-dev.3`. **Helm / PyPI:** Not published for this tag (see [Pre-Release Artifacts](#v120-deepseek-v4-dev3)).
 - **v1.1.0-dev.3**: **Images:** `tensorrtllm-runtime:1.1.0-dev.3`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime` on [pypi.nvidia.com](https://pypi.nvidia.com/) (see [below](#v110-dev3)).
 - **v1.1.0-dev.2**: **Images:** `sglang-runtime:1.1.0-dev.2`, `tensorrtllm-runtime:1.1.0-dev.2`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime` on [pypi.nvidia.com](https://pypi.nvidia.com/) (see [below](#v110-dev2)).
@@ -744,9 +744,9 @@ A GitHub or container tag `v1.1.0-dev.N` maps to a wheel version `1.1.0.devN` (f
 ### v1.3.0-dev.1
 
 - **Branch:** [release/1.3.0-dev.1](https://github.com/ai-dynamo/dynamo/tree/release/1.3.0-dev.1)
-- **GitHub Tag:** [v1.3.0-dev.1](https://github.com/ai-dynamo/dynamo/releases/tag/v1.3.0-dev.1)
+- **GitHub Tag:** `v1.3.0-dev.1` *(tag publication pending)*
 - **Backends:** SGLang `0.5.12.post1` | TensorRT-LLM `1.3.0rc17` | vLLM `0.22.0` | NIXL `1.1.0` (vLLM); `1.0.1` (SGLang); `0.10.1` (TRT-LLM)
-- **Coverage:** Full-platform preview of v1.3.0 -- all runtime containers (vLLM and SGLang on CUDA 12 + 13 + EFA, TensorRT-LLM on CUDA 13 + EFA) and component containers, plus `ai-dynamo` / `ai-dynamo-runtime` / `kvbm` wheels, Rust crates, and the `dynamo-platform` Helm chart. Cut from `main` after the TensorRT-LLM `v1.3.0rc17` upgrade; experimental snapshot, not QA-gated.
+- **Coverage:** Full-platform preview of v1.3.0 -- all runtime containers (vLLM and SGLang on CUDA 12 + 13 + EFA, TensorRT-LLM on CUDA 13 + EFA) and component containers, plus `ai-dynamo` / `ai-dynamo-runtime` / `kvbm` wheels, Rust crates, and the `dynamo-platform` and `snapshot` Helm charts. Cut from `main` after the TensorRT-LLM `v1.3.0rc17` upgrade; experimental snapshot, not QA-gated.
 
 #### Container Images
 
@@ -775,7 +775,7 @@ pip install --pre --extra-index-url https://pypi.nvidia.com ai-dynamo==1.3.0.dev
 
 #### Helm Charts
 
-`dynamo-platform` at `1.3.0-dev.1`.
+`dynamo-platform` and `snapshot` at `1.3.0-dev.1`.
 
 #### Rust Crates
 

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -202,6 +202,7 @@ For backend version pins, see the version-pins table above and the [GitHub Relea
 
 **Pre-Release and Experimental Git Tags**
 
+- **v1.3.0-dev.1**: **Images:** full runtime matrix -- `vllm-runtime` (cuda12/cuda13/efa), `tensorrtllm-runtime` (cuda13/efa), `sglang-runtime` (cuda12/cuda13/efa), plus `dynamo-frontend`, `dynamo-planner`, `kubernetes-operator`, `snapshot-agent`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime`, `kvbm` on [pypi.nvidia.com](https://pypi.nvidia.com/). **Crates:** on [crates.io](https://crates.io/) at `1.3.0-dev.1`. **Helm:** `dynamo-platform` at `1.3.0-dev.1` (see [below](#v130-dev1)).
 - **v1.2.0-deepseek-v4-dev.3**: **Images:** `vllm-runtime:*-deepseek-v4-cuda13-dev.3`, `sglang-runtime:*-deepseek-v4-cuda12-dev.3`, `sglang-runtime:*-deepseek-v4-cuda13-dev.3`. **Helm / PyPI:** Not published for this tag (see [Pre-Release Artifacts](#v120-deepseek-v4-dev3)).
 - **v1.1.0-dev.3**: **Images:** `tensorrtllm-runtime:1.1.0-dev.3`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime` on [pypi.nvidia.com](https://pypi.nvidia.com/) (see [below](#v110-dev3)).
 - **v1.1.0-dev.2**: **Images:** `sglang-runtime:1.1.0-dev.2`, `tensorrtllm-runtime:1.1.0-dev.2`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime` on [pypi.nvidia.com](https://pypi.nvidia.com/) (see [below](#v110-dev2)).
@@ -739,6 +740,46 @@ pip install --pre --extra-index-url https://pypi.nvidia.com ai-dynamo==1.1.0.dev
 ```
 
 A GitHub or container tag `v1.1.0-dev.N` maps to a wheel version `1.1.0.devN` (for example `v1.1.0-dev.2` → `==1.1.0.dev2`). Optional extras such as `ai-dynamo[vllm]` use the same flags; pin the version you want from the sections below.
+
+### v1.3.0-dev.1
+
+- **Branch:** [release/1.3.0-dev.1](https://github.com/ai-dynamo/dynamo/tree/release/1.3.0-dev.1)
+- **GitHub Tag:** [v1.3.0-dev.1](https://github.com/ai-dynamo/dynamo/releases/tag/v1.3.0-dev.1)
+- **Backends:** SGLang `0.5.12.post1` | TensorRT-LLM `1.3.0rc17` | vLLM `0.22.0` | NIXL `1.1.0` (vLLM); `1.0.1` (SGLang); `0.10.1` (TRT-LLM)
+- **Coverage:** Full-platform preview of v1.3.0 -- all runtime containers (vLLM and SGLang on CUDA 12 + 13 + EFA, TensorRT-LLM on CUDA 13 + EFA) and component containers, plus `ai-dynamo` / `ai-dynamo-runtime` / `kvbm` wheels, Rust crates, and the `dynamo-platform` Helm chart. Cut from `main` after the TensorRT-LLM `v1.3.0rc17` upgrade; experimental snapshot, not QA-gated.
+
+#### Container Images
+
+| Image:Tag | Backend | CUDA | Arch |
+|-----------|---------|------|------|
+| `vllm-runtime:1.3.0-dev.1-cuda13` | vLLM `v0.22.0` | `v13.0` | AMD64/ARM64 |
+| `vllm-runtime:1.3.0-dev.1-cuda12` | vLLM `v0.22.0` | `v12.9` | AMD64/ARM64 |
+| `vllm-runtime:1.3.0-dev.1-efa` | vLLM `v0.22.0` (AWS EFA) | `v13.0` | AMD64/ARM64 |
+| `tensorrtllm-runtime:1.3.0-dev.1-cuda13` | TensorRT-LLM `v1.3.0rc17` | `v13.1` | AMD64/ARM64 |
+| `tensorrtllm-runtime:1.3.0-dev.1-efa` | TensorRT-LLM `v1.3.0rc17` (AWS EFA) | `v13.1` | AMD64/ARM64 |
+| `sglang-runtime:1.3.0-dev.1-cuda13` | SGLang `v0.5.12.post1` | `v13.0` | AMD64/ARM64 |
+| `sglang-runtime:1.3.0-dev.1-cuda12` | SGLang `v0.5.12.post1` | `v12.9` | AMD64/ARM64 |
+| `sglang-runtime:1.3.0-dev.1-efa` | SGLang `v0.5.12.post1` (AWS EFA) | `v13.0` | AMD64/ARM64 |
+| `dynamo-frontend:1.3.0-dev.1` | -- | -- | AMD64/ARM64 |
+| `dynamo-planner:1.3.0-dev.1` | -- | -- | AMD64/ARM64 |
+| `kubernetes-operator:1.3.0-dev.1` | -- | -- | AMD64/ARM64 |
+| `snapshot-agent:1.3.0-dev.1` | -- | -- | AMD64 |
+
+#### Python Wheels
+
+`ai-dynamo`, `ai-dynamo-runtime`, and `kvbm` at `1.3.0.dev1` on [pypi.nvidia.com](https://pypi.nvidia.com/) (prerelease index, not public PyPI):
+
+```bash
+pip install --pre --extra-index-url https://pypi.nvidia.com ai-dynamo==1.3.0.dev1
+```
+
+#### Helm Charts
+
+`dynamo-platform` at `1.3.0-dev.1`.
+
+#### Rust Crates
+
+Published to [crates.io](https://crates.io/) at `1.3.0-dev.1` (`dynamo-runtime`, `dynamo-llm`, and the dependent workspace crates).
 
 ### v1.2.0-deepseek-v4-dev.3
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -11,7 +11,7 @@ subtitle: Hardware, software, and build compatibility for Dynamo
 
 **Latest stable release:** [v1.2.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0) -- SGLang `0.5.11` (NIXL `1.0.1`) | TensorRT-LLM `1.3.0rc14` (NIXL `0.10.1`) | vLLM `0.20.1` (NIXL `0.10.1`)
 
-**Experimental release:** [v1.3.0-dev.1](https://github.com/ai-dynamo/dynamo/releases/tag/v1.3.0-dev.1) *(full-platform preview of v1.3.0 -- all runtime + component containers, wheels, crates, Helm)* -- SGLang `0.5.12.post1` | TensorRT-LLM `1.3.0rc17` | vLLM `0.22.0` | NIXL `1.1.0` (vLLM); `1.0.1` (SGLang); `0.10.1` (TRT-LLM)
+**Experimental release:** [v1.3.0-dev.1](https://github.com/ai-dynamo/dynamo/tree/release/1.3.0-dev.1) *(full-platform preview of v1.3.0 -- all runtime + component containers, wheels, crates, Helm)* -- SGLang `0.5.12.post1` | TensorRT-LLM `1.3.0rc17` | vLLM `0.22.0` | NIXL `1.1.0` (vLLM); `1.0.1` (SGLang); `0.10.1` (TRT-LLM)
 
 | Requirement | Supported |
 | :--- | :--- |

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -11,7 +11,7 @@ subtitle: Hardware, software, and build compatibility for Dynamo
 
 **Latest stable release:** [v1.2.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0) -- SGLang `0.5.11` (NIXL `1.0.1`) | TensorRT-LLM `1.3.0rc14` (NIXL `0.10.1`) | vLLM `0.20.1` (NIXL `0.10.1`)
 
-**Experimental release:** [v1.2.0-deepseek-v4-dev.3](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0-deepseek-v4-dev.3) *(DeepSeek-V4-Flash / V4-Pro on Blackwell, vLLM + SGLang containers only)* -- vLLM `0.20.1` | SGLang upstream `deepseek-v4-blackwell` preview | NIXL `0.10.1`
+**Experimental release:** [v1.3.0-dev.1](https://github.com/ai-dynamo/dynamo/releases/tag/v1.3.0-dev.1) *(full-platform preview of v1.3.0 -- all runtime + component containers, wheels, crates, Helm)* -- SGLang `0.5.12.post1` | TensorRT-LLM `1.3.0rc17` | vLLM `0.22.0` | NIXL `1.1.0` (vLLM); `1.0.1` (SGLang); `0.10.1` (TRT-LLM)
 
 | Requirement | Supported |
 | :--- | :--- |
@@ -32,6 +32,7 @@ The following table shows the backend framework versions included with each Dyna
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
 | **main (ToT)** | `0.5.11` | `1.3.0rc17` | `0.21.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
+| **v1.3.0-dev.1** *(experimental)* | `0.5.12.post1` | `1.3.0rc17` | `0.22.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
 | **v1.2.0** | `0.5.11` | `1.3.0rc14` | `0.20.1` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
 | **v1.2.0-deepseek-v4-dev.3** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.1` | `0.10.1` |
 | **v1.2.0-deepseek-v4-dev.2** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.0` | `0.10.1` |


### PR DESCRIPTION
Docs-only version bump for the **v1.3.0-dev.1** experimental release (full-platform preview of v1.3.0).

- **support-matrix.md** — added the `v1.3.0-dev.1` backend row (SGLang `0.5.12.post1`, TensorRT-LLM `1.3.0rc17`, vLLM `0.22.0`) and pointed the Experimental-release callout at it.
- **release-artifacts.md** — added the `v1.3.0-dev.1` pre-release list entry and a detailed section (full container matrix, prerelease wheels on `pypi.nvidia.com`, crates, Helm).

Prerelease wheels are published on `pypi.nvidia.com` (not public PyPI), consistent with the existing dev-release pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added v1.3.0-dev.1 pre-release documentation with container images, wheels, Helm charts, and Rust crates across multiple hardware configurations (CUDA12, CUDA13, EFA).
  * Updated support matrix with v1.3.0-dev.1 backend framework versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->