### PR TITLE
docs(readme): update docs URL to docs.nvidia.com/dynamo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -410,9 +410,9 @@ The Fern site supports a version dropdown in the UI. Each version is defined by:
 
 ### URL structure
 
-- **Latest (default):** `docs.dynamo.nvidia.com/dynamo/`
-- **Specific version:** `docs.dynamo.nvidia.com/dynamo/v0.8.1/`
-- **Dev:** `docs.dynamo.nvidia.com/dynamo/dev/`
+- **Latest (default):** `docs.nvidia.com/dynamo/`
+- **Specific version:** `docs.nvidia.com/dynamo/v0.8.1/`
+- **Dev:** `docs.nvidia.com/dynamo/dev/`
 
 ### Creating a new version
 
@@ -443,7 +443,7 @@ automatically.
 │       │                                                             │
 │       ▼                                                             │
 │  sync-dev job:                                                      │
-│    1. Copy docs/ content → fern/pages/ on docs-website branch │
+│    1. Copy docs/ content → fern/pages/ on docs-website branch       │
 │    2. Copy fern/ configs → fern/ on docs-website branch             │
 │    3. Convert GitHub callouts → Fern admonitions                    │
 │    4. Preserve version list from docs-website's docs.yml            │
@@ -451,7 +451,7 @@ automatically.
 │    6. fern generate --docs (publishes to Fern)                      │
 │       │                                                             │
 │       ▼                                                             │
-│  Live on docs.dynamo.nvidia.com/dynamo/dev/ within minutes          │
+│  Live on docs.nvidia.com/dynamo/dev/ within minutes                 │
 └─────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -464,15 +464,15 @@ automatically.
 │    1. Validate tag format (vX.Y.Z only)                             │
 │    2. Check version doesn't already exist                           │
 │    3. Snapshot fern/pages/ → fern/pages-vX.Y.Z/                     │
-│    4. Rewrite GitHub links (tree/main → tree/vX.Y.Z)               │
+│    4. Rewrite GitHub links (tree/main → tree/vX.Y.Z)                │
 │    5. Convert callouts in snapshot                                  │
-│    6. Create fern/versions/vX.Y.Z.yml (paths → pages-vX.Y.Z/)     │
+│    6. Create fern/versions/vX.Y.Z.yml (paths → pages-vX.Y.Z/)       │
 │    7. Update fern/docs.yml (insert version, set as default)         │
 │    8. Commit + push to docs-website                                 │
 │    9. fern generate --docs (publishes to Fern)                      │
 │       │                                                             │
 │       ▼                                                             │
-│  New version visible in dropdown at docs.dynamo.nvidia.com/dynamo/  │
+│  New version visible in dropdown at docs.nvidia.com/dynamo/         │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,12 +9,7 @@ This document describes the architecture, workflows, and maintenance procedures 
 NVIDIA Dynamo documentation website powered by [Fern](https://buildwithfern.com).
 
 <Note>
-The documentation website is hosted entirely on
-[Fern](https://buildwithfern.com). CI publishes to
-`dynamo.docs.buildwithfern.com`; the production domain
-`docs.dynamo.nvidia.com` is a custom domain alias that points to the
-Fern-hosted site. There is no separate server — Fern handles hosting,
-CDN, and versioned URL routing.
+The documentation website is published at [https://docs.nvidia.com/dynamo](https://docs.nvidia.com/dynamo). CI handles publishing, including hosting, CDN, and versioned URL routing.
 </Note>
 
 <Error>

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -14,7 +14,7 @@ Release history in this document begins at v0.6.0.
 ## Current Release: Dynamo v1.2.0
 
 - **GitHub Release:** [v1.2.0](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0)
-- **Docs:** [v1.2.0](https://docs.dynamo.nvidia.com/dynamo)
+- **Docs:** [v1.2.0](https://docs.nvidia.com/dynamo)
 - **NGC Collection:** [ai-dynamo](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)
 
 > **Experimental:** [v1.2.0-deepseek-v4-dev.3](#v120-deepseek-v4-dev3) *(DeepSeek-V4-Flash / V4-Pro on Blackwell, vLLM + SGLang containers only)* is available as an experimental preview. Tagged **Pre-Releases** and experimental builds are listed under [Pre-Release Artifacts](#pre-release-artifacts).
@@ -242,19 +242,19 @@ These crates use repository `https://github.com/ai-dynamo/dynamo.git`. The table
 
 | Version | Release Date | GitHub | Docs | Notes |
 |---------|--------------|--------|------|-------|
-| `v1.2.0` | Jun 2, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0) | [Docs](https://docs.dynamo.nvidia.com/dynamo) | |
+| `v1.2.0` | Jun 2, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0) | [Docs](https://docs.nvidia.com/dynamo) | |
 | `v1.2.0-deepseek-v4-dev.3` | May 9, 2026 | [Tag](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0-deepseek-v4-dev.3) | — | Experimental (DeepSeek-V4-Flash / V4-Pro Blackwell preview; vLLM + SGLang containers only) |
 | `v1.2.0-deepseek-v4-dev.2` | May 1, 2026 | [Tag](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0-deepseek-v4-dev.2) | — | Experimental (DeepSeek-V4-Flash / V4-Pro Blackwell preview; vLLM + SGLang containers only) |
 | `v1.2.0-sglang-deepseek-v4-dev.1` | Apr 25, 2026 | [Tag](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0-sglang-deepseek-v4-dev.1) | — | Experimental (SGLang container only; DeepSeek-V4 Blackwell preview) |
-| `v1.1.1` | May 5, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.1) | [Docs](https://docs.dynamo.nvidia.com/dynamo) | |
-| `v1.1.0` | May 1, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0) | [Docs](https://docs.dynamo.nvidia.com/dynamo) | |
+| `v1.1.1` | May 5, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.1) | [Docs](https://docs.nvidia.com/dynamo) | |
+| `v1.1.0` | May 1, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0) | [Docs](https://docs.nvidia.com/dynamo) | |
 | `v1.1.0-dev.3` | Apr 18, 2026 | [Tag](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0-dev.3) | — | Pre-Release (TRT-LLM Runtime Image + Wheels; see Pre-Release Artifacts) |
 | `v1.1.0-dev.2` | Apr 9, 2026 | [Tag](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0-dev.2) | — | Pre-Release (SGLang + TRT-LLM Runtime Images + Wheels; see Pre-Release Artifacts) |
 | `v1.1.0-dev.1` | Mar 17, 2026 | [Tag](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0-dev.1) | — | Experimental |
-| `v1.0.2` | Apr 22, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.2) | [Docs](https://docs.dynamo.nvidia.com/dynamo) | |
-| `v1.0.1` | Mar 16, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.1) | [Docs](https://docs.dynamo.nvidia.com/dynamo) | |
-| `v1.0.0` | Mar 12, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0) | [Docs](https://docs.dynamo.nvidia.com/dynamo) | |
-| `v0.9.1` | Mar 4, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.1) | [Docs](https://docs.dynamo.nvidia.com/dynamo) |
+| `v1.0.2` | Apr 22, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.2) | [Docs](https://docs.nvidia.com/dynamo) | |
+| `v1.0.1` | Mar 16, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.1) | [Docs](https://docs.nvidia.com/dynamo) | |
+| `v1.0.0` | Mar 12, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.0) | [Docs](https://docs.nvidia.com/dynamo) | |
+| `v0.9.1` | Mar 4, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.1) | [Docs](https://docs.nvidia.com/dynamo) |
 | `v0.9.0` | Feb 11, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.9.0) | Archived docs unavailable |
 | `v0.8.1` | Jan 23, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1) | Archived docs unavailable |
 | `v0.8.0` | Jan 15, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.0) | Archived docs unavailable |


### PR DESCRIPTION
## Summary

- Replaces all `docs.dynamo.nvidia.com` references with the correct production URL (`docs.nvidia.com/dynamo`) across:
  - `docs/README.md` — hosting description, URL structure examples, and ASCII CI workflow diagrams
  - `docs/reference/release-artifacts.md` — docs links in the release history table and current release section
- Fixes minor whitespace alignment in ASCII diagrams.

## Validation

- No code changes; documentation text only.
- Verified all updated URLs are consistent with the production domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)