### PR TITLE
Add support for TRT-LLM self benchmarking

### DIFF
--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -17,6 +17,7 @@ from dynamo.common.configuration.utils import add_argument, add_negatable_bool_a
 
 from . import __version__
 from .constants import DisaggregationMode, Modality
+from .self_benchmark import benchmark_options_without_mode
 
 DEFAULT_MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 
@@ -231,6 +232,81 @@ class DynamoTrtllmArgGroup(ArgGroup):
             choices=["xgrammar", "llguidance"],
             help="Backend to use for guided decoding (structured output). "
             "Options: xgrammar, llguidance.",
+        )
+
+        # Benchmark / self-profiling. These flags intentionally match the
+        # Dynamo vLLM benchmark path; they are translated to TRT-LLM's native
+        # self_benchmark_* CLI/LLM args at launch.
+        add_argument(
+            g,
+            flag_name="--benchmark-mode",
+            env_var="DYN_BENCHMARK_MODE",
+            default=None,
+            obsolete_flag="--self_benchmark_mode",
+            choices=["prefill", "decode", "agg"],
+            help=(
+                "Run TRT-LLM startup self-benchmark before registering this "
+                "worker for routing."
+            ),
+        )
+        add_argument(
+            g,
+            flag_name="--benchmark-prefill-granularity",
+            env_var="DYN_BENCHMARK_PREFILL_GRANULARITY",
+            default=None,
+            arg_type=int,
+            dest="benchmark_prefill_isl_granularity",
+            obsolete_flag="--self_benchmark_prefill_granularity",
+            help="Number of ISL sample points for TRT-LLM prefill sweep.",
+        )
+        add_argument(
+            g,
+            flag_name="--benchmark-decode-length-granularity",
+            env_var="DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY",
+            default=None,
+            arg_type=int,
+            dest="benchmark_decode_context_granularity",
+            obsolete_flag="--self_benchmark_decode_length_granularity",
+            help="Number of context length sample points for TRT-LLM decode sweep.",
+        )
+        add_argument(
+            g,
+            flag_name="--benchmark-decode-batch-granularity",
+            env_var="DYN_BENCHMARK_DECODE_BATCH_GRANULARITY",
+            default=None,
+            arg_type=int,
+            obsolete_flag="--self_benchmark_decode_batch_granularity",
+            help="Number of batch size sample points per decode context length.",
+        )
+        add_argument(
+            g,
+            flag_name="--benchmark-warmup-iterations",
+            env_var="DYN_BENCHMARK_WARMUP_ITERATIONS",
+            default=None,
+            arg_type=int,
+            obsolete_flag="--self_benchmark_warmup_iterations",
+            help="Warmup iterations before TRT-LLM self-benchmark.",
+        )
+        add_argument(
+            g,
+            flag_name="--benchmark-output-path",
+            env_var="DYN_BENCHMARK_OUTPUT_PATH",
+            default=None,
+            obsolete_flag="--self_benchmark_output_path",
+            help=(
+                "Path for TRT-LLM rank-0 self-benchmark JSON. If omitted, "
+                "Dynamo generates a unique /tmp path."
+            ),
+        )
+        add_argument(
+            g,
+            flag_name="--benchmark-timeout",
+            env_var="DYN_BENCHMARK_TIMEOUT",
+            default=None,
+            arg_type=int,
+            dest="benchmark_timeout_s",
+            obsolete_flag="--self_benchmark_timeout",
+            help="Maximum seconds to wait for TRT-LLM self-benchmark output.",
         )
 
         # --- Diffusion Options ---
@@ -452,6 +528,13 @@ class DynamoTrtllmConfig(ConfigBase):
     load_format: str
     model_loader_extra_config: str
     guided_decoding_backend: Optional[str] = None
+    benchmark_mode: Optional[str] = None
+    benchmark_prefill_isl_granularity: Optional[int] = None
+    benchmark_decode_context_granularity: Optional[int] = None
+    benchmark_decode_batch_granularity: Optional[int] = None
+    benchmark_warmup_iterations: Optional[int] = None
+    benchmark_output_path: Optional[str] = None
+    benchmark_timeout_s: Optional[int] = None
 
     disaggregation_mode: DisaggregationMode
     modality: Modality
@@ -488,5 +571,21 @@ class DynamoTrtllmConfig(ConfigBase):
             self.disaggregation_mode = DisaggregationMode(self.disaggregation_mode)
         if isinstance(self.modality, str):
             self.modality = Modality(self.modality)
+        missing_mode_options = benchmark_options_without_mode(self)
+        if missing_mode_options:
+            raise ValueError(
+                "Self-benchmark options require --benchmark-mode: "
+                + ", ".join(missing_mode_options)
+            )
+        if self.benchmark_mode is not None:
+            if self.disaggregation_mode == DisaggregationMode.ENCODE:
+                raise ValueError(
+                    "TRT-LLM self-benchmark is not supported for encode workers"
+                )
+            if self.enable_attention_dp:
+                raise ValueError(
+                    "TRT-LLM self-benchmark is not supported with "
+                    "--enable-attention-dp"
+                )
         if not self.served_model_name:
             self.served_model_name = None

--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -261,6 +261,19 @@ class DynamoTrtllmArgGroup(ArgGroup):
         )
         add_argument(
             g,
+            flag_name="--benchmark-prefill-kv-read-granularity",
+            env_var="DYN_BENCHMARK_PREFILL_KV_READ_GRANULARITY",
+            default=None,
+            arg_type=int,
+            dest="benchmark_prefill_kv_read_granularity",
+            obsolete_flag="--self_benchmark_prefill_kv_read_granularity",
+            help=(
+                "Number of block-aligned KV-read sample points per ISL for "
+                "TRT-LLM prefill sweep."
+            ),
+        )
+        add_argument(
+            g,
             flag_name="--benchmark-decode-length-granularity",
             env_var="DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY",
             default=None,
@@ -530,6 +543,7 @@ class DynamoTrtllmConfig(ConfigBase):
     guided_decoding_backend: Optional[str] = None
     benchmark_mode: Optional[str] = None
     benchmark_prefill_isl_granularity: Optional[int] = None
+    benchmark_prefill_kv_read_granularity: Optional[int] = None
     benchmark_decode_context_granularity: Optional[int] = None
     benchmark_decode_batch_granularity: Optional[int] = None
     benchmark_warmup_iterations: Optional[int] = None

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -63,6 +63,12 @@ from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
 from dynamo.trtllm.logits_processing.adapter import attach_logits_processors
 from dynamo.trtllm.request_handlers.handler_base import TRTLLMEnginePauseController
+from dynamo.trtllm.self_benchmark import (
+    TRTLLM_SELF_BENCHMARK_RUNTIME_KEY,
+    TrtllmSelfBenchmarkConfig,
+    prepare_self_benchmark,
+    wait_for_self_benchmark_output,
+)
 from dynamo.trtllm.utils.disagg_utils import (
     DisaggregatedParams,
     DisaggregatedParamsCodec,
@@ -134,6 +140,7 @@ class TrtllmLLMEngine(LLMEngine):
         disaggregation_mode: DisaggregationMode = DisaggregationMode.AGGREGATED,
         component: str = "backend",
         publish_events_and_metrics: bool = False,
+        self_benchmark_config: TrtllmSelfBenchmarkConfig | None = None,
     ):
         self.engine_args = engine_args
         self.model_name = model_name
@@ -148,6 +155,8 @@ class TrtllmLLMEngine(LLMEngine):
         # `_kv_events_thread`). Component metrics + native `trtllm_*` metrics
         # emit unconditionally.
         self.publish_events_and_metrics = publish_events_and_metrics
+        self._self_benchmark_config = self_benchmark_config
+        self._benchmark_results: dict[str, Any] | None = None
         self._component = component
         self._additional_metrics: Optional["AdditionalMetricsCollector"] = None
         kv_cache_config = self.engine_args.get("kv_cache_config", {})
@@ -287,6 +296,8 @@ class TrtllmLLMEngine(LLMEngine):
                 kv_cfg["event_buffer_max_size"] = _DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
             engine_args["kv_cache_config"] = kv_cfg
 
+        self_benchmark_config = prepare_self_benchmark(config, engine_args)
+
         # Force tokenizer init for the smoke hook, after all overrides so an
         # explicit user `skip_tokenizer_init=True` can't starve the processor.
         # Gated to generation roles for the same reason as the spec resolution
@@ -309,6 +320,7 @@ class TrtllmLLMEngine(LLMEngine):
             disaggregation_mode=config.disaggregation_mode,
             component=config.component,
             publish_events_and_metrics=config.publish_events_and_metrics,
+            self_benchmark_config=self_benchmark_config,
         )
         worker_config = WorkerConfig.from_runtime_config(
             config,
@@ -333,6 +345,11 @@ class TrtllmLLMEngine(LLMEngine):
         self._engine = TensorRTLLMEngine(self.engine_args, self.disaggregation_mode)
         await self._engine.initialize()
         self._pause_controller = TRTLLMEnginePauseController(self._engine)
+        if self._self_benchmark_config is not None:
+            self._benchmark_results = await wait_for_self_benchmark_output(
+                self._self_benchmark_config,
+                worker_id=str(worker_id),
+            )
 
         # Resolve the engine-declared spec now the engine (and its tokenizer)
         # is initialized; see `logits_processor_spec()`.
@@ -379,6 +396,12 @@ class TrtllmLLMEngine(LLMEngine):
         )
         self._metrics_thread.start()
 
