### PR TITLE
feat(llm): add frontend tokio lag admission

### DIFF
--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -29,6 +29,16 @@ def _clear_admission_control_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
+def _clear_frontend_load_admission_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "DYN_FRONTEND_ADMISSION_CONTROL",
+        "DYN_FRONTEND_LAG_THRESHOLD_MS",
+        "DYN_FRONTEND_LAG_CHECK_INTERVAL_MS",
+        "DYN_FRONTEND_LAG_COOLDOWN_MS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
 def test_aic_perf_moe_cli_flows_to_binding_kwargs() -> None:
     parser = argparse.ArgumentParser()
     AicPerfArgGroup().add_arguments(parser)
@@ -476,6 +486,82 @@ def test_frontend_admission_control_defaults_to_none(monkeypatch) -> None:
     assert config.active_prefill_tokens_threshold is None
     assert config.active_prefill_tokens_threshold_frac is None
     assert config.router_queue_threshold == 16.0
+
+
+def test_frontend_load_admission_defaults_to_none(monkeypatch) -> None:
+    _clear_frontend_load_admission_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    config = FrontendConfig.from_cli_args(parser.parse_args([]))
+    config.validate()
+
+    assert config.frontend_admission_control == "none"
+    assert config.frontend_lag_threshold_ms == 50
+    assert config.frontend_lag_check_interval_ms == 10
+    assert config.frontend_lag_cooldown_ms == 1000
+
+
+def test_frontend_load_admission_tokio_lag_cli(monkeypatch) -> None:
+    _clear_frontend_load_admission_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--frontend-admission-control",
+            "tokio-lag",
+            "--frontend-lag-threshold-ms",
+            "75",
+            "--frontend-lag-check-interval-ms",
+            "5",
+            "--frontend-lag-cooldown-ms",
+            "250",
+        ]
+    )
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.frontend_admission_control == "tokio-lag"
+    assert config.frontend_lag_threshold_ms == 75
+    assert config.frontend_lag_check_interval_ms == 5
+    assert config.frontend_lag_cooldown_ms == 250
+
+
+def test_frontend_load_admission_env(monkeypatch) -> None:
+    monkeypatch.setenv("DYN_FRONTEND_ADMISSION_CONTROL", "tokio-lag")
+    monkeypatch.setenv("DYN_FRONTEND_LAG_THRESHOLD_MS", "80")
+    monkeypatch.setenv("DYN_FRONTEND_LAG_CHECK_INTERVAL_MS", "20")
+    monkeypatch.setenv("DYN_FRONTEND_LAG_COOLDOWN_MS", "500")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    config = FrontendConfig.from_cli_args(parser.parse_args([]))
+    config.validate()
+
+    assert config.frontend_admission_control == "tokio-lag"
+    assert config.frontend_lag_threshold_ms == 80
+    assert config.frontend_lag_check_interval_ms == 20
+    assert config.frontend_lag_cooldown_ms == 500
+
+
+def test_frontend_load_admission_rejects_zero_threshold(monkeypatch) -> None:
+    _clear_frontend_load_admission_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--frontend-admission-control",
+            "tokio-lag",
+            "--frontend-lag-threshold-ms",
+            "0",
+        ]
+    )
+    config = FrontendConfig.from_cli_args(args)
+
+    with pytest.raises(ValueError, match="frontend-lag-threshold-ms"):
+        config.validate()
 
 
 def test_admission_control_token_capacity_preserves_busy_thresholds(

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -58,6 +58,10 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     http_port: int
     tls_cert_path: Optional[pathlib.Path]
     tls_key_path: Optional[pathlib.Path]
+    frontend_admission_control: str
+    frontend_lag_threshold_ms: int
+    frontend_lag_check_interval_ms: int
+    frontend_lag_cooldown_ms: int
 
     namespace: Optional[str] = None
     namespace_prefix: Optional[str] = None
@@ -87,6 +91,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     trust_remote_code: bool
 
     _VALID_TOKENIZER_BACKENDS = {"default", "fastokens"}
+    _VALID_FRONTEND_ADMISSION_CONTROLS = {"none", "tokio-lag"}
 
     def validate(self) -> None:
         if self.load_aware:
@@ -114,6 +119,30 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
                 f"--tokenizer: invalid value '{self.tokenizer_backend}' "
                 f"(choose from {sorted(self._VALID_TOKENIZER_BACKENDS)})"
             )
