### PR TITLE
perf(llm): reduce Responses stream overhead

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2110,12 +2110,12 @@ async fn responses(
                     &mut http_queue_guard,
                 );
 
-                // Check for backend error before extracting data.
-                // Error events have data: None and event: Some("error").
+                if extract_backend_error_if_present(&annotated_chunk).is_some() {
+                    saw_error = true;
+                    continue;
+                }
+
                 let Some(stream_resp) = annotated_chunk.data else {
-                    if annotated_chunk.event.as_deref() == Some("error") {
-                        saw_error = true;
-                    }
                     continue;
                 };
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2084,72 +2084,56 @@ async fn responses(
         // The engine yields Annotated<NvCreateChatCompletionStreamResponse>. We extract the
         // inner stream response data and convert it to Responses API events.
         use crate::protocols::openai::responses::stream_converter::ResponseStreamConverter;
-        use std::sync::atomic::{AtomicBool, Ordering};
 
         let mut converter = match responses_ctx {
             Some(ctx) => ResponseStreamConverter::with_context(model.clone(), response_params, ctx),
             None => ResponseStreamConverter::new(model.clone(), response_params),
         };
-        let start_events = converter.emit_start_events();
-
-        // Use std::sync::Mutex (not tokio) since process_chunk/emit_end_events are
-        // synchronous -- no .await while lock is held. Avoids async lock overhead per token.
-        let converter = std::sync::Arc::new(std::sync::Mutex::new(converter));
-        let converter_end = converter.clone();
-
-        // Track whether the backend sent an error event during the stream.
-        // Shared between event_stream (writer) and done_stream (reader).
-        let saw_error = std::sync::Arc::new(AtomicBool::new(false));
-        let saw_error_end = saw_error.clone();
 
         let mut http_queue_guard = Some(http_queue_guard);
 
-        // Process each annotated chunk: extract the stream response data, convert to events
-        let event_stream = engine_stream
-            .inspect(move |response| {
+        let mut engine_stream = Box::pin(engine_stream);
+        let full_stream = async_stream::stream! {
+            let mut events = Vec::with_capacity(4);
+            converter.append_start_events(&mut events);
+            for event in events.drain(..) {
+                yield event.map_err(axum::Error::new);
+            }
+
+            // Track whether the backend sent an error event during the stream.
+            let mut saw_error = false;
+
+            while let Some(annotated_chunk) = engine_stream.next().await {
                 process_response_and_observe_metrics(
-                    response,
+                    &annotated_chunk,
                     &mut response_collector,
                     &mut http_queue_guard,
                 );
-            })
-            .filter_map(move |annotated_chunk| {
-                let converter = converter.clone();
-                let saw_error = saw_error.clone();
-                async move {
-                    // Check for backend error before extracting data.
-                    // Error events have data: None and event: Some("error").
-                    if annotated_chunk.data.is_none() {
-                        if annotated_chunk.event.as_deref() == Some("error") {
-                            saw_error.store(true, Ordering::Release);
-                        }
-                        return None;
+
+                // Check for backend error before extracting data.
+                // Error events have data: None and event: Some("error").
+                let Some(stream_resp) = annotated_chunk.data else {
+                    if annotated_chunk.event.as_deref() == Some("error") {
+                        saw_error = true;
                     }
-                    let stream_resp = annotated_chunk.data?;
-                    let mut conv = converter.lock().expect("converter lock poisoned");
-                    let events = conv.process_chunk(&stream_resp);
-                    Some(stream::iter(events))
+                    continue;
+                };
+
+                converter.append_chunk_events(&stream_resp, &mut events);
+                for event in events.drain(..) {
+                    yield event.map_err(axum::Error::new);
                 }
-            })
-            .flatten();
+            }
 
-        // Chain: start_events -> chunk_events -> end_events
-        let start_stream = stream::iter(start_events);
-
-        let done_stream = stream::once(async move {
-            let mut conv = converter_end.lock().expect("converter lock poisoned");
-            let end_events = if saw_error_end.load(Ordering::Acquire) {
-                conv.emit_error_events()
+            if saw_error {
+                converter.append_error_events(&mut events);
             } else {
-                conv.emit_end_events()
-            };
-            stream::iter(end_events)
-        })
-        .flatten();
-
-        let full_stream = start_stream.chain(event_stream).chain(done_stream);
-
-        let full_stream = full_stream.map(|result| result.map_err(axum::Error::new));
+                converter.append_end_events(&mut events);
+            }
+            for event in events.drain(..) {
+                yield event.map_err(axum::Error::new);
+            }
+        };
 
         // Wrap with disconnect monitoring: detects client disconnects, cancels generation,
         // and defers inflight_guard.mark_ok() until the stream completes.

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -23,6 +23,10 @@ use dynamo_protocols::types::responses::{
     ResponseTextDoneEvent, ResponseTextParam, ResponseUsage, ServiceTier, Status,
     TextResponseFormatConfiguration, ToolChoiceOptions, ToolChoiceParam, Truncation,
 };
+use serde::{
+    Serialize,
+    ser::{SerializeMap, Serializer},
+};
 use uuid::Uuid;
 
 use dynamo_protocols::types::ChatCompletionMessageContent;
@@ -168,7 +172,12 @@ impl ResponseStreamConverter {
     /// Emit the initial lifecycle events: created + in_progress.
     pub fn emit_start_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::with_capacity(2);
+        self.append_start_events(&mut events);
+        events
+    }
 
+    /// Append the initial lifecycle events: created + in_progress.
+    pub fn append_start_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
         let created = ResponseStreamEvent::ResponseCreated(ResponseCreatedEvent {
             sequence_number: self.next_seq(),
             response: self.make_response(Status::InProgress, vec![]),
@@ -180,8 +189,6 @@ impl ResponseStreamConverter {
             response: self.make_response(Status::InProgress, vec![]),
         });
         events.push(self.make_sse_event(&in_progress));
-
-        events
     }
 
     /// Process a single chat completion stream chunk and return zero or more SSE events.
@@ -190,7 +197,16 @@ impl ResponseStreamConverter {
         chunk: &NvCreateChatCompletionStreamResponse,
     ) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::new();
+        self.append_chunk_events(chunk, &mut events);
+        events
+    }
 
+    /// Process a single chat completion stream chunk and append zero or more SSE events.
+    pub fn append_chunk_events(
+        &mut self,
+        chunk: &NvCreateChatCompletionStreamResponse,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+    ) {
         // Capture usage stats from the final chunk (sent when stream_options.include_usage=true)
         if let Some(ref u) = chunk.inner.usage {
             self.usage = Some(ResponseUsage {
@@ -405,14 +421,17 @@ impl ResponseStreamConverter {
                 }
             }
         }
-
-        events
     }
 
     /// Emit the final events when the stream ends: done events + completed.
     pub fn emit_end_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::new();
+        self.append_end_events(&mut events);
+        events
+    }
 
+    /// Append the final events when the stream ends: done events + completed.
+    pub fn append_end_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
         // Close text message if it was started
         if self.message_started {
             let text_done = ResponseStreamEvent::ResponseOutputTextDone(ResponseTextDoneEvent {
@@ -535,21 +554,22 @@ impl ResponseStreamConverter {
             response: self.make_response(Status::Completed, output),
         });
         events.push(self.make_sse_event(&completed));
-
-        events
     }
 
     /// Emit error events when the stream ends due to a backend error.
     pub fn emit_error_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::new();
+        self.append_error_events(&mut events);
+        events
+    }
 
+    /// Append error events when the stream ends due to a backend error.
+    pub fn append_error_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
         let failed = ResponseStreamEvent::ResponseFailed(ResponseFailedEvent {
             sequence_number: self.next_seq(),
             response: self.make_response(Status::Failed, vec![]),
         });
         events.push(self.make_sse_event(&failed));
-
-        events
     }
 }
 
