### PR TITLE
fix(vllm): normalize unified served model name

### DIFF
--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -218,6 +218,7 @@ class VllmLLMEngine(LLMEngine):
         return engine, worker_config
 
     async def start(self, worker_id: int) -> EngineConfig:
+        """Start vLLM and return normalized metadata for runtime registration."""
         del worker_id  # vLLM's NixlConnector handles its own per-worker IDs
         os.environ.setdefault("VLLM_NO_USAGE_STATS", "1")
         os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
@@ -271,7 +272,7 @@ class VllmLLMEngine(LLMEngine):
 
         return EngineConfig(
             model=self.engine_args.model,
-            served_model_name=self.engine_args.served_model_name,
+            served_model_name=self._served_model_name,
             llm=LlmRegistration(
                 context_length=self._model_max_len,
                 kv_cache_block_size=block_size,

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -407,6 +407,67 @@ def test_unified_generate_passes_enable_rl_to_sampling_params(monkeypatch):
     assert captured["enable_rl"] is True
 
 
+@pytest.mark.asyncio
+async def test_unified_start_returns_normalized_served_model_name(monkeypatch):
+    """Return the Dynamo-normalized served model name from EngineConfig."""
+    from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
+    from dynamo.vllm import llm_engine
+
+    served_model_name = "Qwen/Qwen3-0.6B"
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(num_gpu_blocks=8),
+        model_config=SimpleNamespace(max_model_len=4096),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=2,
+            max_num_batched_tokens=8192,
+        ),
+    )
+    engine_args = SimpleNamespace(
+        model=served_model_name,
+        served_model_name=[served_model_name],
+        create_model_config=lambda: SimpleNamespace(get_diff_sampling_param=lambda: {}),
+        create_engine_config=lambda usage_context: vllm_config,
+    )
+    engine_client = SimpleNamespace(vllm_config=vllm_config, shutdown=lambda: None)
+
+    monkeypatch.setattr(
+        llm_engine.AsyncLLM,
+        "from_vllm_config",
+        lambda **kwargs: engine_client,
+    )
+    monkeypatch.setattr(llm_engine, "get_dp_range_for_worker", lambda config: (0, 1))
+    monkeypatch.setattr(llm_engine, "per_rank_kv_blocks", lambda blocks, size: blocks)
+    monkeypatch.setattr(
+        llm_engine,
+        "configure_kv_event_block_size",
+        lambda client, config: asyncio.sleep(0),
+    )
+    monkeypatch.setattr(
+        llm_engine, "get_configured_kv_event_block_size", lambda config: 16
+    )
+    monkeypatch.setattr(
+        llm_engine.VllmLLMEngine,
+        "logits_processor_spec",
+        lambda self: asyncio.sleep(0),
+    )
+    monkeypatch.setattr(
+        llm_engine, "VllmEnginePauseController", lambda client: object()
+    )
+
+    engine = llm_engine.VllmLLMEngine(
+        engine_args,
+        CommonDisaggregationMode.AGGREGATED,
+        served_model_name=served_model_name,
+        component="backend",
+    )
+
+    config = await engine.start(worker_id=0)
+    await engine.cleanup()
+
+    assert engine_args.served_model_name == [served_model_name]
+    assert config.served_model_name == served_model_name
+
+
 def test_should_prefetch_model_for_default_load_format():
     from dynamo.vllm.main import should_prefetch_model
 


### PR DESCRIPTION
## Summary
- Return the normalized unified vLLM served model name from `VllmLLMEngine.start()` instead of the raw vLLM `engine_args.served_model_name` value.
- Prevent vLLM's single-item `served_model_name` list from reaching the PyO3 `EngineConfig` binding, which expects `Optional[str]`.
- Add a focused regression test that keeps the raw vLLM field as a list and verifies the runtime-facing `EngineConfig.served_model_name` is a string.

## Related Issues
- Related to #8038 and #8040, which track broader multiple served-model-name alias support for vLLM. This PR is intentionally narrower: it preserves the current single-name unified backend contract and fixes the registration failure when vLLM represents one served model name as a single-item list.

## Validation
- `git diff --check`
- `.venv/bin/python -m pytest -W ignore::DeprecationWarning components/src/dynamo/vllm/tests/test_vllm_unit.py -k "unified_start_returns_normalized_served_model_name or unified_from_args_applies_rl_logprobs_default"`
- `.venv/bin/python -m pytest -W ignore::DeprecationWarning components/src/dynamo/vllm/tests/test_vllm_unit.py`

Note: the warning override is for a local Python 3.10 OpenTelemetry/importlib.metadata deprecation warning during vLLM import; the full vLLM unit file passes with it.
