### PR TITLE
fix(vllm): serialize routed_experts as base64 with start offset

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -653,7 +653,9 @@ def _accumulate_engine_data(
     tok["engine_data"] = engine_data
 
 
-def _serialize_routed_experts(routed_experts: Any) -> Optional[Dict[str, Any]]:
+def _serialize_routed_experts(
+    routed_experts: Any, start: int = 0
+) -> Optional[Dict[str, Any]]:
     if routed_experts is None:
         return None
 
@@ -667,10 +669,16 @@ def _serialize_routed_experts(routed_experts: Any) -> Optional[Dict[str, Any]]:
         return None
 
     return {
-        "data": base64.b85encode(tobytes()).decode("ascii"),
+        # base64 (not base85): the prime-rl RL consumer decodes with
+        # pybase64.b64decode, matching the SGLang / SLIME / vLLM-native encoding.
+        "data": base64.b64encode(tobytes()).decode("ascii"),
         "shape": [int(dim) for dim in shape],
+        # Row offset of the first returned routing entry within the full
+        # sequence (= SamplingParams.routed_experts_prompt_start; vLLM trims the
+        # leading prompt rows). Lets the RL consumer align the completion.
+        "start": int(start),
         # Encode dtype so the consumer decodes the raw bytes with the right
-        # element type instead of assuming int32.
+        # element type instead of assuming a fixed width.
         "dtype": str(getattr(routed_experts, "dtype", "")),
     }
 
@@ -3024,7 +3032,13 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 out, prompt_logprobs_payload
                             )
                         routed_experts = _serialize_routed_experts(
-                            raw_routed_experts_by_output.get(output_idx)
+                            raw_routed_experts_by_output.get(output_idx),
+                            start=int(
+                                getattr(
+                                    sampling_params, "routed_experts_prompt_start", 0
+                                )
+                                or 0
+                            ),
                         )
                         if routed_experts is not None:
                             _attach_routed_experts_engine_data(out, routed_experts)

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3054,7 +3054,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             or 0
                         )
                         prompt_len = len(getattr(res, "prompt_token_ids", None) or [])
