### PR TITLE
test: add Bulwark shadow-engine failover smoke test (vLLM, TP=2)

### DIFF
--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -10,6 +10,7 @@ import logging
 import os
 import sys
 from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
 
 import requests
@@ -24,6 +25,11 @@ from tests.utils.port_utils import allocate_ports, deallocate_ports
 logger = logging.getLogger(__name__)
 
 
+def _http_ok(response) -> bool:
+    """Readiness predicate: the endpoint answered with HTTP 200."""
+    return response.status_code == 200
+
+
 class GMSProcessManager:
     """Start the shared GMS daemons and frontend for one test scenario."""
 
@@ -34,29 +40,50 @@ class GMSProcessManager:
         *,
         read_only_weights: bool = False,
         tags: tuple[str, ...] = ("weights", "kv_cache"),
+        tp: int = 1,
+        model: str = FAULT_TOLERANCE_MODEL_NAME,
+        shadow: bool = False,
+        lock_path: str | None = None,
     ):
         self._request = request
         self._engine_cls = engine_cls
         self._read_only_weights = read_only_weights
         self._tags = tags
+        self._tp = tp
+        self._model = model
+        self._shadow = shadow
+        # Shadow engines coordinate active/standby through one shared flock.
+        self._lock_path = lock_path
         self._stack: ExitStack | None = None
         self.frontend_port: int | None = None
+        # Per-device GMS daemons. `weights_gms`/`kv_cache_gms` expose device 0
+        # as the representative server for single-GPU assertions; the *_by_device
+        # dicts hold every rank's server for TP>1.
         self.weights_gms = None
         self.kv_cache_gms = None
+        self.weights_gms_by_device: dict[int, GMSServer] = {}
+        self.kv_cache_gms_by_device: dict[int, GMSServer] = {}
         self._engine_ids: set[str] = set()
         self.engines: dict[str, GMSEngineProcess] = {}
+
+    @property
+    def lock_path(self) -> str | None:
+        return self._lock_path
 
     def __enter__(self):
         stack = ExitStack()
         try:
