### PR TITLE
docs(digest): draft AICR Dynamo deployment post

### DIFF
--- a/docs/digest/deploying-dynamo-with-aicr-vllm-agg-epp.yaml
+++ b/docs/digest/deploying-dynamo-with-aicr-vllm-agg-epp.yaml
@@ -80,7 +80,7 @@ spec:
               effect: NoExecute
           containers:
             - name: main
-              image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.0
+              image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
               env:
                 - name: DYN_KV_CACHE_BLOCK_SIZE
                   value: "128"
@@ -207,6 +207,9 @@ metadata:
   name: vllm-agg-epp
   namespace: dynamo-workload
 spec:
+  # Use a hostname unique to this workload. The AICR inference Gateway is shared.
+  hostnames:
+    - vllm-agg-epp.example.com
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway

--- a/docs/digest/deploying-dynamo-with-aicr-vllm-agg-epp.yaml
+++ b/docs/digest/deploying-dynamo-with-aicr-vllm-agg-epp.yaml
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Prerequisites:
+#   - KAI Scheduler installed (provides default-parent-queue)
+#   - Dynamo platform deployed (dynamo-crds + dynamo-platform)
+#   - agentgateway and inference-gateway installed by the AICR inference recipe
+
+---
+# KAI Scheduler queue for Dynamo workloads
+apiVersion: scheduling.run.ai/v2
+kind: Queue
+metadata:
+  name: dynamo
+spec:
+  parentQueue: default-parent-queue
+  resources:
+    gpu:
+      limit: -1
+      overQuotaWeight: 1
+      quota: 0
+    cpu:
+      limit: -1
+      overQuotaWeight: 1
+      quota: 0
+    memory:
+      limit: -1
+      overQuotaWeight: 1
+      quota: 0
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dynamo-workload
+
+---
+# DRA ResourceClaim for GPU allocation (required on DRA-only clusters).
+# The kai.scheduler/queue label is required for KAI scheduler to manage the claim.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: vllm-epp-gpu-claim
+  namespace: dynamo-workload
+  labels:
+    kai.scheduler/queue: dynamo
+spec:
+  devices:
+    requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: 1
+
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg-epp
+  namespace: dynamo-workload
+spec:
+  backendFramework: vllm
+  components:
+    - name: Epp
+      type: epp
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector:
+            nodeGroup: cpu-worker
+          tolerations:
+            - key: dedicated
+              operator: Equal
+              value: worker-workload
+              effect: NoSchedule
+            - key: dedicated
+              operator: Equal
+              value: worker-workload
+              effect: NoExecute
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/epp-image:1.2.0
+              env:
+                - name: DYN_KV_CACHE_BLOCK_SIZE
+                  value: "128"
+                - name: DYN_MODEL_NAME
+                  value: Qwen/Qwen3-0.6B
+                - name: DYN_ENFORCE_DISAGG
+                  value: "false"
+                - name: HF_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: aicr-hf-token
+                      key: token
+                      optional: true
+                - name: HUGGING_FACE_HUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: aicr-hf-token
+                      key: token
+                      optional: true
+      eppConfig:
+        config:
+          plugins:
+            - type: disagg-profile-handler
+            - name: decode-filter
+              type: label-filter
+              parameters:
+                label: nvidia.com/dynamo-component-type
+                validValues:
+                  - decode
+                allowsNoLabel: true
+            - name: picker
+              type: max-score-picker
+            - name: dyn-decode
+              type: dyn-decode-scorer
+          schedulingProfiles:
+            - name: decode
+              plugins:
+                - pluginRef: decode-filter
+                  weight: 1
+                - pluginRef: dyn-decode
+                  weight: 1
+                - pluginRef: picker
+                  weight: 1
+    - name: VllmDecodeWorker
+      type: decode
+      replicas: 1
+      sharedMemorySize: 2Gi
+      frontendSidecar: sidecar-frontend
+      podTemplate:
+        spec:
+          nodeSelector:
+            nodeGroup: gpu-worker
+          tolerations:
+            - key: dedicated
+              operator: Equal
+              value: worker-workload
+              effect: NoSchedule
+            - key: dedicated
+              operator: Equal
+              value: worker-workload
+              effect: NoExecute
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          resourceClaims:
+            - name: gpu
+              resourceClaimName: vllm-epp-gpu-claim
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              workingDir: /workspace/examples/backends/vllm
+              command: ["python3", "-m", "dynamo.vllm"]
+              args:
+                - --model
+                - Qwen/Qwen3-0.6B
+                - --served-model-name
+                - Qwen/Qwen3-0.6B
+                - --enable-prefix-caching
+                - --block-size
+                - "128"
+                - --kv-events-config
+                - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}'
+              env:
+                - name: HF_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: aicr-hf-token
+                      key: token
+                      optional: true
+                - name: HUGGING_FACE_HUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: aicr-hf-token
+                      key: token
+                      optional: true
+              resources:
+                claims:
+                  - name: gpu
+            - name: sidecar-frontend
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+              args:
+                - -m
+                - dynamo.frontend
+                - --router-mode
+                - direct
+              env:
+                - name: HF_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: aicr-hf-token
+                      key: token
+                      optional: true
+                - name: HUGGING_FACE_HUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: aicr-hf-token
+                      key: token
+                      optional: true
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vllm-agg-epp
+  namespace: dynamo-workload
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+      namespace: agentgateway-system
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-agg-epp-pool
+          namespace: dynamo-workload
+          port: 8000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -261,7 +261,8 @@ apply a Dynamo workload, such as the vLLM aggregation example in the
 
 The example manifest assumes specific node labels, including `nodeGroup=cpu-worker`. If your cluster
 uses different labels, such as `nodeGroup=system-worker`, adapt the `DynamoGraphDeployment` node
-selectors before applying it.
+selectors before applying it. Do the same for taints and tolerations if the Kubernetes cluster uses
+different scheduling constraints.
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/NVIDIA/aicr/refs/heads/main/demos/workloads/inference/vllm-agg.yaml

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -101,19 +101,23 @@ serving graph, while the `dynamo-platform` chart provides the operator, CRDs, NA
 control-plane services.
 
 Dynamo is Kubernetes-native in this path. Frontends, vLLM workers, EPP components, and other Dynamo
-services discover each other through Kubernetes resources instead of an etcd deployment. The
-`dynamo-platform` chart still installs NATS because the event plane is separate from discovery:
-KV-aware routing needs live worker cache events, and the validated Kubernetes path uses NATS for
-those events.
+services discover each other through Kubernetes resources instead of an etcd deployment. NATS serves
+a different purpose: it is part of the Dynamo dataplane for real-time, high-throughput streaming of
+KV cache location updates. The `dynamo-platform` chart installs NATS so the router and EPP can track
+which workers hold which KV blocks as those blocks are stored and evicted.
 
 KV-aware routing is one of the main reasons to run Dynamo. Agentic workloads repeatedly append to a
 long prefix: system prompt, tool definitions, conversation history, tool results, and generated
 reasoning. If each turn lands on a worker that does not already hold the prefix, the system
 recomputes the same tokens again and again. Cache-aware placement keeps turns close to the workers
