### PR TITLE
fix(epp): correct bookkeeping and router configuration

### DIFF
--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 
 [dependencies]
 dynamo-kv-router = { workspace = true, features = ["metrics", "runtime-protocols"] }
-dynamo-llm = { workspace = true }
 dynamo-runtime = { workspace = true }
 
 anyhow = { workspace = true }
@@ -49,3 +48,9 @@ ignored = ["prost"]
 
 [build-dependencies]
 tonic-build = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dynamo-llm = { path = "../../../lib/llm" }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+dynamo-llm = { path = "../../../lib/llm", default-features = false }

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
-use dynamo_kv_router::config::{KvRouterConfig, RouterConfigOverride};
+use dynamo_kv_router::config::{RouterConfigOverride, kv_router_config_from_dynamo_env};
 use dynamo_kv_router::protocols::{RoutingConstraints, WorkerWithDpRank};
 use dynamo_llm::discovery::{ModelManager, WORKER_TYPE_DECODE};
 use dynamo_llm::kv_router::prefill_router::PrefillQueryOutcome;
@@ -27,6 +27,34 @@ use dynamo_runtime::{DistributedRuntime, Runtime};
 use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo};
 
 const BOOKKEEPING_TIMEOUT: Duration = Duration::from_secs(5);
+const DYN_KUBE_DISCOVERY_MODE: &str = "DYN_KUBE_DISCOVERY_MODE";
+
+fn validate_kube_discovery_mode() -> Result<()> {
+    match std::env::var(DYN_KUBE_DISCOVERY_MODE) {
+        Ok(mode) => validate_kube_discovery_mode_value(Some(&mode)),
+        Err(std::env::VarError::NotPresent) => validate_kube_discovery_mode_value(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("{DYN_KUBE_DISCOVERY_MODE} must be valid Unicode")
+        }
+    }
+}
+
+fn validate_kube_discovery_mode_value(mode: Option<&str>) -> Result<()> {
+    match mode {
+        None | Some("pod") => Ok(()),
+        Some("container") => {
+            // TODO(epp-container-discovery): Resolve container-level discovery IDs to pod
+            // endpoints, including non-main worker containers, then remove this restriction.
+            anyhow::bail!(
+                "Rust EPP does not support {DYN_KUBE_DISCOVERY_MODE}=container because it resolves \
+                 worker endpoints by pod identity; use {DYN_KUBE_DISCOVERY_MODE}=pod"
+            )
+        }
+        Some(mode) => anyhow::bail!(
+            "Invalid {DYN_KUBE_DISCOVERY_MODE} value {mode:?}; valid values are 'pod' and 'container'"
+        ),
+    }
+}
 
 fn decode_router_config_override(is_disaggregated: bool) -> Option<RouterConfigOverride> {
     is_disaggregated.then_some(RouterConfigOverride {
@@ -69,6 +97,8 @@ impl Router {
         component: &str,
         enforce_disagg: bool,
     ) -> Result<Self> {
+        validate_kube_discovery_mode()?;
+
         let runtime = Runtime::from_settings()?;
         let drt = DistributedRuntime::from_settings(runtime.clone()).await?;
 
@@ -81,7 +111,11 @@ impl Router {
         let enable_eagle = bootstrap.card.runtime_config.enable_eagle;
         let actual_namespace = &bootstrap.actual_namespace;
 
-        let mut kv_router_config = kv_router_config_from_env();
+        // TODO(epp-rolling-namespace): Rebind both routers when the active
+        // generation-suffixed worker namespace changes during a rolling update.
+        let mut kv_router_config = kv_router_config_from_dynamo_env();
+        // TODO(epp-multi-replica): Provide authoritative admission across EPP
+        // replicas; replica-sync alone does not close the selection-to-booking race.
         kv_router_config.skip_initial_worker_wait = true;
 
         let component_handle = drt.namespace(actual_namespace)?.component(component)?;
@@ -170,6 +204,9 @@ impl Router {
     /// `lib/llm/src/preprocessor.rs` so this gateway path produces the same
     /// queue ordering as a non-GAIE deployment.
     pub fn tokenize(&self, request_json: &str) -> Result<(Vec<u32>, f64)> {
+        // TODO(epp-request-routing): Reuse shared preprocessing so expected output
+        // length, LoRA, pins, sessions, topology constraints, additional protocols,
+        // and multimodal routing hashes are preserved.
         let request: dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest =
             serde_json::from_str(request_json)?;
 
@@ -266,6 +303,8 @@ impl Router {
             self.prefill_router.register_workers(ids);
         }
 
+        // TODO(epp-prefill-booking): Atomically reserve the selected prefill worker
+        // and release it on first output, cancellation, or routing failure.
         let outcome = self
             .prefill_router
             .query_prefill_worker(
@@ -758,57 +797,6 @@ fn spawn_prefill_discovery_watcher(
     });
 }
 
-fn kv_router_config_from_env() -> KvRouterConfig {
-    let mut cfg = KvRouterConfig::default();
-
-    fn env_f64(key: &str) -> Option<f64> {
-        std::env::var(key).ok().and_then(|v| v.parse().ok())
-    }
-    fn env_bool(key: &str) -> Option<bool> {
-        std::env::var(key)
-            .ok()
-            .and_then(|v| match v.to_lowercase().as_str() {
-                "true" | "1" | "yes" | "on" => Some(true),
-                "false" | "0" | "no" | "off" => Some(false),
-                _ => None,
-            })
-    }
-
-    if let Some(v) = env_f64("DYN_OVERLAP_SCORE_WEIGHT") {
-        cfg.overlap_score_credit = v;
-    }
-    if let Some(v) = env_f64("DYN_ROUTER_TEMPERATURE") {
-        cfg.router_temperature = v;
-    }
-    if let Some(v) = env_bool("DYN_USE_KV_EVENTS") {
-        cfg.use_kv_events = v;
-    }
-    if let Some(v) = env_bool("DYN_ROUTER_REPLICA_SYNC") {
-        cfg.router_replica_sync = v;
-    }
-    if let Some(v) = env_bool("DYN_ROUTER_TRACK_ACTIVE_BLOCKS") {
-        cfg.router_track_active_blocks = v;
-    }
-    if let Some(v) = env_bool("DYN_ROUTER_TRACK_OUTPUT_BLOCKS") {
-        cfg.router_track_output_blocks = v;
-    }
-    if let Some(v) = env_bool("DYN_ROUTER_TRACK_PREFILL_TOKENS") {
-        cfg.router_track_prefill_tokens = v;
-    }
-    if let Some(v) = env_f64("DYN_ROUTER_QUEUE_THRESHOLD") {
-        cfg.router_queue_threshold = Some(v);
-    }
-
-    tracing::info!(
-        overlap_score_weight = cfg.overlap_score_credit,
-        router_temperature = cfg.router_temperature,
-        use_kv_events = cfg.use_kv_events,
-        "KvRouterConfig initialized"
-    );
-
-    cfg
-}
-
 // ---------------------------------------------------------------------------
 // EndpointPicker trait implementation (mirrors Go LW-EPP from GAIE #2834)
 // ---------------------------------------------------------------------------
@@ -955,11 +943,17 @@ impl EndpointPicker for Router {
             }
         };
 
+        // TODO(epp-atomic-admission): Replace query-only selection plus add_request
+        // with one tracked operation. Propagate booking failures, use an internal
+        // booking ID independent of x-request-id, handle cancellation races, roll
+        // back endpoint-resolution failures, and never forward to an unbooked fallback.
         let (decode_worker, _overlap) = self
             .route_decode(&tokens, is_disaggregated, priority_jump, allowed_worker_ids)
             .await
             .map_err(|e| PickError::RoutingFailed(e.to_string()))?;
 
+        // TODO(epp-endpoint-reconciliation): Reconcile Dynamo discovery with the
+        // pod reflector and retry selection when the chosen worker has no endpoint.
         let endpoint = if worker_map.is_empty() {
             self.resolve_worker_endpoint(decode_worker.worker_id)
                 .ok_or_else(|| {
@@ -1091,6 +1085,22 @@ mod tests {
     #[test]
     fn aggregated_decode_uses_configured_bookkeeping() {
         assert!(decode_router_config_override(false).is_none());
+    }
+
+    #[test]
+    fn pod_discovery_mode_is_supported() {
+        validate_kube_discovery_mode_value(None).unwrap();
+        validate_kube_discovery_mode_value(Some("pod")).unwrap();
+    }
+
+    #[test]
+    fn container_discovery_mode_is_rejected() {
+        let error = validate_kube_discovery_mode_value(Some("container")).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("does not support DYN_KUBE_DISCOVERY_MODE=container")
+        );
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -1082,37 +1082,6 @@ impl EndpointPicker for Router {
 mod tests {
     use super::*;
 
-    #[test]
-    fn aggregated_decode_uses_configured_bookkeeping() {
-        assert!(decode_router_config_override(false).is_none());
-    }
-
-    #[test]
-    fn pod_discovery_mode_is_supported() {
-        validate_kube_discovery_mode_value(None).unwrap();
-        validate_kube_discovery_mode_value(Some("pod")).unwrap();
-    }
-
-    #[test]
-    fn container_discovery_mode_is_rejected() {
-        let error = validate_kube_discovery_mode_value(Some("container")).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("does not support DYN_KUBE_DISCOVERY_MODE=container")
-        );
-    }
-
-    #[test]
-    fn disaggregated_decode_disables_decode_side_prefill_tracking() {
-        let override_config =
-            decode_router_config_override(true).expect("disaggregated mode must override config");
-
-        assert_eq!(override_config.overlap_score_credit, Some(0.0));
-        assert_eq!(override_config.assume_kv_reuse, Some(false));
-        assert_eq!(override_config.track_prefill_tokens, Some(false));
-    }
-
     /// Proves the core feature: `nvext.agent_hints.priority` lifts into a
     /// non-zero `priority_jump`, and absence collapses to `0.0`. If this
     /// regresses, the GAIE ext-proc path is back to ignoring priority.

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -28,6 +28,15 @@ use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo
 
 const BOOKKEEPING_TIMEOUT: Duration = Duration::from_secs(5);
 
+fn decode_router_config_override(is_disaggregated: bool) -> Option<RouterConfigOverride> {
+    is_disaggregated.then_some(RouterConfigOverride {
+        overlap_score_credit: Some(0.0),
+        assume_kv_reuse: Some(false),
+        track_prefill_tokens: Some(false),
+        ..Default::default()
+    })
+}
+
 /// Name of the inference-serving HTTP port on a Dynamo worker pod.
 ///
 /// Mirrors `commonconsts.DynamoContainerPortName` in
@@ -305,16 +314,7 @@ impl Router {
             self.decode_router.register_workers(ids);
         }
 
-        let config_override = if is_disaggregated {
-            Some(RouterConfigOverride {
-                overlap_score_credit: Some(0.0),
-                assume_kv_reuse: Some(false),
-                track_prefill_tokens: Some(false),
-                ..Default::default()
-            })
-        } else {
-            None
-        };
+        let config_override = decode_router_config_override(is_disaggregated);
 
         self.decode_router
             .find_best_match(
@@ -340,6 +340,7 @@ impl Router {
         tokens: &[u32],
         worker_id: u64,
         dp_rank: u32,
+        is_disaggregated: bool,
     ) -> Result<()> {
         let decode_router = self.decode_router.clone();
         let request_id = request_id.to_owned();
@@ -347,12 +348,7 @@ impl Router {
 
         tokio::time::timeout(BOOKKEEPING_TIMEOUT, async {
             let worker = WorkerWithDpRank::new(worker_id, dp_rank);
-            let router_config_override = RouterConfigOverride {
-                overlap_score_credit: Some(0.0),
-                assume_kv_reuse: Some(false),
-                track_prefill_tokens: Some(false),
-                ..Default::default()
-            };
+            let router_config_override = decode_router_config_override(is_disaggregated);
 
             let overlap_blocks = decode_router
                 .get_overlap_blocks(&tokens, None, worker, None)
@@ -370,7 +366,7 @@ impl Router {
                     None,
                     worker,
                     None,
-                    Some(&router_config_override),
+                    router_config_override.as_ref(),
                 )
                 .await;
 
@@ -996,6 +992,7 @@ impl EndpointPicker for Router {
                     &tokens,
                     decode_worker.worker_id,
                     decode_worker.dp_rank,
+                    is_disaggregated,
                 )
                 .await
         {
@@ -1090,6 +1087,21 @@ impl EndpointPicker for Router {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn aggregated_decode_uses_configured_bookkeeping() {
+        assert!(decode_router_config_override(false).is_none());
+    }
+
+    #[test]
+    fn disaggregated_decode_disables_decode_side_prefill_tracking() {
+        let override_config =
+            decode_router_config_override(true).expect("disaggregated mode must override config");
+
+        assert_eq!(override_config.overlap_score_credit, Some(0.0));
+        assert_eq!(override_config.assume_kv_reuse, Some(false));
+        assert_eq!(override_config.track_prefill_tokens, Some(false));
+    }
 
     /// Proves the core feature: `nvext.agent_hints.priority` lifts into a
     /// non-zero `priority_jump`, and absence collapses to `0.0`. If this

--- a/deploy/inference-gateway/ext-proc/src/picker.rs
+++ b/deploy/inference-gateway/ext-proc/src/picker.rs
@@ -80,8 +80,8 @@ pub trait EndpointPicker: Send + Sync + 'static {
         endpoints: &[Endpoint],
     ) -> Result<PickResult, PickError>;
 
-    /// Called when response headers arrive from the backend in disaggregated
-    /// mode. This signals that prefill is done and decode has started.
+    /// Called when the first response body arrives from the backend. This
+    /// signals that prefill is done and decode has started.
     /// Mirrors Go EPP's PostResponse → MarkPrefillComplete.
     async fn on_prefill_complete(&self, _request_id: &str) {}
 

--- a/deploy/inference-gateway/ext-proc/src/server.rs
+++ b/deploy/inference-gateway/ext-proc/src/server.rs
@@ -50,7 +50,6 @@ struct RequestContext {
     response_size: usize,
     response_complete: bool,
     model_server_streaming: bool,
-    is_disaggregated: bool,
     prefill_complete_signaled: bool,
 
     /// Set once we've validated the gateway's `ProtocolConfiguration`.
@@ -83,7 +82,6 @@ impl RequestContext {
             response_size: 0,
             response_complete: false,
             model_server_streaming: false,
-            is_disaggregated: false,
             prefill_complete_signaled: false,
             protocol_validated: false,
             request_headers: Vec::new(),
@@ -287,11 +285,6 @@ impl<P: EndpointPicker> ExtProcServer<P> {
         ctx.target_endpoint = result.endpoint.clone();
         ctx.incoming_model_name = model;
         ctx.target_model_name = ctx.incoming_model_name.clone();
-        ctx.is_disaggregated = result
-            .headers
-            .iter()
-            .any(|(k, v)| k == "x-dynamo-routing-mode" && v == "disaggregated");
-
         tracing::info!(
             request_id = %ctx.request_id,
             endpoint = %result.endpoint,
@@ -491,10 +484,7 @@ impl<P: EndpointPicker> ExternalProcessor for ExtProcServer<P> {
                             // bookkeeping before decode actually starts. The
                             // first non-empty body chunk is the earliest signal
                             // that prefill produced output and decode is underway.
-                            if ctx.is_disaggregated
-                                && !ctx.prefill_complete_signaled
-                                && !body.body.is_empty()
-                            {
+                            if !ctx.prefill_complete_signaled && !body.body.is_empty() {
                                 ctx.prefill_complete_signaled = true;
                                 picker.on_prefill_complete(&ctx.request_id).await;
                             }
@@ -855,7 +845,14 @@ mod tests {
             },
             ProcessingRequest {
                 request: Some(ProcReq::ResponseBody(HttpBody {
-                    body: b"{}".to_vec(),
+                    body: b"{".to_vec(),
+                    end_of_stream: false,
+                })),
+                ..Default::default()
+            },
+            ProcessingRequest {
+                request: Some(ProcReq::ResponseBody(HttpBody {
+                    body: b"}".to_vec(),
                     end_of_stream: true,
                 })),
                 ..Default::default()
@@ -881,13 +878,15 @@ mod tests {
         assert_eq!(t.add.load(Ordering::SeqCst), 1);
     }
 
-    /// mark_prefill_complete: on_prefill_complete() fires on the first non-empty
-    /// ResponseBody chunk (the first generated token) in disagg mode.
+    /// mark_prefill_complete: on_prefill_complete() fires exactly once on the first
+    /// non-empty ResponseBody chunk (the first generated token) in both routing modes.
     #[tokio::test]
-    async fn test_mark_prefill_complete_called() {
-        let t = Arc::new(Tracker::disagg());
-        run(&mut connect(t.clone()).await).await;
-        assert_eq!(t.prefill_complete.load(Ordering::SeqCst), 1);
+    async fn test_mark_prefill_complete_called_once_for_both_routing_modes() {
+        for tracker in [Tracker::agg(), Tracker::disagg()] {
+            let tracker = Arc::new(tracker);
+            run(&mut connect(tracker.clone()).await).await;
+            assert_eq!(tracker.prefill_complete.load(Ordering::SeqCst), 1);
+        }
     }
 
     /// free_request: on_request_complete() fires when the stream ends.

--- a/deploy/inference-gateway/ext-proc/src/server.rs
+++ b/deploy/inference-gateway/ext-proc/src/server.rs
@@ -50,6 +50,7 @@ struct RequestContext {
     response_size: usize,
     response_complete: bool,
     model_server_streaming: bool,
+    body_routed: bool,
     prefill_complete_signaled: bool,
 
     /// Set once we've validated the gateway's `ProtocolConfiguration`.
@@ -82,6 +83,7 @@ impl RequestContext {
             response_size: 0,
             response_complete: false,
             model_server_streaming: false,
+            body_routed: false,
             prefill_complete_signaled: false,
             protocol_validated: false,
             request_headers: Vec::new(),
@@ -282,6 +284,7 @@ impl<P: EndpointPicker> ExtProcServer<P> {
             .await
             .map_err(ExtProcError::from_pick_error)?;
 
+        ctx.body_routed = true;
         ctx.target_endpoint = result.endpoint.clone();
         ctx.incoming_model_name = model;
         ctx.target_model_name = ctx.incoming_model_name.clone();
@@ -484,7 +487,10 @@ impl<P: EndpointPicker> ExternalProcessor for ExtProcServer<P> {
                             // bookkeeping before decode actually starts. The
                             // first non-empty body chunk is the earliest signal
                             // that prefill produced output and decode is underway.
-                            if !ctx.prefill_complete_signaled && !body.body.is_empty() {
+                            if ctx.body_routed
+                                && !ctx.prefill_complete_signaled
+                                && !body.body.is_empty()
+                            {
                                 ctx.prefill_complete_signaled = true;
                                 picker.on_prefill_complete(&ctx.request_id).await;
                             }
@@ -549,7 +555,7 @@ impl<P: EndpointPicker> ExternalProcessor for ExtProcServer<P> {
             // work continuing after an ext_proc disconnect affect booking ownership.
             // Notify the picker that this request is complete so it can free router
             // bookkeeping state (mirrors Go EPP PostResponse).
-            if !ctx.request_id.is_empty() {
+            if ctx.body_routed && !ctx.request_id.is_empty() {
                 picker.on_request_complete(&ctx.request_id).await;
             }
         });
@@ -864,14 +870,53 @@ mod tests {
         ]
     }
 
-    async fn run(c: &mut ExternalProcessorClient<tonic::transport::Channel>) {
+    fn header_only_stream() -> Vec<ProcessingRequest> {
+        vec![
+            ProcessingRequest {
+                request: Some(ProcReq::RequestHeaders(HttpHeaders {
+                    headers: Some(HeaderMap {
+                        headers: vec![HeaderValue {
+                            key: "x-request-id".into(),
+                            value: "r1".into(),
+                            raw_value: vec![],
+                        }],
+                    }),
+                    end_of_stream: true,
+                })),
+                ..Default::default()
+            },
+            ProcessingRequest {
+                request: Some(ProcReq::ResponseHeaders(HttpHeaders {
+                    headers: Some(HeaderMap { headers: vec![] }),
+                    end_of_stream: false,
+                })),
+                ..Default::default()
+            },
+            ProcessingRequest {
+                request: Some(ProcReq::ResponseBody(HttpBody {
+                    body: b"{}".to_vec(),
+                    end_of_stream: true,
+                })),
+                ..Default::default()
+            },
+        ]
+    }
+
+    async fn run_stream(
+        c: &mut ExternalProcessorClient<tonic::transport::Channel>,
+        requests: Vec<ProcessingRequest>,
+    ) {
         let mut r = c
-            .process(tokio_stream::iter(stream()))
+            .process(tokio_stream::iter(requests))
             .await
             .unwrap()
             .into_inner();
         while r.message().await.unwrap().is_some() {}
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    async fn run(c: &mut ExternalProcessorClient<tonic::transport::Channel>) {
+        run_stream(c, stream()).await;
     }
 
     /// add_request: pick() is invoked → registers request with the slot tracker.
@@ -899,5 +944,15 @@ mod tests {
         let t = Arc::new(Tracker::agg());
         run(&mut connect(t.clone()).await).await;
         assert_eq!(t.free.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_header_only_response_skips_router_lifecycle_callbacks() {
+        let t = Arc::new(Tracker::agg());
+        run_stream(&mut connect(t.clone()).await, header_only_stream()).await;
+
+        assert_eq!(t.add.load(Ordering::SeqCst), 1);
+        assert_eq!(t.prefill_complete.load(Ordering::SeqCst), 0);
+        assert_eq!(t.free.load(Ordering::SeqCst), 0);
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/server.rs
+++ b/deploy/inference-gateway/ext-proc/src/server.rs
@@ -489,6 +489,8 @@ impl<P: EndpointPicker> ExternalProcessor for ExtProcServer<P> {
                                 picker.on_prefill_complete(&ctx.request_id).await;
                             }
 
+                            // TODO(epp-output-tracking): Parse generated-token progress and
+                            // update router output blocks instead of tracking only phase changes.
                             if ctx.model_server_streaming {
                                 ExtProcServer::<P>::handle_response_body(&mut ctx, body);
                             } else {
@@ -543,8 +545,10 @@ impl<P: EndpointPicker> ExternalProcessor for ExtProcServer<P> {
                 let _ = tx.send(Err(e)).await;
             }
 
-            // Notify the picker that this request is complete so it can
-            // free router bookkeeping state (mirrors Go EPP PostResponse).
+            // TODO(epp-disconnect-semantics): Define how Envoy retries and backend
+            // work continuing after an ext_proc disconnect affect booking ownership.
+            // Notify the picker that this request is complete so it can free router
+            // bookkeeping state (mirrors Go EPP PostResponse).
             if !ctx.request_id.is_empty() {
                 picker.on_request_complete(&ctx.request_id).await;
             }

--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -184,6 +184,7 @@ resolution and router configuration:
 | `DYN_NAMESPACE` | `vllm-agg` | Dynamo discovery namespace (fallback) |
 | `DYN_COMPONENT_NAME` | `backend` | Dynamo component name |
 | `DYN_ENFORCE_DISAGG` | `false` | Enforce disaggregated prefill/decode routing |
+| `DYN_KUBE_DISCOVERY_MODE` | `pod` | Kubernetes discovery identity mode; Rust EPP currently rejects `container` |
 | `RUST_LOG` | `info` | Tracing log level filter |
 
 The gRPC port is hardcoded to `9002` (matching the operator's `EPPGRPCPort` constant).
@@ -192,14 +193,23 @@ Namespace resolution follows the same logic as the Go EPP plugin:
 `DYN_NAMESPACE_PREFIX` > `DYN_NAMESPACE` > `"vllm-agg"` (default).
 
 The Rust EPP also respects the standard Dynamo router environment variables
-(`DYN_OVERLAP_SCORE_WEIGHT`, `DYN_ROUTER_TEMPERATURE`, `DYN_USE_KV_EVENTS`, etc.)
-documented in the Configuration section below.
+(`DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT`, `DYN_ROUTER_PREFILL_LOAD_SCALE`,
+`DYN_ROUTER_TEMPERATURE`, `DYN_USE_KV_EVENTS`, etc.) documented in the
+Configuration section below. The deprecated overlap-weight aliases remain
+supported with the same precedence as the Go EPP.
 
 > [!NOTE]
 > The Rust EPP is experimental. It uses Dynamo's native discovery system
 > (`DistributedRuntime`) instead of the GAIE Kubernetes controllers, so it
 > does not require `InferencePool` or `InferenceModel` CRDs for endpoint
 > discovery. It discovers workers through Dynamo's own registration mechanism.
+
+> [!WARNING]
+> The Rust EPP currently supports only pod-level Kubernetes discovery. Deploy
+> one Rust EPP replica per pool because request selection and booking are not
+> yet atomic across concurrent EPP replicas. After a worker-generation rolling
+> update, restart the Rust EPP so it binds to the new generation namespace.
+> Exact streamed output-block updates are also not yet wired into the Rust EPP.
 
 #### `InferencePool` and the data plane (Istio, kGateway, Agentgateway)
 
@@ -365,6 +375,7 @@ To disable the EPP from listening for KV events (e.g., when prefix caching is of
 - `DYN_ROUTER_REPLICA_SYNC` — Enable replica synchronization (default: false)
 - `DYN_ROUTER_TRACK_ACTIVE_BLOCKS` — Track active blocks (default: true)
 - `DYN_ROUTER_TRACK_OUTPUT_BLOCKS` — Track output blocks during generation (default: false)
+- `DYN_ROUTER_PREDICTED_TTL_SECS` — Enable predict-on-route entries with this TTL in seconds
 - See the [KV cache routing design](../design-docs/router-design.md) for details.
 
 

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -12,9 +12,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use dynamo_kv_router::{
-    config::{
-        KvRouterConfig, RouterConfigOverride, apply_deprecated_overlap_score_weight_override,
-    },
+    config::{RouterConfigOverride, kv_router_config_from_dynamo_env},
     protocols::*,
 };
 use dynamo_llm::kv_router::publisher::KvEventPublisher;
@@ -625,85 +623,6 @@ pub enum QueryRouterResult {
     ErrBackpressure = 7,
 }
 
-/// Build a `KvRouterConfig` from defaults, overridden by optional `DYN_*` environment variables.
-fn kv_router_config_from_env() -> KvRouterConfig {
-    let mut cfg = KvRouterConfig::default();
-
-    fn env_f64(key: &str) -> Option<f64> {
-        std::env::var(key).ok().and_then(|v| v.parse().ok())
-    }
-    fn env_bool(key: &str) -> Option<bool> {
-        std::env::var(key)
-            .ok()
-            .and_then(|v| match v.to_lowercase().as_str() {
-                "true" | "1" | "yes" | "on" => Some(true),
-                "false" | "0" | "no" | "off" => Some(false),
-                _ => None,
-            })
-    }
-
-    if let Some(v) = env_f64("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT") {
-        cfg.overlap_score_credit = v;
-    }
-    if let Some(v) = env_f64("DYN_ROUTER_PREFILL_LOAD_SCALE") {
-        cfg.prefill_load_scale = v;
-    }
-    for key in [
-        "DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT",
-        "DYN_OVERLAP_SCORE_WEIGHT",
-    ] {
-        if let Some(v) = env_f64(key) {
-            tracing::warn!("{key} is deprecated; use DYN_ROUTER_PREFILL_LOAD_SCALE");
-            apply_deprecated_overlap_score_weight_override(
-                v,
-                &mut cfg.overlap_score_credit,
-                &mut cfg.prefill_load_scale,
-            );
-            break;
-        }
-    }
-    if let Some(v) = env_f64("DYN_ROUTER_TEMPERATURE") {
-        cfg.router_temperature = v;
-    }
-    if let Some(v) = env_bool("DYN_USE_KV_EVENTS") {
-        cfg.use_kv_events = v;
-    }
-    if let Some(v) = env_bool("DYN_ROUTER_REPLICA_SYNC") {
-        cfg.router_replica_sync = v;
-    }
-    if let Some(v) = env_bool("DYN_ROUTER_TRACK_ACTIVE_BLOCKS") {
-        cfg.router_track_active_blocks = v;
-    }
-    if let Some(v) = env_bool("DYN_ROUTER_TRACK_OUTPUT_BLOCKS") {
-        cfg.router_track_output_blocks = v;
-    }
-    if let Some(v) = env_bool("DYN_ROUTER_TRACK_PREFILL_TOKENS") {
-        cfg.router_track_prefill_tokens = v;
-    }
-    if let Some(v) = env_f64("DYN_ROUTER_QUEUE_THRESHOLD") {
-        cfg.router_queue_threshold = Some(v);
-    }
-    if let Some(v) = env_f64("DYN_ROUTER_PREDICTED_TTL_SECS") {
-        cfg.router_predicted_ttl_secs = Some(v);
-    }
-    tracing::info!(
-        overlap_score_credit = cfg.overlap_score_credit,
-        prefill_load_scale = cfg.prefill_load_scale,
-        router_temperature = cfg.router_temperature,
-        use_kv_events = cfg.use_kv_events,
-        router_replica_sync = cfg.router_replica_sync,
-        router_track_active_blocks = cfg.router_track_active_blocks,
-        router_track_output_blocks = cfg.router_track_output_blocks,
-        router_track_prefill_tokens = cfg.router_track_prefill_tokens,
-        router_queue_threshold = ?cfg.router_queue_threshold,
-        router_predicted_ttl_secs = ?cfg.router_predicted_ttl_secs,
-        queue_depth_tiers_unbounded = cfg.router_queue_by_incoming_missing_isl.is_unbounded(),
-        "KvRouterConfig initialized (DYN_* env overrides applied)"
-    );
-
-    cfg
-}
-
 /// Create router handles for query-only routing
 ///
 /// This function waits for at least one decode worker to be discovered before returning.
@@ -790,7 +709,7 @@ pub unsafe extern "C" fn create_routers(
             );
         }
 
-        let mut kv_router_config = kv_router_config_from_env();
+        let mut kv_router_config = kv_router_config_from_dynamo_env();
         kv_router_config.skip_initial_worker_wait = true;
 
         // Build endpoint using the actual namespace discovered from workers,

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -86,6 +86,89 @@ pub fn apply_deprecated_overlap_score_weight_override(
     }
 }
 
+/// Build a [`KvRouterConfig`] from defaults and standard Dynamo environment variables.
+pub fn kv_router_config_from_dynamo_env() -> KvRouterConfig {
+    let config = kv_router_config_from_lookup(|key| env::var(key).ok());
+    tracing::info!(
+        overlap_score_credit = config.overlap_score_credit,
+        prefill_load_scale = config.prefill_load_scale,
+        router_temperature = config.router_temperature,
+        use_kv_events = config.use_kv_events,
+        router_replica_sync = config.router_replica_sync,
+        router_track_active_blocks = config.router_track_active_blocks,
+        router_track_output_blocks = config.router_track_output_blocks,
+        router_track_prefill_tokens = config.router_track_prefill_tokens,
+        router_queue_threshold = ?config.router_queue_threshold,
+        router_predicted_ttl_secs = ?config.router_predicted_ttl_secs,
+        queue_depth_tiers_unbounded = config.router_queue_by_incoming_missing_isl.is_unbounded(),
+        "KvRouterConfig initialized (DYN_* env overrides applied)"
+    );
+    config
+}
+
+fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvRouterConfig {
+    fn parse_f64(get_env: &impl Fn(&str) -> Option<String>, key: &str) -> Option<f64> {
+        get_env(key).and_then(|value| value.parse().ok())
+    }
+
+    fn parse_bool(get_env: &impl Fn(&str) -> Option<String>, key: &str) -> Option<bool> {
+        get_env(key).and_then(|value| match value.to_ascii_lowercase().as_str() {
+            "true" | "1" | "yes" | "on" => Some(true),
+            "false" | "0" | "no" | "off" => Some(false),
+            _ => None,
+        })
+    }
+
+    let mut config = KvRouterConfig::default();
+
+    if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT") {
+        config.overlap_score_credit = value;
+    }
+    if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_PREFILL_LOAD_SCALE") {
+        config.prefill_load_scale = value;
+    }
+    for key in [
+        "DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT",
+        "DYN_OVERLAP_SCORE_WEIGHT",
+    ] {
+        if let Some(value) = parse_f64(&get_env, key) {
+            tracing::warn!("{key} is deprecated; use DYN_ROUTER_PREFILL_LOAD_SCALE");
+            apply_deprecated_overlap_score_weight_override(
+                value,
+                &mut config.overlap_score_credit,
+                &mut config.prefill_load_scale,
+            );
+            break;
+        }
+    }
+    if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_TEMPERATURE") {
+        config.router_temperature = value;
+    }
+    if let Some(value) = parse_bool(&get_env, "DYN_USE_KV_EVENTS") {
+        config.use_kv_events = value;
+    }
+    if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_REPLICA_SYNC") {
+        config.router_replica_sync = value;
+    }
+    if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_ACTIVE_BLOCKS") {
+        config.router_track_active_blocks = value;
+    }
+    if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_OUTPUT_BLOCKS") {
+        config.router_track_output_blocks = value;
+    }
+    if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_PREFILL_TOKENS") {
+        config.router_track_prefill_tokens = value;
+    }
+    if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_QUEUE_THRESHOLD") {
+        config.router_queue_threshold = Some(value);
+    }
+    if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_PREDICTED_TTL_SECS") {
+        config.router_predicted_ttl_secs = Some(value);
+    }
+
+    config
+}
+
 fn apply_deprecated_overlap_score_weight_override_option(
     value: f64,
     overlap_score_credit: &mut Option<f64>,
@@ -841,6 +924,92 @@ impl KvRouterConfig {
 mod tests {
     use super::*;
     use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo};
+    use std::collections::HashMap;
+
+    fn config_from_values(values: &[(&str, &str)]) -> KvRouterConfig {
+        let values: HashMap<&str, &str> = values.iter().copied().collect();
+        kv_router_config_from_lookup(|key| values.get(key).map(|value| (*value).to_string()))
+    }
+
+    #[test]
+    fn dynamo_env_config_uses_defaults_when_unset() {
+        let config = config_from_values(&[]);
+        let default = KvRouterConfig::default();
+
+        assert_eq!(config.overlap_score_credit, default.overlap_score_credit);
+        assert_eq!(config.prefill_load_scale, default.prefill_load_scale);
+        assert_eq!(config.use_kv_events, default.use_kv_events);
+        assert_eq!(
+            config.router_predicted_ttl_secs,
+            default.router_predicted_ttl_secs
+        );
+    }
+
+    #[test]
+    fn dynamo_env_config_parses_canonical_settings() {
+        let config = config_from_values(&[
+            ("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", "0.25"),
+            ("DYN_ROUTER_PREFILL_LOAD_SCALE", "2.5"),
+            ("DYN_ROUTER_TEMPERATURE", "0.7"),
+            ("DYN_USE_KV_EVENTS", "false"),
+            ("DYN_ROUTER_REPLICA_SYNC", "yes"),
+            ("DYN_ROUTER_TRACK_ACTIVE_BLOCKS", "0"),
+            ("DYN_ROUTER_TRACK_OUTPUT_BLOCKS", "on"),
+            ("DYN_ROUTER_TRACK_PREFILL_TOKENS", "false"),
+            ("DYN_ROUTER_QUEUE_THRESHOLD", "4.5"),
+        ]);
+
+        assert_eq!(config.overlap_score_credit, 0.25);
+        assert_eq!(config.prefill_load_scale, 2.5);
+        assert_eq!(config.router_temperature, 0.7);
+        assert!(!config.use_kv_events);
+        assert!(config.router_replica_sync);
+        assert!(!config.router_track_active_blocks);
+        assert!(config.router_track_output_blocks);
+        assert!(!config.router_track_prefill_tokens);
+        assert_eq!(config.router_queue_threshold, Some(4.5));
+
+        let predicted = config_from_values(&[("DYN_ROUTER_PREDICTED_TTL_SECS", "60")]);
+        assert_eq!(predicted.router_predicted_ttl_secs, Some(60.0));
+        assert!(predicted.validate_config().is_ok());
+    }
+
+    #[test]
+    fn dynamo_env_config_preserves_deprecated_alias_precedence() {
+        let config = config_from_values(&[
+            ("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", "0.25"),
+            ("DYN_ROUTER_PREFILL_LOAD_SCALE", "2"),
+            ("DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT", "3"),
+            ("DYN_OVERLAP_SCORE_WEIGHT", "4"),
+        ]);
+
+        assert_eq!(config.overlap_score_credit, 0.25);
+        assert_eq!(config.prefill_load_scale, 3.0);
+
+        let disabled = config_from_values(&[
+            ("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", "0.75"),
+            ("DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT", "0"),
+        ]);
+        assert_eq!(disabled.overlap_score_credit, 0.0);
+        assert_eq!(disabled.prefill_load_scale, 0.0);
+    }
+
+    #[test]
+    fn dynamo_env_config_ignores_unparseable_values_and_validates_ranges() {
+        let unparseable = config_from_values(&[
+            ("DYN_ROUTER_TEMPERATURE", "warm"),
+            ("DYN_ROUTER_TRACK_ACTIVE_BLOCKS", "sometimes"),
+        ]);
+        let default = KvRouterConfig::default();
+        assert_eq!(unparseable.router_temperature, default.router_temperature);
+        assert_eq!(
+            unparseable.router_track_active_blocks,
+            default.router_track_active_blocks
+        );
+
+        let out_of_range = config_from_values(&[("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", "1.5")]);
+        assert!(out_of_range.validate_config().is_err());
+    }
 
     #[test]
     fn compute_seq_hashes_for_tracking_uses_mm_hashes() {


### PR DESCRIPTION
## Summary

- preserve configured overlap, KV reuse, and prefill tracking for aggregated requests while applying the decode-side override only to disaggregated requests
- mark decode-router prefill complete on the first non-empty response chunk in both routing modes, with idempotent final cleanup
- share Dynamo router environment parsing between Rust EPP and the C bindings without adding runtime dependencies
- reject container discovery at Rust EPP startup, document current operational restrictions, and record deferred gaps as focused TODOs

## Validation

- `cargo test -p dynamo-ext-proc`
- `cargo test -p dynamo-llm --no-default-features kv_router::tests::test_find_best_match_maps_overload_to_resource_exhausted`
- `cargo test -p dynamo-kv-router`
- `cargo test -p libdynamo_llm`
- clippy with `-D warnings` for `dynamo-kv-router`, `dynamo-ext-proc`, and `libdynamo_llm`
- `cargo fmt` for all affected Rust crates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable support for KV router configuration using standard Dynamo-style variables.
  * Introduced validation for Kubernetes discovery mode configuration.

* **Improvements**
  * Enhanced prefill completion callback behavior to work consistently across routing modes.
  * Improved router configuration loading mechanism.

* **Documentation**
  * Updated inference gateway configuration guide with new environment variables and routing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->