### PR TITLE
fix(parsers): reassemble chunk-split <think>/</think> markers in streaming reasoning

### DIFF
--- a/docs/tool-calling/troubleshooting.md
+++ b/docs/tool-calling/troubleshooting.md
@@ -105,6 +105,51 @@ output, before any tool-call parser touched it. That is the key piece for
 triage: it tells us what the model actually produced, separately from what
 the parser made of it.
 
+## Parser debug mode
+
+When a parse failure shows up on only a small percentage of requests, the
+decisive artifact is one raw model completion next to its parsed output.
+Setting `DYN_PARSER_DEBUG=1` makes the frontend emit exactly that: one
+structured log event per choice at stream end, pairing the raw pre-parse
+completion text with the parsed `reasoning_content`, `content`, and
+`tool_calls`.
+
+> **Opt-in only.** Raw completions carry user data, so this mode is off by
+> default. Enable it only in environments where logging request content is
+> acceptable.
+
+Run the frontend with both flags set (JSONL makes the event queryable):
+
+```bash
+DYN_PARSER_DEBUG=1 DYN_LOGGING_JSONL=true python -m dynamo.frontend ...
+```
+
+Each event carries `stream_id`, `choice_index`, `reasoning_parser`,
+`tool_parser`, `raw`, `raw_chunks`, `reasoning_content`, `content`,
+`tool_call_count`, `tool_call_names`, and `finish_reason` as separate
+fields. `raw` is the full pre-parse completion text; `raw_chunks` is the
+same text split exactly as the stream deltas arrived -- streaming parse
+failures are often chunk-boundary-dependent, so the boundaries are what
+lets you replay and reproduce the failure.
+
+A real failure shape: the model emits a well-formed tool call, but a
+delta boundary splits the closing `</think>` marker and the reasoning
+parser swallows the entire tool call into `reasoning_content` --
+`tool_calls` stays empty and `finish_reason` is `stop`. The event shows
+`raw` containing the intact `<function=...>` markup the parsers
+destroyed, and `raw_chunks` shows the exact split needed to reproduce:
+
+```json
+{"target":"parser_debug","fields":{"stream_id":"chatcmpl-abc","choice_index":0,"reasoning_parser":"nemotron_v3","tool_parser":"qwen3_coder","raw":"<think>pick a command</think>\n<tool_call>\n<function=terminal>...","raw_chunks":"[\"<think>pick a command<\", \"/think>\\n<tool_call>\\n<\", \"function=terminal>...\"]","reasoning_content":"pick a command</think>\n<tool_call>\n<function=terminal>...","content":"","tool_call_count":0,"tool_call_names":"[]","finish_reason":"Stop"}}
+```
+
+One grep over the frontend log surfaces every request where parsing
+produced no tool calls despite tool-call-shaped raw text:
+
+```bash
+grep '"target":"parser_debug"' frontend.jsonl | jq 'select(.fields.tool_call_count == 0)'
+```
+
 ## What to include when reporting an issue
 
 Share these four things in the bug report or issue thread:

--- a/docs/tool-calling/troubleshooting.md
+++ b/docs/tool-calling/troubleshooting.md
@@ -105,26 +105,30 @@ output, before any tool-call parser touched it. That is the key piece for
 triage: it tells us what the model actually produced, separately from what
 the parser made of it.
 
-## Parser debug mode
+## Parser anomaly detection
 
 When a parse failure shows up on only a small percentage of requests, the
-decisive artifact is one raw model completion next to its parsed output.
-Setting `DYN_PARSER_DEBUG=1` makes the frontend emit exactly that: one
-structured log event per choice at stream end, pairing the raw pre-parse
-completion text with the parsed `reasoning_content`, `content`, and
-`tool_calls`.
+decisive artifact is one raw model completion next to its parsed output. The
+frontend emits exactly that automatically: whenever it detects a parse
+anomaly it logs one structured `warn` event per affected choice at stream
+end, pairing the raw pre-parse completion text with the parsed
+`reasoning_content`, `content`, and `tool_calls`. Healthy requests log
+nothing, so it stays quiet in production and fires only on the
+small-percentage failures that are otherwise hard to reproduce from logs.
 
-> **Opt-in only.** Raw completions carry user data, so this mode is off by
-> default. Enable it only in environments where logging request content is
-> acceptable.
+An event fires when any of these trips: `tool_call_dropped` (raw has a
+tool-call start marker but no call was extracted -- the silent empty-stop),
+`tool_markup_in_content` (parser-owned markup leaked into `content`),
+`tool_markup_in_reasoning` (a tool block was absorbed into
+`reasoning_content`), or `all_output_lost`.
 
-Run the frontend with both flags set (JSONL makes the event queryable):
+Set `DYN_LOGGING_JSONL=true` so the events are queryable:
 
 ```bash
-DYN_PARSER_DEBUG=1 DYN_LOGGING_JSONL=true python -m dynamo.frontend ...
+DYN_LOGGING_JSONL=true python -m dynamo.frontend ...
 ```
 
-Each event carries `stream_id`, `choice_index`, `reasoning_parser`,
+Each event carries `anomalies`, `stream_id`, `choice_index`, `reasoning_parser`,
 `tool_parser`, `raw`, `raw_chunks`, `reasoning_content`, `content`,
 `tool_call_count`, `tool_call_names`, and `finish_reason` as separate
 fields. `raw` is the full pre-parse completion text; `raw_chunks` is the
@@ -132,22 +136,21 @@ same text split exactly as the stream deltas arrived -- streaming parse
 failures are often chunk-boundary-dependent, so the boundaries are what
 lets you replay and reproduce the failure.
 
-A real failure shape: the model emits a well-formed tool call, but a
-delta boundary splits the closing `</think>` marker and the reasoning
-parser swallows the entire tool call into `reasoning_content` --
-`tool_calls` stays empty and `finish_reason` is `stop`. The event shows
-`raw` containing the intact `<function=...>` markup the parsers
-destroyed, and `raw_chunks` shows the exact split needed to reproduce:
+A real failure shape (the Nemotron empty-stop): the model emits a tool call
+but omits the `<function=NAME>` line, so the jail finds no name to extract,
+strips the block, and `content` ends up empty with `tool_calls` empty and
+`finish_reason` `stop`. The event flags `tool_call_dropped`, with `raw`
+retaining the `<tool_call>`/`<parameter=...>` markup the parser could not
+recover and `raw_chunks` the exact delta split:
 
 ```json
-{"target":"parser_debug","fields":{"stream_id":"chatcmpl-abc","choice_index":0,"reasoning_parser":"nemotron_v3","tool_parser":"qwen3_coder","raw":"<think>pick a command</think>\n<tool_call>\n<function=terminal>...","raw_chunks":"[\"<think>pick a command<\", \"/think>\\n<tool_call>\\n<\", \"function=terminal>...\"]","reasoning_content":"pick a command</think>\n<tool_call>\n<function=terminal>...","content":"","tool_call_count":0,"tool_call_names":"[]","finish_reason":"Stop"}}
+{"target":"parser_debug","level":"warn","fields":{"anomalies":"[\"tool_call_dropped\"]","stream_id":"chatcmpl-abc","choice_index":0,"reasoning_parser":"nemotron_v3","tool_parser":"qwen3_coder","raw":"...prose</think>\n<tool_call>\n<parameter=command>\nls\n</parameter>\n</tool_call>\n","reasoning_content":"...prose","content":"\n\n","tool_call_count":0,"tool_call_names":"[]","finish_reason":"Stop"}}
 ```
 
-One grep over the frontend log surfaces every request where parsing
-produced no tool calls despite tool-call-shaped raw text:
+One grep over the frontend log surfaces every flagged request:
 
 ```bash
-grep '"target":"parser_debug"' frontend.jsonl | jq 'select(.fields.tool_call_count == 0)'
+grep '"target":"parser_debug"' frontend.jsonl | jq 'select(.fields.anomalies)'
 ```
 
 ## What to include when reporting an issue

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -14,6 +14,7 @@
 #[cfg(feature = "mm-routing")]
 pub mod lightseek_mm;
 pub mod media;
+pub mod parser_debug;
 pub mod prompt;
 pub mod speculative_prefill;
 mod structural_tag;
