### PR TITLE
perf(kv-router): reduce lookup hot-path overhead

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
@@ -213,7 +213,7 @@ impl ConcurrentRadixTreeCompressed {
             worker_lookup,
             blocks.iter().map(|block| block.block_hash),
             node,
-        )
+        ) > 0
     }
 
     // ------------------------------------------------------------------

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
@@ -19,6 +19,7 @@ use super::{
     MatchDetails, PreBoundEventCounters, SyncIndexer, WorkerLookupStats, WorkerTask,
 };
 use crate::cleanup::{CleanupGuard, CleanupState};
+use crate::lookup_update::update_arc_lookup_for_keys;
 use crate::protocols::*;
 
 mod node;
@@ -208,19 +209,11 @@ impl ConcurrentRadixTreeCompressed {
         blocks: &[KvCacheStoredBlockData],
         node: &SharedNode,
     ) -> bool {
-        let mut changed = false;
-        for block in blocks {
-            match worker_lookup.insert(block.block_hash, node.clone()) {
-                Some(existing) if Arc::ptr_eq(&existing, node) => {}
-                Some(_) => {
-                    changed = true;
-                }
-                None => {
-                    changed = true;
-                }
-            }
-        }
-        changed
+        update_arc_lookup_for_keys(
+            worker_lookup,
+            blocks.iter().map(|block| block.block_hash),
+            node,
+        )
     }
 
     // ------------------------------------------------------------------

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 
@@ -183,12 +184,18 @@ impl Node {
         children
     }
 
+    #[cfg(test)]
     pub(super) fn children_snapshot(&self) -> Vec<SharedNode> {
         let _gate = self.shape_gate.read();
         self.children
             .iter()
             .map(|entry| entry.value().clone())
             .collect()
+    }
+
+    pub(super) fn push_children_into(&self, queue: &mut VecDeque<SharedNode>) {
+        let _gate = self.shape_gate.read();
+        queue.extend(self.children.iter().map(|entry| entry.value().clone()));
     }
 
     pub(super) fn child_edges_snapshot(&self) -> Vec<(LocalBlockHash, SharedNode)> {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/repair.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/repair.rs
@@ -58,27 +58,23 @@ impl ConcurrentRadixTreeCompressed {
         direction: LookupRepairDirection,
     ) {
         #[cfg(feature = "bench")]
-        let mut changed_entries = 0u64;
+        let mut changed_entries_total = 0u64;
 
         for (&worker, worker_lookup) in lookup.iter_mut() {
-            for covered_hash in resolved.lookup_hashes_for_worker_repair(worker, hash, direction) {
-                let previous = worker_lookup.insert(covered_hash, resolved.clone());
-                let changed = match previous {
-                    Some(previous) => !Arc::ptr_eq(&previous, resolved),
-                    None => true,
-                };
-                if changed {
-                    #[cfg(feature = "bench")]
-                    {
-                        changed_entries += 1;
-                    }
-                }
+            let _changed_entries = update_arc_lookup_for_keys(
+                worker_lookup,
+                resolved.lookup_hashes_for_worker_repair(worker, hash, direction),
+                resolved,
+            );
+            #[cfg(feature = "bench")]
+            {
+                changed_entries_total += _changed_entries as u64;
             }
         }
 
         #[cfg(feature = "bench")]
         self.bench_metrics
             .lookup_repair_entries
-            .fetch_add(changed_entries, Ordering::Relaxed);
+            .fetch_add(changed_entries_total, Ordering::Relaxed);
     }
 }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/repair.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/repair.rs
@@ -10,12 +10,16 @@ impl ConcurrentRadixTreeCompressed {
         start: &SharedNode,
         hash: ExternalSequenceBlockHash,
     ) -> Option<SharedNode> {
-        let mut queue = VecDeque::from(start.children_snapshot());
+        // Reuse one BFS queue. `push_children_into` preserves the same per-node
+        // snapshot semantics as `children_snapshot`, but avoids allocating a
+        // fresh child Vec for each scanned node during lookup repair.
+        let mut queue = VecDeque::new();
+        start.push_children_into(&mut queue);
         while let Some(node) = queue.pop_front() {
             if node.contains_edge_hash(hash) {
                 return Some(node);
             }
-            queue.extend(node.children_snapshot());
+            node.push_children_into(&mut queue);
         }
         None
     }

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -7,7 +7,7 @@
 //! approximate-mode blocks in the radix tree.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BinaryHeap, VecDeque};
+use std::collections::{BTreeMap, BinaryHeap, VecDeque, hash_map::Entry};
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
@@ -124,20 +124,36 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
 
     /// Inserts timers using a caller-provided timestamp.
     pub fn insert_at(&mut self, keys: Vec<K>, now: Instant) {
+        let len = keys.len();
         let expiry_time = if self.ttl.is_zero() {
             now
         } else {
             self.bucket_expiry(now + self.ttl)
         };
+        let mut bucket_inserts = Vec::with_capacity(len);
 
-        self.timers.reserve(keys.len());
+        self.timers.reserve(len);
         for key in keys {
-            if let Some(old_expiry) = self.timers.insert(key.clone(), expiry_time)
-                && old_expiry != expiry_time
-            {
-                self.remove_from_bucket(&old_expiry, &key);
+            match self.timers.entry(key.clone()) {
+                Entry::Occupied(entry) if *entry.get() == expiry_time => {
+                    continue;
+                }
+                Entry::Occupied(mut entry) => {
+                    let old_expiry = *entry.get();
+                    entry.insert(expiry_time);
+                    self.remove_from_bucket(&old_expiry, &key);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(expiry_time);
+                }
             }
-            self.expirations.entry(expiry_time).or_default().insert(key);
+            bucket_inserts.push(key);
+        }
+
+        if !bucket_inserts.is_empty() {
+            let bucket = self.expirations.entry(expiry_time).or_default();
+            bucket.reserve(bucket_inserts.len());
+            bucket.extend(bucket_inserts);
         }
     }
 
@@ -680,6 +696,25 @@ mod tests {
         assert_eq!(pm.expirations.len(), 1);
         assert!(pm.remove(&2));
         assert!(pm.expirations.is_empty());
+    }
+
+    #[test]
+    fn test_prune_manager_same_bucket_update_dedupes() {
+        const TTL: Duration = Duration::from_millis(50);
+        let prune_config = PruneConfig { ttl: TTL };
+        let mut pm: PruneManager<u32> = PruneManager::new(prune_config);
+
+        let now = pm.bucket_origin + Duration::from_millis(1);
+        pm.insert_at(vec![42], now);
+        let expiry = *pm.get_expiry(&42).expect("expiry missing for key 42");
+
+        pm.insert_at(vec![42], now + Duration::from_millis(20));
+
+        assert_eq!(pm.get_expiry(&42), Some(&expiry));
+        assert_eq!(pm.expirations.len(), 1);
+        assert_eq!(pm.expirations.get(&expiry).map(FxHashSet::len), Some(1));
+        assert_eq!(pm.pop_expired(expiry), vec![42]);
+        assert!(pm.is_empty());
     }
 
     #[test]

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -130,7 +130,7 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
         } else {
             self.bucket_expiry(now + self.ttl)
         };
-        let mut bucket_inserts = Vec::with_capacity(len);
+        let mut bucket_inserts: Option<Vec<K>> = None;
 
         self.timers.reserve(len);
         for key in keys {
@@ -147,10 +147,12 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
                     entry.insert(expiry_time);
                 }
             }
