### PR TITLE
build: update release version to 1.2.1

### DIFF
--- a/ATTRIBUTIONS-Rust.md
+++ b/ATTRIBUTIONS-Rust.md
@@ -9056,7 +9056,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ```
 
-## dynamo-backend-common - 1.2.0
+## dynamo-backend-common - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9136,7 +9136,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-bench - 1.2.0
+## dynamo-bench - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9296,7 +9296,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-config - 1.2.0
+## dynamo-config - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9376,7 +9376,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-kv-router - 1.2.0
+## dynamo-kv-router - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9456,7 +9456,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-llm - 1.2.0
+## dynamo-llm - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9536,7 +9536,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-memory - 1.2.0
+## dynamo-memory - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9616,7 +9616,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-mocker - 1.2.0
+## dynamo-mocker - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9696,7 +9696,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-mocker-backend - 1.2.0
+## dynamo-mocker-backend - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9776,7 +9776,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-parsers - 1.2.0
+## dynamo-parsers - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9856,7 +9856,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-protocols - 1.2.0
+## dynamo-protocols - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0 AND MIT
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -9936,7 +9936,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-runtime - 1.2.0
+## dynamo-runtime - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE
@@ -10144,7 +10144,7 @@ limitations under the License.
    limitations under the License.
 ```
 