-            if "weights" in self._tags:
-                self.weights_gms = stack.enter_context(
-                    GMSServer(device=0, tag="weights")
-                )
-            if "kv_cache" in self._tags:
-                self.kv_cache_gms = stack.enter_context(
-                    GMSServer(device=0, tag="kv_cache")
-                )
+            for device in range(self._tp):
+                if "weights" in self._tags:
+                    self.weights_gms_by_device[device] = stack.enter_context(
+                        GMSServer(device=device, tag="weights")
+                    )
+                if "kv_cache" in self._tags:
+                    self.kv_cache_gms_by_device[device] = stack.enter_context(
+                        GMSServer(device=device, tag="kv_cache")
+                    )
+            self.weights_gms = self.weights_gms_by_device.get(0)
+            self.kv_cache_gms = self.kv_cache_gms_by_device.get(0)
             frontend = stack.enter_context(
                 DynamoFrontendProcess(
                     self._request,
@@ -78,6 +105,8 @@ class GMSProcessManager:
         self.frontend_port = None
         self.weights_gms = None
         self.kv_cache_gms = None
+        self.weights_gms_by_device.clear()
+        self.kv_cache_gms_by_device.clear()
         self._engine_ids.clear()
         self.engines.clear()
         if stack is None:
@@ -105,6 +134,10 @@ class GMSProcessManager:
             self.frontend_port,
             engine_id=engine_id,
             read_only_weights=read_only_weights,
+            tp=self._tp,
+            model=self._model,
+            shadow=self._shadow,
+            lock_path=self._lock_path,
         )
         self._engine_ids.add(engine_id)
         return engine
@@ -125,6 +158,52 @@ class GMSProcessManager:
         self.engines[engine_id] = engine
         return engine
 
+    def start_engines_concurrently(
+        self,
+        engine_ids: list[str],
+        *,
+        read_only_weights: bool | None = None,
+    ) -> dict[str, GMSEngineProcess]:
+        """Start several engines at once and block until all are ready.
+
+        Shadow engines race for the flock during startup, so they must come up
+        concurrently (sequential start would let the first always win the lock).
+        Each engine's context is still registered on the manager's ExitStack for
+        teardown. Re-raises the first startup failure after cleaning up.
+        """
+        if self._stack is None:
+            raise RuntimeError(
+                "GMSProcessManager must be entered before starting engines"
+            )
+        created = {
+            engine_id: self.create_engine(
+                engine_id, read_only_weights=read_only_weights
+            )
+            for engine_id in engine_ids
+        }
+        # Enter (start + health-gate) each engine in its own thread, but DON'T
+        # touch the shared ExitStack from those threads — ExitStack isn't
+        # thread-safe. Register cleanup single-threaded after the join.
+        with ThreadPoolExecutor(max_workers=len(created)) as executor:
+            futures = {
+                engine_id: executor.submit(engine.__enter__)
+                for engine_id, engine in created.items()
+            }
+            started: dict[str, GMSEngineProcess] = {}
+            errors = []
+            for engine_id, future in futures.items():
+                try:
+                    started[engine_id] = future.result()
+                except Exception as exc:  # noqa: BLE001 — surface after joining all
+                    errors.append((engine_id, exc))
+        for engine_id, engine in started.items():
+            self._stack.push(engine)
+            self.engines[engine_id] = engine
+        if errors:
+            engine_id, exc = errors[0]
+            raise RuntimeError(f"engine {engine_id!r} failed to start: {exc}") from exc
+        return {engine_id: self.engines[engine_id] for engine_id in engine_ids}
+
 
 class GMSEngineProcess(EngineProcess, ABC):
     """Backend process wrapper with a common pause/resume surface."""
@@ -141,11 +220,19 @@ class GMSEngineProcess(EngineProcess, ABC):
         reserved_ports: list[int],
         *,
         read_only_weights: bool = False,
+        tp: int = 1,
+        model: str = FAULT_TOLERANCE_MODEL_NAME,
+        shadow: bool = False,
+        lock_path: str | None = None,
     ):
         self.engine_id = engine_id
         self.system_port = system_port
         self._reserved_ports = reserved_ports
         self.read_only_weights = read_only_weights
+        self.tp = tp
+        self.model = model
+        self.shadow = shadow
+        self.lock_path = lock_path
 
         super().__init__(
             command=self.command(),
@@ -155,11 +242,20 @@ class GMSEngineProcess(EngineProcess, ABC):
                 "DYN_SYSTEM_PORT": str(system_port),
                 **self.env_updates(),
             },
-            health_check_urls=[
-                (f"http://localhost:{system_port}/health", self._is_ready),
-                (f"http://localhost:{frontend_port}/v1/models", check_models_api),
-                (f"http://localhost:{frontend_port}/health", check_health_generate),
-            ],
+            # Shadow engines auto-pause into STANDBY and never register a
+            # `generate` endpoint until they win the flock, so we can't gate on
+            # the frontend discovering them. Readiness = the engine's own system
+            # probe answering 200 (passes in both ACTIVE and STANDBY); the test
+            # then asserts active/standby via GMS state and frontend inference.
+            health_check_urls=(
+                [(f"http://localhost:{system_port}/health", _http_ok)]
+                if shadow
+                else [
+                    (f"http://localhost:{system_port}/health", self._is_ready),
+                    (f"http://localhost:{frontend_port}/v1/models", check_models_api),
+                    (f"http://localhost:{frontend_port}/health", check_health_generate),
+                ]
+            ),
             timeout=300,
             display_output=True,
             terminate_all_matching_process_names=False,
@@ -244,6 +340,10 @@ class VLLMWithGMSProcess(GMSEngineProcess):
         *,
         engine_id: str,
         read_only_weights: bool = False,