@@ -1893,6 +1894,31 @@ impl OpenAIPreprocessor {
             && !suppress_reasoning_after_tool
             && !skip_reasoning_for_guided_json;
 
+        // Determine tool jailing up front (pure from request fields) so the
+        // parser-debug gate can be evaluated before the reasoning tap.
+        let has_tools = request
+            .inner
+            .tools
+            .as_ref()
+            .is_some_and(|tools| !tools.is_empty());
+        let should_jail = Self::should_apply_tool_jail(
+            self.tool_call_parser.as_ref(),
+            request.inner.tool_choice.as_ref(),
+            has_tools,
+        )?;
+
+        // Parser debug mode (opt-in via DYN_PARSER_DEBUG): capture the RAW pre-parse
+        // text at stream entry, before the reasoning parser rewrites delta content.
+        // The matching exit tap below emits one record per choice at stream end.
+        // Only active when a parser stage runs (otherwise raw == content).
+        let parser_debug_acc = (*parser_debug::PARSER_DEBUG_ENABLED
+            && (should_parse_reasoning || should_strip_disabled_reasoning_start || should_jail))
+            .then(parser_debug::RawAccumulator::new);
+        let stream: Pin<Box<dyn Stream<Item = _> + Send>> = match parser_debug_acc.clone() {
+            Some(acc) => Box::pin(parser_debug::tap_raw(stream, acc)),
+            None => Box::pin(stream),
+        };
+
         // Reasoning Content Parsing Transformation Step
         // Current Solution:
         // This step operates on Deltas created by the transform_postprocessor_stream function
@@ -1914,20 +1940,6 @@ impl OpenAIPreprocessor {
         } else {
             Box::pin(stream)
         };
-
-        // Check if tools are present and if we should apply jail
-        let has_tools = request
-            .inner
-            .tools
-            .as_ref()
-            .is_some_and(|tools| !tools.is_empty());
-
-        // Determine if we should apply jail (do this before moving request)
-        let should_jail = Self::should_apply_tool_jail(
-            self.tool_call_parser.as_ref(),
-            request.inner.tool_choice.as_ref(),
-            has_tools,
-        )?;
 
         // Convert OpenAI tools to parser ToolDefinition format before applying jail
         let tool_definitions = request.inner.tools.as_ref().map(|tools| {
@@ -1952,6 +1964,18 @@ impl OpenAIPreprocessor {
             ))
         } else {
             Box::pin(stream)
+        };
+
+        // Parser debug exit tap: accumulate parsed outputs per choice and emit one
+        // record (raw vs parsed) at stream end. Shares the entry tap's accumulator.
+        let transformed_stream: Pin<Box<dyn Stream<Item = _> + Send>> = match parser_debug_acc {
+            Some(acc) => Box::pin(parser_debug::tap_parsed_and_emit(
+                transformed_stream,
+                acc,
+                self.runtime_config.reasoning_parser.clone(),
+                self.tool_call_parser.clone(),
+            )),
+            None => transformed_stream,
         };
 
         Ok(transformed_stream)

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1907,13 +1907,14 @@ impl OpenAIPreprocessor {
             has_tools,
         )?;
 
-        // Parser debug mode (opt-in via DYN_PARSER_DEBUG): capture the RAW pre-parse
-        // text at stream entry, before the reasoning parser rewrites delta content.
-        // The matching exit tap below emits one record per choice at stream end.
+        // Parser anomaly detection (always on): capture the RAW pre-parse text at
+        // stream entry, before the reasoning parser rewrites delta content. The
+        // matching exit tap below evaluates anomaly predicates at stream end and
+        // warns only when the raw-vs-parsed pairing indicates a parse defect.
         // Only active when a parser stage runs (otherwise raw == content).
-        let parser_debug_acc = (*parser_debug::PARSER_DEBUG_ENABLED
-            && (should_parse_reasoning || should_strip_disabled_reasoning_start || should_jail))
-            .then(parser_debug::RawAccumulator::new);
+        let parser_debug_acc =
+            (should_parse_reasoning || should_strip_disabled_reasoning_start || should_jail)
+                .then(parser_debug::RawAccumulator::new);
         let stream: Pin<Box<dyn Stream<Item = _> + Send>> = match parser_debug_acc.clone() {
             Some(acc) => Box::pin(parser_debug::tap_raw(stream, acc)),
             None => Box::pin(stream),
@@ -1968,13 +1969,24 @@ impl OpenAIPreprocessor {
 
         // Parser debug exit tap: accumulate parsed outputs per choice and emit one
         // record (raw vs parsed) at stream end. Shares the entry tap's accumulator.
+        // The tool parser's start markers drive the dropped/leak/absorb predicates;
+        // only anomalous choices are logged (at warn), healthy streams emit nothing.
         let transformed_stream: Pin<Box<dyn Stream<Item = _> + Send>> = match parser_debug_acc {
-            Some(acc) => Box::pin(parser_debug::tap_parsed_and_emit(
-                transformed_stream,
-                acc,
-                self.runtime_config.reasoning_parser.clone(),
-                self.tool_call_parser.clone(),
-            )),
+            Some(acc) => {
+                let tool_start_tokens = self
+                    .tool_call_parser
+                    .as_deref()
+                    .and_then(|p| get_tool_parser_map().get(p))
+                    .map(|c| c.parser_config.tool_call_start_tokens())
+                    .unwrap_or_default();
+                Box::pin(parser_debug::tap_parsed_and_emit(
+                    transformed_stream,
+                    acc,
+                    self.runtime_config.reasoning_parser.clone(),
+                    self.tool_call_parser.clone(),
+                    tool_start_tokens,
+                ))
+            }
             None => transformed_stream,
         };
 

--- a/lib/llm/src/preprocessor/parser_debug.rs
+++ b/lib/llm/src/preprocessor/parser_debug.rs
@@ -1,39 +1,34 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Parser debug mode (opt-in via `DYN_PARSER_DEBUG`).
+//! Parser anomaly detection (always on).
 //!
-//! When enabled, the chat postprocessor emits one structured `tracing` event per
-//! choice at stream end, pairing the RAW model completion text (pre-parse, captured
+//! The chat postprocessor pairs the RAW model completion text (pre-parse, captured
 //! at stream entry) with the parsed result (`reasoning_content` / `content` /
-//! `tool_calls` / `finish_reason`). This lets intermittent parse failures be
-//! diagnosed from logs — e.g. a completion whose raw text contains `<function=...`
-//! markup the parser failed to extract shows up as `raw` with the markup and
-//! `tool_call_count = 0` — instead of requiring hand-instrumented gateway captures.
+//! `tool_calls` / `finish_reason`) per choice, and at stream end emits one
+//! structured `warn` event for any choice whose pairing indicates a parse defect —
+//! e.g. raw text containing the tool parser's start marker while zero tool calls
+//! were extracted (a silently dropped call), or tool-call markup surviving into
+//! `content` (a leak) or `reasoning_content` (an absorb). Healthy requests emit
+//! nothing, so this stays quiet in production and fires exactly on the
+//! small-percentage failures that are otherwise unreproducible from logs.
 //!
 //! The reasoning parser rewrites `choice.delta.content` in place per delta, so the
 //! raw text only exists at stream entry while the parsed result is only complete
 //! after the tool-call jail. Two taps therefore share a per-choice accumulator: an
 //! entry tap captures raw text before any parsing, and an exit tap captures the
-//! parsed deltas and emits at stream end.
-//!
-//! WARNING: raw completions carry user data; this mode is opt-in only.
+//! parsed deltas and evaluates the anomaly predicates at stream end.
 
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, Mutex};
 
 use futures::Stream;
 use futures::stream::{self, StreamExt};
 
 use dynamo_protocols::types::ChatCompletionMessageContent;
-use dynamo_runtime::config::env_is_truthy;
-use dynamo_runtime::config::environment_names::llm::DYN_PARSER_DEBUG;
 use dynamo_runtime::protocols::annotated::Annotated;
 
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
-
-/// Whether parser debug mode is enabled. Read once from `DYN_PARSER_DEBUG`.
-pub static PARSER_DEBUG_ENABLED: LazyLock<bool> = LazyLock::new(|| env_is_truthy(DYN_PARSER_DEBUG));
 
 /// Shared per-choice accumulator for the RAW (pre-parse) completion text, keyed by
 /// choice index. Populated by the entry tap, read by the exit tap at stream end.
@@ -134,13 +129,64 @@ fn build_records(
         .collect()
 }
 
-/// Emit one structured tracing event per record. Each field is a separate `tracing`
-/// field (not a formatted string) so the event is queryable in `DYN_LOGGING_JSONL`
-/// deployments.
-fn emit(records: &[ParserDebugRecord]) {
+impl ParserDebugRecord {
+    /// Anomaly predicates over the raw-vs-parsed pairing. Returns the names of
+    /// every predicate that fired (empty = healthy). `tool_start_tokens` are the
+    /// configured tool parser's start markers (e.g. `<tool_call>`); marker-based
+    /// predicates are skipped when no tool parser is configured.
+    ///
+    /// The three marker predicates map 1:1 to the production failure shapes from
+    /// the Nemotron tool-call-leak incident: a start marker in `raw` with zero
+    /// extracted calls is a silently dropped call (the model emitted a block the
+    /// parser could not extract — e.g. a missing `<function=NAME>` line); a marker
+    /// in `content` is a leak (parser-owned markup reached the client); a marker in
+    /// `reasoning_content` is an absorb (the block was swallowed into reasoning).
+    /// `all_output_lost` is marker-independent and catches total-loss shapes even
+    /// for parsers whose markers are unknown here.
+    pub fn anomalies(&self, tool_start_tokens: &[String]) -> Vec<&'static str> {
+        let mut found = Vec::new();
+        let contains_marker = |text: &str| {
+            tool_start_tokens
+                .iter()
+                .any(|t| !t.is_empty() && text.contains(t.as_str()))
+        };
+
+        if !tool_start_tokens.is_empty() {
+            if self.tool_call_count == 0 && contains_marker(&self.raw) {
+                found.push("tool_call_dropped");
+            }
+            if contains_marker(&self.content) {
+                found.push("tool_markup_in_content");
+            }
+            if contains_marker(&self.reasoning_content) {
+                found.push("tool_markup_in_reasoning");
+            }
+        }
+
+        if !self.raw.trim().is_empty()
+            && self.content.trim().is_empty()
+            && self.reasoning_content.trim().is_empty()
+            && self.tool_call_count == 0
+        {
+            found.push("all_output_lost");
+        }
+
+        found
+    }
+}
+
+/// Emit one structured `warn` event per ANOMALOUS record (healthy records emit
+/// nothing). Each field is a separate `tracing` field (not a formatted string) so
+/// the event is queryable in `DYN_LOGGING_JSONL` deployments.
+fn emit_anomalous(records: &[ParserDebugRecord], tool_start_tokens: &[String]) {
     for r in records {
-        tracing::info!(
+        let anomalies = r.anomalies(tool_start_tokens);
+        if anomalies.is_empty() {
+            continue;
+        }
+        tracing::warn!(
             target: "parser_debug",
+            anomalies = ?anomalies,
             stream_id = %r.stream_id,
             choice_index = r.choice_index,
             reasoning_parser = %r.reasoning_parser,
@@ -152,7 +198,7 @@ fn emit(records: &[ParserDebugRecord]) {
             tool_call_count = r.tool_call_count,
             tool_call_names = ?r.tool_call_names,
             finish_reason = %r.finish_reason,
-            "parser debug: raw completion vs parsed output"
+            "parser anomaly: raw completion vs parsed output disagree"
         );
     }
 }
@@ -180,23 +226,26 @@ where
         }
         Some((response, (stream, acc)))
     })
+    .fuse()
 }
 
 /// Exit tap: accumulate the PARSED outputs per choice as they flow, yield each
-/// response unchanged, and emit one debug record per choice (via `emit`) when the
-/// stream ends. Production entry point — see [`tap_parsed_collecting`] for the
-/// callback-generic core that tests drive with a capturing sink.
+/// response unchanged, and at stream end emit a `warn` event for every choice whose
+/// raw-vs-parsed pairing is anomalous (healthy choices emit nothing). Production
+/// entry point — see [`tap_parsed_collecting`] for the callback-generic core that
+/// tests drive with a capturing sink.
 pub fn tap_parsed_and_emit<S>(
     stream: S,
     raw: RawAccumulator,
     reasoning_parser: Option<String>,
     tool_parser: Option<String>,
+    tool_start_tokens: Vec<String>,
 ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
 where
     S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
 {
-    tap_parsed_collecting(stream, raw, reasoning_parser, tool_parser, |records| {
-        emit(&records)
+    tap_parsed_collecting(stream, raw, reasoning_parser, tool_parser, move |records| {
+        emit_anomalous(&records, &tool_start_tokens)
     })
 }
 
@@ -284,6 +333,7 @@ where
             }
         }
     })
+    .fuse()
 }
 
 #[cfg(test)]
