### PR TITLE
feat: PR train 5: Wire everything together

### DIFF
--- a/deploy/inference-gateway/ext-proc/Dockerfile
+++ b/deploy/inference-gateway/ext-proc/Dockerfile
@@ -94,7 +94,16 @@ WORKDIR /
 
 COPY --from=builder /dynamo-ext-proc /dynamo-ext-proc
 
-RUN useradd -r -u 65532 -g nogroup nonroot
+RUN useradd -r -u 65532 -g nogroup nonroot \
+    && mkdir -p /home/nonroot/.cache/huggingface \
+    && chown -R 65532:65534 /home/nonroot
+
+# Router-only mode builds the tokenizer/preprocessor offline at startup, which
+# writes to the HuggingFace cache. The container runs as non-root, so give it a
+# writable HOME + HF cache; otherwise HF cannot create ~/.cache and the EPP
+# crashes on startup. Deployments may override HF_HOME to a mounted volume.
+ENV HF_HOME=/home/nonroot/.cache/huggingface
+
 USER 65532:65534
 
 ENTRYPOINT ["/dynamo-ext-proc"]

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -24,7 +24,11 @@ use dynamo_runtime::discovery::{DiscoveryInstance, DiscoveryQuery, hash_pod_name
 use dynamo_runtime::pipeline::RouterMode;
 use dynamo_runtime::{DistributedRuntime, Runtime};
 
+use crate::kv_republisher::KvRepublisher;
 use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo};
+use crate::router_only::RouterOnlyConfig;
+use crate::router_only_reflector::RouterOnlyPodReflector;
+use crate::router_only_runtime::RouterOnlyParts;
 
 const BOOKKEEPING_TIMEOUT: Duration = Duration::from_secs(5);
 const DYN_KUBE_DISCOVERY_MODE: &str = "DYN_KUBE_DISCOVERY_MODE";
