### PR TITLE
feat(routing): unified structured Selected-worker INFO log across all router modes

### DIFF
--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -420,13 +420,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 logit = best_logit,
                 host_pinned_blocks = best_host_pinned_overlap_blocks,
                 disk_blocks = best_disk_overlap_blocks,
-                "Selected worker: worker_type={}, worker_id={} dp_rank={:?}, logit: {:.3}, host_pinned blocks: {}, disk blocks: {}",
-                self.worker_type,
-                best_worker.worker_id,
-                best_worker.dp_rank,
-                best_logit,
-                best_host_pinned_overlap_blocks,
-                best_disk_overlap_blocks,
+                "Selected worker: kv"
             );
             let effective_overlap_blocks = request.effective_overlap_blocks_for(best_worker);
             let cached_tokens = request.effective_cached_tokens_for(best_worker);
@@ -442,11 +436,9 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
         let best_overlap = request.effective_overlap_blocks_for(best_worker);
         let best_cached_tokens = request.effective_cached_tokens_for(best_worker);
 
-        let total_blocks_info = workers
+        let total_kv_blocks = workers
             .get(&best_worker.worker_id)
-            .and_then(|cfg| cfg.total_kv_blocks())
-            .map(|blocks| format!(", total blocks: {}", blocks))
-            .unwrap_or_default();
+            .and_then(|cfg| cfg.total_kv_blocks());
 
         tracing::info!(
             router_mode = "kv",
@@ -457,15 +449,8 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             effective_cached_blocks = best_overlap,
             host_pinned_blocks = best_host_pinned_overlap_blocks,
             disk_blocks = best_disk_overlap_blocks,
-            "Selected worker: worker_type={}, worker_id={} dp_rank={:?}, logit: {:.3}, effective cached blocks: {:.2}, host_pinned blocks: {}, disk blocks: {}{}",
-            self.worker_type,
-            best_worker.worker_id,
-            best_worker.dp_rank,
-            best_logit,
-            best_overlap,
-            best_host_pinned_overlap_blocks,
-            best_disk_overlap_blocks,
-            total_blocks_info
+            total_kv_blocks = ?total_kv_blocks,
+            "Selected worker: kv"
         );
 
         Ok(WorkerSelectionResult {

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -420,7 +420,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 logit = best_logit,
                 host_pinned_blocks = best_host_pinned_overlap_blocks,
                 disk_blocks = best_disk_overlap_blocks,
-                "Selected worker: kv"
+                "Selected worker"
             );
             let effective_overlap_blocks = request.effective_overlap_blocks_for(best_worker);
             let cached_tokens = request.effective_cached_tokens_for(best_worker);
@@ -450,7 +450,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             host_pinned_blocks = best_host_pinned_overlap_blocks,
             disk_blocks = best_disk_overlap_blocks,
             total_kv_blocks = ?total_kv_blocks,
-            "Selected worker: kv"
+            "Selected worker"
         );
 
         Ok(WorkerSelectionResult {

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -413,6 +413,13 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
 
         if self.worker_type == "decode" {
             tracing::info!(
+                router_mode = "kv",
+                worker_id = best_worker.worker_id,
+                worker_type = %self.worker_type,
+                dp_rank = ?best_worker.dp_rank,
+                logit = best_logit,
+                host_pinned_blocks = best_host_pinned_overlap_blocks,
+                disk_blocks = best_disk_overlap_blocks,
                 "Selected worker: worker_type={}, worker_id={} dp_rank={:?}, logit: {:.3}, host_pinned blocks: {}, disk blocks: {}",
                 self.worker_type,
                 best_worker.worker_id,
@@ -442,6 +449,14 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             .unwrap_or_default();
 
         tracing::info!(
+            router_mode = "kv",
+            worker_id = best_worker.worker_id,
+            worker_type = %self.worker_type,
+            dp_rank = ?best_worker.dp_rank,
+            logit = best_logit,
+            effective_cached_blocks = best_overlap,
+            host_pinned_blocks = best_host_pinned_overlap_blocks,
+            disk_blocks = best_disk_overlap_blocks,
             "Selected worker: worker_type={}, worker_id={} dp_rank={:?}, logit: {:.3}, effective cached blocks: {:.2}, host_pinned blocks: {}, disk blocks: {}{}",
             self.worker_type,
             best_worker.worker_id,

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -190,7 +190,7 @@ fn p2c_select_from(occupancy_state: &RoutingOccupancyState, instance_ids: &[u64]
             worker_id,
             candidate_count = count,
             load = occupancy_state.load(worker_id),
-            "Selected worker: power-of-two-choices (single candidate)"
+            "Selected worker"
         );
         return worker_id;
     }
@@ -211,7 +211,7 @@ fn p2c_select_from(occupancy_state: &RoutingOccupancyState, instance_ids: &[u64]
         candidate_a_load = load1,
         candidate_b = id2,
         candidate_b_load = load2,
-        "Selected worker: power-of-two-choices"
+        "Selected worker"
     );
     selected
 }
@@ -530,7 +530,7 @@ where
             router_mode = "round-robin",
             worker_id = instance_id,
             candidate_count,
-            "Selected worker: round-robin"
+            "Selected worker"
         );
 
         self.generate_with_fault_detection(instance_id, request)
@@ -552,7 +552,7 @@ where
             router_mode = "random",
             worker_id = instance_id,
             candidate_count,
-            "Selected worker: random"
+            "Selected worker"
         );
 
         self.generate_with_fault_detection(instance_id, request)
@@ -610,7 +610,7 @@ where
         tracing::info!(
             router_mode = "direct",
             worker_id = instance_id,
-            "Selected worker: direct"
+            "Selected worker"
         );
 
         self.generate_with_fault_detection(instance_id, request)
@@ -674,7 +674,7 @@ where
             load = state.load(instance_id),
             endpoint = %endpoint_id,
             is_cpu,
-            "Selected worker: device-aware-weighted"
+            "Selected worker"
         );
 
         match self