@@ -339,6 +389,81 @@ mod tests {
     fn empty_state_yields_no_records() {
         let records = build_records("id", "-", "-", &HashMap::new(), &HashMap::new());
         assert!(records.is_empty());
+    }
+
+    fn record(
+        raw: &str,
+        reasoning: &str,
+        content: &str,
+        tool_call_count: usize,
+    ) -> ParserDebugRecord {
+        ParserDebugRecord {
+            stream_id: "sid".to_string(),
+            choice_index: 0,
+            reasoning_parser: "nemotron3".to_string(),
+            tool_parser: "qwen3_coder".to_string(),
+            raw: raw.to_string(),
+            raw_chunks: vec![raw.to_string()],
+            reasoning_content: reasoning.to_string(),
+            content: content.to_string(),
+            tool_call_count,
+            tool_call_names: Vec::new(),
+            finish_reason: "Stop".to_string(),
+        }
+    }
+
+    fn markers() -> Vec<String> {
+        vec!["<tool_call>".to_string()]
+    }
+
+    #[test]
+    fn anomaly_dropped_call() {
+        // The Nemotron empty-stop shape: raw has a tool block (sans <function=NAME>),
+        // jail strips it, nothing extracted — content is just the stripped newlines.
+        let r = record(
+            "prose</think>\n<tool_call>\n<parameter=command>\nls\n</parameter>\n</tool_call>\n",
+            "prose",
+            "\n\n",
+            0,
+        );
+        assert_eq!(r.anomalies(&markers()), vec!["tool_call_dropped"]);
+    }
+
+    #[test]
+    fn anomaly_leak_into_content() {
+        let r = record("raw", "", "before <tool_call>x</tool_call> after", 0);
+        assert!(r.anomalies(&markers()).contains(&"tool_markup_in_content"));
+    }
+
+    #[test]
+    fn anomaly_absorb_into_reasoning() {
+        // The chunk-split absorb shape: whole tool block swallowed into reasoning.
+        let r = record("raw", "plan <tool_call>x</tool_call>", "", 0);
+        assert!(
+            r.anomalies(&markers())
+                .contains(&"tool_markup_in_reasoning")
+        );
+    }
+
+    #[test]
+    fn anomaly_all_output_lost_without_markers() {
+        // Marker-independent: everything vanished even though raw had text.
+        let r = record("some raw text", "", "  \n", 0);
+        assert_eq!(r.anomalies(&[]), vec!["all_output_lost"]);
+    }
+
+    #[test]
+    fn healthy_tool_call_is_not_anomalous() {
+        // Marker in raw is fine when a call WAS extracted and markup stayed out of
+        // content/reasoning.
+        let r = record("<tool_call>...</tool_call>", "plan", "done", 1);
+        assert!(r.anomalies(&markers()).is_empty());
+    }
+
+    #[test]
+    fn healthy_plain_text_is_not_anomalous() {
+        let r = record("hello world", "", "hello world", 0);
+        assert!(r.anomalies(&markers()).is_empty());
     }
 
     #[test]

--- a/lib/llm/src/preprocessor/parser_debug.rs
+++ b/lib/llm/src/preprocessor/parser_debug.rs
@@ -1,0 +1,521 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parser debug mode (opt-in via `DYN_PARSER_DEBUG`).
+//!
+//! When enabled, the chat postprocessor emits one structured `tracing` event per
+//! choice at stream end, pairing the RAW model completion text (pre-parse, captured
+//! at stream entry) with the parsed result (`reasoning_content` / `content` /
+//! `tool_calls` / `finish_reason`). This lets intermittent parse failures be
+//! diagnosed from logs — e.g. a completion whose raw text contains `<function=...`
+//! markup the parser failed to extract shows up as `raw` with the markup and
+//! `tool_call_count = 0` — instead of requiring hand-instrumented gateway captures.
+//!
+//! The reasoning parser rewrites `choice.delta.content` in place per delta, so the
+//! raw text only exists at stream entry while the parsed result is only complete
+//! after the tool-call jail. Two taps therefore share a per-choice accumulator: an
+//! entry tap captures raw text before any parsing, and an exit tap captures the
+//! parsed deltas and emits at stream end.
+//!
+//! WARNING: raw completions carry user data; this mode is opt-in only.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+
+use futures::Stream;
+use futures::stream::{self, StreamExt};
+
+use dynamo_protocols::types::ChatCompletionMessageContent;
+use dynamo_runtime::config::env_is_truthy;
+use dynamo_runtime::config::environment_names::llm::DYN_PARSER_DEBUG;
+use dynamo_runtime::protocols::annotated::Annotated;
+
+use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+
+/// Whether parser debug mode is enabled. Read once from `DYN_PARSER_DEBUG`.
+pub static PARSER_DEBUG_ENABLED: LazyLock<bool> = LazyLock::new(|| env_is_truthy(DYN_PARSER_DEBUG));
+
+/// Shared per-choice accumulator for the RAW (pre-parse) completion text, keyed by
+/// choice index. Populated by the entry tap, read by the exit tap at stream end.
+///
+/// Each delta is stored as its own chunk: parse failures in the streaming parsers
+/// are frequently chunk-boundary-dependent (a marker split across deltas parses
+/// differently from the same bytes in one delta), so the boundaries are required
+/// to *reproduce* a failure, not just to see it.
+#[derive(Clone, Default)]
+pub struct RawAccumulator(Arc<Mutex<HashMap<u32, Vec<String>>>>);
+
+impl RawAccumulator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn push(&self, index: u32, text: &str) {
+        let mut guard = self
+            .0
+            .lock()
+            .expect("parser-debug raw accumulator poisoned");
+        guard.entry(index).or_default().push(text.to_string());
+    }
+
+    fn snapshot(&self) -> HashMap<u32, Vec<String>> {
+        self.0
+            .lock()
+            .expect("parser-debug raw accumulator poisoned")
+            .clone()
+    }
+}
+
+/// One emitted debug record per choice: the raw completion next to the parsed result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParserDebugRecord {
+    pub stream_id: String,
+    pub choice_index: u32,
+    pub reasoning_parser: String,
+    pub tool_parser: String,
+    /// Full pre-parse completion text (concatenated) — grep this for expected markup.
+    pub raw: String,
+    /// The same text split exactly as the deltas arrived — replay these chunks
+    /// through the parser to reproduce chunk-boundary-dependent failures.
+    pub raw_chunks: Vec<String>,
+    pub reasoning_content: String,
+    pub content: String,
+    pub tool_call_count: usize,
+    pub tool_call_names: Vec<String>,
+    pub finish_reason: String,
+}
+
+/// Per-choice accumulator for the PARSED outputs, built by the exit tap.
+#[derive(Default)]
+struct ParsedAccum {
+    reasoning_content: String,
+    content: String,
+    tool_call_names: Vec<String>,
+    tool_call_count: usize,
+    finish_reason: Option<String>,
+}
+
+/// Build one record per choice from the accumulated raw + parsed state.
+///
+/// Pure: takes the captured maps and parser names, returns the records. Tests assert
+/// on the returned structs rather than on emitted log output.
+fn build_records(
+    stream_id: &str,
+    reasoning_parser: &str,
+    tool_parser: &str,
+    raw: &HashMap<u32, Vec<String>>,
+    parsed: &HashMap<u32, ParsedAccum>,
+) -> Vec<ParserDebugRecord> {
+    // Union of choice indices seen on either side. A choice with raw but no parsed
+    // output (or vice versa) still gets a record so the gap is visible.
+    let mut indices: Vec<u32> = raw.keys().chain(parsed.keys()).copied().collect();
+    indices.sort_unstable();
+    indices.dedup();
+
+    indices
+        .into_iter()
+        .map(|index| {
+            let p = parsed.get(&index);
+            let raw_chunks = raw.get(&index).cloned().unwrap_or_default();
+            ParserDebugRecord {
+                stream_id: stream_id.to_string(),
+                choice_index: index,
+                reasoning_parser: reasoning_parser.to_string(),
+                tool_parser: tool_parser.to_string(),
+                raw: raw_chunks.concat(),
+                raw_chunks,
+                reasoning_content: p.map(|p| p.reasoning_content.clone()).unwrap_or_default(),
+                content: p.map(|p| p.content.clone()).unwrap_or_default(),
+                tool_call_count: p.map(|p| p.tool_call_count).unwrap_or(0),
+                tool_call_names: p.map(|p| p.tool_call_names.clone()).unwrap_or_default(),
+                finish_reason: p.and_then(|p| p.finish_reason.clone()).unwrap_or_default(),
+            }
+        })
+        .collect()
+}
+
+/// Emit one structured tracing event per record. Each field is a separate `tracing`
+/// field (not a formatted string) so the event is queryable in `DYN_LOGGING_JSONL`
+/// deployments.
+fn emit(records: &[ParserDebugRecord]) {
+    for r in records {
+        tracing::info!(
+            target: "parser_debug",
+            stream_id = %r.stream_id,
+            choice_index = r.choice_index,
+            reasoning_parser = %r.reasoning_parser,
+            tool_parser = %r.tool_parser,
+            raw = %r.raw,
+            raw_chunks = ?r.raw_chunks,
+            reasoning_content = %r.reasoning_content,
+            content = %r.content,
+            tool_call_count = r.tool_call_count,
+            tool_call_names = ?r.tool_call_names,
+            finish_reason = %r.finish_reason,
+            "parser debug: raw completion vs parsed output"
+        );
+    }
+}
+
+/// Entry tap: accumulate the RAW (pre-parse) text content per choice, then yield each
+/// response unchanged. Multimodal `Parts` content is skipped (text-only deltas are
+/// what the parsing seam operates on).
+pub fn tap_raw<S>(
+    stream: S,
+    acc: RawAccumulator,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    stream::unfold((Box::pin(stream), acc), |(mut stream, acc)| async move {
+        let response = stream.next().await?;
+        if let Some(data) = response.data.as_ref() {
+            for choice in &data.inner.choices {
+                if let Some(ChatCompletionMessageContent::Text(text)) =
+                    choice.delta.content.as_ref()
+                {
+                    acc.push(choice.index, text);
+                }
+            }
+        }
+        Some((response, (stream, acc)))
+    })
+}
+
+/// Exit tap: accumulate the PARSED outputs per choice as they flow, yield each
+/// response unchanged, and emit one debug record per choice (via `emit`) when the
+/// stream ends. Production entry point — see [`tap_parsed_collecting`] for the
+/// callback-generic core that tests drive with a capturing sink.
+pub fn tap_parsed_and_emit<S>(
+    stream: S,
+    raw: RawAccumulator,
+    reasoning_parser: Option<String>,
+    tool_parser: Option<String>,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    tap_parsed_collecting(stream, raw, reasoning_parser, tool_parser, |records| {
+        emit(&records)
+    })
+}
+
+/// Callback-generic exit tap: same accumulation as [`tap_parsed_and_emit`], but
+/// routes the built records to `on_end` at stream end instead of hardcoding `emit`.
+/// Lets tests assert on `Vec<ParserDebugRecord>` directly (no log capture).
+pub fn tap_parsed_collecting<S, F>(
+    stream: S,
+    raw: RawAccumulator,
+    reasoning_parser: Option<String>,
+    tool_parser: Option<String>,
+    on_end: F,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+    F: FnOnce(Vec<ParserDebugRecord>) + Send + 'static,
+{
+    struct ExitState<St, G> {
+        stream: std::pin::Pin<Box<St>>,
+        raw: RawAccumulator,
+        reasoning_parser: String,
+        tool_parser: String,
+        stream_id: String,
+        parsed: HashMap<u32, ParsedAccum>,
+        on_end: Option<G>,
+    }
+
+    let state = ExitState {
+        stream: Box::pin(stream),
+        raw,
+        reasoning_parser: reasoning_parser.unwrap_or_else(|| "-".to_string()),
+        tool_parser: tool_parser.unwrap_or_else(|| "-".to_string()),
+        stream_id: String::new(),
+        parsed: HashMap::new(),
+        on_end: Some(on_end),
+    };
+
+    stream::unfold(state, |mut state| async move {
+        match state.stream.next().await {
+            Some(response) => {
+                if let Some(data) = response.data.as_ref() {
+                    if !data.inner.id.is_empty() {
+                        state.stream_id = data.inner.id.clone();
+                    }
+                    for choice in &data.inner.choices {
+                        let acc = state.parsed.entry(choice.index).or_default();
+                        if let Some(reasoning) = choice.delta.reasoning_content.as_ref() {
+                            acc.reasoning_content.push_str(reasoning);
+                        }
+                        if let Some(ChatCompletionMessageContent::Text(text)) =
+                            choice.delta.content.as_ref()
+                        {
+                            acc.content.push_str(text);
+                        }
+                        if let Some(tool_calls) = choice.delta.tool_calls.as_ref() {
+                            for tc in tool_calls {
+                                if let Some(name) =
+                                    tc.function.as_ref().and_then(|f| f.name.clone())
+                                {
+                                    // Name arrives once per tool call (first delta).
+                                    acc.tool_call_count += 1;
+                                    acc.tool_call_names.push(name);
+                                }
+                            }
+                        }
+                        if let Some(fr) = choice.finish_reason {
+                            acc.finish_reason = Some(format!("{fr:?}"));
+                        }
+                    }
+                }
+                Some((response, state))
+            }
+            None => {
+                if let Some(on_end) = state.on_end.take() {
+                    let records = build_records(
+                        &state.stream_id,
+                        &state.reasoning_parser,
+                        &state.tool_parser,
+                        &state.raw.snapshot(),
+                        &state.parsed,
+                    );
+                    on_end(records);
+                }
+                None
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accum(reasoning: &str, content: &str, names: &[&str], finish: Option<&str>) -> ParsedAccum {
+        ParsedAccum {
+            reasoning_content: reasoning.to_string(),
+            content: content.to_string(),
+            tool_call_names: names.iter().map(|s| s.to_string()).collect(),
+            tool_call_count: names.len(),
+            finish_reason: finish.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn one_record_per_choice() {
+        let mut raw = HashMap::new();
+        raw.insert(0, vec!["ra".to_string(), "w0".to_string()]);
+        raw.insert(1, vec!["raw1".to_string()]);
+        let mut parsed = HashMap::new();
+        parsed.insert(0, accum("r0", "c0", &["get_weather"], Some("Stop")));
+        parsed.insert(1, accum("", "c1", &[], Some("Stop")));
+
+        let records = build_records("id-x", "qwen3", "harmony", &raw, &parsed);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].choice_index, 0);
+        assert_eq!(records[0].raw, "raw0");
+        assert_eq!(records[0].tool_call_names, vec!["get_weather"]);
+        assert_eq!(records[0].tool_call_count, 1);
+        assert_eq!(records[0].reasoning_parser, "qwen3");
+        assert_eq!(records[1].choice_index, 1);
+        assert_eq!(records[1].tool_call_count, 0);
+    }
+
+    #[test]
+    fn raw_without_parsed_still_gets_record() {
+        // A choice that produced raw text but no parsed output (parser dropped it).
+        let mut raw = HashMap::new();
+        raw.insert(0, vec!["<function=foo>{}".to_string()]);
+        let parsed = HashMap::new();
+
+        let records = build_records("id", "-", "harmony", &raw, &parsed);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].raw, "<function=foo>{}");
+        assert_eq!(records[0].tool_call_count, 0);
+        assert_eq!(records[0].content, "");
+        assert_eq!(records[0].finish_reason, "");
+    }
+
+    #[test]
+    fn empty_state_yields_no_records() {
+        let records = build_records("id", "-", "-", &HashMap::new(), &HashMap::new());
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn raw_accumulator_concats_per_choice() {
+        let acc = RawAccumulator::new();
+        acc.push(0, "a");
+        acc.push(0, "b");
+        acc.push(1, "x");
+        let snap = acc.snapshot();
+        assert_eq!(
+            snap.get(&0).unwrap(),
+            &vec!["a".to_string(), "b".to_string()]
+        );
+        assert_eq!(snap.get(&1).unwrap(), &vec!["x".to_string()]);
+    }
+
+    // --- tap-driving tests (accumulation behavior, synthetic streams) ---
+
+    use dynamo_protocols::types::{
+        ChatChoiceStream, ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta,
+        CreateChatCompletionStreamResponse, FinishReason, FunctionCallStream, Role,
+    };
+    use std::sync::Mutex as StdMutex;
+
+    /// Per-choice test delta: (index, content, reasoning, tool_name, finish).
+    type ChoiceSpec<'a> = (
+        u32,
+        Option<&'a str>,
+        Option<&'a str>,
+        Option<&'a str>,
+        Option<FinishReason>,
+    );
+
+    /// One stream chunk built from per-choice specs.
+    #[allow(deprecated)]
+    fn chunk(choices: &[ChoiceSpec<'_>]) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let choices = choices
+            .iter()
+            .map(
+                |(index, content, reasoning, tool_name, finish)| ChatChoiceStream {
+                    index: *index,
+                    delta: ChatCompletionStreamResponseDelta {
+                        role: Some(Role::Assistant),
+                        content: content.map(|c| ChatCompletionMessageContent::Text(c.to_string())),
+                        tool_calls: tool_name.map(|n| {
+                            vec![ChatCompletionMessageToolCallChunk {
+                                index: 0,
+                                function: Some(FunctionCallStream {
+                                    name: Some(n.to_string()),
+                                    arguments: None,
+                                }),
+                                ..Default::default()
+                            }]
+                        }),
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: reasoning.map(|r| r.to_string()),
+                    },
+                    finish_reason: *finish,
+                    logprobs: None,
+                },
+            )
+            .collect();
+        Annotated::from_data(NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "sid".to_string(),
+                choices,
+                created: 0,
+                model: "m".to_string(),
+                system_fingerprint: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            },
+            nvext: None,
+        })
+    }
+
+    /// Drive tap_raw -> tap_parsed_collecting over `chunks` and return the records.
+    fn drive(
+        chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>>,
+        reasoning_parser: Option<&str>,
+        tool_parser: Option<&str>,
+    ) -> Vec<ParserDebugRecord> {
+        let sink = Arc::new(StdMutex::new(Vec::new()));
+        let sink_w = sink.clone();
+        let raw = RawAccumulator::new();
+        // Entry tap captures raw, exit tap accumulates parsed. No parser in between
+        // here: these tests assert the tap accumulation/record-build, not parsing.
+        let entry = tap_raw(stream::iter(chunks), raw.clone());
+        let exit = tap_parsed_collecting(
+            entry,
+            raw,
+            reasoning_parser.map(str::to_string),
+            tool_parser.map(str::to_string),
+            move |records| *sink_w.lock().unwrap() = records,
+        );
+        futures::executor::block_on(exit.collect::<Vec<_>>());
+        Arc::try_unwrap(sink).unwrap().into_inner().unwrap()
+    }
+
+    #[test]
+    fn tap_finish_reason_takes_last_non_none() {
+        let records = drive(
+            vec![
+                chunk(&[(0, Some("hi"), None, None, None)]),
+                chunk(&[(0, Some(" there"), None, None, Some(FinishReason::Stop))]),
+                chunk(&[(0, None, None, None, None)]),
+            ],
+            Some("qwen3"),
+            None,
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].content, "hi there");
+        assert_eq!(records[0].finish_reason, "Stop");
+        assert_eq!(records[0].reasoning_parser, "qwen3");
+        assert_eq!(records[0].tool_parser, "-");
+    }
+
+    #[test]
+    fn tap_collects_tool_call_names_and_count() {
+        let records = drive(
+            vec![
+                chunk(&[(0, None, None, Some("get_weather"), None)]),
+                chunk(&[(
+                    0,
+                    None,
+                    None,
+                    Some("get_time"),
+                    Some(FinishReason::ToolCalls),
+                )]),
+            ],
+            None,
+            Some("harmony"),
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].tool_call_count, 2);
+        assert_eq!(records[0].tool_call_names, vec!["get_weather", "get_time"]);
+        assert_eq!(records[0].finish_reason, "ToolCalls");
+    }
+
+    #[test]
+    fn tap_two_choices_distinct_raw() {
+        let records = drive(
+            vec![
+                chunk(&[
+                    (0, Some("a0"), None, None, None),
+                    (1, Some("b1"), None, None, None),
+                ]),
+                chunk(&[(0, Some("a0b"), None, None, None)]),
+            ],
+            None,
+            None,
+        );
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].choice_index, 0);
+        assert_eq!(records[0].raw, "a0a0b");
+        assert_eq!(records[1].choice_index, 1);
+        assert_eq!(records[1].raw, "b1");
+    }
+
+    #[test]
+    fn tap_reasoning_split_from_content() {
+        // Simulates post-reasoning-parser deltas: reasoning_content + content set
+        // separately. Raw (entry tap) only sees the text content here.
+        let records = drive(
+            vec![
+                chunk(&[(0, None, Some("plan"), None, None)]),
+                chunk(&[(0, Some("answer"), None, None, Some(FinishReason::Stop))]),
+            ],
+            Some("qwen3"),
+            None,
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].reasoning_content, "plan");
+        assert_eq!(records[0].content, "answer");
+        // Entry tap saw only the "answer" text delta as raw (reasoning delta has no content).
+        assert_eq!(records[0].raw, "answer");
+    }
+}

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1790,3 +1790,225 @@ async fn tool_choice_matrix_immediate_jail_reasoning_only_first_chunk() {
     );
     assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
 }
