### PR TITLE
perf(router): compress single-threaded radix recovery dumps

### DIFF
--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -211,9 +211,8 @@ impl MooncakeIndexerConfig {
         prune_config: PruneConfig,
     ) -> anyhow::Result<Arc<dyn KvIndexerInterface + Send + Sync>> {
         let indexer: Arc<dyn KvIndexerInterface + Send + Sync> = match self.kind {
-            MooncakeIndexerKind::RadixTree => Arc::new(KvIndexer::new_with_frequency(
+            MooncakeIndexerKind::RadixTree => Arc::new(KvIndexer::new_with_pruning(
                 CancellationToken::new(),
-                None,
                 block_size,
                 metrics,
                 Some(prune_config),

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -525,16 +525,12 @@ pub(crate) struct RadixTree {
 #[pymethods]
 impl RadixTree {
     #[new]
-    #[pyo3(signature = (expiration_duration_secs=None))]
-    fn new(expiration_duration_secs: Option<f64>) -> PyResult<Self> {
-        let expiration_duration = expiration_duration_secs.map(std::time::Duration::from_secs_f64);
-
+    fn new() -> PyResult<Self> {
         let (request_tx, request_rx) = mpsc::channel::<RadixTreeRequest>();
 
         // Spawn dedicated thread with simplified sync processing
         std::thread::spawn(move || {
-            let mut radix_tree =
-                dynamo_kv_router::indexer::RadixTree::new_with_frequency(expiration_duration);
+            let mut radix_tree = dynamo_kv_router::indexer::RadixTree::new();
 
             loop {
                 match request_rx.recv() {

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -823,13 +823,9 @@ class RadixTree:
     release the Python GIL.
     """
 
-    def __init__(self, expiration_duration_secs: Optional[float] = None) -> None:
+    def __init__(self) -> None:
         """
         Create a new RadixTree instance.
-
-        Args:
-            expiration_duration_secs: Optional expiration duration in seconds for cached blocks.
-                                    If None, blocks never expire.
         """
         ...
 

--- a/lib/bindings/python/tests/test_kv_bindings.py
+++ b/lib/bindings/python/tests/test_kv_bindings.py
@@ -98,16 +98,14 @@ def test_radix_tree_binding():
 @pytest.mark.timeout(5)  # Expected: ~1s, timeout set to 5x for safety
 @pytest.mark.parametrize("num_threads", [2, 3, 5, 128])
 @pytest.mark.parametrize("prepopulate_worker_ids", [True, False])
-@pytest.mark.parametrize("expiration_duration_secs", [None])
 @pytest.mark.parametrize("is_threaded", [True, False])
 def test_radix_tree_thread_safety(
     num_threads,
     prepopulate_worker_ids,
-    expiration_duration_secs,
     is_threaded,
 ):
     """Test RadixTree thread safety by applying events from multiple threads."""
-    radix_tree = RadixTree(expiration_duration_secs=expiration_duration_secs)
+    radix_tree = RadixTree()
     threads = []
     done_counter = 0
     exception_counter = 0

--- a/lib/bindings/python/tests/test_mm_kv_router.py
+++ b/lib/bindings/python/tests/test_mm_kv_router.py
@@ -150,7 +150,13 @@ def test_radix_tree_mm_block_chaining():
 
     # Verify chain exists
     all_blocks = radix_tree.dump_tree_as_events()
-    assert len(all_blocks) == 2
+    assert (
+        sum(
+            len(json.loads(event)["event"]["data"]["stored"]["blocks"])
+            for event in all_blocks
+        )
+        == 2
+    )
 
     # Query with both hashes should match the chain
     scores = radix_tree.find_matches([parent_hash, child_hash])
@@ -201,7 +207,13 @@ def test_radix_tree_clear_all_blocks():
         make_store_event(1, [make_block(1000), make_block(2000)]),
     )
 
-    assert len(radix_tree.dump_tree_as_events()) == 2
+    assert (
+        sum(
+            len(json.loads(event)["event"]["data"]["stored"]["blocks"])
+            for event in radix_tree.dump_tree_as_events()
+        )
+        == 2
+    )
 
     # Clear all blocks for worker
     radix_tree.clear_all_blocks(worker_id)

--- a/lib/kv-router/src/indexer/README.md
+++ b/lib/kv-router/src/indexer/README.md
@@ -13,7 +13,8 @@ The concurrent indexers achieve a combined throughput of over **10 million event
 | `types.rs` | `KvRouterError`, `MatchRequest`, `WorkerTask`, channel message types |
 | `metrics.rs` | `KvIndexerMetrics` — Prometheus counters and histograms |
 | `kv_indexer.rs` | `KvIndexer` — single-threaded async wrapper around `RadixTree` with tokio mpsc channels |
-| `radix_tree.rs` | `RadixTree` — single-threaded tree with `Rc<RefCell<RadixBlock>>` nodes, tracks per-block frequency |
+| `compressed_radix.rs` | Shared immutable compressed-edge and worker-coverage state |
+| `radix_tree.rs` | `RadixTree` — single-threaded compressed tree with `Rc<RefCell<RadixBlock>>` nodes |
 | `concurrent_radix_tree.rs` | `ConcurrentRadixTree` — thread-safe variant with `Arc<RwLock<Block>>` nodes and `DashMap` lookup |
 | `positional.rs` | `PositionalIndexer` — flat `DashMap<(pos, hash), SeqEntry>` with jump optimization |
 | `thread_pool.rs` | `ThreadPoolIndexer<T: SyncIndexer>` — N OS threads for sticky-routed writes, inline reads; wraps `ConcurrentRadixTree` or `PositionalIndexer` |
@@ -108,10 +109,12 @@ RadixTree
 └── lookup: HashMap<Worker, HashMap<SeqHash, SharedRadixBlock>>
 
 RadixBlock
+├── state.edge: Vec<(LocalBlockHash, SeqHash)>
+├── state.edge_index: HashMap<SeqHash, Position>
+├── state.worker_cutoffs: HashMap<Worker, Position>
+├── state.full_edge_workers: HashSet<Worker>
 ├── children: HashMap<LocalBlockHash, SharedRadixBlock>
-├── workers: HashSet<Worker>
-├── block_hash: Option<SeqHash>
-└── recent_uses: VecDeque<Instant>
+└── internal: bool
 ```
 
 ### Visual Representation
@@ -197,7 +200,8 @@ find_matches() ──→ │   Arc<ConcurrentRadixTree>       │ ← reads go i
 
 This same pattern — inline reads on the caller thread, sticky-routed writes through a thread pool — is shared with `PositionalIndexer` (see below). Both implement the `SyncIndexer` trait and are wrapped in `ThreadPoolIndexer`.
 
-One trade-off: `ConcurrentRadixTree` drops the `recent_uses` frequency tracking from `RadixTree`, keeping `find_matches` fully read-only (no mutable state updates on the read path).
+All indexers keep `find_matches` read-only. The legacy `OverlapScores.frequencies`
+wire field remains present for compatibility and is returned empty.
 
 ---
 

--- a/lib/kv-router/src/indexer/compressed_radix.rs
+++ b/lib/kv-router/src/indexer/compressed_radix.rs
@@ -5,6 +5,58 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use crate::protocols::*;
 
+pub(crate) fn append_dump_events(
+    events: &mut Vec<RouterEvent>,
+    event_id: &mut u64,
+    parent_hash: Option<ExternalSequenceBlockHash>,
+    edge: &[(LocalBlockHash, ExternalSequenceBlockHash)],
+    full_workers: &[WorkerWithDpRank],
+    worker_cutoffs: &[(WorkerWithDpRank, usize)],
+) {
+    let blocks = edge
+        .iter()
+        .map(|&(tokens_hash, block_hash)| KvCacheStoredBlockData {
+            block_hash,
+            tokens_hash,
+            mm_extra_info: None,
+        })
+        .collect::<Vec<_>>();
+
+    for &worker in full_workers {
+        events.push(dump_event(worker, *event_id, parent_hash, blocks.clone()));
+        *event_id += 1;
+    }
+    for &(worker, cutoff) in worker_cutoffs {
+        events.push(dump_event(
+            worker,
+            *event_id,
+            parent_hash,
+            blocks[..cutoff].to_vec(),
+        ));
+        *event_id += 1;
+    }
+}
+
+fn dump_event(
+    worker: WorkerWithDpRank,
+    event_id: u64,
+    parent_hash: Option<ExternalSequenceBlockHash>,
+    blocks: Vec<KvCacheStoredBlockData>,
+) -> RouterEvent {
+    RouterEvent::new(
+        worker.worker_id,
+        KvCacheEvent {
+            event_id,
+            data: KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash,
+                start_position: None,
+                blocks,
+            }),
+            dp_rank: worker.dp_rank,
+        },
+    )
+}
+
 pub(crate) struct RemoveOutcome {
     pub(crate) stale_hashes: Vec<ExternalSequenceBlockHash>,
 }

--- a/lib/kv-router/src/indexer/compressed_radix.rs
+++ b/lib/kv-router/src/indexer/compressed_radix.rs
@@ -3,25 +3,53 @@
 
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
-use super::RemoveOutcome;
 use crate::protocols::*;
 
+pub(crate) struct RemoveOutcome {
+    pub(crate) stale_hashes: Vec<ExternalSequenceBlockHash>,
+}
+
 #[derive(Debug)]
-pub(super) struct NodeState {
+pub(crate) struct NodeState {
     /// Compressed edge: sequence of `(LocalBlockHash, ExternalSequenceBlockHash)` pairs.
     /// Empty for the root node; non-empty for all other nodes.
-    pub(super) edge: Vec<(LocalBlockHash, ExternalSequenceBlockHash)>,
+    pub(crate) edge: Vec<(LocalBlockHash, ExternalSequenceBlockHash)>,
     /// Reverse index: `ExternalSequenceBlockHash` -> position in `edge`.
-    pub(super) edge_index: FxHashMap<ExternalSequenceBlockHash, usize>,
+    pub(crate) edge_index: FxHashMap<ExternalSequenceBlockHash, usize>,
     /// Workers with partial edge coverage. `worker_cutoffs[w] = k` means worker `w`
     /// has cached `edge[0..k]`, where `0 < k < edge.len()`.
-    pub(super) worker_cutoffs: FxHashMap<WorkerWithDpRank, usize>,
-    /// Workers with full edge coverage (match index == edge.len()).
-    pub(super) full_edge_workers: FxHashSet<WorkerWithDpRank>,
+    pub(crate) worker_cutoffs: FxHashMap<WorkerWithDpRank, usize>,
+    /// Workers with full edge coverage.
+    pub(crate) full_edge_workers: FxHashSet<WorkerWithDpRank>,
 }
 
 impl NodeState {
-    pub(super) fn edge_index_for(
+    pub(crate) fn empty() -> Self {
+        Self {
+            edge: Vec::new(),
+            edge_index: FxHashMap::default(),
+            worker_cutoffs: FxHashMap::default(),
+            full_edge_workers: FxHashSet::default(),
+        }
+    }
+
+    pub(crate) fn for_blocks(blocks: &[KvCacheStoredBlockData], worker: WorkerWithDpRank) -> Self {
+        let edge = blocks
+            .iter()
+            .map(|block| (block.tokens_hash, block.block_hash))
+            .collect::<Vec<_>>();
+        let mut full_edge_workers = FxHashSet::with_capacity_and_hasher(1, FxBuildHasher);
+        full_edge_workers.insert(worker);
+
+        Self {
+            edge_index: Self::edge_index_for(&edge),
+            edge,
+            worker_cutoffs: FxHashMap::default(),
+            full_edge_workers,
+        }
+    }
+
+    pub(crate) fn edge_index_for(
         edge: &[(LocalBlockHash, ExternalSequenceBlockHash)],
     ) -> FxHashMap<ExternalSequenceBlockHash, usize> {
         let mut edge_index = FxHashMap::with_capacity_and_hasher(edge.len(), FxBuildHasher);
@@ -32,7 +60,7 @@ impl NodeState {
     }
 
     #[inline]
-    pub(super) fn current_cutoff(&self, worker: WorkerWithDpRank) -> usize {
+    pub(crate) fn current_cutoff(&self, worker: WorkerWithDpRank) -> usize {
         if self.full_edge_workers.contains(&worker) {
             self.edge.len()
         } else {
@@ -41,7 +69,7 @@ impl NodeState {
     }
 
     #[inline]
-    pub(super) fn covers_pos(&self, worker: WorkerWithDpRank, pos: usize) -> bool {
+    pub(crate) fn covers_pos(&self, worker: WorkerWithDpRank, pos: usize) -> bool {
         self.full_edge_workers.contains(&worker)
             || matches!(self.worker_cutoffs.get(&worker), Some(&cutoff) if pos < cutoff)
     }
@@ -52,23 +80,23 @@ impl NodeState {
     }
 
     #[inline]
-    pub(super) fn drop_worker(&mut self, worker: WorkerWithDpRank) {
+    pub(crate) fn drop_worker(&mut self, worker: WorkerWithDpRank) {
         self.full_edge_workers.remove(&worker);
         self.worker_cutoffs.remove(&worker);
     }
 
     #[inline]
-    pub(super) fn promote_to_full(&mut self, worker: WorkerWithDpRank) -> bool {
-        if !self.full_edge_workers.contains(&worker) {
-            self.worker_cutoffs.remove(&worker);
-            self.full_edge_workers.insert(worker);
-            true
-        } else {
-            false
+    pub(crate) fn promote_to_full(&mut self, worker: WorkerWithDpRank) -> bool {
+        if self.full_edge_workers.contains(&worker) {
+            return false;
         }
+
+        self.worker_cutoffs.remove(&worker);
+        self.full_edge_workers.insert(worker);
+        true
     }
 
-    pub(super) fn cover_prefix_for_worker(
+    pub(crate) fn cover_prefix_for_worker(
         &mut self,
         worker: WorkerWithDpRank,
         cutoff: usize,
@@ -97,13 +125,13 @@ impl NodeState {
         }
     }
 
-    pub(super) fn tail_hash_is(&self, hash: ExternalSequenceBlockHash) -> bool {
+    pub(crate) fn tail_hash_is(&self, hash: ExternalSequenceBlockHash) -> bool {
         self.edge
             .last()
             .is_some_and(|&(_, edge_hash)| edge_hash == hash)
     }
 
-    pub(super) fn suffix_matches_store(
+    pub(crate) fn suffix_matches_store(
         &self,
         parent_pos: usize,
         blocks: &[KvCacheStoredBlockData],
@@ -114,16 +142,16 @@ impl NodeState {
         if blocks.len() > suffix.len() {
             return false;
         }
-        for (&(local_hash, block_hash), block) in suffix.iter().zip(blocks) {
-            if local_hash != block.tokens_hash || block_hash != block.block_hash {
-                return false;
-            }
-        }
 
-        true
+        suffix
+            .iter()
+            .zip(blocks)
+            .all(|(&(local_hash, block_hash), block)| {
+                local_hash == block.tokens_hash && block_hash == block.block_hash
+            })
     }
 
-    pub(super) fn store_starts_with_suffix(
+    pub(crate) fn store_starts_with_suffix(
         &self,
         parent_pos: usize,
         blocks: &[KvCacheStoredBlockData],
@@ -132,16 +160,20 @@ impl NodeState {
         if blocks.len() <= suffix.len() {
             return None;
         }
-        for (&(local_hash, block_hash), block) in suffix.iter().zip(blocks) {
-            if local_hash != block.tokens_hash || block_hash != block.block_hash {
-                return None;
-            }
+        if !suffix
+            .iter()
+            .zip(blocks)
+            .all(|(&(local_hash, block_hash), block)| {
+                local_hash == block.tokens_hash && block_hash == block.block_hash
+            })
+        {
+            return None;
         }
 
         Some(suffix.len())
     }
 
-    pub(super) fn append_blocks_to_leaf(
+    pub(crate) fn append_blocks_to_leaf(
         &mut self,
         worker: WorkerWithDpRank,
         blocks: &[KvCacheStoredBlockData],
@@ -149,12 +181,12 @@ impl NodeState {
         debug_assert!(!blocks.is_empty());
 
         let old_len = self.edge.len();
-        let downgraded_workers: Vec<WorkerWithDpRank> = self
+        let downgraded_workers = self
             .full_edge_workers
             .iter()
             .copied()
             .filter(|&full_worker| full_worker != worker)
-            .collect();
+            .collect::<Vec<_>>();
         for downgraded_worker in downgraded_workers {
             self.full_edge_workers.remove(&downgraded_worker);
             self.worker_cutoffs.insert(downgraded_worker, old_len);
@@ -169,7 +201,7 @@ impl NodeState {
         }
     }
 
-    pub(super) fn remove_worker_at_pos(
+    pub(crate) fn remove_worker_at_pos(
         &mut self,
         worker: WorkerWithDpRank,
         pos: usize,
@@ -195,7 +227,7 @@ impl NodeState {
         RemoveOutcome { stale_hashes }
     }
 
-    pub(super) fn has_any_workers(&self) -> bool {
+    pub(crate) fn has_any_workers(&self) -> bool {
         !self.full_edge_workers.is_empty() || !self.worker_cutoffs.is_empty()
     }
 }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -12,9 +12,7 @@
 //!
 //! # Limitations vs RadixTree
 //!
-//! - Does NOT support `expiration_duration` / frequency tracking
-//! - `new_with_frequency()` is not provided
-//! - `find_matches` does not populate `OverlapScores.frequencies`
+//! - Does not populate the legacy `OverlapScores.frequencies` field
 //!
 //! # Concurrency Model
 //!
@@ -52,8 +50,6 @@ struct Block {
     workers: FxHashSet<WorkerWithDpRank>,
     /// The external sequence block hash for this block (None for root).
     block_hash: Option<ExternalSequenceBlockHash>,
-    // NOTE: No recent_uses field.
-    // Frequency tracking is not supported - keeps find_matches fully read-only.
 }
 
 impl Block {
@@ -109,9 +105,7 @@ impl CleanableNode for Block {
 ///
 /// # Limitations vs RadixTree
 ///
-/// - Does NOT support `expiration_duration` / frequency tracking
-/// - `new_with_frequency()` is not provided
-/// - `find_matches` does not populate `OverlapScores.frequencies`
+/// - Does not populate the legacy `OverlapScores.frequencies` field
 ///
 /// # Concurrency Model
 ///
@@ -179,7 +173,7 @@ impl ConcurrentRadixTree {
     /// ### Returns
     ///
     /// An `OverlapScores` representing the match scores.
-    /// Note: `frequencies` field will be empty since frequency tracking is not supported.
+    /// The legacy `frequencies` field is empty.
     pub fn find_matches_impl(
         &self,
         sequence: &[LocalBlockHash],

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/README.md
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/README.md
@@ -190,8 +190,6 @@ state and child pointers without taking `shape_gate` on the hot step, so it may
 observe adjacent tree shapes during a split and undercount. It must not panic or
 return a match past a valid reachable prefix.
 
-## Limitations Compared With `RadixTree`
+## Wire Compatibility
 
-- It does not support `expiration_duration` or frequency tracking.
-- It does not provide `new_with_frequency()`.
-- `find_matches` does not populate `OverlapScores.frequencies`.
+- `find_matches` leaves the legacy `OverlapScores.frequencies` field empty.

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/dump.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/dump.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::indexer::compressed_radix::append_dump_events;
 
 impl ConcurrentRadixTreeCompressed {
     // ------------------------------------------------------------------
@@ -64,46 +65,16 @@ impl ConcurrentRadixTreeCompressed {
                     break;
                 }
 
-                let full_blocks: Vec<KvCacheStoredBlockData> = merged_edge
-                    .iter()
-                    .map(|&(local, ext)| KvCacheStoredBlockData {
-                        tokens_hash: local,
-                        block_hash: ext,
-                        mm_extra_info: None,
-                    })
-                    .collect();
                 let last_ext = merged_edge.last().unwrap().1;
 
-                for worker in snapshot.full_edge_workers {
-                    events.push(RouterEvent::new(
-                        worker.worker_id,
-                        KvCacheEvent {
-                            event_id: *event_id,
-                            data: KvCacheEventData::Stored(KvCacheStoreData {
-                                parent_hash,
-                                start_position: None,
-                                blocks: full_blocks.clone(),
-                            }),
-                            dp_rank: worker.dp_rank,
-                        },
-                    ));
-                    *event_id += 1;
-                }
-                for (worker, cutoff) in snapshot.worker_cutoffs {
-                    events.push(RouterEvent::new(
-                        worker.worker_id,
-                        KvCacheEvent {
-                            event_id: *event_id,
-                            data: KvCacheEventData::Stored(KvCacheStoreData {
-                                parent_hash,
-                                start_position: None,
-                                blocks: full_blocks[..cutoff].to_vec(),
-                            }),
-                            dp_rank: worker.dp_rank,
-                        },
-                    ));
-                    *event_id += 1;
-                }
+                append_dump_events(
+                    events,
+                    event_id,
+                    parent_hash,
+                    &merged_edge,
+                    &snapshot.full_edge_workers,
+                    &snapshot.worker_cutoffs,
+                );
 
                 for child in snapshot.live_children {
                     queue.push_back((child, Some(last_ext)));

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -9,16 +9,10 @@ use parking_lot::RwLock;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use super::types::*;
+use crate::indexer::compressed_radix::{NodeState, RemoveOutcome};
 use crate::protocols::*;
 
-#[path = "node_state.rs"]
-mod node_state;
-use node_state::NodeState;
-
 type NodeChildren = DashMap<LocalBlockHash, SharedNode, FxBuildHasher>;
-pub(super) struct RemoveOutcome {
-    pub(super) stale_hashes: Vec<ExternalSequenceBlockHash>,
-}
 
 fn record_last_matched_hash(
     last_matched_hashes: &mut Option<&mut FxHashMap<WorkerWithDpRank, ExternalSequenceBlockHash>>,

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -78,6 +78,12 @@ impl ConcurrentRadixTreeCompressed {
             };
 
             loop {
+                // TODO(CORRECTNESS): Invalidate this worker throughout the descendant
+                // subtree when a mid-edge removal leaves the node alive for another
+                // worker. Otherwise stale descendants can be reused as store parents,
+                // reactivated by restoring only the removed block, or emitted by dumps
+                // without a valid worker-specific parent. Preserve CRTC's locking and
+                // snapshot guarantees when implementing the traversal.
                 match cur_node.remove_worker_for_hash(worker, block_hash) {
                     Some(outcome) => {
                         if let Some(wl) = lookup.get_mut(&worker) {

--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "bench")]
 use std::time::Instant;
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot};
@@ -192,15 +192,13 @@ impl KvIndexer {
     /// ### Arguments
     ///
     /// * `token` - A `CancellationToken` for managing shutdown.
-    /// * `expiration_duration` - The amount of time that block usage should be buffered.
     /// * `prune_config` - Optional TTL configuration for approximate-mode routing decisions.
     ///
     /// ### Returns
     ///
     /// A new `KvIndexer`.
-    pub fn new_with_frequency(
+    pub fn new_with_pruning(
         token: CancellationToken,
-        expiration_duration: Option<Duration>,
         kv_block_size: u32,
         metrics: Arc<KvIndexerMetrics>,
         prune_config: Option<PruneConfig>,
@@ -237,7 +235,7 @@ impl KvIndexer {
                     let mut get_workers_rx = get_workers_rx;
                     let mut dump_rx = dump_rx;
                     let mut flush_rx = flush_rx;
-                    let mut trie = RadixTree::new_with_frequency(expiration_duration);
+                    let mut trie = RadixTree::new();
 
                     let prune_manager = prune_config.map(WorkerPruneManager::new);
                     let mut prune_ready_rx = prune_manager.as_ref().map(|pm| pm.subscribe_ready());
@@ -410,7 +408,7 @@ impl KvIndexer {
         kv_block_size: u32,
         metrics: Arc<KvIndexerMetrics>,
     ) -> Self {
-        Self::new_with_frequency(token, None, kv_block_size, metrics, None)
+        Self::new_with_pruning(token, kv_block_size, metrics, None)
     }
 
     /// Get a sender for `RouterEvent`s.

--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "bench")]
 use std::time::Instant;
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot};
@@ -93,16 +93,25 @@ fn apply_routing_decision_with_prune_tracking(
 }
 
 fn apply_prune_removes(trie: &mut RadixTree, entries: Vec<BlockEntry>, event_id_counter: &mut u64) {
+    let mut entries_by_worker = BTreeMap::<WorkerWithDpRank, Vec<BlockEntry>>::new();
     for entry in entries {
+        entries_by_worker
+            .entry(entry.worker)
+            .or_default()
+            .push(entry);
+    }
+
+    for (worker, mut entries) in entries_by_worker {
+        entries.sort_unstable_by_key(|entry| entry.seq_position);
         *event_id_counter += 1;
         let event = RouterEvent::new(
-            entry.worker.worker_id,
+            worker.worker_id,
             KvCacheEvent {
                 event_id: *event_id_counter,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
-                    block_hashes: vec![entry.key],
+                    block_hashes: entries.into_iter().map(|entry| entry.key).collect(),
                 }),
-                dp_rank: entry.worker.dp_rank,
+                dp_rank: worker.dp_rank,
             },
         );
         let _ = trie.apply_event(event);

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -571,17 +571,32 @@ impl LocalKvIndexer {
 
     async fn build_fresh_dump(indexer: KvIndexer, last_event_id: u64) -> FreshDumpOutput {
         match indexer.dump_events().await {
-            Ok(events) => FreshDumpOutput {
-                response: WorkerKvQueryResponse::TreeDump {
-                    events: events.clone(),
+            Ok(events) => {
+                let represented_blocks = events
+                    .iter()
+                    .map(|event| match &event.event.data {
+                        KvCacheEventData::Stored(store) => store.blocks.len(),
+                        _ => 0,
+                    })
+                    .sum::<usize>();
+                tracing::info!(
+                    event_count = events.len(),
+                    represented_block_count = represented_blocks,
                     last_event_id,
-                },
-                snapshot: Some(CachedRecoverySnapshot {
-                    events: Arc::new(events),
-                    base_last_event_id: last_event_id,
-                    last_event_id,
-                }),
-            },
+                    "Built compressed radix recovery dump"
+                );
+                FreshDumpOutput {
+                    response: WorkerKvQueryResponse::TreeDump {
+                        events: events.clone(),
+                        last_event_id,
+                    },
+                    snapshot: Some(CachedRecoverySnapshot {
+                        events: Arc::new(events),
+                        base_last_event_id: last_event_id,
+                        last_event_id,
+                    }),
+                }
+            }
             Err(error) => {
                 tracing::warn!("Failed to build recovery dump: {error}");
                 FreshDumpOutput {

--- a/lib/kv-router/src/indexer/mod.rs
+++ b/lib/kv-router/src/indexer/mod.rs
@@ -32,6 +32,7 @@
 //! This module provides a scalable and efficient way to manage and retrieve data blocks for LLM inference, leveraging a global KV cache to optimize performance.
 
 mod branch_sharded;
+mod compressed_radix;
 mod shard_handle;
 
 use std::any::Any;

--- a/lib/kv-router/src/indexer/radix_tree.rs
+++ b/lib/kv-router/src/indexer/radix_tree.rs
@@ -7,7 +7,7 @@ use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
-use super::compressed_radix::NodeState;
+use super::compressed_radix::{NodeState, append_dump_events};
 use super::{EventWarningKind, MatchDetails, PreBoundEventCounters};
 use crate::protocols::*;
 
@@ -721,34 +721,16 @@ impl RadixTree {
                     break;
                 }
 
-                let blocks = merged_edge
-                    .iter()
-                    .map(|&(tokens_hash, block_hash)| KvCacheStoredBlockData {
-                        block_hash,
-                        tokens_hash,
-                        mm_extra_info: None,
-                    })
-                    .collect::<Vec<_>>();
                 let last_hash = merged_edge.last().unwrap().1;
 
-                for worker in full_workers {
-                    events.push(Self::dump_event(
-                        worker,
-                        event_id,
-                        parent_hash,
-                        blocks.clone(),
-                    ));
-                    event_id += 1;
-                }
-                for (worker, cutoff) in cutoffs {
-                    events.push(Self::dump_event(
-                        worker,
-                        event_id,
-                        parent_hash,
-                        blocks[..cutoff].to_vec(),
-                    ));
-                    event_id += 1;
-                }
+                append_dump_events(
+                    &mut events,
+                    &mut event_id,
+                    parent_hash,
+                    &merged_edge,
+                    &full_workers,
+                    &cutoffs,
+                );
                 for child in live_children {
                     queue.push_back((child, Some(last_hash)));
                 }
@@ -757,26 +739,6 @@ impl RadixTree {
         }
 
         events
-    }
-
-    fn dump_event(
-        worker: WorkerWithDpRank,
-        event_id: u64,
-        parent_hash: Option<ExternalSequenceBlockHash>,
-        blocks: Vec<KvCacheStoredBlockData>,
-    ) -> RouterEvent {
-        RouterEvent::new(
-            worker.worker_id,
-            KvCacheEvent {
-                event_id,
-                data: KvCacheEventData::Stored(KvCacheStoreData {
-                    parent_hash,
-                    start_position: None,
-                    blocks,
-                }),
-                dp_rank: worker.dp_rank,
-            },
-        )
     }
 
     pub fn current_size(&self) -> usize {
@@ -899,18 +861,21 @@ mod tests {
         );
 
         let mut uncompressed_events = Vec::new();
+        let mut uncompressed_event_id = 0;
         for event in &events {
             let KvCacheEventData::Stored(store) = &event.event.data else {
                 unreachable!();
             };
             let mut parent_hash = store.parent_hash;
             for block in &store.blocks {
-                uncompressed_events.push(RadixTree::dump_event(
-                    WorkerWithDpRank::new(event.worker_id, event.event.dp_rank),
-                    uncompressed_events.len() as u64,
+                append_dump_events(
+                    &mut uncompressed_events,
+                    &mut uncompressed_event_id,
                     parent_hash,
-                    vec![block.clone()],
-                ));
+                    &[(block.tokens_hash, block.block_hash)],
+                    &[WorkerWithDpRank::new(event.worker_id, event.event.dp_rank)],
+                    &[],
+                );
                 parent_hash = Some(block.block_hash);
             }
         }

--- a/lib/kv-router/src/indexer/radix_tree.rs
+++ b/lib/kv-router/src/indexer/radix_tree.rs
@@ -1,99 +1,54 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Radix Tree implementation for KV cache routing.
-//!
-//! This module provides a radix tree (prefix tree) data structure optimized for
-//! efficient KV cache block lookup and management in distributed LLM inference.
-//!
-//! # Overview
-//!
-//! The main components include:
-//!
-//! - **RadixTree**: The main data structure with nodes (`RadixBlock`) containing
-//!   children and associated worker IDs. Allows efficient storage and retrieval
-//!   of data blocks based on their hashes.
+//! Single-threaded compressed radix tree for KV cache routing.
 
-use std::{
-    cell::RefCell,
-    collections::VecDeque,
-    rc::Rc,
-    time::{Duration, Instant},
-};
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
+use super::compressed_radix::NodeState;
 use super::{EventWarningKind, MatchDetails, PreBoundEventCounters};
-use crate::active_set::reconcile_active_workers;
 use crate::protocols::*;
 
-/// A shared reference to a [`RadixBlock`].
 pub(crate) type SharedRadixBlock = Rc<RefCell<RadixBlock>>;
+type WorkerLookup = FxHashMap<ExternalSequenceBlockHash, SharedRadixBlock>;
 
-/// A block in the Radix Tree.
 #[derive(Debug)]
 pub(crate) struct RadixBlock {
-    /// A map of child blocks, keyed by their local block hash.
-    pub(crate) children: FxHashMap<LocalBlockHash, SharedRadixBlock>,
-    /// The set of workers that have this block cached.
-    pub(crate) workers: FxHashSet<WorkerWithDpRank>,
-    /// The external sequence block hash for this block (None for root).
-    /// This is the same for all workers under the simplifying assumption.
-    pub(crate) block_hash: Option<ExternalSequenceBlockHash>,
-    /// A buffer of times that this block was last traversed
-    pub(crate) recent_uses: VecDeque<Instant>,
+    state: NodeState,
+    children: FxHashMap<LocalBlockHash, SharedRadixBlock>,
+    /// Once a node has children it is never eligible for leaf extension again.
+    internal: bool,
 }
 
 impl RadixBlock {
-    /// Create a new `RadixBlock` (used for root node).
-    ///
-    /// ### Returns
-    ///
-    /// A new `RadixBlock` with no block_hash.
-    pub fn new() -> Self {
+    fn root() -> Self {
         Self {
+            state: NodeState::empty(),
             children: FxHashMap::default(),
-            workers: FxHashSet::default(),
-            block_hash: None,
-            recent_uses: VecDeque::new(),
+            internal: true,
         }
     }
 
-    /// Create a new `RadixBlock` with a specific block hash.
-    ///
-    /// ### Returns
-    ///
-    /// A new `RadixBlock` with the given block_hash.
-    pub fn with_hash(block_hash: ExternalSequenceBlockHash) -> Self {
+    fn for_blocks(blocks: &[KvCacheStoredBlockData], worker: WorkerWithDpRank) -> Self {
         Self {
+            state: NodeState::for_blocks(blocks, worker),
             children: FxHashMap::default(),
-            workers: FxHashSet::default(),
-            block_hash: Some(block_hash),
-            recent_uses: VecDeque::new(),
+            internal: false,
         }
     }
 
-    #[inline]
-    fn drop_worker(&mut self, worker: WorkerWithDpRank) {
-        self.workers.remove(&worker);
-        if self.workers.is_empty() {
+    fn clear_children_if_unreachable(&mut self) {
+        if self.state.full_edge_workers.is_empty() {
             self.children.clear();
         }
     }
 }
 
 pub struct RadixTree {
-    /// This is the root of the radix/prefix tree
-    /// This will only contain root blocks
-    pub(crate) root: SharedRadixBlock,
-
-    /// Per-worker lookup table for O(1) block access.
-    /// Maps worker -> (block_hash -> block).
-    pub(crate) lookup:
-        FxHashMap<WorkerWithDpRank, FxHashMap<ExternalSequenceBlockHash, SharedRadixBlock>>,
-
-    /// The time buffer the radix tree should check when considering frequence of block accesses
-    pub(crate) expiration_duration: Option<Duration>,
+    root: SharedRadixBlock,
+    lookup: FxHashMap<WorkerWithDpRank, WorkerLookup>,
 }
 
 impl Default for RadixTree {
@@ -102,228 +57,150 @@ impl Default for RadixTree {
     }
 }
 
-// Dropping Radix blocks can cause a cascade of drops that can overflow the stack.
-// This custom drop implementation avoids this using an iterative approach.
 impl Drop for RadixTree {
     fn drop(&mut self) {
-        let mut stack: Vec<SharedRadixBlock> = Vec::new();
-        // Break root -> children edge up front
-        {
-            let mut root = self.root.borrow_mut();
-            stack.extend(root.children.drain().map(|(_, v)| v));
+        let mut stack = self
+            .root
+            .borrow_mut()
+            .children
+            .drain()
+            .map(|(_, child)| child)
+            .collect::<Vec<_>>();
+        for (_, worker_lookup) in self.lookup.drain() {
+            stack.extend(worker_lookup.into_values());
         }
 
-        // Remove all lookup references (they may include blocks not reachable from root)
-        for (_, worker_blocks) in self.lookup.drain() {
-            stack.extend(worker_blocks.into_values());
-        }
-
-        // Iteratively free any uniquely-owned blocks without recursion
         while let Some(block) = stack.pop() {
-            match Rc::try_unwrap(block) {
-                Ok(cell) => {
-                    // We own the cell, so we can take inner and it will drop after this block.
-                    let mut inner: RadixBlock = cell.into_inner();
-                    stack.extend(inner.children.drain().map(|(_, v)| v));
-                }
-                Err(rc) => {
-                    // We don't own the cell, just call drop on it.
-                    drop(rc);
-                }
+            if let Ok(cell) = Rc::try_unwrap(block) {
+                stack.extend(cell.into_inner().children.into_values());
             }
         }
     }
 }
 
 impl RadixTree {
-    /// Create a new `RadixTree`.
-    ///
-    /// ### Returns
-    ///
-    /// A new `RadixTree`.
-    pub fn new_with_frequency(expiration_duration: Option<Duration>) -> Self {
+    pub fn new() -> Self {
         Self {
-            root: Rc::new(RefCell::new(RadixBlock::new())),
+            root: Rc::new(RefCell::new(RadixBlock::root())),
             lookup: FxHashMap::default(),
-            expiration_duration,
         }
     }
 
-    pub fn new() -> Self {
-        Self::new_with_frequency(None)
-    }
-
-    /// Traverse the radix tree to find the best match for a given sequence of [`LocalBlockHash`]es.
-    ///
-    /// ### Arguments
-    ///
-    /// * `sequence` - A vector of `LocalBlockHash` representing the sequence to match.
-    /// * `early_exit` - A boolean indicating whether to exit early if a single match is found.
-    ///
-    /// ### Returns
-    ///
-    /// A `MatchDetails` representing overlap scores plus continuation state.
     pub fn find_match_details(
         &self,
         sequence: Vec<LocalBlockHash>,
         early_exit: bool,
     ) -> MatchDetails {
         let mut details = MatchDetails::new();
-        let MatchDetails {
-            overlap_scores: scores,
-            last_matched_hashes,
-        } = &mut details;
-
         if sequence.is_empty() {
             return details;
         }
 
-        let now = Instant::now();
+        let mut next = self.root.borrow().children.get(&sequence[0]).cloned();
+        let mut active = FxHashSet::default();
+        let mut matched_depth = 0usize;
+        let mut seq_pos = 0usize;
+        let mut first_node = true;
+        let mut last_matched_hash = None;
 
-        tracing::trace!(
-            "RadixTree::find_matches: looking for sequence={:?}",
-            sequence.iter().map(|h| h.0).collect::<Vec<_>>()
-        );
-
-        // Get first child from root.
-        let first_child = {
-            let current_borrow = self.root.borrow();
-            current_borrow.children.get(&sequence[0]).cloned()
-        };
-
-        let Some(first_child) = first_child else {
-            return details;
-        };
-
-        // Initialize active worker set from first child.
-        let (mut active, mut active_count) = {
-            let borrow = first_child.borrow();
-            (borrow.workers.clone(), borrow.workers.len())
-        };
-
-        // Frequency tracking for first child.
-        if let Some(expiration_duration) = self.expiration_duration {
-            let mut block_mut = first_child.borrow_mut();
-            while let Some(access_time) = block_mut.recent_uses.front() {
-                if now.duration_since(*access_time) > expiration_duration {
-                    block_mut.recent_uses.pop_front();
-                } else {
-                    break;
-                }
-            }
-            scores.add_frequency(block_mut.recent_uses.len());
-            block_mut.recent_uses.push_back(now);
-        }
-
-        if active.is_empty() {
-            return details;
-        }
-
-        let mut current_hash = first_child
-            .borrow()
-            .block_hash
-            .expect("matched radix node must have a block hash");
-
-        if early_exit && active_count == 1 {
-            for worker in &active {
-                scores.scores.insert(*worker, 1);
-                last_matched_hashes.insert(*worker, current_hash);
-            }
-            return details;
-        }
-
-        let mut current = first_child;
-        let mut matched_depth = 1u32;
-
-        // Traverse remaining levels. In a clean tree, workers at a child node
-        // are always a subset of the parent (along the same path), so:
-        //   - workers can only drop out, never join, as we descend
-        //   - if child.workers.len() == active_count, the sets are identical
-        //
-        // However, because apply_event(Removed) does NOT cascade to descendants,
-        // a child may transiently have MORE workers than its parent (stale
-        // entries from an ancestor remove whose descendant remove events
-        // haven't arrived yet). We detect this via child_count > active_count
-        // and fall back to a full membership check.
-        for (idx, item) in sequence.iter().enumerate().skip(1) {
-            let next_block = {
-                let current_borrow = current.borrow();
-                current_borrow.children.get(item).cloned()
-            };
-
-            let Some(block) = next_block else {
+        while seq_pos < sequence.len() {
+            let Some(node) = next.take() else {
                 break;
             };
+            let node = node.borrow();
+            let walk_len = node.state.edge.len().min(sequence.len() - seq_pos);
+            let edge_match_len = node
+                .state
+                .edge
+                .iter()
+                .take(walk_len)
+                .zip(&sequence[seq_pos..])
+                .take_while(|((local_hash, _), query_hash)| local_hash == *query_hash)
+                .count();
 
-            {
-                let borrow = block.borrow();
-                let child_count = borrow.workers.len();
-
-                if child_count != active_count {
-                    reconcile_active_workers(&mut active, &borrow.workers, |worker| {
-                        scores.scores.insert(worker, matched_depth);
-                        last_matched_hashes.insert(worker, current_hash);
-                    });
-                    active_count = active.len();
-                }
+            if edge_match_len == 0 {
+                break;
             }
 
-            // Frequency tracking (always runs when enabled, independent of dropout).
-            if let Some(expiration_duration) = self.expiration_duration {
-                let mut block_mut = block.borrow_mut();
-                while let Some(access_time) = block_mut.recent_uses.front() {
-                    if now.duration_since(*access_time) > expiration_duration {
-                        block_mut.recent_uses.pop_front();
-                    } else {
-                        break;
+            if first_node {
+                active.clone_from(&node.state.full_edge_workers);
+                for (&worker, &cutoff) in &node.state.worker_cutoffs {
+                    let contribution = cutoff.min(edge_match_len);
+                    if contribution == 0 {
+                        continue;
                     }
+                    details
+                        .overlap_scores
+                        .scores
+                        .insert(worker, contribution as u32);
+                    details
+                        .last_matched_hashes
+                        .insert(worker, node.state.edge[contribution - 1].1);
                 }
-                scores.add_frequency(block_mut.recent_uses.len());
-                block_mut.recent_uses.push_back(now);
+                first_node = false;
+            } else {
+                active.retain(|worker| {
+                    if node.state.full_edge_workers.contains(worker) {
+                        return true;
+                    }
+
+                    if let Some(&cutoff) = node.state.worker_cutoffs.get(worker) {
+                        let contribution = cutoff.min(edge_match_len);
+                        details
+                            .overlap_scores
+                            .scores
+                            .insert(*worker, (matched_depth + contribution) as u32);
+                        let hash = if contribution > 0 {
+                            node.state.edge[contribution - 1].1
+                        } else {
+                            last_matched_hash.expect("non-root match must have a prior hash")
+                        };
+                        details.last_matched_hashes.insert(*worker, hash);
+                    } else {
+                        details
+                            .overlap_scores
+                            .scores
+                            .insert(*worker, matched_depth as u32);
+                        if let Some(hash) = last_matched_hash {
+                            details.last_matched_hashes.insert(*worker, hash);
+                        }
+                    }
+                    false
+                });
             }
 
-            if active_count == 0 {
+            matched_depth += edge_match_len;
+            last_matched_hash = Some(node.state.edge[edge_match_len - 1].1);
+
+            if active.is_empty()
+                || edge_match_len < node.state.edge.len()
+                || matched_depth == sequence.len()
+                || (early_exit && active.len() == 1)
+            {
                 break;
             }
 
-            if early_exit && active_count == 1 {
-                matched_depth = (idx + 1) as u32;
-                current_hash = block
-                    .borrow()
-                    .block_hash
-                    .expect("matched radix node must have a block hash");
-                break;
+            seq_pos += edge_match_len;
+            next = node.children.get(&sequence[seq_pos]).cloned();
+        }
+
+        for worker in active {
+            details
+                .overlap_scores
+                .scores
+                .insert(worker, matched_depth as u32);
+            if let Some(hash) = last_matched_hash {
+                details.last_matched_hashes.insert(worker, hash);
             }
-
-            current_hash = block
-                .borrow()
-                .block_hash
-                .expect("matched radix node must have a block hash");
-            current = block;
-            matched_depth = (idx + 1) as u32;
         }
-
-        // Record scores for workers that survived through the deepest matched level.
-        for worker in &active {
-            scores.scores.insert(*worker, matched_depth);
-            last_matched_hashes.insert(*worker, current_hash);
-        }
-
-        tracing::trace!("RadixTree::find_matches: final scores={:?}", scores.scores);
 
         details
     }
 
-    /// An `OverlapScores` representing the match scores.
     pub fn find_matches(&self, sequence: Vec<LocalBlockHash>, early_exit: bool) -> OverlapScores {
         self.find_match_details(sequence, early_exit).overlap_scores
     }
 
-    /// Apply a [`RouterEvent`] to the radix tree.
-    ///
-    /// ### Arguments
-    ///
-    /// * `event` - The `RouterEvent` to apply.
     pub fn apply_event(&mut self, event: RouterEvent) -> Result<(), KvCacheEventError> {
         self.apply_event_with_counters(event, None)
     }
@@ -333,146 +210,13 @@ impl RadixTree {
         event: RouterEvent,
         counters: Option<&PreBoundEventCounters>,
     ) -> Result<(), KvCacheEventError> {
-        let (worker_id, kv_event) = (event.worker_id, event.event);
-        let (id, op) = (kv_event.event_id, kv_event.data);
+        let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
+        let event_id = event.event.event_id;
+        self.lookup.entry(worker).or_default();
 
-        // Construct WorkerWithDpRank from worker_id and dp_rank from the event
-        let worker = WorkerWithDpRank::new(worker_id, kv_event.dp_rank);
-
-        tracing::trace!(id, "RadixTree::apply_event: Store operation: {:?}", op);
-
-        let worker_lookup = self.lookup.entry(worker).or_default();
-
-        match op {
-            KvCacheEventData::Stored(op) => {
-                // find the parent block from this worker's lookup
-                let mut current = match op.parent_hash {
-                    Some(parent) => match worker_lookup.get(&parent) {
-                        Some(current) => current.clone(),
-                        None => {
-                            tracing::warn!(
-                                worker_id = worker.worker_id.to_string(),
-                                dp_rank = worker.dp_rank,
-                                id,
-                                parent_hash = ?op.parent_hash,
-                                num_blocks = op.blocks.len(),
-                                "Failed to find parent block; skipping store operation"
-                            );
-                            return Err(KvCacheEventError::ParentBlockNotFound);
-                        }
-                    },
-                    None => self.root.clone(),
-                };
-
-                let mut needs_worker_insert = false;
-                let mut duplicate_store = !op.blocks.is_empty();
-
-                // In each iteration we lock the parent and insert the worker
-                // deferred from the previous iteration, avoiding a second
-                // borrow on the same block.
-                for block_data in op.blocks {
-                    let mut parent_mut = current.borrow_mut();
-
-                    if needs_worker_insert && parent_mut.workers.insert(worker) {
-                        duplicate_store = false;
-                    }
-                    needs_worker_insert = true;
-
-                    let child = match parent_mut.children.get(&block_data.tokens_hash) {
-                        Some(block) => {
-                            // Verify our simplifying assumption: block_hash is uniform across workers
-                            if block.borrow().block_hash != Some(block_data.block_hash) {
-                                duplicate_store = false;
-                                tracing::warn!(
-                                    expected = ?block_data.block_hash,
-                                    actual = ?block.borrow().block_hash,
-                                    "block_hash mismatch: sequence hashes should be uniform across workers"
-                                );
-                            }
-                            block.clone()
-                        }
-                        None => {
-                            duplicate_store = false;
-                            let new_block = worker_lookup
-                                .get(&block_data.block_hash)
-                                .cloned()
-                                .unwrap_or_else(|| {
-                                    Rc::new(RefCell::new(RadixBlock::with_hash(
-                                        block_data.block_hash,
-                                    )))
-                                });
-
-                            parent_mut
-                                .children
-                                .insert(block_data.tokens_hash, new_block.clone());
-
-                            new_block
-                        }
-                    };
-
-                    // Self-reference check: try_borrow_mut will fail if child
-                    // is the same Rc as current (parent_mut holds a mutable borrow).
-                    if child.try_borrow_mut().is_err() {
-                        tracing::warn!(
-                            worker_id = worker.worker_id.to_string(),
-                            dp_rank = worker.dp_rank,
-                            id,
-                            block_hash = ?block_data.block_hash,
-                            "Detected self referencing block in store event; rejecting sequence"
-                        );
-                        return Err(KvCacheEventError::InvalidBlockSequence);
-                    }
-
-                    match worker_lookup.insert(block_data.block_hash, child.clone()) {
-                        Some(existing) if Rc::ptr_eq(&existing, &child) => {}
-                        _ => duplicate_store = false,
-                    }
-
-                    drop(parent_mut);
-                    current = child;
-                }
-
-                // Insert worker into the last child.
-                if needs_worker_insert && current.borrow_mut().workers.insert(worker) {
-                    duplicate_store = false;
-                }
-
-                if duplicate_store && let Some(counters) = counters {
-                    counters.inc_warning(EventWarningKind::DuplicateStore);
-                }
-
-                Ok(())
-            }
-            KvCacheEventData::Removed(remove) => {
-                let mut kv_cache_err: Option<KvCacheEventError> = None;
-                for block in remove.block_hashes {
-                    // lookup block in worker's table
-                    let entry = match worker_lookup.get(&block) {
-                        Some(entry) => entry.clone(),
-                        None => {
-                            tracing::warn!(
-                                worker_id = worker.worker_id.to_string(),
-                                dp_rank = worker.dp_rank,
-                                id,
-                                block_hash = ?block,
-                                "Failed to find block to remove; skipping remove operation"
-                            );
-                            // Kv cache removed events may be batched; we should try to apply all
-                            // operations in the batch before returning an error. Return the first
-                            // error.
-                            if kv_cache_err.is_none() {
-                                kv_cache_err = Some(KvCacheEventError::BlockNotFound);
-                            }
-                            continue;
-                        }
-                    };
-
-                    entry.borrow_mut().drop_worker(worker);
-                    // remove the block from the worker's lookup table
-                    worker_lookup.remove(&block);
-                }
-                kv_cache_err.map_or(Ok(()), Err)
-            }
+        match event.event.data {
+            KvCacheEventData::Stored(store) => self.apply_stored(worker, store, event_id, counters),
+            KvCacheEventData::Removed(remove) => self.apply_removed(worker, remove, event_id),
             KvCacheEventData::Cleared => {
                 self.clear_all_blocks(worker.worker_id);
                 Ok(())
@@ -480,28 +224,396 @@ impl RadixTree {
         }
     }
 
-    /// Helper function to remove or clear blocks for a worker.
-    /// If `keep_worker` is true, the worker remains in lookup with empty blocks.
-    /// If `keep_worker` is false, the worker is completely removed from lookup.
+    fn apply_stored(
+        &mut self,
+        worker: WorkerWithDpRank,
+        store: KvCacheStoreData,
+        event_id: u64,
+        counters: Option<&PreBoundEventCounters>,
+    ) -> Result<(), KvCacheEventError> {
+        if let Some(parent_hash) = store.parent_hash
+            && store
+                .blocks
+                .iter()
+                .any(|block| block.block_hash == parent_hash)
+        {
+            tracing::warn!(
+                worker_id = worker.worker_id,
+                dp_rank = worker.dp_rank,
+                event_id,
+                ?parent_hash,
+                "Detected self-referencing store event"
+            );
+            return Err(KvCacheEventError::InvalidBlockSequence);
+        }
+
+        let mut duplicate_store = !store.blocks.is_empty();
+        let mut parent = match store.parent_hash {
+            Some(parent_hash) => {
+                let Some(node) = self.lookup[&worker].get(&parent_hash).cloned() else {
+                    self.log_missing_parent(worker, event_id, &store);
+                    return Err(KvCacheEventError::ParentBlockNotFound);
+                };
+                let parent_pos = {
+                    let node_ref = node.borrow();
+                    let Some(&pos) = node_ref.state.edge_index.get(&parent_hash) else {
+                        self.log_missing_parent(worker, event_id, &store);
+                        return Err(KvCacheEventError::ParentBlockNotFound);
+                    };
+                    if !node_ref.state.covers_pos(worker, pos) {
+                        self.lookup.get_mut(&worker).unwrap().remove(&parent_hash);
+                        self.log_missing_parent(worker, event_id, &store);
+                        return Err(KvCacheEventError::ParentBlockNotFound);
+                    }
+                    pos
+                };
+
+                if let Some(done_duplicate) =
+                    self.try_reuse_parent_edge(worker, &node, parent_pos, &store.blocks)
+                {
+                    duplicate_store &= done_duplicate;
+                    if duplicate_store && let Some(counters) = counters {
+                        counters.inc_warning(EventWarningKind::DuplicateStore);
+                    }
+                    return Ok(());
+                }
+
+                if !node.borrow().state.tail_hash_is(parent_hash) {
+                    self.split_node(&node, parent_pos + 1);
+                }
+                node
+            }
+            None => self.root.clone(),
+        };
+
+        let mut remaining = store.blocks.as_slice();
+        while !remaining.is_empty() {
+            let first_local = remaining[0].tokens_hash;
+            let child = parent.borrow().children.get(&first_local).cloned();
+
+            let Some(child) = child else {
+                let can_extend = {
+                    let parent_ref = parent.borrow();
+                    !parent_ref.state.edge.is_empty()
+                        && !parent_ref.internal
+                        && parent_ref
+                            .state
+                            .covers_pos(worker, parent_ref.state.edge.len() - 1)
+                };
+                if can_extend {
+                    parent
+                        .borrow_mut()
+                        .state
+                        .append_blocks_to_leaf(worker, remaining);
+                    self.update_lookup_for_blocks(worker, remaining, &parent);
+                    duplicate_store = false;
+                    break;
+                }
+
+                let child = Rc::new(RefCell::new(RadixBlock::for_blocks(remaining, worker)));
+                {
+                    let mut parent_ref = parent.borrow_mut();
+                    parent_ref.internal = true;
+                    parent_ref.children.insert(first_local, child.clone());
+                }
+                self.update_lookup_for_blocks(worker, remaining, &child);
+                duplicate_store = false;
+                break;
+            };
+
+            let (edge_len, match_len, mismatch) = {
+                let child_ref = child.borrow();
+                let edge_len = child_ref.state.edge.len();
+                let mut mismatch = None;
+                let match_len = child_ref
+                    .state
+                    .edge
+                    .iter()
+                    .zip(remaining)
+                    .take_while(|((local_hash, existing_hash), block)| {
+                        if local_hash != &block.tokens_hash {
+                            return false;
+                        }
+                        if existing_hash != &block.block_hash && mismatch.is_none() {
+                            mismatch = Some((block.block_hash, *existing_hash));
+                        }
+                        true
+                    })
+                    .count();
+                (edge_len, match_len, mismatch)
+            };
+
+            if let Some((expected, actual)) = mismatch {
+                duplicate_store = false;
+                tracing::warn!(
+                    ?expected,
+                    ?actual,
+                    "block_hash mismatch: sequence hashes should be uniform across workers"
+                );
+            }
+
+            if match_len < edge_len {
+                if match_len == remaining.len() {
+                    let changed = child
+                        .borrow_mut()
+                        .state
+                        .cover_prefix_for_worker(worker, match_len);
+                    duplicate_store &= !changed;
+                    duplicate_store &= !self.update_lookup_for_blocks(worker, remaining, &child);
+                    break;
+                }
+
+                self.split_node(&child, match_len);
+                child.borrow_mut().state.promote_to_full(worker);
+                self.update_lookup_for_blocks(worker, &remaining[..match_len], &child);
+
+                let tail = &remaining[match_len..];
+                let tail_node = Rc::new(RefCell::new(RadixBlock::for_blocks(tail, worker)));
+                {
+                    let mut child_ref = child.borrow_mut();
+                    child_ref.internal = true;
+                    child_ref
+                        .children
+                        .insert(tail[0].tokens_hash, tail_node.clone());
+                }
+                self.update_lookup_for_blocks(worker, tail, &tail_node);
+                duplicate_store = false;
+                break;
+            }
+
+            if child.borrow_mut().state.promote_to_full(worker) {
+                duplicate_store = false;
+            }
+            if self.update_lookup_for_blocks(worker, &remaining[..edge_len], &child) {
+                duplicate_store = false;
+            }
+            remaining = &remaining[edge_len..];
+            parent = child;
+        }
+
+        if duplicate_store && let Some(counters) = counters {
+            counters.inc_warning(EventWarningKind::DuplicateStore);
+        }
+        Ok(())
+    }
+
+    fn try_reuse_parent_edge(
+        &mut self,
+        worker: WorkerWithDpRank,
+        node: &SharedRadixBlock,
+        parent_pos: usize,
+        blocks: &[KvCacheStoredBlockData],
+    ) -> Option<bool> {
+        let (reuse_cutoff, append_start) = {
+            let node_ref = node.borrow();
+            if node_ref.state.suffix_matches_store(parent_pos, blocks) {
+                (Some(parent_pos + 1 + blocks.len()), None)
+            } else if !node_ref.internal {
+                (
+                    None,
+                    node_ref.state.store_starts_with_suffix(parent_pos, blocks),
+                )
+            } else {
+                (None, None)
+            }
+        };
+
+        if let Some(cutoff) = reuse_cutoff {
+            let changed = node
+                .borrow_mut()
+                .state
+                .cover_prefix_for_worker(worker, cutoff);
+            let lookup_changed = self.update_lookup_for_blocks(worker, blocks, node);
+            return Some(!changed && !lookup_changed);
+        }
+
+        if let Some(append_start) = append_start {
+            node.borrow_mut()
+                .state
+                .append_blocks_to_leaf(worker, &blocks[append_start..]);
+            self.update_lookup_for_blocks(worker, blocks, node);
+            return Some(false);
+        }
+
+        None
+    }
+
+    fn split_node(&mut self, node: &SharedRadixBlock, pos: usize) {
+        let suffix = {
+            let mut node_ref = node.borrow_mut();
+            debug_assert!(pos > 0 && pos < node_ref.state.edge.len());
+
+            let suffix_edge = node_ref.state.edge.split_off(pos);
+            let suffix_first_local = suffix_edge[0].0;
+            for &(_, hash) in &suffix_edge {
+                node_ref.state.edge_index.remove(&hash);
+            }
+
+            let mut suffix_full = FxHashSet::with_capacity_and_hasher(
+                node_ref.state.full_edge_workers.len(),
+                FxBuildHasher,
+            );
+            suffix_full.extend(node_ref.state.full_edge_workers.iter().copied());
+            let mut suffix_cutoffs = FxHashMap::with_capacity_and_hasher(
+                node_ref.state.worker_cutoffs.len(),
+                FxBuildHasher,
+            );
+            let mut promote_prefix = Vec::new();
+            for (&worker, &cutoff) in &node_ref.state.worker_cutoffs {
+                if cutoff < pos {
+                    continue;
+                }
+                promote_prefix.push(worker);
+                let suffix_cutoff = cutoff - pos;
+                if suffix_cutoff > 0 {
+                    suffix_cutoffs.insert(worker, suffix_cutoff);
+                }
+            }
+            for worker in promote_prefix {
+                node_ref.state.worker_cutoffs.remove(&worker);
+                node_ref.state.full_edge_workers.insert(worker);
+            }
+
+            let suffix = Rc::new(RefCell::new(RadixBlock {
+                state: NodeState {
+                    edge_index: NodeState::edge_index_for(&suffix_edge),
+                    edge: suffix_edge,
+                    worker_cutoffs: suffix_cutoffs,
+                    full_edge_workers: suffix_full,
+                },
+                children: std::mem::take(&mut node_ref.children),
+                internal: node_ref.internal,
+            }));
+            node_ref.children.insert(suffix_first_local, suffix.clone());
+            node_ref.internal = true;
+            suffix
+        };
+
+        let suffix_ref = suffix.borrow();
+        for &worker in &suffix_ref.state.full_edge_workers {
+            let blocks = suffix_ref.state.edge.iter().map(|&(_, hash)| hash);
+            let lookup = self.lookup.get_mut(&worker).unwrap();
+            for hash in blocks {
+                lookup.insert(hash, suffix.clone());
+            }
+        }
+        for (&worker, &cutoff) in &suffix_ref.state.worker_cutoffs {
+            let lookup = self.lookup.get_mut(&worker).unwrap();
+            for &(_, hash) in &suffix_ref.state.edge[..cutoff] {
+                lookup.insert(hash, suffix.clone());
+            }
+        }
+    }
+
+    fn update_lookup_for_blocks(
+        &mut self,
+        worker: WorkerWithDpRank,
+        blocks: &[KvCacheStoredBlockData],
+        node: &SharedRadixBlock,
+    ) -> bool {
+        let lookup = self.lookup.get_mut(&worker).unwrap();
+        let mut changed = false;
+        for block in blocks {
+            match lookup.insert(block.block_hash, node.clone()) {
+                Some(existing) if Rc::ptr_eq(&existing, node) => {}
+                _ => changed = true,
+            }
+        }
+        changed
+    }
+
+    fn log_missing_parent(
+        &self,
+        worker: WorkerWithDpRank,
+        event_id: u64,
+        store: &KvCacheStoreData,
+    ) {
+        tracing::warn!(
+            worker_id = worker.worker_id,
+            dp_rank = worker.dp_rank,
+            event_id,
+            parent_hash = ?store.parent_hash,
+            num_blocks = store.blocks.len(),
+            "Failed to find parent block; skipping store operation"
+        );
+    }
+
+    fn apply_removed(
+        &mut self,
+        worker: WorkerWithDpRank,
+        remove: KvCacheRemoveData,
+        event_id: u64,
+    ) -> Result<(), KvCacheEventError> {
+        if !self.lookup.contains_key(&worker) {
+            return Err(KvCacheEventError::BlockNotFound);
+        }
+        let mut first_error = None;
+        let mut eagerly_removed = FxHashSet::default();
+
+        for block_hash in remove.block_hashes {
+            let Some(node) = self
+                .lookup
+                .get(&worker)
+                .and_then(|lookup| lookup.get(&block_hash))
+                .cloned()
+            else {
+                if eagerly_removed.contains(&block_hash) {
+                    continue;
+                }
+                tracing::warn!(
+                    worker_id = worker.worker_id,
+                    dp_rank = worker.dp_rank,
+                    event_id,
+                    ?block_hash,
+                    "Failed to find block to remove; skipping remove operation"
+                );
+                first_error.get_or_insert(KvCacheEventError::BlockNotFound);
+                continue;
+            };
+
+            let outcome = {
+                let mut node_ref = node.borrow_mut();
+                let Some(&pos) = node_ref.state.edge_index.get(&block_hash) else {
+                    first_error.get_or_insert(KvCacheEventError::BlockNotFound);
+                    continue;
+                };
+                let outcome = node_ref.state.remove_worker_at_pos(worker, pos, block_hash);
+                node_ref.clear_children_if_unreachable();
+                outcome
+            };
+            let lookup = self.lookup.get_mut(&worker).unwrap();
+            for stale_hash in outcome.stale_hashes {
+                lookup.remove(&stale_hash);
+                eagerly_removed.insert(stale_hash);
+            }
+        }
+
+        first_error.map_or(Ok(()), Err)
+    }
+
     fn remove_or_clear_worker_blocks(&mut self, worker_id: WorkerId, keep_worker: bool) {
-        // Collect all WorkerWithDpRank keys that match this worker_id
-        let workers: Vec<WorkerWithDpRank> = self
+        let workers = self
             .lookup
             .keys()
-            .filter(|w| w.worker_id == worker_id)
+            .filter(|worker| worker.worker_id == worker_id)
             .copied()
-            .collect();
+            .collect::<Vec<_>>();
 
         for worker in workers {
-            if let Some((worker_key, blocks)) = self.lookup.remove_entry(&worker) {
-                for (_, block) in blocks {
-                    block.borrow_mut().drop_worker(worker);
+            let Some((worker_key, blocks)) = self.lookup.remove_entry(&worker) else {
+                continue;
+            };
+            let mut seen = FxHashSet::default();
+            for node in blocks.into_values() {
+                if !seen.insert(Rc::as_ptr(&node)) {
+                    continue;
                 }
-
-                if keep_worker {
-                    // Re-insert worker with empty blocks map to keep it tracked
-                    self.lookup.insert(worker_key, FxHashMap::default());
-                }
+                let mut node_ref = node.borrow_mut();
+                node_ref.state.drop_worker(worker);
+                node_ref.clear_children_if_unreachable();
+            }
+            if keep_worker {
+                self.lookup.insert(worker_key, FxHashMap::default());
             }
         }
     }
@@ -511,11 +623,18 @@ impl RadixTree {
     }
 
     pub fn remove_worker_dp_rank(&mut self, worker_id: WorkerId, dp_rank: DpRank) {
-        let key = WorkerWithDpRank { worker_id, dp_rank };
-        if let Some(blocks) = self.lookup.remove(&key) {
-            for (_, block) in blocks {
-                block.borrow_mut().drop_worker(key);
+        let worker = WorkerWithDpRank { worker_id, dp_rank };
+        let Some(blocks) = self.lookup.remove(&worker) else {
+            return;
+        };
+        let mut seen = FxHashSet::default();
+        for node in blocks.into_values() {
+            if !seen.insert(Rc::as_ptr(&node)) {
+                continue;
             }
+            let mut node_ref = node.borrow_mut();
+            node_ref.state.drop_worker(worker);
+            node_ref.clear_children_if_unreachable();
         }
     }
 
@@ -523,674 +642,285 @@ impl RadixTree {
         self.remove_or_clear_worker_blocks(worker_id, true);
     }
 
-    /// Get all worker IDs currently tracked in the radix tree.
-    /// Returns unique worker_ids (ignoring dp_rank differences).
     pub fn get_workers(&self) -> Vec<WorkerId> {
-        let mut worker_ids: Vec<WorkerId> = self.lookup.keys().map(|w| w.worker_id).collect();
-        worker_ids.sort_unstable();
-        worker_ids.dedup();
-        worker_ids
+        let mut workers = self
+            .lookup
+            .keys()
+            .map(|worker| worker.worker_id)
+            .collect::<Vec<_>>();
+        workers.sort_unstable();
+        workers.dedup();
+        workers
     }
 
-    /// Dump the radix tree as a series of RouterEvents that can reconstruct the tree.
-    /// Uses BFS traversal to ensure that the tree reconstruction is unique,
-    /// though the exact event ordering will be lost.
     pub fn dump_tree_as_events(&self) -> Vec<RouterEvent> {
-        tracing::debug!(
-            "Dumping radix tree as events (contains information about {:?} workers)",
-            self.lookup.len()
-        );
-
         let mut events = Vec::new();
         let mut event_id = 0u64;
+        let mut queue = self
+            .root
+            .borrow()
+            .children
+            .values()
+            .cloned()
+            .map(|node| (node, None))
+            .collect::<VecDeque<_>>();
 
-        // Queue entries: (current_block, parent_hash, tokens_hash)
-        let mut queue = VecDeque::new();
+        while let Some((start_node, parent_hash)) = queue.pop_front() {
+            let mut merged_edge = Vec::new();
+            let mut current = start_node;
 
-        // Process root's children first
-        let root_borrow = self.root.borrow();
-        for (tokens_hash, child_block) in &root_borrow.children {
-            queue.push_back((child_block.clone(), None, *tokens_hash));
-        }
-        drop(root_borrow);
-
-        while let Some((current_block, parent_hash, tokens_hash)) = queue.pop_front() {
-            let current_borrow = current_block.borrow();
-
-            // Get this block's hash (same for all workers)
-            let block_hash = current_borrow
-                .block_hash
-                .expect("non-root block must have block_hash");
-
-            // For each worker that has this block
-            for worker in &current_borrow.workers {
-                // Create a store event for this worker
-                let event = RouterEvent {
-                    worker_id: worker.worker_id,
-                    storage_tier: crate::protocols::StorageTier::Device,
-                    event: KvCacheEvent {
-                        event_id,
-                        data: KvCacheEventData::Stored(KvCacheStoreData {
-                            parent_hash,
-                            start_position: None,
-                            blocks: vec![KvCacheStoredBlockData {
-                                block_hash,
-                                mm_extra_info: None,
-                                tokens_hash,
-                            }],
-                        }),
-                        dp_rank: worker.dp_rank,
-                    },
+            loop {
+                let (full_workers, cutoffs, live_children, can_merge) = {
+                    let node = current.borrow();
+                    if !node.state.has_any_workers() && node.children.is_empty() {
+                        break;
+                    }
+                    merged_edge.extend_from_slice(&node.state.edge);
+                    let live_children = node
+                        .children
+                        .values()
+                        .filter(|child| {
+                            let child = child.borrow();
+                            child.state.has_any_workers() || !child.children.is_empty()
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    let can_merge =
+                        node.state.worker_cutoffs.is_empty() && live_children.len() == 1 && {
+                            let child = live_children[0].borrow();
+                            child.state.worker_cutoffs.is_empty()
+                                && child.state.full_edge_workers == node.state.full_edge_workers
+                                && child.state.has_any_workers()
+                        };
+                    (
+                        node.state
+                            .full_edge_workers
+                            .iter()
+                            .copied()
+                            .collect::<Vec<_>>(),
+                        node.state
+                            .worker_cutoffs
+                            .iter()
+                            .map(|(&worker, &cutoff)| (worker, cutoff))
+                            .collect::<Vec<_>>(),
+                        live_children,
+                        can_merge,
+                    )
                 };
-                events.push(event);
-                event_id += 1;
-            }
 
-            // Enqueue children with this block's hash as their parent
-            for (child_tokens_hash, child_block) in &current_borrow.children {
-                queue.push_back((child_block.clone(), Some(block_hash), *child_tokens_hash));
+                if can_merge {
+                    current = live_children[0].clone();
+                    continue;
+                }
+                if merged_edge.is_empty() {
+                    break;
+                }
+
+                let blocks = merged_edge
+                    .iter()
+                    .map(|&(tokens_hash, block_hash)| KvCacheStoredBlockData {
+                        block_hash,
+                        tokens_hash,
+                        mm_extra_info: None,
+                    })
+                    .collect::<Vec<_>>();
+                let last_hash = merged_edge.last().unwrap().1;
+
+                for worker in full_workers {
+                    events.push(Self::dump_event(
+                        worker,
+                        event_id,
+                        parent_hash,
+                        blocks.clone(),
+                    ));
+                    event_id += 1;
+                }
+                for (worker, cutoff) in cutoffs {
+                    events.push(Self::dump_event(
+                        worker,
+                        event_id,
+                        parent_hash,
+                        blocks[..cutoff].to_vec(),
+                    ));
+                    event_id += 1;
+                }
+                for child in live_children {
+                    queue.push_back((child, Some(last_hash)));
+                }
+                break;
             }
         }
 
         events
     }
 
+    fn dump_event(
+        worker: WorkerWithDpRank,
+        event_id: u64,
+        parent_hash: Option<ExternalSequenceBlockHash>,
+        blocks: Vec<KvCacheStoredBlockData>,
+    ) -> RouterEvent {
+        RouterEvent::new(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash,
+                    start_position: None,
+                    blocks,
+                }),
+                dp_rank: worker.dp_rank,
+            },
+        )
+    }
+
     pub fn current_size(&self) -> usize {
-        self.lookup.values().map(|m| m.len()).sum()
+        self.lookup.values().map(FxHashMap::len).sum()
     }
 
     #[cfg(test)]
     pub(crate) fn tree_size_for_worker(&self, worker: WorkerWithDpRank) -> Option<usize> {
-        self.lookup.get(&worker).map(|blocks| blocks.len())
+        self.lookup.get(&worker).map(FxHashMap::len)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn edge_lengths_for_test(&self) -> Vec<usize> {
+        let mut queue = VecDeque::from([self.root.clone()]);
+        let mut lengths = Vec::new();
+        while let Some(node) = queue.pop_front() {
+            let node = node.borrow();
+            for child in node.children.values() {
+                lengths.push(child.borrow().state.edge.len());
+                queue.push_back(child.clone());
+            }
+        }
+        lengths.sort_unstable();
+        lengths
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
-    use crate::protocols::{ExternalSequenceBlockHash, LocalBlockHash};
-    use crate::test_utils::{create_remove_event, create_store_event};
+    use crate::indexer::WorkerKvQueryResponse;
+    use crate::test_utils::{create_store_event, make_store_event, snapshot_events};
 
     #[test]
-    fn test_radix_tree() {
-        let mut trie = RadixTree::new();
-
-        let worker_1 = 0;
-        let worker_2 = 1;
-
-        trie.apply_event(create_store_event(worker_1, 1, vec![1, 2, 3], None))
+    fn rejects_self_referencing_store() {
+        let mut tree = RadixTree::new();
+        tree.apply_event(create_store_event(0, 0, vec![1], None))
             .unwrap();
-
-        let scores = trie.find_matches(
-            vec![LocalBlockHash(1), LocalBlockHash(2), LocalBlockHash(3)],
-            false,
-        );
-        assert_eq!(
-            scores
-                .scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap(),
-            &3
-        );
-
-        assert_eq!(trie.lookup.len(), 1);
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap()
-                .len(),
-            3
-        );
-        assert_eq!(trie.root.borrow().workers.len(), 0);
-        assert_eq!(trie.root.borrow().children.len(), 1);
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .workers
-                .len(),
-            1
-        );
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .children
-                .len(),
-            1
-        );
-
-        trie.apply_event(create_store_event(worker_2, 1, vec![1, 4, 5], None))
-            .unwrap();
-
-        let scores = trie.find_matches(
-            vec![LocalBlockHash(1), LocalBlockHash(2), LocalBlockHash(3)],
-            false,
-        );
-        assert_eq!(
-            scores
-                .scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap(),
-            &3
-        );
-        assert_eq!(
-            scores
-                .scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_2))
-                .unwrap(),
-            &1
-        );
-
-        assert_eq!(trie.lookup.len(), 2);
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap()
-                .len(),
-            3
-        );
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_2))
-                .unwrap()
-                .len(),
-            3
-        );
-        assert_eq!(trie.root.borrow().workers.len(), 0);
-        assert_eq!(trie.root.borrow().children.len(), 1);
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .workers
-                .len(),
-            2
-        );
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .children
-                .len(),
-            2
-        );
-
-        trie.apply_event(create_remove_event(worker_2, 2, vec![5]))
-            .unwrap();
-        assert_eq!(trie.lookup.len(), 2);
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap()
-                .len(),
-            3
-        );
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_2))
-                .unwrap()
-                .len(),
-            2
-        );
-        assert_eq!(trie.root.borrow().workers.len(), 0);
-        assert_eq!(trie.root.borrow().children.len(), 1);
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .workers
-                .len(),
-            2
-        );
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .children
-                .len(),
-            2
-        );
-
-        trie.apply_event(create_remove_event(worker_2, 3, vec![4]))
-            .unwrap();
-
-        assert_eq!(trie.lookup.len(), 2);
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap()
-                .len(),
-            3
-        );
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_2))
-                .unwrap()
-                .len(),
-            1
-        );
-        assert_eq!(trie.root.borrow().workers.len(), 0);
-        assert_eq!(trie.root.borrow().children.len(), 1);
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .workers
-                .len(),
-            2
-        );
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .children
-                .len(),
-            2
-        );
-
-        trie.apply_event(create_store_event(
-            worker_2,
-            4,
-            vec![2, 6, 7],
+        let result = tree.apply_event(create_store_event(
+            0,
+            1,
+            vec![1, 2],
             Some(ExternalSequenceBlockHash(100)),
+        ));
+        assert!(matches!(
+            result,
+            Err(KvCacheEventError::InvalidBlockSequence)
+        ));
+    }
+
+    #[test]
+    fn linear_tree_dumps_as_one_event() {
+        let mut tree = RadixTree::new();
+        tree.apply_event(make_store_event(0, &[1, 2, 3, 4]))
+            .unwrap();
+
+        assert_eq!(tree.edge_lengths_for_test(), vec![4]);
+        assert_eq!(
+            snapshot_events(tree.dump_tree_as_events()),
+            vec![make_store_event(0, &[1, 2, 3, 4])]
+        );
+    }
+
+    #[test]
+    fn compact_dump_preserves_order_and_replays() {
+        let mut tree = RadixTree::new();
+        tree.apply_event(make_store_event(1, &[1, 2, 3, 4, 5, 6]))
+            .unwrap();
+        tree.apply_event(make_store_event(2, &[1, 2, 3])).unwrap();
+        tree.apply_event(crate::test_utils::make_store_event_with_parent(
+            2,
+            &[1, 2, 3],
+            &[7, 8],
         ))
         .unwrap();
 
-        let scores = trie.find_matches(
-            vec![LocalBlockHash(1), LocalBlockHash(2), LocalBlockHash(3)],
-            false,
-        );
+        let events = tree.dump_tree_as_events();
+        let represented_blocks = events
+            .iter()
+            .map(|event| match &event.event.data {
+                KvCacheEventData::Stored(store) => store.blocks.len(),
+                _ => 0,
+            })
+            .sum::<usize>();
+        assert_eq!(events.len(), 4);
+        assert_eq!(represented_blocks, 11);
         assert_eq!(
-            scores
-                .scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap(),
-            &3
+            events
+                .iter()
+                .map(|event| event.event.event_id)
+                .collect::<Vec<_>>(),
+            (0..events.len() as u64).collect::<Vec<_>>()
         );
+
+        let mut seen = HashSet::new();
+        for event in &events {
+            let KvCacheEventData::Stored(store) = &event.event.data else {
+                panic!("tree dumps must contain only stored events");
+            };
+            if let Some(parent_hash) = store.parent_hash {
+                assert!(
+                    seen.contains(&(event.worker_id, event.event.dp_rank, parent_hash)),
+                    "dump child appeared before its worker-specific parent"
+                );
+            }
+            for block in &store.blocks {
+                seen.insert((event.worker_id, event.event.dp_rank, block.block_hash));
+            }
+        }
+
+        let mut restored = RadixTree::new();
+        for event in events.clone() {
+            restored.apply_event(event).unwrap();
+        }
         assert_eq!(
-            scores
-                .scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_2))
-                .unwrap(),
-            &2
+            snapshot_events(restored.dump_tree_as_events()),
+            snapshot_events(events.clone())
         );
 
-        assert_eq!(trie.lookup.len(), 2);
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap()
-                .len(),
-            3
-        );
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_2))
-                .unwrap()
-                .len(),
-            4
-        );
-        assert_eq!(trie.root.borrow().workers.len(), 0);
-        assert_eq!(trie.root.borrow().children.len(), 1);
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .workers
-                .len(),
-            2
-        );
-        assert_eq!(
-            trie.root
-                .borrow()
-                .children
-                .get(&LocalBlockHash(1))
-                .unwrap()
-                .borrow()
-                .children
-                .len(),
-            2
-        );
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap()
-                .get(&ExternalSequenceBlockHash(200))
-                .unwrap()
-                .borrow()
-                .workers
-                .len(),
-            2
-        );
-    }
+        let mut uncompressed_events = Vec::new();
+        for event in &events {
+            let KvCacheEventData::Stored(store) = &event.event.data else {
+                unreachable!();
+            };
+            let mut parent_hash = store.parent_hash;
+            for block in &store.blocks {
+                uncompressed_events.push(RadixTree::dump_event(
+                    WorkerWithDpRank::new(event.worker_id, event.event.dp_rank),
+                    uncompressed_events.len() as u64,
+                    parent_hash,
+                    vec![block.clone()],
+                ));
+                parent_hash = Some(block.block_hash);
+            }
+        }
 
-    #[test]
-    fn test_radix_tree_apply_event_errors() {
-        let mut trie = RadixTree::new();
-        let worker_0 = 0;
-
-        // Parent block not found
-        let result = trie.apply_event(create_store_event(
-            worker_0,
-            0,
-            vec![1, 2, 3],
-            Some(ExternalSequenceBlockHash(12345)),
-        ));
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            KvCacheEventError::ParentBlockNotFound
-        ));
-
-        // Block not found for remove event.
-        let result = trie.apply_event(create_remove_event(worker_0, 0, vec![1, 2, 3]));
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            KvCacheEventError::BlockNotFound
-        ));
-
-        // Parent appears in blocks: parent=1, blocks=[1, 2, 3]
-        // This should be rejected as block 1 (hash 100) is the parent - this is
-        // a self referencing block.
-        trie.apply_event(create_store_event(worker_0, 4, vec![1], None))
-            .unwrap();
-        let result = trie.apply_event(create_store_event(
-            worker_0,
-            5,
-            vec![1, 2, 3],
-            Some(ExternalSequenceBlockHash(100)),
-        ));
-        assert!(matches!(
-            result.unwrap_err(),
-            KvCacheEventError::InvalidBlockSequence
-        ));
-    }
-
-    #[test]
-    fn test_clear_all_blocks() {
-        let mut trie = RadixTree::new();
-
-        let worker_0 = 0;
-        let worker_1 = 1;
-
+        let compact = WorkerKvQueryResponse::TreeDump {
+            events,
+            last_event_id: 42,
+        };
+        let uncompressed = WorkerKvQueryResponse::TreeDump {
+            events: uncompressed_events,
+            last_event_id: 42,
+        };
         assert!(
-            trie.find_matches(vec![LocalBlockHash(0)], false)
-                .scores
-                .is_empty()
+            serde_json::to_vec(&compact).unwrap().len()
+                < serde_json::to_vec(&uncompressed).unwrap().len()
         );
-
-        // Test clearing an empty worker
-        trie.clear_all_blocks(worker_0);
-        assert!(
-            !trie
-                .lookup
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_0))
-        );
-
-        // Test clearing a worker with shared blocks
-        trie.apply_event(create_store_event(worker_0, 0, vec![0, 1, 3], None))
-            .unwrap();
-        trie.apply_event(create_store_event(worker_1, 0, vec![0, 2, 3], None))
-            .unwrap();
-
-        let result = trie.find_matches(vec![LocalBlockHash(0)], false).scores;
-        assert!(
-            result.len() == 2
-                && result[&WorkerWithDpRank::from_worker_id(worker_0)] == 1
-                && result[&WorkerWithDpRank::from_worker_id(worker_1)] == 1
-        );
-
-        trie.clear_all_blocks(worker_0);
-
-        assert!(
-            trie.lookup
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_0))
-        );
-        assert!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_0))
-                .unwrap()
-                .is_empty()
-        );
-        let result = trie
-            .find_matches(vec![LocalBlockHash(0), LocalBlockHash(2)], false)
-            .scores;
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[&WorkerWithDpRank::from_worker_id(worker_1)], 2);
-        let result = trie
-            .find_matches(
-                vec![LocalBlockHash(0), LocalBlockHash(1), LocalBlockHash(3)],
-                false,
-            )
-            .scores;
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[&WorkerWithDpRank::from_worker_id(worker_1)], 1);
-
-        // Test re-adding blocks after clearing worker
-        trie.apply_event(create_store_event(worker_0, 0, vec![4, 5], None))
-            .unwrap();
-        let result = trie
-            .find_matches(vec![LocalBlockHash(4), LocalBlockHash(5)], false)
-            .scores;
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[&WorkerWithDpRank::from_worker_id(worker_0)], 2);
-
-        // Test multiple clears
-        trie.clear_all_blocks(worker_0);
-        trie.clear_all_blocks(worker_0);
-        assert!(
-            trie.lookup
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_0))
-        );
-
-        // Test clearing all workers
-        trie.clear_all_blocks(worker_0);
-        trie.clear_all_blocks(worker_1);
-        assert!(!trie.lookup.is_empty());
-        assert!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_0))
-                .unwrap()
-                .is_empty()
-        );
-        assert!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                .unwrap()
-                .is_empty()
-        );
-
-        // Test clearing a worker that has been removed
-        trie.apply_event(create_store_event(worker_0, 0, vec![6], None))
-            .unwrap();
-        trie.apply_event(create_store_event(worker_1, 0, vec![6], None))
-            .unwrap();
-        trie.remove_worker(worker_0);
-        trie.clear_all_blocks(worker_0);
-        assert!(
-            !trie
-                .lookup
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_0))
-        );
-        let result = trie.find_matches(vec![LocalBlockHash(6)], false).scores;
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[&WorkerWithDpRank::from_worker_id(worker_1)], 1);
-
-        // Test clearing a worker that doesn't exist
-        let worker_fake = 2;
-        assert!(
-            !trie
-                .lookup
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_fake))
-        );
-        trie.clear_all_blocks(worker_fake);
-        assert!(
-            !trie
-                .lookup
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_fake))
-        );
-        assert!(
-            trie.lookup
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_1))
-        );
-        let result = trie.find_matches(vec![LocalBlockHash(6)], false).scores;
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[&WorkerWithDpRank::from_worker_id(worker_1)], 1);
-    }
-
-    #[test]
-    fn test_radix_tree_default() {
-        let radix_tree: RadixTree = Default::default();
-        assert!(radix_tree.root.borrow().children.is_empty());
-        assert!(radix_tree.root.borrow().workers.is_empty());
-        assert!(radix_tree.lookup.is_empty());
-    }
-
-    #[test]
-    fn test_remove_worker_verifies_hash_removal() {
-        let mut trie = RadixTree::new();
-
-        let worker_0 = 0;
-        let worker_1 = 1;
-        let worker_2 = 2;
-
-        // Add blocks for multiple workers
-        trie.apply_event(create_store_event(worker_0, 0, vec![1, 2, 3], None))
-            .unwrap();
-        trie.apply_event(create_store_event(worker_1, 0, vec![1, 2, 3], None))
-            .unwrap();
-        trie.apply_event(create_store_event(worker_2, 0, vec![1, 4, 5], None))
-            .unwrap();
-
-        // Verify worker_0 has 3 blocks in lookup
-        assert_eq!(
-            trie.lookup
-                .get(&WorkerWithDpRank::from_worker_id(worker_0))
-                .unwrap()
-                .len(),
-            3
-        );
-
-        // Verify that blocks have the correct workers
-        let block_1 = trie
-            .lookup
-            .get(&WorkerWithDpRank::from_worker_id(worker_0))
-            .unwrap()
-            .get(&ExternalSequenceBlockHash(100))
-            .unwrap();
-        assert_eq!(block_1.borrow().workers.len(), 3); // worker_0, worker_1, and worker_2 (all have hash 1)
-        assert!(
-            block_1
-                .borrow()
-                .workers
-                .contains(&WorkerWithDpRank::from_worker_id(worker_0))
-        );
-        assert!(
-            block_1
-                .borrow()
-                .workers
-                .contains(&WorkerWithDpRank::from_worker_id(worker_1))
-        );
-        assert!(
-            block_1
-                .borrow()
-                .workers
-                .contains(&WorkerWithDpRank::from_worker_id(worker_2))
-        );
-
-        // Remove worker_0
-        trie.remove_worker(worker_0);
-
-        // Verify worker_0 is completely removed from lookup table
-        assert!(
-            !trie
-                .lookup
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_0))
-        );
-        assert_eq!(trie.lookup.len(), 2);
-
-        // Verify that worker_0's hash is removed from the workers set
-        let block_1 = trie
-            .lookup
-            .get(&WorkerWithDpRank::from_worker_id(worker_1))
-            .unwrap()
-            .get(&ExternalSequenceBlockHash(100))
-            .unwrap();
-        assert_eq!(block_1.borrow().workers.len(), 2); // worker_1 and worker_2 remain
-        assert!(
-            !block_1
-                .borrow()
-                .workers
-                .contains(&WorkerWithDpRank::from_worker_id(worker_0))
-        );
-        assert!(
-            block_1
-                .borrow()
-                .workers
-                .contains(&WorkerWithDpRank::from_worker_id(worker_1))
-        );
-        assert!(
-            block_1
-                .borrow()
-                .workers
-                .contains(&WorkerWithDpRank::from_worker_id(worker_2))
-        );
-
-        // Verify that blocks with no remaining workers have their children cleared
-        // This tests the optimization where empty blocks clear their children
-        let block_2 = trie
-            .lookup
-            .get(&WorkerWithDpRank::from_worker_id(worker_1))
-            .unwrap()
-            .get(&ExternalSequenceBlockHash(200))
-            .unwrap();
-        assert_eq!(block_2.borrow().workers.len(), 1); // only worker_1
-        assert!(
-            block_2
-                .borrow()
-                .workers
-                .contains(&WorkerWithDpRank::from_worker_id(worker_1))
-        );
-
-        // Verify match results no longer include worker_0
-        let result = trie
-            .find_matches(
-                vec![LocalBlockHash(1), LocalBlockHash(2), LocalBlockHash(3)],
-                false,
-            )
-            .scores;
-        assert_eq!(result.len(), 2);
-        assert!(!result.contains_key(&WorkerWithDpRank::from_worker_id(worker_0)));
-        assert!(result.contains_key(&WorkerWithDpRank::from_worker_id(worker_1)));
-        assert!(result.contains_key(&WorkerWithDpRank::from_worker_id(worker_2)));
     }
 }

--- a/lib/kv-router/src/indexer/radix_tree.rs
+++ b/lib/kv-router/src/indexer/radix_tree.rs
@@ -577,6 +577,11 @@ impl RadixTree {
                     first_error.get_or_insert(KvCacheEventError::BlockNotFound);
                     continue;
                 };
+                // TODO(CORRECTNESS): Invalidate this worker throughout the descendant
+                // subtree when a mid-edge removal leaves the node alive for another
+                // worker. Otherwise stale descendants can be reused as store parents,
+                // reactivated by restoring only the removed block, or emitted by dumps
+                // without a valid worker-specific parent.
                 let outcome = node_ref.state.remove_worker_at_pos(worker, pos, block_hash);
                 node_ref.clear_children_if_unreachable();
                 outcome

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use rstest::rstest;
 use rstest_reuse::{self, *};
@@ -38,6 +38,13 @@ fn indexer_template(
 #[rstest]
 fn tree_size_indexer_template(
     #[values("single", "concurrent", "concurrent_compressed")] variant: &str,
+) {
+}
+
+#[template]
+#[rstest]
+fn compressed_tree_size_indexer_template(
+    #[values("single", "concurrent_compressed")] variant: &str,
 ) {
 }
 
@@ -101,9 +108,8 @@ fn make_approx_indexer(variant: &str, ttl: Duration) -> Box<dyn KvIndexerInterfa
     let prune_config = PruneConfig { ttl };
 
     match variant {
-        "single" => Box::new(KvIndexer::new_with_frequency(
+        "single" => Box::new(KvIndexer::new_with_pruning(
             token,
-            None,
             kv_block_size,
             metrics,
             Some(prune_config),
@@ -420,13 +426,10 @@ mod interface_tests {
         let continuation_remove = make_remove_event_with_parent(0, &[1, 2, 3], &[4, 5]);
         let prefix_remove = make_remove_event(0, &[1, 2, 3]);
 
-        // TODO: The non-compressed radix-family implementations still have a broader
-        // tree-size accounting gap after mid-chain removes because descendant
-        // lookup entries are cleaned up lazily. That means "store -> partial
-        // remove -> restore continuation" can still miscount restored coverage
-        // in single and concurrent. This test is intentionally scoped
-        // to duplicate store/remove replay so all tree-size variants share the
-        // same stable baseline.
+        // The uncompressed concurrent implementation still cleans descendant
+        // lookup entries lazily after mid-chain removes, so the shared matrix
+        // keeps this duplicate store/remove baseline. Compressed variants cover
+        // eager suffix cleanup in a focused test below.
 
         index.apply_event(prefix_event.clone()).await;
         index.flush().await;
@@ -506,6 +509,66 @@ mod interface_tests {
         assert!(duplicate_empty_scores.scores.is_empty());
         assert_eq!(index.tree_size_for_worker(worker).await, Some(0));
         assert!(index.snapshot_tree().await.is_empty());
+    }
+
+    #[tokio::test]
+    #[apply(compressed_tree_size_indexer_template)]
+    async fn test_mid_edge_remove_repairs_lookup_and_restores_explicitly(variant: &str) {
+        let mut index = TreeSizeTestIndexer::new(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let local_hashes = [1, 2, 3, 4, 5];
+        let sequence_hashes = compute_seq_hash_for_block(
+            &local_hashes
+                .iter()
+                .copied()
+                .map(LocalBlockHash)
+                .collect::<Vec<_>>(),
+        );
+
+        index
+            .apply_event(make_store_event(worker.worker_id, &local_hashes))
+            .await;
+        index.flush().await;
+        index
+            .assert_score_and_tree_size(&local_hashes, worker, 5, 5)
+            .await;
+
+        index
+            .apply_event(remove_event(
+                worker.worker_id,
+                1,
+                worker.dp_rank,
+                vec![ExternalSequenceBlockHash(sequence_hashes[2])],
+            ))
+            .await;
+        index.flush().await;
+        index
+            .assert_score_and_tree_size(&local_hashes, worker, 2, 2)
+            .await;
+
+        index
+            .apply_event(make_store_event_with_parent(
+                worker.worker_id,
+                &[1, 2],
+                &[3],
+            ))
+            .await;
+        index.flush().await;
+        index
+            .assert_score_and_tree_size(&local_hashes, worker, 3, 3)
+            .await;
+
+        index
+            .apply_event(make_store_event_with_parent(
+                worker.worker_id,
+                &[1, 2, 3],
+                &[4, 5],
+            ))
+            .await;
+        index.flush().await;
+        index
+            .assert_score_and_tree_size(&local_hashes, worker, 5, 5)
+            .await;
     }
 
     #[tokio::test]
@@ -2030,45 +2093,14 @@ mod long_sequence_tests {
 }
 
 // ============================================================================
-// Tests specific to tree-based implementations with frequency/pruning support.
-// These use features not available in PositionalIndexer
+// Tests specific to pruning behavior.
 // ============================================================================
-
-#[template]
-#[rstest]
-fn tree_indexer_template(#[values("single")] variant: &str) {}
-
-fn make_tree_indexer_with_frequency(
-    variant: &str,
-    expiration: Duration,
-) -> Box<dyn KvIndexerInterface> {
-    let token = CancellationToken::new();
-    let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-    let kv_block_size = 32;
-
-    match variant {
-        "single" => Box::new(KvIndexer::new_with_frequency(
-            token,
-            Some(expiration),
-            kv_block_size,
-            metrics,
-            None,
-        )),
-        _ => panic!("Unknown variant: {}", variant),
-    }
-}
 
 #[tokio::test]
 async fn test_routing_decision_assigns_first_seen_worker() {
     let token = CancellationToken::new();
     let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-    let index = KvIndexer::new_with_frequency(
-        token,
-        Some(Duration::from_secs(60)),
-        32,
-        metrics,
-        Some(PruneConfig::default()),
-    );
+    let index = KvIndexer::new_with_pruning(token, 32, metrics, Some(PruneConfig::default()));
     let worker = WorkerWithDpRank::new(42, 0);
     let local_hashes = vec![LocalBlockHash(11), LocalBlockHash(22)];
     let sequence_hashes = compute_seq_hash_for_block(&local_hashes);
@@ -2086,93 +2118,6 @@ async fn test_routing_decision_assigns_first_seen_worker() {
 
     let scores = query_scores(&index, &[11, 22]).await;
     assert!(!scores.scores.contains_key(&worker));
-}
-
-mod tree_specific_tests {
-    use super::*;
-    use rstest_reuse::apply;
-
-    #[tokio::test]
-    #[apply(tree_indexer_template)]
-    async fn test_frequency(variant: &str) {
-        const ONE_MILLIS: Duration = Duration::from_millis(1);
-
-        let expiration = Duration::from_millis(50);
-        let kv_indexer = make_tree_indexer_with_frequency(variant, expiration);
-
-        // The blocks
-        let block_hashes = vec![
-            LocalBlockHash(1),
-            LocalBlockHash(2),
-            LocalBlockHash(3),
-            LocalBlockHash(4),
-        ];
-
-        let overlap = kv_indexer.find_matches(block_hashes.clone()).await.unwrap();
-        assert_eq!(
-            overlap.frequencies.len(),
-            0,
-            "Should be no cached blocks yet"
-        );
-
-        // Blocks go in cache
-        let event = make_store_event(0, &[1, 2, 3, 4]);
-        kv_indexer.apply_event(event).await;
-
-        // First access - poll briefly since store event is applied async
-        let mut overlap = OverlapScores::default();
-        let timeout = Duration::from_millis(10);
-        let start = Instant::now();
-        while overlap.scores.is_empty() && Instant::now().duration_since(start) < timeout {
-            time::sleep(ONE_MILLIS).await;
-            overlap = kv_indexer.find_matches(block_hashes.clone()).await.unwrap();
-        }
-        assert_eq!(
-            overlap.scores.len(),
-            1,
-            "One worker has these blocks cached"
-        );
-        assert_eq!(
-            overlap.frequencies.len(),
-            0,
-            "Blocks have not previously been accessed"
-        );
-
-        // Second access
-        let overlap = kv_indexer.find_matches(block_hashes.clone()).await.unwrap();
-        assert_eq!(overlap.scores.len(), 1, "Still one worker matches");
-        assert_eq!(
-            overlap.frequencies,
-            vec![1, 1, 1, 1],
-            "We should see the first access now"
-        );
-
-        // Let those two accesses expire
-        time::sleep(expiration + Duration::from_millis(10)).await;
-
-        // New first access
-        let overlap = kv_indexer.find_matches(block_hashes.clone()).await.unwrap();
-        assert_eq!(
-            overlap.frequencies.len(),
-            0,
-            "Blocks were accessed too long ago"
-        );
-
-        // New second access
-        let _ = kv_indexer.find_matches(block_hashes.clone()).await.unwrap();
-
-        // Access only the first three blocks
-        let overlap = kv_indexer
-            .find_matches(block_hashes[0..3].to_vec())
-            .await
-            .unwrap();
-        // We see the previous two new accesses
-        assert_eq!(overlap.frequencies, vec![2, 2, 2]);
-
-        // The third access did not touch the last block
-        let overlap = kv_indexer.find_matches(block_hashes.clone()).await.unwrap();
-        assert_eq!(overlap.frequencies, vec![3, 3, 3, 2]);
-    }
 }
 
 // ============================================================================

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -979,16 +979,6 @@ impl OverlapScores {
             *score += 1;
         }
     }
-
-    /// Add an entry in the frequency list.
-    pub fn add_frequency(&mut self, frequency: usize) {
-        if frequency != 0 {
-            self.frequencies
-                .last()
-                .inspect(|elem| debug_assert!(**elem >= frequency));
-            self.frequencies.push(frequency);
-        }
-    }
 }
 
 // ------

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -961,7 +961,7 @@ impl OverlapScores {
     pub fn new() -> Self {
         Self {
             scores: FxHashMap::default(),
-            frequencies: Vec::with_capacity(32),
+            frequencies: Vec::new(),
         }
     }
 

--- a/lib/kv-router/src/services/indexer/backend.rs
+++ b/lib/kv-router/src/services/indexer/backend.rs
@@ -481,9 +481,8 @@ pub fn create_indexer(block_size: u32, num_threads: usize) -> Indexer {
         }
     } else {
         Indexer::Single {
-            primary: KvIndexer::new_with_frequency(
+            primary: KvIndexer::new_with_pruning(
                 CancellationToken::new(),
-                None,
                 block_size,
                 Arc::new(KvIndexerMetrics::new_unregistered()),
                 None,

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -130,9 +130,8 @@ impl Indexer {
 
             let cancellation_token = component.drt().primary_token();
             return Ok(Self::KvIndexer {
-                primary: KvIndexer::new_with_frequency(
+                primary: KvIndexer::new_with_pruning(
                     cancellation_token,
-                    None,
                     block_size,
                     kv_indexer_metrics,
                     prune_config,
@@ -167,9 +166,8 @@ impl Indexer {
         let cancellation_token = component.drt().primary_token();
 
         Ok(Self::KvIndexer {
-            primary: KvIndexer::new_with_frequency(
+            primary: KvIndexer::new_with_pruning(
                 cancellation_token,
-                None,
                 block_size,
                 kv_indexer_metrics,
                 None,

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -435,12 +435,20 @@ impl WorkerQueryClient {
                 events,
                 last_event_id,
             }) => {
+                let represented_blocks = events
+                    .iter()
+                    .map(|event| match &event.event.data {
+                        KvCacheEventData::Stored(store) => store.blocks.len(),
+                        _ => 0,
+                    })
+                    .sum::<usize>();
                 tracing::info!(
-                    "Got tree dump from worker {} dp_rank {} (range too old or unspecified), count: {}, last_event_id: {}",
-                    key.0,
-                    key.1,
-                    events.len(),
-                    last_event_id
+                    worker_id = key.0,
+                    dp_rank = key.1,
+                    event_count = events.len(),
+                    represented_block_count = represented_blocks,
+                    last_event_id,
+                    "Got tree dump (range too old or unspecified)"
                 );
                 self.apply_tree_dump_replace_locked(key.0, key.1, events)
                     .await;

--- a/lib/llm/src/kv_router/indexer/remote.rs
+++ b/lib/llm/src/kv_router/indexer/remote.rs
@@ -564,9 +564,8 @@ mod tests {
         let worker = WorkerWithDpRank::new(7, 0);
         let block_hashes = vec![LocalBlockHash(11), LocalBlockHash(12)];
         let sequence_hashes = compute_seq_hash_for_block(&block_hashes);
-        let side = KvIndexer::new_with_frequency(
+        let side = KvIndexer::new_with_pruning(
             CancellationToken::new(),
-            None,
             4,
             Arc::new(KvIndexerMetrics::new_unregistered()),
             Some(PruneConfig {

--- a/lib/llm/src/kv_router/indexer/side.rs
+++ b/lib/llm/src/kv_router/indexer/side.rs
@@ -52,9 +52,8 @@ impl SideIndexer {
         }
 
         let cancellation_token = component.drt().primary_token();
-        Some(Self::KvIndexer(KvIndexer::new_with_frequency(
+        Some(Self::KvIndexer(KvIndexer::new_with_pruning(
             cancellation_token,
-            None,
             block_size,
             metrics,
             prune_config,

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -195,7 +195,7 @@ pub enum MoveBlock {
         Uuid,
         SequenceHash,
         Option<u64>,
-        BlockHash,
+        Option<BlockHash>,
         PositionalLineageHash,
         Option<Vec<u32>>,
     ),

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -16,12 +16,15 @@ fn create_sequence_cache(
     enable_prefix_caching: bool,
 ) -> (Vec<UniqueBlock>, Vec<BlockHash>, Vec<PositionalLineageHash>) {
     let mut unique_blocks = Vec::with_capacity(tokens.blocks().len() + 1);
-    let mut block_hashes: Vec<BlockHash> = Vec::with_capacity(tokens.blocks().len());
+    let mut block_hashes = Vec::new();
+    if enable_prefix_caching {
+        block_hashes.reserve(tokens.blocks().len());
+    }
     let mut plhs = Vec::with_capacity(tokens.blocks().len());
 
     for (pos, block) in tokens.blocks().iter().enumerate() {
-        block_hashes.push(block.block_hash());
         if enable_prefix_caching {
+            block_hashes.push(block.block_hash());
             unique_blocks.push(UniqueBlock::FullBlock(block.sequence_hash()));
             plhs.push(block.positional_lineage_hash());
         } else {
@@ -101,7 +104,7 @@ impl ActiveSequence {
             num_input_tokens,
             num_allocated_tokens: 0,
             enable_prefix_caching,
-            emit_token_ids,
+            emit_token_ids: emit_token_ids && enable_prefix_caching,
         };
         seq.validate().expect("invalid ActiveSequence");
         seq
@@ -155,7 +158,9 @@ impl ActiveSequence {
         let hash_end = target_blocks.min(self.block_hashes.len());
         let hashes = self.block_hashes[hash_start..hash_end].to_vec();
         // Cached per-sequence PLHs (stable across calls).
-        let plhs = self.plhs[hash_start..hash_end].to_vec();
+        let plh_start = prev_blocks.min(self.plhs.len());
+        let plh_end = target_blocks.min(self.plhs.len());
+        let plhs = self.plhs[plh_start..plh_end].to_vec();
 
         let token_ids = if self.emit_token_ids && hash_start < hash_end {
             Some(
@@ -247,7 +252,9 @@ impl ActiveSequence {
             } else {
                 random::<u64>()
             };
-            let last_block_hash = last_complete.block_hash();
+            let last_block_hash = self
+                .enable_prefix_caching
+                .then(|| last_complete.block_hash());
             // Same randomization story as `last_seq_hash`: with prefix caching off,
             // two identical prompts must not share blocks, so the PLH we promote
             // with must also be unique — otherwise `process_promote`'s
@@ -255,14 +262,16 @@ impl ActiveSequence {
             let last_plh = if self.enable_prefix_caching {
                 last_complete.positional_lineage_hash()
             } else {
-                PositionalLineageHash::new(random::<u64>(), None, self.block_hashes.len() as u64)
+                PositionalLineageHash::new(random::<u64>(), None, self.plhs.len() as u64)
             };
             let promote_token_ids = if self.emit_token_ids {
                 Some(last_complete.tokens().to_vec())
             } else {
                 None
             };
-            self.block_hashes.push(last_block_hash);
+            if let Some(last_block_hash) = last_block_hash {
+                self.block_hashes.push(last_block_hash);
+            }
             self.plhs.push(last_plh);
             self.unique_blocks.pop();
 

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -424,7 +424,9 @@ impl KvManager {
                 },
             );
             stored_seq_hashes.push(entry.seq_hash);
-            stored_local_hashes.push(entry.local_hash);
+            if let Some(local_hash) = entry.local_hash {
+                stored_local_hashes.push(local_hash);
+            }
             metadata_parent_hash = Some(entry.seq_hash);
             consumed_entries += 1;
         }
@@ -454,7 +456,12 @@ impl KvManager {
         }
 
         let full_blocks = std::mem::take(stored_seq_hashes);
-        let local_hashes = std::mem::take(stored_local_hashes);
+        let local_hashes = if stored_local_hashes.len() == full_blocks.len() {
+            std::mem::take(stored_local_hashes)
+        } else {
+            stored_local_hashes.clear();
+            Vec::new()
+        };
         let token_ids = if stored_token_ids.len() == full_blocks.len() {
             Some(std::mem::take(stored_token_ids))
         } else {

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -87,7 +87,7 @@ pub struct SwapInRegistrationOutcome {
 pub(crate) struct SwapInRegistrationBlock {
     pub(crate) seq_hash: SequenceHash,
     pub(crate) plh: PositionalLineageHash,
-    pub(crate) local_hash: BlockHash,
+    pub(crate) local_hash: Option<BlockHash>,
     pub(crate) token_ids: Option<Vec<u32>>,
 }
 
@@ -149,7 +149,7 @@ struct RegisteredBlockInfo {
     #[cfg_attr(not(feature = "kvbm-offload"), allow(dead_code))]
     parent_hash: Option<SequenceHash>,
     #[cfg_attr(not(feature = "kvbm-offload"), allow(dead_code))]
-    local_hash: BlockHash,
+    local_hash: Option<BlockHash>,
     #[cfg_attr(not(feature = "kvbm-offload"), allow(dead_code))]
     token_ids: Option<Vec<u32>>,
 }
@@ -641,9 +641,10 @@ impl KvManager {
         for event in events {
             match event {
                 G2RouterEvent::Stored(meta) => {
+                    let local_hashes = meta.local_hash.into_iter().collect::<Vec<_>>();
                     self.publish_kv_event_for_tier(
                         vec![meta.seq_hash],
-                        &[meta.local_hash],
+                        &local_hashes,
                         meta.parent_hash,
                         true,
                         meta.token_ids.map(|ids| vec![ids]),
@@ -1008,10 +1009,7 @@ impl KvManager {
                                     seq_hash: *seq_hash,
                                     block_id,
                                     parent_hash: metadata_parent_hash,
-                                    local_hash: local_hashes
-                                        .get(full_idx)
-                                        .copied()
-                                        .unwrap_or_default(),
+                                    local_hash: local_hashes.get(full_idx).copied(),
                                     token_ids: token_ids.and_then(|ids| ids.get(full_idx).cloned()),
                                 },
                             );
@@ -1090,8 +1088,8 @@ impl KvManager {
                         blocks_stored.push(*seq_hash);
                         let full_idx =
                             current_full_idx.expect("NewStore is only emitted for full blocks");
-                        if let Some(lh) = local_hashes.get(full_idx) {
-                            stored_local_hashes.push(*lh);
+                        if let Some(local_hash) = local_hashes.get(full_idx) {
+                            stored_local_hashes.push(*local_hash);
                         }
                         if let (Some(ref mut stids), Some(ids)) =
                             (stored_token_ids.as_mut(), token_ids)
@@ -1217,7 +1215,7 @@ impl KvManager {
         uuid: Uuid,
         seq_hash: SequenceHash,
         parent_hash: Option<u64>,
-        local_hash: BlockHash,
+        local_hash: Option<BlockHash>,
         plh: PositionalLineageHash,
         token_ids: Option<Vec<u32>>,
     ) {
@@ -1260,9 +1258,10 @@ impl KvManager {
         };
 
         if is_new {
+            let local_hashes = local_hash.into_iter().collect::<Vec<_>>();
             self.publish_kv_event(
                 vec![seq_hash],
-                &[local_hash],
+                &local_hashes,
                 parent_hash,
                 true,
                 token_ids.map(|t| vec![t]),
@@ -1597,7 +1596,7 @@ mod tests {
         let mut mgr = make_mgr(10, 16);
         let uuid = Uuid::new_v4();
         use_partial(&mut mgr, uuid);
-        mgr.process(&MoveBlock::Promote(uuid, 42, None, 0, plh(500), None));
+        mgr.process(&MoveBlock::Promote(uuid, 42, None, Some(0), plh(500), None));
         assert_eq!(mgr.num_active_blocks(), 1);
         assert!(mgr.active_partial.is_empty());
         assert!(mgr.active_full.contains_key(&42));
@@ -1611,7 +1610,7 @@ mod tests {
             Uuid::new_v4(),
             42,
             None,
-            0,
+            Some(0),
             plh(500),
             None,
         ));
@@ -2043,13 +2042,13 @@ mod tests {
             SwapInRegistrationBlock {
                 seq_hash: 12,
                 plh: plh(12),
-                local_hash: 120,
+                local_hash: Some(120),
                 token_ids: Some(vec![1; 16]),
             },
             SwapInRegistrationBlock {
                 seq_hash: 13,
                 plh: plh(13),
-                local_hash: 130,
+                local_hash: Some(130),
                 token_ids: Some(vec![2; 16]),
             },
         ];
@@ -2534,7 +2533,7 @@ mod tests {
             let entries = vec![SwapInRegistrationBlock {
                 seq_hash: 1,
                 plh: plh(1),
-                local_hash: 101,
+                local_hash: Some(101),
                 token_ids: Some(token_ids.clone()),
             }];
             let outcome = mgr.register_swapped_in_blocks(entries, None, slots);

--- a/lib/mocker/src/kvbm_offload/engine.rs
+++ b/lib/mocker/src/kvbm_offload/engine.rs
@@ -200,7 +200,7 @@ impl PendingStagedSwapIn {
 pub(crate) struct G2BlockEventMetadata {
     pub(crate) seq_hash: RouterSequenceHash,
     pub(crate) parent_hash: Option<RouterSequenceHash>,
-    pub(crate) local_hash: BlockHash,
+    pub(crate) local_hash: Option<BlockHash>,
     pub(crate) token_ids: Option<Vec<u32>>,
 }
 

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -80,9 +80,8 @@ fn create_replay_indexer(block_size: u32, num_threads: usize) -> ReplayIndexer {
         )));
     }
 
-    ReplayIndexer::Single(KvIndexer::new_with_frequency(
+    ReplayIndexer::Single(KvIndexer::new_with_pruning(
         CancellationToken::new(),
-        None,
         block_size,
         Arc::new(KvIndexerMetrics::new_unregistered()),
         None,

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -408,6 +408,11 @@ impl VllmCore {
         kv_event_publishers: KvEventPublishers,
     ) -> Self {
         let args = args.normalized().expect("invalid MockEngineArgs");
+        let kv_event_publishers = if args.enable_prefix_caching {
+            kv_event_publishers
+        } else {
+            KvEventPublishers::default()
+        };
         let speculative_sampler = args.aic_nextn.map(|nextn| {
             let rates =
                 normalize_conditional_accept_rates(nextn, args.aic_nextn_accept_rates.as_deref())
@@ -599,16 +604,15 @@ impl VllmCore {
             unique
                 .iter()
                 .zip(plhs.iter())
-                .zip(local_hashes.iter())
-                .zip(token_ids.iter())
+                .enumerate()
                 .skip(skip)
                 .take(count)
-                .filter_map(|(((block, plh), local), token_ids)| match block {
+                .filter_map(|(idx, (block, plh))| match block {
                     UniqueBlock::FullBlock(seq_hash) => Some(SwapInRegistrationBlock {
                         seq_hash: *seq_hash,
                         plh: *plh,
-                        local_hash: *local,
-                        token_ids: Some(token_ids.clone()),
+                        local_hash: local_hashes.get(idx).copied(),
+                        token_ids: token_ids.get(idx).cloned(),
                     }),
                     UniqueBlock::PartialBlock(_) => None,
                 })

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -4,7 +4,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use dynamo_kv_router::indexer::METRIC_EVENT_STORED;
+use dynamo_kv_router::indexer::{METRIC_EVENT_REMOVED, METRIC_EVENT_STORED};
 use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, WorkerId};
 use rstest::rstest;
 use tokio::sync::mpsc;
@@ -934,6 +934,12 @@ mod live_scheduler {
         let _ = tokio::time::timeout(Duration::from_secs(2), forwarder_task).await;
         harness.flush().await;
         harness.assert_no_event_errors();
+        if enable_prefix_caching {
+            assert!(harness.ok_count(METRIC_EVENT_STORED) > 0);
+        } else {
+            assert_eq!(harness.ok_count(METRIC_EVENT_STORED), 0);
+            assert_eq!(harness.ok_count(METRIC_EVENT_REMOVED), 0);
+        }
         // NOTE: we do NOT assert `dump_events().is_empty()` here because
         // mocker's protocol does not emit router `Removed` events on
         // request completion.


### PR DESCRIPTION
## Summary
- replace the single-threaded radix index with compressed edges backed by shared `NodeState` semantics while leaving CRTC's concurrent dump walker unchanged
- emit recovery dumps as parent plus block-vector events, preserve replay ordering and worker/rank coverage, and remove the obsolete frequency configuration/API
- eagerly repair suffix lookups after mid-edge removal and log compressed event counts alongside represented block counts
- add focused regression coverage for mid-edge removal/restoration, compact dump shape, parent ordering, replay equivalence, and serialized payload reduction

Refs #10524

## Validation
- `cargo test -p dynamo-kv-router --no-default-features`
- `cargo test -p dynamo-kv-router --no-default-features --features metrics,runtime-protocols`
- `cargo test -p dynamo-llm --no-default-features kv_router::indexer::recovery::worker_query`
- `cd lib/bindings/python && cargo test --lib`
- `cargo fmt --all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed `expiration_duration_secs` parameter from Python `RadixTree` constructor.
  * Replaced frequency-based indexer initialization with pruning-based configuration.

* **Refactor**
  * Restructured KV router indexer implementation with optimized internal representation.
  * Updated `RadixTree` API to streamline initialization and pruning behavior.

* **Documentation**
  * Clarified that legacy `frequencies` field in overlap scores is now empty; updated compatibility notes across indexer modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->