### PR TITLE
test: fix flaky tracing tests under parallel execution

### DIFF
--- a/lib/backend-common/src/adapter.rs
+++ b/lib/backend-common/src/adapter.rs
@@ -1233,23 +1233,14 @@ mod tests {
 
     /// Force-enable the recording fast-path and install a fresh subscriber
     /// that captures every `engine.generate` field write into a shared map.
-    /// Ensure the test binary has a process-global default subscriber so the
-    /// `engine.generate` span callsite stays enabled for the whole run.
+    /// Pin a global default `tracing` subscriber for the whole test binary.
     ///
-    /// `tracing` caches per-callsite interest in a single process-global table.
-    /// When tests install and drop thread-local subscribers (`set_default`) in
-    /// parallel, that table is recomputed against whichever dispatchers are live
-    /// at the instant of the rebuild. If the `engine.generate` callsite is ever
-    /// evaluated with only the empty global default in scope, it can be cached
-    /// as disabled; the trace-context tests then never see the span born, so
-    /// `worker_trace_link` comes back `None` and they flake non-deterministically
-    /// under parallel execution.
-    ///
-    /// Installing a real (empty) registry as the *global* default keeps that
-    /// callsite enabled binary-wide: every interest rebuild now combines an
-    /// always-enabled dispatcher, so it can never collapse to disabled. Per-test
-    /// `set_default` subscribers still override this on their own thread, so the
-    /// capture / injection behaviour the tests assert on is unchanged.
+    /// `tracing` caches "is this span enabled?" per callsite in one global
+    /// table. With tests installing and dropping subscribers in parallel, the
+    /// `engine.generate` callsite can briefly be cached as disabled, so the
+    /// trace-context tests miss their span and flake. An always-present global
+    /// default keeps it enabled; per-test `set_default` subscribers still take
+    /// over on their own thread, so what the tests assert on is unchanged.
     fn ensure_global_test_subscriber() {
         use std::sync::Once;
         static INIT: Once = Once::new();

--- a/lib/backend-common/src/adapter.rs
+++ b/lib/backend-common/src/adapter.rs
@@ -1233,7 +1233,35 @@ mod tests {
 
     /// Force-enable the recording fast-path and install a fresh subscriber
     /// that captures every `engine.generate` field write into a shared map.
+    /// Ensure the test binary has a process-global default subscriber so the
+    /// `engine.generate` span callsite stays enabled for the whole run.
+    ///
+    /// `tracing` caches per-callsite interest in a single process-global table.
+    /// When tests install and drop thread-local subscribers (`set_default`) in
+    /// parallel, that table is recomputed against whichever dispatchers are live
+    /// at the instant of the rebuild. If the `engine.generate` callsite is ever
+    /// evaluated with only the empty global default in scope, it can be cached
+    /// as disabled; the trace-context tests then never see the span born, so
+    /// `worker_trace_link` comes back `None` and they flake non-deterministically
+    /// under parallel execution.
+    ///
+    /// Installing a real (empty) registry as the *global* default keeps that
+    /// callsite enabled binary-wide: every interest rebuild now combines an
+    /// always-enabled dispatcher, so it can never collapse to disabled. Per-test
+    /// `set_default` subscribers still override this on their own thread, so the
+    /// capture / injection behaviour the tests assert on is unchanged.
+    fn ensure_global_test_subscriber() {
+        use std::sync::Once;
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            // Ignore the error if a global default was already set elsewhere;
+            // any real subscriber is enough to keep the callsite enabled.
+            let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
+        });
+    }
+
     fn install_capture() -> (CapturedFields, CaptureGuard) {
+        ensure_global_test_subscriber();
         let otlp = OtlpExportOverride::enable();
         let captured = CapturedFields::default();
         let layer = CaptureLayer {
@@ -1348,6 +1376,7 @@ mod tests {
     #[tokio::test]
     async fn auto_span_fires_without_otlp_override() {
         // Install ONLY the capture layer — no `OtlpExportOverride::enable()`.
+        ensure_global_test_subscriber();
         let captured = CapturedFields::default();
         let layer = CaptureLayer {
             out: captured.clone(),
@@ -1546,6 +1575,7 @@ mod tests {
         const TRACE_ID: &str = "11111111111111111111111111111111";
         const SPAN_ID: &str = "2222222222222222";
 
+        ensure_global_test_subscriber();
         let template = Arc::new(std::sync::OnceLock::new());
         let inject = InjectingTraceContext {
             template: template.clone(),


### PR DESCRIPTION
## Problem

`adapter_stamps_worker_trace_link_on_first_non_empty_chunk` and the other trace-context tests fail intermittently:

```
first non-empty chunk must carry worker_trace_link
```

Failing logs: https://github.com/ai-dynamo/dynamo/actions/runs/27382292958/job/80921687638

It showed up once in CI and passed on a plain re-run, so it's a flake, not a real regression.

## Cause

These tests only stamp `worker_trace_link` when the `engine.generate` span is enabled, because the context they check is attached by a layer that runs when the span is created. `tracing` keeps one process-global table of which span callsites are enabled. The test binary runs many tests in parallel: some install a subscriber, some call `generate()` with none. As subscribers come and go on other threads, that table gets recomputed, and there's a brief window where `engine.generate` can be recorded as disabled. If that lands while a trace test is running, its span never fires the layer and the link comes back `None`.

Since it's timing-dependent, it's rare on big machines and turns up occasionally on smaller CI runners.

## Fix

Install an empty `registry()` as the global default subscriber once, from the test setup helpers. A real global default keeps `engine.generate` enabled regardless of what the parallel tests do, and each test's own `set_default` still takes over on its own thread, so nothing the tests assert on changes.

```rust
fn ensure_global_test_subscriber() {
    use std::sync::Once;
    static INIT: Once = Once::new();
    INIT.call_once(|| {
        let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
    });
}
```

## Notes

Test-only, no production code. I couldn't reproduce the flake locally even under load, so this targets the one path that produces the observed failure rather than a confirmed repro. Full suite passes and a repeated 2-core stress run is clean.