### PR TITLE
docs(backend): document streaming overhead and the stream_interval lever

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -389,6 +389,31 @@ Performance note: attribute values are rendered via Python `repr()` for
 non-primitive types. Don't pass large objects per-token inside hot loops;
 record summary attributes instead.
 
+## Performance: streaming overhead
+
+`generate()` yields one chunk per engine step, and each chunk crosses into Rust
+through the PyO3 bridge (`spawn_blocking` + `with_gil` + deserialize). At high
+concurrency this per-token crossing is **GIL-bound**: aggregate throughput
+stays roughly flat as concurrency rises (adding cores/workers doesn't help) and
+per-token latency degrades. This is inherent to wrapping a Python engine — the
+unified bridge measures at parity with the legacy per-token path, not a
+regression.
+
+The lever is **fewer, larger crossings** — emit more tokens per chunk. Every
+backend has a native `stream_interval` for this; set it > 1 so the engine
+coalesces N tokens per streamed step:
+
+| Backend | How to set |
+|---|---|
+| vLLM | `--stream-interval N` |
+| SGLang | `--stream-interval N` |
+| TRT-LLM | `--trtllm.stream_interval N` (or `stream_interval: N` in the `--extra-engine-args` YAML, or `--override-engine-args '{"stream_interval": N}'`) |
+
+Tradeoff: coarser inter-token streaming (the client receives tokens in batches
+of N); TTFT is unaffected since the first token still flushes immediately. It
+matters most for high-concurrency serving of small/fast models, where the
+aggregate token rate can approach the bridge's single-GIL ceiling.
+
 ## File Index
 
 ```text


### PR DESCRIPTION
## Summary

Documents a performance characteristic of the Python unified backend in
`components/src/dynamo/common/backend/README.md` (new **Performance: streaming
overhead** section). Docs-only — no code change.

The Rust↔Python bridge crosses the GIL once per token (`spawn_blocking` +
`with_gil` + deserialize), so aggregate throughput is **GIL-bound** and stays
roughly flat as concurrency rises. The note records:

- the symptom (and that the unified bridge is at **parity with the legacy
  per-token path** — not a regression);
- the lever — coalesce tokens per chunk via each engine's native
  `stream_interval`:
  - vLLM / SGLang: `--stream-interval N`
  - TRT-LLM: `stream_interval: N` in the `--extra_llm_api_options` YAML
- the tradeoff (coarser inter-token streaming; TTFT preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added performance tuning guidance for backend streaming configurations, documenting the trade-off between streaming granularity and aggregate throughput to help optimize your setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->