### PR TITLE
feat(mocker): support pluggable replay latency models

### DIFF
--- a/lib/mocker/src/common/perf_model.rs
+++ b/lib/mocker/src/common/perf_model.rs
@@ -3,9 +3,8 @@
 
 //! Performance model for timing simulations in the mocker.
 //!
-//! This module provides two timing models:
-//! 1. Polynomial: Hardcoded polynomial formulas (default, backward compatible)
-//! 2. Interpolated: Grid-based interpolation from profiler data (loaded from NPZ files)
+//! Built-in timing comes from polynomial, interpolated, or AI Configurator
+//! models. Embedding applications can provide a native Rust model instead.
 
 use anyhow::{Context, Result};
 use ndarray::{Array1, Array2};
@@ -14,6 +13,166 @@ use ndarray_interp::interp1d::{Interp1DBuilder, Linear};
 use ndarray_interp::interp2d::{Bilinear, Interp2DBuilder};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
+
+/// Exact request shapes for one replay prefill forward pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReplayPrefillInput<'a> {
+    /// Per-request sequence lengths in forward-pass order.
+    pub sequence_lengths: &'a [usize],
+    /// Per-request cached-prefix lengths in the same order.
+    pub prefix_lengths: &'a [usize],
+}
+
+impl<'a> ReplayPrefillInput<'a> {
+    /// Validate and construct an exact prefill batch description.
+    pub fn new(sequence_lengths: &'a [usize], prefix_lengths: &'a [usize]) -> Result<Self> {
+        if sequence_lengths.is_empty() {
+            anyhow::bail!("replay prefill input requires at least one request");
+        }
+        if sequence_lengths.len() != prefix_lengths.len() {
+            anyhow::bail!(
+                "replay prefill input length mismatch: sequence_lengths={}, prefix_lengths={}",
+                sequence_lengths.len(),
+                prefix_lengths.len()
+            );
+        }
+        if let Some((index, (prefix, sequence))) = prefix_lengths
+            .iter()
+            .zip(sequence_lengths)
+            .enumerate()
+            .find(|(_, (prefix, sequence))| prefix > sequence)
+        {
+            anyhow::bail!(
+                "replay prefill prefix length exceeds sequence length at index {index}: prefix={prefix}, sequence={sequence}"
+            );
+        }
+        Ok(Self {
+            sequence_lengths,
+            prefix_lengths,
+        })
+    }
+
+    /// Number of requests in the forward pass.
+    pub fn batch_size(&self) -> usize {
+        self.sequence_lengths.len()
+    }
+
+    /// Integer average of the exact sequence lengths.
+    pub fn avg_sequence_length(&self) -> usize {
+        average_length(self.sequence_lengths)
+    }
+
+    /// Integer average of the exact cached-prefix lengths.
+    pub fn avg_prefix_length(&self) -> usize {
+        average_length(self.prefix_lengths)
+    }
+
+    /// AIC-compatible average sequence length minus average prefix length.
+    pub fn avg_effective_input_length(&self) -> usize {
+        self.avg_sequence_length()
+            .saturating_sub(self.avg_prefix_length())
+    }
+}
+
+/// Exact request shapes and KV occupancy for one replay decode forward pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReplayDecodeInput<'a> {
+    /// Per-request context lengths in forward-pass order.
+    pub sequence_lengths: &'a [usize],
+    /// KV tokens active for this forward pass.
+    pub active_kv_tokens: usize,
+    /// Total KV-token capacity of the worker.
+    pub total_kv_tokens: usize,
+    /// Number of output tokens attempted per request.
+    pub output_length: usize,
+}
+
+impl ReplayDecodeInput<'_> {
+    /// Number of requests in the forward pass.
+    pub fn batch_size(&self) -> usize {
+        self.sequence_lengths.len()
+    }
+
+    /// Integer average of the exact context lengths.
+    pub fn avg_context_length(&self) -> usize {
+        average_length(self.sequence_lengths)
+    }
+}
+
+fn average_length(lengths: &[usize]) -> usize {
+    if lengths.is_empty() {
+        return 0;
+    }
+    lengths.iter().sum::<usize>() / lengths.len()
+}
+
+/// Prefill latency model used by replay schedulers.
+pub trait ReplayPrefillLatencyModel: Send + Sync {
+    /// Predict prefill latency in milliseconds for one exact forward pass.
+    fn prefill_latency_ms(&self, input: ReplayPrefillInput<'_>) -> f64;
+}
+
+/// Decode latency model used by replay schedulers.
+pub trait ReplayDecodeLatencyModel: Send + Sync {
+    /// Predict decode latency in milliseconds for one exact forward pass.
+    fn decode_latency_ms(&self, input: ReplayDecodeInput<'_>) -> f64;
+}
+
+/// Combined latency model for applications that use one model for both phases.
+pub trait ReplayLatencyModel: ReplayPrefillLatencyModel + ReplayDecodeLatencyModel {}
+
+impl<T> ReplayLatencyModel for T where T: ReplayPrefillLatencyModel + ReplayDecodeLatencyModel {}
+
+pub(crate) fn normalize_replay_latency_ms(
+    latency_ms: f64,
+    minimum_ms: f64,
+    phase: &'static str,
+) -> f64 {
+    if latency_ms.is_finite() && latency_ms >= 0.0 {
+        return latency_ms.max(minimum_ms);
+    }
+
+    tracing::warn!(
+        phase,
+        latency_ms,
+        minimum_ms,
+        "Replay latency model returned an invalid latency; using the minimum"
+    );
+    minimum_ms
+}
+
+pub(crate) fn replay_latency_duration(
+    latency_ms: f64,
+    minimum_ms: f64,
+    phase: &'static str,
+) -> Duration {
+    let seconds = normalize_replay_latency_ms(latency_ms, minimum_ms, phase) / 1000.0;
+    duration_from_seconds(seconds, phase)
+}
+
+pub(crate) fn scale_replay_duration(
+    duration: Duration,
+    speedup_ratio: f64,
+    phase: &'static str,
+) -> Duration {
+    if duration.is_zero() || !speedup_ratio.is_finite() || speedup_ratio <= 0.0 {
+        return duration;
+    }
+    duration_from_seconds(duration.as_secs_f64() / speedup_ratio, phase)
+}
+
+fn duration_from_seconds(seconds: f64, phase: &'static str) -> Duration {
+    if seconds.is_finite() && seconds >= 0.0 && seconds < Duration::MAX.as_secs_f64() {
+        return Duration::from_secs_f64(seconds);
+    }
+    tracing::warn!(
+        phase,
+        seconds,
+        "Replay latency exceeds the representable duration; clamping to Duration::MAX"
+    );
+    Duration::MAX
+}
 
 /// Trait to abstract over 1D interpolation for prefill timing
 pub trait PrefillInterpolator: Send + Sync {
@@ -96,6 +255,11 @@ pub enum PerfModel {
         callback: Arc<dyn AicCallback>,
         attention_dp_size: usize,
     },
+    /// Native replay models supplied by an embedding Rust application.
+    Custom {
+        prefill: Arc<dyn ReplayPrefillLatencyModel>,
+        decode: Arc<dyn ReplayDecodeLatencyModel>,
+    },
 }
 
 impl Clone for PerfModel {
@@ -116,6 +280,10 @@ impl Clone for PerfModel {
                 callback: Arc::clone(callback),
                 attention_dp_size: *attention_dp_size,
             },
+            PerfModel::Custom { prefill, decode } => PerfModel::Custom {
+                prefill: Arc::clone(prefill),
+                decode: Arc::clone(decode),
+            },
         }
     }
 }
