### PR TITLE
test(http): fix flaky nvext propagation test by pinning env var

### DIFF
--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -958,17 +958,25 @@ mod tests {
     /// exposed via the accessor used by the openai handlers.
     #[test]
     fn test_enable_nvext_propagates_through_builder_to_state() {
-        let on = HttpService::builder().enable_nvext(true).build().unwrap();
-        assert!(on.state.nvext_enabled());
+        use dynamo_runtime::config::environment_names::llm::DYN_ENABLE_FRONTEND_NVEXT;
 
-        let off = HttpService::builder().enable_nvext(false).build().unwrap();
-        assert!(!off.state.nvext_enabled());
+        // `build()` ANDs the builder flag with the env var, so this test must
+        // pin the env to unset. Going through `temp_env` also serializes it
+        // against `test_dyn_enable_frontend_nvext_env_var_mirror`, which mutates
+        // the same process-global var in parallel.
+        temp_env::with_var_unset(DYN_ENABLE_FRONTEND_NVEXT, || {
+            let on = HttpService::builder().enable_nvext(true).build().unwrap();
+            assert!(on.state.nvext_enabled());
 
-        let default = HttpService::builder().build().unwrap();
-        assert!(
-            default.state.nvext_enabled(),
-            "default should preserve current behavior (nvext on)"
-        );
+            let off = HttpService::builder().enable_nvext(false).build().unwrap();
+            assert!(!off.state.nvext_enabled());
+
+            let default = HttpService::builder().build().unwrap();
+            assert!(
+                default.state.nvext_enabled(),
+                "default should preserve current behavior (nvext on)"
+            );
+        });
     }
 
     /// `DYN_ENABLE_FRONTEND_NVEXT` is the env-var mirror of the builder


### PR DESCRIPTION
## What this fixes

The `dynamo-llm` unit test `test_enable_nvext_propagates_through_builder_to_state` fails intermittently in CI. It is a flaky test caused by shared process-global env state, not a real product bug.

`HttpService::build()` computes the flag like this:

```rust
let nvext_enabled =
    config.enable_nvext && !env_is_falsey(env_llm::DYN_ENABLE_FRONTEND_NVEXT);
```

So the builder result depends on the `DYN_ENABLE_FRONTEND_NVEXT` env var. The sibling test `test_dyn_enable_frontend_nvext_env_var_mirror` deliberately sets that same env var to falsey values (`false`, `0`, `no`, `off`) to verify the override behavior, using `temp_env`.

Rust runs unit tests as parallel threads inside one process, so env vars are shared global state. The propagation test did not guard the env var. When the mirror test had `DYN_ENABLE_FRONTEND_NVEXT` set to a falsey value at the exact moment the propagation test called `build()`, the flag resolved to `true && !true == false` and this assertion panicked:

```
assertion failed: on.state.nvext_enabled()
```

Whether it fails comes down to thread scheduling, which is why CI saw 1301 passed / 1 failed and local runs usually pass.

## Before

Forcing the env var to a falsey value (which is exactly what the parallel mirror test does at the wrong moment) reproduces the CI failure every time:

```
$ DYN_ENABLE_FRONTEND_NVEXT=false cargo test -p dynamo-llm --lib \
    test_enable_nvext_propagates_through_builder_to_state

test ...propagates_through_builder_to_state ... FAILED
panicked at lib/llm/src/http/service/service_v2.rs:962:9:
assertion failed: on.state.nvext_enabled()
test result: FAILED. 0 passed; 1 failed
```

## After

The same command passes, and stress-running both nvext tests together in parallel 5 times stays green:

```
$ DYN_ENABLE_FRONTEND_NVEXT=false cargo test -p dynamo-llm --lib \
    test_enable_nvext_propagates_through_builder_to_state
test ...propagates_through_builder_to_state ... ok
test result: ok. 1 passed; 0 failed

$ for i in $(seq 5); do cargo test -p dynamo-llm --lib nvext; done
test result: ok. 44 passed; 0 failed   (x5)
```

## The change

Wrap the test body in `temp_env::with_var_unset(DYN_ENABLE_FRONTEND_NVEXT, ...)`. This does two things:

1. Pins the env var to unset for the duration of the test, so `build()` reads a known state.
2. Routes the test through `temp_env`, whose calls share one process-global lock. The propagation test and the mirror test are now serialized instead of racing.

After this change every reader of `DYN_ENABLE_FRONTEND_NVEXT` in the test module goes through `temp_env`, so the race class is removed rather than papered over. The change is test-only; no production code is touched.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and reliability by enhancing environment variable handling during unit testing to prevent concurrent state mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->