### PR TITLE
test(serve): shrink heavy CI model footprints to speed up GPU test packing

### DIFF
--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -594,22 +594,21 @@ sglang_configs = {
         marks=[
             pytest.mark.core,
             pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(
-                9.8
-            ),  # actual peak at recommended token count
+            # Qwen3-Embedding-0.6B runs the same assertions as the 4B variant
+            # (batch, Matryoshka-128, base64). Profiled locally.
+            pytest.mark.profiled_vram_gib(3.0),  # actual nvidia-smi peak
             pytest.mark.requested_sglang_kv_tokens(
                 128
-            ),  # KV cache cap (2x safety over min=64)
-            # Qwen3-Embedding-4B (~8 GB bf16) cold-loads + warms up in 130-150s
-            # on L4 CI before the first request; the 24s "profiled" figure is
-            # the steady-state run only. 147s left no headroom for startup and
-            # blew up 100% of recent amd64 runs in `_check_url`. 300s aligns
-            # with sibling 4B-class agg configs in this file.
-            pytest.mark.timeout(300),  # profiled 24s on RTX 6000 Ada
+            ),  # KV cache cap (peak is flat vs token count for embeddings)
+            # Generous timeout: CI model download dominates startup on a cold runner.
+            pytest.mark.timeout(300),
             pytest.mark.pre_merge,
             pytest.mark.nightly,
         ],
-        model="Qwen/Qwen3-Embedding-4B",
+        model="Qwen/Qwen3-Embedding-0.6B",
+        # agg_embed.sh defaults to the 4B model; model= alone only drives
+        # predownload, so set the served model here too.
+        script_args=["--model-path", "Qwen/Qwen3-Embedding-0.6B"],
         delayed_start=0,
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
@@ -634,9 +633,9 @@ sglang_configs = {
                 repeat_count=1,
                 expected_response=["Generated 3 embeddings with dimension"],
             ),
