### PR TITLE
fix(sglang): stop re-encoding routed_experts from sglang 0.5.11+ (#9657)

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -13,6 +13,11 @@ Policy: support current SGLang release + 1 version back (N and N-1). Each
 fallback branch must document which version it covers and when it can be
 removed. When the old version falls outside the support window, delete the
 fallback and any associated polyfills.
+
+Runtime data-contract notes (not code-level shims):
+
+* ``meta_info["routed_experts"]`` is a base64 UTF-8 string from sglang
+  >= 0.5.11. Pass through; do not re-encode.
 """
 
 import inspect

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -7,7 +7,6 @@ import os
 import time
 from typing import Any, AsyncGenerator, Dict, Optional
 
-import pybase64
 import sglang as sgl
 from PIL.Image import Image as PILImage
 
@@ -644,11 +643,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
                 routed_experts = res["meta_info"].get("routed_experts")
                 if routed_experts is not None:
-                    # Base64-encode tensor bytes to match sglang's output format.
-                    routed_experts = pybase64.b64encode(
-                        routed_experts.numpy().tobytes()
-                    ).decode("utf-8")
-                    # Internal transport field consumed by frontend nvext mapping.
+                    # sglang >= 0.5.11 base64-encodes routed_experts upstream.
                     out["disaggregated_params"] = {"routed_experts": routed_experts}
                 if finish_reason:
                     input_tokens = res["meta_info"]["prompt_tokens"]
@@ -742,10 +737,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     response_nvext["stop_reason"] = stop_reason
                 routed_experts = res["meta_info"].get("routed_experts")
                 if routed_experts is not None:
-                    # Base64-encode tensor bytes to match sglang's output format.
-                    routed_experts = pybase64.b64encode(
-                        routed_experts.numpy().tobytes()
-                    ).decode("utf-8")
+                    # sglang >= 0.5.11 base64-encodes routed_experts upstream.
                     response_nvext["routed_experts"] = routed_experts
                 if response_nvext:
                     response["nvext"] = response_nvext


### PR DESCRIPTION
## Summary
- Cherry-pick of #9657 to release/1.2.1.
- `--enable-return-routed-experts` crashes on the first decoded token for non-DSv4 MoE models (`AttributeError: 'str' object has no attribute 'numpy'`). sglang v0.5.11 moved the base64 encode of `routed_experts` upstream into `tokenizer_manager`; the decode handler still re-encoded what is now already a `str`. This passes the string through at both emit sites.
- Version-correct for this branch: release/1.2.1 pins the sglang runtime to v0.5.11 (`container/context.yaml`), exactly where the upstream change landed.

Fixes https://nvbugs/6179574

## Original PR
- Main PR: #9657
- Merge commit: 82bccf8a3731bb7683f2b4376c855f20837dafc9

## Test plan
- [ ] CI passes