### PR TITLE
fix(vllm): reuse engine model config

### DIFF
--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -232,14 +232,13 @@ class VllmLLMEngine(LLMEngine):
 
         self._prometheus_temp_dir = ensure_prometheus_multiproc_dir("vllm_prometheus_")
 
-        self._default_sampling_params = (
-            self.engine_args.create_model_config().get_diff_sampling_param()
-        )
-
         vllm_config = self.engine_args.create_engine_config(
             usage_context=UsageContext.OPENAI_API_SERVER
         )
         self._vllm_config = vllm_config
+        self._default_sampling_params = (
+            vllm_config.model_config.get_diff_sampling_param()
+        )
 
         self._dp_range = get_dp_range_for_worker(vllm_config)
         self._stat_logger_factory = _UnifiedStatLoggerFactory()

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -544,14 +544,6 @@ def setup_vllm_engine(
             configure_gms_lock_mode(engine_args)
             configure_mx_ports(engine_args)
 
-    # ModelExpress uses vLLM's plugin path with --load-format=modelexpress.
-    # Dynamo does not register loaders or set a custom worker class here.
-
-    # Load default sampling params from `generation_config.json`
-    default_sampling_params = (
-        engine_args.create_model_config().get_diff_sampling_param()
-    )
-
     # Configure ec_both mode with DynamoMultimodalEmbeddingCacheConnector.
     # Must happen BEFORE engine setup so vLLM sees ec_transfer_config.
     if (
@@ -581,6 +573,7 @@ def setup_vllm_engine(
     # Taken from build_async_engine_client_from_engine_args()
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
+    default_sampling_params = vllm_config.model_config.get_diff_sampling_param()
 
     # Set up consolidator endpoints if KVBM (DynamoConnector) is enabled
     consolidator_endpoints = None

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -458,6 +458,69 @@ def test_should_register_model_fetch_weights_for_default_load_format():
     assert should_register_model_ignore_weights(config) is False
 
 
+def test_setup_vllm_engine_reuses_engine_config_model_config(monkeypatch):
+    from dynamo.vllm import main as vllm_main
+
+    class FakeModelConfig:
+        def get_diff_sampling_param(self):
+            return {"temperature": 0.7}
+
+    vllm_config = SimpleNamespace(
+        additional_config={},
+        cache_config=SimpleNamespace(block_size=None),
+        model_config=FakeModelConfig(),
+    )
+
+    class FakeEngineArgs:
+        enable_log_requests = False
+        enable_lora = False
+        disable_log_stats = True
+        load_format = "modelexpress"
+
+        def create_model_config(self):
+            raise AssertionError("setup_vllm_engine must not create ModelConfig twice")
+
+        def create_engine_config(self, usage_context):
+            return vllm_config
+
+    engine_client = SimpleNamespace(vllm_config=vllm_config)
+
+    class FakeAsyncLLM:
+        @staticmethod
+        def from_vllm_config(**_kwargs):
+            return engine_client
+
+    class FakeMetrics:
+        def __init__(self, **_kwargs):
+            pass
+
+        def set_model_load_time(self, _load_time):
+            pass
+
+    monkeypatch.setattr(vllm_main, "setup_multiprocess_prometheus", lambda: None)
+    monkeypatch.setattr(vllm_main, "LLMBackendMetrics", FakeMetrics)
+    monkeypatch.setattr(vllm_main, "_uses_dynamo_connector", lambda _args: False)
+    monkeypatch.setattr(vllm_main, "AsyncLLM", FakeAsyncLLM)
+    monkeypatch.setattr(
+        vllm_main,
+        "get_engine_cache_info",
+        lambda _engine: {"block_size": 16},
+    )
+
+    config = SimpleNamespace(
+        component="backend",
+        engine_args=FakeEngineArgs(),
+        gms_shadow_mode=False,
+        multimodal_embedding_cache_capacity_gb=0,
+        route_to_encoder=False,
+        served_model_name="Qwen/Qwen3-0.6B",
+    )
+
+    _, _, default_sampling_params, _, _ = vllm_main.setup_vllm_engine(config)
+
+    assert default_sampling_params == {"temperature": 0.7}
+
+
 # --disaggregation-mode tests
 
 


### PR DESCRIPTION
## Overview:

This PR avoids constructing vLLM `ModelConfig` twice during Dynamo vLLM engine startup.

For ModelExpress/object-storage load formats, `ModelConfig.__post_init__()` has side effects that resolve the model path and initialize loader metadata. Calling `create_model_config()` before `create_engine_config()` can run those side effects once outside the final engine config, then run them again when vLLM builds the real `VllmConfig`.

## Details:

- Reuse `vllm_config.model_config` for default sampling params in `setup_vllm_engine()`.
- Apply the same pattern in `VllmEngine.start()`.
- Add a unit regression test that fails if `setup_vllm_engine()` calls `create_model_config()` directly.

Validation:
- `python3 -m py_compile components/src/dynamo/vllm/main.py components/src/dynamo/vllm/llm_engine.py components/src/dynamo/vllm/tests/test_vllm_unit.py`
- `git diff --check`
- E2E on nscale with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-cuda13`, patched files mounted into the runtime, `modelexpress==0.4.0`, and `s3://model-express-models/Qwen/Qwen3.5-0.8B`: RunAI Model Streamer loaded `488/488` tensors and logged `MxModelLoader.load_model() COMPLETE in 5.18s`.

Note: the E2E also exposed the separate `register_model()` raw `s3://` Hugging Face fallback failure after worker initialization. That is the adjacent #10599-class issue, not this duplicate-`ModelConfig` fix.

## Where should the reviewer start?

- `components/src/dynamo/vllm/main.py`
- `components/src/dynamo/vllm/llm_engine.py`
- `components/src/dynamo/vllm/tests/test_vllm_unit.py`

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue**:
- [x] Confirmed — no related GitHub issue

Related internal bug: NVBug 6310722.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized vLLM engine initialization for improved configuration handling.

* **Tests**
  * Added verification test for vLLM engine configuration reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->