### PR TITLE
fix(sglang): pass required worker_type in modelexpress register unit test

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -551,6 +551,7 @@ async def test_register_model_uses_metadata_only_for_sglang_modelexpress(monkeyp
         endpoint=SimpleNamespace(),
         server_args=server_args,
         dynamo_args=dynamo_args,
+        worker_type=sglang_register.WorkerType.Aggregated,
     )
 
     assert result is True


### PR DESCRIPTION
## What

`test_register_model_uses_metadata_only_for_sglang_modelexpress` (in `components/src/dynamo/sglang/tests/test_sglang_unit.py`) called `_register_model_with_runtime_config()` without the now-required keyword-only `worker_type` argument, so it failed in the **nightly** pipeline with:

```
TypeError: _register_model_with_runtime_config() missing 1 required keyword-only argument: 'worker_type'
```

The function declares `worker_type: WorkerType` as a required keyword-only parameter (`register.py`), and the real aggregated registration callers (`register.py`, `init_embedding.py`, `init_diffusion.py`) all pass `WorkerType.Aggregated`.

## Fix

Pass `worker_type=sglang_register.WorkerType.Aggregated` in the test call (one line). `WorkerType` is already importable via the test's `register as sglang_register` import. The test's assertions (`result is True`, `ignore_weights is True`) are independent of `worker_type`, so behavior is unchanged.

## Validation

- `py_compile` passes; `WorkerType.Aggregated` resolves at runtime.
- Note: could not run the sglang test in a vllm-only local container (module imports `sglang`); the change supplies the single missing required kwarg and matches the production callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for internal testing infrastructure.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->