### PR TITLE
chore(parser): visualization update, render Python parser exceptions as ✗ in parity tables

### DIFF
--- a/tests/parity/common.py
+++ b/tests/parity/common.py
@@ -191,7 +191,7 @@ def parity_cell_class(marker: str) -> str:
         return "na"
     if marker in {"D", "·"}:
         return "donly"
-    if "!" in marker:
+    if "!" in marker or "✗" in marker:
         return "err"
     if "↯" in marker:
         return "leak"

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -232,7 +232,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 <p class="legend summary-only">
   <strong>Overview:</strong>
   <span class="summary-key ok" aria-hidden="true"></span>green = selected implementation output is clean ·
-  <span class="summary-key problem" aria-hidden="true"></span>red = selected implementation leaks parser markup or has an expected error ·
+  <span class="summary-key problem" aria-hidden="true"></span>red = selected implementation leaks parser markup or has a parser exception ·
   <span class="summary-key na" aria-hidden="true"></span>gray = not applicable, unavailable, or missing fixture.
 </p>
 <p class="legend details-only">
@@ -251,8 +251,8 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   (e.g. V?, S? — diverges with no <code>reason:</code> yet) ·
   <span style="color:#b00">↯</span> Dynamo leaks tool call markup into <code>normal_text</code>
   (<code>expected.dynamo.reason:</code> carries the explanation) ·
-  <span style="color:#b00">!</span> expected-error suffix
-  (e.g. V!, S! — engine crashes by design) ·
+  <span style="color:#b00">✗</span> parser exception
+  (e.g. V✗, S✗ — Python parser raised) ·
   <span style="color:#aaa">n/a</span> not applicable ·
   <span style="color:#8a6d3b">—</span> missing fixture coverage ·
   <span class="parser-suffix">†</span> = no vLLM peer tool calling parser for this family ·
@@ -298,7 +298,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   (have <code>reason:</code>) ·
   <span style="color:#b00">{{ panel.stats.research }} research-needed</span>
   (no <code>reason:</code> yet) ·
-  <span style="color:#b00">{{ panel.stats.errors }} expected-errors</span>.
+  <span style="color:#b00">{{ panel.stats.errors }} parser errors</span>.
 </p>
 {% if panel.glossary_groups %}
 <div class="details-only">

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -514,8 +514,10 @@ def _has_dynamo_leak(case: dict[str, Any], family: str | None) -> bool:
 
 
 def _overview_status(case: dict[str, Any] | None, family: str | None, impl: str) -> str:
-    if case is None or "expected" not in case:
+    if case is None:
         return "na"
+    if "expected" not in case:
+        return "problem" if impl in _python_exception_impls(case, family) else "na"
     block = case.get("expected", {}).get(impl)
     if not isinstance(block, dict) or "unavailable" in block:
         return "na"
@@ -593,13 +595,15 @@ def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -
     if case is None:
         return "—"
     if "expected" not in case:
+        if impl in _python_exception_impls(case, family):
+            return "✗"
         return "n/a"
     expected = case.get("expected", {})
     block = expected.get(impl)
     if not isinstance(block, dict) or "unavailable" in block:
         return "n/a"
     if "error" in block:
-        return "!"
+        return "✗"
     if _block_leak_reason(block, family):
         return "↯"
     if impl == "dynamo":
@@ -771,11 +775,69 @@ def _is_na_stub(case: dict[str, Any]) -> bool:
     )
 
 
+def _case_has_parser_input(case: dict[str, Any]) -> bool:
+    return "model_text" in case or "chunks" in case
+
+
+def _python_peer_has_parser(family: str | None, impl: str) -> bool:
+    if family is None:
+        return False
+    if impl == "vllm":
+        return family in _FAMILY_TO_VLLM_REASONING
+    if impl == "sglang":
+        return family in _FAMILY_TO_SGLANG_REASONING
+    return False
+
+
+def _python_exception_impls(
+    case: dict[str, Any] | None,
+    family: str | None,
+) -> tuple[str, ...]:
+    """Impls whose Python parser would raise on this input-less n/a stub.
+
+    A no-`expected` n/a stub carries no `model_text`/`chunks`, so feeding it to
+    the vLLM/SGLang Python parser raises ``KeyError: 'model_text'``. Surface that
+    as a parser exception for any family that has a Python peer parser.
+    """
+    if not case or "expected" in case or not _is_na_stub(case):
+        return ()
+    if _case_has_parser_input(case):
+        return ()
+    return tuple(
+        impl for impl in ("vllm", "sglang") if _python_peer_has_parser(family, impl)
+    )
+
+
+def _python_exception_marker(
+    case: dict[str, Any] | None,
+    family: str | None,
+) -> str:
+    letters = {"vllm": "V", "sglang": "S"}
+    return "".join(
+        f"{letters[impl]}✗" for impl in _python_exception_impls(case, family)
+    )
+
+
+def _python_exception_tooltip_lines(
+    case: dict[str, Any] | None,
+    family: str | None,
+) -> list[str]:
+    names = {"vllm": "vLLM Python", "sglang": "SGLang Python"}
+    return [
+        f"{names[impl]}: parser exception — KeyError: 'model_text'"
+        for impl in _python_exception_impls(case, family)
+    ]
+
+
 def _cell(case: dict[str, Any] | None, family: str | None = None) -> tuple[str, str]:
     if case is None:
         return "—", "missing fixture coverage"
     if "expected" not in case:
         if _is_na_stub(case):
