### PR TITLE
feat: add llama-4-scout-17b-16e-fp8 recipe (vllm / disagg-single-node)

### DIFF
--- a/recipes/llama-4-scout-17b-16e-fp8/README.md
+++ b/recipes/llama-4-scout-17b-16e-fp8/README.md
@@ -1,0 +1,83 @@
+# Llama-4-Scout-17B-16E-Instruct-FP8 — Single-Node Disaggregated (vLLM)
+
+Disaggregated serving recipe for `nvidia/Llama-4-Scout-17B-16E-Instruct-FP8`
+on a single 8×H100-80GB node. Default layout is **1 prefill + 3 decode**
+(TP=2 each), using all 8 GPUs — chosen because Scout's decode is HBM-bandwidth-
+bound and adds throughput linearly with decode replicas at the workload
+points we measured.
+
+## Why this layout
+
+| Knob | Choice | Reason |
+|---|---|---|
+| TP | 2 | ~109 GB FP8 / 2 = ~55 GB/GPU on 80 GB H100. TP=1 won't fit; TP=4 burns idle GPUs. |
+| Replicas | 1P + 3D | Matched-concurrency head-to-head: 1P+3D beat the 1P+2D baseline on throughput (+39%), p50 latency (−29%), and tok/Wh (+16%) at c=36. Use 1P+1D (4 GPUs) for the minimum useful disagg layout. |
+| `--max-model-len` | 4096 | Llama 4 native context is huge (10M); pinning keeps KV pool predictable and ensures the prefill/decode NIXL shape contract is met (they MUST match). |
+| Router | `kv` | Required for disagg. `round_robin` silently bypasses NIXL handoff. |
+| Prefill GPU util | 0.85 | Flashinfer MoE workspace needs transient scratch. |
+| Decode GPU util | 0.88 | Validated decode value; raise to 0.92 only if KV pool becomes the binding constraint. |
+| `UCX_MEMTYPE_CACHE=n` | both | Without it, PyTorch VMM remap invalidates UCX's cached (addr→memtype) → `cuMemcpyAsync illegal memory access` kills all TP ranks. |
+| `expandable_segments` | **decode only** | Required on decode to avoid fragmentation OOM. Causes a CUDAGraph replay segfault on prefill (VMM remap leaves captured raw pointers dangling), so prefill uses classic cudaMalloc + lower util. |
+| `NCCL_CUMEM_ENABLE=0` | decode only | Companion to `expandable_segments` — avoids VMM/NCCL allocator collision. |
+| `--disable-custom-all-reduce` | both | vLLM custom AR + `hostIPC` collide between prefill+decode on the same node. |
+
+See inline comments in `vllm/disagg-single-node/deploy.yaml` for the full
+provenance.
+
+## Runtime compatibility
+
+Tested on `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1`. The disagg flags
+match the 1.0.x API:
+
+- `--is-prefill-worker` on prefill
+- Split `kv_role`: `kv_producer` (prefill) / `kv_consumer` (decode)
+
+For 1.2.0+: replace with `--disaggregation-mode {prefill,decode}` and
+`"kv_role":"kv_both"` (see the `qwen3-32b` recipe for the 1.2.0 pattern).
+
+## Prerequisites
+
+1. Dynamo platform installed — see the [Kubernetes Deployment Guide](../../docs/kubernetes/README.md).
+2. One 8×H100-80GB node (or larger; 4 GPUs suffice for the minimum 1P+1D layout).
+3. HuggingFace token (the FP8 checkpoint is gated):
+   ```bash
+   export NAMESPACE=your-namespace
+   kubectl create secret generic hf-token-secret \
+     --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
+   ```
+
+## Quick start
+
+```bash
+# 1. Storage — edit model-cache/model-cache.yaml to set storageClassName first
+kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+
+# 2. Download weights (~109 GB)
+kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=1800s
+
+# 3. Deploy
+kubectl apply -f vllm/disagg-single-node/deploy.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=vllm-llama-4-scout-disagg \
+  -n ${NAMESPACE} --timeout=1800s
+# First boot warms CUDA graphs across the prompt-length range (~20 min);
+# subsequent restarts hit the compilation-cache in <5 min.
+
+# 4. Benchmark
+kubectl apply -f vllm/disagg-single-node/perf.yaml -n ${NAMESPACE}
+kubectl exec -it -n ${NAMESPACE} vllm-llama-4-scout-disagg-benchmark -- tmux a -t benchmark
+```
+
+## Scaling notes
+
+- **1P + 1D (4 GPUs)** — set decode `replicas: 1`. Minimum disagg layout; leaves 4 GPUs free.
+- **1P + 3D (8 GPUs, default)** — best tok/s and tok/Wh on ISL=1024/OSL=512.
+- **2P + 2D (8 GPUs)** — better for very long-prompt workloads where prefill becomes the queue.
+
+## Cleanup
+
+```bash
+kubectl delete pod -l app=benchmark -n ${NAMESPACE}
+kubectl delete dynamographdeployment vllm-llama-4-scout-disagg -n ${NAMESPACE}
+```