@@ -83,8 +87,136 @@ pub struct Router {
     decode_router: Arc<KvRouter>,
     preprocessor: Arc<OpenAIPreprocessor>,
     runtime: Runtime,
-    pod_store: kube::runtime::reflector::Store<k8s_openapi::api::core::v1::Pod>,
-    pod_store_ready: Arc<AtomicBool>,
+    discovery: Discovery,
+}
+
+/// Endpoint-discovery source backing a `Router`.
+///
+/// Dynamo mode reflects operator-labeled worker pods and resolves the container
+/// port named `http`; router-only ("on-ramp") mode reflects raw `vllm serve` pods
+/// by an arbitrary selector and resolves an explicit target port. Both stamp
+/// `worker_id = hash_pod_name(pod)`.
+enum Discovery {
+    Dynamo {
+        pod_store: kube::runtime::reflector::Store<k8s_openapi::api::core::v1::Pod>,
+        ready: Arc<AtomicBool>,
+    },
+    RouterOnly {
+        reflector: Arc<RouterOnlyPodReflector>,
+        /// Held so the per-pod ZMQ listeners + event-plane publisher stay alive
+        /// for the lifetime of the router.
+        _republisher: Arc<KvRepublisher>,
+    },
+}
+
+impl Discovery {
+    fn is_ready(&self) -> bool {
+        match self {
+            Discovery::Dynamo { ready, .. } => ready.load(Ordering::Acquire),
+            Discovery::RouterOnly { reflector, .. } => reflector.is_ready(),
+        }
+    }
+
+    fn ready_flag(&self) -> Arc<AtomicBool> {
+        match self {
+            Discovery::Dynamo { ready, .. } => ready.clone(),
+            Discovery::RouterOnly { reflector, .. } => reflector.ready_flag(),
+        }
+    }
+
+    fn resolve_worker_endpoint(&self, worker_id: u64) -> Option<String> {
+        match self {
+            Discovery::Dynamo { pod_store, .. } => {
+                for pod in pod_store.state() {
+                    let Some(pod_name) = pod.metadata.name.as_deref() else {
+                        continue;
+                    };
+                    if hash_pod_name(pod_name) == worker_id {
+                        return pod_endpoint_address(&pod);
+                    }
+                }
+                None
+            }
+            Discovery::RouterOnly { reflector, .. } => reflector.resolve_worker_endpoint(worker_id),
+        }
+    }
+
+    fn resolve_any_worker_endpoint(&self) -> Option<String> {
+        match self {
+            Discovery::Dynamo { pod_store, .. } => pod_store
+                .state()
+                .iter()
+                .find_map(|pod| pod_endpoint_address(pod)),
+            Discovery::RouterOnly { reflector, .. } => reflector.resolve_any_worker_endpoint(),
+        }
+    }
+
+    fn resolve_any_worker_endpoint_in_subset(&self, allowed: &HashSet<u64>) -> Option<String> {
+        match self {
+            Discovery::Dynamo { pod_store, .. } => {
+                for pod in pod_store.state() {
+                    let Some(pod_name) = pod.metadata.name.as_deref() else {
+                        continue;
+                    };
+                    if allowed.contains(&hash_pod_name(pod_name))
+                        && let Some(addr) = pod_endpoint_address(&pod)
+                    {
+                        return Some(addr);
+                    }
+                }
+                None
+            }
+            Discovery::RouterOnly { reflector, .. } => reflector
+                .ready_workers()
+                .into_iter()
+                .find(|(id, _)| allowed.contains(id))
+                .map(|(_, endpoint)| endpoint),
+        }
+    }
+
+    fn subset_to_worker_ids(&self, candidate_subset: &[String]) -> HashSet<u64> {
+        let candidates: HashSet<&str> = candidate_subset.iter().map(|s| s.as_str()).collect();
+        let mut ids = HashSet::new();
+        let matches =
+            |addr_port: &str, ip: &str| candidates.contains(addr_port) || candidates.contains(ip);
+        match self {
+            Discovery::Dynamo { pod_store, .. } => {
+                for pod in pod_store.state() {
+                    let Some(pod_name) = pod.metadata.name.as_deref() else {
+                        continue;
+                    };
+                    let Some(addr_port) = pod_endpoint_address(&pod) else {
+                        continue;
+                    };
+                    let ip = addr_port.split(':').next().unwrap_or("");
+                    if matches(addr_port.as_str(), ip) {
+                        ids.insert(hash_pod_name(pod_name));
+                    }
+                }
+            }
+            Discovery::RouterOnly { reflector, .. } => {
+                for (id, addr_port) in reflector.ready_workers() {
+                    let ip = addr_port.split(':').next().unwrap_or("");
+                    if matches(addr_port.as_str(), ip) {
+                        ids.insert(id);
+                    }
+                }
+            }
+        }
+        ids
+    }
+
+    /// Default scheduler admission set when there is no Envoy subset hint.
+    ///
+    /// Dynamo mode lets the scheduler use all discovery-registered workers
+    /// (`None`); router-only mode must explicitly admit the Ready raw-vLLM pods,
+    /// because they never register in Dynamo discovery.
+    fn default_allowed_worker_ids(&self) -> Option<HashSet<u64>> {
+        match self {
+            Discovery::Dynamo { .. } => None,
+            Discovery::RouterOnly { reflector, .. } => Some(reflector.ready_worker_ids()),
+        }
+    }
 }
 
 impl Router {
@@ -191,8 +323,43 @@ impl Router {
             decode_router,
             preprocessor: bootstrap.preprocessor,
             runtime,
-            pod_store,
-            pod_store_ready,
+            discovery: Discovery::Dynamo {
+                pod_store,
+                ready: pod_store_ready,
+            },
+        })
+    }
+
+    /// Initialize the router in router-only ("on-ramp") mode.
+    ///
+    /// Fronts a fleet of raw `vllm serve` pods with no Dynamo control plane:
+    /// an inert `mem`-backed runtime (no etcd/NATS), an offline preprocessor
+    /// built from `DYN_MODEL_NAME`, a label-selector pod reflector, and a ZMQ
+    /// republisher that feeds each pod's native vLLM KV events into the embedded
+    /// router's event plane. See [`crate::router_only_runtime`] and
+    /// `deploy/inference-gateway/ext-proc/examples/onramp/`.
+    ///
+    /// This is the aggregated path; the `PrefillRouter` is built inactive so
+    /// prefill routing falls back to decode-only.
+    pub async fn from_router_only(cfg: RouterOnlyConfig) -> Result<Self> {
+        let RouterOnlyParts {
+            runtime,
+            preprocessor,
+            decode_router,
+            prefill_router,
+            reflector,
+            republisher,
+        } = crate::router_only_runtime::build_router_only(&cfg).await?;
+
+        Ok(Self {
+            prefill_router,
+            decode_router,
+            preprocessor,
+            runtime,
+            discovery: Discovery::RouterOnly {
+                reflector,
+                _republisher: republisher,
+            },
         })
     }
 
