### PR TITLE
fix(sglang): skip model prefetch for object storage paths

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -69,8 +69,14 @@ def use_modelexpress_remote_instance(args: Any) -> bool:
     )
 
 
+def is_object_storage_path(model_path: str) -> bool:
+    return model_path.startswith(("s3://", "gs://", "az://"))
+
+
 def should_fetch_model(args: Any, model_path: str) -> bool:
     if os.path.exists(model_path):
+        return False
+    if is_object_storage_path(model_path):
         return False
     return not use_modelexpress_remote_instance(args)
 
@@ -84,9 +90,9 @@ def _preprocess_for_encode_config(
     return {
         "server_args": config.server_args,
         "dynamo_args": config.dynamo_args,
-        "serving_mode": config.serving_mode.value
-        if config.serving_mode is not None
-        else "None",
+        "serving_mode": (
+            config.serving_mode.value if config.serving_mode is not None else "None"
+        ),
     }
 
 

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -510,6 +510,20 @@ def test_should_fetch_model_skips_sglang_modelexpress_remote_instance():
     assert should_fetch_model(args, "Qwen/Qwen3-0.6B") is False
 
 
+@pytest.mark.parametrize(
+    "model_path",
+    [
+        "s3://bucket/model/",
+        "gs://bucket/model/",
+        "az://container/model/",
+    ],
+)
+def test_should_fetch_model_skips_object_storage_paths(model_path):
+    args = SimpleNamespace(load_format="runai_streamer")
+
+    assert should_fetch_model(args, model_path) is False
+
+
 def test_should_fetch_model_keeps_default_non_local_fetch():
     args = SimpleNamespace(load_format="auto")
 
@@ -556,6 +570,63 @@ async def test_register_model_uses_metadata_only_for_sglang_modelexpress(monkeyp
 
     assert result is True
     assert captured["kwargs"]["ignore_weights"] is True
+
+
+@pytest.mark.asyncio
+async def test_register_model_uses_engine_managed_path_for_runai_object_storage(
+    monkeypatch,
+):
+    if sglang_register is None:
+        pytest.skip("dynamo.sglang.register is unavailable")
+
+    captured: dict = {}
+
+    async def fake_get_runtime_config(engine, server_args, dynamo_args):
+        return None
+
+    async def fake_register_model(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        if args[3].startswith("s3://"):
+            raise AssertionError("object-storage path used as a normal model_path")
+
+    monkeypatch.setattr(sglang_register, "_get_runtime_config", fake_get_runtime_config)
+    monkeypatch.setattr(sglang_register, "register_model", fake_register_model)
+
+    server_args = SimpleNamespace(
+        model_path="s3://bucket/model",
+        served_model_name="bucket-model",
+        context_length=4096,
+        page_size=1,
+        load_format="runai_streamer",
+        remote_instance_weight_loader_backend=None,
+    )
+    dynamo_args = SimpleNamespace(
+        use_sglang_tokenizer=False,
+        frontend_decoding=False,
+        custom_jinja_template=None,
+    )
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            model_config=SimpleNamespace(
+                model_weights="s3://bucket/model",
+                model_path="/tmp/runai-model-metadata",
+            )
+        )
+    )
+
+    result = await sglang_register._register_model_with_runtime_config(
+        engine=engine,
+        endpoint=SimpleNamespace(),
+        server_args=server_args,
+        dynamo_args=dynamo_args,
+        worker_type=sglang_register.WorkerType.Aggregated,
+    )
+
+    assert result is True
+    assert captured["args"][3] == "/tmp/runai-model-metadata"
+    assert "skip_model_path_fetch" not in captured["kwargs"]
+    assert captured["kwargs"]["ignore_weights"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Overview:

This PR fixes Dynamo SGLang backend argument handling for object storage model paths.

When `python -m dynamo.sglang` is started with a model path such as `s3://...` and `--load-format runai_streamer`, Dynamo currently attempts to prefetch the model via `fetch_model()` before SGLang can handle the object storage URI. That makes Dynamo treat the `s3://...` path as a Hugging Face model ID and fail during model resolution.

This change skips Dynamo-side model prefetch for object storage paths and lets SGLang handle them through its configured loader.

## Details:

- Added object storage path detection for `s3://`, `gs://`, and `az://` model paths.
- Updated `should_fetch_model()` so Dynamo does not call `fetch_model()` for object storage URIs.
- Added unit coverage for object storage paths in the SGLang backend tests.
- Preserved existing behavior for local filesystem paths, default Hugging Face model IDs, and `remote_instance` + `modelexpress`.

## Where should the reviewer start?

Please start with:

- `components/src/dynamo/sglang/args.py`

The core behavior change is in `should_fetch_model()`.

Then review:

- `components/src/dynamo/sglang/tests/test_sglang_unit.py`

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**

- Closes #10655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for object-storage model paths (S3, Google Cloud Storage, Azure) allowing users to specify remote model locations directly.
  * Improved model loading logic to skip unnecessary local file operations for remote storage paths.

* **Tests**
  * Added unit tests for object-storage path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->