### PR TITLE
feat(kv-router): decay overlap credit under prefill load

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -27,6 +27,7 @@ from dynamo.common.configuration.utils import (
 _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "overlap_score_weight",
     "overlap_score_credit",
+    "overlap_score_credit_decay",
     "prefill_load_scale",
     "host_cache_hit_weight",
     "disk_cache_hit_weight",
@@ -109,6 +110,7 @@ class KvRouterConfigBase(ConfigBase):
 
     overlap_score_weight: Optional[float] = None
     overlap_score_credit: float
+    overlap_score_credit_decay: float
     prefill_load_scale: float
     host_cache_hit_weight: float
     disk_cache_hit_weight: float
@@ -180,6 +182,20 @@ class KvRouterArgGroup(ArgGroup):
             ),
             arg_type=float,
             dest="overlap_score_credit",
+        )
+        add_argument(
+            g,
+            flag_name="--router-kv-overlap-score-credit-decay",
+            env_var="DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT_DECAY",
+            default=0.0,
+            help=(
+                "KV Router: Decay rate for device-local overlap credit as active "
+                "prefill load rises above the least-loaded eligible worker. "
+                "0 disables decay; 1 halves credit at one request-equivalent "
+                "of excess active prefill load."
+            ),
+            arg_type=float,
+            dest="overlap_score_credit_decay",
         )
         g.add_argument(
             "--router-kv-overlap-score-weight",

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -119,6 +119,17 @@ def test_overlap_score_credit_cli_uses_kv_router_config_field() -> None:
     assert args.overlap_score_weight is None
 
 
+def test_overlap_score_credit_decay_cli_uses_kv_router_config_field() -> None:
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(["--router-kv-overlap-score-credit-decay", "0.5"])
+
+    assert args.overlap_score_credit_decay == 0.5
+    config = KvRouterConfigBase.from_cli_args(args)
+    assert config.kv_router_kwargs()["overlap_score_credit_decay"] == 0.5
+
+
 def test_deprecated_overlap_score_weight_cli_flows_to_binding_kwargs() -> None:
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -197,6 +197,7 @@ async def worker(runtime: DistributedRuntime):
     logger.debug(
         f"Configuration: endpoint={config.endpoint}, router_block_size={config.router_block_size}, "
         f"overlap_score_credit={config.overlap_score_credit}, "
+        f"overlap_score_credit_decay={config.overlap_score_credit_decay}, "
         f"prefill_load_scale={config.prefill_load_scale}, "
         f"router_temperature={config.router_temperature}, "
         f"use_kv_events={config.use_kv_events}, "

--- a/docs/components/router/router-concepts.md
+++ b/docs/components/router/router-concepts.md
@@ -42,9 +42,17 @@ The router uses a cost function that considers both the prefill cost (influenced
 4. **Cost formula**:
 
 ```text
+excess_active_prefill_blocks =
+    (active_prefill_tokens - minimum_eligible_active_prefill_tokens)
+    / block_size
+normalized_excess = excess_active_prefill_blocks / request_blocks
+effective_overlap_score_credit =
+    overlap_score_credit
+    / (1 + overlap_score_credit_decay * normalized_excess)
+
 adjusted_prefill_blocks = max(
     prefill_blocks
-    - overlap_score_credit * device_overlap_blocks
+    - effective_overlap_score_credit * device_overlap_blocks
     - host_cache_hit_weight * host_overlap_blocks
     - disk_cache_hit_weight * disk_overlap_blocks
     - shared_cache_multiplier * shared_beyond_blocks,
@@ -55,7 +63,7 @@ cost = prefill_load_scale * adjusted_prefill_blocks + decode_blocks
 
 Lower costs indicate better routing choices.
 `overlap_score_credit` is the device-local prefix-overlap credit multiplier, from 0.0 to 1.0.
-Higher values favor cache reuse (improving TTFT), while lower values prioritize even load distribution (improving ITL). `prefill_load_scale` controls the weight of the adjusted prompt-side load relative to decode blocks.
+Higher values favor cache reuse (improving TTFT), while lower values prioritize even load distribution (improving ITL). `overlap_score_credit_decay` optionally reduces only the device-local credit on workers with excess active prefill load; its default of 0 preserves the fixed credit. `prefill_load_scale` controls the weight of the adjusted prompt-side load relative to decode blocks.
 
 ### Active Load Modeling
 

--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -10,6 +10,7 @@ This page collects the main router flags for frontend-embedded and standalone de
 ## Routing Behavior
 
 - `--router-kv-overlap-score-credit`: Device-local prefix-overlap credit multiplier in the prefill cost calculation, from 0.0 to 1.0. Higher values improve Time To First Token (TTFT) at the cost of Inter-Token Latency (ITL). When set to 0, the router ignores prefix caches and skips creating a local indexer. Defaults to 1.
+- `--router-kv-overlap-score-credit-decay`: Decays device-local overlap credit for workers whose active prefill load exceeds the least-loaded eligible worker. `0` disables decay. Defaults to 0.
 - `--router-prefill-load-scale`: Scale applied to adjusted prompt-side prefill load after device, lower-tier, and shared-cache credits are subtracted. Defaults to 1.
 - `--router-host-cache-hit-weight`: Credit multiplier for host-pinned (CPU offload) prefix overlap, from 0.0 to 1.0. Symmetric to `--router-kv-overlap-score-credit` but applied to the host-pinned tier when a backend exposes CPU offload via a KV connector. Defaults to 0.75.
 - `--router-disk-cache-hit-weight`: Credit multiplier for disk/lower-tier (e.g. NVMe-backed) prefix overlap, from 0.0 to 1.0. Defaults to 0.25.
@@ -115,6 +116,8 @@ These activate automatically with `--router-mode kv` -- no additional flags are 
 ## Tuning Guidelines
 
 `--router-kv-overlap-score-credit` is the primary knob for cache reuse. It credits device-local prefix overlap against the prefill load and must be between 0.0 and 1.0. Higher values steer requests toward workers with better cache overlap and reduce TTFT. Lower values distribute load more evenly and reduce ITL. The default of 1.0 is a reasonable starting point. This credit can also be overridden per request via `nvext.agent_hints.kv_overlap_score_credit`.
+
+Use `--router-kv-overlap-score-credit-decay` to reduce that device-local credit when a worker has more active prefill work than the least-loaded eligible worker. This helps prevent busy, cache-rich workers from repeatedly winning while newly autoscaled or lightly loaded workers receive too little traffic. The router normalizes the excess active prefill blocks by the incoming request size and multiplies the configured overlap credit by `1 / (1 + decay * normalized_excess)`. For example, a decay of `1` halves device credit at one request-equivalent of excess prefill load. Host, disk, and shared-cache credits are unchanged. This setting requires prefill-token tracking to have an effect and defaults to `0`.
 
 Use `--load-aware` when you want the KV scheduler's active load model without prefix/cache reuse. This is equivalent to using KV mode with overlap credit set to 0, KV events disabled, KV reuse assumptions disabled, active load tracking enabled, and shared-cache routing disabled. `--router-prefill-load-scale` remains available to tune prompt-side load relative to decode blocks.
 

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -197,7 +197,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, durable_kv_events=false, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_snapshot_threshold=1000000, router_reset_states=false, router_ttl_secs=120.0, router_queue_threshold=Some(16.0), router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, *, overlap_score_credit=1.0, prefill_load_scale=1.0, router_queue_by_incoming_missing_isl=None))]
+    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, durable_kv_events=false, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_snapshot_threshold=1000000, router_reset_states=false, router_ttl_secs=120.0, router_queue_threshold=Some(16.0), router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, *, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, router_queue_by_incoming_missing_isl=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: Option<f64>,
@@ -224,6 +224,7 @@ impl KvRouterConfig {
         shared_cache_type: &str,
         router_predicted_ttl_secs: Option<f64>,
         mut overlap_score_credit: f64,
+        overlap_score_credit_decay: f64,
         mut prefill_load_scale: f64,
         router_queue_by_incoming_missing_isl: Option<Vec<(usize, usize)>>,
     ) -> PyResult<Self> {
@@ -237,6 +238,7 @@ impl KvRouterConfig {
 
         let inner = RsKvRouterConfig {
             overlap_score_credit,
+            overlap_score_credit_decay,
             prefill_load_scale,
             host_cache_hit_weight,
             disk_cache_hit_weight,
@@ -302,6 +304,20 @@ impl KvRouterConfig {
     }
 
     #[getter]
+    fn overlap_score_credit_decay(&self) -> f64 {
+        self.inner.overlap_score_credit_decay
+    }
+
+    #[setter]
+    fn set_overlap_score_credit_decay(&mut self, value: f64) -> PyResult<()> {
+        let mut inner = self.inner.clone();
+        inner.overlap_score_credit_decay = value;
+        validate_kv_router_config(&inner)?;
+        self.inner = inner;
+        Ok(())
+    }
+
+    #[getter]
     fn overlap_score_weight(&self) -> f64 {
         self.inner.prefill_load_scale
     }
@@ -333,16 +349,20 @@ impl KvRouterConfig {
         Ok(())
     }
 
-    #[pyo3(signature = (overlap_score_weight=None, *, overlap_score_credit=None, prefill_load_scale=None))]
+    #[pyo3(signature = (overlap_score_weight=None, *, overlap_score_credit=None, overlap_score_credit_decay=None, prefill_load_scale=None))]
     fn with_overrides(
         &self,
         overlap_score_weight: Option<f64>,
         overlap_score_credit: Option<f64>,
+        overlap_score_credit_decay: Option<f64>,
         prefill_load_scale: Option<f64>,
     ) -> PyResult<Self> {
         let mut inner = self.inner.clone();
         if let Some(credit) = overlap_score_credit {
             inner.overlap_score_credit = credit;
+        }
+        if let Some(decay) = overlap_score_credit_decay {
+            inner.overlap_score_credit_decay = decay;
         }
         if let Some(scale) = prefill_load_scale {
             inner.prefill_load_scale = scale;

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -47,6 +47,10 @@ const fn default_prefill_load_scale() -> f64 {
     1.0
 }
 
+const fn default_overlap_score_credit_decay() -> f64 {
+    0.0
+}
+
 pub const OVERLAP_SCORE_CREDIT_RANGE_ERROR: &str =
     "overlap_score_credit must be between 0.0 and 1.0";
 pub const OVERLAP_SCORE_CREDIT_MIGRATION_ERROR: &str = concat!(
@@ -91,6 +95,7 @@ pub fn kv_router_config_from_dynamo_env() -> KvRouterConfig {
     let config = kv_router_config_from_lookup(|key| env::var(key).ok());
     tracing::info!(
         overlap_score_credit = config.overlap_score_credit,
+        overlap_score_credit_decay = config.overlap_score_credit_decay,
         prefill_load_scale = config.prefill_load_scale,
         router_temperature = config.router_temperature,
         use_kv_events = config.use_kv_events,
@@ -123,6 +128,9 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
 
     if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT") {
         config.overlap_score_credit = value;
+    }
+    if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT_DECAY") {
+        config.overlap_score_credit_decay = value;
     }
     if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_PREFILL_LOAD_SCALE") {
         config.prefill_load_scale = value;
@@ -498,6 +506,7 @@ impl TryFrom<RouterConfigOverrideSerde> for RouterConfigOverride {
 #[serde(default)]
 struct KvRouterConfigSerde {
     overlap_score_credit: f64,
+    overlap_score_credit_decay: f64,
     prefill_load_scale: f64,
     overlap_score_weight: Option<f64>,
     host_cache_hit_weight: f64,
@@ -532,6 +541,7 @@ impl Default for KvRouterConfigSerde {
         let config = KvRouterConfig::default();
         Self {
             overlap_score_credit: config.overlap_score_credit,
+            overlap_score_credit_decay: config.overlap_score_credit_decay,
             prefill_load_scale: config.prefill_load_scale,
             overlap_score_weight: None,
             host_cache_hit_weight: config.host_cache_hit_weight,
@@ -571,6 +581,12 @@ pub struct KvRouterConfig {
     /// load before sampling (0.0 to 1.0). Set to 0.0 to ignore prefix matching.
     #[validate(custom(function = "validate_overlap_score_credit"))]
     pub overlap_score_credit: f64,
+
+    /// Decay rate for device-local overlap credit as active prefill load rises
+    /// above the least-loaded eligible worker. A value of 0.0 disables decay.
+    #[serde(default = "default_overlap_score_credit_decay")]
+    #[validate(range(min = 0.0))]
+    pub overlap_score_credit_decay: f64,
 
     /// Scale applied after overlap/cache-hit credits reduce the prompt-side
     /// prefill load. Defaults to 1.0.
@@ -712,6 +728,7 @@ impl Default for KvRouterConfig {
     fn default() -> Self {
         Self {
             overlap_score_credit: 1.0,
+            overlap_score_credit_decay: default_overlap_score_credit_decay(),
             prefill_load_scale: default_prefill_load_scale(),
             host_cache_hit_weight: default_host_cache_hit_weight(),
             disk_cache_hit_weight: default_disk_cache_hit_weight(),
@@ -758,6 +775,7 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
 
         validate_and_return(Self {
             overlap_score_credit,
+            overlap_score_credit_decay: compat.overlap_score_credit_decay,
             prefill_load_scale,
             host_cache_hit_weight: compat.host_cache_hit_weight,
             disk_cache_hit_weight: compat.disk_cache_hit_weight,
@@ -937,6 +955,10 @@ mod tests {
         let default = KvRouterConfig::default();
 
         assert_eq!(config.overlap_score_credit, default.overlap_score_credit);
+        assert_eq!(
+            config.overlap_score_credit_decay,
+            default.overlap_score_credit_decay
+        );
         assert_eq!(config.prefill_load_scale, default.prefill_load_scale);
         assert_eq!(config.use_kv_events, default.use_kv_events);
         assert_eq!(
@@ -949,6 +971,7 @@ mod tests {
     fn dynamo_env_config_parses_canonical_settings() {
         let config = config_from_values(&[
             ("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", "0.25"),
+            ("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT_DECAY", "0.75"),
             ("DYN_ROUTER_PREFILL_LOAD_SCALE", "2.5"),
             ("DYN_ROUTER_TEMPERATURE", "0.7"),
             ("DYN_USE_KV_EVENTS", "false"),
@@ -960,6 +983,7 @@ mod tests {
         ]);
 
         assert_eq!(config.overlap_score_credit, 0.25);
+        assert_eq!(config.overlap_score_credit_decay, 0.75);
         assert_eq!(config.prefill_load_scale, 2.5);
         assert_eq!(config.router_temperature, 0.7);
         assert!(!config.use_kv_events);

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -94,6 +94,7 @@ pub struct DefaultWorkerSelector {
 #[derive(Debug, Clone, Copy)]
 struct LogitWeights {
     overlap_score_credit: f64,
+    overlap_score_credit_decay: f64,
     prefill_load_scale: f64,
     shared_cache_multiplier: f64,
 }
@@ -111,6 +112,7 @@ impl DefaultWorkerSelector {
         request: &SchedulingRequest,
         worker: WorkerWithDpRank,
         block_size: u32,
+        min_active_prefill_tokens: usize,
         weights: LogitWeights,
         formula_name: &'static str,
     ) -> f64 {
@@ -174,7 +176,23 @@ impl DefaultWorkerSelector {
             };
 
         let raw_prefill_blocks = raw_prefill_tokens / block_size_f64;
-        let overlap_credit_blocks = weights.overlap_score_credit * device_overlap_blocks
+        // Normalize backlog above the least-loaded eligible worker by this request's
+        // size. The rational decay softly trades cache locality for prefill balance,
+        // while leaving workers at the load floor with their full device credit.
+        let overlap_credit_decay =
+            if request.track_prefill_tokens && weights.overlap_score_credit_decay > 0.0 {
+                let active_prefill_tokens = worker_load.unwrap_or_default().active_prefill_tokens;
+                let excess_active_prefill_blocks =
+                    active_prefill_tokens.saturating_sub(min_active_prefill_tokens) as f64
+                        / block_size_f64;
+                let normalized_prefill_load =
+                    excess_active_prefill_blocks / request.request_blocks(block_size) as f64;
+                1.0 / (1.0 + weights.overlap_score_credit_decay * normalized_prefill_load)
+            } else {
+                1.0
+            };
+        let effective_overlap_score_credit = weights.overlap_score_credit * overlap_credit_decay;
+        let overlap_credit_blocks = effective_overlap_score_credit * device_overlap_blocks
             + self.kv_router_config.host_cache_hit_weight * host_overlap_blocks
             + self.kv_router_config.disk_cache_hit_weight * disk_overlap_blocks
             + shared_overlap_blocks;
@@ -190,7 +208,8 @@ impl DefaultWorkerSelector {
                  {shared_beyond} shared blocks beyond device (multiplier={shared_cache_multiplier:.2}): {logit:.3} \
                  = prefill_load_scale * adjusted_prefill_blocks + decode_blocks \
                  = {prefill_load_scale:.3} * {adjusted_prefill_blocks:.3} + {decode_cost_blocks:.3} \
-                 (raw_prefill_blocks: {raw_prefill_blocks:.3}, overlap_credit_blocks: {overlap_credit_blocks:.3})",
+                 (raw_prefill_blocks: {raw_prefill_blocks:.3}, overlap_credit_blocks: {overlap_credit_blocks:.3}, \
+                 overlap_credit_decay: {overlap_credit_decay:.3})",
                 worker.worker_id,
                 worker.dp_rank,
                 shared_cache_multiplier = weights.shared_cache_multiplier,
@@ -201,7 +220,8 @@ impl DefaultWorkerSelector {
                 "{formula_name} for worker_id={} dp_rank={:?} with {effective_overlap_blocks:.2} effective cached blocks: {logit:.3} \
                  = prefill_load_scale * adjusted_prefill_blocks + decode_blocks \
                  = {prefill_load_scale:.3} * {adjusted_prefill_blocks:.3} + {decode_cost_blocks:.3} \
-                 (raw_prefill_blocks: {raw_prefill_blocks:.3}, overlap_credit_blocks: {overlap_credit_blocks:.3})",
+                 (raw_prefill_blocks: {raw_prefill_blocks:.3}, overlap_credit_blocks: {overlap_credit_blocks:.3}, \
+                 overlap_credit_decay: {overlap_credit_decay:.3})",
                 worker.worker_id,
                 worker.dp_rank,
                 prefill_load_scale = weights.prefill_load_scale
@@ -251,6 +271,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 .as_ref()
                 .and_then(|cfg| cfg.overlap_score_credit)
                 .unwrap_or(self.kv_router_config.overlap_score_credit),
+            overlap_score_credit_decay: self.kv_router_config.overlap_score_credit_decay,
             prefill_load_scale: request
                 .router_config_override
                 .as_ref()
@@ -274,7 +295,15 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 Err(_) => return Err(KvSchedulerError::NoEndpoints),
             }
 
-            let logit = self.worker_logit(request, worker, block_size, weights, "Pinned formula");
+            let min_active_prefill_tokens = request.worker_load_for(worker).active_prefill_tokens;
+            let logit = self.worker_logit(
+                request,
+                worker,
+                block_size,
+                min_active_prefill_tokens,
+                weights,
+                "Pinned formula",
+            );
             let effective_overlap_blocks = request.effective_overlap_blocks_for(worker);
             let cached_tokens = request.effective_cached_tokens_for(worker);
 
@@ -300,8 +329,26 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             .as_ref()
             .and_then(|cfg| cfg.router_temperature)
             .unwrap_or(self.kv_router_config.router_temperature);
+        let min_active_prefill_tokens =
+            if request.track_prefill_tokens && weights.overlap_score_credit_decay > 0.0 {
+                let mut minimum = usize::MAX;
+                eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
+                    minimum = minimum.min(request.worker_load_for(worker).active_prefill_tokens);
+                });
+                debug_assert_ne!(minimum, usize::MAX);
+                minimum
+            } else {
+                0
+            };
         let get_score = |worker: WorkerWithDpRank| -> f64 {
-            let base_score = self.worker_logit(request, worker, block_size, weights, "Formula");
+            let base_score = self.worker_logit(
+                request,
+                worker,
+                block_size,
+                min_active_prefill_tokens,
+                weights,
+                "Formula",
+            );
             let Some(config) = workers.get(&worker.worker_id) else {
                 return base_score;
             };
@@ -1158,19 +1205,74 @@ mod tests {
         let selector = DefaultWorkerSelector::new(Some(KvRouterConfig::default()), "test");
         let weights = LogitWeights {
             overlap_score_credit: 1.0,
+            overlap_score_credit_decay: 0.0,
             prefill_load_scale: 2.0,
             shared_cache_multiplier: 0.0,
         };
 
         assert_eq!(
-            selector.worker_logit(&request, worker, 16, weights, "test"),
+            selector.worker_logit(&request, worker, 16, 0, weights, "test"),
             7.0
         );
 
         request.track_prefill_tokens = false;
         assert_eq!(
-            selector.worker_logit(&request, worker, 16, weights, "test"),
+            selector.worker_logit(&request, worker, 16, 0, weights, "test"),
             5.0
+        );
+    }
+
+    #[test]
+    fn test_overlap_credit_decay_can_prefer_less_loaded_cold_worker() {
+        use crate::test_utils::SimpleWorkerConfig;
+
+        let block_size = 16u32;
+        let warm_worker = WorkerWithDpRank::from_worker_id(0);
+        let cold_worker = WorkerWithDpRank::from_worker_id(1);
+        let workers = HashMap::from([
+            (warm_worker.worker_id, SimpleWorkerConfig::default()),
+            (cold_worker.worker_id, SimpleWorkerConfig::default()),
+        ]);
+
+        let mut request = base_request(64);
+        request.tier_overlap_blocks.device.insert(warm_worker, 4);
+        request.effective_cached_tokens.insert(warm_worker, 64);
+        request.worker_loads.insert(
+            warm_worker,
+            crate::sequences::WorkerLoadProjection {
+                active_prefill_tokens: 48,
+                ..Default::default()
+            },
+        );
+
+        let no_decay = DefaultWorkerSelector::new(
+            Some(KvRouterConfig {
+                overlap_score_credit_decay: 0.0,
+                ..Default::default()
+            }),
+            "test",
+        );
+        let with_decay = DefaultWorkerSelector::new(
+            Some(KvRouterConfig {
+                overlap_score_credit_decay: 1.0,
+                ..Default::default()
+            }),
+            "test",
+        );
+
+        assert_eq!(
+            no_decay
+                .select_worker(&workers, &request, request.eligibility(), block_size)
+                .unwrap()
+                .worker,
+            warm_worker
+        );
+        assert_eq!(
+            with_decay
+                .select_worker(&workers, &request, request.eligibility(), block_size)
+                .unwrap()
+                .worker,
+            cold_worker
         );
     }
 


### PR DESCRIPTION
## Summary

- Decay device-local overlap credit according to active prefill load above the least-loaded eligible worker: `credit / (1 + decay * excess_prefill_blocks / request_blocks)`.
- Keep existing behavior by default with `overlap_score_credit_decay=0`; expose the opt-in through Rust, Python, CLI, environment configuration, and router documentation.
- Leave host, disk, shared-cache credits, and decode cost unchanged.

### DynoSim results and tradeoffs

- Aggregate and disaggregated Mooncake replays showed no material latency or cache-reuse regression through decay `2`, but also little cold-worker benefit because candidate overlap was usually low.
- In a sticky 878-request Applied Compute agentic planner replay scaling from 1 to 4 workers with a 15-second startup delay, decay `0.5` improved the weakest new worker's first-100-request share from 20% to 25%.
- At decay `0.5`, whole-trace mean TTFT improved 0.5%, while mean ITL regressed 2.2% and p90 ITL regressed 5.2%; realized cache reuse increased 0.6 percentage points.
- Decay `1-2` warmed new workers more strongly but produced materially worse TTFT/ITL.

### Controlled scale-up follow-up

- A planner-independent replay expanded the first 256 Applied Compute sessions into 3,951 requests, started with 2 workers, and activated 2 more at a fixed simulated time.
- Under heavy load, the existing load cost and queued/new uncached work already warmed the new workers: the weakest new worker received 26% of the first 100 post-scale admissions with or without decay. Decay `0.5` instead reduced cache reuse by 1.39 percentage points and increased mean ITL by 1.0%.
- Under moderate sticky load with little queueing, decay `0.5` improved the weakest new worker's first-100 share from 20% to 25%, but mean TTFT increased 7.1%, mean ITL increased 2.8%, and cache reuse fell 1.64 percentage points.
- A shared-system-prefix variant made 25% of each variable-length initial prompt globally reusable, up to 3,584 shared tokens. Decay produced no warming improvement: the weakest new-worker first-100 share remained 22%, while mean TTFT increased 3.5%, mean ITL increased 1.25%, and cache reuse fell 1.18 percentage points.
- Planner diagnostics on the longer trace reached the same conclusion: scale decisions and initial new-worker routing were effectively unchanged; decay `0.5` changed mean TTFT by +0.03%, mean ITL by +0.70%, cache reuse by -0.86 percentage points, and GPU-hours by +0.40%.
- A normalized load deadband reduced unnecessary migration under heavy load but also weakened the moderate-load warming benefit, so it was not adopted.
- Conclusion: keep the default disabled. Decay `0.5` is a narrow opt-in for deployments that have measured cold-worker starvation under moderate sticky load; it is not expected to help when new uncached requests, queue draining, shared prefixes, or ordinary load imbalance already warm new workers.

## Validation

- `cargo test -p dynamo-kv-router`
- `cargo test -p dynamo-mocker`
- Focused Python KV-router CLI test
- `cargo clippy` and `cargo fmt` for `lib/kv-router` and `lib/bindings/python`
- Aggregate, disaggregated, planner-in-loop, and controlled scale-up DynoSim replay sweeps
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--router-kv-overlap-score-credit-decay` configuration parameter to control how device-local KV cache credit decays under higher prefill load, enabling fine-tuned tradeoffs between cache reuse and load distribution.

* **Documentation**
  * Updated routing concepts and configuration guides with details on the new decay parameter, including normalization behavior and tuning recommendations.

* **Tests**
  * Added test coverage for the new configuration parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->