+
+// ---------------------------------------------------------------------------
+// Parser debug mode: raw completion captured alongside parsed output.
+//
+// These compose the parser-debug taps around the REAL reasoning parser exactly
+// as `postprocessor_parsing_stream` wires them, and assert the emitted records
+// via a capturing sink (no log capture, no process-env mutation). The env-off
+// passthrough case (f) is covered by every other test in this file: when the
+// taps are absent the stream is byte-identical, which those fixtures pin.
+// ---------------------------------------------------------------------------
+
+use dynamo_llm::preprocessor::parser_debug::{
+    ParserDebugRecord, RawAccumulator, tap_parsed_collecting, tap_raw,
+};
+use std::sync::Mutex as StdMutex;
+
+#[tokio::test]
+async fn parser_debug_reasoning_raw_retained() {
+    // RAW tap is placed BEFORE the reasoning parser, which rewrites delta.content
+    // in place. The record must show the original `<think>` markup in `raw` even
+    // though the parser stripped it from `content` and moved it to reasoning.
+    let chunk = mock_content_chunk("<think>plan</think>answer");
+
+    let raw = RawAccumulator::new();
+    let sink = Arc::new(StdMutex::new(Vec::<ParserDebugRecord>::new()));
+    let sink_w = sink.clone();
+
+    let entry = tap_raw(stream::iter(vec![Annotated::from_data(chunk)]), raw.clone());
+    let reasoned =
+        OpenAIPreprocessor::parse_reasoning_content_from_stream(entry, "qwen".to_string(), false);
+    let exit = tap_parsed_collecting(
+        reasoned,
+        raw,
+        Some("qwen".to_string()),
+        None,
+        move |records| *sink_w.lock().unwrap() = records,
+    );
+    let _: Vec<_> = exit.collect().await;
+
+    let records = sink.lock().unwrap().clone();
+    assert_eq!(records.len(), 1, "one record for the single choice");
+    let r = &records[0];
+    assert!(
+        r.raw.contains("<think>"),
+        "raw must retain the original markup the parser stripped; got {:?}",
+        r.raw
+    );
+    assert_eq!(r.raw, "<think>plan</think>answer");
+    assert!(
+        !r.content.contains("<think>"),
+        "parsed content must have the think markup stripped; got {:?}",
+        r.content
+    );
+    assert!(
+        r.reasoning_content.contains("plan"),
+        "reasoning_content should hold the think body; got {:?}",
+        r.reasoning_content
+    );
+    assert_eq!(r.reasoning_parser, "qwen");
+    assert_eq!(r.stream_id, "test-id");
+}
+
+#[tokio::test]
+async fn parser_debug_split_marker_destruction_preserves_raw() {
+    // Destroyed-evidence repro: nemotron force-reasoning + qwen3_coder jail.
+    // A chunk boundary splits `</think>` at the lone `<`; the reasoning parser
+    // fails to reassemble it and swallows the ENTIRE tool call into
+    // reasoning_content — tool_calls empty, content empty, finish=Stop. The
+    // evidence (and the chunking needed to reproduce) exists only in the
+    // parser-debug record: raw shows `<function=terminal>` intact, raw_chunks
+    // shows the exact split. The same bytes unsplit parse fine (control below),
+    // so the boundaries are the repro-critical information.
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), Some("qwen3_coder"));
+    let request = request_with_terminal_tool();
+
+    let chunks = [
+        "<think>pick a command<",
+        "/think>\n<tool_call>\n<",
+        "function=terminal>\n<parameter=command>\nls -la\n</parameter>\n</function>\n</tool_call>",
+    ];
+
+    let raw = RawAccumulator::new();
+    let sink = Arc::new(StdMutex::new(Vec::<ParserDebugRecord>::new()));
+    let sink_w = sink.clone();
+
+    let input = chunks
+        .iter()
+        .map(|c| Annotated::from_data(mock_content_chunk(c)))
+        .chain(std::iter::once(Annotated::from_data(mock_final_chunk())))
+        .collect::<Vec<_>>();
+    let entry = tap_raw(stream::iter(input), raw.clone());
+    let piped = preprocessor
+        .postprocessor_parsing_stream(entry, &request, false, false)
+        .expect("pipeline should build");
+    let exit = tap_parsed_collecting(
+        piped,
+        raw,
+        Some("nemotron_v3".to_string()),
+        Some("qwen3_coder".to_string()),
+        move |records| *sink_w.lock().unwrap() = records,
+    );
+    let _: Vec<_> = exit.collect().await;
+
+    let records = sink.lock().unwrap().clone();
+    assert_eq!(records.len(), 1);
+    let r = &records[0];
+    // The destruction: no tool call extracted, nothing in content.
+    assert_eq!(r.tool_call_count, 0, "split marker destroys the tool call");
+    assert_eq!(r.content, "");
+    // The evidence: raw retains the full markup the parsers destroyed...
+    assert!(
+        r.raw.contains("<function=terminal>"),
+        "raw must prove the model emitted the function tag; got {:?}",
+        r.raw
+    );
+    // ...and raw_chunks retains the exact chunking needed to REPRODUCE the bug
+    // (the same bytes in one chunk parse fine — see the control test).
+    assert_eq!(r.raw_chunks.len(), 3);
+    assert!(r.raw_chunks[0].ends_with('<') && r.raw_chunks[1].ends_with('<'));
+}
+
+#[tokio::test]
+async fn parser_debug_unsplit_control_parses_clean() {
+    // Control for the split-marker repro: identical bytes in ONE chunk parse
+    // cleanly (reasoning extracted, calls=1 terminal). Proves the failure above
+    // is purely chunk-boundary-dependent — why raw_chunks must keep boundaries.
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), Some("qwen3_coder"));
+    let request = request_with_terminal_tool();
+
+    let text = "<think>pick a command</think>\n<tool_call>\n<function=terminal>\n<parameter=command>\nls -la\n</parameter>\n</function>\n</tool_call>";
+
+    let raw = RawAccumulator::new();
+    let sink = Arc::new(StdMutex::new(Vec::<ParserDebugRecord>::new()));
+    let sink_w = sink.clone();
+
+    let input = vec![
+        Annotated::from_data(mock_content_chunk(text)),
+        Annotated::from_data(mock_final_chunk()),
+    ];
+    let entry = tap_raw(stream::iter(input), raw.clone());
+    let piped = preprocessor
+        .postprocessor_parsing_stream(entry, &request, false, false)
+        .expect("pipeline should build");
+    let exit = tap_parsed_collecting(
+        piped,
+        raw,
+        Some("nemotron_v3".to_string()),
+        Some("qwen3_coder".to_string()),
+        move |records| *sink_w.lock().unwrap() = records,
+    );
+    let _: Vec<_> = exit.collect().await;
+
+    let records = sink.lock().unwrap().clone();
+    assert_eq!(records.len(), 1);
+    let r = &records[0];
+    assert_eq!(r.tool_call_count, 1, "unsplit input must parse the call");
+    assert_eq!(r.tool_call_names, vec!["terminal"]);
+    assert_eq!(r.reasoning_content, "pick a command");
+    assert_eq!(r.finish_reason, "ToolCalls");
+}
+
+#[tokio::test]
+async fn parser_debug_jail_strip_preserves_raw() {
+    // Malformed-generation shape: the `<function=...>` line is
+    // missing entirely, so no parser can extract a call (no tool name). The
+    // qwen3_coder jail STRIPS the whole block — content empty, calls=0 — which
+    // destroys all evidence of what the model emitted. The parser-debug record
+    // is then the only artifact showing the malformed markup.
+    let preprocessor = build_preprocessor(None, Some("qwen3_coder"));
+    let request = request_with_terminal_tool();
+
+    let leaked = "<tool_call>\n<parameter=command>\nls -la\n</parameter>\n</tool_call>";
+
+    let raw = RawAccumulator::new();
+    let sink = Arc::new(StdMutex::new(Vec::<ParserDebugRecord>::new()));
+    let sink_w = sink.clone();
+
+    let input = vec![
+        Annotated::from_data(mock_content_chunk(leaked)),
+        Annotated::from_data(mock_final_chunk()),
+    ];
+    let entry = tap_raw(stream::iter(input), raw.clone());
+    let piped = preprocessor
+        .postprocessor_parsing_stream(entry, &request, false, false)
+        .expect("pipeline should build");
+    let exit = tap_parsed_collecting(
+        piped,
+        raw,
+        None,
+        Some("qwen3_coder".to_string()),
+        move |records| *sink_w.lock().unwrap() = records,
+    );
+    let _: Vec<_> = exit.collect().await;
+
+    let records = sink.lock().unwrap().clone();
+    assert_eq!(records.len(), 1);
+    let r = &records[0];
+    assert_eq!(r.tool_call_count, 0);
+    assert_eq!(
+        r.content, "",
+        "jail strips the unparseable block — evidence gone"
+    );
+    assert!(
+        r.raw.contains("<tool_call>") && !r.raw.contains("<function="),
+        "raw is the only record: markup present, function tag missing; got {:?}",
+        r.raw
+    );
+}
+
+fn request_with_terminal_tool() -> NvCreateChatCompletionRequest {
+    let mut request: NvCreateChatCompletionRequest =
+        serde_json::from_str(REQUEST_JSON).expect("request should parse");
+    request.inner.tools = Some(
+        serde_json::from_value(serde_json::json!([
+            {"type":"function","function":{"name":"terminal","description":"run a command",
+             "parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}}
+        ]))
+        .unwrap(),
+    );
+    request.inner.tool_choice = Some(ChatCompletionToolChoiceOption::Auto);
+    request
+}

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1853,15 +1853,14 @@ async fn parser_debug_reasoning_raw_retained() {
 }
 
 #[tokio::test]
-async fn parser_debug_split_marker_destruction_preserves_raw() {
-    // Destroyed-evidence repro: nemotron force-reasoning + qwen3_coder jail.
-    // A chunk boundary splits `</think>` at the lone `<`; the reasoning parser
-    // fails to reassemble it and swallows the ENTIRE tool call into
-    // reasoning_content — tool_calls empty, content empty, finish=Stop. The
-    // evidence (and the chunking needed to reproduce) exists only in the
-    // parser-debug record: raw shows `<function=terminal>` intact, raw_chunks
-    // shows the exact split. The same bytes unsplit parse fine (control below),
-    // so the boundaries are the repro-critical information.
+async fn parser_debug_split_marker_call_survives_and_raw_preserved() {
+    // Chunk boundaries split `</think>` and `<tool_call>` at the lone `<`.
+    // On this branch the reasoning parser reassembles a marker split at the
+    // lone `<` (the chunk-split fix), so this chunking parses CLEAN: the call
+    // is extracted and nothing is absorbed into reasoning_content. The debug
+    // record still preserves the exact delta boundaries (raw_chunks) so any
+    // future regression of this shape is reproducible from one log line, and
+    // a healthy parse like this one must trip NO anomaly predicates.
     let preprocessor = build_preprocessor(Some("nemotron_v3"), Some("qwen3_coder"));
     let request = request_with_terminal_tool();
 
@@ -1896,19 +1895,26 @@ async fn parser_debug_split_marker_destruction_preserves_raw() {
     let records = sink.lock().unwrap().clone();
     assert_eq!(records.len(), 1);
     let r = &records[0];
-    // The destruction: no tool call extracted, nothing in content.
-    assert_eq!(r.tool_call_count, 0, "split marker destroys the tool call");
-    assert_eq!(r.content, "");
-    // The evidence: raw retains the full markup the parsers destroyed...
+    // The fix: the split markers reassemble, so the call is extracted.
+    assert_eq!(
+        r.tool_call_count, 1,
+        "split markers must reassemble into a parsed call"
+    );
+    assert_eq!(r.tool_call_names, vec!["terminal"]);
+    assert_eq!(r.reasoning_content, "pick a command");
+    // The record still preserves the raw markup and the exact chunking.
     assert!(
         r.raw.contains("<function=terminal>"),
-        "raw must prove the model emitted the function tag; got {:?}",
+        "raw must keep the model-emitted function tag; got {:?}",
         r.raw
     );
-    // ...and raw_chunks retains the exact chunking needed to REPRODUCE the bug
-    // (the same bytes in one chunk parse fine — see the control test).
     assert_eq!(r.raw_chunks.len(), 3);
     assert!(r.raw_chunks[0].ends_with('<') && r.raw_chunks[1].ends_with('<'));
+    // A healthy parse trips no anomaly predicates.
+    assert!(
+        r.anomalies(&["<tool_call>".to_string()]).is_empty(),
+        "clean split-marker parse must not be flagged anomalous"
+    );
 }
 
 #[tokio::test]

--- a/lib/parsers/REASONING_CASES.md
+++ b/lib/parsers/REASONING_CASES.md
@@ -134,8 +134,8 @@ then chunk-boundary cases.
 - **`REASONING.stream.3.a`** Start-marker chunk-boundary split — opening `<think>` (or analog) straddles a chunk boundary; partial-token matching must keep buffering instead of flushing as plain text.
 - **`REASONING.stream.3.b`** End-marker chunk-boundary split — closing `</think>` straddles a chunk boundary; same buffering contract as `REASONING.stream.3.a`.
 - **`REASONING.stream.3.c`** Partial marker prefix later proves not to be a marker — emit the buffered text according to the parser's current state.
-- **`REASONING.stream.3.d`** End-marker split at the lone `<` — the off-by-one of `3.b` where the chunk boundary lands on the marker's first character; the parser must hold the lone `<` and still reassemble `</think>`, else reasoning never exits and trailing content (e.g. a tool-call block) is absorbed into reasoning_text (DIS-2223).
-- **`REASONING.stream.3.e`** Re-entry start-marker split at the lone `<` — the start-marker symmetric of `3.d`: a second `<think>` straddles the boundary on its lone `<`. The parser must reassemble it and re-enter reasoning so the re-think is parsed as reasoning, not leaked as raw `<think>` markup into normal_text with its span misrouted (DIS-2223). Pairs with `REASONING.stream.2.b` for the re-entry contract.
+- **`REASONING.stream.3.d`** End-marker split at the lone `<` — the off-by-one of `3.b` where the chunk boundary lands on the marker's first character; the parser must hold the lone `<` and still reassemble `</think>`, else reasoning never exits and trailing content (e.g. a tool-call block) is absorbed into reasoning_text.
+- **`REASONING.stream.3.e`** Re-entry start-marker split at the lone `<` — the start-marker symmetric of `3.d`: a second `<think>` straddles the boundary on its lone `<`. The parser must reassemble it and re-enter reasoning so the re-think is parsed as reasoning, not leaked as raw `<think>` markup into normal_text with its span misrouted. Pairs with `REASONING.stream.2.b` for the re-entry contract.
 
 ### Upstream test inventory
 

--- a/lib/parsers/REASONING_CASES.md
+++ b/lib/parsers/REASONING_CASES.md
@@ -134,6 +134,8 @@ then chunk-boundary cases.
 - **`REASONING.stream.3.a`** Start-marker chunk-boundary split — opening `<think>` (or analog) straddles a chunk boundary; partial-token matching must keep buffering instead of flushing as plain text.
 - **`REASONING.stream.3.b`** End-marker chunk-boundary split — closing `</think>` straddles a chunk boundary; same buffering contract as `REASONING.stream.3.a`.
 - **`REASONING.stream.3.c`** Partial marker prefix later proves not to be a marker — emit the buffered text according to the parser's current state.
+- **`REASONING.stream.3.d`** End-marker split at the lone `<` — the off-by-one of `3.b` where the chunk boundary lands on the marker's first character; the parser must hold the lone `<` and still reassemble `</think>`, else reasoning never exits and trailing content (e.g. a tool-call block) is absorbed into reasoning_text (DIS-2223).
+- **`REASONING.stream.3.e`** Re-entry start-marker split at the lone `<` — the start-marker symmetric of `3.d`: a second `<think>` straddles the boundary on its lone `<`. The parser must reassemble it and re-enter reasoning so the re-think is parsed as reasoning, not leaked as raw `<think>` markup into normal_text with its span misrouted (DIS-2223). Pairs with `REASONING.stream.2.b` for the re-entry contract.
 
 ### Upstream test inventory
 

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -342,7 +342,7 @@ impl ReasoningParser for BasicReasoningParser {
                         // lone '<'. A `>= 2` threshold dropped single-char overlaps, so a
                         // </think> split at the '<' chunk boundary never reassembled —
                         // reasoning never exited and the trailing content (e.g. a tool
-                        // call) was absorbed into reasoning_content (DIS-2223).
+                        // call) was absorbed into reasoning_content.
                         if ol >= 1 {
                             let safe_end = current_text.len() - ol;
                             if safe_end > 0 {
@@ -400,7 +400,7 @@ impl ReasoningParser for BasicReasoningParser {
                         // (both start with `<`), so check both and use the wider overlap.
                         // Hold back ANY non-empty overlap, including a lone `<`. A re-entry
                         // `<think>` (or a stray `</think>`) split at the `<` chunk boundary
-                        // must reassemble (DIS-2223); a `>= 2` threshold flushed the lone `<`,
+                        // must reassemble; a `>= 2` threshold flushed the lone `<`,
                         // so the marker leaked into normal_text and the re-think span was
                         // misrouted. Holding a lone `<` is lossless: it is flushed merged with
                         // the next chunk — so a tool-call tag like `<invoke>` still reaches the
@@ -513,7 +513,7 @@ mod tests {
 
     #[test] // REASONING.stream.3.d — end token </think> split across chunks at the lone '<' boundary
     fn test_streaming_end_token_split_at_open_bracket() {
-        // Repro for the Nemotron 3 Ultra tool-call leak (DIS-2223): nemotron3 /
+        // Repro for the Nemotron 3 Ultra tool-call leak: nemotron3 /
         // nemotron_v3 / deepseek_r1 are force-reasoning, so the completion starts
         // in reasoning. When the </think> end marker is split so a lone '<' lands
         // at a chunk boundary, the parser must still reassemble </think>, exit
@@ -541,7 +541,7 @@ mod tests {
 
     #[test] // REASONING.stream.3.e — re-entry <think> split across chunks at the lone '<' boundary
     fn test_streaming_reentry_start_token_split_at_open_bracket() {
-        // Symmetric to 3.d, on the START marker (DIS-2223). After a force-reasoning
+        // Symmetric to 3.d, on the START marker. After a force-reasoning
         // parser closes its block, a SECOND <think> whose '<' lands on a chunk
         // boundary must reassemble so the re-think is parsed as reasoning — not
         // leaked as raw <think> markup into normal_text, with its span misrouted.
@@ -874,7 +874,7 @@ mod tests {
     fn test_post_reasoning_angle_bracket_held_one_chunk_then_flushed() {
         // After reasoning ends, a lone `<` could begin EITHER a re-entry `<think>`
         // split at the `<` boundary OR a tool-call tag (`<invoke`). It is held back
-        // one chunk so a split start marker can reassemble (DIS-2223), then flushed
+        // one chunk so a split start marker can reassemble, then flushed
         // merged with the next chunk — so the downstream tool-call jail still sees
         // every byte (`<invoke` stays intact), one chunk later. The accumulated
         // stream is byte-identical to flushing immediately.

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -338,7 +338,12 @@ impl ReasoningParser for BasicReasoningParser {
                             .map(|tok| overlap(&current_text, tok))
                             .unwrap_or(0);
                         let ol = ol_end.max(ol_tool);
-                        if ol >= 2 {
+                        // Hold back ANY non-empty marker-prefix overlap, including a
+                        // lone '<'. A `>= 2` threshold dropped single-char overlaps, so a
+                        // </think> split at the '<' chunk boundary never reassembled —
+                        // reasoning never exited and the trailing content (e.g. a tool
+                        // call) was absorbed into reasoning_content (DIS-2223).
+                        if ol >= 1 {
                             let safe_end = current_text.len() - ol;
                             if safe_end > 0 {
                                 accumulated_reasoning.push_str(&current_text[..safe_end]);
@@ -499,6 +504,34 @@ mod tests {
         let result = parser.parse_reasoning_streaming_incremental("<think>with reasoning", &[]);
         assert_eq!(result.normal_text, "");
         assert_eq!(result.reasoning_text, "with reasoning");
+    }
+
+    #[test] // REASONING.stream.3.c — end token </think> split across chunks at the lone '<' boundary
+    fn test_streaming_end_token_split_at_open_bracket() {
+        // Repro for the Nemotron 3 Ultra tool-call leak (DIS-2223): nemotron3 /
+        // nemotron_v3 / deepseek_r1 are force-reasoning, so the completion starts
+        // in reasoning. When the </think> end marker is split so a lone '<' lands
+        // at a chunk boundary, the parser must still reassemble </think>, exit
+        // reasoning, and route the trailing content (e.g. a tool-call block) to
+        // normal_text. If it instead drops the lone '<', </think> never
+        // reassembles, reasoning never exits, and everything after is absorbed
+        // into reasoning_text (normal_text empty) — so the downstream tool jail
+        // never sees the tool call.
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
+        let r1 = parser.parse_reasoning_streaming_incremental("reasoning content<", &[]);
+        let r2 =
+            parser.parse_reasoning_streaming_incremental("/think>\n<tool_call>x</tool_call>", &[]);
+        let reasoning = format!("{}{}", r1.reasoning_text, r2.reasoning_text);
+        let normal = format!("{}{}", r1.normal_text, r2.normal_text);
+        assert_eq!(
+            reasoning, "reasoning content",
+            "a </think> split at the lone '<' must not pull the marker or trailing content into reasoning"
+        );
+        assert_eq!(
+            normal, "\n<tool_call>x</tool_call>",
+            "content after a split </think> must reach normal_text (else the tool jail never sees the call)"
+        );
     }
 
     #[test] // REASONING.batch.6.a — multi-block

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -398,12 +398,17 @@ impl ReasoningParser for BasicReasoningParser {
                         // No complete marker — check for partial at end of buffer.
                         // The partial could be a prefix of either <think> or </think>
                         // (both start with `<`), so check both and use the wider overlap.
-                        // Require overlap >= 2 so a lone `<` passes through for tool call
-                        // XML tags like `<invoke>` or `<minimax:tool_call>`.
+                        // Hold back ANY non-empty overlap, including a lone `<`. A re-entry
+                        // `<think>` (or a stray `</think>`) split at the `<` chunk boundary
+                        // must reassemble (DIS-2223); a `>= 2` threshold flushed the lone `<`,
+                        // so the marker leaked into normal_text and the re-think span was
+                        // misrouted. Holding a lone `<` is lossless: it is flushed merged with
+                        // the next chunk — so a tool-call tag like `<invoke>` still reaches the
+                        // jail intact, one chunk later — or by finish_reasoning_stream at EOF.
                         let ol_start = overlap(&current_text, &self.think_start_token);
                         let ol_end = overlap(&current_text, &self.think_end_token);
                         let ol = ol_start.max(ol_end);
-                        if ol >= 2 {
+                        if ol >= 1 {
                             let safe_end = current_text.len() - ol;
                             if safe_end > 0 {
                                 accumulated_normal.push_str(&current_text[..safe_end]);
@@ -506,7 +511,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "with reasoning");
     }
 
-    #[test] // REASONING.stream.3.c — end token </think> split across chunks at the lone '<' boundary
+    #[test] // REASONING.stream.3.d — end token </think> split across chunks at the lone '<' boundary
     fn test_streaming_end_token_split_at_open_bracket() {
         // Repro for the Nemotron 3 Ultra tool-call leak (DIS-2223): nemotron3 /
         // nemotron_v3 / deepseek_r1 are force-reasoning, so the completion starts
@@ -532,6 +537,47 @@ mod tests {
             normal, "\n<tool_call>x</tool_call>",
             "content after a split </think> must reach normal_text (else the tool jail never sees the call)"
         );
+    }
+
+    #[test] // REASONING.stream.3.e — re-entry <think> split across chunks at the lone '<' boundary
+    fn test_streaming_reentry_start_token_split_at_open_bracket() {
+        // Symmetric to 3.d, on the START marker (DIS-2223). After a force-reasoning
+        // parser closes its block, a SECOND <think> whose '<' lands on a chunk
+        // boundary must reassemble so the re-think is parsed as reasoning — not
+        // leaked as raw <think> markup into normal_text, with its span misrouted.
+        // (Per the Harmony reading: an ambiguous re-think is parsed, info is kept.)
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
+        let r1 = parser.parse_reasoning_streaming_incremental("first</think>mid<", &[]);
+        let r2 = parser.parse_reasoning_streaming_incremental("think>second</think>end", &[]);
+        let reasoning = format!("{}{}", r1.reasoning_text, r2.reasoning_text);
+        let normal = format!("{}{}", r1.normal_text, r2.normal_text);
+        assert_eq!(
+            reasoning, "firstsecond",
+            "a re-entry <think> split at the lone '<' must reassemble so the second span is reasoning"
+        );
+        assert_eq!(
+            normal, "midend",
+            "the <think> marker must not leak into normal_text when split at the '<' boundary"
+        );
+    }
+
+    #[test] // REASONING.batch.3.a — EOF flush of a held lone '<' (no-loss guarantee)
+    fn test_post_reasoning_dangling_open_bracket_flushed_at_eof() {
+        // A lone '<' held at end-of-stream (no next chunk to merge with) must be
+        // flushed as normal_text by finish_reasoning_stream — never dropped. This is
+        // what makes holding the lone '<' lossless for the downstream tool jail.
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
+        let _ = parser.parse_reasoning_streaming_incremental("<think>x</think>", &[]);
+        let r = parser.parse_reasoning_streaming_incremental("<", &[]);
+        assert_eq!(
+            r.normal_text, "",
+            "lone '<' is held, not flushed mid-stream"
+        );
+        let f = parser.finish_reasoning_stream();
+        assert_eq!(f.normal_text, "<", "held '<' must be flushed at EOF");
+        assert_eq!(f.reasoning_text, "");
     }
 
     #[test] // REASONING.batch.6.a — multi-block
@@ -824,12 +870,14 @@ mod tests {
         assert_eq!(r3.normal_text, " final");
     }
 
-    #[test] // REASONING.batch.3.a
-    fn test_post_reasoning_angle_bracket_not_buffered() {
-        // After reasoning ends, a standalone `<` should pass through immediately
-        // as normal text. It must NOT be buffered as a potential prefix of <think>
-        // or </think>, because that would cause the downstream tool call jail to
-        // miss the `<` (e.g., `<invoke` becomes `invoke`).
+    #[test] // REASONING.batch.3.a, REASONING.stream.3.e
+    fn test_post_reasoning_angle_bracket_held_one_chunk_then_flushed() {
+        // After reasoning ends, a lone `<` could begin EITHER a re-entry `<think>`
+        // split at the `<` boundary OR a tool-call tag (`<invoke`). It is held back
+        // one chunk so a split start marker can reassemble (DIS-2223), then flushed
+        // merged with the next chunk — so the downstream tool-call jail still sees
+        // every byte (`<invoke` stays intact), one chunk later. The accumulated
+        // stream is byte-identical to flushing immediately.
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
 
@@ -839,14 +887,15 @@ mod tests {
         assert_eq!(r1.reasoning_text, "reasoning content");
         assert_eq!(r1.normal_text, "");
 
-        // After reasoning ends, a lone `<` must pass through as normal text
+        // A lone `<` is held one chunk (it could open a re-entry `<think>`).
         let r2 = parser.parse_reasoning_streaming_incremental("<", &[]);
-        assert_eq!(r2.normal_text, "<");
+        assert_eq!(r2.normal_text, "");
         assert_eq!(r2.reasoning_text, "");
 
-        // The next token should arrive independently (not merged with buffered `<`)
+        // The next chunk resolves it as a tool-call tag: the held `<` is flushed
+        // merged, so the jail receives `<invoke ...>` intact (nothing lost).
         let r3 = parser.parse_reasoning_streaming_incremental("invoke name=\"get_weather\">", &[]);
-        assert_eq!(r3.normal_text, "invoke name=\"get_weather\">");
+        assert_eq!(r3.normal_text, "<invoke name=\"get_weather\">");
         assert_eq!(r3.reasoning_text, "");
     }
 
@@ -871,12 +920,13 @@ mod tests {
         let r4 = parser.parse_reasoning_streaming_incremental("\n", &[]);
         assert_eq!(r4.normal_text, "\n");
 
-        // `<` arriving as a separate token after reasoning must NOT be buffered
+        // `<` arriving as a separate token after reasoning is held one chunk...
         let r5 = parser.parse_reasoning_streaming_incremental("<", &[]);
-        assert_eq!(r5.normal_text, "<");
+        assert_eq!(r5.normal_text, "");
 
+        // ...then flushed merged with the next chunk, so the jail still sees `<invoke`.
         let r6 = parser.parse_reasoning_streaming_incremental("invoke name=\"get_weather\">", &[]);
-        assert_eq!(r6.normal_text, "invoke name=\"get_weather\">");
+        assert_eq!(r6.normal_text, "<invoke name=\"get_weather\">");
     }
 
     #[test] // REASONING.stream.2.b, REASONING.batch.6.a, REASONING.batch.2.c
@@ -991,20 +1041,22 @@ mod tests {
 
     #[test] // REASONING.batch.3.a, helper
     fn test_lone_angle_bracket_between_reasoning_blocks() {
-        // A lone `<` between reasoning blocks should pass through (not buffer)
+        // A lone `<` between reasoning blocks is held one chunk (it could open a
+        // re-entry `<think>`), then flushed merged with the next chunk — lossless.
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
 
         let r1 = parser.parse_reasoning_streaming_incremental("<think>thought</think>", &[]);
         assert_eq!(r1.reasoning_text, "thought");
 
-        // Lone `<` must not be buffered — could be a tool call
+        // Lone `<` is held one chunk...
         let r2 = parser.parse_reasoning_streaming_incremental("<", &[]);
-        assert_eq!(r2.normal_text, "<");
+        assert_eq!(r2.normal_text, "");
         assert_eq!(r2.reasoning_text, "");
 
+        // ...and flushed merged when the next chunk proves it a tool-call tag.
         let r3 = parser.parse_reasoning_streaming_incremental("tool_call>", &[]);
-        assert_eq!(r3.normal_text, "tool_call>");
+        assert_eq!(r3.normal_text, "<tool_call>");
         assert_eq!(r3.reasoning_text, "");
 
         // But a real <think> should still work after

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -311,6 +311,16 @@ pub mod llm {
     pub const DYN_ENABLE_STREAMING_REASONING_DISPATCH: &str =
         "DYN_ENABLE_STREAMING_REASONING_DISPATCH";
 
+    /// Enable parser debug mode (off by default). When enabled, the frontend emits
+    /// one structured tracing event per choice at stream end pairing the RAW model
+    /// completion text with the parsed result (reasoning_content / content /
+    /// tool_calls / finish_reason), so intermittent parse failures can be diagnosed
+    /// from logs (queryable under `DYN_LOGGING_JSONL=true`) instead of hand-captured.
+    ///
+    /// WARNING: raw completions carry user data — this is opt-in only. Unset / `0` /
+    /// `false` = off; any other value = on.
+    pub const DYN_PARSER_DEBUG: &str = "DYN_PARSER_DEBUG";
+
     /// Backend stream inactivity timeout in seconds.
     ///
     /// When set to a positive integer, the frontend will kill the engine context

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -311,16 +311,6 @@ pub mod llm {
     pub const DYN_ENABLE_STREAMING_REASONING_DISPATCH: &str =
         "DYN_ENABLE_STREAMING_REASONING_DISPATCH";
 
-    /// Enable parser debug mode (off by default). When enabled, the frontend emits
-    /// one structured tracing event per choice at stream end pairing the RAW model
-    /// completion text with the parsed result (reasoning_content / content /
-    /// tool_calls / finish_reason), so intermittent parse failures can be diagnosed
-    /// from logs (queryable under `DYN_LOGGING_JSONL=true`) instead of hand-captured.
-    ///
-    /// WARNING: raw completions carry user data — this is opt-in only. Unset / `0` /
-    /// `false` = off; any other value = on.
-    pub const DYN_PARSER_DEBUG: &str = "DYN_PARSER_DEBUG";
-
     /// Backend stream inactivity timeout in seconds.
     ///
     /// When set to a positive integer, the frontend will kill the engine context

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -102,6 +102,44 @@ cases:
         normal_text: ''
       vllm: *d_s6
       sglang: *d_s6
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '<' (off-by-one from 3.b), force-reasoning shape with no leading start marker — the production Nemotron 3 Ultra shape
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - thinking<
+    - /think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+        reason: Dynamo buffers a split end delimiter (incl. a lone '<' at the chunk boundary) and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
+      sglang:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+        reason: Dynamo reassembles an end marker split at the lone '<' and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the answer stays in reasoning_text.
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '<' (start-marker symmetric of 3.d), force-reasoning shape — a second <think> straddles the boundary, so the re-think must reassemble and not leak
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - first</think>mid<
+    - think>second</think>end
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: midend
+      vllm:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo buffers a re-entry <think> split at the lone '<' and re-enters reasoning for the second span; vLLM does not re-enter, so the later complete span stays in normal_text.
+      sglang:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo reassembles the second <think> split at the lone '<' and concatenates both spans; SGLang exits at the first end marker and does not re-enter, leaving the later span in normal_text.
   REASONING.stream.1.b:
     description: Plain text stays in force-reasoning mode until an end marker
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -92,6 +92,25 @@ cases:
         reasoning_text: thinking</think>answer
         normal_text: ''
         reason: Dynamo buffers an end marker split across chunk boundaries and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the split marker is never reassembled and the answer stays in reasoning_text.
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '<' (off-by-one from 3.b)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>thinking<
+    - /think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking</think>answer
+        normal_text: ''
+        reason: Dynamo buffers a split end delimiter (incl. a lone '<' at the chunk boundary) and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
+      sglang:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+        reason: Dynamo reassembles an end marker split at the lone '<' and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the answer stays in reasoning_text.
   REASONING.stream.3.c:
     description: Partial start-marker prefix later resolves as force-reasoning text
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -92,6 +92,21 @@ cases:
         reasoning_text: thinking</think>answer
         normal_text: ''
         reason: Dynamo buffers an end marker split across chunk boundaries and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the split marker is never reassembled and the answer stays in reasoning_text.
+  REASONING.stream.3.c:
+    description: Partial start-marker prefix later resolves as force-reasoning text
+    ref: *upstream_ref
+    chunks:
+    - plain <th
+    - esis answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: plain <thesis answer
+        normal_text: ''
+      vllm: *d_s6
+      sglang:
+        reasoning_text: ''
+        normal_text: plain <thesis answer
+        reason: Dynamo/vLLM keep marker-free chunks in force-reasoning mode; SGLang treats the unresolved partial marker as normal_text.
   REASONING.stream.3.d:
     description: End marker split across chunks at the lone '<' (off-by-one from 3.b)
     ref: dynamo
@@ -130,21 +145,6 @@ cases:
         reasoning_text: first
         normal_text: "mid<think>second</think>end"
         reason: Dynamo reassembles the second <think> split at the lone '<' and concatenates both spans; SGLang exits at the first end marker and does not re-enter, leaving the later span in normal_text.
-  REASONING.stream.3.c:
-    description: Partial start-marker prefix later resolves as force-reasoning text
-    ref: *upstream_ref
-    chunks:
-    - plain <th
-    - esis answer
-    expected:
-      dynamo: &d_s6
-        reasoning_text: plain <thesis answer
-        normal_text: ''
-      vllm: *d_s6
-      sglang:
-        reasoning_text: ''
-        normal_text: plain <thesis answer
-        reason: Dynamo/vLLM keep marker-free chunks in force-reasoning mode; SGLang treats the unresolved partial marker as normal_text.
   REASONING.stream.1.b:
     description: Plain text stays in force-reasoning mode until an end marker
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -111,6 +111,25 @@ cases:
         reasoning_text: thinking</think>answer
         normal_text: ''
         reason: Dynamo reassembles an end marker split at the lone '<' and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the answer stays in reasoning_text.
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '<' (start-marker symmetric of 3.d) — a second <think> straddles the boundary, so the re-think must reassemble and not leak
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>first</think>mid<
+    - think>second</think>end
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: midend
+      vllm:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo buffers a re-entry <think> split at the lone '<' and re-enters reasoning for the second span; vLLM does not re-enter, so the later complete span stays in normal_text.
+      sglang:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo reassembles the second <think> split at the lone '<' and concatenates both spans; SGLang exits at the first end marker and does not re-enter, leaving the later span in normal_text.
   REASONING.stream.3.c:
     description: Partial start-marker prefix later resolves as force-reasoning text
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -103,6 +103,44 @@ cases:
         normal_text: plain <thesis answer
       vllm: *d_s6
       sglang: *d_s6
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '<' (off-by-one from 3.b)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>thinking<
+    - /think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking</think>answer
+        normal_text: ''
+        reason: Dynamo buffers a split end delimiter (incl. a lone '<' at the chunk boundary) and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
+      sglang:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+        reason: Dynamo reassembles an end marker split at the lone '<' and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the answer stays in reasoning_text.
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '<' (start-marker symmetric of 3.d) — a second <think> straddles the boundary, so the re-think must reassemble and not leak
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>first</think>mid<
+    - think>second</think>end
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: midend
+      vllm:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo buffers a re-entry <think> split at the lone '<' and re-enters reasoning for the second span; vLLM does not re-enter, so the later complete span stays in normal_text.
+      sglang:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo reassembles the second <think> split at the lone '<' and concatenates both spans; SGLang exits at the first end marker and does not re-enter, leaving the later span in normal_text.
   REASONING.stream.1.b:
     description: Plain text never enters reasoning mode in Dynamo
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
@@ -125,6 +125,44 @@ cases:
         normal_text: plain <|chance answer
       vllm: *d_s6
       sglang: *d_s6
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '<' (off-by-one from 3.b)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - "<|channel>thought\nthinking<"
+    - channel|>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: "<|channel>thought\nthinking<channel|>answer"
+        normal_text: ''
+        reason: Dynamo buffers a split Gemma end delimiter (incl. a lone '<' at the chunk boundary) and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
+      sglang:
+        reasoning_text: thinking<channel|>answer
+        normal_text: ''
+        reason: Dynamo reassembles a Gemma end marker split at the lone '<' and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the answer stays in reasoning_text.
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '<' (start-marker symmetric of 3.d) — a second thought channel straddles the boundary, so it must reassemble and not leak
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - "<|channel>thought\nfirst<channel|>mid<"
+    - "|channel>thought\nsecond<channel|>end"
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: midend
+      vllm:
+        reasoning_text: first
+        normal_text: "mid<|channel>thought\nsecond<channel|>end"
+        reason: Dynamo buffers a re-entry Gemma thought channel split at the lone '<' and re-enters reasoning; vLLM does not re-enter, so the later complete channel stays in normal_text.
+      sglang:
+        reasoning_text: first
+        normal_text: "mid<|channel>thought\nsecond<channel|>end"
+        reason: Dynamo reassembles the second thought channel split at the lone '<' and concatenates both spans; SGLang exits at the first end marker and does not re-enter, leaving the later channel in normal_text.
   REASONING.stream.1.b:
     description: Plain text never enters reasoning mode
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -92,6 +92,41 @@ cases:
         reasoning_text: ''
         normal_text: ''
       sglang: *id001
+  REASONING.stream.3.d:
+    description: Harmony end token split across chunks at the lone '<' (off-by-one from 3.b)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <|channel|>analysis<|message|>thinking<
+    - '|end|><|start|>assistant<|channel|>final<|message|>answer'
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM gpt-oss streaming parity for a split Harmony end token needs explicit token_chunks; text-only chunks are not faithful.
+      sglang:
+        reasoning_text: thinking<|end|><|start|>assistant<|channel|>final<|message|>answer
+        normal_text: ''
+        reason: SGLang does not recognize the Harmony end marker split at the lone '<' in text-only streaming chunks, so the final-channel text remains in reasoning_text instead of being emitted as normal_text.
+  REASONING.stream.3.e:
+    description: Second analysis-channel start split across chunks at the lone '<' (start-marker symmetric of 3.d)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <|channel|>analysis<|message|>first<|end|><|start|>assistant<
+    - '|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>done'
+    expected:
+      dynamo:
+        reasoning_text: "first\nsecond"
+        normal_text: done
+      vllm:
+        reasoning_text: "first\nsecond"
+        normal_text: done
+      sglang:
+        reasoning_text: firstsecond
+        normal_text: done
+        reason: SGLang concatenates multiple Harmony analysis spans without an inserted separator, while Dynamo/vLLM preserve the span boundary with a newline.
   REASONING.stream.4.a:
     description: Recipientless Harmony commentary is visible normal text across chunks
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
@@ -96,6 +96,39 @@ cases:
       vllm: *d_s6
       sglang:
         unavailable: SGLang has no reasoning parser for family='granite'
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone 'H' first character (off-by-one from 3.b)
+    dynamo_leak: true
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - 'Here is my thought process: thinking H'
+    - 'ere is my response: answer'
+    expected:
+      dynamo:
+        reasoning_text: ' thinking Here is my response: answer'
+        normal_text: ''
+      vllm:
+        reasoning_text: 'Here is my thought process: thinking H'
+        normal_text: ' answer'
+      sglang:
+        unavailable: SGLang has no reasoning parser for family='granite'
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone 'H' first character — granite does not re-enter, so the split marker text passes through to normal_text
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - 'Here is my thought process: first Here is my response: mid H'
+    - 'ere is my thought process: second Here is my response: end'
+    expected:
+      dynamo:
+        reasoning_text: ' first '
+        normal_text: ' mid Here is my thought process: second Here is my response: end'
+      vllm:
+        reasoning_text: 'st '
+        normal_text: ' mid Here is my thought process: second Here is my response: end'
+      sglang:
+        unavailable: SGLang has no reasoning parser for family='granite'
   REASONING.stream.1.b:
     description: Plain text never enters reasoning mode
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
@@ -88,6 +88,38 @@ cases:
       vllm:
         unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
       sglang: *d_s6
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '◁' first character (off-by-one from 3.b)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - ◁think▷thinking◁
+    - /think▷answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        reasoning_text: thinking◁/think▷answer
+        normal_text: ''
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '◁' first character (start-marker symmetric of 3.d)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - ◁think▷first◁/think▷mid◁
+    - think▷second◁/think▷end
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: midend
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        reasoning_text: first
+        normal_text: mid◁think▷second◁/think▷end
   REASONING.stream.1.b:
     description: Plain text without reasoning markers
     ref: dynamo

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
@@ -104,6 +104,46 @@ cases:
         reasoning_text: plain <thesis answer
         normal_text: ''
       sglang: *sg_stream_3_c
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '<' (off-by-one from 3.b)
+    force_reasoning: true
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>thinking<
+    - /think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking</think>answer
+        normal_text: ''
+        reason: Dynamo buffers a split end delimiter (incl. a lone '<' at the chunk boundary) and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
+      sglang:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+        reason: Dynamo reassembles an end marker split at the lone '<' and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the answer stays in reasoning_text.
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '<' (start-marker symmetric of 3.d) — a second <think> straddles the boundary, so the re-think must reassemble and not leak
+    force_reasoning: true
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>first</think>mid<
+    - think>second</think>end
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: midend
+      vllm:
+        reasoning_text: <think>first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo buffers a re-entry <think> split at the lone '<' and re-enters reasoning for the second span; vLLM Kimi K2 streaming parser leaks the first start marker and does not re-enter, so the later complete span stays in normal_text.
+      sglang:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo reassembles the second <think> split at the lone '<' and concatenates both spans; SGLang exits at the first end marker and does not re-enter, leaving the later span in normal_text.
   REASONING.stream.1.b:
     description: Plain text stays in force-reasoning mode until an end marker
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
@@ -79,6 +79,32 @@ cases:
         normal_text: <think>plain <thesis answer
       vllm: *d_s6
       sglang: *d_s6
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '<' is still normal text
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - reasoning<
+    - /think>answer
+    expected:
+      dynamo: &d_s3d
+        reasoning_text: ''
+        normal_text: <think>reasoning</think>answer
+      vllm: *d_s3d
+      sglang: *d_s3d
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '<' is still normal text
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - first</think>mid<
+    - think>second</think>end
+    expected:
+      dynamo: &d_s3e
+        reasoning_text: ''
+        normal_text: <think>first</think>mid<think>second</think>end
+      vllm: *d_s3e
+      sglang: *d_s3e
   REASONING.stream.1.b:
     description: Plain text is passed through after the synthetic opener
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
@@ -96,6 +96,40 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: plain [THESIS answer
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '[' (off-by-one from 3.b)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - '[THINK]thinking['
+    - /THINK]answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: '[THINK]thinking[/THINK]answer'
+        normal_text: ''
+      sglang:
+        reasoning_text: thinking[/THINK]answer
+        normal_text: ''
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '[' (start-marker symmetric of 3.d)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - '[THINK]first[/THINK]mid['
+    - THINK]second[/THINK]end
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: midend
+      vllm:
+        reasoning_text: first
+        normal_text: mid[THINK]second[/THINK]end
+      sglang:
+        reasoning_text: first
+        normal_text: mid[THINK]second[/THINK]end
   REASONING.stream.1.b:
     description: Plain text stays in force-reasoning mode until an end marker
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -106,6 +106,44 @@ cases:
         normal_text: ''
         reason: vLLM GLM/Nemotron parser (`glm45`) defaults thinking on and routes marker-free deltas to reasoning.
       sglang: *d_s6
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '<' (off-by-one from 3.b)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>thinking<
+    - /think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking</think>answer
+        normal_text: ''
+        reason: Dynamo buffers a split end delimiter (incl. a lone '<' at the chunk boundary) and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
+      sglang:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+        reason: Dynamo reassembles an end marker split at the lone '<' and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the answer stays in reasoning_text.
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '<' (start-marker symmetric of 3.d) — a second <think> straddles the boundary, so the re-think must reassemble and not leak
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>first</think>mid<
+    - think>second</think>end
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: midend
+      vllm:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo buffers a re-entry <think> split at the lone '<' and re-enters reasoning for the second span; vLLM does not re-enter, so the later complete span stays in normal_text.
+      sglang:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo reassembles the second <think> split at the lone '<' and concatenates both spans; SGLang exits at the first end marker and does not re-enter, leaving the later span in normal_text.
   REASONING.stream.1.b:
     description: Plain text without reasoning markers
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
@@ -102,6 +102,44 @@ cases:
         normal_text: ''
         reason: vLLM Qwen streaming parser treats marker-free stream text as reasoning in this shape.
       sglang: *d_s6
+  REASONING.stream.3.d:
+    description: End marker split across chunks at the lone '<' (off-by-one from 3.b)
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>thinking<
+    - /think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+        reason: Dynamo buffers a split end delimiter (incl. a lone '<' at the chunk boundary) and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
+      sglang:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+        reason: Dynamo reassembles an end marker split at the lone '<' and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the answer stays in reasoning_text.
+  REASONING.stream.3.e:
+    description: Re-entry start marker split across chunks at the lone '<' (start-marker symmetric of 3.d) — a second <think> straddles the boundary, so the re-think must reassemble and not leak
+    ref: dynamo
+    spec_ref: lib/parsers/REASONING_CASES.md
+    chunks:
+    - <think>first</think>mid<
+    - think>second</think>end
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: midend
+      vllm:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo buffers a re-entry <think> split at the lone '<' and re-enters reasoning for the second span; vLLM does not re-enter, so the later complete span stays in normal_text.
+      sglang:
+        reasoning_text: first
+        normal_text: "mid<think>second</think>end"
+        reason: Dynamo reassembles the second <think> split at the lone '<' and concatenates both spans; SGLang exits at the first end marker and does not re-enter, leaving the later span in normal_text.
   REASONING.stream.1.b:
     description: Plain text never enters reasoning mode
     ref: *upstream_ref

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -73,7 +73,10 @@ CASE_GROUPS = [
     ),
     ("Reasoning extraction", ("stream.2.a",)),
     ("Multi-span", ("stream.2.b", "stream.2.c")),
-    ("Chunk boundaries", ("stream.3.a", "stream.3.b", "stream.3.c")),
+    (
+        "Chunk boundaries",
+        ("stream.3.a", "stream.3.b", "stream.3.c", "stream.3.d", "stream.3.e"),
+    ),
 ]
 _CASE_GROUP_BY_CASE = {
     case_id: label for label, case_ids in CASE_GROUPS for case_id in case_ids


### PR DESCRIPTION
#### Overview:

This PR makes the streaming reasoning parser reassemble a `<think>` or `</think>` marker split across stream chunks at the lone `<`, so a chunk boundary can no longer change how reasoning and tool calls are parsed.

#### What goes wrong:

A lone `<` at a chunk's end was flushed instead of held, so a split marker never reassembled. Two failure modes, one root cause:

```
end marker (3.d):    "...think<"  + "/think>\n<tool_call>..."
  -> </think> never reassembles -> reasoning never exits -> the <tool_call> block is
     absorbed into reasoning_content; the tool jail sees nothing (the original DIS-2223 leak)

re-entry start (3.e): "<think>first</think>mid<"  + "think>second</think>end"
  before:  reasoning_text="first"        normal_text="mid<think>second</think>end"   <- marker leaked, span misrouted
  after:   reasoning_text="firstsecond"  normal_text="midend"
```


Because chunk boundaries vary run-to-run in a streaming system, the same generation parsed differently each run.

#### Fix:

Hold back ANY non-empty marker-prefix overlap (`ol >= 1`) at a chunk's end in BOTH branches of `parse_reasoning_streaming_incremental`, not just `>= 2`. A lone `<` is buffered one chunk so a split `<think>` / `</think>` reassembles, then flushed merged with the next chunk (or by `finish_reasoning_stream` at EOF) — lossless, so a tool-call tag like `<invoke>` still reaches the jail intact. One change in the shared `BasicReasoningParser`, covering every `<think>`-family parser (`deepseek_r1`, `nemotron3`, `nemotron_v3`, `kimi_k25`, ...).

#### Tests:

New cases `REASONING.stream.3.d` / `3.e` (end-split and re-entry-split at the lone `<`) — unit tests in `lib/parsers/src/reasoning/base_parser.rs`, parity fixtures across all 12 reasoning families under `tests/parity/reasoning/fixtures/*/REASONING.stream.yaml`.


Reasoning-stream chunk-boundary parity (`3.a`–`3.e`) across all families — `3.d`/`3.e` are the new cases; `VS` = dynamo reassembles the chunk-split marker where vLLM/SGLang don't.

<img width="760" alt="reasoning-stream chunk-boundary parity table" src="https://github.com/user-attachments/assets/cc6d99ce-d381-4d9f-95b3-e232136c48c6" />

#### Also in this PR: always-on parser anomaly detection

Two transparent taps around the parsing pipeline pair the RAW pre-parse completion (with exact delta boundaries) against the parsed result per choice. At stream end, a `warn` event with the full raw-vs-parsed record fires only when a predicate trips: `tool_call_dropped` (tool-start marker in raw, zero calls extracted — the Nemotron empty-stop shape), `tool_markup_in_content` (leak), `tool_markup_in_reasoning` (absorb), `all_output_lost`. Healthy streams emit nothing; no env var. One log line now carries both the evidence and the exact chunking needed to reproduce this class of failure.

#### Where should the reviewer start?

`lib/parsers/src/reasoning/base_parser.rs` (both overlap branches now `>= 1`), then `tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml` (force-reasoning production shape).

#### Status:

Draft / in-progress.

#### Related Issues:

Relates to [DIS-2223](https://linear.app/nvidia/issue/DIS-2223). Supersedes #10625 (rolled in here).

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved streaming reasoning parser stability when reasoning markers are split across chunk boundaries, preventing content misrouting.
  * Enhanced partial marker detection at buffer boundaries to ensure correct reassembly and prevent data loss.

* **Tests**
  * Added comprehensive regression test cases covering streaming edge cases for multiple model families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->