### PR TITLE
perf(llm): reduce Anthropic messages stream overhead

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -26,7 +26,7 @@ use axum::{
 };
 use dynamo_runtime::config::{env_is_truthy, environment_names::llm as env_llm};
 use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
-use futures::{StreamExt, stream};
+use futures::StreamExt;
 use tracing::Instrument;
 
 use super::{
@@ -370,65 +370,54 @@ async fn anthropic_messages(
     if streaming {
         stream_handle.arm();
 
-        use std::sync::atomic::{AtomicBool, Ordering};
-
         let mut converter = match anthropic_ctx {
             Some(ctx) => {
                 AnthropicStreamConverter::with_context(model_for_resp, estimated_input_tokens, ctx)
             }
             None => AnthropicStreamConverter::new(model_for_resp, estimated_input_tokens),
         };
-        let start_events = converter.emit_start_events();
-
-        let converter = std::sync::Arc::new(std::sync::Mutex::new(converter));
-        let converter_end = converter.clone();
-
-        let saw_error = std::sync::Arc::new(AtomicBool::new(false));
-        let saw_error_end = saw_error.clone();
 
         let mut http_queue_guard = Some(http_queue_guard);
+        let mut engine_stream = engine_stream;
 
-        let event_stream = engine_stream
-            .inspect(move |response| {
+        let full_stream = async_stream::stream! {
+            let mut events = Vec::with_capacity(4);
+            converter.append_start_events(&mut events);
+            for event in events.drain(..) {
+                yield event.map_err(axum::Error::new);
+            }
+
+            let mut saw_error = false;
+
+            while let Some(annotated_chunk) = engine_stream.next().await {
                 process_response_and_observe_metrics(
-                    response,
+                    &annotated_chunk,
                     &mut response_collector,
                     &mut http_queue_guard,
                 );
-            })
-            .filter_map(move |annotated_chunk| {
-                let converter = converter.clone();
-                let saw_error = saw_error.clone();
-                async move {
-                    if annotated_chunk.data.is_none() {
-                        if annotated_chunk.event.as_deref() == Some("error") {
-                            saw_error.store(true, Ordering::Release);
-                        }
-                        return None;
+
+                let Some(stream_resp) = annotated_chunk.data else {
+                    if annotated_chunk.event.as_deref() == Some("error") {
+                        saw_error = true;
                     }
-                    let stream_resp = annotated_chunk.data?;
-                    let mut conv = converter.lock().expect("converter lock poisoned");
-                    let events = conv.process_chunk(&stream_resp);
-                    Some(stream::iter(events))
+                    continue;
+                };
+
+                converter.append_chunk_events(&stream_resp, &mut events);
+                for event in events.drain(..) {
+                    yield event.map_err(axum::Error::new);
                 }
-            })
-            .flatten();
+            }
 
-        let start_stream = stream::iter(start_events);
-
-        let done_stream = stream::once(async move {
-            let mut conv = converter_end.lock().expect("converter lock poisoned");
-            let end_events = if saw_error_end.load(Ordering::Acquire) {
-                conv.emit_error_events()
+            if saw_error {
+                converter.append_error_events(&mut events);
             } else {
-                conv.emit_end_events()
-            };
-            stream::iter(end_events)
-        })
-        .flatten();
-
-        let full_stream = start_stream.chain(event_stream).chain(done_stream);
-        let full_stream = full_stream.map(|result| result.map_err(axum::Error::new));
+                converter.append_end_events(&mut events);
+            }
+            for event in events.drain(..) {
+                yield event.map_err(axum::Error::new);
+            }
+        };
 
         let stream = monitor_for_disconnects(full_stream, ctx, inflight_guard, stream_handle);
 

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -95,6 +95,13 @@ impl AnthropicStreamConverter {
 
     /// Emit the initial `message_start` event.
     pub fn emit_start_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
+        let mut events = Vec::with_capacity(1);
+        self.append_start_events(&mut events);
+        events
+    }
+
+    /// Append the initial `message_start` event.
+    pub fn append_start_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
         // TODO: When AnthropicMessageResponse gains a `service_tier` field,
         // populate it from `self.api_context` (if the original request specified one).
         let message = AnthropicMessageResponse {
@@ -114,7 +121,7 @@ impl AnthropicStreamConverter {
         };
 
         let event = AnthropicStreamEvent::MessageStart { message };
-        vec![make_sse_event("message_start", &event)]
+        events.push(make_sse_event("message_start", &event));
     }
 
     /// Process a single chat completion stream chunk and return zero or more SSE events.
@@ -123,7 +130,16 @@ impl AnthropicStreamConverter {
         chunk: &NvCreateChatCompletionStreamResponse,
     ) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::new();
+        self.append_chunk_events(chunk, &mut events);
+        events
+    }
 
+    /// Process a single chat completion stream chunk and append zero or more SSE events.
+    pub fn append_chunk_events(
+        &mut self,
+        chunk: &NvCreateChatCompletionStreamResponse,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+    ) {
         // Capture token usage from engine when available (typically on the final chunk).
         // Only update output_token_count — input_token_count is set once from the
         // estimate in new() and must stay consistent between message_start and
@@ -360,14 +376,17 @@ impl AnthropicStreamConverter {
                 }
             }
         }
-
-        events
     }
 
     /// Emit the final events when the stream ends.
     pub fn emit_end_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::new();
+        self.append_end_events(&mut events);
+        events
+    }
 
+    /// Append the final events when the stream ends.
+    pub fn append_end_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
         // Close thinking block if started and not already closed mid-stream
         if self.thinking_block_started && !self.thinking_block_closed {
             self.thinking_block_closed = true;
@@ -420,19 +439,24 @@ impl AnthropicStreamConverter {
         // Emit message_stop
         let message_stop = AnthropicStreamEvent::MessageStop {};
         events.push(make_sse_event("message_stop", &message_stop));
-
-        events
     }
 
     /// Emit error events when the stream ends due to a backend error.
     pub fn emit_error_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
+        let mut events = Vec::with_capacity(1);
+        self.append_error_events(&mut events);
+        events
+    }
+
+    /// Append error events when the stream ends due to a backend error.
+    pub fn append_error_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
         let error_event = AnthropicStreamEvent::Error {
             error: AnthropicErrorBody {
                 error_type: "api_error".to_string(),
                 message: "An internal error occurred during generation.".to_string(),
             },
         };
-        vec![make_sse_event("error", &error_event)]
+        events.push(make_sse_event("error", &error_event));
     }
 }
 