+        if self.frontend_admission_control not in (
+            self._VALID_FRONTEND_ADMISSION_CONTROLS
+        ):
+            raise ValueError(
+                "--frontend-admission-control: invalid value "
+                f"'{self.frontend_admission_control}' "
+                f"(choose from {sorted(self._VALID_FRONTEND_ADMISSION_CONTROLS)})"
+            )
+        if (
+            self.frontend_admission_control == "tokio-lag"
+            and self.frontend_lag_threshold_ms <= 0
+        ):
+            raise ValueError(
+                "--frontend-lag-threshold-ms must be > 0 when tokio-lag admission is enabled"
+            )
+        if (
+            self.frontend_admission_control == "tokio-lag"
+            and self.frontend_lag_check_interval_ms <= 0
+        ):
+            raise ValueError(
+                "--frontend-lag-check-interval-ms must be > 0 when tokio-lag admission is enabled"
+            )
+        if self.frontend_lag_cooldown_ms < 0:
+            raise ValueError("--frontend-lag-cooldown-ms must be >= 0")
         if self.router_prefill_load_model == "aic":
             if self.router_mode != "kv":
                 raise ValueError(
@@ -211,6 +240,45 @@ class FrontendArgGroup(ArgGroup):
             env_var="DYN_HTTP_PORT",
             default=8000,
             help="HTTP port for the engine (u16).",
+            arg_type=int,
+        )
+        add_argument(
+            g,
+            flag_name="--frontend-admission-control",
+            env_var="DYN_FRONTEND_ADMISSION_CONTROL",
+            default="none",
+            help=(
+                "Frontend-local admission control mode. 'none' disables frontend "
+                "load-based rejection; 'tokio-lag' rejects inference requests when "
+                "Tokio scheduling lag exceeds the configured threshold."
+            ),
+            choices=["none", "tokio-lag"],
+        )
+        add_argument(
+            g,
+            flag_name="--frontend-lag-threshold-ms",
+            env_var="DYN_FRONTEND_LAG_THRESHOLD_MS",
+            default=50,
+            help="Tokio scheduling lag threshold for frontend admission, in milliseconds.",
+            arg_type=int,
+        )
+        add_argument(
+            g,
+            flag_name="--frontend-lag-check-interval-ms",
+            env_var="DYN_FRONTEND_LAG_CHECK_INTERVAL_MS",
+            default=10,
+            help="Tokio scheduling lag canary check interval, in milliseconds.",
+            arg_type=int,
+        )
+        add_argument(
+            g,
+            flag_name="--frontend-lag-cooldown-ms",
+            env_var="DYN_FRONTEND_LAG_COOLDOWN_MS",
+            default=1000,
+            help=(
+                "Minimum time to keep frontend admission in overloaded state "
+                "after lag exceeds the threshold, in milliseconds."
+            ),
             arg_type=int,
         )
         add_negatable_bool_argument(

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -249,6 +249,10 @@ async def async_main():
         "kv_cache_block_size": config.kv_cache_block_size,
         "router_config": router_config,
         "migration_limit": config.migration_limit,
+        "frontend_admission_control": config.frontend_admission_control,
+        "frontend_lag_threshold_ms": config.frontend_lag_threshold_ms,
+        "frontend_lag_check_interval_ms": config.frontend_lag_check_interval_ms,
+        "frontend_lag_cooldown_ms": config.frontend_lag_cooldown_ms,
     }
     if config.migration_max_seq_len is not None:
         kwargs["migration_max_seq_len"] = config.migration_max_seq_len

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -19,6 +19,7 @@ use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::RouterConfig as RsRouterConfig;
 use dynamo_llm::entrypoint::input::Input;
 use dynamo_llm::entrypoint::{ChatEngineFactoryCallback, PrefillRoutedEngine};
+use dynamo_llm::http::service::admission::FrontendAdmissionConfig;
 use dynamo_llm::local_model::DEFAULT_HTTP_PORT;
 use dynamo_llm::local_model::{LocalModel, LocalModelBuilder};
 use dynamo_llm::mocker::make_mocker_engine;
@@ -457,13 +458,14 @@ pub(crate) struct EntrypointArgs {
     migration_max_seq_len: Option<u32>,
     chat_engine_factory: Option<PyEngineFactory>,
     aic_perf_config: Option<AicPerfConfig>,
+    frontend_admission_config: FrontendAdmissionConfig,
 }
 
 #[pymethods]
 impl EntrypointArgs {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, mocker_engine_args=None, runtime_config=None, namespace=None, namespace_prefix=None, is_prefill=false, is_decode=false, migration_limit=0, migration_max_seq_len=None, chat_engine_factory=None, aic_perf_config=None))]
