### PR TITLE
fix(parser): renumber tool_call.id at emission so parallel calls get unique call_id

### DIFF
--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -9,6 +9,7 @@ use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, load_harmony_encoding
 use regex::{Captures, Regex};
 use serde_json::Value;
 use std::sync::OnceLock;
+use uuid::Uuid;
 
 static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
 static COMMENTARY_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
@@ -290,9 +291,8 @@ fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
             continue;
         }
         let args_json = serialize_harmony_arguments(raw_args);
-        let call_idx = out.len() + 1;
         out.push(ToolCallResponse {
-            id: format!("call-{call_idx}"),
+            id: format!("call-{}", Uuid::new_v4()),
             tp: ToolCallType::Function,
             function: CalledFunction {
                 name: name.to_string(),
@@ -381,7 +381,6 @@ pub async fn parse_tool_calls_harmony_complete(
     };
 
     let mut res = Vec::with_capacity(messages.len());
-    let mut call_idx = 0; // Index of the tool call
     let mut normal_text = String::new();
     let has_tool_call_stop = text.contains("<|call|>");
     let has_recipientless_commentary_call = contains_recipientless_commentary_call(text);
@@ -420,9 +419,8 @@ pub async fn parse_tool_calls_harmony_complete(
                 continue;
             };
 
-            call_idx += 1;
             res.push(ToolCallResponse {
-                id: format!("call-{}", call_idx),
+                id: format!("call-{}", Uuid::new_v4()),
                 tp: ToolCallType::Function,
                 function: CalledFunction {
                     name: fname.to_string(),
@@ -916,6 +914,39 @@ mod tests {
         assert_eq!(name1, "get_weather");
         assert_eq!(args0["city"], "NYC");
         assert_eq!(args1["city"], "LA");
+    }
+
+    /// Regression test: the harmony parser must produce ids that are unique
+    /// not just within a single invocation but also across multiple invocations.
+    /// `jail.rs` slices the raw stream at each `<|call|>` boundary and invokes
+    /// the parser once per section. With index-based ids ("call-1", "call-2", ...)
+    /// each per-section invocation would restart from "call-1", and the
+    /// downstream OpenAI Chat Completions response would carry duplicate ids,
+    /// which clients (and Dynamo's own E2E harness) reject as
+    /// `duplicate_tool_ids`. Using `Uuid::new_v4()` at construction guarantees
+    /// uniqueness independent of how many times the parser is invoked.
+    #[tokio::test]
+    async fn test_parse_tool_calls_harmony_unique_ids_across_invocations() {
+        // Two independent invocations, each on a single tool-call section —
+        // matches the jail's per-<|call|> emission pattern.
+        let chunk_a = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>"#;
+        let chunk_b = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NY"}<|call|>"#;
+
+        let (calls_a, _) = parse_tool_calls_harmony_complete(chunk_a, &Default::default(), None)
+            .await
+            .unwrap();
+        let (calls_b, _) = parse_tool_calls_harmony_complete(chunk_b, &Default::default(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(calls_a.len(), 1, "first chunk should produce 1 call");
+        assert_eq!(calls_b.len(), 1, "second chunk should produce 1 call");
+        assert_ne!(
+            calls_a[0].id, calls_b[0].id,
+            "Tool call ids must be unique across separate parser invocations \
+             (jail invokes the parser once per <|call|> boundary; identical ids \
+             would surface as duplicate_tool_ids in the OpenAI response)",
+        );
     }
 }
 


### PR DESCRIPTION

#### Overview

`dynamo`'s harmony-parser path emits **duplicate `tool_calls[*].id`** when the model produces multiple parallel tool calls in a single response. Every call ends up with `id="call-1"` because the jail invokes the parser **incrementally per `<|call|>` boundary** and each per-call invocation restarts the parser's local `call_idx` from 1. E2E test harness reject the response with `duplicate_tool_ids`.

This PR fixes the id at the jail's emission site so every emitted tool call gets a fresh UUID — matching the convention already used by the json / xml parser families.

#### Details
`JailedStream::should_end_jail` detects each completed tool-call section (for harmony, every `<|call|>` boundary) and emits at that split. `create_tool_call_choice` then runs the configured parser on the slice. The parser (harmony, pythonic) numbers tool calls via local index → since each invocation sees one call → every emitted id is `"call-1"`. The `index` field was already global (`tool_call_offset + idx`), but the `id` was passed through unchanged from the parser's local state.

**Before**

```json
{
  "finish_reason": "tool_calls",
  "message": {
    "role": "assistant",
    "reasoning_content": "We need to call three tools.\nNow calculate.\nNow search web.",
    "tool_calls": [
      {"id": "call-1", "type": "function", "function": {"name": "get_weather", "arguments": "{\"location\":\"Paris\",\"unit\":\"celsius\"}"}},
      {"id": "call-1", "type": "function", "function": {"name": "calculate",   "arguments": "{\"expression\":\"15 * 23 + 7\"}"}},
      {"id": "call-1", "type": "function", "function": {"name": "search_web",  "arguments": "{\"query\":\"Dynamo tool calling docs\",\"num_results\":5}"}}
    ]
  }
}
```

E2E harness reports `duplicate_tool_ids`.

**After**
```json
{
  "finish_reason": "tool_calls",
  "message": {
    "role": "assistant",
    "reasoning_content": "We need to call three tools.\nNow calculate.\nNow search web.",
    "tool_calls": [
      {"id": "call-<uuid1>", "type": "function", "function": {"name": "get_weather", "arguments": "{\"location\":\"Paris\",\"unit\":\"celsius\"}"}},
      {"id": "call-<uuid2>", "type": "function", "function": {"name": "calculate",   "arguments": "{\"expression\":\"15 * 23 + 7\"}"}},
      {"id": "call-<uuid3>", "type": "function", "function": {"name": "search_web",  "arguments": "{\"query\":\"Dynamo tool calling docs\",\"num_results\":5}"}}
    ]
  }
}
```

#### Where should the reviewer start?

1. **`lib/llm/src/protocols/openai/chat_completions/jail.rs`**

## Related Issues
- #9778 
- #10366 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool-call ID duplication issue to ensure each tool call receives a unique identifier during processing and execution.

* **Tests**
  * Added regression test validating unique tool-call ID generation across incremental processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->