+        tp: int = 1,
+        model: str = FAULT_TOLERANCE_MODEL_NAME,
+        shadow: bool = False,
+        lock_path: str | None = None,
     ):
         reserved_ports = allocate_ports(3, DefaultPort.SYSTEM1.value)
         self.kv_event_port = reserved_ports[1]
@@ -256,13 +356,24 @@ class VLLMWithGMSProcess(GMSEngineProcess):
                 frontend_port,
                 reserved_ports,
                 read_only_weights=read_only_weights,
+                tp=tp,
+                model=model,
+                shadow=shadow,
+                lock_path=lock_path,
             )
         except Exception:
             deallocate_ports(reserved_ports)
             raise
 
     def env_updates(self) -> dict[str, str]:
-        return {"VLLM_NIXL_SIDE_CHANNEL_PORT": str(self.nixl_port)}
+        env = {"VLLM_NIXL_SIDE_CHANNEL_PORT": str(self.nixl_port)}
+        if self.shadow:
+            # ENGINE_ID=0 loads + commits weights (RW); others import (RO).
+            # The numeric suffix of "engine-N" drives RW/RO and the MX port offset.
+            env["ENGINE_ID"] = self.engine_id.rsplit("-", 1)[-1]
+            if self.lock_path is not None:
+                env["FAILOVER_LOCK_PATH"] = self.lock_path
+        return env
 
     def command(self) -> list[str]:
         kv_events_cfg = json.dumps(
@@ -278,18 +389,24 @@ class VLLMWithGMSProcess(GMSEngineProcess):
             "-m",
             "dynamo.vllm",
             "--model",
-            FAULT_TOLERANCE_MODEL_NAME,
+            self.model,
+            "--tensor-parallel-size",
+            str(self.tp),
             "--load-format",
             "gms",
             "--enforce-eager",
-            "--enable-sleep-mode",
-            "--max-num-seqs",
-            "1",
             "--gpu-memory-utilization",
             "0.8",
             "--kv-events-config",
             kv_events_cfg,
         ]
+        if self.shadow:
+            # Shadow engines auto-pause and auto-wake via the flock; sleep mode
+            # is implied by GMS shadow mode, so --enable-sleep-mode is omitted.
+            command.append("--gms-shadow-mode")
+        else:
+            command.append("--enable-sleep-mode")
+            command.extend(["--max-num-seqs", "1"])
         extra_config = self.model_loader_extra_config()
         if extra_config is not None:
             command.extend(
@@ -330,6 +447,10 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
         *,
         engine_id: str,
         read_only_weights: bool = False,
+        tp: int = 1,
+        model: str = FAULT_TOLERANCE_MODEL_NAME,
+        shadow: bool = False,
+        lock_path: str | None = None,
         override_engine_args: str | None = None,
     ):
         reserved_ports = allocate_ports(1, DefaultPort.SYSTEM1.value)
@@ -342,6 +463,10 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
                 frontend_port,
                 reserved_ports,
                 read_only_weights=read_only_weights,
+                tp=tp,
+                model=model,
+                shadow=shadow,
+                lock_path=lock_path,
             )
         except Exception:
             deallocate_ports(reserved_ports)
@@ -405,6 +530,10 @@ class SGLangWithGMSProcess(GMSEngineProcess):
         *,
         engine_id: str,
         read_only_weights: bool = False,
+        tp: int = 1,
+        model: str = FAULT_TOLERANCE_MODEL_NAME,
+        shadow: bool = False,
+        lock_path: str | None = None,
     ):
         reserved_ports = allocate_ports(2, DefaultPort.SYSTEM1.value)
         self.serve_port = reserved_ports[1]
@@ -416,6 +545,10 @@ class SGLangWithGMSProcess(GMSEngineProcess):
                 frontend_port,
                 reserved_ports,
                 read_only_weights=read_only_weights,
+                tp=tp,
+                model=model,
+                shadow=shadow,
+                lock_path=lock_path,
             )
         except Exception:
             deallocate_ports(reserved_ports)
