### PR TITLE
ci(junit): add junit.xml upload where missing

### DIFF
--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -129,7 +129,7 @@ runs:
           ${EXTRA_PYTEST_ARGS} \
           -v -s \
           --durations=10 \
-          --junitxml=test-results/pytest_deploy_${TEST_NAME}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml \
+          --junitxml=test-results/junit.xml \
           --alluredir=test-results/allure-results \
           --log-cli-level=INFO
 
@@ -178,12 +178,38 @@ runs:
         fi
         echo "name=${TEST_NAME}" >> $GITHUB_OUTPUT
 
+    - name: Ensure JUnit Report
+      if: always()
+      shell: bash
+      env:
+        DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+        TEST_NAME: ${{ steps.test-name.outputs.name }}
+      run: |
+        if [[ -f test-results/junit.xml ]]; then
+          echo "✅ JUnit XML generated successfully"
+          exit 0
+        fi
+
+        STATUS="${DEPLOY_OUTCOME:-failure}"
+        if [[ "${STATUS}" == "skipped" ]]; then
+          STATUS="failure"
+        fi
+        echo "⚠️  JUnit XML file not found - writing fallback junit.xml"
+        PYTHON_BIN="$(command -v python3 || command -v python)"
+        "${PYTHON_BIN}" "${GITHUB_WORKSPACE}/.github/scripts/write_junit_report.py" \
+          --suite-name "deploy-${TEST_NAME:-unknown}" \
+          --test-name "${TEST_NAME:-deploy}" \
+          --status "${STATUS}" \
+          --output test-results/junit.xml \
+          --message "Deploy test did not produce a JUnit XML report. The deploy step completed with status ${STATUS}."
+
     - name: Upload Test Results
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6
       if: always()
       with:
         name: test-results-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
