### PR TITLE
chore(container): drop duplicate attribution/wheel COPY in vllm runtime Dockerfile

### DIFF
--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -134,10 +134,6 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
         "nixl-cu12==${NIXL_VERSION}"
 {% endif %}
 
-# Copy attribution files and wheels
-COPY --chmod=664 --chown=dynamo:0 ATTRIBUTION* LICENSE /workspace/
-COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
-
 # Install device-specific NIXL wheels for non-CUDA devices.
 # These are custom-built in wheel_builder and required for dev builds to link against NIXL libraries.
 {% if device != "cuda" %}


### PR DESCRIPTION
## Overview

Remove a redundant, byte-identical `COPY` block in `container/templates/vllm_runtime.Dockerfile`. This is the pre-existing redundancy [flagged by Devin on #10647](https://github.com/ai-dynamo/dynamo/pull/10647), split out into its own change rather than expanding that XS fix.

## Details

The vLLM runtime template had **two identical** COPY blocks for the attribution files and Dynamo wheels — one at the top of the `runtime` stage and another a few lines later:

```dockerfile
# Copy attribution files and wheels
COPY --chmod=664 --chown=dynamo:0 ATTRIBUTION* LICENSE /workspace/
COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
```

No `FROM` stage boundary sits between them, and nothing in between writes to `/workspace/` or `/opt/dynamo/wheelhouse/` (the NIXL install writes into the Python env). So the second block re-copied the same files to the same destinations, producing a redundant Docker layer with no effect on the final image.

This PR removes the second block. The first already populates both destinations before any consumer reads from them.

## Verification

Rendered the template with `container/render.py --show-result` for both device branches:

- **cuda** (`--device cuda --target runtime --cuda-version 13.0`) and **xpu** (`--device xpu --target runtime`) builds each now emit **exactly one** attribution COPY and **one** wheelhouse COPY (previously two of each).
- The template renders without error in both cases.
- The surviving wheelhouse COPY still precedes **every** `uv pip install` that reads from `/opt/dynamo/wheelhouse/` (`ai_dynamo_runtime`, `ai_dynamo*any`, KVBM, GMS). The `nixl/` subdir is populated by separate dedicated COPYs and is unaffected.

## Where should the reviewer start?

`container/templates/vllm_runtime.Dockerfile` — the deleted block just below the non-CUDA NIXL install, around the `# Install device-specific NIXL wheels` comment.

## Related Issues

- Addresses the pre-existing duplicate-COPY redundancy noted by Devin Review on #10647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM runtime container build process to optimize artifact handling during image construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->