### PR TITLE
feat(llm): parser debug mode — emit raw completion alongside parsed output

### DIFF
--- a/docs/tool-calling/troubleshooting.md
+++ b/docs/tool-calling/troubleshooting.md
@@ -105,6 +105,51 @@ output, before any tool-call parser touched it. That is the key piece for
 triage: it tells us what the model actually produced, separately from what
 the parser made of it.
 
+## Parser debug mode
+
+When a parse failure shows up on only a small percentage of requests, the
+decisive artifact is one raw model completion next to its parsed output.
+Setting `DYN_PARSER_DEBUG=1` makes the frontend emit exactly that: one
+structured log event per choice at stream end, pairing the raw pre-parse
+completion text with the parsed `reasoning_content`, `content`, and
+`tool_calls`.
+
+> **Opt-in only.** Raw completions carry user data, so this mode is off by
+> default. Enable it only in environments where logging request content is
+> acceptable.
+
+Run the frontend with both flags set (JSONL makes the event queryable):
+
+```bash
+DYN_PARSER_DEBUG=1 DYN_LOGGING_JSONL=true python -m dynamo.frontend ...
+```
+
+Each event carries `stream_id`, `choice_index`, `reasoning_parser`,
+`tool_parser`, `raw`, `raw_chunks`, `reasoning_content`, `content`,
+`tool_call_count`, `tool_call_names`, and `finish_reason` as separate
+fields. `raw` is the full pre-parse completion text; `raw_chunks` is the
+same text split exactly as the stream deltas arrived -- streaming parse
+failures are often chunk-boundary-dependent, so the boundaries are what
+lets you replay and reproduce the failure.
+
+A real failure shape: the model emits a well-formed tool call, but a
+delta boundary splits the closing `</think>` marker and the reasoning
+parser swallows the entire tool call into `reasoning_content` --
+`tool_calls` stays empty and `finish_reason` is `stop`. The event shows
+`raw` containing the intact `<function=...>` markup the parsers
+destroyed, and `raw_chunks` shows the exact split needed to reproduce:
+
+```json
+{"target":"parser_debug","fields":{"stream_id":"chatcmpl-abc","choice_index":0,"reasoning_parser":"nemotron_v3","tool_parser":"qwen3_coder","raw":"<think>pick a command</think>\n<tool_call>\n<function=terminal>...","raw_chunks":"[\"<think>pick a command<\", \"/think>\\n<tool_call>\\n<\", \"function=terminal>...\"]","reasoning_content":"pick a command</think>\n<tool_call>\n<function=terminal>...","content":"","tool_call_count":0,"tool_call_names":"[]","finish_reason":"Stop"}}
+```
+
+One grep over the frontend log surfaces every request where parsing
+produced no tool calls despite tool-call-shaped raw text:
+
+```bash
+grep '"target":"parser_debug"' frontend.jsonl | jq 'select(.fields.tool_call_count == 0)'
+```
+
 ## What to include when reporting an issue
 
 Share these four things in the bug report or issue thread:

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -14,6 +14,7 @@
 #[cfg(feature = "mm-routing")]
 pub mod lightseek_mm;
 pub mod media;
+pub mod parser_debug;
 pub mod prompt;
 pub mod speculative_prefill;
 mod structural_tag;
