### PR TITLE
fix: unbreak main — kv-router strict_priority call sites + vllm get_diff_sampling_param test mock

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -416,7 +416,9 @@ async def test_unified_start_returns_normalized_served_model_name(monkeypatch):
     served_model_name = "Qwen/Qwen3-0.6B"
     vllm_config = SimpleNamespace(
         cache_config=SimpleNamespace(num_gpu_blocks=8),
-        model_config=SimpleNamespace(max_model_len=4096),
+        model_config=SimpleNamespace(
+            max_model_len=4096, get_diff_sampling_param=lambda: {}
+        ),
         scheduler_config=SimpleNamespace(
             max_num_seqs=2,
             max_num_batched_tokens=8192,

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -438,7 +438,7 @@ impl SelectionCore {
                 false,
                 req.prompt.lora_name.clone(),
                 req.priority_jump.unwrap_or_default(),
-                0, // strict_priority: baseline tier
+                req.strict_priority.unwrap_or(0),
                 req.expected_output_tokens,
                 req.pinned_worker,
                 req.allowed_worker_ids,
@@ -474,7 +474,7 @@ impl SelectionCore {
                 true,
                 req.prompt.lora_name.clone(),
                 req.priority_jump.unwrap_or_default(),
-                0, // strict_priority: baseline tier
+                req.strict_priority.unwrap_or(0),
                 req.expected_output_tokens,
                 req.pinned_worker,
                 req.allowed_worker_ids,

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -438,6 +438,7 @@ impl SelectionCore {
                 false,
                 req.prompt.lora_name.clone(),
                 req.priority_jump.unwrap_or_default(),
+                0, // strict_priority: baseline tier
                 req.expected_output_tokens,
                 req.pinned_worker,
                 req.allowed_worker_ids,
@@ -473,6 +474,7 @@ impl SelectionCore {
                 true,
                 req.prompt.lora_name.clone(),
                 req.priority_jump.unwrap_or_default(),
+                0, // strict_priority: baseline tier
                 req.expected_output_tokens,
                 req.pinned_worker,
                 req.allowed_worker_ids,

--- a/lib/kv-router/src/services/selection/types.rs
+++ b/lib/kv-router/src/services/selection/types.rs
@@ -410,6 +410,8 @@ pub struct SelectRequest {
     #[serde(default)]
     pub priority_jump: Option<f64>,
     #[serde(default)]
+    pub strict_priority: Option<u32>,
+    #[serde(default)]
     pub pinned_worker: Option<WorkerWithDpRank>,
     #[serde(default)]
     pub allowed_worker_ids: Option<HashSet<WorkerId>>,
@@ -435,6 +437,8 @@ pub struct SelectAndReserveRequest {
     pub expected_output_tokens: Option<u32>,
     #[serde(default)]
     pub priority_jump: Option<f64>,
+    #[serde(default)]
+    pub strict_priority: Option<u32>,
     #[serde(default)]
     pub pinned_worker: Option<WorkerWithDpRank>,
     #[serde(default)]


### PR DESCRIPTION
Fixes a build break on `main`: `dynamo-kv-router` does not compile (`E0061`).

## Cause
A semantic merge conflict between two PRs that merged the same day and do not overlap textually:

- **#10638** (`feat(kv-router): add per-request strict priority tiers`, merged ~22:54 UTC) added a new `strict_priority: u32` parameter to `KvScheduler::schedule_with_block_hashes` and updated all call sites that existed at the time.
- **#10641** (`feat(kv-router): add runtime-free selection service`, merged earlier ~16:28 UTC) added new callers — `select` / `select_and_reserve` in `services/selection/core/mod.rs` — that #10638 never saw, so they were not updated.

Git merged both cleanly (different files), but the result calls the 17-arg method with 16 args:

```
error[E0061]: this method takes 17 arguments but 16 arguments were supplied
  --> lib/kv-router/src/services/selection/core/mod.rs:429:14
note: method defined here
  --> lib/kv-router/src/scheduling/local.rs:254:18
```

This fails the build job on every open PR.

## Fix
Pass `strict_priority = 0` (the baseline tier) at both call sites. `strict_priority` is the high-order component of the scheduling sort key `(strict_priority, policy_score)`; `0` is the default tier and preserves the pre-#10638 behavior of these callers (which had no concept of strict priority).

Verified locally with `cargo check -p dynamo-kv-router` (clean).

cc @PeaBrane (author of both #10638 and #10641) — flagging in case you would rather wire `strict_priority` through `SelectRequest` instead of defaulting; this PR is the minimal unbreak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal priority handling during selection operations to improve request scheduling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related Issues
Standalone build fix — does not close a tracked issue. Resolves the `dynamo-kv-router` `E0061` build break introduced on `main` by the #10638 + #10641 merge interaction.

---

## Update: second independent main break folded in (commit d41d1bd3bd)
While validating CI, a **second** broken-main failure surfaced — unrelated to kv-router and to this PR's original diff:

- **#10667** (`fix(vllm): reuse engine model config`) changed `llm_engine.start()` to read sampling params from `vllm_config.model_config.get_diff_sampling_param()`.
- **#10648** (`fix(vllm): normalize unified served model name`) added `test_unified_start_returns_normalized_served_model_name` with a mock that only puts `get_diff_sampling_param` on `create_model_config()` — not on `vllm_config.model_config` — so the test raises `AttributeError` on current `main`.

Same concurrent-merge pattern as the kv-router break. Because these are two **independent** breaks on `main`, no single-fix PR can reach green CI in isolation — so both unbreaks are bundled here so this PR can actually go green and unblock everyone. The vllm change is a 1-line test-mock fix (returns `{}`, matching the pre-#10667 path and the sibling test).
