### PR TITLE
perf(kv-router): bucket prune expiries

### DIFF
--- a/lib/kv-router/src/indexer/README.md
+++ b/lib/kv-router/src/indexer/README.md
@@ -18,7 +18,7 @@ The concurrent indexers achieve a combined throughput of over **10 million event
 | `positional.rs` | `PositionalIndexer` — flat `DashMap<(pos, hash), SeqEntry>` with jump optimization |
 | `thread_pool.rs` | `ThreadPoolIndexer<T: SyncIndexer>` — N OS threads for sticky-routed writes, inline reads; wraps `ConcurrentRadixTree` or `PositionalIndexer` |
 | `local.rs` | `LocalKvIndexer` — thin wrapper around `KvIndexer` with a circular event buffer for worker-side decentralized routing |
-| `pruning.rs` | `PruneManager` — TTL-based expiration and size-based pruning via `BinaryHeap<BlockEntry>` |
+| `pruning.rs` | `PruneManager` — TTL-based approximate expiration via 100ms buckets and per-worker pruning queues |
 | `naive.rs` | Brute-force baseline indexers (bench-only, behind `bench` feature flag) |
 | `tests.rs` | Integration tests for all indexer variants |
 

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -20,6 +20,8 @@ use tokio_util::sync::CancellationToken;
 use crate::protocols::{ExternalSequenceBlockHash, WorkerId, WorkerWithDpRank};
 
 const WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD: usize = 10;
+/// Approximate TTL expirations are rounded up to this interval. A non-zero TTL
+/// can remain routable for up to one extra bucket interval.
 const EXPIRY_BUCKET: Duration = Duration::from_millis(100);
 
 /// Block entry tracked by [`PruneManager`] until its TTL bucket expires.
@@ -122,7 +124,11 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
 
     /// Inserts timers using a caller-provided timestamp.
     pub fn insert_at(&mut self, keys: Vec<K>, now: Instant) {
-        let expiry_time = self.bucket_expiry(now + self.ttl);
+        let expiry_time = if self.ttl.is_zero() {
+            now
+        } else {
+            self.bucket_expiry(now + self.ttl)
+        };
 
         self.timers.reserve(keys.len());
         for key in keys {
@@ -674,6 +680,21 @@ mod tests {
         assert_eq!(pm.expirations.len(), 1);
         assert!(pm.remove(&2));
         assert!(pm.expirations.is_empty());
+    }
+
+    #[test]
+    fn test_prune_manager_zero_ttl_expires_immediately() {
+        let prune_config = PruneConfig {
+            ttl: Duration::ZERO,
+        };
+        let mut pm: PruneManager<u32> = PruneManager::new(prune_config);
+
+        let now = pm.bucket_origin + Duration::from_millis(1);
+        pm.insert_at(vec![7], now);
+
+        assert_eq!(pm.get_expiry(&7), Some(&now));
+        assert_eq!(pm.pop_expired(now), vec![7]);
+        assert!(pm.is_empty());
     }
 
     /// Validate that reinserting an existing key extends its TTL and prevents premature expiry.

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -7,7 +7,7 @@
 //! approximate-mode blocks in the radix tree.
 
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, VecDeque};
+use std::collections::{BTreeMap, BinaryHeap, VecDeque};
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
@@ -19,10 +19,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::protocols::{ExternalSequenceBlockHash, WorkerId, WorkerWithDpRank};
 
-const HEAP_REBUILD_THRESHOLD: usize = 50;
 const WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD: usize = 10;
+const EXPIRY_BUCKET: Duration = Duration::from_millis(100);
 
-/// Block entry to be inserted in the [`PruneManager::expirations`] heap.
+/// Block entry tracked by [`PruneManager`] until its TTL bucket expires.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct BlockEntry {
     /// The key of the block entry.
@@ -64,22 +64,22 @@ impl Default for PruneConfig {
 }
 
 /// A data structure to manage a collection of timers, addressable by a key.
-/// This is structured as a sort of "priority queue" of keys, where the priority is the expiration time.
-/// It supports insertion as well as updating the expiration time of a key.
-/// The [`PruneManager::expirations`] heap is lazily updated to reflect the true expiration times in [`PruneManager::timers`]
-/// For now, we have a fixed expiration time for all keys.
+/// Expiration times are rounded up to fixed buckets so high-churn approximate
+/// routing does not push one priority-queue entry per block.
 #[derive(Debug)]
 pub struct PruneManager<K: Clone + Hash + Eq + Ord> {
     /// The source of truth. Maps a key to its current expiration instant.
     timers: FxHashMap<K, Instant>,
 
-    /// A max-heap of (Reverse<expiration_instant>, key) used to efficiently find the
-    /// next expiring timer. Reverse<Instant> makes earlier times pop first.
-    /// An entry in this heap is "stale" if the instant does not match the one in the `timers` map.
-    expirations: BinaryHeap<(Reverse<Instant>, K)>,
+    /// Bucketed keys by expiration instant. The map key is the bucket boundary,
+    /// rounded up from the precise TTL expiry.
+    expirations: BTreeMap<Instant, FxHashSet<K>>,
 
     /// The expiration duration of the timers.
     ttl: Duration,
+
+    /// Local origin used to make bucket boundaries stable within this manager.
+    bucket_origin: Instant,
 }
 
 impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
@@ -88,18 +88,27 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
         let ttl = prune_config.ttl;
         PruneManager {
             timers: FxHashMap::default(),
-            expirations: BinaryHeap::new(),
+            expirations: BTreeMap::new(),
             ttl,
+            bucket_origin: Instant::now(),
         }
     }
 
