### PR TITLE
chore: bump trtllm to v1.3.0rc18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5590,9 +5590,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "2ebc0a255ea1cbd18ba08d7bc430ea781105c5ceb278a46b52b93fc2dca0ed06"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -102,7 +102,7 @@ trtllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: nvcr.io/nvidia/tensorrt-llm/release
     base_image_tag: 26.02-cuda13.1-devel-ubuntu24.04
-    runtime_image_tag: 1.3.0rc17
+    runtime_image_tag: 1.3.0rc18
   nixl_ref: 0.10.1
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -24,7 +24,7 @@ dynamo:
   nats_version: v2.10.28
   etcd_version: v3.5.30
 
-  nixl_ref: 0.10.1
+  nixl_ref: v1.0.1
   nixl_ucx_ref: v1.20.x
   nixl_gdrcopy_ref: v2.5.2
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
@@ -92,7 +92,7 @@ sglang:
   # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang
   # NIXL Python stack — its wheel COPY is narrowed to ai_dynamo*.whl so the SDK
   # build doesn't leak into the runtime image.
-  nixl_ref: 0.10.1
+  nixl_ref: v1.0.1
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"
@@ -103,7 +103,7 @@ trtllm:
     runtime_image: nvcr.io/nvidia/tensorrt-llm/release
     base_image_tag: 26.02-cuda13.1-devel-ubuntu24.04
     runtime_image_tag: 1.3.0rc18
-  nixl_ref: 0.10.1
+  nixl_ref: v1.0.1
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"

--- a/container/deps/requirements.trtllm.txt
+++ b/container/deps/requirements.trtllm.txt
@@ -19,10 +19,10 @@ imageio-ffmpeg>=0.6.0  # binary skipped per --no-binary directive at top of file
 # does not need this).
 msgspec>=0.19.0
 # KVBM uses `import nixl` to load libnixl.so via DT_RPATH (matching its
-# nixl-sys=0.10.1 ABI). Upstream's NIXL 0.9.0 at /opt/nvidia/nvda_nixl coexists
+# nixl-sys ABI). Upstream's NIXL at /opt/nvidia/nvda_nixl coexists
 # unused because Dynamo's --connector kvbm bypasses TRT-LLM's native NIXL
-# transceiver. The 42 MB nixl-cu13 wheel is harmless if KVBM is disabled.
-nixl==0.10.1
-nixl-cu13==0.10.1
+# transceiver. The nixl-cu13 wheel is harmless if KVBM is disabled.
+nixl==1.0.1
+nixl-cu13==1.0.1
 # Required by ai_dynamo_runtime (companion to msgspec above).
 uvloop>=0.21.0

--- a/deploy/pre-deployment/nixl/README.md
+++ b/deploy/pre-deployment/nixl/README.md
@@ -95,11 +95,11 @@ The script only prompts for Docker registry information when needed:
 ## What Each Step Does
 
 ### Step 1: Build nixlbench Docker Image
-- Downloads NIXL source code (version 0.10.1) from GitHub
+- Downloads NIXL source code (version 1.0.1) from GitHub
 - Extracts and navigates to the build directory
 - Pauses for user confirmation before building
 - Builds Docker image with specified registry and architecture
-- Tags image as: `{registry}/nixlbench:0.10.1-{arch}`
+- Tags image as: `{registry}/nixlbench:1.0.1-{arch}`
 
 ### Step 2: Update Deployment YAML File
 - Copies base deployment template (`nixlbench-deployment.yaml`)
@@ -231,7 +231,7 @@ This will help diagnose:
 
 2. **Image Pull Issues**:
    - Verify registry credentials are configured
-   - Check image exists: `docker pull {registry}/nixlbench:0.10.1-{arch}`
+   - Check image exists: `docker pull {registry}/nixlbench:1.0.1-{arch}`
    - Ensure image was pushed successfully after build
 
 3. **Build Failures**:

--- a/deploy/pre-deployment/nixl/build_and_deploy.sh
+++ b/deploy/pre-deployment/nixl/build_and_deploy.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 
-NIXL_VERSION="0.10.1"
+NIXL_VERSION="1.0.1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Function to check if a command exists
@@ -182,8 +182,9 @@ build_nixlbench() {
     cd "${NIXL_BUILD_DIR}"
 
     echo "Downloading NIXL source..."
-    wget https://github.com/ai-dynamo/nixl/archive/refs/tags/${NIXL_VERSION}.zip
-    unzip "${NIXL_VERSION}.zip"
+    # Tag is v-prefixed; GitHub strips the leading "v" from the extracted dir.
+    wget https://github.com/ai-dynamo/nixl/archive/refs/tags/v${NIXL_VERSION}.zip
+    unzip "v${NIXL_VERSION}.zip"
     cd "nixl-${NIXL_VERSION}/benchmark/nixlbench/contrib"
     read -p "Press Enter to continue"
     echo "Building Docker image..."

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -31,7 +31,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.11` | `1.3.0rc17` | `0.21.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
+| **main (ToT)** | `0.5.11` | `1.3.0rc18` | `0.21.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
 | **v1.3.0-dev.1** *(experimental)* | `0.5.12.post1` | `1.3.0rc17` | `0.22.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
 | **v1.2.0** | `0.5.11` | `1.3.0rc14` | `0.20.1` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
 | **v1.2.0-deepseek-v4-dev.3** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.1` | `0.10.1` |

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -31,7 +31,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.11` | `1.3.0rc18` | `0.21.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
+| **main (ToT)** | `0.5.11` | `1.3.0rc18` | `0.21.0` | `1.0.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
 | **v1.3.0-dev.1** *(experimental)* | `0.5.12.post1` | `1.3.0rc17` | `0.22.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
 | **v1.2.0** | `0.5.11` | `1.3.0rc14` | `0.20.1` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
 | **v1.2.0-deepseek-v4-dev.3** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.1` | `0.10.1` |

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3955,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "2ebc0a255ea1cbd18ba08d7bc430ea781105c5ceb278a46b52b93fc2dca0ed06"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/lib/bindings/kvbm/pyproject.toml
+++ b/lib/bindings/kvbm/pyproject.toml
@@ -26,7 +26,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "nixl[cu13]==0.10.1",
+    "nixl[cu13]==1.0.1",
     "pydantic>=2.0"
 ]
 classifiers = [
@@ -45,8 +45,8 @@ classifiers = [
 keywords = ["llm", "genai", "inference", "nvidia", "kvcache", "dynamo"]
 
 [project.optional-dependencies]
-cu12 = ["nixl[cu12]==0.10.1"]
-cu13 = ["nixl[cu13]==0.10.1"]
+cu12 = ["nixl[cu12]==1.0.1"]
+cu13 = ["nixl[cu13]==1.0.1"]
 dev = [
     "maturin>=1.0,<2.0",
     "patchelf",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -4947,9 +4947,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "2ebc0a255ea1cbd18ba08d7bc430ea781105c5ceb278a46b52b93fc2dca0ed06"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -128,7 +128,7 @@ dialoguer = { version = "0.11", default-features = false, features = [
 
 # block_manager
 aligned-vec = { version = "0.6.4", optional = true }
-nixl-sys = { version = "=0.10.1", optional = true }
+nixl-sys = { version = "=1.0.1", optional = true }
 cudarc = { workspace = true, optional = true }
 nix = { version = "0.26", optional = true }
 

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -25,7 +25,7 @@ testing-all = ["testing-cuda", "testing-nixl"]
 [dependencies]
 anyhow = { workspace = true }
 cudarc = { workspace = true }
-nixl-sys = { version = "=0.10.1" }
+nixl-sys = { version = "=1.0.1" }
 serde = { workspace = true}
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [project.optional-dependencies]
 trtllm =[
     "uvloop",
-    "tensorrt-llm==1.3.0rc17",
+    "tensorrt-llm==1.3.0rc18",
 ]
 
 vllm = [


### PR DESCRIPTION
## Automated dependency upgrade — trtllm v1.3.0rc18

Post-merge CI did not pass (conclusion: `failure`). Investigate before merging.

- **Framework:** trtllm
- **Target version:** v1.3.0rc18
- **Branch:** deps/upgrade-trtllm-v1.3.0rc18
- **Validating run:** https://github.com/ai-dynamo/dynamo/actions/runs/27272706959

closes: OPS-7112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NIXL dependency from 0.10.1 to 1.0.1 across container configuration, Python, and Rust manifests.
  * Updated TensorRT-LLM to 1.3.0rc18 in build configuration and project dependencies.
  * Updated deployment scripts and documentation to reflect new dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->