@@ -225,41 +392,21 @@ impl Router {
     /// Lock-free read from the in-memory reflector store — no K8s API calls.
     /// Port is read from the pod's Dynamo HTTP container port.
     pub fn resolve_worker_endpoint(&self, worker_id: u64) -> Option<String> {
-        for pod in self.pod_store.state() {
-            let Some(pod_name) = pod.metadata.name.as_deref() else {
-                continue;
-            };
-            if hash_pod_name(pod_name) == worker_id {
-                return pod_endpoint_address(&pod);
-            }
-        }
-        None
+        self.discovery.resolve_worker_endpoint(worker_id)
     }
 
     /// Resolve any available worker to its endpoint address (ip:port).
     /// Used for body-less requests (GET /v1/models) where we just need any backend.
     pub fn resolve_any_worker_endpoint(&self) -> Option<String> {
-        self.pod_store
-            .state()
-            .iter()
-            .find_map(|pod| pod_endpoint_address(pod))
+        self.discovery.resolve_any_worker_endpoint()
     }
 
     /// Resolve any reflected worker whose worker_id is in `allowed`.
     /// Used for body-less requests that still carry an Envoy subset hint, so
     /// we never resolve a backend outside the requested subset.
     fn resolve_any_worker_endpoint_in_subset(&self, allowed: &HashSet<u64>) -> Option<String> {
-        for pod in self.pod_store.state() {
-            let Some(pod_name) = pod.metadata.name.as_deref() else {
-                continue;
-            };
-            if allowed.contains(&hash_pod_name(pod_name))
-                && let Some(addr) = pod_endpoint_address(&pod)
-            {
-                return Some(addr);
-            }
-        }
-        None
+        self.discovery
+            .resolve_any_worker_endpoint_in_subset(allowed)
     }
 
     /// Map an Envoy `candidate_subset` (endpoint addresses, "ip:port" or bare
@@ -271,21 +418,7 @@ impl Router {
     /// pod reflector rather than a caller-supplied slice. An empty result for
     /// a non-empty subset means no reflected pod matched the hint.
     fn subset_to_worker_ids(&self, candidate_subset: &[String]) -> HashSet<u64> {
-        let candidates: HashSet<&str> = candidate_subset.iter().map(|s| s.as_str()).collect();
-        let mut ids = HashSet::new();
-        for pod in self.pod_store.state() {
-            let Some(pod_name) = pod.metadata.name.as_deref() else {
-                continue;
-            };
-            let Some(addr_port) = pod_endpoint_address(&pod) else {
-                continue;
-            };
-            let ip = addr_port.split(':').next().unwrap_or("");
-            if candidates.contains(addr_port.as_str()) || candidates.contains(ip) {
-                ids.insert(hash_pod_name(pod_name));
-            }
-        }
-        ids
+        self.discovery.subset_to_worker_ids(candidate_subset)
     }
 
     /// Route a prefill request. Returns (worker_id, dp_rank).
@@ -458,7 +591,7 @@ impl Router {
     /// the gRPC health reporter) can gate their SERVING status on it to avoid
     /// advertising readiness while routing would still 503.
     pub fn pod_store_ready(&self) -> Arc<AtomicBool> {
-        self.pod_store_ready.clone()
+        self.discovery.ready_flag()
     }
 }
 
@@ -829,7 +962,7 @@ impl EndpointPicker for Router {
         req: &RequestInfo,
         endpoints: &[Endpoint],
     ) -> Result<PickResult, PickError> {
-        if !self.pod_store_ready.load(Ordering::Acquire) {
+        if !self.discovery.is_ready() {
             return Err(PickError::RoutingFailed(
                 "Pod reflector is not ready yet; endpoint cache is still syncing".to_string(),
             ));
@@ -847,7 +980,10 @@ impl EndpointPicker for Router {
         // subset.
         let (allowed_worker_ids, worker_map) = if endpoints.is_empty() {
             if req.candidate_subset.is_empty() {
-                (None, Vec::new())
+                // No subset hint: Dynamo mode lets the scheduler use all
+                // discovery-registered workers (None); router-only mode admits the
+                // Ready raw-vLLM pods, which never register in Dynamo discovery.
+                (self.discovery.default_allowed_worker_ids(), Vec::new())
             } else {
                 let ids = self.subset_to_worker_ids(&req.candidate_subset);
                 if ids.is_empty() {

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -19,6 +19,7 @@ pub mod picker;
 pub mod proto;
 pub mod router_only;
 pub mod router_only_reflector;
+pub mod router_only_runtime;
 pub mod server;
 
 pub use epp::Router;

--- a/deploy/inference-gateway/ext-proc/src/router_only.rs
+++ b/deploy/inference-gateway/ext-proc/src/router_only.rs
@@ -17,9 +17,9 @@
 //!   `mem` discovery backend (no etcd/NATS). See
 //!   [`crate::epp::Router::from_router_only`].
 //!
-//! This module defines the configuration surface for router-only mode, parses it
-//! from the environment, and (for now) provides a stub `Router::from_router_only`
-//! constructor. The runtime wiring lands in later changes.
+//! This module defines the configuration surface for router-only mode and
+//! parses it from the environment; the constructor that consumes it is
+//! [`crate::epp::Router::from_router_only`].
 
 use anyhow::{Context, Result};
 
@@ -133,35 +133,6 @@ impl RouterOnlyConfig {
     /// (a prefill/decode role label is set).
     pub fn is_disaggregated(&self) -> bool {
         self.role_label.is_some()
-    }
-}
-
-impl crate::epp::Router {
-    /// Initialize the router in router-only ("on-ramp") mode.
-    ///
-    /// Router-only mode fronts a fleet of raw `vllm serve` pods with no Dynamo
-    /// control plane: discovery is a Kubernetes label selector, KV-cache state
-    /// comes from each pod's native vLLM ZMQ event stream (republished onto the
-    /// embedded router's event plane), and the runtime uses the inert `mem`
-    /// discovery backend (no etcd/NATS). See [`RouterOnlyConfig`] and
-    /// `deploy/inference-gateway/ext-proc/examples/onramp/`.
-    ///
-    /// NOTE: this is currently a stub. The construction path (offline
-    /// preprocessor, mem-backed component, label-selector reflector, and the
-    /// ZMQ KV republisher) lands in subsequent changes. It is defined here so
-    /// the `DYN_EPP_MODE` mode switch and configuration surface can be
-    /// reviewed independently — and so this change touches no existing
-    /// `epp.rs` (Dynamo-mode) code.
-    pub async fn from_router_only(cfg: RouterOnlyConfig) -> Result<Self> {
-        anyhow::bail!(
-            "router-only mode (DYN_EPP_MODE=router-only) is not yet implemented: \
-             parsed config for model '{}' (block_size={}, selector='{}', disagg={}). \
-             Use the default Dynamo mode for now.",
-            cfg.model_name,
-            cfg.block_size,
-            cfg.pod_selector,
-            cfg.is_disaggregated(),
-        )
     }
 }
 

--- a/deploy/inference-gateway/ext-proc/src/router_only_runtime.rs
+++ b/deploy/inference-gateway/ext-proc/src/router_only_runtime.rs
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Router-only ("on-ramp") mode construction.
+//!
+//! Builds the pieces the embedded router needs to front raw `vllm serve` pods
+//! with no Dynamo control plane, and assembles them into [`RouterOnlyParts`] that
+//! [`crate::epp::Router::from_router_only`] folds into a `Router`. Keeping the
+//! I/O-heavy construction here keeps the `epp.rs` integration small.
+//!
+//! Pipeline:
+//! 1. **Inert runtime** — `DistributedRuntime` on the `mem` discovery backend
+//!    with the ZMQ event plane (set via `DYN_DISCOVERY_BACKEND=mem` /
+//!    `DYN_EVENT_PLANE=zmq` in the deployment). No etcd/NATS is contacted.
+//! 2. **Offline preprocessor** — download just the tokenizer/config for
+//!    `DYN_MODEL_NAME` from HF and build an `OpenAIPreprocessor` (no GPU, no
+//!    Dynamo model card).
+//! 3. **Decode `KvRouter`** — built against an in-process `mem` component; its
+//!    event-plane subscriber consumes what the [`KvRepublisher`] emits.
+//! 4. **Pod reflector** — [`RouterOnlyPodReflector`] over `DYN_EPP_POD_SELECTOR`.
+//! 5. **KV republisher + reconciler** — per Ready pod, bridge its native vLLM
+//!    ZMQ KV events onto the router's event plane.
+//!
+//! NOTE: this builds the **aggregated** path. The `PrefillRouter` is created
+//! inactive (never receives an activation endpoint), so prefill routing always
+//! falls back to decode-only. Disaggregated prefill discovery + routing is a
+//! follow-up.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio_util::sync::CancellationToken;
+
+use dynamo_kv_router::config::kv_router_config_from_dynamo_env;
+use dynamo_llm::discovery::{ModelManager, WORKER_TYPE_DECODE};
+use dynamo_llm::kv_router::{KvRouter, PrefillRouter};
+use dynamo_llm::local_model::LocalModel;
+use dynamo_llm::model_card::ModelDeploymentCard;
+use dynamo_llm::preprocessor::OpenAIPreprocessor;
+use dynamo_runtime::pipeline::RouterMode;
+use dynamo_runtime::{DistributedRuntime, Runtime};
+
+use crate::kv_republisher::KvRepublisher;
+use crate::router_only::RouterOnlyConfig;
+use crate::router_only_reflector::RouterOnlyPodReflector;
+
+/// In-process namespace/component the embedded router and KV republisher share.
+/// Router-only mode has no Dynamo discovery, so these names only need to match
+/// between the router's event-plane subscriber and the republisher's publisher.
+const ROUTER_ONLY_NAMESPACE: &str = "dynamo-epp-router-only";
+const ROUTER_ONLY_COMPONENT: &str = "vllm";
+
+/// How often the listener reconciler diffs the reflector's Ready set against
+/// active per-pod ZMQ listeners.
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// The constructed router-only-mode pieces, assembled into a `Router` by
+/// [`crate::epp::Router::from_router_only`].
+pub struct RouterOnlyParts {
+    pub runtime: Runtime,
+    pub preprocessor: Arc<OpenAIPreprocessor>,
+    pub decode_router: Arc<KvRouter>,
+    pub prefill_router: Arc<PrefillRouter>,
+    pub reflector: Arc<RouterOnlyPodReflector>,
+    pub republisher: Arc<KvRepublisher>,
+}
+
+/// Build the router-only-mode router pieces from configuration.
+pub async fn build_router_only(cfg: &RouterOnlyConfig) -> Result<RouterOnlyParts> {
+    let runtime = Runtime::from_settings()?;
+    let drt = DistributedRuntime::from_settings(runtime.clone()).await?;
+
+    // Router-only mode must run NATS-free. If the runtime resolved to the NATS
+    // event plane, the deployment is misconfigured (expected DYN_EVENT_PLANE=zmq
+    // + DYN_DISCOVERY_BACKEND=mem); warn loudly rather than silently dialing NATS.
+    if drt.default_event_transport_kind() != dynamo_runtime::discovery::EventTransportKind::Zmq {
+        tracing::warn!(
+            transport = ?drt.default_event_transport_kind(),
+            "Router-only mode expects the ZMQ event plane; set DYN_EVENT_PLANE=zmq and \
+             DYN_DISCOVERY_BACKEND=mem to keep the EPP runtime-free (no NATS/etcd)."
+        );
+    }
+
+    let preprocessor = build_offline_preprocessor(cfg).await?;
+
+    // One in-process `mem` component shared by the decode router's event-plane
+    // subscriber and the KV republisher's publisher, so republished events flow
+    // into the router's index.
+    let component = drt
+        .namespace(ROUTER_ONLY_NAMESPACE)?
+        .component(ROUTER_ONLY_COMPONENT)?;
+    let endpoint = component.endpoint("generate");
+
+    let mut kv_router_config = kv_router_config_from_dynamo_env();
+    // Raw vLLM workers never register a ModelRuntimeConfig in discovery; they are
+    // admitted into the scheduler via register_workers(allowed_worker_ids) on the
+    // hot path, so we must not block startup waiting for discovery registration.
+    kv_router_config.skip_initial_worker_wait = true;
+
+    let model_manager = Arc::new(ModelManager::new());
+    let decode_router = model_manager
+        .kv_chooser_for(
+            &endpoint,
+            cfg.block_size,
+            Some(kv_router_config.clone()),
+            None,
+            WORKER_TYPE_DECODE,
+            Some(cfg.model_name.clone()),
+            false, // enable_eagle: raw vLLM does not expose an eagle config here
+        )
+        .await?;
+
+    // Aggregated path: build the PrefillRouter but never activate it (no
+    // activation endpoint is ever sent), so route_prefill always returns an
+    // error and pick() falls back to decode-only. Disagg is a follow-up.
+    let mut prefill_config = kv_router_config;
+    prefill_config.router_track_active_blocks = false;
+    let (_prefill_tx, prefill_rx) = tokio::sync::oneshot::channel();
+    let prefill_router = PrefillRouter::new(
+        prefill_rx,
+        model_manager.clone(),
+        RouterMode::KV,
+        cfg.block_size,
+        Some(prefill_config),
+        None,
+        false, // enforce_disagg: forced off in aggregated router-only mode
+        cfg.model_name.clone(),
+        ROUTER_ONLY_NAMESPACE.to_string(),
+        false,
+    );
+
+    let k8s_namespace = std::env::var("POD_NAMESPACE").map_err(|_| {
+        anyhow::anyhow!(
+            "POD_NAMESPACE environment variable is not set. \
+             Inject it via the downward API (fieldRef metadata.namespace) on the EPP pod."
+        )
+    })?;
+    let reflector = Arc::new(
+        RouterOnlyPodReflector::spawn(&k8s_namespace, &cfg.pod_selector, cfg.target_port).await?,
+    );
+
+    let republisher = Arc::new(
+        KvRepublisher::new(
+            &component,
+            cfg.block_size,
+            cfg.kv_event_port,
+            cfg.kv_event_topic.clone(),
+        )
+        .await?,
+    );
+
+    if cfg.kv_events {
+        spawn_listener_reconciler(reflector.clone(), republisher.clone());
+    } else {
+        tracing::info!(
+            "DYN_EPP_KV_EVENTS=false: skipping per-pod ZMQ KV ingestion (load-aware routing only)"
+        );
+    }
+
+    Ok(RouterOnlyParts {
+        runtime,
+        preprocessor,
+        decode_router,
+        prefill_router,
+        reflector,
+        republisher,
+    })
+}
+
+/// Download just the tokenizer/config for `cfg.model_name` from Hugging Face and
+/// build an `OpenAIPreprocessor`. No GPU and no Dynamo model card are required;
+/// the worker re-tokenizes, so this is only used for routing-side tokenization.
+async fn build_offline_preprocessor(cfg: &RouterOnlyConfig) -> Result<Arc<OpenAIPreprocessor>> {
+    let model_path = LocalModel::fetch(&cfg.model_name, /* ignore_weights = */ true)
+        .await
+        .with_context(|| format!("downloading tokenizer/config for '{}'", cfg.model_name))?;
+    let mut card = ModelDeploymentCard::load_from_disk(&model_path, None)
+        .with_context(|| format!("loading model card for '{}'", cfg.model_name))?;
+    card.set_name(&cfg.model_name);
+    card.kv_cache_block_size = cfg.block_size;
+    let preprocessor = OpenAIPreprocessor::new(card)
+        .with_context(|| format!("building preprocessor for '{}'", cfg.model_name))?;
+    tracing::info!(
+        model = %cfg.model_name,
+        block_size = cfg.block_size,
+        "Built offline preprocessor for router-only mode"
+    );
+    Ok(preprocessor)
+}
+
+/// Background task: keep one per-pod ZMQ KV-event listener running for every
+/// Ready vLLM pod. Starts listeners for newly-Ready pods and cancels them when
+/// pods leave the reflector's Ready set.
+fn spawn_listener_reconciler(
+    reflector: Arc<RouterOnlyPodReflector>,
+    republisher: Arc<KvRepublisher>,
+) {
+    tokio::spawn(async move {
+        let mut active: HashMap<u64, CancellationToken> = HashMap::new();
+        loop {
+            let ready: HashMap<u64, String> = reflector.ready_workers().into_iter().collect();
+
+            // Start listeners for newly-Ready pods.
+            for (worker_id, endpoint) in &ready {
+                if active.contains_key(worker_id) {
+                    continue;
+                }
+                // endpoint is "ip:port"; the republisher appends the KV-event
+                // port, so it only needs the pod IP.
+                let Some((ip, _port)) = endpoint.rsplit_once(':') else {
+                    tracing::warn!(worker_id, endpoint = %endpoint, "Malformed endpoint; skipping");
+                    continue;
+                };
+                let token = republisher.register_worker(*worker_id, ip);
+                active.insert(*worker_id, token);
+            }
+
+            // Cancel listeners for pods that are no longer Ready.
+            active.retain(|worker_id, token| {
+                if ready.contains_key(worker_id) {
+                    true
+                } else {
+                    tracing::info!(worker_id, "Pod gone; cancelling its KV-event listener");
+                    token.cancel();
+                    false
+                }
+            });
+
+            tokio::time::sleep(RECONCILE_INTERVAL).await;
+        }
+    });
+}


### PR DESCRIPTION
## Overview:

This PR wires everything together:

1. Inert mem runtime — DistributedRuntime::from_settings() with DYN_DISCOVERY_BACKEND=mem + DYN_EVENT_PLANE=zmq, so a Component exists for the router/publisher to bind to, but no etcd/NATS is ever contacted.
2. Offline preprocessor — build the tokenizer/OpenAIPreprocessor from DYN_MODEL_NAME (no Dynamo model card in external mode), so the EPP can tokenize prompts for routing.
3. The existing KvRouter used as "embedded". It is constructed against the mem Component with skip_initial_worker_wait=true, use_kv_events=true; its existing event-plane subscriber will consume what the republisher emits. 
4. ExternalPodReflector (PR 4) — discovers Ready raw vLLM pods by DYN_EPP_POD_SELECTOR, supplies ready_worker_ids to the scheduler and <pod-ip>:DYN_EPP_TARGET_PORT endpoint resolution.
5. KvRepublisher (PR 3) — for each discovered pod, start the per-pod ZMQ→event-plane bridge so the router's index reflects real vLLM cache state.
6. token_ids = None on the forwarded request (llm-d parity: the worker re-tokenizes; the EPP only tokenizes internally for routing).

[Scheduler admission dependency](https://github.com/ai-dynamo/dynamo/pull/10337) must be merged.
The KvRouter's scheduler only routes to workers it considers valid candidates. In normal Dynamo mode, a worker becomes a candidate by registering itself in discovery (etcd) with a ModelRuntimeConfig (block size, etc.); the router's workers_with_configs watch populates from that, and from_discovery even waits for at least one config to appear.

Limitations:
Aggregated only. PrefillRouter is built inactive; disagg (role-label split + x-prefiller-host-port) is PR 6.




Raw vLLM pods in router-only mode never register in Dynamo discovery and have no ModelRuntimeConfig. Instead the EPP discovers them via the K8s pod reflector and, on each pick, calls decode_router.register_workers(allowed_worker_ids) + constrains selection to those IDs (and we set skip_initial_worker_wait=true, so we don't block waiting for a config that never comes).

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue
