### PR TITLE
feat: train PR2: New Epp config for the DYN_EPP_MODE=router-only

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -16,8 +16,10 @@ pub mod envoy_helpers;
 pub mod epp;
 pub mod picker;
 pub mod proto;
+pub mod router_only;
 pub mod server;
 
 pub use epp::Router;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
+pub use router_only::RouterOnlyConfig;
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/main.rs
+++ b/deploy/inference-gateway/ext-proc/src/main.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_ext_proc::{ExtProcServer, Router};
+use dynamo_ext_proc::{ExtProcServer, Router, RouterOnlyConfig};
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 
@@ -119,6 +119,7 @@ async fn main() -> Result<()> {
         )
         .init();
 
+    let router_only = RouterOnlyConfig::is_enabled();
     let config = Config::from_env();
 
     tracing::info!(
@@ -127,6 +128,7 @@ async fn main() -> Result<()> {
         namespace = %config.namespace,
         component = %config.component,
         enforce_disagg = config.enforce_disagg,
+        router_only_mode = router_only,
         "Starting Dynamo Rust EPP"
     );
 
@@ -144,9 +146,22 @@ async fn main() -> Result<()> {
             .serve(health_addr),
     );
 
-    tracing::info!("Initializing KV-aware router from discovery...");
-    let router =
-        Router::from_discovery(&config.namespace, &config.component, config.enforce_disagg).await?;
+    // Mode selection: router-only ("on-ramp", raw vLLM, no Dynamo runtime) vs the
+    // default Dynamo mode (DistributedRuntime over etcd/NATS + Dynamo workers).
+    let router = if router_only {
+        let ro_cfg = RouterOnlyConfig::from_env()?;
+        tracing::info!(
+            model = %ro_cfg.model_name,
+            block_size = ro_cfg.block_size,
+            pod_selector = %ro_cfg.pod_selector,
+            disaggregated = ro_cfg.is_disaggregated(),
+            "Initializing KV-aware router in router-only (raw-vLLM) mode..."
+        );
+        Router::from_router_only(ro_cfg).await?
+    } else {
+        tracing::info!("Initializing KV-aware router from discovery...");
+        Router::from_discovery(&config.namespace, &config.component, config.enforce_disagg).await?
+    };
 
     // Gate SERVING on pod-reflector readiness. `from_discovery` returns once
     // worker discovery and the model card are ready, but the K8s pod reflector's

--- a/deploy/inference-gateway/ext-proc/src/router_only.rs
+++ b/deploy/inference-gateway/ext-proc/src/router_only.rs
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Router-only ("on-ramp") mode configuration.
+//!
+//! The EPP runs in one of two modes, selected at startup by `DYN_EPP_MODE`:
+//!
+//! * **`full-dynamo-stack`** (default): the EPP attaches to a Dynamo deployment —
+//!   `DistributedRuntime` over etcd/NATS, Dynamo workers, model-card-derived
+//!   preprocessor, and the KV router's own event-plane subscriber. See
+//!   [`crate::epp::Router::from_discovery`].
+//!
+//! * **`router-only`** (`DYN_EPP_MODE=router-only`): the EPP fronts a fleet of
+//!   *raw* `vllm serve` pods with **no Dynamo control plane**. Discovery is a
+//!   plain Kubernetes label selector, KV-cache state comes from each pod's
+//!   native vLLM ZMQ event stream, and the embedded router runs on the inert
+//!   `mem` discovery backend (no etcd/NATS). See
+//!   [`crate::epp::Router::from_router_only`].
+//!
+//! This module defines the configuration surface for router-only mode, parses it
+//! from the environment, and (for now) provides a stub `Router::from_router_only`
+//! constructor. The runtime wiring lands in later changes.
+
+use anyhow::{Context, Result};
+
+/// Default vLLM OpenAI HTTP port (the InferencePool `targetPort`).
+const DEFAULT_TARGET_PORT: u16 = 8000;
+/// Default vLLM `--kv-events-config` ZMQ PUB port.
+const DEFAULT_KV_EVENT_PORT: u16 = 5557;
+
+/// Configuration for router-only (raw-vLLM, runtime-free) mode.
+///
+/// All values are sourced from the environment by [`RouterOnlyConfig::from_env`].
+/// The corresponding deployment manifests live in
+/// `deploy/inference-gateway/ext-proc/examples/onramp/`.
+#[derive(Debug, Clone)]
+pub struct RouterOnlyConfig {
+    /// Kubernetes label selector identifying the raw vLLM worker pods, e.g.
+    /// `app=vllm-qwen`. Sourced from `DYN_EPP_POD_SELECTOR`.
+    pub pod_selector: String,
+
+    /// vLLM OpenAI HTTP port that the gateway forwards inference traffic to
+    /// (the InferencePool `targetPort`). Sourced from `DYN_EPP_TARGET_PORT`.
+    pub target_port: u16,
+
+    /// Model id used to build the tokenizer/preprocessor offline (router-only
+    /// mode has no Dynamo model card). Sourced from `DYN_MODEL_NAME`.
+    pub model_name: String,
+
+    /// KV-cache block size. MUST match vLLM's `--block-size`. Sourced from
+    /// `DYN_KV_CACHE_BLOCK_SIZE`.
+    pub block_size: u32,
+
+    /// Whether to consume per-pod native vLLM ZMQ KV-cache events for precise
+    /// prefix routing. Sourced from `DYN_EPP_KV_EVENTS` (default `true`).
+    pub kv_events: bool,
+
+    /// Port of each vLLM pod's `--kv-events-config` ZMQ PUB socket. Sourced
+    /// from `DYN_EPP_KV_EVENT_PORT`.
+    pub kv_event_port: u16,
+
+    /// ZMQ topic configured in vLLM's `--kv-events-config` (`""` = no topic,
+    /// the vLLM default). Sourced from `DYN_EPP_KV_EVENT_TOPIC`.
+    pub kv_event_topic: String,
+
+    /// Pod label key that distinguishes prefill vs decode pods in
+    /// disaggregated deployments (e.g. `dynamo-role`). `None` ⇒ aggregated.
+    /// Sourced from `DYN_EPP_ROLE_LABEL`.
+    pub role_label: Option<String>,
+
+    /// Fail requests rather than falling back to aggregated serving when
+    /// prefill routing is unavailable. Sourced from `DYN_ENFORCE_DISAGG`.
+    pub enforce_disagg: bool,
+
+    /// Emit the selected prefill pod's `ip:port` as `x-prefiller-host-port`
+    /// for a decode-side P/D routing sidecar. Sourced from
+    /// `DYN_EPP_EMIT_PREFILLER_HOST_PORT`.
+    pub emit_prefiller_host_port: bool,
+}
+
+impl RouterOnlyConfig {
+    /// Returns `true` when `DYN_EPP_MODE=router-only` is selected.
+    ///
+    /// `DYN_EPP_MODE` chooses the EPP mode: `full-dynamo-stack` (default)
+    /// attaches to a Dynamo deployment; `router-only` fronts raw vLLM pods with
+    /// no Dynamo control plane (this module). Unset/empty ⇒ `full-dynamo-stack`.
+    pub fn is_enabled() -> bool {
+        match std::env::var("DYN_EPP_MODE").ok().as_deref() {
+            Some("router-only") => true,
+            None | Some("" | "full-dynamo-stack") => false,
+            Some(other) => {
+                tracing::warn!(
+                    "Invalid DYN_EPP_MODE value '{other}'. Valid values: \
+                     'full-dynamo-stack' (default), 'router-only'. Defaulting to full-dynamo-stack."
+                );
+                false
+            }
+        }
+    }
+
+    /// Parse the router-only-mode configuration from the environment.
+    ///
+    /// Errors if a required value (`DYN_EPP_POD_SELECTOR`, `DYN_MODEL_NAME`,
+    /// `DYN_KV_CACHE_BLOCK_SIZE`) is missing or malformed, so a
+    /// misconfiguration fails fast at startup instead of silently 503-ing.
+    pub fn from_env() -> Result<Self> {
+        let pod_selector = require_env("DYN_EPP_POD_SELECTOR")?;
+        let model_name = require_env("DYN_MODEL_NAME")?;
+        let block_size = require_env("DYN_KV_CACHE_BLOCK_SIZE")?
+            .parse::<u32>()
+            .context("DYN_KV_CACHE_BLOCK_SIZE must be a positive integer")?;
+        if block_size == 0 {
+            anyhow::bail!("DYN_KV_CACHE_BLOCK_SIZE must be greater than 0");
+        }
+
+        let role_label = env_opt("DYN_EPP_ROLE_LABEL");
+
+        Ok(Self {
+            pod_selector,
+            target_port: env_parse("DYN_EPP_TARGET_PORT", DEFAULT_TARGET_PORT)?,
+            model_name,
+            block_size,
+            kv_events: env_bool("DYN_EPP_KV_EVENTS", true),
+            kv_event_port: env_parse("DYN_EPP_KV_EVENT_PORT", DEFAULT_KV_EVENT_PORT)?,
+            kv_event_topic: std::env::var("DYN_EPP_KV_EVENT_TOPIC").unwrap_or_default(),
+            role_label,
+            enforce_disagg: env_bool("DYN_ENFORCE_DISAGG", false),
+            emit_prefiller_host_port: env_bool("DYN_EPP_EMIT_PREFILLER_HOST_PORT", false),
+        })
+    }
+
+    /// Whether this configuration describes a disaggregated deployment
+    /// (a prefill/decode role label is set).
+    pub fn is_disaggregated(&self) -> bool {
+        self.role_label.is_some()
+    }
+}
+
+impl crate::epp::Router {
+    /// Initialize the router in router-only ("on-ramp") mode.
+    ///
+    /// Router-only mode fronts a fleet of raw `vllm serve` pods with no Dynamo
+    /// control plane: discovery is a Kubernetes label selector, KV-cache state
+    /// comes from each pod's native vLLM ZMQ event stream (republished onto the
+    /// embedded router's event plane), and the runtime uses the inert `mem`
+    /// discovery backend (no etcd/NATS). See [`RouterOnlyConfig`] and
+    /// `deploy/inference-gateway/ext-proc/examples/onramp/`.
+    ///
+    /// NOTE: this is currently a stub. The construction path (offline
+    /// preprocessor, mem-backed component, label-selector reflector, and the
+    /// ZMQ KV republisher) lands in subsequent changes. It is defined here so
+    /// the `DYN_EPP_MODE` mode switch and configuration surface can be
+    /// reviewed independently — and so this change touches no existing
+    /// `epp.rs` (Dynamo-mode) code.
+    pub async fn from_router_only(cfg: RouterOnlyConfig) -> Result<Self> {
+        anyhow::bail!(
+            "router-only mode (DYN_EPP_MODE=router-only) is not yet implemented: \
+             parsed config for model '{}' (block_size={}, selector='{}', disagg={}). \
+             Use the default Dynamo mode for now.",
+            cfg.model_name,
+            cfg.block_size,
+            cfg.pod_selector,
+            cfg.is_disaggregated(),
+        )
+    }
+}
+
+fn require_env(key: &str) -> Result<String> {
+    let value = std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    value.ok_or_else(|| {
+        anyhow::anyhow!("router-only mode requires {key} to be set (DYN_EPP_MODE=router-only)")
+    })
+}
+
+fn env_opt(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn env_parse<T>(key: &str, default: T) -> Result<T>
+where
+    T: std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    match env_opt(key) {
+        Some(v) => v
+            .parse::<T>()
+            .map_err(|e| anyhow::anyhow!("{key} is invalid: {e}")),
+        None => Ok(default),
+    }
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| match v.trim().to_lowercase().as_str() {
+            "true" | "1" | "yes" | "on" => Some(true),
+            "false" | "0" | "no" | "off" => Some(false),
+            _ => None,
+        })
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Env access is process-global; serialize the tests that mutate it.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear() {
+        for k in [
+            "DYN_EPP_MODE",
+            "DYN_EPP_POD_SELECTOR",
+            "DYN_EPP_TARGET_PORT",
+            "DYN_MODEL_NAME",
+            "DYN_KV_CACHE_BLOCK_SIZE",
+            "DYN_EPP_KV_EVENTS",
+            "DYN_EPP_KV_EVENT_PORT",
+            "DYN_EPP_KV_EVENT_TOPIC",
+            "DYN_EPP_ROLE_LABEL",
+            "DYN_ENFORCE_DISAGG",
+            "DYN_EPP_EMIT_PREFILLER_HOST_PORT",
+        ] {
+            unsafe { std::env::remove_var(k) };
+        }
+    }
+
+    #[test]
+    fn parses_minimal_agg_config_with_defaults() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear();
+        unsafe {
+            std::env::set_var("DYN_EPP_POD_SELECTOR", "app=vllm-qwen");
+            std::env::set_var("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B");
+            std::env::set_var("DYN_KV_CACHE_BLOCK_SIZE", "16");
+        }
+
+        let cfg = RouterOnlyConfig::from_env().unwrap();
+        assert_eq!(cfg.pod_selector, "app=vllm-qwen");
+        assert_eq!(cfg.target_port, DEFAULT_TARGET_PORT);
+        assert_eq!(cfg.kv_event_port, DEFAULT_KV_EVENT_PORT);
+        assert!(cfg.kv_events);
+        assert!(!cfg.is_disaggregated());
+        clear();
+    }
+
+    #[test]
+    fn missing_required_value_errors() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear();
+        unsafe {
+            std::env::set_var("DYN_EPP_POD_SELECTOR", "app=vllm-qwen");
+        }
+        // DYN_MODEL_NAME / DYN_KV_CACHE_BLOCK_SIZE missing.
+        assert!(RouterOnlyConfig::from_env().is_err());
+        clear();
+    }
+
+    #[test]
+    fn role_label_marks_disaggregated() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear();
+        unsafe {
+            std::env::set_var("DYN_EPP_POD_SELECTOR", "app=vllm-qwen");
+            std::env::set_var("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B");
+            std::env::set_var("DYN_KV_CACHE_BLOCK_SIZE", "16");
+            std::env::set_var("DYN_EPP_ROLE_LABEL", "dynamo-role");
+        }
+        let cfg = RouterOnlyConfig::from_env().unwrap();
+        assert!(cfg.is_disaggregated());
+        assert_eq!(cfg.role_label.as_deref(), Some("dynamo-role"));
+        clear();
+    }
+}


### PR DESCRIPTION
## Overview:

new config when the mode is router-only

The EPP runs in one of two modes, selected at startup by `DYN_EPP_MODE`:

* **`full-dynamo-stack`** (default): the EPP attaches to a Dynamo deployment —
   `DistributedRuntime` over etcd/NATS, Dynamo workers, model-card-derived
   preprocessor, and the KV router's own event-plane subscriber. See
  [`crate::epp::Router::from_discovery`].
 * **`router-only`** (`DYN_EPP_MODE=router-only`): the EPP fronts a fleet of
   *raw* `vllm serve` pods with **no Dynamo control plane**. Discovery is a
  plain Kubernetes label selector, KV-cache state comes from each pod's
   native vLLM ZMQ event stream, and the embedded router runs on the inert
  `mem` discovery backend (no NATS). See
   [`crate::epp::Router::from_router_only`].

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for on-ramp deployment mode to integrate existing vLLM serving fleets

* **Documentation**
  * Added setup guide and example Kubernetes configurations for on-ramp deployments with aggregated and disaggregated topologies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->