### PR TITLE
fix(llm): resolve eos/bos token ids from tokenizer_config and special_tokens_map

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -1637,29 +1637,26 @@ impl HFConfig {
             );
         };
 
-        let gencfg_path = file_path
-            .parent()
-            .unwrap_or_else(|| Path::new(""))
-            .join("generation_config.json");
+        let model_dir = file_path.parent().unwrap_or_else(|| Path::new(""));
+        let gencfg_path = model_dir.join("generation_config.json");
 
-        // bos_token_id is optional - not all models have it
-        // Try to load from generation_config.json if not in config.json
-        if text_config.bos_token_id.is_none() {
-            text_config.bos_token_id =
-                crate::file_json_field::<TokenIdType>(&gencfg_path, "bos_token_id").ok();
-        }
+        // bos and eos resolve through the same chain, highest priority first:
+        //   generation_config.json -> config.json -> tokenizer_config.json
+        //   -> special_tokens_map.json
+        // generation_config wins over config.json (HF convention); the tokenizer
+        // rungs rescue models that ship the token only there, not in config.
+        text_config.bos_token_id =
+            crate::file_json_field::<TokenIdType>(&gencfg_path, "bos_token_id")
+                .ok()
+                .or(text_config.bos_token_id)
+                .or_else(|| resolve_token_id_from_tokenizer_files(model_dir, "bos_token"));
 
-        // TODO: refactor this when we switch to per-architecture tokenization
-        // eos_token_id can appear in multiple places, and as suggested by HuggingFace
-        // community that the priority should be:
-        // 1. generation_config.json;
-        // 2. config.json, or text_config field in config.json.
-        // https://github.com/huggingface/transformers/issues/25395#issuecomment-1671863257
+        // Same chain as bos above, but eos may be a single id or a list.
+        // TODO: refactor when we switch to per-architecture tokenization.
         let mut final_eos_token_ids: Vec<TokenIdType> = {
-                // Firstly check the generation_config.json
                 crate::file_json_field::<serde_json::Value>(&gencfg_path, "eos_token_id")
                 .inspect_err(
-                    |err| tracing::warn!(%err, "Missing eos_token_id in generation_config.json"),
+                    |err| tracing::debug!(%err, "eos_token_id not found in generation_config.json, will fall back"),
                 )
                 .ok().and_then(|v| {
                     if v.is_number() {
@@ -1683,7 +1680,6 @@ impl HFConfig {
                     }
                 })
             }.or_else(|| {
-                // Check config.json and text_config
                 config
                 .eos_token_id
                 .as_ref()
@@ -1707,23 +1703,23 @@ impl HFConfig {
                     }
                 })
             })
+            .or_else(|| {
+                resolve_token_id_from_tokenizer_files(model_dir, "eos_token").map(|id| vec![id])
+            })
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "missing eos_token_id in config.json and generation_config.json, cannot load"
+                    "missing eos_token_id in generation_config.json, config.json, \
+                     tokenizer_config.json, and special_tokens_map.json — cannot load"
                 )
             })?;
-        // Also check tokenizer_config.json for the tokenizer's eos_token.
-        // Some models (e.g. Qwen3.5) have text_config.eos_token_id = <|endoftext|>
-        // but the tokenizer's eos_token is <|im_end|> — the token the model actually
-        // emits to end generation. Merge the tokenizer's EOS into the set so both
-        // are recognized as stop tokens.
-        let tokenizer_cfg_path = file_path
-            .parent()
-            .unwrap_or_else(|| Path::new(""))
-            .join("tokenizer_config.json");
-        if let Ok(tokenizer_eos_id) =
-            resolve_eos_token_id_from_tokenizer_config(&tokenizer_cfg_path)
-            && !final_eos_token_ids.contains(&tokenizer_eos_id)
+
+        // Some models (e.g. Qwen3.5) set eos in config.json but emit a different
+        // token (<|im_end|>) at generation end; both must count as stop tokens.
+        // Add the tokenizer's eos when it differs. Idempotent if already present.
+        if let Ok(tokenizer_eos_id) = resolve_token_id_from_tokenizer_config(
+            &model_dir.join("tokenizer_config.json"),
+            "eos_token",
+        ) && !final_eos_token_ids.contains(&tokenizer_eos_id)
         {
             final_eos_token_ids.push(tokenizer_eos_id);
         }
