### PR TITLE
test: rename sglang multimodal pd_no_encoder test to mm_pd

### DIFF
--- a/tests/serve/multimodal_profiles/sglang.py
+++ b/tests/serve/multimodal_profiles/sglang.py
@@ -11,10 +11,10 @@ from tests.utils.multimodal import (
     make_image_payload_cached_tokens,
 )
 
-# pd_no_encoder = disaggregated prefill+decode, single GPU, no encode worker.
+# pd = multimodal prefill+decode on one GPU, no separate encode worker.
 SGLANG_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "agg_router": "agg_multimodal_router.sh",
-    "pd_no_encoder": "disagg_same_gpu.sh",
+    "pd": "disagg_same_gpu.sh",
 }
 
 # VLM coverage mirrors the vLLM profile registry. SINGLE_GPU=true packs both
@@ -43,7 +43,7 @@ SGLANG_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             ),
             # Plain color-check payload; disagg KV semantics make the
             # cached-tokens hit-rate assertions inapplicable here.
-            "pd_no_encoder": TopologyConfig(
+            "pd": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
                 timeout_s=500,
                 profiled_vram_gib=22.0,


### PR DESCRIPTION
Follow-up to #10643 (review nit: https://github.com/ai-dynamo/dynamo/pull/10643#discussion_r3400778622).

Renames the SGLang multimodal disaggregated test topology from `pd_no_encoder` to `pd`. "no_encoder" read as "no vision", which is misleading since these are multimodal tests; the intent was "no separate encode worker". The factory already prefixes `mm_`, so the test id reads clearly as multimodal prefill+decode.

Before: `mm_pd_no_encoder_qwen3-vl-2b`
After: `mm_pd_qwen3-vl-2b`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for multimodal model evaluation to align topology naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->