@@ -560,20 +580,189 @@ impl ResponseStreamConverter {
     /// `self.params` rather than hardcoded at each emit site.
     fn make_sse_event(&self, event: &ResponseStreamEvent) -> Result<Event, anyhow::Error> {
         let event_type = get_event_type(event);
-        let mut value = serde_json::to_value(event)?;
-        if let serde_json::Value::Object(ref mut obj) = value
-            && let Some(serde_json::Value::Object(inner)) = obj.get_mut("response")
-        {
-            super::patch_response_for_spec(
-                inner,
-                self.params.presence_penalty.unwrap_or(0.0),
-                self.params.frequency_penalty.unwrap_or(0.0),
-                self.params.store.unwrap_or(false),
-            );
-        }
-        let data = serde_json::to_string(&value)?;
+        let data = self.serialize_event_data(event)?;
         Ok(Event::default().event(event_type).data(data))
     }
+
+    fn serialize_event_data(
+        &self,
+        event: &ResponseStreamEvent,
+    ) -> Result<String, serde_json::Error> {
+        let spec = ResponseSpecFields {
+            presence_penalty: self.params.presence_penalty.unwrap_or(0.0),
+            frequency_penalty: self.params.frequency_penalty.unwrap_or(0.0),
+            store: self.params.store.unwrap_or(false),
+        };
+
+        match event {
+            ResponseStreamEvent::ResponseCreated(event) => {
+                serde_json::to_string(&ResponseEventForSpec::new(
+                    "response.created",
+                    event.sequence_number,
+                    &event.response,
+                    spec,
+                ))
+            }
+            ResponseStreamEvent::ResponseInProgress(event) => {
+                serde_json::to_string(&ResponseEventForSpec::new(
+                    "response.in_progress",
+                    event.sequence_number,
+                    &event.response,
+                    spec,
+                ))
+            }
+            ResponseStreamEvent::ResponseCompleted(event) => {
+                serde_json::to_string(&ResponseEventForSpec::new(
+                    "response.completed",
+                    event.sequence_number,
+                    &event.response,
+                    spec,
+                ))
+            }
+            ResponseStreamEvent::ResponseFailed(event) => {
+                serde_json::to_string(&ResponseEventForSpec::new(
+                    "response.failed",
+                    event.sequence_number,
+                    &event.response,
+                    spec,
+                ))
+            }
+            ResponseStreamEvent::ResponseIncomplete(event) => {
+                serde_json::to_string(&ResponseEventForSpec::new(
+                    "response.incomplete",
+                    event.sequence_number,
+                    &event.response,
+                    spec,
+                ))
+            }
+            ResponseStreamEvent::ResponseQueued(event) => {
+                serde_json::to_string(&ResponseEventForSpec::new(
+                    "response.queued",
+                    event.sequence_number,
+                    &event.response,
+                    spec,
+                ))
+            }
+            _ => serde_json::to_string(event),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ResponseSpecFields {
+    presence_penalty: f32,
+    frequency_penalty: f32,
+    store: bool,
+}
+
+struct ResponseEventForSpec<'a> {
+    event_type: &'static str,
+    sequence_number: u64,
+    response: &'a Response,
+    spec: ResponseSpecFields,
+}
+
+impl<'a> ResponseEventForSpec<'a> {
+    fn new(
+        event_type: &'static str,
+        sequence_number: u64,
+        response: &'a Response,
+        spec: ResponseSpecFields,
+    ) -> Self {
+        Self {
+            event_type,
+            sequence_number,
+            response,
+            spec,
+        }
+    }
+}
+
+impl Serialize for ResponseEventForSpec<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(3))?;
+        map.serialize_entry("type", self.event_type)?;
+        map.serialize_entry("sequence_number", &self.sequence_number)?;
+        map.serialize_entry(
+            "response",
+            &ResponseForSpec {
+                response: self.response,
+                spec: self.spec,
+            },
+        )?;
+        map.end()
+    }
+}
+
+struct ResponseForSpec<'a> {
+    response: &'a Response,
+    spec: ResponseSpecFields,
+}
+
+// Mirrors async-openai's `Response` serialization while writing Dynamo's
+// OpenResponses spec fields directly, avoiding a per-stream-event Value tree.
+impl Serialize for ResponseForSpec<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let response = self.response;
+        let mut map = serializer.serialize_map(None)?;
+
+        serialize_optional_entry(&mut map, "background", &response.background)?;
+        map.serialize_entry("billing", &response.billing)?;
+        map.serialize_entry("conversation", &response.conversation)?;
+        map.serialize_entry("created_at", &response.created_at)?;
+        map.serialize_entry("completed_at", &response.completed_at)?;
+        map.serialize_entry("error", &response.error)?;
+        map.serialize_entry("id", &response.id)?;
+        map.serialize_entry("incomplete_details", &response.incomplete_details)?;
+        map.serialize_entry("instructions", &response.instructions)?;
+        map.serialize_entry("max_output_tokens", &response.max_output_tokens)?;
+        map.serialize_entry("max_tool_calls", &None::<u32>)?;
+        serialize_optional_entry(&mut map, "metadata", &response.metadata)?;
+        map.serialize_entry("model", &response.model)?;
+        map.serialize_entry("object", &response.object)?;
+        map.serialize_entry("output", &response.output)?;
+        serialize_optional_entry(
+            &mut map,
+            "parallel_tool_calls",
+            &response.parallel_tool_calls,
+        )?;
+        map.serialize_entry("previous_response_id", &response.previous_response_id)?;
+        map.serialize_entry("prompt", &response.prompt)?;
+        map.serialize_entry("prompt_cache_key", &response.prompt_cache_key)?;
+        map.serialize_entry("prompt_cache_retention", &response.prompt_cache_retention)?;
+        map.serialize_entry("reasoning", &response.reasoning)?;
+        map.serialize_entry("safety_identifier", &response.safety_identifier)?;
+        serialize_optional_entry(&mut map, "service_tier", &response.service_tier)?;
+        map.serialize_entry("status", &response.status)?;
+        serialize_optional_entry(&mut map, "temperature", &response.temperature)?;
+        serialize_optional_entry(&mut map, "text", &response.text)?;
+        serialize_optional_entry(&mut map, "tool_choice", &response.tool_choice)?;
+        serialize_optional_entry(&mut map, "tools", &response.tools)?;
+        serialize_optional_entry(&mut map, "top_logprobs", &response.top_logprobs)?;
+        serialize_optional_entry(&mut map, "top_p", &response.top_p)?;
+        serialize_optional_entry(&mut map, "truncation", &response.truncation)?;
+        map.serialize_entry("usage", &response.usage)?;
+        map.serialize_entry("presence_penalty", &self.spec.presence_penalty)?;
+        map.serialize_entry("frequency_penalty", &self.spec.frequency_penalty)?;
+        map.serialize_entry("store", &self.spec.store)?;
+
+        map.end()
+    }
+}
+
+fn serialize_optional_entry<S, T>(
+    map: &mut S,
+    key: &'static str,
+    value: &Option<T>,
+) -> Result<(), S::Error>
+where
+    S: SerializeMap,
+    T: Serialize,
+{
+    if let Some(value) = value {
+        map.serialize_entry(key, value)?;
+    }
+    Ok(())
 }
 
 fn get_event_type(event: &ResponseStreamEvent) -> &'static str {