@@ -126,6 +294,7 @@ impl std::fmt::Debug for PerfModel {
             PerfModel::Polynomial => write!(f, "PerfModel::Polynomial"),
             PerfModel::Interpolated { .. } => write!(f, "PerfModel::Interpolated {{ .. }}"),
             PerfModel::Aiconfigurator { .. } => write!(f, "PerfModel::Aiconfigurator"),
+            PerfModel::Custom { .. } => write!(f, "PerfModel::Custom {{ .. }}"),
         }
     }
 }
@@ -248,6 +417,25 @@ impl PerfModel {
         }
     }
 
+    /// Use one native Rust model for both replay phases.
+    pub fn from_replay_latency_model<M>(model: Arc<M>) -> Self
+    where
+        M: ReplayLatencyModel + 'static,
+    {
+        let prefill: Arc<dyn ReplayPrefillLatencyModel> = model.clone();
+        let decode: Arc<dyn ReplayDecodeLatencyModel> = model;
+        Self::Custom { prefill, decode }
+    }
+
+    /// Use independent native Rust models for prefill and decode replay.
+    pub fn from_replay_latency_models<P, D>(prefill: Arc<P>, decode: Arc<D>) -> Self
+    where
+        P: ReplayPrefillLatencyModel + 'static,
+        D: ReplayDecodeLatencyModel + 'static,
+    {
+        Self::Custom { prefill, decode }
+    }
+
     /// Global batch -> per-rank batch for the AIC SDK; see the
     /// `Aiconfigurator { attention_dp_size }` doc. `div_ceil` bounds the step by
     /// the busiest rank, and dp == 1 (live / non-DP) is a no-op.
