### PR TITLE
fix(kv-router): cancel in-flight recovery when worker is removed

### DIFF
--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -268,11 +268,6 @@ impl WorkerQueryClient {
     }
 
     async fn remove_worker_dp_state(&self, worker_id: WorkerId, dp_rank: DpRank) {
-        // Stop any in-flight recovery retry/backoff loop for this rank.
-        if let Some((_, cancel)) = self.recovery_cancels.remove(&(worker_id, dp_rank)) {
-            cancel.cancel();
-        }
-
         let Some(worker_state) = self
             .worker_states
             .get(&worker_id)
@@ -288,6 +283,15 @@ impl WorkerQueryClient {
             }
             worker_state.is_empty()
         };
+
+        // Stop any in-flight recovery retry/backoff loop for this rank.  This
+        // runs AFTER the rank teardown above: a racing spawn either passed its
+        // liveness check before `remove_rank` (so its token is already
+        // registered and cancelled here), or it observes the rank as gone and
+        // exits on its own.
+        if let Some((_, cancel)) = self.recovery_cancels.remove(&(worker_id, dp_rank)) {
+            cancel.cancel();
+        }
 
         if should_remove_worker {
             tracing::warn!("WorkerQueryClient: all dp_ranks gone for worker {worker_id}, removing");
@@ -372,6 +376,28 @@ impl WorkerQueryClient {
         let cancel = self.recovery_cancels.entry(key).or_default().clone();
 
         tokio::spawn(async move {
+            // The caller decided to spawn outside the worker-state lock, so the
+            // rank may have been torn down in between — and a token registered
+            // after `remove_worker_dp_state` drained the map would never be
+            // cancelled.  Re-checking under the lock closes that race: if the
+            // rank is still present here, `remove_rank` has not run yet, so the
+            // removal path is guaranteed to see (and cancel) our token.
+            let alive = match client.worker_states.get(&key.0).map(|e| e.clone()) {
+                Some(worker_state) => {
+                    let worker_state = worker_state.lock().await;
+                    worker_state.epoch == epoch && worker_state.ranks.contains_key(&key.1)
+                }
+                None => false,
+            };
+            if !alive {
+                tracing::debug!(
+                    "Skipping recovery for worker {} dp_rank {}: rank removed or epoch changed",
+                    key.0,
+                    key.1
+                );
+                return;
+            }
+
             let recovery = async {
                 // Add jitter only for full-restore (start_event_id is None)
                 // to permute semaphore acquisition order and reduce thundering herd risk on initial discovery.
@@ -1125,6 +1151,20 @@ mod tests {
         // A non-cancelled task would retry after RECOVERY_INITIAL_BACKOFF_MS.
         tokio::time::sleep(Duration::from_millis(3 * RECOVERY_INITIAL_BACKOFF_MS)).await;
         assert_eq!(transport.call_count(), 1);
+        kv_indexer.flush().await;
+    }
+
+    #[tokio::test]
+    async fn test_spawn_recovery_for_removed_rank_does_not_query() {
+        let (client, transport, kv_indexer) = make_test_client("spawn-after-remove").await;
+
+        // A follow-up spawn can race rank removal (the spawn decision happens
+        // outside the worker-state lock). With no rank state, the task's
+        // liveness check must drop it before it ever queries the transport.
+        client.spawn_recovery_task((1, 0), 0, Some(5), None);
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(transport.call_count(), 0);
         kv_indexer.flush().await;
     }
 

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -373,30 +373,43 @@ impl WorkerQueryClient {
         end_event_id: Option<u64>,
     ) {
         let client = self.clone();
-        let cancel = self.recovery_cancels.entry(key).or_default().clone();
 
         tokio::spawn(async move {
-            // The caller decided to spawn outside the worker-state lock, so the
-            // rank may have been torn down in between — and a token registered
-            // after `remove_worker_dp_state` drained the map would never be
-            // cancelled.  Re-checking under the lock closes that race: if the
-            // rank is still present here, `remove_rank` has not run yet, so the
-            // removal path is guaranteed to see (and cancel) our token.
-            let alive = match client.worker_states.get(&key.0).map(|e| e.clone()) {
-                Some(worker_state) => {
-                    let worker_state = worker_state.lock().await;
-                    worker_state.epoch == epoch && worker_state.ranks.contains_key(&key.1)
-                }
-                None => false,
+            // Re-check liveness under the worker-state lock, then register the
+            // cancellation token only if the rank is still present. Removal holds
+            // this same lock to drop the rank before it drains `recovery_cancels`,
+            // so a token registered here is guaranteed to be observed — and
+            // cancelled — by that drain. A rank that is already gone registers
+            // nothing, so a spawn that loses the removal race cannot leak an entry
+            // that no later teardown would reclaim.
+            let cancel = {
+                let live = match client.worker_states.get(&key.0).map(|e| e.clone()) {
+                    Some(worker_state) => {
+                        let worker_state = worker_state.lock().await;
+                        // TODO(#10580 follow-up): pre-existing ABA case — if removing
+                        // the final rank deletes `WorkerState` and rediscovery
+                        // recreates it at epoch 0, a stale follow-up still carrying
+                        // epoch 0 can pass this check against the freshly discovered
+                        // endpoint. Out of scope for the #10580 fix (the base branch
+                        // already has a resettable epoch + dynamic target resolution);
+                        // a follow-up should fold the endpoint/rank incarnation into
+                        // the recovery identity, or use a generation that survives
+                        // removal.
+                        (worker_state.epoch == epoch && worker_state.ranks.contains_key(&key.1))
+                            .then(|| client.recovery_cancels.entry(key).or_default().clone())
+                    }
+                    None => None,
+                };
+                let Some(cancel) = live else {
+                    tracing::debug!(
+                        "Skipping recovery for worker {} dp_rank {}: rank removed or epoch changed",
+                        key.0,
+                        key.1
+                    );
+                    return;
+                };
+                cancel
             };
-            if !alive {
-                tracing::debug!(
-                    "Skipping recovery for worker {} dp_rank {}: rank removed or epoch changed",
-                    key.0,
-                    key.1
-                );
-                return;
-            }
 
             let recovery = async {
                 // Add jitter only for full-restore (start_event_id is None)
@@ -1160,11 +1173,17 @@ mod tests {
 
         // A follow-up spawn can race rank removal (the spawn decision happens
         // outside the worker-state lock). With no rank state, the task's
-        // liveness check must drop it before it ever queries the transport.
+        // liveness check must drop it before it ever queries the transport — and
+        // without registering a cancellation token that no later teardown would
+        // ever reclaim.
         client.spawn_recovery_task((1, 0), 0, Some(5), None);
 
         tokio::time::sleep(Duration::from_millis(100)).await;
         assert_eq!(transport.call_count(), 0);
+        assert!(
+            client.recovery_cancels.is_empty(),
+            "a spawn that lost the removal race must not leak a recovery_cancels entry"
+        );
         kv_indexer.flush().await;
     }
 

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -64,6 +64,9 @@ pub struct WorkerQueryClient {
     worker_states: DashMap<WorkerId, Arc<Mutex<WorkerState>>>,
     query_endpoints: WorkerQueryEndpointDirectory,
     recovery_semaphore: Arc<Semaphore>,
+    /// Per-rank cancellation for in-flight recovery tasks; cancelled on rank
+    /// removal so retry backoff stops polling workers that no longer exist.
+    recovery_cancels: DashMap<RecoveryKey, tokio_util::sync::CancellationToken>,
 }
 
 impl WorkerQueryClient {
@@ -79,6 +82,7 @@ impl WorkerQueryClient {
             worker_states: DashMap::new(),
             query_endpoints: WorkerQueryEndpointDirectory::default(),
             recovery_semaphore: Arc::new(Semaphore::new(RECOVERY_CONCURRENCY_LIMIT)),
+            recovery_cancels: DashMap::new(),
         })
     }
 
@@ -264,6 +268,11 @@ impl WorkerQueryClient {
     }
 
     async fn remove_worker_dp_state(&self, worker_id: WorkerId, dp_rank: DpRank) {
+        // Stop any in-flight recovery retry/backoff loop for this rank.
+        if let Some((_, cancel)) = self.recovery_cancels.remove(&(worker_id, dp_rank)) {
+            cancel.cancel();
+        }
+
         let Some(worker_state) = self
             .worker_states
             .get(&worker_id)
@@ -360,24 +369,44 @@ impl WorkerQueryClient {
         end_event_id: Option<u64>,
     ) {
         let client = self.clone();
+        let cancel = self.recovery_cancels.entry(key).or_default().clone();
 
         tokio::spawn(async move {
-            // Add jitter only for full-restore (start_event_id is None)
-            // to permute semaphore acquisition order and reduce thundering herd risk on initial discovery.
-            // This distributes load when multiple routers start simultaneously.
-            if start_event_id.is_none() {
-                let jitter_us = rand::rng().random_range(0..3000u64);
-                tokio::time::sleep(Duration::from_micros(jitter_us)).await;
-            }
+            let recovery = async {
+                // Add jitter only for full-restore (start_event_id is None)
+                // to permute semaphore acquisition order and reduce thundering herd risk on initial discovery.
+                // This distributes load when multiple routers start simultaneously.
+                if start_event_id.is_none() {
+                    let jitter_us = rand::rng().random_range(0..3000u64);
+                    tokio::time::sleep(Duration::from_micros(jitter_us)).await;
+                }
 
-            let Ok(_permit) = client.recovery_semaphore.clone().acquire_owned().await else {
-                return;
+                let _permit = client
+                    .recovery_semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .ok()?;
+
+                Some(
+                    client
+                        .fetch_recovery_response(key.0, key.1, start_event_id, end_event_id)
+                        .await,
+                )
             };
 
-            let result = client
-                .fetch_recovery_response(key.0, key.1, start_event_id, end_event_id)
-                .await;
-            client.finish_recovery_task(key, epoch, result).await;
+            let result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    tracing::debug!("Recovery cancelled for worker {} dp_rank {}", key.0, key.1);
+                    return;
+                }
+                result = recovery => result,
+            };
+
+            if let Some(result) = result {
+                client.finish_recovery_task(key, epoch, result).await;
+            }
         });
     }
 
@@ -1055,6 +1084,47 @@ mod tests {
 
         assert_eq!(transport.cancelled_instances(), vec![endpoint_id]);
         wait_for(|| !rank_state_matches(&client, key, |_| true)).await;
+        kv_indexer.flush().await;
+    }
+
+    #[tokio::test]
+    async fn test_removed_query_endpoint_stops_recovery_retries() {
+        let (client, transport, kv_indexer) = make_test_client("remove-stops-retries").await;
+        let key = (100, 4);
+        let endpoint_name = worker_kv_indexer_query_endpoint_for_worker(key.0, key.1);
+        let target = make_instance(endpoint_name, 11);
+        let endpoint_id = target.endpoint_instance_id();
+
+        // Queue a single failing attempt; the failure schedules retries with
+        // exponential backoff, and any retry would call the transport again.
+        let started = Arc::new(Notify::new());
+        transport.push_action(
+            key,
+            MockQueryAction {
+                started: Some(started.clone()),
+                release: None,
+                response: Err("transient failure".to_string()),
+            },
+        );
+
+        client
+            .handle_discovered_query_endpoint(DiscoveredQueryEndpoint {
+                worker_id: key.0,
+                dp_rank: key.1,
+                target,
+            })
+            .await;
+        started.notified().await;
+
+        // Removing the rank mid-backoff must cancel the in-flight recovery.
+        client
+            .handle_removed_query_endpoint(key.0, key.1, endpoint_id)
+            .await;
+        wait_for(|| client.recovery_cancels.is_empty()).await;
+
+        // A non-cancelled task would retry after RECOVERY_INITIAL_BACKOFF_MS.
+        tokio::time::sleep(Duration::from_millis(3 * RECOVERY_INITIAL_BACKOFF_MS)).await;
+        assert_eq!(transport.call_count(), 1);
         kv_indexer.flush().await;
     }
 


### PR DESCRIPTION
## Overview:

During a worker rollout, the router's initial KV recovery can get stuck retrying a worker that has already been removed: `remove_worker_dp_state` logs `all dp_ranks gone for worker X, removing`, yet the in-flight recovery task keeps polling that worker with exponential backoff (`query owner missing on attempt N, retrying`) for up to `RECOVERY_MAX_RETRIES = 8` attempts (~51s of wasted backoff per rank), exactly as reported in #10580.

## Details:

- `WorkerQueryClient` now tracks a `CancellationToken` per `(worker_id, dp_rank)` recovery (`recovery_cancels: DashMap<RecoveryKey, CancellationToken>`).
- `spawn_recovery_task` races the jitter/semaphore/fetch future against `cancel.cancelled()` via `tokio::select!` (biased toward cancellation), so removal aborts the retry/backoff loop immediately — including while sleeping in backoff or blocked on a query. `finish_recovery_task` only runs for non-cancelled tasks (and is additionally guarded by the existing epoch check).
- `remove_worker_dp_state` cancels and drops the rank's token before tearing down state, covering both the endpoint-removal path and the `all dp_ranks gone` worker-removal path from the issue.
- If a rank is rediscovered later, a fresh token is created, so restore-on-rediscovery is unaffected.

New regression test `test_removed_query_endpoint_stops_recovery_retries`: queues a single failing query attempt (which schedules backoff retries), removes the rank mid-backoff, and asserts no further transport calls happen past the backoff window. Verified the test fails without the fix and passes with it; all 27 `worker_query` tests pass.

```
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 1281 filtered out
```

## Where should the reviewer start?

`lib/llm/src/kv_router/indexer/recovery/worker_query.rs` — `spawn_recovery_task` (the `tokio::select!`) and `remove_worker_dp_state` (the cancel).

## Related Issues

** This PR is linked to an issue:**

- Closes #10580

---
 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where recovery retry loops continued after endpoint removal, preventing unnecessary transport calls and improving system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->