### PR TITLE
fix(container): remove sglang empty continuation

### DIFF
--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -193,12 +193,12 @@ RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/
 
 RUN chmod 755 /opt/dynamo/.launch_screen && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc && \
-{% if device == "xpu" %}
+{%- if device == "xpu" %}
     echo '. /opt/miniforge3/bin/activate sglang' >> /etc/bash.bashrc && \
     echo 'source /opt/intel/oneapi/setvars.sh --force' >> /etc/bash.bashrc && \
     mkdir -p /sgl-workspace && \
     ln -sf /workspace /sgl-workspace/dynamo
-{% else %}
+{%- else %}
     ln -s /workspace /sgl-workspace/dynamo && \
     NSYS_BIN=$(find /opt/nvidia/nsight-compute -maxdepth 6 -type f -name nsys -executable 2>/dev/null | head -n1) && \
     if [ -n "$NSYS_BIN" ]; then ln -sf "$NSYS_BIN" /usr/local/bin/nsys; \


### PR DESCRIPTION
## Summary
- Remove the empty continuation line generated in the SGLang runtime Dockerfile.
- Keep the XPU and CUDA launch setup commands unchanged while preventing Docker from warning on the rendered Dockerfile.

This fixes the Docker build warning:

```text
1 warning found (use --debug to expand):
 - NoEmptyContinuation: Empty continuation line (line 788)
```
<img width="1684" height="774" alt="image" src="https://github.com/user-attachments/assets/94a5723a-d9af-4ba2-b35a-2fcbaedd77b4" />

## Validation
- `python3 container/render.py --framework sglang --target runtime --platform linux/amd64 --output-short-filename`
- Verified the rendered CUDA Dockerfile has no blank line immediately after a continued line.
- `python3 container/render.py --framework sglang --device xpu --target runtime --platform linux/amd64 --output-short-filename`
- Verified the rendered XPU Dockerfile has no blank line immediately after a continued line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and organization in build configuration files.

**Note:** This update involves internal code restructuring with no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->