@@ -813,6 +837,37 @@ mod tests {
 
     fn event_types(events: &[TaggedEvent]) -> Vec<&str> {
         events.iter().map(|e| e.event_type.as_str()).collect()
+    }
+
+    #[test]
+    fn test_append_events_reuse_caller_storage() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        let mut events = Vec::with_capacity(4);
+
+        conv.append_start_events(&mut events);
+        assert_eq!(events.len(), 1);
+        assert!(events.iter().all(Result::is_ok));
+
+        events.clear();
+        let capacity = events.capacity();
+        conv.append_chunk_events(&text_chunk("I'll edit the file."), &mut events);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events.capacity(), capacity);
+        assert!(events.iter().all(Result::is_ok));
+
+        events.clear();
+        conv.append_chunk_events(
+            &tool_call_chunk(
+                0,
+                Some("call-1"),
+                Some("Edit"),
+                Some("{\"file_path\":\"/tmp/test.txt\"}"),
+            ),
+            &mut events,
+        );
+        assert_eq!(events.len(), 4);
+        assert_eq!(events.capacity(), capacity);
+        assert!(events.iter().all(Result::is_ok));
     }
 
     /// Regression test: text block must be closed (content_block_stop)

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -868,6 +868,18 @@ mod tests {
         assert_eq!(events.len(), 4);
         assert_eq!(events.capacity(), capacity);
         assert!(events.iter().all(Result::is_ok));
+
+        events.clear();
+        conv.append_end_events(&mut events);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events.capacity(), capacity);
+        assert!(events.iter().all(Result::is_ok));
+
+        events.clear();
+        conv.append_error_events(&mut events);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events.capacity(), capacity);
+        assert!(events.iter().all(Result::is_ok));
     }
 
     /// Regression test: text block must be closed (content_block_stop)


### PR DESCRIPTION
## Summary
- Rework the Anthropic Messages streaming adapter to own the converter directly and drain a reusable event buffer from a single async stream.
- Remove the per-chunk Arc<Mutex> + filter_map + stream::iter + flatten + chain path while preserving backend error handling, disconnect monitoring, keepalive behavior, and queue guard release semantics.
- Add append-style AnthropicStreamConverter methods and unit coverage for caller-owned event storage.

## Perf Note
- This is the Anthropic Messages sibling to the profiled Responses stream hot-path change. Anthropic already serialized SSE data with serde_json::to_string + Event::data, so this PR only targets the stream orchestration/event-storage part.
- Not separately benchmarked yet. The expected impact is a reduction in generic stream/futures orchestration overhead for Anthropic streaming workloads.

## Where should the reviewer start?
- `lib/llm/src/protocols/anthropic/stream_converter.rs`
- `lib/llm/src/http/service/anthropic.rs`

## Related Issues
- [x] Confirmed no related issue.

## Validation
- cargo fmt --check
- cargo test -p dynamo-llm protocols::anthropic::stream_converter
- cargo test -p dynamo-llm http::service::anthropic
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized streaming event processing for improved performance and reduced memory overhead

* **Tests**
  * Added regression test for streaming event handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
