### PR TITLE
chore(tokens): clarify default block comment

### DIFF
--- a/lib/tokens/src/blocks.rs
+++ b/lib/tokens/src/blocks.rs
@@ -20,7 +20,7 @@ pub enum UniqueBlock {
 
 impl Default for UniqueBlock {
     fn default() -> Self {
-        // Generate a random UUID when default is used
+        // Generate a random UUID for the default partial block.
         Self::PartialBlock(Uuid::new_v4())
     }
 }


### PR DESCRIPTION
## Summary

- Clarify the comment describing the default `UniqueBlock` UUID behavior.
- Keep runtime behavior unchanged while providing a minimal review-ready PR for Datadog integration validation.

## Validation

- `git diff --check`
- Repository pre-commit hooks (all passed)
- Tests not run because this is a comment-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation describing default value generation behavior.

**Note:** This release contains documentation updates only. No functional changes or new features for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->