+        runtime_data = None
+        if self._benchmark_results is not None:
+            runtime_data = {
+                TRTLLM_SELF_BENCHMARK_RUNTIME_KEY: self._benchmark_results,
+            }
+
         return EngineConfig(
             model=self.model_name,
             served_model_name=self.served_model_name,
@@ -387,6 +410,7 @@ class TrtllmLLMEngine(LLMEngine):
             max_num_seqs=self.max_batch_size,
             max_num_batched_tokens=self.max_num_tokens,
             data_parallel_size=self._attention_dp_size,
+            runtime_data=runtime_data,
         )
 
     # TRT-LLM's `get_kv_cache_events` / `get_stats` block the calling

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -249,6 +249,8 @@ class HandlerBase(BaseGenerativeHandler):
     across all generative handlers (LLM, video, image).
     """
 
+    _benchmark_results: Optional[dict] = None
+
     def __init__(self, config: RequestHandlerConfig):
         self.engine = config.engine
         self.default_sampling_params = config.default_sampling_params
@@ -407,6 +409,14 @@ class HandlerBase(BaseGenerativeHandler):
             except Exception as exc:
                 logger.error("resume_memory_occupation failed: %s", exc)
                 return {"status": "error", "message": str(exc)}
+
+    async def get_perf_metrics(self, request=None):
+        """Return startup self-benchmark FPM results, or an error dict."""
+        result = getattr(self, "_benchmark_results", None)
+        if result is None:
+            yield {"status": "error", "message": "no benchmark data"}
+        else:
+            yield result
 
     @staticmethod
     def _extract_logprobs(

--- a/components/src/dynamo/trtllm/self_benchmark.py
+++ b/components/src/dynamo/trtllm/self_benchmark.py
@@ -1,0 +1,436 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT-LLM startup self-benchmark integration helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import msgspec
+
+from dynamo.common.forward_pass_metrics import (
+    ForwardPassMetrics,
+    QueuedRequestMetrics,
+    ScheduledRequestMetrics,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PREFILL_ISL_GRANULARITY = 16
+DEFAULT_DECODE_CONTEXT_GRANULARITY = 6
+DEFAULT_DECODE_BATCH_GRANULARITY = 6
+DEFAULT_WARMUP_ITERATIONS = 5
+DEFAULT_TIMEOUT_S = 300
+TRTLLM_SELF_BENCHMARK_RUNTIME_KEY = "trtllm_self_benchmark"
+
+_OPTION_ATTRS = {
+    "benchmark_prefill_isl_granularity": "--benchmark-prefill-granularity",
+    "benchmark_decode_context_granularity": "--benchmark-decode-length-granularity",
+    "benchmark_decode_batch_granularity": "--benchmark-decode-batch-granularity",
+    "benchmark_warmup_iterations": "--benchmark-warmup-iterations",
+    "benchmark_output_path": "--benchmark-output-path",
+    "benchmark_timeout_s": "--benchmark-timeout",
+}
+
+
+@dataclass(frozen=True)
+class TrtllmSelfBenchmarkConfig:
+    """Backend-neutral Dynamo config resolved to TRT-LLM's native surface."""
+
+    mode: str
+    prefill_isl_granularity: int = DEFAULT_PREFILL_ISL_GRANULARITY
+    decode_context_granularity: int = DEFAULT_DECODE_CONTEXT_GRANULARITY
+    decode_batch_granularity: int = DEFAULT_DECODE_BATCH_GRANULARITY
+    warmup_iterations: int = DEFAULT_WARMUP_ITERATIONS
+    output_path: str = ""
+    timeout_s: int = DEFAULT_TIMEOUT_S
+
+
+def benchmark_options_without_mode(config: Any) -> list[str]:
+    """Return self-benchmark option flags set while benchmark mode is absent."""
+
+    if getattr(config, "benchmark_mode", None) is not None:
+        return []
+    return [
+        flag
+        for attr, flag in _OPTION_ATTRS.items()
+        if getattr(config, attr, None) not in (None, "")
+    ]
+
+
+def build_self_benchmark_config(config: Any) -> TrtllmSelfBenchmarkConfig | None:
+    """Resolve Dynamo benchmark config to a concrete TRT-LLM config."""
+
+    mode = getattr(config, "benchmark_mode", None)
+    if mode is None:
+        unexpected = benchmark_options_without_mode(config)
+        if unexpected:
+            raise ValueError(
+                "Self-benchmark options require --benchmark-mode: "
+                + ", ".join(unexpected)
+            )
+        return None
+
+    output_path = getattr(config, "benchmark_output_path", None) or str(
+        Path(tempfile.gettempdir())
+        / f"trtllm_self_benchmark_{os.getpid()}_{uuid.uuid4().hex}.json"
+    )
+    cfg = TrtllmSelfBenchmarkConfig(
+        mode=mode,
+        prefill_isl_granularity=_positive_int_or_default(
+            getattr(config, "benchmark_prefill_isl_granularity", None),
+            DEFAULT_PREFILL_ISL_GRANULARITY,
+            "benchmark_prefill_isl_granularity",
+        ),
+        decode_context_granularity=_positive_int_or_default(
+            getattr(config, "benchmark_decode_context_granularity", None),
+            DEFAULT_DECODE_CONTEXT_GRANULARITY,
+            "benchmark_decode_context_granularity",
+        ),
+        decode_batch_granularity=_positive_int_or_default(
+            getattr(config, "benchmark_decode_batch_granularity", None),
+            DEFAULT_DECODE_BATCH_GRANULARITY,
+            "benchmark_decode_batch_granularity",
+        ),
+        warmup_iterations=_non_negative_int_or_default(
+            getattr(config, "benchmark_warmup_iterations", None),
+            DEFAULT_WARMUP_ITERATIONS,
+            "benchmark_warmup_iterations",
+        ),
+        output_path=output_path,
+        timeout_s=_positive_int_or_default(
+            getattr(config, "benchmark_timeout_s", None),
+            DEFAULT_TIMEOUT_S,
+            "benchmark_timeout_s",
+        ),
+    )
+    return cfg
+
+
+def prepare_self_benchmark(
+    config: Any, engine_args: dict[str, Any]
+) -> TrtllmSelfBenchmarkConfig | None:
+    """Validate, clean stale output, and inject TRT-LLM benchmark args."""
+
+    cfg = build_self_benchmark_config(config)
+    if cfg is None:
+        return None
+    validate_self_benchmark_supported(config, engine_args)
+    remove_self_benchmark_output(cfg.output_path)
+    apply_self_benchmark_engine_args(engine_args, cfg)
+    return cfg
+
+
+def validate_self_benchmark_supported(config: Any, engine_args: dict[str, Any]) -> None:
+    """Fail fast for TRT-LLM modes that do not support self-benchmarking."""
+
+    disaggregation_mode = getattr(config, "disaggregation_mode", None)
+    if getattr(disaggregation_mode, "name", None) == "ENCODE":
+        raise ValueError("TRT-LLM self-benchmark is not supported for encode workers")
+    if bool(engine_args.get("enable_attention_dp", False)):
+        raise ValueError(
+            "TRT-LLM self-benchmark is not supported with enable_attention_dp"
+        )
+    for unsupported in ("encode_only", "mm_encoder_only"):
+        if bool(engine_args.get(unsupported, False)):
+            raise ValueError(
+                f"TRT-LLM self-benchmark is not supported with {unsupported}"
+            )
+
+
+def apply_self_benchmark_engine_args(
+    engine_args: dict[str, Any], cfg: TrtllmSelfBenchmarkConfig
+) -> None:
+    """Inject TRT-LLM native self-benchmark kwargs into LLM engine args."""
+
+    engine_args.update(
+        {
+            "self_benchmark_mode": cfg.mode,
+            "self_benchmark_prefill_granularity": cfg.prefill_isl_granularity,
+            "self_benchmark_decode_length_granularity": cfg.decode_context_granularity,
+            "self_benchmark_decode_batch_granularity": cfg.decode_batch_granularity,
+            "self_benchmark_warmup_iterations": cfg.warmup_iterations,
+            "self_benchmark_output_path": cfg.output_path,
+            "self_benchmark_timeout": cfg.timeout_s,
+        }
+    )
+
+
+def trtllm_self_benchmark_cli_args(cfg: TrtllmSelfBenchmarkConfig) -> list[str]:
+    """Return the equivalent ``trtllm-serve`` CLI arguments."""
+
+    return [
+        "--self_benchmark_mode",
+        cfg.mode,
+        "--self_benchmark_prefill_granularity",
+        str(cfg.prefill_isl_granularity),
+        "--self_benchmark_decode_length_granularity",
+        str(cfg.decode_context_granularity),
+        "--self_benchmark_decode_batch_granularity",
+        str(cfg.decode_batch_granularity),
+        "--self_benchmark_warmup_iterations",
+        str(cfg.warmup_iterations),
+        "--self_benchmark_output_path",
+        cfg.output_path,
+        "--self_benchmark_timeout",
+        str(cfg.timeout_s),
+    ]
+
+
+def remove_self_benchmark_output(output_path: str) -> None:
+    """Remove a stale rank-0 benchmark result before TRT-LLM startup."""
+
+    try:
+        Path(output_path).unlink()
+    except FileNotFoundError:
+        return
+
+
+async def wait_for_self_benchmark_output(
+    cfg: TrtllmSelfBenchmarkConfig,
+    *,
+    worker_id: str = "",
+) -> dict[str, Any]:
+    """Poll, parse, and normalize TRT-LLM's rank-0 benchmark JSON output."""
+
+    output = Path(cfg.output_path)
+    deadline = time.monotonic() + cfg.timeout_s
+    logger.info(
+        "Waiting for TRT-LLM self-benchmark output (file=%s, timeout=%ss)",
+        output,
+        cfg.timeout_s,
+    )
+    while not output.exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"TRT-LLM self-benchmark did not write {output} within "
+                f"{cfg.timeout_s}s"
+            )
+        await asyncio.sleep(0.1)
+
+    try:
+        with output.open() as f:
+            payload = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Invalid TRT-LLM self-benchmark JSON in {output}: {exc}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"Invalid TRT-LLM self-benchmark JSON in {output}: root must be an object"
+        )
+
+    normalized = normalize_self_benchmark_payload(payload, worker_id=worker_id)
+    logger.info(
+        "Loaded TRT-LLM self-benchmark output (points=%d, timed_out=%s)",
+        len(normalized.get("results", [])),
+        normalized.get("metadata", {}).get("timed_out", False),
+    )
+    return normalized
+
+
+def normalize_self_benchmark_payload(
+    payload: dict[str, Any],
+    *,
+    worker_id: str = "",
+) -> dict[str, Any]:
+    """Convert TRT-LLM JSON into Dynamo's benchmark ``results[].fpms[]`` shape."""
+
+    raw_results = payload.get("results", [])
+    if not isinstance(raw_results, list):
+        raise ValueError("TRT-LLM self-benchmark JSON field results must be a list")
+
+    warnings: list[str] = []
+    if payload.get("timed_out") is True:
+        warnings.append("TRT-LLM self-benchmark timed out; publishing partial data")
+        logger.warning(warnings[-1])
+
+    results: list[dict[str, Any]] = []
+    profile: dict[str, dict[str, Any]] = {"prefill": {}, "decode": {}}
+    skipped_points: list[dict[str, Any]] = []
+
+    for raw_result in raw_results:
+        if not isinstance(raw_result, dict):
+            continue
+        point = raw_result.get("point") or {}
+        if not isinstance(point, dict):
+            continue
+        point_type = str(point.get("point_type", ""))
+        skipped_reason = raw_result.get("skipped_reason")
+        iteration_stats = raw_result.get("iteration_stats") or []
+        if not isinstance(iteration_stats, list):
+            iteration_stats = []
+
+        result = dict(raw_result)
+        result["point"] = dict(point)
+        result["iteration_stats"] = iteration_stats
+        result["fpms"] = []
+        normalized_key = _normalized_key(point)
+        if normalized_key is not None:
+            result["normalized_key"] = normalized_key
+
+        if skipped_reason:
+            skipped_points.append(
+                {
+                    "point": dict(point),
+                    "skipped_reason": skipped_reason,
+                    "normalized_key": normalized_key,
+                }
+            )
+            results.append(result)
+            continue
+
+        fpms = [
+            _fpm_to_dict(_fpm_from_iteration_stat(point, stat, worker_id))
+            for stat in iteration_stats
+            if isinstance(stat, dict)
+        ]
+        result["fpms"] = fpms
+        results.append(result)
+
+        if normalized_key is None:
+            continue
+        table_name = "prefill" if point_type == "prefill" else "decode"
+        if table_name not in profile:
+            continue
+        profile[table_name][_profile_key(point)] = {
+            "key": normalized_key,
+            "point": dict(point),
+            "fpms": fpms,
+            "iteration_stats": iteration_stats,
+        }
+
+    return {
+        "status": "ok",
+        "backend": "trtllm",
+        "results": results,
+        "profile": profile,
+        "metadata": {
+            "backend": "trtllm",
+            "timed_out": payload.get("timed_out") is True,
+            "warnings": warnings,
+            "skipped_points": skipped_points,
+            "raw_trtllm_self_benchmark": payload,
+        },
+    }
+
+
+def _fpm_from_iteration_stat(
+    point: dict[str, Any], stat: dict[str, Any], worker_id: str
+) -> ForwardPassMetrics:
+    point_type = str(point.get("point_type", ""))
+    batch_size = _int_or(point.get("batch_size"), 1)
+    isl = _int_or(point.get("isl"), 0)
+    context_length = _int_or(point.get("context_length"), 0)
+    ibs = stat.get("inflightBatchingStats") or {}
+    if not isinstance(ibs, dict):
+        ibs = {}
+
+    queued_num_decode = _int_or(ibs.get("numPausedRequests"), 0) + _int_or(
+        ibs.get("numQueuedGenRequests"), 0
+    )
+    queued_sum_decode_kv_tokens = _int_or(ibs.get("numPausedKvTokens"), 0) + _int_or(
+        ibs.get("numQueuedGenKvTokens"), 0
+    )
+    scheduled = ScheduledRequestMetrics(
+        num_prefill_requests=_int_or(
+            ibs.get("numContextRequests"),
+            batch_size if point_type == "prefill" else 0,
+        ),
+        sum_prefill_tokens=_int_or(
+            ibs.get("numCtxTokens"),
+            isl * batch_size if point_type == "prefill" else 0,
+        ),
+        sum_prefill_kv_tokens=_int_or(
+            ibs.get("numCtxKvTokens"),
+            context_length * batch_size if point_type == "prefill" else 0,
+        ),
+        num_decode_requests=_int_or(
+            ibs.get("numGenRequests"),
+            batch_size if point_type == "decode" else 0,
+        ),
+        sum_decode_kv_tokens=_int_or(
+            ibs.get("numGenKvTokens"),
+            context_length * batch_size if point_type == "decode" else 0,
+        ),
+    )
+    queued = QueuedRequestMetrics(
+        num_prefill_requests=_int_or(ibs.get("numQueuedContextRequests"), 0),
+        sum_prefill_tokens=_int_or(ibs.get("numQueuedCtxTokens"), 0),
+        num_decode_requests=queued_num_decode,
+        sum_decode_kv_tokens=queued_sum_decode_kv_tokens,
+    )
+    attention_dp_rank = stat.get("attentionDpRank")
+    dp_rank = _int_or(attention_dp_rank, 0)
+    return ForwardPassMetrics(
+        worker_id=worker_id,
+        dp_rank=dp_rank,
+        wall_time=_wall_time_secs(stat),
+        scheduled_requests=scheduled,
+        queued_requests=queued,
+    )
+
+
+def _wall_time_secs(stat: dict[str, Any]) -> float:
+    for key in ("hostStepTimeMS", "iterLatencyMS", "prevDeviceStepTimeMS"):
+        value = stat.get(key)
+        if isinstance(value, (int, float)):
+            return float(value) / 1000.0
+    return 0.0
+
+
+def _fpm_to_dict(fpm: ForwardPassMetrics) -> dict[str, Any]:
+    return msgspec.to_builtins(fpm)
+
+
+def _normalized_key(point: dict[str, Any]) -> int | list[int] | None:
+    point_type = str(point.get("point_type", ""))
+    if point_type == "prefill":
+        return _int_or(point.get("isl"), 0)
+    if point_type == "decode":
+        return [
+            _int_or(point.get("context_length"), 0),
+            _int_or(point.get("batch_size"), 1),
+        ]
+    return None
+
+
+def _profile_key(point: dict[str, Any]) -> str:
+    point_type = str(point.get("point_type", ""))
+    if point_type == "prefill":
+        return str(_int_or(point.get("isl"), 0))
+    return f"{_int_or(point.get('context_length'), 0)},{_int_or(point.get('batch_size'), 1)}"
+
+
+def _int_or(value: Any, default: int) -> int:
+    try:
+        if value is None:
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _positive_int_or_default(value: Any, default: int, name: str) -> int:
+    resolved = default if value is None else _int_or(value, default)
+    if resolved <= 0:
+        raise ValueError(f"{name} must be > 0")
+    return resolved
+
+
+def _non_negative_int_or_default(value: Any, default: int, name: str) -> int:
+    resolved = default if value is None else _int_or(value, default)
+    if resolved < 0:
+        raise ValueError(f"{name} must be >= 0")
+    return resolved

--- a/components/src/dynamo/trtllm/self_benchmark.py
+++ b/components/src/dynamo/trtllm/self_benchmark.py
@@ -27,6 +27,7 @@ from dynamo.common.forward_pass_metrics import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_PREFILL_ISL_GRANULARITY = 16
+DEFAULT_PREFILL_KV_READ_GRANULARITY = 4
 DEFAULT_DECODE_CONTEXT_GRANULARITY = 6
 DEFAULT_DECODE_BATCH_GRANULARITY = 6
 DEFAULT_WARMUP_ITERATIONS = 5
@@ -35,6 +36,9 @@ TRTLLM_SELF_BENCHMARK_RUNTIME_KEY = "trtllm_self_benchmark"
 
 _OPTION_ATTRS = {
     "benchmark_prefill_isl_granularity": "--benchmark-prefill-granularity",
+    "benchmark_prefill_kv_read_granularity": (
+        "--benchmark-prefill-kv-read-granularity"
+    ),
     "benchmark_decode_context_granularity": "--benchmark-decode-length-granularity",
     "benchmark_decode_batch_granularity": "--benchmark-decode-batch-granularity",
     "benchmark_warmup_iterations": "--benchmark-warmup-iterations",
@@ -49,6 +53,7 @@ class TrtllmSelfBenchmarkConfig:
 
     mode: str
     prefill_isl_granularity: int = DEFAULT_PREFILL_ISL_GRANULARITY
+    prefill_kv_read_granularity: int = DEFAULT_PREFILL_KV_READ_GRANULARITY
     decode_context_granularity: int = DEFAULT_DECODE_CONTEXT_GRANULARITY
     decode_batch_granularity: int = DEFAULT_DECODE_BATCH_GRANULARITY
     warmup_iterations: int = DEFAULT_WARMUP_ITERATIONS
@@ -91,6 +96,11 @@ def build_self_benchmark_config(config: Any) -> TrtllmSelfBenchmarkConfig | None
             getattr(config, "benchmark_prefill_isl_granularity", None),
             DEFAULT_PREFILL_ISL_GRANULARITY,
             "benchmark_prefill_isl_granularity",
+        ),
+        prefill_kv_read_granularity=_positive_int_or_default(
+            getattr(config, "benchmark_prefill_kv_read_granularity", None),
+            DEFAULT_PREFILL_KV_READ_GRANULARITY,
+            "benchmark_prefill_kv_read_granularity",
         ),
         decode_context_granularity=_positive_int_or_default(
             getattr(config, "benchmark_decode_context_granularity", None),
@@ -157,6 +167,9 @@ def apply_self_benchmark_engine_args(
         {
             "self_benchmark_mode": cfg.mode,
             "self_benchmark_prefill_granularity": cfg.prefill_isl_granularity,
+            "self_benchmark_prefill_kv_read_granularity": (
+                cfg.prefill_kv_read_granularity
+            ),
             "self_benchmark_decode_length_granularity": cfg.decode_context_granularity,
             "self_benchmark_decode_batch_granularity": cfg.decode_batch_granularity,
             "self_benchmark_warmup_iterations": cfg.warmup_iterations,
@@ -174,6 +187,8 @@ def trtllm_self_benchmark_cli_args(cfg: TrtllmSelfBenchmarkConfig) -> list[str]:
         cfg.mode,
         "--self_benchmark_prefill_granularity",
         str(cfg.prefill_isl_granularity),
+        "--self_benchmark_prefill_kv_read_granularity",
+        str(cfg.prefill_kv_read_granularity),
         "--self_benchmark_decode_length_granularity",
         str(cfg.decode_context_granularity),
         "--self_benchmark_decode_batch_granularity",
@@ -309,6 +324,8 @@ def normalize_self_benchmark_payload(
             "point": dict(point),
             "fpms": fpms,
             "iteration_stats": iteration_stats,
+            "observed_kv_read_tokens": raw_result.get("observed_kv_read_tokens"),
+            "cache_hit_validated": raw_result.get("cache_hit_validated"),
         }
 
     return {
@@ -332,6 +349,7 @@ def _fpm_from_iteration_stat(
     point_type = str(point.get("point_type", ""))
     batch_size = _int_or(point.get("batch_size"), 1)
     isl = _int_or(point.get("isl"), 0)
+    kv_read_tokens = _kv_read_tokens(point)
     context_length = _int_or(point.get("context_length"), 0)
     ibs = stat.get("inflightBatchingStats") or {}
     if not isinstance(ibs, dict):
@@ -350,11 +368,13 @@ def _fpm_from_iteration_stat(
         ),
         sum_prefill_tokens=_int_or(
             ibs.get("numCtxTokens"),
-            isl * batch_size if point_type == "prefill" else 0,
+            max(0, isl - kv_read_tokens) * batch_size
+            if point_type == "prefill"
+            else 0,
         ),
         sum_prefill_kv_tokens=_int_or(
             ibs.get("numCtxKvTokens"),
-            context_length * batch_size if point_type == "prefill" else 0,
+            kv_read_tokens * batch_size if point_type == "prefill" else 0,
         ),
         num_decode_requests=_int_or(
             ibs.get("numGenRequests"),
@@ -397,6 +417,8 @@ def _fpm_to_dict(fpm: ForwardPassMetrics) -> dict[str, Any]:
 def _normalized_key(point: dict[str, Any]) -> int | list[int] | None:
     point_type = str(point.get("point_type", ""))
     if point_type == "prefill":
+        if "kv_read_tokens" in point:
+            return [_int_or(point.get("isl"), 0), _kv_read_tokens(point)]
         return _int_or(point.get("isl"), 0)
     if point_type == "decode":
         return [
@@ -409,8 +431,17 @@ def _normalized_key(point: dict[str, Any]) -> int | list[int] | None:
 def _profile_key(point: dict[str, Any]) -> str:
     point_type = str(point.get("point_type", ""))
     if point_type == "prefill":
+        if "kv_read_tokens" in point:
+            return (
+                f"{_int_or(point.get('isl'), 0)},"
+                f"{_kv_read_tokens(point)}"
+            )
         return str(_int_or(point.get("isl"), 0))
     return f"{_int_or(point.get('context_length'), 0)},{_int_or(point.get('batch_size'), 1)}"
+
+
+def _kv_read_tokens(point: dict[str, Any]) -> int:
+    return max(0, _int_or(point.get("kv_read_tokens"), 0))
 
 
 def _int_or(value: Any, default: int) -> int:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_self_benchmark.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_self_benchmark.py
@@ -34,6 +34,7 @@ def _payload(*, timed_out: bool = False, include_skipped: bool = False) -> dict:
                 "point_type": "prefill",
                 "index": 5,
                 "isl": 1024,
+                "kv_read_tokens": 512,
                 "context_length": 0,
                 "batch_size": 1,
             },
@@ -44,14 +45,16 @@ def _payload(*, timed_out: bool = False, include_skipped: bool = False) -> dict:
                     "schedulerMode": "overlap",
                     "inflightBatchingStats": {
                         "numContextRequests": 1,
-                        "numCtxTokens": 1024,
-                        "numCtxKvTokens": 0,
+                        "numCtxTokens": 512,
+                        "numCtxKvTokens": 512,
                         "numGenRequests": 0,
                         "numGenKvTokens": 0,
                     },
                 }
             ],
             "skipped_reason": None,
+            "observed_kv_read_tokens": 512,
+            "cache_hit_validated": True,
         },
         {
             "point": {
@@ -103,6 +106,7 @@ def test_cli_args_and_engine_args_use_trtllm_native_surface():
     cfg = TrtllmSelfBenchmarkConfig(
         mode="agg",
         prefill_isl_granularity=2,
+        prefill_kv_read_granularity=5,
         decode_context_granularity=3,
         decode_batch_granularity=4,
         warmup_iterations=1,
@@ -115,6 +119,8 @@ def test_cli_args_and_engine_args_use_trtllm_native_surface():
         "agg",
         "--self_benchmark_prefill_granularity",
         "2",
+        "--self_benchmark_prefill_kv_read_granularity",
+        "5",
         "--self_benchmark_decode_length_granularity",
         "3",
         "--self_benchmark_decode_batch_granularity",
@@ -132,6 +138,7 @@ def test_cli_args_and_engine_args_use_trtllm_native_surface():
     assert engine_args == {
         "self_benchmark_mode": "agg",
         "self_benchmark_prefill_granularity": 2,
+        "self_benchmark_prefill_kv_read_granularity": 5,
         "self_benchmark_decode_length_granularity": 3,
         "self_benchmark_decode_batch_granularity": 4,
         "self_benchmark_warmup_iterations": 1,
@@ -150,15 +157,48 @@ async def test_wait_for_output_parses_and_normalizes_fpms(tmp_path):
 
     assert data["status"] == "ok"
     assert data["backend"] == "trtllm"
-    assert "1024" in data["profile"]["prefill"]
+    assert "1024,512" in data["profile"]["prefill"]
     assert "2048,4" in data["profile"]["decode"]
+    assert data["results"][0]["normalized_key"] == [1024, 512]
+    assert data["profile"]["prefill"]["1024,512"]["cache_hit_validated"] is True
+    assert (
+        data["profile"]["prefill"]["1024,512"]["observed_kv_read_tokens"] == 512
+    )
     prefill_fpm = data["results"][0]["fpms"][0]
     assert prefill_fpm["worker_id"] == "worker-1"
     assert prefill_fpm["wall_time"] == pytest.approx(0.0123)
-    assert prefill_fpm["scheduled_requests"]["sum_prefill_tokens"] == 1024
+    assert prefill_fpm["scheduled_requests"]["sum_prefill_tokens"] == 512
+    assert prefill_fpm["scheduled_requests"]["sum_prefill_kv_tokens"] == 512
     assert data["metadata"]["raw_trtllm_self_benchmark"]["limits"][
         "max_num_scheduled_tokens"
     ] == 8192
+
+
+def test_prefill_kv_read_fallback_uses_point_schema():
+    data = normalize_self_benchmark_payload(
+        {
+            "timed_out": False,
+            "results": [
+                {
+                    "point": {
+                        "point_type": "prefill",
+                        "index": 1,
+                        "isl": 1024,
+                        "kv_read_tokens": 256,
+                        "batch_size": 2,
+                    },
+                    "iteration_stats": [{"hostStepTimeMS": 1.0}],
+                    "skipped_reason": None,
+                }
+            ],
+        }
+    )
+
+    fpm = data["results"][0]["fpms"][0]
+    assert data["results"][0]["normalized_key"] == [1024, 256]
+    assert fpm["scheduled_requests"]["num_prefill_requests"] == 2
+    assert fpm["scheduled_requests"]["sum_prefill_tokens"] == 1536
+    assert fpm["scheduled_requests"]["sum_prefill_kv_tokens"] == 512
 
 
 @pytest.mark.asyncio
@@ -207,6 +247,7 @@ def test_benchmark_options_require_mode():
     config = SimpleNamespace(
         benchmark_mode=None,
         benchmark_prefill_isl_granularity=None,
+        benchmark_prefill_kv_read_granularity=None,
         benchmark_decode_context_granularity=None,
         benchmark_decode_batch_granularity=None,
         benchmark_warmup_iterations=None,
@@ -231,6 +272,8 @@ def test_native_trt_self_benchmark_aliases_parse():
             "agg",
             "--self_benchmark_prefill_granularity",
             "2",
+            "--self_benchmark_prefill_kv_read_granularity",
+            "5",
             "--self_benchmark_decode_length_granularity",
             "3",
             "--self_benchmark_decode_batch_granularity",
@@ -246,6 +289,7 @@ def test_native_trt_self_benchmark_aliases_parse():
 
     assert config.benchmark_mode == "agg"
     assert config.benchmark_prefill_isl_granularity == 2
+    assert config.benchmark_prefill_kv_read_granularity == 5
     assert config.benchmark_decode_context_granularity == 3
     assert config.benchmark_decode_batch_granularity == 4
     assert config.benchmark_warmup_iterations == 1
@@ -333,6 +377,7 @@ async def test_init_worker_waits_for_benchmark_before_registering(monkeypatch, t
         benchmark_mode="agg",
         benchmark_output_path=str(output_path),
         benchmark_prefill_isl_granularity=None,
+        benchmark_prefill_kv_read_granularity=None,
         benchmark_timeout_s=1,
         benchmark_warmup_iterations=None,
         component="backend",

--- a/components/src/dynamo/trtllm/tests/test_trtllm_self_benchmark.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_self_benchmark.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dynamo.trtllm.constants import DisaggregationMode, Modality
+from dynamo.trtllm.self_benchmark import (
+    TrtllmSelfBenchmarkConfig,
+    apply_self_benchmark_engine_args,
+    benchmark_options_without_mode,
+    normalize_self_benchmark_payload,
+    trtllm_self_benchmark_cli_args,
+    wait_for_self_benchmark_output,
+)
+
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.pre_merge,
+]
+
+
+def _payload(*, timed_out: bool = False, include_skipped: bool = False) -> dict:
+    results = [
+        {
+            "point": {
+                "point_type": "prefill",
+                "index": 5,
+                "isl": 1024,
+                "context_length": 0,
+                "batch_size": 1,
+            },
+            "iteration_stats": [
+                {
+                    "hostStepTimeMS": 12.3,
+                    "prevDeviceStepTimeMS": 10.8,
+                    "schedulerMode": "overlap",
+                    "inflightBatchingStats": {
+                        "numContextRequests": 1,
+                        "numCtxTokens": 1024,
+                        "numCtxKvTokens": 0,
+                        "numGenRequests": 0,
+                        "numGenKvTokens": 0,
+                    },
+                }
+            ],
+            "skipped_reason": None,
+        },
+        {
+            "point": {
+                "point_type": "decode",
+                "index": 6,
+                "isl": 0,
+                "context_length": 2048,
+                "batch_size": 4,
+            },
+            "iteration_stats": [
+                {
+                    "hostStepTimeMS": 8.0,
+                    "schedulerMode": "overlap",
+                    "inflightBatchingStats": {
+                        "numContextRequests": 0,
+                        "numCtxTokens": 0,
+                        "numCtxKvTokens": 0,
+                        "numGenRequests": 4,
+                        "numGenKvTokens": 8192,
+                    },
+                }
+            ],
+            "skipped_reason": None,
+        },
+    ]
+    if include_skipped:
+        results.append(
+            {
+                "point": {
+                    "point_type": "decode",
+                    "index": 7,
+                    "isl": 0,
+                    "context_length": 4096,
+                    "batch_size": 8,
+                },
+                "iteration_stats": [],
+                "skipped_reason": "kv cache exhausted",
+            }
+        )
+    return {
+        "config": {"mode": "agg", "output_path": "/tmp/trt.json"},
+        "limits": {"max_num_scheduled_tokens": 8192},
+        "timed_out": timed_out,
+        "results": results,
+    }
+
+
+def test_cli_args_and_engine_args_use_trtllm_native_surface():
+    cfg = TrtllmSelfBenchmarkConfig(
+        mode="agg",
+        prefill_isl_granularity=2,
+        decode_context_granularity=3,
+        decode_batch_granularity=4,
+        warmup_iterations=1,
+        output_path="/tmp/out.json",
+        timeout_s=9,
+    )
+
+    assert trtllm_self_benchmark_cli_args(cfg) == [
+        "--self_benchmark_mode",
+        "agg",
+        "--self_benchmark_prefill_granularity",
+        "2",
+        "--self_benchmark_decode_length_granularity",
+        "3",
+        "--self_benchmark_decode_batch_granularity",
+        "4",
+        "--self_benchmark_warmup_iterations",
+        "1",
+        "--self_benchmark_output_path",
+        "/tmp/out.json",
+        "--self_benchmark_timeout",
+        "9",
+    ]
+
+    engine_args = {}
+    apply_self_benchmark_engine_args(engine_args, cfg)
+    assert engine_args == {
+        "self_benchmark_mode": "agg",
+        "self_benchmark_prefill_granularity": 2,
+        "self_benchmark_decode_length_granularity": 3,
+        "self_benchmark_decode_batch_granularity": 4,
+        "self_benchmark_warmup_iterations": 1,
+        "self_benchmark_output_path": "/tmp/out.json",
+        "self_benchmark_timeout": 9,
+    }
+
+
+@pytest.mark.asyncio
+async def test_wait_for_output_parses_and_normalizes_fpms(tmp_path):
+    output = tmp_path / "trt.json"
+    output.write_text(json.dumps(_payload()))
+    cfg = TrtllmSelfBenchmarkConfig(mode="agg", output_path=str(output), timeout_s=1)
+
+    data = await wait_for_self_benchmark_output(cfg, worker_id="worker-1")
+
+    assert data["status"] == "ok"
+    assert data["backend"] == "trtllm"
+    assert "1024" in data["profile"]["prefill"]
+    assert "2048,4" in data["profile"]["decode"]
+    prefill_fpm = data["results"][0]["fpms"][0]
+    assert prefill_fpm["worker_id"] == "worker-1"
+    assert prefill_fpm["wall_time"] == pytest.approx(0.0123)
+    assert prefill_fpm["scheduled_requests"]["sum_prefill_tokens"] == 1024
+    assert data["metadata"]["raw_trtllm_self_benchmark"]["limits"][
+        "max_num_scheduled_tokens"
+    ] == 8192
+
+
+@pytest.mark.asyncio
+async def test_wait_for_output_missing_file_times_out(tmp_path):
+    cfg = TrtllmSelfBenchmarkConfig(
+        mode="agg",
+        output_path=str(tmp_path / "missing.json"),
+        timeout_s=0,
+    )
+
+    with pytest.raises(TimeoutError, match="did not write"):
+        await wait_for_self_benchmark_output(cfg)
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_fails_startup(tmp_path):
+    output = tmp_path / "bad.json"
+    output.write_text("{not-json")
+    cfg = TrtllmSelfBenchmarkConfig(mode="agg", output_path=str(output), timeout_s=1)
+
+    with pytest.raises(ValueError, match="Invalid TRT-LLM self-benchmark JSON"):
+        await wait_for_self_benchmark_output(cfg)
+
+
+def test_timed_out_payload_warns_and_publishes_partial_data():
+    data = normalize_self_benchmark_payload(_payload(timed_out=True))
+
+    assert data["metadata"]["timed_out"] is True
+    assert data["metadata"]["warnings"] == [
+        "TRT-LLM self-benchmark timed out; publishing partial data"
+    ]
+    assert data["profile"]["prefill"]
+
+
+def test_skipped_points_are_kept_but_excluded_from_profile_tables():
+    data = normalize_self_benchmark_payload(_payload(include_skipped=True))
+
+    skipped_result = data["results"][-1]
+    assert skipped_result["skipped_reason"] == "kv cache exhausted"
+    assert skipped_result["fpms"] == []
+    assert "4096,8" not in data["profile"]["decode"]
+    assert data["metadata"]["skipped_points"][-1]["normalized_key"] == [4096, 8]
+
+
+def test_benchmark_options_require_mode():
+    config = SimpleNamespace(
+        benchmark_mode=None,
+        benchmark_prefill_isl_granularity=None,
+        benchmark_decode_context_granularity=None,
+        benchmark_decode_batch_granularity=None,
+        benchmark_warmup_iterations=None,
+        benchmark_output_path="/tmp/out.json",
+        benchmark_timeout_s=None,
+    )
+
+    assert benchmark_options_without_mode(config) == ["--benchmark-output-path"]
+
+
+def test_native_trt_self_benchmark_aliases_parse():
+    try:
+        from dynamo.trtllm.backend_args import DynamoTrtllmArgGroup
+    except ImportError as exc:
+        pytest.skip(f"TRT-LLM package is unavailable: {exc}")
+
+    parser = argparse.ArgumentParser()
+    DynamoTrtllmArgGroup().add_arguments(parser)
+    config = parser.parse_args(
+        [
+            "--self_benchmark_mode",
+            "agg",
+            "--self_benchmark_prefill_granularity",
+            "2",
+            "--self_benchmark_decode_length_granularity",
+            "3",
+            "--self_benchmark_decode_batch_granularity",
+            "4",
+            "--self_benchmark_warmup_iterations",
+            "1",
+            "--self_benchmark_output_path",
+            "/tmp/trt.json",
+            "--self_benchmark_timeout",
+            "9",
+        ]
+    )
+
+    assert config.benchmark_mode == "agg"
+    assert config.benchmark_prefill_isl_granularity == 2
+    assert config.benchmark_decode_context_granularity == 3
+    assert config.benchmark_decode_batch_granularity == 4
+    assert config.benchmark_warmup_iterations == 1
+    assert config.benchmark_output_path == "/tmp/trt.json"
+    assert config.benchmark_timeout_s == 9
+
+
+@pytest.mark.asyncio
+async def test_init_worker_waits_for_benchmark_before_registering(monkeypatch, tmp_path):
+    try:
+        from dynamo.trtllm.workers import llm_worker as worker_mod
+    except ImportError as exc:
+        pytest.skip(f"TRT-LLM worker runtime binding is unavailable: {exc}")
+
+    events: list[str] = []
+    output_path = tmp_path / "bench.json"
+
+    class FakeEndpoint:
+        def __init__(self, name: str):
+            self.name = name
+
+        def connection_id(self):
+            return 42
+
+        async def serve_endpoint(self, *args, **kwargs):
+            events.append(f"serve:{self.name}")
+
+    class FakeRuntime:
+        def endpoint(self, name: str):
+            return FakeEndpoint(name)
+
+    class FakeEngine:
+        def start_health_monitor(self, *args, **kwargs):
+            events.append("health")
+
+        def get_attention_dp_size(self):
+            return 1
+
+    @asynccontextmanager
+    async def fake_get_llm_engine(*args, **kwargs):
+        events.append("engine")
+        yield FakeEngine()
+
+    async def fake_wait_for_output(*args, **kwargs):
+        events.append("benchmark")
+        return {"status": "ok", "results": [], "metadata": {}}
+
+    async def fake_register_model(*args, **kwargs):
+        events.append("register")
+
+    class FakeHandler:
+        _benchmark_results = None
+
+        async def generate(self, *args, **kwargs):
+            yield {}
+
+        async def get_perf_metrics(self, *args, **kwargs):
+            yield self._benchmark_results
+
+    class FakeFactory:
+        def get_request_handler(self, config):
+            return FakeHandler()
+
+    monkeypatch.setattr(worker_mod, "get_llm_engine", fake_get_llm_engine)
+    monkeypatch.setattr(
+        worker_mod, "wait_for_self_benchmark_output", fake_wait_for_output
+    )
+    monkeypatch.setattr(worker_mod, "register_model", fake_register_model)
+    monkeypatch.setattr(worker_mod, "RequestHandlerFactory", lambda: FakeFactory())
+    monkeypatch.setattr(worker_mod, "tokenizer_factory", lambda *args, **kwargs: None)
+    monkeypatch.setattr(worker_mod, "dump_config", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        worker_mod, "register_engine_metrics_callback", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "LLMBackendMetrics",
+        lambda *args, **kwargs: SimpleNamespace(set_model_load_time=lambda *a: None),
+    )
+
+    config = SimpleNamespace(
+        allowed_local_media_path="",
+        benchmark_decode_batch_granularity=None,
+        benchmark_decode_context_granularity=None,
+        benchmark_mode="agg",
+        benchmark_output_path=str(output_path),
+        benchmark_prefill_isl_granularity=None,
+        benchmark_timeout_s=1,
+        benchmark_warmup_iterations=None,
+        component="backend",
+        connector=["none"],
+        custom_jinja_template=None,
+        default_guidance_scale=5.0,
+        default_height=1024,
+        default_num_frames=81,
+        default_num_images_per_prompt=1,
+        default_num_inference_steps=50,
+        default_width=1024,
+        disaggregation_mode=DisaggregationMode.AGGREGATED,
+        dit_cfg_size=1,
+        dit_ring_size=1,
+        dit_ulysses_size=1,
+        dump_config_to=None,
+        dyn_enable_structural_tag=False,
+        dyn_reasoning_parser=None,
+        dyn_structural_tag_schema="auto",
+        dyn_structural_tag_scope="auto",
+        dyn_tool_call_parser=None,
+        enable_attention_dp=False,
+        enable_cuda_graph=False,
+        enable_fullgraph=False,
+        enable_layerwise_nvtx_marker=False,
+        enable_local_indexer=True,
+        enable_teacache=False,
+        encode_endpoint="",
+        endpoint="generate",
+        endpoint_types="chat,completions",
+        exclude_tools_when_tool_choice_none=True,
+        expert_parallel_size=None,
+        extra_engine_args="",
+        free_gpu_memory_fraction=0.9,
+        frontend_decoding=False,
+        gpus_per_node=1,
+        guided_decoding_backend=None,
+        kv_block_size=32,
+        load_format="auto",
+        max_batch_size=8,
+        max_beam_width=1,
+        max_file_size_mb=50,
+        max_num_tokens=8192,
+        max_seq_len=32768,
+        modality=Modality.TEXT,
+        model="Qwen/Qwen3-0.6B",
+        model_loader_extra_config="",
+        multimodal_embedding_cache_capacity_gb=0,
+        namespace="dynamo",
+        override_engine_args="",
+        pipeline_parallel_size=1,
+        publish_events_and_metrics=False,
+        quant_algo=None,
+        quant_dynamic=True,
+        revision=None,
+        served_model_name=None,
+        skip_warmup=False,
+        tensor_parallel_size=1,
+        torch_dtype="bfloat16",
+        disable_torch_compile=False,
+        teacache_thresh=0.2,
+        teacache_use_ret_steps=True,
+    )
+    config.has_connector = lambda name: name in config.connector
+
+    await worker_mod.init_llm_worker(
+        FakeRuntime(),
+        config,
+        shutdown_event=AsyncMock(),
+        shutdown_endpoints=[],
+    )
+
+    assert events.index("benchmark") < events.index("register")
+    assert events.index("register") < events.index("serve:dynamo.backend.generate")
+    assert "serve:dynamo.backend.get_perf_metrics" in events

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -65,6 +65,12 @@ from dynamo.trtllm.request_handlers.handlers import (
     RequestHandlerConfig,
     RequestHandlerFactory,
 )
+from dynamo.trtllm.self_benchmark import (
+    TRTLLM_SELF_BENCHMARK_RUNTIME_KEY,
+    prepare_self_benchmark,
+    trtllm_self_benchmark_cli_args,
+    wait_for_self_benchmark_output,
+)
 from dynamo.trtllm.utils.trtllm_utils import deep_update, get_spec_decode_runtime_data
 
 # Default buffer size for kv cache events.
@@ -300,6 +306,13 @@ async def init_llm_worker(
 
     _sync_config_from_engine_args(config, arg_map)
 
+    benchmark_config = prepare_self_benchmark(config, arg_map)
+    if benchmark_config is not None:
+        logging.info(
+            "TRT-LLM self-benchmark enabled with native args: %s",
+            trtllm_self_benchmark_cli_args(benchmark_config),
+        )
+
     event_buffer_max_size = 0
     if config.publish_events_and_metrics:
         # 'event_buffer_max_size' is required to enable TRTLLM to publish kv cache events.
@@ -510,9 +523,21 @@ async def init_llm_worker(
         endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
         )
+        benchmark_results = None
+        perf_endpoint = None
+        if benchmark_config is not None:
+            benchmark_results = await wait_for_self_benchmark_output(
+                benchmark_config,
+                worker_id=str(endpoint.connection_id()),
+            )
+            perf_endpoint = runtime.endpoint(
+                f"{config.namespace}.{config.component}.get_perf_metrics"
+            )
 
         if shutdown_endpoints is not None:
             shutdown_endpoints[:] = [endpoint]
+            if perf_endpoint is not None:
+                shutdown_endpoints.append(perf_endpoint)
 
         # should ideally call get_engine_runtime_config
         # this is because we don't have a good way to
@@ -570,6 +595,13 @@ async def init_llm_worker(
                 "Published TRT-LLM spec decode runtime metadata: %s",
                 spec_decode_runtime_data,
             )
+
+        if benchmark_results is not None:
+            runtime_config.set_engine_specific(
+                TRTLLM_SELF_BENCHMARK_RUNTIME_KEY,
+                json.dumps(benchmark_results),
+            )
+            logging.info("Published TRT-LLM self-benchmark runtime metadata")
 
         logging.info(f"Set runtime config max_num_seqs: {runtime_config.max_num_seqs}")
         logging.info(
@@ -778,6 +810,7 @@ async def init_llm_worker(
             ) as publisher:
                 handler_config.publisher = publisher
                 handler = RequestHandlerFactory().get_request_handler(handler_config)
+                handler._benchmark_results = benchmark_results
                 if config.load_format == "gms":
                     _register_memory_routes(runtime, handler)
 
@@ -789,19 +822,37 @@ async def init_llm_worker(
                         model_name=model_name_for_metrics,
                         component_name=config.component,
                     )
-                await endpoint.serve_endpoint(
-                    handler.generate,
-                    metrics_labels=metrics_labels,
-                    health_check_payload=health_check_payload,
-                )
+                serve_tasks = [
+                    endpoint.serve_endpoint(
+                        handler.generate,
+                        metrics_labels=metrics_labels,
+                        health_check_payload=health_check_payload,
+                    )
+                ]
+                if perf_endpoint is not None:
+                    serve_tasks.append(
+                        perf_endpoint.serve_endpoint(
+                            handler.get_perf_metrics,
+                            metrics_labels=metrics_labels,
+                        )
+                    )
+                await asyncio.gather(*serve_tasks)
 
             # Shutdown consolidator publisher if it was created
             if consolidator_publisher:
                 consolidator_publisher.shutdown()
         else:
             handler = RequestHandlerFactory().get_request_handler(handler_config)
+            handler._benchmark_results = benchmark_results
             if config.load_format == "gms":
                 _register_memory_routes(runtime, handler)
-            await endpoint.serve_endpoint(
-                handler.generate, health_check_payload=health_check_payload
-            )
+            serve_tasks = [
+                endpoint.serve_endpoint(
+                    handler.generate, health_check_payload=health_check_payload
+                )
+            ]
+            if perf_endpoint is not None:
+                serve_tasks.append(
+                    perf_endpoint.serve_endpoint(handler.get_perf_metrics)
+                )
+            await asyncio.gather(*serve_tasks)


### PR DESCRIPTION
## Overview:

Adds Dynamo integration for TRT-LLM startup self-benchmarking without adding a public HTTP benchmark endpoint. When enabled, Dynamo passes TRT-LLM’s native self-benchmark args, waits for the rank-0 JSON output, parses it, and avoids registering the worker for routing until benchmark handling completes.

## Details:

- Add TRT-LLM benchmark config support using Dynamo’s existing benchmark option shape.
- Map Dynamo benchmark fields to TRT-LLM native `self_benchmark_*` engine/CLI args.
- Generate a unique output path when none is provided and remove stale output before launch.
- Poll and parse TRT-LLM rank-0 JSON output.
- Preserve the raw TRT-LLM payload in runtime metadata/debug data.
- Normalize benchmark points into Dynamo `ForwardPassMetrics`-style profile data.
- Keep skipped points in metadata/results while excluding them from normalized perf tables.
- Treat missing output after timeout and invalid JSON as startup failures.
- Publish partial data with a warning when TRT reports `timed_out=true`.
- Gate worker registration/routability until benchmark output is collected or fails explicitly.

## Where should the reviewer start?

- `components/src/dynamo/trtllm/self_benchmark.py`
- `components/src/dynamo/trtllm/workers/llm_worker.py`
- `components/src/dynamo/trtllm/llm_engine.py`
- `components/src/dynamo/trtllm/tests/test_trtllm_self_benchmark.py`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-benchmarking support for TensorRT-LLM backend with configurable benchmark modes, granularities, warmup iterations, and output parameters
  * New performance metrics endpoint available for retrieving benchmark results from self-benchmark runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->