### PR TITLE
fix: synthesize terminal finish_reason when streamed tool calls end without one

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1422,19 +1422,35 @@ impl JailedStream {
             // produced tool calls (observed with speculative decoding, where the
             // stream ends with a usage-only chunk and no terminal finish chunk).
             let mut finish_reason_seen: HashSet<u32> = HashSet::new();
+            // Usage-only chunks are deferred to end-of-stream so that tool calls
+            // recovered by the jail's EOF finalize path — and any synthesized
+            // finish_reason chunk — precede usage, matching OpenAI stream ordering.
+            let mut deferred_usage_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = Vec::new();
+            // Once an error frame is observed, do not synthesize a clean
+            // `tool_calls` terminal state over an errored stream.
+            let mut error_seen = false;
             // Stream metadata so synthesized terminal chunks carry real values
             let mut last_id = String::new();
             let mut last_model = String::new();
             let mut last_created: u32 = 0;
 
             while let Some(mut response) = input_stream.next().await {
-                // Track if any choice emitted tool calls
+                if response.is_error() {
+                    error_seen = true;
+                }
+                // Track if any choice emitted tool calls (an empty tool_calls
+                // array counts as no tool calls, matching aggregator semantics)
                 if let Some(ref data) = response.data {
                     last_id.clone_from(&data.inner.id);
                     last_model.clone_from(&data.inner.model);
                     last_created = data.inner.created;
                     for choice in &data.inner.choices {
-                        if choice.delta.tool_calls.is_some() {
+                        if choice
+                            .delta
+                            .tool_calls
+                            .as_ref()
+                            .is_some_and(|tc| !tc.is_empty())
+                        {
                             has_tool_calls_per_choice.insert(choice.index, true);
                         }
                     }
@@ -1472,39 +1488,36 @@ impl JailedStream {
                     }
                 }
 
-                // A usage-only chunk (empty choices, usage set) is the engine's
-                // terminal chunk. If a tool-call choice still has no finish_reason
-                // by now, the engine dropped it: synthesize the terminal chunk
-                // first so clients see finish_reason before usage, matching
-                // OpenAI stream ordering.
-                let is_terminal_usage_chunk = response.data.as_ref().is_some_and(|d| {
+                // Defer usage-only chunks (empty choices, usage set) so they are
+                // emitted last, after any EOF-finalized tool calls and synthesized
+                // finish_reason chunks.
+                let is_usage_only_chunk = response.data.as_ref().is_some_and(|d| {
                     d.inner.choices.is_empty() && d.inner.usage.is_some()
                 });
-                if is_terminal_usage_chunk {
-                    for chunk in Self::synthesize_missing_tool_calls_finish(
-                        &has_tool_calls_per_choice,
-                        &mut finish_reason_seen,
-                        &last_id,
-                        &last_model,
-                        last_created,
-                    ) {
-                        yield chunk;
-                    }
+                if is_usage_only_chunk {
+                    deferred_usage_chunks.push(response);
+                    continue;
                 }
 
                 yield response;
             }
 
-            // Stream ended without a usage chunk: synthesize for any tool-call
-            // choice that never got a finish_reason.
-            for chunk in Self::synthesize_missing_tool_calls_finish(
-                &has_tool_calls_per_choice,
-                &mut finish_reason_seen,
-                &last_id,
-                &last_model,
-                last_created,
-            ) {
-                yield chunk;
+            // Stream ended: synthesize finish_reason for any tool-call choice that
+            // never got one (skipped if the stream errored — an error frame must
+            // not be followed by a clean terminal state), then flush usage chunks.
+            if !error_seen {
+                for chunk in Self::synthesize_missing_tool_calls_finish(
+                    &has_tool_calls_per_choice,
+                    &mut finish_reason_seen,
+                    &last_id,
+                    &last_model,
+                    last_created,
+                ) {
+                    yield chunk;
+                }
+            }
+            for usage_chunk in deferred_usage_chunks {
+                yield usage_chunk;
             }
         }
     }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -17,7 +17,7 @@ use dynamo_parsers::tool_calling::{
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::{Stream, StreamExt};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use uuid::Uuid;
 
 use crate::utils::{MarkerMatcher, MatchResult};
@@ -1415,7 +1415,8 @@ impl JailedStream {
     {
         stream! {
             tokio::pin!(input_stream);
-            let mut has_tool_calls_per_choice: HashMap<u32, bool> = HashMap::new();
+            // Choices that emitted a non-empty tool_calls delta.
+            let mut tool_call_choices: HashSet<u32> = HashSet::new();
             // Choices that carried a non-null finish_reason at some point. Used to
             // synthesize the OpenAI-required terminal `finish_reason: "tool_calls"`
             // chunk when the engine never emits a finish_reason for a choice that
@@ -1451,7 +1452,7 @@ impl JailedStream {
                             .as_ref()
                             .is_some_and(|tc| !tc.is_empty())
                         {
-                            has_tool_calls_per_choice.insert(choice.index, true);
+                            tool_call_choices.insert(choice.index);
                         }
                     }
                 }
@@ -1463,7 +1464,7 @@ impl JailedStream {
                             finish_reason_seen.insert(choice.index);
                             // Only modify Stop finish reason, preserve Length/ContentFilter
                             if finish == FinishReason::Stop {
-                                let has_tool_calls = has_tool_calls_per_choice.get(&choice.index).copied().unwrap_or(false);
+                                let has_tool_calls = tool_call_choices.contains(&choice.index);
 
                                 // OpenAI spec: whenever tool_calls were emitted on this
                                 // choice, finish_reason MUST be "tool_calls" — regardless of
@@ -1506,9 +1507,13 @@ impl JailedStream {
             // never got one (skipped if the stream errored — an error frame must
             // not be followed by a clean terminal state), then flush usage chunks.
             if !error_seen {
-                for chunk in Self::synthesize_missing_tool_calls_finish(
-                    &has_tool_calls_per_choice,
-                    &mut finish_reason_seen,
+                let mut missing: Vec<u32> = tool_call_choices
+                    .difference(&finish_reason_seen)
+                    .copied()
+                    .collect();
+                missing.sort_unstable();
+                for chunk in Self::synthesize_tool_calls_finish_chunks(
+                    &missing,
                     &last_id,
                     &last_model,
                     last_created,
@@ -1522,28 +1527,17 @@ impl JailedStream {
         }
     }
 
-    /// Build synthetic `finish_reason: "tool_calls"` chunks for every choice that
-    /// emitted tool calls but never carried a non-null finish_reason. Marks the
-    /// indices as seen so callers can invoke this more than once without
-    /// duplicating chunks.
-    fn synthesize_missing_tool_calls_finish(
-        has_tool_calls_per_choice: &HashMap<u32, bool>,
-        finish_reason_seen: &mut HashSet<u32>,
+    /// Build synthetic empty-delta `finish_reason: "tool_calls"` chunks for the
+    /// given choice indices.
+    fn synthesize_tool_calls_finish_chunks(
+        indices: &[u32],
         id: &str,
         model: &str,
         created: u32,
     ) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
-        let mut missing: Vec<u32> = has_tool_calls_per_choice
+        indices
             .iter()
-            .filter(|(idx, has)| **has && !finish_reason_seen.contains(idx))
-            .map(|(idx, _)| *idx)
-            .collect();
-        missing.sort_unstable();
-
-        missing
-            .into_iter()
-            .map(|index| {
-                finish_reason_seen.insert(index);
+            .map(|&index| {
                 tracing::debug!(
                     choice_index = index,
                     "Synthesizing missing finish_reason=tool_calls chunk for tool-call choice"

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -17,7 +17,7 @@ use dynamo_parsers::tool_calling::{
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::{Stream, StreamExt};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use crate::utils::{MarkerMatcher, MatchResult};
@@ -1416,10 +1416,23 @@ impl JailedStream {
         stream! {
             tokio::pin!(input_stream);
             let mut has_tool_calls_per_choice: HashMap<u32, bool> = HashMap::new();
+            // Choices that carried a non-null finish_reason at some point. Used to
+            // synthesize the OpenAI-required terminal `finish_reason: "tool_calls"`
+            // chunk when the engine never emits a finish_reason for a choice that
+            // produced tool calls (observed with speculative decoding, where the
+            // stream ends with a usage-only chunk and no terminal finish chunk).
+            let mut finish_reason_seen: HashSet<u32> = HashSet::new();
+            // Stream metadata so synthesized terminal chunks carry real values
+            let mut last_id = String::new();
+            let mut last_model = String::new();
+            let mut last_created: u32 = 0;
 
             while let Some(mut response) = input_stream.next().await {
                 // Track if any choice emitted tool calls
                 if let Some(ref data) = response.data {
+                    last_id.clone_from(&data.inner.id);
+                    last_model.clone_from(&data.inner.model);
+                    last_created = data.inner.created;
                     for choice in &data.inner.choices {
                         if choice.delta.tool_calls.is_some() {
                             has_tool_calls_per_choice.insert(choice.index, true);
@@ -1431,6 +1444,7 @@ impl JailedStream {
                 if let Some(ref mut data) = response.data {
                     for choice in &mut data.inner.choices {
                         if let Some(finish) = choice.finish_reason {
+                            finish_reason_seen.insert(choice.index);
                             // Only modify Stop finish reason, preserve Length/ContentFilter
                             if finish == FinishReason::Stop {
                                 let has_tool_calls = has_tool_calls_per_choice.get(&choice.index).copied().unwrap_or(false);
@@ -1458,9 +1472,104 @@ impl JailedStream {
                     }
                 }
 
+                // A usage-only chunk (empty choices, usage set) is the engine's
+                // terminal chunk. If a tool-call choice still has no finish_reason
+                // by now, the engine dropped it: synthesize the terminal chunk
+                // first so clients see finish_reason before usage, matching
+                // OpenAI stream ordering.
+                let is_terminal_usage_chunk = response.data.as_ref().is_some_and(|d| {
+                    d.inner.choices.is_empty() && d.inner.usage.is_some()
+                });
+                if is_terminal_usage_chunk {
+                    for chunk in Self::synthesize_missing_tool_calls_finish(
+                        &has_tool_calls_per_choice,
+                        &mut finish_reason_seen,
+                        &last_id,
+                        &last_model,
+                        last_created,
+                    ) {
+                        yield chunk;
+                    }
+                }
+
                 yield response;
             }
+
+            // Stream ended without a usage chunk: synthesize for any tool-call
+            // choice that never got a finish_reason.
+            for chunk in Self::synthesize_missing_tool_calls_finish(
+                &has_tool_calls_per_choice,
+                &mut finish_reason_seen,
+                &last_id,
+                &last_model,
+                last_created,
+            ) {
+                yield chunk;
+            }
         }
+    }
+
+    /// Build synthetic `finish_reason: "tool_calls"` chunks for every choice that
+    /// emitted tool calls but never carried a non-null finish_reason. Marks the
+    /// indices as seen so callers can invoke this more than once without
+    /// duplicating chunks.
+    fn synthesize_missing_tool_calls_finish(
+        has_tool_calls_per_choice: &HashMap<u32, bool>,
+        finish_reason_seen: &mut HashSet<u32>,
+        id: &str,
+        model: &str,
+        created: u32,
+    ) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
+        let mut missing: Vec<u32> = has_tool_calls_per_choice
+            .iter()
+            .filter(|(idx, has)| **has && !finish_reason_seen.contains(idx))
+            .map(|(idx, _)| *idx)
+            .collect();
+        missing.sort_unstable();
+
+        missing
+            .into_iter()
+            .map(|index| {
+                finish_reason_seen.insert(index);
+                tracing::debug!(
+                    choice_index = index,
+                    "Synthesizing missing finish_reason=tool_calls chunk for tool-call choice"
+                );
+                #[allow(deprecated)]
+                let choice = ChatChoiceStream {
+                    index,
+                    delta: ChatCompletionStreamResponseDelta {
+                        role: None,
+                        content: None,
+                        tool_calls: None,
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: Some(FinishReason::ToolCalls),
+                    logprobs: None,
+                };
+                Annotated {
+                    data: Some(NvCreateChatCompletionStreamResponse {
+                        inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                            id: id.to_string(),
+                            object: "chat.completion.chunk".to_string(),
+                            created,
+                            model: model.to_string(),
+                            choices: vec![choice],
+                            usage: None,
+                            service_tier: None,
+                            system_fingerprint: None,
+                        },
+                        nvext: None,
+                    }),
+                    id: None,
+                    event: None,
+                    comment: None,
+                    error: None,
+                }
+            })
+            .collect()
     }
 }
 

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -1051,7 +1051,7 @@ mod tests {
         assert_eq!(
             results.len(),
             6,
-            "Should emit exactly 5 chunks as documented above"
+            "Should emit exactly 6 chunks as documented above (includes synthesized finish chunk)"
         );
 
         // === Verify individual chunks ===
@@ -1434,7 +1434,7 @@ mod tests {
         assert_eq!(
             results.len(),
             4,
-            "Should emit exactly 3 chunks as documented above"
+            "Should emit exactly 4 chunks as documented above (includes synthesized finish chunk)"
         );
 
         // === Verify individual chunks ===
@@ -1849,7 +1849,7 @@ mod tests {
         assert_eq!(
             results.len(),
             3,
-            "Should emit exactly 2 chunks: [0] 'text' content, [1] tool call"
+            "Should emit exactly 3 chunks: content, tool call, and synthesized finish chunk"
         );
 
         // === Verify individual chunks ===
@@ -2230,7 +2230,11 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(results.len(), 4, "Should have 3 chunks");
+        assert_eq!(
+            results.len(),
+            4,
+            "Should have 4 chunks (includes synthesized finish chunk)"
+        );
 
         test_utils::assert_content(&results[0], "Let me search for that. ");
         test_utils::assert_tool_call(
@@ -4432,6 +4436,124 @@ mod tool_call_terminal_finish_reason_tests {
         });
         assert!(
             finish_pos.unwrap() < usage_pos.unwrap(),
+            "finish_reason chunk must precede the usage chunk"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_tool_calls_array_does_not_trigger_synthesis() {
+        // Upstream backends can emit `tool_calls: []`; that is not a tool call
+        // (matching aggregator semantics) and must not produce a synthesized
+        // finish_reason: "tool_calls" terminal chunk.
+        let mut chunk = test_utils::create_mock_response_chunk("hello".to_string(), 0);
+        if let Some(ref mut data) = chunk.data {
+            data.inner.choices[0].delta.tool_calls = Some(vec![]);
+        }
+        let chunks = vec![chunk, usage_only_chunk()];
+
+        let results = run_qwen3_coder_jail(chunks).await;
+
+        assert!(
+            emitted_tool_call_names(&results).is_empty(),
+            "no tool calls should be emitted"
+        );
+        assert!(
+            collected_finish_reasons(&results).is_empty(),
+            "must not synthesize finish_reason for an empty tool_calls array"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_synthesis_after_error_frame() {
+        // A stream that errors after emitting a tool call must not be capped
+        // with a clean `tool_calls` terminal state.
+        let mut chunks = trinity_tool_call_chunks();
+        chunks.push(Annotated {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: Some(vec!["engine exploded".to_string()]),
+            error: None,
+        });
+
+        let results = run_qwen3_coder_jail(chunks).await;
+
+        assert_eq!(
+            emitted_tool_call_names(&results),
+            vec!["write_file".to_string()],
+            "tool call emitted before the error is preserved"
+        );
+        assert!(
+            collected_finish_reasons(&results).is_empty(),
+            "must not synthesize a clean finish_reason over an errored stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn eof_recovered_tool_call_and_synthesized_finish_precede_usage() {
+        // The tool call is never terminated by its end marker, so it is only
+        // recovered by the jail's EOF finalize path — which runs after the
+        // usage-only chunk has already been seen. Output ordering must still
+        // be: tool_calls delta, finish_reason, usage.
+        let mut chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = [
+            "<tool_call>",
+            "<function=write_file>",
+            "<parameter=path>\nok.txt\n</parameter>",
+            "</function>",
+        ]
+        .iter()
+        .map(|s| test_utils::create_mock_response_chunk(s.to_string(), 0))
+        .collect();
+        chunks.push(usage_only_chunk());
+
+        let results = run_qwen3_coder_jail(chunks).await;
+
+        assert_eq!(
+            emitted_tool_call_names(&results),
+            vec!["write_file".to_string()],
+            "tool call must be recovered at EOF"
+        );
+        assert_eq!(
+            collected_finish_reasons(&results),
+            vec![FinishReason::ToolCalls],
+            "stream must carry exactly one finish_reason and it must be tool_calls"
+        );
+        let tool_pos = results
+            .iter()
+            .position(|r| {
+                r.data.as_ref().is_some_and(|d| {
+                    d.inner
+                        .choices
+                        .iter()
+                        .any(|c| c.delta.tool_calls.as_ref().is_some_and(|tc| !tc.is_empty()))
+                })
+            })
+            .unwrap();
+        let finish_pos = results
+            .iter()
+            .position(|r| {
+                r.data.as_ref().is_some_and(|d| {
+                    d.inner
+                        .choices
+                        .iter()
+                        .any(|c| c.finish_reason == Some(FinishReason::ToolCalls))
+                })
+            })
+            .unwrap();
+        let usage_pos = results
+            .iter()
+            .position(|r| {
+                r.data
+                    .as_ref()
+                    .is_some_and(|d| d.inner.choices.is_empty() && d.inner.usage.is_some())
+            })
+            .unwrap();
+        assert!(
+            tool_pos <= finish_pos,
+            "tool_calls delta must not come after the finish_reason chunk"
+        );
+        assert!(
+            finish_pos < usage_pos,
             "finish_reason chunk must precede the usage chunk"
         );
     }

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -563,7 +563,7 @@ mod tests {
         // Should have exactly 2 chunks: tool call + trailing content
         assert_eq!(
             results.len(),
-            2,
+            3,
             "Should have tool call and trailing content"
         );
 
@@ -658,7 +658,7 @@ mod tests {
         // Should have exactly 3 chunks: content + tool call + content
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should have content, tool call, and trailing content"
         );
 
@@ -703,7 +703,7 @@ mod tests {
         // Should have exactly 3 chunks: content + tool call + content
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should have content, tool call, and trailing content"
         );
 
@@ -744,7 +744,7 @@ mod tests {
         // Should have exactly 3 chunks: content + tool call + content
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should have content, tool call, and trailing content"
         );
 
@@ -792,7 +792,7 @@ mod tests {
         // Should have exactly 3 chunks: content + tool call + content
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should have content, tool call, and trailing content"
         );
 
@@ -838,7 +838,7 @@ mod tests {
         // Should have exactly 3 chunks: content + tool call + content
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should have content, tool call, and trailing content"
         );
 
@@ -968,7 +968,7 @@ mod tests {
 
         assert_eq!(
             results.len(),
-            2,
+            3,
             "Should emit prefix content + recovered tool call"
         );
 
@@ -1050,7 +1050,7 @@ mod tests {
         // === Verify chunk count ===
         assert_eq!(
             results.len(),
-            5,
+            6,
             "Should emit exactly 5 chunks as documented above"
         );
 
@@ -1159,7 +1159,7 @@ mod tests {
         // Expected output: [Content(), ToolCall(), Content()]
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should consolidate fragments into 3 chunks"
         );
 
@@ -1433,7 +1433,7 @@ mod tests {
         // === Verify chunk count ===
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should emit exactly 3 chunks as documented above"
         );
 
@@ -1475,7 +1475,7 @@ mod tests {
         // Should have exactly 3 chunks: content + tool call + trailing
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should have content, tool call, and trailing content"
         );
 
@@ -1848,7 +1848,7 @@ mod tests {
         // === Verify chunk count ===
         assert_eq!(
             results.len(),
-            2,
+            3,
             "Should emit exactly 2 chunks: [0] 'text' content, [1] tool call"
         );
 
@@ -2177,7 +2177,7 @@ mod tests {
 
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should have content, tool call, and trailing content"
         );
 
@@ -2230,7 +2230,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(results.len(), 3, "Should have 3 chunks");
+        assert_eq!(results.len(), 4, "Should have 3 chunks");
 
         test_utils::assert_content(&results[0], "Let me search for that. ");
         test_utils::assert_tool_call(
@@ -2272,7 +2272,7 @@ mod tests {
 
         assert_eq!(
             results.len(),
-            3,
+            4,
             "Should have content, tool call, and trailing content"
         );
 
@@ -4240,6 +4240,218 @@ fahrenheit
         assert!(
             !emitted_text.contains("search"),
             "wrong-tool JSON leaked to content: {emitted_text:?}"
+        );
+    }
+}
+
+/// Regression tests: a tool call parsed from marker-based jailing must always
+/// surface `finish_reason: "tool_calls"` somewhere in the output stream.
+///
+/// Mirrors the stream shape produced by a qwen3_coder-parser deployment with
+/// speculative decoding (observed on arcee-ai/trinity-large-thinking): the
+/// engine emits the tool-call XML, then a content-less chunk carrying
+/// `finish_reason: stop`, then a usage-only chunk. Strict OpenAI clients hang
+/// if no chunk ever carries a non-null finish_reason.
+mod tool_call_terminal_finish_reason_tests {
+    use super::tests::test_utils;
+    use super::*;
+    use futures::StreamExt;
+    use futures::stream;
+
+    fn trinity_tool_call_chunks() -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
+        [
+            "<tool_call>",
+            "<function=write_file>",
+            "<parameter=path>\nok.txt\n</parameter>",
+            "<parameter=content>\nDONE\n</parameter>",
+            "</function>",
+            "</tool_call>",
+        ]
+        .iter()
+        .map(|s| test_utils::create_mock_response_chunk(s.to_string(), 0))
+        .collect()
+    }
+
+    fn content_chunk_with_finish(
+        text: &str,
+        finish: Option<FinishReason>,
+    ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let mut chunk = test_utils::create_mock_response_chunk(text.to_string(), 0);
+        if let Some(ref mut data) = chunk.data {
+            data.inner.choices[0].finish_reason = finish;
+        }
+        chunk
+    }
+
+    fn usage_only_chunk() -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let mut chunk = test_utils::create_mock_response_chunk(String::new(), 0);
+        if let Some(ref mut data) = chunk.data {
+            data.inner.choices.clear();
+            data.inner.usage = Some(CompletionUsage {
+                prompt_tokens: 270,
+                completion_tokens: 99,
+                total_tokens: 369,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
+            });
+        }
+        chunk
+    }
+
+    async fn run_qwen3_coder_jail(
+        chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>>,
+    ) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
+        let jail = JailedStream::builder()
+            .tool_call_parser("qwen3_coder")
+            .build();
+        jail.apply_with_finish_reason(stream::iter(chunks))
+            .collect()
+            .await
+    }
+
+    fn collected_finish_reasons(
+        results: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Vec<FinishReason> {
+        results
+            .iter()
+            .flat_map(|r| r.data.iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter_map(|c| c.finish_reason)
+            .collect()
+    }
+
+    fn emitted_tool_call_names(
+        results: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Vec<String> {
+        results
+            .iter()
+            .flat_map(|r| r.data.iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .flat_map(|c| c.delta.tool_calls.iter().flatten())
+            .filter_map(|tc| tc.function.as_ref().and_then(|f| f.name.clone()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn finish_only_chunk_after_tool_call_yields_tool_calls_finish() {
+        let mut chunks = trinity_tool_call_chunks();
+        chunks.push(test_utils::create_final_response_chunk(0));
+        chunks.push(usage_only_chunk());
+
+        let results = run_qwen3_coder_jail(chunks).await;
+
+        assert_eq!(
+            emitted_tool_call_names(&results),
+            vec!["write_file".to_string()],
+            "tool call must be parsed and emitted"
+        );
+        assert_eq!(
+            collected_finish_reasons(&results),
+            vec![FinishReason::ToolCalls],
+            "stream must carry exactly one finish_reason and it must be tool_calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn finish_only_chunk_after_tool_call_and_trailing_newline() {
+        let mut chunks = trinity_tool_call_chunks();
+        chunks.push(test_utils::create_mock_response_chunk("\n".to_string(), 0));
+        chunks.push(test_utils::create_final_response_chunk(0));
+        chunks.push(usage_only_chunk());
+
+        let results = run_qwen3_coder_jail(chunks).await;
+
+        assert_eq!(
+            emitted_tool_call_names(&results),
+            vec!["write_file".to_string()],
+            "tool call must be parsed and emitted"
+        );
+        assert_eq!(
+            collected_finish_reasons(&results),
+            vec![FinishReason::ToolCalls],
+            "stream must carry exactly one finish_reason and it must be tool_calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn finish_on_last_tool_call_content_chunk_yields_tool_calls_finish() {
+        // Speculative decoding can attach finish_reason to the chunk that also
+        // carries the last piece of tool-call text.
+        let mut chunks = trinity_tool_call_chunks();
+        let last = chunks.len() - 1;
+        chunks[last] = content_chunk_with_finish("</tool_call>", Some(FinishReason::Stop));
+        chunks.push(usage_only_chunk());
+
+        let results = run_qwen3_coder_jail(chunks).await;
+
+        assert_eq!(
+            emitted_tool_call_names(&results),
+            vec!["write_file".to_string()],
+            "tool call must be parsed and emitted"
+        );
+        assert_eq!(
+            collected_finish_reasons(&results),
+            vec![FinishReason::ToolCalls],
+            "stream must carry exactly one finish_reason and it must be tool_calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_ending_without_any_finish_chunk_still_yields_tool_calls_finish() {
+        // Engine drops the terminal chunk entirely (worst case).
+        let mut chunks = trinity_tool_call_chunks();
+        chunks.push(usage_only_chunk());
+
+        let results = run_qwen3_coder_jail(chunks).await;
+
+        assert_eq!(
+            emitted_tool_call_names(&results),
+            vec!["write_file".to_string()],
+            "tool call must be parsed and emitted"
+        );
+        assert_eq!(
+            collected_finish_reasons(&results),
+            vec![FinishReason::ToolCalls],
+            "stream must carry exactly one finish_reason and it must be tool_calls"
+        );
+
+        // OpenAI ordering: the terminal finish_reason chunk must precede the
+        // usage-only chunk.
+        let finish_pos = results.iter().position(|r| {
+            r.data.as_ref().is_some_and(|d| {
+                d.inner
+                    .choices
+                    .iter()
+                    .any(|c| c.finish_reason == Some(FinishReason::ToolCalls))
+            })
+        });
+        let usage_pos = results.iter().position(|r| {
+            r.data
+                .as_ref()
+                .is_some_and(|d| d.inner.choices.is_empty() && d.inner.usage.is_some())
+        });
+        assert!(
+            finish_pos.unwrap() < usage_pos.unwrap(),
+            "finish_reason chunk must precede the usage chunk"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_ending_without_finish_or_usage_still_yields_tool_calls_finish() {
+        // No finish chunk and no usage chunk: synthesize at stream end.
+        let chunks = trinity_tool_call_chunks();
+
+        let results = run_qwen3_coder_jail(chunks).await;
+
+        assert_eq!(
+            emitted_tool_call_names(&results),
+            vec!["write_file".to_string()],
+            "tool call must be parsed and emitted"
+        );
+        assert_eq!(
+            collected_finish_reasons(&results),
+            vec![FinishReason::ToolCalls],
+            "stream must carry exactly one finish_reason and it must be tool_calls"
         );
     }
 }


### PR DESCRIPTION
## Overview:

Streamed tool calls can end without any chunk carrying a non-null `finish_reason` when the backend output ends without a finish_reason chunk after the tool-call markers (e.g. under draft-model speculative decoding). The OpenAI spec requires the terminal chunk of a tool-calling choice to carry `finish_reason: "tool_calls"`; strict clients hang without it. `fix_finish_reason` only rewrites an existing `Stop` → `ToolCalls` and never synthesizes a missing one.

This PR makes the jail's post-processor synthesize the terminal chunk when it is missing.

## Details:

- `fix_finish_reason` now tracks, per choice index, whether tool calls were emitted and whether any non-null `finish_reason` passed through, plus the stream's id/model/created for synthesis.
- New `synthesize_missing_tool_calls_finish` builds an empty-delta `finish_reason: "tool_calls"` chunk for every tool-call choice that never carried a finish_reason. It is invoked:
  - just before passing through a usage-only terminal chunk (empty `choices`, `usage` set), so the synthesized chunk precedes usage per OpenAI stream ordering, and
  - at stream end, covering streams without a usage chunk.
  - Indices are marked seen on synthesis, so the two call sites can't double-emit.
- Healthy streams are untouched: if the upstream emitted a finish_reason for the choice, nothing is synthesized.
- New regression tests (`tool_call_terminal_finish_reason_tests` in `tests/test_jail.rs`) cover four input shapes observed around this bug: finish-only chunk after the tool call, finish-only chunk after trailing newline, finish_reason on the last tool-call content chunk (speculative-decoding shape, regression-pins #9593), stream ending with usage but no finish chunk (fails before this PR), and stream ending with neither (fails before this PR). The usage-chunk test also asserts the synthesized chunk precedes the usage chunk.
- Existing jail tests that end their input streams without any finish_reason chunk now see one extra synthesized terminal chunk; their expected chunk counts are bumped by one (15 tests, mechanical). Positional assertions are unaffected since the synthesized chunk is appended after existing output.

Validation: `cargo test -p dynamo-llm --no-default-features --test test_jail` (73 passed), `--test tool_choice` (36 passed), `--lib jail` (6 passed), `cargo clippy --tests` clean, `cargo fmt --check` clean.

## Where should the reviewer start?

- `lib/llm/src/protocols/openai/chat_completions/jail.rs`: `fix_finish_reason` and the new `synthesize_missing_tool_calls_finish`.
- `lib/llm/tests/test_jail.rs`: `tool_call_terminal_finish_reason_tests` module (end of file).

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #10513

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool-call termination signals in streaming responses to ensure proper completion markers are consistently emitted, even when streams end without explicit termination chunks.
  * Enhanced stream ordering and protocol compliance when processing tool-call sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->