### PR TITLE
feat: support multimodal inputs in sglang disaggregated prefill/decode

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -376,9 +376,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             routing = request.get("routing") or {}
             dp_rank = routing.get("dp_rank")
 
-            # Multimodal: decode re-encodes the image/video so it reproduces the
-            # same expanded token layout prefill used and the transferred KV lines
-            # up. Shared with prefill so both sides extract media identically.
+            # Decode re-extracts the media so its token layout matches prefill's
+            # and the transferred KV lines up.
             decode_mm_kwargs = build_disagg_mm_kwargs(request)
 
             decode = await self.engine.async_generate(

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -19,6 +19,12 @@ from dynamo.sglang._compat import filter_supported_async_generate_kwargs
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
+from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
+    IMAGE_URL_KEY,
+    VIDEO_URL_KEY,
+    build_disagg_mm_kwargs,
+    extract_media_urls,
+)
 
 _SAMPLING_OPTION_FIELDS = (
     "presence_penalty",
@@ -29,27 +35,6 @@ _SAMPLING_OPTION_FIELDS = (
     "top_k",
     "min_p",
 )
-
-
-def _extract_media_urls(mm_data: Dict[str, Any], media_key: str) -> list[str] | None:
-    """Normalize multimodal URL items from the frontend wire format."""
-
-    items = mm_data.get(media_key)
-    if not items:
-        return None
-
-    urls: list[str] = []
-    for item in items:
-        if isinstance(item, str):
-            urls.append(item)
-            continue
-
-        if isinstance(item, dict):
-            url = item.get("Url")
-            if isinstance(url, str):
-                urls.append(url)
-
-    return urls or None
 
 
 def _nvext_extra_field_requested(request: Dict[str, Any], field: str) -> bool:
@@ -391,8 +376,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             routing = request.get("routing") or {}
             dp_rank = routing.get("dp_rank")
 
+            # Multimodal: decode re-encodes the image/video so it reproduces the
+            # same expanded token layout prefill used and the transferred KV lines
+            # up. Shared with prefill so both sides extract media identically.
+            decode_mm_kwargs = build_disagg_mm_kwargs(request)
+
             decode = await self.engine.async_generate(
                 **input_param,
+                **decode_mm_kwargs,
                 sampling_params=sampling_params,
                 stream=True,
                 **self._routed_experts_kwargs,
@@ -430,7 +421,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             # Extract image/video URLs for multimodal requests. SGLang's mm_data_processor
             # handles loading/preprocessing, and the scheduler does vision encoding.
             mm_data = request.get("multi_modal_data", {})
-            video_data = _extract_media_urls(mm_data, "video_url")
+            video_data = extract_media_urls(mm_data, VIDEO_URL_KEY)
 
             image_data: list[str] | list[PILImage] | None
             if self._enable_frontend_decoding:
@@ -438,13 +429,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # _enable_frontend_decoding is True. Assert narrows the
                 # Optional for the type checker without runtime branching.
                 assert self._image_loader is not None
-                image_items = mm_data.get("image_url") or []
+                image_items = mm_data.get(IMAGE_URL_KEY) or []
                 if image_items:
                     image_data = await self._image_loader.load_image_batch(image_items)
                 else:
                     image_data = None
             else:
-                image_data = _extract_media_urls(mm_data, "image_url")
+                image_data = extract_media_urls(mm_data, IMAGE_URL_KEY)
 
             trace_header = context.trace_headers() if self.enable_trace else None
 

--- a/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
@@ -1,27 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared helpers for multimodal inputs in disaggregated prefill/decode (P/D) serving.
-
-In disaggregated serving the prefill worker computes the KV cache (including the
-vision context) and transfers it to the decode worker over NIXL. The decode
-worker still has to reproduce the same *token layout* — the image placeholder
-must expand to the same number of patch tokens prefill used — so the transferred
-KV indices and mRoPE positions line up.
-
-Both workers achieve this by feeding the image/video URLs to ``async_generate``;
-SGLang's multimodal path downloads + encodes them and expands the placeholder
-tokens identically on each side. This matches upstream SGLang's own native PD
-behavior (its router dispatches the request to both prefill and decode, each of
-which processes the media independently). The decode worker's vision encode is
-redundant with the transferred KV, but guarantees the layout is consistent.
-
-Follow-up (not implemented here): decode could skip the GPU vision tower by
-feeding SGLang a synthetic ``precomputed_embedding`` sized from a grid forwarded
-by prefill, mirroring the dynamo vLLM backend. On SGLang that requires either a
-frontend change to forward the grid (prefill runs asynchronously under the
-bootstrap router, so it cannot hand decode the grid) or re-deriving the grid in
-decode. Tracked as a separate optimization.
+"""Multimodal media extraction shared by the disaggregated prefill and decode
+workers, so both feed identical image/video URLs to the engine and reproduce the
+same token layout the transferred KV depends on.
 """
 
 import logging
@@ -36,21 +18,9 @@ VIDEO_URL_KEY = "video_url"
 def extract_media_urls(
     mm_data: Optional[Dict[str, Any]], media_key: str
 ) -> list[str] | None:
-    """Normalize multimodal URL items from the frontend wire format.
-
-    The Rust frontend populates ``multi_modal_data`` as
-    ``{"image_url": [{"Url": "..."}, ...], "video_url": [...]}``. Plain string
-    items are also accepted for forward/backward compatibility. Returns ``None``
-    when the modality is absent so callers can pass it straight through to
-    ``async_generate`` (which treats ``None`` as "no media").
-
-    Malformed or unsupported payloads raise ``ValueError`` rather than silently
-    degrading to text. In disaggregated serving both workers depend on this
-    helper, so a dropped item would not just be a local parse bug — it would
-    desync the prefill/decode token layout and corrupt the answer. This mirrors
-    the explicit wire-variant validation in ``MultimodalEncodeWorkerHandler``;
-    in particular, frontend-decoded (``Decoded``) media is rejected because the
-    disaggregated path is URL-passthrough only.
+    """Return the URLs under ``media_key`` (``{"Url": ...}`` or string items), or
+    ``None`` if absent. Raises on malformed or frontend-decoded payloads rather
+    than silently degrading a multimodal request to text.
     """
     if not mm_data:
         return None
@@ -84,15 +54,8 @@ def extract_media_urls(
 
 
 def build_disagg_mm_kwargs(request: Dict[str, Any]) -> Dict[str, Any]:
-    """Build the ``image_data``/``video_data`` kwargs for a disaggregated
-    worker's ``async_generate`` call.
-
-    Both the prefill and decode workers call this so they extract the media
-    identically and reproduce the same expanded token layout — a divergence
-    between the two sides would misalign the transferred KV (the exact failure
-    this module guards against). Always returns both keys (value ``None`` when a
-    modality is absent), matching the aggregated path's long-standing call shape;
-    SGLang treats ``None`` as "no media".
+    """Build the ``image_data``/``video_data`` kwargs for a disaggregated worker's
+    ``async_generate`` call. Both keys are always present (``None`` when absent).
     """
     mm_data = request.get("multi_modal_data") or {}
     image_data = extract_media_urls(mm_data, IMAGE_URL_KEY)

--- a/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
@@ -43,6 +43,14 @@ def extract_media_urls(
     items are also accepted for forward/backward compatibility. Returns ``None``
     when the modality is absent so callers can pass it straight through to
     ``async_generate`` (which treats ``None`` as "no media").
+
+    Malformed or unsupported payloads raise ``ValueError`` rather than silently
+    degrading to text. In disaggregated serving both workers depend on this
+    helper, so a dropped item would not just be a local parse bug — it would
+    desync the prefill/decode token layout and corrupt the answer. This mirrors
+    the explicit wire-variant validation in ``MultimodalEncodeWorkerHandler``;
+    in particular, frontend-decoded (``Decoded``) media is rejected because the
+    disaggregated path is URL-passthrough only.
     """
     if not mm_data:
         return None
@@ -50,6 +58,10 @@ def extract_media_urls(
     items = mm_data.get(media_key)
     if not items:
         return None
+    if not isinstance(items, list):
+        raise ValueError(
+            f"{media_key} must be a list of URL items, got {type(items).__name__}"
+        )
 
     urls: list[str] = []
     for item in items:
@@ -60,6 +72,13 @@ def extract_media_urls(
             url = item.get("Url")
             if isinstance(url, str):
                 urls.append(url)
+                continue
+            if "Decoded" in item:
+                raise ValueError(
+                    f"Frontend-decoded media is not supported for disaggregated "
+                    f"{media_key}; use URL-based inputs."
+                )
+        raise ValueError(f"Unsupported {media_key} item: {item!r}")
 
     return urls or None
 

--- a/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for multimodal inputs in disaggregated prefill/decode (P/D) serving.
+
+In disaggregated serving the prefill worker computes the KV cache (including the
+vision context) and transfers it to the decode worker over NIXL. The decode
+worker still has to reproduce the same *token layout* — the image placeholder
+must expand to the same number of patch tokens prefill used — so the transferred
+KV indices and mRoPE positions line up.
+
+Both workers achieve this by feeding the image/video URLs to ``async_generate``;
+SGLang's multimodal path downloads + encodes them and expands the placeholder
+tokens identically on each side. This matches upstream SGLang's own native PD
+behavior (its router dispatches the request to both prefill and decode, each of
+which processes the media independently). The decode worker's vision encode is
+redundant with the transferred KV, but guarantees the layout is consistent.
+
+Follow-up (not implemented here): decode could skip the GPU vision tower by
+feeding SGLang a synthetic ``precomputed_embedding`` sized from a grid forwarded
+by prefill, mirroring the dynamo vLLM backend. On SGLang that requires either a
+frontend change to forward the grid (prefill runs asynchronously under the
+bootstrap router, so it cannot hand decode the grid) or re-deriving the grid in
+decode. Tracked as a separate optimization.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+IMAGE_URL_KEY = "image_url"
+VIDEO_URL_KEY = "video_url"
+
+
+def extract_media_urls(
+    mm_data: Optional[Dict[str, Any]], media_key: str
+) -> list[str] | None:
+    """Normalize multimodal URL items from the frontend wire format.
+
+    The Rust frontend populates ``multi_modal_data`` as
+    ``{"image_url": [{"Url": "..."}, ...], "video_url": [...]}``. Plain string
+    items are also accepted for forward/backward compatibility. Returns ``None``
+    when the modality is absent so callers can pass it straight through to
+    ``async_generate`` (which treats ``None`` as "no media").
+    """
+    if not mm_data:
+        return None
+
+    items = mm_data.get(media_key)
+    if not items:
+        return None
+
+    urls: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            urls.append(item)
+            continue
+        if isinstance(item, dict):
+            url = item.get("Url")
+            if isinstance(url, str):
+                urls.append(url)
+
+    return urls or None
+
+
+def build_disagg_mm_kwargs(request: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the ``image_data``/``video_data`` kwargs for a disaggregated
+    worker's ``async_generate`` call.
+
+    Both the prefill and decode workers call this so they extract the media
+    identically and reproduce the same expanded token layout — a divergence
+    between the two sides would misalign the transferred KV (the exact failure
+    this module guards against). Always returns both keys (value ``None`` when a
+    modality is absent), matching the aggregated path's long-standing call shape;
+    SGLang treats ``None`` as "no media".
+    """
+    mm_data = request.get("multi_modal_data") or {}
+    image_data = extract_media_urls(mm_data, IMAGE_URL_KEY)
+    video_data = extract_media_urls(mm_data, VIDEO_URL_KEY)
+    if image_data or video_data:
+        logger.debug(
+            "disaggregated multimodal request: images=%d, videos=%d",
+            len(image_data or []),
+            len(video_data or []),
+        )
+    return {"image_data": image_data, "video_data": video_data}

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -131,10 +131,8 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
         input_param = self._get_input_param(inner_request)
 
-        # Multimodal: the prefill worker always runs vision encoding so the KV
-        # cache it transfers to decode includes the image/video context. The
-        # shared helper extracts the URLs identically to the decode side so both
-        # reproduce the same expanded token layout.
+        # Prefill encodes the media so the KV it transfers carries the vision
+        # context; decode extracts the same URLs to match the token layout.
         mm_kwargs = build_disagg_mm_kwargs(inner_request)
 
         routing = inner_request.get("routing") or {}

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -13,6 +13,7 @@ from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 from dynamo.sglang.request_handlers.llm.decode_handler import _sampling_option_params
+from dynamo.sglang.request_handlers.llm.mm_disagg_utils import build_disagg_mm_kwargs
 
 # Sentinel value matching u32::MAX from the C/Go prefill-routing ABI.
 # This remains as a compatibility fallback for older callers that still encode
@@ -129,6 +130,13 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         }
 
         input_param = self._get_input_param(inner_request)
+
+        # Multimodal: the prefill worker always runs vision encoding so the KV
+        # cache it transfers to decode includes the image/video context. The
+        # shared helper extracts the URLs identically to the decode side so both
+        # reproduce the same expanded token layout.
+        mm_kwargs = build_disagg_mm_kwargs(inner_request)
+
         routing = inner_request.get("routing") or {}
         priority = routing.get("priority")
         dp_rank = routing.get("dp_rank")
@@ -146,6 +154,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
         results = await self.engine.async_generate(
             **input_param,
+            **mm_kwargs,
             sampling_params=sampling_params,
             stream=True,
             bootstrap_host=bootstrap_host,

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -41,7 +41,6 @@ def test_extract_media_urls_supports_string_and_wire_items():
         "video_url": [
             "file:///tmp/test.mp4",
             {"Url": "https://example.com/test.mp4"},
-            {"ignored": "value"},
         ]
     }
 
@@ -51,12 +50,24 @@ def test_extract_media_urls_supports_string_and_wire_items():
     ]
 
 
-def test_extract_media_urls_returns_none_for_missing_or_invalid_items():
+def test_extract_media_urls_returns_none_for_missing_modality():
     assert extract_media_urls({}, "image_url") is None
     assert extract_media_urls(None, "image_url") is None
-    assert (
-        extract_media_urls({"image_url": [{"ignored": "value"}]}, "image_url") is None
-    )
+    assert extract_media_urls({"image_url": []}, "image_url") is None
+
+
+def test_extract_media_urls_rejects_malformed_payloads():
+    # A bare string (not a list) would otherwise split into per-character items.
+    with pytest.raises(ValueError, match="must be a list"):
+        extract_media_urls({"image_url": "https://example.com/a.png"}, "image_url")
+
+    # Frontend-decoded media is URL-passthrough only in the disaggregated path.
+    with pytest.raises(ValueError, match="Frontend-decoded"):
+        extract_media_urls({"image_url": [{"Decoded": "..."}]}, "image_url")
+
+    # Unsupported dict variant fails clearly instead of degrading to text.
+    with pytest.raises(ValueError, match="Unsupported"):
+        extract_media_urls({"image_url": [{"ignored": "value"}]}, "image_url")
 
 
 @pytest.mark.parametrize(

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -10,12 +10,12 @@ import pytest
 from dynamo.common.metadata_upload import MetadataUploader
 from dynamo.sglang.request_handlers.llm.decode_handler import (
     DecodeWorkerHandler,
-    _extract_media_urls,
     _extract_sglang_stop_reason,
     _nvext_extra_field_requested,
     _openai_stop_sampling_params,
     _user_stop_token_ids,
 )
+from dynamo.sglang.request_handlers.llm.mm_disagg_utils import extract_media_urls
 from dynamo.sglang.request_handlers.multimodal.worker_handler import StreamProcessor
 
 pytestmark = [
@@ -45,16 +45,17 @@ def test_extract_media_urls_supports_string_and_wire_items():
         ]
     }
 
-    assert _extract_media_urls(mm_data, "video_url") == [
+    assert extract_media_urls(mm_data, "video_url") == [
         "file:///tmp/test.mp4",
         "https://example.com/test.mp4",
     ]
 
 
 def test_extract_media_urls_returns_none_for_missing_or_invalid_items():
-    assert _extract_media_urls({}, "image_url") is None
+    assert extract_media_urls({}, "image_url") is None
+    assert extract_media_urls(None, "image_url") is None
     assert (
-        _extract_media_urls({"image_url": [{"ignored": "value"}]}, "image_url") is None
+        extract_media_urls({"image_url": [{"ignored": "value"}]}, "image_url") is None
     )
 
 

--- a/examples/backends/sglang/launch/disagg_same_gpu.sh
+++ b/examples/backends/sglang/launch/disagg_same_gpu.sh
@@ -29,6 +29,11 @@ MODEL="Qwen/Qwen3-0.6B"
 while [[ $# -gt 0 ]]; do
     case $1 in
         --model)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "Missing value for --model"
+                echo "Use --help for usage information"
+                exit 1
+            fi
             MODEL="$2"
             shift 2
             ;;

--- a/examples/backends/sglang/launch/disagg_same_gpu.sh
+++ b/examples/backends/sglang/launch/disagg_same_gpu.sh
@@ -21,11 +21,8 @@ source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 
 MODEL="Qwen/Qwen3-0.6B"
 
-# Parse command line arguments. --model lets the test harness / caller serve a
-# different model (e.g. a small VLM to exercise the disaggregated multimodal
-# P/D path). --single-gpu is accepted as a no-op: this script already co-locates
-# both workers on one GPU, so the flag is only here for parity with the other
-# multimodal launch scripts that the test harness drives uniformly.
+# --model overrides the default (e.g. a VLM for the multimodal P/D test).
+# --single-gpu is a no-op kept for parity with the other launch scripts.
 while [[ $# -gt 0 ]]; do
     case $1 in
         --model)

--- a/examples/backends/sglang/launch/disagg_same_gpu.sh
+++ b/examples/backends/sglang/launch/disagg_same_gpu.sh
@@ -21,6 +21,34 @@ source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 
 MODEL="Qwen/Qwen3-0.6B"
 
+# Parse command line arguments. --model lets the test harness / caller serve a
+# different model (e.g. a small VLM to exercise the disaggregated multimodal
+# P/D path). --single-gpu is accepted as a no-op: this script already co-locates
+# both workers on one GPU, so the flag is only here for parity with the other
+# multimodal launch scripts that the test harness drives uniformly.
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        --single-gpu)
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--model <name>] [--single-gpu]"
+            echo "  --model <name>  Model to serve (default: $MODEL)"
+            echo "  --single-gpu    Accepted no-op; both workers already share GPU 0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
 # ---- Tunable (override via env vars) ----
 CONTEXT_LENGTH="${CONTEXT_LENGTH:-4096}"
 MAX_RUNNING_REQUESTS="${MAX_RUNNING_REQUESTS:-2}"

--- a/tests/serve/multimodal_profiles/sglang.py
+++ b/tests/serve/multimodal_profiles/sglang.py
@@ -7,12 +7,15 @@ from tests.utils.multimodal import (
     MmCase,
     MultimodalModelProfile,
     TopologyConfig,
+    make_image_payload,
     make_image_payload_cached_tokens,
 )
 
-# agg_router only for now; disagg/EPD variants when their scripts exist.
+# agg_router and disaggregated prefill+decode with no encode worker (pd_no_encoder,
+# single GPU) for now; EPD variants when their generic launch wiring exists.
 SGLANG_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "agg_router": "agg_multimodal_router.sh",
+    "pd_no_encoder": "disagg_same_gpu.sh",
 }
 
 # VLM coverage mirrors the vLLM profile registry. SINGLE_GPU=true packs both
@@ -38,6 +41,19 @@ SGLANG_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                         )
                     )
                 ],
