### PR TITLE
fix(sglang): reject multimodal requests when worker lacks --multimodal-worker

### DIFF
--- a/components/src/dynamo/sglang/CLAUDE.md
+++ b/components/src/dynamo/sglang/CLAUDE.md
@@ -44,8 +44,12 @@ Worker dispatch (main.py:60-132):
   --image-diffusion-worker    -> init_diffusion.init_image_diffusion()
   --video-generation-worker   -> init_diffusion.init_video_diffusion()
   --embedding-worker          -> init_embedding.init_embedding()
-  --multimodal-encode-worker  -> init_multimodal.init_multimodal_encode_worker()
-  --multimodal-worker         -> init_multimodal.init_multimodal_worker() or _prefill_worker()
+  --enable-multimodal --disaggregation-mode encode
+                              -> init_multimodal.init_multimodal_encode_worker()
+  --enable-multimodal --dedicated-mm-encoder --disaggregation-mode pd/decode
+                              -> init_multimodal.init_multimodal_worker()
+  --enable-multimodal --dedicated-mm-encoder --disaggregation-mode prefill
+                              -> init_multimodal.init_multimodal_prefill_worker()
   --dllm-algorithm <algo>     -> init_diffusion.init_llm_diffusion()
   (default, prefill mode)     -> init_llm.init_prefill()
   (default, decode/agg mode)  -> init_llm.init_decode()
@@ -57,7 +61,7 @@ Worker dispatch (main.py:60-132):
 
 **Two config paths:**
 
-1. **LLM workers** (decode, prefill, embedding, multimodal-worker, dllm): Creates full
+1. **LLM workers** (decode, prefill, embedding, internal multimodal, dllm): Creates full
    `sglang.srt.server_args.ServerArgs` via `ServerArgs.from_cli_args()`. This triggers
    model config loading, tokenizer detection, etc.
 
@@ -68,7 +72,7 @@ Worker dispatch (main.py:60-132):
 
 **DynamoConfig** combines `DynamoRuntimeConfig` (common flags like `--namespace`,
 `--output-modalities`, `--media-output-fs-url`) with `DynamoSGLangConfig` (sglang-specific
-flags like `--multimodal-encode-worker`, `--embedding-worker`).
+flags like `--enable-multimodal`, `--dedicated-mm-encoder`, `--embedding-worker`).
 
 Key gotcha: `--output-modalities` defaults to `["text"]` globally. Image/video diffusion
 workers override this in their init functions to `["image"]`/`["video"]` to ensure correct
@@ -117,8 +121,8 @@ BaseGenerativeHandler (handler_base.py)
 | Worker | Engine | Notes |
 |--------|--------|-------|
 | decode, prefill, dllm, embedding | `sgl.Engine` | Full SGLang inference engine |
-| multimodal-worker, multimodal-prefill | `sgl.Engine` | Plus EmbeddingsProcessor |
-| multimodal-encode-worker | None | `MMEncoder` from SGLang, pre-tokenized input |
+| internal multimodal worker / prefill | `sgl.Engine` | `--dedicated-mm-encoder`; plus EmbeddingsProcessor |
+| multimodal encode worker | None | `--disaggregation-mode encode`; `MMEncoder` from SGLang, pre-tokenized input |
 | image-diffusion-worker | `DiffGenerator` | From `sglang.multimodal_gen` |
 | video-generation-worker | `DiffGenerator` | From `sglang.multimodal_gen` |
 

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -156,9 +156,14 @@ def _set_cli_flag_value(args: list[str], flag: str, value: str) -> list[str]:
 def _normalize_multimodal_disaggregation_args(
     unknown: list[str], dynamo_config: "DynamoConfig"
 ) -> list[str]:
-    """Map Dynamo's canonical multimodal EPD args to SGLang's current flags."""
+    """Map Dynamo's canonical multimodal args to SGLang's current flags."""
     disaggregation_mode = _get_last_cli_flag_value(unknown, "--disaggregation-mode")
     if disaggregation_mode is None:
+        if dynamo_config.dedicated_mm_encoder and not dynamo_config.multimodal_worker:
+            raise ValueError(
+                "--dedicated-mm-encoder requires --disaggregation-mode=pd, "
+                "--disaggregation-mode=prefill, or --disaggregation-mode=decode."
+            )
         return unknown
 
     requested_disaggregation_mode = disaggregation_mode
