### PR TITLE
fix: unify multimodal EPD flags

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -104,6 +104,19 @@ def _has_cli_flag(args: list[str], flag: str) -> bool:
     return any(arg == flag or arg.startswith(f"{flag}=") for arg in args)
 
 
+def _get_cli_flag_value(args: list[str], flag: str) -> Optional[str]:
+    """Return a CLI flag value from '--flag val' or '--flag=val' form."""
+    prefix = f"{flag}="
+    for idx, arg in enumerate(args):
+        if arg.startswith(prefix):
+            return arg[len(prefix) :]
+        if arg == flag:
+            if idx + 1 >= len(args):
+                return None
+            return args[idx + 1]
+    return None
+
+
 def _remove_cli_flag_and_value(args: list[str], flag: str) -> list[str]:
     """Remove a flag from CLI args, supporting '--flag val' and '--flag=val' forms."""
     updated: list[str] = []
@@ -119,6 +132,60 @@ def _remove_cli_flag_and_value(args: list[str], flag: str) -> list[str]:
             continue
         updated.append(arg)
     return updated
+
+
+def _replace_cli_flag_value(args: list[str], flag: str, value: str) -> list[str]:
+    """Replace a flag value, supporting '--flag val' and '--flag=val' forms."""
+    updated: list[str] = []
+    skip_next = False
+    prefix = f"{flag}="
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == flag:
+            updated.extend([flag, value])
+            skip_next = True
+            continue
+        if arg.startswith(prefix):
+            updated.append(f"{flag}={value}")
+            continue
+        updated.append(arg)
+    return updated
+
+
+def _normalize_multimodal_disaggregation_args(
+    unknown: list[str], dynamo_config: "DynamoConfig"
+) -> list[str]:
+    """Map Dynamo's canonical multimodal EPD args to SGLang's current flags."""
+    disaggregation_mode = _get_cli_flag_value(unknown, "--disaggregation-mode")
+    if disaggregation_mode is None:
+        return unknown
+
+    if disaggregation_mode == DisaggregationMode.AGGREGATED.value:
+        unknown = _replace_cli_flag_value(unknown, "--disaggregation-mode", "null")
+        disaggregation_mode = "null"
+
+    if disaggregation_mode == DisaggregationMode.ENCODE.value:
+        if not dynamo_config.enable_multimodal:
+            logging.warning(
+                "--disaggregation-mode=encode is only valid for SGLang "
+                "multimodal EPD; treating it as --enable-multimodal "
+                "--disaggregation-mode=encode for this release."
+            )
+            dynamo_config.enable_multimodal = True
+        dynamo_config.multimodal_encode_worker = True
+        return _remove_cli_flag_and_value(unknown, "--disaggregation-mode")
+
+    if (
+        dynamo_config.enable_multimodal
+        and not dynamo_config.multimodal_encode_worker
+        and not dynamo_config.multimodal_worker
+        and disaggregation_mode in {"null", "prefill", "decode"}
+    ):
+        dynamo_config.multimodal_worker = True
+
+    return unknown
 
 
 def _load_disagg_config_section(config_path: str, config_key: str) -> dict[str, Any]:
@@ -237,6 +304,9 @@ async def parse_args(args: list[str]) -> Config:
     if "--config" in unknown:
         config_merger = ConfigArgumentMerger(parser=sglang_only_parser)
         unknown = config_merger.merge_config_with_args(unknown)
+
+    unknown = _normalize_multimodal_disaggregation_args(unknown, dynamo_config)
+    dynamo_config.validate_multimodal_topology()
 
     parsed_args = sglang_only_parser.parse_args(unknown)
 

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -28,6 +28,7 @@ from dynamo.sglang._compat import enable_disjoint_streaming_output
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 
 configure_dynamo_logging()
+PREFILL_DECODE_DISAGGREGATION_MODE = "pd"
 
 
 class DynamoConfig(DynamoRuntimeConfig, DynamoSGLangConfig):
@@ -162,7 +163,11 @@ def _normalize_multimodal_disaggregation_args(
     if disaggregation_mode is None:
         return unknown
 
-    if disaggregation_mode == DisaggregationMode.AGGREGATED.value:
+    requested_disaggregation_mode = disaggregation_mode
+    if disaggregation_mode in {
+        DisaggregationMode.AGGREGATED.value,
+        PREFILL_DECODE_DISAGGREGATION_MODE,
+    }:
         unknown = _replace_cli_flag_value(unknown, "--disaggregation-mode", "null")
         disaggregation_mode = "null"
 
@@ -181,7 +186,10 @@ def _normalize_multimodal_disaggregation_args(
         dynamo_config.enable_multimodal
         and not dynamo_config.multimodal_encode_worker
         and not dynamo_config.multimodal_worker
-        and disaggregation_mode in {"null", "prefill", "decode"}
+        and (
+            requested_disaggregation_mode == PREFILL_DECODE_DISAGGREGATION_MODE
+            or disaggregation_mode in {"prefill", "decode"}
+        )
     ):
         dynamo_config.multimodal_worker = True
 

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -105,17 +105,18 @@ def _has_cli_flag(args: list[str], flag: str) -> bool:
     return any(arg == flag or arg.startswith(f"{flag}=") for arg in args)
 
 
-def _get_cli_flag_value(args: list[str], flag: str) -> Optional[str]:
-    """Return a CLI flag value from '--flag val' or '--flag=val' form."""
+def _get_last_cli_flag_value(args: list[str], flag: str) -> Optional[str]:
+    """Return the last CLI flag value from '--flag val' or '--flag=val' form."""
     prefix = f"{flag}="
+    value = None
     for idx, arg in enumerate(args):
         if arg.startswith(prefix):
-            return arg[len(prefix) :]
+            value = arg[len(prefix) :]
         if arg == flag:
             if idx + 1 >= len(args):
-                return None
-            return args[idx + 1]
-    return None
+                continue
+            value = args[idx + 1]
+    return value
 
 
 def _remove_cli_flag_and_value(args: list[str], flag: str) -> list[str]:
@@ -135,23 +136,10 @@ def _remove_cli_flag_and_value(args: list[str], flag: str) -> list[str]:
     return updated
 
 
-def _replace_cli_flag_value(args: list[str], flag: str, value: str) -> list[str]:
-    """Replace a flag value, supporting '--flag val' and '--flag=val' forms."""
-    updated: list[str] = []
-    skip_next = False
-    prefix = f"{flag}="
-    for arg in args:
-        if skip_next:
-            skip_next = False
-            continue
-        if arg == flag:
-            updated.extend([flag, value])
-            skip_next = True
-            continue
-        if arg.startswith(prefix):
-            updated.append(f"{flag}={value}")
-            continue
-        updated.append(arg)
+def _set_cli_flag_value(args: list[str], flag: str, value: str) -> list[str]:
+    """Set a flag value once, preserving argparse's last-value-wins behavior."""
+    updated = _remove_cli_flag_and_value(args, flag)
+    updated.extend([flag, value])
     return updated
 
 
@@ -159,7 +147,7 @@ def _normalize_multimodal_disaggregation_args(
     unknown: list[str], dynamo_config: "DynamoConfig"
 ) -> list[str]:
     """Map Dynamo's canonical multimodal EPD args to SGLang's current flags."""
-    disaggregation_mode = _get_cli_flag_value(unknown, "--disaggregation-mode")
+    disaggregation_mode = _get_last_cli_flag_value(unknown, "--disaggregation-mode")
     if disaggregation_mode is None:
         return unknown
 
@@ -168,7 +156,7 @@ def _normalize_multimodal_disaggregation_args(
         DisaggregationMode.AGGREGATED.value,
         PREFILL_DECODE_DISAGGREGATION_MODE,
     }:
-        unknown = _replace_cli_flag_value(unknown, "--disaggregation-mode", "null")
+        unknown = _set_cli_flag_value(unknown, "--disaggregation-mode", "null")
         disaggregation_mode = "null"
 
     if disaggregation_mode == DisaggregationMode.ENCODE.value:

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -4,6 +4,8 @@
 """Dynamo SGLang wrapper configuration ArgGroup."""
 
 import argparse
+import logging
+import warnings
 from typing import Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
@@ -15,6 +17,13 @@ from dynamo.common.configuration.utils import add_argument, add_negatable_bool_a
 from dynamo.common.constants import EmbeddingTransferMode
 
 from . import __version__
+
+logger = logging.getLogger(__name__)
+
+
+def _warn_deprecated(message: str) -> None:
+    logger.warning(message)
+    warnings.warn(message, DeprecationWarning, stacklevel=3)
 
 
 class DynamoSGLangArgGroup(ArgGroup):
@@ -49,14 +58,28 @@ class DynamoSGLangArgGroup(ArgGroup):
             flag_name="--multimodal-encode-worker",
             env_var="DYN_SGL_MULTIMODAL_ENCODE_WORKER",
             default=False,
-            help="Run as multimodal encode worker component for processing images/videos.",
+            help="DEPRECATED: use --enable-multimodal --disaggregation-mode=encode.",
         )
         add_negatable_bool_argument(
             g,
             flag_name="--multimodal-worker",
             env_var="DYN_SGL_MULTIMODAL_WORKER",
             default=False,
-            help="Run as multimodal worker component for LLM inference with multimodal data.",
+            help=(
+                "DEPRECATED: use --enable-multimodal with "
+                "--disaggregation-mode=agg/prefill/decode."
+            ),
+        )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--enable-multimodal",
+            env_var="DYN_SGL_ENABLE_MULTIMODAL",
+            default=False,
+            help=(
+                "Enable multimodal processing. When an explicit "
+                "--disaggregation-mode is provided, this selects the matching "
+                "Dynamo multimodal EPD worker role."
+            ),
         )
 
         add_argument(
@@ -134,6 +157,7 @@ class DynamoSGLangConfig(ConfigBase):
     use_sglang_tokenizer: bool
     multimodal_encode_worker: bool
     multimodal_worker: bool
+    enable_multimodal: bool = False
     embedding_transfer_mode: EmbeddingTransferMode
     embedding_worker: bool
     image_diffusion_worker: bool
@@ -157,6 +181,25 @@ class DynamoSGLangConfig(ConfigBase):
                 "Both 'disagg_config' and 'disagg_config_key' must be provided together."
             )
 
