### PR TITLE
fix(routing): enable disagg-bootstrap for LeastLoaded / P2C / DeviceAwareWeighted

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -324,7 +324,13 @@ impl Router {
             .map_err(|e| anyhow::anyhow!("Prefill query failed: {:?}", e))?;
 
         match outcome {
-            PrefillQueryOutcome::Routed { worker_id, dp_rank } => Ok((worker_id, dp_rank)),
+            // External-dispatch query: the gateway routes/tracks the worker
+            // itself, so we don't retain the occupancy booking (drop the permit).
+            PrefillQueryOutcome::Routed {
+                worker_id,
+                dp_rank,
+                permit: _,
+            } => Ok((worker_id, dp_rank)),
             // Surface backpressure as an error so the caller's
             // enforce_disagg / aggregated-fallback logic in `pick()` can
             // decide whether to fail the request or fall back to decode-only.

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -483,7 +483,13 @@ impl RouterHandles {
                 QueryRouterResult::ErrQueryFailed
             })?;
         match outcome {
-            PrefillQueryOutcome::Routed { worker_id, dp_rank } => Ok((worker_id, dp_rank)),
+            // External-dispatch query: the C caller routes/tracks the worker
+            // itself, so we don't retain the occupancy booking (drop the permit).
+            PrefillQueryOutcome::Routed {
+                worker_id,
+                dp_rank,
+                permit: _,
+            } => Ok((worker_id, dp_rank)),
             PrefillQueryOutcome::Backpressure {
                 reason,
                 queued_isl_tokens,

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -74,7 +74,11 @@ impl PrefillRouter {
                 dp_rank = worker.dp_rank,
                 "Using sticky prefill worker for bootstrap"
             );
-            (worker.worker_id, Some(worker.dp_rank), book(worker.worker_id))
+            (
+                worker.worker_id,
+                Some(worker.dp_rank),
+                book(worker.worker_id),
+            )
         } else if let Some(id) = preselected_worker {
             let dp_rank = req
                 .routing

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -333,13 +333,9 @@ impl PrefillRouter {
     /// The `phase_transition_permit` is passed to the spawned task and released after routing
     /// completes, allowing the main task's `set_phase(Decode)` to proceed.
     ///
-    /// `load_permit` is the occupancy-state handle returned by
-    /// `InnerPrefillRouter::track_dispatch`. It's moved into the spawned task
-    /// so its drop emits the load decrement when the prefill stream ends — this
-    /// keeps load accounting symmetric for the bootstrap path (which dispatches
-    /// via `router.direct()` and would otherwise skip both inc and dec). `None`
-    /// for routing modes that don't use occupancy-state tracking (KV /
-    /// RoundRobin / Random / Direct).
+    /// `load_permit` is held for the spawned task's lifetime; its drop emits the
+    /// occupancy decrement for the bootstrap dispatch. `None` for modes without
+    /// occupancy tracking.
     pub(super) fn spawn_prefill_task(
         &self,
         prefill_request: SingleIn<PreprocessedRequest>,
@@ -353,7 +349,7 @@ impl PrefillRouter {
 
         tokio::spawn(
             async move {
-                let _load_permit = load_permit;
+                let _load_permit = load_permit; // drop emits decrement
                 match Self::execute_prefill(
                     router,
                     prefill_request,
@@ -369,7 +365,6 @@ impl PrefillRouter {
                         tracing::warn!("Prefill background task error: {e:?}");
                     }
                 }
-                // _load_permit drops here → state.decrement(worker_id)
             }
             .instrument(span),
         );

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -57,14 +57,24 @@ impl PrefillRouter {
             None
         };
 
-        // Worker selection
-        let (worker_id, dp_rank) = if let Some(worker) = sticky_worker {
+        // Worker selection. `permit` books occupancy for LL/P2C/DAW so the
+        // later `direct()` dispatch is counted; held by the returned decision
+        // for the request's lifetime. For an externally-fixed worker (sticky /
+        // preselected) there is no selection race, so a plain track_dispatch
+        // books it; the router-selected path books atomically inside
+        // query_prefill_worker. `None` for KV/RoundRobin/Random.
+        let book = |worker_id: u64| {
+            self.prefill_router
+                .get()
+                .and_then(|r| r.track_dispatch(worker_id))
+        };
+        let (worker_id, dp_rank, permit) = if let Some(worker) = sticky_worker {
             tracing::debug!(
                 worker_id = worker.worker_id,
                 dp_rank = worker.dp_rank,
                 "Using sticky prefill worker for bootstrap"
             );
-            (worker.worker_id, Some(worker.dp_rank))
+            (worker.worker_id, Some(worker.dp_rank), book(worker.worker_id))
         } else if let Some(id) = preselected_worker {
             let dp_rank = req
                 .routing
@@ -75,7 +85,7 @@ impl PrefillRouter {
                 dp_rank = ?dp_rank,
                 "Using pre-selected prefill worker for bootstrap"
             );
-            (id, dp_rank)
+            (id, dp_rank, book(id))
         } else {
             // Use shared worker selection logic (update_states=false for peek behavior)
             // Extract queue and request metadata from routing hints.
@@ -113,7 +123,11 @@ impl PrefillRouter {
                 )
                 .await
             {
-                Ok(PrefillQueryOutcome::Routed { worker_id, dp_rank }) => (worker_id, dp_rank),
+                Ok(PrefillQueryOutcome::Routed {
+                    worker_id,
+                    dp_rank,
+                    permit,
+                }) => (worker_id, dp_rank, permit),
                 Ok(PrefillQueryOutcome::Backpressure {
                     reason,
                     queued_isl_tokens,
@@ -134,13 +148,25 @@ impl PrefillRouter {
             .model_manager
             .get_disaggregated_endpoint(endpoint_id, worker_id)
         else {
-            return PrefillResolveDecision::NoBootstrapEndpoint { worker_id, dp_rank };
+            return PrefillResolveDecision::NoBootstrapEndpoint {
+                worker_id,
+                dp_rank,
+                permit,
+            };
         };
         let Some(host) = endpoint.bootstrap_host else {
-            return PrefillResolveDecision::NoBootstrapEndpoint { worker_id, dp_rank };
+            return PrefillResolveDecision::NoBootstrapEndpoint {
+                worker_id,
+                dp_rank,
+                permit,
+            };
         };
         let Some(port) = endpoint.bootstrap_port else {
-            return PrefillResolveDecision::NoBootstrapEndpoint { worker_id, dp_rank };
+            return PrefillResolveDecision::NoBootstrapEndpoint {
+                worker_id,
+                dp_rank,
+                permit,
+            };
         };
 
         let dp_size: Option<u32> = self
@@ -167,6 +193,7 @@ impl PrefillRouter {
                 bootstrap_port: port,
                 bootstrap_room,
             },
+            permit,
         }
     }
 
@@ -415,9 +442,12 @@ impl PrefillRouter {
                     .await?;
                 match outcome {
                     crate::kv_router::FindBestMatchOutcome::Routed { worker, .. } => {
+                        // KV tracks load via worker-pushed kv_metrics, not the
+                        // occupancy counter, so no permit here.
                         Ok(PrefillQueryOutcome::Routed {
                             worker_id: worker.worker_id,
                             dp_rank: Some(worker.dp_rank),
+                            permit: None,
                         })
                     }
                     crate::kv_router::FindBestMatchOutcome::Backpressure {
@@ -432,15 +462,32 @@ impl PrefillRouter {
                 }
             }
             InnerPrefillRouter::SimpleRouter(r) => {
-                let worker_id = if update_states {
-                    r.select_next_worker()
+                // Peek path (update_states=false) is the bootstrap resolve: for
+                // LL/P2C/DAW, atomically select+book via select_and_reserve so a
+                // concurrent resolve can't pick the same min; RoundRobin/Random
+                // have no occupancy state, so fall back to a plain peek (no
+                // permit). The select path (update_states=true) advances the
+                // RoundRobin/Random cursor and never books occupancy.
+                let (worker_id, permit) = if update_states {
+                    let id = r
+                        .select_next_worker()
+                        .ok_or_else(|| anyhow::anyhow!("No workers available for prefill"))?;
+                    (id, None)
                 } else {
-                    r.peek_next_worker()
-                }
-                .ok_or_else(|| anyhow::anyhow!("No workers available for prefill"))?;
+                    match r.select_and_reserve().await {
+                        Some((id, permit)) => (id, Some(permit)),
+                        None => {
+                            let id = r.peek_next_worker().ok_or_else(|| {
+                                anyhow::anyhow!("No workers available for prefill")
+                            })?;
+                            (id, None)
+                        }
+                    }
+                };
                 Ok(PrefillQueryOutcome::Routed {
                     worker_id,
                     dp_rank: None,
+                    permit,
                 })
             }
         }

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -332,11 +332,20 @@ impl PrefillRouter {
     ///
     /// The `phase_transition_permit` is passed to the spawned task and released after routing
     /// completes, allowing the main task's `set_phase(Decode)` to proceed.
+    ///
+    /// `load_permit` is the occupancy-state handle returned by
+    /// `InnerPrefillRouter::track_dispatch`. It's moved into the spawned task
+    /// so its drop emits the load decrement when the prefill stream ends — this
+    /// keeps load accounting symmetric for the bootstrap path (which dispatches
+    /// via `router.direct()` and would otherwise skip both inc and dec). `None`
+    /// for routing modes that don't use occupancy-state tracking (KV /
+    /// RoundRobin / Random / Direct).
     pub(super) fn spawn_prefill_task(
         &self,
         prefill_request: SingleIn<PreprocessedRequest>,
         target_worker: Option<u64>,
         phase_transition_permit: OwnedSemaphorePermit,
+        load_permit: Option<dynamo_runtime::pipeline::OccupancyPermit>,
     ) {
         let router = self.prefill_router.get().cloned();
         // Capture current span to propagate trace context to the spawned task
@@ -344,6 +353,7 @@ impl PrefillRouter {
 
         tokio::spawn(
             async move {
+                let _load_permit = load_permit;
                 match Self::execute_prefill(
                     router,
                     prefill_request,
@@ -359,6 +369,7 @@ impl PrefillRouter {
                         tracing::warn!("Prefill background task error: {e:?}");
                     }
                 }
+                // _load_permit drops here → state.decrement(worker_id)
             }
             .instrument(span),
         );

--- a/lib/llm/src/kv_router/prefill_router/inner.rs
+++ b/lib/llm/src/kv_router/prefill_router/inner.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use dynamo_kv_router::protocols::WorkerWithDpRank;
 
 use dynamo_runtime::{
-    pipeline::{AsyncEngine, ManyOut, PushRouter, SingleIn},
+    pipeline::{AsyncEngine, ManyOut, OccupancyPermit, PushRouter, SingleIn},
     protocols::annotated::Annotated,
 };
 
@@ -111,6 +111,22 @@ impl InnerPrefillRouter {
             router
                 .sticky
                 .refresh_worker_for_phase(request, RequestPhase::Prefill);
+        }
+    }
+
+    /// Commit load tracking for a worker chosen via [`Self::generate_to_worker`]'s
+    /// disagg-bootstrap path. Returns `Some(permit)` only for `SimpleRouter` modes
+    /// whose underlying `PushRouter` maintains an occupancy counter
+    /// (LeastLoaded / PowerOfTwoChoices / DeviceAwareWeighted). Drop the permit
+    /// when the dispatched request finishes — typically by moving it into the
+    /// spawned prefill task so it lives for the prefill stream's lifetime.
+    ///
+    /// `KvRouter` routes via `KvPushRouter::select_worker`, which has its own
+    /// state-keeping via worker-pushed kv_metrics events, so this returns `None`.
+    pub(super) fn track_dispatch(&self, instance_id: u64) -> Option<OccupancyPermit> {
+        match self {
+            InnerPrefillRouter::SimpleRouter(router) => router.track_dispatch(instance_id),
+            InnerPrefillRouter::KvRouter(_) => None,
         }
     }
 }

--- a/lib/llm/src/kv_router/prefill_router/inner.rs
+++ b/lib/llm/src/kv_router/prefill_router/inner.rs
@@ -114,15 +114,9 @@ impl InnerPrefillRouter {
         }
     }
 
-    /// Commit load tracking for a worker chosen via [`Self::generate_to_worker`]'s
-    /// disagg-bootstrap path. Returns `Some(permit)` only for `SimpleRouter` modes
-    /// whose underlying `PushRouter` maintains an occupancy counter
-    /// (LeastLoaded / PowerOfTwoChoices / DeviceAwareWeighted). Drop the permit
-    /// when the dispatched request finishes — typically by moving it into the
-    /// spawned prefill task so it lives for the prefill stream's lifetime.
-    ///
-    /// `KvRouter` routes via `KvPushRouter::select_worker`, which has its own
-    /// state-keeping via worker-pushed kv_metrics events, so this returns `None`.
+    /// Commit occupancy load for a bootstrap-dispatched worker. `Some` only for
+    /// `SimpleRouter` occupancy modes; `KvRouter` tracks load via worker-pushed
+    /// kv_metrics events instead.
     pub(super) fn track_dispatch(&self, instance_id: u64) -> Option<OccupancyPermit> {
         match self {
             InnerPrefillRouter::SimpleRouter(router) => router.track_dispatch(instance_id),

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -142,6 +142,33 @@ impl
                 let topology_constraints =
                     self.preflight_kv_transfer_constraints(endpoint_id, Some(worker_id))?;
 
+                // Bootstrap optimization path: spawn prefill in background.
+                //
+                // Load accounting for the bootstrap dispatch: the actual prefill
+                // request is sent via `router.direct(worker_id)` from the spawned
+                // task, which bypasses the per-mode dispatcher's
+                // increment/Permit-drop pair. Without an explicit
+                // `track_dispatch` here, LL / P2C / DeviceAwareWeighted would
+                // accumulate no occupancy state for bootstrap-routed requests,
+                // and peek-based selection would degenerate to all-equal-zero
+                // → uniform-random. Acquire a permit at the commit point and
+                // hand it to the spawned task; its drop emits the matching
+                // decrement when the prefill stream ends.
+                let load_permit = self
+                    .prefill_router
+                    .get()
+                    .and_then(|router| router.track_dispatch(worker_id));
+
+                // For routing modes that *do* advance state via the existing
+                // `select_next_worker` call site (RoundRobin advances its
+                // counter; LeastLoaded etc. are no-ops here and rely on the
+                // permit above), keep the call so RR's counter still ticks.
+                if !self.router_mode.is_kv_routing()
+                    && let Some(router) = self.prefill_router.get()
+                {
+                    router.select_next_worker();
+                }
+
                 // Bootstrap optimization path: spawn prefill in background
                 self.commit_selected_prefill_worker(
                     &mut prefill_req,
@@ -168,7 +195,12 @@ impl
 
                 // Pass the phase barrier to the spawned task. It is released after routing
                 // completes so worker recording finishes before phase changes to Decode.
-                self.spawn_prefill_task(prefill_context, Some(worker_id), prefill_phase_barrier);
+                self.spawn_prefill_task(
+                    prefill_context,
+                    Some(worker_id),
+                    prefill_phase_barrier,
+                    load_permit,
+                );
 
                 (
                     Ok(PrefillOutcome::Bootstrap {

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -142,27 +142,16 @@ impl
                 let topology_constraints =
                     self.preflight_kv_transfer_constraints(endpoint_id, Some(worker_id))?;
 
-                // Bootstrap optimization path: spawn prefill in background.
-                //
-                // Load accounting for the bootstrap dispatch: the actual prefill
-                // request is sent via `router.direct(worker_id)` from the spawned
-                // task, which bypasses the per-mode dispatcher's
-                // increment/Permit-drop pair. Without an explicit
-                // `track_dispatch` here, LL / P2C / DeviceAwareWeighted would
-                // accumulate no occupancy state for bootstrap-routed requests,
-                // and peek-based selection would degenerate to all-equal-zero
-                // → uniform-random. Acquire a permit at the commit point and
-                // hand it to the spawned task; its drop emits the matching
-                // decrement when the prefill stream ends.
+                // The spawned task dispatches via `direct(worker_id)`, which skips
+                // load tracking; this permit charges/credits the occupancy counter
+                // so LL/P2C/DAW selection doesn't degenerate to uniform-random.
                 let load_permit = self
                     .prefill_router
                     .get()
                     .and_then(|router| router.track_dispatch(worker_id));
 
-                // For routing modes that *do* advance state via the existing
-                // `select_next_worker` call site (RoundRobin advances its
-                // counter; LeastLoaded etc. are no-ops here and rely on the
-                // permit above), keep the call so RR's counter still ticks.
+                // RoundRobin advances its counter here; LL/P2C/DAW are no-ops and
+                // rely on the permit above.
                 if !self.router_mode.is_kv_routing()
                     && let Some(router) = self.prefill_router.get()
                 {

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -138,22 +138,21 @@ impl
                 worker_id,
                 dp_rank,
                 bootstrap_info,
+                permit: load_permit,
             } => {
                 let topology_constraints =
                     self.preflight_kv_transfer_constraints(endpoint_id, Some(worker_id))?;
 
-                // The spawned task dispatches via `direct(worker_id)`, which skips
-                // load tracking; this permit charges/credits the occupancy counter
-                // so LL/P2C/DAW selection doesn't degenerate to uniform-random.
-                let load_permit = self
-                    .prefill_router
-                    .get()
-                    .and_then(|router| router.track_dispatch(worker_id));
-
+                // `load_permit` was booked atomically during resolve (peek+book
+                // in one step, no select/track race). The spawned task dispatches
+                // via `direct(worker_id)`, which skips load tracking, so the
+                // permit is held across the spawned prefill to keep LL/P2C/DAW
+                // selection accurate. `None` for KV/RoundRobin/Random.
+                //
                 // RoundRobin counter advance happens inside
                 // commit_selected_prefill_worker below (gated on
-                // preselected_worker.is_none()); LL/P2C/DAW rely on the permit
-                // above. Advancing here too would double-count RoundRobin.
+                // preselected_worker.is_none()); advancing here too would
+                // double-count RoundRobin.
 
                 // Bootstrap optimization path: spawn prefill in background
                 self.commit_selected_prefill_worker(
@@ -222,6 +221,7 @@ impl
             PrefillResolveDecision::NoBootstrapEndpoint {
                 worker_id: resolved_wid,
                 dp_rank: resolved_dp_rank,
+                permit: load_permit,
             } => {
                 let topology_constraints =
                     self.preflight_kv_transfer_constraints(endpoint_id, Some(resolved_wid))?;
@@ -245,6 +245,10 @@ impl
                     request_id.clone(),
                     metadata.clone(),
                 );
+                // This branch also dispatches via `direct(resolved_wid)` (inside
+                // execute_prefill), which skips load tracking — so hold the
+                // occupancy booking across the synchronous prefill so LL/P2C/DAW
+                // load is counted here too. Dropped when prefill completes.
                 let completion = Self::execute_prefill(
                     self.prefill_router.get().cloned(),
                     prefill_context,
@@ -252,6 +256,7 @@ impl
                     None,
                 )
                 .await?;
+                drop(load_permit);
                 (
                     Ok(PrefillOutcome::Completed {
                         result: completion.result,

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -150,13 +150,10 @@ impl
                     .get()
                     .and_then(|router| router.track_dispatch(worker_id));
 
-                // RoundRobin advances its counter here; LL/P2C/DAW are no-ops and
-                // rely on the permit above.
-                if !self.router_mode.is_kv_routing()
-                    && let Some(router) = self.prefill_router.get()
-                {
-                    router.select_next_worker();
-                }
+                // RoundRobin counter advance happens inside
+                // commit_selected_prefill_worker below (gated on
+                // preselected_worker.is_none()); LL/P2C/DAW rely on the permit
+                // above. Advancing here too would double-count RoundRobin.
 
                 // Bootstrap optimization path: spawn prefill in background
                 self.commit_selected_prefill_worker(

--- a/lib/llm/src/kv_router/prefill_router/types.rs
+++ b/lib/llm/src/kv_router/prefill_router/types.rs
@@ -3,6 +3,7 @@
 
 use dynamo_kv_router::config::RouterConfigOverride;
 use dynamo_kv_router::protocols::RouterBackpressureReason;
+use dynamo_runtime::pipeline::OccupancyPermit;
 
 use crate::protocols::common::preprocessor::{BootstrapInfo, PrefillResult, TraceLink};
 
@@ -50,15 +51,22 @@ pub(super) enum PrefillResolveDecision {
         worker_id: u64,
         dp_rank: Option<u32>,
         bootstrap_info: BootstrapInfo,
+        /// Occupancy booking for LL/P2C/DAW; held across the spawned prefill so
+        /// `direct()` dispatch is reflected in the load counter. `None` for
+        /// KV/RoundRobin/Random.
+        permit: Option<OccupancyPermit>,
     },
     Unavailable,
     NotActivated,
     /// Bootstrap endpoint unavailable after a worker was selected.
-    /// Carries the peeked worker so the synchronous prefill path can commit
+    /// Carries the selected worker so the synchronous prefill path can commit
     /// that selection instead of re-entering router selection.
     NoBootstrapEndpoint {
         worker_id: u64,
         dp_rank: Option<u32>,
+        /// Same occupancy booking as `Resolved`; the synchronous path holds it
+        /// across `execute_prefill` so this branch tracks load too.
+        permit: Option<OccupancyPermit>,
     },
     Backpressure {
         reason: RouterBackpressureReason,
@@ -77,6 +85,10 @@ pub enum PrefillQueryOutcome {
     Routed {
         worker_id: u64,
         dp_rank: Option<u32>,
+        /// Atomic occupancy booking when the SimpleRouter selected via
+        /// `select_and_reserve` (LL/P2C/DAW). `None` for KV (own accounting),
+        /// RoundRobin/Random (peeked, no counter), and pinned workers.
+        permit: Option<OccupancyPermit>,
     },
     Backpressure {
         reason: RouterBackpressureReason,

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -73,11 +73,6 @@ impl RoutingOccupancyState {
     /// Tie-break policy matches [`select_exact_min_and_increment`] so peek and
     /// select observe the same selection distribution, modulo concurrent races.
     pub(crate) fn peek_min(&self, instance_ids: &[u64]) -> Option<u64> {
-        let deterministic_ties = std::env::var("DYN_ROUTER_LL_DETERMINISTIC_TIES")
-            .ok()
-            .as_deref()
-            == Some("1");
-
         let mut min_load = u64::MAX;
         let mut selected = None;
         let mut tie_count = 0usize;
@@ -93,7 +88,8 @@ impl RoutingOccupancyState {
 
             if load == min_load {
                 tie_count += 1;
-                if !deterministic_ties && rng.random_range(0..tie_count) == 0 {
+                // Reservoir sampling keeps tied minima uniform; matches select_exact_min_and_increment.
+                if rng.random_range(0..tie_count) == 0 {
                     selected = Some(id);
                 }
             }

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -63,6 +63,45 @@ impl RoutingOccupancyState {
         Some(id)
     }
 
+    /// Read-only mirror of [`select_exact_min_and_increment`] used by routing
+    /// modes (e.g. least-loaded) that want to *peek* a candidate without
+    /// committing the load increment — for example, the disagg-bootstrap path
+    /// in `prefill_router` which needs a worker_id to resolve `bootstrap_info`
+    /// before the actual prefill request is dispatched (and dispatching via
+    /// `direct(preselected_worker)` then performs the real load accounting).
+    ///
+    /// Tie-break policy matches [`select_exact_min_and_increment`] so peek and
+    /// select observe the same selection distribution, modulo concurrent races.
+    pub(crate) fn peek_min(&self, instance_ids: &[u64]) -> Option<u64> {
+        let deterministic_ties = std::env::var("DYN_ROUTER_LL_DETERMINISTIC_TIES")
+            .ok()
+            .as_deref()
+            == Some("1");
+
+        let mut min_load = u64::MAX;
+        let mut selected = None;
+        let mut tie_count = 0usize;
+        let mut rng = rand::rng();
+        for &id in instance_ids {
+            let load = self.load(id);
+            if load < min_load {
+                min_load = load;
+                selected = Some(id);
+                tie_count = 1;
+                continue;
+            }
+
+            if load == min_load {
+                tie_count += 1;
+                if !deterministic_ties && rng.random_range(0..tie_count) == 0 {
+                    selected = Some(id);
+                }
+            }
+        }
+
+        selected
+    }
+
     pub(crate) fn decrement(&self, instance_id: u64) {
         if let Some(count) = self.counts.get(&instance_id) {
             let _ = count.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -63,15 +63,9 @@ impl RoutingOccupancyState {
         Some(id)
     }
 
-    /// Read-only mirror of [`select_exact_min_and_increment`] used by routing
-    /// modes (e.g. least-loaded) that want to *peek* a candidate without
-    /// committing the load increment — for example, the disagg-bootstrap path
-    /// in `prefill_router` which needs a worker_id to resolve `bootstrap_info`
-    /// before the actual prefill request is dispatched (and dispatching via
-    /// `direct(preselected_worker)` then performs the real load accounting).
-    ///
-    /// Tie-break policy matches [`select_exact_min_and_increment`] so peek and
-    /// select observe the same selection distribution, modulo concurrent races.
+    /// Least-loaded selection without the increment. Same tie-break policy as
+    /// [`Self::select_exact_min_and_increment`] so peek and select share a
+    /// distribution.
     pub(crate) fn peek_min(&self, instance_ids: &[u64]) -> Option<u64> {
         let mut min_load = u64::MAX;
         let mut selected = None;

--- a/lib/runtime/src/pipeline.rs
+++ b/lib/runtime/src/pipeline.rs
@@ -15,7 +15,9 @@ pub mod context;
 pub mod error;
 pub mod network;
 pub use network::egress::addressed_router::{AddressedPushRouter, AddressedRequest};
-pub use network::egress::push_router::{PushRouter, RouterMode, WorkerLoadMonitor};
+pub use network::egress::push_router::{
+    OccupancyPermit, PushRouter, RouterMode, WorkerLoadMonitor,
+};
 pub mod registry;
 
 pub use crate::engine::{

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -61,7 +61,20 @@ fn response_inactivity_timeout() -> Option<std::time::Duration> {
         .map(std::time::Duration::from_secs)
 }
 
-struct OccupancyPermit {
+/// RAII handle for a single in-flight unit of work charged against
+/// [`RoutingOccupancyState`].
+///
+/// Construction is the *commit* point — the underlying counter has already
+/// been incremented (by [`PushRouter::track_dispatch`] or
+/// [`RoutingOccupancyState::select_exact_min_and_increment`]). Dropping the
+/// permit, or letting it be consumed by [`Self::into_tracked_stream`], emits
+/// the matching decrement when the request finishes.
+///
+/// `pub` so the disagg-bootstrap path in `prefill_router` (a separate crate)
+/// can hold a permit for the lifetime of the spawned prefill task without
+/// going through the [`PushRouter::least_loaded`] dispatch — see
+/// [`PushRouter::track_dispatch`].
+pub struct OccupancyPermit {
     state: Arc<RoutingOccupancyState>,
     instance_id: u64,
     armed: bool,
@@ -714,10 +727,22 @@ where
 
     /// Peek the next worker according to the routing mode without incrementing the counter.
     /// Useful for checking if a worker is suitable before committing to it.
-    /// Returns None for modes that require request lifecycle tracking or explicit routing hints.
+    ///
+    /// This is the read-only counterpart of [`Self::select_next_worker`] / the
+    /// per-mode `least_loaded`/`p2c`/`device_aware_weighted` dispatchers. The
+    /// disagg-bootstrap path in `prefill_router::resolve_prefill_worker` calls
+    /// this to obtain a worker_id ahead of the actual prefill request so it
+    /// can look up that worker's `bootstrap_info` and attach it to the decode
+    /// request — without which sglang/NIXL-rendezvous backends cannot complete
+    /// disagg under non-KV routing.
+    ///
+    /// Returns `None` only for [`RouterMode::Direct`] (caller-supplied
+    /// routing) and panics for [`RouterMode::KV`] (KV path uses
+    /// `kv_chooser::find_best_match` directly).
     pub fn peek_next_worker(&self) -> Option<u64> {
-        let routing_instances = self.client.routing_instances();
-        let count = routing_instances.free_ids().len();
+        // DIS-2105: select among free workers — see round_robin for rationale.
+        let instance_ids = self.client.routing_instances().free_ids().to_vec();
+        let count = instance_ids.len();
         if count == 0 {
             return None;
         }
@@ -726,23 +751,83 @@ where
             RouterMode::RoundRobin => {
                 // Just peek at the current counter value without incrementing
                 let counter = self.round_robin_counter.load(Ordering::Relaxed) as usize;
-                Some(routing_instances.free_ids()[counter % count])
+                Some(instance_ids[counter % count])
             }
             RouterMode::Random => {
                 // For random, peeking implies a fresh random selection since it's stateless.
                 // Note: The caller must realize that select_next_worker() will pick a DIFFERENT random worker.
                 let counter = rand::rng().random::<u64>() as usize;
-                Some(routing_instances.free_ids()[counter % count])
+                Some(instance_ids[counter % count])
             }
-            RouterMode::PowerOfTwoChoices
-            | RouterMode::Direct
-            | RouterMode::LeastLoaded
-            | RouterMode::DeviceAwareWeighted => None,
+            RouterMode::LeastLoaded => {
+                // Mirror least_loaded() selection logic read-only. Same tie-break
+                // policy as select_exact_min_and_increment. The caller is expected
+                // to follow up with `track_dispatch(worker_id)` to commit the load
+                // increment and obtain a permit whose drop emits the decrement when
+                // the dispatched request finishes — see `prefill_router` for the
+                // disagg-bootstrap usage that exercises this pattern.
+                self.occupancy_state.as_deref()?.peek_min(&instance_ids)
+            }
+            RouterMode::PowerOfTwoChoices => {
+                // p2c_select_from is already a sync read-only selector.
+                Some(p2c_select_from(
+                    self.occupancy_state.as_deref()?,
+                    &instance_ids,
+                ))
+            }
+            RouterMode::DeviceAwareWeighted => {
+                // Skip device-class partitioning in peek — the bootstrap-path
+                // peek is only used to resolve bootstrap_info on the chosen
+                // worker; the real device-aware policy is enforced when the
+                // actual prefill request dispatches via the device_aware_weighted
+                // path. For peek we degenerate to least-loaded across all free
+                // instances, which matches the mode's documented fallback.
+                self.occupancy_state.as_deref()?.peek_min(&instance_ids)
+            }
+            RouterMode::Direct => None,
             RouterMode::KV => {
                 panic!(
                     "peek_next_worker should not be called for {:?} routing mode",
                     self.router_mode
                 )
+            }
+        }
+    }
+
+    /// Commit load to a worker chosen externally (e.g., via [`Self::peek_next_worker`])
+    /// and return a permit whose drop emits the matching decrement.
+    ///
+    /// This is the missing primitive for callers that dispatch via
+    /// [`Self::direct`] (such as `prefill_router`'s disagg-bootstrap path).
+    /// `direct()` deliberately bypasses load tracking — it's used by callers
+    /// who have already picked a worker and want the routing layer to honor
+    /// that pick — so the bookkeeping has to be done here, at the
+    /// "we've committed to this worker" decision point.
+    ///
+    /// Returns `Some(permit)` only for routing modes that maintain a
+    /// per-worker occupancy counter (LeastLoaded, PowerOfTwoChoices,
+    /// DeviceAwareWeighted). Returns `None` for the other modes —
+    /// RoundRobin's counter is advanced through a different call site
+    /// (`select_next_worker`), Random is stateless, and KV is decoupled from
+    /// `OccupancyState` (load is fed from worker-pushed events instead).
+    /// Callers should hold the permit for the lifetime of the dispatched
+    /// request — typically by moving it into the spawned task that runs the
+    /// dispatch.
+    pub fn track_dispatch(&self, instance_id: u64) -> Option<OccupancyPermit> {
+        let state = self.occupancy_state.as_ref()?.clone();
+        // Same modes that produce a permit in their per-mode dispatcher
+        // (least_loaded, power_of_two_choices, device_aware_weighted) — keeping
+        // this gate aligned ensures the bootstrap path's accounting matches
+        // the aggregated path's accounting on the same router mode.
+        match self.router_mode {
+            RouterMode::LeastLoaded
+            | RouterMode::PowerOfTwoChoices
+            | RouterMode::DeviceAwareWeighted => {
+                state.increment(instance_id);
+                Some(OccupancyPermit::new(state, instance_id))
+            }
+            RouterMode::RoundRobin | RouterMode::Random | RouterMode::Direct | RouterMode::KV => {
+                None
             }
         }
     }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -724,7 +724,8 @@ where
     /// `None` for [`RouterMode::Direct`] (caller-supplied routing); panics for
     /// [`RouterMode::KV`], which selects via `kv_chooser::find_best_match`.
     pub fn peek_next_worker(&self) -> Option<u64> {
-        // DIS-2105: select among free workers — see round_robin for rationale.
+        // Select among free (admission-eligible) workers — see select_next_worker
+        // for the per-mode selection rationale.
         let instance_ids = self.client.routing_instances().free_ids().to_vec();
         let count = instance_ids.len();
         if count == 0 {

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -61,19 +61,12 @@ fn response_inactivity_timeout() -> Option<std::time::Duration> {
         .map(std::time::Duration::from_secs)
 }
 
-/// RAII handle for a single in-flight unit of work charged against
-/// [`RoutingOccupancyState`].
+/// RAII handle for one in-flight unit of work charged against
+/// [`RoutingOccupancyState`]. The counter is incremented at construction; the
+/// matching decrement is emitted on drop (or by [`Self::into_tracked_stream`]).
 ///
-/// Construction is the *commit* point — the underlying counter has already
-/// been incremented (by [`PushRouter::track_dispatch`] or
-/// [`RoutingOccupancyState::select_exact_min_and_increment`]). Dropping the
-/// permit, or letting it be consumed by [`Self::into_tracked_stream`], emits
-/// the matching decrement when the request finishes.
-///
-/// `pub` so the disagg-bootstrap path in `prefill_router` (a separate crate)
-/// can hold a permit for the lifetime of the spawned prefill task without
-/// going through the [`PushRouter::least_loaded`] dispatch — see
-/// [`PushRouter::track_dispatch`].
+/// `pub` so `prefill_router` (a separate crate) can hold one across its spawned
+/// prefill task — see [`PushRouter::track_dispatch`].
 pub struct OccupancyPermit {
     state: Arc<RoutingOccupancyState>,
     instance_id: u64,
@@ -728,17 +721,8 @@ where
     /// Peek the next worker according to the routing mode without incrementing the counter.
     /// Useful for checking if a worker is suitable before committing to it.
     ///
-    /// This is the read-only counterpart of [`Self::select_next_worker`] / the
-    /// per-mode `least_loaded`/`p2c`/`device_aware_weighted` dispatchers. The
-    /// disagg-bootstrap path in `prefill_router::resolve_prefill_worker` calls
-    /// this to obtain a worker_id ahead of the actual prefill request so it
-    /// can look up that worker's `bootstrap_info` and attach it to the decode
-    /// request — without which sglang/NIXL-rendezvous backends cannot complete
-    /// disagg under non-KV routing.
-    ///
-    /// Returns `None` only for [`RouterMode::Direct`] (caller-supplied
-    /// routing) and panics for [`RouterMode::KV`] (KV path uses
-    /// `kv_chooser::find_best_match` directly).
+    /// `None` for [`RouterMode::Direct`] (caller-supplied routing); panics for
+    /// [`RouterMode::KV`], which selects via `kv_chooser::find_best_match`.
     pub fn peek_next_worker(&self) -> Option<u64> {
         // DIS-2105: select among free workers — see round_robin for rationale.
         let instance_ids = self.client.routing_instances().free_ids().to_vec();
@@ -759,29 +743,15 @@ where
                 let counter = rand::rng().random::<u64>() as usize;
                 Some(instance_ids[counter % count])
             }
-            RouterMode::LeastLoaded => {
-                // Mirror least_loaded() selection logic read-only. Same tie-break
-                // policy as select_exact_min_and_increment. The caller is expected
-                // to follow up with `track_dispatch(worker_id)` to commit the load
-                // increment and obtain a permit whose drop emits the decrement when
-                // the dispatched request finishes — see `prefill_router` for the
-                // disagg-bootstrap usage that exercises this pattern.
-                self.occupancy_state.as_deref()?.peek_min(&instance_ids)
-            }
-            RouterMode::PowerOfTwoChoices => {
-                // p2c_select_from is already a sync read-only selector.
-                Some(p2c_select_from(
-                    self.occupancy_state.as_deref()?,
-                    &instance_ids,
-                ))
-            }
+            RouterMode::LeastLoaded => self.occupancy_state.as_deref()?.peek_min(&instance_ids),
+            RouterMode::PowerOfTwoChoices => Some(p2c_select_from(
+                self.occupancy_state.as_deref()?,
+                &instance_ids,
+            )),
             RouterMode::DeviceAwareWeighted => {
-                // Skip device-class partitioning in peek — the bootstrap-path
-                // peek is only used to resolve bootstrap_info on the chosen
-                // worker; the real device-aware policy is enforced when the
-                // actual prefill request dispatches via the device_aware_weighted
-                // path. For peek we degenerate to least-loaded across all free
-                // instances, which matches the mode's documented fallback.
+                // Peek only resolves bootstrap_info; device-class partitioning is
+                // applied when the request actually dispatches. Degenerate to
+                // least-loaded, the mode's documented fallback.
                 self.occupancy_state.as_deref()?.peek_min(&instance_ids)
             }
             RouterMode::Direct => None,
@@ -794,31 +764,16 @@ where
         }
     }
 
-    /// Commit load to a worker chosen externally (e.g., via [`Self::peek_next_worker`])
-    /// and return a permit whose drop emits the matching decrement.
+    /// Commit load to an externally-chosen worker (e.g. from
+    /// [`Self::peek_next_worker`]) and return a permit that decrements on drop.
+    /// Needed because [`Self::direct`], used by callers who pre-pick a worker,
+    /// bypasses load tracking — so it must happen here.
     ///
-    /// This is the missing primitive for callers that dispatch via
-    /// [`Self::direct`] (such as `prefill_router`'s disagg-bootstrap path).
-    /// `direct()` deliberately bypasses load tracking — it's used by callers
-    /// who have already picked a worker and want the routing layer to honor
-    /// that pick — so the bookkeeping has to be done here, at the
-    /// "we've committed to this worker" decision point.
-    ///
-    /// Returns `Some(permit)` only for routing modes that maintain a
-    /// per-worker occupancy counter (LeastLoaded, PowerOfTwoChoices,
-    /// DeviceAwareWeighted). Returns `None` for the other modes —
-    /// RoundRobin's counter is advanced through a different call site
-    /// (`select_next_worker`), Random is stateless, and KV is decoupled from
-    /// `OccupancyState` (load is fed from worker-pushed events instead).
-    /// Callers should hold the permit for the lifetime of the dispatched
-    /// request — typically by moving it into the spawned task that runs the
-    /// dispatch.
+    /// `Some` only for the occupancy-counter modes (LeastLoaded,
+    /// PowerOfTwoChoices, DeviceAwareWeighted). Hold the permit for the
+    /// dispatched request's lifetime.
     pub fn track_dispatch(&self, instance_id: u64) -> Option<OccupancyPermit> {
         let state = self.occupancy_state.as_ref()?.clone();
-        // Same modes that produce a permit in their per-mode dispatcher
-        // (least_loaded, power_of_two_choices, device_aware_weighted) — keeping
-        // this gate aligned ensures the bootstrap path's accounting matches
-        // the aggregated path's accounting on the same router mode.
         match self.router_mode {
             RouterMode::LeastLoaded
             | RouterMode::PowerOfTwoChoices

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -1489,7 +1489,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn least_loaded_select_and_peek_return_none_with_available_worker() {
+    async fn least_loaded_peek_returns_available_worker_select_stays_none() {
         let rt = Runtime::from_current().unwrap();
         let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
             .await
@@ -1508,8 +1508,13 @@ mod tests {
             .await
             .unwrap();
 
+        // LeastLoaded routes via peek + OccupancyPermit dispatch, so select_next_worker
+        // stays None; peek must resolve the available worker (the disagg-bootstrap fix).
         assert_eq!(router.select_next_worker(), None);
-        assert_eq!(router.peek_next_worker(), None);
+        assert!(
+            router.peek_next_worker().is_some(),
+            "LeastLoaded peek must return the available worker for disagg bootstrap"
+        );
 
         rt.shutdown();
     }
@@ -1712,7 +1717,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn device_aware_weighted_select_and_peek_return_none_with_available_worker() {
+    async fn device_aware_weighted_peek_returns_available_worker_select_stays_none() {
         let rt = Runtime::from_current().unwrap();
         let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
             .await
@@ -1732,8 +1737,13 @@ mod tests {
                 .await
                 .unwrap();
 
+        // DeviceAwareWeighted degenerates to least-loaded for peek (device-class
+        // partitioning happens at dispatch); select_next_worker stays None.
         assert_eq!(router.select_next_worker(), None);
-        assert_eq!(router.peek_next_worker(), None);
+        assert!(
+            router.peek_next_worker().is_some(),
+            "DeviceAwareWeighted peek must return the available worker for disagg bootstrap"
+        );
 
         rt.shutdown();
     }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -788,6 +788,77 @@ where
         }
     }
 
+    /// Atomically select a worker AND book its load, returning the worker id plus
+    /// a permit that releases the booking on drop.
+    ///
+    /// This is the booking counterpart of [`Self::peek_next_worker`] for callers
+    /// (e.g. disagg bootstrap) that resolve a worker up front and then dispatch
+    /// via [`Self::direct`] (which bypasses load tracking). Unlike
+    /// `peek_next_worker()` followed by a separate [`Self::track_dispatch`],
+    /// selection and booking happen as a single operation, so concurrent callers
+    /// cannot observe the same minimum and over-subscribe one worker
+    /// (addresses the LL/P2C/DAW bootstrap accounting race).
+    ///
+    /// Mirrors each mode's normal dispatch policy: LeastLoaded uses the locked
+    /// `select_exact_min_and_increment`; DeviceAwareWeighted applies the same
+    /// device-class candidate grouping as [`Self::device_aware_weighted`] before
+    /// the locked min-select (so the device ratio is preserved on the bootstrap
+    /// path, not degenerated to global least-loaded); P2C matches
+    /// [`Self::power_of_two_choices`].
+    ///
+    /// `Some` only for the occupancy-counter modes (LeastLoaded,
+    /// PowerOfTwoChoices, DeviceAwareWeighted); `None` for RoundRobin/Random
+    /// (no occupancy state — callers fall back to `peek_next_worker`), Direct,
+    /// and KV (which tracks load via worker-pushed metrics, not this counter).
+    pub async fn select_and_reserve(&self) -> Option<(u64, OccupancyPermit)> {
+        let state = self.occupancy_state.as_ref()?.clone();
+        let routing_instances = self.client.routing_instances();
+        let instance_ids = routing_instances.free_ids().to_vec();
+        if instance_ids.is_empty() {
+            return None;
+        }
+
+        let instance_id = match self.router_mode {
+            RouterMode::LeastLoaded => state.select_exact_min_and_increment(&instance_ids).await?,
+            RouterMode::PowerOfTwoChoices => {
+                // Matches power_of_two_choices(): p2c is inherently approximate,
+                // so it selects then increments without the exact-select lock.
+                let id = p2c_select_from(state.as_ref(), &instance_ids);
+                state.increment(id);
+                id
+            }
+            RouterMode::DeviceAwareWeighted => {
+                // Mirror device_aware_weighted(): partition by device class and
+                // apply the CPU budget, then min-select within the chosen group.
+                let device_type_map: std::collections::HashMap<u64, Option<DeviceType>> = self
+                    .client
+                    .instances()
+                    .iter()
+                    .map(|inst| (inst.instance_id, inst.device_type.clone()))
+                    .collect();
+                let cuda_to_cpu_ratio = std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
+                    .ok()
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .filter(|v| *v >= 1)
+                    .unwrap_or(8);
+                let candidates = device_aware_candidate_group(
+                    state.as_ref(),
+                    &instance_ids,
+                    &device_type_map,
+                    cuda_to_cpu_ratio,
+                );
+                state.select_exact_min_and_increment(&candidates).await?
+            }
+            RouterMode::RoundRobin | RouterMode::Random | RouterMode::Direct | RouterMode::KV => {
+                return None;
+            }
+        };
+
+        // select_exact_min_and_increment / increment above already booked the
+        // load; OccupancyPermit only credits it back on drop (no double-count).
+        Some((instance_id, OccupancyPermit::new(state, instance_id)))
+    }
+
     fn occupancy_state(&self) -> anyhow::Result<Arc<RoutingOccupancyState>> {
         self.occupancy_state.clone().ok_or_else(|| {
             anyhow::anyhow!(
@@ -1515,6 +1586,40 @@ mod tests {
             router.peek_next_worker().is_some(),
             "LeastLoaded peek must return the available worker for disagg bootstrap"
         );
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn select_and_reserve_books_load_and_credits_on_drop() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_reserve_router".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+
+        endpoint.register_endpoint_instance().await.unwrap();
+        client.wait_for_instances().await.unwrap();
+
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::LeastLoaded)
+            .await
+            .unwrap();
+        let state = router.occupancy_state.clone().unwrap();
+
+        // select_and_reserve picks the worker AND books its load atomically, so a
+        // bootstrap-dispatched (direct()) request is reflected in the counter.
+        let (id, permit) = router
+            .select_and_reserve()
+            .await
+            .expect("LeastLoaded reserves the available worker");
+        assert_eq!(state.load(id), 1, "reserve books one in-flight request");
+
+        // The permit credits the booking back on drop (request completed).
+        drop(permit);
+        assert_eq!(state.load(id), 0, "permit releases the booking on drop");
 
         rt.shutdown();
     }


### PR DESCRIPTION
## Summary

Disaggregated serving is broken on `main` for the `LeastLoaded`, `PowerOfTwoChoices`, and `DeviceAwareWeighted` routing modes: a request never receives `bootstrap_info`, so the decode worker has no `room_id` to dial the prefill bootstrap server and the request hangs until the client request-timeout. KV / RoundRobin / Random are unaffected.

## Root cause

The disagg prefill router resolves a prefill worker up front via `PushRouter::peek_next_worker()` (a side-effect-free probe). That method returns `None` for `LeastLoaded` / `PowerOfTwoChoices` / `DeviceAwareWeighted`, so resolution bails to the "Using original prefill path" fallback — which forwards the prefill result to decode but **never sets `bootstrap_info`**.

## Fix

- Add a read-only `peek_min` on the occupancy state and wire it into `peek_next_worker`'s LL / P2C / DeviceAwareWeighted arms (LL uses the same reservoir tie-break as `select_exact_min_and_increment`).
- Add dispatch-time load tracking (`OccupancyPermit` via `track_dispatch`): the bootstrap path dispatches via `router.direct(worker_id)`, which bypasses load accounting, so without an explicit permit LL's occupancy counter would never increment and peek-selection would degenerate to uniform-random. The permit is moved into the spawned prefill task and emits the matching decrement when the stream ends.

Invariants preserved: `KV` still panics (it routes via the kv-chooser, which needs the request), and `Direct` still returns `None` (the caller supplies the worker).

## Test

Repro: Qwen3-0.6B, sglang 1P+1D, `--router-mode least_loaded`, disaggregated — `curl` hangs ~60s with 0 bytes and "Using original prefill path" in the FE log; fixed with this change. `cargo check` / `fmt` / `clippy` clean on `dynamo-runtime` + `dynamo-llm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced occupancy-aware routing capabilities for improved request load distribution.

* **Refactor**
  * Enhanced internal load tracking and occupancy accounting mechanisms to optimize resource utilization during request routing and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->