### PR TITLE
fix(renderer): render chat templates closer to vLLM/SGLang behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5257,6 +5257,7 @@ version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
 dependencies = [
+ "indexmap 2.14.0",
  "memo-map",
  "serde",
  "serde_json",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3683,6 +3683,7 @@ version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
 dependencies = [
+ "indexmap 2.14.0",
  "memo-map",
  "serde",
 ]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -4658,6 +4658,7 @@ version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
 dependencies = [
+ "indexmap 2.14.0",
  "memo-map",
  "serde",
  "serde_json",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -167,7 +167,13 @@ galil-seiferas = { version = "0.1" }
 
 # preprocessor
 bs62 = { version = "0.1" }
-minijinja = { version = "2.20.0", features = ["loader", "loop_controls"] }
+# "preserve_order" backs minijinja's object values with IndexMap instead of
+# BTreeMap, so JSON object keys survive template rendering in client order.
+# Without it, tool schemas and tool-call arguments render with keys sorted
+# alphabetically, diverging from Python frontends (vLLM/SGLang) which preserve
+# dict insertion order. serde_json already has its preserve_order enabled
+# (see above / lib/renderer); minijinja's map is the remaining sort point.
+minijinja = { version = "2.20.0", features = ["loader", "loop_controls", "preserve_order"] }
 json-five = { version = "0.3" }
 
 # media loading in the preprocessor

--- a/lib/llm/tests/snapshots/preprocessor__multi_turn_with_system_with_tools@meta-llama_llama-3_1-70b-instruct--1605565.snap
+++ b/lib/llm/tests/snapshots/preprocessor__multi_turn_with_system_with_tools@meta-llama_llama-3_1-70b-instruct--1605565.snap
@@ -59,52 +59,52 @@ Given the following functions, please respond with a JSON for a function call wi
 Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}.Do not use variables.
 
 {
+    "type": "function",
     "function": {
-        "description": "Get the current temperature for a specific location",
         "name": "get_current_temperature",
+        "description": "Get the current temperature for a specific location",
         "parameters": {
+            "type": "object",
             "properties": {
                 "location": {
-                    "description": "The city and state, e.g., San Francisco, CA",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The city and state, e.g., San Francisco, CA"
                 },
                 "unit": {
-                    "description": "The temperature unit to use. Infer this from the user\u0027s location.",
+                    "type": "string",
                     "enum": [
                         "Celsius",
                         "Fahrenheit"
                     ],
-                    "type": "string"
+                    "description": "The temperature unit to use. Infer this from the user's location."
                 }
             },
             "required": [
                 "location",
                 "unit"
-            ],
-            "type": "object"
+            ]
         }
-    },
-    "type": "function"
+    }
 }
 
 {
+    "type": "function",
     "function": {
-        "description": "Get the probability of rain for a specific location",
         "name": "get_rain_probability",
+        "description": "Get the probability of rain for a specific location",
         "parameters": {
+            "type": "object",
             "properties": {
                 "location": {
-                    "description": "The city and state, e.g., San Francisco, CA",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The city and state, e.g., San Francisco, CA"
                 }
             },
             "required": [
                 "location"
-            ],
-            "type": "object"
+            ]
         }
-    },
-    "type": "function"
+    }
 }
 
 How do I reverse a string in Python?<|eot_id|><|start_header_id|>assistant<|end_header_id|>

--- a/lib/llm/tests/snapshots/preprocessor__single_turn_with_tools@meta-llama_llama-3_1-70b-instruct--1605565.snap
+++ b/lib/llm/tests/snapshots/preprocessor__single_turn_with_tools@meta-llama_llama-3_1-70b-instruct--1605565.snap
@@ -53,52 +53,52 @@ Given the following functions, please respond with a JSON for a function call wi
 Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}.Do not use variables.
 
 {
+    "type": "function",
     "function": {
-        "description": "Get the current temperature for a specific location",
         "name": "get_current_temperature",
+        "description": "Get the current temperature for a specific location",
         "parameters": {
+            "type": "object",
             "properties": {
                 "location": {
-                    "description": "The city and state, e.g., San Francisco, CA",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The city and state, e.g., San Francisco, CA"
                 },
                 "unit": {
-                    "description": "The temperature unit to use. Infer this from the user\u0027s location.",
+                    "type": "string",
                     "enum": [
                         "Celsius",
                         "Fahrenheit"
                     ],
-                    "type": "string"
+                    "description": "The temperature unit to use. Infer this from the user's location."
                 }
             },
             "required": [
                 "location",
                 "unit"
-            ],
-            "type": "object"
+            ]
         }
-    },
-    "type": "function"
+    }
 }
 
 {
+    "type": "function",
     "function": {
-        "description": "Get the probability of rain for a specific location",
         "name": "get_rain_probability",
+        "description": "Get the probability of rain for a specific location",
         "parameters": {
+            "type": "object",
             "properties": {
                 "location": {
-                    "description": "The city and state, e.g., San Francisco, CA",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The city and state, e.g., San Francisco, CA"
                 }
             },
             "required": [
                 "location"
-            ],
-            "type": "object"
+            ]
         }
-    },
-    "type": "function"
+    }
 }
 
 What is deep learning?<|eot_id|><|start_header_id|>assistant<|end_header_id|>

--- a/lib/renderer/Cargo.toml
+++ b/lib/renderer/Cargo.toml
@@ -27,7 +27,13 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order", "raw_value"] }
 tracing = { workspace = true }
 
-minijinja = { version = "2.20.0", features = ["loader", "loop_controls"] }
+# "preserve_order" backs minijinja's object values with IndexMap instead of
+# BTreeMap, so JSON object keys survive template rendering in client order.
+# Without it, tool schemas and tool-call arguments render with keys sorted
+# alphabetically, diverging from Python frontends (vLLM/SGLang) which preserve
+# dict insertion order. serde_json already has its preserve_order enabled
+# (see above / lib/renderer); minijinja's map is the remaining sort point.
+minijinja = { version = "2.20.0", features = ["loader", "loop_controls", "preserve_order"] }
 minijinja-contrib = { version = "2.20.0", features = ["pycompat"] }
 
 [dev-dependencies]

--- a/lib/renderer/src/template/oai.rs
+++ b/lib/renderer/src/template/oai.rs
@@ -1533,10 +1533,11 @@ NORMAL MODE
             .render(context! { messages => messages.as_array().unwrap() })
             .unwrap();
 
-        // Should produce clean JSON without double-encoding
+        // Should produce clean JSON without double-encoding, with Python
+        // json.dumps separators (what transformers' tojson emits).
         assert_eq!(
             out,
-            r#"{"format":"celsius","location":"San Francisco, CA"}"#
+            r#"{"format": "celsius", "location": "San Francisco, CA"}"#
         );
     }
 

--- a/lib/renderer/src/template/tokcfg.rs
+++ b/lib/renderer/src/template/tokcfg.rs
@@ -111,38 +111,69 @@ pub struct GenerationConfig {
     eos_token_id: Either<u32, Vec<u32>>,
 }
 
