### PR TITLE
feat: PR train 7: decode-side P/D routing sidecar for vanilla vLLM disaggregation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-pd-sidecar"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.4",
+ "futures",
+ "reqwest 0.12.28",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "dynamo-protocols"
 version = "1.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "lib/bindings/c",
     "lib/bindings/python/codegen",
     "deploy/inference-gateway/ext-proc",
+    "deploy/inference-gateway/pd-sidecar",
 ]
 resolver = "3"
 

--- a/deploy/inference-gateway/ext-proc/Dockerfile
+++ b/deploy/inference-gateway/ext-proc/Dockerfile
@@ -66,6 +66,10 @@ COPY --from=dynamo lib/ lib/
 # Copy the ext-proc crate itself
 COPY --from=dynamo deploy/inference-gateway/ext-proc/ deploy/inference-gateway/ext-proc/
 
+# The Cargo workspace also lists the pd-sidecar crate as a member; copy it so the
+# workspace loads (only dynamo-ext-proc is actually compiled by the -p flag below).
+COPY --from=dynamo deploy/inference-gateway/pd-sidecar/ deploy/inference-gateway/pd-sidecar/
+
 # Build the binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETARCH} \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETARCH} \

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -29,6 +29,10 @@ binary serves both.
 
 - `agg.yaml` — aggregated: one vLLM pool, KV-aware load balancing.
 - `disagg.yaml` — disaggregated: prefill + decode pools, KV-aware P/D selection.
+  The decode pod bundles the `pd-router-sidecar` (Dynamo,
+  `deploy/inference-gateway/pd-sidecar`), which fronts the pool target port,
+  reads `x-prefiller-host-port` from the EPP, and runs vLLM's NIXL
+  `kv_transfer_params` handshake (decode vLLM listens in-pod on `:8001`).
 
 ## Prerequisites (install once)
 

--- a/deploy/inference-gateway/ext-proc/examples/onramp/disagg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/disagg.yaml
@@ -130,6 +130,9 @@ spec:
         dynamo-role: decode
     spec:
       containers:
+        # Decode vLLM listens on :8001 (in-pod only). The pd-router-sidecar
+        # below fronts the pool targetPort :8000 and drives the prefill->decode
+        # KV-transfer handshake before forwarding here.
         - name: vllm
           image: vllm/vllm-openai:latest
           args:
@@ -138,7 +141,7 @@ spec:
             - "--served-model-name"
             - "Qwen/Qwen3-0.6B"
             - "--port"
-            - "8000"
+            - "8001"
             - "--enable-prefix-caching"
             - "--block-size"
             - "16"
@@ -151,8 +154,8 @@ spec:
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
           ports:
-            - name: http
-              containerPort: 8000
+            - name: vllm-local
+              containerPort: 8001
             - name: kv-events
               containerPort: 5557
           env:
@@ -176,14 +179,30 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
-        # --- OPTIONAL: decode-side P/D routing sidecar -------------------------
-        # Reads `x-prefiller-host-port` (set by the EPP) and runs vLLM's
-        # kv_transfer_params handshake against the selected prefill pod. Provide
-        # your own image here; the EPP only emits the header, it does not run
-        # the transfer. See issue #10426 (non-goals) for why this lives on the
-        # decode side rather than in the EPP.
-        # - name: pd-router-sidecar
-        #   image: <your-pd-routing-sidecar>
+        # Dynamo decode-side P/D routing sidecar: receives gateway traffic on
+        # :8000 (the InferencePool targetPort), reads x-prefiller-host-port set
+        # by the EPP, runs vLLM's NIXL kv_transfer_params handshake against the
+        # selected prefill pod, then forwards decode to the local vLLM (:8001).
+        - name: pd-router-sidecar
+          image: nvcr.io/nvidia/ai-dynamo/pd-sidecar:my-tag
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            - name: DYN_PD_LISTEN_ADDR
+              value: "0.0.0.0:8000"
+            - name: DYN_PD_DECODE_URL
+              value: "http://127.0.0.1:8001"
+            - name: RUST_LOG
+              value: "info"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
       tolerations:
         - effect: NoSchedule
           key: nvidia.com/gpu

