### PR TITLE
docs: clean up SGLang docs

### DIFF
--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -128,7 +128,6 @@ pip install -e .
 | [**Request Cancellation**](../../fault-tolerance/request-cancellation.md) | ✅ | Aggregated full; disaggregated decode-only |
 | [**Graceful Shutdown**](../../fault-tolerance/graceful-shutdown.md) | ✅ | Discovery unregister + grace period |
 | [**Observability**](sglang-observability.md) | ✅ | Metrics, tracing, and Grafana dashboards |
-| [**KVBM**](../../components/kvbm/README.md) | ❌ | Planned |
 
 ## Quick Start
 

--- a/docs/backends/sglang/sglang-examples.md
+++ b/docs/backends/sglang/sglang-examples.md
@@ -144,7 +144,7 @@ Options: `--wan-size 1b|14b`, `--num-frames`, `--height`, `--width`, `--num-infe
 
 For full details on all diffusion worker types (LLM, image, video), see [Diffusion](sglang-diffusion.md).
 
-### Kubernetes Deployment
+## Kubernetes Deployment
 
 For complete K8s deployment examples, see:
 


### PR DESCRIPTION
## Summary

- Remove the planned KVBM row from the SGLang backend feature matrix.
- Promote Kubernetes Deployment in the SGLang examples page to a top-level section alongside Diffusion Models.
- Leave the processor fallback doc naming unchanged.

## Validation

- `git diff --check origin/main...HEAD`

Linear: DYN-3222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated KVBM entry from the SGLang backend feature matrix
  * Updated documentation structure with heading level adjustments for improved organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->