### PR TITLE
fix(planner): PlannerConfig.decode_scale_up_kv_rate typo fix

### DIFF
--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -585,7 +585,7 @@ class PlannerConfig(BaseModel):
         ge=0,
         le=100,
         validation_alias=AliasChoices(
-            "decode_scale_up_kv_rate", "decode_sacle_up_kv_rate"
+            "decode_scale_up_kv_rate"
         ),
         description=(
             "Decode KV utilization percentage that triggers scale-up when "

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -584,9 +584,7 @@ class PlannerConfig(BaseModel):
         default=SLAPlannerDefaults.decode_scale_up_kv_rate,
         ge=0,
         le=100,
-        validation_alias=AliasChoices(
-            "decode_scale_up_kv_rate"
-        ),
+        validation_alias=AliasChoices("decode_scale_up_kv_rate"),
         description=(
             "Decode KV utilization percentage that triggers scale-up when "
             "optimization_target='load'. Accepts 0-100."


### PR DESCRIPTION
## Overview:

Fix typo in alias for `decode_scale_up_kv_rate` in `PlannerConfig`

## Details:

Minor typo fix

## Where should the reviewer start?

the only file that changed, planner_config.py

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration key validation to accept the properly spelled parameter name. Users with existing configurations using the previous misspelled variant should update their settings to use the corrected spelling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->