@@ -1734,42 +1730,107 @@ impl HFConfig {
     }
 }
 
-/// Resolve the tokenizer's `eos_token` to a token ID by reading `tokenizer_config.json`.
-///
-/// Reads the `eos_token` field (string) and looks it up in `added_tokens_decoder`
-/// to find the corresponding token ID. This handles models where the tokenizer's
-/// EOS token differs from `config.json`'s `eos_token_id`.
-fn resolve_eos_token_id_from_tokenizer_config(path: &Path) -> anyhow::Result<TokenIdType> {
-    let contents = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read tokenizer_config.json: {:?}", path))?;
-    let config: serde_json::Value = serde_json::from_str(&contents)
-        .with_context(|| format!("Failed to parse tokenizer_config.json: {:?}", path))?;
+/// Rungs 3-4 of the chain in `HFConfig::from_json_file`: resolve a token id
+/// from the tokenizer artifacts, trying `tokenizer_config.json` then
+/// `special_tokens_map.json`. `token_key` is the HF field, e.g. `"eos_token"`.
+fn resolve_token_id_from_tokenizer_files(model_dir: &Path, token_key: &str) -> Option<TokenIdType> {
+    if let Ok(id) =
+        resolve_token_id_from_tokenizer_config(&model_dir.join("tokenizer_config.json"), token_key)
+    {
+        return Some(id);
+    }
+    resolve_token_id_from_special_tokens_map(model_dir, token_key).ok()
+}
 
-    // Get eos_token — can be a plain string or a dict with a "content" field (older HF format)
-    let eos_token_str = match config.get("eos_token") {
-        Some(serde_json::Value::String(s)) => s.clone(),
-        Some(serde_json::Value::Object(obj)) => obj
-            .get("content")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .ok_or_else(|| anyhow::anyhow!("eos_token is an object without 'content' field"))?,
-        _ => anyhow::bail!("eos_token not found or not a string in tokenizer_config.json"),
-    };
-
-    // Look up the token string in added_tokens_decoder to get its ID
+/// Read `<token_key>` from `tokenizer_config.json` (a string or
+/// `{"content": ...}` object) and look it up in `added_tokens_decoder`.
+fn resolve_token_id_from_tokenizer_config(
+    path: &Path,
+    token_key: &str,
+) -> anyhow::Result<TokenIdType> {
+    let config = read_json(path)
+        .with_context(|| format!("Failed to read or parse tokenizer_config.json: {:?}", path))?;
+    let token_str = extract_token_string(config.get(token_key), token_key)?;
     let added_tokens = config
         .get("added_tokens_decoder")
         .and_then(|v| v.as_object())
         .ok_or_else(|| {
             anyhow::anyhow!("added_tokens_decoder not found in tokenizer_config.json")
         })?;
+    lookup_id_in_added_tokens_decoder(added_tokens, &token_str)
+}
 
+/// Read and JSON-parse a file, returning `None` if it is missing or invalid.
+fn read_json(path: &Path) -> Option<serde_json::Value> {
+    serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()
+}
+
+/// Look up `token_str`'s id in `tokenizer_config.json`'s `added_tokens_decoder`.
+fn lookup_id_in_tokenizer_config(model_dir: &Path, token_str: &str) -> Option<TokenIdType> {
+    let cfg = read_json(&model_dir.join("tokenizer_config.json"))?;
+    let added = cfg.get("added_tokens_decoder")?.as_object()?;
+    lookup_id_in_added_tokens_decoder(added, token_str).ok()
+}
+
+/// Look up `token_str`'s id in `tokenizer.json`'s `added_tokens` array.
+fn lookup_id_in_tokenizer_json(model_dir: &Path, token_str: &str) -> Option<TokenIdType> {
+    let tok = read_json(&model_dir.join("tokenizer.json"))?;
+    tok.get("added_tokens")?
+        .as_array()?
+        .iter()
+        .filter(|e| e.get("content").and_then(|v| v.as_str()) == Some(token_str))
+        .find_map(|e| e.get("id").and_then(|v| v.as_u64()))
+        .map(|id| id as TokenIdType)
+}
+
+/// `special_tokens_map.json` carries only the token string, so resolve its id
+/// via `tokenizer_config.json` then `tokenizer.json`.
+fn resolve_token_id_from_special_tokens_map(
+    model_dir: &Path,
+    token_key: &str,
+) -> anyhow::Result<TokenIdType> {
+    let stm = read_json(&model_dir.join("special_tokens_map.json"))
+        .context("Failed to read or parse special_tokens_map.json")?;
+    let token_str = extract_token_string(stm.get(token_key), token_key)?;
+
+    lookup_id_in_tokenizer_config(model_dir, &token_str)
+        .or_else(|| lookup_id_in_tokenizer_json(model_dir, &token_str))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{token_key} '{token_str}' from special_tokens_map.json not found in \
+                 tokenizer_config.json added_tokens_decoder or tokenizer.json added_tokens"
+            )
+        })
+}
+
+/// Pull a token string out of a JSON field that may be `"<str>"` or
+/// `{"content": "<str>", ...}` (the older HF format used in both
+/// `tokenizer_config.json` and `special_tokens_map.json`).
+fn extract_token_string(
+    field: Option<&serde_json::Value>,
+    token_key: &str,
+) -> anyhow::Result<String> {
+    match field {
+        Some(serde_json::Value::String(s)) => Ok(s.clone()),
+        Some(serde_json::Value::Object(obj)) => obj
+            .get("content")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow::anyhow!("{} is an object without 'content' field", token_key)),
+        _ => anyhow::bail!("{} not found or not a string", token_key),
+    }
+}
+
+fn lookup_id_in_added_tokens_decoder(
+    added_tokens: &serde_json::Map<String, serde_json::Value>,
+    token_str: &str,
+) -> anyhow::Result<TokenIdType> {
     for (id_str, token_info) in added_tokens {
         let content = token_info
             .get("content")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        if content == eos_token_str {
+        if content == token_str {
             let token_id: TokenIdType = id_str.parse().with_context(|| {
                 format!(
                     "Failed to parse token ID '{}' from added_tokens_decoder",
@@ -1779,11 +1840,7 @@ fn resolve_eos_token_id_from_tokenizer_config(path: &Path) -> anyhow::Result<Tok
             return Ok(token_id);
         }
     }
-
-    anyhow::bail!(
-        "eos_token '{}' not found in added_tokens_decoder",
-        eos_token_str
-    )
+    anyhow::bail!("token '{}' not found in added_tokens_decoder", token_str)
 }
 
 impl ModelInfo for HFConfig {
@@ -2019,6 +2076,72 @@ mod tests {
             "Should contain tokenizer eos_token (248046 <|im_end|>)"
         );
         Ok(())
+    }
+
+    /// Rung 3: model ships only `config.json` + `tokenizer_config.json`. No
+    /// `generation_config.json`, no eos/bos in `config.json`. Both token ids
+    /// must come from `tokenizer_config.json`'s `eos_token`/`bos_token` strings
+    /// resolved through `added_tokens_decoder`.
+    #[test]
+    fn test_config_json_eos_bos_from_tokenizer_config_only() -> anyhow::Result<()> {
+        let config_file = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-tokenizer-config-only/config.json");
+        let config = HFConfig::from_json_file(&config_file)?;
+        assert_eq!(config.bos_token_id(), Some(101));
+        let eos: HashSet<_> = config.eos_token_ids().iter().cloned().collect();
+        assert!(
+            eos.contains(&100),
+            "eos should resolve to 100 from tokenizer_config.json"
+        );
+        Ok(())
+    }
+
+    /// Rung 4: model ships only `config.json` + `special_tokens_map.json` +
+    /// `tokenizer.json`. The token strings live in `special_tokens_map.json`
+    /// and the id mapping in `tokenizer.json:added_tokens`. This is the rung
+    /// that rescues models that don't duplicate eos/bos into
+    /// `generation_config.json` or `config.json`.
+    #[test]
+    fn test_config_json_eos_bos_from_special_tokens_map() -> anyhow::Result<()> {
+        let config_file = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-special-tokens-only/config.json");
+        let config = HFConfig::from_json_file(&config_file)?;
+        assert_eq!(config.bos_token_id(), Some(201));
+        let eos: HashSet<_> = config.eos_token_ids().iter().cloned().collect();
+        assert!(
+            eos.contains(&200),
+            "eos should resolve to 200 from special_tokens_map"
+        );
+        Ok(())
+    }
+
+    /// All four rungs miss → the error message must name every source so the
+    /// operator knows what to add. Guards against the failure mode where
+    /// only `generation_config.json` is mentioned.
+    #[test]
+    fn test_config_json_missing_eos_everywhere_lists_all_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            br#"{"architectures":["FakeForCausalLM"],"model_type":"fake"}"#,
+        )
+        .unwrap();
+        let err = match HFConfig::from_json_file(dir.path().join("config.json")) {
+            Ok(_) => panic!("expected error when no eos source is available"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        for needle in [
+            "generation_config.json",
+            "config.json",
+            "tokenizer_config.json",
+            "special_tokens_map.json",
+        ] {
+            assert!(
+                msg.contains(needle),
+                "error must name {needle} as a source it checked; got: {msg}"
+            );
+        }
     }
 
     fn test_cf(uri: &str, size: u64) -> super::CheckedFile {

--- a/lib/llm/tests/data/sample-models/mock-special-tokens-only/config.json
+++ b/lib/llm/tests/data/sample-models/mock-special-tokens-only/config.json
@@ -1,0 +1,4 @@
+{
+  "architectures": ["FakeForCausalLM"],
+  "model_type": "fake"
+}

--- a/lib/llm/tests/data/sample-models/mock-special-tokens-only/special_tokens_map.json
+++ b/lib/llm/tests/data/sample-models/mock-special-tokens-only/special_tokens_map.json
@@ -1,0 +1,23 @@
+{
+  "bos_token": {
+    "content": "<bos>",
+    "lstrip": false,
+    "normalized": false,
+    "rstrip": false,
+    "single_word": false
+  },
+  "eos_token": {
+    "content": "<eos>",
+    "lstrip": false,
+    "normalized": false,
+    "rstrip": false,
+    "single_word": false
+  },
+  "pad_token": {
+    "content": "<pad>",
+    "lstrip": false,
+    "normalized": false,
+    "rstrip": false,
+    "single_word": false
+  }
+}

--- a/lib/llm/tests/data/sample-models/mock-special-tokens-only/tokenizer.json
+++ b/lib/llm/tests/data/sample-models/mock-special-tokens-only/tokenizer.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "added_tokens": [
+    {"id": 200, "content": "<eos>", "special": true},
+    {"id": 201, "content": "<bos>", "special": true},
+    {"id": 202, "content": "<pad>", "special": true}
+  ],
+  "model": {"type": "BPE", "vocab": {}, "merges": []}
+}

--- a/lib/llm/tests/data/sample-models/mock-tokenizer-config-only/config.json
+++ b/lib/llm/tests/data/sample-models/mock-tokenizer-config-only/config.json
@@ -1,0 +1,4 @@
+{
+  "architectures": ["FakeForCausalLM"],
+  "model_type": "fake"
+}

--- a/lib/llm/tests/data/sample-models/mock-tokenizer-config-only/tokenizer_config.json
+++ b/lib/llm/tests/data/sample-models/mock-tokenizer-config-only/tokenizer_config.json
@@ -1,0 +1,22 @@
+{
+  "bos_token": "<bos>",
+  "eos_token": "<eos>",
+  "added_tokens_decoder": {
+    "100": {
+      "content": "<eos>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "101": {
+      "content": "<bos>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Resolve `eos_token_id` and `bos_token_id` for models that ship those tokens only in `tokenizer_config.json` or `special_tokens_map.json` instead of duplicating them into `config.json` / `generation_config.json`. Today the MDC builder fails such models at frontend discovery with `missing eos_token_id in config.json and generation_config.json, cannot load`, blocking model registration even though the worker handled the same files fine.

Context: Minimax-M3 is one of these models and needs this support.

## Details

`HFConfig::from_json_file` now walks the same fallback chain HuggingFace itself documents (see [transformers#25395](https://github.com/huggingface/transformers/issues/25395#issuecomment-1671863257)):

1. `generation_config.json`
2. `config.json` / `text_config`
3. `tokenizer_config.json` (`<key>_token` string + `added_tokens_decoder` id mapping)
4. `special_tokens_map.json` (`<key>_token` string, id resolved via `tokenizer_config.json` then `tokenizer.json`)

Three new helpers in `lib/llm/src/model_card.rs`:

* `resolve_token_id_from_tokenizer_files(dir, key)` orchestrates rungs 3+4.
* `resolve_token_id_from_tokenizer_config(path, key)` generalises the existing Qwen3.5 helper so it works for both `eos_token` and `bos_token`.
* `resolve_token_id_from_special_tokens_map(dir, key)` reads the token string from `special_tokens_map.json`, then resolves the id via `tokenizer_config.json:added_tokens_decoder` or `tokenizer.json:added_tokens`.

`bos_token_id` resolution now uses the full 4-rung chain too (previously only rungs 1+2). The existing post-hoc augmentation that picks up `<|im_end|>` for Qwen3.5-style models is preserved. The `WARN Missing eos_token_id in generation_config.json` is demoted to `debug!` since it now fires for every model that legitimately ships its eos elsewhere.

The error message now names all four sources it checked, so an operator hitting the truly-missing case immediately sees where to look.

## Before / After

A 12-line probe binary (`lib/llm/examples/show_token_ids.rs`, not in this MR) was run on the model directory that originally surfaced this bug. `config.json` has no `eos_token_id` / `bos_token_id`, no `generation_config.json` exists, and the token strings live only in `special_tokens_map.json` + `tokenizer_config.json`.

```
=== BASELINE (origin/main) ===
Error: missing eos_token_id in config.json and
       generation_config.json, cannot load
exit=1

=== WITH FIX ===
bos_token_id  = Some(200019)
eos_token_ids = [200020]
exit=0
```

Same binary, same model directory, only `lib/llm/src/model_card.rs` swapped.

## Cross-impl

Bare `sglang.launch_server` resolves these ids lazily from the tokenizer at inference time and handles the same files without a hitch. vLLM does the same. Dynamo lifts stream termination out of the engine into a Rust pipeline that needs the id at MDC build time, so the contract is stricter. This change makes Dynamo's lookup behaviour match the rest of the HF ecosystem rather than requiring operators to drop a sidecar `generation_config.json` next to weights.

## Tests

`lib/llm/src/model_card.rs` adds three new tests:

* `test_config_json_eos_bos_from_tokenizer_config_only` (rung 3 supplies both ids)
* `test_config_json_eos_bos_from_special_tokens_map` (rung 4 supplies both ids)
* `test_config_json_missing_eos_everywhere_lists_all_sources` (when all 4 sources miss, the error message names every source it checked)

Plus two new sample-model fixtures under `lib/llm/tests/data/sample-models/`. Existing tests (`test_config_json_llama3`, `test_config_json_llama4`, `test_config_json_qwen35_eos_from_tokenizer`) still pass; the Qwen3.5 augmentation behaviour is unchanged.

`cargo test -p dynamo-llm --lib model_card` -> 31 passed. `cargo fmt` + `cargo clippy -- -D warnings` clean.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved special token loading from model configurations with a more robust fallback chain across multiple configuration sources.
  * Enhanced error messages now clearly identify all checked configuration sources when token loading fails.

* **Tests**
  * Expanded test coverage for various model configuration scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->