@@ -170,6 +175,12 @@ def _normalize_multimodal_disaggregation_args(
         disaggregation_mode = "null"
 
     if disaggregation_mode == DisaggregationMode.ENCODE.value:
+        if dynamo_config.dedicated_mm_encoder:
+            raise ValueError(
+                "--dedicated-mm-encoder is for PD/P/D workers that consume or "
+                "forward embeddings from a separate encode worker. Do not "
+                "combine it with --disaggregation-mode=encode."
+            )
         if not dynamo_config.enable_multimodal:
             logging.warning(
                 "--disaggregation-mode=encode is only valid for SGLang "
@@ -180,14 +191,22 @@ def _normalize_multimodal_disaggregation_args(
         dynamo_config.multimodal_encode_worker = True
         return _remove_cli_flag_and_value(unknown, "--disaggregation-mode")
 
+    internal_multimodal_role = (
+        requested_disaggregation_mode == PREFILL_DECODE_DISAGGREGATION_MODE
+        or disaggregation_mode in {"prefill", "decode"}
+    )
+    if dynamo_config.dedicated_mm_encoder and not internal_multimodal_role:
+        raise ValueError(
+            "--dedicated-mm-encoder only applies to --disaggregation-mode=pd, "
+            "--disaggregation-mode=prefill, or --disaggregation-mode=decode."
+        )
+
     if (
         dynamo_config.enable_multimodal
+        and dynamo_config.dedicated_mm_encoder
         and not dynamo_config.multimodal_encode_worker
         and not dynamo_config.multimodal_worker
-        and (
-            requested_disaggregation_mode == PREFILL_DECODE_DISAGGREGATION_MODE
-            or disaggregation_mode in {"prefill", "decode"}
-        )
+        and internal_multimodal_role
     ):
         dynamo_config.multimodal_worker = True
 

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -68,8 +68,8 @@ class DynamoSGLangArgGroup(ArgGroup):
             env_var="DYN_SGL_MULTIMODAL_WORKER",
             default=False,
             help=(
-                "DEPRECATED: use --enable-multimodal with "
-                "--disaggregation-mode=pd/prefill/decode."
+                "DEPRECATED: use --enable-multimodal --dedicated-mm-encoder "
+                "with --disaggregation-mode=pd/prefill/decode."
             ),
         )
         add_negatable_bool_argument(
@@ -78,9 +78,22 @@ class DynamoSGLangArgGroup(ArgGroup):
             env_var="DYN_SGL_ENABLE_MULTIMODAL",
             default=False,
             help=(
-                "Enable multimodal processing. When an explicit "
-                "--disaggregation-mode is provided, this selects the matching "
-                "Dynamo multimodal EPD worker role."
+                "Enable multimodal processing. This is a capability flag for "
+                "raw multimodal inputs; use --dedicated-mm-encoder when this "
+                "worker is part of the internal encode-worker topology."
+            ),
+        )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--dedicated-mm-encoder",
+            env_var="DYN_SGL_DEDICATED_MM_ENCODER",
+            default=False,
+            help=(
+                "Select the internal SGLang topology with a dedicated "
+                "multimodal encode worker. Required on PD/P/D workers that "
+                "consume or forward precomputed embeddings from that encode "
+                "worker. Do not use it for native P/D workers that receive "
+                "raw media metadata."
             ),
         )
 
@@ -160,6 +173,7 @@ class DynamoSGLangConfig(ConfigBase):
     multimodal_encode_worker: bool
     multimodal_worker: bool
     enable_multimodal: bool = False
+    dedicated_mm_encoder: bool = False
     embedding_transfer_mode: EmbeddingTransferMode
     embedding_worker: bool
     image_diffusion_worker: bool
@@ -183,8 +197,6 @@ class DynamoSGLangConfig(ConfigBase):
                 "Both 'disagg_config' and 'disagg_config_key' must be provided together."
             )
 
-        self.validate_multimodal_topology()
-
         if self.multimodal_encode_worker:
             _warn_deprecated(
                 "--multimodal-encode-worker is deprecated; use "
@@ -195,20 +207,34 @@ class DynamoSGLangConfig(ConfigBase):
         if self.multimodal_worker:
             _warn_deprecated(
                 "--multimodal-worker is deprecated; use --enable-multimodal "
-                "with --disaggregation-mode=pd, --disaggregation-mode=prefill, "
-                "or --disaggregation-mode=decode. This release will map the "
-                "legacy flag to the new arguments."
+                "--dedicated-mm-encoder with --disaggregation-mode=pd, "
+                "--disaggregation-mode=prefill, or --disaggregation-mode=decode. "
+                "This release will map the legacy flag to the new arguments."
             )
             self.enable_multimodal = True
 
+        self.validate_dedicated_mm_encoder()
+        self.validate_multimodal_topology()
+
+    def validate_dedicated_mm_encoder(self) -> None:
+        if self.dedicated_mm_encoder and not self.enable_multimodal:
+            raise ValueError(
+                "--dedicated-mm-encoder requires --enable-multimodal. The "
+                "dedicated encoder flag selects the internal encode-worker "
+                "topology; it is not a standalone multimodal capability switch."
+            )
+
     def validate_multimodal_topology(self) -> None:
         if self.frontend_decoding and (
-            self.multimodal_encode_worker or self.multimodal_worker
+            self.multimodal_encode_worker
+            or self.multimodal_worker
+            or self.dedicated_mm_encoder
         ):
             raise ValueError(
                 "--frontend-decoding is incompatible with the EPD multimodal topology "
-                "(--multimodal-encode-worker / --multimodal-worker). The encode worker "
-                "needs URLs to run MMEncoder, while --frontend-decoding ships pre-decoded "
-                "pixels. Use --frontend-decoding on the default aggregated decode worker "
-                "(no --multimodal-* flag) instead."
+                "(--dedicated-mm-encoder / --multimodal-encode-worker / "
+                "--multimodal-worker). The encode worker needs URLs to run "
+                "MMEncoder, while --frontend-decoding ships pre-decoded pixels. "
+                "Use --frontend-decoding on a native worker that does not use "
+                "the dedicated encode-worker topology instead."
             )

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -197,6 +197,8 @@ class DynamoSGLangConfig(ConfigBase):
                 "Both 'disagg_config' and 'disagg_config_key' must be provided together."
             )
 
