### PR TITLE
fix(parser): force-exit deepseek_v4 reasoning at the DSML tool-call marker

### DIFF
--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -21,6 +21,14 @@ pub use minimax_append_think_parser::MiniMaxAppendThinkParser;
 /// `KimiK2ParserConfig::default().section_start` in `crate::tool_calling::config`.
 pub(crate) const KIMI_K2_TOOL_SECTION_BEGIN: &str = "<|tool_calls_section_begin|>";
 
+/// DeepSeek-V4 DSML tool-call block opener. When the model is primed into reasoning
+/// (`set_in_reasoning(true)`) it may emit this block directly without first closing
+/// `</think>`; treating it as a reasoning-exit marker keeps the tool call out of
+/// `reasoning_content` so the tool-call parser can see it. Mirrors
+/// `ToolCallConfig::deepseek_v4`'s `block_start` (`block_name = "tool_calls"`) in
+/// `crate::tool_calling::config`.
+pub(crate) const DEEPSEEK_V4_TOOL_CALLS_BEGIN: &str = "<｜DSML｜tool_calls>";
+
 static REASONING_PARSER_MAP: OnceLock<HashMap<&'static str, ReasoningParserType>> = OnceLock::new();
 
 /// Initialize the global reasoning parser map
@@ -219,11 +227,24 @@ impl ReasoningParserType {
             ReasoningParserType::Qwen => ReasoningParserWrapper {
                 parser: Box::new(basic_parser),
             },
-            // Same `<think>` / `</think>` config as Qwen today; kept as a
-            // distinct variant so V4-specific divergence has somewhere to land.
+            // Same `<think>` / `</think>` config as Qwen, plus a tool-start
+            // force-exit. When primed into reasoning (`set_in_reasoning(true)`) the
+            // model can emit a `<｜DSML｜tool_calls>` block with no preceding
+            // `</think>`; without the marker the reasoning parser swallows the whole
+            // block into `reasoning_content` and the tool-call parser is starved
+            // (the tool call is silently dropped). Mirrors `KimiK25`.
+            //
+            // Force-exit consumes from the marker to the end, so a hypothetical
+            // interleaved `</think>...tool_calls...<think>B` would route B to
+            // normal_text in batch (streaming re-enters on the next `<think>`).
+            // That is safe in practice: a primed DSv4 tool-use turn ends after the
+            // tool block (finish_reason=tool_calls), so no post-tool reasoning.
             // See `ReasoningParserType::DeepSeekV4` docstring for rationale.
             ReasoningParserType::DeepSeekV4 => ReasoningParserWrapper {
-                parser: Box::new(basic_parser),
+                parser: Box::new(
+                    BasicReasoningParser::new("<think>".into(), "</think>".into(), false, true)
+                        .with_tool_start_token(DEEPSEEK_V4_TOOL_CALLS_BEGIN),
+                ),
             },
             ReasoningParserType::NemotronDeci => ReasoningParserWrapper {
                 parser: Box::new(basic_parser),
@@ -683,5 +704,99 @@ mod tests {
         }
         assert_eq!(all_reasoning, "Weighing options.");
         assert_eq!(all_content, "Beijing is sunny.");
+    }
+
+    // Primed into reasoning (prompt ended in <think>), the model emits a bare
+    // <｜DSML｜tool_calls> block with NO preceding </think>. The tool-start marker
+    // must force-exit reasoning so the DSML block lands in normal_text (handed to
+    // the tool-call parser). Before the fix the whole block was swallowed into
+    // reasoning_text and the tool call was silently dropped.
+    // Parity coverage: reasoning/fixtures/deepseek_v4/REASONING.{batch,stream}.yaml.
+    #[test]
+    fn test_deepseek_v4_primed_bare_tool_call_routes_to_normal() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("deepseek_v4");
+        parser.set_in_reasoning(true);
+
+        let input = "\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n\
+                     <｜DSML｜parameter name=\"filePath\" string=\"true\">/a/b.ts</｜DSML｜parameter>\n\
+                     </｜DSML｜invoke>\n</｜DSML｜tool_calls>";
+        let result = parser.detect_and_parse_reasoning(input, &[]);
+
+        // Batch trims reasoning (trim_start on force-exit), so the whitespace-only
+        // prefix collapses to empty; the whole DSML block lands in normal_text.
+        assert_eq!(result.reasoning_text, "");
+        assert!(
+            result.normal_text.starts_with("<｜DSML｜tool_calls>"),
+            "normal_text should hold the DSML block, got: {:?}",
+            result.normal_text
+        );
+        assert!(result.normal_text.contains("invoke name=\"read\""));
+    }
+
+    // Same bug under streaming, with the tool-start marker SPLIT across chunk
+    // boundaries (and mid-codepoint of the full-width `｜`). Partial-prefix
+    // buffering must reassemble the marker and force-exit reasoning.
+    #[test]
+    fn test_deepseek_v4_primed_bare_tool_call_streaming() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("deepseek_v4");
+        parser.set_in_reasoning(true);
+
+        // "<｜DSML｜tool_calls>" deliberately split across the chunk boundary.
+        let tokens = &[
+            "\n\n<｜DS",
+            "ML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",
+        ];
+        let mut reasoning = String::new();
+        let mut normal = String::new();
+        for t in tokens {
+            let r = parser.parse_reasoning_streaming_incremental(t, &[]);
+            reasoning.push_str(&r.reasoning_text);
+            normal.push_str(&r.normal_text);
+        }
+
+        assert_eq!(reasoning, "\n\n");
+        assert!(
+            normal.starts_with("<｜DSML｜tool_calls>"),
+            "normal should hold the DSML block, got: {normal:?}"
+        );
+        assert!(!reasoning.contains("DSML"));
+    }
+
+    // Regression guard for the common (clean) path: when the model DOES emit a
+    // closing </think> before the tool call, reasoning is captured normally and
+    // the DSML block still routes to normal_text.
+    #[test]
+    fn test_deepseek_v4_primed_reasoning_then_tool_call() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("deepseek_v4");
+        parser.set_in_reasoning(true);
+
+        let input = "Let me read it.</think>\n\n<｜DSML｜tool_calls>\n\
+                     <｜DSML｜invoke name=\"read\">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>";
+        let result = parser.detect_and_parse_reasoning(input, &[]);
+
+        assert_eq!(result.reasoning_text, "Let me read it.");
+        // normal_text is trimmed in batch mode, so the inter-tag whitespace is gone.
+        assert!(
+            result.normal_text.starts_with("<｜DSML｜tool_calls>"),
+            "normal_text should hold the DSML block, got: {:?}",
+            result.normal_text
+        );
+    }
+
+    // Drift guard: the reasoning force-exit marker must stay byte-identical to the
+    // tool-call parser's DSML block opener. The two live in separate modules and
+    // are independent string sources; if `deepseek_v4`'s block name ever changes,
+    // fail loudly here instead of silently resurrecting the swallow bug.
+    #[test]
+    fn test_deepseek_v4_tool_marker_matches_tool_call_config() {
+        use crate::tool_calling::config::{ParserConfig, ToolCallConfig};
+        let cfg = ToolCallConfig::deepseek_v4();
+        match cfg.parser_config {
+            ParserConfig::Dsml(dsml) => assert_eq!(
+                DEEPSEEK_V4_TOOL_CALLS_BEGIN, dsml.block_start,
+                "reasoning force-exit marker drifted from ToolCallConfig::deepseek_v4 block_start"
+            ),
+            _ => panic!("expected a DSML parser config for deepseek_v4"),
+        }
     }
 }

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -50,9 +50,54 @@ cases:
       vllm: *d_2
       sglang: *d_2
   REASONING.batch.3.b:
-    description: Open reasoning interrupted by downstream tool-call text is not configured for DeepSeek V4
-    ref: *upstream_ref
-    reason: Dynamo's DeepSeek V4 reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.
+    description: Open reasoning interrupted by a DSML tool-call block with no closing </think>
+    ref: dynamo
+    spec_ref: tests/parity/README.md; lib/parsers/REASONING_CASES.md
+    in_reasoning: true
+    model_text: |-
+      Let me read that file.<｜DSML｜tool_calls>
+      <｜DSML｜invoke name="read">
+      <｜DSML｜parameter name="filePath" string="true">/a/b.ts</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    expected:
+      dynamo:
+        reasoning_text: Let me read that file.
+        normal_text: |-
+          <｜DSML｜tool_calls>
+          <｜DSML｜invoke name="read">
+          <｜DSML｜parameter name="filePath" string="true">/a/b.ts</｜DSML｜parameter>
+          </｜DSML｜invoke>
+          </｜DSML｜tool_calls>
+        reason: 'Primed into reasoning (the prompt ended in <think>), the model emits a DSML tool-call block with no preceding </think>. The tool-call-begin marker force-exits reasoning so the block lands in normal_text for the tool-call parser; without the marker the whole block is swallowed into reasoning_text and the tool call is silently dropped.'
+      vllm:
+        unavailable: vLLM's reasoning parser takes no in_reasoning priming flag and has no DeepSeek DSML tool-call boundary, so the primed-handoff scenario has no apples-to-apples peer.
+      sglang:
+        unavailable: SGLang's reasoning detector takes no in_reasoning priming flag and has no DeepSeek DSML tool-call boundary, so the primed-handoff scenario has no apples-to-apples peer.
+  REASONING.batch.3.c:
+    description: Primed reasoning, immediate tool call with only whitespace before the marker
+    ref: dynamo
+    spec_ref: tests/parity/README.md; lib/parsers/REASONING_CASES.md
+    in_reasoning: true
+    model_text: |-
+
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="read">
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: |-
+          <｜DSML｜tool_calls>
+          <｜DSML｜invoke name="read">
+          </｜DSML｜invoke>
+          </｜DSML｜tool_calls>
+        reason: 'The model skips reasoning entirely and emits the tool call first; batch trim_start collapses the whitespace-only reasoning prefix to empty, and the whole DSML block force-exits to normal_text.'
+      vllm:
+        unavailable: vLLM's reasoning parser takes no in_reasoning priming flag and has no DeepSeek DSML tool-call boundary, so the primed-handoff scenario has no apples-to-apples peer.
+      sglang:
+        unavailable: SGLang's reasoning detector takes no in_reasoning priming flag and has no DeepSeek DSML tool-call boundary, so the primed-handoff scenario has no apples-to-apples peer.
   REASONING.batch.2.c:
     description: Reasoning followed by normal answer text
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -136,3 +136,25 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.3.d:
+    description: Primed reasoning, DSML tool-call begin marker split across chunks
+    ref: dynamo
+    spec_ref: tests/parity/README.md; lib/parsers/REASONING_CASES.md
+    in_reasoning: true
+    chunks:
+    - 'Let me read it.<｜DS'
+    - 'ML｜tool_calls>'
+    - "\n<｜DSML｜invoke name=\"read\">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>"
+    expected:
+      dynamo:
+        reasoning_text: Let me read it.
+        normal_text: |-
+          <｜DSML｜tool_calls>
+          <｜DSML｜invoke name="read">
+          </｜DSML｜invoke>
+          </｜DSML｜tool_calls>
+        reason: 'Streaming counterpart of REASONING.batch.3.b with the tool-call-begin marker split across chunk boundaries (mid full-width codepoint). Partial-prefix buffering reassembles the marker and force-exits reasoning so the DSML block routes to normal_text.'
+      vllm:
+        unavailable: vLLM's reasoning parser takes no in_reasoning priming flag and has no DeepSeek DSML tool-call boundary, so the primed-handoff scenario has no apples-to-apples peer.
+      sglang:
+        unavailable: SGLang's reasoning detector takes no in_reasoning priming flag and has no DeepSeek DSML tool-call boundary, so the primed-handoff scenario has no apples-to-apples peer.

