### PR TITLE
perf(llm): incrementally track worker overload state

### DIFF
--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -340,9 +340,11 @@ impl OverloadedWorkerTracker {
     }
 
     fn remove_workers(&mut self, removed_workers: &[u64]) -> bool {
-        removed_workers
-            .iter()
-            .any(|worker_id| self.overloaded_workers.remove(worker_id))
+        let mut changed = false;
+        for worker_id in removed_workers {
+            changed |= self.overloaded_workers.remove(worker_id);
+        }
+        changed
     }
 
     #[cfg(test)]
@@ -900,10 +902,10 @@ mod tests {
         assert!(tracker.replace(HashSet::from([1, 3, 5])));
         assert!(!tracker.replace(HashSet::from([1, 3, 5])));
 
-        assert!(tracker.remove_workers(&[3, 4]));
+        assert!(tracker.remove_workers(&[3, 5]));
         assert!(tracker.contains(1));
         assert!(!tracker.contains(3));
-        assert!(tracker.contains(5));
+        assert!(!tracker.contains(5));
 
         assert!(!tracker.remove_workers(&[2, 4]));
     }

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -307,6 +307,67 @@ impl WorkerLoadState {
             false
         })
     }
+
+    fn is_overloaded_for_config(&self, config: &LoadThresholdConfig) -> bool {
+        self.is_overloaded(
+            config.active_decode_blocks_threshold,
+            config.active_prefill_tokens_threshold,
+            config.active_prefill_tokens_threshold_frac,
+        )
+    }
+}
+
+#[derive(Debug, Default)]
+struct OverloadedWorkerTracker {
+    overloaded_workers: HashSet<u64>,
+}
+
+impl OverloadedWorkerTracker {
+    fn update_worker(&mut self, worker_id: u64, overloaded: bool) -> bool {
+        if overloaded {
+            self.overloaded_workers.insert(worker_id)
+        } else {
+            self.overloaded_workers.remove(&worker_id)
+        }
+    }
+
+    fn replace(&mut self, overloaded_workers: HashSet<u64>) -> bool {
+        if self.overloaded_workers == overloaded_workers {
+            return false;
+        }
+        self.overloaded_workers = overloaded_workers;
+        true
+    }
+
+    fn remove_workers(&mut self, removed_workers: &[u64]) -> bool {
+        removed_workers
+            .iter()
+            .any(|worker_id| self.overloaded_workers.remove(worker_id))
+    }
+
+    #[cfg(test)]
+    fn contains(&self, worker_id: u64) -> bool {
+        self.overloaded_workers.contains(&worker_id)
+    }
+
+    fn ids(&self) -> Vec<u64> {
+        self.overloaded_workers.iter().copied().collect()
+    }
+}
+
+fn collect_overloaded_workers(
+    worker_load_states: &DashMap<u64, WorkerLoadState>,
+    config: &LoadThresholdConfig,
+) -> HashSet<u64> {
+    worker_load_states
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .value()
+                .is_overloaded_for_config(config)
+                .then_some(*entry.key())
+        })
+        .collect()
 }
 
 /// Worker monitor for tracking KV cache usage and overload states.
@@ -536,6 +597,8 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 
             let mut known_worker_dp_ranks: HashMap<u64, std::collections::HashSet<u32>> =
                 HashMap::new();
+            let mut overloaded_tracker = OverloadedWorkerTracker::default();
+            let mut last_thresholds = thresholds.read().unwrap().clone();
 
             loop {
                 // Create a future that either reads from kv_metrics or pends forever if unavailable
@@ -580,6 +643,7 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                         }
 
                         worker_load_states.retain(|lease_id, _| runtime_configs.contains_key(lease_id));
+                        overloaded_tracker.remove_workers(&removed_workers);
                         client.clear_overloaded_instances_for_removed(&removed_workers);
 
                         // Update worker load states with runtime config values for all dp_ranks
@@ -610,6 +674,22 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                                 }
                             }
                         }