--- a/recipes/llama-4-scout-17b-16e-fp8/model-cache/model-cache.yaml
+++ b/recipes/llama-4-scout-17b-16e-fp8/model-cache/model-cache.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Llama-4-Scout-17B-16E-Instruct-FP8 weights are ~109 GB on disk.
+# model-cache: holds the downloaded Hugging Face weights (~109 GB for the FP8
+# checkpoint). ReadWriteMany so prefill/decode worker pods can mount it concurrently.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 150Gi
+  storageClassName: "your-storage-class-name"
+---
+# compilation-cache: stores vLLM / torch.compile compiled-graph artifacts so they
+# are reused across pod restarts instead of being recompiled on every startup.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: compilation-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: "your-storage-class-name"
+---
+# perf-cache: stores performance/kernel autotuning results, persisted so the
+# tuning step does not re-run on every restart.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: perf-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: "your-storage-class-name"

--- a/recipes/llama-4-scout-17b-16e-fp8/model-cache/model-download.yaml
+++ b/recipes/llama-4-scout-17b-16e-fp8/model-cache/model-download.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: "nvidia/Llama-4-Scout-17B-16E-Instruct-FP8"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.11.0
+              hf download $MODEL_NAME
+          resources:
+            requests:
+              cpu: "2"
+              memory: "64Gi"
+            limits:
+              cpu: "8"
+              memory: "64Gi"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /home/dynamo/.cache/huggingface
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/recipes/llama-4-scout-17b-16e-fp8/vllm/disagg-single-node/deploy.yaml
+++ b/recipes/llama-4-scout-17b-16e-fp8/vllm/disagg-single-node/deploy.yaml
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# DynamoGraphDeployment for nvidia/Llama-4-Scout-17B-16E-Instruct-FP8,
+# single-node disaggregated with decode scale-out.
+#
+# Layout (1 × 8×H100-80GB node, all 8 GPUs used):
+#   Frontend            x1   (no GPU)
+#   VllmPrefillWorker   x1   (TP=2, 2 GPUs)  — kv_producer
+#   VllmDecodeWorker    x3   (TP=2, 2 GPUs ea.) — kv_consumer, 6 decode GPUs
+#
+# Why TP=2:
+#   ~109 GB FP8 / 2 GPUs = ~55 GB/GPU on 80 GB H100 → ~25 GB/GPU headroom.
+#   TP=1 won't fit (single-GPU < 109 GB). TP=4 underutilizes the per-GPU
+#   budget and burns idle GPUs to no benefit.
+#
+# Why 1P + 3D (decode-heavy):
+#   Llama-4 Scout's decode is HBM-bandwidth-bound at steady state, while
+#   prefill compute saturates earlier. Adding decode replicas pushes more
+#   aggregate decode throughput per node than adding prefill. Scale prefill
+#   back up (1P → 2P, decode 3D → 2D) for very long-prompt workloads where
+#   prefill becomes the queue.
+#
+# Architecture: Llama4ForCausalLM (16 experts, 17B active per token).
+# Native vLLM path — uses the stock dynamo runtime image, no custom
+# transformers override needed.
+#
+# Tested on nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1 (1.0.x disagg API).
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-llama-4-scout-disagg
+spec:
+  pvcs:
+  - create: false
+    name: model-cache
+  - create: false
+    name: compilation-cache
+  services:
+
+    # ─────────────────────────────────────────────────────────────────
+    # FRONTEND — OpenAI-compat API + KV-aware router
+    # ─────────────────────────────────────────────────────────────────
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      envs:
+        - name: HF_HOME
+          value: /home/dynamo/.cache/huggingface
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace
+          command: [python, -m, dynamo.frontend]
+          args:
+            - --router-mode
+            # MUST be "kv" for disagg. Under "round_robin" the frontend treats
+            # prefill and decode endpoints as interchangeable → half the
+            # traffic skips NIXL handoff and the prefill worker sits idle.
+            - kv
+      resources:
+        requests:
+          cpu: "8"
+        limits:
+          cpu: "8"
+
+    # ─────────────────────────────────────────────────────────────────
+    # DECODE WORKER — autoregressive generation, HBM-bandwidth-bound.
+    # TP=2, 2 GPUs per replica. 3 replicas → 6 decode GPUs.
+    # ─────────────────────────────────────────────────────────────────
+    VllmDecodeWorker:
+      componentType: worker
+      subComponentType: decode
+      envFromSecret: hf-token-secret
+      replicas: 3   # Drop to 1 for the minimal 1P+1D layout (4 GPUs total).
+      extraPodSpec:
+        hostIPC: true   # Required by NixlConnector.
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace
+          command: [python3, -m, dynamo.vllm]
+          args:
+          - --model
+          - nvidia/Llama-4-Scout-17B-16E-Instruct-FP8
+          - --trust-remote-code
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+          - --tensor-parallel-size
+          - "2"
+          - --gpu-memory-utilization
+          # 0.88 is the validated decode value carried over from the 235B
+          # incidents. Plenty of weight headroom at TP=2 here (~25 GB free),
+          # but the same allocator/NCCL collision class applies. Raise to
+          # 0.92 only if KV pool becomes the binding constraint.
+          - "0.88"
+          - --max-num-seqs
+          # 1024 lifts the scheduler ceiling so decode batch density (~95
+          # in-flight observed) is bounded by ingress rate rather than the
+          # scheduler.
+          - "1024"
+          - --max-num-batched-tokens
+          - "32768"
+          - --max-model-len
+          # Llama 4 native context is huge (10M); pin to 4096 to keep the KV pool predictable.
+          # Prefill MUST match this — NIXL KV shape is a strict contract between workers.
+          - "4096"
+          - --enable-chunked-prefill
+          - --no-enable-prefix-caching   # Benchmark hygiene.
+          - --disable-custom-all-reduce  # Custom AR + hostIPC collide between
+                                         # prefill and decode on the same node.
+          env:
+          - name: DYN_HEALTH_CHECK_ENABLED
+            value: "false"
+          - name: HF_HOME
+            value: /home/dynamo/.cache/huggingface
+          - name: UCX_MEMTYPE_CACHE
+            # Avoid stale-mapping race between PyTorch VMM remap and UCX's cached (addr→memtype) lookups → cuMemcpyAsync illegal-memory-
+            # access kills all TP ranks together. <1% overhead.
+            value: "n"
+          - name: PYTORCH_CUDA_ALLOC_CONF
+            # Required to avoid decode fragmentation OOM under sustained load
+            value: expandable_segments:True
+          - name: NCCL_CUMEM_ENABLE
+            # Companion to expandable_segments — forces NCCL onto cudaMalloc
+            # to avoid VMM collision with PyTorch (cudaErrorIllegalAddress).
+            value: "0"
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]   # mlock pinned host pages for ibv_reg_mr().
+      resources:
+        limits:
+          gpu: "2"
+        requests:
+          gpu: "2"
+      volumeMounts:
+      - name: model-cache
+        mountPoint: /home/dynamo/.cache/huggingface
+      - name: compilation-cache
+        mountPoint: /home/dynamo/.cache/vllm
+        useAsCompilationCache: true
+      sharedMemory:
+        size: 16Gi   # NIXL control buffers/descriptors. 16 GiB at TP=2
+
+    # ─────────────────────────────────────────────────────────────────
+    # PREFILL WORKER — full-prompt attention, produces KV cache.
+    # TP=2, 2 GPUs. Compute-bound on long prompts.
+    # ─────────────────────────────────────────────────────────────────
+    VllmPrefillWorker:
+      componentType: worker
+      subComponentType: prefill
+      envFromSecret: hf-token-secret
+      replicas: 1
+      extraPodSpec:
+        hostIPC: true
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace
+          command: [python3, -m, dynamo.vllm]
+          args:
+          - --model
+          - nvidia/Llama-4-Scout-17B-16E-Instruct-FP8
+          - --trust-remote-code
+          - --is-prefill-worker
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+          - --tensor-parallel-size
+          - "2"
+          - --gpu-memory-utilization
+          # 0.85 — flashinfer MoE workspace is the binding constraint on prefill
+          - "0.85"
+          - --max-num-seqs
+          - "1024"
+          - --max-num-batched-tokens
+          - "32768"   # Larger prefill chunks → push more KV/sec to decode.
+          - --max-model-len
+          - "4096"    # MUST match decode (NIXL shape contract).
+          - --enable-chunked-prefill
+          - --no-enable-prefix-caching
+          - --disable-custom-all-reduce
+          env:
+          - name: DYN_HEALTH_CHECK_ENABLED
+            value: "false"
+          - name: HF_HOME
+            value: /home/dynamo/.cache/huggingface
+          - name: UCX_MEMTYPE_CACHE
+            value: "n"
+          # NOTE: expandable_segments and NCCL_CUMEM_ENABLE are intentionally
+          # NOT set on the prefill worker. expandable_segments + CUDA graphs
+          # caused a replay segfault (allocator VMM remap left
+          # captured raw pointers dangling). Prefill uses classic cudaMalloc
+          # + lower gpu-memory-utilization for headroom.
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+      resources:
+        limits:
+          gpu: "2"
+        requests:
+          gpu: "2"
+      volumeMounts:
+      - name: model-cache
+        mountPoint: /home/dynamo/.cache/huggingface
+      - name: compilation-cache
+        mountPoint: /home/dynamo/.cache/vllm
+        useAsCompilationCache: true
+      sharedMemory:
+        size: 16Gi

