### PR TITLE
feat(observability): overlay SLA targets on planner Observed Latency …

### DIFF
--- a/deploy/observability/grafana-planner-dashboard-configmap.yaml
+++ b/deploy/observability/grafana-planner-dashboard-configmap.yaml
@@ -489,6 +489,10 @@ data:
                     "value": "left"
                   },
                   {
+                    "id": "custom.axisLabel",
+                    "value": "TTFT (ms)"
+                  },
+                  {
                     "id": "custom.fillOpacity",
                     "value": 0
                   },
@@ -517,6 +521,10 @@ data:
                   {
                     "id": "custom.axisPlacement",
                     "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "ITL (ms)"
                   },
                   {
                     "id": "custom.fillOpacity",

--- a/deploy/observability/grafana-planner-dashboard-configmap.yaml
+++ b/deploy/observability/grafana-planner-dashboard-configmap.yaml
@@ -470,6 +470,66 @@ data:
                     "value": "ITL (ms)"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SLA TTFT"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FF6B6B",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "left"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "dash": [10, 10],
+                      "fill": "dash"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SLA ITL"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#4ECDC4",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "dash": [10, 10],
+                      "fill": "dash"
+                    }
+                  }
+                ]
               }
             ]
           },
@@ -508,6 +568,20 @@ data:
               "legendFormat": "ITL",
               "range": true,
               "refId": "B"
+            },
+            {
+              "editorMode": "code",
+              "expr": "dynamo_planner_sla_target_ttft_ms{namespace=~\"$namespace\"}",
+              "legendFormat": "SLA TTFT",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "editorMode": "code",
+              "expr": "dynamo_planner_sla_target_itl_ms{namespace=~\"$namespace\"}",
+              "legendFormat": "SLA ITL",
+              "range": true,
+              "refId": "D"
             }
           ],
           "title": "Observed Latency (TTFT & ITL)",


### PR DESCRIPTION
## Overview:

Add SLA target reference lines to the "Observed Latency (TTFT & ITL)" panel in the planner Grafana dashboard so observed values can be compared against their SLA targets at a glance.

## Details:

- Add dynamo_planner_sla_target_ttft_ms and dynamo_planner_sla_target_itl_ms targets (introduced in #10032) as "SLA TTFT" / "SLA ITL" series
- Match each SLA line to its observed counterpart's color and axis (TTFT left, ITL right) with fillOpacity 0 and a dashed line style so the target is visually distinct from the observed line

## Where should the reviewer start?

This PR touches only single file so you could just look at the file.

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**

#10032 feat(planner): expose SLA target metrics to Prometheus


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Service Level Agreement (SLA) target metrics to the latency monitoring dashboard
  * Included separate SLA thresholds for first-token and inter-token latency with dedicated styling and visualization
  * Enhanced performance tracking with new SLA indicators for improved threshold visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<img width="926" height="378" alt="itl" src="https://github.com/user-attachments/assets/1c73f4f9-9e9d-4c43-bf8f-92613d419c59" />
<img width="928" height="380" alt="ttft" src="https://github.com/user-attachments/assets/88a99e7c-3670-4e9f-8612-cf96fa57e379" />
📸 Note: in the screenshot the SLA TTFT target is set below the observed value on purpose, just to make the dashed overlay easy to see. Not a real SLA breach — no need to panic! 😄
