### PR TITLE
fix(deepseek): recover 3 more cases of unterminated DSML tool calls

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -13,7 +13,7 @@ use dynamo_parsers::tool_calling::json::try_tool_call_parse_basic_json;
 use dynamo_parsers::tool_calling::parsers::get_tool_parser_map;
 use dynamo_parsers::tool_calling::{
     detect_tool_call_start, find_tool_call_end_position, try_tool_call_parse_aggregate,
-    try_tool_call_parse_aggregate_stream_finalize,
+    try_tool_call_parse_aggregate_finalize,
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::{Stream, StreamExt};
@@ -1048,7 +1048,7 @@ impl JailedStream {
                 // Traditional marker-based tool call parsing
                 let tools_slice = self.tool_definitions.as_deref();
                 let parse_result = if is_finalize {
-                    try_tool_call_parse_aggregate_stream_finalize(
+                    try_tool_call_parse_aggregate_finalize(
                         accumulated_content,
                         self.tool_call_parser.as_deref(),
                         tools_slice,

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -447,22 +447,21 @@ mod tests {
     //   - TOOLCALLING.harmony.1 / TOOLCALLING.harmony.2 N/A — Harmony-only.
     //
     // EOF recovery:
-    //   - TOOLCALLING.stream.4.a  Stream finalization sets
-    //             `allow_eof_recovery=true` and recovers complete
-    //             <｜DSML｜invoke>...</｜DSML｜invoke> pairs even when the
-    //             outer close fence is absent at EOS. Streaming early-exit and
-    //             batch/non-streaming aggregate paths keep recovery disabled so
-    //             they do not claim DSML calls before `</｜DSML｜tool_calls>`
-    //             actually arrives.
+    //   - TOOLCALLING.stream.4.a / TOOLCALLING.batch.5  Both the stream-finalize
+    //             and batch/non-streaming finalize paths set
+    //             `allow_eof_recovery=true` (via
+    //             `detect_and_parse_tool_call_with_recovery`) and recover every
+    //             complete <｜DSML｜invoke>...</｜DSML｜invoke> pair even when the
+    //             outer close fence is absent at EOS, keeping the pre-block prose
+    //             as normal_text and dropping any trailing invoke that was never
+    //             closed. Only streaming early-exit keeps recovery disabled so it
+    //             does not claim DSML calls before `</｜DSML｜tool_calls>` actually
+    //             arrives (see test_parse_deepseek_v4_missing_end_token_without_recovery).
     //
     // TODO — bugs pinned, parser still needs to be fixed:
-    //   - TOOLCALLING.batch.5  BUG: parser drops all calls when </｜DSML｜tool_calls> is
-    //             absent (max_tokens / EOS before close). Same class as
-    //             Kimi K2 pre-PR #8208. Fix: scan for complete
-    //             <｜DSML｜invoke>...</｜DSML｜invoke> pairs even without the
-    //             outer close fence (see kimi_k2_parser.rs for precedent).
-    //             Pinning tests below assert the current silent-drop;
-    //             flip them once the parser is fixed.
+    //   - (TOOLCALLING.batch.5  FIXED: batch/non-streaming finalize now recovers
+    //     complete invokes when </｜DSML｜tool_calls> is absent, matching the
+    //     stream-finalize path. Same class as Kimi K2 pre-PR #8208.)
     //   - (TOOLCALLING.batch.4 missing-parameter-close & middle-invoke-truncation now
     //     pinned: see test_parse_deepseek_v4_missing_parameter_close_loses_param,
     //     test_parse_deepseek_v4_middle_invoke_truncation_corrupts_next.)

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -54,6 +54,8 @@ pub use structural_tag::{
     DsmlToolCallsConfig, StructuralTagBuilder, StructuralTagSchemaMode, TOOL_NAME_PLACEHOLDER,
     ToolCallFormatBuildContext, TriggeredTagsConfig,
 };
+#[allow(deprecated)]
+pub use tools::try_tool_call_parse_aggregate_stream_finalize;
 pub use tools::{
     try_tool_call_parse_aggregate, try_tool_call_parse_aggregate_finalize,
     try_tool_call_parse_stream,

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -56,7 +56,7 @@ pub use structural_tag::{
 };
 pub use tools::{
     try_tool_call_parse_aggregate, try_tool_call_parse_aggregate_finalize,
-    try_tool_call_parse_aggregate_stream_finalize, try_tool_call_parse_stream,
+    try_tool_call_parse_stream,
 };
 pub use xml::try_tool_call_parse_kimi_k2;
 pub use xml::try_tool_call_parse_xml;

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -116,38 +116,22 @@ pub async fn try_tool_call_parse(
 }
 
 /// Same as [`detect_and_parse_tool_call`] but flips `allow_eof_recovery=true`
-/// on the JSON / XML configs so finalize / non-streaming aggregate paths
-/// recover from missing-end-token / truncated-JSON instead of silently
+/// on the JSON / XML / DSML configs so finalize / non-streaming aggregate
+/// paths recover from missing-end-token / truncated-JSON instead of silently
 /// dropping the call. Streaming jails MUST keep using the non-recovery
 /// variant — otherwise `should_exit_jail_early` fires before the end-token
 /// has actually arrived (see jail.rs).
+///
+/// DSML recovery covers DeepSeek V4: when the outer `</｜DSML｜tool_calls>`
+/// wrapper never arrives (EOS / max_tokens), still recover every complete
+/// `<｜DSML｜invoke>...</｜DSML｜invoke>` pair and keep the pre-block prose as
+/// `normal_text`, while dropping any trailing invoke that was never closed.
+/// This is best-effort recovery from the bytes already received, so the same
+/// behavior applies on both batch/non-streaming and stream-finalize paths.
 pub async fn detect_and_parse_tool_call_with_recovery(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[ToolDefinition]>,
-) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
-    detect_and_parse_tool_call_with_recovery_options(message, parser_str, tools, false).await
-}
-
-/// Stream-end finalize variant of [`detect_and_parse_tool_call_with_recovery`].
-///
-/// DeepSeek V4's vLLM streaming parser emits a tool call once a complete
-/// `<｜DSML｜invoke>...</｜DSML｜invoke>` arrives, even if the outer
-/// `</｜DSML｜tool_calls>` wrapper never appears before EOS. Keep that recovery
-/// scoped to stream finalization so batch/non-streaming parity remains strict.
-pub async fn detect_and_parse_tool_call_with_stream_finalize_recovery(
-    message: &str,
-    parser_str: Option<&str>,
-    tools: Option<&[ToolDefinition]>,
-) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
-    detect_and_parse_tool_call_with_recovery_options(message, parser_str, tools, true).await
-}
-
-async fn detect_and_parse_tool_call_with_recovery_options(
-    message: &str,
-    parser_str: Option<&str>,
-    tools: Option<&[ToolDefinition]>,
-    recover_dsml_eof: bool,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let parser_map = get_tool_parser_map();
     let parser_key = match parser_str {
@@ -172,7 +156,7 @@ async fn detect_and_parse_tool_call_with_recovery_options(
             c.allow_eof_recovery = true;
             ParserConfig::Xml(c)
         }
-        ParserConfig::Dsml(c) if recover_dsml_eof => {
+        ParserConfig::Dsml(c) => {
             let mut c = c.clone();
             c.allow_eof_recovery = true;
             ParserConfig::Dsml(c)
@@ -1909,8 +1893,12 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             serde_json::from_str(&tool_calls[0].function.arguments).unwrap();
         assert_eq!(args["timezone"], "Asia/Shanghai");
     }
+    /// Both the batch/non-streaming finalize and stream-finalize paths now run
+    /// `detect_and_parse_tool_call_with_recovery`, which enables DSML EOF
+    /// recovery: a complete `<｜DSML｜invoke>...</｜DSML｜invoke>` is recovered
+    /// even when the outer `</｜DSML｜tool_calls>` wrapper never arrives.
     #[tokio::test]
-    async fn test_deepseek_v4_common_recovery_stays_strict_without_outer_close() {
+    async fn test_deepseek_v4_recovery_recovers_without_outer_close() {
         let input = r#"<｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_datetime">
 <｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
@@ -1920,25 +1908,6 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             detect_and_parse_tool_call_with_recovery(input, Some("deepseek_v4"), None)
                 .await
                 .expect("Failed to parse");
-
-        assert!(tool_calls.is_empty());
-        assert_eq!(normal_text, Some("".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_deepseek_v4_stream_finalize_recovery_recovers_without_outer_close() {
-        let input = r#"<｜DSML｜tool_calls>
-<｜DSML｜invoke name="get_datetime">
-<｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
-</｜DSML｜invoke>"#;
-
-        let (tool_calls, normal_text) = detect_and_parse_tool_call_with_stream_finalize_recovery(
-            input,
-            Some("deepseek_v4"),
-            None,
-        )
-        .await
-        .expect("Failed to parse");
 
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].function.name, "get_datetime");

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -173,6 +173,20 @@ pub async fn detect_and_parse_tool_call_with_recovery(
     try_tool_call_parse(message, &cfg, tools).await
 }
 
+/// Deprecated compatibility shim retained for the published `dynamo-parsers`
+/// API. Batch/non-streaming and stream-end finalize now share one recovery
+/// path; call [`detect_and_parse_tool_call_with_recovery`] directly.
+#[deprecated(
+    note = "batch and stream finalize now share one recovery path; use detect_and_parse_tool_call_with_recovery"
+)]
+pub async fn detect_and_parse_tool_call_with_stream_finalize_recovery(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    detect_and_parse_tool_call_with_recovery(message, parser_str, tools).await
+}
+
 // Base Detector to call for all tool parsing
 pub async fn detect_and_parse_tool_call(
     message: &str,

--- a/lib/parsers/src/tool_calling/tools.rs
+++ b/lib/parsers/src/tool_calling/tools.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use super::config::ToolCallConfig;
+#[allow(deprecated)]
+pub use super::parsers::detect_and_parse_tool_call_with_stream_finalize_recovery;
 pub use super::parsers::{detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery};
 pub use super::response::{
     CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
@@ -50,6 +52,20 @@ pub async fn try_tool_call_parse_aggregate_finalize(
         return Ok((vec![], content));
     }
     Ok((parsed, content))
+}
+
+/// Deprecated compatibility shim retained for the published `dynamo-parsers`
+/// API. Batch/non-streaming and stream-end finalize now share one recovery
+/// path; call [`try_tool_call_parse_aggregate_finalize`] directly.
+#[deprecated(
+    note = "batch and stream finalize now share one recovery path; use try_tool_call_parse_aggregate_finalize"
+)]
+pub async fn try_tool_call_parse_aggregate_stream_finalize(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[super::ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    try_tool_call_parse_aggregate_finalize(message, parser_str, tools).await
 }
 
 /// Try parsing a string as a structured tool call, for streaming (delta) usage.

--- a/lib/parsers/src/tool_calling/tools.rs
+++ b/lib/parsers/src/tool_calling/tools.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use super::config::ToolCallConfig;
-pub use super::parsers::{
-    detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery,
-    detect_and_parse_tool_call_with_stream_finalize_recovery,
-};
+pub use super::parsers::{detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery};
 pub use super::response::{
     CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
 };
@@ -37,11 +34,11 @@ pub async fn try_tool_call_parse_aggregate(
 }
 
 /// Finalize-only variant of [`try_tool_call_parse_aggregate`] that enables
-/// the common EOF recovery paths (missing outer end-token, truncated JSON args).
-/// Use this from non-streaming aggregator paths — never from streaming jail
-/// early-exit logic. Stream-end jail finalization uses
-/// [`try_tool_call_parse_aggregate_stream_finalize`] so DSML can salvage
-/// completed invokes without changing batch/non-streaming behavior.
+/// the common EOF recovery paths (missing outer end-token, truncated JSON
+/// args, and — for DSML/DeepSeek V4 — a missing outer `</｜DSML｜tool_calls>`
+/// wrapper). Use this from finalize paths: both non-streaming aggregate and
+/// stream-end jail finalization. Never use it from streaming jail early-exit
+/// logic, which must keep `allow_eof_recovery=false`.
 pub async fn try_tool_call_parse_aggregate_finalize(
     message: &str,
     parser_str: Option<&str>,
@@ -49,25 +46,6 @@ pub async fn try_tool_call_parse_aggregate_finalize(
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let (parsed, content) =
         detect_and_parse_tool_call_with_recovery(message, parser_str, tools).await?;
-    if parsed.is_empty() {
-        return Ok((vec![], content));
-    }
-    Ok((parsed, content))
-}
-
-/// Stream-end variant of [`try_tool_call_parse_aggregate_finalize`].
-///
-/// It keeps the normal finalize recovery for JSON/XML and additionally lets
-/// DSML recover complete invokes from an unterminated outer wrapper. This is
-/// intentionally not used by batch/non-streaming aggregate paths.
-pub async fn try_tool_call_parse_aggregate_stream_finalize(
-    message: &str,
-    parser_str: Option<&str>,
-    tools: Option<&[super::ToolDefinition]>,
-) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
-    let (parsed, content) =
-        detect_and_parse_tool_call_with_stream_finalize_recovery(message, parser_str, tools)
-            .await?;
     if parsed.is_empty() {
         return Ok((vec![], content));
     }

--- a/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
@@ -21,8 +21,11 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
-        calls: []
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
         calls: []
@@ -33,8 +36,11 @@ cases:
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
 
           </｜DSML｜invoke>'
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
-      sglang: *d_5_a
+        reason: "vLLM leaks the DSML envelope into normal_text on missing end-marker recovery; Dynamo recovers the complete <｜DSML｜invoke> call and strips the unterminated outer tag."
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: "SGLang drops the call and emits empty content when </｜DSML｜function_calls> is missing; Dynamo recovers the complete <｜DSML｜invoke> call."
   TOOLCALLING.batch.5.b:
     description: Closing </｜DSML｜function_calls> without matching open
     ref: dynamo
@@ -99,7 +105,13 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
@@ -133,7 +145,10 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:

--- a/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -22,7 +22,10 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
         calls: []
@@ -31,7 +34,7 @@ cases:
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
           </｜DSML｜invoke>
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: "vLLM leaks the DSML envelope into normal_text on missing end-marker recovery; Dynamo recovers the complete <｜DSML｜invoke> call and strips the unterminated outer tag."
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.5.b:
@@ -99,7 +102,13 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
@@ -115,7 +124,7 @@ cases:
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">New York</｜DSML｜parameter>
           </｜DSML｜invoke>
-        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path"
+        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path; Dynamo recovers both complete <｜DSML｜invoke> calls (bodies fully closed) and keeps the prefix prose as normal_text."
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -131,7 +140,10 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
@@ -146,7 +158,7 @@ cases:
           </｜DSML｜invoke>
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">New York
-        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path"
+        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path; Dynamo recovers only the complete Boston call and drops the New York call whose <｜DSML｜invoke> was never closed, keeping the prefix prose as normal_text."
   TOOLCALLING.batch.5.f:
     description: Bare valid invoke before a complete wrapped call
     ref: dynamo


### PR DESCRIPTION
#### Overview:

Make DSv4 recovery better: harden the DSML batch parser's error recovery so it recovers 3 previously-dropped cases (`TOOLCALLING.batch.5.a`, `5.d`, `5.e`). When the outer `</｜DSML｜tool_calls>` close fence is missing (EOS / max_tokens), the batch parser now recovers the complete tool calls instead of dropping them.

#### Details:

- **How is this fixed?** It recovers each complete `<｜DSML｜invoke>...</｜DSML｜invoke>`, keeps the prefix prose as `normal_text`, and drops only a trailing invoke that was never closed.

| Case | Input | Before (dropped) | After (recovered) |
|---|---|---|---|
| `5.a` | single call, missing outer close | `calls=[]` | `calls=[get_weather(NYC)]` |
| `5.d` | prose + 2 complete calls, missing outer close | `calls=[]`, prose kept | `calls=[get_weather(Boston), get_weather(New York)]`, prose kept |
| `5.e` | prose + complete Boston call + unterminated New York call | `calls=[]`, prose kept | `calls=[get_weather(Boston)]`, prose kept (New York dropped — never closed) |

#### Verification:

`cargo test -p dynamo-parsers` + jail + streaming + full toolcalling parity (1363 passed, 0 failed).

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/parsers.rs`, then `lib/parsers/src/tool_calling/dsml/parser.rs`

#### Related Issues:

Relates to DIS-2059

/coderabbit profile chill