+
+                        let cfg = thresholds.read().unwrap().clone();
+                        last_thresholds = cfg.clone();
+                        let overloaded_workers = collect_overloaded_workers(&worker_load_states, &cfg);
+                        if overloaded_tracker.replace(overloaded_workers) {
+                            let overloaded_instances = overloaded_tracker.ids();
+                            if client.set_overloaded_instances(&overloaded_instances) {
+                                let counts = client.routing_instance_counts();
+                                tracing::debug!(
+                                    overloaded_instances = ?overloaded_instances,
+                                    free_workers = counts.free,
+                                    total_workers = counts.discovered,
+                                    "overloaded instances changed after runtime config update"
+                                );
+                            }
+                        }
                     }
 
                     // Handle KV metrics updates (ActiveLoad) - only if subscriber is available
@@ -638,35 +718,22 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                         // Snapshot thresholds once per event — rare writes (HTTP endpoint)
                         // mean RwLock contention is effectively zero.
                         let cfg = thresholds.read().unwrap().clone();
+                        let thresholds_changed = cfg != last_thresholds;
 
                         // Update worker load state per dp_rank (for overload detection only).
                         // Note: Prometheus gauges are updated directly by sequence.rs
-                        let total_blocks = {
+                        let (total_blocks, worker_overloaded) = {
                             let mut state = worker_load_states.entry(worker_id).or_default();
                             state.update_from_active_load(
                                 &active_load,
                                 cfg.active_decode_blocks_threshold,
                             );
-                            state.kv_total_blocks.get(&dp_rank).copied()
+                            let total_blocks = state.kv_total_blocks.get(&dp_rank).copied();
+                            let worker_overloaded = state.is_overloaded_for_config(&cfg);
+                            (total_blocks, worker_overloaded)
                         };
 
-                        // Recalculate all overloaded instances and update.
-                        let overloaded_instances: Vec<u64> = worker_load_states
-                            .iter()
-                            .filter_map(|entry| {
-                                entry
-                                    .value()
-                                    .is_overloaded(
-                                        cfg.active_decode_blocks_threshold,
-                                        cfg.active_prefill_tokens_threshold,
-                                        cfg.active_prefill_tokens_threshold_frac,
-                                    )
-                                    .then_some(*entry.key())
-                            })
-                            .collect();
-
                         if tracing::enabled!(tracing::Level::DEBUG) {
-                            let worker_overloaded = overloaded_instances.contains(&worker_id);
                             tracing::debug!(
                                 worker_id,
                                 dp_rank,
@@ -682,14 +749,26 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                             );
                         }
 
-                        if client.set_overloaded_instances(&overloaded_instances) {
-                            let counts = client.routing_instance_counts();
-                            tracing::debug!(
-                                overloaded_instances = ?overloaded_instances,
-                                free_workers = counts.free,
-                                total_workers = counts.discovered,
-                                "overloaded instances changed"
-                            );
+                        let overloaded_changed = if thresholds_changed {
+                            last_thresholds = cfg.clone();
+                            let overloaded_workers =
+                                collect_overloaded_workers(&worker_load_states, &cfg);
+                            overloaded_tracker.replace(overloaded_workers)
+                        } else {
+                            overloaded_tracker.update_worker(worker_id, worker_overloaded)
+                        };
+
+                        if overloaded_changed {
+                            let overloaded_instances = overloaded_tracker.ids();
+                            if client.set_overloaded_instances(&overloaded_instances) {
+                                let counts = client.routing_instance_counts();
+                                tracing::debug!(
+                                    overloaded_instances = ?overloaded_instances,
+                                    free_workers = counts.free,
+                                    total_workers = counts.discovered,
+                                    "overloaded instances changed"
+                                );
+                            }
                         }
                     }
 
@@ -797,8 +876,37 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 
 #[cfg(test)]
 mod tests {
-    use super::{LoadThresholdConfig, WorkerLoadState};
+    use super::{LoadThresholdConfig, OverloadedWorkerTracker, WorkerLoadState};
     use dynamo_kv_router::protocols::ActiveLoad;
+    use std::collections::HashSet;
+
+    #[test]
+    fn overloaded_worker_tracker_updates_one_worker() {
+        let mut tracker = OverloadedWorkerTracker::default();
+
+        assert!(tracker.update_worker(7, true));
+        assert!(tracker.contains(7));
+        assert!(!tracker.update_worker(7, true));
+
+        assert!(tracker.update_worker(7, false));
+        assert!(!tracker.contains(7));
+        assert!(!tracker.update_worker(7, false));
+    }
+
+    #[test]
+    fn overloaded_worker_tracker_replaces_and_removes_workers() {
+        let mut tracker = OverloadedWorkerTracker::default();
+
+        assert!(tracker.replace(HashSet::from([1, 3, 5])));
+        assert!(!tracker.replace(HashSet::from([1, 3, 5])));
+
+        assert!(tracker.remove_workers(&[3, 4]));
+        assert!(tracker.contains(1));
+        assert!(!tracker.contains(3));
+        assert!(tracker.contains(5));
+
+        assert!(!tracker.remove_workers(&[2, 4]));
+    }
 
     #[test]
     fn load_threshold_config_default_is_not_configured() {

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -799,6 +799,8 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                                     worker_id
                                 );
                             }
+                            overloaded_tracker.remove_workers(&removed_workers);
+                            client.clear_overloaded_instances_for_removed(&removed_workers);
                         }
 
                         known_decode_workers = current_instances;
