### PR TITLE
Forward trace context to Python engines

### DIFF
--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -222,8 +222,9 @@ where
         let id = context.id().to_string();
         tracing::trace!("processing request: {}", id);
 
-        // Capture current trace context
-        let current_trace_context = get_distributed_tracing_context();
+        // Capture request trace context from the engine context first; it does not depend on
+        // logging-layer span extensions being installed.
+        let current_trace_context = ctx.trace_context().or_else(get_distributed_tracing_context);
         let metadata = context.metadata().clone();
 
         let stream = invoke_generator(

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -125,10 +125,11 @@ fn create_request_context(
     match parent_ctx {
         // If there is a parent context, link the request as a child context of it
         Some(parent_ctx) => {
-            let child_ctx = RsContext::with_id_and_metadata(
+            let child_ctx = RsContext::with_id_and_metadata_and_trace_context(
                 request,
                 parent_ctx.inner().id().to_string(),
                 parent_ctx.metadata_snapshot(),
+                parent_ctx.trace_context().cloned(),
             );
             parent_ctx.inner().link_child(child_ctx.context());
             if parent_ctx.inner().is_stopped() || parent_ctx.inner().is_killed() {

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -25,6 +25,7 @@ use axum::{
     routing::{get, post},
 };
 use dynamo_runtime::config::{env_is_truthy, environment_names::llm as env_llm};
+use dynamo_runtime::logging::request_trace_context_from_headers;
 use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
 use futures::StreamExt;
 use tracing::Instrument;
@@ -164,7 +165,12 @@ async fn handler_anthropic_messages(
             &err.to_string(),
         )
     })?;
-    let request = Context::with_id_and_metadata(request, request_id, metadata);
+    let request = Context::with_id_and_metadata_and_trace_context(
+        request,
+        request_id,
+        metadata,
+        request_trace_context_from_headers(&headers),
+    );
     let context = request.context();
 
     // Create connection handles

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -66,7 +66,9 @@ use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_protocols::types::ChatCompletionMessageToolCallChunk;
 use dynamo_protocols::types::ChatCompletionStreamResponseDelta;
 use dynamo_protocols::types::Choice;
-use dynamo_runtime::logging::get_distributed_tracing_context;
+use dynamo_runtime::logging::{
+    get_distributed_tracing_context, request_trace_context_from_headers,
+};
 use tracing::Instrument;
 
 pub const DYNAMO_REQUEST_ID_HEADER: &str = "x-dynamo-request-id";
@@ -513,7 +515,13 @@ fn context_from_headers<T: Send + Sync + 'static>(
 ) -> Result<Context<T>, ErrorResponse> {
     let metadata = extract_metadata_from_http(headers)
         .map_err(|err| ErrorMessage::request_headers_too_large(&err.to_string()))?;
-    let mut request = Context::with_id_and_metadata(request, request_id, metadata);
+    let trace_context = request_trace_context_from_headers(headers);
+    let mut request = Context::with_id_and_metadata_and_trace_context(
+        request,
+        request_id,
+        metadata,
+        trace_context,
+    );
     attach_x_request_id(&mut request, headers);
     Ok(request)
 }
@@ -861,10 +869,11 @@ async fn completions_batch(
 
         // Generate unique request_id for each prompt: original_id-{prompt_idx}
         let unique_request_id = format!("{}-{}", request.id(), prompt_idx);
-        let mut single_request_context = Context::with_id_and_metadata(
+        let mut single_request_context = Context::with_id_and_metadata_and_trace_context(
             single_request,
             unique_request_id,
             request.metadata().clone(),
+            request.trace_context(),
         );
         copy_x_request_id(&request, &mut single_request_context);
 

--- a/lib/runtime/src/engine.rs
+++ b/lib/runtime/src/engine.rs
@@ -68,6 +68,7 @@ use std::{
     sync::Arc,
 };
 
+use crate::logging::DistributedTraceContext;
 pub use async_trait::async_trait;
 use futures::stream::Stream;
 
@@ -116,6 +117,11 @@ pub trait AsyncEngineController: Send + Sync {}
 pub trait AsyncEngineContext: Send + Sync + Debug {
     /// Unique ID for the Stream
     fn id(&self) -> &str;
+
+    /// Distributed trace context associated with this stream, when available.
+    fn trace_context(&self) -> Option<DistributedTraceContext> {
+        None
+    }
 
     /// Returns true if `stop_generating()` has been called; otherwise, false.
     fn is_stopped(&self) -> bool;

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -210,6 +210,29 @@ impl DistributedTraceContext {
     }
 }
 
+pub fn request_trace_context_from_headers<H: GenericHeaders>(
+    headers: &H,
+) -> Option<DistributedTraceContext> {
+    if let Some(context) = get_distributed_tracing_context() {
+        return Some(context);
+    }
+
+    let trace_parent = TraceParent::from_headers(headers);
+    let trace_id = trace_parent.trace_id?;
+    let span_id = trace_parent.parent_id?;
+
+    Some(DistributedTraceContext {
+        trace_id,
+        span_id,
+        parent_id: None,
+        tracestate: trace_parent.tracestate,
+        start: None,
+        end: None,
+        x_request_id: trace_parent.x_request_id,
+        request_id: trace_parent.request_id,
+    })
+}
+
 /// Parse a traceparent string into its components
 pub fn parse_traceparent(traceparent: &str) -> (Option<String>, Option<String>) {
     let pieces: Vec<_> = traceparent.split('-').collect();
@@ -619,9 +642,11 @@ pub fn inject_current_trace_into_nats_headers(headers: &mut async_nats::HeaderMa
     inject_otel_context_into_nats_headers(headers, None);
 }
 
-// Inject trace headers into a generic HashMap for HTTP/TCP transports
-pub fn inject_trace_headers_into_map(headers: &mut std::collections::HashMap<String, String>) {
-    if let Some(trace_context) = get_distributed_tracing_context() {
+pub fn inject_trace_context_into_map(
+    headers: &mut std::collections::HashMap<String, String>,
+    trace_context: Option<DistributedTraceContext>,
+) {
+    if let Some(trace_context) = trace_context {
         // Inject W3C traceparent header
         headers.insert(
             "traceparent".to_string(),
@@ -641,6 +666,11 @@ pub fn inject_trace_headers_into_map(headers: &mut std::collections::HashMap<Str
             headers.insert("request-id".to_string(), request_id);
         }
     }
+}
+
+// Inject trace headers into a generic HashMap for HTTP/TCP transports
+pub fn inject_trace_headers_into_map(headers: &mut std::collections::HashMap<String, String>) {
+    inject_trace_context_into_map(headers, get_distributed_tracing_context());
 }
 
 /// Create a client_request span linked to the parent trace context
@@ -1485,6 +1515,34 @@ pub mod tests {
     use std::io::{BufRead, BufReader};
     use stdio_override::*;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_request_trace_context_from_headers_parses_traceparent() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                .parse()
+                .unwrap(),
+        );
+        headers.insert("tracestate", "test-state".parse().unwrap());
+        headers.insert("x-request-id", "req-123".parse().unwrap());
+        headers.insert(
+            "request-id",
+            "550e8400-e29b-41d4-a716-446655440000".parse().unwrap(),
+        );
+
+        let trace_context = request_trace_context_from_headers(&headers).unwrap();
+        assert_eq!(trace_context.trace_id, "4bf92f3577b34da6a3ce929d0e0e4736");
+        assert_eq!(trace_context.span_id, "00f067aa0ba902b7");
+        assert!(trace_context.parent_id.is_none());
+        assert_eq!(trace_context.tracestate, Some("test-state".to_string()));
+        assert_eq!(trace_context.x_request_id, Some("req-123".to_string()));
+        assert_eq!(
+            trace_context.request_id,
+            Some("550e8400-e29b-41d4-a716-446655440000".to_string())
+        );
+    }
 
     static LOG_LINE_SCHEMA: &str = r#"
     {

--- a/lib/runtime/src/pipeline/context.rs
+++ b/lib/runtime/src/pipeline/context.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use super::{AsyncEngineContext, AsyncEngineContextProvider, Data};
 use crate::engine::AsyncEngineController;
+use crate::logging::DistributedTraceContext;
 use async_trait::async_trait;
 
 use super::registry::Registry;
@@ -72,9 +73,18 @@ impl<T: Send + Sync + 'static> Context<T> {
         id: String,
         metadata: BTreeMap<String, String>,
     ) -> Self {
+        Self::with_id_and_metadata_and_trace_context(current, id, metadata, None)
+    }
+
+    pub fn with_id_and_metadata_and_trace_context(
+        current: T,
+        id: String,
+        metadata: BTreeMap<String, String>,
+        trace_context: Option<DistributedTraceContext>,
+    ) -> Self {
         Context {
             current,
-            controller: Arc::new(Controller::new(id)),
+            controller: Arc::new(Controller::new_with_trace_context(id, trace_context)),
             registry: Registry::new(),
             stages: Vec::new(),
             metadata,
@@ -109,6 +119,10 @@ impl<T: Send + Sync + 'static> Context<T> {
 
     pub fn insert_metadata<K: Into<String>, V: Into<String>>(&mut self, key: K, value: V) {
         self.metadata.insert(key.into(), value.into());
+    }
+
+    pub fn trace_context(&self) -> Option<DistributedTraceContext> {
+        self.controller.trace_context()
     }
 
     /// Insert an object into the registry with a specific key.
@@ -306,6 +320,10 @@ impl AsyncEngineContext for StreamContext {
         self.controller.id()
     }
 
+    fn trace_context(&self) -> Option<DistributedTraceContext> {
+        self.controller.trace_context()
+    }
+
     fn stop(&self) {
         self.controller.stop();
     }
@@ -366,6 +384,7 @@ enum State {
 #[derive(Debug)]
 pub struct Controller {
     id: String,
+    trace_context: Option<DistributedTraceContext>,
     tx: Sender<State>,
     rx: Receiver<State>,
     child_context: Mutex<Vec<Arc<dyn AsyncEngineContext>>>,
@@ -376,6 +395,21 @@ impl Controller {
         let (tx, rx) = channel(State::Live);
         Self {
             id,
+            trace_context: None,
+            tx,
+            rx,
+            child_context: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn new_with_trace_context(
+        id: String,
+        trace_context: Option<DistributedTraceContext>,
+    ) -> Self {
+        let (tx, rx) = channel(State::Live);
+        Self {
+            id,
+            trace_context,
             tx,
             rx,
             child_context: Mutex::new(Vec::new()),
@@ -399,6 +433,10 @@ impl AsyncEngineController for Controller {}
 impl AsyncEngineContext for Controller {
     fn id(&self) -> &str {
         &self.id
+    }
+
+    fn trace_context(&self) -> Option<DistributedTraceContext> {
+        self.trace_context.clone()
     }
 
     fn is_stopped(&self) -> bool {
@@ -603,6 +641,34 @@ mod tests {
 
         assert_eq!(input.value, "Hello");
         assert_eq!(ctx.length, 5);
+    }
+
+    #[test]
+    fn test_trace_context_transfers_with_context() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                .parse()
+                .unwrap(),
+        );
+        headers.insert("x-request-id", "req-123".parse().unwrap());
+
+        let trace_context = crate::logging::request_trace_context_from_headers(&headers);
+        let ctx = Context::with_id_and_metadata_and_trace_context(
+            Input {
+                value: "Hello".to_string(),
+            },
+            "request-1".to_string(),
+            BTreeMap::new(),
+            trace_context,
+        );
+
+        let (_, ctx) = ctx.transfer(Processed { length: 5 });
+        let trace_context = ctx.trace_context().unwrap();
+        assert_eq!(trace_context.trace_id, "4bf92f3577b34da6a3ce929d0e0e4736");
+        assert_eq!(trace_context.span_id, "00f067aa0ba902b7");
+        assert_eq!(trace_context.x_request_id, Some("req-123".to_string()));
     }
 
     #[test]

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -12,7 +12,9 @@ use crate::discovery::EndpointInstanceId;
 use crate::dynamo_nvtx_range;
 use crate::engine::{AsyncEngine, AsyncEngineContextProvider, Data};
 use crate::error::{DynamoError, ErrorType};
-use crate::logging::inject_trace_headers_into_map;
+use crate::logging::{
+    DistributedTraceContext, get_distributed_tracing_context, inject_trace_context_into_map,
+};
 use crate::metrics::frontend_perf::STAGE_DURATION_SECONDS;
 use crate::metrics::request_plane::{
     REQUEST_PLANE_INFLIGHT, REQUEST_PLANE_QUEUE_SECONDS, REQUEST_PLANE_ROUNDTRIP_TTFT_SECONDS,
@@ -517,7 +519,8 @@ impl AddressedPushRouter {
         REQUEST_PLANE_QUEUE_SECONDS.observe(queue_start.elapsed().as_secs_f64());
 
         let tx_start = Instant::now();
-        self.dispatch_buffer(address, buffer, context.id()).await?;
+        self.dispatch_buffer(address, buffer, context.id(), context.trace_context())
+            .await?;
         REQUEST_PLANE_SEND_SECONDS.observe(tx_start.elapsed().as_secs_f64());
 
         // Spawn the forwarder before awaiting the response prologue so request
@@ -634,9 +637,13 @@ impl AddressedPushRouter {
         address: String,
         buffer: bytes::Bytes,
         request_id: &str,
+        trace_context: Option<DistributedTraceContext>,
     ) -> Result<(), Error> {
         let mut headers = std::collections::HashMap::new();
-        inject_trace_headers_into_map(&mut headers);
+        inject_trace_context_into_map(
+            &mut headers,
+            trace_context.or_else(get_distributed_tracing_context),
+        );
         headers.insert("request-id".to_string(), request_id.to_string());
         let send_ts_ns = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -347,8 +347,13 @@ where
         );
         tracing::trace!("received request: {:?}", request_t);
 
-        let request: context::Context<T> =
-            Context::with_id_and_metadata(request_t, control_msg.id, control_msg.metadata);
+        let trace_context = crate::logging::get_distributed_tracing_context();
+        let request: context::Context<T> = Context::with_id_and_metadata_and_trace_context(
+            request_t,
+            control_msg.id,
+            control_msg.metadata,
+            trace_context,
+        );
 
         Ok(ParsedRequest {
             request,
@@ -407,11 +412,14 @@ where
                 ))
             })?;
 
-        let request_context: context::Context<()> = context::Context::with_id_and_metadata(
-            (),
-            control_msg.id.clone(),
-            control_msg.metadata.clone(),
-        );
+        let trace_context = crate::logging::get_distributed_tracing_context();
+        let request_context: context::Context<()> =
+            context::Context::with_id_and_metadata_and_trace_context(
+                (),
+                control_msg.id.clone(),
+                control_msg.metadata.clone(),
+                trace_context,
+            );
         let context_arc: Arc<dyn AsyncEngineContext> = request_context.context();
 
         // Open the request stream (upstream → worker) up front. The shared


### PR DESCRIPTION
## Summary

This PR preserves distributed trace context across Dynamo runtime contexts and Python engine callbacks.

Upstream already has Python-facing tracing helpers (`Context.trace_headers()`, span proxies, and an `engine.generate` span bridge), and the request plane already propagates W3C headers into the worker-side `handle_payload` span. This PR uses those existing pieces and only freezes the trace context into Dynamo's request `Context` at ingress boundaries so Python engine callbacks do not have to depend on whatever `tracing::Span::current()` happens to be after async/task/Python transitions.

This change makes trace context explicit request data:

- adds an optional `trace_context()` accessor to `AsyncEngineContext`
- stores `DistributedTraceContext` on runtime `Context` / `Controller`
- captures W3C `traceparent` / `tracestate` from HTTP headers when creating request contexts
- freezes worker-side request-plane trace context into the worker request `Context`
- passes the stored context into Python engine callbacks, while preserving the existing active-span fallback

## Impact

Python engines can attach downstream spans or trace headers to the same inbound request trace even after the request crosses Dynamo's async/network/Python boundaries. Existing callers without trace context keep the prior behavior.

No Python user-facing API change is required; this feeds the existing Python `Context` tracing helpers more reliably.

## Validation

- `cargo fmt --all --check`
- `cargo check -p dynamo-runtime -p dynamo-llm`
- `cd lib/bindings/python && cargo fmt --all --check && cargo check -p dynamo-py3`
- `cargo test -p dynamo-runtime test_request_trace_context_from_headers_parses_traceparent`
- `cargo test -p dynamo-runtime test_trace_context_transfers_with_context`