### PR TITLE
docs(dgdr): document router configuration

### DIFF
--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -80,7 +80,8 @@ For the complete CRD spec, see the [API Reference](api-reference.md).
 > [!NOTE]
 > DGDR does not currently expose a `features.kvRouter` field. To configure
 > router mode or KV-aware routing details, use a direct DGD, a tuned recipe, or
-> `overrides.dgd` when you still want DGDR to generate the base deployment.
+> `overrides.dgd` when you still want DGDR to generate the non-EPP base
+> deployment.
 
 ### Generated DGD Overrides
 
@@ -130,6 +131,209 @@ spec:
 > [!NOTE]
 > `overrides.profilingJob` only customizes the profiling Job. Use
 > `overrides.dgd` for settings that must appear on the deployed worker pods.
+
+### Routing
+
+DGDR-generated deployments include a standalone `Frontend` service. That
+frontend runs Dynamo's embedded router and defaults to `round-robin` routing.
+Because DGDR does not yet expose a first-class router feature, configure the
+generated frontend with `spec.overrides.dgd`.
+
+For example, enable KV-aware routing on the generated frontend:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: qwen3-kv-router
+spec:
+  model: Qwen/Qwen3-0.6B
+  backend: vllm
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  overrides:
+    dgd:
+      apiVersion: nvidia.com/v1alpha1
+      kind: DynamoGraphDeployment
+      spec:
+        services:
+          Frontend:
+            envs:
+              - name: DYN_ROUTER_MODE
+                value: kv
+```
+
+Use the same `Frontend` override for other frontend router modes, such as
+`random`, `least-loaded`, or `device-aware-weighted`. For normal DGDR
+deployments, use `kv` when you want prefix-cache-aware routing and
+`round-robin` or `least-loaded` when you only want load balancing. Use
+`direct` only when an external router supplies explicit worker IDs in the
+request routing hints.
+
+KV-aware routing is most precise when workers publish KV cache events. If the
+workers do not publish events, run the frontend in approximate KV mode:
+
+```yaml
+spec:
+  overrides:
+    dgd:
+      apiVersion: nvidia.com/v1alpha1
+      kind: DynamoGraphDeployment
+      spec:
+        services:
+          Frontend:
+            envs:
+              - name: DYN_ROUTER_MODE
+                value: kv
+              - name: DYN_ROUTER_USE_KV_EVENTS
+                value: "false"
+```
+
+If you also need to change backend worker arguments for event publication,
+override the generated worker service by name. Service names depend on the
+selected backend and topology, so inspect the generated DGD first, especially
+when `autoApply: false`.
+
+For example, a generated vLLM disaggregated deployment may contain a
+`VllmPrefillWorker` service. This override appends the vLLM KV-event publishing
+arguments to that service while enabling the frontend KV router:
+
+```yaml
+spec:
+  overrides:
+    dgd:
+      apiVersion: nvidia.com/v1alpha1
+      kind: DynamoGraphDeployment
+      spec:
+        services:
+          Frontend:
+            envs:
+              - name: DYN_ROUTER_MODE
+                value: kv
+          VllmPrefillWorker:
+            extraPodSpec:
+              mainContainer:
+                args:
+                  - --kv-events-config
+                  - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+```
+
+Worker KV-event flags are backend-specific. The usual patterns are:
+
+| Backend | Worker-side event publishing |
+|---|---|
+| vLLM | `--kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'` |
+| SGLang | `--kv-events-config` with the SGLang event endpoint |
+| TRT-LLM | `--publish-events-and-metrics` |
+
+In Kubernetes deployments the Dynamo runtime normally uses Kubernetes
+discovery and the NATS event plane. Some backends, such as vLLM and SGLang,
+emit raw KV events over ZMQ; the Dynamo worker consumes those backend events
+and republishes router events through the Dynamo event plane.
+
+### EPP and Gateway Routing
+
+EPP/Gateway routing is a different topology from the standalone frontend that
+DGDR generates:
+
+```text
+client -> Gateway -> EPP selects worker -> worker frontend sidecar -> engine
+```
+
+In this mode the EPP owns worker selection. The worker-local frontend sidecar
+must run with `--router-mode direct` so it honors the worker IDs selected by
+EPP. In the normal Gateway path, the selected endpoint and the frontend sidecar
+are the same worker pod; if they differ, direct mode can still forward to the
+worker ID supplied by EPP.
+
+DGDR does not currently generate EPP components or frontend sidecars. Also,
+`overrides.dgd` only patches services that already exist in the generated DGD,
+so it cannot be used to add a missing `Epp` service to a DGDR-generated
+deployment. Use a direct DGD manifest or a GAIE recipe for EPP deployments.
+
+A current v1beta1 DGD EPP deployment has this shape:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: qwen-gaie
+spec:
+  backendFramework: vllm
+  components:
+    - name: Epp
+      type: epp
+      eppConfig:
+        config:
+          plugins:
+            - type: disagg-profile-handler
+            - name: decode-filter
+              type: label-filter
+              parameters:
+                label: nvidia.com/dynamo-component-type
+                validValues:
+                  - decode
+                allowsNoLabel: true
+            - name: picker
+              type: max-score-picker
+            - name: dyn-decode
+              type: dyn-decode-scorer
+          schedulingProfiles:
+            - name: decode
+              plugins:
+                - pluginRef: decode-filter
+                  weight: 1
+                - pluginRef: dyn-decode
+                  weight: 1
+                - pluginRef: picker
+                  weight: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/epp-image:my-tag
+              env:
+                - name: DYN_MODEL_NAME
+                  value: Qwen/Qwen3-0.6B
+                - name: DYN_KV_CACHE_BLOCK_SIZE
+                  value: "128"
+                - name: DYN_ENFORCE_DISAGG
+                  value: "false"
+    - name: VllmDecodeWorker
+      type: decode
+      frontendSidecar: sidecar-frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+              command:
+                - /bin/sh
+                - -c
+              args:
+                - python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME
+                  --enable-prefix-caching --block-size 128 --kv-events-config '{"enable_kv_cache_events":true}'
+              env:
+                - name: MODEL_PATH
+                  value: Qwen/Qwen3-0.6B
+                - name: SERVED_MODEL_NAME
+                  value: Qwen/Qwen3-0.6B
+            - name: sidecar-frontend
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+              args:
+                - -m
+                - dynamo.frontend
+                - --router-mode
+                - direct
+```
+
+EPP uses its own router configuration variables. For example,
+`DYN_USE_KV_EVENTS=false` disables KV-event consumption in the EPP and falls
+back to approximate routing. This is distinct from
+`DYN_ROUTER_USE_KV_EVENTS`, which configures the standalone Python frontend
+router used in non-EPP DGDR deployments.
+
+For full Gateway setup and route manifests, see
+[Gateway API Inference Extension](inference-gateway.md).
 
 ### SKU Format
 

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -88,8 +88,9 @@ For the complete CRD spec, see the [API Reference](api-reference.md).
 
 Use `spec.overrides.dgd` when the generated `DynamoGraphDeployment` needs a
 field that DGDR does not expose directly. The value is a partial
-`nvidia.com/v1alpha1` DGD object that is merged into the profiler-generated
-deployment after Dynamo selects a configuration.
+DGD object that is merged into the profiler-generated deployment after Dynamo
+selects a configuration. The payload must match the generated DGD shape, so
+inspect the generated DGD first when overriding service-specific fields.
 
 For example, to inject an environment variable into every generated service:
 
@@ -104,7 +105,7 @@ spec:
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0"  # dynamo-frontend for Dynamo < 1.1.0
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1alpha1
+      apiVersion: nvidia.com/v1beta1
       kind: DynamoGraphDeployment
       spec:
         envs:
@@ -119,7 +120,7 @@ target a single service, override that service's `envs` entry instead:
 spec:
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1alpha1
+      apiVersion: nvidia.com/v1beta1
       kind: DynamoGraphDeployment
       spec:
         services:
@@ -157,7 +158,7 @@ spec:
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1alpha1
+      apiVersion: nvidia.com/v1beta1
       kind: DynamoGraphDeployment
       spec:
         services:
@@ -172,7 +173,8 @@ Use the same `Frontend` override for other frontend router modes, such as
 deployments, use `kv` when you want prefix-cache-aware routing and
 `round-robin` or `least-loaded` when you only want load balancing. Use
 `direct` only when an external router supplies explicit worker IDs in the
-request routing hints.
+request routing hints. For detailed mode definitions, see
+[Router Guide](../components/router/router-guide.md#routing-modes-router-mode).
 
 KV-aware routing has two independent pieces: the frontend must run in `kv`
 mode, and workers must publish KV cache events for event-driven prefix-cache
@@ -183,7 +185,7 @@ state. If worker event publication is not configured, keep
 spec:
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1alpha1
+      apiVersion: nvidia.com/v1beta1
       kind: DynamoGraphDeployment
       spec:
         services:
@@ -208,7 +210,7 @@ arguments to that service while enabling the frontend KV router:
 spec:
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1alpha1
+      apiVersion: nvidia.com/v1beta1
       kind: DynamoGraphDeployment
       spec:
         services:

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -79,18 +79,15 @@ For the complete CRD spec, see the [API Reference](api-reference.md).
 
 > [!NOTE]
 > DGDR does not currently expose a `features.kvRouter` field. To configure
-> router mode or KV-aware routing details, see [Routing](#routing).
-> `overrides.dgd` can configure the generated standalone frontend and worker
-> services. Use a direct DGD or tuned recipe when you need a topology DGDR does
-> not generate, such as EPP/Gateway routing.
+> router mode or KV-aware routing details, use a direct DGD, a tuned recipe, or
+> `overrides.dgd` when you still want DGDR to generate the base deployment.
 
 ### Generated DGD Overrides
 
 Use `spec.overrides.dgd` when the generated `DynamoGraphDeployment` needs a
 field that DGDR does not expose directly. The value is a partial
-DGD object that is merged into the profiler-generated deployment after Dynamo
-selects a configuration. The payload must match the generated DGD shape, so
-inspect the generated DGD first when overriding service-specific fields.
+`nvidia.com/v1alpha1` DGD object that is merged into the profiler-generated
+deployment after Dynamo selects a configuration.
 
 For example, to inject an environment variable into every generated service:
 
@@ -105,7 +102,7 @@ spec:
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0"  # dynamo-frontend for Dynamo < 1.1.0
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1beta1
+      apiVersion: nvidia.com/v1alpha1
       kind: DynamoGraphDeployment
       spec:
         envs:
@@ -120,7 +117,7 @@ target a single service, override that service's `envs` entry instead:
 spec:
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1beta1
+      apiVersion: nvidia.com/v1alpha1
       kind: DynamoGraphDeployment
       spec:
         services:
@@ -137,9 +134,9 @@ spec:
 ### Routing
 
 DGDR-generated deployments include a standalone `Frontend` service. That
-frontend runs Dynamo's embedded router and defaults to `round-robin` routing.
-Because DGDR does not yet expose a first-class router feature, configure the
-generated frontend with `spec.overrides.dgd`.
+frontend runs Dynamo's embedded router and defaults to `round-robin` routing,
+which is often not optimal. Because DGDR does not yet expose a first-class
+router feature, configure the generated frontend with `spec.overrides.dgd`.
 
 For the full router mode and environment variable reference, see
 [Router Guide](../components/router/router-guide.md) and

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -79,9 +79,10 @@ For the complete CRD spec, see the [API Reference](api-reference.md).
 
 > [!NOTE]
 > DGDR does not currently expose a `features.kvRouter` field. To configure
-> router mode or KV-aware routing details, see [Routing](#routing). Use a
-> direct DGD or tuned recipe when you need full router control or EPP/Gateway
-> routing.
+> router mode or KV-aware routing details, see [Routing](#routing).
+> `overrides.dgd` can configure the generated standalone frontend and worker
+> services. Use a direct DGD or tuned recipe when you need a topology DGDR does
+> not generate, such as EPP/Gateway routing.
 
 ### Generated DGD Overrides
 

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -154,7 +154,7 @@ spec:
   backend: vllm
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1beta1
+      apiVersion: nvidia.com/v1alpha1  # v1beta1 not yet supported for overrides
       kind: DynamoGraphDeployment
       spec:
         services:
@@ -181,7 +181,7 @@ state. If worker event publication is not configured, keep
 spec:
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1beta1
+      apiVersion: nvidia.com/v1alpha1  # v1beta1 not yet supported for overrides
       kind: DynamoGraphDeployment
       spec:
         services:
@@ -193,10 +193,16 @@ spec:
                 value: "false"
 ```
 
