### PR TITLE
docs: train PR1 - raw-vLLM + EPP on-ramp examples (agg + disagg)

### DIFF
--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -27,7 +27,7 @@ binary serves both.
 
 LIMITATIONS:
 
-Concern | Gap vs the Dynamo/NATS path
+Concern | Gap vs the Full Dynamo Stack
 -- | --
 Duplicate store/remove (vLLM "retries") | parity
 In-stream ordering |  parity

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -37,8 +37,8 @@ binary serves both.
 
 LIMITATIONS:
 
-Concern | Gap vs the Full Dynamo Stack
--- | --
+| | This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
+|---|---|---|
 Duplicate store/remove (vLLM "retries") | parity
 In-stream ordering |  parity
 Transient disconnects | parity-ish

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -22,10 +22,9 @@ no Dynamo worker.
 | Operator | not required | required (DynamoGraphDeployment) |
 | Tokenization | EPP tokenizes for routing; worker re-tokenizes | model-card preprocessor, no double tokenization |
 
-The two modes are selected at startup by **`DYN_EPP_MODE`** (`full-dynamo-stack` | `router-only`). The same EPP
-binary serves both.
+The EPP can be served in 2 modes. The two modes are selected at startup by **`DYN_EPP_MODE`** (`full-dynamo-stack` | `router-only`). The same EPP binary serves both.
 
-LIMITATIONS:
+## Limitations
 
 | This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
 |---|---|
