### PR TITLE
fix: import-time compat for AMD ROCm / Python 3.10 hosts (#9929)

### DIFF
--- a/components/src/dynamo/common/configuration/config_base.py
+++ b/components/src/dynamo/common/configuration/config_base.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import argparse
-from typing import Self
+
+# typing.Self is 3.11+; pyproject declares requires-python>=3.10 so use the
+# typing_extensions back-port (added as an explicit dep in pyproject.toml).
+from typing_extensions import Self
 
 
 class ConfigBase:

--- a/components/src/dynamo/common/configuration/groups/http_args.py
+++ b/components/src/dynamo/common/configuration/groups/http_args.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-from typing import Optional, Self
+from typing import Optional
+
+# typing.Self is 3.11+; pyproject declares requires-python>=3.10 so use the
+# typing_extensions back-port (added as an explicit dep in pyproject.toml).
+from typing_extensions import Self
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase

--- a/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
+++ b/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
@@ -38,13 +38,51 @@ except ImportError as e:
         "PyTorch must be installed to use this module. Please install PyTorch, ex: 'pip install torch'."
     ) from e
 
+
+class _NixlImportProxy:
+    """Stand-in for a missing NIXL submodule that re-raises the deferred
+    import error on any attribute access or call.
+
+    Defer NIXL import error to only where NIXL is required. The `nixl`
+    pip wheel only ships CUDA builds (`nixl-cu12`); on platforms without
+    a NIXL wheel (e.g. AMD ROCm), letting `import dynamo.nixl_connect`
+    succeed lets transitive importers — router, planner, frontend — load.
+    Any code path that actually touches the bindings (today the only one
+    is `Connection.__init__` via `nixl_api.nixl_agent(...)`; tomorrow any
+    new one) fails loudly with a clear, deferred ImportError — no
+    explicit `_require_nixl()` guard call needed at each use site.
+    """
+
+    __slots__ = ("_module_name", "_orig_error")
+
+    def __init__(self, module_name: str, orig_error: ImportError) -> None:
+        # Bypass __setattr__ in case a subclass overrides it.
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_orig_error", orig_error)
+
+    def _raise(self) -> None:
+        raise ImportError(
+            "NIXL Python bindings must be installed to use this module. "
+            "Please install NIXL, ex: 'pip install nixl'."
+        ) from self._orig_error
+
+    def __getattr__(self, name: str):
+        self._raise()
+
+    def __call__(self, *args, **kwargs):
+        self._raise()
+
+    def __repr__(self) -> str:
+        return f"<unavailable NIXL submodule {self._module_name!r}>"
+
+
 try:
     import nixl._api as nixl_api
     import nixl._bindings as nixl_bindings
 except ImportError as e:
-    raise ImportError(
-        "NIXL Python bindings must be installed to use this module. Please install NIXL, ex: 'pip install nixl'."
-    ) from e
+    nixl_api = _NixlImportProxy("nixl._api", e)  # type: ignore[assignment]
+    nixl_bindings = _NixlImportProxy("nixl._bindings", e)  # type: ignore[assignment]
+
 
 logger = logging.getLogger(__name__)
 
@@ -579,6 +617,9 @@ class Connection:
         self._connector: Connector = connector
         self._is_initialized = False
         self._name = f"{connector.name}-{number}"
+        # If NIXL bindings are absent, `nixl_api` is a `_NixlImportProxy`
+        # and the next line raises the deferred ImportError on attribute
+        # access — no explicit guard needed.
         self._nixl = nixl_api.nixl_agent(self._name)
 
         self._remote_refs: dict[str, int] = {}  # ref-count remote agents