@@ -1887,6 +1888,31 @@ impl OpenAIPreprocessor {
             && !suppress_reasoning_after_tool
             && !skip_reasoning_for_guided_json;
 
+        // Determine tool jailing up front (pure from request fields) so the
+        // parser-debug gate can be evaluated before the reasoning tap.
+        let has_tools = request
+            .inner
+            .tools
+            .as_ref()
+            .is_some_and(|tools| !tools.is_empty());
+        let should_jail = Self::should_apply_tool_jail(
+            self.tool_call_parser.as_ref(),
+            request.inner.tool_choice.as_ref(),
+            has_tools,
+        )?;
+
+        // Parser debug mode (opt-in via DYN_PARSER_DEBUG): capture the RAW pre-parse
+        // text at stream entry, before the reasoning parser rewrites delta content.
+        // The matching exit tap below emits one record per choice at stream end.
+        // Only active when a parser stage runs (otherwise raw == content).
+        let parser_debug_acc = (*parser_debug::PARSER_DEBUG_ENABLED
+            && (should_parse_reasoning || should_strip_disabled_reasoning_start || should_jail))
+            .then(parser_debug::RawAccumulator::new);
+        let stream: Pin<Box<dyn Stream<Item = _> + Send>> = match parser_debug_acc.clone() {
+            Some(acc) => Box::pin(parser_debug::tap_raw(stream, acc)),
+            None => Box::pin(stream),
+        };
+
         // Reasoning Content Parsing Transformation Step
         // Current Solution:
         // This step operates on Deltas created by the transform_postprocessor_stream function
@@ -1908,20 +1934,6 @@ impl OpenAIPreprocessor {
         } else {
             Box::pin(stream)
         };
-
-        // Check if tools are present and if we should apply jail
-        let has_tools = request
-            .inner
-            .tools
-            .as_ref()
-            .is_some_and(|tools| !tools.is_empty());
-
-        // Determine if we should apply jail (do this before moving request)
-        let should_jail = Self::should_apply_tool_jail(
-            self.tool_call_parser.as_ref(),
-            request.inner.tool_choice.as_ref(),
-            has_tools,
-        )?;
 
         // Convert OpenAI tools to parser ToolDefinition format before applying jail
         let tool_definitions = request.inner.tools.as_ref().map(|tools| {
@@ -1946,6 +1958,18 @@ impl OpenAIPreprocessor {
             ))
         } else {
             Box::pin(stream)
+        };
+
+        // Parser debug exit tap: accumulate parsed outputs per choice and emit one
+        // record (raw vs parsed) at stream end. Shares the entry tap's accumulator.
+        let transformed_stream: Pin<Box<dyn Stream<Item = _> + Send>> = match parser_debug_acc {
+            Some(acc) => Box::pin(parser_debug::tap_parsed_and_emit(
+                transformed_stream,
+                acc,
+                self.runtime_config.reasoning_parser.clone(),
+                self.tool_call_parser.clone(),
+            )),
+            None => transformed_stream,
         };
 
         Ok(transformed_stream)

--- a/lib/llm/src/preprocessor/parser_debug.rs
+++ b/lib/llm/src/preprocessor/parser_debug.rs
@@ -1,0 +1,521 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parser debug mode (opt-in via `DYN_PARSER_DEBUG`).
+//!
+//! When enabled, the chat postprocessor emits one structured `tracing` event per
+//! choice at stream end, pairing the RAW model completion text (pre-parse, captured
+//! at stream entry) with the parsed result (`reasoning_content` / `content` /
+//! `tool_calls` / `finish_reason`). This lets intermittent parse failures be
+//! diagnosed from logs — e.g. a completion whose raw text contains `<function=...`
+//! markup the parser failed to extract shows up as `raw` with the markup and
+//! `tool_call_count = 0` — instead of requiring hand-instrumented gateway captures.
+//!
+//! The reasoning parser rewrites `choice.delta.content` in place per delta, so the
+//! raw text only exists at stream entry while the parsed result is only complete
+//! after the tool-call jail. Two taps therefore share a per-choice accumulator: an
+//! entry tap captures raw text before any parsing, and an exit tap captures the
+//! parsed deltas and emits at stream end.
+//!
+//! WARNING: raw completions carry user data; this mode is opt-in only.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+
+use futures::Stream;
+use futures::stream::{self, StreamExt};
+
+use dynamo_protocols::types::ChatCompletionMessageContent;
+use dynamo_runtime::config::env_is_truthy;
+use dynamo_runtime::config::environment_names::llm::DYN_PARSER_DEBUG;
+use dynamo_runtime::protocols::annotated::Annotated;
+
+use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+
+/// Whether parser debug mode is enabled. Read once from `DYN_PARSER_DEBUG`.
+pub static PARSER_DEBUG_ENABLED: LazyLock<bool> = LazyLock::new(|| env_is_truthy(DYN_PARSER_DEBUG));
+
+/// Shared per-choice accumulator for the RAW (pre-parse) completion text, keyed by
+/// choice index. Populated by the entry tap, read by the exit tap at stream end.
+///
+/// Each delta is stored as its own chunk: parse failures in the streaming parsers
+/// are frequently chunk-boundary-dependent (a marker split across deltas parses
+/// differently from the same bytes in one delta), so the boundaries are required
+/// to *reproduce* a failure, not just to see it.
+#[derive(Clone, Default)]
+pub struct RawAccumulator(Arc<Mutex<HashMap<u32, Vec<String>>>>);
+
+impl RawAccumulator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn push(&self, index: u32, text: &str) {
+        let mut guard = self
+            .0
+            .lock()
+            .expect("parser-debug raw accumulator poisoned");
+        guard.entry(index).or_default().push(text.to_string());
+    }
+
+    fn snapshot(&self) -> HashMap<u32, Vec<String>> {
+        self.0
+            .lock()
+            .expect("parser-debug raw accumulator poisoned")
+            .clone()
+    }
+}
+
+/// One emitted debug record per choice: the raw completion next to the parsed result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParserDebugRecord {
+    pub stream_id: String,
+    pub choice_index: u32,
+    pub reasoning_parser: String,
+    pub tool_parser: String,
+    /// Full pre-parse completion text (concatenated) — grep this for expected markup.
+    pub raw: String,
+    /// The same text split exactly as the deltas arrived — replay these chunks
+    /// through the parser to reproduce chunk-boundary-dependent failures.
+    pub raw_chunks: Vec<String>,
+    pub reasoning_content: String,
+    pub content: String,
+    pub tool_call_count: usize,
+    pub tool_call_names: Vec<String>,
+    pub finish_reason: String,
+}
+
+/// Per-choice accumulator for the PARSED outputs, built by the exit tap.
+#[derive(Default)]
+struct ParsedAccum {
+    reasoning_content: String,
+    content: String,
+    tool_call_names: Vec<String>,
+    tool_call_count: usize,
+    finish_reason: Option<String>,
+}
+
+/// Build one record per choice from the accumulated raw + parsed state.
+///
+/// Pure: takes the captured maps and parser names, returns the records. Tests assert
+/// on the returned structs rather than on emitted log output.
+fn build_records(
+    stream_id: &str,
+    reasoning_parser: &str,
+    tool_parser: &str,
+    raw: &HashMap<u32, Vec<String>>,
+    parsed: &HashMap<u32, ParsedAccum>,
+) -> Vec<ParserDebugRecord> {
+    // Union of choice indices seen on either side. A choice with raw but no parsed
+    // output (or vice versa) still gets a record so the gap is visible.
+    let mut indices: Vec<u32> = raw.keys().chain(parsed.keys()).copied().collect();
+    indices.sort_unstable();
+    indices.dedup();
+
+    indices
+        .into_iter()
+        .map(|index| {
+            let p = parsed.get(&index);
+            let raw_chunks = raw.get(&index).cloned().unwrap_or_default();
+            ParserDebugRecord {
+                stream_id: stream_id.to_string(),
+                choice_index: index,
+                reasoning_parser: reasoning_parser.to_string(),
+                tool_parser: tool_parser.to_string(),
+                raw: raw_chunks.concat(),
+                raw_chunks,
+                reasoning_content: p.map(|p| p.reasoning_content.clone()).unwrap_or_default(),
+                content: p.map(|p| p.content.clone()).unwrap_or_default(),
+                tool_call_count: p.map(|p| p.tool_call_count).unwrap_or(0),
+                tool_call_names: p.map(|p| p.tool_call_names.clone()).unwrap_or_default(),
+                finish_reason: p.and_then(|p| p.finish_reason.clone()).unwrap_or_default(),
+            }
+        })
+        .collect()
+}
+
+/// Emit one structured tracing event per record. Each field is a separate `tracing`
+/// field (not a formatted string) so the event is queryable in `DYN_LOGGING_JSONL`
+/// deployments.
+fn emit(records: &[ParserDebugRecord]) {
+    for r in records {
+        tracing::info!(
+            target: "parser_debug",
+            stream_id = %r.stream_id,
+            choice_index = r.choice_index,
+            reasoning_parser = %r.reasoning_parser,
+            tool_parser = %r.tool_parser,
+            raw = %r.raw,
+            raw_chunks = ?r.raw_chunks,
+            reasoning_content = %r.reasoning_content,
+            content = %r.content,
+            tool_call_count = r.tool_call_count,
+            tool_call_names = ?r.tool_call_names,
+            finish_reason = %r.finish_reason,
+            "parser debug: raw completion vs parsed output"
+        );
+    }
+}
+
+/// Entry tap: accumulate the RAW (pre-parse) text content per choice, then yield each
+/// response unchanged. Multimodal `Parts` content is skipped (text-only deltas are
+/// what the parsing seam operates on).
+pub fn tap_raw<S>(
+    stream: S,
+    acc: RawAccumulator,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    stream::unfold((Box::pin(stream), acc), |(mut stream, acc)| async move {
+        let response = stream.next().await?;
+        if let Some(data) = response.data.as_ref() {
+            for choice in &data.inner.choices {
+                if let Some(ChatCompletionMessageContent::Text(text)) =
+                    choice.delta.content.as_ref()
+                {
+                    acc.push(choice.index, text);
+                }
+            }
+        }
+        Some((response, (stream, acc)))
+    })
+}
+
+/// Exit tap: accumulate the PARSED outputs per choice as they flow, yield each
+/// response unchanged, and emit one debug record per choice (via `emit`) when the
+/// stream ends. Production entry point — see [`tap_parsed_collecting`] for the
+/// callback-generic core that tests drive with a capturing sink.
+pub fn tap_parsed_and_emit<S>(
+    stream: S,
+    raw: RawAccumulator,
+    reasoning_parser: Option<String>,
+    tool_parser: Option<String>,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    tap_parsed_collecting(stream, raw, reasoning_parser, tool_parser, |records| {
+        emit(&records)
+    })
+}
+
+/// Callback-generic exit tap: same accumulation as [`tap_parsed_and_emit`], but
+/// routes the built records to `on_end` at stream end instead of hardcoding `emit`.
+/// Lets tests assert on `Vec<ParserDebugRecord>` directly (no log capture).
+pub fn tap_parsed_collecting<S, F>(
+    stream: S,
+    raw: RawAccumulator,
+    reasoning_parser: Option<String>,
+    tool_parser: Option<String>,
+    on_end: F,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+    F: FnOnce(Vec<ParserDebugRecord>) + Send + 'static,
+{
+    struct ExitState<St, G> {
+        stream: std::pin::Pin<Box<St>>,
+        raw: RawAccumulator,
+        reasoning_parser: String,
+        tool_parser: String,
+        stream_id: String,
+        parsed: HashMap<u32, ParsedAccum>,
+        on_end: Option<G>,
+    }
+
+    let state = ExitState {
+        stream: Box::pin(stream),
+        raw,
+        reasoning_parser: reasoning_parser.unwrap_or_else(|| "-".to_string()),
+        tool_parser: tool_parser.unwrap_or_else(|| "-".to_string()),
+        stream_id: String::new(),
+        parsed: HashMap::new(),
+        on_end: Some(on_end),
+    };
+
+    stream::unfold(state, |mut state| async move {
+        match state.stream.next().await {
+            Some(response) => {
+                if let Some(data) = response.data.as_ref() {
+                    if !data.inner.id.is_empty() {
+                        state.stream_id = data.inner.id.clone();
+                    }
+                    for choice in &data.inner.choices {
+                        let acc = state.parsed.entry(choice.index).or_default();
+                        if let Some(reasoning) = choice.delta.reasoning_content.as_ref() {
+                            acc.reasoning_content.push_str(reasoning);
+                        }
+                        if let Some(ChatCompletionMessageContent::Text(text)) =
+                            choice.delta.content.as_ref()
+                        {
+                            acc.content.push_str(text);
+                        }
+                        if let Some(tool_calls) = choice.delta.tool_calls.as_ref() {
+                            for tc in tool_calls {
+                                if let Some(name) =
+                                    tc.function.as_ref().and_then(|f| f.name.clone())
+                                {
+                                    // Name arrives once per tool call (first delta).
+                                    acc.tool_call_count += 1;
+                                    acc.tool_call_names.push(name);
+                                }
+                            }
+                        }
+                        if let Some(fr) = choice.finish_reason {
+                            acc.finish_reason = Some(format!("{fr:?}"));
+                        }
+                    }
+                }
+                Some((response, state))
+            }
+            None => {
+                if let Some(on_end) = state.on_end.take() {
+                    let records = build_records(
+                        &state.stream_id,
+                        &state.reasoning_parser,
+                        &state.tool_parser,
+                        &state.raw.snapshot(),
+                        &state.parsed,
+                    );
+                    on_end(records);
+                }
+                None
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accum(reasoning: &str, content: &str, names: &[&str], finish: Option<&str>) -> ParsedAccum {
+        ParsedAccum {
+            reasoning_content: reasoning.to_string(),
+            content: content.to_string(),
+            tool_call_names: names.iter().map(|s| s.to_string()).collect(),
+            tool_call_count: names.len(),
+            finish_reason: finish.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn one_record_per_choice() {
+        let mut raw = HashMap::new();
+        raw.insert(0, vec!["ra".to_string(), "w0".to_string()]);
+        raw.insert(1, vec!["raw1".to_string()]);
+        let mut parsed = HashMap::new();
+        parsed.insert(0, accum("r0", "c0", &["get_weather"], Some("Stop")));
+        parsed.insert(1, accum("", "c1", &[], Some("Stop")));
+
+        let records = build_records("id-x", "qwen3", "harmony", &raw, &parsed);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].choice_index, 0);
+        assert_eq!(records[0].raw, "raw0");
+        assert_eq!(records[0].tool_call_names, vec!["get_weather"]);
+        assert_eq!(records[0].tool_call_count, 1);
+        assert_eq!(records[0].reasoning_parser, "qwen3");
+        assert_eq!(records[1].choice_index, 1);
+        assert_eq!(records[1].tool_call_count, 0);
+    }
+
+    #[test]
+    fn raw_without_parsed_still_gets_record() {
+        // A choice that produced raw text but no parsed output (parser dropped it).
+        let mut raw = HashMap::new();
+        raw.insert(0, vec!["<function=foo>{}".to_string()]);
+        let parsed = HashMap::new();
+
+        let records = build_records("id", "-", "harmony", &raw, &parsed);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].raw, "<function=foo>{}");
+        assert_eq!(records[0].tool_call_count, 0);
+        assert_eq!(records[0].content, "");
+        assert_eq!(records[0].finish_reason, "");
+    }
+
+    #[test]
+    fn empty_state_yields_no_records() {
+        let records = build_records("id", "-", "-", &HashMap::new(), &HashMap::new());
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn raw_accumulator_concats_per_choice() {
+        let acc = RawAccumulator::new();
+        acc.push(0, "a");
+        acc.push(0, "b");
+        acc.push(1, "x");
+        let snap = acc.snapshot();
+        assert_eq!(
+            snap.get(&0).unwrap(),
+            &vec!["a".to_string(), "b".to_string()]
+        );
+        assert_eq!(snap.get(&1).unwrap(), &vec!["x".to_string()]);
+    }
+
+    // --- tap-driving tests (accumulation behavior, synthetic streams) ---
+
+    use dynamo_protocols::types::{
+        ChatChoiceStream, ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta,
+        CreateChatCompletionStreamResponse, FinishReason, FunctionCallStream, Role,
+    };
+    use std::sync::Mutex as StdMutex;
+
+    /// Per-choice test delta: (index, content, reasoning, tool_name, finish).
+    type ChoiceSpec<'a> = (
+        u32,
+        Option<&'a str>,
+        Option<&'a str>,
+        Option<&'a str>,
+        Option<FinishReason>,
+    );
+
+    /// One stream chunk built from per-choice specs.
+    #[allow(deprecated)]
+    fn chunk(choices: &[ChoiceSpec<'_>]) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let choices = choices
+            .iter()
+            .map(
+                |(index, content, reasoning, tool_name, finish)| ChatChoiceStream {
+                    index: *index,
+                    delta: ChatCompletionStreamResponseDelta {
+                        role: Some(Role::Assistant),
+                        content: content.map(|c| ChatCompletionMessageContent::Text(c.to_string())),
+                        tool_calls: tool_name.map(|n| {
+                            vec![ChatCompletionMessageToolCallChunk {
+                                index: 0,
+                                function: Some(FunctionCallStream {
+                                    name: Some(n.to_string()),
+                                    arguments: None,
+                                }),
+                                ..Default::default()
+                            }]
+                        }),
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: reasoning.map(|r| r.to_string()),
+                    },
+                    finish_reason: *finish,
+                    logprobs: None,
+                },
+            )
+            .collect();
+        Annotated::from_data(NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "sid".to_string(),
+                choices,
+                created: 0,
+                model: "m".to_string(),
+                system_fingerprint: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            },
+            nvext: None,
+        })
+    }
+
+    /// Drive tap_raw -> tap_parsed_collecting over `chunks` and return the records.
+    fn drive(
+        chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>>,
+        reasoning_parser: Option<&str>,
+        tool_parser: Option<&str>,
+    ) -> Vec<ParserDebugRecord> {
+        let sink = Arc::new(StdMutex::new(Vec::new()));
+        let sink_w = sink.clone();
+        let raw = RawAccumulator::new();
+        // Entry tap captures raw, exit tap accumulates parsed. No parser in between
+        // here: these tests assert the tap accumulation/record-build, not parsing.
+        let entry = tap_raw(stream::iter(chunks), raw.clone());
+        let exit = tap_parsed_collecting(
+            entry,
+            raw,
+            reasoning_parser.map(str::to_string),
+            tool_parser.map(str::to_string),
+            move |records| *sink_w.lock().unwrap() = records,
+        );
+        futures::executor::block_on(exit.collect::<Vec<_>>());
+        Arc::try_unwrap(sink).unwrap().into_inner().unwrap()
+    }
+
+    #[test]
+    fn tap_finish_reason_takes_last_non_none() {
+        let records = drive(
+            vec![
+                chunk(&[(0, Some("hi"), None, None, None)]),
+                chunk(&[(0, Some(" there"), None, None, Some(FinishReason::Stop))]),
+                chunk(&[(0, None, None, None, None)]),
+            ],
+            Some("qwen3"),
+            None,
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].content, "hi there");
+        assert_eq!(records[0].finish_reason, "Stop");
+        assert_eq!(records[0].reasoning_parser, "qwen3");
+        assert_eq!(records[0].tool_parser, "-");
+    }
+
+    #[test]
+    fn tap_collects_tool_call_names_and_count() {
+        let records = drive(
+            vec![
+                chunk(&[(0, None, None, Some("get_weather"), None)]),
+                chunk(&[(
+                    0,
+                    None,
+                    None,
+                    Some("get_time"),
+                    Some(FinishReason::ToolCalls),
+                )]),
+            ],
+            None,
+            Some("harmony"),
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].tool_call_count, 2);
+        assert_eq!(records[0].tool_call_names, vec!["get_weather", "get_time"]);
+        assert_eq!(records[0].finish_reason, "ToolCalls");
+    }
+
+    #[test]
+    fn tap_two_choices_distinct_raw() {
+        let records = drive(
+            vec![
+                chunk(&[
+                    (0, Some("a0"), None, None, None),
+                    (1, Some("b1"), None, None, None),
+                ]),
+                chunk(&[(0, Some("a0b"), None, None, None)]),
+            ],
+            None,
+            None,
+        );
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].choice_index, 0);
+        assert_eq!(records[0].raw, "a0a0b");
+        assert_eq!(records[1].choice_index, 1);
+        assert_eq!(records[1].raw, "b1");
+    }
+
+    #[test]
+    fn tap_reasoning_split_from_content() {
+        // Simulates post-reasoning-parser deltas: reasoning_content + content set
+        // separately. Raw (entry tap) only sees the text content here.
+        let records = drive(
+            vec![
+                chunk(&[(0, None, Some("plan"), None, None)]),
+                chunk(&[(0, Some("answer"), None, None, Some(FinishReason::Stop))]),
+            ],
+            Some("qwen3"),
+            None,
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].reasoning_content, "plan");
+        assert_eq!(records[0].content, "answer");
+        // Entry tap saw only the "answer" text delta as raw (reasoning delta has no content).
+        assert_eq!(records[0].raw, "answer");
+    }
+}

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1790,3 +1790,225 @@ async fn tool_choice_matrix_immediate_jail_reasoning_only_first_chunk() {
     );
     assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
 }