-            # Test `dimensions` truncation (Matryoshka). Qwen3-Embedding-4B
-            # has a hidden dim well above 128, so the truncated vector should
-            # be exactly 128 floats long.
+            # Test `dimensions` truncation (Matryoshka). Qwen3-Embedding-0.6B
+            # has a hidden dim (1024) well above 128, so the truncated vector
+            # should be exactly 128 floats long.
             embedding_payload(
                 input_text="Hello, world!",
                 repeat_count=1,
@@ -662,22 +661,28 @@ sglang_configs = {
         marks=[
             pytest.mark.core,
             pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(
-                15.7
-            ),  # ~14.7 weights + ~1 GiB for 2048-token KV cache on deepseek-llm-7b
+            # Verifies dynamo+backend can serve a model that ships NO chat
+            # template, via the completions endpoint. The model is NOT
+            # incidental: it must be a base model without a chat template.
+            # TinyLlama-1.1B (intermediate base checkpoint) is a small Llama-
+            # family base without a chat template (replaces deepseek-llm-7b-base,
+            # 7B) -- keeps the coverage, cuts VRAM. TinyLlama-1.1B-Chat is
+            # already used in the router e2e suite.
+            # Profiled locally on an RTX 6000 Ada at the 2048-token KV cap below.
+            pytest.mark.profiled_vram_gib(3.9),  # actual nvidia-smi peak
             pytest.mark.requested_sglang_kv_tokens(
                 2048
             ),  # >= prompt(~16) + max_tokens(1000) + scheduler reserve;
             # SGLang 0.5.11 silently hangs when prompt+max_tokens nears
             # max_total_tokens (bisected ~1040 for these payloads). Matches
             # the "aggregated" config above.
-            pytest.mark.timeout(750),  # 3x ~249s (sglang gpu_1 log)
+            pytest.mark.timeout(300),  # 1.1B loads quickly; CI margin
             pytest.mark.post_merge,
         ],
-        model="deepseek-ai/deepseek-llm-7b-base",
+        model="TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
         script_args=[
             "--model-path",
-            "deepseek-ai/deepseek-llm-7b-base",
+            "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
             "--dyn-endpoint-types",
             "completions",
         ],

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -597,14 +597,16 @@ trtllm_configs = {
             pytest.mark.post_merge,
             pytest.mark.skip(reason="DIS-1566"),
             pytest.mark.timeout(
-                480
-            ),  # 3x measured time (83.85s) + download time (210s) for 7B model
+                300
+            ),  # 1.1B loads quickly; margin covers CI model download
         ],
-        model="deepseek-ai/deepseek-llm-7b-base",
+        # Base model with NO chat template (the point of completions_only),
+        # matching the vllm/sglang configs. Replaces deepseek-llm-7b-base (7B).
+        model="TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
         script_args=["--dyn-endpoint-types", "completions"],
         env={
-            "MODEL_PATH": "deepseek-ai/deepseek-llm-7b-base",
-            "SERVED_MODEL_NAME": "deepseek-ai/deepseek-llm-7b-base",
+            "MODEL_PATH": "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
+            "SERVED_MODEL_NAME": "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
         },
         request_payloads=[
             completion_payload_default(),

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -541,19 +541,29 @@ vllm_configs = {
         marks=[
             pytest.mark.core,
             pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(18.3),  # actual profiled peak with kv-bytes
+            # Verifies dynamo+backend can serve a model that ships NO chat
+            # template, via the completions endpoint. The model is NOT
+            # incidental: it must be a base model without a chat template.
+            # TinyLlama-1.1B (intermediate base checkpoint) is a small Llama-
+            # family base without a chat template (replaces deepseek-llm-7b-base,
+            # 7B) -- keeps the coverage, cuts VRAM. TinyLlama-1.1B-Chat is
+            # already used in the router e2e suite.
+            # VRAM + KV cap profiled locally on an RTX 6000 Ada.
+            pytest.mark.profiled_vram_gib(3.9),  # actual nvidia-smi peak
             pytest.mark.requested_vllm_kv_cache_bytes(
-                4_074_898_000
-            ),  # KV cache cap (2x safety over min=2_037_448_704)
+                530_432_000
+            ),  # KV cache cap (2x safety over profiled min=265_216_000)
             pytest.mark.timeout(
-                420
-            ),  # 7B model loads ~48s on CI (A10G/L4) vs ~15s locally
+                300
+            ),  # 1.1B loads quickly; margin covers CI model download
             pytest.mark.post_merge,
         ],
-        model="deepseek-ai/deepseek-llm-7b-base",
+        model="TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
+        # TinyLlama-1.1B caps at 2048 positions; agg.sh defaults to 4096.
+        env={"MAX_MODEL_LEN": "2048"},
         script_args=[
             "--model",
-            "deepseek-ai/deepseek-llm-7b-base",
+            "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
             "--dyn-endpoint-types",
             "completions",
         ],


### PR DESCRIPTION
## What

Swap the largest models in the serve completions/embedding CI tests for small in-family equivalents that preserve each test's coverage. Single-GPU CI jobs bin-pack tests into a 24 GiB VRAM budget via `@pytest.mark.profiled_vram_gib`, so lowering a heavy test's footprint lets more tests co-schedule and cuts wall-clock.

## Context

- Deepseek related tests were added in this PR: https://github.com/ai-dynamo/dynamo/commit/03070fd5b5b55c051342576fd916e18762ee4667
- Embedding_agg tests were added in this PR: https://github.com/ai-dynamo/dynamo/commit/d809906e62840e5a566c69bb364ececf56dba11b
- Validation run here: https://github.com/ai-dynamo/dynamo/actions/runs/27239348987

## Changes

- **completions_only (vLLM, SGLang, trtllm): deepseek-llm-7b-base (7B) -> TinyLlama-1.1B base.** This test verifies dynamo+backend can serve a model that ships **no chat template** (hence `--dyn-endpoint-types completions`), so the replacement must also be a chat-template-free base model -- it is *not* incidental. `TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T` is a small Llama-family base with no chat template; TinyLlama-1.1B-Chat is already used in the router e2e suite. Validated locally that it serves via the completions endpoint and passes the assertion. trtllm is skipped (DIS-1566) -- parity only.
- **embedding_agg (SGLang): Qwen3-Embedding-4B -> Qwen3-Embedding-0.6B** (identical assertions: batch, Matryoshka-128, base64). Adds `script_args --model-path` so the override reaches `agg_embed.sh` (`model=` alone only drives predownload + payload validation).

## Measured VRAM (profiled locally on an RTX 6000 Ada)

| Test | Before | After |
|---|---|---|
| vLLM completions_only | 18.3 GiB | 3.9 GiB |
| SGLang completions_only | 15.7 GiB | 3.9 GiB |
| SGLang embedding_agg | 9.8 GiB | 3.0 GiB |

## CI per-test wall time

Measured in the post-merge run on main ([27288832950](https://github.com/ai-dynamo/dynamo/actions/runs/27288832950)); before = the 7B/4B models on main:

| Test | Before | After | Delta |
|---|---|---|---|
| vLLM completions_only | 248s | 119s | -52% |
| SGLang completions_only | 279s | 105s | -62% |
| SGLang embedding_agg | 90s | 81s | -10% |
## Notes

- The completions model must ship **no chat template** (raised in review: Qwen/Qwen3-0.6B and the whole Qwen3 family, incl. -Base, bundle one). TinyLlama caps at 2048 positions, so `MAX_MODEL_LEN=2048` is set (payload needs ~1040).
- SGLang completions keeps the 2048-token KV cap (hang-safety, consistent with the `aggregated` config).
- Left unchanged (model-specific or modality-bound): gpt-oss-20b (harmony/tool parser), DeepSeek-V2-Lite (MoE), Ministral-3-3B (Mistral tool format), multimodal family-coverage profiles, router-e2e (mem_fraction-governed).

## Test

Each swapped test was launched end-to-end (frontend + worker, real model) under `tests/utils/profile_pytest.py` and passed; the marks reflect the measured nvidia-smi peaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations across multiple test suites to use more efficient model variants, improving testing speed and resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

