### PR TITLE
docs(kubernetes): document custom discovery service accounts

### DIFF
--- a/docs/kubernetes/service-discovery.md
+++ b/docs/kubernetes/service-discovery.md
@@ -67,7 +67,80 @@ A pod is marked ready if the readiness probe succeeds. On Dynamo workers, this i
 
 #### RBAC
 
-Each Dynamo component pod is automatically given a ServiceAccount that allows it to watch `EndpointSlice` and `DynamoWorkerMetadata` resources within its namespace.
+By default, each Dynamo component pod is given a ServiceAccount that allows it
+to watch `EndpointSlice` and `DynamoWorkerMetadata` resources within its
+namespace.
+
+When Kubernetes discovery is enabled, the operator creates these RBAC resources
+in the `DynamoGraphDeployment` namespace:
+
+- ServiceAccount: `<DGD NAME>-k8s-service-discovery`
+- Role: `<DGD NAME>-k8s-service-discovery-role`
+- RoleBinding: `<DGD NAME>-k8s-service-discovery-binding`
+
+The Role is scoped to the `DynamoGraphDeployment` and is deleted with it.
+
+##### Use a Pre-Created ServiceAccount
+
+If a normal frontend or worker component needs to run as an existing Kubernetes
+ServiceAccount, such as a cloud workload identity ServiceAccount, set
+`spec.components[*].podTemplate.spec.serviceAccountName`. The controller does
+not overwrite a non-empty `podTemplate.spec.serviceAccountName` for normal
+frontend and worker components, including prefill and decode workers.
+
+Kubernetes-native service discovery still uses the generated
+`<DGD NAME>-k8s-service-discovery-role`. Bind your custom ServiceAccount to that
+Role in the same namespace as the `DynamoGraphDeployment`.
+
+```yaml
+# Relevant fields only.
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: my-dgd
+  namespace: dynamo-system
+spec:
+  components:
+    - name: decode
+      type: decode
+      podTemplate:
+        spec:
+          serviceAccountName: workload-identity-sa
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest
+```
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workload-identity-discovery
+  namespace: dynamo-system
+subjects:
+  - kind: ServiceAccount
+    name: workload-identity-sa
+    namespace: dynamo-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: my-dgd-k8s-service-discovery-role
+```
+
+Keep these caveats in mind:
+
+- Kubernetes discovery must be enabled. It is the default Kubernetes backend, but
+  the discovery Role is not reconciled when the deployment selects the `etcd`
+  backend.
+- You can apply the custom RoleBinding before the generated Role exists. It
+  grants permissions only after the operator reconciles the
+  `DynamoGraphDeployment` and creates the Role.
+- The operator still creates the default discovery ServiceAccount and
+  RoleBinding. This is harmless when the component pods use your custom
+  ServiceAccount.
+- Planner and Endpoint Picker Plugin (EPP) components have separate
+  service-account and RBAC paths. Validate those paths before overriding their
+  pod template ServiceAccount.
 
 #### Environment Variables
 

--- a/docs/kubernetes/service-discovery.md
+++ b/docs/kubernetes/service-discovery.md
@@ -84,13 +84,14 @@ The Role is scoped to the `DynamoGraphDeployment` and is deleted with it.
 
 If a normal frontend or worker component needs to run as an existing Kubernetes
 ServiceAccount, such as a cloud workload identity ServiceAccount, set
-`spec.components[*].podTemplate.spec.serviceAccountName`. The controller does
-not overwrite a non-empty `podTemplate.spec.serviceAccountName` for normal
-frontend and worker components, including prefill and decode workers.
+`spec.components[*].podTemplate.spec.serviceAccountName`. The controller uses
+that custom ServiceAccount for normal frontend and worker components, including
+prefill and decode workers.
 
-Kubernetes-native service discovery still uses the generated
-`<DGD NAME>-k8s-service-discovery-role`. Bind your custom ServiceAccount to that
-Role in the same namespace as the `DynamoGraphDeployment`.
+Those component pods need the permissions defined in the generated
+`<DGD NAME>-k8s-service-discovery-role` for Kubernetes-native service
+discovery. Bind your custom ServiceAccount to that Role in the same namespace
+as the `DynamoGraphDeployment`.
 
 ```yaml
 # Relevant fields only.
@@ -138,9 +139,9 @@ Keep these caveats in mind:
 - The operator still creates the default discovery ServiceAccount and
   RoleBinding. This is harmless when the component pods use your custom
   ServiceAccount.
-- Planner and Endpoint Picker Plugin (EPP) components have separate
-  service-account and RBAC paths. Validate those paths before overriding their
-  pod template ServiceAccount.
+- This custom ServiceAccount path applies to normal frontend and worker
+  components. Planner and Endpoint Picker Plugin (EPP) components have separate
+  service-account and RBAC paths.
 
 #### Environment Variables
 


### PR DESCRIPTION
Summary
- Document how to use a pre-created Kubernetes ServiceAccount for normal DynamoGraphDeployment frontend and worker components with Kubernetes discovery.
- Add DGD and RoleBinding YAML examples plus caveats for generated discovery RBAC, Role lifecycle, default discovery ServiceAccount creation, and planner/EPP paths.

Validation
- python3 .github/workflows/detect_broken_links.py --verbose --format json --check-symlinks --output /tmp/service-discovery-links.json docs/kubernetes/service-discovery.md
- Parsed all YAML code fences in docs/kubernetes/service-discovery.md with PyYAML
- Checked frontmatter/SPDX and no body H1 outside fenced code
- git diff --check -- docs/kubernetes/service-discovery.md
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Kubernetes service discovery documentation with detailed RBAC configuration guidance, including ServiceAccount permissions, operator-created resources, custom ServiceAccount usage patterns, binding considerations, and important caveats for different deployment scenarios and backend selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->