### PR TITLE
build(container): skip unused sglang nixl wheel

### DIFF
--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -601,6 +601,7 @@ RUN echo "$NIXL_LIB_DIR" > /etc/ld.so.conf.d/nixl.conf && \
     echo "$NIXL_PLUGIN_DIR" >> /etc/ld.so.conf.d/nixl.conf && \
     ldconfig
 
+{% if not (framework == "sglang" and device == "cuda" and target in ("runtime", "dev", "local-dev")) %}
 # Build NIXL wheel → /opt/dynamo/dist/nixl/nixl*.whl (C++ transport library, all targets)
 ARG PYTHON_VERSION
 RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token \
@@ -614,6 +615,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     fi && \
     cd /workspace/nixl && \
     uv build . --wheel --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
+{% endif %}
 
 {% if target not in ("dev", "local-dev") %}
 # Copy source code (order matters for layer caching)


### PR DESCRIPTION
## Summary
- Skip building the NIXL Python wheel for SGLang CUDA `runtime`, `dev`, and `local-dev` image targets.
- Keep the NIXL wheel build for `--target wheel_builder`, SGLang XPU, and other framework/device combinations that still consume the wheel.

SGLang CUDA runtime installs only the Dynamo wheels and relies on the upstream `lmsysorg/sglang` runtime image for its NIXL Python stack, so the `uv build . --wheel --out-dir /opt/dynamo/dist/nixl` step is not consumed by that target.

This build stage is also expensive in practice. In one observed build, the unused NIXL wheel step stayed at:

```text
=> [wheel_builder 3/9] RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-  357.9s
 => => # Building wheel...
```

Skipping it avoids spending several minutes on a wheel that SGLang CUDA runtime does not install.

## Validation
- `python3 container/render.py --framework sglang --target runtime --platform linux/amd64 --output-short-filename`
- Confirmed the rendered SGLang CUDA runtime Dockerfile no longer contains `uv build . --wheel --out-dir /opt/dynamo/dist/nixl`.
- `python3 container/render.py --framework sglang --target dev --platform linux/amd64 --output-short-filename`
- Confirmed the rendered SGLang CUDA dev Dockerfile no longer contains `uv build . --wheel --out-dir /opt/dynamo/dist/nixl`.
- `python3 container/render.py --framework sglang --target wheel_builder --platform linux/amd64 --output-short-filename`
- Confirmed the rendered SGLang CUDA wheel_builder Dockerfile still contains the NIXL wheel build.
- `python3 container/render.py --framework sglang --device xpu --target runtime --platform linux/amd64 --output-short-filename`
- Confirmed the rendered SGLang XPU runtime Dockerfile still contains the NIXL wheel build and installs `/opt/dynamo/wheelhouse/nixl/nixl*.whl`.
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build process for specific configurations to improve build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->