--- a/deploy/inference-gateway/pd-sidecar/Cargo.toml
+++ b/deploy/inference-gateway/pd-sidecar/Cargo.toml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-pd-sidecar"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Decode-side P/D routing sidecar for vanilla vLLM disaggregation (runs the NIXL kv_transfer_params handshake driven by the EPP's x-prefiller-host-port header)"
+
+[[bin]]
+name = "dynamo-pd-sidecar"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+futures = { workspace = true }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt"] }

--- a/deploy/inference-gateway/pd-sidecar/Dockerfile
+++ b/deploy/inference-gateway/pd-sidecar/Dockerfile
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dynamo P/D routing sidecar (vanilla vLLM disaggregation).
+# 2-stage build: pure-Rust binary -> minimal Ubuntu runtime.
+#
+# Build via buildx with the repo root as the `dynamo` build context:
+#   docker buildx build --build-context dynamo=../../.. \
+#     -t dynamo/pd-sidecar:dev -f Dockerfile .
+
+ARG RUST_IMAGE=rust:1.93.1
+ARG BASE_IMAGE=ubuntu:24.04
+
+# =============================================================================
+# Stage 1: Build the sidecar binary
+# =============================================================================
+FROM ${RUST_IMAGE} AS builder
+
+WORKDIR /dynamo
+
+# Copy workspace manifests + lockfile. The Cargo workspace refuses to load if a
+# listed member is missing, so we copy the full member tree below; only
+# `dynamo-pd-sidecar` (a pure-Rust crate, no dynamo deps) is actually compiled.
+COPY --from=dynamo .cargo/ .cargo/
+COPY --from=dynamo Cargo.toml Cargo.lock README.md ./
+COPY --from=dynamo lib/ lib/
+COPY --from=dynamo deploy/inference-gateway/ deploy/inference-gateway/
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo build --release -p dynamo-pd-sidecar \
+    && cp target/release/dynamo-pd-sidecar /dynamo-pd-sidecar
+
+# =============================================================================
+# Stage 2: Runtime
+# =============================================================================
+FROM ${BASE_IMAGE}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
+
+COPY --from=builder /dynamo-pd-sidecar /dynamo-pd-sidecar
+
+RUN useradd -r -u 65532 -g nogroup nonroot
+USER 65532:65534
+
+ENTRYPOINT ["/dynamo-pd-sidecar"]