+        self.validate_multimodal_topology()
+
         if self.multimodal_encode_worker:
             _warn_deprecated(
                 "--multimodal-encode-worker is deprecated; use "
@@ -214,7 +216,6 @@ class DynamoSGLangConfig(ConfigBase):
             self.enable_multimodal = True
 
         self.validate_dedicated_mm_encoder()
-        self.validate_multimodal_topology()
 
     def validate_dedicated_mm_encoder(self) -> None:
         if self.dedicated_mm_encoder and not self.enable_multimodal:

--- a/components/src/dynamo/sglang/init_multimodal.py
+++ b/components/src/dynamo/sglang/init_multimodal.py
@@ -131,7 +131,8 @@ async def init_multimodal_worker(
 
     This worker is always an internal component that should not register with
     the Frontend. Public registration is handled by the Encode Worker component
-    (--multimodal-encode-worker). For standalone serving, use init() (default).
+    (--enable-multimodal --disaggregation-mode encode). For standalone serving,
+    use init() (default).
     """
     server_args, dynamo_args = config.server_args, config.dynamo_args
 

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -24,6 +24,7 @@ from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
     VIDEO_URL_KEY,
     build_disagg_mm_kwargs,
     extract_media_urls,
+    raise_if_unextracted_multimodal,
 )
 
 _SAMPLING_OPTION_FIELDS = (
@@ -355,6 +356,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             logging.debug(f"Request {context.id()} will use LoRA adapter: {lora_path}")
 
         if self.serving_mode == DisaggregationMode.DECODE:
+            raise_if_unextracted_multimodal(request)
+
             # Check if bootstrap_info is pre-computed in the request (from frontend)
             bootstrap_info = request.get("bootstrap_info")
 
@@ -416,6 +419,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 ):
                     yield out
         else:
+            raise_if_unextracted_multimodal(request)
+
             # Extract image/video URLs for multimodal requests. SGLang's mm_data_processor
             # handles loading/preprocessing, and the scheduler does vision encoding.
             mm_data = request.get("multi_modal_data", {})

--- a/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
@@ -16,19 +16,6 @@ VIDEO_URL_KEY = "video_url"
 _SUPPORTED_MULTIMODAL_CONTENT_TYPES = frozenset({IMAGE_URL_KEY, VIDEO_URL_KEY})
 
 
-def _request_has_multimodal(
-    request: Dict[str, Any],
-    *,
-    mm_data: Dict[str, Any] | None = None,
-    raw_types: set[str] | None = None,
-) -> bool:
-    if mm_data is None:
-        mm_data = _multi_modal_data(request)
-    if raw_types is None:
-        raw_types = _raw_multimodal_content_types(request)
-    return bool(mm_data or raw_types)
-
-
 def _multi_modal_data(request: Dict[str, Any]) -> Dict[str, Any]:
     if "multi_modal_data" not in request or request.get("multi_modal_data") is None:
         return {}
@@ -66,7 +53,7 @@ def raise_if_unextracted_multimodal(request: Dict[str, Any]) -> None:
 
     mm_data = _multi_modal_data(request)
     raw_types = _raw_multimodal_content_types(request)
-    if not _request_has_multimodal(request, mm_data=mm_data, raw_types=raw_types):
+    if not (mm_data or raw_types):
         return
 
     missing_mm_types = {

--- a/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
@@ -13,6 +13,77 @@ logger = logging.getLogger(__name__)
 
 IMAGE_URL_KEY = "image_url"
 VIDEO_URL_KEY = "video_url"
+_SUPPORTED_MULTIMODAL_CONTENT_TYPES = frozenset({IMAGE_URL_KEY, VIDEO_URL_KEY})
+
+
+def _request_has_multimodal(
+    request: Dict[str, Any],
+    *,
+    mm_data: Dict[str, Any] | None = None,
+    raw_types: set[str] | None = None,
+) -> bool:
+    if mm_data is None:
+        mm_data = _multi_modal_data(request)
+    if raw_types is None:
+        raw_types = _raw_multimodal_content_types(request)
+    return bool(mm_data or raw_types)
+
+
+def _multi_modal_data(request: Dict[str, Any]) -> Dict[str, Any]:
+    if "multi_modal_data" not in request or request.get("multi_modal_data") is None:
+        return {}
+
+    mm_data = request["multi_modal_data"]
+    if not isinstance(mm_data, dict):
+        raise ValueError(
+            "multi_modal_data must be an object, " f"got {type(mm_data).__name__}"
+        )
+    return mm_data
+
+
+def _raw_multimodal_content_types(request: Dict[str, Any]) -> set[str]:
+    extra_args = request.get("extra_args") or {}
+    messages = extra_args.get("messages") or request.get("messages") or []
+    content_types: set[str] = set()
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if (
+                isinstance(part, dict)
+                and part.get("type") in _SUPPORTED_MULTIMODAL_CONTENT_TYPES
+            ):
+                content_types.add(part["type"])
+    return content_types
+
+
+def raise_if_unextracted_multimodal(request: Dict[str, Any]) -> None:
+    """Reject raw multimodal messages that were not extracted by the frontend."""
+
+    mm_data = _multi_modal_data(request)
+    raw_types = _raw_multimodal_content_types(request)
+    if not _request_has_multimodal(request, mm_data=mm_data, raw_types=raw_types):
+        return
+
+    missing_mm_types = {
+        content_type for content_type in raw_types if not mm_data.get(content_type)
+    }
+    if not missing_mm_types:
+        return
+
+    types_str = ", ".join(sorted(missing_mm_types))
+    message = (
+        "Multimodal input received but SGLang worker did not receive "
+        f"corresponding multi_modal_data for: {types_str}. Ensure the "
+        "frontend processor extracted image_url/video_url content or remove "
+        "image_url/video_url content."
+    )
+    logger.error(message)
+    raise RuntimeError(message)
 
 
 def extract_media_urls(
@@ -57,7 +128,7 @@ def build_disagg_mm_kwargs(request: Dict[str, Any]) -> Dict[str, Any]:
     """Build the ``image_data``/``video_data`` kwargs for a disaggregated worker's
     ``async_generate`` call. Both keys are always present (``None`` when absent).
     """
-    mm_data = request.get("multi_modal_data") or {}
+    mm_data = _multi_modal_data(request)
     image_data = extract_media_urls(mm_data, IMAGE_URL_KEY)
     video_data = extract_media_urls(mm_data, VIDEO_URL_KEY)
     if image_data or video_data:

--- a/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
@@ -118,6 +118,10 @@ def build_disagg_mm_kwargs(request: Dict[str, Any]) -> Dict[str, Any]:
     mm_data = _multi_modal_data(request)
     image_data = extract_media_urls(mm_data, IMAGE_URL_KEY)
     video_data = extract_media_urls(mm_data, VIDEO_URL_KEY)
+    # TODO: Native EP/D works with this raw-media path, but both prefill and
+    # decode call it, so SGLang may fetch/load/preprocess the same media twice.
+    # Remove the duplicate preprocessing once native EP/D can share processed
+    # media or embeddings while preserving decode-side token layout.
     if image_data or video_data:
         logger.debug(
             "disaggregated multimodal request: images=%d, videos=%d",

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -13,7 +13,10 @@ from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 from dynamo.sglang.request_handlers.llm.decode_handler import _sampling_option_params
-from dynamo.sglang.request_handlers.llm.mm_disagg_utils import build_disagg_mm_kwargs
+from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
+    build_disagg_mm_kwargs,
+    raise_if_unextracted_multimodal,
+)
 
 # Sentinel value matching u32::MAX from the C/Go prefill-routing ABI.
 # This remains as a compatibility fallback for older callers that still encode
@@ -149,6 +152,8 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             logging.debug(
                 f"Prefill request {context.id()} will use LoRA adapter: {lora_path}"
             )
+
+        raise_if_unextracted_multimodal(inner_request)
 
         results = await self.engine.async_generate(
             **input_param,

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -15,7 +15,10 @@ from dynamo.sglang.request_handlers.llm.decode_handler import (
     _openai_stop_sampling_params,
     _user_stop_token_ids,
 )
-from dynamo.sglang.request_handlers.llm.mm_disagg_utils import extract_media_urls
+from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
+    extract_media_urls,
+    raise_if_unextracted_multimodal,
+)
 from dynamo.sglang.request_handlers.multimodal.worker_handler import StreamProcessor
 
 pytestmark = [
@@ -260,6 +263,33 @@ def test_build_sampling_params_forwards_repetition_controls_for_openai_requests(
     assert sampling_params["min_p"] == 0.01
     assert sampling_params["sampling_seed"] == 1234
     assert "seed" not in sampling_params
+
+
+class TestMultimodalGuard:
+    """Tests for multimodal guard when frontend extraction is missing."""
+
+    IMAGE_MESSAGE = {
+        "role": "user",
+        "content": [
+            {"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}},
+            {"type": "text", "text": "describe image"},
+        ],
+    }
+
+    @pytest.mark.parametrize(
+        "request_factory",
+        [
+            lambda msg: {"token_ids": [1, 2, 3], "messages": [msg]},
+            lambda msg: {"token_ids": [1, 2, 3], "extra_args": {"messages": [msg]}},
+        ],
+        ids=["top_level_messages", "extra_args_messages"],
+    )
+    def test_raises_for_image_url(self, request_factory):
+        with pytest.raises(RuntimeError, match="multi_modal_data"):
+            raise_if_unextracted_multimodal(request_factory(self.IMAGE_MESSAGE))
+
+    def test_text_only_request_bypasses_guard(self):
+        raise_if_unextracted_multimodal({"token_ids": [10, 20, 30]})
 
 
 def test_build_logprob_kwargs_allows_chosen_token_logprobs(monkeypatch):

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -268,13 +268,18 @@ def test_build_sampling_params_forwards_repetition_controls_for_openai_requests(
 class TestMultimodalGuard:
     """Tests for multimodal guard when frontend extraction is missing."""
 
-    IMAGE_MESSAGE = {
-        "role": "user",
-        "content": [
-            {"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}},
-            {"type": "text", "text": "describe image"},
-        ],
-    }
+    @staticmethod
+    def _image_message():
+        return {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/a.jpg"},
+                },
+                {"type": "text", "text": "describe image"},
+            ],
+        }
 
     @pytest.mark.parametrize(
         "request_factory",
@@ -286,7 +291,7 @@ class TestMultimodalGuard:
     )
     def test_raises_for_image_url(self, request_factory):
         with pytest.raises(RuntimeError, match="multi_modal_data"):
-            raise_if_unextracted_multimodal(request_factory(self.IMAGE_MESSAGE))
+            raise_if_unextracted_multimodal(request_factory(self._image_message()))
 
     def test_text_only_request_bypasses_guard(self):
         raise_if_unextracted_multimodal({"token_ids": [10, 20, 30]})

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -64,6 +64,7 @@ def _make_sglang_config(**overrides):
     config.multimodal_encode_worker = False
     config.multimodal_worker = False
     config.enable_multimodal = False
+    config.dedicated_mm_encoder = False
     config.embedding_transfer_mode = EmbeddingTransferMode.NIXL_WRITE
     config.embedding_worker = False
     config.image_diffusion_worker = False
@@ -348,10 +349,10 @@ async def test_namespace_flag_drives_default_endpoint_namespace(mock_sglang_cli)
     ),
     [
         ("encode", True, False, []),
-        ("prefill", False, True, ["--disaggregation-mode", "prefill"]),
-        ("decode", False, True, ["--disaggregation-mode", "decode"]),
+        ("prefill", False, False, ["--disaggregation-mode", "prefill"]),
+        ("decode", False, False, ["--disaggregation-mode", "decode"]),
         ("agg", False, False, ["--disaggregation-mode", "null"]),
-        ("pd", False, True, ["--disaggregation-mode", "null"]),
+        ("pd", False, False, ["--disaggregation-mode", "null"]),
     ],
 )
 def test_enable_multimodal_disaggregation_mode_maps_sglang_roles(
@@ -372,9 +373,56 @@ def test_enable_multimodal_disaggregation_mode_maps_sglang_roles(
     assert config.multimodal_worker is expected_mm_worker
 
 
-def test_multimodal_disaggregation_mode_uses_last_cli_value():
+@pytest.mark.parametrize(
+    ("mode", "expected_args"),
+    [
+        ("prefill", ["--disaggregation-mode", "prefill"]),
+        ("decode", ["--disaggregation-mode", "decode"]),
+        ("pd", ["--disaggregation-mode", "null"]),
+    ],
+)
+def test_dedicated_mm_encoder_selects_internal_multimodal_worker(mode, expected_args):
+    """Dedicated-mm-encoder selects internal E/PD or E/P/D workers."""
+    config = _make_sglang_config(enable_multimodal=True, dedicated_mm_encoder=True)
+
+    normalized = _normalize_multimodal_disaggregation_args(
+        ["--disaggregation-mode", mode], config
+    )
+
+    assert normalized == expected_args
+    assert config.multimodal_encode_worker is False
+    assert config.multimodal_worker is True
+
+
+def test_dedicated_mm_encoder_rejects_standalone_modes():
+    """The dedicated encoder flag must not silently turn agg/encode into a different topology."""
+    config = _make_sglang_config(enable_multimodal=True, dedicated_mm_encoder=True)
+
+    with pytest.raises(ValueError, match="--dedicated-mm-encoder only applies"):
+        _normalize_multimodal_disaggregation_args(
+            ["--disaggregation-mode", "agg"], config
+        )
+
+
+def test_dedicated_mm_encoder_rejects_encode_worker_mode():
+    config = _make_sglang_config(enable_multimodal=True, dedicated_mm_encoder=True)
+
+    with pytest.raises(ValueError, match="Do not combine"):
+        _normalize_multimodal_disaggregation_args(
+            ["--disaggregation-mode", "encode"], config
+        )
+
+
+def test_dedicated_mm_encoder_requires_explicit_worker_role():
+    config = _make_sglang_config(enable_multimodal=True, dedicated_mm_encoder=True)
+
+    with pytest.raises(ValueError, match="requires --disaggregation-mode"):
+        _normalize_multimodal_disaggregation_args([], config)
+
+
+def test_multimodal_disaggregation_mode_uses_last_cli_value_with_dedicated_mm_encoder():
     """Config-merged args precede CLI args, so the last explicit value must win."""
-    config = _make_sglang_config(enable_multimodal=True)
+    config = _make_sglang_config(enable_multimodal=True, dedicated_mm_encoder=True)
 
     normalized = _normalize_multimodal_disaggregation_args(
         ["--disaggregation-mode", "prefill", "--disaggregation-mode", "pd"],
@@ -406,6 +454,14 @@ def test_legacy_multimodal_worker_sets_enable_multimodal():
 
     assert config.enable_multimodal is True
     assert config.multimodal_worker is True
+
+
+def test_dedicated_mm_encoder_requires_enable_multimodal():
+    """Dedicated-mm-encoder is a topology modifier, not a multimodal enable switch."""
+    config = _make_sglang_config(dedicated_mm_encoder=True)
+
+    with pytest.raises(ValueError, match="requires --enable-multimodal"):
+        config.validate()
 
 
 @pytest.mark.asyncio

--- a/docs/backends/sglang/sglang-reference-guide.md
+++ b/docs/backends/sglang/sglang-reference-guide.md
@@ -18,9 +18,10 @@ Dynamo SGLang uses SGLang's native argument parser -- all SGLang engine argument
 | **Decode** *(default)* | Standard LLM inference (aggregated or disaggregated decode) |
 | **Prefill** | Disaggregated prefill phase (`--disaggregation-mode prefill`) |
 | **Embedding** | Text embedding models (`--embedding-worker`) |
-| **Multimodal Encode** | Frontend-facing: vision encoding, embeddings generation (`--multimodal-encode-worker`) |
-| **Multimodal Worker** | LLM inference with multimodal data (`--multimodal-worker`) |
-| **Multimodal Prefill** | Prefill phase for multimodal disaggregation (`--multimodal-worker --disaggregation-mode prefill`) |
+| **Multimodal Encode** | Frontend-facing: vision encoding, embeddings generation (`--enable-multimodal --disaggregation-mode encode`) |
+| **Native Multimodal P/D** | Normal prefill/decode workers that pass raw media to SGLang (`--enable-multimodal --disaggregation-mode prefill/decode`) |
+| **Internal Multimodal Worker** | E/PD or E/P/D worker that consumes embeddings from a separate encode worker (`--enable-multimodal --dedicated-mm-encoder --disaggregation-mode pd/decode`) |
+| **Internal Multimodal Prefill** | Prefill phase for E/P/D multimodal disaggregation (`--enable-multimodal --dedicated-mm-encoder --disaggregation-mode prefill`) |
 | **Image Diffusion** | Image generation via DiffGenerator (`--image-diffusion-worker`) |
 | **Video Generation** | Text/image-to-video via DiffGenerator (`--video-generation-worker`) |
 | **LLM Diffusion** | Diffusion language models like LLaDA (`--dllm-algorithm <algo>`) |
@@ -39,8 +40,10 @@ These arguments are added by Dynamo on top of SGLang's native arguments.
 | `--dyn-reasoning-parser` | `DYN_REASONING_PARSER` | `None` | [Reasoning](../../reasoning/README.md#supported-reasoning-parsers) parser for chain-of-thought models |
 | `--custom-jinja-template` | `DYN_CUSTOM_JINJA_TEMPLATE` | `None` | Custom chat template path (incompatible with `--use-sglang-tokenizer`) |
 | `--embedding-worker` | `DYN_SGL_EMBEDDING_WORKER` | `false` | Run as embedding worker (also sets SGLang's `--is-embedding`) |
-| `--multimodal-encode-worker` | `DYN_SGL_MULTIMODAL_ENCODE_WORKER` | `false` | Run as [multimodal](../../features/multimodal/multimodal-sglang.md) encode worker (frontend-facing) |
-| `--multimodal-worker` | `DYN_SGL_MULTIMODAL_WORKER` | `false` | Run as multimodal LLM worker |
+| `--enable-multimodal` | `DYN_SGL_ENABLE_MULTIMODAL` | `false` | Allow [multimodal](../../features/multimodal/multimodal-sglang.md) inputs on this worker |
+| `--dedicated-mm-encoder` | `DYN_SGL_DEDICATED_MM_ENCODER` | `false` | Select the internal encode-worker topology for multimodal PD/P/D workers |
+| `--multimodal-encode-worker` | `DYN_SGL_MULTIMODAL_ENCODE_WORKER` | `false` | **[Deprecated]** Use `--enable-multimodal --disaggregation-mode encode` |
+| `--multimodal-worker` | `DYN_SGL_MULTIMODAL_WORKER` | `false` | **[Deprecated]** Use `--enable-multimodal --dedicated-mm-encoder --disaggregation-mode pd/prefill/decode` for internal encode-worker topologies |
 | `--image-diffusion-worker` | `DYN_SGL_IMAGE_DIFFUSION_WORKER` | `false` | Run as [image diffusion](sglang-diffusion.md#image-diffusion) worker |
 | `--video-generation-worker` | `DYN_SGL_VIDEO_GENERATION_WORKER` | `false` | Run as [video generation](sglang-diffusion.md#video-generation) worker |
 | `--disagg-config` | `DYN_SGL_DISAGG_CONFIG` | `None` | Path to YAML disaggregation config file |
@@ -49,6 +52,12 @@ These arguments are added by Dynamo on top of SGLang's native arguments.
 <Note>
 `--disagg-config` and `--disagg-config-key` must be provided together. The selected section is written to a temp YAML file and passed to SGLang's `--config` flag.
 </Note>
+
+<Warning>
+Keep `--dedicated-mm-encoder` separate from `--enable-multimodal`. `--enable-multimodal --disaggregation-mode prefill/decode` is also the native P/D multimodal shape where normal prefill/decode handlers both pass raw media metadata to SGLang: prefill builds the vision context, and decode reprocesses the same metadata to match token layout with the transferred KV cache. `--dedicated-mm-encoder` is what changes those workers into internal E/P/D components that expect precomputed embeddings from an encode worker and do not provide the public OpenAI surface.
+
+Unlike vLLM, SGLang E/P/D needs `--dedicated-mm-encoder` on both decode and prefill workers. The encode worker delegates generation to `backend.generate`, which is the decode worker, and that internal decode worker forwards the precomputed multimodal payload to prefill. Keeping this flag in the encode-worker topology also prevents falling back to native P/D's duplicate raw-media preprocessing.
+</Warning>
 
 The current supported parser names for both flags are documented in [Tool Call Parsing (Dynamo)](../../tool-calling/README.md#supported-tool-call-parsers) and [Reasoning Parsing (Dynamo)](../../reasoning/README.md#supported-reasoning-parsers).
 

--- a/docs/features/multimodal/multimodal-sglang.md
+++ b/docs/features/multimodal/multimodal-sglang.md
@@ -4,7 +4,7 @@
 title: SGLang Multimodal
 ---
 
-This document provides a comprehensive guide for multimodal inference using SGLang backend in Dynamo. SGLang multimodal supports **EPD**, **E/PD**, and **E/P/D** flows, with NIXL (RDMA) for zero-copy tensor transfer in disaggregated modes.
+This document provides a comprehensive guide for multimodal inference using SGLang backend in Dynamo. SGLang multimodal supports native **EPD** and **EP/D** flows where the SGLang engine performs media encoding, plus explicit encode-worker **E/PD** and **E/P/D** flows with NIXL (RDMA) for zero-copy tensor transfer.
 
 ## Support Matrix
 
@@ -26,23 +26,30 @@ This document provides a comprehensive guide for multimodal inference using SGLa
 
 ## Deployment Patterns
 
-SGLang supports EPD, E/PD, and E/P/D patterns. See [Multimodal Architecture Patterns](README.md#architecture-patterns) for detailed explanations.
+SGLang supports EPD, EP/D, E/PD, and E/P/D patterns. See [Multimodal Architecture Patterns](README.md#architecture-patterns) for detailed explanations.
 
 | Pattern | Supported | Launch Script | Notes |
 |---------|-----------|---------------|-------|
 | EPD (Simple Aggregated) | ✅ | `agg_vision.sh` | Internal encoding |
+| EP/D or P/D (No Separate Encode Worker) | ✅ | `disagg.sh`, `disagg_same_gpu.sh` | Native SGLang P/D launchers; prefill performs encode + prefill, decode reprocesses raw media metadata for token layout |
 | E/PD (Encode Separate) | ✅ | `multimodal_epd.sh` | Vision encoder separate |
 | E/P/D (Full Disaggregation) | ✅ | `multimodal_disagg.sh` | KV cache via bootstrap |
-| EP/D (Traditional Disaggregated) | ❌ | N/A | Not supported |
 
 ### Component Flags
 
 | Component | Flag | Purpose |
 |-----------|------|---------|
-| Encode Worker | `--multimodal-encode-worker` | Frontend-facing, vision encoding, embeddings generation (Rust frontend tokenizes) |
-| PD Worker | `--multimodal-worker` | Prefill + Decode with embeddings |
-| Decode Worker | `--multimodal-worker --serving-mode=decode` | Entry point for disaggregation |
-| Prefill Worker | `--multimodal-worker --serving-mode=prefill` | Called by Decode, bootstrap coordination |
+| Native multimodal worker | `--enable-multimodal` | Allow raw multimodal inputs. In EP/D or P/D this keeps the normal prefill/decode workers; both receive raw media metadata. |
+| Encode Worker | `--enable-multimodal --disaggregation-mode encode` | Frontend-facing, vision encoding, embeddings generation (Rust frontend tokenizes) |
+| Internal PD Worker | `--enable-multimodal --dedicated-mm-encoder --disaggregation-mode pd` | Prefill + decode worker that consumes embeddings from the encode worker |
+| Internal Decode Worker | `--enable-multimodal --dedicated-mm-encoder --disaggregation-mode decode` | Entry point for E/P/D after the encode worker has produced embeddings |
+| Internal Prefill Worker | `--enable-multimodal --dedicated-mm-encoder --disaggregation-mode prefill` | Called by internal decode, bootstrap coordination with precomputed embeddings |
+
+<Warning>
+`--dedicated-mm-encoder` is intentionally explicit. Do not infer the internal E/PD or E/P/D worker path from `--enable-multimodal --disaggregation-mode prefill/decode`. Native EP/D or P/D uses those same two disaggregation modes, but it stays on the normal SGLang handlers: prefill processes raw image/video inputs to build vision context, while decode reprocesses the same raw media metadata so token layout matches the transferred KV cache. If the dedicated encoder flag is removed or made implicit, native disaggregated deployments can register only internal topology workers and lose the public OpenAI chat/completions surface.
+
+In SGLang E/P/D, keep this flag on both the decode and prefill workers. This differs from vLLM: SGLang's encode worker delegates generation to `backend.generate`, which is the decode worker, and that decode worker forwards the precomputed multimodal payload to prefill. With this flag, the internal workers consume transferred embeddings instead of raw image/video URLs, avoiding the duplicate raw-media preprocessing used by native EP/D or P/D.
+</Warning>
 
 ### SGLang-Specific Characteristics
 
@@ -143,6 +150,50 @@ curl http://localhost:8000/v1/chat/completions \
     "stream": false
   }' | jq
 ```
+
+## EP/D or P/D Serving (No Separate Encode Worker)
+
+### Components
+
+- workers:
+  - [PrefillWorkerHandler](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py) receives raw multimodal metadata and lets SGLang perform media loading, encoding, token expansion, and KV production during prefill.
+  - [DecodeWorkerHandler](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py) receives matching multimodal metadata so token layout stays aligned with the transferred KV cache.
+
+### Workflow
+
+The Rust frontend tokenizes the request and forwards image/video URLs as `multi_modal_data`. There is no encode worker. The prefill worker passes those URLs to SGLang's normal multimodal engine path, so the vision context is produced inside the prefill worker. The decode worker also passes the same URLs to SGLang so the tokenizer manager can reproduce the multimodal token layout while consuming KV cache from prefill.
+
+This native EP/D or P/D path intentionally trades simplicity for duplicated raw-media preprocessing: both prefill and decode call SGLang with `image_data`/`video_data`, so SGLang's multimodal processor may fetch/load/preprocess the same media twice. Use the E/PD or E/P/D encode-worker topology when the deployment must preprocess media once and forward precomputed embeddings.
+
+```mermaid
+flowchart LR
+  HTTP --> decode_worker
+  decode_worker --request + raw media metadata--> prefill_worker
+  prefill_worker --SGLang media encode + KV Cache--> decode_worker
+  decode_worker -.-> HTTP
+```
+
+### Launch
+
+Native P/D and EP/D use the same launchers. The topology is selected by the
+model: text-only models run P/D, while VLMs run native EP/D where the prefill
+worker performs the media encode step. Neither path has a separate encode
+worker.
+
+```bash
+cd $DYNAMO_HOME/examples/backends/sglang
+
+# P/D: text-only model, prefill on GPU 0 and decode on GPU 1.
+./launch/disagg.sh --model Qwen/Qwen3-0.6B
+
+# EP/D: VLM, same launcher; prefill performs media encoding and decode runs separately.
+./launch/disagg.sh --model Qwen/Qwen3-VL-4B-Instruct
+
+# Single-GPU smoke test: same EP/D behavior with prefill and decode packed together.
+./launch/disagg_same_gpu.sh --model Qwen/Qwen3-VL-4B-Instruct
+```
+
+These launchers pass `--enable-multimodal` to the prefill and decode workers but deliberately do not pass `--dedicated-mm-encoder`.
 
 ## E/PD Serving (Encode Separate)
 
@@ -408,10 +459,11 @@ Supported templates: `qwen2-vl`, `llama-3`, `vicuna`, etc.
 | Use Case | NIXL Used? | Data Transfer | Notes |
 |----------|------------|---------------|-------|
 | EPD (Simple Aggregated) | No | N/A | All processing internal to SGLang |
+| EP/D or P/D (No Separate Encode Worker) | No | Prefill → Decode (KV cache via bootstrap) | Prefill performs SGLang media encoding inline |
 | E/PD (Encode Separate) | Yes | Encoder → PD (embeddings) | Vision encoder separate |
 | E/P/D (Full Disaggregation) | Yes | Encoder → Prefill (embeddings) | KV cache via SGLang bootstrap |
 
-**Key Difference:** SGLang P/D uses bootstrap mechanism, not NIXL for KV cache like vLLM.
+**Key Difference:** SGLang native EP/D or P/D uses bootstrap mechanism, not NIXL for KV cache like vLLM.
 
 ## Environment Variables
 

--- a/examples/backends/sglang/launch/disagg.sh
+++ b/examples/backends/sglang/launch/disagg.sh
@@ -72,6 +72,7 @@ python3 -m dynamo.frontend &
 OTEL_SERVICE_NAME=dynamo-worker-prefill DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT=${DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT:-60} \
 python3 -m "$WORKER_MODULE" \
+  --enable-multimodal \
   --model-path "$MODEL" \
   --served-model-name "$MODEL" \
   --page-size 16 \
@@ -90,6 +91,7 @@ python3 -m "$WORKER_MODULE" \
 # run decode worker
 OTEL_SERVICE_NAME=dynamo-worker-decode DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 CUDA_VISIBLE_DEVICES=1 python3 -m "$WORKER_MODULE" \
+  --enable-multimodal \
   --model-path "$MODEL" \
   --served-model-name "$MODEL" \
   --page-size 16 \

--- a/examples/backends/sglang/launch/disagg.sh
+++ b/examples/backends/sglang/launch/disagg.sh
@@ -18,13 +18,24 @@ pick_worker_module dynamo.sglang dynamo.sglang.unified_main "$@"
 set -- "${REMAINING_ARGS[@]}"
 
 ENABLE_OTEL=false
+MODEL="Qwen/Qwen3-0.6B"
 while [[ $# -gt 0 ]]; do
     case $1 in
         --enable-otel) ENABLE_OTEL=true; shift ;;
+        --model)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "Missing value for --model"
+                echo "Use --help for usage information"
+                exit 1
+            fi
+            MODEL="$2"
+            shift 2
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
             echo "  --enable-otel        Enable OpenTelemetry tracing"
+            echo "  --model <name>       Model to serve (default: $MODEL)"
             echo "  --unified            Use the unified backend entry point"
             echo "                       (python -m dynamo.sglang.unified_main)"
             echo "  -h, --help           Show this help message"
@@ -46,8 +57,6 @@ if [ "$ENABLE_OTEL" = true ]; then
     export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-http://localhost:4317}
     TRACE_ARGS+=(--enable-trace --otlp-traces-endpoint localhost:4317)
 fi
-
-MODEL="Qwen/Qwen3-0.6B"
 
 GPU_MEM_ARGS=$(build_sglang_gpu_mem_args)
 

--- a/examples/backends/sglang/launch/disagg_same_gpu.sh
+++ b/examples/backends/sglang/launch/disagg_same_gpu.sh
@@ -108,6 +108,7 @@ CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES \
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT=${DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT:-60} \
 python3 -m "$WORKER_MODULE" \
+  --enable-multimodal \
   --model-path "$MODEL" \
   --served-model-name "$MODEL" \
   --page-size 16 \
@@ -136,6 +137,7 @@ wait_for_ready "http://localhost:${PREFILL_SYSTEM_PORT}/health" 45 || true
 CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES \
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 python3 -m "$WORKER_MODULE" \
+  --enable-multimodal \
   --model-path "$MODEL" \
   --served-model-name "$MODEL" \
   --page-size 16 \

--- a/examples/backends/sglang/launch/multimodal_disagg.sh
+++ b/examples/backends/sglang/launch/multimodal_disagg.sh
@@ -156,6 +156,7 @@ echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (GPU mem: $DYN_PREF
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 env ${_PREFILL_CUDA_PIN:+"$_PREFILL_CUDA_PIN"} python3 -m dynamo.sglang \
   --enable-multimodal \
+  --dedicated-mm-encoder \
   --model-path "$MODEL_NAME" \
   $SERVED_MODEL_ARG \
   --page-size 16 \
@@ -179,6 +180,7 @@ fi
 echo "Starting decode worker on GPU $DYN_DECODE_WORKER_GPU (GPU mem: $DYN_DECODE_GPU_MEM)..."
 env ${_DECODE_CUDA_PIN:+"$_DECODE_CUDA_PIN"} python3 -m dynamo.sglang \
   --enable-multimodal \
+  --dedicated-mm-encoder \
   --model-path "$MODEL_NAME" \
   $SERVED_MODEL_ARG \
   --page-size 16 \

--- a/examples/backends/sglang/launch/multimodal_epd.sh
+++ b/examples/backends/sglang/launch/multimodal_epd.sh
@@ -149,6 +149,7 @@ echo "Starting PD worker on GPU $DYN_WORKER_GPU..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 env ${_WORKER_CUDA_PIN:+"$_WORKER_CUDA_PIN"} python3 -m dynamo.sglang \
   --enable-multimodal \
+  --dedicated-mm-encoder \
   --disaggregation-mode pd \
   --model-path "$MODEL_NAME" \
   $SERVED_MODEL_ARG \


### PR DESCRIPTION
#### Overview:

Guard SGLang PD workers against raw multimodal requests when the frontend did not extract corresponding `multi_modal_data`, preventing image/video inputs from being silently dropped and decoded as text-only requests.

#### Details:

When serving `dynamo.sglang` with P/D disaggregation without an `--multimodal-encode-worker` or `--multimodal-worker` flag, for example:

```bash
python3 -m dynamo.frontend &

python3 -m dynamo.sglang \
  --model-path Qwen/Qwen3-VL-2B-Instruct \
  --page-size 16 \
  --tp 1 \
  --trust-remote-code \
  --disaggregation-mode prefill \
  --disaggregation-bootstrap-port 12345 \
  --host 0.0.0.0 \
  --disaggregation-transfer-backend nixl &

python3 -m dynamo.sglang \
  --model-path Qwen/Qwen3-VL-2B-Instruct \
  --page-size 16 \
  --tp 1 \
  --trust-remote-code \
  --disaggregation-mode decode \
  --disaggregation-bootstrap-port 12345 \
  --host 0.0.0.0 \
  --disaggregation-transfer-backend nixl &
```

A request containing raw multimodal content such as `image_url` / `video_url` could reach the SGLang P/D workers without corresponding extracted `multi_modal_data`. In that case, the image/video input was effectively ignored and the worker could continue as a text-only request, which can produce hallucinated output.

After this fix, SGLang raises a `RuntimeError` in the P/D request path before calling `engine.async_generate`. Both P/D worker need to include the flag for multimodal request to work.

#### Where should the reviewer start?

- `components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py`
- `components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py`
- `components/src/dynamo/sglang/request_handlers/llm/decode_handler.py`
- `components/src/dynamo/sglang/tests/test_sglang_decode_handler.py`

#### Related Issues
- Relates to #7064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Added validation checks to ensure multimodal content (images/videos) is properly processed before generation. Requests with unextracted multimodal inputs will now raise an error to prevent generation issues.

* **Tests**
  * Enhanced test coverage for multimodal input validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->