### PR TITLE
feat(sglang): upload partial metadata on cancellation

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 import time
+from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 import sglang as sgl
@@ -131,6 +132,98 @@ def _extract_sglang_stop_reason(
         return matched
 
     return None
+
+
+_CANCELLED_METADATA_UPLOAD_TIMEOUT_SECONDS = 10.0
+
+
+class _MetadataUploadTracker:
+    """Own the latest cumulative SGLang metadata snapshot for each choice."""
+
+    def __init__(self, uploader: MetadataUploader | None) -> None:
+        self._uploader = uploader
+        self._latest: dict[int, dict[str, Any]] = {}
+
+    def retain(self, choice_index: int, metadata: dict[str, Any]) -> None:
+        if self._uploader is None:
+            return
+
+        previous = self._latest.get(choice_index)
+        if previous is metadata:
+            return
+        if previous is not None:
+            for key, value in previous.items():
+                metadata.setdefault(key, value)
+            previous.clear()
+        self._latest[choice_index] = metadata
+
+    async def upload_terminal(self, choice_index: int) -> None:
+        if self._uploader is None:
+            return
+        metadata = self._latest.get(choice_index)
+        if metadata is None:
+            return
+        try:
+            await self._uploader.upload_choice(choice_index, metadata)
+        except asyncio.CancelledError:
+            # Keep the snapshot so the cancellation finalizer can retry it
+            # with an abort finish reason.
+            raise
+        except Exception:
+            self._latest.pop(choice_index, None)
+            metadata.clear()
+            raise
+        else:
+            self._latest.pop(choice_index, None)
+            metadata.clear()
+
+    async def upload_cancelled(self) -> None:
+        if self._uploader is None:
+            return
+
+        for choice_index, metadata in list(self._latest.items()):
+            metadata["finish_reason"] = {"type": "abort"}
+            try:
+                await asyncio.wait_for(
+                    self._uploader.upload_choice(choice_index, metadata),
+                    timeout=_CANCELLED_METADATA_UPLOAD_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logging.error(
+                    "Timed out uploading cancelled metadata for choice %d",
+                    choice_index,
+                )
+            except Exception:
+                logging.exception(
+                    "Failed to upload cancelled metadata for choice %d",
+                    choice_index,
+                )
+            finally:
+                metadata.clear()
+                self._latest.pop(choice_index, None)
+
+    def clear(self) -> None:
+        for metadata in self._latest.values():
+            metadata.clear()
+        self._latest.clear()
+
+
+@asynccontextmanager
+async def _metadata_upload_lifecycle(
+    tracker: _MetadataUploadTracker, context: Context
+) -> AsyncGenerator[None, None]:
+    cancelled = False
+    try:
+        yield
+    except (asyncio.CancelledError, GeneratorExit):
+        cancelled = True
+        raise
+    finally:
+        try:
+            if cancelled or context.is_stopped():
+                await tracker.upload_cancelled()
+        finally:
+            tracker.clear()
 
 
 class DecodeWorkerHandler(BaseWorkerHandler):
@@ -510,7 +603,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # With n>1, chunks for different choices are interleaved, so track the
         # cumulative-logprob cursor per choice index instead of globally.
         output_logprobs_per_choice: dict[int, int] = {}
-        async with self._cancellation_monitor(request_id_future, context):
+        metadata_tracker = _MetadataUploadTracker(metadata_uploader)
+        async with (
+            self._cancellation_monitor(request_id_future, context),
+            _metadata_upload_lifecycle(metadata_tracker, context),
+        ):
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
                 # Extract SGLang request ID from the first response and set the future
@@ -527,6 +624,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # SGLang omits index for non-n/legacy chunks; treat those as
                 # choice 0 while preserving explicit indices for n>1.
                 output_idx = res.get("index") or 0
+                metadata_tracker.retain(output_idx, meta_info)
 
                 out: dict[str, Any] = {"index": output_idx}
                 finish_reason = meta_info["finish_reason"]
@@ -589,12 +687,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         "prompt_tokens_details": prefill_prompt_tokens_details,
                     }
                     if metadata_uploader is not None:
-                        try:
-                            await metadata_uploader.upload_choice(output_idx, meta_info)
-                        finally:
-                            meta_info.clear()
-                elif metadata_uploader is not None:
-                    meta_info.clear()
+                        await metadata_tracker.upload_terminal(output_idx)
                 if not context.is_stopped():
                     yield out
 
@@ -623,7 +716,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         # Use Future pattern for request ID - will be set when first response arrives
         request_id_future: asyncio.Future[str] = asyncio.Future()
-        async with self._cancellation_monitor(request_id_future, context):
+        metadata_tracker = _MetadataUploadTracker(metadata_uploader)
+        async with (
+            self._cancellation_monitor(request_id_future, context),
+            _metadata_upload_lifecycle(metadata_tracker, context),
+        ):
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
                 # Extract SGLang request ID from the first response and set the future
@@ -640,6 +737,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
                 # Same defaulting as token mode: non-n chunks are choice 0.
                 index = res.get("index") or 0
+                metadata_tracker.retain(index, meta_info)
 
                 text = res.get("text", "")
 
@@ -679,12 +777,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     # sglang >= 0.5.11 base64-encodes routed_experts upstream.
                     response_nvext["routed_experts"] = routed_experts
                 if finish_reason and metadata_uploader is not None:
-                    try:
-                        await metadata_uploader.upload_choice(index, meta_info)
-                    finally:
-                        meta_info.clear()
-                elif metadata_uploader is not None:
-                    meta_info.clear()
+                    await metadata_tracker.upload_terminal(index)
                 if response_nvext:
                     response["nvext"] = response_nvext
                 if not context.is_stopped():

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -620,13 +620,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             Dict with token_ids and optional finish_reason.
         """
         if metadata_uploader is not None:
-            async for out in self._process_token_stream_with_metadata(
+            async for chunk in self._process_token_stream_with_metadata(
                 stream_source,
                 context,
                 metadata_uploader,
                 user_stop_token_ids=user_stop_token_ids,
             ):
-                yield out
+                yield chunk
             return
 
         # Use Future pattern for request ID - will be set when first response arrives

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -138,91 +138,114 @@ _CANCELLED_METADATA_UPLOAD_TIMEOUT_SECONDS = 10.0
 
 
 class _MetadataUploadTracker:
-    """Own the latest cumulative SGLang metadata snapshot for each choice."""
-
-    def __init__(self, uploader: MetadataUploader | None) -> None:
+    def __init__(self, uploader: MetadataUploader) -> None:
         self._uploader = uploader
-        self._latest: dict[int, dict[str, Any]] = {}
+        self._choice_index: int | None = None
+        self._metadata: dict[str, Any] | None = None
+        self._upload_task: asyncio.Task[None] | None = None
 
-    def retain(self, choice_index: int, metadata: dict[str, Any]) -> None:
-        if self._uploader is None:
-            return
+    def retain(self, choice_index: int, metadata: dict[str, Any]) -> dict[str, Any]:
+        if self._choice_index not in (None, choice_index):
+            raise RuntimeError("SGLang metadata upload supports only one choice")
 
-        previous = self._latest.get(choice_index)
+        previous = self._metadata
         if previous is metadata:
-            return
+            return metadata
         if previous is not None:
             for key, value in previous.items():
                 metadata.setdefault(key, value)
             previous.clear()
-        self._latest[choice_index] = metadata
+        self._choice_index = choice_index
+        self._metadata = metadata
+        return metadata
 
-    async def upload_terminal(self, choice_index: int) -> None:
-        if self._uploader is None:
+    async def upload_terminal(self) -> None:
+        if self._metadata is None or self._choice_index is None:
             return
-        metadata = self._latest.get(choice_index)
-        if metadata is None:
-            return
+        self._upload_task = asyncio.create_task(
+            self._uploader.upload_choice(self._choice_index, self._metadata)
+        )
         try:
-            await self._uploader.upload_choice(choice_index, metadata)
+            await asyncio.shield(self._upload_task)
         except asyncio.CancelledError:
-            # Keep the snapshot so the cancellation finalizer can retry it
-            # with an abort finish reason.
             raise
         except Exception:
-            self._latest.pop(choice_index, None)
-            metadata.clear()
+            self.clear()
             raise
         else:
-            self._latest.pop(choice_index, None)
-            metadata.clear()
+            self.clear()
 
     async def upload_cancelled(self) -> None:
-        if self._uploader is None:
+        if self._metadata is None or self._choice_index is None:
             return
 
-        for choice_index, metadata in list(self._latest.items()):
+        metadata = self._metadata
+        choice_index = self._choice_index
+        previous_upload = self._upload_task
+
+        async def replace_with_abort() -> None:
+            if previous_upload is not None:
+                try:
+                    await asyncio.shield(previous_upload)
+                except Exception:
+                    pass
             metadata["finish_reason"] = {"type": "abort"}
-            try:
-                await asyncio.wait_for(
-                    self._uploader.upload_choice(choice_index, metadata),
-                    timeout=_CANCELLED_METADATA_UPLOAD_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-                logging.error(
-                    "Timed out uploading cancelled metadata for choice %d",
-                    choice_index,
-                )
-            except Exception:
-                logging.exception(
-                    "Failed to upload cancelled metadata for choice %d",
-                    choice_index,
-                )
-            finally:
-                metadata.clear()
-                self._latest.pop(choice_index, None)
+            await self._uploader.upload_choice(choice_index, metadata)
+
+        self._upload_task = asyncio.create_task(replace_with_abort())
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self._upload_task),
+                timeout=_CANCELLED_METADATA_UPLOAD_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logging.error(
+                "Timed out uploading cancelled metadata for choice %d",
+                choice_index,
+            )
+            tasks = {self._upload_task}
+            if previous_upload is not None:
+                tasks.add(previous_upload)
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            # A cancelled to_thread call may still be serializing this dict.
+            # Drop tracker ownership without mutating the in-flight snapshot.
+            self._release()
+        except Exception:
+            logging.exception(
+                "Failed to upload cancelled metadata for choice %d",
+                choice_index,
+            )
+            self.clear()
+        else:
+            self.clear()
 
     def clear(self) -> None:
-        for metadata in self._latest.values():
-            metadata.clear()
-        self._latest.clear()
+        if self._metadata is not None:
+            self._metadata.clear()
+        self._release()
+
+    def _release(self) -> None:
+        self._choice_index = None
+        self._metadata = None
+        self._upload_task = None
 
 
 @asynccontextmanager
 async def _metadata_upload_lifecycle(
     tracker: _MetadataUploadTracker, context: Context
 ) -> AsyncGenerator[None, None]:
-    cancelled = False
+    is_cancelled = False
     try:
         yield
     except (asyncio.CancelledError, GeneratorExit):
-        cancelled = True
+        is_cancelled = True
         raise
     finally:
-        try:
-            if cancelled or context.is_stopped():
-                await tracker.upload_cancelled()
-        finally:
+        if is_cancelled or context.is_stopped():
+            await tracker.upload_cancelled()
+        else:
             tracker.clear()
 
 
@@ -596,6 +619,16 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         Yields:
             Dict with token_ids and optional finish_reason.
         """
+        if metadata_uploader is not None:
+            async for out in self._process_token_stream_with_metadata(
+                stream_source,
+                context,
+                metadata_uploader,
+                user_stop_token_ids=user_stop_token_ids,
+            ):
+                yield out
+            return
+
         # Use Future pattern for request ID - will be set when first response arrives
         request_id_future: asyncio.Future[str] = asyncio.Future()
         # SGLang's token stream is asymmetric: output_ids are disjoint deltas
@@ -603,11 +636,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # With n>1, chunks for different choices are interleaved, so track the
         # cumulative-logprob cursor per choice index instead of globally.
         output_logprobs_per_choice: dict[int, int] = {}
-        metadata_tracker = _MetadataUploadTracker(metadata_uploader)
-        async with (
-            self._cancellation_monitor(request_id_future, context),
-            _metadata_upload_lifecycle(metadata_tracker, context),
-        ):
+        async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
                 # Extract SGLang request ID from the first response and set the future
@@ -624,7 +653,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # SGLang omits index for non-n/legacy chunks; treat those as
                 # choice 0 while preserving explicit indices for n>1.
                 output_idx = res.get("index") or 0
-                metadata_tracker.retain(output_idx, meta_info)
 
                 out: dict[str, Any] = {"index": output_idx}
                 finish_reason = meta_info["finish_reason"]
@@ -650,25 +678,24 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # Pass through disjoint token segments directly
                 out["token_ids"] = output_ids
 
-                if metadata_uploader is None:
-                    # Extract logprobs for new tokens if available
-                    (
-                        log_probs,
-                        top_logprobs,
-                        next_logprobs_total,
-                    ) = self._extract_logprobs(
-                        meta_info,
-                        output_logprobs_per_choice.get(output_idx, 0),
-                        return_tokens_as_token_ids=return_tokens_as_token_ids,
-                    )
-                    output_logprobs_per_choice[output_idx] = next_logprobs_total
-                    if log_probs is not None:
-                        out["log_probs"] = log_probs
-                    if top_logprobs is not None:
-                        out["top_logprobs"] = top_logprobs
+                # Extract logprobs for new tokens if available
+                (
+                    log_probs,
+                    top_logprobs,
+                    next_logprobs_total,
+                ) = self._extract_logprobs(
+                    meta_info,
+                    output_logprobs_per_choice.get(output_idx, 0),
+                    return_tokens_as_token_ids=return_tokens_as_token_ids,
+                )
+                output_logprobs_per_choice[output_idx] = next_logprobs_total
+                if log_probs is not None:
+                    out["log_probs"] = log_probs
+                if top_logprobs is not None:
+                    out["top_logprobs"] = top_logprobs
 
                 routed_experts = meta_info.get("routed_experts")
-                if routed_experts is not None and metadata_uploader is None:
+                if routed_experts is not None:
                     # sglang >= 0.5.11 base64-encodes routed_experts upstream. It rides
                     # the engine's opaque engine_data passthrough (surfaced by the frontend
                     # as nvext.routed_experts); disaggregated_params stays KV-transfer only.
@@ -686,8 +713,65 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         "total_tokens": input_tokens + completion_tokens,
                         "prompt_tokens_details": prefill_prompt_tokens_details,
                     }
