### PR TITLE
perf(mocker): use single runtime for all engines

### DIFF
--- a/docs/dynosim/runs.md
+++ b/docs/dynosim/runs.md
@@ -39,7 +39,7 @@ flowchart LR
     H --> TC[Trace Collector]
 ```
 
-The load driver is either a Mooncake-style JSONL trace (timestamps, ISL/OSL, `hash_ids`) or a synthetic generator parameterized by `isl`/`osl`/`concurrency`. Single-engine simulation (`SES`) is the fast path for `num_workers == 1` with the vLLM engine; multi-engine simulation (`MES`) covers aggregated multi-worker runs, disaggregated prefill/decode runs, and KV-router runs. The trace collector produces the AIPerf-style summary table, the JSON report, and the per-request timing fields consumed by downstream analysis.
+The load driver is either a Mooncake-style JSONL trace (timestamps, ISL/OSL, `hash_ids`) or a synthetic generator parameterized by `isl`/`osl`/`concurrency`. Single-engine simulation (`SES`) is the fast path for `num_workers == 1` with vLLM, SGLang, or TRT-LLM; multi-engine simulation (`MES`) covers aggregated multi-worker runs, disaggregated prefill/decode runs, and KV-router runs. The trace collector produces the AIPerf-style summary table, the JSON report, and the per-request timing fields consumed by downstream analysis.
 
 Each simulation composes a different set of components. SES drives the engine core directly (scheduler + forward-pass modeling). MES composes multiple engine cores with KV transfer/offloading, KV routing, and planner simulation layered on top:
 
@@ -506,7 +506,7 @@ If `--report-json` is not provided, `python -m dynamo.replay` writes a timestamp
 
 Shared constraints:
 
-- `extra_engine_args.engine_type` must be `vllm` or `sglang`
+- `extra_engine_args.engine_type` must be `vllm`, `sglang`, or `trtllm`
 - aggregated simulation requires the existing aggregated args path
 - disaggregated simulation requires both `prefill_engine_args` and `decode_engine_args`
 - disaggregated simulation requires `router_mode=kv_router`
@@ -516,9 +516,8 @@ Shared constraints:
 Additional offline constraints:
 
 - offline `kv_router` requires `num_workers > 1`
-- single-worker offline mode is still a dedicated fast path for `vllm`, but it now supports both
-  flat request runs and workload-driven multi-turn runs
-- `sglang` still goes through the shared multi-worker runtime even when `num_workers=1`
+- single-worker offline mode is a dedicated fast path for `vllm`, `sglang`, and `trtllm`;
+  it supports flat request runs and workload-driven multi-turn runs
 - offline disaggregated simulation is a separate two-stage runtime with prefill and decode worker pools
 
 Additional online constraints:

--- a/lib/bench/README.md
+++ b/lib/bench/README.md
@@ -110,6 +110,7 @@ See also: [Agent Hints documentation](../../docs/components/frontend/nvext.md#ag
 ```bash
 cargo bench --package dynamo-bench --bench offline_replay_bench -- \
   /path/to/mooncake_trace.jsonl \
+  --engine-type sglang \
   --num-workers 4 \
   --router-mode kv-router \
   --arrival-speedup-ratio 4 \
