### PR TITLE
fix(profiler): tolerate long inline JSON --config that exceeds path limit

### DIFF
--- a/components/src/dynamo/profiler/__main__.py
+++ b/components/src/dynamo/profiler/__main__.py
@@ -71,7 +71,15 @@ def _parse_dgdr_spec(config_arg: str) -> DynamoGraphDeploymentRequestSpec:
     Accepts a file path (JSON/YAML) or an inline JSON string.
     """
     path = Path(config_arg)
-    if path.is_file():
+    try:
+        is_file = path.is_file()
+    except OSError:
+        # A large inline JSON --config (e.g. a marshaled DGDR spec passed by the
+        # operator) can exceed the OS path-length limit, so is_file() raises
+        # OSError (ENAMETOOLONG) instead of returning False. Treat that as
+        # "not a path" and fall through to JSON parsing below.
+        is_file = False
+    if is_file:
         text = path.read_text()
         suffix = path.suffix.lower()
         if suffix in (".yaml", ".yml"):

--- a/components/src/dynamo/profiler/__main__.py
+++ b/components/src/dynamo/profiler/__main__.py
@@ -103,6 +103,12 @@ def _parse_dgdr_spec(config_arg: str) -> DynamoGraphDeploymentRequestSpec:
 
 
 def _parse_args() -> tuple[DynamoGraphDeploymentRequestSpec, ProfilerOperationalConfig]:
+    """Parse profiler CLI arguments.
+
+    Returns the parsed DGDR spec (from ``--config``) and the operational
+    configuration (output directory, timeouts, interpolation granularities,
+    dry-run flag) used to drive profiling.
+    """
     parser = argparse.ArgumentParser(description="Dynamo Profiler")
     parser.add_argument(
         "--config",
@@ -154,6 +160,12 @@ def _parse_args() -> tuple[DynamoGraphDeploymentRequestSpec, ProfilerOperational
 
 
 def main() -> None:
+    """Profiler entry point.
+
+    Configures logging, parses CLI arguments, and runs SLA profiling. On
+    argument-parsing failure it writes a status file before exiting so the
+    container surfaces a useful failure reason.
+    """
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",

--- a/components/src/dynamo/profiler/tests/unit/test_parse_dgdr_spec.py
+++ b/components/src/dynamo/profiler/tests/unit/test_parse_dgdr_spec.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the profiler ``--config`` parser (_parse_dgdr_spec)."""
+
+import json
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.planner,
+    pytest.mark.parallel,
+]
+
+try:
+    from dynamo.profiler.__main__ import _parse_dgdr_spec
+except ImportError:
+    pytest.skip("dynamo.llm bindings not available", allow_module_level=True)
+
+
+def test_parses_short_inline_json() -> None:
+    spec = _parse_dgdr_spec(json.dumps({"model": "Qwen/Qwen3-32B"}))
+    assert spec.model == "Qwen/Qwen3-32B"
+
+
+def test_parses_large_inline_json_exceeding_path_limit() -> None:
+    """A large inline JSON config must not be mistaken for a file path.
+
+    Regression test for the case where ``Path(config_arg).is_file()`` raises
+    ``OSError`` (ENAMETOOLONG) for an inline JSON string longer than the OS
+    path limit. The profiler must fall through to JSON parsing instead of
+    crashing before it ever reaches ``json.loads``.
+    """
+    spec_dict = {
+        "model": "Qwen/Qwen3-32B",
+        "overrides": {"dgd": {f"field_{i}": "x" * 64 for i in range(80)}},
+    }
+    config_arg = json.dumps(spec_dict)
+    # Well beyond the typical 255-byte per-component path limit.
+    assert len(config_arg) > 255
+
+    spec = _parse_dgdr_spec(config_arg)
+    assert spec.model == "Qwen/Qwen3-32B"
+
+
+def test_invalid_inline_json_raises_valueerror() -> None:
+    with pytest.raises(ValueError):
+        _parse_dgdr_spec("{not valid json")


### PR DESCRIPTION
## Overview:

The DGDR profiler crashes on a valid inline JSON `--config` when the marshaled spec is large enough, because it probes the argument as a filesystem path before attempting JSON parsing.

## Details:

`_parse_dgdr_spec` (`components/src/dynamo/profiler/__main__.py`) ran `Path(config_arg).is_file()` before `json.loads(config_arg)`. The operator passes the marshaled DGDR spec directly as an inline JSON string, and for realistic specs (overrides, model cache, planner, hardware, SLA, workload) that string exceeds the OS path-length limit. `is_file()` then raises `OSError` (ENAMETOOLONG, errno 36 on Linux / 63 on macOS) instead of returning `False`, so the profiler fails on valid JSON before it ever reaches the parse step. This blocks `DynamoGraphDeploymentRequest` deploys (`autoApply: true` never reaches DGD creation).

This is the short-term parser fix suggested in the issue: guard the `is_file()` probe and treat `OSError` as 'not a path', falling through to JSON parsing. The more robust operator-side change (write the spec to a mounted file / ConfigMap instead of an inline arg) is out of scope here.

## Where should the reviewer start?

- `components/src/dynamo/profiler/__main__.py` — the `try/except OSError` guard around `is_file()` in `_parse_dgdr_spec`.
- `components/src/dynamo/profiler/tests/unit/test_parse_dgdr_spec.py` — regression tests: short inline JSON, large inline JSON beyond the path limit (the bug), and invalid JSON.

## Related Issues

- Closes #10719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The profiler CLI config parser now properly handles excessively long configuration values without failing, treating them as inline JSON/YAML content instead of invalid paths.

* **Tests**
  * Added comprehensive unit test coverage for the config parser, including regression tests for long values exceeding system path limits and JSON validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->