-that already hold their KV blocks. Together with disaggregated serving, this changes the shape of
-many long-running token workloads from repeated prefix recomputation toward reuse of already computed
-state. For sessions whose prompt grows turn by turn, that moves the dominant prefill work from
-quadratic growth toward linear reuse.
+that already hold their KV blocks.
+
+This separation of prefill and decode is disaggregated serving. It lets the expensive
+prompt-processing phase and the token-generation phase scale independently. With cached KV state on
+the decode path, long-running sessions can reuse previously computed prefixes instead of recomputing
+them on every turn. For prompts that grow turn by turn, KV-aware routing plus disaggregated serving
+avoid repeated quadratic prefill and enable linear reuse during the decode phase. That combination
+makes Dynamo well suited to datacenter-scale inference.
 
 > [!IMPORTANT]
 > The request plane and the KV event plane are separate. In Dynamo 1.2, the request plane defaults

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -1,0 +1,234 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Deploying Dynamo 1.2 with NVIDIA AI Cluster Runtime"
+sidebar-title: Deploying Dynamo with AICR
+subtitle: "A validated Kubernetes runtime path for Dynamo inference - June 2026"
+description: "How NVIDIA AI Cluster Runtime packages Dynamo 1.2 with the GPU, scheduling, health, observability, and routing components needed for Kubernetes inference."
+keywords: Dynamo, NVIDIA AI Cluster Runtime, AICR, Kubernetes, GPU Operator, EPP, NATS, KV cache routing, vLLM
+last-updated: June 11, 2026
+---
+
+Running Dynamo on Kubernetes starts with a `DynamoGraphDeployment`, but the graph is only the top of
+the stack. A production inference cluster also needs GPU drivers, device discovery, scheduling,
+health signals, observability, Gateway API resources, and the event transport that lets KV-aware
+routing see live cache state.
+
+[NVIDIA AI Cluster Runtime (AICR)](https://github.com/NVIDIA/aicr) packages the lower stack as a
+validated, version-locked recipe. You bring an existing GPU Kubernetes cluster. AICR captures its
+state, selects a matching recipe, validates the constraints, and renders a deployable bundle. For
+Dynamo users, that makes AICR a fast path from "I have GPUs in Kubernetes" to "I have a validated
+Dynamo 1.2 runtime."
+
+## Why the Runtime Below Dynamo Matters
+
+Dynamo coordinates inference across multiple components: frontends, routers, workers, the Dynamo
+operator, and optional Gateway API Inference Extension (GAIE) / Endpoint Picker Plugin (EPP)
+components. Those components depend on cluster-level services that must agree on Kubernetes version,
+driver stack, GPU allocation model, scheduling policy, node health, metrics, and network reachability.
+
+A hand-written Dynamo manifest can start the serving graph, but it does not answer questions like:
+
+- Is the NVIDIA GPU Operator installed with a driver stack that matches the nodes?
+- Are GPU nodes labeled and discoverable?
+- Does the cluster expose GPUs through the expected Dynamic Resource Allocation (DRA) driver?
+- Can the scheduler place GPU workers with the right topology and gang semantics?
+- Are node health signals available before workloads land on a bad node?
+- Is Prometheus reachable for Dynamo and accelerator metrics?
+- Is NATS available for the Kubernetes KV event plane?
+- Is the Gateway / EPP path configured when the deployment should be Kubernetes-native at ingress?
+
+AICR moves those answers into the recipe. The recipe captures a known-good combination for a
+specific environment, such as EKS on H100 with Ubuntu and inference intent, then validates a live
+cluster against that combination before rendering deployment artifacts.
+
+## What AICR Ships for Dynamo
+
+AICR does not only point at Dynamo. A Dynamo recipe includes Dynamo and the runtime below it.
+
+At the Dynamo layer, AICR ships the `dynamo-platform` chart, the Dynamo operator, Dynamo runtime
+images, and Kubernetes manifests that use the Dynamo 1.2 `nvidia.com/v1beta1`
+`DynamoGraphDeployment` API. That gives the recipe a single Dynamo version boundary instead of a
+mix of operator, chart, and runtime image versions.
+
+Below Dynamo, the recipe brings the cluster services Dynamo expects for validated GPU inference:
+
+- **NVIDIA GPU Operator** for the driver and GPU software stack.
+- **Node Feature Discovery** and GPU labels for placement.
+- **NVIDIA DRA driver for GPUs** for Kubernetes-native GPU allocation.
+- **KAI Scheduler** for accelerator-aware scheduling and gang-style placement.
+- **Grove** for Dynamo component lifecycle on Kubernetes.
+- **Prometheus stack** for cluster, accelerator, and Dynamo service metrics.
+- **Node health management** components such as NVSentinel and Nodewright, where supported by the
+  selected recipe.
+- **NATS** from the Dynamo platform chart for the standard Kubernetes KV event plane.
+
+The result is a runtime recipe, not a loose list of charts. AICR records the component versions,
+values, node selectors, tolerations, checksums, and validation expectations that make the bundle
+repeatable.
+
+## Dynamo 1.2 in the Recipe
+
+Dynamo 1.2 is the right baseline for the AICR path because it aligns the Kubernetes deployment model
+around the v1beta1 graph API, Kubernetes discovery, the Dynamo platform chart, and NATS-backed event
+delivery for KV-aware routing.
+
+In the AICR Dynamo recipe, Kubernetes discovery is the expected path. That means Dynamo components
+discover each other through Kubernetes resources instead of an etcd deployment. The `dynamo-platform`
+chart still installs NATS because the event plane is separate from discovery: KV-aware routing needs
+live worker cache events, and the validated Kubernetes path uses NATS for those events.
+
+> [!IMPORTANT]
+> The request plane and the KV event plane are separate. In Dynamo 1.2, the request plane defaults
+> to TCP unless `DYN_REQUEST_PLANE` is set. The Kubernetes KV event plane defaults to NATS when
+> `DYN_DISCOVERY_BACKEND=kubernetes` and `DYN_EVENT_PLANE` is not overridden.
+
+That distinction matters for vLLM. A vLLM worker may include a setting like:
+
+```json
+{"enable_kv_cache_events": true, "publisher": "zmq", "endpoint": "tcp://*:5557"}
+```
+
+That ZMQ publisher is the local vLLM engine event source. Dynamo reads those raw local KV events from
+the worker, normalizes them, and republishes them onto the Dynamo event plane. In the Kubernetes AICR
+path, that event plane is NATS. The recipe should not set `DYN_EVENT_PLANE=zmq` for the Dynamo
+runtime unless it is intentionally leaving the validated Kubernetes event-plane path.
+
+## Two Routing Paths
+
+AICR's Dynamo recipe covers both Dynamo 1.2 Kubernetes routing paths because they solve different
+operational problems.
+
+The default path is the **Dynamo frontend router**. A `Frontend` component runs with
+`DYN_ROUTER_MODE=kv`, receives OpenAI-compatible requests, tokenizes prompts, subscribes to worker KV
+events, and chooses a worker based on cache overlap and load. This path keeps the user-facing service
+inside the Dynamo graph and is the shortest route for validating Dynamo itself.
+
+The Kubernetes-native ingress path is **Gateway / EPP**. In that mode, traffic flows through the
+Kubernetes Gateway API and an InferencePool. The EPP performs endpoint selection using Dynamo's
+KV-aware scoring. Worker frontend sidecars run in `--router-mode direct`, so they honor the worker
+chosen by the EPP instead of making another placement decision. This path matters when the platform
+team wants model-aware routing at the Kubernetes Gateway layer while keeping Dynamo's cache-aware
+selection logic.
+
+Both paths depend on the same principle: workers must publish live KV cache events. Without live
+events, Dynamo can fall back to approximate routing, but that is not the validated AICR path for
+cache-aware placement.
+
+## Recipe Flow
+
+The AICR flow has four phases: snapshot, recipe, validate, and bundle.
+
+First, capture the current cluster state:
+
+```bash
+aicr snapshot \
+  --namespace aicr-validation \
+  --node-selector nodeGroup=gpu-worker \
+  --toleration dedicated=worker-workload:NoSchedule \
+  --toleration dedicated=worker-workload:NoExecute \
+  --output snapshot.yaml
+```
+
+Then select the Dynamo inference recipe for the target environment:
+
+```bash
+aicr recipe \
+  --service eks \
+  --accelerator h100 \
+  --intent inference \
+  --os ubuntu \
+  --platform dynamo \
+  --output recipe.yaml
+```
+
+Validate the recipe against the snapshot before installing anything:
+
+```bash
+aicr validate \
+  --recipe recipe.yaml \
+  --snapshot snapshot.yaml \
+  --no-cluster \
+  --phase deployment \
+  --output dry-run.json
+```
+
+Render the deployment bundle with the node placement rules for system and GPU workloads:
+
+```bash
+aicr bundle \
+  --recipe recipe.yaml \
+  --accelerated-node-selector nodeGroup=gpu-worker \
+  --accelerated-node-toleration dedicated=worker-workload:NoSchedule \
+  --accelerated-node-toleration dedicated=worker-workload:NoExecute \
+  --system-node-selector nodeGroup=system-worker \
+  --system-node-toleration dedicated=system-workload:NoSchedule \
+  --system-node-toleration dedicated=system-workload:NoExecute \
+  --output bundle
+```
+
+Deploy the rendered bundle with the deployer that fits your environment:
+
+```bash
+cd bundle
+chmod +x deploy.sh
+./deploy.sh
+```
+
+After the runtime is installed, run validation against the live cluster:
+
+```bash
+aicr validate \
+  --recipe recipe.yaml \
+  --toleration dedicated=worker-workload:NoSchedule \
+  --toleration dedicated=worker-workload:NoExecute \
+  --phase all \
+  --output report.json
+```
+
+At this point, the bundle has installed the validated runtime under Dynamo. The remaining step is to
+apply a Dynamo workload, such as the vLLM aggregation example in the
+[AICR repository](https://github.com/NVIDIA/aicr/tree/main/demos/workloads/inference), and watch the
+`DynamoGraphDeployment` converge.
+
+```bash
+kubectl apply -f demos/workloads/inference/vllm-agg.yaml
+kubectl get dynamographdeployments -n dynamo-workload
+kubectl get pods -n dynamo-workload -o wide -w
+```
+
+For the default Dynamo-router path, verify the frontend service. For the Gateway / EPP path, verify
+the Gateway, InferencePool, HTTPRoute, EPP pod, and worker frontend sidecars.
+
+## What Validation Covers
+
+AICR validation gives the Dynamo deployment a concrete runtime contract. A Dynamo inference recipe can
+check that the cluster has:
+
+- The expected Kubernetes service, accelerator, operating system, and workload intent.
+- GPU Operator health and accelerator metrics.
+- DRA support for GPU allocation.
+- Secure accelerator access.
+- Gang and accelerator-aware scheduling.
+- Prometheus reachability for AI service metrics.
+- Dynamo platform health, including operator readiness.
+- NATS reachability for the Kubernetes KV event plane.
+- Gateway / EPP resources when validating the Kubernetes-native ingress path.
+- Autoscaling prerequisites where the selected recipe requires them.
+
+This validation is the main reason to use AICR instead of starting from raw Helm commands. It turns
+"install the charts" into "install this versioned runtime and prove the cluster satisfies the recipe."
+
+## Where This Fits
+
+AICR is not a Kubernetes distribution and not a cluster provisioner. It assumes a GPU Kubernetes
+cluster already exists. Its job is to provide the validated runtime configuration between that cluster
+and the Dynamo serving graph.
+
+That boundary is useful for platform teams. The cloud, GPU, OS, scheduler, health, observability, and
+Gateway choices become recipe inputs. Dynamo arrives with the matching operator, runtime images, NATS
+event plane, and graph API. The application team still owns the model and serving graph, but it starts
+from a cluster runtime that has already been checked for Dynamo.
+
+For teams bringing up Dynamo on Kubernetes, that is the fast path: select the AICR Dynamo recipe,
+validate the cluster, deploy the bundle, then run the graph.

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -34,10 +34,10 @@ Editorial title direction:
   keep that clarification in the body.
 -->
 
-Running Dynamo on Kubernetes starts with a `DynamoGraphDeployment`, but the graph is only the top of
-the stack. A production inference cluster also needs GPU drivers, device discovery, scheduling,
-health signals, observability, Gateway API resources, and the event transport that lets KV-aware
-routing see live cache state.
+Running a model with Dynamo on Kubernetes starts with a `DynamoGraphDeployment`, but the graph is
+only the top of the stack. A production inference cluster also needs GPU drivers, device discovery,
+scheduling, health signals, observability, Gateway API resources, and the event transport that lets
+KV-aware routing see live cache state.
 
 [NVIDIA AI Cluster Runtime (AICR)](https://github.com/NVIDIA/aicr) packages the lower stack as a
 validated, version-locked recipe. You bring an existing GPU Kubernetes cluster. AICR captures its

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -200,12 +200,26 @@ aicr recipe \
   --output recipe.yaml
 ```
 
-Validate the recipe against the snapshot before installing anything:
+Because that recipe was selected from `snapshot.yaml`, validating the same recipe against the same
+snapshot is not the interesting check: recipe selection already used those facts. Pre-install
+validation is useful when the recipe came from elsewhere, when it was generated from explicit
+criteria, or when you want to prove it against the live cluster. To check the recipe against the
+current cluster before installing the bundle, omit `--snapshot` and `--no-cluster`:
 
 ```bash
 aicr validate \
   --recipe recipe.yaml \
-  --snapshot snapshot.yaml \
+  --phase deployment \
+  --output preflight.json
+```
+
+To compare the recipe against a different captured cluster without touching that cluster, validate
+against a different snapshot in `--no-cluster` mode:
+
+```bash
+aicr validate \
+  --recipe recipe.yaml \
+  --snapshot candidate-snapshot.yaml \
   --no-cluster \
   --phase deployment \
   --output dry-run.json

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -146,47 +146,68 @@ plane. In the Kubernetes AICR path, that event plane is NATS.
 
 ## Two Routing Paths
 
-AICR's Dynamo recipe covers both Dynamo 1.2 Kubernetes routing paths because they solve different
-operational problems.
+AICR's Dynamo recipe covers two Kubernetes routing paths. Both use Dynamo's token-aware KV router,
+the NATS-backed KV event plane, and the same worker runtime. The choice is not KV-aware versus
+load-aware routing. It is whether the Dynamo frontend or the Kubernetes Gateway layer owns ingress
+and delivers the request to the selected worker.
 
-### Path 1: Direct Dynamo Frontend
+### Path 1: Dynamo Router
 
-The default path is the **Dynamo frontend router**. A `Frontend` component runs with
-`DYN_ROUTER_MODE=kv`, receives OpenAI-compatible requests, tokenizes prompts, subscribes to worker KV
-events, and chooses a worker based on cache overlap and load. This path keeps the user-facing service
-inside the Dynamo graph and is the shortest route for validating Dynamo itself.
+The default path exposes a Dynamo `Frontend` component behind a Kubernetes Service. It runs with
+`DYN_ROUTER_MODE=kv`, receives OpenAI-compatible requests, tokenizes prompts, consumes worker KV
+events, and chooses a worker from cache overlap and load. It then sends the request to that worker on
+the Dynamo request plane, which defaults to TCP.
+
+Choose this path when an application team owns a model-specific endpoint, or when an existing edge
+proxy only needs to forward traffic to the Dynamo frontend Service. It is the smallest topology for
+bringing up and validating a Dynamo graph, and remains a production serving option. It does not need
+Gateway API inference resources, an EPP, or per-worker frontend sidecars.
 
 ```mermaid
 flowchart LR
     Client["Client\nOpenAI-compatible HTTP"] --> Service["Kubernetes Service\nvllm-agg-frontend"]
     Service --> Frontend["Dynamo Frontend\nDYN_ROUTER_MODE=kv"]
-    Frontend -->|"tokenize + score\nKV overlap / load"| Router["Dynamo router\ncache-aware placement"]
-    Router -->|"request plane\nTCP by default"| Worker["vLLM worker"]
+    Frontend -->|"tokenize + KV score\nrequest plane: TCP by default"| Worker["vLLM worker"]
 
     Worker -.->|"local ZMQ\nraw KV events"| Publisher["Dynamo worker\nKV publisher"]
     Publisher -.->|"NATS-backed\nKV event plane"| Frontend
 ```
 
-### Path 2: Gateway / EPP
+### Path 2: GAIE / EPP
 
-The Kubernetes-native ingress path is **Gateway / EPP**. In that mode, traffic flows through
-[agentgateway](https://github.com/agentgateway/agentgateway), the Kubernetes
-[Gateway API](https://github.com/kubernetes-sigs/gateway-api), an `HTTPRoute`, and a
-[GAIE](https://github.com/kubernetes-sigs/gateway-api-inference-extension) `InferencePool`. Dynamo
-natively integrates with that path: the Dynamo operator reconciles a `DynamoGraphDeployment`
-component of type `epp`, generates the matching `InferencePool`, and runs the EPP that performs
-endpoint selection with Dynamo's KV-aware scoring. Worker frontend sidecars run in
-`--router-mode direct`, so they honor the worker chosen by the EPP instead of making another
-placement decision. This path matters when the platform team wants model-aware routing at the
-Kubernetes Gateway layer while keeping Dynamo's cache-aware selection logic.
+The Kubernetes-native ingress path uses the [Gateway API](https://github.com/kubernetes-sigs/gateway-api)
+and [Gateway API Inference Extension (GAIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension).
+In the AICR example, [agentgateway](https://github.com/agentgateway/agentgateway) resolves an
+`HTTPRoute` to an `InferencePool`. The Dynamo operator reconciles an `epp` component in the
+`DynamoGraphDeployment` and generates that `InferencePool`, which identifies the worker pods and
+the EPP service.
+
+The Gateway calls the EPP through the GAIE endpoint-picker protocol. The EPP tokenizes the request,
+uses Dynamo's KV router and the same live KV events to select a worker, then returns the selected
+endpoint and worker identifiers to the Gateway. The Gateway sends the model request directly to the
+selected worker frontend sidecar. The EPP does not proxy request or response traffic. That sidecar
+runs with `--router-mode direct`, so it honors the EPP selection instead of making a second routing
+decision.
+
+Choose this path when the platform team owns a shared Kubernetes ingress and needs model endpoints
+to participate in its Gateway and `HTTPRoute` workflow. The trade-off is a larger operational
+surface: a GAIE-compatible Gateway implementation, Gateway API and GAIE resources, an EPP, and
+worker frontend sidecars.
+
+> [!NOTE]
+> This article uses GAIE's supported operator-managed `DynamoGraphDeployment` path. It is not the
+> experimental vanilla vLLM on-ramp, where the EPP subscribes directly to per-pod ZMQ events and
+> rebuilds an empty cache index after restart. The AICR path retains the Dynamo NATS/JetStream event
+> plane, so the EPP receives routing-state snapshots and subsequent worker updates.
 
 ```mermaid
 flowchart LR
     Client["Client\nOpenAI-compatible HTTP"] --> Gateway["agentgateway\nGateway API data plane"]
     Gateway --> Route["HTTPRoute"]
-    Route --> Pool["InferencePool\nGAIE"]
-    Pool --> EPP["Dynamo EPP\nKV-aware endpoint picker"]
-    EPP -->|"selected endpoint"| Sidecar["Worker frontend sidecar\n--router-mode direct"]
+    Route --> Pool["InferencePool\nworker eligibility + EPP reference"]
+    Gateway -.->|"GAIE endpoint-picker call"| EPP["Dynamo EPP\ntoken-aware KV selection"]
+    EPP -.->|"selected endpoint +\nworker IDs"| Gateway
+    Gateway --> Sidecar["Worker frontend sidecar\n--router-mode direct"]
     Sidecar -->|"request plane\nTCP by default"| Worker["vLLM worker"]
 
     Worker -.->|"local ZMQ\nraw KV events"| Publisher["Dynamo worker\nKV publisher"]
@@ -197,9 +218,18 @@ flowchart LR
     Operator -.->|"runs"| EPP
 ```
 
-Both paths depend on the same principle: workers must publish live KV cache events. Without live
-events, Dynamo can fall back to approximate routing, but that is not the validated AICR path for
-cache-aware placement.
+### Choosing a Path
+
+| Decision | Dynamo Router | GAIE / EPP |
+| --- | --- | --- |
+| **Ingress owner** | Dynamo frontend Service | Gateway and `HTTPRoute` |
+| **Worker selection** | Frontend selects and dispatches to a worker | Gateway asks the EPP; the EPP returns the selected endpoint and worker identifiers |
+| **Best fit** | A model-specific Dynamo endpoint with the smallest serving topology | A shared Kubernetes ingress expressed through Gateway and `HTTPRoute` resources |
+| **Additional infrastructure** | None beyond the Dynamo frontend and workers | GAIE-compatible Gateway, `InferencePool`, EPP, and worker frontend sidecars |
+| **KV-cache behavior** | Token-aware KV scoring from live worker events | The same token-aware KV scoring from the same live worker events |
+
+Both paths require workers to publish live KV cache events. Without them, Dynamo can fall back to
+approximate routing, but that is not the validated AICR path for cache-aware placement.
 
 ## Recipe Flow
 

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -217,7 +217,9 @@ aicr validate \
 The full live validation happens after deployment, when AICR can also check that the runtime was
 installed as expected.
 
-Render the deployment bundle with the node placement rules for system and GPU workloads:
+Render the deployment bundle with the node placement rules for system and GPU workloads. The
+selectors and tolerations are cluster-specific: use the labels and taints from your Kubernetes
+nodes, not these example values verbatim.
 
 ```bash
 aicr bundle \

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -42,13 +42,14 @@ routing see live cache state.
 [NVIDIA AI Cluster Runtime (AICR)](https://github.com/NVIDIA/aicr) packages the lower stack as a
 validated, version-locked recipe. You bring an existing GPU Kubernetes cluster. AICR captures its
 state, selects a matching recipe, validates the constraints, and renders a deployable bundle. For
-Dynamo users, that makes AICR a fast path from "I have GPUs in Kubernetes" to "I have a validated
-Dynamo 1.2 runtime."
+Dynamo users, that makes AICR a fast path from "I have GPUs in Kubernetes" to "I have a full,
+validated Dynamo 1.2 inference runtime stack."
 
 ## Why the Runtime Below Dynamo Matters
 
 Dynamo coordinates inference across multiple components: frontends, routers, workers, the Dynamo
-operator, and optional Gateway API Inference Extension (GAIE) / Endpoint Picker Plugin (EPP)
+operator, and optional
+[Gateway API Inference Extension (GAIE) / Endpoint Picker Plugin (EPP)](../kubernetes/inference-gateway.md)
 components. Those components depend on cluster-level services that must agree on Kubernetes version,
 driver stack, GPU allocation model, scheduling policy, node health, metrics, and network reachability.
 
@@ -94,14 +95,25 @@ repeatable.
 
 ## Dynamo 1.2 in the Recipe
 
-Dynamo 1.2 is the right baseline for the AICR path because it aligns the Kubernetes deployment model
-around the v1beta1 graph API, Kubernetes discovery, the Dynamo platform chart, and NATS-backed event
-delivery for KV-aware routing.
+Dynamo 1.2 is the stable release where the `DynamoGraphDeployment` API has moved from alpha to a
+more production-oriented `nvidia.com/v1beta1` API. AICR uses that API as the recipe boundary for the
+serving graph, while the `dynamo-platform` chart provides the operator, CRDs, NATS, and supporting
+control-plane services.
 
-In the AICR Dynamo recipe, Kubernetes discovery is the expected path. That means Dynamo components
-discover each other through Kubernetes resources instead of an etcd deployment. The `dynamo-platform`
-chart still installs NATS because the event plane is separate from discovery: KV-aware routing needs
-live worker cache events, and the validated Kubernetes path uses NATS for those events.
+Dynamo is Kubernetes-native in this path. Frontends, vLLM workers, EPP components, and other Dynamo
+services discover each other through Kubernetes resources instead of an etcd deployment. The
+`dynamo-platform` chart still installs NATS because the event plane is separate from discovery:
+KV-aware routing needs live worker cache events, and the validated Kubernetes path uses NATS for
+those events.
+
+KV-aware routing is one of the main reasons to run Dynamo. Agentic workloads repeatedly append to a
+long prefix: system prompt, tool definitions, conversation history, tool results, and generated
+reasoning. If each turn lands on a worker that does not already hold the prefix, the system
+recomputes the same tokens again and again. Cache-aware placement keeps turns close to the workers
+that already hold their KV blocks. Together with disaggregated serving, this changes the shape of
+many long-running token workloads from repeated prefix recomputation toward reuse of already computed
+state. For sessions whose prompt grows turn by turn, that moves the dominant prefill work from
+quadratic growth toward linear reuse.
 
 > [!IMPORTANT]
 > The request plane and the KV event plane are separate. In Dynamo 1.2, the request plane defaults
@@ -116,8 +128,7 @@ That distinction matters for vLLM. A vLLM worker may include a setting like:
 
 That ZMQ publisher is the local vLLM engine event source. Dynamo reads those raw local KV events from
 the worker, normalizes them, and republishes them onto the Dynamo event plane. In the Kubernetes AICR
-path, that event plane is NATS. The recipe should not set `DYN_EVENT_PLANE=zmq` for the Dynamo
-runtime unless it is intentionally leaving the validated Kubernetes event-plane path.
+path, that event plane is NATS.
 
 ## Two Routing Paths
 
@@ -129,12 +140,30 @@ The default path is the **Dynamo frontend router**. A `Frontend` component runs 
 events, and chooses a worker based on cache overlap and load. This path keeps the user-facing service
 inside the Dynamo graph and is the shortest route for validating Dynamo itself.
 
+```mermaid
+flowchart LR
+    Client["Client"] -->|"OpenAI-compatible request"| Frontend["Dynamo Frontend\nDYN_ROUTER_MODE=kv"]
+    Frontend -->|"request plane\nTCP by default"| Worker["vLLM worker"]
+    Worker -.->|"local ZMQ\nraw KV events"| Publisher["Dynamo worker\nKV publisher"]
+    Publisher -.->|"NATS-backed\nKV event plane"| Frontend
+```
+
 The Kubernetes-native ingress path is **Gateway / EPP**. In that mode, traffic flows through the
 Kubernetes Gateway API and an InferencePool. The EPP performs endpoint selection using Dynamo's
 KV-aware scoring. Worker frontend sidecars run in `--router-mode direct`, so they honor the worker
 chosen by the EPP instead of making another placement decision. This path matters when the platform
 team wants model-aware routing at the Kubernetes Gateway layer while keeping Dynamo's cache-aware
 selection logic.
+
+```mermaid
+flowchart LR
+    Client["Client"] -->|"HTTP"| Gateway["Kubernetes Gateway"]
+    Gateway -->|"InferencePool"| EPP["Dynamo EPP\nKV-aware selection"]
+    EPP -->|"chosen worker"| Sidecar["Worker frontend sidecar\n--router-mode direct"]
+    Sidecar --> Worker["vLLM worker"]
+    Worker -.->|"local ZMQ\nraw KV events"| Publisher["Dynamo worker\nKV publisher"]
+    Publisher -.->|"NATS-backed\nKV event plane"| EPP
+```
 
 Both paths depend on the same principle: workers must publish live KV cache events. Without live
 events, Dynamo can fall back to approximate routing, but that is not the validated AICR path for

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -272,7 +272,9 @@ aicr bundle \
 
 ### 5. Deploy the Runtime
 
-Deploy the rendered bundle with the deployer that fits your environment:
+`deploy.sh` is the fastest path to a working deployment and keeps this walkthrough approachable.
+For production environments, AICR also supports the more mature, recommended GitOps deployment
+paths through Argo CD and Flux.
 
 ```bash
 cd bundle

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "From Kubernetes to Datacenter-Scale Inference with NVIDIA Dynamo and AICR"
 sidebar-title: Deploying Dynamo with AICR
-subtitle: "Stefan Schimanski and Yuan Chen - June 2026"
+subtitle: "How NVIDIA AI Cluster Runtime turns GPU Kubernetes into a validated, production-ready inference platform for Dynamo."
 description: "How NVIDIA AI Cluster Runtime turns an existing GPU Kubernetes cluster into a validated Dynamo inference stack."
 keywords: Dynamo, NVIDIA AI Cluster Runtime, AICR, Kubernetes, GPU Operator, EPP, NATS, KV cache routing, vLLM
 last-updated: June 11, 2026

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "Deploying Dynamo 1.2 with NVIDIA AI Cluster Runtime"
 sidebar-title: Deploying Dynamo with AICR
-subtitle: "A validated Kubernetes runtime path for Dynamo inference - June 2026"
+subtitle: "Stefan Schimanski and Yuan Chen - June 2026"
 description: "How NVIDIA AI Cluster Runtime packages Dynamo 1.2 with the GPU, scheduling, health, observability, and routing components needed for Kubernetes inference."
 keywords: Dynamo, NVIDIA AI Cluster Runtime, AICR, Kubernetes, GPU Operator, EPP, NATS, KV cache routing, vLLM
 last-updated: June 11, 2026

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -289,9 +289,13 @@ curl http://localhost:8000/v1/chat/completions \
 ```
 
 AICR inference recipes also install `agentgateway` and an `inference-gateway` Gateway in the
-`agentgateway-system` namespace. The `vllm-agg` example above uses the direct frontend path; for the
-Gateway / EPP path, deploy a workload that creates the EPP component, `InferencePool`, and
-`HTTPRoute`, then send the same OpenAI-compatible requests through the Gateway address:
+`agentgateway-system` namespace. `agentgateway` is the Gateway API data plane, not the Dynamo EPP.
+The Dynamo EPP comes from a `DynamoGraphDeployment` component of type `epp`; the Dynamo operator
+generates the matching `InferencePool`, and the Gateway path uses an `HTTPRoute` that references
+that pool, as described in the
+[Gateway API Inference Extension guide](../kubernetes/inference-gateway.md). The `vllm-agg` example
+above uses the direct frontend path. For a Gateway / EPP workload, send the same OpenAI-compatible
+requests through the Gateway address:
 
 ```bash
 kubectl get gateway inference-gateway -n agentgateway-system
@@ -299,6 +303,10 @@ kubectl get inferencepool,httproute -n dynamo-workload
 
 GATEWAY_HOST=$(kubectl get gateway inference-gateway -n agentgateway-system -o jsonpath='{.status.addresses[0].value}')
 curl "http://${GATEWAY_HOST}/v1/models"
+
+curl "http://${GATEWAY_HOST}/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello from AICR Dynamo through Gateway / EPP"}],"max_tokens":30,"stream":false}'
 ```
 
 For the Gateway / EPP path, also verify the EPP pod and worker frontend sidecars.

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -203,9 +203,13 @@ cache-aware placement.
 
 ## Recipe Flow
 
-The AICR flow has four phases: snapshot, recipe, validate, and bundle.
+The AICR flow separates runtime bring-up from workload testing. First, capture the cluster, select a
+recipe, validate it, render and deploy the runtime bundle, and validate the installed runtime. Only
+then install a `DynamoGraphDeployment` and run end-to-end API checks against that workload.
 
-First, capture the current cluster state:
+### 1. Snapshot the Cluster
+
+Capture the current cluster state:
 
 ```bash
 aicr snapshot \
@@ -216,9 +220,11 @@ aicr snapshot \
   --output snapshot.yaml
 ```
 
-Then let AICR select the Dynamo inference recipe from the snapshot. The snapshot supplies the
-cluster facts, such as the Kubernetes service, GPU accelerator, GPU count, and node OS. You provide
-the workload intent and platform you want to install:
+### 2. Select the Dynamo Recipe
+
+Let AICR select the Dynamo inference recipe from the snapshot. The snapshot supplies the cluster
+facts, such as the Kubernetes service, GPU accelerator, GPU count, and node OS. You provide the
+workload intent and platform you want to install:
 
 ```bash
 aicr recipe \
@@ -227,6 +233,8 @@ aicr recipe \
   --platform dynamo \
   --output recipe.yaml
 ```
+
+### 3. Validate Before Deployment
 
 Because that recipe was selected from `snapshot.yaml`, validating the same recipe against the same
 snapshot is not the interesting check: recipe selection already used those facts. Offline validation
@@ -242,8 +250,7 @@ aicr validate \
   --output dry-run.json
 ```
 
-The full live validation happens after deployment, when AICR can also check that the runtime was
-installed as expected.
+### 4. Render the Runtime Bundle
 
 Render the deployment bundle with the node placement rules for system and GPU workloads. The
 selectors and tolerations are cluster-specific: use the labels and taints from your Kubernetes
@@ -263,6 +270,8 @@ aicr bundle \
   --output bundle
 ```
 
+### 5. Deploy the Runtime
+
 Deploy the rendered bundle with the deployer that fits your environment:
 
 ```bash
@@ -271,7 +280,10 @@ chmod +x deploy.sh
 ./deploy.sh
 ```
 
-After the runtime is installed, run validation against the live cluster:
+### 6. Validate the Installed Runtime
+
+After the runtime is installed, run validation against the live cluster before installing a Dynamo
+workload:
 
 ```bash
 aicr validate \
@@ -282,8 +294,33 @@ aicr validate \
   --output report.json
 ```
 
-At this point, the bundle has installed the validated runtime under Dynamo. The remaining step is to
-apply a Dynamo workload, such as the vLLM aggregation example in the
+The full live validation happens after deployment, when AICR can also check that the runtime was
+installed as expected.
+
+## What Does Validate Check?
+
+AICR validation gives the Dynamo deployment a concrete runtime contract. A Dynamo inference recipe can
+check that the cluster has:
+
+- The expected Kubernetes service, accelerator, operating system, and workload intent.
+- GPU Operator health and accelerator metrics.
+- DRA support for GPU allocation.
+- Secure accelerator access.
+- Gang and accelerator-aware scheduling.
+- Prometheus reachability for AI service metrics.
+- Dynamo platform health, including operator readiness.
+- NATS reachability for the Kubernetes KV event plane.
+- Gateway API and agentgateway prerequisites when validating the Kubernetes-native ingress path.
+- Autoscaling prerequisites where the selected recipe requires them.
+
+This validation is the main reason to use AICR instead of starting from raw
+[Helm](https://helm.sh/) commands. It turns "install the charts" into "install this versioned runtime
+and prove the cluster satisfies the recipe."
+
+## Deploying a Model with Dynamo
+
+At this point, the bundle has installed and validated the runtime under Dynamo. Now apply a Dynamo
+workload, such as the vLLM aggregation example in the
 [AICR repository](https://github.com/NVIDIA/aicr/tree/main/demos/workloads/inference), and watch the
 `DynamoGraphDeployment` converge.
 
@@ -297,6 +334,13 @@ kubectl apply -f https://raw.githubusercontent.com/NVIDIA/aicr/refs/heads/main/d
 kubectl get dynamographdeployments -n dynamo-workload
 kubectl get pods -n dynamo-workload -o wide -w
 ```
+
+## Testing the OpenAI API
+
+The following checks are end-to-end workload smoke tests. They prove that the deployed
+`DynamoGraphDeployment` is serving OpenAI-compatible requests through the chosen routing path.
+
+### Direct Dynamo Frontend
 
 For the default Dynamo-router path, call the OpenAI-compatible API through the Dynamo frontend
 service:
@@ -316,6 +360,8 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello from AICR Dynamo"}],"max_tokens":30,"stream":false}'
 ```
 
+### Gateway / EPP
+
 AICR inference recipes also install [agentgateway](https://github.com/agentgateway/agentgateway) and
 an `inference-gateway` Gateway in the `agentgateway-system` namespace. `agentgateway` is the
 Gateway API data plane, not the Dynamo EPP. The Dynamo EPP comes from a `DynamoGraphDeployment`
@@ -323,7 +369,11 @@ component of type `epp`; the Dynamo operator generates the matching `InferencePo
 path uses an `HTTPRoute` that references that pool, as described in the
 [Gateway API Inference Extension guide](../kubernetes/inference-gateway.md). That is native Dynamo
 integration with GAIE: Gateway stays Kubernetes-native at ingress, while Dynamo owns the cache-aware
-endpoint selection. The `vllm-agg` example above uses the direct frontend path. For a Gateway / EPP
+endpoint selection.
+
+The `vllm-agg` example above uses the direct frontend path. To exercise the Gateway / EPP path, use
+an EPP-enabled `DynamoGraphDeployment` and `HTTPRoute`, such as the GAIE examples linked from the
+[Inference Gateway deploy guide](../kubernetes/inference-gateway.md#5-deploy). For a Gateway / EPP
 workload, send the same OpenAI-compatible requests through the Gateway address:
 
 ```bash
@@ -346,26 +396,6 @@ curl "http://${GATEWAY_HOST}/v1/chat/completions" \
 ```
 
 For the Gateway / EPP path, also verify the EPP pod and worker frontend sidecars.
-
-## What Validation Covers
-
-AICR validation gives the Dynamo deployment a concrete runtime contract. A Dynamo inference recipe can
-check that the cluster has:
-
-- The expected Kubernetes service, accelerator, operating system, and workload intent.
-- GPU Operator health and accelerator metrics.
-- DRA support for GPU allocation.
-- Secure accelerator access.
-- Gang and accelerator-aware scheduling.
-- Prometheus reachability for AI service metrics.
-- Dynamo platform health, including operator readiness.
-- NATS reachability for the Kubernetes KV event plane.
-- Gateway / EPP resources when validating the Kubernetes-native ingress path.
-- Autoscaling prerequisites where the selected recipe requires them.
-
-This validation is the main reason to use AICR instead of starting from raw
-[Helm](https://helm.sh/) commands. It turns "install the charts" into "install this versioned runtime
-and prove the cluster satisfies the recipe."
 
 ## Where This Fits
 

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -219,7 +219,8 @@ installed as expected.
 
 Render the deployment bundle with the node placement rules for system and GPU workloads. The
 selectors and tolerations are cluster-specific: use the labels and taints from your Kubernetes
-nodes, not these example values verbatim.
+nodes, not these example values verbatim. If the recipe components need persistent volumes, set
+`--storage-class` to a StorageClass that exists in the target cluster.
 
 ```bash
 aicr bundle \
@@ -230,6 +231,7 @@ aicr bundle \
   --system-node-selector nodeGroup=system-worker \
   --system-node-toleration dedicated=system-workload:NoSchedule \
   --system-node-toleration dedicated=system-workload:NoExecute \
+  --storage-class <storage-class> \
   --output bundle
 ```
 

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -238,6 +238,15 @@ aicr recipe \
   --output recipe.yaml
 ```
 
+The generated recipe defaults its `inference-routing-mode` performance constraint to `dynamo-router`.
+To validate the GAIE / EPP path instead, change the existing constraint in `recipe.yaml` before running
+performance validation:
+
+```yaml
+- name: inference-routing-mode
+  value: gateway-epp
+```
+
 ### 3. Validate Before Deployment
 
 Because that recipe was selected from `snapshot.yaml`, validating the same recipe against the same
@@ -288,20 +297,21 @@ chmod +x deploy.sh
 
 ### 6. Validate the Installed Runtime
 
-After the runtime is installed, run validation against the live cluster before installing a Dynamo
-workload:
+After the runtime is installed, run deployment and conformance validation against the live cluster
+before installing a Dynamo workload:
 
 ```bash
 aicr validate \
   --recipe recipe.yaml \
   --toleration dedicated=worker-workload:NoSchedule \
   --toleration dedicated=worker-workload:NoExecute \
-  --phase all \
+  --phase deployment \
+  --phase conformance \
   --output report.json
 ```
 
-The full live validation happens after deployment, when AICR can also check that the runtime was
-installed as expected.
+Run `--phase performance` separately when you want to benchmark inference. That phase deploys a
+temporary `DynamoGraphDeployment` and AIPerf Job, consumes GPUs, and can run for up to 65 minutes.
 
 #### What Does Validate Check?
 
@@ -380,7 +390,8 @@ endpoint selection.
 The `vllm-agg` example above uses the direct frontend path. To exercise the Gateway / EPP path, apply
 the companion [vLLM aggregation EPP manifest](deploying-dynamo-with-aicr-vllm-agg-epp.yaml). It
 creates an EPP-enabled `DynamoGraphDeployment` and an `HTTPRoute` that points at the operator-created
-`InferencePool`:
+`InferencePool`. The route uses `vllm-agg-epp.example.com` so it remains distinct from other workloads
+on the shared Gateway; replace that hostname with one owned by your deployment:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/ai-dynamo/dynamo/refs/heads/main/docs/digest/deploying-dynamo-with-aicr-vllm-agg-epp.yaml
@@ -402,9 +413,13 @@ found`.
 
 ```bash
 GATEWAY_HOST=$(kubectl get gateway inference-gateway -n agentgateway-system -o jsonpath='{.status.addresses[0].value}')
-curl "http://${GATEWAY_HOST}/v1/models"
+ROUTE_HOST=vllm-agg-epp.example.com
+
+curl "http://${GATEWAY_HOST}/v1/models" \
+  -H "Host: ${ROUTE_HOST}"
 
 curl "http://${GATEWAY_HOST}/v1/chat/completions" \
+  -H "Host: ${ROUTE_HOST}" \
   -H "Content-Type: application/json" \
   -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello from AICR Dynamo through Gateway / EPP"}],"max_tokens":30,"stream":false}'
 ```

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -329,7 +329,14 @@ workload, send the same OpenAI-compatible requests through the Gateway address:
 ```bash
 kubectl get gateway inference-gateway -n agentgateway-system
 kubectl get inferencepool,httproute -n dynamo-workload
+```
 
+Only continue with the Gateway call when the workload has an `InferencePool` and `HTTPRoute`. If the
+second command returns `No resources found`, the direct frontend path is working as expected for the
+`vllm-agg` example, but the Gateway has no route for that workload and will return `404 route not
+found`.
+
+```bash
 GATEWAY_HOST=$(kubectl get gateway inference-gateway -n agentgateway-system -o jsonpath='{.status.addresses[0].value}')
 curl "http://${GATEWAY_HOST}/v1/models"
 

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -201,20 +201,9 @@ aicr recipe \
 ```
 
 Because that recipe was selected from `snapshot.yaml`, validating the same recipe against the same
-snapshot is not the interesting check: recipe selection already used those facts. Pre-install
-validation is useful when the recipe came from elsewhere, when it was generated from explicit
-criteria, or when you want to prove it against the live cluster. To check the recipe against the
-current cluster before installing the bundle, omit `--snapshot` and `--no-cluster`:
-
-```bash
-aicr validate \
-  --recipe recipe.yaml \
-  --phase deployment \
-  --output preflight.json
-```
-
-To compare the recipe against a different captured cluster without touching that cluster, validate
-against a different snapshot in `--no-cluster` mode:
+snapshot is not the interesting check: recipe selection already used those facts. Offline validation
+is useful when the recipe came from elsewhere, when it was generated from explicit criteria, or when
+you want to compare it with a different captured cluster without touching that cluster:
 
 ```bash
 aicr validate \
@@ -224,6 +213,9 @@ aicr validate \
   --phase deployment \
   --output dry-run.json
 ```
+
+The full live validation happens after deployment, when AICR can also check that the runtime was
+installed as expected.
 
 Render the deployment bundle with the node placement rules for system and GPU workloads:
 

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -9,31 +9,6 @@ keywords: Dynamo, NVIDIA AI Cluster Runtime, AICR, Kubernetes, GPU Operator, EPP
 last-updated: June 11, 2026
 ---
 
-<!--
-Editorial title direction:
-
-- Chosen title:
-  From Kubernetes to Datacenter-Scale Inference with NVIDIA Dynamo and AICR
-- Original direction:
-  From empty Kubernetes to datacenter-scale inference: with NVIDIA Dynamo and NVIDIA AICR Optimized Kubernetes Runtime.
-- Shorter variants considered:
-  - From GPU Kubernetes to Dynamo Inference with AICR
-  - Fast-Tracking Dynamo Inference on Kubernetes with AICR
-  - Dynamo on Kubernetes, Validated by AICR
-  - A Validated Path to Dynamo Inference on Kubernetes
-  - From Kubernetes Cluster to Dynamo Stack with AICR
-  - Deploying the Full Dynamo Stack with AICR
-  - Dynamo Inference on NVIDIA's Validated Kubernetes Runtime
-  - The Fast Path to Dynamo on Kubernetes
-  - AICR: The Validated Runtime Path for Dynamo on Kubernetes
-- Subtitle/narrative direction:
-  NVIDIA AI Cluster Runtime provides the optimized and validated Kubernetes runtime below Dynamo,
-  from GPU operators and node health to NATS, scheduling, observability, and Gateway/EPP routing.
-- Wording constraint:
-  Avoid rendering "empty Kubernetes" as-is because AICR assumes an existing GPU Kubernetes cluster;
-  keep that clarification in the body.
--->
-
 Running a model with [Dynamo](https://github.com/ai-dynamo/dynamo) on
 [Kubernetes](https://kubernetes.io/) starts with a `DynamoGraphDeployment`, but the graph is only the
 top of the stack. A production inference cluster also needs GPU drivers, device discovery,
@@ -50,11 +25,10 @@ validated Dynamo 1.2 inference runtime stack."
 ## Why the Runtime Below Dynamo Matters
 
 Dynamo coordinates inference across multiple components: frontends, routers, workers, the Dynamo
-operator, and optional [Gateway API](https://github.com/kubernetes-sigs/gateway-api)
-[Inference Extension (GAIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) /
-[Endpoint Picker Plugin (EPP)](../kubernetes/inference-gateway.md) components. Those components
-depend on cluster-level services that must agree on Kubernetes version, driver stack, GPU allocation
-model, scheduling policy, node health, metrics, and network reachability.
+operator, and optional [Gateway API Inference Extension (GAIE) / Endpoint Picker Plugin (EPP)
+components](../kubernetes/gateway-api/README.mdx). Those components depend on cluster-level services
+that must agree on Kubernetes version, driver stack, GPU allocation model, scheduling policy, node
+health, metrics, and network reachability.
 
 A hand-written Dynamo manifest can start the serving graph, but it does not answer questions like:
 
@@ -399,7 +373,7 @@ an `inference-gateway` Gateway in the `agentgateway-system` namespace. `agentgat
 Gateway API data plane, not the Dynamo EPP. The Dynamo EPP comes from a `DynamoGraphDeployment`
 component of type `epp`; the Dynamo operator generates the matching `InferencePool`, and the Gateway
 path uses an `HTTPRoute` that references that pool, as described in the
-[Gateway API Inference Extension guide](../kubernetes/inference-gateway.md). That is native Dynamo
+[Gateway API Inference Extension overview](../kubernetes/gateway-api/README.mdx). That is native Dynamo
 integration with GAIE: Gateway stays Kubernetes-native at ingress, while Dynamo owns the cache-aware
 endpoint selection.
 

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -1,13 +1,38 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: "Deploying Dynamo 1.2 with NVIDIA AI Cluster Runtime"
+title: "From Kubernetes to Datacenter-Scale Inference with NVIDIA Dynamo and AICR"
 sidebar-title: Deploying Dynamo with AICR
 subtitle: "Stefan Schimanski and Yuan Chen - June 2026"
-description: "How NVIDIA AI Cluster Runtime packages Dynamo 1.2 with the GPU, scheduling, health, observability, and routing components needed for Kubernetes inference."
+description: "How NVIDIA AI Cluster Runtime turns an existing GPU Kubernetes cluster into a validated Dynamo inference stack."
 keywords: Dynamo, NVIDIA AI Cluster Runtime, AICR, Kubernetes, GPU Operator, EPP, NATS, KV cache routing, vLLM
 last-updated: June 11, 2026
 ---
+
+<!--
+Editorial title direction:
+
+- Chosen title:
+  From Kubernetes to Datacenter-Scale Inference with NVIDIA Dynamo and AICR
+- Original direction:
+  From empty Kubernetes to datacenter-scale inference: with NVIDIA Dynamo and NVIDIA AICR Optimized Kubernetes Runtime.
+- Shorter variants considered:
+  - From GPU Kubernetes to Dynamo Inference with AICR
+  - Fast-Tracking Dynamo Inference on Kubernetes with AICR
+  - Dynamo on Kubernetes, Validated by AICR
+  - A Validated Path to Dynamo Inference on Kubernetes
+  - From Kubernetes Cluster to Dynamo Stack with AICR
+  - Deploying the Full Dynamo Stack with AICR
+  - Dynamo Inference on NVIDIA's Validated Kubernetes Runtime
+  - The Fast Path to Dynamo on Kubernetes
+  - AICR: The Validated Runtime Path for Dynamo on Kubernetes
+- Subtitle/narrative direction:
+  NVIDIA AI Cluster Runtime provides the optimized and validated Kubernetes runtime below Dynamo,
+  from GPU operators and node health to NATS, scheduling, observability, and Gateway/EPP routing.
+- Wording constraint:
+  Avoid rendering "empty Kubernetes" as-is because AICR assumes an existing GPU Kubernetes cluster;
+  keep that clarification in the body.
+-->
 
 Running Dynamo on Kubernetes starts with a `DynamoGraphDeployment`, but the graph is only the top of
 the stack. A production inference cluster also needs GPU drivers, device discovery, scheduling,

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -259,8 +259,12 @@ apply a Dynamo workload, such as the vLLM aggregation example in the
 [AICR repository](https://github.com/NVIDIA/aicr/tree/main/demos/workloads/inference), and watch the
 `DynamoGraphDeployment` converge.
 
+The example manifest assumes specific node labels, including `nodeGroup=cpu-worker`. If your cluster
+uses different labels, such as `nodeGroup=system-worker`, adapt the `DynamoGraphDeployment` node
+selectors before applying it.
+
 ```bash
-kubectl apply -f demos/workloads/inference/vllm-agg.yaml
+kubectl apply -f https://raw.githubusercontent.com/NVIDIA/aicr/refs/heads/main/demos/workloads/inference/vllm-agg.yaml
 kubectl get dynamographdeployments -n dynamo-workload
 kubectl get pods -n dynamo-workload -o wide -w
 ```

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -188,14 +188,14 @@ aicr snapshot \
   --output snapshot.yaml
 ```
 
-Then select the Dynamo inference recipe for the target environment:
+Then let AICR select the Dynamo inference recipe from the snapshot. The snapshot supplies the
+cluster facts, such as the Kubernetes service, GPU accelerator, GPU count, and node OS. You provide
+the workload intent and platform you want to install:
 
 ```bash
 aicr recipe \
-  --service eks \
-  --accelerator h100 \
+  --snapshot snapshot.yaml \
   --intent inference \
-  --os ubuntu \
   --platform dynamo \
   --output recipe.yaml
 ```

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -270,8 +270,38 @@ kubectl get dynamographdeployments -n dynamo-workload
 kubectl get pods -n dynamo-workload -o wide -w
 ```
 
-For the default Dynamo-router path, verify the frontend service. For the Gateway / EPP path, verify
-the Gateway, InferencePool, HTTPRoute, EPP pod, and worker frontend sidecars.
+For the default Dynamo-router path, call the OpenAI-compatible API through the Dynamo frontend
+service:
+
+```bash
+kubectl get svc vllm-agg-frontend -n dynamo-workload
+kubectl port-forward -n dynamo-workload svc/vllm-agg-frontend 8000:8000
+```
+
+In another terminal:
+
+```bash
+curl http://localhost:8000/v1/models
+
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello from AICR Dynamo"}],"max_tokens":30,"stream":false}'
+```
+
+AICR inference recipes also install `agentgateway` and an `inference-gateway` Gateway in the
+`agentgateway-system` namespace. The `vllm-agg` example above uses the direct frontend path; for the
+Gateway / EPP path, deploy a workload that creates the EPP component, `InferencePool`, and
+`HTTPRoute`, then send the same OpenAI-compatible requests through the Gateway address:
+
+```bash
+kubectl get gateway inference-gateway -n agentgateway-system
+kubectl get inferencepool,httproute -n dynamo-workload
+
+GATEWAY_HOST=$(kubectl get gateway inference-gateway -n agentgateway-system -o jsonpath='{.status.addresses[0].value}')
+curl "http://${GATEWAY_HOST}/v1/models"
+```
+
+For the Gateway / EPP path, also verify the EPP pod and worker frontend sidecars.
 
 ## What Validation Covers
 

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -34,10 +34,12 @@ Editorial title direction:
   keep that clarification in the body.
 -->
 
-Running a model with Dynamo on Kubernetes starts with a `DynamoGraphDeployment`, but the graph is
-only the top of the stack. A production inference cluster also needs GPU drivers, device discovery,
-scheduling, health signals, observability, Gateway API resources, and the event transport that lets
-KV-aware routing see live cache state.
+Running a model with [Dynamo](https://github.com/ai-dynamo/dynamo) on
+[Kubernetes](https://kubernetes.io/) starts with a `DynamoGraphDeployment`, but the graph is only the
+top of the stack. A production inference cluster also needs GPU drivers, device discovery,
+scheduling, health signals, observability,
+[Gateway API](https://github.com/kubernetes-sigs/gateway-api) resources, and the event transport that
+lets KV-aware routing see live cache state.
 
 [NVIDIA AI Cluster Runtime (AICR)](https://github.com/NVIDIA/aicr) packages the lower stack as a
 validated, version-locked recipe. You bring an existing GPU Kubernetes cluster. AICR captures its
@@ -48,10 +50,11 @@ validated Dynamo 1.2 inference runtime stack."
 ## Why the Runtime Below Dynamo Matters
 
 Dynamo coordinates inference across multiple components: frontends, routers, workers, the Dynamo
-operator, and optional
-[Gateway API Inference Extension (GAIE) / Endpoint Picker Plugin (EPP)](../kubernetes/inference-gateway.md)
-components. Those components depend on cluster-level services that must agree on Kubernetes version,
-driver stack, GPU allocation model, scheduling policy, node health, metrics, and network reachability.
+operator, and optional [Gateway API](https://github.com/kubernetes-sigs/gateway-api)
+[Inference Extension (GAIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) /
+[Endpoint Picker Plugin (EPP)](../kubernetes/inference-gateway.md) components. Those components
+depend on cluster-level services that must agree on Kubernetes version, driver stack, GPU allocation
+model, scheduling policy, node health, metrics, and network reachability.
 
 A hand-written Dynamo manifest can start the serving graph, but it does not answer questions like:
 
@@ -79,15 +82,21 @@ mix of operator, chart, and runtime image versions.
 
 Below Dynamo, the recipe brings the cluster services Dynamo expects for validated GPU inference:
 
-- **NVIDIA GPU Operator** for the driver and GPU software stack.
-- **Node Feature Discovery** and GPU labels for placement.
-- **NVIDIA DRA driver for GPUs** for Kubernetes-native GPU allocation.
-- **KAI Scheduler** for accelerator-aware scheduling and gang-style placement.
-- **Grove** for Dynamo component lifecycle on Kubernetes.
-- **Prometheus stack** for cluster, accelerator, and Dynamo service metrics.
+- **[NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)** for the driver and GPU software
+  stack.
+- **[Node Feature Discovery](https://github.com/kubernetes-sigs/node-feature-discovery)** and GPU
+  labels for placement.
+- **[DRA Driver for NVIDIA GPUs](https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu)** for
+  Kubernetes-native GPU allocation.
+- **[KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler)** for accelerator-aware
+  scheduling and gang-style placement.
+- **[Grove](https://github.com/ai-dynamo/grove)** for Dynamo component lifecycle on Kubernetes.
+- **[Prometheus stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)**
+  for cluster, accelerator, and Dynamo service metrics.
 - **Node health management** components such as NVSentinel and Nodewright, where supported by the
   selected recipe.
-- **NATS** from the Dynamo platform chart for the standard Kubernetes KV event plane.
+- **[NATS](https://github.com/nats-io/nats-server)** from the Dynamo platform chart for the standard
+  Kubernetes KV event plane.
 
 The result is a runtime recipe, not a loose list of charts. AICR records the component versions,
 values, node selectors, tolerations, checksums, and validation expectations that make the bundle
@@ -100,11 +109,12 @@ more production-oriented `nvidia.com/v1beta1` API. AICR uses that API as the rec
 serving graph, while the `dynamo-platform` chart provides the operator, CRDs, NATS, and supporting
 control-plane services.
 
-Dynamo is Kubernetes-native in this path. Frontends, vLLM workers, EPP components, and other Dynamo
-services discover each other through Kubernetes resources instead of an etcd deployment. NATS serves
-a different purpose: it is part of the Dynamo dataplane for real-time, high-throughput streaming of
-KV cache location updates. The `dynamo-platform` chart installs NATS so the router and EPP can track
-which workers hold which KV blocks as those blocks are stored and evicted.
+Dynamo is Kubernetes-native in this path. Frontends, [vLLM](https://github.com/vllm-project/vllm)
+workers, EPP components, and other Dynamo services discover each other through Kubernetes resources
+instead of an [etcd](https://etcd.io/) deployment. [NATS](https://github.com/nats-io/nats-server)
+serves a different purpose: it is part of the Dynamo dataplane for real-time, high-throughput
+streaming of KV cache location updates. The `dynamo-platform` chart installs NATS so the router and
+EPP can track which workers hold which KV blocks as those blocks are stored and evicted.
 
 KV-aware routing is one of the main reasons to run Dynamo. Agentic workloads repeatedly append to a
 long prefix: system prompt, tool definitions, conversation history, tool results, and generated
@@ -130,14 +140,16 @@ That distinction matters for vLLM. A vLLM worker may include a setting like:
 {"enable_kv_cache_events": true, "publisher": "zmq", "endpoint": "tcp://*:5557"}
 ```
 
-That ZMQ publisher is the local vLLM engine event source. Dynamo reads those raw local KV events from
-the worker, normalizes them, and republishes them onto the Dynamo event plane. In the Kubernetes AICR
-path, that event plane is NATS.
+That [ZMQ](https://zeromq.org/) publisher is the local vLLM engine event source. Dynamo reads those
+raw local KV events from the worker, normalizes them, and republishes them onto the Dynamo event
+plane. In the Kubernetes AICR path, that event plane is NATS.
 
 ## Two Routing Paths
 
 AICR's Dynamo recipe covers both Dynamo 1.2 Kubernetes routing paths because they solve different
 operational problems.
+
+### Path 1: Direct Dynamo Frontend
 
 The default path is the **Dynamo frontend router**. A `Frontend` component runs with
 `DYN_ROUTER_MODE=kv`, receives OpenAI-compatible requests, tokenizes prompts, subscribes to worker KV
@@ -146,27 +158,43 @@ inside the Dynamo graph and is the shortest route for validating Dynamo itself.
 
 ```mermaid
 flowchart LR
-    Client["Client"] -->|"OpenAI-compatible request"| Frontend["Dynamo Frontend\nDYN_ROUTER_MODE=kv"]
-    Frontend -->|"request plane\nTCP by default"| Worker["vLLM worker"]
+    Client["Client\nOpenAI-compatible HTTP"] --> Service["Kubernetes Service\nvllm-agg-frontend"]
+    Service --> Frontend["Dynamo Frontend\nDYN_ROUTER_MODE=kv"]
+    Frontend -->|"tokenize + score\nKV overlap / load"| Router["Dynamo router\ncache-aware placement"]
+    Router -->|"request plane\nTCP by default"| Worker["vLLM worker"]
+
     Worker -.->|"local ZMQ\nraw KV events"| Publisher["Dynamo worker\nKV publisher"]
     Publisher -.->|"NATS-backed\nKV event plane"| Frontend
 ```
 
-The Kubernetes-native ingress path is **Gateway / EPP**. In that mode, traffic flows through the
-Kubernetes Gateway API and an InferencePool. The EPP performs endpoint selection using Dynamo's
-KV-aware scoring. Worker frontend sidecars run in `--router-mode direct`, so they honor the worker
-chosen by the EPP instead of making another placement decision. This path matters when the platform
-team wants model-aware routing at the Kubernetes Gateway layer while keeping Dynamo's cache-aware
-selection logic.
+### Path 2: Gateway / EPP
+
+The Kubernetes-native ingress path is **Gateway / EPP**. In that mode, traffic flows through
+[agentgateway](https://github.com/agentgateway/agentgateway), the Kubernetes
+[Gateway API](https://github.com/kubernetes-sigs/gateway-api), an `HTTPRoute`, and a
+[GAIE](https://github.com/kubernetes-sigs/gateway-api-inference-extension) `InferencePool`. Dynamo
+natively integrates with that path: the Dynamo operator reconciles a `DynamoGraphDeployment`
+component of type `epp`, generates the matching `InferencePool`, and runs the EPP that performs
+endpoint selection with Dynamo's KV-aware scoring. Worker frontend sidecars run in
+`--router-mode direct`, so they honor the worker chosen by the EPP instead of making another
+placement decision. This path matters when the platform team wants model-aware routing at the
+Kubernetes Gateway layer while keeping Dynamo's cache-aware selection logic.
 
 ```mermaid
 flowchart LR
-    Client["Client"] -->|"HTTP"| Gateway["Kubernetes Gateway"]
-    Gateway -->|"InferencePool"| EPP["Dynamo EPP\nKV-aware selection"]
-    EPP -->|"chosen worker"| Sidecar["Worker frontend sidecar\n--router-mode direct"]
-    Sidecar --> Worker["vLLM worker"]
+    Client["Client\nOpenAI-compatible HTTP"] --> Gateway["agentgateway\nGateway API data plane"]
+    Gateway --> Route["HTTPRoute"]
+    Route --> Pool["InferencePool\nGAIE"]
+    Pool --> EPP["Dynamo EPP\nKV-aware endpoint picker"]
+    EPP -->|"selected endpoint"| Sidecar["Worker frontend sidecar\n--router-mode direct"]
+    Sidecar -->|"request plane\nTCP by default"| Worker["vLLM worker"]
+
     Worker -.->|"local ZMQ\nraw KV events"| Publisher["Dynamo worker\nKV publisher"]
     Publisher -.->|"NATS-backed\nKV event plane"| EPP
+
+    DGD["DynamoGraphDeployment\ncomponent type: epp"] -.-> Operator["Dynamo operator"]
+    Operator -.->|"creates / reconciles"| Pool
+    Operator -.->|"runs"| EPP
 ```
 
 Both paths depend on the same principle: workers must publish live KV cache events. Without live
@@ -288,14 +316,15 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello from AICR Dynamo"}],"max_tokens":30,"stream":false}'
 ```
 
-AICR inference recipes also install `agentgateway` and an `inference-gateway` Gateway in the
-`agentgateway-system` namespace. `agentgateway` is the Gateway API data plane, not the Dynamo EPP.
-The Dynamo EPP comes from a `DynamoGraphDeployment` component of type `epp`; the Dynamo operator
-generates the matching `InferencePool`, and the Gateway path uses an `HTTPRoute` that references
-that pool, as described in the
-[Gateway API Inference Extension guide](../kubernetes/inference-gateway.md). The `vllm-agg` example
-above uses the direct frontend path. For a Gateway / EPP workload, send the same OpenAI-compatible
-requests through the Gateway address:
+AICR inference recipes also install [agentgateway](https://github.com/agentgateway/agentgateway) and
+an `inference-gateway` Gateway in the `agentgateway-system` namespace. `agentgateway` is the
+Gateway API data plane, not the Dynamo EPP. The Dynamo EPP comes from a `DynamoGraphDeployment`
+component of type `epp`; the Dynamo operator generates the matching `InferencePool`, and the Gateway
+path uses an `HTTPRoute` that references that pool, as described in the
+[Gateway API Inference Extension guide](../kubernetes/inference-gateway.md). That is native Dynamo
+integration with GAIE: Gateway stays Kubernetes-native at ingress, while Dynamo owns the cache-aware
+endpoint selection. The `vllm-agg` example above uses the direct frontend path. For a Gateway / EPP
+workload, send the same OpenAI-compatible requests through the Gateway address:
 
 ```bash
 kubectl get gateway inference-gateway -n agentgateway-system
@@ -327,8 +356,9 @@ check that the cluster has:
 - Gateway / EPP resources when validating the Kubernetes-native ingress path.
 - Autoscaling prerequisites where the selected recipe requires them.
 
-This validation is the main reason to use AICR instead of starting from raw Helm commands. It turns
-"install the charts" into "install this versioned runtime and prove the cluster satisfies the recipe."
+This validation is the main reason to use AICR instead of starting from raw
+[Helm](https://helm.sh/) commands. It turns "install the charts" into "install this versioned runtime
+and prove the cluster satisfies the recipe."
 
 ## Where This Fits
 

--- a/docs/digest/deploying-dynamo-with-aicr.md
+++ b/docs/digest/deploying-dynamo-with-aicr.md
@@ -297,7 +297,7 @@ aicr validate \
 The full live validation happens after deployment, when AICR can also check that the runtime was
 installed as expected.
 
-## What Does Validate Check?
+#### What Does Validate Check?
 
 AICR validation gives the Dynamo deployment a concrete runtime contract. A Dynamo inference recipe can
 check that the cluster has:
@@ -371,10 +371,18 @@ path uses an `HTTPRoute` that references that pool, as described in the
 integration with GAIE: Gateway stays Kubernetes-native at ingress, while Dynamo owns the cache-aware
 endpoint selection.
 
-The `vllm-agg` example above uses the direct frontend path. To exercise the Gateway / EPP path, use
-an EPP-enabled `DynamoGraphDeployment` and `HTTPRoute`, such as the GAIE examples linked from the
-[Inference Gateway deploy guide](../kubernetes/inference-gateway.md#5-deploy). For a Gateway / EPP
-workload, send the same OpenAI-compatible requests through the Gateway address:
+The `vllm-agg` example above uses the direct frontend path. To exercise the Gateway / EPP path, apply
+the companion [vLLM aggregation EPP manifest](deploying-dynamo-with-aicr-vllm-agg-epp.yaml). It
+creates an EPP-enabled `DynamoGraphDeployment` and an `HTTPRoute` that points at the operator-created
+`InferencePool`:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/ai-dynamo/dynamo/refs/heads/main/docs/digest/deploying-dynamo-with-aicr-vllm-agg-epp.yaml
+kubectl get dynamographdeployments -n dynamo-workload
+kubectl get pods -n dynamo-workload -o wide -w
+```
+
+Then send the same OpenAI-compatible requests through the Gateway address:
 
 ```bash
 kubectl get gateway inference-gateway -n agentgateway-system

--- a/docs/digest/index.mdx
+++ b/docs/digest/index.mdx
@@ -7,6 +7,14 @@ Technical deep dives, announcements, and updates from the Dynamo team.
 
 <CardGroup cols={2}>
   <Card
+    title="Deploying Dynamo 1.2 with NVIDIA AI Cluster Runtime"
+    icon="regular server"
+    href="/dynamo/dev/digest/deploying-dynamo-with-aicr"
+  >
+    How AICR packages Dynamo 1.2 with the validated GPU, scheduling, health,
+    observability, NATS event plane, and Gateway/EPP runtime below it.
+  </Card>
+  <Card
     title="NVIDIA Dynamo Snapshot: Fast Startup for Inference Workloads on Kubernetes"
     icon="regular clock"
     href="/dynamo/dev/digest/dynamo-snapshot-fast-startup"

--- a/docs/digest/index.mdx
+++ b/docs/digest/index.mdx
@@ -7,7 +7,7 @@ Technical deep dives, announcements, and updates from the Dynamo team.
 
 <CardGroup cols={2}>
   <Card
-    title="Deploying Dynamo 1.2 with NVIDIA AI Cluster Runtime"
+    title="From Kubernetes to Datacenter-Scale Inference with NVIDIA Dynamo and AICR"
     icon="regular server"
     href="/dynamo/dev/digest/deploying-dynamo-with-aicr"
   >

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -100,7 +100,7 @@ navigation:
         path: digest/index.mdx
         slug: digest
         contents:
-          - page: "Deploying Dynamo 1.2 with NVIDIA AI Cluster Runtime"
+          - page: "From Kubernetes to Datacenter-Scale Inference with NVIDIA Dynamo and AICR"
             path: digest/deploying-dynamo-with-aicr.md
             slug: deploying-dynamo-with-aicr
           - page: "NVIDIA Dynamo Snapshot: Fast Startup for Inference Workloads on Kubernetes"

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -100,6 +100,9 @@ navigation:
         path: digest/index.mdx
         slug: digest
         contents:
+          - page: "Deploying Dynamo 1.2 with NVIDIA AI Cluster Runtime"
+            path: digest/deploying-dynamo-with-aicr.md
+            slug: deploying-dynamo-with-aicr
           - page: "NVIDIA Dynamo Snapshot: Fast Startup for Inference Workloads on Kubernetes"
             path: digest/snapshot/dynamo-snapshot-fast-startup.md
             slug: dynamo-snapshot-fast-startup


### PR DESCRIPTION
## Summary

- Add a Dynamo Digest draft on deploying Dynamo 1.2 with NVIDIA AI Cluster Runtime.
- Wire the post into the Digest nav and landing page.
- Cover AICR as the validated runtime below Dynamo, including GPU Operator, DRA, scheduling, node health, Prometheus, NATS event plane, and Gateway/EPP routing.
- Clarify the Dynamo 1.2 transport split: the request plane defaults to TCP, vLLM emits raw local ZMQ KV events, and Dynamo relays KV events onto NATS under Kubernetes discovery.

## Related Issues

- [x] Confirmed - no related issue.

## Validation

- `pre-commit run --files docs/digest/deploying-dynamo-with-aicr.md docs/digest/index.mdx docs/index.yml`

## Prompt Trail

- Asked whether Digest/blog posts live in this repo, then requested a blog outline for deploying Dynamo through NVIDIA AICR.
- Emphasized the narrative that AICR provides the validated runtime below Dynamo and ships Dynamo itself.
- Required Dynamo 1.2, standard NATS event-plane behavior, and coverage of the Gateway/EPP path.
- Asked to draft the blog as a PR.
