### PR TITLE
docs(router): clarify e2e process wording

### DIFF
--- a/docs/components/router/router-testing.md
+++ b/docs/components/router/router-testing.md
@@ -62,7 +62,7 @@ Use this layer when a feature changes router behavior over time, depends on real
 
 ## 3. Full Router E2E Process Tests
 
-Use the Python tests in `tests/router` when you need the full request plane and event plane in play. These tests launch router and mocker or backend processes and exercise cross-process behavior that bench-backed replay cannot cover.
+Use the Python tests in `tests/router` when you need the full request plane and event plane in play. These tests launch router, mocker, or backend processes and exercise cross-process behavior that bench-backed replay cannot cover.
 
 Current entry points include:
 


### PR DESCRIPTION
## Summary

- Clarify the list of processes launched by the full router E2E tests.
- Provide a docs-only pull request for CI and review integration validation.

## Validation

- `git diff --check`
- Repository pre-commit hooks (all passed)
- Tests not run because this is a documentation-only change.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved router testing documentation with clearer guidance on when full end-to-end process tests should be utilized to validate cross-process behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->