### PR TITLE
fix(backends): use engine's runai-pulled local dir for register_model

### DIFF
--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -59,8 +59,12 @@ def _register_model_source_path(engine: sgl.Engine, server_args: ServerArgs) -> 
     the Rust-side HF download entirely (lib/bindings/python/rust/lib.rs:314)
     and don't need this rewrite.
     """
-    mc = getattr(getattr(engine, "tokenizer_manager", None), "model_config", None)
-    if mc is not None and getattr(mc, "model_weights", ""):
+    try:
+        mc = engine.tokenizer_manager.model_config
+    except AttributeError:
+        return server_args.model_path
+    weights = getattr(mc, "model_weights", None)
+    if weights:
         return mc.model_path
     return server_args.model_path
 

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -37,6 +37,34 @@ SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
 SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 
 
+def _register_model_source_path(engine: sgl.Engine, server_args: ServerArgs) -> str:
+    """Pick the path passed to `register_model` for MDC construction.
+
+    When `--model-path` is a remote URI (`s3://...`, `gs://...`), SGLang's
+    `ModelConfig.maybe_pull_model_tokenizer_from_remote` (sglang/srt/configs/
+    model_config.py) pulls metadata files (`*config.json`) to a local temp dir
+    and rewrites the engine's ModelConfig:
+
+      - `.model_weights = <original URI>`  (preserved for the weight loader)
+      - `.model_path    = <local temp dir>` (now contains the metadata)
+
+    `server_args.model_path` itself is NOT mutated. Dynamo's `register_model`
+    would otherwise pass the raw URI through `hub.rs` -> ModelExpress, which
+    has no S3 provider and 404s. Returning the post-pull local dir lets
+    `register_model` take its `fs::exists` shortcut and skip the broken MX
+    path.
+
+    Temporary LLM-only workaround mirroring the vLLM fix in
+    `components/src/dynamo/vllm/main.py`. Diffusion paths (Images/Videos) skip
+    the Rust-side HF download entirely (lib/bindings/python/rust/lib.rs:314)
+    and don't need this rewrite.
+    """
+    mc = getattr(getattr(engine, "tokenizer_manager", None), "model_config", None)
+    if mc is not None and getattr(mc, "model_weights", ""):
+        return mc.model_path
+    return server_args.model_path
+
+
 def _build_media_decoder_and_fetcher():
     """Construct MediaDecoder/MediaFetcher for frontend-decoded multimodal.
 