--- a/deploy/inference-gateway/pd-sidecar/src/main.rs
+++ b/deploy/inference-gateway/pd-sidecar/src/main.rs
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Decode-side P/D routing sidecar for **vanilla vLLM** disaggregation.
+//!
+//! The Dynamo EPP (router-only mode) makes the KV-aware prefill+decode decision
+//! and emits the selected prefill pod's address as `x-prefiller-host-port`; the
+//! gateway then forwards the request to the **decode** pod. This sidecar runs in
+//! that decode pod, in front of the local vLLM, and performs vLLM's NIXL
+//! `kv_transfer_params` handshake so stock `vllm serve` gets disaggregated
+//! serving with no Dynamo worker/runtime:
+//!
+//! ```text
+//! gateway ─▶ sidecar(:8000) ──(1) prefill, do_remote_decode──▶ prefiller vLLM (x-prefiller-host-port)
+//!                           ◀── kv_transfer_params ───────────
+//!                           ──(2) decode, reuse those params ─▶ local vLLM (:8001) ──▶ stream back
+//! ```
+//!
+//! Pull-based NIXL only: the prefill request carries
+//! `{do_remote_decode:true, ...}` and the decode request reuses the
+//! `kv_transfer_params` returned on the prefill response (mirrors the
+//! `NixlConnectorProtocol` in `components/src/dynamo/vllm/kv_connector_protocols.py`).
+//!
+//! Requests without `x-prefiller-host-port` (and all non-completion paths such
+//! as `GET /v1/models`, `/health`) are transparently proxied to the local vLLM,
+//! so the sidecar is a safe drop-in even for aggregated traffic.
+//!
+//! ## Configuration (env)
+//! | var | default | meaning |
+//! |-----|---------|---------|
+//! | `DYN_PD_LISTEN_ADDR` | `0.0.0.0:8000` | address the sidecar binds (the pool targetPort) |
+//! | `DYN_PD_DECODE_URL` | `http://127.0.0.1:8001` | local vLLM OpenAI base URL |
+//! | `DYN_PD_PREFILLER_HEADER` | `x-prefiller-host-port` | header carrying the prefiller `host:port` |
+//! | `DYN_PD_PREFILL_SCHEME` | `http` | scheme used to dial the prefiller |
+//! | `DYN_PD_TIMEOUT_SECS` | `300` | per-request upstream timeout |
+//!
+//! NOTE: this is **vLLM-specific** and coupled to vLLM's `kv_transfer_params`
+//! wire shape; pin the sidecar image to a compatible vLLM release.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    Router,
+    body::Body,
+    extract::{Request, State},
+    http::{HeaderMap, Method, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use serde_json::{Value, json};
+
+/// Cap request bodies the sidecar will buffer for the prefill/decode rewrite.
+const MAX_BODY_BYTES: usize = 32 * 1024 * 1024;
+
+#[derive(Clone)]
+struct AppState {
+    client: reqwest::Client,
+    /// Local vLLM OpenAI base URL (no trailing slash).
+    decode_url: String,
+    /// Lower-cased header name carrying the prefiller `host:port`.
+    prefiller_header: String,
+    /// Scheme used to dial the prefiller.
+    prefill_scheme: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let listen_addr = env_or("DYN_PD_LISTEN_ADDR", "0.0.0.0:8000");
+    let decode_url = env_or("DYN_PD_DECODE_URL", "http://127.0.0.1:8001")
+        .trim_end_matches('/')
+        .to_string();
+    let prefiller_header =
+        env_or("DYN_PD_PREFILLER_HEADER", "x-prefiller-host-port").to_lowercase();
+    let prefill_scheme = env_or("DYN_PD_PREFILL_SCHEME", "http");
+    let timeout_secs: u64 = env_or("DYN_PD_TIMEOUT_SECS", "300").parse().unwrap_or(300);
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()?;
+
+    let state = AppState {
+        client,
+        decode_url: decode_url.clone(),
+        prefiller_header: prefiller_header.clone(),
+        prefill_scheme: prefill_scheme.clone(),
+    };
+
+    tracing::info!(
+        listen_addr,
+        decode_url,
+        prefiller_header,
+        prefill_scheme,
+        timeout_secs,
+        "Starting Dynamo P/D routing sidecar (vanilla vLLM disaggregation)"
+    );
+
+    let app = Router::new().fallback(handle).with_state(Arc::new(state));
+    let listener = tokio::net::TcpListener::bind(&listen_addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Route every request: disaggregate completion requests that carry the
+/// prefiller header, otherwise transparently proxy to the local vLLM.
+async fn handle(State(st): State<Arc<AppState>>, req: Request) -> Response {
+    let (parts, body) = req.into_parts();
+
+    let bytes = match axum::body::to_bytes(body, MAX_BODY_BYTES).await {
+        Ok(b) => b,
+        Err(e) => {
+            return error_response(StatusCode::BAD_REQUEST, format!("failed to read body: {e}"));
+        }
+    };
+
+    let path = parts.uri.path().to_string();
+    let path_and_query = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.as_str().to_string())
+        .unwrap_or_else(|| path.clone());
+
+    let is_completion = parts.method == Method::POST
+        && (path == "/v1/chat/completions" || path == "/v1/completions");
+    let prefiller = parts
+        .headers
+        .get(&st.prefiller_header)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    match (is_completion, prefiller) {
+        (true, Some(prefiller)) => disaggregate(&st, &path, &bytes, &prefiller).await,
+        _ => {
+            proxy_to_decode(
+                &st,
+                &parts.method,
+                &path_and_query,
+                &parts.headers,
+                bytes.to_vec(),
+            )
+            .await
+        }
+    }
+}
+
+/// Run the NIXL prefill→decode handshake and stream the decode response back.
+async fn disaggregate(st: &AppState, path: &str, body: &[u8], prefiller: &str) -> Response {
+    let base: Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(e) => {
+            return error_response(StatusCode::BAD_REQUEST, format!("invalid JSON body: {e}"));
+        }
+    };
+
+    // (1) Prefill: do_remote_decode, single-token, non-streaming.
+    let mut prefill = base.clone();
+    if let Some(obj) = prefill.as_object_mut() {
+        obj.insert(
+            "kv_transfer_params".to_string(),
+            json!({
+                "do_remote_decode": true,
+                "do_remote_prefill": false,
+                "remote_engine_id": null,
+                "remote_block_ids": null,
+                "remote_host": null,
+                "remote_port": null,
+            }),
+        );
+        obj.insert("max_tokens".to_string(), json!(1));
+        obj.insert("max_completion_tokens".to_string(), json!(1));
+        obj.insert("stream".to_string(), json!(false));
+    }
+
+    let prefill_url = format!("{}://{}{}", st.prefill_scheme, prefiller, path);
+    let prefill_resp = match st.client.post(&prefill_url).json(&prefill).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                format!("prefill request to {prefiller} failed: {e}"),
+            );
+        }
+    };
+    if !prefill_resp.status().is_success() {
+        let status = prefill_resp.status();
+        let detail = prefill_resp.text().await.unwrap_or_default();
+        return error_response(
+            StatusCode::BAD_GATEWAY,
+            format!("prefiller {prefiller} returned {status}: {detail}"),
+        );
+    }
+    let prefill_json: Value = match prefill_resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                format!("could not decode prefill response: {e}"),
+            );
+        }
+    };
+
+    let kv_transfer_params = prefill_json.get("kv_transfer_params").cloned();
+    if kv_transfer_params.is_none() {
+        // Without transfer params the decode worker can't pull the prefill KV;
+        // surface it rather than silently running a full (non-disagg) decode.
+        return error_response(
+            StatusCode::BAD_GATEWAY,
+            "prefill response carried no kv_transfer_params; \
+             ensure the prefiller runs vLLM with a NixlConnector kv-transfer-config"
+                .to_string(),
+        );
+    }
+
+    // (2) Decode: reuse the prefill's kv_transfer_params; preserve the client's
+    // original streaming preference.
+    let mut decode = base;
+    if let (Some(obj), Some(ktp)) = (decode.as_object_mut(), kv_transfer_params) {
+        obj.insert("kv_transfer_params".to_string(), ktp);
+    }
+
+    let decode_url = format!("{}{}", st.decode_url, path);
+    match st.client.post(&decode_url).json(&decode).send().await {
+        Ok(resp) => stream_back(resp),
+        Err(e) => error_response(
+            StatusCode::BAD_GATEWAY,
+            format!("decode request to local vLLM failed: {e}"),
+        ),
+    }
+}
+
+/// Transparently forward a request to the local vLLM and stream the response.
+async fn proxy_to_decode(
+    st: &AppState,
+    method: &Method,
+    path_and_query: &str,
+    headers: &HeaderMap,
+    body: Vec<u8>,
+) -> Response {
+    let url = format!("{}{}", st.decode_url, path_and_query);
+    let reqwest_method =
+        reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap_or(reqwest::Method::GET);
+
+    let mut builder = st.client.request(reqwest_method, &url);
+    if let Some(ct) = headers.get(header::CONTENT_TYPE) {
+        builder = builder.header(reqwest::header::CONTENT_TYPE, ct.as_bytes());
+    }
+    if !body.is_empty() {
+        builder = builder.body(body);
+    }
+
+    match builder.send().await {
+        Ok(resp) => stream_back(resp),
+        Err(e) => error_response(
+            StatusCode::BAD_GATEWAY,
+            format!("proxy to local vLLM failed: {e}"),
+        ),
+    }
+}
+
+/// Convert an upstream `reqwest` response into a streaming axum response,
+/// preserving status and content-type (so SSE streams flow through unbuffered).
+fn stream_back(resp: reqwest::Response) -> Response {
+    let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .map(|v| v.as_bytes().to_vec());
+
+    let mut builder = Response::builder().status(status);
+    if let Some(ct) = content_type {
+        builder = builder.header(header::CONTENT_TYPE, ct);
+    }
+    match builder.body(Body::from_stream(resp.bytes_stream())) {
+        Ok(response) => response,
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to build streamed response: {e}"),
+        ),
+    }
+}
+
+/// Build an OpenAI-shaped JSON error response.
+fn error_response(status: StatusCode, message: String) -> Response {
+    tracing::warn!(%message, status = %status, "P/D sidecar error");
+    let body = serde_json::to_vec(&json!({
+        "error": { "message": message, "type": "pd_sidecar_error" }
+    }))
+    .unwrap_or_default();
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}