@@ -262,18 +450,37 @@ impl PerfModel {
     ///   (`batch_size * (isl - prefix)`), modeling GPU processing total tokens in parallel
     /// - Aiconfigurator: passes (batch_size, isl - prefix, prefix) to the AIC SDK
     pub fn predict_prefill_time(&self, batch_size: usize, isl: usize, prefix: usize) -> f64 {
-        let new_tokens_per_req = isl.saturating_sub(prefix);
-        if batch_size == 0 || new_tokens_per_req == 0 {
+        if batch_size == 0 {
+            return 0.0;
+        }
+        if matches!(self, Self::Custom { .. }) {
+            let sequence_lengths = vec![isl; batch_size];
+            let prefix_lengths = vec![prefix; batch_size];
+            return self.prefill_latency_ms(
+                ReplayPrefillInput::new(&sequence_lengths, &prefix_lengths)
+                    .expect("aggregate prefill shape must be valid"),
+            );
+        }
+        self.predict_prefill_aggregates(batch_size, isl.saturating_sub(prefix), prefix)
+    }
+
+    fn predict_prefill_aggregates(
+        &self,
+        batch_size: usize,
+        avg_effective_input_length: usize,
+        avg_prefix_length: usize,
+    ) -> f64 {
+        if batch_size == 0 || avg_effective_input_length == 0 {
             return 0.0;
         }
         let time = match self {
             PerfModel::Polynomial => {
                 // Total tokens across the batch — GPU processes them in parallel
-                let tokens = (batch_size * new_tokens_per_req) as f64;
+                let tokens = (batch_size * avg_effective_input_length) as f64;
                 4.209989e-07 * tokens.powi(2) + 1.518344e-02 * tokens + 1.650142e+01
             }
             PerfModel::Interpolated { prefill_interp, .. } => {
-                let tokens = (batch_size * new_tokens_per_req) as f64;
+                let tokens = (batch_size * avg_effective_input_length) as f64;
                 prefill_interp.interp(tokens).unwrap_or(0.0)
             }
             PerfModel::Aiconfigurator {
@@ -281,9 +488,10 @@ impl PerfModel {
                 attention_dp_size,
             } => callback.predict_prefill(
                 Self::aic_per_rank_batch(batch_size, *attention_dp_size),
-                new_tokens_per_req,
-                prefix,
+                avg_effective_input_length,
+                avg_prefix_length,
             ),
+            PerfModel::Custom { .. } => unreachable!("custom model handled before aggregation"),
         };
         time.max(0.0)
     }
@@ -304,6 +512,33 @@ impl PerfModel {
         if batch_size == 0 {
             return 0.0;
         }
+        if matches!(self, Self::Custom { .. }) {
+            let sequence_lengths = vec![context_length; batch_size];
+            return self.decode_latency_ms(ReplayDecodeInput {
+                sequence_lengths: &sequence_lengths,
+                active_kv_tokens,
+                total_kv_tokens,
+                output_length: 2,
+            });
+        }
+        self.predict_decode_aggregates(
+            batch_size,
+            active_kv_tokens,
+            context_length,
+            total_kv_tokens,
+        )
+    }
+
+    fn predict_decode_aggregates(
+        &self,
+        batch_size: usize,
+        active_kv_tokens: usize,
+        avg_context_length: usize,
+        total_kv_tokens: usize,
+    ) -> f64 {
+        if batch_size == 0 {
+            return 0.0;
+        }
         let time = match self {
             PerfModel::Polynomial => {
                 let active_perc = if total_kv_tokens > 0 {
@@ -315,30 +550,106 @@ impl PerfModel {
                 -25.74 * active_perc.powi(2) + 54.01 * active_perc + 5.74
             }
             PerfModel::Interpolated { decode_interp, .. } => decode_interp
-                .interp(active_kv_tokens as f64, context_length as f64)
+                .interp(active_kv_tokens as f64, avg_context_length as f64)
                 .unwrap_or(0.0),
             PerfModel::Aiconfigurator {
                 callback,
                 attention_dp_size,
             } => callback.predict_decode(
                 Self::aic_per_rank_batch(batch_size, *attention_dp_size),
-                context_length,
+                avg_context_length,
                 2,
             ),
+            PerfModel::Custom { .. } => unreachable!("custom model handled before aggregation"),
         };
         // Token-emitting decode steps should not collapse onto the same timestamp.
         let result = time.max(1.0);
         tracing::trace!(
-            "Decode time prediction: batch_size={batch_size}, active_kv_tokens={active_kv_tokens}, context_length={context_length}, time={result:.2}ms"
+            "Decode time prediction: batch_size={batch_size}, active_kv_tokens={active_kv_tokens}, context_length={avg_context_length}, time={result:.2}ms"
         );
         result
     }
 }
 
+impl ReplayPrefillLatencyModel for PerfModel {
+    fn prefill_latency_ms(&self, input: ReplayPrefillInput<'_>) -> f64 {
+        match self {
+            Self::Custom { prefill, .. } => prefill.prefill_latency_ms(input),
+            _ => self.predict_prefill_aggregates(
+                input.batch_size(),
+                input.avg_effective_input_length(),
+                input.avg_prefix_length(),
+            ),
+        }
+    }
+}
+
+impl ReplayDecodeLatencyModel for PerfModel {
+    fn decode_latency_ms(&self, input: ReplayDecodeInput<'_>) -> f64 {
+        match self {
+            Self::Custom { decode, .. } => decode.decode_latency_ms(input),
+            _ => self.predict_decode_aggregates(
+                input.batch_size(),
+                input.active_kv_tokens,
+                input.avg_context_length(),
+                input.total_kv_tokens,
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{AicCallback, PerfModel};
-    use std::sync::Arc;
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingAicCallback {
+        prefill_calls: Mutex<Vec<(usize, usize, usize)>>,
+        decode_calls: Mutex<Vec<(usize, usize, usize)>>,
+    }
+
+    impl AicCallback for RecordingAicCallback {
+        fn predict_prefill(&self, batch_size: usize, effective_isl: usize, prefix: usize) -> f64 {
+            self.prefill_calls
+                .lock()
+                .unwrap()
+                .push((batch_size, effective_isl, prefix));
+            2.0
+        }
+
+        fn predict_decode(&self, batch_size: usize, isl: usize, osl: usize) -> f64 {
+            self.decode_calls
+                .lock()
+                .unwrap()
+                .push((batch_size, isl, osl));
+            1.0
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingPrefillInterpolator {
+        calls: Mutex<Vec<f64>>,
+    }
+
+    impl PrefillInterpolator for RecordingPrefillInterpolator {
+        fn interp(&self, x: f64) -> Result<f64, InterpolateError> {
+            self.calls.lock().unwrap().push(x);
+            Ok(7.0)
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingDecodeInterpolator {
+        calls: Mutex<Vec<(f64, f64)>>,
+    }
+
+    impl DecodeInterpolator for RecordingDecodeInterpolator {
+        fn interp(&self, x: f64, y: f64) -> Result<f64, InterpolateError> {
+            self.calls.lock().unwrap().push((x, y));
+            Ok(11.0)
+        }
+    }
 
     #[test]
     fn fully_cached_prompt_skips_prefill() {
@@ -392,5 +703,122 @@ mod tests {
         let m = PerfModel::from_aic_callback_with_attention_dp(Arc::new(EchoBatchCallback), 8);
         assert_eq!(m.predict_prefill_time(8, 1024, 0), 1.0);
         assert_eq!(m.predict_prefill_time(128, 1024, 0), 16.0);
+    }
+
+    #[test]
+    fn normalize_replay_latency_ms_enforces_contract() {
+        for (latency_ms, minimum_ms, expected_ms) in [
+            (f64::NAN, 1.0, 1.0),
+            (-1.0, 1.0, 1.0),
+            (0.5, 1.0, 1.0),
+            (2.0, 1.0, 2.0),
+        ] {
+            assert_eq!(
+                normalize_replay_latency_ms(latency_ms, minimum_ms, "test"),
+                expected_ms
+            );
+        }
+    }
+
+    #[test]
+    fn replay_latency_duration_clamps_unrepresentable_values() {
+        assert_eq!(
+            replay_latency_duration(f64::MAX, 0.0, "test"),
+            Duration::MAX
+        );
+        assert_eq!(
+            scale_replay_duration(Duration::from_secs(1), f64::MIN_POSITIVE, "test"),
+            Duration::MAX
+        );
+    }
+
+    #[test]
+    fn replay_prefill_input_validates_request_shapes() {
+        assert!(ReplayPrefillInput::new(&[], &[]).is_err());
+        assert!(ReplayPrefillInput::new(&[8, 12], &[0]).is_err());
+        assert!(ReplayPrefillInput::new(&[8, 12], &[0, 13]).is_err());
+    }
+
+    #[test]
+    fn replay_inputs_derive_legacy_averages_from_exact_lengths() {
+        let prefill = ReplayPrefillInput::new(&[8, 13], &[4, 5]).unwrap();
+        assert_eq!(prefill.batch_size(), 2);
+        assert_eq!(prefill.avg_sequence_length(), 10);
+        assert_eq!(prefill.avg_prefix_length(), 4);
+        assert_eq!(prefill.avg_effective_input_length(), 6);
+
+        let decode = ReplayDecodeInput {
+            sequence_lengths: &[9, 14],
+            active_kv_tokens: 23,
+            total_kv_tokens: 128,
+            output_length: 3,
+        };
+        assert_eq!(decode.batch_size(), 2);
+        assert_eq!(decode.avg_context_length(), 11);
+        assert_eq!(decode.output_length, 3);
+    }
+
+    #[test]
+    fn polynomial_model_uses_legacy_aggregates_from_exact_lengths() {
+        let model = PerfModel::Polynomial;
+        let prefill = ReplayPrefillInput::new(&[8, 13], &[4, 5]).unwrap();
+        let decode = ReplayDecodeInput {
+            sequence_lengths: &[9, 14],
+            active_kv_tokens: 23,
+            total_kv_tokens: 128,
+            output_length: 3,
+        };
+
+        assert_eq!(
+            model.prefill_latency_ms(prefill),
+            model.predict_prefill_time(2, 10, 4)
+        );
+        assert_eq!(
+            model.decode_latency_ms(decode),
+            model.predict_decode_time(2, 23, 11, 128)
+        );
+    }
+
+    #[test]
+    fn interpolated_model_uses_legacy_aggregates_from_exact_lengths() {
+        let prefill_interp = Arc::new(RecordingPrefillInterpolator::default());
+        let decode_interp = Arc::new(RecordingDecodeInterpolator::default());
+        let model = PerfModel::Interpolated {
+            prefill_interp: prefill_interp.clone(),
+            decode_interp: decode_interp.clone(),
+        };
+
+        assert_eq!(
+            model.prefill_latency_ms(ReplayPrefillInput::new(&[8, 13], &[4, 5]).unwrap()),
+            7.0
+        );
+        assert_eq!(
+            model.decode_latency_ms(ReplayDecodeInput {
+                sequence_lengths: &[9, 14],
+                active_kv_tokens: 23,
+                total_kv_tokens: 128,
+                output_length: 3,
+            }),
+            11.0
+        );
+        assert_eq!(*prefill_interp.calls.lock().unwrap(), vec![12.0]);
+        assert_eq!(*decode_interp.calls.lock().unwrap(), vec![(23.0, 11.0)]);
+    }
+
+    #[test]
+    fn aic_model_derives_legacy_aggregates_from_exact_lengths() {
+        let callback = Arc::new(RecordingAicCallback::default());
+        let model = PerfModel::from_aic_callback(callback.clone());
+
+        model.prefill_latency_ms(ReplayPrefillInput::new(&[8, 13], &[4, 5]).unwrap());
+        model.decode_latency_ms(ReplayDecodeInput {
+            sequence_lengths: &[9, 14],
+            active_kv_tokens: 23,
+            total_kv_tokens: 128,
+            output_length: 3,
+        });
+
+        assert_eq!(*callback.prefill_calls.lock().unwrap(), vec![(2, 6, 4)]);
+        assert_eq!(*callback.decode_calls.lock().unwrap(), vec![(2, 11, 2)]);
     }
 }

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -13,6 +13,10 @@ mod validate;
 use std::collections::VecDeque;
 use std::sync::Arc;
 
+pub use crate::common::perf_model::{
+    PerfModel, ReplayDecodeInput, ReplayDecodeLatencyModel, ReplayLatencyModel, ReplayPrefillInput,
+    ReplayPrefillLatencyModel,
+};
 use crate::common::protocols::{DirectRequest, MockEngineArgs};
 use dynamo_kv_router::PrefillLoadEstimator;
 
@@ -145,7 +149,85 @@ pub(crate) fn normalize_trace_requests(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use uuid::Uuid;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct RecordedPrefillInput {
+        sequence_lengths: Vec<usize>,
+        prefix_lengths: Vec<usize>,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct RecordedDecodeInput {
+        sequence_lengths: Vec<usize>,
+        active_kv_tokens: usize,
+        total_kv_tokens: usize,
+        output_length: usize,
+    }
+
+    #[derive(Default)]
+    struct RecordingLatencyModel {
+        prefill_inputs: Mutex<Vec<RecordedPrefillInput>>,
+        decode_inputs: Mutex<Vec<RecordedDecodeInput>>,
+    }
+
+    impl ReplayPrefillLatencyModel for RecordingLatencyModel {
+        fn prefill_latency_ms(&self, input: ReplayPrefillInput<'_>) -> f64 {
+            self.prefill_inputs
+                .lock()
+                .unwrap()
+                .push(RecordedPrefillInput {
+                    sequence_lengths: input.sequence_lengths.to_vec(),
+                    prefix_lengths: input.prefix_lengths.to_vec(),
+                });
+            2.0
+        }
+    }
+
+    impl ReplayDecodeLatencyModel for RecordingLatencyModel {
+        fn decode_latency_ms(&self, input: ReplayDecodeInput<'_>) -> f64 {
+            self.decode_inputs
+                .lock()
+                .unwrap()
+                .push(RecordedDecodeInput {
+                    sequence_lengths: input.sequence_lengths.to_vec(),
+                    active_kv_tokens: input.active_kv_tokens,
+                    total_kv_tokens: input.total_kv_tokens,
+                    output_length: input.output_length,
+                });
+            1.0
+        }
+    }
+
+    fn replay_args(
+        engine_type: crate::common::protocols::EngineType,
+        model: Arc<RecordingLatencyModel>,
+    ) -> MockEngineArgs {
+        let mut args = MockEngineArgs::builder()
+            .engine_type(engine_type)
+            .block_size(4)
+            .num_gpu_blocks(128)
+            .max_num_batched_tokens(Some(64))
+            .max_num_seqs(Some(4))
+            .enable_prefix_caching(true)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        args.perf_model = Arc::new(PerfModel::from_replay_latency_model(model));
+        args
+    }
+
+    fn replay_request(uuid: u128, tokens: Vec<u32>, arrival_timestamp_ms: f64) -> DirectRequest {
+        DirectRequest {
+            tokens,
+            max_output_tokens: 2,
+            uuid: Some(Uuid::from_u128(uuid)),
+            dp_rank: 0,
+            arrival_timestamp_ms: Some(arrival_timestamp_ms),
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn test_replay_itl_uses_per_token_gaps() {
@@ -210,5 +292,68 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(arrivals, vec![0.0, 10.0]);
+    }
+
+    #[test]
+    fn replay_preserves_heterogeneous_request_shapes() {
+        for engine_type in [
+            crate::common::protocols::EngineType::Vllm,
+            crate::common::protocols::EngineType::Sglang,
+        ] {
+            let model = Arc::new(RecordingLatencyModel::default());
+            let report = simulate_trace_requests(
+                replay_args(engine_type, Arc::clone(&model)),
+                vec![
+                    replay_request(1, vec![1; 8], 0.0),
+                    replay_request(2, vec![2; 12], 0.0),
+                ],
+                1,
+                1.0,
+            )
+            .unwrap();
+
+            assert_eq!(report.request_counts.completed_requests, 2);
+            assert!(model.prefill_inputs.lock().unwrap().iter().any(|input| {
+                input.sequence_lengths == [8, 12] && input.prefix_lengths == [0, 0]
+            }));
+            assert!(
+                model
+                    .decode_inputs
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .any(|input| { input.sequence_lengths == [8, 12] && input.output_length == 1 })
+            );
+        }
+    }
+
+    #[test]
+    fn replay_preserves_cached_prefix_lengths() {
+        for engine_type in [
+            crate::common::protocols::EngineType::Vllm,
+            crate::common::protocols::EngineType::Sglang,
+        ] {
+            let model = Arc::new(RecordingLatencyModel::default());
+            let report = simulate_trace_requests(
+                replay_args(engine_type, Arc::clone(&model)),
+                vec![
+                    replay_request(1, vec![1, 1, 1, 1, 2, 2, 2, 2], 0.0),
+                    replay_request(2, vec![1, 1, 1, 1, 3, 3, 3, 3], 100.0),
+                ],
+                1,
+                1.0,
+            )
+            .unwrap();
+
+            assert_eq!(report.request_counts.completed_requests, 2);
+            assert!(
+                model
+                    .prefill_inputs
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .any(|input| { input.sequence_lengths == [8] && input.prefix_lengths == [4] })
+            );
+        }
     }
 }

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -8,6 +8,9 @@ use dynamo_kv_router::protocols::WorkerId;
 use uuid::Uuid;
 
 use crate::common::handoff::HandoffId;
+use crate::common::perf_model::{
+    ReplayPrefillInput, ReplayPrefillLatencyModel, replay_latency_duration, scale_replay_duration,
+};
 use crate::common::protocols::{DirectRequest, KvEventPublishers, MockEngineArgs, WorkerType};
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
 use crate::common::utils::prefill_handoff_transfer_timing;
@@ -572,7 +575,7 @@ impl SglangCore {
         apply_schedule_policy(&mut self.waiting, &self.kv_manager, &self.config);
 
         let admission = AdmissionInvariant::new(self.pending_destinations.has_pending());
-        let mut admit = match admission.stage_for(materialized_waiting) {
+        let admit = match admission.stage_for(materialized_waiting) {
             AdmissionStage::Materialized | AdmissionStage::PendingDestinationHead => {
                 Default::default()
             }
@@ -589,36 +592,51 @@ impl SglangCore {
             self.new_token_ratio = self.config.init_new_token_ratio;
         }
 
-        admissions.append(&mut admit.admissions);
+        let scheduled_prefills = admit.scheduled_prefills;
+        admissions.extend(scheduled_prefills.iter().map(|scheduled| {
+            crate::scheduler::AdmissionEvent {
+                uuid: scheduled.request.uuid,
+                reused_input_tokens: scheduled.prefix_tokens,
+            }
+        }));
         for admission in &admissions {
             if let Some(collector) = collector.as_deref_mut() {
                 collector.on_admit(admission.uuid, now_ms, admission.reused_input_tokens);
             }
         }
 
-        // Capture per-request prefill FPM data before dispersing can_run.
-        let prefill_fpm = admit.prefill_fpm;
+        let prefill_sequence_lengths = scheduled_prefills
+            .iter()
+            .map(|scheduled| scheduled.request.materialized_tokens)
+            .collect::<Vec<_>>();
+        let prefill_prefix_lengths = scheduled_prefills
+            .iter()
+            .map(|scheduled| scheduled.prefix_tokens)
+            .collect::<Vec<_>>();
+        let prefill_time = simulate_prefill_duration(
+            &prefill_sequence_lengths,
+            &prefill_prefix_lengths,
+            &self.config,
+            true,
+        );
 
-        let batch_size = admit.can_run.len();
-        let mean_isl = if batch_size > 0 {
-            admit.total_isl / batch_size
-        } else {
-            0
-        };
-        let mean_prefix = if batch_size > 0 {
-            admit.total_prefix / batch_size
-        } else {
-            0
-        };
-        let prefill_time =
-            simulate_prefill_duration(batch_size, mean_isl, mean_prefix, &self.config, true);
-
-        for mut req in admit.can_run {
-            if req.materialized_tokens < req.current_sequence_len() {
-                cache_materialized_prefix(&mut req, &mut self.kv_manager, &self.config);
-                self.waiting.push_front(req);
+        let prefill_fpm = scheduled_prefills
+            .iter()
+            .map(|scheduled| {
+                (
+                    scheduled.prompt_len as u64,
+                    scheduled.prefix_tokens as u64,
+                    scheduled.tokens_computed as u64,
+                )
+            })
+            .collect::<Vec<_>>();
+        for scheduled in scheduled_prefills {
+            let mut request = scheduled.request;
+            if request.materialized_tokens < request.current_sequence_len() {
+                cache_materialized_prefix(&mut request, &mut self.kv_manager, &self.config);
+                self.waiting.push_front(request);
             } else {
-                self.running.push(req);
+                self.running.push(request);
             }
         }
 
@@ -663,11 +681,11 @@ impl SglangCore {
         // Build FPM snapshot now that all state has settled.
         let sglang_cache_hit_tokens = prefill_fpm
             .iter()
-            .map(|item| item.prefix_tokens as u64)
+            .map(|(_, prefix_tokens, _)| *prefix_tokens)
             .sum::<u64>();
         let sglang_cache_total_tokens = prefill_fpm
             .iter()
-            .map(|item| (item.prefix_tokens + item.tokens_computed) as u64)
+            .map(|(_, prefix_tokens, tokens_computed)| prefix_tokens + tokens_computed)
             .sum::<u64>();
         let queued_prefills = self
             .waiting
@@ -704,13 +722,7 @@ impl SglangCore {
                     .map(|reservation| reservation.request.prompt_len() as u64),
             );
         let fpm = build_fpm_snapshot(
-            prefill_fpm.iter().map(|p| {
-                (
-                    p.prompt_len as u64,
-                    p.prefix_tokens as u64,
-                    p.tokens_computed as u64,
-                )
-            }),
+            prefill_fpm.iter().copied(),
             scheduled_decode_lens.into_iter(),
             queued_prefills,
             ordinary_queued_decodes.chain(preactivation_decodes),
@@ -782,26 +794,25 @@ impl SglangCore {
 }
 
 fn simulate_prefill_duration(
-    batch_size: usize,
-    mean_isl: usize,
-    mean_prefix: usize,
+    sequence_lengths: &[usize],
+    prefix_lengths: &[usize],
     config: &SglangConfig,
     apply_speedup: bool,
 ) -> Duration {
-    if batch_size == 0 || config.worker_type == WorkerType::Decode {
+    if sequence_lengths.is_empty() || config.worker_type == WorkerType::Decode {
         return Duration::ZERO;
     }
 
-    let prefill_time = config
-        .perf_model
-        .predict_prefill_time(batch_size, mean_isl, mean_prefix);
-    let total_time = Duration::from_secs_f64(prefill_time / 1000.0);
+    let input = ReplayPrefillInput::new(sequence_lengths, prefix_lengths)
+        .expect("scheduled prefill shape must be valid");
+    let total_time =
+        replay_latency_duration(config.perf_model.prefill_latency_ms(input), 0.0, "prefill");
 
-    if !apply_speedup || config.speedup_ratio <= 0.0 || total_time <= Duration::ZERO {
+    if !apply_speedup {
         return total_time;
     }
 
-    Duration::from_secs_f64(total_time.as_secs_f64() / config.speedup_ratio)
+    scale_replay_duration(total_time, config.speedup_ratio, "prefill")
 }
 
 fn debug_assert_sglang_scheduler_state(

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
-
+use crate::common::perf_model::{
+    ReplayDecodeInput, ReplayDecodeLatencyModel, replay_latency_duration, scale_replay_duration,
+};
 use crate::common::protocols::OutputSignal;
 use crate::common::speculative::SpeculativeDecodeSampler;
 use crate::common::utils::compute_prefill_handoff_delay_ms;
@@ -223,22 +224,27 @@ pub(super) fn simulate_decode_step_with_sampler(
         };
     }
 
-    let total_context: usize = running
+    let sequence_lengths = running
         .iter()
         .map(SglangRequest::current_sequence_len)
-        .sum();
-    let avg_context = total_context / running.len();
-    let active_kv_tokens = total_context.min(config.total_kv_tokens);
-    let decode_time = config.perf_model.predict_decode_time(
-        running.len(),
-        active_kv_tokens,
-        avg_context,
-        config.total_kv_tokens,
+        .collect::<Vec<_>>();
+    let active_kv_tokens = sequence_lengths
+        .iter()
+        .sum::<usize>()
+        .min(config.total_kv_tokens);
+    let unscaled_time = replay_latency_duration(
+        config.perf_model.decode_latency_ms(ReplayDecodeInput {
+            sequence_lengths: &sequence_lengths,
+            active_kv_tokens,
+            total_kv_tokens: config.total_kv_tokens,
+            output_length: max_burst,
+        }),
+        1.0,
+        "decode",
     );
-    let unscaled_time = Duration::from_secs_f64(decode_time / 1000.0);
     let effective_ratio = config.speedup_ratio * config.decode_speedup_ratio;
-    let total_time = if apply_speedup && effective_ratio > 0.0 && unscaled_time > Duration::ZERO {
-        Duration::from_secs_f64(unscaled_time.as_secs_f64() / effective_ratio)
+    let total_time = if apply_speedup {
+        scale_replay_duration(unscaled_time, effective_ratio, "decode")
     } else {
         unscaled_time
     };

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -3,13 +3,13 @@
 
 use std::collections::VecDeque;
 
-use super::super::AdmissionEvent;
 use super::config::{SglangConfig, ceil_to_block};
 use super::request::SglangRequest;
 use crate::kv_manager::SglangKvManager;
 
-/// Per-request prefill data needed for FPM snapshot construction.
-pub(super) struct PrefillFpmItem {
+/// One request selected for the current SGLang prefill forward pass.
+pub(super) struct ScheduledPrefill {
+    pub(super) request: SglangRequest,
     pub(super) prompt_len: usize,
     pub(super) tokens_computed: usize,
     pub(super) prefix_tokens: usize,
@@ -17,13 +17,8 @@ pub(super) struct PrefillFpmItem {
 
 #[derive(Default)]
 pub(super) struct AdmitResult {
-    pub(super) can_run: Vec<SglangRequest>,
-    pub(super) admissions: Vec<AdmissionEvent>,
-    pub(super) total_isl: usize,
-    pub(super) total_prefix: usize,
+    pub(super) scheduled_prefills: Vec<ScheduledPrefill>,
     pub(super) oom: bool,
-    /// Per-request prefill info for building FPM snapshots.
-    pub(super) prefill_fpm: Vec<PrefillFpmItem>,
 }
 
 pub(super) fn get_new_batch_prefill(
@@ -58,16 +53,12 @@ pub(super) fn get_new_batch_prefill(
     let mut rem_input_tokens = config.max_prefill_tokens as f64;
     let mut rem_chunk_tokens = config.chunked_prefill_size as f64;
 
-    let mut can_run = Vec::new();
-    let mut admissions = Vec::new();
-    let mut prefill_fpm = Vec::new();
+    let mut scheduled_prefills = Vec::new();
     let mut rejected = VecDeque::new();
     let mut oom = false;
-    let mut total_isl = 0usize;
-    let mut total_prefix = 0usize;
 
     let available_running_slots = config.max_running_requests.saturating_sub(running.len());
-    while can_run.len() < available_running_slots
+    while scheduled_prefills.len() < available_running_slots
         && let Some(mut req) = waiting.pop_front()
     {
         let extend_input = req.extend_input_len();
@@ -147,22 +138,16 @@ pub(super) fn get_new_batch_prefill(
         req.allocated_tokens = ceil_to_block(chunk_end, config.block_size);
         req.debug_assert_invariants(config.block_size);
 
-        admissions.push(AdmissionEvent {
-            uuid: req.uuid,
-            reused_input_tokens: alloc.prefix_len,
-        });
-        prefill_fpm.push(PrefillFpmItem {
-            prompt_len: req.prompt_len(),
-            tokens_computed: chunk_tokens,
-            prefix_tokens: alloc.prefix_len,
-        });
-
-        total_isl += chunk_end;
-        total_prefix += alloc.prefix_len;
+        let prompt_len = req.prompt_len();
         rem_total_tokens -= (req.allocated_tokens - old_allocated_tokens + output_reserve) as f64;
         rem_input_tokens -= charged_input_tokens;
         rem_chunk_tokens -= charged_input_tokens;
-        can_run.push(req);
+        scheduled_prefills.push(ScheduledPrefill {
+            request: req,
+            prompt_len,
+            tokens_computed: chunk_tokens,
+            prefix_tokens: alloc.prefix_len,
+        });
 
         if rem_chunk_tokens <= 0.0 {
             break;
@@ -174,11 +159,7 @@ pub(super) fn get_new_batch_prefill(
     }
 
     AdmitResult {
-        can_run,
-        admissions,
-        total_isl,
-        total_prefix,
+        scheduled_prefills,
         oom,
-        prefill_fpm,
     }
 }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -1020,9 +1020,9 @@ mod core_behavior {
         }]);
 
         let admit = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[]);
-        assert_eq!(admit.can_run.len(), 1);
-        assert_eq!(admit.can_run[0].materialized_tokens, 6);
-        assert_eq!(admit.can_run[0].allocated_tokens, 8);
+        assert_eq!(admit.scheduled_prefills.len(), 1);
+        assert_eq!(admit.scheduled_prefills[0].request.materialized_tokens, 6);
+        assert_eq!(admit.scheduled_prefills[0].request.allocated_tokens, 8);
     }
 
     #[test]
@@ -1052,8 +1052,8 @@ mod core_behavior {
         }]);
 
         let admit = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[]);
-        assert_eq!(admit.can_run.len(), 1);
-        assert_eq!(admit.can_run[0].materialized_tokens, 8);
+        assert_eq!(admit.scheduled_prefills.len(), 1);
+        assert_eq!(admit.scheduled_prefills[0].request.materialized_tokens, 8);
     }
 
     #[test]
@@ -1100,8 +1100,8 @@ mod core_behavior {
         ]);
 
         let admit = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[]);
-        assert_eq!(admit.can_run.len(), 1);
-        assert_eq!(admit.can_run[0].uuid, first_uuid);
+        assert_eq!(admit.scheduled_prefills.len(), 1);
+        assert_eq!(admit.scheduled_prefills[0].request.uuid, first_uuid);
         assert_eq!(waiting.len(), 1);
         assert_eq!(waiting[0].uuid, second_uuid);
     }
@@ -1691,13 +1691,22 @@ mod router_events {
         }]);
 
         let chunk1 = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[]);
-        let mut req1 = chunk1.can_run.into_iter().next().unwrap();
+        let mut req1 = chunk1
+            .scheduled_prefills
+            .into_iter()
+            .next()
+            .unwrap()
+            .request;
         decode::cache_materialized_prefix(&mut req1, &mut kv_manager, &config);
         waiting.push_front(req1);
         harness.apply_events(buffer.drain()).await;
 
         let chunk2 = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[]);
-        let mut running = chunk2.can_run;
+        let mut running = chunk2
+            .scheduled_prefills
+            .into_iter()
+            .map(|scheduled| scheduled.request)
+            .collect::<Vec<_>>();
         let decode1 = simulate_decode_step(&mut running, &mut kv_manager, &config, 0.0, false);
         assert_eq!(decode1.output_signals.len(), 1);
         harness.apply_events(buffer.drain()).await;
@@ -1717,7 +1726,11 @@ mod router_events {
         loop {
             let admit =
                 get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &running);
-            for mut req in admit.can_run {
+            for mut req in admit
+                .scheduled_prefills
+                .into_iter()
+                .map(|scheduled| scheduled.request)
+            {
                 if req.materialized_tokens < req.current_sequence_len() {
                     decode::cache_materialized_prefix(&mut req, &mut kv_manager, &config);
                     waiting.push_front(req);

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -11,6 +11,10 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::common::handoff::HandoffId;
+use crate::common::perf_model::{
+    ReplayDecodeInput, ReplayDecodeLatencyModel, ReplayPrefillInput, ReplayPrefillLatencyModel,
+    replay_latency_duration, scale_replay_duration,
+};
 use crate::common::protocols::{
     DirectRequest, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal, PreemptionMode,
     PrefillCost, WorkerType,
@@ -1319,9 +1323,6 @@ impl VllmCore {
                 .len()
                 .saturating_add(self.state.waiting.len().min(16)),
         );
-        let mut batch_count = 0usize;
-        let mut batch_total_isl = 0usize;
-        let mut batch_total_prefix = 0usize;
         let mut admissions = Vec::with_capacity(self.state.waiting.len().min(16));
         let mut preempted_any = false;
 
@@ -1334,9 +1335,6 @@ impl VllmCore {
                 None,
                 &mut token_budget,
                 &mut scheduled,
-                &mut batch_count,
-                &mut batch_total_isl,
-                &mut batch_total_prefix,
                 &mut preempted_any,
             ) {
                 ScheduleOutcome::Scheduled { admission, .. } => {
@@ -1455,9 +1453,6 @@ impl VllmCore {
                 Some(&prefill_cost),
                 &mut token_budget,
                 &mut scheduled,
-                &mut batch_count,
-                &mut batch_total_isl,
-                &mut batch_total_prefix,
                 &mut preempted_any,
             ) {
                 ScheduleOutcome::Scheduled {
@@ -1485,8 +1480,19 @@ impl VllmCore {
             }
         }
 
-        let prefill_time =
-            predict_prefill_duration(batch_count, batch_total_isl, batch_total_prefix, &self.args);
+        let (prefill_sequence_lengths, prefill_prefix_lengths): (Vec<_>, Vec<_>) = self
+            .state
+            .running
+            .iter()
+            .filter_map(|uuid| scheduled.get(uuid))
+            .filter(|work| work.prompt_tokens > 0)
+            .map(|work| (work.prefix_tokens + work.prompt_tokens, work.prefix_tokens))
+            .unzip();
+        let prefill_time = predict_prefill_duration(
+            &prefill_sequence_lengths,
+            &prefill_prefix_lengths,
+            &self.args,
+        );
         let decode_start_ms = now_ms + prefill_time.as_secs_f64() * 1000.0;
         let (decode_time, mut output_signals) = self.emit_ready_tokens(collector, decode_start_ms);
         // Emit the terminal signals for the requests the gate rejected above
@@ -1701,7 +1707,6 @@ impl VllmCore {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     #[cfg_attr(feature = "profile", inline(never))]
     fn schedule_request(
         &mut self,
@@ -1710,9 +1715,6 @@ impl VllmCore {
         prefill_cost: Option<&PrefillCost>,
         token_budget: &mut usize,
         scheduled: &mut FxHashMap<Uuid, ScheduledWork>,
-        batch_count: &mut usize,
-        batch_total_isl: &mut usize,
-        batch_total_prefix: &mut usize,
         preempted_any: &mut bool,
     ) -> ScheduleOutcome {
         let request = self
@@ -1834,12 +1836,6 @@ impl VllmCore {
             *preempted_any = true;
             if let Some(undone) = scheduled.remove(&preempted.uuid) {
                 *token_budget += undone.total_tokens;
-                if undone.prompt_tokens > 0 && self.args.worker_type != WorkerType::Decode {
-                    *batch_count = batch_count.saturating_sub(1);
-                    *batch_total_isl =
-                        batch_total_isl.saturating_sub(undone.prefix_tokens + undone.prompt_tokens);
-                    *batch_total_prefix = batch_total_prefix.saturating_sub(undone.prefix_tokens);
-                }
             }
             if preempted.uuid == uuid {
                 return ScheduleOutcome::CurrentPreempted;
@@ -1872,12 +1868,6 @@ impl VllmCore {
                 sequence_len,
             },
         );
-        if prompt_tokens > 0 && self.args.worker_type != WorkerType::Decode {
-            *batch_count += 1;
-            *batch_total_isl += prompt_before + prompt_tokens;
-            *batch_total_prefix += prompt_before;
-        }
-
         if from_waiting {
             self.state.transition_to_running(uuid);
         }
@@ -1904,7 +1894,7 @@ impl VllmCore {
         decode_start_ms: f64,
     ) -> (Duration, Vec<OutputSignal>) {
         let mut ready = Vec::with_capacity(self.state.running.len());
-        let mut total_length = 0usize;
+        let mut sequence_lengths = Vec::with_capacity(self.state.running.len());
         for uuid in self.state.running.iter().copied() {
             let Some(request) = self.state.requests.get(&uuid) else {
                 continue;
@@ -1915,7 +1905,7 @@ impl VllmCore {
                 continue;
             }
             ready.push(uuid);
-            total_length += request.sequence.len();
+            sequence_lengths.push(request.sequence.len());
         }
         if ready.is_empty() {
             return (Duration::ZERO, Vec::new());
@@ -1932,13 +1922,12 @@ impl VllmCore {
         } else {
             let active_kv_tokens = self.kv_manager.num_active_blocks() * self.args.block_size;
             let total_kv_tokens = self.args.num_gpu_blocks * self.args.block_size;
-            let context_length = total_length / ready.len();
-            let decode_ms = self.args.perf_model.predict_decode_time(
-                ready.len(),
+            let decode_ms = self.args.perf_model.decode_latency_ms(ReplayDecodeInput {
+                sequence_lengths: &sequence_lengths,
                 active_kv_tokens,
-                context_length,
                 total_kv_tokens,
-            );
+                output_length: 1,
+            });
             let dt = scale_decode_time(decode_ms, &self.args);
             (dt, decode_start_ms + dt.as_secs_f64() * 1000.0)
         };
@@ -2161,11 +2150,11 @@ impl VllmCore {
             }
         };
 
-        let total_length = ready
+        let sequence_lengths = ready
             .iter()
             .filter_map(|uuid| self.state.requests.get(uuid))
             .map(|request| request.sequence.len())
-            .sum::<usize>();
+            .collect::<Vec<_>>();
         let (decode_time, decode_end_ms) = if self.args.worker_type == WorkerType::Prefill {
             (Duration::ZERO, decode_start_ms)
         } else {
@@ -2175,13 +2164,12 @@ impl VllmCore {
                 .saturating_sub(reservation.len())
                 * self.args.block_size;
             let total_kv_tokens = self.args.num_gpu_blocks * self.args.block_size;
-            let context_length = total_length / ready.len();
-            let decode_ms = self.args.perf_model.predict_decode_time(
-                ready.len(),
+            let decode_ms = self.args.perf_model.decode_latency_ms(ReplayDecodeInput {
+                sequence_lengths: &sequence_lengths,
                 active_kv_tokens,
-                context_length,
                 total_kv_tokens,
-            );
+                output_length: max_burst,
+            });
             let duration = scale_decode_time(decode_ms, &self.args);
             (duration, decode_start_ms + duration.as_secs_f64() * 1000.0)
         };
@@ -2314,34 +2302,25 @@ impl VllmCore {
 }
 
 fn predict_prefill_duration(
-    batch_count: usize,
-    batch_total_isl: usize,
-    batch_total_prefix: usize,
+    sequence_lengths: &[usize],
+    prefix_lengths: &[usize],
     args: &MockEngineArgs,
 ) -> Duration {
-    if batch_count == 0 || args.worker_type == WorkerType::Decode {
+    if sequence_lengths.is_empty() || args.worker_type == WorkerType::Decode {
         return Duration::ZERO;
     }
 
-    let mean_isl = batch_total_isl / batch_count;
-    let mean_prefix = batch_total_prefix / batch_count;
-    let prefill_ms = args
-        .perf_model
-        .predict_prefill_time(batch_count, mean_isl, mean_prefix);
-    let total_time = Duration::from_secs_f64(prefill_ms / 1000.0);
-    if args.speedup_ratio <= 0.0 || total_time <= Duration::ZERO {
-        return total_time;
-    }
-    Duration::from_secs_f64(total_time.as_secs_f64() / args.speedup_ratio)
+    let input = ReplayPrefillInput::new(sequence_lengths, prefix_lengths)
+        .expect("scheduled prefill shape must be valid");
+    let total_time =
+        replay_latency_duration(args.perf_model.prefill_latency_ms(input), 0.0, "prefill");
+    scale_replay_duration(total_time, args.speedup_ratio, "prefill")
 }
 
 fn scale_decode_time(decode_ms: f64, args: &MockEngineArgs) -> Duration {
-    let unscaled = Duration::from_secs_f64(decode_ms / 1000.0);
+    let unscaled = replay_latency_duration(decode_ms, 1.0, "decode");
     let effective_ratio = args.speedup_ratio * args.decode_speedup_ratio;
-    if effective_ratio <= 0.0 || unscaled <= Duration::ZERO {
-        return unscaled;
-    }
-    Duration::from_secs_f64(unscaled.as_secs_f64() / effective_ratio)
+    scale_replay_duration(unscaled, effective_ratio, "decode")
 }
 
 fn split_terminal_effects(signals: Vec<MoveBlock>) -> VllmTerminalEffects {


### PR DESCRIPTION
## Summary

- Add native prefill and decode latency traits for in-process Rust replay integrations.
- Preserve exact ordered request lengths, cached-prefix lengths, KV occupancy, and speculative decode width.
- Keep the existing replay APIs and worker/runtime types unchanged by adapting native models through `MockEngineArgs.perf_model`.
- Make each SGLang scheduled-prefill record the source for timing, admissions, queue transitions, cache metrics, and FPM data.

The previous generic implementation touched 21 files and 4,783 lines. This replacement touches 7 files and 909 lines, an 81% reduction in review surface.

## Design

`PerfModel::Custom` stores independent `ReplayPrefillLatencyModel` and `ReplayDecodeLatencyModel` trait objects. Applications using one combined model can construct it with `PerfModel::from_replay_latency_model`; applications with separate phase models can use `PerfModel::from_replay_latency_models`.

The existing vLLM and SGLang scheduler implementations build `ReplayPrefillInput` and `ReplayDecodeInput` directly from each forward pass. Polynomial, interpolation, and AIC variants derive their legacy aggregate inputs from those exact slices, preserving existing Dynamo behavior. Existing free replay functions remain the only execution path, and scaled workers inherit the model through the existing cloned `MockEngineArgs`.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p dynamo-mocker --all-features`
- `cargo clippy -p dynamo-mocker --lib -- -D warnings`
- `cargo test -p dynamo-mocker --lib common::perf_model::tests` (12 passed)
- `cargo test -p dynamo-mocker --lib replay::tests::replay_preserves` (2 passed, vLLM and SGLang)
- `cargo check` in `lib/bindings/python`

The full Dynamo library run completed 496 tests successfully; 8 unrelated bootstrap socket tests cannot bind in the local sandbox (`EPERM`). The all-target/all-feature clippy invocation reaches existing warnings in untouched upstream files; default-feature library clippy passes with warnings denied.
