### PR TITLE
feat(router): expose registered worker metric

### DIFF
--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -343,6 +343,8 @@ class router:
     OUTPUT_SEQUENCE_TOKENS = "router_output_sequence_tokens"
     # Predicted KV cache hit rate at routing time (0.0-1.0)
     KV_HIT_RATE = "router_kv_hit_rate"
+    # Whether the router currently has a worker/dp_rank registered (1 = registered)
+    WORKER_REGISTERED = "router_worker_registered"
 
 
 class router_request:

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -74,6 +74,12 @@ pub trait SequencePublisher: Send + Sync {
         blocks: usize,
         tokens: usize,
     );
+
+    /// Observe that a worker/dp_rank is currently registered in the router.
+    fn observe_worker_registered(&self, _worker: &WorkerWithDpRank, _worker_type: &str) {}
+
+    /// Observe that a worker/dp_rank was removed from the router.
+    fn observe_worker_removed(&self, _worker: &WorkerWithDpRank, _worker_type: &str) {}
 }
 
 /// Abstraction over event subscription for replica sync.
@@ -195,7 +201,12 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         assert!(block_size > 0, "block_size must be greater than 0");
         let (remote_state_updates, _) = watch::channel(());
         let workers = WorkerTable::new(block_size, &dp_range);
-        let prompt_registry = PromptRegistry::new(workers.workers());
+        let initial_workers: Vec<_> = workers.workers().collect();
+        let prompt_registry = PromptRegistry::new(initial_workers.iter().copied());
+        let publisher = Arc::new(publisher);
+        for worker in &initial_workers {
+            publisher.observe_worker_registered(worker, worker_type);
+        }
 
         Self {
             workers: RwLock::new(workers),
@@ -203,7 +214,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             prompt_registry,
             block_size,
             router_id,
-            publisher: Arc::new(publisher),
+            publisher,
             remote_state_updates,
             #[cfg(test)]
             remote_state_update_count: AtomicUsize::new(0),
@@ -415,6 +426,12 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
     fn apply_worker_topology_change(&self, change: WorkerTopologyChange) {
         for removed in &change.removed {
             self.request_index.remove_worker_requests(removed.worker);
+            self.publisher
+                .observe_worker_removed(&removed.worker, self.worker_type);
+        }
+        for worker in &change.added {
+            self.publisher
+                .observe_worker_registered(worker, self.worker_type);
         }
         self.prompt_registry.apply_topology_change(change);
     }
@@ -1169,6 +1186,8 @@ mod tests {
         single_loads: Mutex<Vec<ActiveLoad>>,
         load_batches: Mutex<Vec<Vec<ActiveLoad>>>,
         observations: Mutex<Vec<(WorkerWithDpRank, usize, usize)>>,
+        registered: Mutex<Vec<WorkerWithDpRank>>,
+        removed: Mutex<Vec<WorkerWithDpRank>>,
     }
 
     impl RecordingPublisherState {
@@ -1180,6 +1199,8 @@ mod tests {
             self.single_loads.lock().unwrap().clear();
             self.load_batches.lock().unwrap().clear();
             self.observations.lock().unwrap().clear();
+            self.registered.lock().unwrap().clear();
+            self.removed.lock().unwrap().clear();
         }
     }
 
@@ -1216,6 +1237,14 @@ mod tests {
                 .unwrap()
                 .push((*worker, blocks, tokens));
         }
+
+        fn observe_worker_registered(&self, worker: &WorkerWithDpRank, _worker_type: &str) {
+            self.state.registered.lock().unwrap().push(*worker);
+        }
+
+        fn observe_worker_removed(&self, worker: &WorkerWithDpRank, _worker_type: &str) {
+            self.state.removed.lock().unwrap().push(*worker);
+        }
     }
 
     fn make_recording_sequences(
@@ -1236,6 +1265,31 @@ mod tests {
             "test",
         );
         (sequences, state)
+    }
+
+    #[test]
+    fn worker_topology_observes_registered_and_removed_workers() {
+        let (sequences, state) = make_recording_sequences(HashMap::from([(1, (0, 2))]));
+        assert_eq!(
+            *state.registered.lock().unwrap(),
+            vec![WorkerWithDpRank::new(1, 0), WorkerWithDpRank::new(1, 1)]
+        );
+
+        state.clear();
+        sequences
+            .register_worker(WorkerDpRange::new(2, 0, 1))
+            .unwrap();
+        assert_eq!(
+            *state.registered.lock().unwrap(),
+            vec![WorkerWithDpRank::new(2, 0)]
+        );
+
+        state.clear();
+        sequences.unregister_worker(1).unwrap();
+        assert_eq!(
+            *state.removed.lock().unwrap(),
+            vec![WorkerWithDpRank::new(1, 0), WorkerWithDpRank::new(1, 1)]
+        );
     }
 
     fn replica_add(

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -17,7 +17,7 @@ use crate::http::service::metrics::{
     WORKER_LAST_TIME_TO_FIRST_TOKEN_GAUGE,
 };
 use crate::kv_router::KV_METRICS_SUBJECT;
-use crate::kv_router::metrics::{WORKER_LOAD_METRICS, router_worker_status_metrics};
+use crate::kv_router::metrics::WORKER_LOAD_METRICS;
 use crate::model_card::ModelDeploymentCard;
 use dynamo_runtime::component::Client;
 use dynamo_runtime::discovery::{DiscoveryQuery, watch_and_extract_field};
@@ -29,7 +29,7 @@ use dynamo_runtime::transports::event_plane::EventSubscriber;
 pub use crate::protocols::common::timing::{WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
 const UNSET_DP_RANK_LABEL: &str = "none";
 
-/// Clean up all Prometheus metrics for a worker across the specified dp_ranks.
+/// Clean up load and latency Prometheus metrics for a worker across the specified dp_ranks.
 ///
 /// This removes metrics with the given worker_id, dp_rank, and worker_type label combination.
 /// Called when workers are removed to prevent stale metrics from accumulating.
@@ -44,9 +44,6 @@ fn cleanup_worker_metrics(worker_id: u64, dp_ranks: &[u32], worker_type: &str) {
         let _ = WORKER_LAST_TIME_TO_FIRST_TOKEN_GAUGE.remove_label_values(labels);
         let _ = WORKER_LAST_INPUT_SEQUENCE_TOKENS_GAUGE.remove_label_values(labels);
         let _ = WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE.remove_label_values(labels);
-        if let Some(metrics) = router_worker_status_metrics() {
-            metrics.remove_worker(worker_id, *dp_rank, worker_type);
-        }
     }
 
     let unset_labels = &[worker_id_str.as_str(), UNSET_DP_RANK_LABEL, worker_type];

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -17,7 +17,7 @@ use crate::http::service::metrics::{
     WORKER_LAST_TIME_TO_FIRST_TOKEN_GAUGE,
 };
 use crate::kv_router::KV_METRICS_SUBJECT;
-use crate::kv_router::metrics::WORKER_LOAD_METRICS;
+use crate::kv_router::metrics::{WORKER_LOAD_METRICS, router_worker_status_metrics};
 use crate::model_card::ModelDeploymentCard;
 use dynamo_runtime::component::Client;
 use dynamo_runtime::discovery::{DiscoveryQuery, watch_and_extract_field};
@@ -44,6 +44,9 @@ fn cleanup_worker_metrics(worker_id: u64, dp_ranks: &[u32], worker_type: &str) {
         let _ = WORKER_LAST_TIME_TO_FIRST_TOKEN_GAUGE.remove_label_values(labels);
         let _ = WORKER_LAST_INPUT_SEQUENCE_TOKENS_GAUGE.remove_label_values(labels);
         let _ = WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE.remove_label_values(labels);
+        if let Some(metrics) = router_worker_status_metrics() {
+            metrics.remove_worker(worker_id, *dp_rank, worker_type);
+        }
     }
 
     let unset_labels = &[worker_id_str.as_str(), UNSET_DP_RANK_LABEL, worker_type];

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -61,6 +61,8 @@ use prometheus::{HistogramOpts, IntCounter, IntCounterVec, IntGaugeVec, Opts};
 
 use crate::http::service::metrics::generate_log_buckets;
 
+pub(crate) const ROUTER_WORKER_ID_LABEL: &str = "router_worker_id";
+
 /// Buckets for CPU-bound compute phases (block hashing, sequence hashing).
 fn compute_overhead_buckets() -> Vec<f64> {
     prometheus::exponential_buckets(0.001, 2.0, 15).unwrap()
@@ -185,6 +187,60 @@ impl KvPublisherMetrics {
 
 pub(crate) fn kv_publisher_metrics() -> Option<Arc<KvPublisherMetrics>> {
     KV_PUBLISHER_METRICS.get().cloned()
+}
+
+// ---------------------------------------------------------------------------
+// Router worker status metrics (component-scoped gauges)
+// ---------------------------------------------------------------------------
+
+/// Component-scoped router gauges for worker discovery.
+pub(crate) struct RouterWorkerStatusMetrics {
+    pub registered: IntGaugeVec,
+}
+
+static ROUTER_WORKER_STATUS_METRICS: OnceLock<Arc<RouterWorkerStatusMetrics>> = OnceLock::new();
+
+impl RouterWorkerStatusMetrics {
+    /// Create component-scoped gauges for standalone router observability.
+    ///
+    /// The `MetricsHierarchy` injects labels such as `dynamo_namespace` and
+    /// `dynamo_component`. It reserves `worker_id` for the metric producer, so
+    /// the backend worker ID discovered by the router uses `router_worker_id`.
+    pub fn from_component(component: &Component) -> Arc<Self> {
+        ROUTER_WORKER_STATUS_METRICS
+            .get_or_init(|| {
+                let metrics = component.metrics();
+                let registered = metrics
+                    .create_intgaugevec(
+                        router::WORKER_REGISTERED,
+                        "Whether the router currently has this worker/dp_rank registered (1 = registered)",
+                        &[ROUTER_WORKER_ID_LABEL, labels::DP_RANK, labels::WORKER_TYPE],
+                        &[],
+                    )
+                    .expect("failed to create router_worker_registered gauge");
+
+                Arc::new(Self { registered })
+            })
+            .clone()
+    }
+
+    pub fn set_registered(&self, worker_id: u64, dp_rank: u32, worker_type: &str) {
+        let worker_id = worker_id.to_string();
+        let dp_rank = dp_rank.to_string();
+        let labels = &[worker_id.as_str(), dp_rank.as_str(), worker_type];
+        self.registered.with_label_values(labels).set(1);
+    }
+
+    pub fn remove_worker(&self, worker_id: u64, dp_rank: u32, worker_type: &str) {
+        let worker_id = worker_id.to_string();
+        let dp_rank = dp_rank.to_string();
+        let labels = &[worker_id.as_str(), dp_rank.as_str(), worker_type];
+        let _ = self.registered.remove_label_values(labels);
+    }
+}
+
+pub(crate) fn router_worker_status_metrics() -> Option<Arc<RouterWorkerStatusMetrics>> {
+    ROUTER_WORKER_STATUS_METRICS.get().cloned()
 }
 
 // ---------------------------------------------------------------------------
@@ -749,6 +805,45 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
         assert_eq!(
             output, expected,
             "\nActual PEF:\n{output}\nExpected PEF:\n{expected}"
+        );
+    }
+
+    #[test]
+    fn test_router_worker_status_metrics_pef() {
+        let registry = prometheus::Registry::new();
+        let metrics = RouterWorkerStatusMetrics {
+            registered: IntGaugeVec::new(
+                Opts::new(
+                    format!(
+                        "{}_{}",
+                        name_prefix::COMPONENT,
+                        router::WORKER_REGISTERED
+                    ),
+                    "Whether the router currently has this worker/dp_rank registered (1 = registered)",
+                ),
+                &[ROUTER_WORKER_ID_LABEL, labels::DP_RANK, labels::WORKER_TYPE],
+            )
+            .unwrap(),
+        };
+        registry
+            .register(Box::new(metrics.registered.clone()))
+            .unwrap();
+
+        metrics.set_registered(123, 0, "decode");
+
+        let output = gather_pef(&registry);
+        assert!(
+            output.contains(
+                "dynamo_component_router_worker_registered{dp_rank=\"0\",router_worker_id=\"123\",worker_type=\"decode\"} 1"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+
+        metrics.remove_worker(123, 0, "decode");
+        let output = gather_pef(&registry);
+        assert!(
+            !output.contains("router_worker_id=\"123\""),
+            "\nActual PEF after remove:\n{output}"
         );
     }
 

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -239,10 +239,6 @@ impl RouterWorkerStatusMetrics {
     }
 }
 
-pub(crate) fn router_worker_status_metrics() -> Option<Arc<RouterWorkerStatusMetrics>> {
-    ROUTER_WORKER_STATUS_METRICS.get().cloned()
-}
-
 // ---------------------------------------------------------------------------
 // Worker load metrics (gauges)
 // ---------------------------------------------------------------------------

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use super::metrics::WORKER_LOAD_METRICS;
+use super::metrics::{RouterWorkerStatusMetrics, WORKER_LOAD_METRICS};
 use crate::kv_router::{ACTIVE_SEQUENCES_SUBJECT, KV_METRICS_SUBJECT};
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 #[cfg(test)]
@@ -32,6 +32,7 @@ use dynamo_kv_router::protocols::PrefillLoadHint;
 pub struct RuntimeSequencePublisher {
     event_publisher: EventPublisher,
     metrics_publisher: Arc<EventPublisher>,
+    worker_status_metrics: Arc<RouterWorkerStatusMetrics>,
 }
 
 impl SequencePublisher for RuntimeSequencePublisher {
@@ -82,6 +83,16 @@ impl SequencePublisher for RuntimeSequencePublisher {
             tokens,
         );
     }
+
+    fn observe_worker_registered(&self, worker: &WorkerWithDpRank, worker_type: &str) {
+        self.worker_status_metrics
+            .set_registered(worker.worker_id, worker.dp_rank, worker_type);
+    }
+
+    fn observe_worker_removed(&self, worker: &WorkerWithDpRank, worker_type: &str) {
+        self.worker_status_metrics
+            .remove_worker(worker.worker_id, worker.dp_rank, worker_type);
+    }
 }
 
 /// Concrete [`SequenceSubscriber`] backed by NATS typed event stream.
@@ -127,10 +138,12 @@ pub async fn create_multi_worker_sequences(
         EventPublisher::for_component(&component, ACTIVE_SEQUENCES_SUBJECT).await?;
     let metrics_publisher =
         Arc::new(EventPublisher::for_namespace(component.namespace(), KV_METRICS_SUBJECT).await?);
+    let worker_status_metrics = RouterWorkerStatusMetrics::from_component(&component);
 
     let publisher = RuntimeSequencePublisher {
         event_publisher,
         metrics_publisher,
+        worker_status_metrics,
     };
 
     let dp_range: HashMap<u64, (u32, u32)> = workers_with_configs

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -604,6 +604,9 @@ pub mod router {
 
     /// Shared cache blocks beyond device overlap for the selected worker
     pub const SHARED_CACHE_BEYOND_BLOCKS: &str = "router_shared_cache_beyond_blocks";
+
+    /// Whether the router currently has a worker/dp_rank registered (1 = registered)
+    pub const WORKER_REGISTERED: &str = "router_worker_registered";
 }
 
 /// Frontend pipeline stage and event-loop metrics


### PR DESCRIPTION
## Summary

- add a router component gauge for registered backend workers
- update the gauge when router worker topology is initialized or changes
- clean up the gauge when workers are removed

## Metric

- dynamo_component_router_worker_registered

Labels:

- router_worker_id
- dp_rank
- worker_type

## Testing

- cargo fmt --package dynamo-runtime --package dynamo-llm --package dynamo-kv-router --check
- cargo test -p dynamo-kv-router worker_topology_observes_registered_and_removed_workers --lib
- cargo test -p dynamo-llm --no-default-features kv_router::metrics::tests::test_router_worker_status_metrics_pef --lib
- cargo check -p dynamo-llm --no-default-features --lib

Closes #10585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prometheus metrics now track router worker registration status in real-time, enabling monitoring of worker availability across your deployment.
  * Worker lifecycle events—registration and removal—are automatically captured and reflected in metrics, improving observability for system operations and alerting.
  * Metrics include detailed labeling by worker ID, data-parallel rank, and worker type for comprehensive worker-level monitoring and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->