+            ),
+            # Disaggregated prefill+decode on one GPU, no encode worker. Smoke
+            # test that the P/D multimodal path returns a correct image answer
+            # (prefill encodes + transfers KV; decode re-encodes for token-layout
+            # parity). Plain color-identification payload, since disagg KV
+            # semantics make the cached-tokens hit-rate assertions inapplicable.
+            "pd_no_encoder": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=500,
+                profiled_vram_gib=22.0,
+                requested_sglang_kv_tokens=8192,
+                delayed_start=10,
+                tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
         },
     ),

--- a/tests/serve/multimodal_profiles/sglang.py
+++ b/tests/serve/multimodal_profiles/sglang.py
@@ -11,8 +11,7 @@ from tests.utils.multimodal import (
     make_image_payload_cached_tokens,
 )
 
-# agg_router and disaggregated prefill+decode with no encode worker (pd_no_encoder,
-# single GPU) for now; EPD variants when their generic launch wiring exists.
+# pd_no_encoder = disaggregated prefill+decode, single GPU, no encode worker.
 SGLANG_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "agg_router": "agg_multimodal_router.sh",
     "pd_no_encoder": "disagg_same_gpu.sh",
@@ -42,11 +41,8 @@ SGLANG_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                     )
                 ],
             ),
-            # Disaggregated prefill+decode on one GPU, no encode worker. Smoke
-            # test that the P/D multimodal path returns a correct image answer
-            # (prefill encodes + transfers KV; decode re-encodes for token-layout
-            # parity). Plain color-identification payload, since disagg KV
-            # semantics make the cached-tokens hit-rate assertions inapplicable.
+            # Plain color-check payload; disagg KV semantics make the
+            # cached-tokens hit-rate assertions inapplicable here.
             "pd_no_encoder": TopologyConfig(
                 marks=[pytest.mark.post_merge],
                 timeout_s=500,

--- a/tests/serve/multimodal_profiles/sglang.py
+++ b/tests/serve/multimodal_profiles/sglang.py
@@ -44,7 +44,7 @@ SGLANG_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             # Plain color-check payload; disagg KV semantics make the
             # cached-tokens hit-rate assertions inapplicable here.
             "pd_no_encoder": TopologyConfig(
-                marks=[pytest.mark.post_merge],
+                marks=[pytest.mark.pre_merge],
                 timeout_s=500,
                 profiled_vram_gib=22.0,
                 requested_sglang_kv_tokens=8192,


### PR DESCRIPTION
## Overview

Dynamo's SGLang backend silently dropped image and video inputs when running disaggregated serving (separate prefill and decode workers). The request still carried the image and the frontend still forwarded `multi_modal_data`, but the prefill and decode handlers never passed it to `async_generate`, so the model ran on the text tokens alone and returned a hallucinated answer. Aggregated serving and the EPD encode-worker path already worked; only plain prefill+decode was affected.

This forwards the media to both disaggregated workers. Prefill encodes the vision tokens and transfers the KV cache to decode over NIXL. Decode re-encodes the same image so its token layout matches prefill's and the transferred KV lines up, which is how upstream SGLang's own PD router behaves (it dispatches the request to both workers). Text-only requests are unchanged.

It also adds a regression test, `mm_pd_no_encoder`, that brings up a single-GPU prefill+decode deployment of Qwen3-VL-2B with no encode worker and checks the image answer.

## Reproduce

Against a 1 prefill + 1 decode deployment (no encode worker), e.g. `disagg_same_gpu.sh --model Qwen/Qwen3-VL-2B-Instruct`:

```bash
curl -s localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' -d '{
    "model": "Qwen/Qwen3-VL-2B-Instruct",
    "messages": [{"role": "user", "content": [
      {"type": "text", "text": "Describe this image in one sentence. Be specific about the objects and their colors."},
      {"type": "image_url", "image_url": {"url": "http://images.cocodataset.org/val2017/000000039769.jpg"}}
    ]}],
    "max_tokens": 80, "temperature": 0
  }'
```

The image is two cats asleep on a bright pink couch with two TV remotes.

## Before

```json
{
  "choices": [{
    "message": {"content": "A close-up photograph captures a small, dark brown, textured object, possibly a piece of bark or a dried leaf, resting on a smooth, light gray surface."},
    "finish_reason": "stop"
  }],
  "usage": {"prompt_tokens": 27, "completion_tokens": 57}
}
```

`prompt_tokens` is 27 with no image patches in the sequence, so the image never reached the engine and the answer is a hallucination.

## After

```json
{
  "choices": [{
    "message": {"content": "Two cats, one with a black and tan striped coat and the other with a brown and black tabby pattern, are sleeping on a bright pink couch, with two remote controls placed between them."},
    "finish_reason": "stop"
  }],
  "usage": {"prompt_tokens": 326, "completion_tokens": 40}
}
```

`prompt_tokens` is 326 with the image encoded into patch tokens, and the description is correct.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line argument support (`--model`, `--help`) to disaggregated serving launch script.

* **Improvements**
  * Enhanced multimodal image and video request handling for disaggregated prefill/decode serving.
  * Standardized media extraction for improved frontend decoding compatibility.

* **Tests**
  * Added test coverage for multimodal media extraction scenarios.
  * Introduced new disaggregated topology configuration for multimodal testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->