### PR TITLE
feat(mocker): use aiconfigurator unified KV-cache API for num_gpu_blocks

### DIFF
--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -25,7 +25,6 @@ DEFAULT_STATIC_STRIDE = 32
 DEFAULT_GPU_MEMORY_UTILIZATION = 0.9
 DEFAULT_MEM_FRACTION_STATIC = 0.88
 DEFAULT_FREE_GPU_MEMORY_FRACTION = 0.9
-_BYTES_PER_GIB = 1 << 30
 
 
 def _validate_kv_capacity_backend(backend_name: str) -> None:
@@ -244,123 +243,6 @@ class AicSession:
         """Predict decode (generation) latency in ms."""
         return self._predict_generation_latency(batch_size, isl, osl)
 
-    def estimate_num_gpu_blocks(
-        self,
-        *,
-        block_size: int,
-        max_num_batched_tokens: int,
-        gpu_memory_utilization: float = DEFAULT_GPU_MEMORY_UTILIZATION,
-        mem_fraction_static: float | None = None,
-        free_gpu_memory_fraction: float | None = None,
-    ) -> int:
-        """Estimate rank-local KV cache blocks from AIC's per-GPU memory model."""
-        _validate_kv_capacity_backend(self._backend_name)
-        if block_size <= 0:
-            raise ValueError(
-                f"block_size must be positive, got block_size={block_size}"
-            )
-        if max_num_batched_tokens <= 0:
-            raise ValueError(
-                "max_num_batched_tokens must be positive, "
-                f"got max_num_batched_tokens={max_num_batched_tokens}"
-            )
-        if not 0 < gpu_memory_utilization <= 1:
-            raise ValueError(
-                "gpu_memory_utilization must be in (0, 1], "
-                f"got gpu_memory_utilization={gpu_memory_utilization}"
-            )
-
-        if mem_fraction_static is None:
-            mem_fraction_static = DEFAULT_MEM_FRACTION_STATIC
-        if not 0 < mem_fraction_static <= 1:
-            raise ValueError(
-                "mem_fraction_static must be in (0, 1], "
-                f"got mem_fraction_static={mem_fraction_static}"
-            )
-
-        if free_gpu_memory_fraction is None:
-            free_gpu_memory_fraction = DEFAULT_FREE_GPU_MEMORY_FRACTION
-        if not 0 < free_gpu_memory_fraction <= 1:
-            raise ValueError(
-                "free_gpu_memory_fraction must be in (0, 1], "
-                f"got free_gpu_memory_fraction={free_gpu_memory_fraction}"
-            )
-
-        # AIC's memory model is already rank-local for the configured TP/DP shape.
-        # The returned weight/KV numbers have been sharded, so mocker should not
-        # multiply the resulting block count by TP or DP.
-        memory = self._backend._get_memory_usage(
-            self._model,
-            self._database,
-            batch_size=1,
-            beam_width=1,
-            isl=0,
-            osl=0,
-            num_tokens=max_num_batched_tokens,
-        )
-        gpu_capacity_bytes = float(self._database.system_spec["gpu"]["mem_capacity"])
-        # AIC exposes KV bytes for one sequence of block_size tokens; that is the
-        # byte cost of one scheduler block on this rank.
-        block_bytes = float(self._model.get_kvcache_bytes_per_sequence(block_size))
-        if block_bytes <= 0:
-            raise ValueError(
-                f"AIC returned non-positive KV block size: block_bytes={block_bytes}"
-            )
-
-        # Non-KV memory footprint AIC models for this rank (everything resident
-        # besides the KV pool: weights, activations, runtime). The vLLM and
-        # TRT-LLM budgets below both derive from it; SGLang uses its own static
-        # figure instead.
-        non_kv_bytes = (
-            float(memory["total"]) - float(memory.get("kvcache", 0.0))
-        ) * _BYTES_PER_GIB
-
-        if self._backend_name == "sglang":
-            # SGLang's knob reserves a static fraction of HBM for weights,
-            # runtime allocations, and the KV pool. AIC reports those static
-            # non-KV allocations separately, in GiB.
-            static_non_kv_bytes = (
-                float(memory["weights"])
-                + float(memory["nccl"])
-                + float(memory["others"])
-            ) * _BYTES_PER_GIB
-            kv_budget_bytes = (
-                gpu_capacity_bytes * mem_fraction_static - static_non_kv_bytes
-            )
-            fraction_name = "mem_fraction_static"
-            fraction_value = mem_fraction_static
-        elif self._backend_name == "trtllm":
-            # TRT-LLM allocates `free_gpu_memory_fraction` of the memory that
-            # remains *after* the model is loaded — unlike vLLM's
-            # `gpu_memory_utilization`, which is a fraction of *total* memory.
-            free_bytes = gpu_capacity_bytes - non_kv_bytes
-            kv_budget_bytes = free_bytes * free_gpu_memory_fraction
-            fraction_name = "free_gpu_memory_fraction"
-            fraction_value = free_gpu_memory_fraction
-        else:
-            # vLLM's knob caps total engine memory. Subtract AIC's modeled
-            # non-KV footprint from that cap to get the KV budget.
-            kv_budget_bytes = gpu_capacity_bytes * gpu_memory_utilization - non_kv_bytes
-            fraction_name = "gpu_memory_utilization"
-            fraction_value = gpu_memory_utilization
-
-        if kv_budget_bytes <= 0:
-            raise ValueError(
-                "AIC estimated no available KV cache memory: "
-                f"backend={self._backend_name!r}, {fraction_name}={fraction_value}, "
-                f"kv_budget_gib={kv_budget_bytes / _BYTES_PER_GIB:.3f}"
-            )
-
-        num_gpu_blocks = math.floor(kv_budget_bytes / block_bytes)
-        if num_gpu_blocks <= 0:
-            raise ValueError(
-                "AIC estimated fewer than one KV cache block: "
-                f"backend={self._backend_name!r}, block_size={block_size}, "
-                f"block_bytes={block_bytes:.0f}, "
-                f"kv_budget_gib={kv_budget_bytes / _BYTES_PER_GIB:.3f}"
-            )
-        return num_gpu_blocks
-
 
 def create_session(
     backend_name: str,
@@ -404,25 +286,78 @@ def estimate_num_gpu_blocks(
     moe_ep_size: int | None = None,
     attention_dp_size: int | None = None,
 ) -> int:
-    """Estimate rank-local KV cache blocks for mocker/replay AIC configs."""
+    """Estimate rank-local KV cache blocks for mocker/replay AIC configs.
+
+    Delegates the budget math to aiconfigurator's unified
+    ``sdk.memory.estimate_num_gpu_blocks`` (the single source of truth as of
+    aiconfigurator 0.8.0, PR #1159) instead of recomputing it here. The result is
+    per rank (per single GPU): AIC's memory model is already sharded for the
+    configured TP/DP shape, so the caller must not multiply it by TP or DP.
+
+    The backend selects which memory-fraction knob applies, mapped onto AIC's
+    ``memory_fraction_kind``/``memory_fraction_value``:
+
+    - ``vllm``   -> ``of_total`` with ``gpu_memory_utilization`` (fraction of total HBM)
+    - ``sglang`` -> ``of_total`` with ``mem_fraction_static``
+    - ``trtllm`` -> ``of_free`` with ``free_gpu_memory_fraction`` (fraction of the
+      HBM left after the model is loaded)
+    """
     _validate_kv_capacity_backend(backend_name)
-    # TODO: account for whether specdec is enabled, (i.e. pass in `nextn=...`
-    #   to `create_session``). Currently omitted to downstream AIC calculation
-    #   bug causing `_get_memory_usage` to predict negative KV capacity w/ Eagle.
-    session = create_session(
-        backend_name=backend_name,
-        system=system,
-        model_path=model_path,
-        tp_size=tp_size,
-        backend_version=backend_version,
-        moe_tp_size=moe_tp_size,
-        moe_ep_size=moe_ep_size,
-        attention_dp_size=attention_dp_size,
-    )
-    return session.estimate_num_gpu_blocks(
-        block_size=block_size,
-        max_num_batched_tokens=max_num_batched_tokens,
-        gpu_memory_utilization=gpu_memory_utilization,
-        mem_fraction_static=mem_fraction_static,
-        free_gpu_memory_fraction=free_gpu_memory_fraction,
+
+    if backend_name == "trtllm":
+        memory_fraction_kind = "of_free"
+        memory_fraction_value = (
+            free_gpu_memory_fraction
+            if free_gpu_memory_fraction is not None
+            else DEFAULT_FREE_GPU_MEMORY_FRACTION
+        )
+    elif backend_name == "sglang":
+        memory_fraction_kind = "of_total"
+        memory_fraction_value = (
+            mem_fraction_static
+            if mem_fraction_static is not None
+            else DEFAULT_MEM_FRACTION_STATIC
+        )
+    else:  # vllm
+        memory_fraction_kind = "of_total"
+        memory_fraction_value = gpu_memory_utilization
+
+    # Imported lazily: aiconfigurator is an optional dependency (the `mocker`
+    # extra), so importing it at module scope would break callers that never run
+    # AIC estimation. Estimation is opt-in (only reached when an AIC backend is
+    # configured), so a missing install is a hard error -- fail loudly with an
+    # actionable message rather than silently using the default block count.
+    # Mirrors `_load_aiconfigurator`.
+    # TODO: account for whether specdec is enabled (pass `nextn=...`). Currently
+    #   omitted due to a downstream AIC bug where `_get_memory_usage` predicts
+    #   negative KV capacity with Eagle.
+    try:
+        from aiconfigurator.sdk import memory
+    except ImportError as exc:
+        raise RuntimeError(
+            "aiconfigurator is required for AIC KV-cache estimation but is not "
+            "installed; install the 'mocker' extra or set num_gpu_blocks "
+            "explicitly (e.g. --num-gpu-blocks-override)"
+        ) from exc
+
+    # AIC's non-KV memory is independent of batch size (activations track
+    # max_num_tokens), so the fixed max_batch_size here does not affect the result.
+    return int(
+        memory.estimate_num_gpu_blocks(
+            model_path,
+            system,
+            backend_name,
+            backend_version=resolve_backend_version(backend_name, backend_version),
+            scheduler_block_size=block_size,
+            max_num_tokens=max_num_batched_tokens,
+            max_batch_size=1,
+            memory_fraction_kind=memory_fraction_kind,
+            memory_fraction_value=memory_fraction_value,
+            tp_size=tp_size,
+            attention_dp_size=(
+                attention_dp_size if attention_dp_size is not None else 1
+            ),
+            moe_tp_size=moe_tp_size,
+            moe_ep_size=moe_ep_size,
+        )
     )

--- a/lib/bindings/python/tests/test_aic_capacity.py
+++ b/lib/bindings/python/tests/test_aic_capacity.py
@@ -6,8 +6,10 @@ import pytest
 from dynamo._internal.aic import (
     _DEFAULT_NEXTN_ACCEPT_RATES,
     _NEXTN_ACCEPT_RATES_LEN,
-    AicSession,
+    DEFAULT_FREE_GPU_MEMORY_FRACTION,
+    DEFAULT_MEM_FRACTION_STATIC,
     _pad_nextn_accept_rates,
+    estimate_num_gpu_blocks,
     resolve_backend_version,
 )
 
@@ -19,123 +21,170 @@ pytestmark = [
 ]
 
 
-_GIB = 1 << 30
+def _patch_memory(monkeypatch, return_value=123):
+    """Patch aiconfigurator's unified estimator and record forwarded kwargs.
+
+    ``estimate_num_gpu_blocks`` now delegates the budget math to
+    ``aiconfigurator.sdk.memory.estimate_num_gpu_blocks`` (the single source of
+    truth), so these tests assert the dynamo->AIC mapping rather than recompute
+    the math themselves.
+    """
+    memory = pytest.importorskip("aiconfigurator.sdk.memory")
+    calls = []
+
+    def fake(model_path, system, backend, **kwargs):
+        calls.append(
+            {"model_path": model_path, "system": system, "backend": backend, **kwargs}
+        )
+        return return_value
+
+    monkeypatch.setattr(memory, "estimate_num_gpu_blocks", fake)
+    return calls
 
 
-class FakeBackend:
-    def __init__(self, memory):
-        self._memory = memory
+def test_estimate_num_gpu_blocks_maps_vllm_to_total_fraction(monkeypatch):
+    calls = _patch_memory(monkeypatch, 45)
 
-    def _get_memory_usage(self, *_args, **_kwargs):
-        return self._memory
-
-
-class FakeModel:
-    def get_kvcache_bytes_per_sequence(self, seq_len):
-        return seq_len * _GIB
-
-
-class FakeDatabase:
-    def __init__(self):
-        self.system_spec = {"gpu": {"mem_capacity": 1000 * _GIB}}
-
-
-def make_session(backend_name, memory):
-    session = object.__new__(AicSession)
-    session._backend_name = backend_name
-    session._backend = FakeBackend(memory)
-    session._database = FakeDatabase()
-    session._model = FakeModel()
-    return session
-
-
-def test_estimate_num_gpu_blocks_uses_vllm_total_memory_fraction():
-    session = make_session(
-        "vllm",
-        {
-            "total": 400.0,
-            "kvcache": 50.0,
-            "weights": 300.0,
-            "activations": 40.0,
-            "nccl": 5.0,
-            "others": 5.0,
-        },
-    )
-
-    blocks = session.estimate_num_gpu_blocks(
+    blocks = estimate_num_gpu_blocks(
+        backend_name="vllm",
+        system="h200_sxm",
+        model_path="some/model",
+        tp_size=1,
         block_size=10,
         max_num_batched_tokens=128,
         gpu_memory_utilization=0.8,
     )
 
     assert blocks == 45
+    kw = calls[0]
+    assert kw["backend"] == "vllm"
+    assert kw["memory_fraction_kind"] == "of_total"
+    assert kw["memory_fraction_value"] == 0.8
+    assert kw["scheduler_block_size"] == 10
+    assert kw["max_num_tokens"] == 128
+    assert kw["tp_size"] == 1
 
 
-def test_estimate_num_gpu_blocks_uses_sglang_static_memory_fraction():
-    session = make_session(
-        "sglang",
-        {
-            "total": 900.0,
-            "kvcache": 0.0,
-            "weights": 300.0,
-            "activations": 500.0,
-            "nccl": 10.0,
-            "others": 20.0,
-        },
-    )
+def test_estimate_num_gpu_blocks_maps_sglang_to_static_fraction(monkeypatch):
+    calls = _patch_memory(monkeypatch, 37)
 
-    blocks = session.estimate_num_gpu_blocks(
+    blocks = estimate_num_gpu_blocks(
+        backend_name="sglang",
+        system="h200_sxm",
+        model_path="some/model",
+        tp_size=1,
         block_size=10,
         max_num_batched_tokens=128,
         mem_fraction_static=0.7,
     )
 
     assert blocks == 37
+    assert calls[0]["memory_fraction_kind"] == "of_total"
+    assert calls[0]["memory_fraction_value"] == 0.7
+
+
+def test_estimate_num_gpu_blocks_sglang_defaults_static_fraction(monkeypatch):
+    calls = _patch_memory(monkeypatch)
+
+    estimate_num_gpu_blocks(
+        backend_name="sglang",
+        system="h200_sxm",
+        model_path="some/model",
+        tp_size=1,
+        block_size=10,
+        max_num_batched_tokens=128,
+    )
+
+    assert calls[0]["memory_fraction_value"] == DEFAULT_MEM_FRACTION_STATIC
+
+
+def test_estimate_num_gpu_blocks_maps_trtllm_to_free_fraction(monkeypatch):
+    calls = _patch_memory(monkeypatch, 58)
+
+    # gpu_memory_utilization is accepted for signature parity but ignored for
+    # trtllm; the default free_gpu_memory_fraction drives the budget.
+    estimate_num_gpu_blocks(
+        backend_name="trtllm",
+        system="h200_sxm",
+        model_path="some/model",
+        tp_size=1,
+        block_size=10,
+        max_num_batched_tokens=128,
+        gpu_memory_utilization=0.8,
+    )
+    assert calls[0]["memory_fraction_kind"] == "of_free"
+    assert calls[0]["memory_fraction_value"] == DEFAULT_FREE_GPU_MEMORY_FRACTION
+
+    calls.clear()
+    estimate_num_gpu_blocks(
+        backend_name="trtllm",
+        system="h200_sxm",
+        model_path="some/model",
+        tp_size=1,
+        block_size=10,
+        max_num_batched_tokens=128,
+        free_gpu_memory_fraction=0.8,
+    )
+    assert calls[0]["memory_fraction_value"] == 0.8
+
+
+def test_estimate_num_gpu_blocks_forwards_parallel_mapping_and_version(monkeypatch):
+    calls = _patch_memory(monkeypatch)
+
+    estimate_num_gpu_blocks(
+        backend_name="vllm",
+        system="h200_sxm",
+        model_path="some/model",
+        tp_size=2,
+        block_size=10,
+        max_num_batched_tokens=128,
+        backend_version="0.99.0",
+        moe_tp_size=4,
+        moe_ep_size=8,
+        attention_dp_size=2,
+    )
+
+    kw = calls[0]
+    assert kw["backend_version"] == "0.99.0"
+    assert kw["tp_size"] == 2
+    assert kw["moe_tp_size"] == 4
+    assert kw["moe_ep_size"] == 8
+    assert kw["attention_dp_size"] == 2
+
+
+def test_estimate_num_gpu_blocks_rejects_unsupported_backend():
+    # Validated before aiconfigurator is imported, so no patching is needed.
+    with pytest.raises(ValueError, match="does not support backend"):
+        estimate_num_gpu_blocks(
+            backend_name="not-a-backend",
+            system="h200_sxm",
+            model_path="some/model",
+            tp_size=1,
+            block_size=10,
+            max_num_batched_tokens=128,
+        )
+
+
+def test_estimate_num_gpu_blocks_errors_clearly_when_aic_missing(monkeypatch):
+    # Estimation is opt-in; if it is reached without aiconfigurator installed,
+    # fail loudly with an actionable message (not a raw ModuleNotFoundError, and
+    # not a silent fallback to the default block count).
+    import sys
+
+    monkeypatch.setitem(sys.modules, "aiconfigurator.sdk", None)
+    with pytest.raises(RuntimeError, match="aiconfigurator is required"):
+        estimate_num_gpu_blocks(
+            backend_name="vllm",
+            system="h200_sxm",
+            model_path="some/model",
+            tp_size=1,
+            block_size=10,
+            max_num_batched_tokens=128,
+        )
 
 
 def test_trtllm_version_resolution():
     assert resolve_backend_version("trtllm", "0.20.0") == "0.20.0"
-
-
-def test_estimate_num_gpu_blocks_uses_trtllm_free_memory_fraction():
-    # TRT-LLM now supports KV capacity estimation (it previously raised). It
-    # applies free_gpu_memory_fraction to the memory left *after* the model
-    # footprint, unlike vLLM's gpu_memory_utilization (a fraction of total):
-    #   non_kv = total - kvcache       = 400 - 50   = 350 GiB
-    #   free   = capacity - non_kv     = 1000 - 350  = 650 GiB
-    #   blocks = floor(free * fraction / block_bytes)
-    session = make_session(
-        "trtllm",
-        {
-            "total": 400.0,
-            "kvcache": 50.0,
-            "weights": 300.0,
-            "activations": 40.0,
-            "nccl": 5.0,
-            "others": 5.0,
-        },
-    )
-
-    # Default free_gpu_memory_fraction (0.9): floor(650 * 0.9 / 10) = 58.
-    # gpu_memory_utilization is accepted for signature parity but ignored here.
-    assert (
-        session.estimate_num_gpu_blocks(
-            block_size=10,
-            max_num_batched_tokens=128,
-            gpu_memory_utilization=0.8,
-        )
-        == 58
-    )
-
-    # Explicit free_gpu_memory_fraction drives the budget: floor(650 * 0.8 / 10) = 52.
-    assert (
-        session.estimate_num_gpu_blocks(
-            block_size=10,
-            max_num_batched_tokens=128,
-            free_gpu_memory_fraction=0.8,
-        )
-        == 52
-    )
 
 
 def test_pad_nextn_accept_rates_defaults_when_omitted():


### PR DESCRIPTION
## Summary

Routes the mocker/replay `num_gpu_blocks` estimator through aiconfigurator's **unified** `sdk.memory.estimate_num_gpu_blocks` — the single source of truth as of aiconfigurator 0.8.0 ([ai-dynamo/aiconfigurator#1159](https://github.com/ai-dynamo/aiconfigurator/pull/1159)) — instead of recomputing the per-backend KV-cache budget by hand.

### Background
The dynamo mocker KV-cache estimator landed in [#10150](https://github.com/ai-dynamo/dynamo/pull/10150) on **2026-06-01**, ~9 days *before* aiconfigurator's unified capacity API existed (**2026-06-10**). So `AicSession.estimate_num_gpu_blocks` hand-rolled the budget math (`_get_memory_usage` + `system_spec["gpu"]["mem_capacity"]` + per-backend formulas). This PR hands that math back to AIC now that the API is available.

## Changes
- **`lib/bindings/python/src/dynamo/_internal/aic.py`**: the module-level `estimate_num_gpu_blocks` maps the backend's memory-fraction knob onto AIC's `memory_fraction_kind`/`memory_fraction_value` (`vllm`/`sglang` → `of_total`, `trtllm` → `of_free`) and delegates to `sdk.memory`. The hand-rolled `AicSession.estimate_num_gpu_blocks` method and the now-unused `_BYTES_PER_GIB` constant are removed.
- **Signature preserved** → `config.py`, `replay/main.py`, and the Rust `aic_callback.rs` PyO3 contract are untouched (no Rust rebuild).
- **`test_aic_capacity.py`**: capacity tests now assert the dynamo→AIC mapping (fraction kind/value + forwarded parallel mapping) instead of recomputing the math against fake AIC internals.

## Behavior
- **vLLM / TRT-LLM**: block counts unchanged (identical non-KV footprint and budget formula).
- **SGLang**: now subtracts AIC's *full* non-KV memory under `of_total` rather than the prior weights+runtime-only static figure → slightly more conservative, and matches AIC's canonical model.
- The estimate remains **per rank** (AIC's model is already sharded for the TP/DP shape; never multiplied by TP/DP).

## Test
- `lib/bindings/python/tests/test_aic_capacity.py` (rewritten) — 14 passed.
- Real-AIC sanity: `vllm` Qwen3-0.6B tp1=17796, tp2=35741 (unchanged from the unified API directly).
- `config.py` / `replay` / their tests are unchanged (module-fn signature preserved).