--- a/tests/parity/reasoning/test_reasoning_fixture_schema.py
+++ b/tests/parity/reasoning/test_reasoning_fixture_schema.py
@@ -24,6 +24,7 @@ CASE_KEYS = {
     "chunks",
     "chat_template_kwargs",
     "force_reasoning",
+    "in_reasoning",
     "expected",
     "reason",
     "dynamo_leak",


### PR DESCRIPTION
#### Overview:

DeepSeek-V4 with thinking enabled is primed into reasoning by the frontend: the chat template ends the prompt with `<think>`, so the OpenAI preprocessor calls `set_in_reasoning(true)` and the streaming reasoning parser starts inside a reasoning block with no opening tag. When the model then emits a tool call without first closing `</think>` (it goes straight to `<｜DSML｜tool_calls>`), the `deepseek_v4` reasoning parser had no tool-call boundary, so it swallowed the entire DSML tool block into `reasoning_content`. The tool-call parser received empty `normal_text`, so the tool call was silently dropped (`finish_reason=stop`, no `tool_calls`). Under load this showed up as raw DSML markup leaking into reasoning output and missing tool calls.

#### Details:

- Wire the `deepseek_v4` reasoning parser with `with_tool_start_token("<｜DSML｜tool_calls>")`, mirroring `KimiK25`. While in reasoning, the parser now force-exits at the earlier of the tool-call-begin marker or `</think>`, routing the DSML block to `normal_text` where the (already correct) tool-call parser handles it. No new parser logic: this reuses the existing `tool_start_token` force-exit path, which already covers batch, streaming, multi-byte tokens, and split-across-chunks markers.
- Add a drift-guard test pinning `DEEPSEEK_V4_TOOL_CALLS_BEGIN` to `ToolCallConfig::deepseek_v4().block_start`, so the reasoning marker can never silently diverge from the tool-call parser's block name.
- CI coverage in the reasoning parity suite: convert the previously table-only stub `REASONING.batch.3.b` (which documented this exact gap) into a real case, and add `REASONING.batch.3.c` (whitespace-only prefix) and `REASONING.stream.3.d` (marker split across chunks). vLLM/SGLang are marked `unavailable` for these cases since neither exposes an `in_reasoning` priming flag or a DSML tool-call boundary. Allow the `in_reasoning` field in the fixture schema validator.

Behavior is unchanged for the common path (the model emits `</think>` before the tool call) and for every other reasoning family; a regression-guard test covers the `</think>`-first case.

#### Where should the reviewer start?

- `lib/parsers/src/reasoning/mod.rs`: the `DeepSeekV4` match arm (the one-line behavior change) and the four new unit tests, including the config drift-guard.

#### Related Issues:

- Relates to the DeepSeek-V4 agent-perf serving investigation (no tracking issue).

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced DeepSeek-V4 tool-call handling to properly detect and process tool-call boundaries when interrupting reasoning contexts.

* **Tests**
  * Added batch and streaming test fixtures for DeepSeek-V4 tool-call scenarios, including edge cases with split markers across chunks.
  * Updated test schema to support in-reasoning state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->