--- a/recipes/llama-4-scout-17b-16e-fp8/vllm/disagg-single-node/perf.yaml
+++ b/recipes/llama-4-scout-17b-16e-fp8/vllm/disagg-single-node/perf.yaml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vllm-llama-4-scout-disagg-benchmark
+  labels:
+    app: benchmark
+spec:
+  containers:
+  - name: python
+    image: python:3.11
+    command:
+      - /bin/bash
+      - -lc
+      - |
+        ulimit -n 1048576
+        ulimit -u 65536
+        apt update && apt install tmux wget curl jq -y
+
+        pip install aiperf==0.6.0
+
+        echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."
+        until curl -s "http://${FRONTEND}:8000/v1/models" | jq -e --arg model "${MODEL_NAME}" '.data[]? | select(.id == $model)' >/dev/null 2>&1; do
+          echo "[$(date '+%H:%M:%S')] Model not ready, retrying in 5s..."
+          sleep 5
+        done
+        echo "Model '${MODEL_NAME}' is ready!"
+
+        mkdir -p ${BASE_DIR}/artifacts
+        export MODEL_BASE_NAME="${MODEL_NAME##*/}"
+        export FRONTEND_LIB="${FRONTEND%-frontend}"
+        export ARTIFACT_DIR="${BASE_DIR}/artifacts/${MODEL_BASE_NAME}_${FRONTEND_LIB}"
+        mkdir -p "${ARTIFACT_DIR}"
+
+        # ISL=1024 / OSL=512, c=36 — mirrors the head-to-head sweep where the
+        # 1P+3D disagg layout beat the aggregated baseline on throughput,
+        # p50 latency, and tok/Wh.
+        tmux new-session -d -s benchmark -c "${ARTIFACT_DIR}"
+        tmux send-keys -t benchmark "aiperf profile \
+          -m ${MODEL_NAME} \
+          --url http://${FRONTEND}:8000 \
+          --streaming \
+          --synthetic-input-tokens-mean 1024 \
+          --synthetic-input-tokens-stddev 0 \
+          --output-tokens-mean 512 \
+          --output-tokens-stddev 0 \
+          --concurrency 36 \
+          --request-count 720 \
+          --artifact-dir ${ARTIFACT_DIR} \
+          --goodput \"time_to_first_token:3000 inter_token_latency:40\"" C-m
+        sleep 7200
+    env:
+      - name: MODEL_NAME
+        value: nvidia/Llama-4-Scout-17B-16E-Instruct-FP8
+      - name: FRONTEND
+        value: vllm-llama-4-scout-disagg-frontend
+      - name: BASE_DIR
+        value: /perf-cache
+    resources:
+      requests:
+        cpu: "8"
+        memory: 16Gi
+      limits:
+        cpu: "16"
+        memory: 32Gi
+    volumeMounts:
+    - name: model-cache
+      mountPath: /home/dynamo/.cache/huggingface
+    - name: perf-cache
+      mountPath: /perf-cache
+    workingDir: /workspace
+  volumes:
+  - name: model-cache
+    persistentVolumeClaim:
+      claimName: model-cache
+  - name: perf-cache
+    persistentVolumeClaim:
+      claimName: perf-cache
+  restartPolicy: Never


### PR DESCRIPTION
## Summary
Adds a new recipe under `recipes/llama-4-scout-17b-16e-fp8/` covering vLLM deployment in disaggregated single-node mode.

## Structure (per `recipes/CONTRIBUTING.md`)
- `model-cache/{model-cache,model-download}.yaml`
- `vllm/disagg-single-node/{deploy,perf}.yaml`
- `README.md`

## Test plan
- [ ] `recipes/run.sh` validation passes for `llama-4-scout-17b-16e-fp8 vllm disagg-single-node`
- [ ] Reviewers spot-check YAML values
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recipe for deploying `nvidia/Llama-4-Scout-17B-16E-Instruct-FP8` with disaggregated vLLM on 8×H100-80GB systems using Kubernetes.
  * Includes model caching, download, and benchmarking infrastructure.

* **Documentation**
  * Added comprehensive deployment guide with configuration, quick-start commands, and scaling notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->