-                    if metadata_uploader is not None:
-                        await metadata_tracker.upload_terminal(output_idx)
+                if not context.is_stopped():
+                    yield out
+
+    async def _process_token_stream_with_metadata(
+        self,
+        stream_source: AsyncGenerator[Dict[str, Any], None],
+        context: Context,
+        metadata_uploader: MetadataUploader,
+        user_stop_token_ids: set[int] | None = None,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        request_id_future: asyncio.Future[str] = asyncio.Future()
+        metadata_tracker = _MetadataUploadTracker(metadata_uploader)
+        async with (
+            self._cancellation_monitor(request_id_future, context),
+            _metadata_upload_lifecycle(metadata_tracker, context),
+        ):
+            async for res in stream_source:
+                meta_info = res.get("meta_info", {})
+                if not request_id_future.done():
+                    sglang_request_id = meta_info.get("id")
+                    if sglang_request_id:
+                        request_id_future.set_result(sglang_request_id)
+                        logging.debug(f"New SGLang Request ID: {sglang_request_id}")
+
+                output_idx = res.get("index") or 0
+                meta_info = metadata_tracker.retain(output_idx, meta_info)
+                out: dict[str, Any] = {"index": output_idx}
+                finish_reason = meta_info["finish_reason"]
+                if finish_reason:
+                    out["finish_reason"] = normalize_finish_reason(
+                        finish_reason["type"]
+                    )
+                    stop_reason = _extract_sglang_stop_reason(
+                        finish_reason, user_stop_token_ids
+                    )
+                    if stop_reason is not None:
+                        out["stop_reason"] = stop_reason
+
+                output_ids = res.get("output_ids", [])
+                if not output_ids and not finish_reason:
+                    if context.is_stopped():
+                        break
+                    continue
+
+                out["token_ids"] = output_ids
+                if finish_reason:
+                    input_tokens = meta_info["prompt_tokens"]
+                    completion_tokens = meta_info["completion_tokens"]
+                    cached_tokens = meta_info["cached_tokens"]
+                    prefill_prompt_tokens_details = None
+                    if cached_tokens is not None and cached_tokens > 0:
+                        prefill_prompt_tokens_details = {"cached_tokens": cached_tokens}
+                    out["completion_usage"] = {
+                        "prompt_tokens": input_tokens,
+                        "completion_tokens": completion_tokens,
+                        "total_tokens": input_tokens + completion_tokens,
+                        "prompt_tokens_details": prefill_prompt_tokens_details,
+                    }
+                    await metadata_tracker.upload_terminal()
                 if not context.is_stopped():
                     yield out
 
@@ -716,11 +800,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         # Use Future pattern for request ID - will be set when first response arrives
         request_id_future: asyncio.Future[str] = asyncio.Future()
-        metadata_tracker = _MetadataUploadTracker(metadata_uploader)
-        async with (
-            self._cancellation_monitor(request_id_future, context),
-            _metadata_upload_lifecycle(metadata_tracker, context),
-        ):
+        async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
                 # Extract SGLang request ID from the first response and set the future
@@ -737,7 +817,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
                 # Same defaulting as token mode: non-n chunks are choice 0.
                 index = res.get("index") or 0
-                metadata_tracker.retain(index, meta_info)
 
                 text = res.get("text", "")
 
@@ -777,7 +856,12 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     # sglang >= 0.5.11 base64-encodes routed_experts upstream.
                     response_nvext["routed_experts"] = routed_experts
                 if finish_reason and metadata_uploader is not None:
-                    await metadata_tracker.upload_terminal(index)
+                    try:
+                        await metadata_uploader.upload_choice(index, meta_info)
+                    finally:
+                        meta_info.clear()
+                elif metadata_uploader is not None:
+                    meta_info.clear()
                 if response_nvext:
                     response["nvext"] = response_nvext
                 if not context.is_stopped():

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
@@ -468,6 +469,108 @@ async def test_process_token_stream_tracks_logprobs_per_choice_index():
     assert [chunk["index"] for chunk in chunks] == [0, 1, 0]
     assert [chunk["token_ids"] for chunk in chunks] == [[101], [201], [102]]
     assert [chunk["log_probs"] for chunk in chunks] == [[-0.1], [-0.2], [-0.3]]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_uploads_latest_metadata_when_cancelled(tmp_path):
+    handler = _new_decode_handler()
+    uploader = MetadataUploader(url=(tmp_path / "metadata/cancelled").as_uri())
+    stream_blocked = asyncio.Event()
+    never_finish = asyncio.Event()
+    latest_meta_info = {
+        "id": "sglang-cancelled",
+        "finish_reason": None,
+        "output_token_logprobs": [(-0.1, 101, "a")],
+        "routed_experts": b"partial-experts",
+        "weight_version": "policy-v7",
+        "prompt_tokens": 2,
+        "completion_tokens": 1,
+        "cached_tokens": 0,
+    }
+
+    async def cancellable_stream():
+        yield {
+            "index": 0,
+            "output_ids": [101],
+            "meta_info": latest_meta_info,
+        }
+        stream_blocked.set()
+        await never_finish.wait()
+
+    collect_task = asyncio.create_task(
+        _collect(
+            handler._process_token_stream(
+                cancellable_stream(),
+                _Context(),
+                metadata_uploader=uploader,
+            )
+        )
+    )
+    await asyncio.wait_for(stream_blocked.wait(), timeout=1)
+    collect_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await collect_task
+
+    payload = _read_zstd_payload(tmp_path / "metadata/cancelled/choice_0.msgpack.zst")
+    assert payload["metadata"]["finish_reason"] == {"type": "abort"}
+    assert payload["metadata"]["output_token_logprobs"] == [[-0.1, 101, "a"]]
+    assert payload["metadata"]["routed_experts"] == b"partial-experts"
+    assert payload["metadata"]["weight_version"] == "policy-v7"
+    assert payload["metadata"]["completion_tokens"] == 1
+    assert latest_meta_info == {}
+
+
+@pytest.mark.asyncio
+async def test_terminal_upload_cancel_retries_as_aborted_metadata():
+    handler = _new_decode_handler()
+
+    class BlockingUploader:
+        def __init__(self):
+            self.calls = 0
+            self.first_upload_started = asyncio.Event()
+            self.never_finish = asyncio.Event()
+            self.uploaded_metadata = None
+
+        async def upload_choice(self, choice_index, metadata):
+            self.calls += 1
+            if self.calls == 1:
+                self.first_upload_started.set()
+                await self.never_finish.wait()
+            self.uploaded_metadata = dict(metadata)
+
+    uploader = BlockingUploader()
+    collect_task = asyncio.create_task(
+        _collect(
+            handler._process_token_stream(
+                _stream(
+                    [
+                        {
+                            "index": 0,
+                            "output_ids": [101],
+                            "meta_info": {
+                                "id": "sglang-terminal-cancel",
+                                "finish_reason": {"type": "stop"},
+                                "output_token_logprobs": [(-0.1, 101, "a")],
+                                "prompt_tokens": 2,
+                                "completion_tokens": 1,
+                                "cached_tokens": 0,
+                            },
+                        }
+                    ]
+                ),
+                _Context(),
+                metadata_uploader=uploader,
+            )
+        )
+    )
+    await asyncio.wait_for(uploader.first_upload_started.wait(), timeout=1)
+    collect_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await collect_task
+
+    assert uploader.calls == 2
+    assert uploader.uploaded_metadata["finish_reason"] == {"type": "abort"}
+    assert uploader.uploaded_metadata["output_token_logprobs"] == [(-0.1, 101, "a")]
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -3,12 +3,14 @@
 
 import asyncio
 import json
+import threading
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import pytest
 
 from dynamo.common.metadata_upload import MetadataUploader
+from dynamo.sglang.request_handlers.llm import decode_handler as decode_handler_module
 from dynamo.sglang.request_handlers.llm.decode_handler import (
     DecodeWorkerHandler,
     _extract_sglang_stop_reason,
@@ -28,13 +30,27 @@ pytestmark = [
 ]
 
 
-def _read_zstd_payload(path):
+def _decode_zstd_payload(data):
+    import msgspec
     import zstandard as zstd
 
-    raw = zstd.ZstdDecompressor().decompress(path.read_bytes())
-    import msgspec
-
+    raw = zstd.ZstdDecompressor().decompress(data)
     return msgspec.msgpack.decode(raw)
+
+
+def _read_zstd_payload(path):
+    return _decode_zstd_payload(path.read_bytes())
+
+
+def _mock_memory_metadata_fs(monkeypatch):
+    fsspec = pytest.importorskip("fsspec")
+    memory_fs = fsspec.filesystem("memory")
+    memory_fs.store.clear()
+    monkeypatch.setattr(
+        "dynamo.common.storage.fsspec.filesystem",
+        lambda protocol, **kwargs: memory_fs,
+    )
+    return memory_fs
 
 
 def test_extract_media_urls_supports_string_and_wire_items():
@@ -472,6 +488,34 @@ async def test_process_token_stream_tracks_logprobs_per_choice_index():
 
 
 @pytest.mark.asyncio
+async def test_process_token_stream_without_s3_does_not_create_tracker(monkeypatch):
+    handler = _new_decode_handler()
+    meta_info = {
+        "id": "request-1",
+        "finish_reason": None,
+        "output_token_logprobs": [(-0.1, 101, "a")],
+        "routed_experts": b"expert-bytes",
+    }
+
+    def fail_if_constructed(*args, **kwargs):
+        raise AssertionError("metadata tracker constructed without an uploader")
+
+    monkeypatch.setattr(
+        decode_handler_module, "_MetadataUploadTracker", fail_if_constructed
+    )
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream([{"index": 0, "output_ids": [101], "meta_info": meta_info}]),
+            _Context(),
+        )
+    )
+
+    assert chunks[0]["log_probs"] == [-0.1]
+    assert chunks[0]["engine_data"] == {"routed_experts": b"expert-bytes"}
+    assert meta_info["output_token_logprobs"] == [(-0.1, 101, "a")]
+
+
+@pytest.mark.asyncio
 async def test_process_token_stream_uploads_latest_metadata_when_cancelled(tmp_path):
     handler = _new_decode_handler()
     uploader = MetadataUploader(url=(tmp_path / "metadata/cancelled").as_uri())