@@ -106,7 +134,7 @@ async def _register_model_with_runtime_config(
             input_type,
             output_type,
             endpoint,
-            server_args.model_path,
+            _register_model_source_path(engine, server_args),
             server_args.served_model_name,
             kv_cache_block_size=server_args.page_size,
             runtime_config=runtime_config,

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -79,6 +79,29 @@ def should_register_model_ignore_weights(config: Config) -> bool:
     return uses_modelexpress_load_format(config)
 
 
+def _register_model_source_path(config: Config, vllm_config: VllmConfig) -> str:
+    """Pick the path passed to `register_model` for MDC construction.
+
+    When `--model` is an object-storage URI (`s3://...`, `gs://...`, `az://...`),
+    vLLM's `maybe_pull_model_tokenizer_for_runai` (vllm/config/model.py) pulls
+    metadata files to a local temp dir and rewrites `vllm_config.model_config`:
+
+      - `.model_weights = <original URI>`  (used by runai-streamer / mx plugin)
+      - `.model = <local temp dir>`        (contains config.json, tokenizer, …)
+
+    Dynamo's `register_model` would otherwise try to resolve the raw URI via
+    `hub.rs` → ModelExpress, which has no S3 provider and 404s. Returning the
+    local dir lets `register_model` take its `fs::exists` shortcut.
+
+    Temporary vLLM-only workaround until `hub.rs` learns object-storage routing.
+    Falls back to `config.model` whenever vLLM did not pull (HF id, local path,
+    or older vLLM without `model_weights`).
+    """
+    if getattr(vllm_config.model_config, "model_weights", ""):
+        return vllm_config.model_config.model
+    return config.model
+
+
 def build_headless_namespace(config: Config) -> argparse.Namespace:
     """Build an argparse Namespace from engine_args for vLLM's run_headless().
 
@@ -770,7 +793,7 @@ async def register_vllm_model(
         model_input,
         model_type,
         generate_endpoint,
-        config.model,
+        _register_model_source_path(config, vllm_config),
         config.served_model_name,
         kv_cache_block_size=runtime_values["kv_event_block_size"],
         runtime_config=runtime_config,


### PR DESCRIPTION
## Summary

When `--model` (vLLM) / `--model-path` (SGLang) is an object-storage URI (`s3://`, `gs://`, `az://`), the engine pulls metadata files to a local temp dir during config construction and rewrites the runtime ModelConfig:

- **vLLM** `maybe_pull_model_tokenizer_for_runai` (`vllm/config/model.py:734`) — sets `model_config.model = <local dir>`, `model_config.model_weights = <original URI>`
- **SGLang** `maybe_pull_model_tokenizer_from_remote` (`sglang/srt/configs/model_config.py:505`) — sets `model_config.model_path = <local dir>`, `model_config.model_weights = <original URI>`

Dynamo's `register_model` was still receiving the raw URI (from `config.model` / `server_args.model_path`), routing it through `lib/llm/src/hub.rs` → ModelExpress. `MxModelProvider` has only three variants — `HuggingFace`, `Ngc`, `Gcs` — **no S3**. The call defaults to `HuggingFace` (`hub.rs:155,163,207`) and 404s:

```
modelexpress_client: Requesting model: s3://… from provider: HuggingFace
ERROR Failed to fetch model 's3://…' from HuggingFace.
  Is this a valid HuggingFace ID?
  Error: HTTP 404 for url (https://huggingface.co/api/models/s3://…/revision/main)
```

This crashes the worker before engine startup completes.

## Fix

New helper `_register_model_source_path(...)` per backend:

- **vLLM** (`components/src/dynamo/vllm/main.py`): reads `vllm_config.model_config.model_weights` as the sentinel; returns `vllm_config.model_config.model` (post-pull local dir) when set.
- **SGLang** (`components/src/dynamo/sglang/register.py`): reads through the engine handle: `engine.tokenizer_manager.model_config.model_weights`; returns its `.model_path` when set. SGLang mutates the engine's ModelConfig — *not* `ServerArgs.model_path` — so the access goes through the engine.

In both cases `register_model` then takes its `fs::exists` shortcut (`lib/bindings/python/rust/lib.rs:455`) and skips the broken MX path.

## Scope

- vLLM: `main.py` `register_vllm_model` callsite.
- SGLang: `register.py` LLM-path callsite (`_register_model_with_runtime_config`). Image/video diffusion paths already skip the Rust-side HF download (`lib/bindings/python/rust/lib.rs:314`) and don't need this.
- TRT-LLM: deferred — model-load pattern is fundamentally different (pre-built engines, not runtime URI pull). Not on a known deployment path today.

## Why "temporary workaround"

The proper fix belongs in `hub.rs`: detect object-storage schemes and route to the matching `MxModelProvider` variant (Gcs exists, S3 doesn't), or skip MX for schemes the server cannot serve. Larger Rust + Python-binding change; this PR unblocks deployments today.

## Test plan

- [x] vLLM helper unit-tested (4 cases): `s3 + pulled → local`, `HF id → original`, `local path → identity`, `missing attr → original (fallback)`.
- [x] SGLang helper unit-tested (4 cases): `s3 + pulled → local`, `HF id → original`, `no tokenizer_manager → fallback`, `no model_config → fallback`.
- [x] Both files `ast.parse` clean.
- [ ] Manual: redeploy vLLM DynamoGraphDeployment with `--model s3://...` + `--load-format modelexpress`; confirm worker starts and serves.
- [ ] Manual: SGLang `--model-path s3://...` smoke if a deployment is available.
- [ ] CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)