### PR TITLE
test(router): intentionally ignore KV overlap

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -64,7 +64,6 @@ use route_lookup::{TieredLookupResult, query_tiered_matches, split_retained_bloc
 use scheduler_inputs::{
     CacheHitEstimates, KvRouterOverlapRefresher, WorkerCacheHitEstimate,
     cache_hit_estimates_from_tiered_matches, cache_hit_for_worker, shared_cache_overlap_score,
-    tier_overlap_blocks_from_tiered_matches,
 };
 
 use crate::{
@@ -431,7 +430,7 @@ where
         let retain_block_hashes = supports_overlap_refresh || return_routing_hashes;
 
         let TieredLookupResult {
-            tiered_matches,
+            tiered_matches: _tiered_matches,
             shared_cache_hits,
             indexer_duration,
             shared_cache_duration,
@@ -456,8 +455,6 @@ where
             })
             .unwrap_or((None, None));
 
-        let tier_overlap_blocks = tier_overlap_blocks_from_tiered_matches(&tiered_matches);
-        let cache_hit_estimates = self.cache_hit_estimates_from_tiered_matches(&tiered_matches);
         let find_matches_elapsed = start.elapsed();
 
         // Capture shared cache info for metrics before moving into schedule().
@@ -473,9 +470,9 @@ where
                 isl_tokens,
                 maybe_seq_hashes,
                 block_hashes_for_refresh,
-                tier_overlap_blocks,
-                cache_hit_estimates.effective_overlap_blocks,
-                cache_hit_estimates.cached_tokens,
+                Default::default(),
+                HashMap::new(),
+                HashMap::new(),
                 router_config_override,
                 update_states,
                 lora_name,


### PR DESCRIPTION
## Summary

> **DO NOT MERGE:** intentional negative-control PR for validating pre-merge CI coverage.

- Discard indexer-derived KV overlap and cached-token inputs at the scheduler boundary.
- Preserve indexer queries and overlap score reporting so the regression specifically affects routing decisions.
- Expect the mocker `test_router_decisions` E2E variants to fail longest-prefix worker assertions if they run.

## Validation

- `cargo test -p dynamo-llm --no-default-features kv_router::`: 167 passed, 2 ignored.
- Full `dynamo-llm` unit run reached 1,100 passing tests; one unrelated model-cache path assertion failed locally.
- PR marker collection selects all 8 focused mocker router-decision variants.
- Repository pre-commit hooks passed.
- No tests were modified.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to key-value router matching logic with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->