+        if self.multimodal_encode_worker:
+            _warn_deprecated(
+                "--multimodal-encode-worker is deprecated; use "
+                "--enable-multimodal --disaggregation-mode=encode. "
+                "This release will map the legacy flag to the new arguments."
+            )
+            self.enable_multimodal = True
+        if self.multimodal_worker:
+            _warn_deprecated(
+                "--multimodal-worker is deprecated; use --enable-multimodal "
+                "with --disaggregation-mode=agg, --disaggregation-mode=prefill, "
+                "or --disaggregation-mode=decode. This release will map the "
+                "legacy flag to the new arguments."
+            )
+            self.enable_multimodal = True
+
+        self.validate_multimodal_topology()
+
+    def validate_multimodal_topology(self) -> None:
         if self.frontend_decoding and (
             self.multimodal_encode_worker or self.multimodal_worker
         ):

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -67,7 +67,7 @@ class DynamoSGLangArgGroup(ArgGroup):
             default=False,
             help=(
                 "DEPRECATED: use --enable-multimodal with "
-                "--disaggregation-mode=agg/prefill/decode."
+                "--disaggregation-mode=pd/prefill/decode."
             ),
         )
         add_negatable_bool_argument(
@@ -181,6 +181,8 @@ class DynamoSGLangConfig(ConfigBase):
                 "Both 'disagg_config' and 'disagg_config_key' must be provided together."
             )
 
+        self.validate_multimodal_topology()
+
         if self.multimodal_encode_worker:
             _warn_deprecated(
                 "--multimodal-encode-worker is deprecated; use "
@@ -196,8 +198,6 @@ class DynamoSGLangConfig(ConfigBase):
                 "legacy flag to the new arguments."
             )
             self.enable_multimodal = True
