### PR TITLE
fix(chart): Ensure worker PodMonitor scrapes decode and prefill workers

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
@@ -70,13 +70,31 @@ spec:
   - interval: 5s
     path: /metrics
     port: system
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_nvidia_com_dynamo_component_type
+      targetLabel: dynamo_component_type
   - interval: 5s
     path: /metrics
     port: nixl
+    relabelings:
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_nvidia_com_dynamo_component_type
+      targetLabel: dynamo_component_type
   selector:
-    matchLabels:
-      nvidia.com/dynamo-component-type: worker
-      nvidia.com/metrics-enabled: "true"
+    matchExpressions:
+      - key: nvidia.com/dynamo-component-type
+        operator: In
+        values:
+          - worker
+          - decode
+          - prefill
+      - key: nvidia.com/metrics-enabled
+        operator: In
+        values:
+          - "true"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor


### PR DESCRIPTION

## Overview:

Ensure the worker PodMonitor scrapes all types of workers, added `decode` and `prefill` to the kinds of workers scraped.

## Details:

Maintains previous behavior but also beings to scrape decode and prefill workers.

Add the `dynamo_component_type` so that `dynamo_component_type=worker` can be filtered if only prefill/decode have NIXL running.

## Related Issues

Fixes #10596

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded monitoring coverage to include additional component types (decode and prefill components) alongside existing worker components in Prometheus metrics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->