### PR DESCRIPTION
## Summary
Adds a runtime-free Rust sidecar (`dynamo-pd-sidecar`) that turns the EPP's
`x-prefiller-host-port` header into an actual disaggregated request against
**stock `vllm serve`** pods, making the router-only disagg on-ramp turnkey (no
bring-your-own component).

## What it does
On the decode pod the sidecar reads
`x-prefiller-host-port` (set by the Dynamo EPP), and runs vLLM's **pull-based
NIXL** `kv_transfer_params` handshake:
1. POST the prompt to the prefiller with `{do_remote_decode: true, ...}` (single-token, non-streaming),
2. reuse the `kv_transfer_params` returned on the prefill response,
3. POST the decode request to the local vLLM (`:8001`) and stream the response back.

Header-less / non-completion requests (`GET /v1/models`, `/health`) are
transparently proxied, so it's a safe drop-in. Mirrors `NixlConnectorProtocol`
in `components/src/dynamo/vllm/kv_connector_protocols.py`.

## Contents
- `deploy/inference-gateway/pd-sidecar/` — the `dynamo-pd-sidecar` crate (axum + reqwest) + 2-stage nonroot `Dockerfile` + workspace member.
- `examples/onramp/disagg.yaml` — wires the sidecar on the decode pod (sidecar on `:8000`, decode vLLM moved to in-pod `:8001`) + README note.