@@ -521,24 +565,28 @@ async def test_process_token_stream_uploads_latest_metadata_when_cancelled(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_terminal_upload_cancel_retries_as_aborted_metadata():
+async def test_terminal_upload_cancel_writes_abort_after_inflight_upload(monkeypatch):
     handler = _new_decode_handler()
+    memory_fs = _mock_memory_metadata_fs(monkeypatch)
+    original_pipe_file = memory_fs.pipe_file
+    first_write_started = threading.Event()
+    release_first_write = threading.Event()
+    second_write_started = threading.Event()
+    finish_reasons = []
 
-    class BlockingUploader:
-        def __init__(self):
-            self.calls = 0
-            self.first_upload_started = asyncio.Event()
-            self.never_finish = asyncio.Event()
-            self.uploaded_metadata = None
+    def controlled_pipe_file(path, data, **kwargs):
+        finish_reason = _decode_zstd_payload(data)["metadata"]["finish_reason"]
+        finish_reasons.append(finish_reason)
+        if len(finish_reasons) == 1:
+            first_write_started.set()
+            if not release_first_write.wait(timeout=5):
+                raise TimeoutError("test did not release first metadata write")
+        else:
+            second_write_started.set()
+        return original_pipe_file(path, data, **kwargs)
 
-        async def upload_choice(self, choice_index, metadata):
-            self.calls += 1
-            if self.calls == 1:
-                self.first_upload_started.set()
-                await self.never_finish.wait()
-            self.uploaded_metadata = dict(metadata)
-
-    uploader = BlockingUploader()
+    monkeypatch.setattr(memory_fs, "pipe_file", controlled_pipe_file)
+    uploader = MetadataUploader(url="memory://metadata-race")
     collect_task = asyncio.create_task(
         _collect(
             handler._process_token_stream(
@@ -563,14 +611,142 @@ async def test_terminal_upload_cancel_retries_as_aborted_metadata():
             )
         )
     )
-    await asyncio.wait_for(uploader.first_upload_started.wait(), timeout=1)
+    assert await asyncio.to_thread(first_write_started.wait, 1)
     collect_task.cancel()
+    await asyncio.sleep(0.05)
+    assert not second_write_started.is_set()
+
+    release_first_write.set()
     with pytest.raises(asyncio.CancelledError):
         await collect_task
 
-    assert uploader.calls == 2
-    assert uploader.uploaded_metadata["finish_reason"] == {"type": "abort"}
-    assert uploader.uploaded_metadata["output_token_logprobs"] == [(-0.1, 101, "a")]
+    assert finish_reasons == [{"type": "stop"}, {"type": "abort"}]
+    payload = _decode_zstd_payload(memory_fs.cat("metadata-race/choice_0.msgpack.zst"))
+    assert payload["metadata"]["finish_reason"] == {"type": "abort"}
+    assert payload["metadata"]["output_token_logprobs"] == [[-0.1, 101, "a"]]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_metadata_upload_failure_preserves_cancellation(
+    monkeypatch, caplog
+):
+    handler = _new_decode_handler()
+    memory_fs = _mock_memory_metadata_fs(monkeypatch)
+    stream_blocked = asyncio.Event()
+    never_finish = asyncio.Event()
+    latest_meta_info = {
+        "id": "sglang-cancelled",
+        "finish_reason": None,
+        "output_token_logprobs": [(-0.1, 101, "a")],
+    }
+
+    def failing_pipe_file(path, data, **kwargs):
+        raise OSError("injected metadata write failure")
+
+    monkeypatch.setattr(memory_fs, "pipe_file", failing_pipe_file)
+
+    async def cancellable_stream():
+        yield {
+            "index": 0,
+            "output_ids": [101],
+            "meta_info": latest_meta_info,
+        }
+        stream_blocked.set()
+        await never_finish.wait()
+
+    collect_task = asyncio.create_task(
+        _collect(
+            handler._process_token_stream(
+                cancellable_stream(),
+                _Context(),
+                metadata_uploader=MetadataUploader(url="memory://metadata-failure"),
+            )
+        )
+    )
+    await asyncio.wait_for(stream_blocked.wait(), timeout=1)
+    collect_task.cancel()
+    with caplog.at_level("ERROR"):
+        with pytest.raises(asyncio.CancelledError):
+            await collect_task
+
+    assert "Failed to upload cancelled metadata for choice 0" in caplog.text
+    assert "injected metadata write failure" in caplog.text
+    assert latest_meta_info == {}
+
+
+@pytest.mark.asyncio
+async def test_cancelled_metadata_upload_timeout_releases_tracker(monkeypatch, caplog):
+    handler = _new_decode_handler()
+    memory_fs = _mock_memory_metadata_fs(monkeypatch)
+    original_pipe_file = memory_fs.pipe_file
+    write_started = threading.Event()
+    release_write = threading.Event()
+    write_finished = threading.Event()
+    stream_blocked = asyncio.Event()
+    never_finish = asyncio.Event()
+    trackers = []
+    tracker_type = decode_handler_module._MetadataUploadTracker
+
+    class RecordingTracker(tracker_type):
+        def __init__(self, uploader):
+            super().__init__(uploader)
+            trackers.append(self)
+
+    def blocking_pipe_file(path, data, **kwargs):
+        write_started.set()
+        try:
+            if not release_write.wait(timeout=5):
+                raise TimeoutError("test did not release metadata write")
+            return original_pipe_file(path, data, **kwargs)
+        finally:
+            write_finished.set()
+
+    monkeypatch.setattr(
+        decode_handler_module, "_MetadataUploadTracker", RecordingTracker
+    )
+    monkeypatch.setattr(
+        decode_handler_module,
+        "_CANCELLED_METADATA_UPLOAD_TIMEOUT_SECONDS",
+        0.05,
+    )
+    monkeypatch.setattr(memory_fs, "pipe_file", blocking_pipe_file)
+
+    async def cancellable_stream():
+        yield {
+            "index": 0,
+            "output_ids": [101],
+            "meta_info": {
+                "id": "sglang-timeout",
+                "finish_reason": None,
+                "output_token_logprobs": [(-0.1, 101, "a")],
+            },
+        }
+        stream_blocked.set()
+        await never_finish.wait()
+
+    collect_task = asyncio.create_task(
+        _collect(
+            handler._process_token_stream(
+                cancellable_stream(),
+                _Context(),
+                metadata_uploader=MetadataUploader(url="memory://metadata-timeout"),
+            )
+        )
+    )
+    await asyncio.wait_for(stream_blocked.wait(), timeout=1)
+    collect_task.cancel()
+    try:
+        with caplog.at_level("ERROR"):
+            with pytest.raises(asyncio.CancelledError):
+                await collect_task
+        assert write_started.is_set()
+        assert "Timed out uploading cancelled metadata for choice 0" in caplog.text
+        assert len(trackers) == 1
+        assert trackers[0]._metadata is None
+        assert trackers[0]._upload_task is None
+    finally:
+        release_write.set()
+        assert await asyncio.to_thread(write_finished.wait, 1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Overview:

Preserve the latest cumulative SGLang token metadata when a streaming request is cancelled, then upload that partial metadata with `finish_reason.type = "abort"`.

This allows partial-rollout callers to recover generated-token logprobs, routed-expert information, weight versions, and token counts after disconnecting before the normal terminal chunk.

This remains a draft because the contribution guide requires an approved Contribution Request before review.

## Details:

- Keep the ordinary non-S3 token path on the existing implementation, with no metadata tracker or extra per-token allocation.
- Use a dedicated token/S3 path that retains one cumulative metadata object. The public SGLang frontend supports only `n=1`.
- Merge fields omitted by newer SGLang chunks from the previous metadata object.
- On cancellation, write the retained metadata with an abort finish reason.
- If cancellation races a terminal upload, wait for that write before replacing it with abort metadata so the stale terminal object cannot win.
- Bound cancellation cleanup to 10 seconds. On timeout, cancel Dynamo tasks and release tracker ownership without mutating metadata that an uncancellable `fsspec` worker thread may still be serializing.
- Preserve `CancelledError` when cancellation-time storage fails, while logging the upload failure.
- Leave the text streaming path unchanged; cancellation metadata is required for token-in/token-out RL requests.

## Validation:

- `pytest -q components/src/dynamo/sglang/tests/test_sglang_decode_handler.py` - 51 passed.
- `ruff check components/src/dynamo/sglang/request_handlers/llm/decode_handler.py components/src/dynamo/sglang/tests/test_sglang_decode_handler.py` - passed.
- Tests use an in-memory `fsspec` filesystem for terminal-write races, write failures, and bounded timeouts.
- GCP Dynamo + SGLang smoke test: cancelling a stateful `/v1/responses` request after the first streamed delta produced an S3 metadata object with an abort finish reason, 31 chosen-token logprobs, routed experts, and weight version metadata.
- Normal completion smoke test uploaded terminal metadata with 64 chosen-token logprobs, routed experts, and weight version metadata.

## Where should the reviewer start?

- `components/src/dynamo/sglang/request_handlers/llm/decode_handler.py`
  - `_MetadataUploadTracker`
  - `_metadata_upload_lifecycle`
  - `_process_token_stream_with_metadata`
- `components/src/dynamo/sglang/tests/test_sglang_decode_handler.py`
  - cancellation between chunks
  - cancellation racing an in-flight terminal write
  - storage failure and timeout handling
  - no-S3 path isolation

## Related Issues

**This PR is not linked to an issue**:
- [x] Confirmed - no related issue