-    /// Rebuilds the expirations heap from the timers map, removing all stale entries.
-    fn rebuild_heap(&mut self) {
-        self.expirations = self
-            .timers
-            .iter()
-            .map(|(key, &expiry)| (Reverse(expiry), key.clone()))
-            .collect();
+    fn bucket_expiry(&self, expiry: Instant) -> Instant {
+        let elapsed = expiry.saturating_duration_since(self.bucket_origin);
+        self.bucket_origin + round_up_duration(elapsed, EXPIRY_BUCKET)
+    }
+
+    fn remove_from_bucket(&mut self, expiry: &Instant, key: &K) {
+        let should_remove_bucket = if let Some(bucket) = self.expirations.get_mut(expiry) {
+            bucket.remove(key);
+            bucket.is_empty()
+        } else {
+            false
+        };
+        if should_remove_bucket {
+            self.expirations.remove(expiry);
+        }
     }
 
     /// Inserts a new timer or updates an existing one for the given key.
@@ -113,31 +122,26 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
 
     /// Inserts timers using a caller-provided timestamp.
     pub fn insert_at(&mut self, keys: Vec<K>, now: Instant) {
-        let expiry_time = now + self.ttl;
+        let expiry_time = self.bucket_expiry(now + self.ttl);
 
         self.timers.reserve(keys.len());
-        self.expirations.reserve(keys.len());
         for key in keys {
-            // Insert or update the authoritative time in the map.
-            self.timers.insert(key.clone(), expiry_time);
-
-            // Push the new expiration onto the heap. If the key was updated,
-            // this leaves a "stale" entry on the heap for the old time,
-            // which will be ignored when it's popped.
-            self.expirations.push((Reverse(expiry_time), key));
-        }
-
-        // Check if we should rebuild the heap to remove stale entries
-        if !self.timers.is_empty()
-            && self.expirations.len() > self.timers.len() * HEAP_REBUILD_THRESHOLD
-        {
-            self.rebuild_heap();
+            if let Some(old_expiry) = self.timers.insert(key.clone(), expiry_time)
+                && old_expiry != expiry_time
+            {
+                self.remove_from_bucket(&old_expiry, &key);
+            }
+            self.expirations.entry(expiry_time).or_default().insert(key);
         }
     }
 
     /// Removes a timer for the given key.
     pub fn remove(&mut self, key: &K) -> bool {
-        self.timers.remove(key).is_some()
+        let Some(expiry) = self.timers.remove(key) else {
+            return false;
+        };
+        self.remove_from_bucket(&expiry, key);
+        true
     }
 
     /// Polls for expired timers and returns a list of keys for all timers
@@ -145,19 +149,18 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
     pub fn pop_expired(&mut self, now: Instant) -> Vec<K> {
         let mut expired_keys = Vec::new();
 
-        while let Some((Reverse(expiry_time), _)) = self.expirations.peek() {
-            // If the next timer in the heap is not yet expired, we can stop.
-            if *expiry_time > now {
+        while let Some((&expiry_time, _)) = self.expirations.first_key_value() {
+            if expiry_time > now {
                 break;
             }
 
-            // The timer might be expired, so pop it from the heap.
-            let (Reverse(expiry_time), key) = self.expirations.pop().unwrap();
-
-            if self.timers.get(&key) == Some(&expiry_time) {
-                // This is a valid, non-stale, expired timer.
-                self.timers.remove(&key);
-                expired_keys.push(key);
+            let (_, bucket) = self.expirations.pop_first().unwrap();
+            expired_keys.reserve(bucket.len());
+            for key in bucket {
+                if self.timers.get(&key) == Some(&expiry_time) {
+                    self.timers.remove(&key);
+                    expired_keys.push(key);
+                }
             }
         }
 
@@ -166,13 +169,9 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
 
     /// Returns the next non-stale expiry time, if it exists.
     pub fn peek_next_valid_expiry(&mut self) -> Option<Instant> {
-        while let Some((Reverse(expiry_time), key)) = self.expirations.peek() {
-            if self.timers.get(key) == Some(expiry_time) {
-                return Some(*expiry_time);
-            }
-            self.expirations.pop();
-        }
-        None
+        self.expirations
+            .first_key_value()
+            .map(|(&expiry, _)| expiry)
     }
 
     pub fn len(&self) -> usize {
@@ -182,6 +181,18 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
     pub fn is_empty(&self) -> bool {
         self.timers.is_empty()
     }
+}
+
+fn round_up_duration(duration: Duration, bucket: Duration) -> Duration {
+    debug_assert!(!bucket.is_zero());
+    let duration_ns = duration.as_nanos();
+    let bucket_ns = bucket.as_nanos();
+    let rounded_ns = if duration_ns == 0 {
+        0
+    } else {
+        ((duration_ns - 1) / bucket_ns + 1) * bucket_ns
+    };
+    Duration::from_nanos(u64::try_from(rounded_ns).unwrap_or(u64::MAX))
 }
 
 #[derive(Debug)]
@@ -625,61 +636,70 @@ mod tests {
     }
 
     /// Validate basic insert / expiry behaviour of [`PruneManager`].
-    #[tokio::test]
-    async fn test_prune_manager_expiry() {
+    #[test]
+    fn test_prune_manager_expiry() {
         const TTL: Duration = Duration::from_millis(50);
         let prune_config = PruneConfig { ttl: TTL };
         let mut pm: PruneManager<u32> = PruneManager::new(prune_config);
 
-        pm.insert(vec![1, 2, 3]);
-        assert!(pm.get_expiry(&1).is_some());
-        assert!(pm.get_expiry(&2).is_some());
-        assert!(pm.get_expiry(&3).is_some());
+        let now = pm.bucket_origin + Duration::from_millis(1);
+        pm.insert_at(vec![1, 2, 3], now);
+        let expiry = *pm.get_expiry(&1).expect("expiry missing after insert");
+        assert_eq!(pm.get_expiry(&2), Some(&expiry));
+        assert_eq!(pm.get_expiry(&3), Some(&expiry));
+        assert!(expiry >= now + TTL);
 
-        // Wait until after the TTL
-        time::sleep(TTL + Duration::from_millis(20)).await;
-        let expired = pm.pop_expired(Instant::now());
+        let expired = pm.pop_expired(expiry);
         assert_eq!(expired.len(), 3);
         assert!(pm.get_expiry(&1).is_none());
         assert!(pm.get_expiry(&2).is_none());
         assert!(pm.get_expiry(&3).is_none());
     }
 
-    /// Validate that reinserting an existing key extends its TTL and prevents premature expiry.
-    #[tokio::test]
-    async fn test_prune_manager_update_resets_ttl() {
-        // Validate that reinserting an existing key extends its TTL and prevents premature expiry.
+    #[test]
+    fn test_prune_manager_buckets_nearby_expiries() {
         const TTL: Duration = Duration::from_millis(50);
         let prune_config = PruneConfig { ttl: TTL };
         let mut pm: PruneManager<u32> = PruneManager::new(prune_config);
 
-        // Initial insert and capture the original expiry.
-        pm.insert(vec![42]);
+        let now = pm.bucket_origin + Duration::from_millis(1);
+        pm.insert_at(vec![1], now);
+        pm.insert_at(vec![2], now + Duration::from_millis(20));
+
+        let expiry = *pm.get_expiry(&1).expect("expiry missing for key 1");
+        assert_eq!(pm.get_expiry(&2), Some(&expiry));
+        assert_eq!(pm.expirations.len(), 1);
+
+        assert!(pm.remove(&1));
+        assert_eq!(pm.expirations.len(), 1);
+        assert!(pm.remove(&2));
+        assert!(pm.expirations.is_empty());
+    }
+
+    /// Validate that reinserting an existing key extends its TTL and prevents premature expiry.
+    #[test]
+    fn test_prune_manager_update_resets_ttl() {
+        const TTL: Duration = Duration::from_millis(50);
+        let prune_config = PruneConfig { ttl: TTL };
+        let mut pm: PruneManager<u32> = PruneManager::new(prune_config);
+
+        let now = pm.bucket_origin + Duration::from_millis(1);
+        pm.insert_at(vec![42], now);
         let first_expiry = *pm
             .get_expiry(&42)
             .expect("expiry missing after first insert");
 
-        // Wait for half of the original TTL before reinserting.
-        time::sleep(Duration::from_millis(25)).await;
-        pm.insert(vec![42]);
+        pm.insert_at(vec![42], now + EXPIRY_BUCKET);
         let second_expiry = *pm
             .get_expiry(&42)
             .expect("expiry missing after reinsertion");
 
-        // The expiry after reinsertion must be strictly later than the first one.
         assert!(second_expiry > first_expiry);
 
-        // Wait until *after* the first expiry would have fired, but *before* the new expiry.
-        time::sleep(Duration::from_millis(30)).await; // 25ms already elapsed, +30ms = 55ms > first TTL
-        let expired = pm.pop_expired(Instant::now());
-        assert!(
-            expired.is_empty(),
-            "key expired prematurely despite TTL refresh"
-        );
+        let expired = pm.pop_expired(first_expiry);
+        assert!(expired.is_empty());
 
-        // Now wait until after the second expiry should have occurred.
-        time::sleep(Duration::from_millis(30)).await; // Ensure we pass the refreshed TTL
-        let expired_after = pm.pop_expired(Instant::now());
+        let expired_after = pm.pop_expired(second_expiry);
         assert_eq!(expired_after, vec![42]);
     }
 

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -892,7 +892,7 @@ mod interface_tests {
         route_approx_tokens(index.as_ref(), &tokens, worker).await;
         assert_request_score(index.as_ref(), &tokens, worker, 1).await;
 
-        time::sleep(ttl + Duration::from_millis(25)).await;
+        time::sleep(ttl + Duration::from_millis(125)).await;
         flush_and_settle(index.as_ref()).await;
 
         let scores = request_scores(index.as_ref(), &tokens).await;
@@ -950,7 +950,7 @@ mod interface_tests {
         flush_and_settle(index.as_ref()).await;
         assert_score(index.as_ref(), &[1, 2, 3], worker, 3).await;
 
-        time::sleep(ttl + Duration::from_millis(25)).await;
+        time::sleep(ttl + Duration::from_millis(125)).await;
         flush_and_settle(index.as_ref()).await;
 
         assert_score(index.as_ref(), &[1, 2, 3], worker, 3).await;


### PR DESCRIPTION
## Summary

- replace per-block approximate-prune heap entries with 100ms expiry buckets
- preserve exact immediate expiry when approximate TTL is configured as zero
- improved end-to-end throughput by 13.7% in the bs64 c384 multi-frontend AgentX benchmark
- keep the authoritative per-key timer map so refresh/remove semantics stay exact within the bucketed expiry model
- update approximate TTL tests for the new bucket slack and add bucket-specific coverage

## Overview

This PR changes approximate KV-router TTL pruning from one heap entry per block to bucketed expiration. Non-zero TTLs are rounded up to 100ms buckets, which reduces prune bookkeeping overhead under high block churn. A zero TTL remains an immediate expiry case and is not bucket-rounded.

## Details

- `PruneManager` stores expiration buckets in a `BTreeMap<Instant, FxHashSet<K>>` while retaining `timers` as the authoritative key-to-expiry map.
- Existing remove and refresh semantics stay exact against the authoritative map.
- Non-zero TTL expiration may be delayed by up to one bucket interval.
- Zero TTL entries expire at the caller-provided insertion timestamp.
- The indexer README now describes the bucketed pruning structure instead of the old `BinaryHeap<BlockEntry>` path.

## Where should the reviewer start?

- `lib/kv-router/src/indexer/pruning.rs`: bucketed `PruneManager`, zero-TTL special case, and focused unit coverage.
- `lib/kv-router/src/indexer/tests.rs`: approximate TTL integration test timing updates.
- `lib/kv-router/src/indexer/README.md`: pruning structure documentation update.

## Benchmarked Perf

Measured on the AgentX 060526 multi-frontend profile harness with 4 frontends, KV routing, block size 64, total concurrency 384. This compares the same local benchmark stack before and after this TTL pruning change.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Completed requests | 81,212 | 92,568 | +14.0% |
| Errors | 0 | 0 | same |
| Throughput | 367.2 req/s | 417.6 req/s | +13.7% |
| FE pool busy | 89.3% | 85.5% | lower |
| Other pool busy | 99.2% | 99.8% | still saturated |
| TTL prune CPU bucket | ~9.67% | ~1.16% | -8.51 pp |
| BinaryHeap::pop leaf | ~6.66% | 0.00% | eliminated |
| Router overhead avg | 0.9835 ms | 0.8206 ms | -16.6% |
| Router scheduling avg | 0.8468 ms | 0.7013 ms | -17.2% |

The throughput number is not a pure frontend-only speedup because the non-frontend core pool was saturated after the change, but the CPU profile shows the targeted TTL pruning overhead dropped materially.

## Validation

- `cargo test -p dynamo-kv-router pruning --lib`
- `cargo test -p dynamo-kv-router ttl --lib`
- `cargo test -p dynamo-kv-router --lib`

## Related Issues

None.
