### PR TITLE
chore(gitignore): ignore codex desktop config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ core.*
 !/.claude/skills
 /.agents/*
 !/.agents/skills
+/.codex
 /CLAUDE.md
 /CLAUDE.md.bak
 


### PR DESCRIPTION
Overview
This PR updates the repository gitignore rules so Codex Desktop's repository-local configuration directory is treated like other generated AI tooling files.

Details
- Add /.codex to the # Ruler Generated Files section in .gitignore.
- Keep Codex Desktop worktree setup files out of contributor commits.

Where should the reviewer start
Review the single .gitignore change under the # Ruler Generated Files section.

Related Issues
No related issue.

Validation
- git check-ignore -v .codex
- pre-commit hooks run by git commit