### PR TITLE
docs(kvbm): add GDS/cuFile disk-to-device onboarding troubleshooting

### DIFF
--- a/docs/components/kvbm/kvbm-guide.md
+++ b/docs/components/kvbm/kvbm-guide.md
@@ -457,6 +457,56 @@ Supported values for `DYN_KVBM_DISK_ALLOCATOR_TYPE`:
 export DYN_KVBM_DISK_DISABLE_O_DIRECT=true
 ```
 
+### Disk to Device Onboarding Hangs with cuFile/GDS Errors
+
+**Symptom:** KV cache onboarding from disk to device hangs indefinitely and requests become blocked. KVBM logs show errors similar to:
+
+```text
+GDS_MT: failed to create file handle: GDS_MT: file register error
+```
+
+And `cufile.log` contains errors like:
+
+```text
+cufio:340 cuFileHandleRegister error: internal error
+```
+
+**Cause:** NVIDIA GPUDirect Storage (GDS) fails to register the disk-cache file handle and falls back to its POSIX-compatible mode, but the fallback also fails. This typically happens in containerized environments (including Kubernetes) when cuFile cannot resolve the backing block device for the disk-cache path.
+
+See [ai-dynamo/dynamo#6032](https://github.com/ai-dynamo/dynamo/issues/6032) for the original report and discussion.
+
+**Solution:** Point the disk cache at a path backed by a real block device and, in Kubernetes, expose `/run/udev` so cuFile can query volume attributes.
+
+For a Kubernetes pod spec (e.g., on the prefill worker where `DYN_KVBM_DISK_CACHE_GB > 0`):
+
+```yaml
+extraPodSpec:
+  mainContainer:
+    env:
+      - name: DYN_KVBM_DISK_CACHE_DIR
+        value: "/cache/kvbm"
+    volumeMounts:
+      - name: kvbm-cache
+        mountPath: /cache/kvbm
+      - name: run-udev
+        mountPath: /run/udev
+        readOnly: true
+  volumes:
+    - name: kvbm-cache
+      emptyDir:
+        sizeLimit: <N>Gi
+    - name: run-udev
+      hostPath:
+        path: /run/udev
+```
+
+Key points:
+
+- `/run/udev` must be mounted as a `hostPath` volume. Without it, cuFile cannot read volume attributes and file registration fails.
+- `DYN_KVBM_DISK_CACHE_DIR` must point to a volume backed by a real block device (e.g., an `emptyDir` volume, a `hostPath` mount to a block-backed directory, or any other GDS-supported filesystem). The default `/tmp` is usually overlayfs inside a container, which cuFile cannot handle.
+
+After applying these changes, cuFile should log that it is running in compatible mode and disk-to-device onboarding should proceed.
+
 ## Developing Locally
 
 Inside the Dynamo container, after changing KVBM-related code (Rust and/or Python):


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Add a troubleshooting entry for KVBM Disk→Device onboarding hangs caused by GDS/cuFile compatibility-mode failures in containerized environments.

## Details:

<!-- Describe the changes made in this PR. -->
Documents the issue reported in ai-dynamo/dynamo#6032 where KV cache onboarding from disk to device hangs indefinitely and requests become blocked. The failure occurs because cuFile cannot resolve a backing block device for files located on overlayfs-backed paths, causing both native GDS and the POSIX-compatible fallback to fail.

The new troubleshooting section explains the symptom, the root cause, and a fix method.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

docs/components/kvbm/kvbm-guide.md 

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #6032

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting section for disk-to-device KV cache onboarding hangs, including detailed failure symptoms, root cause analysis for containerized environments, and Kubernetes configuration examples with recommended volume mount paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->