+    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, mocker_engine_args=None, runtime_config=None, namespace=None, namespace_prefix=None, is_prefill=false, is_decode=false, migration_limit=0, migration_max_seq_len=None, chat_engine_factory=None, aic_perf_config=None, frontend_admission_control="none", frontend_lag_threshold_ms=50, frontend_lag_check_interval_ms=10, frontend_lag_cooldown_ms=1000))]
     pub fn new(
         py: Python<'_>,
         engine_type: EngineType,
@@ -490,6 +492,10 @@ impl EntrypointArgs {
         migration_max_seq_len: Option<u32>,
         chat_engine_factory: Option<PyObject>,
         aic_perf_config: Option<AicPerfConfig>,
+        frontend_admission_control: &str,
+        frontend_lag_threshold_ms: u64,
+        frontend_lag_check_interval_ms: u64,
+        frontend_lag_cooldown_ms: u64,
     ) -> PyResult<Self> {
         let endpoint_id_obj: Option<EndpointId> = endpoint_id.as_deref().map(EndpointId::from);
         if let Some(runtime_config) = &runtime_config {
@@ -519,6 +525,14 @@ impl EntrypointArgs {
             })
             .transpose()?;
 
+        let frontend_admission_config = FrontendAdmissionConfig::new(
+            frontend_admission_control,
+            frontend_lag_threshold_ms,
+            frontend_lag_check_interval_ms,
+            frontend_lag_cooldown_ms,
+        )
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
         Ok(EntrypointArgs {
             engine_type,
             model_path,
@@ -544,6 +558,7 @@ impl EntrypointArgs {
             migration_max_seq_len,
             chat_engine_factory,
             aic_perf_config,
+            frontend_admission_config,
         })
     }
 }
@@ -577,6 +592,7 @@ pub fn make_engine<'p>(
         .router_config(args.router_config.clone().map(|rc| rc.into()))
         .migration_limit(Some(args.migration_limit))
         .migration_max_seq_len(args.migration_max_seq_len)
+        .frontend_admission_config(args.frontend_admission_config.clone())
         .http_host(args.http_host.clone())
         .http_port(args.http_port)
         .http_metrics_port(args.http_metrics_port)

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2795,8 +2795,13 @@ class EntrypointArgs:
         is_prefill: bool = False,
         is_decode: bool = False,
         migration_limit: int = 0,
+        migration_max_seq_len: Optional[int] = None,
         chat_engine_factory: Optional[Callable] = None,
         aic_perf_config: Optional[AicPerfConfig] = None,
+        frontend_admission_control: str = "none",
+        frontend_lag_threshold_ms: int = 50,
+        frontend_lag_check_interval_ms: int = 10,
+        frontend_lag_cooldown_ms: int = 1000,
     ) -> None:
         """
         Create EntrypointArgs.
@@ -2823,8 +2828,13 @@ class EntrypointArgs:
             is_prefill: Whether this is a prefill worker
             is_decode: Whether this is a decode worker (disaggregated); pairs with a prefill peer for readiness
             migration_limit: Maximum number of request migrations (0=disabled)
+            migration_max_seq_len: Maximum sequence length eligible for request migration
             chat_engine_factory: Optional Python chat completions engine factory callback
             aic_perf_config: Optional AIC perf-model configuration for default KV routing
+            frontend_admission_control: Frontend admission control mode (none or tokio-lag)
+            frontend_lag_threshold_ms: Tokio scheduling lag threshold for frontend admission
+            frontend_lag_check_interval_ms: Tokio scheduling lag canary check interval
+            frontend_lag_cooldown_ms: Frontend admission overload cooldown
         """
         ...
 

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -54,6 +54,8 @@ pub async fn run(
         http_service_builder.cancel_token(Some(distributed_runtime.primary_token()));
     http_service_builder =
         http_service_builder.with_request_template(engine_config.local_model().request_template());
+    http_service_builder = http_service_builder
+        .frontend_admission_config(local_model.frontend_admission_config().clone());
     // Inject the DRT's metrics registry so that component-scoped metrics
     // (e.g. KvIndexerMetrics) are exposed (default port 8000 if not overridden).
     http_service_builder =

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -18,6 +18,7 @@
 //!
 //! The [`service_v2::HttpService`] can be further extended to host any [`axum::Router`] using the [`service_v2::HttpServiceConfigBuilder`].
 
+pub mod admission;
 mod anthropic;
 pub mod metadata;
 mod openai;

--- a/lib/llm/src/http/service/admission.rs
+++ b/lib/llm/src/http/service/admission.rs
@@ -1,0 +1,374 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Frontend-local admission control.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
+
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use prometheus::{Gauge, IntCounterVec, Opts, Registry};
+use serde::Serialize;
+use tokio_util::sync::CancellationToken;
+
+use dynamo_runtime::metrics::prometheus_names::name_prefix;
+
+const MODE_NONE: &str = "none";
+const MODE_TOKIO_LAG: &str = "tokio-lag";
+const REASON_TOKIO_LAG: &str = "tokio_lag";
+
+const DEFAULT_LAG_THRESHOLD_MS: u64 = 50;
+const DEFAULT_LAG_CHECK_INTERVAL_MS: u64 = 10;
+const DEFAULT_LAG_COOLDOWN_MS: u64 = 1000;
+
+static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+pub static ADMISSION_LAG_SECONDS: LazyLock<Gauge> = LazyLock::new(|| {
+    Gauge::new(
+        format!("{}_admission_lag_seconds", name_prefix::FRONTEND),
+        "Latest frontend admission Tokio scheduling delay sample.",
+    )
+    .expect("frontend admission lag gauge")
+});
+
+pub static ADMISSION_EFFECTIVE_LAG_SECONDS: LazyLock<Gauge> = LazyLock::new(|| {
+    Gauge::new(
+        format!("{}_admission_effective_lag_seconds", name_prefix::FRONTEND),
+        "Effective frontend admission lag used for rejection decisions.",
+    )
+    .expect("frontend admission effective lag gauge")
+});
+
+pub static ADMISSION_OVERLOADED: LazyLock<Gauge> = LazyLock::new(|| {
+    Gauge::new(
+        format!("{}_admission_overloaded", name_prefix::FRONTEND),
+        "Whether frontend admission currently considers the frontend overloaded.",
+    )
+    .expect("frontend admission overloaded gauge")
+});
+
+pub static ADMISSION_REJECTIONS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            format!("{}_admission_rejections_total", name_prefix::FRONTEND),
+            "Total number of requests rejected by frontend admission control.",
+        ),
+        &["reason"],
+    )
+    .expect("frontend admission rejections counter")
+});
+
+pub fn register_frontend_admission_metrics(registry: &Registry) -> Result<(), prometheus::Error> {
+    registry.register(Box::new(ADMISSION_LAG_SECONDS.clone()))?;
+    registry.register(Box::new(ADMISSION_EFFECTIVE_LAG_SECONDS.clone()))?;
+    registry.register(Box::new(ADMISSION_OVERLOADED.clone()))?;
+    registry.register(Box::new(ADMISSION_REJECTIONS_TOTAL.clone()))?;
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FrontendAdmissionMode {
+    None,
+    TokioLag,
+}
+
+impl FrontendAdmissionMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::None => MODE_NONE,
+            Self::TokioLag => MODE_TOKIO_LAG,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FrontendAdmissionConfig {
+    mode: FrontendAdmissionMode,
+    lag_threshold: Duration,
+    lag_check_interval: Duration,
+    lag_cooldown: Duration,
+}
+
+impl Default for FrontendAdmissionConfig {
+    fn default() -> Self {
+        Self {
+            mode: FrontendAdmissionMode::None,
+            lag_threshold: Duration::from_millis(DEFAULT_LAG_THRESHOLD_MS),
+            lag_check_interval: Duration::from_millis(DEFAULT_LAG_CHECK_INTERVAL_MS),
+            lag_cooldown: Duration::from_millis(DEFAULT_LAG_COOLDOWN_MS),
+        }
+    }
+}
+
+impl FrontendAdmissionConfig {
+    pub fn new(
+        mode: &str,
+        lag_threshold_ms: u64,
+        lag_check_interval_ms: u64,
+        lag_cooldown_ms: u64,
+    ) -> anyhow::Result<Self> {
+        let mode = match mode {
+            MODE_NONE => FrontendAdmissionMode::None,
+            MODE_TOKIO_LAG => FrontendAdmissionMode::TokioLag,
+            other => anyhow::bail!(
+                "invalid frontend admission control mode {other:?}; expected '{MODE_NONE}' or '{MODE_TOKIO_LAG}'"
+            ),
+        };
+
+        if mode == FrontendAdmissionMode::TokioLag && lag_threshold_ms == 0 {
+            anyhow::bail!("frontend lag threshold must be > 0 when tokio-lag admission is enabled");
+        }
+        if mode == FrontendAdmissionMode::TokioLag && lag_check_interval_ms == 0 {
+            anyhow::bail!(
+                "frontend lag check interval must be > 0 when tokio-lag admission is enabled"
+            );
+        }
+
+        Ok(Self {
+            mode,
+            lag_threshold: Duration::from_millis(lag_threshold_ms),
+            lag_check_interval: Duration::from_millis(lag_check_interval_ms),
+            lag_cooldown: Duration::from_millis(lag_cooldown_ms),
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.mode != FrontendAdmissionMode::None
+    }
+
+    pub fn mode(&self) -> &FrontendAdmissionMode {
+        &self.mode
+    }
+
+    pub fn lag_threshold(&self) -> Duration {
+        self.lag_threshold
+    }
+
+    pub fn lag_check_interval(&self) -> Duration {
+        self.lag_check_interval
+    }
+
+    pub fn lag_cooldown(&self) -> Duration {
+        self.lag_cooldown
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FrontendAdmissionRejection {
+    effective_lag: Duration,
+    threshold: Duration,
+}
+
+impl FrontendAdmissionRejection {
+    fn message(&self) -> String {
+        format!(
+            "Frontend overloaded: Tokio scheduling lag {:.3}ms exceeded configured threshold {:.3}ms",
+            self.effective_lag.as_secs_f64() * 1000.0,
+            self.threshold.as_secs_f64() * 1000.0,
+        )
+    }
+}
+
+#[derive(Serialize)]
+struct AdmissionErrorBody {
+    message: String,
+    #[serde(rename = "type")]
+    error_type: String,
+    code: u16,
+}
+
+pub fn rejection_response(rejection: FrontendAdmissionRejection) -> Response {
+    let code = StatusCode::SERVICE_UNAVAILABLE;
+    (
+        code,
+        Json(AdmissionErrorBody {
+            message: rejection.message(),
+            error_type: code
+                .canonical_reason()
+                .unwrap_or("Service Unavailable")
+                .to_string(),
+            code: code.as_u16(),
+        }),
+    )
+        .into_response()
+}
+
+pub struct FrontendAdmissionController {
+    config: FrontendAdmissionConfig,
+    last_observed_delay_ns: AtomicU64,
+    last_tick_ns: AtomicU64,
+    overloaded_until_ns: AtomicU64,
+    canary_started: AtomicBool,
+}
+
+impl FrontendAdmissionController {
+    pub fn new(config: FrontendAdmissionConfig) -> Self {
+        let now = now_ns();
+        Self {
+            config,
+            last_observed_delay_ns: AtomicU64::new(0),
+            last_tick_ns: AtomicU64::new(now),
+            overloaded_until_ns: AtomicU64::new(0),
+            canary_started: AtomicBool::new(false),
+        }
+    }
+
+    pub fn config(&self) -> &FrontendAdmissionConfig {
+        &self.config
+    }
+
+    pub fn spawn_canary(self: &Arc<Self>, cancel_token: CancellationToken) {
+        if self.config.mode() != &FrontendAdmissionMode::TokioLag {
+            return;
+        }
+        if self.canary_started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let controller = self.clone();
+        tokio::spawn(async move {
+            controller.run_tokio_lag_canary(cancel_token).await;
+        });
+    }
+
+    pub fn admit(&self) -> Result<(), FrontendAdmissionRejection> {
+        if self.config.mode() == &FrontendAdmissionMode::None {
+            return Ok(());
+        }
+
+        let now = now_ns();
+        let effective_lag = self.effective_lag(now);
+        ADMISSION_EFFECTIVE_LAG_SECONDS.set(duration_from_ns(effective_lag).as_secs_f64());
+
+        let threshold_ns = duration_as_ns(self.config.lag_threshold());
+        let overloaded_until = self.overloaded_until_ns.load(Ordering::Acquire);
+        if now < overloaded_until {
+            ADMISSION_OVERLOADED.set(1.0);
+            return Err(self.reject(effective_lag, threshold_ns));
+        }
+
+        if effective_lag > threshold_ns {
+            let cooldown_until = now.saturating_add(duration_as_ns(self.config.lag_cooldown()));
+            self.overloaded_until_ns
+                .store(cooldown_until, Ordering::Release);
+            ADMISSION_OVERLOADED.set(1.0);
+            return Err(self.reject(effective_lag, threshold_ns));
+        }
+
+        ADMISSION_OVERLOADED.set(0.0);
+        Ok(())
+    }
+
+    async fn run_tokio_lag_canary(&self, cancel_token: CancellationToken) {
+        let interval = self.config.lag_check_interval();
+        loop {
+            let expected = Instant::now() + interval;
+            tokio::select! {
+                _ = tokio::time::sleep_until(expected.into()) => {}
+                _ = cancel_token.cancelled() => {
+                    tracing::debug!("frontend admission tokio-lag canary shutting down");
+                    return;
+                }
+            }
+
+            let observed_delay = Instant::now().saturating_duration_since(expected);
+            self.record_tick(observed_delay);
+        }
+    }
+
+    fn record_tick(&self, observed_delay: Duration) {
+        let observed_delay_ns = duration_as_ns(observed_delay);
+        self.last_observed_delay_ns
+            .store(observed_delay_ns, Ordering::Release);
+        self.last_tick_ns.store(now_ns(), Ordering::Release);
+        ADMISSION_LAG_SECONDS.set(observed_delay.as_secs_f64());
+    }
+
+    fn effective_lag(&self, now: u64) -> u64 {
+        let observed = self.last_observed_delay_ns.load(Ordering::Acquire);
+        let last_tick = self.last_tick_ns.load(Ordering::Acquire);
+        let stale = now.saturating_sub(last_tick);
+        observed.max(stale)
+    }
+
+    fn reject(&self, effective_lag_ns: u64, threshold_ns: u64) -> FrontendAdmissionRejection {
+        ADMISSION_REJECTIONS_TOTAL
+            .with_label_values(&[REASON_TOKIO_LAG])
+            .inc();
+        FrontendAdmissionRejection {
+            effective_lag: duration_from_ns(effective_lag_ns),
+            threshold: duration_from_ns(threshold_ns),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_tick_for_test(&self, observed_delay: Duration) {
+        self.record_tick(observed_delay);
+    }
+}
+
+fn now_ns() -> u64 {
+    let elapsed = PROCESS_START.elapsed().as_nanos();
+    elapsed.min(u64::MAX as u128) as u64
+}
+
+fn duration_as_ns(duration: Duration) -> u64 {
+    duration.as_nanos().min(u64::MAX as u128) as u64
+}
+
+fn duration_from_ns(ns: u64) -> Duration {
+    Duration::from_nanos(ns)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(threshold_ms: u64, cooldown_ms: u64) -> FrontendAdmissionConfig {
+        FrontendAdmissionConfig::new(MODE_TOKIO_LAG, threshold_ms, 10, cooldown_ms).unwrap()
+    }
+
+    #[test]
+    fn disabled_config_accepts() {
+        let controller = FrontendAdmissionController::new(FrontendAdmissionConfig::default());
+        controller.record_tick_for_test(Duration::from_secs(10));
+        assert!(controller.admit().is_ok());
+    }
+
+    #[test]
+    fn low_lag_accepts() {
+        let controller = FrontendAdmissionController::new(config(50, 1000));
+        controller.record_tick_for_test(Duration::from_millis(1));
+        assert!(controller.admit().is_ok());
+    }
+
+    #[test]
+    fn observed_lag_above_threshold_rejects() {
+        let controller = FrontendAdmissionController::new(config(50, 1000));
+        controller.record_tick_for_test(Duration::from_millis(75));
+        assert!(controller.admit().is_err());
+    }
+
+    #[test]
+    fn stale_heartbeat_rejects() {
+        let controller = FrontendAdmissionController::new(config(1, 1000));
+        controller.record_tick_for_test(Duration::from_millis(1));
+        std::thread::sleep(Duration::from_millis(2));
+        assert!(controller.admit().is_err());
+    }
+
+    #[test]
+    fn cooldown_prevents_flapping() {
+        let controller = FrontendAdmissionController::new(config(50, 1000));
+        controller.record_tick_for_test(Duration::from_millis(75));
+        assert!(controller.admit().is_err());
+
+        controller.record_tick_for_test(Duration::from_millis(1));
+        assert!(controller.admit().is_err());
+    }
+}

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -11,9 +11,14 @@ use std::time::Duration;
 
 use axum::body::Body;
 use axum::http::Response;
+use axum::response::IntoResponse;
 
 use super::Metrics;
 use super::RouteDoc;
+use super::admission::{
+    FrontendAdmissionConfig, FrontendAdmissionController, register_frontend_admission_metrics,
+    rejection_response,
+};
 use super::metrics;
 use super::metrics::register_worker_timing_metrics;
 use crate::discovery::ModelManager;
@@ -60,6 +65,7 @@ pub struct State {
     discovery_client: Arc<dyn Discovery>,
     flags: StateFlags,
     cancel_token: CancellationToken,
+    frontend_admission: Option<Arc<FrontendAdmissionController>>,
 }
 
 #[derive(Default, Debug)]
@@ -130,6 +136,7 @@ impl State {
         manager: Arc<ModelManager>,
         discovery_client: Arc<dyn Discovery>,
         cancel_token: CancellationToken,
+        frontend_admission: Option<Arc<FrontendAdmissionController>>,
     ) -> Self {
         Self {
             manager,
@@ -147,6 +154,7 @@ impl State {
                 anthropic_endpoints_enabled: AtomicBool::new(false),
             },
             cancel_token,
+            frontend_admission,
         }
     }
 
@@ -175,6 +183,10 @@ impl State {
     /// Get the cancellation token
     pub fn cancel_token(&self) -> &CancellationToken {
         &self.cancel_token
+    }
+
+    pub fn frontend_admission(&self) -> Option<Arc<FrontendAdmissionController>> {
+        self.frontend_admission.clone()
     }
 
     // TODO
@@ -270,6 +282,9 @@ pub struct HttpServiceConfig {
     /// are registered using discovery.instance_id() and exposed on /metrics.
     #[builder(default = "None")]
     drt_discovery: Option<Arc<dyn Discovery>>,
+
+    #[builder(default)]
+    frontend_admission_config: FrontendAdmissionConfig,
 }
 
 impl HttpService {
@@ -380,6 +395,9 @@ impl HttpService {
 
             // Spawn canary after all fallible startup so it won't leak on early errors
             tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
+            if let Some(admission) = self.state.frontend_admission() {
+                admission.spawn_canary(cancel_token.clone());
+            }
 
             tokio::select! {
                 result = server => {
@@ -428,6 +446,9 @@ impl HttpService {
 
             // Spawn canary after all fallible startup so it won't leak on early errors
             tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
+            if let Some(admission) = self.state.frontend_admission() {
+                admission.spawn_canary(cancel_token.clone());
+            }
 
             axum::serve(listener, router)
                 .with_graceful_shutdown(async move {
@@ -503,7 +524,16 @@ impl HttpServiceConfigBuilder {
                 cancel_token.child_token(),
             )) as Arc<dyn Discovery>
         });
-        let state = Arc::new(State::new(model_manager, discovery_client, cancel_token));
+        let frontend_admission_config = config.frontend_admission_config.clone();
+        let frontend_admission = frontend_admission_config
+            .is_enabled()
+            .then(|| Arc::new(FrontendAdmissionController::new(frontend_admission_config)));
+        let state = Arc::new(State::new(
+            model_manager,
+            discovery_client,
+            cancel_token,
+            frontend_admission,
+        ));
         state
             .flags
             .set(&EndpointType::Chat, config.enable_chat_endpoints);
@@ -561,6 +591,9 @@ impl HttpServiceConfigBuilder {
         }
         if let Err(e) = ensure_transport_metrics_registered_prometheus(&registry) {
             tracing::warn!("Failed to register transport metrics: {}", e);
+        }
+        if let Err(e) = register_frontend_admission_metrics(&registry) {
+            tracing::warn!("Failed to register frontend admission metrics: {}", e);
         }
 
         let mut all_docs = Vec::new();
@@ -708,12 +741,22 @@ impl HttpServiceConfigBuilder {
                     async move {
                         // Check if the endpoint is enabled
                         let enabled = state.flags.get(&endpoint_type);
-                        if enabled {
-                            Ok(next.run(req).await)
-                        } else {
+                        if !enabled {
                             tracing::debug!("{} endpoints are disabled", endpoint_type.as_str());
-                            Err(axum::http::StatusCode::NOT_FOUND)
+                            return axum::http::StatusCode::NOT_FOUND.into_response();
                         }
+
+                        if let Some(admission) = state.frontend_admission()
+                            && let Err(rejection) = admission.admit()
+                        {
+                            tracing::debug!(
+                                endpoint = endpoint_type.as_str(),
+                                "rejecting request due to frontend admission control"
+                            );
+                            return rejection_response(rejection);
+                        }
+
+                        next.run(req).await
                     }
                 },
             ));
@@ -769,6 +812,59 @@ mod tests {
         assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
 
         // Clean up
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_frontend_admission_rejects_inference_but_not_health() {
+        let cancel_token = CancellationToken::new();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let service = HttpService::builder()
+            .port(port)
+            .enable_chat_endpoints(true)
+            .frontend_admission_config(
+                FrontendAdmissionConfig::new("tokio-lag", 50, 10_000, 1_000).unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        service
+            .state()
+            .frontend_admission()
+            .unwrap()
+            .record_tick_for_test(Duration::from_millis(75));
+
+        let service_for_task = service.clone();
+        let server_token = cancel_token.clone();
+        let handle = tokio::spawn(async move {
+            service_for_task
+                .run_with_listener(server_token, listener)
+                .await
+                .unwrap();
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+        let client = reqwest::Client::new();
+        let rejected = client
+            .post(format!("http://localhost:{}/v1/chat/completions", port))
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .expect("chat request failed");
+        assert_eq!(rejected.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+
+        let health = client
+            .get(format!("http://localhost:{}/health", port))
+            .send()
+            .await
+            .expect("health request failed");
+        assert_eq!(health.status(), reqwest::StatusCode::OK);
+
+        cancel_token.cancel();
         handle.abort();
     }
 }

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -16,6 +16,7 @@ use modelexpress_common::providers::{HuggingFaceProvider, ModelProviderTrait as 
 
 use crate::common::checked_file::CheckedFile;
 use crate::entrypoint::RouterConfig;
+use crate::http::service::admission::FrontendAdmissionConfig;
 use crate::model_card::{ModelDeploymentCard, is_weight_file};
 use crate::model_type::{ModelInput, ModelType};
 use crate::preprocessor::media::{MediaDecoder, MediaFetcher};
@@ -65,6 +66,7 @@ pub struct LocalModelBuilder {
     tls_key_path: Option<PathBuf>,
     migration_limit: u32,
     migration_max_seq_len: Option<u32>,
+    frontend_admission_config: FrontendAdmissionConfig,
     is_mocker: bool,
     extra_engine_args: Option<PathBuf>,
     runtime_config: ModelRuntimeConfig,
@@ -95,6 +97,7 @@ impl Default for LocalModelBuilder {
             router_config: Default::default(),
             migration_limit: Default::default(),
             migration_max_seq_len: Default::default(),
+            frontend_admission_config: Default::default(),
             is_mocker: Default::default(),
             extra_engine_args: Default::default(),
             runtime_config: Default::default(),
@@ -212,6 +215,11 @@ impl LocalModelBuilder {
         self
     }
 
+    pub fn frontend_admission_config(&mut self, config: FrontendAdmissionConfig) -> &mut Self {
+        self.frontend_admission_config = config;
+        self
+    }
+
     pub fn is_mocker(&mut self, is_mocker: bool) -> &mut Self {
         self.is_mocker = is_mocker;
         self
@@ -303,6 +311,7 @@ impl LocalModelBuilder {
                 namespace_prefix: self.namespace_prefix.clone(),
                 migration_limit: self.migration_limit,
                 migration_max_seq_len: self.migration_max_seq_len,
+                frontend_admission_config: self.frontend_admission_config.clone(),
                 self_host_metadata: self.self_host_metadata,
                 attached_self_host_suffix: None,
             });
@@ -360,6 +369,7 @@ impl LocalModelBuilder {
             namespace_prefix: self.namespace_prefix.clone(),
             migration_limit: self.migration_limit,
             migration_max_seq_len: self.migration_max_seq_len,
+            frontend_admission_config: self.frontend_admission_config.clone(),
             self_host_metadata: self.self_host_metadata,
             attached_self_host_suffix: None,
         })
@@ -383,6 +393,7 @@ pub struct LocalModel {
     namespace_prefix: Option<String>,
     migration_limit: u32,
     migration_max_seq_len: Option<u32>,
+    frontend_admission_config: FrontendAdmissionConfig,
     self_host_metadata: bool,
     /// Set by `move_to_self_host` so `clear_self_hosted_artifacts`
     /// scopes its unregister to this model's `(slug, suffix)` only.
@@ -456,6 +467,10 @@ impl LocalModel {
 
     pub fn migration_max_seq_len(&self) -> Option<u32> {
         self.migration_max_seq_len
+    }
+
+    pub fn frontend_admission_config(&self) -> &FrontendAdmissionConfig {
+        &self.frontend_admission_config
     }
 
     pub fn namespace(&self) -> Option<&str> {


### PR DESCRIPTION
## Summary
- add configurable frontend admission mode based on Tokio scheduling lag
- plumb Python CLI/env config into the Rust HTTP service
- reject inference routes with HTTP 503 while keeping system routes available
- add frontend admission metrics and focused tests

## Testing
- cargo test -p dynamo-llm admission --lib
- Not run: Python config tests; local .venv lacks pytest and broader project Python execution is blocked by dependency/native _core setup in this environment