### PR TITLE
fix(planner): treat non-finite load readings as zero in predictors

### DIFF
--- a/components/src/dynamo/planner/core/load/predictors.py
+++ b/components/src/dynamo/planner/core/load/predictors.py
@@ -70,7 +70,10 @@ class BasePredictor(ABC):
 
     def add_data_point(self, value: float) -> None:
         """Add new data point to the buffer"""
-        if math.isnan(value):
+        # Treat any non-finite reading (NaN or +/-inf) as zero load: a single
+        # inf would otherwise be stored and propagate into the forecast
+        # (ConstantPredictor returns inf; ARIMA/Prophet fitting breaks).
+        if not math.isfinite(value):
             value = 0
 
         if value == 0 and not self._seen_nonzero_since_idle_reset:
@@ -263,7 +266,8 @@ class ProphetPredictor(BasePredictor):
         """Add new data point to the buffer"""
         # Use proper datetime for Prophet
         timestamp = self.start_date + timedelta(seconds=self.curr_step * self.step_size)
-        value = 0 if math.isnan(value) else value
+        # Treat any non-finite reading (NaN or +/-inf) as zero load (see BasePredictor).
+        value = 0 if not math.isfinite(value) else value
 
         if value == 0 and not self._seen_nonzero_since_idle_reset:
             # skip the beginning idle period (leading zeros), even if pre-warmed

--- a/components/src/dynamo/planner/tests/unit/test_load_predictors.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_predictors.py
@@ -105,6 +105,25 @@ class TestConstantPredictor:
         predictor.add_data_point(float("nan"))
         assert predictor.predict_next() == 0
 
+    @pytest.mark.parametrize("bad", [float("inf"), float("-inf")])
+    def test_inf_treated_as_zero(self, bad):
+        """+/-inf readings are coerced to 0 so they never propagate into the
+        forecast (an un-sanitized inf would make predict_next() return inf)."""
+        predictor = ConstantPredictor(_make_config())
+        predictor.add_data_point(10.0)
+        predictor.add_data_point(bad)
+        result = predictor.predict_next()
+        assert result == 0
+        assert math.isfinite(result)
+
+    def test_leading_inf_skipped_as_idle(self):
+        """A leading non-finite reading is sanitized to 0 and skipped as idle,
+        exactly like a leading zero — it must not seed the buffer."""
+        predictor = ConstantPredictor(_make_config())
+        predictor.add_data_point(float("inf"))
+        assert predictor.predict_next() == 0
+        assert len(predictor.data_buffer) == 0
+
 
 # ---------------------------------------------------------------------------
 # ProphetPredictor timestamp bug regression tests


### PR DESCRIPTION
## Problem

The planner load predictors already sanitize `NaN` load readings to zero:

```python
if math.isnan(value):
    value = 0
```

but `+inf` / `-inf` slip through that guard. A non-finite reading is then
stored in the buffer and propagates into the forecast:

- `ConstantPredictor.predict_next()` returns `inf`;
- the ARIMA path stores `inf` in `_raw_buffer` (and `math.log1p(inf)` in log1p
  mode), breaking/garbaging the fit;
- Prophet fits on an `inf` `y` value.

Upstream, `state_machine.py` only finite-checks `kv_hit_rate` and
`accept_length` — not the `num_req` / `isl` / `osl` values that feed these
predictors — so a single non-finite rate (e.g. a throughput computed by
dividing by a near-zero interval) can poison a scaling decision rather than
being treated as "no load."

## Fix

Widen the existing guard from "is NaN" to "is not finite" so it covers `NaN`
**and** `±inf`, in both `BasePredictor.add_data_point` (inherited by the
Constant / ARIMA / Kalman predictors) and the `ProphetPredictor` override:

```python
if not math.isfinite(value):
    value = 0
```

- Behavior is **unchanged** for finite values and for `NaN`.
- `±inf` is now coerced to `0` exactly like `NaN`, which also makes a *leading*
  `inf` skip the post-deployment idle period the same way a leading zero does.
- This matches the `math.isfinite(...)` checks the codebase already uses
  elsewhere (e.g. `accept_length` in `state_machine.py`).

One concern, +25/−2 lines.

## Tests

Added to `tests/unit/test_load_predictors.py`, mirroring the existing
`test_nan_treated_as_zero`:

- `test_inf_treated_as_zero` — parametrized over `+inf` and `-inf`; asserts the
  reading is sanitized to `0` and the forecast stays finite.
- `test_leading_inf_skipped_as_idle` — a leading `inf` is treated as idle and
  does not seed the buffer.

### What I ran locally vs. deferred to CI

`predictors.py` imports heavy optional deps (`pmdarima`, `prophet`, `filterpy`)
plus the compiled `dynamo.runtime`, which I could not build in my environment,
so I could not run the full `pytest` suite locally. I verified the **actual
edited source** by importing `predictors.py` with those optional deps stubbed
and exercising the real `ConstantPredictor`: `NaN`/`+inf`/`-inf` all sanitize to
`0`, a leading `inf` leaves the buffer empty, finite values are unchanged, and I
confirmed the pre-fix `isnan`-only logic *did* retain `inf` (reproducing the
bug). `black`, `isort`, and `ruff check` pass on the touched files. The full
unit suite will run under CI (`/ok to test`).

---

AI-assisted (Claude); reviewed, verified, and owned by me (the human author).