@@ -117,6 +118,7 @@ cargo bench --package dynamo-bench --bench offline_replay_bench -- \
   --block-size 64
 ```
 
+`--engine-type` accepts `vllm`, `sglang`, or `trtllm` and defaults to `vllm`.
 Use `--speedup-ratio` and `--decode-speedup-ratio` if you want a simple scaling
 knob while keeping the same internal polynomial model.
 

--- a/lib/bench/offline_replay_bench.rs
+++ b/lib/bench/offline_replay_bench.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
-use dynamo_mocker::common::protocols::MockEngineArgs;
+use dynamo_mocker::common::protocols::{EngineType, MockEngineArgs, SglangArgs};
 use dynamo_mocker::loadgen::Trace;
 use dynamo_mocker::replay::{ReplayRouterMode, simulate_trace_workload_with_router_mode};
 
@@ -22,6 +22,23 @@ use dynamo_mocker::replay::{ReplayRouterMode, simulate_trace_workload_with_route
 enum RouterModeArg {
     RoundRobin,
     KvRouter,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+enum EngineTypeArg {
+    Vllm,
+    Sglang,
+    Trtllm,
+}
+
+impl From<EngineTypeArg> for EngineType {
+    fn from(value: EngineTypeArg) -> Self {
+        match value {
+            EngineTypeArg::Vllm => EngineType::Vllm,
+            EngineTypeArg::Sglang => EngineType::Sglang,
+            EngineTypeArg::Trtllm => EngineType::Trtllm,
+        }
+    }
 }
 
 impl From<RouterModeArg> for ReplayRouterMode {
@@ -48,6 +65,10 @@ struct Args {
     /// Number of aggregated workers
     #[arg(long, default_value_t = 4)]
     num_workers: usize,
+
+    /// Mock engine scheduling mode
+    #[arg(long, value_enum, default_value_t = EngineTypeArg::Vllm)]
+    engine_type: EngineTypeArg,
 
     /// Router mode for multi-worker replay
     #[arg(long, value_enum, default_value_t = RouterModeArg::KvRouter)]
@@ -95,8 +116,15 @@ struct Args {
 }
 
 fn build_engine_args(args: &Args) -> Result<MockEngineArgs> {
-    let mut builder = MockEngineArgs::builder();
-    builder = builder.block_size(args.block_size);
+    let mut builder = MockEngineArgs::builder()
+        .engine_type(args.engine_type.into())
+        .block_size(args.block_size);
+    if args.engine_type == EngineTypeArg::Sglang {
+        builder = builder.sglang(Some(SglangArgs {
+            page_size: Some(args.block_size),
+            ..Default::default()
+        }));
+    }
     if let Some(max_num_seqs) = args.max_num_seqs {
         builder = builder.max_num_seqs(Some(max_num_seqs));
     }

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -1088,9 +1088,50 @@ pub fn simulate_concurrency_live_workload_with_router_mode(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::protocols::{EngineType, SglangArgs};
     use crate::loadgen::{SessionTrace, TurnTrace};
     use std::io::Write;
     use tempfile::NamedTempFile;
+    use uuid::Uuid;
+
+    #[test]
+    fn one_worker_sglang_impossible_request_returns_dead_end_error() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Sglang)
+            .block_size(4)
+            .num_gpu_blocks(1)
+            .speedup_ratio(1000.0)
+            .sglang(Some(SglangArgs {
+                page_size: Some(4),
+                chunked_prefill_size: Some(8),
+                ..Default::default()
+            }))
+            .build()
+            .unwrap();
+        let request = DirectRequest {
+            tokens: vec![1; 8],
+            max_output_tokens: 2,
+            uuid: Some(Uuid::from_u128(1)),
+            dp_rank: 0,
+            arrival_timestamp_ms: Some(0.0),
+        };
+
+        let err = simulate_trace_requests_with_router_mode(
+            args,
+            None,
+            None,
+            vec![request],
+            1,
+            1.0,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "offline replay reached a dead end with 1 in-flight requests remaining"
+        );
+    }
 
     #[test]
     fn agentic_mooncake_trace_file_loads_and_scales_timing() {

--- a/lib/mocker/src/replay/offline/README.md
+++ b/lib/mocker/src/replay/offline/README.md
@@ -19,7 +19,7 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
 
 `offline/mod.rs` chooses between three implementations:
 
-- `lib/mocker/src/replay/offline/single.rs` for the special case `num_workers == 1` with the vLLM engine
+- `lib/mocker/src/replay/offline/single.rs` for aggregated replay with `num_workers == 1`
 - `lib/mocker/src/replay/offline/agg.rs` for everything else, including aggregated multi-worker replay and `kv_router` replay
 - `lib/mocker/src/replay/offline/disagg.rs` for offline disaggregated prefill/decode replay
 
@@ -28,7 +28,7 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
 - `lib/mocker/src/replay/offline/mod.rs`
   Chooses single-worker fast path vs multi-worker harness.
 - `lib/mocker/src/replay/offline/single.rs`
-  Minimal replay loop for one vLLM worker.
+  Minimal replay loop for one aggregated worker.
 - `lib/mocker/src/replay/offline/agg.rs`
   General offline cluster simulator for multi-worker replay and KV-router replay.
 - `lib/mocker/src/replay/offline/disagg.rs`
@@ -53,10 +53,8 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
 
 ## Single-Worker Fast Path
 
-The single-worker path is intentionally simple and only used when:
-
-- `num_workers == 1`
-- engine type is `vllm`
+The single-worker path is intentionally simple and used when `num_workers == 1`
+for vLLM, SGLang, and TRT-LLM engine modes.
 
 That path avoids the cluster event queue and router machinery entirely, but it now supports both:
 

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -855,15 +855,18 @@ impl AggRuntime {
 #[cfg(test)]
 mod tests {
     use super::super::entrypoints::{
+        run_agentic_trace_multi_collect_with_stats, run_agentic_trace_single_collect,
         run_concurrency_multi_collect_with_stats, run_concurrency_single_collect,
-        run_concurrency_workload_multi_collect_with_stats, run_trace_multi_collect_with_stats,
-        run_trace_single_collect, run_trace_workload_multi_collect_with_stats,
+        run_concurrency_workload_multi_collect_with_stats, run_concurrency_workload_single_collect,
+        run_trace_multi_collect_with_stats, run_trace_single_collect,
+        run_trace_workload_multi_collect_with_stats, run_trace_workload_single_collect,
     };
     use super::*;
     use crate::common::protocols::{EngineType, SglangArgs};
-    use crate::loadgen::{SessionTrace, Trace, TurnTrace};
-    use crate::replay::normalize_trace_requests;
+    use crate::loadgen::{AgenticTrace, AgenticTurnTrace, SessionTrace, Trace, TurnTrace};
+    use crate::replay::{TraceRequestStatsSnapshot, normalize_trace_requests};
     use dynamo_kv_router::config::{KvRouterConfig, RouterQueuePolicy};
+    use rstest::rstest;
 
     fn replay_args(enable_prefix_caching: bool, enable_chunked_prefill: bool) -> MockEngineArgs {
         MockEngineArgs::builder()
@@ -876,6 +879,147 @@ mod tests {
             .speedup_ratio(0.0)
             .build()
             .unwrap()
+    }
+
+    fn parity_args(engine_type: EngineType) -> MockEngineArgs {
+        let mut builder = MockEngineArgs::builder()
+            .engine_type(engine_type)
+            .block_size(4)
+            .num_gpu_blocks(128)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_prefix_caching(false)
+            .enable_chunked_prefill(true)
+            .speedup_ratio(1000.0);
+        if engine_type == EngineType::Sglang {
+            builder = builder.sglang(Some(SglangArgs {
+                page_size: Some(4),
+                chunked_prefill_size: Some(16),
+                ..Default::default()
+            }));
+        }
+        builder.build().unwrap()
+    }
+
+    fn parity_requests() -> Vec<DirectRequest> {
+        vec![
+            DirectRequest {
+                tokens: vec![1; 4],
+                max_output_tokens: 2,
+                uuid: Some(Uuid::from_u128(11)),
+                dp_rank: 0,
+                arrival_timestamp_ms: Some(100.0),
+            },
+            DirectRequest {
+                tokens: vec![2; 8],
+                max_output_tokens: 4,
+                uuid: Some(Uuid::from_u128(22)),
+                dp_rank: 0,
+                arrival_timestamp_ms: Some(101.0),
+            },
+            DirectRequest {
+                tokens: vec![3; 12],
+                max_output_tokens: 2,
+                uuid: Some(Uuid::from_u128(33)),
+                dp_rank: 0,
+                arrival_timestamp_ms: Some(500.0),
+            },
+        ]
+    }
+
+    fn parity_workload() -> Trace {
+        Trace {
+            block_size: 4,
+            sessions: vec![
+                SessionTrace {
+                    session_id: "session-a".to_string(),
+                    first_arrival_timestamp_ms: Some(0.0),
+                    turns: vec![
+                        TurnTrace {
+                            input_length: 4,
+                            max_output_tokens: 2,
+                            hash_ids: vec![11],
+                            delay_after_previous_ms: 0.0,
+                        },
+                        TurnTrace {
+                            input_length: 12,
+                            max_output_tokens: 2,
+                            hash_ids: vec![21, 22, 23],
+                            delay_after_previous_ms: 5.0,
+                        },
+                    ],
+                },
+                SessionTrace {
+                    session_id: "session-b".to_string(),
+                    first_arrival_timestamp_ms: Some(1.0),
+                    turns: vec![TurnTrace {
+                        input_length: 8,
+                        max_output_tokens: 2,
+                        hash_ids: vec![31, 32],
+                        delay_after_previous_ms: 0.0,
+                    }],
+                },
+            ],
+        }
+    }
+
+    fn parity_agentic_trace() -> AgenticTrace {
+        AgenticTrace {
+            block_size: 4,
+            turns: vec![
+                AgenticTurnTrace {
+                    request_id: "root".to_string(),
+                    session_id: "root".to_string(),
+                    input_length: 4,
+                    max_output_tokens: 2,
+                    hash_ids: vec![1],
+                    first_ready_timestamp_ms: Some(0.0),
+                    delay_after_dependencies_ms: 0.0,
+                    wait_for: Vec::new(),
+                    prefix_reset: true,
+                },
+                AgenticTurnTrace {
+                    request_id: "dependent".to_string(),
+                    session_id: "dependent".to_string(),
+                    input_length: 8,
+                    max_output_tokens: 2,
+                    hash_ids: vec![1, 2],
+                    first_ready_timestamp_ms: Some(100.0),
+                    delay_after_dependencies_ms: 5.0,
+                    wait_for: vec!["root".to_string()],
+                    prefix_reset: true,
+                },
+            ],
+        }
+    }
+
+    fn sorted_snapshots(collector: &TraceCollector) -> Vec<TraceRequestStatsSnapshot> {
+        let mut snapshots = collector.snapshots();
+        snapshots.sort_by_key(|snapshot| snapshot.input_length);
+        snapshots
+    }
+
+    fn assert_collectors_match(single: TraceCollector, multi: TraceCollector) {
+        assert_eq!(sorted_snapshots(&single), sorted_snapshots(&multi));
+
+        let single_report = single.finish();
+        let multi_report = multi.finish();
+        assert_eq!(
+            single_report.request_counts.num_requests,
+            multi_report.request_counts.num_requests
+        );
+        assert_eq!(
+            single_report.request_counts.completed_requests,
+            multi_report.request_counts.completed_requests
+        );
+        assert_eq!(
+            single_report.request_counts.total_input_tokens,
+            multi_report.request_counts.total_input_tokens
+        );
+        assert_eq!(
+            single_report.request_counts.total_output_tokens,
+            multi_report.request_counts.total_output_tokens
+        );
     }
 
     fn fast_router_args() -> MockEngineArgs {
@@ -1982,46 +2126,21 @@ mod tests {
         assert_eq!(stats.max_in_flight_seen, 2);
     }
 
-    #[test]
-    fn test_multi_worker_trace_single_worker_round_robin_matches_single_runtime() {
-        let args = replay_args(true, true);
-        let requests = vec![
-            DirectRequest {
-                tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
-                max_output_tokens: 2,
-                uuid: Some(Uuid::from_u128(11)),
-                dp_rank: 0,
-                arrival_timestamp_ms: Some(100.0),
-            },
-            DirectRequest {
-                tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
-                max_output_tokens: 2,
-                uuid: Some(Uuid::from_u128(22)),
-                dp_rank: 0,
-                arrival_timestamp_ms: Some(101.0),
-            },
-            DirectRequest {
-                tokens: vec![9, 9, 9, 9, 8, 8, 8, 8],
-                max_output_tokens: 2,
-                uuid: Some(Uuid::from_u128(33)),
-                dp_rank: 0,
-                arrival_timestamp_ms: Some(500.0),
-            },
-        ];
-
+    #[rstest]
+    #[case(EngineType::Vllm)]
+    #[case(EngineType::Sglang)]
+    #[case(EngineType::Trtllm)]
+    fn test_multi_worker_trace_single_worker_round_robin_matches_single_runtime(
+        #[case] engine_type: EngineType,
+    ) {
+        let args = parity_args(engine_type);
+        let requests = parity_requests();
         let single = run_trace_single_collect(args.clone(), requests.clone(), 1.0);
         let (multi, stats) =
             run_trace_multi_collect_with_stats(&args, requests, 1, ReplayRouterMode::RoundRobin);
 
         assert_eq!(stats.dispatch_history, vec![0, 0, 0]);
-        for uuid in [11_u128, 22, 33] {
-            assert_eq!(
-                multi.snapshot(Uuid::from_u128(uuid)),
-                single.snapshot(Uuid::from_u128(uuid))
-            );
-        }
-        assert_eq!(multi.finish().request_counts.completed_requests, 3);
-        assert_eq!(single.finish().request_counts.completed_requests, 3);
+        assert_collectors_match(single, multi);
     }
 
     #[test]
@@ -2067,33 +2186,15 @@ mod tests {
         assert_eq!(single.finish().request_counts.completed_requests, 3);
     }
 
-    #[test]
-    fn test_multi_worker_concurrency_single_worker_round_robin_matches_single_runtime() {
-        let args = replay_args(true, true);
-        let requests = vec![
-            DirectRequest {
-                tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
-                max_output_tokens: 2,
-                uuid: Some(Uuid::from_u128(11)),
-                dp_rank: 0,
-                arrival_timestamp_ms: Some(900.0),
-            },
-            DirectRequest {
-                tokens: vec![3, 3, 3, 3, 4, 4, 4, 4],
-                max_output_tokens: 4,
-                uuid: Some(Uuid::from_u128(22)),
-                dp_rank: 0,
-                arrival_timestamp_ms: Some(1000.0),
-            },
-            DirectRequest {
-                tokens: vec![5, 5, 5, 5, 6, 6, 6, 6],
-                max_output_tokens: 2,
-                uuid: Some(Uuid::from_u128(33)),
-                dp_rank: 0,
-                arrival_timestamp_ms: Some(100.0),
-            },
-        ];
-
+    #[rstest]
+    #[case(EngineType::Vllm)]
+    #[case(EngineType::Sglang)]
+    #[case(EngineType::Trtllm)]
+    fn test_multi_worker_concurrency_single_worker_round_robin_matches_single_runtime(
+        #[case] engine_type: EngineType,
+    ) {
+        let args = parity_args(engine_type);
+        let requests = parity_requests();
         let single = run_concurrency_single_collect(args.clone(), requests.clone(), 2);
         let (multi, stats) = run_concurrency_multi_collect_with_stats(
             &args,
@@ -2104,12 +2205,68 @@ mod tests {
         );
 
         assert_eq!(stats.dispatch_history, vec![0, 0, 0]);
-        for uuid in [11_u128, 22, 33] {
-            assert_eq!(
-                multi.snapshot(Uuid::from_u128(uuid)),
-                single.snapshot(Uuid::from_u128(uuid))
-            );
-        }
+        assert_collectors_match(single, multi);
+    }
+
+    #[rstest]
+    #[case(EngineType::Vllm)]
+    #[case(EngineType::Sglang)]
+    #[case(EngineType::Trtllm)]
+    fn test_trace_workload_single_worker_round_robin_matches_single_runtime(
+        #[case] engine_type: EngineType,
+    ) {
+        let args = parity_args(engine_type);
+        let single = run_trace_workload_single_collect(args.clone(), parity_workload());
+        let (multi, stats) = run_trace_workload_multi_collect_with_stats(
+            &args,
+            parity_workload(),
+            1,
+            ReplayRouterMode::RoundRobin,
+        );
+
+        assert_eq!(stats.dispatch_history, vec![0, 0, 0]);
+        assert_collectors_match(single, multi);
+    }
+
+    #[rstest]
+    #[case(EngineType::Vllm)]
+    #[case(EngineType::Sglang)]
+    #[case(EngineType::Trtllm)]
+    fn test_concurrency_workload_single_worker_round_robin_matches_single_runtime(
+        #[case] engine_type: EngineType,
+    ) {
+        let args = parity_args(engine_type);
+        let single = run_concurrency_workload_single_collect(args.clone(), parity_workload(), 1);
+        let (multi, stats) = run_concurrency_workload_multi_collect_with_stats(
+            &args,
+            parity_workload(),
+            1,
+            1,
+            ReplayRouterMode::RoundRobin,
+        );
+
+        assert_eq!(stats.dispatch_history, vec![0, 0, 0]);
+        assert_collectors_match(single, multi);
+    }
+
+    #[rstest]
+    #[case(EngineType::Vllm)]
+    #[case(EngineType::Sglang)]
+    #[case(EngineType::Trtllm)]
+    fn test_agentic_trace_single_worker_round_robin_matches_single_runtime(
+        #[case] engine_type: EngineType,
+    ) {
+        let args = parity_args(engine_type);
+        let single = run_agentic_trace_single_collect(args.clone(), parity_agentic_trace());
+        let (multi, stats) = run_agentic_trace_multi_collect_with_stats(
+            &args,
+            parity_agentic_trace(),
+            1,
+            ReplayRouterMode::RoundRobin,
+        );
+
+        assert_eq!(stats.dispatch_history, vec![0, 0]);
+        assert_collectors_match(single, multi);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -17,7 +17,7 @@ use super::disagg::DisaggRuntimeStats;
 use super::disagg::{DisaggRuntime, ReplayMode as DisaggReplayMode};
 use super::normalize_trace_requests;
 use super::single::{SingleReplayMode, SingleRuntime};
-use crate::common::protocols::{DirectRequest, EngineType, MockEngineArgs};
+use crate::common::protocols::{DirectRequest, MockEngineArgs};
 use crate::loadgen::{AgenticTrace, Trace, WorkloadDriver};
 use crate::replay::OfflineDisaggReplayConfig;
 use crate::replay::{
@@ -42,6 +42,10 @@ fn finish_with_replay_wall_time(
     // as latency sorting is not counted as replay execution.
     let wall_time_ms = started_at.elapsed().as_secs_f64() * 1000.0;
     collector.finish().with_wall_time_ms(wall_time_ms)
+}
+
+fn use_single_runtime(num_workers: usize) -> bool {
+    num_workers == 1
 }
 
 pub(crate) fn generate_trace_worker_artifacts(
@@ -129,7 +133,7 @@ pub(crate) fn simulate_trace(
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
 ) -> Result<TraceSimulationReport> {
-    if num_workers == 1 && args.engine_type == EngineType::Vllm {
+    if use_single_runtime(num_workers) {
         simulate_trace_single(
             args,
             requests,
@@ -164,7 +168,7 @@ pub(crate) fn simulate_concurrency(
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
 ) -> Result<TraceSimulationReport> {
-    if num_workers == 1 && args.engine_type == EngineType::Vllm {
+    if use_single_runtime(num_workers) {
         simulate_concurrency_single(
             args,
             requests,
@@ -219,7 +223,7 @@ pub(crate) fn simulate_agentic_trace_workload(
     num_workers: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
-    if num_workers == 1 && args.engine_type == EngineType::Vllm {
+    if use_single_runtime(num_workers) {
         simulate_agentic_trace_workload_single(args, trace)
     } else {
         simulate_agentic_trace_workload_multi(
@@ -269,7 +273,7 @@ fn simulate_trace_workload_with_delta_mode(
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
 ) -> Result<TraceSimulationReport> {
-    if num_workers == 1 && args.engine_type == EngineType::Vllm {
+    if use_single_runtime(num_workers) {
         simulate_trace_workload_single(
             args,
             trace,
@@ -357,7 +361,7 @@ fn simulate_concurrency_workload_with_delta_mode(
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
 ) -> Result<TraceSimulationReport> {
-    if num_workers == 1 && args.engine_type == EngineType::Vllm {
+    if use_single_runtime(num_workers) {
         simulate_concurrency_workload_single(
             args,
             trace,
@@ -810,6 +814,23 @@ pub(super) fn run_concurrency_workload_single_collect(
 }
 
 #[cfg(test)]
+pub(super) fn run_agentic_trace_single_collect(
+    args: MockEngineArgs,
+    trace: AgenticTrace,
+) -> TraceCollector {
+    let engine_block_size = args.block_size;
+    SingleRuntime::new_workload(
+        args,
+        trace
+            .into_trace_driver_with_block_size(engine_block_size)
+            .unwrap(),
+        SingleReplayMode::Trace,
+    )
+    .run()
+    .unwrap()
+}
+
+#[cfg(test)]
 pub(super) fn run_trace_multi_collect_with_stats(
     args: &MockEngineArgs,
     requests: Vec<DirectRequest>,
@@ -893,6 +914,29 @@ pub(super) fn run_concurrency_workload_multi_collect_with_stats(
             .unwrap(),
         num_workers,
         AggReplayMode::Concurrency { max_in_flight },
+        router_mode,
+    )
+    .unwrap()
+    .run()
+    .unwrap()
+}
+
+#[cfg(test)]
+pub(super) fn run_agentic_trace_multi_collect_with_stats(
+    args: &MockEngineArgs,
+    trace: AgenticTrace,
+    num_workers: usize,
+    router_mode: ReplayRouterMode,
+) -> (TraceCollector, AggRuntimeStats) {
+    AggRuntime::new_workload(
+        args,
+        None,
+        None,
+        trace
+            .into_trace_driver_with_block_size(args.block_size)
+            .unwrap(),
+        num_workers,
+        AggReplayMode::Trace,
         router_mode,
     )
     .unwrap()
@@ -990,9 +1034,15 @@ pub(super) fn run_concurrency_workload_collect(
 
 #[cfg(test)]
 mod tests {
-    use super::generate_trace_worker_artifacts;
+    use super::{generate_trace_worker_artifacts, use_single_runtime};
     use crate::common::protocols::MockEngineArgs;
     use crate::loadgen::{SessionTrace, Trace, TurnTrace};
+
+    #[test]
+    fn single_runtime_selection_depends_only_on_worker_count() {
+        assert!(use_single_runtime(1));
+        assert!(!use_single_runtime(2));
+    }
 
     #[test]
     fn test_generate_trace_worker_artifacts_emits_monotonic_event_timestamps() {

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -44,8 +44,8 @@ fn finish_with_replay_wall_time(
     collector.finish().with_wall_time_ms(wall_time_ms)
 }
 
-fn use_single_runtime(num_workers: usize) -> bool {
-    num_workers == 1
+fn use_single_runtime(num_workers: usize, router_mode: ReplayRouterMode) -> bool {
+    num_workers == 1 && router_mode != ReplayRouterMode::KvRouter
 }
 
 pub(crate) fn generate_trace_worker_artifacts(
@@ -133,7 +133,7 @@ pub(crate) fn simulate_trace(
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers) {
+    if use_single_runtime(num_workers, router_mode) {
         simulate_trace_single(
             args,
             requests,
@@ -168,7 +168,7 @@ pub(crate) fn simulate_concurrency(
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers) {
+    if use_single_runtime(num_workers, router_mode) {
         simulate_concurrency_single(
             args,
             requests,
@@ -223,7 +223,7 @@ pub(crate) fn simulate_agentic_trace_workload(
     num_workers: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers) {
+    if use_single_runtime(num_workers, router_mode) {
         simulate_agentic_trace_workload_single(args, trace)
     } else {
         simulate_agentic_trace_workload_multi(
@@ -273,7 +273,7 @@ fn simulate_trace_workload_with_delta_mode(
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers) {
+    if use_single_runtime(num_workers, router_mode) {
         simulate_trace_workload_single(
             args,
             trace,
@@ -361,7 +361,7 @@ fn simulate_concurrency_workload_with_delta_mode(
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers) {
+    if use_single_runtime(num_workers, router_mode) {
         simulate_concurrency_workload_single(
             args,
             trace,
@@ -1037,11 +1037,14 @@ mod tests {
     use super::{generate_trace_worker_artifacts, use_single_runtime};
     use crate::common::protocols::MockEngineArgs;
     use crate::loadgen::{SessionTrace, Trace, TurnTrace};
+    use crate::replay::ReplayRouterMode;
 
     #[test]
-    fn single_runtime_selection_depends_only_on_worker_count() {
-        assert!(use_single_runtime(1));
-        assert!(!use_single_runtime(2));
+    fn single_runtime_selection_excludes_kv_router() {
+        assert!(use_single_runtime(1, ReplayRouterMode::RoundRobin));
+        assert!(!use_single_runtime(1, ReplayRouterMode::KvRouter));
+        assert!(!use_single_runtime(2, ReplayRouterMode::RoundRobin));
+        assert!(!use_single_runtime(2, ReplayRouterMode::KvRouter));
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -21,6 +21,10 @@ enum AdmissionSource {
     Workload(WorkloadDriver),
 }
 
+// SGLang may intentionally retry 600 same-timestamp passes while reducing its
+// output reservation ratio before an otherwise valid request can be admitted.
+const MAX_CONSECUTIVE_NO_PROGRESS_PASSES: usize = 1024;
+
 pub(super) struct SingleRuntime {
     current_time_ms: f64,
     admission: AdmissionSource,
@@ -28,6 +32,7 @@ pub(super) struct SingleRuntime {
     collector: TraceCollector,
     mode: SingleReplayMode,
     progress: ReplayProgress,
+    consecutive_no_progress_passes: usize,
     /// Optional cap on simulated wall-clock time. When set, `run()` exits
     /// gracefully once `current_time_ms` exceeds this cap, leaving any
     /// in-flight requests as incomplete in the report.
@@ -67,6 +72,7 @@ impl SingleRuntime {
             collector: TraceCollector::default(),
             mode,
             progress: ReplayProgress::new(total_requests, "offline replay"),
+            consecutive_no_progress_passes: 0,
             max_sim_time_ms: None,
         }
     }
@@ -196,11 +202,19 @@ impl SingleRuntime {
         Ok(())
     }
 
-    fn drive_worker(&mut self, admit_arrivals_between_steps: bool) {
+    fn drive_worker(&mut self, admit_arrivals_between_steps: bool) -> anyhow::Result<()> {
+        let pass_start_ms = self.current_time_ms;
+        let requests_before = self.worker.num_requests();
         let pass = self
             .worker
             .execute_pass(&mut self.collector, self.current_time_ms);
         self.current_time_ms = pass.end_ms;
+        let made_progress = self.current_time_ms > pass_start_ms
+            || self.worker.num_requests() < requests_before
+            || pass.completed_requests > 0
+            || !pass.admissions.is_empty()
+            || !pass.output_signals.is_empty()
+            || !pass.kv_events.is_empty();
         if let AdmissionSource::Workload(driver) = &mut self.admission {
             for signal in pass.output_signals.iter().filter(|signal| signal.completed) {
                 driver
@@ -219,6 +233,21 @@ impl SingleRuntime {
         if admit_arrivals_between_steps {
             self.enqueue_trace_arrivals();
         }
+        if made_progress {
+            self.consecutive_no_progress_passes = 0;
+            return Ok(());
+        }
+
+        self.consecutive_no_progress_passes += 1;
+        if self.consecutive_no_progress_passes >= MAX_CONSECUTIVE_NO_PROGRESS_PASSES
+            && !self.worker.is_empty()
+        {
+            bail!(
+                "offline replay reached a dead end with {} in-flight requests remaining",
+                self.worker.num_requests()
+            );
+        }
+        Ok(())
     }
 
     pub(super) fn run(mut self) -> anyhow::Result<TraceCollector> {
@@ -241,7 +270,7 @@ impl SingleRuntime {
                         self.enqueue_trace_arrivals();
                         continue;
                     }
-                    self.drive_worker(true);
+                    self.drive_worker(true)?;
                 }
                 SingleReplayMode::Concurrency { max_in_flight } => {
                     self.enqueue_concurrency_arrivals(max_in_flight);
@@ -252,7 +281,7 @@ impl SingleRuntime {
                         self.advance_to_next_trace_arrival()?;
                         continue;
                     }
-                    self.drive_worker(false);
+                    self.drive_worker(false)?;
                 }
             }
         }
@@ -269,6 +298,7 @@ mod tests {
         simulate_concurrency_single, simulate_trace_single,
     };
     use super::*;
+    use crate::common::protocols::EngineType;
     use crate::loadgen::{SessionTrace, Trace, TurnTrace};
     use crate::replay::{TraceRequestStatsSnapshot, TraceSimulationReport};
     use rstest::rstest;
@@ -839,6 +869,41 @@ mod tests {
         assert!(arrival_times.contains(&0.0));
         assert!(arrival_times.iter().all(|arrival| *arrival >= 0.0));
         assert_eq!(report.request_counts.completed_requests, 3);
+    }
+
+    #[test]
+    fn trtllm_oversized_request_rejected_unblocks_follower_single() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Trtllm)
+            .block_size(4)
+            .num_gpu_blocks(4)
+            .max_num_batched_tokens(Some(64))
+            .max_num_seqs(Some(4))
+            .enable_prefix_caching(false)
+            .enable_chunked_prefill(true)
+            .speedup_ratio(1000.0)
+            .build()
+            .unwrap();
+        let request = |uuid: u128, prompt_tokens: u32, max_output_tokens: usize| DirectRequest {
+            tokens: (0..prompt_tokens).collect(),
+            max_output_tokens,
+            uuid: Some(Uuid::from_u128(uuid)),
+            dp_rank: 0,
+            arrival_timestamp_ms: Some(0.0),
+        };
+
+        let report = simulate_concurrency_single(
+            args,
+            vec![request(1, 20, 8), request(2, 4, 4)],
+            1,
+            false,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(report.request_counts.num_requests, 2);
+        assert_eq!(report.request_counts.completed_requests, 1);
+        assert_eq!(report.request_counts.total_output_tokens, 4);
     }
 
     fn cap_request(uuid: u128, arrival_ms: f64) -> DirectRequest {


### PR DESCRIPTION
## Summary

- route one-worker aggregated offline replay through `SingleRuntime` for vLLM, SGLang, and TRT-LLM across flat, workload, concurrency, and agentic entrypoints
- retain `AggRuntime` for multi-worker, KV-router, planner-driven, and disaggregated replay
- bound same-timestamp no-progress retries so SGLang reservation decay can settle while impossible workloads return the existing dead-end error shape
- add cross-runtime parity coverage for all three engines, plus TRT-LLM rejection and SGLang dead-end regressions
- add `--engine-type` to `offline_replay_bench` and update replay documentation

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-mocker --no-default-features replay::offline` (103 passed)
- `cargo test -p dynamo-mocker --no-default-features replay::entrypoints` (5 passed)
- `cargo bench -p dynamo-bench --bench offline_replay_bench -- --help`

Benchmark sanity check used the first 100 requests from `lib/bench/testdata/mooncake_trace_1000.jsonl`, one worker, round-robin routing, five in-process iterations, and `--speedup-ratio 1000`. The values below are the final replay's reported wall time and are informational, not a performance threshold:

| Engine | Base `AggRuntime` | This PR `SingleRuntime` |
| --- | ---: | ---: |
| SGLang | 63.7 ms | 61.6 ms |
| TRT-LLM | 13.2 ms | 12.4 ms |

Both paths completed the same 100 requests with identical simulated token totals and latency summaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TRT-LLM engine support to offline replay alongside vLLM and SGLang.
  * Added CLI option to select engine type (vllm, sglang, or trtllm; defaults to vllm).

* **Bug Fixes**
  * Improved single-worker simulation to detect and abort stuck replay scenarios with in-flight requests.

* **Documentation**
  * Updated guides to reflect expanded TRT-LLM engine compatibility and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->