+
+// ---------------------------------------------------------------------------
+// Parser debug mode: raw completion captured alongside parsed output.
+//
+// These compose the parser-debug taps around the REAL reasoning parser exactly
+// as `postprocessor_parsing_stream` wires them, and assert the emitted records
+// via a capturing sink (no log capture, no process-env mutation). The env-off
+// passthrough case (f) is covered by every other test in this file: when the
+// taps are absent the stream is byte-identical, which those fixtures pin.
+// ---------------------------------------------------------------------------
+
+use dynamo_llm::preprocessor::parser_debug::{
+    ParserDebugRecord, RawAccumulator, tap_parsed_collecting, tap_raw,
+};
+use std::sync::Mutex as StdMutex;
+
+#[tokio::test]
+async fn parser_debug_reasoning_raw_retained() {
+    // RAW tap is placed BEFORE the reasoning parser, which rewrites delta.content
+    // in place. The record must show the original `<think>` markup in `raw` even
+    // though the parser stripped it from `content` and moved it to reasoning.
+    let chunk = mock_content_chunk("<think>plan</think>answer");
+
+    let raw = RawAccumulator::new();
+    let sink = Arc::new(StdMutex::new(Vec::<ParserDebugRecord>::new()));
+    let sink_w = sink.clone();
+
+    let entry = tap_raw(stream::iter(vec![Annotated::from_data(chunk)]), raw.clone());
+    let reasoned =
+        OpenAIPreprocessor::parse_reasoning_content_from_stream(entry, "qwen".to_string(), false);
+    let exit = tap_parsed_collecting(
+        reasoned,
+        raw,
+        Some("qwen".to_string()),
+        None,
+        move |records| *sink_w.lock().unwrap() = records,
+    );
+    let _: Vec<_> = exit.collect().await;
+
+    let records = sink.lock().unwrap().clone();
+    assert_eq!(records.len(), 1, "one record for the single choice");
+    let r = &records[0];
+    assert!(
+        r.raw.contains("<think>"),
+        "raw must retain the original markup the parser stripped; got {:?}",
+        r.raw
+    );
+    assert_eq!(r.raw, "<think>plan</think>answer");
+    assert!(
+        !r.content.contains("<think>"),
+        "parsed content must have the think markup stripped; got {:?}",
+        r.content
+    );
+    assert!(
+        r.reasoning_content.contains("plan"),
+        "reasoning_content should hold the think body; got {:?}",
+        r.reasoning_content
+    );
+    assert_eq!(r.reasoning_parser, "qwen");
+    assert_eq!(r.stream_id, "test-id");
+}
+
+#[tokio::test]
+async fn parser_debug_split_marker_destruction_preserves_raw() {
+    // Destroyed-evidence repro: nemotron force-reasoning + qwen3_coder jail.
+    // A chunk boundary splits `</think>` at the lone `<`; the reasoning parser
+    // fails to reassemble it and swallows the ENTIRE tool call into
+    // reasoning_content — tool_calls empty, content empty, finish=Stop. The
+    // evidence (and the chunking needed to reproduce) exists only in the
+    // parser-debug record: raw shows `<function=terminal>` intact, raw_chunks
+    // shows the exact split. The same bytes unsplit parse fine (control below),
+    // so the boundaries are the repro-critical information.
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), Some("qwen3_coder"));
+    let request = request_with_terminal_tool();
+
+    let chunks = [
+        "<think>pick a command<",
+        "/think>\n<tool_call>\n<",
+        "function=terminal>\n<parameter=command>\nls -la\n</parameter>\n</function>\n</tool_call>",
+    ];
+
+    let raw = RawAccumulator::new();
+    let sink = Arc::new(StdMutex::new(Vec::<ParserDebugRecord>::new()));
+    let sink_w = sink.clone();
+
+    let input = chunks
+        .iter()
+        .map(|c| Annotated::from_data(mock_content_chunk(c)))
+        .chain(std::iter::once(Annotated::from_data(mock_final_chunk())))
+        .collect::<Vec<_>>();
+    let entry = tap_raw(stream::iter(input), raw.clone());
+    let piped = preprocessor
+        .postprocessor_parsing_stream(entry, &request, false, false)
+        .expect("pipeline should build");
+    let exit = tap_parsed_collecting(
+        piped,
+        raw,
+        Some("nemotron_v3".to_string()),
+        Some("qwen3_coder".to_string()),
+        move |records| *sink_w.lock().unwrap() = records,
+    );
+    let _: Vec<_> = exit.collect().await;
+
+    let records = sink.lock().unwrap().clone();
+    assert_eq!(records.len(), 1);
+    let r = &records[0];
+    // The destruction: no tool call extracted, nothing in content.
+    assert_eq!(r.tool_call_count, 0, "split marker destroys the tool call");
+    assert_eq!(r.content, "");
+    // The evidence: raw retains the full markup the parsers destroyed...
+    assert!(
+        r.raw.contains("<function=terminal>"),
+        "raw must prove the model emitted the function tag; got {:?}",
+        r.raw
+    );
+    // ...and raw_chunks retains the exact chunking needed to REPRODUCE the bug
+    // (the same bytes in one chunk parse fine — see the control test).
+    assert_eq!(r.raw_chunks.len(), 3);
+    assert!(r.raw_chunks[0].ends_with('<') && r.raw_chunks[1].ends_with('<'));
+}
+
+#[tokio::test]
+async fn parser_debug_unsplit_control_parses_clean() {
+    // Control for the split-marker repro: identical bytes in ONE chunk parse
+    // cleanly (reasoning extracted, calls=1 terminal). Proves the failure above
+    // is purely chunk-boundary-dependent — why raw_chunks must keep boundaries.
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), Some("qwen3_coder"));
+    let request = request_with_terminal_tool();
+
+    let text = "<think>pick a command</think>\n<tool_call>\n<function=terminal>\n<parameter=command>\nls -la\n</parameter>\n</function>\n</tool_call>";
+
+    let raw = RawAccumulator::new();
+    let sink = Arc::new(StdMutex::new(Vec::<ParserDebugRecord>::new()));
+    let sink_w = sink.clone();
+
+    let input = vec![
+        Annotated::from_data(mock_content_chunk(text)),
+        Annotated::from_data(mock_final_chunk()),
+    ];
+    let entry = tap_raw(stream::iter(input), raw.clone());
+    let piped = preprocessor
+        .postprocessor_parsing_stream(entry, &request, false, false)
+        .expect("pipeline should build");
+    let exit = tap_parsed_collecting(
+        piped,
+        raw,
+        Some("nemotron_v3".to_string()),
+        Some("qwen3_coder".to_string()),
+        move |records| *sink_w.lock().unwrap() = records,
+    );
+    let _: Vec<_> = exit.collect().await;
+
+    let records = sink.lock().unwrap().clone();
+    assert_eq!(records.len(), 1);
+    let r = &records[0];
+    assert_eq!(r.tool_call_count, 1, "unsplit input must parse the call");
+    assert_eq!(r.tool_call_names, vec!["terminal"]);
+    assert_eq!(r.reasoning_content, "pick a command");
+    assert_eq!(r.finish_reason, "ToolCalls");
+}
+
+#[tokio::test]
+async fn parser_debug_jail_strip_preserves_raw() {
+    // Malformed-generation shape: the `<function=...>` line is
+    // missing entirely, so no parser can extract a call (no tool name). The
+    // qwen3_coder jail STRIPS the whole block — content empty, calls=0 — which
+    // destroys all evidence of what the model emitted. The parser-debug record
+    // is then the only artifact showing the malformed markup.
+    let preprocessor = build_preprocessor(None, Some("qwen3_coder"));
+    let request = request_with_terminal_tool();
+
+    let leaked = "<tool_call>\n<parameter=command>\nls -la\n</parameter>\n</tool_call>";
+
+    let raw = RawAccumulator::new();
+    let sink = Arc::new(StdMutex::new(Vec::<ParserDebugRecord>::new()));
+    let sink_w = sink.clone();
+
+    let input = vec![
+        Annotated::from_data(mock_content_chunk(leaked)),
+        Annotated::from_data(mock_final_chunk()),
+    ];
+    let entry = tap_raw(stream::iter(input), raw.clone());
+    let piped = preprocessor
+        .postprocessor_parsing_stream(entry, &request, false, false)
+        .expect("pipeline should build");
+    let exit = tap_parsed_collecting(
+        piped,
+        raw,
+        None,
+        Some("qwen3_coder".to_string()),
+        move |records| *sink_w.lock().unwrap() = records,
+    );
+    let _: Vec<_> = exit.collect().await;
+
+    let records = sink.lock().unwrap().clone();
+    assert_eq!(records.len(), 1);
+    let r = &records[0];
+    assert_eq!(r.tool_call_count, 0);
+    assert_eq!(
+        r.content, "",
+        "jail strips the unparseable block — evidence gone"
+    );
+    assert!(
+        r.raw.contains("<tool_call>") && !r.raw.contains("<function="),
+        "raw is the only record: markup present, function tag missing; got {:?}",
+        r.raw
+    );
+}
+
+fn request_with_terminal_tool() -> NvCreateChatCompletionRequest {
+    let mut request: NvCreateChatCompletionRequest =
+        serde_json::from_str(REQUEST_JSON).expect("request should parse");
+    request.inner.tools = Some(
+        serde_json::from_value(serde_json::json!([
+            {"type":"function","function":{"name":"terminal","description":"run a command",
+             "parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}}
+        ]))
+        .unwrap(),
+    );
+    request.inner.tool_choice = Some(ChatCompletionToolChoiceOption::Auto);
+    request
+}

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -311,6 +311,16 @@ pub mod llm {
     pub const DYN_ENABLE_STREAMING_REASONING_DISPATCH: &str =
         "DYN_ENABLE_STREAMING_REASONING_DISPATCH";
 
+    /// Enable parser debug mode (off by default). When enabled, the frontend emits
+    /// one structured tracing event per choice at stream end pairing the RAW model
+    /// completion text with the parsed result (reasoning_content / content /
+    /// tool_calls / finish_reason), so intermittent parse failures can be diagnosed
+    /// from logs (queryable under `DYN_LOGGING_JSONL=true`) instead of hand-captured.
+    ///
+    /// WARNING: raw completions carry user data — this is opt-in only. Unset / `0` /
+    /// `false` = off; any other value = on.
+    pub const DYN_PARSER_DEBUG: &str = "DYN_PARSER_DEBUG";
+
     /// Backend stream inactivity timeout in seconds.
     ///
     /// When set to a positive integer, the frontend will kill the engine context


### PR DESCRIPTION
#### Overview:

This PR adds an opt-in parser debug mode (`DYN_PARSER_DEBUG=1`) that emits one structured tracing event per choice at stream end, pairing the RAW model completion (full text + the exact delta chunking) with the parsed result (`reasoning_content` / `content` / `tool_calls` / `finish_reason`), so intermittent parse failures are diagnosable and reproducible from logs.

#### Concrete failures this diagnoses (both reproduced in the test suite):

Nemotron-style reasoning + qwen3_coder tool calling. The model emits a well-formed completion, but a stream delta boundary splits `</think>` at the lone `<`:

```
chunk 1: "<think>pick a command<"
chunk 2: "/think>\n<tool_call>\n<"
chunk 3: "function=terminal>\n<parameter=command>\nls -la\n</parameter>\n</function>\n</tool_call>"
```

The reasoning parser fails to reassemble the split marker and swallows the entire tool call into `reasoning_content`: the client gets `tool_calls: []`, `content: ""`, `finish_reason: stop` — and the evidence is destroyed. The same bytes in ONE chunk parse perfectly (`tool_calls: [terminal]`, `finish_reason: tool_calls`) — the failure is purely chunk-boundary-dependent, which is why the debug event records `raw_chunks` (the exact delta split) and not just the concatenated text: the chunking is what's needed to *reproduce*, not just see, the failure.

The second direction: the model itself generates markup missing its `<function=...>` line entirely (no tool name) — the jail strips the whole block (`content: ""`, `calls: 0`), leaving no trace anywhere except the debug event's `raw`. Here the grep shows the markup MISSING from `raw`, exonerating the parsers and pointing investigation upstream (prompt rendering / model). One event disambiguates both directions: markup present in `raw` but lost in parsed output = parser path; markup absent from `raw` = generation side.

#### Details:

- **How does this work?** Two taps share a per-choice accumulator in `postprocessor_parsing_stream`: an entry tap (`tap_raw`) captures raw delta text (with boundaries) *before* the reasoning parser rewrites `delta.content`, and an exit tap accumulates the parsed deltas and emits one record per choice at stream end. New module `lib/llm/src/preprocessor/parser_debug.rs`.
- Gated by `DYN_PARSER_DEBUG` (new const in `environment_names.rs`); off by default — neither tap is constructed, zero hot-path cost. Raw completions carry user data: opt-in only.
- Event fields (separate tracing fields, queryable under `DYN_LOGGING_JSONL=true`): `stream_id`, `choice_index`, `reasoning_parser`, `tool_parser`, `raw` (concat, grep-able), `raw_chunks` (exact delta split, replay-able), `reasoning_content`, `content`, `tool_call_count`, `tool_call_names`, `finish_reason`.

#### Verification:

`cargo clippy` clean; 8 unit tests; 4 real-pipeline integration tests through `postprocessor_parsing_stream` with `nemotron_v3` + `qwen3_coder` wired: the split-marker destruction repro (raw + chunks preserved while parsed output lost the call), its unsplit control (same bytes parse clean — proves chunk-dependence), the jail-strip shape, and reasoning-markup retention; all 25 pre-existing stream tests pass unchanged (taps absent = passthrough). Live JSONL smoke on a deployed model still pending.

#### Where should the reviewer start?

`lib/llm/src/preprocessor/parser_debug.rs`, then the taps wired in `lib/llm/src/preprocessor.rs` (`postprocessor_parsing_stream`), then `parser_debug_dis2223_*` tests in `lib/llm/tests/postprocessor_parsing_stream.rs`

#### Related Issues:

Relates to DIS-2224

/coderabbit profile chill