-When you do want event-driven prefix-cache state, configure the generated
-worker service with backend-specific event publishing flags. Service names
-depend on the selected backend and topology, so inspect the generated DGD
-first, especially when `autoApply: false`.
+When you do want event-driven prefix-cache state, configure event publication
+on the generated worker service that handles prefill. In aggregated serving,
+the single worker handles both prefill and decode, so configure that worker.
+In disaggregated serving, configure prefill workers only; prefix-overlap
+scoring (`dyn-prefill-scorer`) runs at the prefill stage, while decode workers
+are scored on load (`dyn-decode-scorer`) and normally omit KV-event publishing
+flags. For vLLM, that means prefill workers get `--enable-prefix-caching` and
+`--kv-events-config`; decode workers omit both flags. Service names depend on
+the selected backend and topology, so inspect the generated DGD first,
+especially when `autoApply: false`.
 
 For example, a generated vLLM disaggregated deployment may contain a
 `VllmPrefillWorker` service. This override appends the vLLM KV-event publishing
@@ -206,7 +212,7 @@ arguments to that service while enabling the frontend KV router:
 spec:
   overrides:
     dgd:
-      apiVersion: nvidia.com/v1beta1
+      apiVersion: nvidia.com/v1alpha1  # v1beta1 not yet supported for overrides
       kind: DynamoGraphDeployment
       spec:
         services:
