### PR TITLE
docs(trtllm): specify NIXL as the default mode for KV-cache transfer

### DIFF
--- a/docs/backends/trtllm/trtllm-kv-cache-transfer.md
+++ b/docs/backends/trtllm/trtllm-kv-cache-transfer.md
@@ -8,7 +8,11 @@ For general TensorRT-LLM features and configuration, see the [Reference Guide](t
 
 ---
 
-In disaggregated serving architectures, KV cache must be transferred between prefill and decode workers. TensorRT-LLM supports two methods for this transfer:
+In disaggregated serving architectures, KV cache must be transferred between prefill and decode workers. TensorRT-LLM supports three methods for this transfer:
+* NIXL with UCX (default)
+* NIXL with Libfabric
+* using UCX directly
+
 
 ## Using NIXL for KV Cache Transfer
 

--- a/docs/backends/trtllm/trtllm-kv-cache-transfer.md
+++ b/docs/backends/trtllm/trtllm-kv-cache-transfer.md
@@ -18,7 +18,7 @@ In disaggregated serving architectures, KV cache must be transferred between pre
 
 Start the disaggregated service: See [Disaggregated Serving](./trtllm-examples.md#disaggregated) to learn how to start the deployment.
 
-## Default Method: NIXL
+## Default Method: NIXL with UCX
 By default, TensorRT-LLM uses **NIXL** (NVIDIA Inference Xfer Library) with UCX (Unified Communication X) as backend for KV cache transfer between prefill and decode workers. [NIXL](https://github.com/ai-dynamo/nixl) is NVIDIA's high-performance communication library designed for efficient data transfer in distributed GPU environments.
 
 ### Specify Backends for NIXL

--- a/docs/backends/trtllm/trtllm-reference-guide.md
+++ b/docs/backends/trtllm/trtllm-reference-guide.md
@@ -11,7 +11,12 @@ The Dynamo TensorRT-LLM image layers Dynamo on top of the upstream `nvcr.io/nvid
 
 ## KV Cache Transfer
 
-Dynamo with TensorRT-LLM supports two methods for transferring KV cache in disaggregated serving: UCX (default) and NIXL (experimental). For detailed information and configuration instructions for each method, see the [KV Cache Transfer Guide](./trtllm-kv-cache-transfer.md).
+Dynamo with TensorRT-LLM supports three methods for transferring KV cache in disaggregated serving:
+* NIXL with UCX (default)
+* NIXL with Libfabric
+* using UCX directly
+
+For detailed information and configuration instructions for each method, see the [KV Cache Transfer Guide](./trtllm-kv-cache-transfer.md).
 
 ## Request Migration
 


### PR DESCRIPTION
## Overview:

Currently, UCX is incorrectly specified as the default for KV-Cache transfer for tensor-rt-llm in https://docs.nvidia.com/dynamo/latest/backends/tensor-rt-llm/reference-guide .
NIXL is the default according to
https://docs.nvidia.com/dynamo/additional-resources/tensor-rt-llm-details/kv-cache-transfer .

## Details:

Change tensor-rt-llm reference-guide, KV-Cache transfer section. Specify three modes:
* NIXL with UCX (default)
* NIXL with Libfabric
* using UCX directly

## Where should the reviewer start?

This is a tiny, several-lines PR. Please check for details https://docs.nvidia.com/dynamo/additional-resources/tensor-rt-llm-details/kv-cache-transfer.  

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated KV Cache Transfer reference guide to document three supported disaggregated KV cache transfer methods: NIXL with UCX (default), NIXL with Libfabric, and UCX directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->