### PR TITLE
fix(planner): preserve middle empty windows in warmup trace metrics

### DIFF
--- a/components/src/dynamo/planner/offline/trace_data.py
+++ b/components/src/dynamo/planner/offline/trace_data.py
@@ -17,11 +17,20 @@ def extract_metrics_from_mooncake(
         throughput_adjustment_interval_seconds: Time interval to group requests
 
     Returns:
-        List of dictionaries containing metrics for each interval:
+        List of dictionaries (ordered by time) containing metrics for each interval:
         - interval_start: Start time of the interval (in seconds)
         - request_count: Total number of requests in the interval
         - avg_isl: Average input sequence length
         - avg_osl: Average output sequence length
+
+        Intervals with no requests *between* the first and last active interval
+        are emitted as empty windows (request_count=0, avg_isl=0, avg_osl=0) so
+        gaps in traffic are preserved. This matches the planner's online
+        throughput loop, which feeds zero-traffic windows to the load
+        predictors; collapsing the gaps would let warmup diverge from live
+        behavior. Leading and trailing empty intervals are still omitted (the
+        series starts at the first interval with traffic and ends at the last),
+        matching the predictors' leading-idle skip.
     """
     # Read and parse JSONL data from file
     records = []
@@ -41,11 +50,20 @@ def extract_metrics_from_mooncake(
         )
         interval_groups[interval_start].append(record)
 
-    # Compute metrics for each interval
-    metrics = []
+    # Compute metrics for each interval. Walk every interval from the first to
+    # the last active one (step = interval), filling gaps with empty windows so
+    # zero-traffic intervals are preserved (matching the online throughput loop).
+    metrics: List[Dict[str, Any]] = []
+    if not interval_groups:
+        return metrics
 
-    for interval_start in sorted(interval_groups.keys()):
-        records_in_interval = interval_groups[interval_start]
+    sorted_starts = sorted(interval_groups.keys())
+    for interval_start in range(
+        sorted_starts[0],
+        sorted_starts[-1] + 1,
+        throughput_adjustment_interval_seconds,
+    ):
+        records_in_interval = interval_groups.get(interval_start, [])
 
         # Calculate metrics
         request_count = len(records_in_interval)

--- a/components/src/dynamo/planner/tests/offline/test_trace_data.py
+++ b/components/src/dynamo/planner/tests/offline/test_trace_data.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``extract_metrics_from_mooncake`` window construction.
+
+The planner's online throughput loop feeds *every* interval (including
+zero-traffic ones) to the load predictors, but warmup goes through
+``extract_metrics_from_mooncake``. Before the fix it only emitted intervals
+that contained requests, so middle gaps were collapsed and warmup diverged
+from live behavior. These tests pin the densified behavior: gaps between the
+first and last active interval are emitted as empty windows, while leading and
+trailing empty intervals are omitted.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from dynamo.planner.offline.trace_data import extract_metrics_from_mooncake
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _write_trace(tmp_path, records):
+    path = tmp_path / "trace.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return str(path)
+
+
+def _rec(timestamp_ms, isl, osl):
+    return {"timestamp": timestamp_ms, "input_length": isl, "output_length": osl}
+
+
+def test_middle_empty_windows_are_preserved(tmp_path):
+    # interval=10s; activity in interval 0 (2 reqs) and interval 30 (1 req);
+    # intervals 10 and 20 are empty gaps that must be preserved.
+    records = [
+        _rec(0, 100, 10),
+        _rec(5_000, 300, 30),
+        _rec(35_000, 500, 50),
+    ]
+    metrics = extract_metrics_from_mooncake(_write_trace(tmp_path, records), 10)
+
+    assert [m["interval_start"] for m in metrics] == [0, 10, 20, 30]
+    assert [m["request_count"] for m in metrics] == [2, 0, 0, 1]
+    # active window 0: averages over its two requests
+    assert metrics[0]["avg_isl"] == 200.0
+    assert metrics[0]["avg_osl"] == 20.0
+    # empty middle windows are zero-filled
+    for m in (metrics[1], metrics[2]):
+        assert m["request_count"] == 0
+        assert m["avg_isl"] == 0
+        assert m["avg_osl"] == 0
+    assert metrics[3]["avg_isl"] == 500.0
+
+
+def test_leading_and_trailing_empties_are_dropped(tmp_path):
+    # First activity at interval 30, last at interval 50, gap at 40.
+    records = [
+        _rec(35_000, 100, 10),
+        _rec(55_000, 200, 20),
+    ]
+    metrics = extract_metrics_from_mooncake(_write_trace(tmp_path, records), 10)
+
+    # Starts at the first active interval (no leading 0/10/20) and ends at the
+    # last active interval; the middle gap (40) is kept.
+    assert [m["interval_start"] for m in metrics] == [30, 40, 50]
+    assert [m["request_count"] for m in metrics] == [1, 0, 1]
+
+
+def test_intervals_are_contiguous(tmp_path):
+    records = [_rec(0, 10, 1), _rec(125_000, 20, 2)]
+    metrics = extract_metrics_from_mooncake(_write_trace(tmp_path, records), 30)
+    starts = [m["interval_start"] for m in metrics]
+    assert starts == list(range(0, 121, 30))  # 0,30,60,90,120
+    assert all(b - a == 30 for a, b in zip(starts, starts[1:]))
+
+
+def test_empty_trace_returns_empty(tmp_path):
+    assert extract_metrics_from_mooncake(_write_trace(tmp_path, []), 10) == []


### PR DESCRIPTION
## Problem

`extract_metrics_from_mooncake` (used by the planner's warmup path, `PlannerCore._warm_predictors`) only emitted intervals that contained requests — it iterated `sorted(interval_groups.keys())`, so **zero-traffic gaps were silently collapsed**.

But the **online** throughput loop feeds *every* interval to the load predictors:

```python
# state_machine._observe_traffic
if self._config.enable_throughput_scaling:
    self._num_req_predictor.add_data_point(traffic.num_req)   # 0 on a lull
    self._isl_predictor.add_data_point(traffic.isl)
    self._osl_predictor.add_data_point(traffic.osl)
```

`BasePredictor.add_data_point` skips **leading** zeros (idle period) but keeps **middle** zeros. So warming from a trace produced a different predictor state than live operation would — a lull in the middle of the trace disappeared during warmup but is seen online.

## Fix

Densify the window series: walk every interval from the first to the last active one (step = `throughput_adjustment_interval_seconds`) and emit empty windows (`request_count=0`, `avg_isl=0`, `avg_osl=0`) for the gaps. Leading and trailing empties stay dropped (the series starts at the first interval with traffic and ends at the last), matching the predictors' leading-idle skip.

This makes warmup-from-trace consistent with the online throughput loop.

## Blast radius

`extract_metrics_from_mooncake` has a single caller — the warmup path. No other behavior changes.

## Tests

Adds `tests/offline/test_trace_data.py`:
- middle empty windows preserved (zero-filled)
- leading/trailing empties dropped, middle gap kept
- intervals contiguous (step = interval)
- empty trace → `[]`

`isort` / `black` / `flake8` / `ruff` / pytest-markers pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metrics extraction to correctly preserve zero-traffic intervals between active periods while omitting leading and trailing idle intervals.

* **Tests**
  * Added comprehensive unit tests for metrics extraction interval behavior, including handling of empty windows and contiguous interval generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->