-                        effective_start = min(raw_start, prompt_len) if prompt_len else raw_start
+                        effective_start = min(raw_start, prompt_len)
                         routed_experts = _serialize_routed_experts(
                             raw_routed_experts_by_output.get(output_idx),
                             start=effective_start,

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -669,8 +669,7 @@ def _serialize_routed_experts(
         return None
 
     return {
-        # base64 (not base85): the prime-rl RL consumer decodes with
-        # pybase64.b64decode, matching the SGLang / SLIME / vLLM-native encoding.
+        # base64, matching vLLM-native encoding.
         "data": base64.b64encode(tobytes()).decode("ascii"),
         "shape": [int(dim) for dim in shape],
         # Row offset of the first returned routing entry within the full

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -753,6 +753,19 @@ def build_sampling_params(
         if value is not None and hasattr(sampling_params, key):
             setattr(sampling_params, key, value)
 
+    # routed_experts_prompt_start (RL capture offset) must be a non-negative
+    # int; reject bad client values so the worker emits a sane `start` instead
+    # of a bogus offset the consumer cannot align (vLLM clamps the upper bound).
+    reps = getattr(sampling_params, "routed_experts_prompt_start", None)
+    if reps is not None and (
+        isinstance(reps, bool) or not isinstance(reps, int) or reps < 0
+    ):
+        logger.warning(
+            "Ignoring invalid routed_experts_prompt_start=%r (want non-negative int)",
+            reps,
+        )
+        sampling_params.routed_experts_prompt_start = 0
+
     # Apply stop_conditions
     for key, value in request.get("stop_conditions", {}).items():
         if value is not None and hasattr(sampling_params, key):
@@ -3000,7 +3013,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "token_ids": token_ids,
                     }
                     # Capture the raw routed_experts cheaply here; serialize it
-                    # only once on the final chunk (base85-encoding a tensor on
+                    # only once on the final chunk (base64-encoding a tensor on
                     # every streamed chunk would be wasted work, since only the
                     # final value is emitted).
                     raw_routed_experts = getattr(output, "routed_experts", None)

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3043,14 +3043,21 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             _attach_prompt_logprobs_engine_data(
                                 out, prompt_logprobs_payload
                             )
+                        # Emit the EFFECTIVE trim offset: clamp the requested
+                        # routed_experts_prompt_start to the prompt length. vLLM
+                        # clamps the returned routing rows the same way, so an
+                        # out-of-range request (e.g. start=999 on a 100-token
+                        # prompt) would otherwise publish a `start` the consumer
+                        # cannot align to the (clamped) tensor.
+                        raw_start = int(
+                            getattr(sampling_params, "routed_experts_prompt_start", 0)
+                            or 0
+                        )
+                        prompt_len = len(getattr(res, "prompt_token_ids", None) or [])
+                        effective_start = min(raw_start, prompt_len) if prompt_len else raw_start
                         routed_experts = _serialize_routed_experts(
                             raw_routed_experts_by_output.get(output_idx),
-                            start=int(
-                                getattr(
-                                    sampling_params, "routed_experts_prompt_start", 0
-                                )
-                                or 0
-                            ),
+                            start=effective_start,
                         )
                         if routed_experts is not None:
                             _attach_routed_experts_engine_data(out, routed_experts)

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -372,6 +372,10 @@ class TestReasoningParserForwarding:
         handler._extract_logprobs = MagicMock(return_value=(None, None))
         routed_experts = np.array([[[3]], [[4]]], dtype=np.int16)
 
+        # Prompt longer than the requested start, so the echoed offset is not
+        # clamped to the prompt length.
+        prompt_token_ids = [1, 2, 3, 4, 5, 6]
+
         async def fake_generate(*args, **kwargs):
             yield SimpleNamespace(
                 outputs=[
@@ -383,7 +387,7 @@ class TestReasoningParserForwarding:
                         stop_reason=None,
                     )
                 ],
-                prompt_token_ids=[1, 2],
+                prompt_token_ids=prompt_token_ids,
                 prompt_logprobs=None,
             )
 
@@ -392,13 +396,58 @@ class TestReasoningParserForwarding:
 
         chunks = []
         async for chunk in handler.generate_tokens(
-            PatchedTokensPrompt(prompt_token_ids=[1]),
+            PatchedTokensPrompt(prompt_token_ids=prompt_token_ids),
             sampling_params,
             "req-2",
         ):
             chunks.append(chunk)
 
         assert chunks[-1]["engine_data"]["routed_experts"]["start"] == 5
+
+    @pytest.mark.asyncio
+    async def test_generate_tokens_routed_experts_start_clamped_to_prompt_len(self):
+        """An out-of-range routed_experts_prompt_start is clamped to the prompt
+        length (vLLM clamps the returned rows the same way)."""
+        from vllm.sampling_params import SamplingParams
+
+        sampling_params = SamplingParams(max_tokens=1)
+        try:
+            sampling_params.routed_experts_prompt_start = 99
+        except (AttributeError, TypeError):
+            pytest.skip("installed vLLM has no routed_experts_prompt_start support")
+
+        handler = _make_handler()
+        handler._extract_logprobs = MagicMock(return_value=(None, None))
+        routed_experts = np.array([[[3]], [[4]]], dtype=np.int16)
+
+        async def fake_generate(*args, **kwargs):
+            yield SimpleNamespace(
+                outputs=[
+                    SimpleNamespace(
+                        index=0,
+                        token_ids=[12],
+                        routed_experts=routed_experts,
+                        finish_reason="stop",
+                        stop_reason=None,
+                    )
+                ],
+                prompt_token_ids=[1, 2, 3],
+                prompt_logprobs=None,
+            )
+
+        handler.engine_client = MagicMock()
+        handler.engine_client.generate = fake_generate
+
+        chunks = []
+        async for chunk in handler.generate_tokens(
+            PatchedTokensPrompt(prompt_token_ids=[1, 2, 3]),
+            sampling_params,
+            "req-3",
+        ):
+            chunks.append(chunk)
+
+        # start=99 clamped to prompt_len=3
+        assert chunks[-1]["engine_data"]["routed_experts"]["start"] == 3
 
 
 # ── Tests ────────────────────────────────────────────────────────────

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -346,10 +346,60 @@ class TestReasoningParserForwarding:
         routed = chunks[1]["engine_data"]["routed_experts"]
         assert routed["shape"] == [2, 1, 1]
         assert routed["dtype"] == "int32"
+        # start defaults to 0 when routed_experts_prompt_start is unset.
+        assert routed["start"] == 0
+        # base64 (not base85): the prime-rl RL consumer decodes with b64.
         decoded = np.frombuffer(
-            base64.b85decode(routed["data"]), dtype=np.dtype(routed["dtype"])
+            base64.b64decode(routed["data"]), dtype=np.dtype(routed["dtype"])
         )
         np.testing.assert_array_equal(decoded, routed_experts.reshape(-1))
+
+    @pytest.mark.asyncio
+    async def test_generate_tokens_routed_experts_start_echoes_prompt_start(self):
+        """routed_experts.start echoes SamplingParams.routed_experts_prompt_start
+        (the offset vLLM trimmed) so the RL consumer can align the completion."""
+        from vllm.sampling_params import SamplingParams
+
+        # routed_experts_prompt_start is an RL-patch field; set it post-construct
+        # so the test runs against stock vLLM too (the worker reads it via
+        # getattr, defaulting to 0 when absent).
+        sampling_params = SamplingParams(max_tokens=1)
+        try:
+            sampling_params.routed_experts_prompt_start = 5
+        except Exception:
+            pytest.skip("installed vLLM has no routed_experts_prompt_start support")
+
+        handler = _make_handler()
+        handler._extract_logprobs = MagicMock(return_value=(None, None))
+        routed_experts = np.array([[[3]], [[4]]], dtype=np.int32)
+
+        async def fake_generate(*args, **kwargs):
+            yield SimpleNamespace(
+                outputs=[
+                    SimpleNamespace(
+                        index=0,
+                        token_ids=[12],
+                        routed_experts=routed_experts,
+                        finish_reason="stop",
+                        stop_reason=None,
+                    )
+                ],
+                prompt_token_ids=[1, 2],
+                prompt_logprobs=None,
+            )
+
+        handler.engine_client = MagicMock()
+        handler.engine_client.generate = fake_generate
+
+        chunks = []
+        async for chunk in handler.generate_tokens(
+            PatchedTokensPrompt(prompt_token_ids=[1]),
+            sampling_params,
+            "req-2",
+        ):
+            chunks.append(chunk)
+
+        assert chunks[-1]["engine_data"]["routed_experts"]["start"] == 5
 
 
 # ── Tests ────────────────────────────────────────────────────────────

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -348,7 +348,6 @@ class TestReasoningParserForwarding:
         assert routed["dtype"] == "int32"
         # start defaults to 0 when routed_experts_prompt_start is unset.
         assert routed["start"] == 0
-        # base64 (not base85): the prime-rl RL consumer decodes with b64.
         decoded = np.frombuffer(
             base64.b64decode(routed["data"]), dtype=np.dtype(routed["dtype"])
         )

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -293,7 +293,7 @@ class TestReasoningParserForwarding:
         handler = _make_handler()
         handler._extract_logprobs = MagicMock(return_value=(None, None))
 
-        routed_experts = np.array([[[1]], [[2]]], dtype=np.int32)
+        routed_experts = np.array([[[1]], [[2]]], dtype=np.int16)
 
         async def fake_generate(*args, **kwargs):
             yield SimpleNamespace(
@@ -345,7 +345,7 @@ class TestReasoningParserForwarding:
         assert "disaggregated_params" not in chunks[1]
         routed = chunks[1]["engine_data"]["routed_experts"]
         assert routed["shape"] == [2, 1, 1]
-        assert routed["dtype"] == "int32"
+        assert routed["dtype"] == "int16"
         # start defaults to 0 when routed_experts_prompt_start is unset.
         assert routed["start"] == 0
         decoded = np.frombuffer(
@@ -370,7 +370,7 @@ class TestReasoningParserForwarding:
 
         handler = _make_handler()
         handler._extract_logprobs = MagicMock(return_value=(None, None))
-        routed_experts = np.array([[[3]], [[4]]], dtype=np.int32)
+        routed_experts = np.array([[[3]], [[4]]], dtype=np.int16)
 
         async def fake_generate(*args, **kwargs):
             yield SimpleNamespace(

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -366,7 +366,7 @@ class TestReasoningParserForwarding:
         sampling_params = SamplingParams(max_tokens=1)
         try:
             sampling_params.routed_experts_prompt_start = 5
-        except Exception:
+        except (AttributeError, TypeError):
             pytest.skip("installed vLLM has no routed_experts_prompt_start support")
 
         handler = _make_handler()


### PR DESCRIPTION
## Overview:

Make MoE routed-experts capture portable for RL log-prob recomputation: base64-encoded with a `start` offset so consumers can align the routing to the completion.

## Details:

`_serialize_routed_experts` now:
- encodes the expert-id bytes as **base64** (was base85), matching the encoding consumers already decode;
- emits a **`start`** field (`= SamplingParams.routed_experts_prompt_start`, the leading prompt rows vLLM trims) so consumers can slice to the completion;
- keeps `shape` and `dtype` so the consumer reads the right element width instead of assuming a fixed type.

The token-generation path forwards `start` from the request's sampling params (0 when unset).

## Where should the reviewer start?

`components/src/dynamo/vllm/handlers.py` — `_serialize_routed_experts` and its call site in the token-generation path.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated routed-experts serialization encoding for improved compatibility
  * Enhanced routed expert prompt window alignment with start position tracking

* **Tests**
  * Added validation for routed expert prompt positioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