-            bucket_inserts.push(key);
+            bucket_inserts
+                .get_or_insert_with(|| Vec::with_capacity(len))
+                .push(key);
         }
 
-        if !bucket_inserts.is_empty() {
+        if let Some(bucket_inserts) = bucket_inserts {
             let bucket = self.expirations.entry(expiry_time).or_default();
             bucket.reserve(bucket_inserts.len());
             bucket.extend(bucket_inserts);

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod active_set;
 pub(crate) mod cleanup;
+mod lookup_update;
 
 pub mod indexer;
 pub mod protocols;

--- a/lib/kv-router/src/lookup_update.rs
+++ b/lib/kv-router/src/lookup_update.rs
@@ -11,27 +11,28 @@ use rustc_hash::FxHashMap;
 ///
 /// Duplicate store/repair paths often revisit keys that already resolve to the
 /// same node. Skipping those replacements avoids unnecessary hash table writes
-/// and `Arc` refcount churn while still repairing stale entries.
+/// and `Arc` refcount churn while still repairing stale entries. Returns the
+/// number of entries that were inserted or changed.
 pub(crate) fn update_arc_lookup_for_keys<K, T>(
     lookup: &mut FxHashMap<K, Arc<T>>,
     keys: impl IntoIterator<Item = K>,
     node: &Arc<T>,
-) -> bool
+) -> usize
 where
     K: Eq + Hash,
 {
-    let mut changed = false;
+    let mut changed = 0;
 
     for key in keys {
         match lookup.entry(key) {
             Entry::Occupied(mut entry) if !Arc::ptr_eq(entry.get(), node) => {
                 entry.insert(Arc::clone(node));
-                changed = true;
+                changed += 1;
             }
             Entry::Occupied(_) => {}
             Entry::Vacant(entry) => {
                 entry.insert(Arc::clone(node));
-                changed = true;
+                changed += 1;
             }
         }
     }

--- a/lib/kv-router/src/lookup_update.rs
+++ b/lib/kv-router/src/lookup_update.rs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::hash_map::Entry;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use rustc_hash::FxHashMap;
+
+/// Update an `Arc` lookup map for keys that should point at `node`.
+///
+/// Duplicate store/repair paths often revisit keys that already resolve to the
+/// same node. Skipping those replacements avoids unnecessary hash table writes
+/// and `Arc` refcount churn while still repairing stale entries.
+pub(crate) fn update_arc_lookup_for_keys<K, T>(
+    lookup: &mut FxHashMap<K, Arc<T>>,
+    keys: impl IntoIterator<Item = K>,
+    node: &Arc<T>,
+) -> bool
+where
+    K: Eq + Hash,
+{
+    let mut changed = false;
+
+    for key in keys {
+        match lookup.entry(key) {
+            Entry::Occupied(mut entry) if !Arc::ptr_eq(entry.get(), node) => {
+                entry.insert(Arc::clone(node));
+                changed = true;
+            }
+            Entry::Occupied(_) => {}
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::clone(node));
+                changed = true;
+            }
+        }
+    }
+
+    changed
+}