## Config (env)
`DYN_PD_LISTEN_ADDR` (default `0.0.0.0:8000`), `DYN_PD_DECODE_URL`
(`http://127.0.0.1:8001`), `DYN_PD_PREFILLER_HEADER` (`x-prefiller-host-port`),
`DYN_PD_PREFILL_SCHEME` (`http`), `DYN_PD_TIMEOUT_SECS` (`300`).

## Limitations / notes
- **vLLM-specific** and coupled to vLLM's `kv_transfer_params` wire shape — pin the sidecar image to a compatible vLLM release.
- Consciously **reverses the #10426 "BYO sidecar" non-goal** (turnkey disagg over correctness-of-scope).
- `cargo check` + `clippy -D warnings` clean; **runtime-untested** (needs a GPU cluster).

## Stacking
Stacked on **PR 1** (`epp-raw-workers`); independent of the EPP-code stack (PR 2–6).

## Test plan
- [ ] Build/push the sidecar image; deploy `examples/onramp/disagg.yaml`.
- [ ] Confirm decode pod: sidecar serves `:8000`, vLLM serves `:8001`.
- [ ] e2e: client -> gateway -> EPP (router-only disagg) -> decode sidecar -> NIXL KV transfer from selected prefiller; HTTP 200, streamed.
- [ ] Verify aggregated/header-less requests pass through unaffected.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->