### PR TITLE
REDUNDANT with #10624 (to be deleted) — fix(parsers): preserve model-emitted tool-call argument key order

### DIFF
--- a/lib/parsers/Cargo.toml
+++ b/lib/parsers/Cargo.toml
@@ -26,8 +26,15 @@ keywords.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
-serde_json = { workspace = true, features = ["raw_value"] }
+# preserve_order: tool-call `arguments` must serialize in the model-emitted key
+# order in EVERY build (standalone and dynamo-workspace). Without it, key order
+# rides on feature unification from other crates, and `serde_json::Map` /
+# `Value` round-trips alphabetize — clients echo the reordered arguments back
+# as conversation history, drifting the few-shot prompt away from what the
+# model emitted and breaking append-only KV-cache prefix matching.
+serde_json = { workspace = true, features = ["raw_value", "preserve_order"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -1361,4 +1361,17 @@ mod tests {
         assert_eq!(args0["city"], "NYC");
         assert_eq!(args1["city"], "LA");
     }
+
+    #[test] // helper — serialized arguments must keep the model-emitted parameter order
+    fn test_arguments_preserve_model_emitted_param_order() {
+        let config = get_test_config();
+        // path, old_str, command is deliberately NOT alphabetical.
+        let input = "<｜DSML｜function_calls>\n<｜DSML｜invoke name=\"file_editor\">\n<｜DSML｜parameter name=\"path\" string=\"true\">/a</｜DSML｜parameter>\n<｜DSML｜parameter name=\"old_str\" string=\"true\">x</｜DSML｜parameter>\n<｜DSML｜parameter name=\"command\" string=\"true\">replace</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>";
+        let (calls, _) = try_tool_call_parse_dsml(input, &config).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].function.arguments, r#"{"path":"/a","old_str":"x","command":"replace"}"#,
+            "serde_json::Map must preserve insertion order (needs preserve_order)"
+        );
+    }
 }

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -1095,4 +1095,13 @@ mod detect_parser_tests {
         assert_eq!(calls[0].function.name, "get_weather");
         assert_eq!(normal, Some("Checked.".to_string()));
     }
+
+    #[test] // helper — the JSON round-trip must not reorder argument keys
+    fn test_serialize_harmony_arguments_preserves_key_order() {
+        assert_eq!(
+            serialize_harmony_arguments(r#"{"path":"/a","old_str":"x","command":"replace"}"#),
+            r#"{"path":"/a","old_str":"x","command":"replace"}"#,
+            "Value round-trip must preserve model-emitted key order (needs serde_json preserve_order)"
+        );
+    }
 }

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -5,6 +5,7 @@
 // Format: <tool_call>function_name<arg_key>param1</arg_key><arg_value>value1</arg_value></tool_call>
 // Reference: https://huggingface.co/zai-org/GLM-4.7/blob/main/chat_template.jinja
 
+use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -586,8 +587,10 @@ fn parse_tool_call_block(
         anyhow::bail!("Empty function name in tool call");
     }
 
-    // Parse key-value pairs
-    let mut arguments = HashMap::new();
+    // Parse key-value pairs. IndexMap (not HashMap): serialized `arguments`
+    // must keep the model-emitted key order (echoed back as history; KV-cache
+    // prefix matching).
+    let mut arguments: IndexMap<String, ParsedValue> = IndexMap::new();
     let args_section = &content[function_name.len()..];
 
     // Build regex patterns
@@ -1172,5 +1175,18 @@ mod tests {
             serde_json::from_str(&calls[1].function.arguments).unwrap();
         assert_eq!(args0.get("location").unwrap().as_str().unwrap(), "NYC");
         assert_eq!(args1.get("location").unwrap().as_str().unwrap(), "LA");
+    }
+
+    #[test] // helper — serialized arguments must keep the model-emitted arg order
+    fn test_arguments_preserve_model_emitted_arg_order() {
+        let config = get_test_config();
+        // to, date, from is deliberately NOT alphabetical.
+        let message = "<tool_call>book_flight<arg_key>to</arg_key><arg_value>LAX</arg_value><arg_key>date</arg_key><arg_value>2026-03-15</arg_value><arg_key>from</arg_key><arg_value>NYC</arg_value></tool_call>";
+        let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].function.arguments, r#"{"to":"LAX","date":"2026-03-15","from":"NYC"}"#,
+            "arguments must serialize in model-emitted order"
+        );
     }
 }

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -1139,4 +1139,17 @@ mod tests {
         assert_eq!(args0["location"], "NYC");
         assert_eq!(args1["location"], "LA");
     }
+
+    #[test] // helper — the JSON round-trip must not reorder argument keys
+    fn test_arguments_preserve_model_emitted_key_order() {
+        let config = default_config();
+        // path, old_str, command is deliberately NOT alphabetical.
+        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.editor:0<|tool_call_argument_begin|>{"path":"/a","old_str":"x","command":"replace"}<|tool_call_end|><|tool_calls_section_end|>"#;
+        let (calls, _) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].function.arguments, r#"{"path":"/a","old_str":"x","command":"replace"}"#,
+            "Value round-trip must preserve model-emitted key order (needs serde_json preserve_order)"
+        );
+    }
 }

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use indexmap::IndexMap;
 use num_traits::ToPrimitive;
 use regex::Regex;
 use serde_json::Value;
