### PR TITLE
refactor(kv-router): move potential load DTO to protocols

### DIFF
--- a/docs/components/router/standalone-slot-tracker.md
+++ b/docs/components/router/standalone-slot-tracker.md
@@ -260,7 +260,8 @@ Returns:
     "worker_id": 7,
     "dp_rank": 0,
     "potential_prefill_tokens": 96,
-    "potential_decode_blocks": 4
+    "potential_decode_blocks": 4,
+    "active_requests": 2
   }
 ]
 ```

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -484,6 +484,16 @@ pub enum RouterBackpressureReason {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PotentialLoad {
+    pub worker_id: WorkerId,
+    pub dp_rank: DpRank,
+    pub potential_prefill_tokens: usize,
+    pub potential_decode_blocks: usize,
+    #[serde(default)]
+    pub active_requests: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "method", rename_all = "snake_case")]
 pub enum RouterResponse {
     New {
@@ -506,7 +516,7 @@ pub enum RouterResponse {
     },
     PotentialLoads {
         // loads of every worker tracked by the scheduler.
-        loads: Vec<crate::scheduling::PotentialLoad>,
+        loads: Vec<PotentialLoad>,
         // the queue sizes for this specific router instance.
         #[serde(default)]
         pending_count: usize,
@@ -1779,7 +1789,7 @@ mod tests {
 
     #[test]
     fn test_potential_load_defaults_active_requests() {
-        let load = serde_json::from_str::<crate::scheduling::PotentialLoad>(
+        let load = serde_json::from_str::<PotentialLoad>(
             r#"{"worker_id":1,"dp_rank":0,"potential_prefill_tokens":16,"potential_decode_blocks":4}"#,
         )
         .unwrap();
@@ -1793,7 +1803,7 @@ mod tests {
 
     #[test]
     fn test_potential_load_serializes_active_requests() {
-        let load = crate::scheduling::PotentialLoad {
+        let load = PotentialLoad {
             worker_id: 1,
             dp_rank: 0,
             potential_prefill_tokens: 16,

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -10,9 +10,10 @@ use serde::{Deserialize, Serialize};
 
 use super::config::RouterConfigOverride;
 use super::filter::RoutingEligibility;
+pub use crate::protocols::PotentialLoad;
 use crate::protocols::{
-    DpRank, RouterBackpressureReason, RoutingConstraints, SharedCacheHits, WorkerConfigLike,
-    WorkerId, WorkerWithDpRank,
+    RouterBackpressureReason, RoutingConstraints, SharedCacheHits, WorkerConfigLike, WorkerId,
+    WorkerWithDpRank,
 };
 use crate::sequences::WorkerLoadProjection;
 
@@ -27,16 +28,6 @@ pub struct TierOverlapBlocks {
     pub host_pinned: FxHashMap<WorkerWithDpRank, usize>,
     #[serde(default)]
     pub disk: FxHashMap<WorkerWithDpRank, usize>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PotentialLoad {
-    pub worker_id: WorkerId,
-    pub dp_rank: DpRank,
-    pub potential_prefill_tokens: usize,
-    pub potential_decode_blocks: usize,
-    #[serde(default)]
-    pub active_requests: usize,
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## Summary

- move `PotentialLoad` beside the router wire protocol types
- preserve the existing scheduling export for Rust API compatibility
- document `active_requests` in the standalone slot tracker response

## Validation

- `cargo clippy --no-deps --all-targets -- -D warnings` (`lib/kv-router`)
- `cargo fmt --check` (`lib/kv-router`)
- `cargo test test_potential_load --lib` (`lib/kv-router`)
- repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `POST /potential_loads` endpoint documentation to reflect the expanded response structure now including an `active_requests` field.

* **Refactor**
  * Reorganized internal data type definitions to consolidate response payload structures across modules, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->