-## dynamo-tokenizers - 1.2.0
+## dynamo-tokenizers - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -10224,7 +10224,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## dynamo-tokens - 1.2.0
+## dynamo-tokens - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -16365,7 +16365,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## kvbm-common - 1.2.0
+## kvbm-common - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -16445,7 +16445,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## kvbm-config - 1.2.0
+## kvbm-config - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -16525,7 +16525,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## kvbm-engine - 1.2.0
+## kvbm-engine - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -16605,7 +16605,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## kvbm-kernels - 1.2.0
+## kvbm-kernels - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -16685,7 +16685,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## kvbm-logical - 1.2.0
+## kvbm-logical - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -16765,7 +16765,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-## kvbm-physical - 1.2.0
+## kvbm-physical - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE
@@ -16974,7 +16974,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ```
 
-## libdynamo_llm - 1.2.0
+## libdynamo_llm - 1.2.1
 **Repository URL**: https://github.com/ai-dynamo/dynamo.git
 **License Type(s)**: Apache-2.0
 ### License: https://raw.githubusercontent.com/ai-dynamo/dynamo/HEAD/LICENSE-APACHE

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,7 +2324,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-backend-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-bench"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2384,14 +2384,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-kv-router"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aho-corasick",
  "aligned-vec",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker-backend"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dynamo-protocols",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -4591,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "dynamo-tokens",
  "serde",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-config"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dynamo-memory",
@@ -4619,7 +4619,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-engine"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4659,7 +4659,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-kernels"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 4.6.1",
  "cudarc",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-logical"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-physical"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aligned-vec",
  "anyhow",
@@ -4756,7 +4756,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdynamo_llm"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 description = "Dynamo Inference Framework"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -39,27 +39,27 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Local crates
-dynamo-runtime = { path = "lib/runtime", version = "1.2.0" }
-dynamo-llm = { path = "lib/llm", version = "1.2.0" }
-dynamo-config = { path = "lib/config", version = "1.2.0" }
-dynamo-tokenizers = { path = "lib/tokenizers", version = "1.2.0" }
-dynamo-tokens = { path = "lib/tokens", version = "1.2.0" }
-dynamo-memory = { path = "lib/memory", version = "1.2.0" }
-dynamo-mocker = { path = "lib/mocker", version = "1.2.0" }
-dynamo-kv-router = { path = "lib/kv-router", version = "1.2.0", features = ["metrics", "runtime-protocols"] }
-dynamo-protocols = { path = "lib/protocols", version = "1.2.0" }
-dynamo-parsers = { path = "lib/parsers", version = "1.2.0" }
-dynamo-backend-common = { path = "lib/backend-common", version = "1.2.0" }
+dynamo-runtime = { path = "lib/runtime", version = "1.2.1" }
+dynamo-llm = { path = "lib/llm", version = "1.2.1" }
+dynamo-config = { path = "lib/config", version = "1.2.1" }
+dynamo-tokenizers = { path = "lib/tokenizers", version = "1.2.1" }
+dynamo-tokens = { path = "lib/tokens", version = "1.2.1" }
+dynamo-memory = { path = "lib/memory", version = "1.2.1" }
+dynamo-mocker = { path = "lib/mocker", version = "1.2.1" }
+dynamo-kv-router = { path = "lib/kv-router", version = "1.2.1", features = ["metrics", "runtime-protocols"] }
+dynamo-protocols = { path = "lib/protocols", version = "1.2.1" }
+dynamo-parsers = { path = "lib/parsers", version = "1.2.1" }
+dynamo-backend-common = { path = "lib/backend-common", version = "1.2.1" }
 fastokens = { version = "0.1.0" }
 
 
 # kvbm
-kvbm-common = { path = "lib/kvbm-common", version = "1.2.0" }
-kvbm-config = { path = "lib/kvbm-config", version = "1.2.0" }
-kvbm-engine = { path = "lib/kvbm-engine", version = "1.2.0" }
-kvbm-kernels = { path = "lib/kvbm-kernels", version = "1.2.0" }
-kvbm-logical = { path = "lib/kvbm-logical", version = "1.2.0" }
-kvbm-physical = { path = "lib/kvbm-physical", version = "1.2.0" }
+kvbm-common = { path = "lib/kvbm-common", version = "1.2.1" }
+kvbm-config = { path = "lib/kvbm-config", version = "1.2.1" }
+kvbm-engine = { path = "lib/kvbm-engine", version = "1.2.1" }
+kvbm-kernels = { path = "lib/kvbm-kernels", version = "1.2.1" }
+kvbm-logical = { path = "lib/kvbm-logical", version = "1.2.1" }
+kvbm-physical = { path = "lib/kvbm-physical", version = "1.2.1" }
 
 # velo
 velo = { version = "0.1.0" }

--- a/benchmarks/incluster/benchmark_job.yaml
+++ b/benchmarks/incluster/benchmark_job.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: benchmark-runner
         # TODO: update to latest public image in next release
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/src/dynamo/planner/tests/manual/perf_test_configs/agg_8b.yaml
+++ b/components/src/dynamo/planner/tests/manual/perf_test_configs/agg_8b.yaml
@@ -37,7 +37,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/components/src/dynamo/planner/tests/manual/perf_test_configs/disagg_8b_2p2d.yaml
+++ b/components/src/dynamo/planner/tests/manual/perf_test_configs/disagg_8b_2p2d.yaml
@@ -37,7 +37,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -131,7 +131,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/components/src/dynamo/planner/tests/manual/perf_test_configs/disagg_8b_3p1d.yaml
+++ b/components/src/dynamo/planner/tests/manual/perf_test_configs/disagg_8b_3p1d.yaml
@@ -37,7 +37,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -131,7 +131,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/components/src/dynamo/planner/tests/manual/perf_test_configs/disagg_8b_planner.yaml
+++ b/components/src/dynamo/planner/tests/manual/perf_test_configs/disagg_8b_planner.yaml
@@ -40,7 +40,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -72,7 +72,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           ports:
             - name: metrics
               containerPort: 9085
@@ -125,7 +125,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -179,7 +179,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/components/src/dynamo/planner/tests/manual/perf_test_configs/disagg_8b_tp2.yaml
+++ b/components/src/dynamo/planner/tests/manual/perf_test_configs/disagg_8b_tp2.yaml
@@ -37,7 +37,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -131,7 +131,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/components/src/dynamo/planner/tests/manual/perf_test_configs/image_cache_daemonset.yaml
+++ b/components/src/dynamo/planner/tests/manual/perf_test_configs/image_cache_daemonset.yaml
@@ -20,7 +20,7 @@ spec:
         - name: nvcr-imagepullsecret
       containers:
         - name: image-cache
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           command:
             - /bin/sh
             - -c

--- a/components/src/dynamo/planner/tests/manual/scaling/disagg_planner_load.yaml
+++ b/components/src/dynamo/planner/tests/manual/scaling/disagg_planner_load.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -26,7 +26,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           command:
             - python3
             - -m
@@ -44,7 +44,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -63,7 +63,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/components/src/dynamo/planner/tests/manual/scaling/disagg_planner_throughput.yaml
+++ b/components/src/dynamo/planner/tests/manual/scaling/disagg_planner_throughput.yaml
@@ -12,13 +12,13 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
     Planner:
       componentType: planner
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           command:
             - python3
             - -m
@@ -36,7 +36,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -57,7 +57,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -73,7 +73,7 @@ def test_build_dgd_config_sglang_prefill_mrr_one_sets_dp_safe_cuda_graph_bs() ->
     dgd_config = modifier.build_dgd_config(
         mode="disagg",
         model_name="Qwen/Qwen3-30B-A3B",
-        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1",
         prefill_cli_args=[
             "--tensor-parallel-size",
             "2",
@@ -115,7 +115,7 @@ def test_build_dgd_config_sglang_prefill_keeps_existing_cuda_graph_bs() -> None:
     dgd_config = modifier.build_dgd_config(
         mode="disagg",
         model_name="Qwen/Qwen3-30B-A3B",
-        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1",
         prefill_cli_args=[
             "--max-running-requests",
             "1",

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -102,7 +102,7 @@ class DgdPlannerServiceConfig(BaseModel):
     replicas: int = 1
     extraPodSpec: PodSpec = PodSpec(
         mainContainer=Container(
-            image="nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0",  # placeholder
+            image="nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1",  # placeholder
             workingDir=f"{get_workspace_dir()}/components/src/dynamo/planner",
             command=["python3", "-m", "dynamo.planner"],
             args=[],

--- a/deploy/helm/charts/platform/Chart.yaml
+++ b/deploy/helm/charts/platform/Chart.yaml
@@ -19,11 +19,11 @@ maintainers:
     url: https://www.nvidia.com
 description: A Helm chart for NVIDIA Dynamo Platform.
 type: application
-version: 1.2.0
+version: 1.2.1
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 1.2.0
+    version: 1.2.1
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: nats

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 A Helm chart for NVIDIA Dynamo Platform.
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## 🚀 Overview
 
@@ -97,7 +97,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://components/operator | dynamo-operator | 1.2.0 |
+| file://components/operator | dynamo-operator | 1.2.1 |
 | https://charts.bitnami.com/bitnami | etcd | 12.0.18 |
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 1.3.2 |
 | oci://ghcr.io/ai-dynamo/grove | grove(grove-charts) | v0.1.0-alpha.8 |

--- a/deploy/helm/charts/platform/components/operator/Chart.yaml
+++ b/deploy/helm/charts/platform/components/operator/Chart.yaml
@@ -27,9 +27,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.0"
+appVersion: "1.2.1"

--- a/deploy/helm/charts/snapshot/Chart.yaml
+++ b/deploy/helm/charts/snapshot/Chart.yaml
@@ -16,8 +16,8 @@ apiVersion: v2
 name: snapshot
 description: Checkpoint/Restore infrastructure for Dynamo (PVC + DaemonSet + CRIU Agent)
 type: application
-version: 1.2.0
-appVersion: "1.2.0"
+version: 1.2.1
+appVersion: "1.2.1"
 keywords:
   - nvidia
   - dynamo

--- a/deploy/helm/charts/snapshot/values.yaml
+++ b/deploy/helm/charts/snapshot/values.yaml
@@ -80,7 +80,7 @@ daemonset:
   # Container image
   image:
     repository: nvcr.io/nvidia/ai-dynamo/snapshot-agent
-    tag: 1.2.0
+    tag: 1.2.1
     pullPolicy: Always
 
   # Snapshot agent and nsrestore log level (trace, debug, info, warn, error)

--- a/docs/kubernetes/shadow-engine-failover.md
+++ b/docs/kubernetes/shadow-engine-failover.md
@@ -171,7 +171,7 @@ spec:
         enabled: true
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           args:
             - --model
             - Qwen/Qwen3-0.6B
@@ -206,7 +206,7 @@ spec:
         enabled: true
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/mocker/deploy/agg.yaml
+++ b/examples/backends/mocker/deploy/agg.yaml
@@ -4,7 +4,7 @@
 # NOTE: There is no dedicated `mocker-runtime` image. The published
 # `dynamo-planner` image includes the ai-dynamo wheel, ai-dynamo-runtime, and
 # planner/profiler dependencies needed by `python3 -m dynamo.mocker`.
-# Replace `1.2.0` below with the Dynamo release tag you deploy.
+# Replace `1.2.1` below with the Dynamo release tag you deploy.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -24,7 +24,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           workingDir: /workspace
           command:
           - python3

--- a/examples/backends/mocker/deploy/disagg.yaml
+++ b/examples/backends/mocker/deploy/disagg.yaml
@@ -4,7 +4,7 @@
 # NOTE: There is no dedicated `mocker-runtime` image. The published
 # `dynamo-planner` image includes the ai-dynamo wheel, ai-dynamo-runtime, and
 # planner/profiler dependencies needed by `python3 -m dynamo.mocker`.
-# Replace `1.2.0` below with the Dynamo release tag you deploy.
+# Replace `1.2.1` below with the Dynamo release tag you deploy.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
     prefill:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -24,7 +24,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           workingDir: /workspace
           command:
           - python3
@@ -48,7 +48,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           workingDir: /workspace
           command:
           - python3

--- a/examples/backends/mocker/deploy/v1beta1/agg.yaml
+++ b/examples/backends/mocker/deploy/v1beta1/agg.yaml
@@ -4,7 +4,7 @@
 # NOTE: There is no dedicated `mocker-runtime` image. The published
 # `dynamo-planner` image includes the ai-dynamo wheel, ai-dynamo-runtime, and
 # planner/profiler dependencies needed by `python3 -m dynamo.mocker`.
-# Replace `1.2.0` below with the Dynamo release tag you deploy.
+# Replace `1.2.1` below with the Dynamo release tag you deploy.
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
@@ -15,7 +15,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -39,7 +39,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           name: main
           workingDir: /workspace
     replicas: 1

--- a/examples/backends/mocker/deploy/v1beta1/disagg.yaml
+++ b/examples/backends/mocker/deploy/v1beta1/disagg.yaml
@@ -4,7 +4,7 @@
 # NOTE: There is no dedicated `mocker-runtime` image. The published
 # `dynamo-planner` image includes the ai-dynamo wheel, ai-dynamo-runtime, and
 # planner/profiler dependencies needed by `python3 -m dynamo.mocker`.
-# Replace `1.2.0` below with the Dynamo release tag you deploy.
+# Replace `1.2.1` below with the Dynamo release tag you deploy.
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
@@ -15,7 +15,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -41,7 +41,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           name: main
           workingDir: /workspace
     replicas: 1
@@ -68,7 +68,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           name: main
           workingDir: /workspace
     replicas: 1

--- a/examples/backends/sglang/deploy/README.md
+++ b/examples/backends/sglang/deploy/README.md
@@ -63,7 +63,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
     workingDir: /workspace/examples/backends/sglang
     args:
       - "python3"
@@ -94,7 +94,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
 
 # Configure your model
 args:

--- a/examples/backends/sglang/deploy/agg.yaml
+++ b/examples/backends/sglang/deploy/agg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -26,7 +26,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg_gms.yaml
+++ b/examples/backends/sglang/deploy/agg_gms.yaml
@@ -21,7 +21,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -37,7 +37,7 @@ spec:
         enabled: true
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg_logging.yaml
+++ b/examples/backends/sglang/deploy/agg_logging.yaml
@@ -15,7 +15,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg_router.yaml
+++ b/examples/backends/sglang/deploy/agg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -29,7 +29,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg-multinode.yaml
+++ b/examples/backends/sglang/deploy/disagg-multinode.yaml
@@ -21,7 +21,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
     decode:
       multinode:
         nodeCount: 2
@@ -33,7 +33,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3
@@ -69,7 +69,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg.yaml
+++ b/examples/backends/sglang/deploy/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -23,7 +23,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3
@@ -58,7 +58,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -55,7 +55,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
     Planner:
       envFromSecret: hf-token-secret
       componentType: planner
@@ -69,7 +69,7 @@ spec:
           #     such as kubernetes_asyncio, pmdarima, prophet, aiconfigurator).
           #   Dynamo <  1.1.0: use the backend runtime image
           #     <registry>/sglang-runtime:<version>.
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           command:
           - python3
           - -m
@@ -95,7 +95,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
             - python3
@@ -130,7 +130,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
             - python3

--- a/examples/backends/sglang/deploy/v1beta1/agg.yaml
+++ b/examples/backends/sglang/deploy/v1beta1/agg.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -37,7 +37,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/sglang/deploy/v1beta1/agg_gms.yaml
+++ b/examples/backends/sglang/deploy/v1beta1/agg_gms.yaml
@@ -20,7 +20,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -50,7 +50,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/sglang/deploy/v1beta1/agg_logging.yaml
+++ b/examples/backends/sglang/deploy/v1beta1/agg_logging.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -37,7 +37,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/sglang/deploy/v1beta1/agg_router.yaml
+++ b/examples/backends/sglang/deploy/v1beta1/agg_router.yaml
@@ -14,7 +14,7 @@ spec:
         - env:
           - name: DYN_ROUTER_MODE
             value: kv
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -42,7 +42,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/sglang/deploy/v1beta1/disagg-multinode.yaml
+++ b/examples/backends/sglang/deploy/v1beta1/disagg-multinode.yaml
@@ -12,7 +12,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -48,7 +48,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -88,7 +88,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/sglang/deploy/v1beta1/disagg.yaml
+++ b/examples/backends/sglang/deploy/v1beta1/disagg.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -45,7 +45,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -83,7 +83,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/sglang/deploy/v1beta1/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/v1beta1/disagg_planner.yaml
@@ -54,7 +54,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -80,7 +80,7 @@ spec:
           #     such as kubernetes_asyncio, pmdarima, prophet, aiconfigurator).
           #   Dynamo <  1.1.0: use the backend runtime image
           #     <registry>/sglang-runtime:<version>.
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           name: main
           volumeMounts:
           - mountPath: /workspace/profiling_results
@@ -122,7 +122,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -160,7 +160,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/trtllm/deploy/README.md
+++ b/examples/backends/trtllm/deploy/README.md
@@ -91,7 +91,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+    image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
     workingDir: /workspace/examples/backends/trtllm
     args:
       - "python3"
@@ -145,7 +145,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
 
 # Configure your model and deployment settings
 args:

--- a/examples/backends/trtllm/deploy/agg-with-config.yaml
+++ b/examples/backends/trtllm/deploy/agg-with-config.yaml
@@ -33,7 +33,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -48,7 +48,7 @@ spec:
           configMap:
             name: nvidia-config
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/trtllm
           # mount the configmap as a volume
           volumeMounts:

--- a/examples/backends/trtllm/deploy/agg.yaml
+++ b/examples/backends/trtllm/deploy/agg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -26,7 +26,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/agg_router.yaml
+++ b/examples/backends/trtllm/deploy/agg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -29,7 +29,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/trtllm/deploy/disagg-multinode.yaml
@@ -97,7 +97,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/trtllm
           command:
           - python3
@@ -128,7 +128,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/
               readOnly: true
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
           - python3
@@ -165,7 +165,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/
               readOnly: true
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg.yaml
+++ b/examples/backends/trtllm/deploy/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
     prefill:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -23,7 +23,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
           - python3
@@ -48,7 +48,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -55,7 +55,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/trtllm
           command:
             - python3
@@ -86,7 +86,7 @@ spec:
           #     such as kubernetes_asyncio, pmdarima, prophet, aiconfigurator).
           #   Dynamo <  1.1.0: use the backend runtime image
           #     <registry>/tensorrtllm-runtime:<version>.
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           ports:
             - name: metrics
               containerPort: 9085
@@ -130,7 +130,7 @@ spec:
       extraPodSpec:
         terminationGracePeriodSeconds: 600
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
             - python3
@@ -156,7 +156,7 @@ spec:
       extraPodSpec:
         terminationGracePeriodSeconds: 600
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
             - python3

--- a/examples/backends/trtllm/deploy/disagg_router.yaml
+++ b/examples/backends/trtllm/deploy/disagg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
           - python3
@@ -50,7 +50,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/v1beta1/agg-with-config.yaml
+++ b/examples/backends/trtllm/deploy/v1beta1/agg-with-config.yaml
@@ -31,7 +31,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -53,7 +53,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/trtllm/deploy/v1beta1/agg.yaml
+++ b/examples/backends/trtllm/deploy/v1beta1/agg.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -33,7 +33,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/trtllm/deploy/v1beta1/agg_router.yaml
+++ b/examples/backends/trtllm/deploy/v1beta1/agg_router.yaml
@@ -14,7 +14,7 @@ spec:
         - env:
           - name: DYN_ROUTER_MODE
             value: kv
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -37,7 +37,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/trtllm/deploy/v1beta1/disagg-multinode.yaml
+++ b/examples/backends/trtllm/deploy/v1beta1/disagg-multinode.yaml
@@ -92,7 +92,7 @@ spec:
           - python3
           - -m
           - dynamo.frontend
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           volumeMounts:
           - mountPath: /models
@@ -126,7 +126,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -169,7 +169,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/trtllm/deploy/v1beta1/disagg.yaml
+++ b/examples/backends/trtllm/deploy/v1beta1/disagg.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -35,7 +35,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -63,7 +63,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/trtllm/deploy/v1beta1/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/v1beta1/disagg_planner.yaml
@@ -70,7 +70,7 @@ spec:
           - --no-kv-events
           command:
           - python3
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           workingDir: /workspace/examples/backends/trtllm
     replicas: 1
@@ -97,7 +97,7 @@ spec:
           #     such as kubernetes_asyncio, pmdarima, prophet, aiconfigurator).
           #   Dynamo <  1.1.0: use the backend runtime image
           #     <registry>/tensorrtllm-runtime:<version>.
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           name: main
           ports:
           - containerPort: 9085
@@ -132,7 +132,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           livenessProbe:
             failureThreshold: 1
             httpGet:
@@ -175,7 +175,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/trtllm/deploy/v1beta1/disagg_router.yaml
+++ b/examples/backends/trtllm/deploy/v1beta1/disagg_router.yaml
@@ -14,7 +14,7 @@ spec:
         - env:
           - name: DYN_ROUTER_MODE
             value: kv
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -38,7 +38,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -67,7 +67,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/README.md
+++ b/examples/backends/vllm/deploy/README.md
@@ -89,7 +89,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     workingDir: /workspace/examples/backends/vllm
     args:
       - "python3"
@@ -150,7 +150,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
 
 # Configure your model
 args:

--- a/examples/backends/vllm/deploy/agg.yaml
+++ b/examples/backends/vllm/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -27,7 +27,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/vllm/deploy/agg_failover.yaml
+++ b/examples/backends/vllm/deploy/agg_failover.yaml
@@ -26,7 +26,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -43,7 +43,7 @@ spec:
         enabled: true
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/vllm/deploy/agg_gms.yaml
+++ b/examples/backends/vllm/deploy/agg_gms.yaml
@@ -22,7 +22,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -37,7 +37,7 @@ spec:
         enabled: true
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -29,7 +29,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/agg_router.yaml
+++ b/examples/backends/vllm/deploy/agg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -29,7 +29,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/agg_router_kv_approx.yaml
+++ b/examples/backends/vllm/deploy/agg_router_kv_approx.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           command:
             - python3
           args:
@@ -37,7 +37,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/agg_tracing.yaml
+++ b/examples/backends/vllm/deploy/agg_tracing.yaml
@@ -24,7 +24,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           env:
             - name: OTEL_SERVICE_NAME
               value: "dynamo-frontend"
@@ -41,7 +41,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/vllm/deploy/agg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/agg_xpu_dra.yaml
@@ -26,7 +26,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -41,7 +41,7 @@ spec:
           - name: gpu
             resourceClaimTemplateName: gpu-template
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           resources:
             claims:
               - name: gpu

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -32,7 +32,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -58,7 +58,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -27,7 +27,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -52,7 +52,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -22,7 +22,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -54,7 +54,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -22,7 +22,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -54,7 +54,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -24,7 +24,7 @@ spec:
           gpu: "2"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -60,7 +60,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -55,7 +55,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     Planner:
       componentType: planner
       replicas: 1
@@ -68,7 +68,7 @@ spec:
           #     such as kubernetes_asyncio, pmdarima, prophet, aiconfigurator).
           #   Dynamo <  1.1.0: use the backend runtime image
           #     nvcr.io/nvidia/ai-dynamo/vllm-runtime:<version>.
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           command:
           - python3
           - -m
@@ -94,7 +94,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -113,7 +113,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -29,7 +29,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -53,7 +53,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_tracing.yaml
+++ b/examples/backends/vllm/deploy/disagg_tracing.yaml
@@ -23,7 +23,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           env:
             - name: OTEL_SERVICE_NAME
               value: "dynamo-frontend"
@@ -41,7 +41,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -69,7 +69,7 @@ spec:
             ephemeral-storage: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/disagg_xpu_dra.yaml
@@ -26,7 +26,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -42,7 +42,7 @@ spec:
           - name: gpu
             resourceClaimTemplateName: gpu-template
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           resources:
             claims:
               - name: gpu
@@ -76,7 +76,7 @@ spec:
           - name: gpu
             resourceClaimTemplateName: gpu-template
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           resources:
             claims:
               - name: gpu

--- a/examples/backends/vllm/deploy/gaie/agg.yaml
+++ b/examples/backends/vllm/deploy/gaie/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.1
           env:
             - name: DYN_KV_CACHE_BLOCK_SIZE
               value: "128"
@@ -51,7 +51,7 @@ spec:
       sharedMemory:
         size: 2Gi
       frontendSidecar:
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
         args:
           - -m
           - dynamo.frontend
@@ -72,7 +72,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/examples/backends/vllm/deploy/gaie/disagg.yaml
+++ b/examples/backends/vllm/deploy/gaie/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.1
           imagePullPolicy: IfNotPresent
           env:
             - name: DYN_KV_CACHE_BLOCK_SIZE
@@ -70,7 +70,7 @@ spec:
       sharedMemory:
         size: 2Gi
       frontendSidecar:
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
         args:
           - -m
           - dynamo.frontend
@@ -105,7 +105,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
@@ -121,7 +121,7 @@ spec:
       sharedMemory:
         size: 2Gi
       frontendSidecar:
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
         args:
           - -m
           - dynamo.frontend
@@ -156,7 +156,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           workingDir: /workspace/examples/backends/vllm
       replicas: 1

--- a/examples/backends/vllm/deploy/gaie/v1beta1/agg.yaml
+++ b/examples/backends/vllm/deploy/gaie/v1beta1/agg.yaml
@@ -45,7 +45,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.1
           name: main
     replicas: 1
     type: epp
@@ -71,7 +71,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -87,7 +87,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: sidecar-frontend
     replicas: 1
     sharedMemorySize: 2Gi

--- a/examples/backends/vllm/deploy/gaie/v1beta1/disagg.yaml
+++ b/examples/backends/vllm/deploy/gaie/v1beta1/disagg.yaml
@@ -62,7 +62,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.1
           imagePullPolicy: IfNotPresent
           name: main
     replicas: 1
@@ -100,7 +100,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           name: main
           resources:
@@ -117,7 +117,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: sidecar-frontend
         tolerations:
         - effect: NoSchedule
@@ -160,7 +160,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           name: main
           resources:
@@ -177,7 +177,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: sidecar-frontend
         tolerations:
         - effect: NoSchedule

--- a/examples/backends/vllm/deploy/lora/agg_lora.yaml
+++ b/examples/backends/vllm/deploy/lora/agg_lora.yaml
@@ -11,7 +11,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -24,7 +24,7 @@ spec:
         name: Qwen/Qwen3-0.6B
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           env:
             - name: DYN_LORA_ENABLED

--- a/examples/backends/vllm/deploy/lora/multimodal/agg_qwen_lora.yaml
+++ b/examples/backends/vllm/deploy/lora/multimodal/agg_qwen_lora.yaml
@@ -26,7 +26,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           env:
             - name: DYN_REQUEST_PLANE
               value: tcp
@@ -43,7 +43,7 @@ spec:
         name: Qwen/Qwen3-VL-2B-Instruct
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           env:
             - name: DYN_REQUEST_PLANE
               value: tcp

--- a/examples/backends/vllm/deploy/lora/multimodal/v1beta1/agg_qwen_lora.yaml
+++ b/examples/backends/vllm/deploy/lora/multimodal/v1beta1/agg_qwen_lora.yaml
@@ -32,7 +32,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -93,7 +93,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/lora/v1beta1/agg_lora.yaml
+++ b/examples/backends/vllm/deploy/lora/v1beta1/agg_lora.yaml
@@ -10,7 +10,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -61,7 +61,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/agg.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/agg.yaml
@@ -14,7 +14,7 @@ spec:
         - envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -32,7 +32,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/agg_failover.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/agg_failover.yaml
@@ -27,7 +27,7 @@ spec:
         - envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -52,7 +52,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/agg_gms.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/agg_gms.yaml
@@ -23,7 +23,7 @@ spec:
         - envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -45,7 +45,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/agg_kvbm.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -37,7 +37,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/agg_router.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/agg_router.yaml
@@ -14,7 +14,7 @@ spec:
         - env:
           - name: DYN_ROUTER_MODE
             value: kv
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -34,7 +34,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/agg_router_kv_approx.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/agg_router_kv_approx.yaml
@@ -26,7 +26,7 @@ spec:
           env:
           - name: DYN_ROUTER_MODE
             value: kv
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -46,7 +46,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/agg_tracing.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/agg_tracing.yaml
@@ -21,7 +21,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -42,7 +42,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/agg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/agg_xpu_dra.yaml
@@ -27,7 +27,7 @@ spec:
         - envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -50,7 +50,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             claims:

--- a/examples/backends/vllm/deploy/v1beta1/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg-multinode.yaml
@@ -18,7 +18,7 @@ spec:
           - python3
           - -m
           - dynamo.frontend
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           workingDir: /workspace/examples/backends/vllm
     replicas: 1
@@ -45,7 +45,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -76,7 +76,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/disagg.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -31,7 +31,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -60,7 +60,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg_kvbm.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -36,7 +36,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -68,7 +68,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg_kvbm_2p2d.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -36,7 +36,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -68,7 +68,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg_kvbm_tp2.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -40,7 +40,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -78,7 +78,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg_planner.yaml
@@ -54,7 +54,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -77,7 +77,7 @@ spec:
           #     such as kubernetes_asyncio, pmdarima, prophet, aiconfigurator).
           #   Dynamo <  1.1.0: use the backend runtime image
           #     nvcr.io/nvidia/ai-dynamo/vllm-runtime:<version>.
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1
           name: main
           volumeMounts:
           - mountPath: /workspace/profiling_results
@@ -103,7 +103,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -129,7 +129,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg_router.yaml
@@ -14,7 +14,7 @@ spec:
         - env:
           - name: DYN_ROUTER_MODE
             value: kv
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -34,7 +34,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -65,7 +65,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/disagg_tracing.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg_tracing.yaml
@@ -18,7 +18,7 @@ spec:
         - env:
           - name: OTEL_SERVICE_NAME
             value: dynamo-frontend
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -41,7 +41,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/backends/vllm/deploy/v1beta1/disagg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg_xpu_dra.yaml
@@ -27,7 +27,7 @@ spec:
         - envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -52,7 +52,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             claims:
@@ -89,7 +89,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             claims:

--- a/examples/custom_backend/hello_world/deploy/hello_world.yaml
+++ b/examples/custom_backend/hello_world/deploy/hello_world.yaml
@@ -40,7 +40,7 @@ spec:
           memory: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.2.1
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh
@@ -78,7 +78,7 @@ spec:
           memory: "4Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.2.1
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh

--- a/examples/custom_backend/hello_world/deploy/v1beta1/hello_world.yaml
+++ b/examples/custom_backend/hello_world/deploy/v1beta1/hello_world.yaml
@@ -17,7 +17,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.2.1
           livenessProbe:
             exec:
               command:
@@ -58,7 +58,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:1.2.1
           livenessProbe:
             exec:
               command:

--- a/examples/deployments/ECS/task_definition_frontend.json
+++ b/examples/deployments/ECS/task_definition_frontend.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "name": "dynamo-vllm-frontend",
-            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0",
+            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:AWS_REGION:AWS_ID:secret:ngc_nvcr_access"
             },

--- a/examples/deployments/ECS/task_definition_prefillworker.json
+++ b/examples/deployments/ECS/task_definition_prefillworker.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "name": "dynamo-prefill",
-            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0",
+            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:AWS_REGION:AWS_ID:secret:ngc_access"
             },

--- a/examples/deployments/GKE/sglang/disagg.yaml
+++ b/examples/deployments/GKE/sglang/disagg.yaml
@@ -11,7 +11,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -22,7 +22,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
             - /bin/sh
@@ -44,7 +44,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           workingDir: /workspace/examples/backends/sglang
           command:
             - /bin/sh

--- a/examples/deployments/GKE/sglang/v1beta1/disagg.yaml
+++ b/examples/deployments/GKE/sglang/v1beta1/disagg.yaml
@@ -10,7 +10,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -31,7 +31,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -56,7 +56,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/deployments/GKE/vllm/disagg.yaml
+++ b/examples/deployments/GKE/vllm/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -25,7 +25,7 @@ spec:
         mainContainer:
           startupProbe:
             initialDelaySeconds: 180
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -46,7 +46,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/examples/deployments/GKE/vllm/v1beta1/disagg.yaml
+++ b/examples/deployments/GKE/vllm/v1beta1/disagg.yaml
@@ -11,7 +11,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        - image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
     replicas: 1
     type: frontend
@@ -31,7 +31,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:
@@ -57,7 +57,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           name: main
           resources:
             limits:

--- a/examples/diffusers/deploy/agg.yaml
+++ b/examples/diffusers/deploy/agg.yaml
@@ -18,7 +18,7 @@ spec:
           value: kubernetes
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           workingDir: /opt/app
           command:
@@ -55,7 +55,7 @@ spec:
           mountPoint: /root/.cache/huggingface
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           workingDir: /opt/app
           command:

--- a/examples/diffusers/deploy/agg_user_workload.yaml
+++ b/examples/diffusers/deploy/agg_user_workload.yaml
@@ -29,7 +29,7 @@ spec:
             value: user-workload
             effect: NoExecute
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           workingDir: /opt/app
           command:
@@ -77,7 +77,7 @@ spec:
             value: user-workload
             effect: NoExecute
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           workingDir: /opt/app
           command:

--- a/examples/diffusers/deploy/v1beta1/agg.yaml
+++ b/examples/diffusers/deploy/v1beta1/agg.yaml
@@ -25,7 +25,7 @@ spec:
             value: /cache/triton
           - name: HF_HOME
             value: /root/.cache/huggingface
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           name: main
           resources:
@@ -58,7 +58,7 @@ spec:
           env:
           - name: DYN_DISCOVERY_BACKEND
             value: kubernetes
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           name: main
           workingDir: /opt/app

--- a/examples/diffusers/deploy/v1beta1/agg_user_workload.yaml
+++ b/examples/diffusers/deploy/v1beta1/agg_user_workload.yaml
@@ -25,7 +25,7 @@ spec:
             value: /cache/triton
           - name: HF_HOME
             value: /root/.cache/huggingface
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           name: main
           resources:
@@ -69,7 +69,7 @@ spec:
           env:
           - name: DYN_DISCOVERY_BACKEND
             value: kubernetes
-          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/fastvideo-runtime:1.2.1
           imagePullPolicy: IfNotPresent
           name: main
           workingDir: /opt/app

--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -20,7 +20,7 @@ testing = []
 
 [dependencies]
 dynamo-runtime = { workspace = true }
-dynamo-llm = { path = "../llm", version = "1.2.0", default-features = false }
+dynamo-llm = { path = "../llm", version = "1.2.1", default-features = false }
 dynamo-protocols = { workspace = true }
 
 anyhow = { workspace = true }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1504,14 +1504,14 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-config"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-kv-router"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aho-corasick",
  "aligned-vec",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dynamo-protocols",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-logical"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-py3"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "cudarc",

--- a/lib/bindings/kvbm/Cargo.toml
+++ b/lib/bindings/kvbm/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "kvbm-py3"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/kvbm/pyproject.toml
+++ b/lib/bindings/kvbm/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "kvbm"
-version = "1.2.0.post1"
+version = "1.2.1"
 description = "Dynamo KVBM"
 readme = "README.md"
 authors = [

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2027,7 +2027,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-backend-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2045,14 +2045,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-kv-router"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aho-corasick",
  "aligned-vec",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-mocker"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dynamo-protocols",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-py3"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "dynamo-tokens",
  "serde",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-config"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dynamo-memory",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-engine"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4139,14 +4139,14 @@ dependencies = [
 
 [[package]]
 name = "kvbm-kernels"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cudarc",
 ]
 
 [[package]]
 name = "kvbm-logical"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-physical"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aligned-vec",
  "anyhow",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "dynamo-py3"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "ai-dynamo-runtime"
-version = "1.2.0.post1"
+version = "1.2.1"
 description = "Dynamo Inference Framework Runtime"
 readme = "README.md"
 authors = [

--- a/lib/kvbm-common/Cargo.toml
+++ b/lib/kvbm-common/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-common"
-version = "1.2.0"
+version = "1.2.1"
 edition.workspace = true
 description.workspace = true
 authors.workspace = true

--- a/lib/kvbm-engine/Cargo.toml
+++ b/lib/kvbm-engine/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-engine"
-version = "1.2.0"
+version = "1.2.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/lib/kvbm-kernels/Cargo.toml
+++ b/lib/kvbm-kernels/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-kernels"
-version = "1.2.0"
+version = "1.2.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/lib/kvbm-logical/Cargo.toml
+++ b/lib/kvbm-logical/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-logical"
-version = "1.2.0"
+version = "1.2.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/lib/kvbm-physical/Cargo.toml
+++ b/lib/kvbm-physical/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "kvbm-physical"
-version = "1.2.0"
+version = "1.2.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -791,14 +791,14 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-config"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-runtime"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1282,7 +1282,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_world"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "service_metrics"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "system_metrics"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "dynamo-runtime",

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "ai-dynamo"
-version = "1.2.0.post1"
+version = "1.2.1"
 description = "Distributed Inference Framework"
 readme = "README.md"
 authors = [
@@ -13,7 +13,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "ai-dynamo-runtime==1.2.0.post1",
+    "ai-dynamo-runtime==1.2.1",
     "aiohttp>=3.9.0,<4.0",
     "transformers>=4.56.0",
     "kubernetes>=32.0.1,<33.0.0",

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -48,7 +48,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
@@ -14,7 +14,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -51,7 +51,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -116,7 +116,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_elastic_ep_demo.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_elastic_ep_demo.yaml
@@ -28,7 +28,7 @@ spec:
       extraPodSpec:
         mainContainer:
           # Update tag to match VllmDecodeWorker image below
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -74,7 +74,7 @@ spec:
           persistentVolumeClaim:
             claimName: model-cache
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
           imagePullPolicy: Always
           workingDir: /workspace/examples/backends/vllm
           volumeMounts:


### PR DESCRIPTION
## Overview

Bumps the Dynamo release version from `1.2.0` to `1.2.1`, following the same pattern as #10180 (the `1.2.0-post.1` → `1.2.0` bump).

## Changes

`1.2.0` → `1.2.1` across **125 files**:

- **Rust**: `Cargo.toml` workspace + per-crate versions, all four `Cargo.lock` files
- **Python wheel**: `pyproject.toml` (`version` and `ai-dynamo-runtime==` pin), `1.2.0.post1` → `1.2.1`
- **Helm**: platform/snapshot/operator `Chart.yaml`, `values.yaml`, README badges
- **Deployments**: ~100 example/deploy YAMLs and ECS task-definition JSON image tags (`…runtime:1.2.0` → `:1.2.1`)
- **Attributions**: `ATTRIBUTIONS-Rust.md` dynamo/kvbm crate headers
- **Misc**: profiler configs, docs

## Deliberately preserved / excluded

- **`scopeguard` 1.2.0** — third-party crate genuinely at `1.2.0` in the lockfiles and attributions; left untouched (name-aware bump, not a blanket replace).
- **`.github/workflows/release.yml`** — not modified. Its only `1.2.0` references are illustrative comments (`e.g. release/1.2.0 -> 1.2.0`); the workflow derives `VERSION` dynamically and has no hardcoded version declaration.

## Verification

- `cargo verify-project` → `{"success":"true"}`; `pyproject.toml` parses as valid TOML
- No stale `1.2.0-post.1` / `1.2.0.post1` strings remain
- Lockfile crate versions agree with the workspace `1.2.1`
- Symmetric diff: 382 insertions / 382 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->