### PR TITLE
feat: extend auto dep-upgrade pipeline to vllm and sglang

### DIFF
--- a/.github/scripts/dep_upgrade/bump_dependency.py
+++ b/.github/scripts/dep_upgrade/bump_dependency.py
@@ -38,8 +38,71 @@ TRTLLM_TARGETS: list[tuple[str, Pattern[str], str]] = [
     ),
 ]
 
+VLLM_TARGETS: list[tuple[str, Pattern[str], str]] = [
+    (
+        "container/context.yaml",
+        # cuda13.0 sub-block: runtime_image_tag: v{ver}-ubuntu2404
+        re.compile(
+            r"(?m)(^vllm:\s*?\n(?:[ \t]+[^\n]*\n)*?[ \t]+cuda13\.0:\s*?\n"
+            r"(?:[ \t]+[^\n]*\n)*?[ \t]+runtime_image_tag:\s+v)[^\s-]+(-ubuntu2404\s*$)",
+        ),
+        r"\g<1>{ver}\g<2>",
+    ),
+    (
+        "container/context.yaml",
+        # cpu sub-block: runtime_image_tag: v{ver}  (no image-tag suffix)
+        re.compile(
+            r"(?m)(^vllm:\s*?\n(?:[ \t]+[^\n]*\n)*?[ \t]+cpu:\s*?\n"
+            r"(?:[ \t]+[^\n]*\n)*?[ \t]+runtime_image_tag:\s+v)\S+(\s*$)",
+        ),
+        r"\g<1>{ver}\g<2>",
+    ),
+    (
+        "pyproject.toml",
+        re.compile(r'"vllm\[flashinfer,runai,otel\]==[^"]+"'),
+        '"vllm[flashinfer,runai,otel]=={ver}"',
+    ),
+    (
+        "docs/reference/support-matrix.md",
+        # ToT row, 3rd backtick column (vLLM), after SGLang and TRT-LLM columns.
+        re.compile(
+            r"^(\| \*\*main \(ToT\)\*\* \| `[^`]+` \| `[^`]+` \| `)[^`]+(`)",
+            re.M,
+        ),
+        r"\g<1>{ver}\g<2>",
+    ),
+]
+
+SGLANG_TARGETS: list[tuple[str, Pattern[str], str]] = [
+    (
+        "container/context.yaml",
+        # cuda13.0 sub-block: runtime_image_tag: v{ver}-cu130-runtime
+        re.compile(
+            r"(?m)(^sglang:\s*?\n(?:[ \t]+[^\n]*\n)*?[ \t]+cuda13\.0:\s*?\n"
+            r"(?:[ \t]+[^\n]*\n)*?[ \t]+runtime_image_tag:\s+v)[^\s-]+(-cu130-runtime\s*$)",
+        ),
+        r"\g<1>{ver}\g<2>",
+    ),
+    (
+        "pyproject.toml",
+        re.compile(r'"sglang\[diffusion\]==[^"]+"'),
+        '"sglang[diffusion]=={ver}"',
+    ),
+    (
+        "docs/reference/support-matrix.md",
+        # ToT row, 1st backtick column (SGLang).
+        re.compile(
+            r"^(\| \*\*main \(ToT\)\*\* \| `)[^`]+(`)",
+            re.M,
+        ),
+        r"\g<1>{ver}\g<2>",
+    ),
+]
+
 FRAMEWORK_TARGETS: dict[str, list[tuple[str, Pattern[str], str]]] = {
     "trtllm": TRTLLM_TARGETS,
+    "vllm": VLLM_TARGETS,
+    "sglang": SGLANG_TARGETS,
 }
 
 

--- a/.github/scripts/dep_upgrade/detect_latest_versions.py
+++ b/.github/scripts/dep_upgrade/detect_latest_versions.py
@@ -27,6 +27,22 @@ FRAMEWORK_SOURCES: dict[str, dict[str, object]] = {
             r"(?m)^trtllm:\s*?\n(?:[ \t]+[^\n]*\n)*?[ \t]+runtime_image_tag:\s*(\S+)\s*$",
         ),
     },
+    "vllm": {
+        "github_repo": "vllm-project/vllm",
+        # cuda13.0 tag format: v0.22.1-ubuntu2404 — capture bare version only.
+        "current_regex": re.compile(
+            r"(?m)^vllm:\s*?\n(?:[ \t]+[^\n]*\n)*?[ \t]+cuda13\.0:\s*?\n"
+            r"(?:[ \t]+[^\n]*\n)*?[ \t]+runtime_image_tag:\s+v([^\s-]+)-ubuntu2404\s*$",
+        ),
+    },
+    "sglang": {
+        "github_repo": "sgl-project/sglang",
+        # cuda13.0 tag format: v0.5.12.post1-cu130-runtime — capture bare version only.
+        "current_regex": re.compile(
+            r"(?m)^sglang:\s*?\n(?:[ \t]+[^\n]*\n)*?[ \t]+cuda13\.0:\s*?\n"
+            r"(?:[ \t]+[^\n]*\n)*?[ \t]+runtime_image_tag:\s+v([^\s-]+)-cu130-runtime\s*$",
+        ),
+    },
 }
 
 

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -11,7 +11,7 @@ on:
       framework:
         description: 'Framework to attempt upgrade for'
         type: choice
-        options: [trtllm]
+        options: [trtllm, vllm, sglang]
         default: trtllm
 
 permissions:
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        framework: [trtllm]
+        framework: [trtllm, vllm, sglang]
     steps:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
Add vllm and sglang to the existing automated dependency upgrade workflow (previously trtllm-only). Daily cron and manual dispatch now run upgrade checks for all three frameworks in parallel.

Changes:
- detect_latest_versions.py: add vllm (vllm-project/vllm) and sglang (sgl-project/sglang) to FRAMEWORK_SOURCES with regexes that strip the image-tag suffix (e.g. -ubuntu2404, -cu130-runtime) to recover the bare version for GitHub release comparison.
- bump_dependency.py: add VLLM_TARGETS (context.yaml cuda13.0 + cpu sub-blocks, pyproject.toml, support-matrix ToT vLLM column) and SGLANG_TARGETS (context.yaml cuda13.0, pyproject.toml, support-matrix ToT SGLang column); registered in FRAMEWORK_TARGETS.
- auto-dep-upgrade-trigger.yml: add vllm and sglang to workflow_dispatch options and matrix.framework.