-        path: test-results/pytest_deploy_${{ steps.test-name.outputs.name }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
+        path: test-results/junit.xml
+        if-no-files-found: error
         retention-days: 7
 
     - name: Upload Pod Logs

--- a/.github/actions/junit-report/action.yml
+++ b/.github/actions/junit-report/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: ''
   status:
-    description: 'Job status, usually ${{ job.status }}'
+    description: 'Job status from the caller'
     required: true
   output:
     description: 'Path to write the JUnit XML file'

--- a/.github/actions/junit-report/action.yml
+++ b/.github/actions/junit-report/action.yml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'JUnit Job Report'
+description: 'Create and upload a job-level JUnit XML report'
+
+inputs:
+  suite-name:
+    description: 'JUnit test suite name'
+    required: true
+  test-name:
+    description: 'JUnit testcase name. Defaults to suite-name.'
+    required: false
+    default: ''
+  status:
+    description: 'Job status, usually ${{ job.status }}'
+    required: true
+  output:
+    description: 'Path to write the JUnit XML file'
+    required: false
+    default: test-results/junit.xml
+  artifact-name:
+    description: 'Artifact name for the JUnit XML upload'
+    required: true
+  retention-days:
+    description: 'Artifact retention in days'
+    required: false
+    default: '7'
+
+runs:
+  using: composite
+  steps:
+    - name: Write JUnit XML
+      id: write
+      shell: bash
+      env:
+        REPORT_STATUS: ${{ inputs.status }}
+        SUITE_NAME: ${{ inputs.suite-name }}
+        TEST_NAME: ${{ inputs.test-name }}
+        OUTPUT_PATH: ${{ inputs.output }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+      run: |
+        set -euo pipefail
+
+        if PYTHON_BIN="$(command -v python3 || command -v python)"; then
+          "${PYTHON_BIN}" "${GITHUB_WORKSPACE}/.github/scripts/write_junit_report.py" \
+            --suite-name "${SUITE_NAME}" \
+            --test-name "${TEST_NAME}" \
+            --status "${REPORT_STATUS}" \
+            --output "${OUTPUT_PATH}" \
+            --message "GitHub Actions job completed with status ${REPORT_STATUS}" \
+            --artifact-name "${ARTIFACT_NAME}" \
+            --artifact-output-name artifact_name
+          exit 0
+        fi
+
+        xml_escape() {
+          local value="$1"
+          value="${value//&/&amp;}"
+          value="${value//</&lt;}"
+          value="${value//>/&gt;}"
+          value="${value//\"/&quot;}"
+          printf '%s' "${value}"
+        }
+
+        TEST_NAME="${TEST_NAME:-${SUITE_NAME}}"
+        MESSAGE="GitHub Actions job completed with status ${REPORT_STATUS}"
+        FAILURES=0
+        SKIPPED=0
+        if [[ "${REPORT_STATUS}" == "cancelled" || "${REPORT_STATUS}" == "skipped" ]]; then
+          SKIPPED=1
+        elif [[ "${REPORT_STATUS}" != "success" ]]; then
+          FAILURES=1
+        fi
+
+        mkdir -p "$(dirname "${OUTPUT_PATH}")"
+        {
+          echo '<?xml version="1.0" encoding="utf-8"?>'
+          echo "<testsuites tests=\"1\" failures=\"${FAILURES}\" errors=\"0\" skipped=\"${SKIPPED}\">"
+          echo "  <testsuite name=\"$(xml_escape "${SUITE_NAME}")\" tests=\"1\" failures=\"${FAILURES}\" errors=\"0\" skipped=\"${SKIPPED}\" time=\"0\">"
+          echo "    <testcase classname=\"$(xml_escape "${SUITE_NAME}")\" name=\"$(xml_escape "${TEST_NAME}")\" time=\"0\">"
+          if [[ "${SKIPPED}" == "1" ]]; then
+            echo "      <skipped message=\"$(xml_escape "${MESSAGE}")\" />"
+          elif [[ "${FAILURES}" == "1" ]]; then
+            echo "      <failure message=\"$(xml_escape "${MESSAGE}")\">$(xml_escape "${MESSAGE}")</failure>"
+          fi
+          echo "    </testcase>"
+          echo "  </testsuite>"
+          echo "</testsuites>"
+        } > "${OUTPUT_PATH}"
+
+        ARTIFACT_NAME="$(printf '%s' "${ARTIFACT_NAME}" | sed -E 's/[^A-Za-z0-9_.-]+/-/g; s/^[.-]+//; s/[.-]+$//')"
+        echo "artifact_name=${ARTIFACT_NAME:-junit-results}" >> "${GITHUB_OUTPUT}"
+
+    - name: Upload JUnit XML
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: ${{ steps.write.outputs.artifact_name }}
+        path: ${{ inputs.output }}
+        retention-days: ${{ inputs.retention-days }}
+        if-no-files-found: error

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -249,6 +249,7 @@ runs:
         exit 0
 
     - name: Process Test Results
+      if: always()
       shell: bash
       run: |
 
@@ -256,6 +257,7 @@ runs:
         # Remove commas and spaces from test_type for use in filenames
         STR_TEST_TYPE=$(echo "${{ inputs.test_type }}" | tr ', ' '_')
         echo "STR_TEST_TYPE=${STR_TEST_TYPE}" >> $GITHUB_ENV
+        TEST_EXIT_CODE="${TEST_EXIT_CODE:-1}"
 
         # Check for JUnit XML file and determine test status
         JUNIT_FILE="test-results/pytest_test_report.xml"
@@ -268,15 +270,25 @@ runs:
           ERROR_TESTS=$(grep -o 'errors="[0-9]*"' "$JUNIT_FILE" | grep -o '[0-9]*' | head -1 || echo "0")
           echo "📊 ${TOTAL_TESTS} tests completed (${FAILED_TESTS} failed, ${ERROR_TESTS} errors)"
 
-          # Rename XML file to unique name
-          JUNIT_NAME="pytest_test_report_${{ inputs.test_suite_name }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml"
-          mv "$JUNIT_FILE" "test-results/$JUNIT_NAME"
-          echo "📝 Renamed XML file to: $JUNIT_NAME"
+          mv "$JUNIT_FILE" "test-results/junit.xml"
+          echo "📝 Normalized XML file to: junit.xml"
         else
-          echo "⚠️  JUnit XML file not found - test results may not be available for upload"
+          echo "⚠️  JUnit XML file not found - writing fallback junit.xml"
           TOTAL_TESTS=0
           FAILED_TESTS=1  # Treat missing XML as failure
           ERROR_TESTS=0
+
+          FALLBACK_STATUS="failure"
+          if [[ "${TEST_EXIT_CODE}" == "0" ]]; then
+            FALLBACK_STATUS="success"
+          fi
+          PYTHON_BIN="$(command -v python3 || command -v python)"
+          "${PYTHON_BIN}" "${GITHUB_WORKSPACE}/.github/scripts/write_junit_report.py" \
+            --suite-name "${{ inputs.test_suite_name }}" \
+            --test-name "${STR_TEST_TYPE}" \
+            --status "${FALLBACK_STATUS}" \
+            --output test-results/junit.xml \
+            --message "Pytest did not produce a JUnit XML report. The test runner exited with code ${TEST_EXIT_CODE}."
         fi
 
         exit ${TEST_EXIT_CODE}
@@ -288,7 +300,8 @@ runs:
       if: always()  # Always upload test results, even if tests failed
       with:
         name: test-results-${{ inputs.test_suite_name }}-${{ env.STR_TEST_TYPE }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
-        path: test-results/pytest_test_report_${{ inputs.test_suite_name }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
+        path: test-results/junit.xml
+        if-no-files-found: error
         retention-days: 7
 
     - name: Upload Coverage Data

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -334,6 +334,7 @@ runs:
         exit 0
 
     - name: Process Test Results
+      if: always()
       shell: bash
       run: |
 
@@ -341,6 +342,7 @@ runs:
         # Remove commas and spaces from test_type for use in filenames
         STR_TEST_TYPE=$(echo "${{ inputs.test_type }}" | tr ', ' '_')
         echo "STR_TEST_TYPE=${STR_TEST_TYPE}" >> $GITHUB_ENV
+        TEST_EXIT_CODE="${TEST_EXIT_CODE:-1}"
 
         # Check for JUnit XML file and determine test status
         JUNIT_FILE="test-results/pytest_test_report.xml"
@@ -353,15 +355,25 @@ runs:
           ERROR_TESTS=$(grep -o 'errors="[0-9]*"' "$JUNIT_FILE" | grep -o '[0-9]*' | head -1 || echo "0")
           echo "📊 ${TOTAL_TESTS} tests completed (${FAILED_TESTS} failed, ${ERROR_TESTS} errors)"
 
-          # Rename XML file to unique name
-          JUNIT_NAME="pytest_test_report_${{ inputs.test_suite_name }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml"
-          mv "$JUNIT_FILE" "test-results/$JUNIT_NAME"
-          echo "📝 Renamed XML file to: $JUNIT_NAME"
+          mv "$JUNIT_FILE" "test-results/junit.xml"
+          echo "📝 Normalized XML file to: junit.xml"
         else
-          echo "⚠️  JUnit XML file not found - test results may not be available for upload"
+          echo "⚠️  JUnit XML file not found - writing fallback junit.xml"
           TOTAL_TESTS=0
           FAILED_TESTS=1  # Treat missing XML as failure
           ERROR_TESTS=0
+
+          FALLBACK_STATUS="failure"
+          if [[ "${TEST_EXIT_CODE}" == "0" ]]; then
+            FALLBACK_STATUS="success"
+          fi
+          PYTHON_BIN="$(command -v python3 || command -v python)"
+          "${PYTHON_BIN}" "${GITHUB_WORKSPACE}/.github/scripts/write_junit_report.py" \
+            --suite-name "${{ inputs.test_suite_name }}" \
+            --test-name "${STR_TEST_TYPE}" \
+            --status "${FALLBACK_STATUS}" \
+            --output test-results/junit.xml \
+            --message "Pytest did not produce a JUnit XML report. The test runner exited with code ${TEST_EXIT_CODE}."
         fi
 
         exit ${TEST_EXIT_CODE}
@@ -378,7 +390,8 @@ runs:
       if: always()  # Always upload test results, even if tests failed
       with:
         name: test-results-${{ inputs.test_suite_name }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
-        path: test-results/pytest_test_report_${{ inputs.test_suite_name }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
+        path: test-results/junit.xml
+        if-no-files-found: error
         retention-days: 7
 
     - name: Upload Coverage Data

--- a/.github/scripts/junit_history.py
+++ b/.github/scripts/junit_history.py
@@ -1,0 +1,831 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Summarize JUnit XML artifacts from GitHub Actions history."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import dataclasses
+import datetime as dt
+import io
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import textwrap
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+
+UTC = dt.timezone.utc
+API_ROOT = "https://api.github.com"
+DEFAULT_REPO = os.environ.get("GITHUB_REPOSITORY", "ai-dynamo/dynamo")
+DEFAULT_ARTIFACT_PREFIXES = ("junit-", "test-results-")
+DEFAULT_PRESETS = {
+    "nightly": {
+        "workflow": "Nightly CI Pipeline",
+        "event": "schedule",
+        "branch": "main",
+    },
+    "post-merge": {
+        "workflow": "Post-Merge CI Pipeline",
+        "event": "push",
+        "branch": "main",
+    },
+}
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: N802
+        return None
+
+
+@dataclasses.dataclass(frozen=True)
+class WorkflowQuery:
+    label: str
+    workflow: str
+    event: str | None
+    branch: str | None
+
+
+@dataclasses.dataclass(frozen=True)
+class RunInfo:
+    workflow: str
+    run_id: int
+    attempt: int
+    created_at: dt.datetime
+    event: str
+    branch: str
+    conclusion: str
+    url: str
+
+
+@dataclasses.dataclass(frozen=True)
+class JUnitStats:
+    workflow: str
+    run_id: int
+    run_attempt: int
+    run_created_at: dt.datetime
+    run_conclusion: str
+    artifact_name: str
+    xml_path: str
+    tests: int
+    failures: int
+    errors: int
+    skipped: int
+    seconds: float
+    failed_tests: tuple[str, ...]
+
+
+class GithubClient:
+    def __init__(self, repo: str, token: str | None) -> None:
+        self.repo = repo
+        self.token = token
+
+    def request_json(
+        self, path_or_url: str, params: dict[str, str | int] | None = None
+    ) -> object:
+        data, _headers = self.request(path_or_url, params=params)
+        import json
+
+        return json.loads(data.decode("utf-8"))
+
+    def request_bytes(
+        self, path_or_url: str, params: dict[str, str | int] | None = None
+    ) -> bytes:
+        data, _headers = self.request(path_or_url, params=params)
+        return data
+
+    def request_artifact_archive(self, archive_url: str) -> bytes:
+        request = urllib.request.Request(
+            archive_url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "dynamo-junit-history",
+                **({"Authorization": f"Bearer {self.token}"} if self.token else {}),
+            },
+        )
+        opener = urllib.request.build_opener(NoRedirectHandler)
+        try:
+            with opener.open(request, timeout=60) as response:
+                return response.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code not in {301, 302, 303, 307, 308}:
+                message = exc.read().decode("utf-8", errors="replace")
+                raise RuntimeError(
+                    f"GitHub artifact request failed: HTTP {exc.code} for {archive_url}\n{message}"
+                ) from exc
+            redirect_url = exc.headers.get("Location")
+            if not redirect_url:
+                raise RuntimeError(
+                    f"GitHub artifact request returned HTTP {exc.code} without Location"
+                ) from exc
+
+        # The redirected object-store URL is already signed; GitHub auth headers break Azure blob downloads.
+        redirected = urllib.request.Request(
+            redirect_url, headers={"User-Agent": "dynamo-junit-history"}
+        )
+        with urllib.request.urlopen(redirected, timeout=60) as response:
+            return response.read()
+
+    def request(
+        self,
+        path_or_url: str,
+        params: dict[str, str | int] | None = None,
+    ) -> tuple[bytes, dict[str, str]]:
+        url = (
+            path_or_url
+            if path_or_url.startswith("http")
+            else f"{API_ROOT}{path_or_url}"
+        )
+        if params:
+            query = urllib.parse.urlencode(params)
+            separator = "&" if urllib.parse.urlsplit(url).query else "?"
+            url = f"{url}{separator}{query}"
+
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "dynamo-junit-history",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                return response.read(), dict(response.headers.items())
+        except urllib.error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"GitHub API request failed: HTTP {exc.code} for {url}\n{message}"
+            ) from exc
+
+    def paginate(
+        self, path: str, key: str, params: dict[str, str | int] | None = None
+    ) -> list[dict[str, object]]:
+        page = 1
+        items: list[dict[str, object]] = []
+        while True:
+            page_params = dict(params or {})
+            page_params["per_page"] = 100
+            page_params["page"] = page
+            payload = self.request_json(path, page_params)
+            if not isinstance(payload, dict) or key not in payload:
+                raise RuntimeError(
+                    f"Unexpected GitHub API payload for {path}: missing {key}"
+                )
+            batch = payload[key]
+            if not isinstance(batch, list):
+                raise RuntimeError(
+                    f"Unexpected GitHub API payload for {path}: {key} is not a list"
+                )
+            items.extend(batch)
+            if len(batch) < 100:
+                break
+            page += 1
+        return items
+
+
+def parse_time(value: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def token_from_environment_or_gh() -> str | None:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    token = result.stdout.strip()
+    return token or None
+
+
+def resolve_workflow(client: GithubClient, workflow_spec: str) -> str:
+    if workflow_spec.isdigit():
+        return workflow_spec
+
+    workflows = client.paginate(f"/repos/{client.repo}/actions/workflows", "workflows")
+    matches: list[dict[str, object]] = []
+    for workflow in workflows:
+        name = str(workflow.get("name", ""))
+        path = str(workflow.get("path", ""))
+        basename = path.rsplit("/", 1)[-1]
+        if workflow_spec in {name, path, basename}:
+            matches.append(workflow)
+
+    if len(matches) == 1:
+        return str(matches[0]["id"])
+    if not matches:
+        known = ", ".join(
+            sorted(str(w.get("name", "")) for w in workflows if w.get("name"))
+        )
+        raise RuntimeError(
+            f"Could not resolve workflow {workflow_spec!r}. Known workflows: {known}"
+        )
+    raise RuntimeError(
+        f"Workflow {workflow_spec!r} is ambiguous; use the workflow file or numeric ID."
+    )
+
+
+def list_runs(
+    client: GithubClient,
+    query: WorkflowQuery,
+    cutoff: dt.datetime,
+    include_reruns: bool,
+    max_runs: int,
+) -> list[RunInfo]:
+    workflow_id = resolve_workflow(client, query.workflow)
+    params: dict[str, str | int] = {
+        "created": f">={cutoff.isoformat().replace('+00:00', 'Z')}",
+    }
+    if query.event:
+        params["event"] = query.event
+    if query.branch:
+        params["branch"] = query.branch
+
+    path = f"/repos/{client.repo}/actions/workflows/{urllib.parse.quote(workflow_id, safe='')}/runs"
+    raw_runs = client.paginate(path, "workflow_runs", params)
+    runs: list[RunInfo] = []
+    for raw_run in raw_runs:
+        created_at = parse_time(str(raw_run["created_at"]))
+        if created_at < cutoff:
+            continue
+        attempt = int(raw_run.get("run_attempt") or 1)
+        if attempt > 1 and not include_reruns:
+            continue
+        runs.append(
+            RunInfo(
+                workflow=query.label,
+                run_id=int(raw_run["id"]),
+                attempt=attempt,
+                created_at=created_at,
+                event=str(raw_run.get("event") or ""),
+                branch=str(raw_run.get("head_branch") or ""),
+                conclusion=str(
+                    raw_run.get("conclusion") or raw_run.get("status") or ""
+                ),
+                url=str(raw_run.get("html_url") or ""),
+            )
+        )
+        if max_runs > 0 and len(runs) >= max_runs:
+            break
+    return runs
+
+
+def list_artifacts(client: GithubClient, run_id: int) -> list[dict[str, object]]:
+    return client.paginate(
+        f"/repos/{client.repo}/actions/runs/{run_id}/artifacts", "artifacts"
+    )
+
+
+def artifact_matches(name: str, prefixes: tuple[str, ...]) -> bool:
+    return any(name.startswith(prefix) for prefix in prefixes)
+
+
+def download_artifact_zip(
+    client: GithubClient,
+    artifact: dict[str, object],
+    cache_dir: pathlib.Path,
+    refresh_cache: bool,
+    no_cache: bool,
+) -> bytes:
+    artifact_id = int(artifact["id"])
+    cache_path = cache_dir / f"artifact-{artifact_id}.zip"
+    if not no_cache and cache_path.exists() and not refresh_cache:
+        return cache_path.read_bytes()
+
+    archive_url = str(artifact["archive_download_url"])
+    payload = client.request_artifact_archive(archive_url)
+    if not no_cache:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(payload)
+    return payload
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def int_attr(element: ET.Element, name: str) -> int:
+    try:
+        return int(float(element.attrib.get(name, "0")))
+    except ValueError:
+        return 0
+
+
+def float_attr(element: ET.Element, name: str) -> float:
+    try:
+        return float(element.attrib.get(name, "0") or 0)
+    except ValueError:
+        return 0.0
+
+
+def testcase_name(testcase: ET.Element) -> str:
+    classname = testcase.attrib.get("classname", "").strip()
+    name = testcase.attrib.get("name", "").strip()
+    file_name = testcase.attrib.get("file", "").strip()
+    if classname and name:
+        return f"{classname}.{name}"
+    if name:
+        return name
+    if file_name:
+        return file_name
+    return "<unnamed testcase>"
+
+
+def parse_junit_xml(
+    xml_bytes: bytes,
+    run: RunInfo,
+    artifact_name: str,
+    xml_path: str,
+) -> JUnitStats | None:
+    try:
+        root = ET.fromstring(xml_bytes)
+    except ET.ParseError as exc:
+        print(
+            f"warning: could not parse {artifact_name}/{xml_path}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+    testcases = [
+        element for element in root.iter() if local_name(element.tag) == "testcase"
+    ]
+    tests = len(testcases)
+    failures = 0
+    errors = 0
+    skipped = 0
+    seconds = 0.0
+    failed_tests: list[str] = []
+
+    for testcase in testcases:
+        children = {local_name(child.tag) for child in list(testcase)}
+        seconds += float_attr(testcase, "time")
+        if "error" in children:
+            errors += 1
+            failed_tests.append(testcase_name(testcase))
+        elif "failure" in children:
+            failures += 1
+            failed_tests.append(testcase_name(testcase))
+        elif "skipped" in children:
+            skipped += 1
+
+    # Some JUnit producers only emit suite-level counters. Use them when no cases exist.
+    if not testcases:
+        suites = [
+            element for element in root.iter() if local_name(element.tag) == "testsuite"
+        ] or [root]
+        tests = sum(int_attr(suite, "tests") for suite in suites)
+        failures = sum(int_attr(suite, "failures") for suite in suites)
+        errors = sum(int_attr(suite, "errors") for suite in suites)
+        skipped = sum(int_attr(suite, "skipped") for suite in suites)
+        seconds = sum(float_attr(suite, "time") for suite in suites)
+
+    if tests == 0 and failures == 0 and errors == 0 and skipped == 0:
+        return None
+
+    return JUnitStats(
+        workflow=run.workflow,
+        run_id=run.run_id,
+        run_attempt=run.attempt,
+        run_created_at=run.created_at,
+        run_conclusion=run.conclusion,
+        artifact_name=artifact_name,
+        xml_path=xml_path,
+        tests=tests,
+        failures=failures,
+        errors=errors,
+        skipped=skipped,
+        seconds=seconds,
+        failed_tests=tuple(failed_tests),
+    )
+
+
+def parse_artifact(
+    zip_bytes: bytes,
+    run: RunInfo,
+    artifact_name: str,
+) -> list[JUnitStats]:
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as exc:
+        print(
+            f"warning: could not read artifact {artifact_name}: {exc}", file=sys.stderr
+        )
+        return []
+
+    stats: list[JUnitStats] = []
+    for member in archive.namelist():
+        if member.endswith("/") or not member.lower().endswith(".xml"):
+            continue
+        with archive.open(member) as file:
+            parsed = parse_junit_xml(file.read(), run, artifact_name, member)
+        if parsed:
+            stats.append(parsed)
+    return stats
+
+
+def collect_stats(
+    client: GithubClient,
+    queries: list[WorkflowQuery],
+    cutoff: dt.datetime,
+    args: argparse.Namespace,
+) -> tuple[list[RunInfo], list[JUnitStats]]:
+    all_runs: list[RunInfo] = []
+    all_stats: list[JUnitStats] = []
+
+    for query in queries:
+        runs = list_runs(client, query, cutoff, args.include_reruns, args.max_runs)
+        all_runs.extend(runs)
+        print(f"found {len(runs)} runs for {query.label}", file=sys.stderr)
+
+        for run in runs:
+            artifacts = list_artifacts(client, run.run_id)
+            matched = [
+                artifact
+                for artifact in artifacts
+                if not artifact.get("expired")
+                and artifact_matches(
+                    str(artifact.get("name", "")), args.artifact_prefix
+                )
+            ]
+            print(
+                f"run {run.run_id} {run.created_at.date()} {query.label}: "
+                f"{len(matched)} matching artifacts",
+                file=sys.stderr,
+            )
+            for artifact in matched:
+                name = str(artifact["name"])
+                try:
+                    zip_bytes = download_artifact_zip(
+                        client,
+                        artifact,
+                        args.cache_dir,
+                        args.refresh_cache,
+                        args.no_cache,
+                    )
+                except RuntimeError as exc:
+                    print(
+                        f"warning: could not download artifact {name}: {exc}",
+                        file=sys.stderr,
+                    )
+                    continue
+                all_stats.extend(parse_artifact(zip_bytes, run, name))
+
+    return all_runs, all_stats
+
+
+def format_seconds(seconds: float) -> str:
+    total = int(round(seconds))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m"
+    if minutes:
+        return f"{minutes}m{secs:02d}s"
+    return f"{secs}s"
+
+
+def shorten(value: str, width: int) -> str:
+    if len(value) <= width:
+        return value
+    return value[: max(0, width - 3)] + "..."
+
+
+def build_buckets(
+    runs: list[RunInfo], stats: list[JUnitStats]
+) -> dict[tuple[str, str], dict[str, object]]:
+    buckets: dict[tuple[str, str], dict[str, object]] = collections.defaultdict(
+        lambda: {
+            "runs": set(),
+            "conclusions": collections.Counter(),
+            "artifacts": set(),
+            "xmls": 0,
+            "tests": 0,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 0,
+            "seconds": 0.0,
+        }
+    )
+
+    for run in runs:
+        key = (run.created_at.date().isoformat(), run.workflow)
+        bucket = buckets[key]
+        bucket["runs"].add(run.run_id)
+        bucket["conclusions"][run.conclusion or "unknown"] += 1
+
+    for item in stats:
+        key = (item.run_created_at.date().isoformat(), item.workflow)
+        bucket = buckets[key]
+        bucket["runs"].add(item.run_id)
+        bucket["artifacts"].add((item.run_id, item.artifact_name))
+        bucket["xmls"] += 1
+        bucket["tests"] += item.tests
+        bucket["failures"] += item.failures
+        bucket["errors"] += item.errors
+        bucket["skipped"] += item.skipped
+        bucket["seconds"] += item.seconds
+
+    return buckets
+
+
+def conclusion_summary(counter: collections.Counter[str]) -> str:
+    if not counter:
+        return "-"
+    parts = []
+    for key in ("success", "failure", "cancelled", "timed_out", "skipped", "unknown"):
+        count = counter.get(key, 0)
+        if count:
+            parts.append(f"{key}:{count}")
+    for key, count in sorted(counter.items()):
+        if key not in {
+            "success",
+            "failure",
+            "cancelled",
+            "timed_out",
+            "skipped",
+            "unknown",
+        }:
+            parts.append(f"{key}:{count}")
+    return ",".join(parts)
+
+
+def print_ascii_report(
+    repo: str,
+    cutoff: dt.datetime,
+    runs: list[RunInfo],
+    stats: list[JUnitStats],
+    top: int,
+) -> None:
+    buckets = build_buckets(runs, stats)
+    print(f"Repo: {repo}")
+    print(f"Window: since {cutoff.strftime('%Y-%m-%d %H:%M:%S')} UTC")
+    print(f"Runs: {len(runs)}")
+    print(f"JUnit XML files: {len(stats)}")
+    print()
+
+    header = (
+        f"{'Date':<10}  {'Workflow':<24} {'Runs':>4} {'Artifacts':>9} {'XMLs':>5} "
+        f"{'Cases':>7} {'Pass':>7} {'Fail':>5} {'Err':>4} {'Skip':>6} {'Time':>8}  Conclusions"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for (date, workflow), bucket in sorted(buckets.items()):
+        tests = int(bucket["tests"])
+        failures = int(bucket["failures"])
+        errors = int(bucket["errors"])
+        skipped = int(bucket["skipped"])
+        passed = max(0, tests - failures - errors - skipped)
+        print(
+            f"{date:<10}  {shorten(workflow, 24):<24} "
+            f"{len(bucket['runs']):>4} {len(bucket['artifacts']):>9} {int(bucket['xmls']):>5} "
+            f"{tests:>7} {passed:>7} {failures:>5} {errors:>4} {skipped:>6} "
+            f"{format_seconds(float(bucket['seconds'])):>8}  "
+            f"{conclusion_summary(bucket['conclusions'])}"
+        )
+
+    failure_counts: collections.Counter[tuple[str, str]] = collections.Counter()
+    for item in stats:
+        for failed_test in item.failed_tests:
+            failure_counts[(item.workflow, failed_test)] += 1
+
+    print()
+    if not failure_counts:
+        print("Top failures: none")
+        return
+
+    print(f"Top failures/errors by testcase over this window (top {top}):")
+    print(f"{'Count':>5}  {'Workflow':<24} Testcase")
+    print("-" * 96)
+    for (workflow, test_name), count in failure_counts.most_common(top):
+        print(f"{count:>5}  {shorten(workflow, 24):<24} {shorten(test_name, 62)}")
+
+
+def aggregate_daily(stats: list[JUnitStats]) -> dict[str, dict[str, int]]:
+    daily: dict[str, dict[str, int]] = collections.defaultdict(
+        lambda: {"tests": 0, "failures": 0, "errors": 0, "skipped": 0}
+    )
+    for item in stats:
+        date = item.run_created_at.date().isoformat()
+        daily[date]["tests"] += item.tests
+        daily[date]["failures"] += item.failures
+        daily[date]["errors"] += item.errors
+        daily[date]["skipped"] += item.skipped
+    return daily
+
+
+def write_failure_svg(path: pathlib.Path, stats: list[JUnitStats]) -> None:
+    daily = aggregate_daily(stats)
+    dates = sorted(daily)
+    width = 980
+    height = 360
+    margin_left = 58
+    margin_right = 24
+    margin_top = 28
+    margin_bottom = 70
+    plot_width = width - margin_left - margin_right
+    plot_height = height - margin_top - margin_bottom
+
+    if not dates:
+        body = '<text x="40" y="80" font-size="16">No JUnit data matched.</text>'
+        path.write_text(svg_document(width, height, body), encoding="utf-8")
+        return
+
+    bad_counts = [daily[date]["failures"] + daily[date]["errors"] for date in dates]
+    max_bad = max(max(bad_counts), 1)
+    bar_gap = 4
+    bar_width = max(2, (plot_width - bar_gap * (len(dates) - 1)) / len(dates))
+    elements = [
+        f'<text x="{margin_left}" y="18" font-size="15" font-weight="600">'
+        "JUnit failures/errors per day</text>",
+        f'<line x1="{margin_left}" y1="{margin_top + plot_height}" '
+        f'x2="{margin_left + plot_width}" y2="{margin_top + plot_height}" stroke="#222"/>',
+        f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" '
+        f'y2="{margin_top + plot_height}" stroke="#222"/>',
+    ]
+
+    for tick in range(0, 5):
+        value = round(max_bad * tick / 4)
+        y = margin_top + plot_height - (value / max_bad * plot_height)
+        elements.append(
+            f'<line x1="{margin_left}" y1="{y:.1f}" x2="{margin_left + plot_width}" '
+            f'y2="{y:.1f}" stroke="#e5e7eb"/>'
+        )
+        elements.append(
+            f'<text x="10" y="{y + 4:.1f}" font-size="11" fill="#555">{value}</text>'
+        )
+
+    for index, date in enumerate(dates):
+        bad = bad_counts[index]
+        x = margin_left + index * (bar_width + bar_gap)
+        bar_height = 0 if bad == 0 else max(2, bad / max_bad * plot_height)
+        y = margin_top + plot_height - bar_height
+        color = "#16a34a" if bad == 0 else "#dc2626"
+        elements.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_width:.1f}" '
+            f'height="{bar_height:.1f}" fill="{color}"><title>{date}: {bad} failures/errors, '
+            f'{daily[date]["tests"]} cases</title></rect>'
+        )
+        if len(dates) <= 16 or index % max(1, len(dates) // 12) == 0:
+            label = date[5:]
+            elements.append(
+                f'<text x="{x + bar_width / 2:.1f}" y="{height - 45}" font-size="10" '
+                f'text-anchor="middle" transform="rotate(45 {x + bar_width / 2:.1f},{height - 45})">'
+                f"{label}</text>"
+            )
+        if bad:
+            elements.append(
+                f'<text x="{x + bar_width / 2:.1f}" y="{y - 4:.1f}" font-size="10" '
+                f'text-anchor="middle" fill="#7f1d1d">{bad}</text>'
+            )
+
+    path.write_text(svg_document(width, height, "\n".join(elements)), encoding="utf-8")
+
+
+def svg_document(width: int, height: int, body: str) -> str:
+    return textwrap.dedent(
+        f"""\
+        <svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">
+          <rect width="100%" height="100%" fill="white"/>
+          <style>
+            text {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
+          </style>
+          {body}
+        </svg>
+        """
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download GitHub Actions JUnit XML artifacts and summarize recent CI history.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, help="GitHub repository as owner/name."
+    )
+    parser.add_argument("--days", type=int, default=30, help="History window in days.")
+    parser.add_argument(
+        "--preset",
+        action="append",
+        choices=sorted(DEFAULT_PRESETS),
+        help="Reliable workflow preset. Defaults to nightly and post-merge when no workflow is supplied.",
+    )
+    parser.add_argument(
+        "--workflow",
+        action="append",
+        help="Workflow name, path, basename, or numeric workflow ID. Overrides default presets when supplied.",
+    )
+    parser.add_argument(
+        "--event", help="Event filter for --workflow, for example schedule or push."
+    )
+    parser.add_argument(
+        "--branch", default="main", help="Branch filter for --workflow."
+    )
+    parser.add_argument(
+        "--artifact-prefix",
+        action="append",
+        help="Artifact name prefix to parse. May be repeated.",
+    )
+    parser.add_argument(
+        "--include-reruns",
+        action="store_true",
+        help="Include workflow runs with run_attempt > 1.",
+    )
+    parser.add_argument(
+        "--max-runs",
+        type=int,
+        default=0,
+        help="Maximum runs per workflow query; 0 means unlimited.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=pathlib.Path,
+        default=pathlib.Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
+        / "dynamo-junit-history",
+        help="Artifact ZIP cache directory.",
+    )
+    parser.add_argument(
+        "--refresh-cache",
+        action="store_true",
+        help="Re-download artifacts even if cached.",
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Do not read or write the artifact cache.",
+    )
+    parser.add_argument(
+        "--plot", type=pathlib.Path, help="Write a simple SVG failure history plot."
+    )
+    parser.add_argument(
+        "--top", type=int, default=15, help="Number of failing testcases to show."
+    )
+    return parser.parse_args()
+
+
+def workflow_queries(args: argparse.Namespace) -> list[WorkflowQuery]:
+    if args.workflow:
+        return [
+            WorkflowQuery(
+                label=re.sub(r"\.ya?ml$", "", workflow.rsplit("/", 1)[-1]),
+                workflow=workflow,
+                event=args.event,
+                branch=args.branch,
+            )
+            for workflow in args.workflow
+        ]
+
+    presets = args.preset or ["nightly", "post-merge"]
+    queries = []
+    for preset in presets:
+        config = DEFAULT_PRESETS[preset]
+        queries.append(
+            WorkflowQuery(
+                label=preset,
+                workflow=config["workflow"],
+                event=config["event"],
+                branch=config["branch"],
+            )
+        )
+    return queries
+
+
+def main() -> int:
+    args = parse_args()
+    args.artifact_prefix = tuple(args.artifact_prefix or DEFAULT_ARTIFACT_PREFIXES)
+    cutoff = dt.datetime.now(tz=UTC) - dt.timedelta(days=args.days)
+    token = token_from_environment_or_gh()
+    client = GithubClient(args.repo, token)
+
+    queries = workflow_queries(args)
+    runs, stats = collect_stats(client, queries, cutoff, args)
+    print_ascii_report(args.repo, cutoff, runs, stats, args.top)
+
+    if args.plot:
+        write_failure_svg(args.plot, stats)
+        print(f"\nWrote plot: {args.plot}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/junit_history.py
+++ b/.github/scripts/junit_history.py
@@ -727,7 +727,7 @@ def print_top_flakes(stats: list[JUnitStats], top: int, failure_examples: int) -
         print(f"{rank}. {count} {test_name}")
         print()
         for example in examples[test_name][:failure_examples]:
-            print(f"           {example.date}: {example.url}")
+            print(f"   {example.date}: {example.url}")
         if rank != len(top_items):
             print()
 

--- a/.github/scripts/junit_history.py
+++ b/.github/scripts/junit_history.py
@@ -28,6 +28,7 @@ API_ROOT = "https://api.github.com"
 DEFAULT_REPO = os.environ.get("GITHUB_REPOSITORY", "ai-dynamo/dynamo")
 DEFAULT_ARTIFACT_PREFIXES = ("junit-", "test-results-")
 ARTIFACT_JOB_RE = re.compile(r"[-_](?P<run_id>\d+)[-_](?P<job_id>\d+)$")
+SYNTHETIC_FAILURE_NAMES = {"pytest.internal"}
 DEFAULT_PRESETS = {
     "nightly": {
         "workflow": "Nightly CI Pipeline",
@@ -397,7 +398,8 @@ def filter_aggregate_failures(
     return tuple(
         failed_test
         for failed_test in failed_tests
-        if not is_parent_failure(failed_test, failed_set)
+        if failed_test not in SYNTHETIC_FAILURE_NAMES
+        and not is_parent_failure(failed_test, failed_set)
     )
 
 

--- a/.github/scripts/junit_history.py
+++ b/.github/scripts/junit_history.py
@@ -9,6 +9,7 @@ import argparse
 import collections
 import dataclasses
 import datetime as dt
+import html
 import io
 import os
 import pathlib
@@ -611,102 +612,133 @@ def print_ascii_report(
             f"{conclusion_summary(bucket['conclusions'])}"
         )
 
-    failure_counts: collections.Counter[tuple[str, str]] = collections.Counter()
+    print_top_flakes(stats, top)
+
+
+def flake_history(
+    stats: list[JUnitStats],
+) -> tuple[
+    collections.Counter[tuple[str, str]],
+    dict[tuple[str, str], collections.Counter[str]],
+]:
+    counts: collections.Counter[tuple[str, str]] = collections.Counter()
+    by_day: dict[tuple[str, str], collections.Counter[str]] = collections.defaultdict(
+        collections.Counter
+    )
+
     for item in stats:
+        day = item.run_created_at.date().isoformat()
         for failed_test in item.failed_tests:
-            failure_counts[(item.workflow, failed_test)] += 1
+            key = (item.workflow, failed_test)
+            counts[key] += 1
+            by_day[key][day] += 1
+
+    return counts, by_day
+
+
+def print_top_flakes(stats: list[JUnitStats], top: int) -> None:
+    counts, by_day = flake_history(stats)
 
     print()
-    if not failure_counts:
-        print("Top failures: none")
+    if not counts:
+        print("Top test flakes: none")
         return
 
-    print(f"Top failures/errors by testcase over this window (top {top}):")
-    print(f"{'Count':>5}  {'Workflow':<24} Testcase")
-    print("-" * 96)
-    for (workflow, test_name), count in failure_counts.most_common(top):
-        print(f"{count:>5}  {shorten(workflow, 24):<24} {shorten(test_name, 62)}")
+    print(f"Top test flakes by failure/error occurrence over this window (top {top}):")
+    for rank, ((workflow, test_name), count) in enumerate(counts.most_common(top), 1):
+        days = ", ".join(
+            f"{day}:{n}" for day, n in sorted(by_day[(workflow, test_name)].items())
+        )
+        print(f"{rank:>2}. {count:>4}  [{workflow}] {test_name}")
+        print(f"    days: {days}")
 
 
-def aggregate_daily(stats: list[JUnitStats]) -> dict[str, dict[str, int]]:
-    daily: dict[str, dict[str, int]] = collections.defaultdict(
-        lambda: {"tests": 0, "failures": 0, "errors": 0, "skipped": 0}
+def write_flake_svg(path: pathlib.Path, stats: list[JUnitStats], top: int) -> None:
+    counts, by_day = flake_history(stats)
+    top_items = counts.most_common(top)
+    dates = sorted({item.run_created_at.date().isoformat() for item in stats})
+
+    if not dates or not top_items:
+        body = '<text x="40" y="80" font-size="16">No JUnit failures/errors matched.</text>'
+        path.write_text(svg_document(980, 180, body), encoding="utf-8")
+        return
+
+    label_width = 520
+    cell_width = 72
+    cell_height = 28
+    top_margin = 72
+    left_margin = label_width + 28
+    right_margin = 24
+    bottom_margin = 56
+    width = left_margin + len(dates) * cell_width + right_margin
+    height = top_margin + len(top_items) * cell_height + bottom_margin
+    max_cell = max(
+        (by_day[key][date] for key, _count in top_items for date in dates), default=1
     )
-    for item in stats:
-        date = item.run_created_at.date().isoformat()
-        daily[date]["tests"] += item.tests
-        daily[date]["failures"] += item.failures
-        daily[date]["errors"] += item.errors
-        daily[date]["skipped"] += item.skipped
-    return daily
+    max_total = max((count for _key, count in top_items), default=1)
 
-
-def write_failure_svg(path: pathlib.Path, stats: list[JUnitStats]) -> None:
-    daily = aggregate_daily(stats)
-    dates = sorted(daily)
-    width = 980
-    height = 360
-    margin_left = 58
-    margin_right = 24
-    margin_top = 28
-    margin_bottom = 70
-    plot_width = width - margin_left - margin_right
-    plot_height = height - margin_top - margin_bottom
-
-    if not dates:
-        body = '<text x="40" y="80" font-size="16">No JUnit data matched.</text>'
-        path.write_text(svg_document(width, height, body), encoding="utf-8")
-        return
-
-    bad_counts = [daily[date]["failures"] + daily[date]["errors"] for date in dates]
-    max_bad = max(max(bad_counts), 1)
-    bar_gap = 4
-    bar_width = max(2, (plot_width - bar_gap * (len(dates) - 1)) / len(dates))
     elements = [
-        f'<text x="{margin_left}" y="18" font-size="15" font-weight="600">'
-        "JUnit failures/errors per day</text>",
-        f'<line x1="{margin_left}" y1="{margin_top + plot_height}" '
-        f'x2="{margin_left + plot_width}" y2="{margin_top + plot_height}" stroke="#222"/>',
-        f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" '
-        f'y2="{margin_top + plot_height}" stroke="#222"/>',
+        '<text x="24" y="28" font-size="16" font-weight="600">'
+        "Top test flakes by day</text>",
+        '<text x="24" y="50" font-size="12" fill="#555">'
+        "Cell values are failure/error occurrences in JUnit XML artifacts. Hover for full test names.</text>",
     ]
 
-    for tick in range(0, 5):
-        value = round(max_bad * tick / 4)
-        y = margin_top + plot_height - (value / max_bad * plot_height)
+    for index, date in enumerate(dates):
+        x = left_margin + index * cell_width + cell_width / 2
         elements.append(
-            f'<line x1="{margin_left}" y1="{y:.1f}" x2="{margin_left + plot_width}" '
-            f'y2="{y:.1f}" stroke="#e5e7eb"/>'
-        )
-        elements.append(
-            f'<text x="10" y="{y + 4:.1f}" font-size="11" fill="#555">{value}</text>'
+            f'<text x="{x:.1f}" y="62" font-size="11" text-anchor="middle" fill="#555">'
+            f"{html.escape(date[5:])}</text>"
         )
 
-    for index, date in enumerate(dates):
-        bad = bad_counts[index]
-        x = margin_left + index * (bar_width + bar_gap)
-        bar_height = 0 if bad == 0 else max(2, bad / max_bad * plot_height)
-        y = margin_top + plot_height - bar_height
-        color = "#16a34a" if bad == 0 else "#dc2626"
+    for row, ((workflow, test_name), total) in enumerate(top_items):
+        y = top_margin + row * cell_height
+        label = f"{row + 1}. [{workflow}] {test_name}"
+        visible_label = shorten(label, 74)
         elements.append(
-            f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_width:.1f}" '
-            f'height="{bar_height:.1f}" fill="{color}"><title>{date}: {bad} failures/errors, '
-            f'{daily[date]["tests"]} cases</title></rect>'
+            f'<text x="24" y="{y + 18}" font-size="11" fill="#111">'
+            f"{html.escape(visible_label)}"
+            f"<title>{html.escape(label)} total={total}</title></text>"
         )
-        if len(dates) <= 16 or index % max(1, len(dates) // 12) == 0:
-            label = date[5:]
+        total_width = max(2, (total / max_total) * 72)
+        elements.append(
+            f'<rect x="{label_width - 58}" y="{y + 7}" width="{total_width:.1f}" '
+            f'height="8" rx="1" fill="#991b1b"><title>Total failures/errors: {total}</title></rect>'
+        )
+        elements.append(
+            f'<text x="{label_width + 20}" y="{y + 18}" font-size="11" text-anchor="end" fill="#555">'
+            f"{total}</text>"
+        )
+
+        for col, date in enumerate(dates):
+            count = by_day[(workflow, test_name)][date]
+            x = left_margin + col * cell_width
+            color = heat_color(count, max_cell)
             elements.append(
-                f'<text x="{x + bar_width / 2:.1f}" y="{height - 45}" font-size="10" '
-                f'text-anchor="middle" transform="rotate(45 {x + bar_width / 2:.1f},{height - 45})">'
-                f"{label}</text>"
+                f'<rect x="{x + 6:.1f}" y="{y + 4}" width="{cell_width - 12}" height="{cell_height - 8}" '
+                f'rx="2" fill="{color}" stroke="#ffffff">'
+                f"<title>{html.escape(label)}&#10;{date}: {count}</title></rect>"
             )
-        if bad:
             elements.append(
-                f'<text x="{x + bar_width / 2:.1f}" y="{y - 4:.1f}" font-size="10" '
-                f'text-anchor="middle" fill="#7f1d1d">{bad}</text>'
+                f'<text x="{x + cell_width / 2:.1f}" y="{y + 19}" font-size="10" '
+                f'text-anchor="middle" fill="{cell_text_color(count)}">{count}</text>'
             )
 
     path.write_text(svg_document(width, height, "\n".join(elements)), encoding="utf-8")
+
+
+def heat_color(count: int, max_count: int) -> str:
+    if count <= 0:
+        return "#f3f4f6"
+    ratio = min(1.0, count / max(1, max_count))
+    red = 254 - round(99 * ratio)
+    green = 226 - round(198 * ratio)
+    blue = 226 - round(198 * ratio)
+    return f"#{red:02x}{green:02x}{blue:02x}"
+
+
+def cell_text_color(count: int) -> str:
+    return "#ffffff" if count >= 4 else "#111111"
 
 
 def svg_document(width: int, height: int, body: str) -> str:
@@ -782,7 +814,9 @@ def parse_args() -> argparse.Namespace:
         help="Do not read or write the artifact cache.",
     )
     parser.add_argument(
-        "--plot", type=pathlib.Path, help="Write a simple SVG failure history plot."
+        "--plot",
+        type=pathlib.Path,
+        help="Write an SVG history plot for the top failing/erroring testcases.",
     )
     parser.add_argument(
         "--top", type=int, default=15, help="Number of failing testcases to show."
@@ -829,7 +863,7 @@ def main() -> int:
     print_ascii_report(args.repo, cutoff, runs, stats, args.top)
 
     if args.plot:
-        write_failure_svg(args.plot, stats)
+        write_flake_svg(args.plot, stats, args.top)
         print(f"\nWrote plot: {args.plot}")
 
     return 0

--- a/.github/scripts/junit_history.py
+++ b/.github/scripts/junit_history.py
@@ -27,6 +27,7 @@ UTC = dt.timezone.utc
 API_ROOT = "https://api.github.com"
 DEFAULT_REPO = os.environ.get("GITHUB_REPOSITORY", "ai-dynamo/dynamo")
 DEFAULT_ARTIFACT_PREFIXES = ("junit-", "test-results-")
+ARTIFACT_JOB_RE = re.compile(r"[-_](?P<run_id>\d+)[-_](?P<job_id>\d+)$")
 DEFAULT_PRESETS = {
     "nightly": {
         "workflow": "Nightly CI Pipeline",
@@ -90,6 +91,13 @@ class JUnitStats:
     skipped: int
     seconds: float
     failed_tests: tuple[str, ...]
+    source_url: str
+
+
+@dataclasses.dataclass(frozen=True)
+class FailureExample:
+    date: str
+    url: str
 
 
 class GithubClient:
@@ -308,6 +316,16 @@ def artifact_matches(name: str, prefixes: tuple[str, ...]) -> bool:
     return any(name.startswith(prefix) for prefix in prefixes)
 
 
+def artifact_source_url(repo: str, run: RunInfo, artifact_name: str) -> str:
+    match = ARTIFACT_JOB_RE.search(artifact_name)
+    if match and int(match.group("run_id")) == run.run_id:
+        return (
+            f"https://github.com/{repo}/actions/runs/{run.run_id}"
+            f"/job/{match.group('job_id')}"
+        )
+    return run.url or f"https://github.com/{repo}/actions/runs/{run.run_id}"
+
+
 def download_artifact_zip(
     client: GithubClient,
     artifact: dict[str, object],
@@ -359,11 +377,37 @@ def testcase_name(testcase: ET.Element) -> str:
     return "<unnamed testcase>"
 
 
+def is_parent_failure(candidate: str, failed_tests: set[str]) -> bool:
+    return any(
+        other != candidate
+        and (other.startswith(f"{candidate}.") or other.startswith(f"{candidate}["))
+        for other in failed_tests
+    )
+
+
+def filter_aggregate_failures(
+    failed_tests: list[str], artifact_name: str, include_aggregate_failures: bool
+) -> tuple[str, ...]:
+    if include_aggregate_failures:
+        return tuple(failed_tests)
+    if artifact_name.startswith("junit-"):
+        return ()
+
+    failed_set = set(failed_tests)
+    return tuple(
+        failed_test
+        for failed_test in failed_tests
+        if not is_parent_failure(failed_test, failed_set)
+    )
+
+
 def parse_junit_xml(
     xml_bytes: bytes,
     run: RunInfo,
     artifact_name: str,
     xml_path: str,
+    source_url: str,
+    include_aggregate_failures: bool,
 ) -> JUnitStats | None:
     try:
         root = ET.fromstring(xml_bytes)
@@ -423,7 +467,10 @@ def parse_junit_xml(
         errors=errors,
         skipped=skipped,
         seconds=seconds,
-        failed_tests=tuple(failed_tests),
+        failed_tests=filter_aggregate_failures(
+            failed_tests, artifact_name, include_aggregate_failures
+        ),
+        source_url=source_url,
     )
 
 
@@ -431,6 +478,8 @@ def parse_artifact(
     zip_bytes: bytes,
     run: RunInfo,
     artifact_name: str,
+    source_url: str,
+    include_aggregate_failures: bool,
 ) -> list[JUnitStats]:
     try:
         archive = zipfile.ZipFile(io.BytesIO(zip_bytes))
@@ -445,7 +494,14 @@ def parse_artifact(
         if member.endswith("/") or not member.lower().endswith(".xml"):
             continue
         with archive.open(member) as file:
-            parsed = parse_junit_xml(file.read(), run, artifact_name, member)
+            parsed = parse_junit_xml(
+                file.read(),
+                run,
+                artifact_name,
+                member,
+                source_url,
+                include_aggregate_failures,
+            )
         if parsed:
             stats.append(parsed)
     return stats
@@ -496,7 +552,15 @@ def collect_stats(
                         file=sys.stderr,
                     )
                     continue
-                all_stats.extend(parse_artifact(zip_bytes, run, name))
+                all_stats.extend(
+                    parse_artifact(
+                        zip_bytes,
+                        run,
+                        name,
+                        artifact_source_url(client.repo, run, name),
+                        args.include_aggregate_failures,
+                    )
+                )
 
     return all_runs, all_stats
 
@@ -583,6 +647,7 @@ def print_ascii_report(
     runs: list[RunInfo],
     stats: list[JUnitStats],
     top: int,
+    failure_examples: int,
 ) -> None:
     buckets = build_buckets(runs, stats)
     print(f"Repo: {repo}")
@@ -612,7 +677,7 @@ def print_ascii_report(
             f"{conclusion_summary(bucket['conclusions'])}"
         )
 
-    print_top_flakes(stats, top)
+    print_top_flakes(stats, top, failure_examples)
 
 
 def flake_history(
@@ -620,28 +685,36 @@ def flake_history(
 ) -> tuple[
     collections.Counter[str],
     dict[str, collections.Counter[str]],
-    dict[str, collections.Counter[str]],
+    dict[str, list[FailureExample]],
 ]:
     counts: collections.Counter[str] = collections.Counter()
     by_day: dict[str, collections.Counter[str]] = collections.defaultdict(
         collections.Counter
     )
-    by_workflow: dict[str, collections.Counter[str]] = collections.defaultdict(
-        collections.Counter
-    )
+    examples: dict[str, list[FailureExample]] = collections.defaultdict(list)
+    seen_examples: dict[str, set[tuple[str, str]]] = collections.defaultdict(set)
 
-    for item in stats:
+    for item in sorted(stats, key=lambda stat: stat.run_created_at, reverse=True):
         day = item.run_created_at.date().isoformat()
         for failed_test in item.failed_tests:
             counts[failed_test] += 1
             by_day[failed_test][day] += 1
-            by_workflow[failed_test][item.workflow] += 1
+            example_key = (day, item.source_url)
+            if example_key not in seen_examples[failed_test]:
+                examples[failed_test].append(FailureExample(day, item.source_url))
+                seen_examples[failed_test].add(example_key)
 
-    return counts, by_day, by_workflow
+    return counts, by_day, examples
 
 
-def print_top_flakes(stats: list[JUnitStats], top: int) -> None:
-    counts, by_day, by_workflow = flake_history(stats)
+def top_flake_items(
+    counts: collections.Counter[str], top: int
+) -> list[tuple[str, int]]:
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:top]
+
+
+def print_top_flakes(stats: list[JUnitStats], top: int, failure_examples: int) -> None:
+    counts, _by_day, examples = flake_history(stats)
 
     print()
     if not counts:
@@ -649,19 +722,19 @@ def print_top_flakes(stats: list[JUnitStats], top: int) -> None:
         return
 
     print(f"Top test flakes by failure/error occurrence over this window (top {top}):")
-    for rank, (test_name, count) in enumerate(counts.most_common(top), 1):
-        days = ", ".join(f"{day}:{n}" for day, n in sorted(by_day[test_name].items()))
-        workflows = ", ".join(
-            f"{workflow}:{n}" for workflow, n in sorted(by_workflow[test_name].items())
-        )
-        print(f"{rank:>2}. {count:>4}  {test_name}")
-        print(f"    workflows: {workflows}")
-        print(f"    days: {days}")
+    top_items = top_flake_items(counts, top)
+    for rank, (test_name, count) in enumerate(top_items, 1):
+        print(f"{rank}. {count} {test_name}")
+        print()
+        for example in examples[test_name][:failure_examples]:
+            print(f"           {example.date}: {example.url}")
+        if rank != len(top_items):
+            print()
 
 
 def write_flake_svg(path: pathlib.Path, stats: list[JUnitStats], top: int) -> None:
-    counts, by_day, by_workflow = flake_history(stats)
-    top_items = counts.most_common(top)
+    counts, by_day, _examples = flake_history(stats)
+    top_items = top_flake_items(counts, top)
     dates = sorted({item.run_created_at.date().isoformat() for item in stats})
 
     if not dates or not top_items:
@@ -699,15 +772,12 @@ def write_flake_svg(path: pathlib.Path, stats: list[JUnitStats], top: int) -> No
 
     for row, (test_name, total) in enumerate(top_items):
         y = top_margin + row * cell_height
-        workflows = ", ".join(
-            f"{workflow}:{n}" for workflow, n in sorted(by_workflow[test_name].items())
-        )
         label = f"{row + 1}. {test_name}"
         visible_label = shorten(label, 74)
         elements.append(
             f'<text x="24" y="{y + 18}" font-size="11" fill="#111">'
             f"{html.escape(visible_label)}"
-            f"<title>{html.escape(label)} total={total} workflows={html.escape(workflows)}</title></text>"
+            f"<title>{html.escape(label)} total={total}</title></text>"
         )
         total_width = max(2, (total / max_total) * 72)
         elements.append(
@@ -726,8 +796,7 @@ def write_flake_svg(path: pathlib.Path, stats: list[JUnitStats], top: int) -> No
             elements.append(
                 f'<rect x="{x + 6:.1f}" y="{y + 4}" width="{cell_width - 12}" height="{cell_height - 8}" '
                 f'rx="2" fill="{color}" stroke="#ffffff">'
-                f"<title>{html.escape(label)}&#10;{date}: {count}"
-                f"&#10;workflows: {html.escape(workflows)}</title></rect>"
+                f"<title>{html.escape(label)}&#10;{date}: {count}</title></rect>"
             )
             elements.append(
                 f'<text x="{x + cell_width / 2:.1f}" y="{y + 19}" font-size="10" '
@@ -831,6 +900,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--top", type=int, default=15, help="Number of failing testcases to show."
     )
+    parser.add_argument(
+        "--failure-examples",
+        type=int,
+        default=5,
+        help="Number of example failure job URLs to show per top testcase.",
+    )
+    parser.add_argument(
+        "--include-aggregate-failures",
+        action="store_true",
+        help="Include synthetic job-level and parent aggregate failures in top flakes.",
+    )
     return parser.parse_args()
 
 
@@ -870,7 +950,7 @@ def main() -> int:
 
     queries = workflow_queries(args)
     runs, stats = collect_stats(client, queries, cutoff, args)
-    print_ascii_report(args.repo, cutoff, runs, stats, args.top)
+    print_ascii_report(args.repo, cutoff, runs, stats, args.top, args.failure_examples)
 
     if args.plot:
         write_flake_svg(args.plot, stats, args.top)

--- a/.github/scripts/junit_history.py
+++ b/.github/scripts/junit_history.py
@@ -618,26 +618,30 @@ def print_ascii_report(
 def flake_history(
     stats: list[JUnitStats],
 ) -> tuple[
-    collections.Counter[tuple[str, str]],
-    dict[tuple[str, str], collections.Counter[str]],
+    collections.Counter[str],
+    dict[str, collections.Counter[str]],
+    dict[str, collections.Counter[str]],
 ]:
-    counts: collections.Counter[tuple[str, str]] = collections.Counter()
-    by_day: dict[tuple[str, str], collections.Counter[str]] = collections.defaultdict(
+    counts: collections.Counter[str] = collections.Counter()
+    by_day: dict[str, collections.Counter[str]] = collections.defaultdict(
+        collections.Counter
+    )
+    by_workflow: dict[str, collections.Counter[str]] = collections.defaultdict(
         collections.Counter
     )
 
     for item in stats:
         day = item.run_created_at.date().isoformat()
         for failed_test in item.failed_tests:
-            key = (item.workflow, failed_test)
-            counts[key] += 1
-            by_day[key][day] += 1
+            counts[failed_test] += 1
+            by_day[failed_test][day] += 1
+            by_workflow[failed_test][item.workflow] += 1
 
-    return counts, by_day
+    return counts, by_day, by_workflow
 
 
 def print_top_flakes(stats: list[JUnitStats], top: int) -> None:
-    counts, by_day = flake_history(stats)
+    counts, by_day, by_workflow = flake_history(stats)
 
     print()
     if not counts:
@@ -645,16 +649,18 @@ def print_top_flakes(stats: list[JUnitStats], top: int) -> None:
         return
 
     print(f"Top test flakes by failure/error occurrence over this window (top {top}):")
-    for rank, ((workflow, test_name), count) in enumerate(counts.most_common(top), 1):
-        days = ", ".join(
-            f"{day}:{n}" for day, n in sorted(by_day[(workflow, test_name)].items())
+    for rank, (test_name, count) in enumerate(counts.most_common(top), 1):
+        days = ", ".join(f"{day}:{n}" for day, n in sorted(by_day[test_name].items()))
+        workflows = ", ".join(
+            f"{workflow}:{n}" for workflow, n in sorted(by_workflow[test_name].items())
         )
-        print(f"{rank:>2}. {count:>4}  [{workflow}] {test_name}")
+        print(f"{rank:>2}. {count:>4}  {test_name}")
+        print(f"    workflows: {workflows}")
         print(f"    days: {days}")
 
 
 def write_flake_svg(path: pathlib.Path, stats: list[JUnitStats], top: int) -> None:
-    counts, by_day = flake_history(stats)
+    counts, by_day, by_workflow = flake_history(stats)
     top_items = counts.most_common(top)
     dates = sorted({item.run_created_at.date().isoformat() for item in stats})
 
@@ -691,14 +697,17 @@ def write_flake_svg(path: pathlib.Path, stats: list[JUnitStats], top: int) -> No
             f"{html.escape(date[5:])}</text>"
         )
 
-    for row, ((workflow, test_name), total) in enumerate(top_items):
+    for row, (test_name, total) in enumerate(top_items):
         y = top_margin + row * cell_height
-        label = f"{row + 1}. [{workflow}] {test_name}"
+        workflows = ", ".join(
+            f"{workflow}:{n}" for workflow, n in sorted(by_workflow[test_name].items())
+        )
+        label = f"{row + 1}. {test_name}"
         visible_label = shorten(label, 74)
         elements.append(
             f'<text x="24" y="{y + 18}" font-size="11" fill="#111">'
             f"{html.escape(visible_label)}"
-            f"<title>{html.escape(label)} total={total}</title></text>"
+            f"<title>{html.escape(label)} total={total} workflows={html.escape(workflows)}</title></text>"
         )
         total_width = max(2, (total / max_total) * 72)
         elements.append(
@@ -711,13 +720,14 @@ def write_flake_svg(path: pathlib.Path, stats: list[JUnitStats], top: int) -> No
         )
 
         for col, date in enumerate(dates):
-            count = by_day[(workflow, test_name)][date]
+            count = by_day[test_name][date]
             x = left_margin + col * cell_width
             color = heat_color(count, max_cell)
             elements.append(
                 f'<rect x="{x + 6:.1f}" y="{y + 4}" width="{cell_width - 12}" height="{cell_height - 8}" '
                 f'rx="2" fill="{color}" stroke="#ffffff">'
-                f"<title>{html.escape(label)}&#10;{date}: {count}</title></rect>"
+                f"<title>{html.escape(label)}&#10;{date}: {count}"
+                f"&#10;workflows: {html.escape(workflows)}</title></rect>"
             )
             elements.append(
                 f'<text x="{x + cell_width / 2:.1f}" y="{y + 19}" font-size="10" '

--- a/.github/scripts/junit_history.py
+++ b/.github/scripts/junit_history.py
@@ -40,6 +40,15 @@ DEFAULT_PRESETS = {
 }
 
 
+def default_cache_dir() -> pathlib.Path:
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        return pathlib.Path(xdg_cache_home).expanduser() / "dynamo-junit-history"
+    if sys.platform == "darwin":
+        return pathlib.Path.home() / "Library" / "Caches" / "dynamo-junit-history"
+    return pathlib.Path.home() / ".cache" / "dynamo-junit-history"
+
+
 class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: N802
         return None
@@ -759,8 +768,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--cache-dir",
         type=pathlib.Path,
-        default=pathlib.Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
-        / "dynamo-junit-history",
+        default=default_cache_dir(),
         help="Artifact ZIP cache directory.",
     )
     parser.add_argument(

--- a/.github/scripts/write_junit_report.py
+++ b/.github/scripts/write_junit_report.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Write a minimal JUnit XML report for jobs without native JUnit output."""
+
+import argparse
+import os
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def normalize_artifact_name(name: str) -> str:
+    name = re.sub(r"[^A-Za-z0-9_.-]+", "-", name).strip(".-")
+    return name or "junit-results"
+
+
+def write_report(
+    output: Path, suite_name: str, test_name: str, status: str, message: str
+) -> None:
+    status = status or "failure"
+    skipped = status in {"cancelled", "skipped"}
+    failed = status != "success" and not skipped
+    failures = 1 if failed else 0
+    skipped_count = 1 if skipped else 0
+
+    testsuites = ET.Element(
+        "testsuites",
+        tests="1",
+        failures=str(failures),
+        errors="0",
+        skipped=str(skipped_count),
+    )
+    testsuite = ET.SubElement(
+        testsuites,
+        "testsuite",
+        name=suite_name,
+        tests="1",
+        failures=str(failures),
+        errors="0",
+        skipped=str(skipped_count),
+        time="0",
+    )
+    testcase = ET.SubElement(
+        testsuite,
+        "testcase",
+        classname=suite_name,
+        name=test_name,
+        time="0",
+    )
+    if skipped:
+        ET.SubElement(
+            testcase, "skipped", message=message or f"{suite_name} was skipped"
+        )
+    elif failed:
+        failure = ET.SubElement(
+            testcase,
+            "failure",
+            message=message or f"{suite_name} completed with status {status}",
+        )
+        failure.text = message or f"{suite_name} completed with status {status}."
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if hasattr(ET, "indent"):
+        ET.indent(testsuites)
+    ET.ElementTree(testsuites).write(output, encoding="utf-8", xml_declaration=True)
+
+
+def write_github_output(output_name: str, value: str) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output or not output_name:
+        return
+
+    with open(github_output, "a", encoding="utf-8") as out:
+        out.write(f"{output_name}={value}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--suite-name", required=True)
+    parser.add_argument("--test-name", default="")
+    parser.add_argument("--status", required=True)
+    parser.add_argument("--output", default="test-results/junit.xml")
+    parser.add_argument("--message", default="")
+    parser.add_argument("--artifact-name", default="")
+    parser.add_argument("--artifact-output-name", default="")
+    args = parser.parse_args()
+
+    test_name = args.test_name or args.suite_name
+    write_report(
+        Path(args.output), args.suite_name, test_name, args.status, args.message
+    )
+
+    if args.artifact_name:
+        write_github_output(
+            args.artifact_output_name, normalize_artifact_name(args.artifact_name)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/copyright-checks.yml
+++ b/.github/workflows/copyright-checks.yml
@@ -24,3 +24,10 @@ jobs:
           NVBUILD_VERBOSITY: DETAILED
         timeout-minutes: 2
         working-directory: /workspace
+      - name: Upload JUnit Report
+        if: always()
+        uses: ./.github/actions/junit-report
+        with:
+          suite-name: copyright-checks
+          status: ${{ job.status }}
+          artifact-name: junit-copyright-checks-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -72,6 +72,15 @@ jobs:
           path: .lycheecache
           key: cache-lychee-${{ github.run_id }}
 
+      - name: Upload JUnit Report
+        if: always()
+        uses: ./.github/actions/junit-report
+        with:
+          suite-name: docs-link-check-lychee
+          test-name: lychee
+          status: ${{ job.status }}
+          artifact-name: junit-docs-link-check-lychee-${{ github.run_id }}-${{ job.check_run_id }}
+
   broken-links-check:
     name: Check for broken markdown links
     runs-on: ubuntu-latest
@@ -264,3 +273,12 @@ jobs:
             echo "   - A clickable GitHub URL to jump directly to the problem line"
             exit 1
           fi
+
+      - name: Upload JUnit Report
+        if: always()
+        uses: ./.github/actions/junit-report
+        with:
+          suite-name: docs-link-check-broken-links
+          test-name: broken-links-check
+          status: ${{ job.status }}
+          artifact-name: junit-docs-link-check-broken-links-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -150,6 +150,13 @@ jobs:
           cargo clippy -p kvbm-physical --no-deps --all-targets -- -D warnings
           cargo test --locked -p kvbm-physical --features testing-kvbm -- --nocapture --test-threads=4
           /workspace/container/use-sccache.sh show-stats "Rust Checks"
+      - name: Upload JUnit Report
+        if: always()
+        uses: ./.github/actions/junit-report
+        with:
+          suite-name: dynamo-rust-gpu-checks
+          status: ${{ job.status }}
+          artifact-name: junit-dynamo-rust-gpu-checks-${{ github.run_id }}-${{ job.check_run_id }}
 
   mypy:
     needs: image
@@ -182,6 +189,13 @@ jobs:
         shell: bash
         run: |
           MYPYPATH=lib/bindings/python/src mypy -p dynamo
+      - name: Upload JUnit Report
+        if: always()
+        uses: ./.github/actions/junit-report
+        with:
+          suite-name: dynamo-mypy
+          status: ${{ job.status }}
+          artifact-name: junit-dynamo-mypy-${{ github.run_id }}-${{ job.check_run_id }}
 
   # TODO: real xdist parallelism port conflicts. cpu_parallel_mode='none'
   # below runs -n 0, so this job is NOT actually parallel right now.

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -548,6 +548,13 @@ jobs:
           ${{ matrix.dir }}/coverage-rust.txt
           ${{ matrix.dir }}/coverage-rust.lcov
         retention-days: 7
+    - name: Upload JUnit Report
+      if: always()
+      uses: ./.github/actions/junit-report
+      with:
+        suite-name: nightly-rust-coverage-${{ matrix.dir }}
+        status: ${{ job.status }}
+        artifact-name: junit-nightly-rust-coverage-${{ matrix.dir }}-${{ github.run_id }}-${{ job.check_run_id }}
 
   # ============================================================================
   # RELEASE (workflow_call into release.yml)

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -155,6 +155,13 @@ jobs:
           version: 'v3.17.3'  # match deploy/operator/Makefile HELM_VERSION
       - name: Lint and test
         run: make -C deploy/helm/charts/platform lint test
+      - name: Upload JUnit Report
+        if: always()
+        uses: ./.github/actions/junit-report
+        with:
+          suite-name: helm-chart-tests
+          status: ${{ job.status }}
+          artifact-name: junit-helm-chart-tests-${{ github.run_id }}-${{ job.check_run_id }}
 
 # ============================================================================
 # Snapshot Agent

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -63,6 +63,13 @@ jobs:
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       timeout-minutes: 3
+    - name: Upload JUnit Report
+      if: always()
+      uses: ./.github/actions/junit-report
+      with:
+        suite-name: pre-commit
+        status: ${{ job.status }}
+        artifact-name: junit-pre-commit-${{ github.run_id }}-${{ job.check_run_id }}
 
   # Safe Fern docs checks run in pre-merge with read-only permissions.
   fern-check:
@@ -81,6 +88,13 @@ jobs:
       run: npm install -g fern-api
     - name: Validate Fern configuration
       run: fern check
+    - name: Upload JUnit Report
+      if: always()
+      uses: ./.github/actions/junit-report
+      with:
+        suite-name: fern-configuration-check
+        status: ${{ job.status }}
+        artifact-name: junit-fern-configuration-check-${{ github.run_id }}-${{ job.check_run_id }}
 
   fern-broken-links:
     name: Fern Broken Links Check
@@ -98,6 +112,13 @@ jobs:
       run: npm install -g fern-api
     - name: Check for broken links
       run: fern docs broken-links
+    - name: Upload JUnit Report
+      if: always()
+      uses: ./.github/actions/junit-report
+      with:
+        suite-name: fern-broken-links-check
+        status: ${{ job.status }}
+        artifact-name: junit-fern-broken-links-check-${{ github.run_id }}-${{ job.check_run_id }}
 
   operator:
     needs: changed-files
@@ -113,6 +134,13 @@ jobs:
       with:
         component: operator
         platform: linux/amd64
+    - name: Upload JUnit Report
+      if: always()
+      uses: ./.github/actions/junit-report
+      with:
+        suite-name: operator-checks
+        status: ${{ job.status }}
+        artifact-name: junit-operator-checks-${{ github.run_id }}-${{ job.check_run_id }}
 
   snapshot:
     needs: changed-files
@@ -128,6 +156,13 @@ jobs:
       with:
         component: snapshot
         platform: linux/amd64
+    - name: Upload JUnit Report
+      if: always()
+      uses: ./.github/actions/junit-report
+      with:
+        suite-name: snapshot-agent-checks
+        status: ${{ job.status }}
+        artifact-name: junit-snapshot-agent-checks-${{ github.run_id }}-${{ job.check_run_id }}
 
   rust-tests:
     needs: changed-files
@@ -188,6 +223,13 @@ jobs:
       if: matrix.dir == '.'
       working-directory: ${{ matrix.dir }}
       run: cargo test --locked -p dynamo-bench --test mooncake_trace --features mocker-kvbm-offload -- --nocapture
+    - name: Upload JUnit Report
+      if: always()
+      uses: ./.github/actions/junit-report
+      with:
+        suite-name: rust-tests-${{ matrix.dir }}
+        status: ${{ job.status }}
+        artifact-name: junit-rust-tests-${{ matrix.dir }}-${{ github.run_id }}-${{ job.check_run_id }}
 
   rust-clippy:
     needs: changed-files
@@ -240,3 +282,10 @@ jobs:
       run: |
         cargo-machete --version || cargo install cargo-machete@0.9.1
         cargo machete
+    - name: Upload JUnit Report
+      if: always()
+      uses: ./.github/actions/junit-report
+      with:
+        suite-name: rust-clippy-${{ matrix.dir }}
+        status: ${{ job.status }}
+        artifact-name: junit-rust-clippy-${{ matrix.dir }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/workflows/upload_complete_workflow_metrics.py
+++ b/.github/workflows/upload_complete_workflow_metrics.py
@@ -894,9 +894,7 @@ class WorkflowMetricsUploader:
                 framework = metadata.get("framework", "unknown")
                 test_type = metadata.get("test_type", "unknown")
                 step_name = metadata.get("step_name", "Run tests")
-                junit_xml_file = metadata.get(
-                    "junit_xml_file", "pytest_test_report.xml"
-                )
+                junit_xml_file = metadata.get("junit_xml_file", "junit.xml")
 
                 # Construct step ID from metadata
                 test_step_id = f"{job_id}_{step_name.lower().replace(' ', '_')}"
@@ -907,10 +905,25 @@ class WorkflowMetricsUploader:
                 print(f"   Step Name: {step_name}")
                 print(f"   Step ID: {test_step_id}")
 
-                # Find the corresponding XML file
-                xml_file = f"{test_results_dir}/{junit_xml_file}"
-                if not os.path.exists(xml_file):
-                    print(f"⚠️  JUnit XML file not found: {xml_file}")
+                # Find the corresponding XML file. Prefer the standardized name
+                # while keeping the old pytest filename for older artifacts.
+                xml_candidates = list(
+                    dict.fromkeys(
+                        [junit_xml_file, "junit.xml", "pytest_test_report.xml"]
+                    )
+                )
+                xml_file = next(
+                    (
+                        f"{test_results_dir}/{candidate}"
+                        for candidate in xml_candidates
+                        if os.path.exists(f"{test_results_dir}/{candidate}")
+                    ),
+                    None,
+                )
+                if not xml_file:
+                    print(
+                        f"⚠️  JUnit XML file not found. Tried: {', '.join(xml_candidates)}"
+                    )
                     continue
 
                 print(f"📄 Processing JUnit XML: {xml_file}")


### PR DESCRIPTION
Summary
- Standardize CI test-result artifact payloads on test-results/junit.xml.
- Add a reusable JUnit report action for jobs that do not emit native JUnit.
- Add fallback junit.xml generation for pytest/deploy jobs and keep metrics ingestion compatible with the old pytest filename.
- Add a GitHub Actions JUnit history helper that reports top failing/erroring testcases with per-day history, example job URLs, synthetic/aggregate-row filtering, and an SVG heatmap.

Validation
- git diff --check origin/main..HEAD
- python3 -m py_compile .github/scripts/junit_history.py
- python3 .github/scripts/junit_history.py --help
- python3 .github/scripts/junit_history.py --days 7 --top 25 --plot /private/tmp/dynamo-junit-flakes-7d.svg 2>&1 | tee /private/tmp/dynamo-junit-flakes-7d.txt

JUnit history example

Plot:

![JUnit flake history heatmap](https://gist.githubusercontent.com/sttts/555b4f171289baa87d3d3901e65d053c/raw/1205274980dc58c10b5d0a1a8994ba3780e7853d/dynamo-junit-flakes-7d.png)

Command:

```bash
python3 .github/scripts/junit_history.py --days 7 --top 25 --plot /private/tmp/dynamo-junit-flakes-7d.svg 2>&1 | tee /private/tmp/dynamo-junit-flakes-7d.txt
```

Output excerpt:

```text
Repo: ai-dynamo/dynamo
Window: since 2026-06-09 13:10:00 UTC
Runs: 121
JUnit XML files: 3900

Date        Workflow                 Runs Artifacts  XMLs   Cases    Pass  Fail  Err   Skip     Time  Conclusions
-----------------------------------------------------------------------------------------------------------------
2026-06-09  post-merge                 23       798   805  408441  349899    80    9  58453   74h11m  failure:21,cancelled:2
2026-06-10  nightly                     1        15    15   12750   11020     1    0   1729    1h30m  failure:1
2026-06-10  post-merge                 20       710   710  369258  319667    60    2  49529   65h11m  failure:20
2026-06-11  nightly                     1        17    17   13453   10943    32    0   2478    4h39m  failure:1
2026-06-11  post-merge                 23       793   793  416672  358984    14    2  57672   52h05m  failure:23
2026-06-12  nightly                     1        17    17   13515   11005    32    0   2478    4h05m  failure:1
2026-06-12  post-merge                 28       805   805  420931  362408    10    1  58512   50h04m  failure:28
2026-06-13  nightly                     1         0     0       0       0     0    0      0       0s  failure:1
2026-06-13  post-merge                  4       105   105   57051   47307     0    0   9744    6h27m  failure:4
2026-06-14  nightly                     1        17    17   14051   11013    32    0   3006    4h05m  failure:1
2026-06-14  post-merge                  2        70    70   38034   31537     1    0   6496    4h11m  failure:2
2026-06-15  nightly                     1        15    15   13210   10954     2    1   2253    1h35m  failure:1
2026-06-15  post-merge                  9       327   327  174021  144468     9    0  29544   26h58m  success:3,failure:6
2026-06-16  nightly                     1        19    19   14346   11247    32    0   3067    5h13m  failure:1
2026-06-16  post-merge                  5       185   185   96755   80192     3    0  16560   14h53m  success:2,failure:3

Top test flakes by failure/error occurrence over this window (top 25):
1. 49 tests.serve.test_vllm_xpu.test_serve_deployment[mm_agg_video_qwen3-vl-2b-2]

   2026-06-11: https://github.com/ai-dynamo/dynamo/actions/runs/27322140096/job/80716738376
   2026-06-11: https://github.com/ai-dynamo/dynamo/actions/runs/27320408789/job/80711450311
   2026-06-11: https://github.com/ai-dynamo/dynamo/actions/runs/27314350796/job/80694304211
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27314215463/job/80692764845
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27313491712/job/80690499262

2. 13 tests.serve.test_vllm_xpu.test_serve_deployment[mm_agg_router_chat_processor_qwen3-vl-2b-2]

   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27311264953/job/80685893058
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27308556087/job/80672906047
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27307870731/job/80672898907
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27300466615/job/80648162008
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27254972561/job/80489400428

3. 12 tests.deploy.test_deploy.test_deployment[sglang-agg]

   2026-06-16: https://github.com/ai-dynamo/dynamo/actions/runs/27584949509/job/81553827442
   2026-06-14: https://github.com/ai-dynamo/dynamo/actions/runs/27492022024/job/81259513986
   2026-06-12: https://github.com/ai-dynamo/dynamo/actions/runs/27447586284/job/81136314561
   2026-06-12: https://github.com/ai-dynamo/dynamo/actions/runs/27447282062/job/81135469834
   2026-06-12: https://github.com/ai-dynamo/dynamo/actions/runs/27443484033/job/81123691390

4. 11 tests.serve.test_vllm_xpu.test_serve_deployment[mm_agg_router_qwen3-vl-2b-2]

   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27311264953/job/80685893058
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27309990281/job/80685881240
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27308704347/job/80675822227
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27298463175/job/80637537193
   2026-06-09: https://github.com/ai-dynamo/dynamo/actions/runs/27225157106/job/80406386375

5. 8 tests.deploy.test_deploy.test_deployment[sglang-agg_router]

   2026-06-16: https://github.com/ai-dynamo/dynamo/actions/runs/27600728890/job/81601780626
   2026-06-15: https://github.com/ai-dynamo/dynamo/actions/runs/27583643427/job/81549940830
   2026-06-15: https://github.com/ai-dynamo/dynamo/actions/runs/27583083040/job/81548297868
   2026-06-12: https://github.com/ai-dynamo/dynamo/actions/runs/27388076096/job/80940040386
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27309619504/job/80677155202

6. 8 tests.serve.test_vllm_xpu.test_serve_deployment[mm_agg_router_frontend_decode_qwen3-vl-2b-2]

   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27311264953/job/80685893058
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27308556087/job/80672906047
   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27297676276/job/80634868708
   2026-06-09: https://github.com/ai-dynamo/dynamo/actions/runs/27241258284/job/80455343438
   2026-06-09: https://github.com/ai-dynamo/dynamo/actions/runs/27236870896/job/80440225661

7. 7 tests.deploy.test_dynamocheckpoint.test_dgd_checkpoint_restore_deploy

   2026-06-15: https://github.com/ai-dynamo/dynamo/actions/runs/27583083040/job/81550096217
   2026-06-15: https://github.com/ai-dynamo/dynamo/actions/runs/27563951021/job/81487442952
   2026-06-12: https://github.com/ai-dynamo/dynamo/actions/runs/27429751506/job/81078505307
   2026-06-11: https://github.com/ai-dynamo/dynamo/actions/runs/27378349981/job/80910509611
   2026-06-11: https://github.com/ai-dynamo/dynamo/actions/runs/27366205904/job/80867879485

8. 7 tests.serve.test_vllm_xpu.test_serve_deployment[mm_agg_router_qwen2.5-vl-3b-2]

   2026-06-10: https://github.com/ai-dynamo/dynamo/actions/runs/27288832950/job/80611066316
   2026-06-09: https://github.com/ai-dynamo/dynamo/actions/runs/27217058834/job/80363547280
   2026-06-09: https://github.com/ai-dynamo/dynamo/actions/runs/27216873291/job/80362911781
   2026-06-09: https://github.com/ai-dynamo/dynamo/actions/runs/27216466234/job/80362818870
   2026-06-09: https://github.com/ai-dynamo/dynamo/actions/runs/27215976517/job/80362822833

9. 6 tests.deploy.test_deploy.test_deployment[trtllm-agg_router]

   2026-06-15: https://github.com/ai-dynamo/dynamo/actions/runs/27576361372/job/81527420917
   2026-06-15: https://github.com/ai-dynamo/dynamo/actions/runs/27574055955/job/81519716867
   2026-06-12: https://github.com/ai-dynamo/dynamo/actions/runs/27385570820/job/80933374285
   2026-06-11: https://github.com/ai-dynamo/dynamo/actions/runs/27322140096/job/80716548996
   2026-06-11: https://github.com/ai-dynamo/dynamo/actions/runs/27320408789/job/80711197729

10. 6 tests.serve.test_vllm.test_serve_deployment[deepep-2]

   2026-06-16: https://github.com/ai-dynamo/dynamo/actions/runs/27609047426/job/81631206849
   2026-06-15: https://github.com/ai-dynamo/dynamo/actions/runs/27539067447/job/81398681426
   2026-06-14: https://github.com/ai-dynamo/dynamo/actions/runs/27494125534/job/81265018821
   2026-06-12: https://github.com/ai-dynamo/dynamo/actions/runs/27406972488/job/80998811643
   2026-06-11: https://github.com/ai-dynamo/dynamo/actions/runs/27337410182/job/80770606259

Wrote plot: /private/tmp/dynamo-junit-flakes-7d.svg
```

The top-flake ranking is aggregated by testcase across all selected workflows. Synthetic job-level JUnit rows, parent aggregate rows, and Pytest internal-error rows are filtered by default; use `--include-aggregate-failures` to include them again.

The script caches artifact ZIPs automatically. Override with `--cache-dir`, force re-download with `--refresh-cache`, or disable caching with `--no-cache`.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced standardized JUnit test result reporting across the CI/CD pipeline with automatic artifact uploads for all test jobs.
  * Added fallback test result generation when native test outputs are unavailable.

* **Chores**
  * Updated workflows to use unified test reporting mechanism across multiple CI jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