@@ -37,12 +36,12 @@ Initial cache state | Not handled. (The Dynamo path does an initial worker dum
 Backpressure / EPP restart | PUB drops to slow subscribers (HWM) → silent loss; on restart the index is empty and only re-warms from new traffic.
 Data Parallelism | Not supported
 
-## Files
+## Examples
 
 - `agg.yaml` — aggregated: one vLLM pool, KV-aware load balancing.
 - `disagg.yaml` — disaggregated: prefill + decode pools, KV-aware P/D selection. Note that for the disaggregated serving you need to also build the sidecar to orchestrate the pull of the kv cache from the prefill worker.
 
-## Prerequisites (install once)
+## Prerequisites
 
 ```bash
 # Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -13,38 +13,6 @@ If you already run GAIE + vLLM, you **replace only your EndpointPicker (EPP)**
 with the Dynamo EPP and you are done — no Dynamo operator, no Dynamo runtime,
 no Dynamo worker.
 
-The Dynamo EPP image is named "frontend" and provided to you with each release.
-For disaggreaged serving you also need to use the "sidecar" image provided with the release or build it with commands below.
-```bash
-# export env vars
-export DOCKER_SERVER=ghcr.io/nvidia/dynamo	# Container registry
-export IMAGE_TAG=YOUR-TAG # Or auto from git tag
-cd deploy/inference-gateway/ext-proc/examples/onramp
-make all # Do everything in one command
-```
-
-### Build the P/D routing sidecar image (disaggregated only)
-
-The sidecar is a standalone Rust crate at `deploy/inference-gateway/pd-sidecar/`.
-It is a workspace member, so build it with the **repo root as the `dynamo` build
-context** (the 2-stage Dockerfile copies the workspace, then compiles only
-`dynamo-pd-sidecar`):
-
-```bash
-cd deploy/inference-gateway/pd-sidecar
-docker buildx build \
-  --build-context dynamo=../../.. \
-  -t dynamo/pd-sidecar:dev \
-  -f Dockerfile --load .
-
-# make it reachable by your cluster, e.g. for kind:
-kind load docker-image dynamo/pd-sidecar:dev --name <cluster>
-```
-
-Then set the `pd-router-sidecar` container's `image:` in `disagg.yaml` to the tag
-you built. The sidecar reads the `x-prefiller-host-port` header the EPP emits and
-runs vLLM's `kv_transfer_params` handshake against the selected prefill pod.
-
 | | This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
 |---|---|---|
 | Workers | stock `vllm serve` | Dynamo workers (vLLM/SGLang/TRT-LLM) |
@@ -83,6 +51,31 @@ deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
 # HF token secret (the EPP downloads the tokenizer to tokenize for routing)
 kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-token>
 ```
+The Dynamo EPP image is named "frontend" and provided to you with each release.
+For disaggreaged serving you also need to use the "sidecar" image provided with the release or build it with commands below.
+
+### Build the P/D routing sidecar image (disaggregated only)
+
+The sidecar is a standalone Rust crate at `deploy/inference-gateway/pd-sidecar/`.
+It is a workspace member, so build it with the **repo root as the `dynamo` build
+context** (the 2-stage Dockerfile copies the workspace, then compiles only
+`dynamo-pd-sidecar`):
+
+```bash
+cd deploy/inference-gateway/pd-sidecar
+docker buildx build \
+  --build-context dynamo=../../.. \
+  -t dynamo/pd-sidecar:dev \
+  -f Dockerfile --load .
+
+# make it reachable by your cluster, e.g. for kind:
+kind load docker-image dynamo/pd-sidecar:dev --name <cluster>
+```
+
+Then set the `pd-router-sidecar` container's `image:` in `disagg.yaml` to the tag
+you built. The sidecar reads the `x-prefiller-host-port` header the EPP emits and
+runs vLLM's `kv_transfer_params` handshake against the selected prefill pod.
+
 
 ## Run
 

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -120,7 +120,7 @@ kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-toke
 Now that Gateway and GAIE is installed, we can create an InferencePool and an accompanying Dynamo EPP.
 
 Point the `InferencePool` at your vLLM workers (see the
-[`qwen-pool` InferencePool in `agg.yaml`](./agg.yaml) for a complete example):
+[`qwen-pool` InferencePool in `agg.yaml`](./agg.yaml#L233) for a complete example):
 
 Specifically, these fields depend on the model you deploy, so make sure the settings below are adjusted to match your workers.
 
@@ -147,7 +147,7 @@ Specifically, these fields depend on the model you deploy, so make sure the sett
 ```
 
 Attach the `HTTPRoute` to the gateway and target the pool (see the
-[`qwen-route` HTTPRoute in `agg.yaml`](./agg.yaml) for a complete example):
+[`qwen-route` HTTPRoute in `agg.yaml`](./agg.yaml#L253) for a complete example):
 
 - `spec.rules[].backendRefs[]` — targets the `InferencePool`.
 ```yaml
@@ -189,7 +189,7 @@ kubectl -n <ns> label deployment <vllm-deployment> app=vllm-qwen --overwrite
 
 Remove the vLLM router (if you have it already installed) and replace it with the EPP (Dynamo Router).
 Add the EPP as a `Deployment` + `Service` (see the
-[`qwen-epp` Deployment in `agg.yaml`](./agg.yaml) for a complete example) and set:
+[`qwen-epp` Deployment in `agg.yaml`](./agg.yaml#L109) for a complete example) and set:
 
 ```yaml
 kind: Deployment

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Dynamo Router on-ramp (raw vLLM, no Dynamo control plane)
+# Dynamo Router on-ramp (raw vLLM workers, no Dynamo control plane)
 
 This directory is the **smallest possible** way to put Dynamo's KV/load-aware
 router in front of an existing **vanilla `vllm serve`** fleet that already sits
@@ -41,7 +41,13 @@ Data Parallelism | Not supported
 - `agg.yaml` — aggregated: one vLLM pool, KV-aware load balancing.
 - `disagg.yaml` — disaggregated: prefill + decode pools, KV-aware P/D selection. Note that for the disaggregated serving you need to also build the sidecar to orchestrate the pull of the kv cache from the prefill worker.
 
-## Prerequisites
+## Installation Steps
+
+### 1. Prerequisites
+
+Set up a Gateway-API gateway + Inference Extension (GAIE) if you don't have one
+yet, and create the HuggingFace token secret the EPP uses to download the
+tokenizer:
 
 ```bash
 # Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`
@@ -50,10 +56,95 @@ deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
 # HF token secret (the EPP downloads the tokenizer to tokenize for routing)
 kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-token>
 ```
-The Dynamo EPP image is named "frontend" and provided to you with each release.
-For disaggreaged serving you also need to use the "sidecar" image provided with the release or build it with commands below.
 
-### Build the P/D routing sidecar image (disaggregated only)
+### 2. Wire the InferencePool and HTTPRoute
+
+Point the `InferencePool` at your vLLM workers:
+
+- `spec.selector` — labels matching your vLLM pods.
+- `spec.targetPorts[].number` — the vLLM serving port (usually `8000`).
+- `spec.endpointPickerRef` (a.k.a. `spec.extensionRef`) — the EPP service + port.
+
+Attach the `HTTPRoute` to the gateway and target the pool:
+
+- `spec.rules[].backendRefs[]` — targets the `InferencePool`.
+- `spec.parentRefs[]` — your gateway (set `namespace` + `sectionName` when the
+  gateway lives in another namespace, e.g. `agentgateway-system`).
+
+### 3. Label the workers
+
+Add labels to your vLLM pods that match `InferencePool.spec.selector` (and the
+EPP's `DYN_EPP_POD_SELECTOR`):
+
+```bash
+kubectl -n <ns> label deployment <vllm-deployment> app=vllm-qwen --overwrite
+```
+
+### 4. Add the EPP to your deployment
+
+Remove the vLLM router and replace it with the EPP (Dynamo Router).
+Add the EPP as a `Deployment` + `Service` (see the
+[`qwen-epp` Deployment in `agg.yaml`](./agg.yaml) for a complete example) and set:
+
+```yaml
+kind: Deployment
+metadata:
+  name: qwen-epp
+  labels:
+    app: qwen-epp
+```
+
+1. **Set the EPP image.** The Dynamo EPP ships as the "frontend" image with each
+   release. (Disaggregated serving also needs the "sidecar" image — use the
+   released one or build it, see step 5.)
+
+2. **Point the EPP at the workers' KV-event socket.** The worker publishes KV
+   events via `--kv-events-config`; the EPP subscribes on the matching port.
+
+   vLLM worker arg:
+
+   ```text
+   --kv-events-config '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+   ```
+
+   EPP env:
+
+   ```yaml
+   - name: DYN_EPP_KV_EVENT_PORT
+     value: "5557"
+   ```
+
+3. **Set the model/tokenizer.** The EPP downloads this tokenizer (HF id) to
+   tokenize prompts for routing — it MUST match the model the workers serve:
+
+   ```yaml
+   - name: DYN_MODEL_NAME
+     value: "Qwen/Qwen3-0.6B"
+   ```
+
+4. **Match the ZMQ topic.** Must equal the worker's `--kv-events-config` topic
+   (default `""`):
+
+   ```yaml
+   - name: DYN_EPP_KV_EVENT_TOPIC
+     value: ""
+   ```
+
+5. **(Optional) Tune KV routing:**
+
+   ```yaml
+   # Subscribe to per-pod ZMQ KV events; turn off to fall back to load-only routing.
+   - name: DYN_EPP_KV_EVENTS
+     value: "true"
+   # How heavily prefix-cache (KV) overlap counts vs. load.
+   - name: DYN_OVERLAP_SCORE_WEIGHT
+     value: "1.0"
+   ```
+
+   See the full list in the
+   [environment contract](#router-only-mode-environment-contract) below.
+
+### 5. (Disaggregated only) Build the P/D routing sidecar image
 
 The sidecar is a standalone Rust crate at `deploy/inference-gateway/pd-sidecar/`.
 It is a workspace member, so build it with the **repo root as the `dynamo` build
@@ -80,7 +171,6 @@ runs vLLM's `kv_transfer_params` handshake against the selected prefill pod.
 
 ```bash
 kubectl apply -n <ns> -f agg.yaml        # or disagg.yaml
-kubectl apply  -n <ns> -f http-route.yaml # adjust per your namespace
 
 # terminal 1
 kubectl -n agentgateway-system port-forward svc/inference-gateway 8000:80

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -81,12 +81,24 @@ runs vLLM's `kv_transfer_params` handshake against the selected prefill pod.
 ```bash
 kubectl apply -n <ns> -f agg.yaml        # or disagg.yaml
 kubectl apply  -n <ns> -f http-route.yaml # adjust per your namespace
-GW=$(kubectl -n agentgateway-system get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
-echo "$GW"
-curl http://$GW/v1/chat/completions -H 'content-type: application/json' -d '{
-  "model": "Qwen/Qwen3-0.6B",
-  "messages": [{"role":"user","content":"hello"}]
-}'
+
+# terminal 1
+kubectl -n agentgateway-system port-forward svc/inference-gateway 8000:80
+
+# terminal 2
+GATEWAY_URL=http://localhost:8000
+
+# quick health/smoke first
+curl --max-time 20 -sS "$GATEWAY_URL/v1/models" | jq .
+
+# then chat completion
+curl --max-time 120 -sS "$GATEWAY_URL/v1/chat/completions" \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role":"user","content":"hello"}]
+  }' | jq .
+
 ```
 
 ## router-only-mode environment contract

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -21,7 +21,29 @@ export DOCKER_SERVER=ghcr.io/nvidia/dynamo	# Container registry
 export IMAGE_TAG=YOUR-TAG # Or auto from git tag
 cd deploy/inference-gateway/ext-proc/examples/onramp
 make all # Do everything in one command
+```
 
+### Build the P/D routing sidecar image (disaggregated only)
+
+The sidecar is a standalone Rust crate at `deploy/inference-gateway/pd-sidecar/`.
+It is a workspace member, so build it with the **repo root as the `dynamo` build
+context** (the 2-stage Dockerfile copies the workspace, then compiles only
+`dynamo-pd-sidecar`):
+
+```bash
+cd deploy/inference-gateway/pd-sidecar
+docker buildx build \
+  --build-context dynamo=../../.. \
+  -t dynamo/pd-sidecar:dev \
+  -f Dockerfile --load .
+
+# make it reachable by your cluster, e.g. for kind:
+kind load docker-image dynamo/pd-sidecar:dev --name <cluster>
+```
+
+Then set the `pd-router-sidecar` container's `image:` in `disagg.yaml` to the tag
+you built. The sidecar reads the `x-prefiller-host-port` header the EPP emits and
+runs vLLM's `kv_transfer_params` handshake against the selected prefill pod.
 
 | | This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
 |---|---|---|
@@ -37,8 +59,8 @@ binary serves both.
 
 LIMITATIONS:
 
-| | This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
-|---|---|---|
+| This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
+|---|---|
 Duplicate store/remove (vLLM "retries") | parity
 In-stream ordering |  parity
 Transient disconnects | parity-ish

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -46,13 +46,18 @@ Data Parallelism | Not supported
 ### 1. Prerequisites
 
 Set up a Gateway-API gateway + Inference Extension (GAIE) if you don't have one
-yet, and create the HuggingFace token secret the EPP uses to download the
-tokenizer:
+yet. Follow the instructions for your gateway (i.e. [AgentGateway](https://agentgateway.dev/docs/kubernetes/main/quickstart/install/)) and [Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/guides/).
 
+We provide a convenience script if you are installing from scratch for experimentation.
 ```bash
 # Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`
 deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
+```
 
+Create the HuggingFace token secret the EPP uses to download the
+tokenizer.
+
+```bash
 # HF token secret (the EPP downloads the tokenizer to tokenize for routing)
 kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-token>
 ```
@@ -62,19 +67,59 @@ kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-toke
 Point the `InferencePool` at your vLLM workers:
 
 - `spec.selector` — labels matching your vLLM pods.
+```yaml
+  selector:
+    matchLabels:
+      app: vllm-qwen
+```
+
 - `spec.targetPorts[].number` — the vLLM serving port (usually `8000`).
+```yaml
+  targetPorts:
+    - number: 8000
+```
+
 - `spec.endpointPickerRef` (a.k.a. `spec.extensionRef`) — the EPP service + port.
+```yaml
+  endpointPickerRef:
+    kind: Service
+    name: qwen-epp
+    port:
+      number: 9002
+```
 
 Attach the `HTTPRoute` to the gateway and target the pool:
 
 - `spec.rules[].backendRefs[]` — targets the `InferencePool`.
+```yaml
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: qwen-pool
+          port: 8000
+          weight: 1
+```
+
 - `spec.parentRefs[]` — your gateway (set `namespace` + `sectionName` when the
   gateway lives in another namespace, e.g. `agentgateway-system`).
+```yaml
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+```
 
 ### 3. Label the workers
 
 Add labels to your vLLM pods that match `InferencePool.spec.selector` (and the
 EPP's `DYN_EPP_POD_SELECTOR`):
+
+```yaml
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+```
 
 ```bash
 kubectl -n <ns> label deployment <vllm-deployment> app=vllm-qwen --overwrite
@@ -82,7 +127,7 @@ kubectl -n <ns> label deployment <vllm-deployment> app=vllm-qwen --overwrite
 
 ### 4. Add the EPP to your deployment
 
-Remove the vLLM router and replace it with the EPP (Dynamo Router).
+Remove the vLLM router (if you have it already installed) and replace it with the EPP (Dynamo Router).
 Add the EPP as a `Deployment` + `Service` (see the
 [`qwen-epp` Deployment in `agg.yaml`](./agg.yaml) for a complete example) and set:
 

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -11,7 +11,17 @@ behind a Gateway-API gateway with the Inference Extension (GAIE).
 
 If you already run GAIE + vLLM, you **replace only your EndpointPicker (EPP)**
 with the Dynamo EPP and you are done — no Dynamo operator, no Dynamo runtime,
-no Dynamo worker. For disaggreaged serving you also need to build the disag sidecar.
+no Dynamo worker.
+
+The Dynamo EPP image is named "frontend" and provided to you with each release.
+For disaggreaged serving you also need to use the "sidecar" image provided with the release or build it with commands below.
+```bash
+# export env vars
+export DOCKER_SERVER=ghcr.io/nvidia/dynamo	# Container registry
+export IMAGE_TAG=YOUR-TAG # Or auto from git tag
+cd deploy/inference-gateway/ext-proc/examples/onramp
+make all # Do everything in one command
+
 
 | | This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
 |---|---|---|

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -80,7 +80,9 @@ runs vLLM's `kv_transfer_params` handshake against the selected prefill pod.
 
 ```bash
 kubectl apply -n <ns> -f agg.yaml        # or disagg.yaml
-GW=$(kubectl get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
+kubectl apply  -n <ns> -f http-route.yaml # adjust per your namespace
+GW=$(kubectl -n agentgateway-system get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
+echo "$GW"
 curl http://$GW/v1/chat/completions -H 'content-type: application/json' -d '{
   "model": "Qwen/Qwen3-0.6B",
   "messages": [{"role":"user","content":"hello"}]

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -26,7 +26,7 @@ The EPP can be served in 2 modes. The two modes are selected at startup by **`DY
 
 ## Limitations
 
-| This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
+| Concern | Router-only mode (gap vs full Dynamo) |
 |---|---|
 Duplicate store/remove (vLLM "retries") | parity
 In-stream ordering |  parity
@@ -38,15 +38,68 @@ Data Parallelism | Not supported
 
 ## Examples
 
+If you are starting from scratch install the [Prerequisites](#1-prerequisites) and apply the provided example file:
+
 - `agg.yaml` — aggregated: one vLLM pool, KV-aware load balancing.
 - `disagg.yaml` — disaggregated: prefill + decode pools, KV-aware P/D selection. Note that for the disaggregated serving you need to also build the sidecar to orchestrate the pull of the kv cache from the prefill worker.
 
-## Installation Steps
+```bash
+kubectl apply -n <ns> -f agg.yaml        # or disagg.yaml
+```
+
+Otherwise follow the steps below.
+
+## Example Progression from vLLM to vLLM + Dynamo + GAIE
+
+### Initial Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-qwen
+spec:
+  selector:
+    app: vllm-qwen
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+```
 
 ### 1. Prerequisites
 
 Set up a Gateway-API gateway + Inference Extension (GAIE) if you don't have one
-yet. Follow the instructions for your gateway (i.e. [AgentGateway](https://agentgateway.dev/docs/kubernetes/main/quickstart/install/)) and [Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/guides/).
+yet. Follow the instructions for your gateway (e.g. [AgentGateway](https://agentgateway.dev/docs/kubernetes/main/quickstart/install/)) and [Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/guides/).
 
 We provide a convenience script if you are installing from scratch for experimentation.
 ```bash
@@ -62,9 +115,14 @@ tokenizer.
 kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-token>
 ```
 
-### 2. Wire the InferencePool and HTTPRoute
+### 2. Create / Wire the InferencePool and HTTPRoute
 
-Point the `InferencePool` at your vLLM workers:
+Now that Gateway and GAIE is installed, we can create an InferencePool and an accompanying Dynamo EPP.
+
+Point the `InferencePool` at your vLLM workers (see the
+[`qwen-pool` InferencePool in `agg.yaml`](./agg.yaml) for a complete example):
+
+Specifically, these fields depend on the model you deploy, so make sure the settings below are adjusted to match your workers.
 
 - `spec.selector` — labels matching your vLLM pods.
 ```yaml
@@ -88,7 +146,8 @@ Point the `InferencePool` at your vLLM workers:
       number: 9002
 ```
 
-Attach the `HTTPRoute` to the gateway and target the pool:
+Attach the `HTTPRoute` to the gateway and target the pool (see the
+[`qwen-route` HTTPRoute in `agg.yaml`](./agg.yaml) for a complete example):
 
 - `spec.rules[].backendRefs[]` — targets the `InferencePool`.
 ```yaml
@@ -109,7 +168,7 @@ Attach the `HTTPRoute` to the gateway and target the pool:
       name: inference-gateway
 ```
 
-### 3. Label the workers
+### 3. Update vLLM deployment
 
 Add labels to your vLLM pods that match `InferencePool.spec.selector` (and the
 EPP's `DYN_EPP_POD_SELECTOR`):
@@ -121,6 +180,7 @@ metadata:
     app: vllm-qwen
 ```
 
+or
 ```bash
 kubectl -n <ns> label deployment <vllm-deployment> app=vllm-qwen --overwrite
 ```
@@ -189,6 +249,60 @@ metadata:
    See the full list in the
    [environment contract](#router-only-mode-environment-contract) below.
 
+In the end your Final vLLM deployment will look like below:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--served-model-name"     # NEW: pin the OpenAI model id
+            - "Qwen/Qwen3-0.6B"
+            - "--port"                  # NEW: explicit (8000 is vLLM's default)
+            - "8000"
+            - "--enable-prefix-caching" # NEW: required so vLLM emits prefix KV events
+            - "--block-size"            # NEW: MUST equal the EPP's DYN_KV_CACHE_BLOCK_SIZE
+            - "16"
+            - "--kv-events-config"      # NEW: publish KV events on a ZMQ PUB socket for the EPP
+            - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: kv-events           # NEW: KV-event PUB port the EPP subscribes to
+              containerPort: 5557
+          env:                          # NEW: HF token lets the worker pull the model (required for gated models)
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+```
+
 ### 5. (Disaggregated only) Build the P/D routing sidecar image
 
 The sidecar is a standalone Rust crate at `deploy/inference-gateway/pd-sidecar/`.
@@ -212,11 +326,9 @@ you built. The sidecar reads the `x-prefiller-host-port` header the EPP emits an
 runs vLLM's `kv_transfer_params` handshake against the selected prefill pod.
 
 
-## Run
+## Test
 
 ```bash
-kubectl apply -n <ns> -f agg.yaml        # or disagg.yaml
-
 # terminal 1
 kubectl -n agentgateway-system port-forward svc/inference-gateway 8000:80
 

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -11,7 +11,7 @@ behind a Gateway-API gateway with the Inference Extension (GAIE).
 
 If you already run GAIE + vLLM, you **replace only your EndpointPicker (EPP)**
 with the Dynamo EPP and you are done — no Dynamo operator, no Dynamo runtime,
-no Dynamo worker.
+no Dynamo worker. For disaggreaged serving you also need to build the disag sidecar.
 
 | | This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
 |---|---|---|
@@ -25,10 +25,22 @@ no Dynamo worker.
 The two modes are selected at startup by **`DYN_EPP_MODE`** (`full-dynamo-stack` | `router-only`). The same EPP
 binary serves both.
 
+LIMITATIONS:
+
+Concern | Gap vs the Dynamo/NATS path
+-- | --
+Duplicate store/remove (vLLM "retries") | parity
+In-stream ordering |  parity
+Transient disconnects | parity-ish
+Dropped events / gaps | Not handled. (NATS/JetStream is durable + replayable; the standalone indexer does seq-watermark gap detection + replay.)
+Initial cache state | Not handled. (The Dynamo path does an initial worker dump).
+Backpressure / EPP restart | PUB drops to slow subscribers (HWM) → silent loss; on restart the index is empty and only re-warms from new traffic.
+Data Parallelism | Not supported
+
 ## Files
 
 - `agg.yaml` — aggregated: one vLLM pool, KV-aware load balancing.
-- `disagg.yaml` — disaggregated: prefill + decode pools, KV-aware P/D selection.
+- `disagg.yaml` — disaggregated: prefill + decode pools, KV-aware P/D selection. Note that for the disaggregated serving you need to also build the sidecar to orchestrate the pull of the kv cache from the prefill worker.
 
 ## Prerequisites (install once)
 

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -30,7 +30,7 @@ The EPP can be served in 2 modes. The two modes are selected at startup by **`DY
 |---|---|
 Duplicate store/remove (vLLM "retries") | parity
 In-stream ordering |  parity
-Transient disconnects | parity-ish
+Transient disconnects | parity-ish. If the EPP's connection to a worker drops for a moment (a brief network blip or a quick pod restart), it reconnects on its own and keeps routing; the only catch is that any KV-cache updates the worker sent during that short gap are missed (ZMQ doesn't replay them), so the router's view is briefly a little out of date until normal traffic refreshes it — almost the same as the full stack, which can replay those missed updates.
 Dropped events / gaps | Not handled. (NATS/JetStream is durable + replayable; the standalone indexer does seq-watermark gap detection + replay.)
 Initial cache state | Not handled. (The Dynamo path does an initial worker dump).
 Backpressure / EPP restart | PUB drops to slow subscribers (HWM) → silent loss; on restart the index is empty and only re-warms from new traffic.

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -1,0 +1,78 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Dynamo Router on-ramp (raw vLLM, no Dynamo control plane)
+
+This directory is the **smallest possible** way to put Dynamo's KV/load-aware
+router in front of an existing **vanilla `vllm serve`** fleet that already sits
+behind a Gateway-API gateway with the Inference Extension (GAIE).
+
+If you already run GAIE + vLLM, you **replace only your EndpointPicker (EPP)**
+with the Dynamo EPP and you are done — no Dynamo operator, no Dynamo runtime,
+no Dynamo worker.
+
+| | This on-ramp (router-only mode) | Full Dynamo (full-dynamo-stack mode) |
+|---|---|---|
+| Workers | stock `vllm serve` | Dynamo workers (vLLM/SGLang/TRT-LLM) |
+| Discovery | K8s pod reflector + label selector | Dynamo discovery (etcd/K8s) |
+| KV events | per-pod vLLM ZMQ → EPP wrapper | Dynamo event plane |
+| Runtime | none, `DYN_EVENT_PLANE=zmq` | etcd + NATS |
+| Operator | not required | required (DynamoGraphDeployment) |
+| Tokenization | EPP tokenizes for routing; worker re-tokenizes | model-card preprocessor, no double tokenization |
+
+The two modes are selected at startup by **`DYN_EPP_MODE`** (`full-dynamo-stack` | `router-only`). The same EPP
+binary serves both.
+
+## Files
+
+- `agg.yaml` — aggregated: one vLLM pool, KV-aware load balancing.
+- `disagg.yaml` — disaggregated: prefill + decode pools, KV-aware P/D selection.
+
+## Prerequisites (install once)
+
+```bash
+# Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`
+deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
+
+# HF token secret (the EPP downloads the tokenizer to tokenize for routing)
+kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-token>
+```
+
+## Run
+
+```bash
+kubectl apply -n <ns> -f agg.yaml        # or disagg.yaml
+GW=$(kubectl get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
+curl http://$GW/v1/chat/completions -H 'content-type: application/json' -d '{
+  "model": "Qwen/Qwen3-0.6B",
+  "messages": [{"role":"user","content":"hello"}]
+}'
+```
+
+## router-only-mode environment contract
+
+| Env | Meaning |
+|---|---|
+| `DYN_EPP_MODE=router-only` | Select router-only (on-ramp) mode; `full-dynamo-stack` (default) keeps Dynamo mode |
+| `DYN_EPP_POD_SELECTOR` | Label selector for raw vLLM pods (reflector) |
+| `DYN_EPP_TARGET_PORT` | vLLM OpenAI HTTP port (pool targetPort) |
+| `DYN_EPP_KV_EVENTS=true` | Subscribe to per-pod vLLM ZMQ KV events |
+| `DYN_EPP_KV_EVENT_PORT` | vLLM `--kv-events-config` PUB port (e.g. 5557) |
+| `DYN_EPP_KV_EVENT_TOPIC` | vLLM `--kv-events-config` topic (`""` default) |
+| `DYN_MODEL_NAME` | Model id (no model card in router-only mode) |
+| `DYN_KV_CACHE_BLOCK_SIZE` | MUST equal vLLM `--block-size` |
+| `DYN_DISCOVERY_BACKEND=mem` | Inert runtime — no etcd |
+| `DYN_EVENT_PLANE=zmq` | Inert runtime — no NATS |
+| `DYN_EPP_ROLE_LABEL` | (disagg) pod label key splitting prefill/decode |
+| `DYN_ENFORCE_DISAGG` | (disagg) fail instead of agg fallback |
+| `DYN_EPP_EMIT_PREFILLER_HOST_PORT` | (disagg) emit `x-prefiller-host-port` |
+
+## How KV events reach the router without NATS
+
+vanilla vLLM publishes native KV-cache events on a ZMQ PUB socket
+(`--kv-events-config`). In router-only mode the EPP runs an in-process **ZMQ
+wrapper**: it subscribes to each Ready pod's PUB socket, normalizes the events,
+and feeds them into the embedded `KvRouter`'s index over the runtime's ZMQ event
+plane.

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -16,7 +16,7 @@ metadata:
   labels:
     app: vllm-qwen
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: vllm-qwen

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -128,7 +128,7 @@ spec:
       serviceAccountName: qwen-epp
       containers:
         - name: epp
-          image: nvcr.io/nvidia/ai-dynamo/epp-image:my-tag
+          image:  docker.io/lambda108/epp-inference-extension-dynamo:disagg-test
           ports:
             - name: grpc
               containerPort: 9002

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# =============================================================================
+# Dynamo Router "on-ramp" — AGGREGATED, raw vanilla vLLM, no Dynamo control plane
+# =============================================================================
+
+---
+# -----------------------------------------------------------------------------
+# vLLM workers — attach the pool to the cluster gateway.
+# -----------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          # Enable prefix caching + native KV-cache events on a ZMQ PUB socket.
+          # The EPP subscribes to tcp://<pod-ip>:5557 to learn cached prefixes.
+          # --block-size MUST match the EPP's DYN_KV_CACHE_BLOCK_SIZE below.
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--served-model-name"
+            - "Qwen/Qwen3-0.6B"
+            - "--port"
+            - "8000"
+            - "--enable-prefix-caching"
+            - "--block-size"
+            - "16"
+            - "--kv-events-config"
+            - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: kv-events
+              containerPort: 5557
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+
+---
+# -----------------------------------------------------------------------------
+# RBAC: the EPP's pod reflector needs to list/watch the vLLM pods, and read
+#    its own InferencePool. (The Dynamo operator would normally create these.)
+# -----------------------------------------------------------------------------
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: qwen-epp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: qwen-epp
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["inference.networking.k8s.io"]
+    resources: ["inferencepools"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: qwen-epp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: qwen-epp
+subjects:
+  - kind: ServiceAccount
+    name: qwen-epp
+
+---
+# -----------------------------------------------------------------------------
+# The Dynamo Rust EPP, in router-only (on-ramp) mode.
+#    This is the ONLY Dynamo component in the whole topology.
+# -----------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qwen-epp
+  labels:
+    app: qwen-epp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qwen-epp
+  template:
+    metadata:
+      labels:
+        app: qwen-epp
+    spec:
+      serviceAccountName: qwen-epp
+      containers:
+        - name: epp
+          image: nvcr.io/nvidia/ai-dynamo/epp-image:my-tag
+          ports:
+            - name: grpc
+              containerPort: 9002
+            - name: grpc-health
+              containerPort: 9003
+          env:
+            # --- router-only ("on-ramp") mode switch ----------------------------
+            - name: DYN_EPP_MODE
+              value: "router-only"
+            # Label selector used by the pod reflector to find raw vLLM pods.
+            - name: DYN_EPP_POD_SELECTOR
+              value: "app=vllm-qwen"
+            # The vLLM OpenAI HTTP port the gateway forwards to (pool targetPort).
+            - name: DYN_EPP_TARGET_PORT
+              value: "8000"
+            # --- precise KV routing from vLLM's native ZMQ events ---------------
+            - name: DYN_EPP_KV_EVENTS
+              value: "true"
+            - name: DYN_EPP_KV_EVENT_PORT
+              value: "5557"
+            # vLLM's --kv-events-config topic ("" = no topic prefix, the default).
+            - name: DYN_EPP_KV_EVENT_TOPIC
+              value: ""
+            # The EPP has no Dynamo model card in router-only mode, so the model
+            # name + block size are provided explicitly. block size MUST equal
+            # vLLM's --block-size.
+            - name: DYN_MODEL_NAME
+              value: "Qwen/Qwen3-0.6B"
+            - name: DYN_KV_CACHE_BLOCK_SIZE
+              value: "16"
+            - name: DYN_OVERLAP_SCORE_WEIGHT
+              value: "1.0"
+            # --- inert runtime: NO etcd, NO NATS --------------------------------
+            - name: DYN_DISCOVERY_BACKEND
+              value: "mem"
+            - name: DYN_EVENT_PLANE
+              value: "zmq"
+            # The pod reflector reads its own namespace from the downward API.
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RUST_LOG
+              value: "info,dynamo_llm::kv_router=debug"
+            # HF token: the EPP downloads the tokenizer for the model to tokenize
+            # prompts for routing (no GPU needed; the worker re-tokenizes).
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          readinessProbe:
+            grpc:
+              port: 9003
+              service: inference-extension
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 9003
+              service: inference-extension
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qwen-epp
+spec:
+  selector:
+    app: qwen-epp
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+      appProtocol: http2
+
+---
+# -----------------------------------------------------------------------------
+# GAIE InferencePool — selects the raw vLLM pods and delegates endpoint
+#    selection to the Dynamo EPP. THIS is the single line an existing GAIE user
+#    changes: endpointPickerRef -> the Dynamo EPP service.
+# -----------------------------------------------------------------------------
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: qwen-pool
+spec:
+  targetPorts:
+    - number: 8000
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  endpointPickerRef:
+    kind: Service
+    name: qwen-epp
+    port:
+      number: 9002
+
+---
+# -----------------------------------------------------------------------------
+# HTTPRoute — attach the pool to the cluster gateway.
+# -----------------------------------------------------------------------------
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen-route
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: qwen-pool
+          port: 8000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -65,10 +65,6 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
-      tolerations:
-        - effect: NoSchedule
-          key: nvidia.com/gpu
-          operator: Exists
 
 ---
 # -----------------------------------------------------------------------------

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -173,6 +173,11 @@ spec:
                   fieldPath: metadata.namespace
             - name: RUST_LOG
               value: "info,dynamo_llm::kv_router=debug"
+            # The EPP runs as non-root; point HuggingFace's cache at a writable
+            # dir (the hf-cache emptyDir mounted below) so the startup tokenizer
+            # download can create its cache instead of failing on /home/nonroot.
+            - name: HF_HOME
+              value: /tmp/hf
             # HF token: the EPP downloads the tokenizer for the model to tokenize
             # prompts for routing (no GPU needed; the worker re-tokenizes).
             - name: HF_TOKEN
@@ -200,6 +205,13 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /tmp/hf
+      volumes:
+        # Writable HuggingFace cache for the non-root EPP (tokenizer download).
+        - name: hf-cache
+          emptyDir: {}
 
 ---
 apiVersion: v1

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -106,7 +106,7 @@ subjects:
 
 ---
 # -----------------------------------------------------------------------------
-# The Dynamo Rust EPP, in router-only (on-ramp) mode.
+# The Dynamo EPP, in router-only (on-ramp) mode.
 #    This is the ONLY Dynamo component in the whole topology.
 # -----------------------------------------------------------------------------
 apiVersion: apps/v1

--- a/deploy/inference-gateway/ext-proc/examples/onramp/disagg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/disagg.yaml
@@ -176,14 +176,9 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
-        # --- OPTIONAL: decode-side P/D routing sidecar -------------------------
-        # Reads `x-prefiller-host-port` (set by the EPP) and runs vLLM's
-        # kv_transfer_params handshake against the selected prefill pod. Provide
-        # your own image here; the EPP only emits the header, it does not run
-        # the transfer. See issue #10426 (non-goals) for why this lives on the
-        # decode side rather than in the EPP.
-        # - name: pd-router-sidecar
-        #   image: <your-pd-routing-sidecar>
+        # decode-side P/D routing sidecar -------------------------
+        - name: pd-router-sidecar
+          image: docker.io/lambda108/pd-sidecar-dynamo:disagg-test
       tolerations:
         - effect: NoSchedule
           key: nvidia.com/gpu
@@ -245,7 +240,7 @@ spec:
       serviceAccountName: qwen-epp
       containers:
         - name: epp
-          image: nvcr.io/nvidia/ai-dynamo/epp-image:my-tag
+          image:  docker.io/lambda108/epp-inference-extension-dynamo:disagg-test
           ports:
             - name: grpc
               containerPort: 9002

--- a/deploy/inference-gateway/ext-proc/examples/onramp/disagg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/disagg.yaml
@@ -286,6 +286,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: RUST_LOG
               value: "info,dynamo_llm::kv_router=debug"
+            # Non-root EPP: writable HuggingFace cache for the startup tokenizer
+            # download (the hf-cache emptyDir mounted below).
+            - name: HF_HOME
+              value: /tmp/hf
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -311,6 +315,13 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /tmp/hf
+      volumes:
+        # Writable HuggingFace cache for the non-root EPP (tokenizer download).
+        - name: hf-cache
+          emptyDir: {}
 
 ---
 apiVersion: v1

--- a/deploy/inference-gateway/ext-proc/examples/onramp/disagg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/disagg.yaml
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# =============================================================================
+# Dynamo Router "on-ramp" — DISAGGREGATED, raw vanilla vLLM, no Dynamo control plane
+# =============================================================================
+#
+# Same on-ramp idea as agg.yaml (no Dynamo operator, no Dynamo runtime, no
+# Dynamo worker — the EPP runs the inert `mem` backend + DYN_EVENT_PLANE=zmq),
+# but the vLLM fleet is split into prefill and decode pools and the EPP makes a
+# KV-aware prefill+decode decision.
+#
+# Topology:
+#   client -> gateway -> Dynamo EPP (ext_proc) picks decode worker (KV-aware)
+#                        and the prefill worker; emits BOTH:
+#                          x-worker-instance-id   (decode target)
+#                          x-prefiller-host-port   (selected prefill pod ip:port)
+#                        gateway forwards the request to the DECODE pod.
+#   decode pod -> a decode-side P/D routing sidecar reads x-prefiller-host-port
+#                 and drives vLLM's kv_transfer_params handshake (NixlConnector),
+#                 so prefill happens on the prefill pod and the KV is transferred
+#                 to decode. This sidecar is the ONE piece you provide on the
+#                 decode pod; the EPP never re-implements the KV-transfer protocol.
+#
+# Both prefill and decode pods carry `app: vllm-qwen` (so the InferencePool
+# selects all of them) plus a role label `dynamo-role: prefill|decode` that the
+# EPP uses to tell the two pools apart.
+#
+# Prereqs: deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
+# Apply:   kubectl apply -n <ns> -f disagg.yaml
+# -----------------------------------------------------------------------------
+
+---
+# -----------------------------------------------------------------------------
+# 1a) Raw vanilla vLLM PREFILL pods. NixlConnector + KV events enabled.
+# -----------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen-prefill
+  labels:
+    app: vllm-qwen
+    dynamo-role: prefill
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-qwen
+      dynamo-role: prefill
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+        dynamo-role: prefill
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--served-model-name"
+            - "Qwen/Qwen3-0.6B"
+            - "--port"
+            - "8000"
+            - "--enable-prefix-caching"
+            - "--block-size"
+            - "16"
+            - "--max-model-len"
+            - "16384"
+            - "--gpu-memory-utilization"
+            - "0.50"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
+            - "--kv-events-config"
+            - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: kv-events
+              containerPort: 5557
+          env:
+            - name: UCX_TLS
+              value: "tcp,self"
+            - name: UCX_RNDV_THRESH
+              value: "inf"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+
+---
+# -----------------------------------------------------------------------------
+# 1b) Raw vanilla vLLM DECODE pods. NixlConnector. The decode-side P/D sidecar
+#     (your code; not shipped by Dynamo) consumes x-prefiller-host-port.
+# -----------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen-decode
+  labels:
+    app: vllm-qwen
+    dynamo-role: decode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-qwen
+      dynamo-role: decode
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+        dynamo-role: decode
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--served-model-name"
+            - "Qwen/Qwen3-0.6B"
+            - "--port"
+            - "8000"
+            - "--enable-prefix-caching"
+            - "--block-size"
+            - "16"
+            - "--max-model-len"
+            - "16384"
+            - "--gpu-memory-utilization"
+            - "0.50"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
+            - "--kv-events-config"
+            - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: kv-events
+              containerPort: 5557
+          env:
+            - name: UCX_TLS
+              value: "tcp,self"
+            - name: UCX_RNDV_THRESH
+              value: "inf"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+        # --- OPTIONAL: decode-side P/D routing sidecar -------------------------
+        # Reads `x-prefiller-host-port` (set by the EPP) and runs vLLM's
+        # kv_transfer_params handshake against the selected prefill pod. Provide
+        # your own image here; the EPP only emits the header, it does not run
+        # the transfer. See issue #10426 (non-goals) for why this lives on the
+        # decode side rather than in the EPP.
+        # - name: pd-router-sidecar
+        #   image: <your-pd-routing-sidecar>
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+
+---
+# -----------------------------------------------------------------------------
+# 2) RBAC for the EPP pod reflector.
+# -----------------------------------------------------------------------------
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: qwen-epp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: qwen-epp
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["inference.networking.k8s.io"]
+    resources: ["inferencepools"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: qwen-epp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: qwen-epp
+subjects:
+  - kind: ServiceAccount
+    name: qwen-epp
+
+---
+# -----------------------------------------------------------------------------
+# 3) Dynamo Rust EPP, router-only mode, disaggregated.
+# -----------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qwen-epp
+  labels:
+    app: qwen-epp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qwen-epp
+  template:
+    metadata:
+      labels:
+        app: qwen-epp
+    spec:
+      serviceAccountName: qwen-epp
+      containers:
+        - name: epp
+          image: nvcr.io/nvidia/ai-dynamo/epp-image:my-tag
+          ports:
+            - name: grpc
+              containerPort: 9002
+            - name: grpc-health
+              containerPort: 9003
+          env:
+            - name: DYN_EPP_MODE
+              value: "router-only"
+            # All vLLM pods (prefill + decode) share this selector.
+            - name: DYN_EPP_POD_SELECTOR
+              value: "app=vllm-qwen"
+            # Role label key/values the EPP uses to split prefill vs decode.
+            - name: DYN_EPP_ROLE_LABEL
+              value: "dynamo-role"
+            - name: DYN_EPP_TARGET_PORT
+              value: "8000"
+            - name: DYN_EPP_KV_EVENTS
+              value: "true"
+            - name: DYN_EPP_KV_EVENT_PORT
+              value: "5557"
+            - name: DYN_EPP_KV_EVENT_TOPIC
+              value: ""
+            - name: DYN_MODEL_NAME
+              value: "Qwen/Qwen3-0.6B"
+            - name: DYN_KV_CACHE_BLOCK_SIZE
+              value: "16"
+            - name: DYN_OVERLAP_SCORE_WEIGHT
+              value: "1.0"
+            # Require disagg: fail rather than silently falling back to agg.
+            - name: DYN_ENFORCE_DISAGG
+              value: "true"
+            # Emit x-prefiller-host-port so the decode-side P/D sidecar can run
+            # the vLLM KV-transfer handshake.
+            - name: DYN_EPP_EMIT_PREFILLER_HOST_PORT
+              value: "true"
+            - name: DYN_DISCOVERY_BACKEND
+              value: "mem"
+            - name: DYN_EVENT_PLANE
+              value: "zmq"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RUST_LOG
+              value: "info,dynamo_llm::kv_router=debug"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          readinessProbe:
+            grpc:
+              port: 9003
+              service: inference-extension
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 9003
+              service: inference-extension
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qwen-epp
+spec:
+  selector:
+    app: qwen-epp
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+      appProtocol: http2
+
+---
+# -----------------------------------------------------------------------------
+# 4) InferencePool selects ALL vLLM pods (prefill + decode); the EPP decides
+#    which is which via the dynamo-role label.
+# -----------------------------------------------------------------------------
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: qwen-pool
+spec:
+  targetPorts:
+    - number: 8000
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  endpointPickerRef:
+    kind: Service
+    name: qwen-epp
+    port:
+      number: 9002
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen-route
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: qwen-pool
+          port: 8000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s

--- a/deploy/inference-gateway/ext-proc/examples/onramp/httproute.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/httproute.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# HTTPRoute for the on-ramp example in the `atchernych` namespace.
+# Binds to the shared cluster Gateway in `agentgateway-system`.
+#
+# Apply with:
+#   kubectl apply -n atchernych -f httproute-atchernych.yaml
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen-route
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+      namespace: agentgateway-system
+      sectionName: http
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: qwen-pool
+          port: 8000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s

--- a/deploy/inference-gateway/ext-proc/examples/onramp/httproute.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/httproute.yaml
@@ -4,8 +4,6 @@
 # HTTPRoute for the on-ramp example in the `atchernych` namespace.
 # Binds to the shared cluster Gateway in `agentgateway-system`.
 #
-# Apply with:
-#   kubectl apply -n atchernych -f httproute-atchernych.yaml
 
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
@@ -137,7 +137,6 @@ Required alignment:
 - vLLM `--block-size` must match `tokenProcessorConfig.blockSize`.
 - vLLM KV topic should match `kvEventsConfig.topicFilter` (default prefix `kv@`).
 
-
 ### 4. Add llm-d EPP to your deployment
 
 Deploy llm-d Router in gateway mode with a precise-prefix config.
@@ -260,7 +259,7 @@ Install (local chart path):
 
 ```bash
 helm upgrade -i qwen-router \
-  /home/atchernych/code/gaie/llm-d-router/config/charts/llm-d-router-gateway \
+  llm-d-router/config/charts/llm-d-router-gateway \
   -n <ns> \
   -f values-llmd-gateway.yaml
 ```
@@ -273,6 +272,167 @@ helm upgrade -i qwen-router \
   -n <ns> \
   -f values-llmd-gateway.yaml \
   --version <router-chart-version>
+```
+
+Rendered YAMLs from the Helm chart:
+
+```bash
+helm template qwen-router \
+  llm-d-router/config/charts/llm-d-router-gateway \
+  --namespace default \
+  --set router.modelServers.matchLabels.app=vllm-qwen \
+  --set httpRoute.create=true \
+  --set httpRoute.inferenceGatewayName=inference-gateway \
+  -s templates/epp.yaml \
+  -s templates/httproute.yaml
+```
+
+Rendered `ConfigMap` (default plugin config):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qwen-router-epp
+  namespace: default
+data:
+  default-plugins.yaml: |
+    apiVersion: llm-d.ai/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+    - type: queue-scorer
+    - type: kv-cache-utilization-scorer
+    - type: prefix-cache-scorer
+    - type: metrics-data-source
+      parameters:
+        scheme: "http"
+        path: "/metrics"
+        insecureSkipVerify: true
+    - type: core-metrics-extractor
+    schedulingProfiles:
+    - name: default
+      plugins:
+      - pluginRef: queue-scorer
+        weight: 2
+      - pluginRef: kv-cache-utilization-scorer
+        weight: 2
+      - pluginRef: prefix-cache-scorer
+        weight: 3
+```
+
+Rendered `Service`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: qwen-router-epp
+  namespace: default
+  labels:
+    app.kubernetes.io/name: qwen-router-epp
+    app.kubernetes.io/version: "0.0.0"
+spec:
+  selector:
+    llm-d-router-gateway: qwen-router-epp
+  ports:
+    - name: grpc-ext-proc
+      protocol: TCP
+      port: 9002
+    - name: http-metrics
+      protocol: TCP
+      port: 9090
+  type: ClusterIP
+```
+
+Rendered `Deployment`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qwen-router-epp
+  namespace: default
+  labels:
+    app.kubernetes.io/name: qwen-router-epp
+    app.kubernetes.io/version: "0.0.0"
+    llm-d.ai/igw-mode: llm-d-router-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      llm-d-router-gateway: qwen-router-epp
+  template:
+    metadata:
+      labels:
+        llm-d-router-gateway: qwen-router-epp
+        llm-d.ai/igw-mode: llm-d-router-gateway
+    spec:
+      serviceAccountName: qwen-router-epp
+      containers:
+        - name: epp
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker-dev:main
+          args:
+            - --pool-name
+            - qwen-router
+            - --pool-namespace
+            - default
+            - --pool-group
+            - "inference.networking.k8s.io"
+            - --zap-encoder
+            - "json"
+            - --config-file
+            - "/config/default-plugins.yaml"
+            - --grpc-health-port
+            - "9003"
+            - --tracing=false
+```
+
+Rendered `InferencePool`:
+
+```yaml
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: qwen-router
+  namespace: default
+spec:
+  targetPorts:
+    - number: 8000
+  appProtocol: "http"
+  selector:
+    matchLabels:
+      app: "vllm-qwen"
+  endpointPickerRef:
+    name: qwen-router-epp
+    port:
+      number: 9002
+    failureMode: FailOpen
+```
+
+Rendered `HTTPRoute`:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen-router
+  namespace: default
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: qwen-router
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s
 ```
 
 If `InferencePool` and `HTTPRoute` are already managed separately, set:

--- a/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
@@ -1,4 +1,4 @@
-# llm-d Router on-ramp (raw vLLM workers, no extra control plane)
+# llm-d Router on-ramp
 
 ## Example progression from vLLM to vLLM + llm-d + GAIE
 
@@ -71,7 +71,7 @@ Point the `InferencePool` at your vLLM workers:
 apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool
 metadata:
-  name: qwen-pool
+  name: qwen-router
 spec:
   selector:
     matchLabels:
@@ -91,7 +91,7 @@ Attach your `HTTPRoute` to the gateway and target the pool:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: qwen-route
+  name: qwen-router
 spec:
   parentRefs:
   - group: gateway.networking.k8s.io
@@ -101,7 +101,7 @@ spec:
   - backendRefs:
     - group: inference.networking.k8s.io
       kind: InferencePool
-      name: qwen-pool
+      name: qwen-router
 ```
 
 ### 3. Update vLLM deployment
@@ -274,20 +274,23 @@ helm upgrade -i qwen-router \
   --version <router-chart-version>
 ```
 
-Rendered YAMLs from the Helm chart:
+Rendered YAMLs from the Helm chart (example, precise-prefix KV-aware + load-aware config):
 
 ```bash
 helm template qwen-router \
   llm-d-router/config/charts/llm-d-router-gateway \
   --namespace default \
-  --set router.modelServers.matchLabels.app=vllm-qwen \
-  --set httpRoute.create=true \
-  --set httpRoute.inferenceGatewayName=inference-gateway \
+  -f values-llmd-gateway.yaml \
   -s templates/epp.yaml \
   -s templates/httproute.yaml
 ```
 
-Rendered `ConfigMap` (default plugin config):
+The only differences in Option A vs B are in two resources:
+
+- `ConfigMap`: `token-producer.parameters.vllm.url`
+- `Deployment`: sidecar presence (`vllm-render`), HF token env (Option A), and related sidecar cache volume
+
+Rendered `ConfigMap` (shows precise-prefix KV-aware scorer + load scorers):
 
 ```yaml
 apiVersion: v1
@@ -296,28 +299,51 @@ metadata:
   name: qwen-router-epp
   namespace: default
 data:
-  default-plugins.yaml: |
+  precise-prefix-config.yaml: |
     apiVersion: llm-d.ai/v1alpha1
     kind: EndpointPickerConfig
     plugins:
-    - type: queue-scorer
-    - type: kv-cache-utilization-scorer
-    - type: prefix-cache-scorer
-    - type: metrics-data-source
+    - type: token-producer
       parameters:
-        scheme: "http"
-        path: "/metrics"
-        insecureSkipVerify: true
+        modelName: "Qwen/Qwen3-32B"
+        vllm:
+          url: "http://localhost:8000" # option A; for option B use http://vllm-render.<ns>.svc.cluster.local:8000
+    - type: endpoint-notification-source
+    - type: metrics-data-source
     - type: core-metrics-extractor
+    - type: precise-prefix-cache-producer
+      parameters:
+        tokenProcessorConfig:
+          blockSize: 64
+        kvEventsConfig:
+          topicFilter: "kv@"
+          discoverPods: true
+          podDiscoveryConfig:
+            socketPort: 5557
+    - type: prefix-cache-scorer
+      parameters:
+        prefixMatchInfoProducerName: precise-prefix-cache-producer
+    - type: kv-cache-utilization-scorer
+    - type: queue-scorer
+    - type: max-score-picker
+    dataLayer:
+      sources:
+      - pluginRef: metrics-data-source
+        extractors:
+        - pluginRef: core-metrics-extractor
+      - pluginRef: endpoint-notification-source
+        extractors:
+        - pluginRef: precise-prefix-cache-producer
     schedulingProfiles:
     - name: default
       plugins:
-      - pluginRef: queue-scorer
+      - pluginRef: prefix-cache-scorer
         weight: 2
       - pluginRef: kv-cache-utilization-scorer
-        weight: 2
-      - pluginRef: prefix-cache-scorer
-        weight: 3
+        weight: 1
+      - pluginRef: queue-scorer
+        weight: 1
+      - pluginRef: max-score-picker
 ```
 
 Rendered `Service`:
@@ -344,7 +370,7 @@ spec:
   type: ClusterIP
 ```
 
-Rendered `Deployment`:
+Rendered `Deployment` (Option A shown: EPP-local tokenizer sidecar):
 
 ```yaml
 apiVersion: apps/v1
@@ -381,13 +407,42 @@ spec:
             - --zap-encoder
             - "json"
             - --config-file
-            - "/config/default-plugins.yaml"
+            - "/config/precise-prefix-config.yaml"
             - --grpc-health-port
             - "9003"
             - --tracing=false
+          volumeMounts:
+            - name: plugins-config-volume
+              mountPath: "/config"
+        - name: vllm-render # This is for option A, remove for option B
+          image: docker.io/vllm/vllm-openai-cpu:v0.19.1
+          command:
+            - vllm
+            - launch
+            - render
+          args:
+            - "Qwen/Qwen3-32B"
+            - "--port=8000"
+          env:
+            - name: HF_TOKEN # This is for option A, remove for option B
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          volumeMounts:
+            - name: model-cache
+              mountPath: /root/.cache/huggingface
+      volumes:
+        - name: model-cache
+          emptyDir: {}
+        - name: plugins-config-volume
+          configMap:
+            name: qwen-router-epp
 ```
 
 Rendered `InferencePool`:
+
+Note: these names match the manual examples above because the Helm release name (`qwen-router`) is used for the `InferencePool`/`HTTPRoute` and `qwen-router-epp` for the EPP resources.
 
 ```yaml
 apiVersion: inference.networking.k8s.io/v1

--- a/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
@@ -143,14 +143,11 @@ Required alignment:
 Deploy llm-d Router in gateway mode with a precise-prefix config.
 
 llm-d provides NO guide how to upgrade existing vLLM workers. They need to consult many docs:
-Chart defaults (gateway chart):
-https://github.com/llm-d/llm-d-router/blob/main/config/charts/llm-d-router-gateway/values.yaml
-Shared routerlib defaults:
-https://github.com/llm-d/llm-d-router/blob/main/config/charts/routerlib/values.yaml
-Precise prefix plugin example:
-https://github.com/llm-d/llm-d-router/blob/main/deploy/config/epp-precise-prefix-cache-config.yaml
-Tokenizer + vLLM URL example:
-https://github.com/llm-d/llm-d-router/blob/main/deploy/config/sim-epp-tokenizer-vllm-http-config.yaml
+
+- [Chart defaults (gateway chart)](https://github.com/llm-d/llm-d-router/blob/main/config/charts/llm-d-router-gateway/values.yaml)
+- [Shared routerlib defaults](https://github.com/llm-d/llm-d-router/blob/main/config/charts/routerlib/values.yaml)
+- [Precise prefix plugin example](https://github.com/llm-d/llm-d-router/blob/main/deploy/config/epp-precise-prefix-cache-config.yaml)
+- [Tokenizer + vLLM URL example](https://github.com/llm-d/llm-d-router/blob/main/deploy/config/sim-epp-tokenizer-vllm-http-config.yaml)
 
 If I were to add this guide I would do the following:
 

--- a/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
@@ -1,6 +1,5 @@
-# llm-d Router on-ramp (raw vLLM workers, no extra control plane)
 
-## Example progression from vLLM to vLLM + llm-d + GAIE
+# Example progression from vLLM to vLLM + llm-d + GAIE
 
 ### Initial Deployment
 
@@ -214,7 +213,7 @@ Install:
 
 ```bash
 helm upgrade -i qwen-router \
-  /home/atchernych/code/gaie/llm-d-router/config/charts/llm-d-router-gateway \
+  llm-d-router/config/charts/llm-d-router-gateway \
   -n <ns> \
   -f values-llmd-gateway.yaml
 ```

--- a/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
@@ -442,8 +442,6 @@ spec:
 
 Rendered `InferencePool`:
 
-Note: these names match the manual examples above because the Helm release name (`qwen-router`) is used for the `InferencePool`/`HTTPRoute` and `qwen-router-epp` for the EPP resources.
-
 ```yaml
 apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool

--- a/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
@@ -1,0 +1,308 @@
+# llm-d Router on-ramp (raw vLLM workers, no extra control plane)
+
+## Example progression from vLLM to vLLM + llm-d + GAIE
+
+### Initial Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+      - name: vllm
+        image: vllm/vllm-openai:latest
+        args:
+        - "--model"
+        - "Qwen/Qwen3-32B"
+        ports:
+        - name: http
+          containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-qwen
+spec:
+  selector:
+    app: vllm-qwen
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8000
+```
+
+### 1. Prerequisites
+
+Set up a Gateway-API gateway + Inference Extension (GAIE) if you don't have one yet. Follow the instructions for your gateway (e.g. AgentGateway) and Inference Extension.
+
+Create the HuggingFace token secret.
+
+```bash
+kubectl create secret generic llm-d-hf-token --from-literal=HF_TOKEN=<your-token>
+```
+
+### 2. Create / Wire the InferencePool and HTTPRoute
+
+Point the `InferencePool` at your vLLM workers:
+
+- `spec.selector` must match worker pod labels.
+- `spec.targetPorts[].number` must match vLLM serving port (usually `8000`).
+- `spec.endpointPickerRef` must point to the llm-d EPP service and ext-proc port (`9002`).
+
+```yaml
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: qwen-pool
+spec:
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  targetPorts:
+  - number: 8000
+  endpointPickerRef:
+    kind: Service
+    name: qwen-router-epp
+    port:
+      number: 9002
+```
+
+Attach your `HTTPRoute` to the gateway and target the pool:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen-route
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: inference-gateway
+  rules:
+  - backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: qwen-pool
+```
+
+### 3. Update vLLM deployment
+
+Ensure worker labels match `InferencePool.spec.selector`:
+
+```bash
+kubectl -n <ns> label deployment <vllm-deployment> app=vllm-qwen --overwrite
+```
+
+Patch workers to publish KV events and align block size:
+
+```yaml
+args:
+  - "--served-model-name"
+  - "Qwen/Qwen3-32B"
+  - "--port"
+  - "8000"
+  - "--enable-prefix-caching"
+  - "--block-size"
+  - "64"
+  - "--kv-events-config"
+  - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-32B"}'
+ports:
+  - name: http
+    containerPort: 8000
+  - name: kv-events
+    containerPort: 5557
+```
+
+Required alignment:
+
+- vLLM `--block-size` must match `tokenProcessorConfig.blockSize`.
+- vLLM KV topic should match `kvEventsConfig.topicFilter` (default prefix `kv@`).
+
+### 4. Add llm-d EPP to your deployment
+
+Deploy llm-d Router in gateway mode with a precise-prefix config.
+
+Create `values-llmd-gateway.yaml`:
+
+```yaml
+router:
+  modelServers:
+    matchLabels:
+      app: vllm-qwen
+    targetPorts:
+      - number: 8000
+
+  epp:
+    replicas: 1
+    pluginsConfigFile: precise-prefix-config.yaml
+    pluginsCustomConfig:
+      precise-prefix-config.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: token-producer
+          parameters:
+            modelName: "Qwen/Qwen3-32B"
+            vllm:
+              url: "http://localhost:8000"
+        - type: endpoint-notification-source
+        - type: metrics-data-source
+        - type: core-metrics-extractor
+        - type: decode-filter
+        - type: precise-prefix-cache-producer
+          parameters:
+            tokenProcessorConfig:
+              blockSize: 64
+            kvEventsConfig:
+              topicFilter: "kv@"
+              discoverPods: true
+              podDiscoveryConfig:
+                socketPort: 5557
+        - type: prefix-cache-scorer
+          parameters:
+            prefixMatchInfoProducerName: precise-prefix-cache-producer
+        - type: kv-cache-utilization-scorer
+        - type: queue-scorer
+        - type: max-score-picker
+        dataLayer:
+          sources:
+          - pluginRef: metrics-data-source
+            extractors:
+            - pluginRef: core-metrics-extractor
+          - pluginRef: endpoint-notification-source
+            extractors:
+            - pluginRef: precise-prefix-cache-producer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: decode-filter
+          - pluginRef: prefix-cache-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 1
+          - pluginRef: queue-scorer
+            weight: 1
+          - pluginRef: max-score-picker
+
+  tokenizer:
+    enabled: true
+    modelName: "Qwen/Qwen3-32B"
+
+httpRoute:
+  create: true
+  inferenceGatewayName: inference-gateway
+
+provider:
+  name: none
+```
+
+Install:
+
+```bash
+helm upgrade -i qwen-router \
+  /home/atchernych/code/gaie/llm-d-router/config/charts/llm-d-router-gateway \
+  -n <ns> \
+  -f values-llmd-gateway.yaml
+```
+
+If `InferencePool` and `HTTPRoute` are already managed separately, set:
+
+- `httpRoute.create=false`
+- keep `endpointPickerRef` pointing at the deployed EPP service on port `9002`
+
+## Test
+
+```bash
+# terminal 1
+kubectl -n <gateway-ns> port-forward svc/inference-gateway 8000:80
+
+# terminal 2
+curl --max-time 20 -sS "http://localhost:8000/v1/models" | jq .
+
+curl --max-time 120 -sS "http://localhost:8000/v1/chat/completions" \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3-32B",
+    "messages": [{"role":"user","content":"hello"}]
+  }' | jq .
+```
+
+## Configuration checklist
+
+- `InferencePool.spec.selector.matchLabels` == worker pod labels.
+- `InferencePool.spec.targetPorts[].number` == worker serve port (`8000`).
+- `InferencePool.spec.endpointPickerRef` == llm-d EPP service + ext-proc port (`9002`).
+- worker `--kv-events-config.endpoint` == `kvEventsConfig.podDiscoveryConfig.socketPort`.
+- worker KV topic matches `kvEventsConfig.topicFilter`.
+- worker `--block-size` == `tokenProcessorConfig.blockSize`.
+- `token-producer.parameters.modelName` matches the served model/tokenizer.
+
+## Final vLLM workers deployment
+
+After applying step 3 changes, a full worker deployment looks like this:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+      - name: vllm
+        image: vllm/vllm-openai:latest
+        args:
+          - "--model"
+          - "Qwen/Qwen3-32B"
+          - "--served-model-name"      # NEW: pin the OpenAI model id
+          - "Qwen/Qwen3-32B"
+          - "--port"                   # NEW: explicit worker serving port
+          - "8000"
+          - "--enable-prefix-caching"  # NEW: required to emit prefix-aware KV events
+          - "--block-size"             # NEW: must match llm-d tokenProcessorConfig.blockSize
+          - "64"
+          - "--kv-events-config"       # NEW: publish KV events on a ZMQ socket
+          - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-32B"}'
+        ports:
+          - name: http
+            containerPort: 8000
+          - name: kv-events            # NEW: KV event port the llm-d EPP subscribes to
+            containerPort: 5557
+        env:
+          - name: HF_TOKEN             # NEW: lets worker pull gated/private models
+            valueFrom:
+              secretKeyRef:
+                name: llm-d-hf-token
+                key: HF_TOKEN
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+```

--- a/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/llm-d-router-onramp.md
@@ -1,5 +1,6 @@
+# llm-d Router on-ramp (raw vLLM workers, no extra control plane)
 
-# Example progression from vLLM to vLLM + llm-d + GAIE
+## Example progression from vLLM to vLLM + llm-d + GAIE
 
 ### Initial Deployment
 
@@ -47,7 +48,12 @@ spec:
 
 Set up a Gateway-API gateway + Inference Extension (GAIE) if you don't have one yet. Follow the instructions for your gateway (e.g. AgentGateway) and Inference Extension.
 
-Create the HuggingFace token secret.
+Choose tokenization mode first:
+
+- **Option A (EPP-local tokenizer sidecar):** create `llm-d-hf-token`.
+- **Option B (tokenize through existing vLLM/render endpoint):** no EPP HF secret required.
+
+Create the secret only for Option A:
 
 ```bash
 kubectl create secret generic llm-d-hf-token --from-literal=HF_TOKEN=<your-token>
@@ -131,11 +137,26 @@ Required alignment:
 - vLLM `--block-size` must match `tokenProcessorConfig.blockSize`.
 - vLLM KV topic should match `kvEventsConfig.topicFilter` (default prefix `kv@`).
 
+
 ### 4. Add llm-d EPP to your deployment
 
 Deploy llm-d Router in gateway mode with a precise-prefix config.
 
-Create `values-llmd-gateway.yaml`:
+llm-d provides NO guide how to upgrade existing vLLM workers. They need to consult many docs:
+Chart defaults (gateway chart):
+https://github.com/llm-d/llm-d-router/blob/main/config/charts/llm-d-router-gateway/values.yaml
+Shared routerlib defaults:
+https://github.com/llm-d/llm-d-router/blob/main/config/charts/routerlib/values.yaml
+Precise prefix plugin example:
+https://github.com/llm-d/llm-d-router/blob/main/deploy/config/epp-precise-prefix-cache-config.yaml
+Tokenizer + vLLM URL example:
+https://github.com/llm-d/llm-d-router/blob/main/deploy/config/sim-epp-tokenizer-vllm-http-config.yaml
+
+If I were to add this guide I would do the following:
+
+Create `values-llmd-gateway.yaml` in your real deployment repo (for example in
+the same repo where your Helm release values live). The YAML below is a
+template example you should copy and customize.
 
 ```yaml
 router:
@@ -161,7 +182,6 @@ router:
         - type: endpoint-notification-source
         - type: metrics-data-source
         - type: core-metrics-extractor
-        - type: decode-filter
         - type: precise-prefix-cache-producer
           parameters:
             tokenProcessorConfig:
@@ -188,7 +208,6 @@ router:
         schedulingProfiles:
         - name: default
           plugins:
-          - pluginRef: decode-filter
           - pluginRef: prefix-cache-scorer
             weight: 2
           - pluginRef: kv-cache-utilization-scorer
@@ -209,13 +228,54 @@ provider:
   name: none
 ```
 
-Install:
+The config above is **Option A** (EPP-local tokenizer sidecar).
+For **Option B** (reuse an existing render endpoint), apply these changes:
+
+```yaml
+router:
+  tokenizer:
+    enabled: false
+  epp:
+    pluginsCustomConfig:
+      precise-prefix-config.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: token-producer
+          parameters:
+            modelName: "Qwen/Qwen3-32B"
+            vllm:
+              url: "http://vllm-render.<ns>.svc.cluster.local:8000"
+        # keep the rest of the plugin config unchanged
+```
+
+Customize this template for your deployment:
+
+- `router.modelServers.matchLabels`: set to labels on your vLLM worker pods.
+- `router.modelServers.targetPorts[].number`: set to your worker serving port.
+- `httpRoute.inferenceGatewayName`: set to your gateway name.
+- `token-producer.parameters.modelName`: set to the exact served model id.
+- `tokenProcessorConfig.blockSize`: must match worker `--block-size`.
+- `kvEventsConfig.podDiscoveryConfig.socketPort`: must match worker KV event port.
+- Keep `decode-filter` out for aggregated serving (this example is aggregated).
+
+Install (local chart path):
 
 ```bash
 helm upgrade -i qwen-router \
-  llm-d-router/config/charts/llm-d-router-gateway \
+  /home/atchernych/code/gaie/llm-d-router/config/charts/llm-d-router-gateway \
   -n <ns> \
   -f values-llmd-gateway.yaml
+```
+
+Install (OCI chart):
+
+```bash
+helm upgrade -i qwen-router \
+  oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev \
+  -n <ns> \
+  -f values-llmd-gateway.yaml \
+  --version <router-chart-version>
 ```
 
 If `InferencePool` and `HTTPRoute` are already managed separately, set:
@@ -249,6 +309,9 @@ curl --max-time 120 -sS "http://localhost:8000/v1/chat/completions" \
 - worker KV topic matches `kvEventsConfig.topicFilter`.
 - worker `--block-size` == `tokenProcessorConfig.blockSize`.
 - `token-producer.parameters.modelName` matches the served model/tokenizer.
+- Aggregated serving: do not include `decode-filter` in the plugin chain.
+- Option A: create `llm-d-hf-token` for tokenizer sidecar.
+- Option B: set `router.tokenizer.enabled=false` and point `token-producer.parameters.vllm.url` at your existing render endpoint.
 
 ## Final vLLM workers deployment
 
@@ -292,7 +355,7 @@ spec:
           - name: kv-events            # NEW: KV event port the llm-d EPP subscribes to
             containerPort: 5557
         env:
-          - name: HF_TOKEN             # NEW: lets worker pull gated/private models
+          - name: HF_TOKEN             # NEW (optional): needed only for gated/private models
             valueFrom:
               secretKeyRef:
                 name: llm-d-hf-token


### PR DESCRIPTION
Provide 2 operations modes for EPP:
DYN_EPP_MODE=router-only / full-dynamo-stack

This is an operator-free, runtime-free demo manifests that put the Dynamo EPP in front of an existing vanilla `vllm serve` fleet behind a GAIE gateway:

- examples/onramp/agg.yaml: raw vLLM agg pool + Dynamo EPP (external mode)
  + RBAC + InferencePool + HTTPRoute. No Dynamo operator, no etcd/NATS (EPP runs DistributedRuntime on the inert `mem` backend, DYN_EVENT_PLANE=zmq).
- examples/onramp/disagg.yaml: prefill+decode raw vLLM pools; EPP emits x-prefiller-host-port for a decode-side P/D sidecar.
- examples/onramp/README.md: the "replace only your EPP" on-ramp story and the external-mode environment contract.

These are the deployment surface for the dual-mode EPP work; the Rust external-mode implementation follows in subsequent commits.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive on-ramp deployment guide for configuring Dynamo Router with vLLM fleets without full control plane deployment.

* **Chores**
  * Added example Kubernetes manifests for both aggregated and disaggregated inference gateway deployment configurations with integrated KV-cache routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->