### PR TITLE
perf(llm): avoid repeated suffix cleanup on removes

### DIFF
--- a/lib/kv-router/src/indexer/compressed_radix.rs
+++ b/lib/kv-router/src/indexer/compressed_radix.rs
@@ -126,9 +126,17 @@ impl NodeState {
             || matches!(self.worker_cutoffs.get(&worker), Some(&cutoff) if pos < cutoff)
     }
 
-    fn uncovered_suffix_hashes(&self, cutoff: usize) -> Vec<ExternalSequenceBlockHash> {
-        debug_assert!(cutoff <= self.edge.len());
-        self.edge[cutoff..].iter().map(|&(_, hash)| hash).collect()
+    fn newly_uncovered_hashes(
+        &self,
+        new_cutoff: usize,
+        old_cutoff: usize,
+    ) -> Vec<ExternalSequenceBlockHash> {
+        debug_assert!(new_cutoff <= old_cutoff);
+        debug_assert!(old_cutoff <= self.edge.len());
+        self.edge[new_cutoff..old_cutoff]
+            .iter()
+            .map(|&(_, hash)| hash)
+            .collect()
     }
 
     #[inline]
@@ -267,7 +275,7 @@ impl NodeState {
         }
 
         let new_cutoff = pos;
-        let stale_hashes = self.uncovered_suffix_hashes(new_cutoff);
+        let stale_hashes = self.newly_uncovered_hashes(new_cutoff, current_cutoff);
 
         if new_cutoff == 0 {
             self.drop_worker(worker);
@@ -281,5 +289,50 @@ impl NodeState {
 
     pub(crate) fn has_any_workers(&self) -> bool {
         !self.full_edge_workers.is_empty() || !self.worker_cutoffs.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worker() -> WorkerWithDpRank {
+        WorkerWithDpRank::new(1, 0)
+    }
+
+    fn block(hash: u64) -> KvCacheStoredBlockData {
+        KvCacheStoredBlockData {
+            tokens_hash: LocalBlockHash(hash),
+            block_hash: ExternalSequenceBlockHash(hash),
+            mm_extra_info: None,
+        }
+    }
+
+    #[test]
+    fn leaf_to_root_removes_return_only_newly_uncovered_hashes() {
+        let worker = worker();
+        let blocks = [block(1), block(2), block(3), block(4)];
+        let mut state = NodeState::for_blocks(&blocks, worker);
+
+        let pos_4 = state.edge_index[&ExternalSequenceBlockHash(4)];
+        let outcome = state.remove_worker_at_pos(worker, pos_4, ExternalSequenceBlockHash(4));
+        assert_eq!(outcome.stale_hashes, vec![ExternalSequenceBlockHash(4)]);
+        assert_eq!(state.current_cutoff(worker), 3);
+
+        let pos_3 = state.edge_index[&ExternalSequenceBlockHash(3)];
+        let outcome = state.remove_worker_at_pos(worker, pos_3, ExternalSequenceBlockHash(3));
+        assert_eq!(outcome.stale_hashes, vec![ExternalSequenceBlockHash(3)]);
+        assert_eq!(state.current_cutoff(worker), 2);
+
+        let pos_2 = state.edge_index[&ExternalSequenceBlockHash(2)];
+        let outcome = state.remove_worker_at_pos(worker, pos_2, ExternalSequenceBlockHash(2));
+        assert_eq!(outcome.stale_hashes, vec![ExternalSequenceBlockHash(2)]);
+        assert_eq!(state.current_cutoff(worker), 1);
+
+        let pos_1 = state.edge_index[&ExternalSequenceBlockHash(1)];
+        let outcome = state.remove_worker_at_pos(worker, pos_1, ExternalSequenceBlockHash(1));
+        assert_eq!(outcome.stale_hashes, vec![ExternalSequenceBlockHash(1)]);
+        assert_eq!(state.current_cutoff(worker), 0);
+        assert!(!state.has_any_workers());
     }
 }

--- a/lib/kv-router/src/sequences/prompt_membership_trie.rs
+++ b/lib/kv-router/src/sequences/prompt_membership_trie.rs
@@ -68,9 +68,10 @@ impl PromptTrieNode {
         }
     }
 
-    fn uncovered_suffix_hashes(&self, cutoff: usize) -> Vec<SequenceHash> {
-        debug_assert!(cutoff <= self.edge.len());
-        self.edge[cutoff..].to_vec()
+    fn newly_uncovered_hashes(&self, new_cutoff: usize, old_cutoff: usize) -> Vec<SequenceHash> {
+        debug_assert!(new_cutoff <= old_cutoff);
+        debug_assert!(old_cutoff <= self.edge.len());
+        self.edge[new_cutoff..old_cutoff].to_vec()
     }
 
     fn lookup_hashes_for_worker_repair(
@@ -125,7 +126,7 @@ impl PromptTrieNode {
         }
 
         let new_cutoff = pos;
-        let stale_hashes = self.uncovered_suffix_hashes(new_cutoff);
+        let stale_hashes = self.newly_uncovered_hashes(new_cutoff, current_cutoff);
 
         if new_cutoff == 0 {
             self.drop_worker(worker);
@@ -939,6 +940,39 @@ mod tests {
             trie.compute_overlap_depths(Some(&[1, 2, 3, 4])),
             FxHashMap::from_iter([(worker, 1)]),
         );
+    }
+
+    #[test]
+    fn leaf_to_root_removes_return_only_newly_uncovered_hashes() {
+        let worker = worker(1, 0);
+        let mut node = PromptTrieNode {
+            edge: vec![1, 2, 3, 4],
+            edge_index: PromptTrieNode::edge_index_for(&[1, 2, 3, 4]),
+            worker_cutoffs: FxHashMap::default(),
+            full_edge_workers: PromptTrieNode::full_edge_workers_for(worker),
+            children: FxHashMap::default(),
+        };
+
+        let pos_4 = node.edge_index[&4];
+        let outcome = node.remove_worker_at_pos(worker, pos_4, 4);
+        assert_eq!(outcome.stale_hashes, vec![4]);
+        assert_eq!(node.current_cutoff(worker), 3);
+
+        let pos_3 = node.edge_index[&3];
+        let outcome = node.remove_worker_at_pos(worker, pos_3, 3);
+        assert_eq!(outcome.stale_hashes, vec![3]);
+        assert_eq!(node.current_cutoff(worker), 2);
+
+        let pos_2 = node.edge_index[&2];
+        let outcome = node.remove_worker_at_pos(worker, pos_2, 2);
+        assert_eq!(outcome.stale_hashes, vec![2]);
+        assert_eq!(node.current_cutoff(worker), 1);
+
+        let pos_1 = node.edge_index[&1];
+        let outcome = node.remove_worker_at_pos(worker, pos_1, 1);
+        assert_eq!(outcome.stale_hashes, vec![1]);
+        assert_eq!(node.current_cutoff(worker), 0);
+        assert!(!node.has_any_workers());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change compressed-edge remove bookkeeping to return only the newly uncovered hash range when a worker cutoff moves backward.
- Apply the same delta-suffix behavior to the active-sequence prompt membership trie.
- Add regression coverage for leaf-to-root removals so future changes do not reintroduce repeated suffix cleanup.

## Benchmark
AgentX 060526, 4 frontends, block size 16, total concurrency 512, KV routing with replica sync and output-block tracking, no predicted TTL.

The old approach (on main) was able to process 300k store/remove events within the window, while this PR branch applied ~8.5M within the same window. This constitutes a ~28x speedup.

At a compressed edge size of 1024, microbenchmarks (also in this PR) show a ~5x speedup compared to main. On long-context or agentic workloads with very large distinct subtrees, this has an even larger speedup

## Validation
- `cargo fmt --check`
- `cargo test -p dynamo-kv-router leaf_to_root_removes_return_only_newly_uncovered_hashes --lib`
- `cargo test -p dynamo-kv-router --lib`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added benchmarking infrastructure for performance measurement.
  * Updated build configuration to support new testing capabilities.

* **Tests**
  * Enhanced test validation with comprehensive coverage for internal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->