+            marker = _python_exception_marker(case, family)
+            if marker:
+                parts = [case["reason"], *_python_exception_tooltip_lines(case, family)]
+                return marker, "\n".join(parts)
             return "n/a", case["reason"]
         return "?", "fixture has no expected block"
 
@@ -794,8 +856,8 @@ def _cell(case: dict[str, Any] | None, family: str | None = None) -> tuple[str, 
             tooltip_parts.append(f"{impl}: unavailable — {spec['unavailable']}")
             continue
         if "error" in spec:
-            markers.append(f"{letter}!")
-            tooltip_parts.append(f"{impl}: expected error — {spec['error']}")
+            markers.append(f"{letter}✗")
+            tooltip_parts.append(f"{impl}: parser exception — {spec['error']}")
             continue
         if _canonical(spec) == _canonical(dynamo):
             tooltip_parts.append(f"{impl}: matches Dynamo")
@@ -1529,7 +1591,7 @@ def _tooltip_for(
             continue
         name = _IMPL_DISPLAY.get(impl, impl)
         if "error" in block:
-            parts.append(f"{name}: expected error matching {block['error']!r}")
+            parts.append(f"{name}: parser exception matching {block['error']!r}")
             continue
         if _canonical(block) == _canonical(dyn):
             continue
@@ -1583,10 +1645,19 @@ def _tooltip_html(
         )
     if "expected" not in case:
         reason = case.get("reason", "fixture has no expected block")
+        extra_sections = [("Why not applicable", linkify_text_html(str(reason)))]
+        parser_exceptions = _python_exception_tooltip_lines(case, family)
+        if parser_exceptions:
+            extra_sections.append(
+                (
+                    "Python parser exceptions",
+                    html_lib.escape("\n".join(parser_exceptions)),
+                )
+            )
         return build_parity_tooltip_html(
             head=head,
             description=str(description) if description else None,
-            extra_sections=[("Why not applicable", linkify_text_html(str(reason)))],
+            extra_sections=extra_sections,
             refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
         )
 
@@ -2053,7 +2124,7 @@ def _compute_stats(
                     stats["parity"] += 1
                 elif marker in {"D", "·"}:
                     stats["dynamo_only"] += 1
-                elif "!" in marker:
+                elif "!" in marker or "✗" in marker:
                     stats["errors"] += 1
                 elif "?" in marker:
                     stats["research"] += 1
@@ -2114,8 +2185,8 @@ def _legend_html(rows: dict[str, dict[str, Any]], columns: list[str]) -> str:
         "(e.g. V?, S? — diverges with no <code>reason:</code> yet) · "
         '<span style="color:#b00">↯</span> Dynamo leaks reasoning markup '
         "or final-answer text · "
-        '<span style="color:#b00">!</span> expected-error suffix '
-        "(e.g. V!, S! — engine crashes by design) · "
+        '<span style="color:#b00">✗</span> parser exception '
+        "(e.g. V✗, S✗ — Python parser raised) · "
         '<span style="color:#aaa">n/a</span> not applicable'
         f"{missing_text}."
         "<br>"

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -26,8 +26,8 @@ Cell markers (per peer, vllm + sglang):
   V/S   peer is a concrete inline block AND has `reason:` (intentional)
   V?/S? peer is a concrete inline block AND has no `reason:` yet
         (research-needed; we observed it but haven't classified it)
-  V!/S! peer has `error: <substring>` (expected to crash)
-  VS, V?S, VS!, etc. — combinations
+  V✗/S✗ peer has `error: <substring>` (Python parser raised)
+  VS, V?S, VS✗, etc. — combinations
   ·     Dynamo-only fixture; both peer blocks are `unavailable`
   n/a   family/case doesn't apply
   —     no fixture entry exists for this family/case yet
@@ -718,7 +718,7 @@ def _parser_marker(case: dict | None, impl: str) -> str:
     if not isinstance(block, dict) or "unavailable" in block:
         return "n/a"
     if "error" in block:
-        return "!"
+        return "✗"
     if _block_tool_call_leaks(block):
         return "↯"
     if impl == "dynamo":
@@ -753,11 +753,11 @@ def cell_for(case: dict | None) -> str:
     if v_kind == "div":
         parts.append("V?" if v_unknown else "V")
     elif v_kind == "err":
-        parts.append("V!")
+        parts.append("V✗")
     if s_kind == "div":
         parts.append("S?" if s_unknown else "S")
     elif s_kind == "err":
-        parts.append("S!")
+        parts.append("S✗")
 
     # `reason:` on the `expected.dynamo` block flags Dynamo's own output as
     # leaking tool call markup only when Dynamo also leaves residual
@@ -799,7 +799,7 @@ _LEGEND_MD = (
     "`?` research-needed suffix (e.g. V?, S? — diverges with no `reason:` yet) · "
     "`↯` Dynamo leaks tool call markup into `normal_text` "
     "(`expected.dynamo.reason:` carries the explanation) · "
-    "`!` expected-error suffix (e.g. V!, S! — engine crashes by design) · "
+    "`✗` parser exception (e.g. V✗, S✗ — Python parser raised) · "
     "`n/a` not applicable · "
     "`—` missing fixture coverage · "
     "`†` (tool calling parser column) = no vLLM peer parser for this family · "
@@ -949,7 +949,7 @@ def _tooltip_for(case: dict, dyn: dict) -> str:
     Each non-matching, non-unavailable peer contributes one line:
       vllm: <reason>                        # `reason:` field present
       vllm: UNKNOWN — divergent ...         # divergent, no reason
-      vllm: expected error matching '...'   # `error:` field present
+      vllm: parser exception matching '...' # `error:` field present
     """
     parts: list[str] = []
     n_dyn = {
@@ -964,7 +964,7 @@ def _tooltip_for(case: dict, dyn: dict) -> str:
             continue
         name = _IMPL_DISPLAY.get(impl, impl)
         if "error" in block:
-            parts.append(f"{name}: expected error matching {block['error']!r}")
+            parts.append(f"{name}: parser exception matching {block['error']!r}")
             continue
         # Don't rely on PyYAML preserving anchor identity (the `block is dyn`
         # check above is the fast path; value equality is the safety net).
@@ -1480,7 +1480,7 @@ def _compute_stats(
                 s["parity"] += 1
             elif text in {"D", "·"}:
                 s["dynamo_only"] += 1
-            elif "!" in text:
+            elif "!" in text or "✗" in text:
                 s["errors"] += 1
             elif "↯" in text:
                 s["documented"] += 1

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -83,7 +83,7 @@ def test_generate_parser_parity_table_html() -> None:
     assert 'data-marker-parity-sglang="DV"' in html
     assert 'data-marker-parity-dynamo="↯="' in html
     assert 'data-marker-parity-dynamo="↯VS"' in html
-    assert 'data-marker-dynamo="D!"' not in html
+    assert 'data-marker-dynamo="D✗"' not in html
     assert ".view-details.parity-mode .parity-explainer { display: block; }" in html
     assert "<strong>Parity:</strong>" in html
     assert "color: #8b949e;" in html
@@ -117,8 +117,8 @@ def test_generate_parser_parity_table_html() -> None:
         r'<div class="ttip"><div class="ttip-head">TOOLCALLING\.batch\.4\.a — deepseek_v4',
         html,
     )
-    assert 'data-marker-vllm="!"' in html
-    assert 'data-marker-parity-vllm="!"' in html
+    assert 'data-marker-vllm="✗"' in html
+    assert 'data-marker-parity-vllm="✗"' in html
     assert re.search(
         r'data-status-dynamo="ok" data-status-vllm="ok" data-status-sglang="problem" '
         r'data-marker-dynamo="" data-marker-vllm="" data-marker-sglang="↯" '
@@ -199,8 +199,10 @@ def test_generate_reasoning_parity_table_leak_markers_are_parser_specific() -> N
         r'data-col-toggle="model"[^>]+data-default-visible="true"[^>]+aria-pressed="true"',
         html,
     )
+    # qwen3 3.b is an input-less n/a stub; the vLLM/SGLang Python parsers raise
+    # KeyError: 'model_text' on it, so it renders as a parser-exception cell.
     assert re.search(
-        r'<td class="cell na[^"]*"[^>]*><a href="fixtures/qwen3/REASONING\.batch\.yaml">n/a</a>'
+        r'<td class="cell err[^"]*"[^>]*><a href="fixtures/qwen3/REASONING\.batch\.yaml">V✗S✗</a>'
         r'<div class="ttip"><div class="ttip-head">REASONING\.batch\.3\.b — qwen3',
         html,
     )


### PR DESCRIPTION
#### Overview:

Adding `✗` to the parity tables to flag when a Python (vLLM/SGLang) parser would error on a case. No parser changes — visualization only.

#### Details:

- `✗` replaces `!` for parser failures, and input-less reasoning stubs now show `V✗`/`S✗` where the Python parser would raise.
- Generator + legend/stats wording only (`tests/parity/`); **no fixtures, no parser code.**

<img width="1121" height="530" alt="image" src="https://github.com/user-attachments/assets/0d70f04b-3a41-4e0f-b20b-60d9093a5995" />

/coderabbit profile chill