--- a/lib/kv-router/src/sequences/prompt_membership_trie.rs
+++ b/lib/kv-router/src/sequences/prompt_membership_trie.rs
@@ -9,6 +9,7 @@ use parking_lot::RwLock;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use crate::cleanup::{self, CleanableNode, CleanupGuard, CleanupState};
+use crate::lookup_update::update_arc_lookup_for_keys;
 use crate::protocols::WorkerWithDpRank;
 
 type SharedNode = Arc<RwLock<PromptTrieNode>>;
@@ -256,9 +257,15 @@ impl PromptMembershipTrie {
             let guard = resolved.read();
             guard.lookup_hashes_for_worker_repair(worker, hash, direction)
         };
-        for repair_hash in repair_hashes {
-            worker_lookup.insert(repair_hash, resolved.clone());
-        }
+        Self::update_lookup_for_hashes(worker_lookup, &repair_hashes, resolved);
+    }
+
+    fn update_lookup_for_hashes(
+        worker_lookup: &mut WorkerLookup,
+        hashes: &[SequenceHash],
+        node: &SharedNode,
+    ) {
+        update_arc_lookup_for_keys(worker_lookup, hashes.iter().copied(), node);
     }
 
     fn repair_stale_lookup_from_node(
@@ -457,9 +464,7 @@ impl PromptMembershipTrie {
                         parent_guard.children.insert(first_hash, new_node.clone());
                         drop(parent_guard);
 
-                        for &hash in remaining {
-                            worker_lookup.insert(hash, new_node.clone());
-                        }
+                        Self::update_lookup_for_hashes(worker_lookup, remaining, &new_node);
                         return;
                     }
                 }
@@ -502,17 +507,19 @@ impl PromptMembershipTrie {
                             .insert(tail_first_hash, new_node.clone());
                         drop(child_guard);
 
-                        for &hash in &remaining[..match_len] {
-                            worker_lookup.insert(hash, child.clone());
-                        }
-                        for &hash in tail {
-                            worker_lookup.insert(hash, new_node.clone());
-                        }
+                        Self::update_lookup_for_hashes(
+                            worker_lookup,
+                            &remaining[..match_len],
+                            &child,
+                        );
+                        Self::update_lookup_for_hashes(worker_lookup, tail, &new_node);
                     } else {
                         drop(child_guard);
-                        for &hash in &remaining[..match_len] {
-                            worker_lookup.insert(hash, child.clone());
-                        }
+                        Self::update_lookup_for_hashes(
+                            worker_lookup,
+                            &remaining[..match_len],
+                            &child,
+                        );
                     }
                     return;
                 }
@@ -520,9 +527,7 @@ impl PromptMembershipTrie {
                 child_guard.promote_to_full(worker);
                 drop(child_guard);
 
-                for &hash in &remaining[..edge_len] {
-                    worker_lookup.insert(hash, child.clone());
-                }
+                Self::update_lookup_for_hashes(worker_lookup, &remaining[..edge_len], &child);
 
                 last_hash = Some(remaining[edge_len - 1]);
                 remaining = &remaining[edge_len..];


### PR DESCRIPTION
Summary
- Reuse caller-owned child traversal storage during CRTC lookup repair instead of allocating a child snapshot at each scanned node.
- Avoid redundant same-node worker lookup replacements in the CRTC and prompt-membership trie store/repair paths.
- Reduce PruneManager same-bucket timer refresh overhead by skipping unchanged timer/bucket rewrites and batching expiration-bucket inserts.

Benchmarked Perf
- AgentX 060526, multi-frontend, BLOCK_SIZE=1 profiling found the CRTC lookup-repair allocation fix improved the c512 stack-shape run from 19.0796 req/s to 19.6010 req/s (+2.7%); FE0 was underbusy, so treat this as directional hot-path evidence rather than a capacity claim.
- The CRTC/prompt same-node lookup update changes improved the comparable c384 run from 16.0988 req/s to 16.3516 req/s (+1.6%).
- The PruneManager insert cleanup was not isolated in a standalone benchmark; it targets same-bucket approximate TTL bookkeeping churn seen in the KV-router profile and should be treated as incremental hot-path cleanup, not a separate capacity claim.

Validation
- cargo fmt --check
- cargo clippy --no-deps --all-targets -- -D warnings
- cargo clippy -p dynamo-kv-router --no-deps --all-targets -- -D warnings
- cargo test -p dynamo-kv-router test_prune_manager --lib
- cargo test -p dynamo-kv-router --lib