@@ -786,6 +975,31 @@ mod tests {
         events.iter().map(event_type).collect()
     }
 
+    fn legacy_event_json(
+        event: &ResponseStreamEvent,
+        params: &ResponseParams,
+    ) -> serde_json::Value {
+        let mut value = serde_json::to_value(event).unwrap();
+        if let serde_json::Value::Object(ref mut obj) = value
+            && let Some(serde_json::Value::Object(inner)) = obj.get_mut("response")
+        {
+            super::super::patch_response_for_spec(
+                inner,
+                params.presence_penalty.unwrap_or(0.0),
+                params.frequency_penalty.unwrap_or(0.0),
+                params.store.unwrap_or(false),
+            );
+        }
+        value
+    }
+
+    fn optimized_event_json(
+        converter: &ResponseStreamConverter,
+        event: &ResponseStreamEvent,
+    ) -> serde_json::Value {
+        serde_json::from_str(&converter.serialize_event_data(event).unwrap()).unwrap()
+    }
+
     /// Complete tool call emits function_call_arguments.done + output_item.done inline.
     #[test]
     fn test_complete_tool_call_emits_done_inline() {
@@ -975,5 +1189,88 @@ mod tests {
 
         let response = conv.make_response(Status::Completed, vec![]);
         assert_eq!(response.parallel_tool_calls, Some(false));
+    }
+
+    #[test]
+    fn test_append_chunk_events_preserves_order() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+        let mut events = Vec::with_capacity(4);
+
+        conv.append_chunk_events(&text_chunk("Hello"), &mut events);
+
+        assert_eq!(
+            event_types(&events),
+            vec![
+                "response.output_item.added".to_string(),
+                "response.content_part.added".to_string(),
+                "response.output_text.delta".to_string(),
+            ]
+        );
+
+        events.clear();
+        conv.append_chunk_events(
+            &tool_call_chunk(0, Some("call-1"), Some("lookup"), Some("{\"q\":\"x\"}")),
+            &mut events,
+        );
+
+        assert_eq!(
+            event_types(&events),
+            vec![
+                "response.output_item.added".to_string(),
+                "response.function_call_arguments.delta".to_string(),
+                "response.function_call_arguments.done".to_string(),
+                "response.output_item.done".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_optimized_stream_event_serializer_matches_patched_json() {
+        let params = ResponseParams {
+            presence_penalty: Some(0.25),
+            frequency_penalty: Some(0.5),
+            store: Some(true),
+            ..Default::default()
+        };
+        let mut conv = ResponseStreamConverter::new("test-model".into(), params.clone());
+
+        let response_event = ResponseStreamEvent::ResponseCreated(ResponseCreatedEvent {
+            sequence_number: conv.next_seq(),
+            response: conv.make_response(Status::InProgress, vec![]),
+        });
+        let text_event = ResponseStreamEvent::ResponseOutputTextDelta(ResponseTextDeltaEvent {
+            sequence_number: conv.next_seq(),
+            item_id: "msg_1".to_string(),
+            output_index: 0,
+            content_index: 0,
+            delta: "line\nquote\"slash\\ cjk 漢字 emoji 🚀".to_string(),
+            logprobs: Some(vec![]),
+        });
+        let tool_event = ResponseStreamEvent::ResponseFunctionCallArgumentsDone(
+            ResponseFunctionCallArgumentsDoneEvent {
+                name: Some("lookup".to_string()),
+                sequence_number: conv.next_seq(),
+                item_id: "fc_1".to_string(),
+                output_index: 1,
+                arguments: "{\"q\":\"x\"}".to_string(),
+            },
+        );
+        let completed_event = ResponseStreamEvent::ResponseCompleted(ResponseCompletedEvent {
+            sequence_number: conv.next_seq(),
+            response: conv.make_response(Status::Completed, vec![]),
+        });
+
+        for event in [&response_event, &text_event, &tool_event, &completed_event] {
+            assert_eq!(
+                optimized_event_json(&conv, event),
+                legacy_event_json(event, &params)
+            );
+        }
+
+        let response_json = optimized_event_json(&conv, &response_event);
+        assert_eq!(response_json["response"]["presence_penalty"], 0.25);
+        assert_eq!(response_json["response"]["frequency_penalty"], 0.5);
+        assert_eq!(response_json["response"]["store"], true);
+        assert!(response_json["response"]["max_tool_calls"].is_null());
     }
 }


### PR DESCRIPTION
## Summary
- Rework the Responses API streaming adapter to own the converter directly, reuse event storage, and avoid per-chunk mutex/filter-map/flatten plumbing.
- Add append-style ResponseStreamConverter methods while keeping existing emit/process APIs intact.
- Serialize response-bearing Responses stream events directly with borrowed Serialize wrappers instead of building and patching serde_json::Value trees.

## Benchmarked Perf
- c512 Responses on-CPU profile with msgpack + tokenizer cache: ResponseStreamConverter inclusive CPU dropped from 11.59% to 5.79%.
- make_sse_event dropped from 10.97% to 5.04%; serde_json::Value path dropped from 4.56% to 1.26%.
- Estimated clean e2e uplift is about 6% when the frontend is the bottleneck. The post-change run had 15.9% backend worker errors, so this PR reports profile-confirmed CPU reduction rather than a clean observed throughput delta.

## Where should the reviewer start?
- `lib/llm/src/protocols/openai/responses/stream_converter.rs`
- `lib/llm/src/http/service/openai.rs`

## Related Issues
- [x] Confirmed no related issue.

## Validation
- cargo fmt --check
- cargo test -p dynamo-llm protocols::openai::responses::stream_converter
- cargo test -p dynamo-llm http::service::openai
- cargo test -p dynamo-llm --test http-service-aiperf-responses
- cargo test -p dynamo-llm protocols::openai::responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved backend streaming response architecture for enhanced system efficiency and code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