-
-        self.validate_multimodal_topology()
 
     def validate_multimodal_topology(self) -> None:
         if self.frontend_decoding and (

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO(DIS-2240): Remove deprecated multimodal flags across engine
+
 """Dynamo SGLang wrapper configuration ArgGroup."""
 
 import argparse

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -191,7 +191,7 @@ class DynamoSGLangConfig(ConfigBase):
         if self.multimodal_worker:
             _warn_deprecated(
                 "--multimodal-worker is deprecated; use --enable-multimodal "
-                "with --disaggregation-mode=agg, --disaggregation-mode=prefill, "
+                "with --disaggregation-mode=pd, --disaggregation-mode=prefill, "
                 "or --disaggregation-mode=decode. This release will map the "
                 "legacy flag to the new arguments."
             )

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -34,6 +34,7 @@ def _make_config(
     config.use_sglang_tokenizer = False
     config.multimodal_encode_worker = multimodal_encode_worker
     config.multimodal_worker = multimodal_worker
+    config.enable_multimodal = False
     config.embedding_transfer_mode = EmbeddingTransferMode.NIXL_WRITE
     config.embedding_worker = False
     config.image_diffusion_worker = False
@@ -45,13 +46,19 @@ def _make_config(
 
 def test_validate_rejects_frontend_decoding_with_encode_worker():
     config = _make_config(frontend_decoding=True, multimodal_encode_worker=True)
-    with pytest.raises(ValueError, match="--frontend-decoding is incompatible"):
+    with (
+        pytest.warns(DeprecationWarning, match="--multimodal-encode-worker"),
+        pytest.raises(ValueError, match="--frontend-decoding is incompatible"),
+    ):
         config.validate()
 
 
 def test_validate_rejects_frontend_decoding_with_multimodal_worker():
     config = _make_config(frontend_decoding=True, multimodal_worker=True)
-    with pytest.raises(ValueError, match="--frontend-decoding is incompatible"):
+    with (
+        pytest.warns(DeprecationWarning, match="--multimodal-worker"),
+        pytest.raises(ValueError, match="--frontend-decoding is incompatible"),
+    ):
         config.validate()
 
 

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -34,7 +34,6 @@ def _make_config(
     config.use_sglang_tokenizer = False
     config.multimodal_encode_worker = multimodal_encode_worker
     config.multimodal_worker = multimodal_worker
-    config.enable_multimodal = False
     config.embedding_transfer_mode = EmbeddingTransferMode.NIXL_WRITE
     config.embedding_worker = False
     config.image_diffusion_worker = False
@@ -46,19 +45,13 @@ def _make_config(
 
 def test_validate_rejects_frontend_decoding_with_encode_worker():
     config = _make_config(frontend_decoding=True, multimodal_encode_worker=True)
-    with (
-        pytest.warns(DeprecationWarning, match="--multimodal-encode-worker"),
-        pytest.raises(ValueError, match="--frontend-decoding is incompatible"),
-    ):
+    with pytest.raises(ValueError, match="--frontend-decoding is incompatible"):
         config.validate()
 
 
 def test_validate_rejects_frontend_decoding_with_multimodal_worker():
     config = _make_config(frontend_decoding=True, multimodal_worker=True)
-    with (
-        pytest.warns(DeprecationWarning, match="--multimodal-worker"),
-        pytest.raises(ValueError, match="--frontend-decoding is incompatible"),
-    ):
+    with pytest.raises(ValueError, match="--frontend-decoding is incompatible"):
         config.validate()
 
 

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -13,6 +13,8 @@ import yaml
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 
 import dynamo.sglang._compat as sglang_compat
+import dynamo.sglang.args as sglang_args
+from dynamo.common.constants import DisaggregationMode
 from dynamo.sglang._compat import (
     ensure_sglang_top_level_exports,
     filter_supported_async_generate_kwargs,
@@ -53,6 +55,17 @@ pytestmark = [
 # Create SGLang-specific CLI args fixture
 # This will use monkeypatch to write to argv
 mock_sglang_cli = make_cli_args_fixture("dynamo.sglang")
+
+
+def _patch_parse_args_side_effects(monkeypatch):
+    monkeypatch.setattr(
+        sglang_args, "should_fetch_model", lambda args, model_path: False
+    )
+    monkeypatch.setattr(
+        sglang_args.ServerArgs,
+        "from_cli_args",
+        staticmethod(lambda parsed_args: parsed_args),
+    )
 
 
 def test_compat_restores_sglang_top_level_exports():
@@ -314,6 +327,98 @@ async def test_namespace_flag_drives_default_endpoint_namespace(mock_sglang_cli)
 
     config = await parse_args(sys.argv[1:])
     assert config.dynamo_args.namespace == "custom-ns"
+
+
+@pytest.mark.parametrize(
+    (
+        "mode",
+        "expected_sglang_mode",
+        "expected_encode_worker",
+        "expected_mm_worker",
+        "expected_serving_mode",
+        "expected_component",
+    ),
+    [
+        ("encode", "null", True, False, DisaggregationMode.AGGREGATED, "encode"),
+        ("prefill", "prefill", False, True, DisaggregationMode.PREFILL, "prefill"),
+        ("decode", "decode", False, True, DisaggregationMode.DECODE, "backend"),
+        ("agg", "null", False, True, DisaggregationMode.AGGREGATED, "backend"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_enable_multimodal_disaggregation_mode_maps_sglang_roles(
+    mode,
+    expected_sglang_mode,
+    expected_encode_worker,
+    expected_mm_worker,
+    expected_serving_mode,
+    expected_component,
+    monkeypatch,
+    mock_sglang_cli,
+):
+    """Canonical multimodal roles map to SGLang's current worker flags."""
+    _patch_parse_args_side_effects(monkeypatch)
+    mock_sglang_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--enable-multimodal",
+        "--disaggregation-mode",
+        mode,
+    )
+
+    config = await parse_args(sys.argv[1:])
+
+    assert config.dynamo_args.enable_multimodal is True
+    assert config.dynamo_args.multimodal_encode_worker is expected_encode_worker
+    assert config.dynamo_args.multimodal_worker is expected_mm_worker
+    assert config.server_args.disaggregation_mode == expected_sglang_mode
+    assert config.serving_mode == expected_serving_mode
+    assert config.dynamo_args.component == expected_component
+    assert getattr(config.server_args, "encoder_only", False) is expected_encode_worker
+
+
+@pytest.mark.asyncio
+async def test_enable_multimodal_without_role_keeps_standalone_worker(
+    monkeypatch, mock_sglang_cli
+):
+    """Capability-only SGLang serving should not select the internal EPD worker."""
+    _patch_parse_args_side_effects(monkeypatch)
+    mock_sglang_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--enable-multimodal",
+    )
+
+    config = await parse_args(sys.argv[1:])
+
+    assert config.dynamo_args.enable_multimodal is True
+    assert config.dynamo_args.multimodal_worker is False
+    assert config.dynamo_args.multimodal_encode_worker is False
+    assert config.server_args.disaggregation_mode == "null"
+    assert config.dynamo_args.component == "backend"
+
+
+@pytest.mark.asyncio
+async def test_legacy_multimodal_worker_sets_enable_multimodal(
+    monkeypatch, mock_sglang_cli
+):
+    """Legacy multimodal role stays accepted while enabling the canonical flag."""
+    _patch_parse_args_side_effects(monkeypatch)
+    mock_sglang_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--multimodal-worker",
+        "--disaggregation-mode",
+        "decode",
+    )
+
+    with pytest.warns(DeprecationWarning, match="--multimodal-worker"):
+        config = await parse_args(sys.argv[1:])
+
+    assert config.dynamo_args.enable_multimodal is True
+    assert config.dynamo_args.multimodal_worker is True
+    assert config.server_args.disaggregation_mode == "decode"
+    assert config.serving_mode == DisaggregationMode.DECODE
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -13,17 +13,18 @@ import yaml
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 
 import dynamo.sglang._compat as sglang_compat
-import dynamo.sglang.args as sglang_args
-from dynamo.common.constants import DisaggregationMode
+from dynamo.common.constants import EmbeddingTransferMode
 from dynamo.sglang._compat import (
     ensure_sglang_top_level_exports,
     filter_supported_async_generate_kwargs,
 )
 from dynamo.sglang.args import (
+    _normalize_multimodal_disaggregation_args,
     parse_args,
     should_fetch_model,
     use_modelexpress_remote_instance,
 )
+from dynamo.sglang.backend_args import DynamoSGLangConfig
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
@@ -57,15 +58,24 @@ pytestmark = [
 mock_sglang_cli = make_cli_args_fixture("dynamo.sglang")
 
 
-def _patch_parse_args_side_effects(monkeypatch):
-    monkeypatch.setattr(
-        sglang_args, "should_fetch_model", lambda args, model_path: False
-    )
-    monkeypatch.setattr(
-        sglang_args.ServerArgs,
-        "from_cli_args",
-        staticmethod(lambda parsed_args: parsed_args),
-    )
+def _make_sglang_config(**overrides):
+    config = DynamoSGLangConfig()
+    config.use_sglang_tokenizer = False
+    config.multimodal_encode_worker = False
+    config.multimodal_worker = False
+    config.enable_multimodal = False
+    config.embedding_transfer_mode = EmbeddingTransferMode.NIXL_WRITE
+    config.embedding_worker = False
+    config.image_diffusion_worker = False
+    config.video_generation_worker = False
+    config.enable_rl = False
+    config.frontend_decoding = False
+    config.sglang_trace_level = 2
+    config.disagg_config = None
+    config.disagg_config_key = None
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
 
 
 def test_compat_restores_sglang_top_level_exports():
@@ -332,94 +342,70 @@ async def test_namespace_flag_drives_default_endpoint_namespace(mock_sglang_cli)
 @pytest.mark.parametrize(
     (
         "mode",
-        "expected_sglang_mode",
         "expected_encode_worker",
         "expected_mm_worker",
-        "expected_serving_mode",
-        "expected_component",
+        "expected_args",
     ),
     [
-        ("encode", "null", True, False, DisaggregationMode.AGGREGATED, "encode"),
-        ("prefill", "prefill", False, True, DisaggregationMode.PREFILL, "prefill"),
-        ("decode", "decode", False, True, DisaggregationMode.DECODE, "backend"),
-        ("agg", "null", False, False, DisaggregationMode.AGGREGATED, "backend"),
-        ("pd", "null", False, True, DisaggregationMode.AGGREGATED, "backend"),
+        ("encode", True, False, []),
+        ("prefill", False, True, ["--disaggregation-mode", "prefill"]),
+        ("decode", False, True, ["--disaggregation-mode", "decode"]),
+        ("agg", False, False, ["--disaggregation-mode", "null"]),
+        ("pd", False, True, ["--disaggregation-mode", "null"]),
     ],
 )
-@pytest.mark.asyncio
-async def test_enable_multimodal_disaggregation_mode_maps_sglang_roles(
+def test_enable_multimodal_disaggregation_mode_maps_sglang_roles(
     mode,
-    expected_sglang_mode,
     expected_encode_worker,
     expected_mm_worker,
-    expected_serving_mode,
-    expected_component,
-    monkeypatch,
-    mock_sglang_cli,
+    expected_args,
 ):
     """Canonical multimodal roles map to SGLang's current worker flags."""
-    _patch_parse_args_side_effects(monkeypatch)
-    mock_sglang_cli(
-        "--model",
-        "Qwen/Qwen3-0.6B",
-        "--enable-multimodal",
-        "--disaggregation-mode",
-        mode,
+    config = _make_sglang_config(enable_multimodal=True)
+
+    normalized = _normalize_multimodal_disaggregation_args(
+        ["--disaggregation-mode", mode], config
     )
 
-    config = await parse_args(sys.argv[1:])
-
-    assert config.dynamo_args.enable_multimodal is True
-    assert config.dynamo_args.multimodal_encode_worker is expected_encode_worker
-    assert config.dynamo_args.multimodal_worker is expected_mm_worker
-    assert config.server_args.disaggregation_mode == expected_sglang_mode
-    assert config.serving_mode == expected_serving_mode
-    assert config.dynamo_args.component == expected_component
-    assert getattr(config.server_args, "encoder_only", False) is expected_encode_worker
+    assert normalized == expected_args
+    assert config.multimodal_encode_worker is expected_encode_worker
+    assert config.multimodal_worker is expected_mm_worker
 
 
-@pytest.mark.asyncio
-async def test_enable_multimodal_without_role_keeps_standalone_worker(
-    monkeypatch, mock_sglang_cli
-):
+def test_multimodal_disaggregation_mode_uses_last_cli_value():
+    """Config-merged args precede CLI args, so the last explicit value must win."""
+    config = _make_sglang_config(enable_multimodal=True)
+
+    normalized = _normalize_multimodal_disaggregation_args(
+        ["--disaggregation-mode", "prefill", "--disaggregation-mode", "pd"],
+        config,
+    )
+
+    assert normalized == ["--disaggregation-mode", "null"]
+    assert config.multimodal_worker is True
+
+
+def test_enable_multimodal_without_role_keeps_standalone_worker():
     """Capability-only SGLang serving should not select the internal EPD worker."""
-    _patch_parse_args_side_effects(monkeypatch)
-    mock_sglang_cli(
-        "--model",
-        "Qwen/Qwen3-0.6B",
-        "--enable-multimodal",
-    )
+    config = _make_sglang_config(enable_multimodal=True)
 
-    config = await parse_args(sys.argv[1:])
+    normalized = _normalize_multimodal_disaggregation_args([], config)
 
-    assert config.dynamo_args.enable_multimodal is True
-    assert config.dynamo_args.multimodal_worker is False
-    assert config.dynamo_args.multimodal_encode_worker is False
-    assert config.server_args.disaggregation_mode == "null"
-    assert config.dynamo_args.component == "backend"
+    assert normalized == []
+    assert config.enable_multimodal is True
+    assert config.multimodal_worker is False
+    assert config.multimodal_encode_worker is False
 
 
-@pytest.mark.asyncio
-async def test_legacy_multimodal_worker_sets_enable_multimodal(
-    monkeypatch, mock_sglang_cli
-):
+def test_legacy_multimodal_worker_sets_enable_multimodal():
     """Legacy multimodal role stays accepted while enabling the canonical flag."""
-    _patch_parse_args_side_effects(monkeypatch)
-    mock_sglang_cli(
-        "--model",
-        "Qwen/Qwen3-0.6B",
-        "--multimodal-worker",
-        "--disaggregation-mode",
-        "decode",
-    )
+    config = _make_sglang_config(multimodal_worker=True)
 
     with pytest.warns(DeprecationWarning, match="--multimodal-worker"):
-        config = await parse_args(sys.argv[1:])
+        config.validate()
 
-    assert config.dynamo_args.enable_multimodal is True
-    assert config.dynamo_args.multimodal_worker is True
-    assert config.server_args.disaggregation_mode == "decode"
-    assert config.serving_mode == DisaggregationMode.DECODE
+    assert config.enable_multimodal is True
+    assert config.multimodal_worker is True
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -342,7 +342,8 @@ async def test_namespace_flag_drives_default_endpoint_namespace(mock_sglang_cli)
         ("encode", "null", True, False, DisaggregationMode.AGGREGATED, "encode"),
         ("prefill", "prefill", False, True, DisaggregationMode.PREFILL, "prefill"),
         ("decode", "decode", False, True, DisaggregationMode.DECODE, "backend"),
-        ("agg", "null", False, True, DisaggregationMode.AGGREGATED, "backend"),
+        ("agg", "null", False, False, DisaggregationMode.AGGREGATED, "backend"),
+        ("pd", "null", False, True, DisaggregationMode.AGGREGATED, "backend"),
     ],
 )
 @pytest.mark.asyncio

--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -4,6 +4,8 @@
 """Dynamo TRT-LLM backend configuration ArgGroup."""
 
 import argparse
+import logging
+import warnings
 from typing import Optional
 
 from tensorrt_llm.llmapi import BuildConfig
@@ -19,6 +21,14 @@ from . import __version__
 from .constants import DisaggregationMode, Modality
 
 DEFAULT_MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+CANONICAL_AGGREGATED_MODE = "agg"
+
+logger = logging.getLogger(__name__)
+
+
+def _warn_deprecated(message: str) -> None:
+    logger.warning(message)
+    warnings.warn(message, DeprecationWarning, stacklevel=3)
 
 
 class DynamoTrtllmArgGroup(ArgGroup):
@@ -186,9 +196,23 @@ class DynamoTrtllmArgGroup(ArgGroup):
             g,
             flag_name="--disaggregation-mode",
             env_var="DYN_TRTLLM_DISAGGREGATION_MODE",
-            default=DisaggregationMode.AGGREGATED.value,
-            choices=[mode.value for mode in DisaggregationMode],
-            help="Mode to use for disaggregation.",
+            default=CANONICAL_AGGREGATED_MODE,
+            choices=[
+                CANONICAL_AGGREGATED_MODE,
+                *[mode.value for mode in DisaggregationMode],
+            ],
+            help=(
+                "Worker disaggregation mode. Use 'agg' for aggregated serving, "
+                "'prefill', 'decode', or 'encode'. The legacy "
+                "'prefill_and_decode' value remains accepted temporarily."
+            ),
+        )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--enable-multimodal",
+            env_var="DYN_TRTLLM_ENABLE_MULTIMODAL",
+            default=False,
+            help="Enable multimodal LLM request processing.",
         )
         add_argument(
             g,
@@ -196,7 +220,10 @@ class DynamoTrtllmArgGroup(ArgGroup):
             env_var="DYN_TRTLLM_MODALITY",
             default=Modality.TEXT.value,
             choices=[m.value for m in Modality],
-            help="Modality to use for the model.",
+            help=(
+                "Modality to use for the model. For multimodal LLM serving, "
+                "prefer --enable-multimodal; diffusion modalities remain here."
+            ),
         )
         add_argument(
             g,
@@ -454,6 +481,7 @@ class DynamoTrtllmConfig(ConfigBase):
     guided_decoding_backend: Optional[str] = None
 
     disaggregation_mode: DisaggregationMode
+    enable_multimodal: bool
     modality: Modality
     encode_endpoint: str
     allowed_local_media_path: str
@@ -485,8 +513,32 @@ class DynamoTrtllmConfig(ConfigBase):
 
     def validate(self) -> None:
         if isinstance(self.disaggregation_mode, str):
-            self.disaggregation_mode = DisaggregationMode(self.disaggregation_mode)
+            if self.disaggregation_mode == CANONICAL_AGGREGATED_MODE:
+                self.disaggregation_mode = DisaggregationMode.AGGREGATED
+            else:
+                if self.disaggregation_mode == DisaggregationMode.AGGREGATED.value:
+                    _warn_deprecated(
+                        "--disaggregation-mode=prefill_and_decode is deprecated; "
+                        "use --disaggregation-mode=agg. This release will map "
+                        "the legacy value to the new argument."
+                    )
+                self.disaggregation_mode = DisaggregationMode(self.disaggregation_mode)
         if isinstance(self.modality, str):
             self.modality = Modality(self.modality)
+        if self.enable_multimodal:
+            if Modality.is_diffusion(self.modality):
+                raise ValueError(
+                    "--enable-multimodal cannot be combined with "
+                    f"--modality {self.modality.value}. Use --modality only for "
+                    "diffusion models."
+                )
+            self.modality = Modality.MULTIMODAL
+        elif self.modality == Modality.MULTIMODAL:
+            _warn_deprecated(
+                "--modality multimodal is deprecated for multimodal LLM serving; "
+                "use --enable-multimodal. This release will map the legacy value "
+                "to the new argument."
+            )
+            self.enable_multimodal = True
         if not self.served_model_name:
             self.served_model_name = None

--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -22,6 +22,7 @@ from .constants import DisaggregationMode, Modality
 
 DEFAULT_MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 CANONICAL_AGGREGATED_MODE = "agg"
+PREFILL_DECODE_DISAGGREGATION_MODE = "pd"
 
 logger = logging.getLogger(__name__)
 
@@ -199,11 +200,13 @@ class DynamoTrtllmArgGroup(ArgGroup):
             default=CANONICAL_AGGREGATED_MODE,
             choices=[
                 CANONICAL_AGGREGATED_MODE,
+                PREFILL_DECODE_DISAGGREGATION_MODE,
                 *[mode.value for mode in DisaggregationMode],
             ],
             help=(
                 "Worker disaggregation mode. Use 'agg' for aggregated serving, "
-                "'prefill', 'decode', or 'encode'. The legacy "
+                "'pd' for a combined prefill+decode worker, 'prefill', "
+                "'decode', or 'encode'. The legacy "
                 "'prefill_and_decode' value remains accepted temporarily."
             ),
         )
@@ -513,14 +516,19 @@ class DynamoTrtllmConfig(ConfigBase):
 
     def validate(self) -> None:
         if isinstance(self.disaggregation_mode, str):
-            if self.disaggregation_mode == CANONICAL_AGGREGATED_MODE:
+            if self.disaggregation_mode in {
+                CANONICAL_AGGREGATED_MODE,
+                PREFILL_DECODE_DISAGGREGATION_MODE,
+            }:
                 self.disaggregation_mode = DisaggregationMode.AGGREGATED
             else:
                 if self.disaggregation_mode == DisaggregationMode.AGGREGATED.value:
                     _warn_deprecated(
                         "--disaggregation-mode=prefill_and_decode is deprecated; "
-                        "use --disaggregation-mode=agg. This release will map "
-                        "the legacy value to the new argument."
+                        "use --disaggregation-mode=agg for aggregated serving or "
+                        "--disaggregation-mode=pd for a combined prefill+decode "
+                        "worker. This release will map the legacy value to the "
+                        "new argument."
                     )
                 self.disaggregation_mode = DisaggregationMode(self.disaggregation_mode)
         if isinstance(self.modality, str):
@@ -534,11 +542,6 @@ class DynamoTrtllmConfig(ConfigBase):
                 )
             self.modality = Modality.MULTIMODAL
         elif self.modality == Modality.MULTIMODAL:
-            _warn_deprecated(
-                "--modality multimodal is deprecated for multimodal LLM serving; "
-                "use --enable-multimodal. This release will map the legacy value "
-                "to the new argument."
-            )
             self.enable_multimodal = True
         if not self.served_model_name:
             self.served_model_name = None

--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO(DIS-2240): Remove deprecated multimodal flags across engine
+
 """Dynamo TRT-LLM backend configuration ArgGroup."""
 
 import argparse

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -19,7 +19,7 @@ if not torch.cuda.is_available():
     )
 
 from dynamo.trtllm.args import Config, parse_args
-from dynamo.trtllm.constants import Modality
+from dynamo.trtllm.constants import DisaggregationMode, Modality
 from dynamo.trtllm.tests.conftest import make_cli_args_fixture
 from dynamo.trtllm.utils.trtllm_utils import deep_update, warn_override_collisions
 from dynamo.trtllm.workers.llm_worker import init_llm_worker
@@ -159,6 +159,50 @@ def test_config_multiple_connectors_fails(monkeypatch):
         match="TRT-LLM supports at most one connector entry. Use `--connector none` or `--connector kvbm`.",
     ):
         parse_args(["--connector", "none", "kvbm"])
+
+
+def test_enable_multimodal_maps_to_multimodal_modality():
+    config = parse_args(["--model", "fake-model", "--enable-multimodal"])
+
+    assert config.enable_multimodal is True
+    assert config.modality == Modality.MULTIMODAL
+
+
+def test_modality_multimodal_legacy_flag_warns():
+    with pytest.warns(DeprecationWarning, match="--modality multimodal"):
+        config = parse_args(["--model", "fake-model", "--modality", "multimodal"])
+
+    assert config.enable_multimodal is True
+    assert config.modality == Modality.MULTIMODAL
+
+
+def test_disaggregation_mode_accepts_canonical_agg():
+    config = parse_args(["--model", "fake-model", "--disaggregation-mode", "agg"])
+
+    assert config.disaggregation_mode == DisaggregationMode.AGGREGATED
+    assert config.component == "backend"
+
+
+def test_disaggregation_mode_legacy_aggregated_value_warns():
+    with pytest.warns(DeprecationWarning, match="prefill_and_decode"):
+        config = parse_args(
+            ["--model", "fake-model", "--disaggregation-mode", "prefill_and_decode"]
+        )
+
+    assert config.disaggregation_mode == DisaggregationMode.AGGREGATED
+
+
+def test_enable_multimodal_rejects_diffusion_modality():
+    with pytest.raises(ValueError, match="--enable-multimodal cannot be combined"):
+        parse_args(
+            [
+                "--model",
+                "fake-model",
+                "--enable-multimodal",
+                "--modality",
+                "video_diffusion",
+            ]
+        )
 
 
 # ---- Tests for trtllm_utils.deep_update ----
@@ -356,7 +400,8 @@ class MultimodalProcessorInstantiated(Exception):
 
 @pytest.mark.asyncio
 async def test_init_llm_worker_creates_multimodal_processor():
-    config = parse_args(["--model", "fake-model", "--modality", "multimodal"])
+    with pytest.warns(DeprecationWarning, match="--modality multimodal"):
+        config = parse_args(["--model", "fake-model", "--modality", "multimodal"])
     assert config.modality == Modality.MULTIMODAL
 
     # Mock everything init_llm_worker touches before MultimodalRequestProcessor.

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import re
+import warnings
 from pathlib import Path
 from unittest import mock
 
@@ -168,16 +169,29 @@ def test_enable_multimodal_maps_to_multimodal_modality():
     assert config.modality == Modality.MULTIMODAL
 
 
-def test_modality_multimodal_legacy_flag_warns():
-    with pytest.warns(DeprecationWarning, match="--modality multimodal"):
+def test_modality_multimodal_alias_does_not_warn():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         config = parse_args(["--model", "fake-model", "--modality", "multimodal"])
 
     assert config.enable_multimodal is True
     assert config.modality == Modality.MULTIMODAL
+    assert not [
+        warning
+        for warning in caught
+        if issubclass(warning.category, DeprecationWarning)
+    ]
 
 
 def test_disaggregation_mode_accepts_canonical_agg():
     config = parse_args(["--model", "fake-model", "--disaggregation-mode", "agg"])
+
+    assert config.disaggregation_mode == DisaggregationMode.AGGREGATED
+    assert config.component == "backend"
+
+
+def test_disaggregation_mode_accepts_pd_alias():
+    config = parse_args(["--model", "fake-model", "--disaggregation-mode", "pd"])
 
     assert config.disaggregation_mode == DisaggregationMode.AGGREGATED
     assert config.component == "backend"

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -414,8 +414,7 @@ class MultimodalProcessorInstantiated(Exception):
 
 @pytest.mark.asyncio
 async def test_init_llm_worker_creates_multimodal_processor():
-    with pytest.warns(DeprecationWarning, match="--modality multimodal"):
-        config = parse_args(["--model", "fake-model", "--modality", "multimodal"])
+    config = parse_args(["--model", "fake-model", "--modality", "multimodal"])
     assert config.modality == Modality.MULTIMODAL
 
     # Mock everything init_llm_worker touches before MultimodalRequestProcessor.

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -3,6 +3,7 @@
 
 """Dynamo vLLM wrapper configuration ArgGroup."""
 
+import logging
 import warnings
 from typing import Optional, Union
 
@@ -15,6 +16,13 @@ from dynamo.common.configuration.utils import add_argument, add_negatable_bool_a
 
 from . import __version__
 from .constants import DisaggregationMode, EmbeddingTransferMode
+
+logger = logging.getLogger(__name__)
+
+
+def _warn_deprecated(message: str) -> None:
+    logger.warning(message)
+    warnings.warn(message, DeprecationWarning, stacklevel=3)
 
 
 class DynamoVllmArgGroup(ArgGroup):
@@ -394,10 +402,10 @@ class DynamoVllmConfig(ConfigBase):
            --disaggregation-mode is set.
         """
         if self.multimodal_decode_worker:
-            warnings.warn(
-                "--multimodal-decode-worker is deprecated, use --disaggregation-mode=decode and --enable-multimodal",
-                DeprecationWarning,
-                stacklevel=2,
+            _warn_deprecated(
+                "--multimodal-decode-worker is deprecated; use "
+                "--enable-multimodal --disaggregation-mode=decode. "
+                "This release will map the legacy flag to the new arguments.",
             )
             if (
                 self.disaggregation_mode is not None
@@ -407,11 +415,12 @@ class DynamoVllmConfig(ConfigBase):
                     f"Cannot set --multimodal-decode-worker while --disaggregation-mode is not '{DisaggregationMode.DECODE.value}'"
                 )
             self.disaggregation_mode = DisaggregationMode.DECODE
+            self.enable_multimodal = True
         if self.multimodal_encode_worker:
-            warnings.warn(
-                "--multimodal-encode-worker is deprecated, use --disaggregation-mode=encode and --enable-multimodal",
-                DeprecationWarning,
-                stacklevel=2,
+            _warn_deprecated(
+                "--multimodal-encode-worker is deprecated; use "
+                "--enable-multimodal --disaggregation-mode=encode. "
+                "This release will map the legacy flag to the new arguments.",
             )
             if (
                 self.disaggregation_mode is not None
@@ -421,11 +430,12 @@ class DynamoVllmConfig(ConfigBase):
                     f"Cannot set --multimodal-encode-worker while --disaggregation-mode is not '{DisaggregationMode.ENCODE.value}'"
                 )
             self.disaggregation_mode = DisaggregationMode.ENCODE
+            self.enable_multimodal = True
         if self.multimodal_worker:
-            warnings.warn(
-                "--multimodal-worker is deprecated, use --disaggregation-mode=agg or --disaggregation-mode=prefill and --enable-multimodal",
-                DeprecationWarning,
-                stacklevel=2,
+            _warn_deprecated(
+                "--multimodal-worker is deprecated; use --enable-multimodal "
+                "with --disaggregation-mode=agg or --disaggregation-mode=prefill. "
+                "This release will map the legacy flag to the new arguments.",
             )
             if (
                 self.disaggregation_mode is not None
@@ -439,6 +449,7 @@ class DynamoVllmConfig(ConfigBase):
             # '--disaggregation-mode=prefill' as prefill workers in P/D disaggregation or without for aggregation.
             if self.disaggregation_mode is None:
                 self.disaggregation_mode = DisaggregationMode.AGGREGATED
+            self.enable_multimodal = True
 
     def _count_multimodal_roles(self) -> int:
         """Return the number of multimodal worker roles set (0 or 1 allowed).

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO(DIS-2240): Remove deprecated multimodal flags across engine
+
 """Dynamo vLLM wrapper configuration ArgGroup."""
 
 import logging

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -18,6 +18,7 @@ from . import __version__
 from .constants import DisaggregationMode, EmbeddingTransferMode
 
 logger = logging.getLogger(__name__)
+PREFILL_DECODE_DISAGGREGATION_MODE = "pd"
 
 
 def _warn_deprecated(message: str) -> None:
@@ -44,8 +45,11 @@ class DynamoVllmArgGroup(ArgGroup):
             env_var="DYN_VLLM_DISAGGREGATION_MODE",
             default=None,
             help="Worker disaggregation mode: 'agg' (default, aggregated), "
-            "'prefill' (prefill-only worker), or 'decode' (decode-only worker).",
-            choices=[m.value for m in DisaggregationMode],
+            "'pd' (combined prefill+decode worker), 'prefill' "
+            "(prefill-only worker), 'decode' (decode-only worker), "
+            "or 'encode' (multimodal encode worker).",
+            choices=[PREFILL_DECODE_DISAGGREGATION_MODE]
+            + [m.value for m in DisaggregationMode],
         )
 
         add_negatable_bool_argument(
@@ -343,7 +347,10 @@ class DynamoVllmConfig(ConfigBase):
         # Convert string to enum (non-None means explicitly provided)
         explicit_mode = self.disaggregation_mode is not None
         if isinstance(self.disaggregation_mode, str):
-            self.disaggregation_mode = DisaggregationMode(self.disaggregation_mode)
+            if self.disaggregation_mode == PREFILL_DECODE_DISAGGREGATION_MODE:
+                self.disaggregation_mode = DisaggregationMode.AGGREGATED
+            else:
+                self.disaggregation_mode = DisaggregationMode(self.disaggregation_mode)
 
         # Check for legacy boolean flags
         has_legacy = self.is_prefill_worker or self.is_decode_worker
@@ -434,7 +441,7 @@ class DynamoVllmConfig(ConfigBase):
         if self.multimodal_worker:
             _warn_deprecated(
                 "--multimodal-worker is deprecated; use --enable-multimodal "
-                "with --disaggregation-mode=agg or --disaggregation-mode=prefill. "
+                "with --disaggregation-mode=pd or --disaggregation-mode=prefill. "
                 "This release will map the legacy flag to the new arguments.",
             )
             if (

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -66,6 +66,7 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
             if mode is None or mode == DisaggregationMode.AGGREGATED:
                 config._resolve_disaggregation_model_from_legacy_multimodal_flags()
                 assert config.disaggregation_mode == DisaggregationMode.AGGREGATED
+                assert config.enable_multimodal is True
             else:
                 with pytest.raises(ValueError):
                     config._resolve_disaggregation_model_from_legacy_multimodal_flags()
@@ -78,6 +79,7 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
         with pytest.warns(DeprecationWarning):
             config._resolve_disaggregation_model_from_legacy_multimodal_flags()
             assert config.disaggregation_mode == DisaggregationMode.PREFILL
+            assert config.enable_multimodal is True
 
     @pytest.mark.parametrize(
         "mode",
@@ -97,6 +99,7 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
             if mode is None or mode == DisaggregationMode.ENCODE:
                 config._resolve_disaggregation_model_from_legacy_multimodal_flags()
                 assert config.disaggregation_mode == DisaggregationMode.ENCODE
+                assert config.enable_multimodal is True
             else:
                 with pytest.raises(ValueError):
                     config._resolve_disaggregation_model_from_legacy_multimodal_flags()
@@ -119,6 +122,7 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
             if mode is None or mode == DisaggregationMode.DECODE:
                 config._resolve_disaggregation_model_from_legacy_multimodal_flags()
                 assert config.disaggregation_mode == DisaggregationMode.DECODE
+                assert config.enable_multimodal is True
             else:
                 with pytest.raises(ValueError):
                     config._resolve_disaggregation_model_from_legacy_multimodal_flags()

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -48,6 +48,14 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
     Test suite for resolving disaggregation mode when legacy multimodal flags are set.
     """
 
+    def test_pd_alias_resolves_to_aggregated(self):
+        config = create_config()
+        config.disaggregation_mode = "pd"
+
+        config._resolve_disaggregation_mode()
+
+        assert config.disaggregation_mode == DisaggregationMode.AGGREGATED
+
     @pytest.mark.parametrize(
         "mode",
         [

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -51,6 +51,8 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
     def test_pd_alias_resolves_to_aggregated(self):
         config = create_config()
         config.disaggregation_mode = "pd"
+        config.is_prefill_worker = False
+        config.is_decode_worker = False
 
         config._resolve_disaggregation_mode()
 
@@ -74,7 +76,6 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
             if mode is None or mode == DisaggregationMode.AGGREGATED:
                 config._resolve_disaggregation_model_from_legacy_multimodal_flags()
                 assert config.disaggregation_mode == DisaggregationMode.AGGREGATED
-                assert config.enable_multimodal is True
             else:
                 with pytest.raises(ValueError):
                     config._resolve_disaggregation_model_from_legacy_multimodal_flags()
@@ -87,7 +88,6 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
         with pytest.warns(DeprecationWarning):
             config._resolve_disaggregation_model_from_legacy_multimodal_flags()
             assert config.disaggregation_mode == DisaggregationMode.PREFILL
-            assert config.enable_multimodal is True
 
     @pytest.mark.parametrize(
         "mode",
@@ -107,7 +107,6 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
             if mode is None or mode == DisaggregationMode.ENCODE:
                 config._resolve_disaggregation_model_from_legacy_multimodal_flags()
                 assert config.disaggregation_mode == DisaggregationMode.ENCODE
-                assert config.enable_multimodal is True
             else:
                 with pytest.raises(ValueError):
                     config._resolve_disaggregation_model_from_legacy_multimodal_flags()
@@ -130,7 +129,6 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
             if mode is None or mode == DisaggregationMode.DECODE:
                 config._resolve_disaggregation_model_from_legacy_multimodal_flags()
                 assert config.disaggregation_mode == DisaggregationMode.DECODE
-                assert config.enable_multimodal is True
             else:
                 with pytest.raises(ValueError):
                     config._resolve_disaggregation_model_from_legacy_multimodal_flags()

--- a/examples/backends/sglang/launch/multimodal_disagg.sh
+++ b/examples/backends/sglang/launch/multimodal_disagg.sh
@@ -130,7 +130,14 @@ python3 -m dynamo.frontend &
 # run SGLang multimodal encode worker (frontend-facing: encodes images, routes to worker)
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (GPU mem: $DYN_ENCODE_GPU_MEM)..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
-env ${_ENCODE_CUDA_PIN:+"$_ENCODE_CUDA_PIN"} python3 -m dynamo.sglang --multimodal-encode-worker --model-path "$MODEL_NAME" $SERVED_MODEL_ARG --chat-template "$CHAT_TEMPLATE" --skip-tokenizer-init $ENCODE_EXTRA_ARGS &
+env ${_ENCODE_CUDA_PIN:+"$_ENCODE_CUDA_PIN"} python3 -m dynamo.sglang \
+  --enable-multimodal \
+  --disaggregation-mode encode \
+  --model-path "$MODEL_NAME" \
+  $SERVED_MODEL_ARG \
+  --chat-template "$CHAT_TEMPLATE" \
+  --skip-tokenizer-init \
+  $ENCODE_EXTRA_ARGS &
 
 if [[ "$SINGLE_GPU" == "true" ]]; then
     # Wait for encode worker to initialize before starting prefill worker.
@@ -148,7 +155,7 @@ fi
 echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (GPU mem: $DYN_PREFILL_GPU_MEM)..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 env ${_PREFILL_CUDA_PIN:+"$_PREFILL_CUDA_PIN"} python3 -m dynamo.sglang \
-  --multimodal-worker \
+  --enable-multimodal \
   --model-path "$MODEL_NAME" \
   $SERVED_MODEL_ARG \
   --page-size 16 \
@@ -171,7 +178,7 @@ fi
 # run SGLang multimodal decode worker
 echo "Starting decode worker on GPU $DYN_DECODE_WORKER_GPU (GPU mem: $DYN_DECODE_GPU_MEM)..."
 env ${_DECODE_CUDA_PIN:+"$_DECODE_CUDA_PIN"} python3 -m dynamo.sglang \
-  --multimodal-worker \
+  --enable-multimodal \
   --model-path "$MODEL_NAME" \
   $SERVED_MODEL_ARG \
   --page-size 16 \

--- a/examples/backends/sglang/launch/multimodal_epd.sh
+++ b/examples/backends/sglang/launch/multimodal_epd.sh
@@ -123,7 +123,14 @@ python3 -m dynamo.frontend &
 # run SGLang multimodal encode worker (frontend-facing: encodes images, routes to worker)
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
-env ${_ENCODE_CUDA_PIN:+"$_ENCODE_CUDA_PIN"} python3 -m dynamo.sglang --multimodal-encode-worker --model-path "$MODEL_NAME" $SERVED_MODEL_ARG --chat-template "$CHAT_TEMPLATE" --skip-tokenizer-init $ENCODE_EXTRA_ARGS &
+env ${_ENCODE_CUDA_PIN:+"$_ENCODE_CUDA_PIN"} python3 -m dynamo.sglang \
+  --enable-multimodal \
+  --disaggregation-mode encode \
+  --model-path "$MODEL_NAME" \
+  $SERVED_MODEL_ARG \
+  --chat-template "$CHAT_TEMPLATE" \
+  --skip-tokenizer-init \
+  $ENCODE_EXTRA_ARGS &
 
 if [[ "$SINGLE_GPU" == "true" ]]; then
     # Wait for encode worker to initialize before starting PD worker.
@@ -141,7 +148,8 @@ fi
 echo "Starting PD worker on GPU $DYN_WORKER_GPU..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 env ${_WORKER_CUDA_PIN:+"$_WORKER_CUDA_PIN"} python3 -m dynamo.sglang \
-  --multimodal-worker \
+  --enable-multimodal \
+  --disaggregation-mode pd \
   --model-path "$MODEL_NAME" \
   $SERVED_MODEL_ARG \
   --page-size 16 \

--- a/examples/backends/trtllm/launch/agg_multimodal.sh
+++ b/examples/backends/trtllm/launch/agg_multimodal.sh
@@ -14,7 +14,6 @@ export DYNAMO_HOME=${DYNAMO_HOME:-"/workspace"}
 export MODEL_PATH=${MODEL_PATH:-"Qwen/Qwen2-VL-7B-Instruct"}
 export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"Qwen/Qwen2-VL-7B-Instruct"}
 export AGG_ENGINE_ARGS=${AGG_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/agg.yaml"}
-export MODALITY=${MODALITY:-"multimodal"}
 
 # Profiler/test-harness override: when _PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS or
 # _PROFILE_OVERRIDE_TRTLLM_MAX_GPU_TOTAL_BYTES is set, build_trtllm_override_args_with_mem
@@ -38,7 +37,7 @@ python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$AGG_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   "${TRTLLM_OVERRIDE_ARGS[@]}" \
   --publish-events-and-metrics &
 

--- a/examples/backends/trtllm/launch/agg_multimodal_router.sh
+++ b/examples/backends/trtllm/launch/agg_multimodal_router.sh
@@ -22,7 +22,6 @@ export DYNAMO_HOME=${DYNAMO_HOME:-"/workspace"}
 export MODEL_PATH=${MODEL_PATH:-"Qwen/Qwen3-VL-2B-Instruct"}
 export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"Qwen/Qwen3-VL-2B-Instruct"}
 export AGG_ENGINE_ARGS=${AGG_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/agg.yaml"}
-export MODALITY=${MODALITY:-"multimodal"}
 export MODEL_TYPE=${MODEL_TYPE:-"qwen3_vl"}
 export BLOCK_SIZE=${BLOCK_SIZE:-32}
 
@@ -41,7 +40,7 @@ python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "${SERVED_MODEL_NAME}__internal" \
   --extra-engine-args "$AGG_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   "${TRTLLM_OVERRIDE_ARGS[@]}" \
   --publish-events-and-metrics \
   --kv-block-size "$BLOCK_SIZE" &

--- a/examples/backends/trtllm/launch/disagg_e_pd.sh
+++ b/examples/backends/trtllm/launch/disagg_e_pd.sh
@@ -21,7 +21,6 @@ export ENCODE_ENGINE_ARGS=${ENCODE_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/
 export PD_ENGINE_ARGS=${PD_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/agg.yaml"}
 export ENCODE_CUDA_VISIBLE_DEVICES=${ENCODE_CUDA_VISIBLE_DEVICES:-"0"}
 export ENCODE_ENDPOINT=${ENCODE_ENDPOINT:-"dyn://dynamo.encode.generate"}
-export MODALITY=${MODALITY:-"multimodal"}
 export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}
 export MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
 
@@ -52,7 +51,7 @@ CUDA_VISIBLE_DEVICES=$ENCODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$ENCODE_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   --allowed-local-media-path "$ALLOWED_LOCAL_MEDIA_PATH" \
   --max-file-size-mb "$MAX_FILE_SIZE_MB" \
   --disaggregation-mode encode &
@@ -63,10 +62,10 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$PD_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   --encode-endpoint "$ENCODE_ENDPOINT" \
   "${TRTLLM_OVERRIDE_ARGS[@]}" \
-  --disaggregation-mode prefill_and_decode \
+  --disaggregation-mode pd \
   "${EXTRA_PD_ARGS[@]}" &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest

--- a/examples/backends/trtllm/launch/disagg_multimodal.sh
+++ b/examples/backends/trtllm/launch/disagg_multimodal.sh
@@ -17,7 +17,6 @@ export PREFILL_ENGINE_ARGS=${PREFILL_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backend
 export DECODE_ENGINE_ARGS=${DECODE_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/decode.yaml"}
 export PREFILL_CUDA_VISIBLE_DEVICES=${PREFILL_CUDA_VISIBLE_DEVICES:-"0"}
 export DECODE_CUDA_VISIBLE_DEVICES=${DECODE_CUDA_VISIBLE_DEVICES:-"1"}
-export MODALITY=${MODALITY:-"multimodal"}
 
 # Profiler/test-harness override applied to KV-cache-bearing workers (prefill, decode).
 TRTLLM_OVERRIDE_ARGS=()
@@ -38,7 +37,7 @@ CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args  "$PREFILL_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   "${TRTLLM_OVERRIDE_ARGS[@]}" \
   --disaggregation-mode prefill &
 
@@ -47,7 +46,7 @@ CUDA_VISIBLE_DEVICES=$DECODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args  "$DECODE_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   "${TRTLLM_OVERRIDE_ARGS[@]}" \
   --disaggregation-mode decode &
 

--- a/examples/backends/trtllm/launch/epd_disagg.sh
+++ b/examples/backends/trtllm/launch/epd_disagg.sh
@@ -19,7 +19,6 @@ export PREFILL_CUDA_VISIBLE_DEVICES=${PREFILL_CUDA_VISIBLE_DEVICES:-"0,1,2,3"}
 export DECODE_CUDA_VISIBLE_DEVICES=${DECODE_CUDA_VISIBLE_DEVICES:-"4,5,6,7"}
 export ENCODE_CUDA_VISIBLE_DEVICES=${ENCODE_CUDA_VISIBLE_DEVICES:-"0"}
 export ENCODE_ENDPOINT=${ENCODE_ENDPOINT:-"dyn://dynamo.encode.generate"}
-export MODALITY=${MODALITY:-"multimodal"}
 export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}
 export MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
 
@@ -35,7 +34,7 @@ CUDA_VISIBLE_DEVICES=$ENCODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$ENCODE_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   --allowed-local-media-path "$ALLOWED_LOCAL_MEDIA_PATH" \
   --max-file-size-mb "$MAX_FILE_SIZE_MB" \
   --disaggregation-mode encode &
@@ -45,7 +44,7 @@ CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$PREFILL_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   --disaggregation-mode prefill \
   --encode-endpoint "$ENCODE_ENDPOINT" &
 
@@ -54,7 +53,7 @@ CUDA_VISIBLE_DEVICES=$DECODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$DECODE_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   --disaggregation-mode decode &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest

--- a/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
+++ b/examples/backends/trtllm/launch/epd_multimodal_image_and_embeddings.sh
@@ -20,7 +20,6 @@ export PREFILL_CUDA_VISIBLE_DEVICES=${PREFILL_CUDA_VISIBLE_DEVICES:-"0"}
 export DECODE_CUDA_VISIBLE_DEVICES=${DECODE_CUDA_VISIBLE_DEVICES:-"0"}
 export ENCODE_CUDA_VISIBLE_DEVICES=${ENCODE_CUDA_VISIBLE_DEVICES:-"0"}
 export ENCODE_ENDPOINT=${ENCODE_ENDPOINT:-"dyn://dynamo.encode.generate"}
-export MODALITY=${MODALITY:-"multimodal"}
 export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}
 export MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
 
@@ -51,7 +50,7 @@ CUDA_VISIBLE_DEVICES=$ENCODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$ENCODE_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   --allowed-local-media-path "$ALLOWED_LOCAL_MEDIA_PATH" \
   --max-file-size-mb "$MAX_FILE_SIZE_MB" \
   --disaggregation-mode encode &
@@ -62,7 +61,7 @@ CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$PREFILL_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   "${TRTLLM_OVERRIDE_ARGS[@]}" \
   --disaggregation-mode prefill \
   --encode-endpoint "$ENCODE_ENDPOINT" &
@@ -73,7 +72,7 @@ CUDA_VISIBLE_DEVICES=$DECODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$DECODE_ENGINE_ARGS" \
-  --modality "$MODALITY" \
+  --enable-multimodal \
   --allowed-local-media-path "$ALLOWED_LOCAL_MEDIA_PATH" \
   --max-file-size-mb "$MAX_FILE_SIZE_MB" \
   "${TRTLLM_OVERRIDE_ARGS[@]}" \

--- a/examples/backends/vllm/launch/disagg_multimodal_e_pd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_e_pd.sh
@@ -128,8 +128,8 @@ echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (--gpu-memory-utiliza
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU \
 python -m dynamo.vllm \
-  --multimodal-encode-worker \
   --enable-multimodal \
+  --disaggregation-mode encode \
   --model "$MODEL_NAME" \
   --gpu-memory-utilization "$DYN_ENCODE_GPU_MEM" \
   $EXTRA_ARGS &
@@ -141,6 +141,7 @@ CUDA_VISIBLE_DEVICES=$DYN_PD_WORKER_GPU \
 python -m dynamo.vllm \
   --route-to-encoder \
   --enable-multimodal \
+  --disaggregation-mode pd \
   --enable-mm-embeds \
   --model "$MODEL_NAME" \
   $PD_GPU_MEM_ARGS \

--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -203,7 +203,7 @@ echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (--gpu-memory-utiliza
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=$VLLM_NIXL_SIDE_CHANNEL_PORT_ENCODE \
 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU \
-python -m dynamo.vllm --multimodal-encode-worker --enable-multimodal --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_ENCODE}\"}" &
+python -m dynamo.vllm --enable-multimodal --disaggregation-mode encode --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_ENCODE}\"}" &
 
 # Start prefill worker (also handles encode routing via --route-to-encoder)
 echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (${PREFILL_GPU_MEM_ARGS})..."

--- a/examples/backends/vllm/launch/xpu/disagg_multimodal_epd_xpu.sh
+++ b/examples/backends/vllm/launch/xpu/disagg_multimodal_epd_xpu.sh
@@ -127,7 +127,7 @@ fi
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (GPU mem: $DYN_ENCODE_GPU_MEM)..."
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 env $DEVICE_AFFINITY_ENV=$DYN_ENCODE_WORKER_GPU \
-python -m dynamo.vllm --multimodal-encode-worker --enable-multimodal --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device": "'"$DEVICE_PLATFORM"'"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' &
+python -m dynamo.vllm --enable-multimodal --disaggregation-mode encode --enable-mm-embeds --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device": "'"$DEVICE_PLATFORM"'"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' &
 
 # Start prefill worker (also handles encode routing via --route-to-encoder)
 echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (GPU mem: $DYN_PREFILL_GPU_MEM)..."


### PR DESCRIPTION

#### Overview:

Unifies the multimodal E/P/D flag surface across Dynamo backends while keeping the existing backend-specific flags working for compatibility.

#### Details:

This PR adds canonical multimodal configuration flags and maps the existing outlier args to the new behavior with deprecation warnings.

**Before**

| Worker Layout | vLLM | SGLang | TRT-LLM |
|---|---|---|---|
| Aggregated | `--enable-multimodal` | default worker,<br>no dedicated Dynamo MM role flag | `--modality multimodal`<br>(`--disaggregation-mode prefill_and_decode`) |
| E / Encode | `--multimodal-encode-worker`<br>`--enable-multimodal` | `--multimodal-encode-worker` | `--modality multimodal`<br>`--disaggregation-mode encode` |
| P / Prefill | `--enable-multimodal`<br>`--disaggregation-mode prefill` | `--multimodal-worker`<br>`--disaggregation-mode prefill` | `--modality multimodal`<br>`--disaggregation-mode prefill` |
| D / Decode | `--enable-multimodal`<br>`--disaggregation-mode decode` | `--multimodal-worker`<br>`--disaggregation-mode decode` | `--modality multimodal`<br>`--disaggregation-mode decode` |
| PD in E/PD | `--route-to-encoder`<br>`--enable-multimodal` | `--multimodal-worker` | `--modality multimodal`<br>`--encode-endpoint ...`<br>(`--disaggregation-mode prefill_and_decode`) |

**After**

| Worker Layout | Unified Flags |
|---|---|
| Aggregated | `--enable-multimodal`<br>(`--disaggregation-mode agg`) |
| E / Encode | `--enable-multimodal`<br>`--disaggregation-mode encode` |
| P / Prefill | `--enable-multimodal`<br>`--disaggregation-mode prefill` |
| D / Decode | `--enable-multimodal`<br>`--disaggregation-mode decode` |
| PD in E/PD | `--enable-multimodal`<br>`--disaggregation-mode pd` |

Legacy backend-specific flags remain accepted for compatibility. vLLM and SGLang legacy `--multimodal-*` role flags emit deprecation warnings and are internally mapped to the new canonical spelling.

For TRT-LLM, `--modality` also supports diffusion modes, so `--enable-multimodal` is added as a no-warning alias for `--modality multimodal` rather than replacing `--modality`.

For SGLang, `agg` and `pd` both map to native SGLang `null`, but they differ at the Dynamo wrapper layer. `agg` stays public standalone serving; `pd` becomes the internal E/PD PD worker.

#### Where should the reviewer start?

Start with the backend arg parsing changes:

- `components/src/dynamo/vllm/backend_args.py`
- `components/src/dynamo/sglang/backend_args.py`
- `components/src/dynamo/sglang/args.py`
- `components/src/dynamo/trtllm/backend_args.py`

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--enable-multimodal` flag for unified multimodal enablement across backends.
  * Introduced improved `--disaggregation-mode` support with new modes for better multimodal worker control.

* **Deprecations**
  * Legacy multimodal flags (`--multimodal-encode-worker`, `--multimodal-worker`) now emit deprecation warnings; migrate to `--enable-multimodal` and `--disaggregation-mode`.

* **Tests**
  * Added comprehensive unit tests for new multimodal and disaggregation mode functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->