### PR TITLE
perf(tokenizers): reuse tokenizer cache prefix hash

### DIFF
--- a/lib/tokenizers/src/cache/l1.rs
+++ b/lib/tokenizers/src/cache/l1.rs
@@ -69,6 +69,12 @@ fn boundaries_with(text: &str, matcher: &AhoCorasick) -> Vec<usize> {
     boundaries
 }
 
+fn hash_prefix(input: &str, boundary: usize) -> Blake3Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&input.as_bytes()[..boundary]);
+    *hasher.finalize().as_bytes()
+}
+
 /// Test-only reference: build a one-off automaton and find boundaries. Production goes
 /// through [`L1Cache::boundaries`], which reuses a process-once automaton.
 #[cfg(test)]
@@ -154,6 +160,18 @@ impl L1Cache {
     /// `deepest_boundary` is the deepest special-token boundary in `input` (end-exclusive),
     /// handed back so [`extend_after_match`] need not rescan the input for it.
     pub fn longest_prefix_match(&self, input: &str) -> Option<(Arc<[TokenIdType]>, usize, usize)> {
+        self.longest_prefix_match_with_deepest_hash(input).map(
+            |(tokens, boundary_pos, deepest_boundary, _)| (tokens, boundary_pos, deepest_boundary),
+        )
+    }
+
+    /// Like [`Self::longest_prefix_match`], but also returns the BLAKE3 digest for
+    /// `input[..deepest_boundary]`. The hit-extension path inserts that deepest
+    /// entry, so reusing the digest avoids hashing the same full prefix twice.
+    pub(super) fn longest_prefix_match_with_deepest_hash(
+        &self,
+        input: &str,
+    ) -> Option<(Arc<[TokenIdType]>, usize, usize, Blake3Hash)> {
         let boundaries = self.boundaries(input);
 
         if boundaries.is_empty() {
@@ -179,6 +197,10 @@ impl L1Cache {
             prefix_hashes.push((boundary_pos, *hasher.finalize().as_bytes()));
             last_pos = boundary_pos;
         }
+        let deepest_hash = prefix_hashes
+            .last()
+            .map(|(_, hash_bytes)| *hash_bytes)
+            .expect("prefix_hashes is non-empty when boundaries is non-empty");
 
         // Search from the longest boundary down — return first hit. moka updates recency
         // and frequency on `get`, so no manual timestamp bookkeeping is needed.
@@ -191,7 +213,7 @@ impl L1Cache {
                 // Return the shared `Arc` directly — the caller decides whether to
                 // materialize a `Vec` (and reserves exact capacity when it does),
                 // avoiding a clone of the (large) cached prefix on every hit.
-                return Some((tokens, boundary_pos, deepest_boundary));
+                return Some((tokens, boundary_pos, deepest_boundary, deepest_hash));
             }
         }
 
@@ -312,6 +334,30 @@ impl L1Cache {
         deepest_boundary: usize,
         tokenizer: &E,
     ) -> anyhow::Result<Vec<TokenIdType>> {
+        let deepest_hash = if deepest_boundary > prefix_len {
+            hash_prefix(input, deepest_boundary)
+        } else {
+            Blake3Hash::default()
+        };
+        self.extend_after_match_with_deepest_hash(
+            input,
+            prefix_tokens,
+            prefix_len,
+            deepest_boundary,
+            deepest_hash,
+            tokenizer,
+        )
+    }
+
+    pub(super) fn extend_after_match_with_deepest_hash<E: Encoder + ?Sized>(
+        &self,
+        input: &str,
+        prefix_tokens: Arc<[TokenIdType]>,
+        prefix_len: usize,
+        deepest_boundary: usize,
+        deepest_hash: Blake3Hash,
+        tokenizer: &E,
+    ) -> anyhow::Result<Vec<TokenIdType>> {
         // `deepest_boundary` (from `longest_prefix_match`) is the deepest special-token
         // boundary in `input`; split there only if it lies strictly past the matched
         // prefix. Strict `>` avoids re-inserting the entry we just matched. Boundaries
@@ -344,17 +390,10 @@ impl L1Cache {
         cumulative.extend_from_slice(&prefix_tokens);
         cumulative.extend_from_slice(seg_a.token_ids());
 
-        // Key is blake3 of input[0..deepest]. Built with the same streaming idiom as
-        // `longest_prefix_match`/`insert_at_boundaries` so the digest is byte-for-byte
-        // identical to the incremental one a future lookup computes for this prefix.
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(&input.as_bytes()[..deepest]);
-        let hash_bytes: Blake3Hash = *hasher.finalize().as_bytes();
-
         // Snapshot prefix+seg_a (`as_slice().into()` copies only the populated len, not the
         // reserved capacity) and cache it.
         let tokens: Arc<[TokenIdType]> = cumulative.as_slice().into();
-        self.cache.insert(hash_bytes, tokens);
+        self.cache.insert(deepest_hash, tokens);
 
         // Append the trailing segment for the returned result — no realloc, capacity was
         // reserved above.

--- a/lib/tokenizers/src/cache/mod.rs
+++ b/lib/tokenizers/src/cache/mod.rs
@@ -144,8 +144,8 @@ impl Encoder for CachedTokenizer {
             return self.inner.encode(input);
         }
 
-        if let Some((prefix_tokens, prefix_len, deepest_boundary)) =
-            self.l1.longest_prefix_match(input)
+        if let Some((prefix_tokens, prefix_len, deepest_boundary, deepest_hash)) =
+            self.l1.longest_prefix_match_with_deepest_hash(input)
         {
             let suffix = &input[prefix_len..];
             if suffix.is_empty() {
@@ -155,11 +155,12 @@ impl Encoder for CachedTokenizer {
                 // Cache the new suffix at its deepest boundary so the next turn hits
                 // deeper, then return the full merged tokens. The deepest boundary was
                 // already found by `longest_prefix_match`, so no rescan is needed here.
-                return Ok(Encoding::Sp(self.l1.extend_after_match(
+                return Ok(Encoding::Sp(self.l1.extend_after_match_with_deepest_hash(
                     input,
                     prefix_tokens,
                     prefix_len,
                     deepest_boundary,
+                    deepest_hash,
                     self.inner.as_ref(),
                 )?));
             }


### PR DESCRIPTION
Summary
- Reuse the BLAKE3 digest already computed for the deepest tokenizer-cache boundary when extending a prefix-cache hit.
- Keep the existing public L1 cache helper signatures as compatibility wrappers while routing CachedTokenizer::encode through the hash-carrying fast path.
- Avoid an extra full-prefix hash pass on tokenizer-cache hit extension without changing cache keys, eviction behavior, or tokenization semantics.

Validation
- cargo test -p dynamo-tokenizers cache
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized cache operations to eliminate redundant hash computations during lookup and extension, improving tokenization performance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->