--- a/lib/bindings/python/tests/test_nixl_connect_lazy_import.py
+++ b/lib/bindings/python/tests/test_nixl_connect_lazy_import.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify dynamo.nixl_connect imports on hosts without NIXL bindings.
+
+The NIXL pip wheel ships CUDA only (`nixl-cu12`). On platforms without a
+NIXL wheel (e.g. AMD ROCm hosts) the module must still import so that
+transitive importers — router, planner, frontend, AMD aggregated /
+Mooncake-based disaggregated paths — load. The deferred ImportError
+should be raised only when a code path that actually touches the
+bindings is exercised (today: constructing a `Connector` → `Connection`).
+"""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Pure Python import-error logic; no GPU needed. The `gpu_0` marker is
+# required by .ai/pytest-guidelines.md so CI matrices that filter by
+# GPU class (`-m gpu_0`) pick it up.
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+
+
+@pytest.fixture(scope="module")
+def nixl_connect_no_nixl():
+    """Re-import dynamo.nixl_connect exactly once with nixl masked.
+
+    Uses `patch.dict(sys.modules, ...)` (auto-restoring) to mask nixl —
+    same pattern as `test_nixl_connect_unit.py`. Setting
+    `sys.modules[name] = None` causes `import name` to raise
+    ModuleNotFoundError, matching the real AMD-host behavior.
+
+    Scope is `module` (not `function`) on purpose: re-executing the
+    `dynamo.nixl_connect` module body twice in a single session triggers
+    a `_has_torch_function already has a docstring` RuntimeError from
+    `torch.overrides`. One re-import per file is safe; per-test re-import
+    is not. Per-test state is handled via `monkeypatch.setattr` below.
+    """
+    saved = sys.modules.get("dynamo.nixl_connect")
+    with patch.dict(
+        sys.modules,
+        {"nixl": None, "nixl._api": None, "nixl._bindings": None},
+    ):
+        sys.modules.pop("dynamo.nixl_connect", None)
+        yield importlib.import_module("dynamo.nixl_connect")
+    if saved is None:
+        sys.modules.pop("dynamo.nixl_connect", None)
+    else:
+        sys.modules["dynamo.nixl_connect"] = saved
+
+
+def test_module_imports_without_nixl(nixl_connect_no_nixl):
+    """`import dynamo.nixl_connect` must succeed when nixl is unavailable."""
+    mod = nixl_connect_no_nixl
+    # `nixl_api` / `nixl_bindings` are replaced with proxies, not None,
+    # so any attribute access or call surfaces the deferred ImportError
+    # with a clear message rather than `AttributeError: 'NoneType'...`.
+    assert isinstance(mod.nixl_api, mod._NixlImportProxy)
+    assert isinstance(mod.nixl_bindings, mod._NixlImportProxy)
+
+
+def test_proxy_raises_clear_error_on_attribute_access(nixl_connect_no_nixl):
+    """Any attribute access on the proxy raises the deferred ImportError."""
+    mod = nixl_connect_no_nixl
+    # Covers `nixl_api.nixl_agent`, `nixl_bindings.nixlXferDList`, and
+    # any future use site.
+    with pytest.raises(ImportError, match="NIXL Python bindings must be installed"):
+        _ = mod.nixl_api.nixl_agent
+    with pytest.raises(ImportError, match="NIXL Python bindings must be installed"):
+        _ = mod.nixl_bindings.nixlXferDList
+
+
+def test_proxy_raises_clear_error_on_call(nixl_connect_no_nixl):
+    """Calling the proxy itself (e.g. `nixl_api(...)`) raises the deferred error."""
+    mod = nixl_connect_no_nixl
+    with pytest.raises(ImportError, match="NIXL Python bindings must be installed"):
+        mod.nixl_api()
+
+
+def test_proxy_chains_original_import_error(nixl_connect_no_nixl):
+    """The re-raised ImportError preserves the original cause via __cause__."""
+    mod = nixl_connect_no_nixl
+    with pytest.raises(ImportError) as excinfo:
+        _ = mod.nixl_api.anything
+    assert isinstance(excinfo.value.__cause__, ImportError)
+
+
+def test_connection_construction_raises_without_nixl(nixl_connect_no_nixl):
+    """Constructing a Connection without NIXL must raise the deferred error.
+
+    The runtime use site is `nixl_api.nixl_agent(self._name)` in
+    `Connection.__init__`. With the proxy in place no explicit guard is
+    needed — the call itself raises.
+    """
+    mod = nixl_connect_no_nixl
+    fake_connector = MagicMock(spec=mod.Connector)
+    fake_connector.name = "test"
+    with pytest.raises(ImportError, match="NIXL Python bindings must be installed"):
+        mod.Connection(fake_connector, 1)
+
+
+def test_real_nixl_path_unchanged(nixl_connect_no_nixl, monkeypatch):
+    """When the bindings are present, attribute access goes to the real module.
+
+    Simulates the CUDA path by monkey-patching the imported module's
+    `nixl_api` to a Mock and verifying ordinary attribute access works.
+    """
+    mod = nixl_connect_no_nixl
+    real_like = MagicMock()
+    real_like.nixl_agent.return_value = MagicMock(name="agent")
+    monkeypatch.setattr(mod, "nixl_api", real_like)
+    # Attribute access + call now work normally.
+    agent = mod.nixl_api.nixl_agent("name")
+    assert agent is real_like.nixl_agent.return_value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "msgspec>=0.19.0",
     "pyzmq>=26.0.0",
     "msgpack==1.1.2",
+    # typing.Self is 3.11+; declared minimum is 3.10 (see requires-python),
+    # so back-port Self via typing_extensions in dynamo.common.configuration.
+    "typing_extensions>=4.10.0",
 ]
 
 classifiers = [


### PR DESCRIPTION
## Summary
- Cherry-pick of #9929 to release/1.2.1.
- Two independent import-time fixes that unblock `import dynamo.*` on AMD ROCm / Python 3.10 hosts:
  - `nixl_connect`: defer the NIXL `ImportError` until first actual use (the `nixl` wheel is CUDA-only), so transitive importers (router, planner, frontend) load on hosts without a NIXL wheel. CUDA behavior is unchanged.
  - `dynamo.common.configuration`: use `typing_extensions.Self` instead of `typing.Self` (3.11+), since `requires-python = ">=3.10"`. Adds `typing_extensions>=4.10.0` to dependencies.

## Conflict resolution
- `pyproject.toml`: kept this branch's `msgpack==1.1.2` dependency and added the `typing_extensions>=4.10.0` line from the fix. All other files applied cleanly.

## Original PR
- Main PR: #9929
- Merge commit: 8ea44f3ab09dbe28a18fbc7d79bf562d36af2c8b

## Test plan
- [ ] CI passes (CUDA path)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->