### PR TITLE
fix(parsers): stop mistral parser leaking [TOOL_CALLS] into content

### DIFF
--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -441,6 +441,11 @@ impl ToolCallConfig {
             parser_config: ParserConfig::Json(JsonParserConfig {
                 tool_call_start_tokens: vec!["[TOOL_CALLS]".to_string()],
                 tool_call_end_tokens: vec!["[/TOOL_CALLS]".to_string(), "".to_string()],
+                // On failed-parse recovery, strip the markers instead of leaking
+                // them into normal_text (malformed body, or orphan close with no
+                // opener). Same flag nemotron_deci uses; base_json_parser.rs has
+                // the streaming-path detail.
+                strip_markup_on_recovery: true,
                 ..Default::default()
             }),
             structural_tag_builder: None,

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -528,19 +528,29 @@ pub fn try_tool_call_parse_basic_json(
     }
 
     // Strict recovery (opt-in via `strip_markup_on_recovery`, e.g. nemotron_deci):
-    // every parse above failed, so the fall-through below would return the raw
-    // text verbatim — which leaks the wrapper markers (`<TOOLCALL>` /
-    // `</TOOLCALL>`) into `normal_text`. Instead, strip all configured markers
-    // and retry a strict parse of the remaining payload: recover any well-formed
-    // call (this is what salvages orphan-close framing like
-    // `[{...}]</TOOLCALL>`), otherwise drop the content. Markers never reach the
-    // user either way; `tracing::warn!` records what was recovered or dropped.
-    // Gated on `allow_eof_recovery` so this only runs on finalize / non-streaming
-    // aggregate paths — never on a mid-stream chunk. Firing mid-stream would
-    // claim a "complete" call before the end token arrives (same hazard as
-    // `allow_eof_recovery` itself), which strands the trailing `</TOOLCALL>` as
-    // leaked normal_text on the next chunk.
-    if config.strip_markup_on_recovery && config.allow_eof_recovery {
+    // every parse above failed, so the fall-through below would leak the wrapper
+    // markers verbatim into `normal_text`. Instead, strip the configured markers
+    // and retry a strict parse: recover a well-formed call (salvages orphan-close
+    // framing like `[{...}]</TOOLCALL>`) or drop the content. `tracing::warn!`
+    // records which happened.
+    //
+    // Gated on `allow_eof_recovery` (finalize / batch) so it can't fire on an
+    // incomplete mid-stream chunk and claim a call before the end token arrives.
+    // Mistral also runs it once a complete `[/TOOL_CALLS]` end token is present:
+    // the streaming jail unjails on that marker with `allow_eof_recovery=false`,
+    // and stripping at a *confirmed* end token is safe (a complete region, not a
+    // truncated claim) — without it, orphan-close / malformed-body chunks leak
+    // (TOOLCALLING.stream.4.c). Scoped to mistral via its `[TOOL_CALLS]` start
+    // token so other strip-markup families stay byte-identical.
+    let mistral_end_token_present = config
+        .tool_call_start_tokens
+        .iter()
+        .any(|t| t == "[TOOL_CALLS]")
+        && config
+            .tool_call_end_tokens
+            .iter()
+            .any(|token| !token.is_empty() && trimmed.contains(token.as_str()));
+    if config.strip_markup_on_recovery && (config.allow_eof_recovery || mistral_end_token_present) {
         // Only intervene when a wrapper marker is actually present. Plain text
         // with no tool-call marker is a normal (non-tool) response and MUST
         // pass through unchanged — it must never be dropped or treated as a

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.4.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.4.yaml
@@ -17,16 +17,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        reason: "Dynamo's mistral parser leaves [TOOL_CALLS], [/TOOL_CALLS] in normal_text on malformed input (impl-defined recovery)"
+      dynamo: &d_4_a
         calls: []
-        normal_text: '[TOOL_CALLS]not a json array[/TOOL_CALLS]'
+        normal_text: ''
       vllm:
         calls: []
         normal_text: not a json array[/TOOL_CALLS]
-      sglang:
-        calls: []
-        normal_text: ''
+        reason: "vLLM's mistral parser splits only on the [TOOL_CALLS] opener and has no [/TOOL_CALLS] concept; on a malformed body its pre-v11 path returns the raw post-opener text as content, leaking the [/TOOL_CALLS] close marker. Dynamo strips the wrapper markers on malformed recovery so nothing leaks (TOOLCALLING.batch.4 impl-defined recovery)."
+      sglang: *d_4_a
   TOOLCALLING.batch.4.b:
     description: Missing close brace in JSON
     ref: dynamo
@@ -34,16 +32,14 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo:
-        reason: "Dynamo's mistral parser leaves [TOOL_CALLS], [/TOOL_CALLS] in normal_text on malformed input (impl-defined recovery)"
+      dynamo: &d_4_b
         calls: []
-        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
+        normal_text: ''
       vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
-      sglang:
-        calls: []
-        normal_text: ''
+        reason: "vLLM splits on the [TOOL_CALLS] opener and, when the JSON body fails both raw_decode and the array-regex fallback, returns the raw post-opener text as content, leaking the body and the [/TOOL_CALLS] close marker. Dynamo strips the wrapper markers on malformed recovery so nothing leaks (TOOLCALLING.batch.4 impl-defined recovery)."
+      sglang: *d_4_b
   TOOLCALLING.batch.4.c:
     description: Missing name key
     ref: dynamo

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.batch.5.yaml
@@ -27,6 +27,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "SGLang's MistralDetector requires '[TOOL_CALLS] [' with a space before the JSON array; the canonical mistral_common wire format emits '[TOOL_CALLS][' with no space, so it falls to its compact path, finds no [ARGS], and returns no call. Dynamo recovers the call via the empty end-token. Real SGLang divergence on the genuine Mistral format."
   TOOLCALLING.batch.5.b:
     description: Closing [/TOOL_CALLS] without matching [TOOL_CALLS] open
     ref: dynamo
@@ -34,12 +35,20 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
-        reason: "Dynamo's mistral parser leaves [/TOOL_CALLS] in normal_text on missing/orphan end marker (impl-defined recovery)"
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
-      vllm: *id003
-      sglang: *id003
+        reason: "vLLM requires the [TOOL_CALLS] opener; with only an orphan [/TOOL_CALLS] close it treats the whole string as content and emits no call. Dynamo strips the orphan close marker and recovers the complete call body without leaking markup (TOOLCALLING.batch.5 impl-defined recovery)."
+      sglang:
+        calls: []
+        normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+        reason: "SGLang's MistralDetector matches no [TOOL_CALLS opener (an orphan [/TOOL_CALLS] close does not match) and returns the text unchanged with no call. Dynamo strips the orphan close marker and recovers the complete call body without leaking markup (TOOLCALLING.batch.5 impl-defined recovery)."
   TOOLCALLING.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -78,6 +87,7 @@ cases:
       sglang:
         calls: []
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+        reason: "SGLang's MistralDetector requires '[TOOL_CALLS] [' with a space before the JSON array; the canonical mistral_common format emits '[TOOL_CALLS][' with no space, so it returns no call and keeps the narration prefix. Dynamo recovers both complete calls. Real SGLang divergence on the genuine Mistral format."
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.1.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.1.yaml
@@ -29,9 +29,11 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "SGLang's streaming MistralDetector requires '[TOOL_CALLS] [' with a space; the canonical mistral_common format emits '[TOOL_CALLS][' with no space, so it never enters the JSON-array path and emits no call. Dynamo buffers the payload and recovers the call. Real SGLang divergence on the genuine Mistral format."
       vllm:
         calls: []
         normal_text: ''
+        reason: "vLLM's streaming Mistral parser (pre-v11 ijson path) emits no call when the entire [TOOL_CALLS] payload arrives in one chunk via the parity harness (no incremental delta_token_ids to drive its coroutine); Dynamo buffers and recovers the call."
   TOOLCALLING.stream.1.b:
     description: Complete tool call split across parser-significant boundaries
     ref: derived from TOOLCALLING.batch.1

--- a/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/mistral/TOOLCALLING.stream.4.yaml
@@ -29,6 +29,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "SGLang's streaming MistralDetector requires '[TOOL_CALLS] [' with a space; the canonical mistral_common format emits '[TOOL_CALLS][' with no space, so it never enters the JSON-array path and emits no call. Dynamo recovers the call at stream finalize. Real SGLang divergence on the genuine Mistral format."
       vllm: *id001
   TOOLCALLING.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
@@ -74,11 +75,17 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]'
-      vllm: *id002
+        reason: "vLLM streaming sees no [TOOL_CALLS] opener in the chunk, so it emits the whole string as content with no call, leaking the orphan [/TOOL_CALLS] markers verbatim. Dynamo strips the orphan close markers at the confirmed end token and recovers the complete call body without leaking markup."
       sglang:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}[/TOOL_CALLS[/TOOL_CALLS[/TOOL_CALLS'
-        reason: SGLang strips the trailing ] from each orphan [/TOOL_CALLS] close marker (leaving bracket fragments); Dynamo and vLLM keep the bare body and markers verbatim when the [TOOL_CALLS] opener is absent.
+        reason: "SGLang's streaming MistralDetector matches no [TOOL_CALLS marker and flushes the buffer as normal text, stripping every ']' char via its eot_token replace (leaving bracket fragments). Dynamo strips the orphan close markers at the confirmed end token and recovers the complete call body without leaking markup."


### PR DESCRIPTION
#### Overview

Dynamo's mistral tool-call parser leaked the `[TOOL_CALLS]` / `[/TOOL_CALLS]` wrapper markers into user-visible `message.content` whenever the JSON body failed every parse path: malformed args inside a closed wrapper, or an orphan `[/TOOL_CALLS]` close with no opener (the latter traced to a customer tool-call-leak repro). Tool-call markup must never reach `content`. The `mistral()` config never opted into `strip_markup_on_recovery` — the marker-stripping mechanism `nemotron_deci` already uses — so the recovery fall-through re-emitted the raw text verbatim. This enables it (plus a small, mistral-scoped streaming extension) so the affected parity cells stop leaking.

Mistral M2 parity row: **9 red → 2 red**. The two remaining (`batch.4.c`, `batch.8.d`) are genuine vLLM exceptions (`KeyError` / `ValueError`), recorded as documented `error:` cells and tracked upstream — not Dynamo-fixable.

#### Details

- `lib/parsers/src/tool_calling/config.rs`: set `strip_markup_on_recovery: true` on `mistral()`.
- `lib/parsers/src/tool_calling/json/base_json_parser.rs`: also run the marker-strip when the payload already carries a complete `[/TOOL_CALLS]` end token (not only on `allow_eof_recovery`), scoped to mistral via its `[TOOL_CALLS]` start token. This covers the streaming jail's early-exit unjail, which fires on a complete end marker but passes `allow_eof_recovery=false`. Scoped so `nemotron_deci` (the other `strip_markup_on_recovery` user) stays byte-identical.
- Fixtures: refresh `expected.dynamo` for the de-leaked cases; collapse SGLang to anchor refs where it now matches Dynamo (`4.a` / `4.b`); expand peers to concrete `+reason:` where Dynamo now diverges (`5.b`, `stream.4.c`); classify the SGLang no-space divergences (`5.a` / `5.d` / `stream.4.a` / `stream.1.a`) with a `reason:`.

#### Before / After

Dynamo output on the four de-leaked cases — markers no longer reach `normal_text`:

| Case | Before (leaked) | After |
|---|---|---|
| `batch.4.a` | `calls=[]  normal_text='[TOOL_CALLS]not a json array[/TOOL_CALLS]'` | `calls=[]  normal_text=''` |
| `batch.4.b` | `calls=[]  normal_text='[TOOL_CALLS][{"name":"get_weather","arguments":{"location":"NYC"][/TOOL_CALLS]'` | `calls=[]  normal_text=''` |
| `batch.5.b` | `calls=[]  normal_text='[{"name":"get_weather","arguments":{"location":"NYC"}}][/TOOL_CALLS]'` | `calls=[get_weather(NYC)]  normal_text=''` |
| `stream.4.c` | `calls=[]  normal_text='[{...}}][/TOOL_CALLS][/TOOL_CALLS][/TOOL_CALLS]'` | `calls=[get_weather(NYC)]  normal_text=''` |

#### Dynamo

Enable the existing marker-strip recovery for the mistral family:

```rust
// lib/parsers/src/tool_calling/config.rs — mistral()
JsonParserConfig {
    tool_call_start_tokens: vec!["[TOOL_CALLS]".to_string()],
    tool_call_end_tokens: vec!["[/TOOL_CALLS]".to_string(), "".to_string()],
    // strip wrapper markers instead of leaking them into normal_text when the
    // JSON body fails every parse path
    strip_markup_on_recovery: true,
    ..Default::default()
}
```

```rust
// lib/parsers/src/tool_calling/json/base_json_parser.rs
// Also strip when the payload already carries a complete [/TOOL_CALLS] end
// token (not only on allow_eof_recovery) — covers the streaming jail's
// early-exit unjail, which passes allow_eof_recovery=false. Scoped to mistral
// via its [TOOL_CALLS] start token so nemotron_deci stays byte-identical.
let mistral_end_token_present = config
    .tool_call_start_tokens
    .iter()
    .any(|t| t == "[TOOL_CALLS]")
    && config
        .tool_call_end_tokens
        .iter()
        .any(|token| !token.is_empty() && trimmed.contains(token.as_str()));
if config.strip_markup_on_recovery && (config.allow_eof_recovery || mistral_end_token_present) {
    // strip configured markers at the boundaries, re-parse the payload,
    // recover any complete call or drop to empty — markers never leak
}
```

#### vLLM

`vllm/tool_parsers/mistral_tool_parser.py` splits only on the `[TOOL_CALLS]` opener and has no `[/TOOL_CALLS]` concept. With no opener it returns the whole string as content; on a malformed body it returns the raw post-opener text — so the close marker (and body) leak. Documented divergence (`V`); not Dynamo-fixable.

```python
# no opener -> whole string leaks as content (batch.5.b, stream.4.c)
if self.bot_token not in model_output:
    return ExtractedToolCallInformation(
        tools_called=False, tool_calls=[], content=model_output)
...
# malformed body -> raw post-opener text (incl. [/TOOL_CALLS]) leaks (batch.4.a/4.b)
except (IndexError, json.JSONDecodeError):
    return ExtractedToolCallInformation(
        tools_called=False, tool_calls=[],
        content=stringified_tool_calls)
```

#### SGLang

`sglang/srt/function_call/mistral_detector.py` requires `[TOOL_CALLS] [` **with a space** for the canonical JSON-array path; the real `mistral_common` wire format is `[TOOL_CALLS][` with **no space**, so SGLang returns no call on genuine Mistral output (the row-wide `S`). In the streaming no-marker branch it flushes the buffer as text, stripping every `]` via its `eot_token` replace (the `stream.4.c` bracket fragments). Documented divergence; real upstream SGLang bug to file.

```python
self.bot_token = "[TOOL_CALLS] ["   # requires a space; real format emits none
self.eot_token = "]"
...
# streaming, no [TOOL_CALLS marker -> flush as text, stripping every ']'
if self.eot_token in normal_text:
    normal_text = normal_text.replace(self.eot_token, "")
```

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mistral tool-calling recovery to properly strip wrapper markers when tool-call parsing encounters malformed or incomplete inputs, preventing wrapper leakage in output.
  * Enhanced detection logic for Mistral-specific tool-call boundaries during error recovery.

* **Tests**
  * Updated tool-calling test fixtures to reflect improved wrapper-stripping behavior across multiple edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->