@@ -366,8 +367,12 @@ fn parse_tool_call_block(
         // Get parameter config for this function
         let param_config = get_arguments_config(function_name, tools);
 
-        // Parse parameters from the function body.
-        let mut parameters: HashMap<String, ParsedValue> = HashMap::new();
+        // Parse parameters from the function body. IndexMap (not HashMap): the
+        // serialized `arguments` must keep the model-emitted parameter order —
+        // clients echo it back as conversation history, so a reordered map
+        // drifts the few-shot prompt away from what the model emitted and
+        // breaks append-only KV-cache prefix matching.
+        let mut parameters: IndexMap<String, ParsedValue> = IndexMap::new();
 
         for param_cap in parameter_regex.captures_iter(function_body) {
             let param_name_raw = param_cap.get(1).map(|m| m.as_str().trim()).unwrap_or("");
@@ -1623,5 +1628,19 @@ LA
         let args1: serde_json::Value = serde_json::from_str(&calls[1].function.arguments).unwrap();
         assert_eq!(args0["city"], "NYC");
         assert_eq!(args1["city"], "LA");
+    }
+
+    #[test] // helper — serialized arguments must keep the model-emitted parameter order
+    fn test_arguments_preserve_model_emitted_param_order() {
+        // path, old_str, new_str, command is deliberately NOT alphabetical:
+        // a HashMap (random) or BTreeMap (alphabetical) map both fail this.
+        let input = "<tool_call>\n<function=file_editor>\n<parameter=path>\n/app/x.go\n</parameter>\n<parameter=old_str>\nfoo\n</parameter>\n<parameter=new_str>\nbar\n</parameter>\n<parameter=command>\nstr_replace\n</parameter>\n</function>\n</tool_call>";
+        let (calls, _) = try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].function.arguments,
+            r#"{"path":"/app/x.go","old_str":"foo","new_str":"bar","command":"str_replace"}"#,
+            "arguments must serialize in model-emitted order (clients echo them back as history; KV-cache prefix matching)"
+        );
     }
 }


### PR DESCRIPTION
> ⚠️ **REDUNDANT — to be deleted, do not merge.** The Nemotron tool-call format drift (DIS-2223) is fixed at the renderer layer by #10624 (minijinja `preserve_order` + `tojson` alignment), which the team verified — 0-line rendered-prompt diff vs vLLM, Neal confirmed no empty-stops. The consistent alphabetical ordering Tianhe observed comes from minijinja's `BTreeMap` at render time, not from this parser path; #10624 is the actual fix. This parser-layer change (per-call-random HashMap → IndexMap) does **not** fix the empty-stop and is superseded. Kept open only as a record of the parser-hygiene finding; close/delete once #10624 lands.

---

#### Overview:

This PR makes tool-call `arguments` serialize in the exact key order the model emitted, instead of a per-call-random (HashMap) or build-dependent order.

#### Why this is needed:

The `arguments` string is echoed back to the model as conversation history, so the key order has to be deterministic and match what the model emitted. When it is not, bad things happen:

- **Dropped tool calls (DIS-2223).** Reordered arguments render the chat history in a format the model never produced; conditioned on those examples, Nemotron 3 Ultra starts skipping the `<function=name>` line and the turn comes back empty — a silently lost tool call. vLLM preserves order and does not hit this.
- **KV-cache misses.** Multi-turn requests re-send prior turns verbatim, and prefix caching only reuses them on an exact byte match. Reordered (or per-call-random) keys break the match and force a full re-prefill of a 100k+-token context.
- **Non-reproducible output.** The same generation serializes to different bytes on each call, making responses, fixtures, and eval diffs flaky.

#### Details:

- **How is this fixed?** The shared XML parser (`qwen3_coder` family) and the GLM-4.7 parser collect parameters into an `IndexMap` instead of `HashMap`, and the parsers crate enables serde_json `preserve_order` so the kimi_k2 / DSML / Harmony `Value` round-trips stop reordering keys — deterministic in every build, standalone or workspace.
- The JSON parser family already hit and fixed this exact failure via `RawValue` (`base_json_parser.rs`); the XML family never got the fix.
- `preserve_order` also removes a build divergence: with resolver-2, `cargo test -p dynamo-parsers` ran with alphabetical Maps while full-workspace builds ran insertion-ordered — same code, different key order per environment.
- 5 regression tests (xml, glm47, kimi_k2, dsml, harmony) assert the exact serialized string for deliberately non-alphabetical inputs; `ParsedValue` big-number precision is unchanged.
- Concrete failure mode — model emits `path, old_str, new_str, command`; three parses in the same process returned three different orders:

```
before:  {"new_str":..,"command":..,"old_str":..,"path":..}   run 0
         {"old_str":..,"new_str":..,"command":..,"path":..}   run 1
         {"old_str":..,"command":..,"new_str":..,"path":..}   run 2
after:   {"path":..,"old_str":..,"new_str":..,"command":..}   every run, batch and streaming
```

#### Verification:

`cargo test -p dynamo-parsers --lib`: 610 passed; rebuilt Python binding and probed batch x3 + streaming x3 chunkings — all emit exact model order (pre-fix: a different scramble every call); tool-calling + reasoning parity: 1825 passed (dynamo + live vLLM).

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/xml/parser.rs`, then `lib/parsers/Cargo.toml`

#### Related Issues:

Resolves [DIS-2225](https://linear.app/nvidia/issue/DIS-2225); relates to [DIS-2223](https://linear.app/nvidia/issue/DIS-2223).

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool call arguments are now serialized in their original order as emitted by the model, ensuring consistent parameter ordering.

* **Tests**
  * Added comprehensive tests across multiple tool-calling parser implementations to verify argument order preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->