+/// Formatter matching Python `json.dumps` default separators (`", "` and
+/// `": "`). serde_json's `CompactFormatter` writes `","`/`":"` instead, and
+/// chat templates embed these strings directly into the prompt, so the
+/// separator choice is model-visible.
+struct PyJsonFormatter;
+
+impl serde_json::ser::Formatter for PyJsonFormatter {
+    fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        if !first {
+            writer.write_all(b", ")?;
+        }
+        Ok(())
+    }
+
+    fn begin_object_key<W>(&mut self, writer: &mut W, first: bool) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        if !first {
+            writer.write_all(b", ")?;
+        }
+        Ok(())
+    }
+
+    fn begin_object_value<W>(&mut self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        writer.write_all(b": ")
+    }
+}
+
+/// Mirrors HF transformers' `tojson` filter, not stock Jinja2's. Transformers
+/// overrides Jinja's HTML-safe `tojson` with plain
+/// `json.dumps(x, ensure_ascii=False)` in its chat-template environment, and
+/// vLLM/SGLang render through that — so chat templates (and the models trained
+/// on their output) expect Python separators and **no** HTML escaping
+/// (`'`, `<`, `>`, `&` stay literal). serde_json leaves non-ASCII unescaped by
+/// default, matching `ensure_ascii=False`.
 pub fn tojson(value: Value, kwargs: Kwargs) -> Result<Value, Error> {
-    if let Ok(indent) = kwargs.get("indent") {
-        let mut buf = Vec::new();
+    let mut buf = Vec::new();
+    let result = if let Ok(indent) = kwargs.get("indent") {
+        // Python `json.dumps(indent=n)` separators are `(",", ": ")` with the
+        // item separator followed by newline + indent — PrettyFormatter matches.
         let repeat = b" ".repeat(indent);
         let formatter = serde_json::ser::PrettyFormatter::with_indent(&repeat);
         let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
-        value.serialize(&mut serializer).unwrap();
-        String::from_utf8(buf).map_err(|err| {
-            Error::new(ErrorKind::BadSerialization, "cannot serialize to JSON").with_source(err)
-        })
+        value.serialize(&mut serializer)
     } else {
-        serde_json::to_string(&value).map_err(|err| {
+        let mut serializer = serde_json::Serializer::with_formatter(&mut buf, PyJsonFormatter);
+        value.serialize(&mut serializer)
+    };
+    result.map_err(|err| {
+        Error::new(ErrorKind::BadSerialization, "cannot serialize to JSON").with_source(err)
+    })?;
+    String::from_utf8(buf)
+        .map_err(|err| {
             Error::new(ErrorKind::BadSerialization, "cannot serialize to JSON").with_source(err)
         })
-    }
-    .map_err(|err| {
-        Error::new(ErrorKind::InvalidOperation, "cannot serialize to JSON").with_source(err)
-    })
-    .map(|s| {
-        // When this filter is used the return value is safe for both HTML and JSON
-        let mut rv = String::with_capacity(s.len());
-        for c in s.chars() {
-            match c {
-                '<' => rv.push_str("\\u003c"),
-                '>' => rv.push_str("\\u003e"),
-                '&' => rv.push_str("\\u0026"),
-                '\'' => rv.push_str("\\u0027"),
-                _ => rv.push(c),
-            }
-        }
-        Value::from_safe_string(rv)
-    })
+        .map(Value::from_safe_string)
 }
 
 pub fn strftime_now(format_str: &str) -> Result<Value, Error> {


### PR DESCRIPTION
## Goal

Provide more consistent behavior with vllm/sglang in preprocessing/rendering - ultimately leading to more consistent behavior in tool call parsing. This was motivated by some inconsistencies found in Nemotron Ultra deployments.

## Summary

Dynamo's rendered prompts diverged from vLLM/SGLang for identical requests. Two causes, one commit each:

1. **Key ordering**: minijinja backs object values with BTreeMap, so tool schemas and historical tool-call arguments rendered with keys alphabetized instead of in client order. Python frontends preserve dict insertion order. Fix: enable minijinja's `preserve_order` feature (serde_json's equivalent was already feature-unified in via this crate).
2. **tojson style**: our custom `tojson` filter mimicked stock Jinja2 (compact separators, HTML-escaping `'` to `\u0027`). HF transformers overrides Jinja's `tojson` with plain `json.dumps(x, ensure_ascii=False)`, and vLLM/SGLang render through that environment. Fix: emit Python separators (`", "` / `": "`) and drop the HTML-escape pass.

Related: #9301 fixed the same class of divergence for templates that branch on `arguments is string`; this covers templates that re-serialize (e.g. Nemotron's `arguments|items` loop).

## Validation

Rendered a real 47-message agentic tool-use request (22 tool-call turns) (5 tools, ~99 KB prompt, Nemotron chat template) through `prompt_formatter_from_mdc` and diffed against vLLM's rendered prompt for the same request:

| | diff vs vLLM |
|---|---|
| main | 612 lines |
| + minijinja `preserve_order` | 44 lines |
| + `tojson` alignment | **0 lines** |

All `dynamo-renderer` tests pass; two Llama-3.1-70B tool snapshots re-recorded (key order + literal apostrophes only).

## Behavior change — flagging explicitly

This changes rendered-prompt bytes **for all models with tool use or `tojson` in their templates**, not just Nemotron. The new output matches what transformers-based frontends produce (i.e. what models saw in training), but prompt diffs and KV-cache prefix hashes will not match across Dynamo versions at the upgrade boundary.

## Microbenchmark

No measurable render-path cost from this change.

### Results

Median of 6 interleaved runs per binary (A/B and B/A ordering), 300 iterations/run after 30 warmup, release build with the workspace's `lto = "thin"` / `codegen-units = 1`:

| | main (us/iter) | this PR (us/iter) | delta |
|---|---|---|---|
| render only | 1303 (1251–1423) | 1293 (1263–1335) | −0.8% |
| deserialize + render | 1545 (1468–1667) | 1576 (1511–1648) | +2.0% |

Both deltas are inside the ±7% run-to-run spread of the same binary and point in opposite directions — noise. Mechanically expected: minijinja `preserve_order` swaps BTreeMap for IndexMap (a wash at tool-schema sizes), and the new `tojson` drops the per-character HTML-escape rescan.

### Details

**Payload**: a captured OpenHands agentic coding session (the request from the parity validation above) — 105 KB request JSON: 1 system message (~13 KB agent prompt), 2 user, 22 assistant tool-call turns + 22 tool responses, 5 tools (`terminal`, `file_editor`, `task_tracker`, `finish`, `think`) with JSON-schema parameters; tool-call `arguments` as OpenAI-style JSON strings. Renders to a 99,187-byte prompt through the Nemotron chat template.

**Reproduce**: small bin path-depending on `dynamo-llm`:
```rust
let mdc = ModelDeploymentCard::load_from_disk("<model dir with tokenizer_config.json>", None)?;
let PromptFormatter::OAI(f) = prompt_formatter_from_mdc(&mdc)? else { unreachable!() };
let req: NvCreateChatCompletionRequest = serde_json::from_str(&request_json)?;
// time f.render(&req)? in a loop (30 warmup, 300 timed)
```
Build once on `main`, once on this branch; interleave runs in both orders.