@@ -427,7 +560,7 @@ class SGLangWithGMSProcess(GMSEngineProcess):
             "-m",
             "dynamo.sglang",
             "--model-path",
-            FAULT_TOLERANCE_MODEL_NAME,
+            self.model,
             "--load-format",
             "gms",
             "--enable-memory-saver",

--- a/tests/gpu_memory_service/test_shadow_failover_autonomous.py
+++ b/tests/gpu_memory_service/test_shadow_failover_autonomous.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Autonomous (flock-driven) shadow-engine failover — vLLM, TP>=1.
+
+Unlike the orchestrated variant (``test_shadow_failover_orchestrated.py``),
+nothing in this test resumes the standby. Two ``--gms-shadow-mode`` engines come
+up sharing one flock; one wins it and serves (ACTIVE), the other sleeps
+(STANDBY). When the ACTIVE is SIGKILLed the kernel releases its flock, and the
+STANDBY wakes *itself*, re-acquires the KV-cache RW layout, and resumes serving —
+with no HTTP ``wake_up`` call. Only vLLM supports this path today.
+
+Five stages, asserted on structured surfaces (GMS runtime state + frontend
+inference), not log scraping:
+  1. two engines initialize concurrently → steady state (1 ACTIVE, 1 STANDBY), no OOM
+  2. inference works before failover
+  3. SIGKILL the ACTIVE → the STANDBY auto-wakes via flock release (no HTTP resume)
+  4. inference works after failover
+  5. a fresh shadow can be added back (RO weight import → STANDBY), restoring redundancy
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+
+import pytest
+from gpu_memory_service.server.fsm import ServerState
+
+from tests.gpu_memory_service.common.runtime import (
+    GMSProcessManager,
+    VLLMWithGMSProcess,
+)
+from tests.gpu_memory_service.flow_assertions import assert_completion_ok
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.managed_process import ManagedProcess
+
+pytestmark = [pytest.mark.nightly, pytest.mark.fault_tolerance]
+
+logger = logging.getLogger(__name__)
+
+
+def _sigkill_process_group(process: ManagedProcess) -> None:
+    """SIGKILL the engine's whole process group — a hard crash, the failover
+    trigger we actually want to exercise (vs the orchestrated test's graceful path)."""
+    pid = process.get_pid()
+    if pid is None:
+        raise AssertionError("cannot SIGKILL engine: no PID available")
+    try:
+        os.killpg(os.getpgid(pid), signal.SIGKILL)
+    except ProcessLookupError:
+        logger.warning("process group for pid %d already gone", pid)
+        return
+    try:
+        os.waitpid(pid, 0)
+    except ChildProcessError:
+        pass
+
+
+def _flock_owner(lock_path: str) -> str | None:
+    """Read the failover flock's current owner ("engine-N"), or None.
+
+    The holder stamps its id into the lock file (see FlockFailoverLock); the
+    kernel hands the lock to the standby on the holder's death, which rewrites
+    this — so it's the source of truth for who is ACTIVE.
+    """
+    try:
+        with open(lock_path, "r") as f:
+            return f.read().strip() or None
+    except FileNotFoundError:
+        return None
+
+
+def _split_active_standby(
+    engines: dict[str, ManagedProcess], lock_path: str
+) -> tuple[str, ManagedProcess, ManagedProcess]:
+    owner = _flock_owner(lock_path)
+    assert (
+        owner in engines
+    ), f"flock owner {owner!r} is not a known engine {list(engines)}"
+    standby_ids = [eid for eid in engines if eid != owner]
+    assert len(standby_ids) == 1, f"expected exactly one standby, got {standby_ids}"
+    return owner, engines[owner], engines[standby_ids[0]]
+
+
+def _wait_for_active_kv(kv_cache_gms, *, timeout: float = 120.0):
+    """Poll until an ACTIVE engine holds the KV-cache RW layout.
+
+    KV-cache RW (with allocations) is the stable signal that an engine is live
+    and serving. We deliberately do NOT gate on a weights RO session: engines
+    import the committed weights and then drop the RO session (the mapping is
+    VA-stable without a live session), so the weights server settles into
+    COMMITTED with zero readers at steady state.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        st = kv_cache_gms.get_runtime_state()
+        if st.state == ServerState.RW and st.allocation_count > 0:
+            return st
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                "kv-cache GMS never reached RW with allocations "
+                f"(state={st.state}, allocs={st.allocation_count})"
+            )
+        time.sleep(0.5)
+
+
+@pytest.mark.e2e
+@pytest.mark.vllm
+@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
+@pytest.mark.timeout(900)
+@pytest.mark.parametrize(
+    "model, tp",
+    [
+        pytest.param(
+            FAULT_TOLERANCE_MODEL_NAME, 2, marks=pytest.mark.gpu_2, id="qwen-tp2"
+        ),
+    ],
+)
+def test_shadow_failover_autonomous_vllm(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    tmp_path,
+    model,
+    tp,
+):
+    lock_path = str(tmp_path / "failover.lock")
+
+    with GMSProcessManager(
+        request,
+        VLLMWithGMSProcess,
+        tp=tp,
+        model=model,
+        shadow=True,
+        lock_path=lock_path,
+    ) as manager:
+        frontend_port = manager.frontend_port
+        kv_cache_gms = manager.kv_cache_gms
+
+        # ---- STAGE 1: concurrent init → steady state (1 ACTIVE, 1 STANDBY) ----
+        logger.info("STAGE 1: starting two shadow engines concurrently")
+        engines = manager.start_engines_concurrently(["engine-0", "engine-1"])
+        # An ACTIVE engine exists: the flock winner holds the KV-cache RW layout.
+        # (No OOM: start_engines_concurrently raises if either engine fails to
+        # reach a healthy probe during concurrent init.)
+        _wait_for_active_kv(kv_cache_gms)
+        for engine_id, engine in engines.items():
+            assert engine.get_pid() is not None, f"{engine_id} died during startup"
+        active_id, active, standby = _split_active_standby(engines, lock_path)
+        logger.info("STAGE 1 ok: ACTIVE=%s, STANDBY=%s", active_id, standby.engine_id)
+
+        # ---- STAGE 2: inference before failover ----
+        logger.info("STAGE 2: inference on the ACTIVE engine")
+        assert_completion_ok(
+            frontend_port,
+            "The capital of France is",
+            failure_message="pre-failover inference failed",
+            success_message="pre-failover inference OK",
+            retry_timeout=30.0,
+        )
+
+        # ---- STAGE 3: SIGKILL ACTIVE → autonomous flock-driven wake ----
+        # NOTE: we never call standby.resume(). Recovery must be driven purely by
+        # the kernel releasing the dead engine's flock and the standby waking
+        # itself. We prove that structurally: the flock owner flips to the former
+        # standby and the KV-cache RW layout is re-established.
+        logger.info("STAGE 3: SIGKILL ACTIVE (%s); standby must self-wake", active_id)
+        _sigkill_process_group(active)
+        # Note: we don't poll active.get_pid() here — reaping the group in the
+        # helper makes Popen.poll() unreliable. The flock handoff below is the
+        # real proof the ACTIVE died: the kernel only releases the flock when the
+        # holder's process exits, so owner == standby implies the ACTIVE is gone.
+
+        _wait_for_active_kv(kv_cache_gms, timeout=180.0)
+        new_owner = _flock_owner(lock_path)
+        assert new_owner == standby.engine_id, (
+            f"flock did not hand off to the standby: owner={new_owner!r}, "
+            f"expected {standby.engine_id!r}"
+        )
+        assert standby.get_pid() is not None, "standby died during failover"
+        logger.info("STAGE 3 ok: standby %s is the new ACTIVE", new_owner)
+
+        # ---- STAGE 4: inference after failover ----
+        logger.info("STAGE 4: inference on the promoted standby")
+        assert_completion_ok(
+            frontend_port,
+            "The capital of France is",
+            failure_message="post-failover inference failed",
+            success_message="post-failover inference OK",
+            retry_timeout=60.0,
+        )
+
+        # ---- STAGE 5: replenish a fresh standby (restore redundancy) ----
+        # A new shadow imports the committed weights and parks in STANDBY.
+        # start_engine only returns once its health probe passes, which requires
+        # a successful weight import + pause — so reaching past it is structural
+        # proof the replacement came up as a healthy standby.
+        logger.info("STAGE 5: adding a replacement shadow engine")
+        replacement = manager.start_engine("engine-2")
+        assert (
+            replacement.get_pid() is not None
+        ), "replacement shadow died during startup"
+        # Redundancy restored: still exactly one ACTIVE (the flock owner is
+        # unchanged — the replacement parked as STANDBY, not a second active) and
+        # the cluster still serves.
+        owner_after_replenish = _flock_owner(lock_path)
+        assert owner_after_replenish == standby.engine_id, (
+            f"replacement perturbed the active engine: owner={owner_after_replenish!r}, "
+            f"expected {standby.engine_id!r}"
+        )
+        _wait_for_active_kv(kv_cache_gms, timeout=60.0)
+        assert_completion_ok(
+            frontend_port,
+            "The capital of France is",
+            failure_message="post-replenish inference failed",
+            success_message="post-replenish inference OK",
+            retry_timeout=30.0,
+        )
+        logger.info("STAGE 5 ok: redundancy restored (fresh STANDBY added)")

--- a/tests/gpu_memory_service/test_shadow_failover_orchestrated.py
+++ b/tests/gpu_memory_service/test_shadow_failover_orchestrated.py
@@ -1,6 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Orchestrated shadow-engine failover (gpu_1).
+
+The primary is SIGKILLed, then the standby shadow is resumed via an explicit
+HTTP ``wake_up`` call — the test drives the handoff and asserts the GMS KV-cache
+RW layout transfers cleanly. For the autonomous, flock-driven variant (no HTTP
+resume; the standby wakes itself on lock release, TP>1), see
+``test_shadow_failover_autonomous.py``.
+"""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
### What
Adds an e2e test for **autonomous (flock-driven) shadow-engine failover** (Bulwark): two `--gms-shadow-mode` vLLM engines share one flock; one serves (ACTIVE), one sleeps (STANDBY). SIGKILL the active and the standby **self-wakes via flock release** (no HTTP `wake_up`), re-acquires the KV-cache RW layout, and keeps serving.

Five stages, asserted on structured surfaces (GMS runtime state + frontend inference), not logs:
1. concurrent init → steady state (1 ACTIVE / 1 STANDBY), no OOM
2. inference before failover
3. SIGKILL active → standby auto-wakes (flock owner flips; KV RW re-established)
4. inference after failover
5. fresh shadow replenished → STANDBY (redundancy restored)

### Why
The existing `test_shadow_failover.py` triggers failover by an explicit HTTP `wake_up` (gpu_1). Nothing exercised the real flock-driven auto-wake path that Bulwark uses in production, nor TP>1. This fills that gap. Renamed `test_shadow_failover.py` → `test_shadow_failover_orchestrated.py` to distinguish the two; `common/runtime.py` extended for multi-device GMS + shadow mode (existing tests unaffected — new params default to prior behavior). vLLM-only (only backend supporting this path today).

Validated on 2×B200 (nscale): `1 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end autonomous shadow-engine failover testing for tensor-parallel execution scenarios.
  * Enhanced engine orchestration to support concurrent startup and initialization across multiple devices.
  * Expanded failover testing with lock-based state management and redundancy validation.

* **Chores**
  * Updated test documentation for shadow-engine failover workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->