### PR TITLE
fix(parity): make parity-table overview status reason-aware

### DIFF
--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -64,6 +64,9 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .view-overview.parser-dynamo td.cell[data-status-dynamo="na"],
 .view-overview.parser-vllm td.cell[data-status-vllm="na"],
 .view-overview.parser-sglang td.cell[data-status-sglang="na"] { background: #d3d8de; color: #d3d8de; }
+.view-overview.parser-dynamo td.cell[data-status-dynamo="documented"],
+.view-overview.parser-vllm td.cell[data-status-vllm="documented"],
+.view-overview.parser-sglang td.cell[data-status-sglang="documented"] { background: #6f9bc7; color: #6f9bc7; }
 .view-details.parser-dynamo td.cell[data-status-dynamo="ok"],
 .view-details.parser-vllm td.cell[data-status-vllm="ok"],
 .view-details.parser-sglang td.cell[data-status-sglang="ok"] { background: #bfe3c6; }
@@ -73,6 +76,9 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .view-details.parser-dynamo td.cell[data-status-dynamo="na"],
 .view-details.parser-vllm td.cell[data-status-vllm="na"],
 .view-details.parser-sglang td.cell[data-status-sglang="na"] { background: #e4e8ec; }
+.view-details.parser-dynamo td.cell[data-status-dynamo="documented"],
+.view-details.parser-vllm td.cell[data-status-vllm="documented"],
+.view-details.parser-sglang td.cell[data-status-sglang="documented"] { background: #c7d8ea; }
 .view-overview td.cell > a { color: inherit; }
 .view-overview td.cell > a:hover { background: transparent; }
 .view-overview td.cell:hover { filter: brightness(0.98); }
@@ -285,6 +291,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 <p class="stats summary-only">
   Stats for selected perspective:
   <span style="color:#0a7d2c" data-overview-count="ok">0</span> green ·
+  <span style="color:#3f6f9c" data-overview-count="documented">0</span> blue (documented) ·
   <span style="color:#b00" data-overview-count="problem">0</span> red ·
   <span style="color:#555" data-overview-count="na">0</span> gray.
 </p>
@@ -408,7 +415,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   function updateOverviewStats() {
     const parser = activeParser();
     document.querySelectorAll('.tab-panel').forEach(function (panel) {
-      const counts = {ok: 0, problem: 0, na: 0};
+      const counts = {ok: 0, documented: 0, problem: 0, na: 0};
       panel.querySelectorAll('td.cell').forEach(function (cell) {
         const status = cell.getAttribute('data-status-' + parser) || 'na';
         counts[status] = (counts[status] || 0) + 1;

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -640,13 +640,48 @@ def _block_tool_call_leaks(block: dict) -> bool:
 
 
 def _overview_status(case: dict | None, impl: str) -> str:
+    """Overview-view cell color, reason-aware and consistent with the markers.
+
+    Returns one of:
+      'na'         - block not recorded / unavailable for this impl
+      'problem'    - red: an UNDOCUMENTED error or RESEARCH divergence
+                     (errors/diverges from the agreed output, no `reason:`)
+      'documented' - neutral: an intentional divergence or a documented
+                     parser error (carries `reason:`)
+      'ok'         - green: matches the agreed output
+
+    Mirrors `peer_status()` for the peer impls. The `_block_tool_call_leaks`
+    glyph (the ↯ marker) is independent of this color and stays as-is; a
+    documented leak keeps its ↯ but is no longer flagged red.
+    """
     if case is None or "expected" not in case:
         return "na"
     block = case.get("expected", {}).get(impl)
     if not isinstance(block, dict) or "unavailable" in block:
         return "na"
-    if "error" in block or _block_tool_call_leaks(block):
-        return "problem"
+
+    if impl == "dynamo":
+        # Dynamo is the oracle: it cannot diverge from itself, so the only red
+        # condition is an UNDOCUMENTED error or markup leak. An error or leak
+        # carrying a `reason:` is intentional and reads as documented.
+        if "error" in block:
+            return "documented" if "reason" in block else "problem"
+        if _block_tool_call_leaks(block):
+            return "documented" if "reason" in block else "problem"
+        return "ok"
+
+    # Peer impls: defer to the marker system's classification so the color
+    # tracks parity rather than a bare wrapper-token regex.
+    dyn = case.get("expected", {}).get("dynamo")
+    if not isinstance(dyn, dict):
+        return "ok"
+    kind, is_unknown = peer_status(case, dyn, impl)
+    if kind in ("na", "unavail"):
+        return "na"
+    if kind == "err":
+        return "documented" if "reason" in block else "problem"
+    if kind == "div":
+        return "problem" if is_unknown else "documented"
     return "ok"
 
 

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -110,7 +110,7 @@ def test_generate_parser_parity_table_html() -> None:
     assert "TOOLCALLING.batch.1</td><td>Single tool call" in html
     assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
     assert re.search(
-        r'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="na" '
+        r'data-status-dynamo="ok" data-status-vllm="documented" data-status-sglang="na" '
         r'data-marker-dynamo="" data-marker-vllm="↯" data-marker-sglang="n/a" '
         r'data-marker-parity-dynamo="" data-marker-parity-vllm="↯" '
         r'data-marker-parity-sglang="n/a"><a href="fixtures/deepseek_v4/TOOLCALLING\.batch\.4\.yaml">V</a>'
@@ -120,7 +120,7 @@ def test_generate_parser_parity_table_html() -> None:
     assert 'data-marker-vllm="✗"' in html
     assert 'data-marker-parity-vllm="✗"' in html
     assert re.search(
-        r'data-status-dynamo="ok" data-status-vllm="ok" data-status-sglang="problem" '
+        r'data-status-dynamo="ok" data-status-vllm="ok" data-status-sglang="documented" '
         r'data-marker-dynamo="" data-marker-vllm="" data-marker-sglang="↯" '
         r'data-marker-parity-dynamo="S" data-marker-parity-vllm="S" '
         r'data-marker-parity-sglang="↯DV"><a href="fixtures/harmony/TOOLCALLING\.batch\.yaml">S</a>'
@@ -128,7 +128,7 @@ def test_generate_parser_parity_table_html() -> None:
         html,
     )
     assert re.search(
-        r'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="ok" '
+        r'data-status-dynamo="ok" data-status-vllm="documented" data-status-sglang="documented" '
         r'data-marker-dynamo="" data-marker-vllm="↯" data-marker-sglang="" '
         r'data-marker-parity-dynamo="VS" data-marker-parity-vllm="↯DS" '
         r'data-marker-parity-sglang="DV"><a href="fixtures/llama3_json/TOOLCALLING\.batch\.4\.yaml">VS</a>'


### PR DESCRIPTION
## Overview

The parity dashboard's cell color (`_overview_status` in `tests/parity/toolcalling/table.py`) was computed purely from a wrapper-token regex (`_block_tool_call_leaks`): a cell went red whenever an impl's `normal_text` matched a known tool-call token, ignoring both the `reason:` field and cross-impl parity. The cell *markers* and the summary *stats* already honor `reason:`/parity (via `peer_status`); only the color did not.

That single-classifier gap misclassified in both directions:

```
false-RED:   a documented divergence or a unanimous leak that
             keeps a <tool_call>/[TOOL_CALLS] token -> red,
             even with reason: present and peers in agreement
false-GREEN: a leak whose token was stripped (e.g. SGLang
             returning bare JSON on llama3_json 4.b) -> green,
             because the regex saw no recognized token
```

## Details

`_overview_status` is now reason-aware and consistent with `peer_status()`:

```
problem (red)        = an error, OR a research divergence
                       (diverges from the agreed output, no reason:)
documented (neutral) = an intentional divergence (carries reason:),
                       including a documented leak
ok (green)           = matches the agreed output
```

A new neutral `documented` state is added (CSS + legend swatch + counter key in `parity_table.html.j2`). `_block_tool_call_leaks` and the `↯` leak glyph are unchanged, so a documented leak keeps its `↯` marker but is no longer flagged red.

## Before / After

```
hermes 4.b:      dynamo red->documented; vllm/sglang red->ok
hermes 4.c:      vllm red->documented
llama3_json 4.b: vllm red->documented; sglang ok->documented
                 (the token-stripped false-green)
```

## Cross-impl

Color only. No parser code, no fixtures, no behavior change. The generator, the table test, and the stats are unaffected apart from three test assertions whose cases carry `reason:` moving from `problem` to `documented`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "documented" status variant to parity tables with distinct styling across different view modes.
  * Added visual counter for documented cases in statistics overview.

* **Tests**
  * Updated status classification logic for more consistent and accurate parity reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->