@@ -218,6 +224,7 @@ spec:
             extraPodSpec:
               mainContainer:
                 args:
+                  - --enable-prefix-caching
                   - --kv-events-config
                   - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
 ```
@@ -227,7 +234,7 @@ Worker KV-event flags are backend-specific. For cross-backend behavior, see
 
 | Backend | Detailed docs | Worker-side event publishing |
 |---|---|---|
-| vLLM | [vLLM Reference Guide](../backends/vllm/vllm-reference-guide.md#argument-reference), [vLLM Examples](../backends/vllm/vllm-examples.md#aggregated-serving-with-kv-routing) | `--kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'` |
+| vLLM | [vLLM Reference Guide](../backends/vllm/vllm-reference-guide.md#argument-reference), [vLLM Examples](../backends/vllm/vllm-examples.md#aggregated-serving-with-kv-routing) | `--enable-prefix-caching` and `--kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'` on the aggregated worker or disaggregated prefill worker |
 | SGLang | [SGLang KV Events](../backends/sglang/sglang-reference-guide.md#kv-events), [SGLang Examples](../backends/sglang/sglang-examples.md#aggregated-serving-with-kv-routing) | `--kv-events-config` with the SGLang event endpoint |
 | TRT-LLM | [TRT-LLM DP Rank Routing](../backends/trtllm/trtllm-dp-rank-routing.md#enabling-dp-rank-routing), [TRT-LLM Observability](../backends/trtllm/trtllm-observability.md) | `--publish-events-and-metrics` |
 

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -155,7 +155,6 @@ metadata:
 spec:
   model: Qwen/Qwen3-0.6B
   backend: vllm
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
   overrides:
     dgd:
       apiVersion: nvidia.com/v1beta1

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -230,6 +230,11 @@ discovery and the NATS event plane. Some backends, such as vLLM and SGLang,
 emit raw KV events over ZMQ; the Dynamo worker consumes those backend events
 and republishes router events through the Dynamo event plane.
 
+For more detail on router modes, environment variables, and backend KV-event
+flags, see [Router Guide](../components/router/router-guide.md), [Router
+Configuration](../components/router/router-configuration.md), and [Router
+Operations](../components/router/router-operations.md).
+
 ### EPP and Gateway Routing
 
 EPP/Gateway routing is a different topology from the standalone frontend that
@@ -249,6 +254,10 @@ DGDR does not currently generate EPP components or frontend sidecars. Also,
 `overrides.dgd` only patches services that already exist in the generated DGD,
 so it cannot be used to add a missing `Epp` service to a DGDR-generated
 deployment. Use a direct DGD manifest or a GAIE recipe for EPP deployments.
+The [Gateway API Inference Extension](inference-gateway.md) guide covers the
+standard EPP path and the optional [Rust EPP
+implementation](../../deploy/inference-gateway/ext-proc/), which is currently
+documented as experimental.
 
 A current v1beta1 DGD EPP deployment has this shape:
 

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -79,9 +79,9 @@ For the complete CRD spec, see the [API Reference](api-reference.md).
 
 > [!NOTE]
 > DGDR does not currently expose a `features.kvRouter` field. To configure
-> router mode or KV-aware routing details, use a direct DGD, a tuned recipe, or
-> `overrides.dgd` when you still want DGDR to generate the non-EPP base
-> deployment.
+> router mode or KV-aware routing details, see [Routing](#routing). Use a
+> direct DGD or tuned recipe when you need full router control or EPP/Gateway
+> routing.
 
 ### Generated DGD Overrides
 
@@ -139,6 +139,10 @@ frontend runs Dynamo's embedded router and defaults to `round-robin` routing.
 Because DGDR does not yet expose a first-class router feature, configure the
 generated frontend with `spec.overrides.dgd`.
 
+For the full router mode and environment variable reference, see
+[Router Guide](../components/router/router-guide.md) and
+[Router Configuration](../components/router/router-configuration.md).
+
 For example, enable KV-aware routing on the generated frontend:
 
 ```yaml
@@ -169,8 +173,10 @@ deployments, use `kv` when you want prefix-cache-aware routing and
 `direct` only when an external router supplies explicit worker IDs in the
 request routing hints.
 
-KV-aware routing is most precise when workers publish KV cache events. If the
-workers do not publish events, run the frontend in approximate KV mode:
+KV-aware routing has two independent pieces: the frontend must run in `kv`
+mode, and workers must publish KV cache events for event-driven prefix-cache
+state. If worker event publication is not configured, keep
+`DYN_ROUTER_MODE=kv` but run the frontend in approximate KV mode:
 
 ```yaml
 spec:
@@ -188,10 +194,10 @@ spec:
                 value: "false"
 ```
 
-If you also need to change backend worker arguments for event publication,
-override the generated worker service by name. Service names depend on the
-selected backend and topology, so inspect the generated DGD first, especially
-when `autoApply: false`.
+When you do want event-driven prefix-cache state, configure the generated
+worker service with backend-specific event publishing flags. Service names
+depend on the selected backend and topology, so inspect the generated DGD
+first, especially when `autoApply: false`.
 
 For example, a generated vLLM disaggregated deployment may contain a
 `VllmPrefillWorker` service. This override appends the vLLM KV-event publishing
@@ -217,23 +223,20 @@ spec:
                   - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
 ```
 
-Worker KV-event flags are backend-specific. The usual patterns are:
+Worker KV-event flags are backend-specific. For cross-backend behavior, see
+[Router Operations](../components/router/router-operations.md#additional-notes).
 
-| Backend | Worker-side event publishing |
-|---|---|
-| vLLM | `--kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'` |
-| SGLang | `--kv-events-config` with the SGLang event endpoint |
-| TRT-LLM | `--publish-events-and-metrics` |
+| Backend | Detailed docs | Worker-side event publishing |
+|---|---|---|
+| vLLM | [vLLM Reference Guide](../backends/vllm/vllm-reference-guide.md#argument-reference), [vLLM Examples](../backends/vllm/vllm-examples.md#aggregated-serving-with-kv-routing) | `--kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'` |
+| SGLang | [SGLang KV Events](../backends/sglang/sglang-reference-guide.md#kv-events), [SGLang Examples](../backends/sglang/sglang-examples.md#aggregated-serving-with-kv-routing) | `--kv-events-config` with the SGLang event endpoint |
+| TRT-LLM | [TRT-LLM DP Rank Routing](../backends/trtllm/trtllm-dp-rank-routing.md#enabling-dp-rank-routing), [TRT-LLM Observability](../backends/trtllm/trtllm-observability.md) | `--publish-events-and-metrics` |
 
 In Kubernetes deployments the Dynamo runtime normally uses Kubernetes
 discovery and the NATS event plane. Some backends, such as vLLM and SGLang,
 emit raw KV events over ZMQ; the Dynamo worker consumes those backend events
-and republishes router events through the Dynamo event plane.
-
-For more detail on router modes, environment variables, and backend KV-event
-flags, see [Router Guide](../components/router/router-guide.md), [Router
-Configuration](../components/router/router-configuration.md), and [Router
-Operations](../components/router/router-operations.md).
+and republishes router events through the Dynamo event plane. For the event
+plane model, see [Event Plane](../design-docs/event-plane.md).
 
 ### EPP and Gateway Routing
 
@@ -254,95 +257,11 @@ DGDR does not currently generate EPP components or frontend sidecars. Also,
 `overrides.dgd` only patches services that already exist in the generated DGD,
 so it cannot be used to add a missing `Epp` service to a DGDR-generated
 deployment. Use a direct DGD manifest or a GAIE recipe for EPP deployments.
-The [Gateway API Inference Extension](inference-gateway.md) guide covers the
-standard EPP path and the optional [Rust EPP
-implementation](../../deploy/inference-gateway/ext-proc/), which is currently
-documented as experimental.
-
-A current v1beta1 DGD EPP deployment has this shape:
-
-```yaml
-apiVersion: nvidia.com/v1beta1
-kind: DynamoGraphDeployment
-metadata:
-  name: qwen-gaie
-spec:
-  backendFramework: vllm
-  components:
-    - name: Epp
-      type: epp
-      eppConfig:
-        config:
-          plugins:
-            - type: disagg-profile-handler
-            - name: decode-filter
-              type: label-filter
-              parameters:
-                label: nvidia.com/dynamo-component-type
-                validValues:
-                  - decode
-                allowsNoLabel: true
-            - name: picker
-              type: max-score-picker
-            - name: dyn-decode
-              type: dyn-decode-scorer
-          schedulingProfiles:
-            - name: decode
-              plugins:
-                - pluginRef: decode-filter
-                  weight: 1
-                - pluginRef: dyn-decode
-                  weight: 1
-                - pluginRef: picker
-                  weight: 1
-      podTemplate:
-        spec:
-          containers:
-            - name: main
-              image: nvcr.io/nvidia/ai-dynamo/epp-image:my-tag
-              env:
-                - name: DYN_MODEL_NAME
-                  value: Qwen/Qwen3-0.6B
-                - name: DYN_KV_CACHE_BLOCK_SIZE
-                  value: "128"
-                - name: DYN_ENFORCE_DISAGG
-                  value: "false"
-    - name: VllmDecodeWorker
-      type: decode
-      frontendSidecar: sidecar-frontend
-      podTemplate:
-        spec:
-          containers:
-            - name: main
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-              command:
-                - /bin/sh
-                - -c
-              args:
-                - python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME
-                  --enable-prefix-caching --block-size 128 --kv-events-config '{"enable_kv_cache_events":true}'
-              env:
-                - name: MODEL_PATH
-                  value: Qwen/Qwen3-0.6B
-                - name: SERVED_MODEL_NAME
-                  value: Qwen/Qwen3-0.6B
-            - name: sidecar-frontend
-              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-              args:
-                - -m
-                - dynamo.frontend
-                - --router-mode
-                - direct
-```
-
-EPP uses its own router configuration variables. For example,
-`DYN_USE_KV_EVENTS=false` disables KV-event consumption in the EPP and falls
-back to approximate routing. This is distinct from
-`DYN_ROUTER_USE_KV_EVENTS`, which configures the standalone Python frontend
-router used in non-EPP DGDR deployments.
-
-For full Gateway setup and route manifests, see
-[Gateway API Inference Extension](inference-gateway.md).
+For manifests, `frontendSidecar` configuration, direct routing, EPP routing
+variables such as `DYN_USE_KV_EVENTS`, and route setup, see
+[Gateway API Inference Extension](inference-gateway.md). The same guide also
+documents the optional [Rust EPP](inference-gateway.md#4b-build-rust-epp-image-optional--experimental),
+which is currently experimental.
 
 ### SKU Format
 

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -172,10 +172,10 @@ deployments, use `kv` when you want prefix-cache-aware routing and
 request routing hints. For detailed mode definitions, see
 [Router Guide](../components/router/router-guide.md#routing-modes-router-mode).
 
-KV-aware routing has two independent pieces: the frontend must run in `kv`
-mode, and workers must publish KV cache events for event-driven prefix-cache
-state. If worker event publication is not configured, keep
-`DYN_ROUTER_MODE=kv` but run the frontend in approximate KV mode:
+KV-aware routing can use event-driven prefix-cache state or approximate
+prefix matching. The frontend still runs in `kv` mode in both cases. If you
+do not configure worker KV-event publication, set
+`DYN_ROUTER_USE_KV_EVENTS=false` to use approximate KV mode:
 
 ```yaml
 spec:
@@ -193,16 +193,13 @@ spec:
                 value: "false"
 ```
 
-When you do want event-driven prefix-cache state, configure event publication
-on the generated worker service that handles prefill. In aggregated serving,
-the single worker handles both prefill and decode, so configure that worker.
-In disaggregated serving, configure prefill workers only; prefix-overlap
-scoring (`dyn-prefill-scorer`) runs at the prefill stage, while decode workers
-are scored on load (`dyn-decode-scorer`) and normally omit KV-event publishing
-flags. For vLLM, that means prefill workers get `--enable-prefix-caching` and
-`--kv-events-config`; decode workers omit both flags. Service names depend on
-the selected backend and topology, so inspect the generated DGD first,
-especially when `autoApply: false`.
+For event-driven prefix-cache state, enable worker event publication only
+where prefill happens: the single worker in aggregated serving, or prefill
+workers in disaggregated serving. Decode workers are scored by load
+(`dyn-decode-scorer`), not prefix overlap (`dyn-prefill-scorer`), so vLLM
+decode workers omit both `--enable-prefix-caching` and `--kv-events-config`.
+Service names depend on the selected backend and topology, so inspect the
+generated DGD first, especially when `autoApply: false`.
 
 For example, a generated vLLM disaggregated deployment may contain a
 `VllmPrefillWorker` service. This override appends the vLLM KV-event publishing

--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -314,18 +314,36 @@ kubectl apply -f recipes/llama-3-70b/vllm/disagg-single-node/gaie/http-route.yam
 
 - When using GAIE the FrontEnd does not choose the workers. The routing is determined in the EPP.
 - The FrontEnd must run with `--router-mode direct` so that it respects the EPP's routing decisions passed via request headers.
-- Use the `frontendSidecar` field on a worker service to have the operator automatically inject a fully configured frontend sidecar container with all required Dynamo env vars, probes, and ports:
+- In v1beta1 DGD manifests, set the `frontendSidecar` field on a worker
+  component to the name of a container in that component's pod template. The
+  operator merges the required Dynamo env vars, probes, and ports into that
+  sidecar container:
 
 ```yaml
-frontendSidecar:
-  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
-  args:
-    - --router-mode
-    - direct
-  envFromSecret: hf-token-secret
+frontendSidecar: sidecar-frontend
+podTemplate:
+  spec:
+    containers:
+      - name: main
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        command:
+          - /bin/sh
+          - -c
+        args:
+          - python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME
+      - name: sidecar-frontend
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        args:
+          - -m
+          - dynamo.frontend
+          - --router-mode
+          - direct
+        envFrom:
+          - secretRef:
+              name: hf-token-secret
 ```
 
-- The pre-selected worker (decode and prefill in case of the disaggregated serving) are passed in the request headers.
+- The pre-selected workers (decode and prefill in case of disaggregated serving) are passed in request headers and injected into the request routing hints.
 - The `--router-mode direct` flag ensures the routing respects this selection.
 
 **Startup Probe Timeout:** The EPP has a default startup probe timeout of 30 minutes (10s × 180 failures).

--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -325,14 +325,14 @@ podTemplate:
   spec:
     containers:
       - name: main
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
         command:
           - /bin/sh
           - -c
         args:
           - python3 -m dynamo.vllm --model $MODEL_PATH --served-model-name $SERVED_MODEL_NAME
       - name: sidecar-frontend
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
         args:
           - -m
           - dynamo.frontend


### PR DESCRIPTION
## Summary
- document DGDR standalone frontend router configuration through `overrides.dgd`
- show KV router, approximate KV mode, and backend KV-event publishing examples
- clarify that EPP/Gateway routing is a direct DGD/GAIE topology today and update the frontend sidecar YAML shape

Part of #10270.

## Testing
- `git diff --check`
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Routing section to Kubernetes DGDR documentation with KV-aware routing examples and configuration guidance
  * Updated frontendSidecar configuration instructions for v1beta1 DGD manifests with improved container integration guidance
  * Clarified routing limitations and gateway behavior documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->