@@ -701,7 +701,7 @@ where
             worker_id = instance_id,
             candidate_count = instance_ids.len(),
             load = state.load(instance_id),
-            "Selected worker: least-loaded"
+            "Selected worker"
         );
 
         match self

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -184,7 +184,15 @@ impl RouterMode {
 fn p2c_select_from(occupancy_state: &RoutingOccupancyState, instance_ids: &[u64]) -> u64 {
     let count = instance_ids.len();
     if count == 1 {
-        return instance_ids[0];
+        let worker_id = instance_ids[0];
+        tracing::info!(
+            router_mode = "power-of-two-choices",
+            worker_id,
+            candidate_count = count,
+            load = occupancy_state.load(worker_id),
+            "Selected worker: power-of-two-choices (single candidate)"
+        );
+        return worker_id;
     }
     let mut rng = rand::rng();
     let idx1 = rng.random_range(0..count);
@@ -194,13 +202,16 @@ fn p2c_select_from(occupancy_state: &RoutingOccupancyState, instance_ids: &[u64]
     let load1 = occupancy_state.load(id1);
     let load2 = occupancy_state.load(id2);
     let selected = if load1 <= load2 { id1 } else { id2 };
-    tracing::debug!(
+    tracing::info!(
+        router_mode = "power-of-two-choices",
+        worker_id = selected,
+        candidate_count = count,
+        load = std::cmp::min(load1, load2),
         candidate_a = id1,
         candidate_a_load = load1,
         candidate_b = id2,
         candidate_b_load = load2,
-        selected = selected,
-        "p2c selection"
+        "Selected worker: power-of-two-choices"
     );
     selected
 }
@@ -507,15 +518,20 @@ where
     pub async fn round_robin(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
 
-        let instance_id = {
+        let (instance_id, candidate_count) = {
             let routing_instances = self.client.routing_instances();
             let count = routing_instances.free_ids().len();
             if count == 0 {
                 return Err(self.empty_free_pool_error(&routing_instances));
             }
-            routing_instances.free_ids()[counter % count]
+            (routing_instances.free_ids()[counter % count], count)
         };
-        tracing::trace!("round robin router selected {instance_id}");
+        tracing::info!(
+            router_mode = "round-robin",
+            worker_id = instance_id,
+            candidate_count,
+            "Selected worker: round-robin"
+        );
 
         self.generate_with_fault_detection(instance_id, request)
             .await
@@ -523,16 +539,21 @@ where
 
     /// Issue a request to a random endpoint
     pub async fn random(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
-        let instance_id = {
+        let (instance_id, candidate_count) = {
             let routing_instances = self.client.routing_instances();
             let count = routing_instances.free_ids().len();
             if count == 0 {
                 return Err(self.empty_free_pool_error(&routing_instances));
             }
             let counter = rand::rng().random::<u64>() as usize;
-            routing_instances.free_ids()[counter % count]
+            (routing_instances.free_ids()[counter % count], count)
         };
-        tracing::trace!("random router selected {instance_id}");
+        tracing::info!(
+            router_mode = "random",
+            worker_id = instance_id,
+            candidate_count,
+            "Selected worker: random"
+        );
 
         self.generate_with_fault_detection(instance_id, request)
             .await
@@ -585,6 +606,12 @@ where
                 self.client.endpoint.id()
             ));
         }
+
+        tracing::info!(
+            router_mode = "direct",
+            worker_id = instance_id,
+            "Selected worker: direct"
+        );
 
         self.generate_with_fault_detection(instance_id, request)
             .await
@@ -641,10 +668,13 @@ where
             Some(Some(DeviceType::Cpu))
         );
         tracing::info!(
+            router_mode = "device-aware-weighted",
+            worker_id = instance_id,
+            candidate_count = candidates.len(),
+            load = state.load(instance_id),
             endpoint = %endpoint_id,
-            selected_instance = instance_id,
             is_cpu,
-            "DeviceAwareWeighted selected instance"
+            "Selected worker: device-aware-weighted"
         );
 
         match self
@@ -666,9 +696,12 @@ where
             .await
             .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
         let permit = OccupancyPermit::new(state.clone(), instance_id);
-        tracing::trace!(
-            "least loaded router selected {instance_id} (connections: {})",
-            state.load(instance_id)
+        tracing::info!(
+            router_mode = "least-loaded",
+            worker_id = instance_id,
+            candidate_count = instance_ids.len(),
+            load = state.load(instance_id),
+            "Selected worker: least-loaded"
         );
 
         match self

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -227,6 +227,10 @@ trtllm_configs = {
         ],
         env={
             "DYN_LOG": "dynamo_llm::kv_router::publisher=trace,dynamo_kv_router::scheduling::selector=info",
+            # Disable ANSI so structured tracing fields render as plain
+            # `key=value` (color codes otherwise split `worker_id`/`=`/value and
+            # break the expected_log regex).
+            "DYN_SDK_DISABLE_ANSI_LOGGING": "1",
         },
     ),
     "disaggregated_router": TRTLLMConfig(

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -221,7 +221,7 @@ trtllm_configs = {
             router_selection_chat_payload_default(
                 expected_log=[
                     r"Event processor for worker_id \d+ processing event: Stored\(",
-                    r"Selected worker: worker_type=\w+, worker_id=\d+ dp_rank=.*?, logit: ",
+                    r"Selected worker .*worker_id=\d+ worker_type=\w+ dp_rank=\d+ logit=",
                 ]
             ),
         ],


### PR DESCRIPTION
## Summary

Every router-mode worker selection now emits one consistent, structured, `info`-level **"Selected worker"** log, so routing decisions are visible without flipping `DYN_LOG`. Previously the modes were inconsistent — RoundRobin/Random/LeastLoaded logged at `trace`, P2C at `debug`, DeviceAwareWeighted and KV at `info` but with ad-hoc fields.

## Unified schema

```
info!(router_mode = "<mode>", worker_id = <id>, candidate_count = <n>, load = <load-if-applicable>, … , "Selected worker: …")
```

Per mode:
- **RoundRobin / Random / LeastLoaded** — promoted `trace!` → `info!` with structured fields (LL also logs `load`).
- **PowerOfTwoChoices** — `debug!` → `info!`, retaining the candidate detail (`candidate_a/b`, loads); logs once per selection including the single-candidate path.
- **DeviceAwareWeighted** — re-fielded to the common schema, keeping `endpoint` / `is_cpu`.
- **KV** — kept the existing `info!` messages, added structured fields (`router_mode`, `worker_id`, `worker_type`, `dp_rank`, `logit`, block counts).
- **Direct** — added an `info!` at dispatch (`router_mode="direct"`, `worker_id`; no `candidate_count`/`load` since the worker is caller-supplied).

Log aggregators can now grep/filter on `router_mode` / `worker_id` / `load` uniformly across all modes for imbalance analysis.

## Test

`cargo check` / `fmt` / `clippy` clean on `dynamo-runtime` + `dynamo-kv-router`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced observability and structured logging for worker selection in router components, providing more detailed metrics and context for monitoring and troubleshooting purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->