@@ -848,6 +850,8 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                                     worker_id
                                 );
                             }
+                            overloaded_tracker.remove_workers(&removed_workers);
+                            client.clear_overloaded_instances_for_removed(&removed_workers);
                         }
 
                         known_prefill_workers = current_instances;
@@ -906,6 +910,11 @@ mod tests {
         assert!(tracker.contains(1));
         assert!(!tracker.contains(3));
         assert!(!tracker.contains(5));
+        assert!(
+            tracker.update_worker(3, true),
+            "rejoined overloaded workers must be republished after removal"
+        );
+        assert!(tracker.contains(3));
 
         assert!(!tracker.remove_workers(&[2, 4]));
     }


### PR DESCRIPTION
## Overview:

Optimize KV worker overload tracking by maintaining an incremental overloaded-worker set in `KvWorkerMonitor` instead of rebuilding that set from all worker states on every `ActiveLoad` event.

## Details:

- Add `OverloadedWorkerTracker` to own the current overloaded worker IDs.
- Update only the worker touched by each normal `ActiveLoad` event.
- Preserve full overloaded-set rebuilds for runtime config updates, threshold changes, and worker removals.

## Where should the reviewer start?

- `lib/llm/src/discovery/worker_monitor.rs`, starting with `OverloadedWorkerTracker` and then the `KvWorkerMonitor` metrics loop.

## Related Issues

- [x] Confirmed - no related issue

## Summary

- Keep a local overloaded-worker tracker in `KvWorkerMonitor` so each `ActiveLoad` event updates only the worker that changed.
- Avoid rebuilding the overloaded worker list by iterating all `worker_load_states` on every metrics event.
- Preserve full rebuild behavior for runtime config changes, threshold changes, and worker removals.

## Validation

- `cargo fmt -p dynamo-llm`
- `cargo test -p dynamo-llm discovery::worker_monitor`
- Ran a 32-frontend c512 load-aware AgentX profile on the exact prior benchmark commit plus this patch. The targeted `WorkerLoadMonitor` / `KvWorkerMonitor` bucket dropped from 9.04% to 4.81%, and the `dashmap::iter` subpath dropped from 3.94% to 0.00%. The run had 0.0% request errors.

Benchmark caveat: the profile is valid, but e2e throughput remains noisy for this 32-frontend setup because AIPerf record/server-metrics export creates large artifacts and memory pressure near the end of the run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced worker monitoring efficiency with optimized overload tracking that updates routing state only when the set of overloaded workers changes, reducing computational overhead during operations.

* **Tests**
  * Expanded unit test coverage for worker overload tracking functionality and state management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
