### PR TITLE
ci(snapshot): add snapshot build-on-demand images

### DIFF
--- a/.github/workflows/build-on-demand.yml
+++ b/.github/workflows/build-on-demand.yml
@@ -22,6 +22,26 @@ on:
         description: 'Build and push operator image, tagged with branch name'
         type: boolean
         default: false
+      build_snapshot_agent:
+        description: 'Build and push snapshot-agent image, tagged with branch name'
+        type: boolean
+        default: false
+      build_vllm_placeholder:
+        description: 'Build and push vLLM snapshot placeholder image, tagged with branch name'
+        type: boolean
+        default: false
+      build_sglang_placeholder:
+        description: 'Build and push SGLang snapshot placeholder image, tagged with branch name'
+        type: boolean
+        default: false
+      snapshot_criu_repo:
+        description: 'Optional CRIU git repository for snapshot-agent and placeholder image builds'
+        type: string
+        default: 'https://github.com/checkpoint-restore/criu.git'
+      snapshot_criu_ref:
+        description: 'Optional CRIU git ref for snapshot-agent and placeholder image builds'
+        type: string
+        default: 'criu-dev'
 
 env:
   BUILDER_NAME: b-${{ github.run_id }}-${{ github.run_attempt }}
@@ -52,7 +72,7 @@ jobs:
   vllm-build:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [init]
-    if: inputs.build_vllm
+    if: inputs.build_vllm || inputs.build_vllm_placeholder
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: vllm
@@ -66,7 +86,7 @@ jobs:
   sglang-build:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [init]
-    if: inputs.build_sglang
+    if: inputs.build_sglang || inputs.build_sglang_placeholder
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: sglang
@@ -123,6 +143,92 @@ jobs:
       override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
       copy_timeout_minutes: 10
     secrets: inherit
+
+  # ============================================================================
+  # SNAPSHOT (build-only)
+  # ============================================================================
+
+  snapshot-agent:
+    needs: [init]
+    if: inputs.build_snapshot_agent
+    name: Snapshot Agent
+    runs-on: prod-default-v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Build and push snapshot agent
+        uses: ./.github/actions/build-deploy-component
+        with:
+          component: snapshot
+          image_tag: ${{ github.sha }}-snapshot-agent
+          builder_name: ${{ needs.init.outputs.builder_name }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+          extra_tags: |
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ needs.init.outputs.sanitized_ref_name }}-snapshot-agent
+          extra_build_args: |
+            CRIU_REPO=${{ inputs.snapshot_criu_repo }}
+            CRIU_REF=${{ inputs.snapshot_criu_ref }}
+
+  snapshot-placeholder-vllm:
+    name: vLLM Snapshot Placeholder
+    needs: [init, vllm-copy-to-acr]
+    if: inputs.build_vllm_placeholder
+    runs-on: prod-default-v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Build and push vLLM snapshot placeholder
+        uses: ./.github/actions/build-deploy-component
+        with:
+          component: snapshot
+          target: placeholder
+          image_tag: ${{ github.sha }}-vllm-placeholder
+          builder_name: ${{ needs.init.outputs.builder_name }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+          extra_tags: |
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-placeholder
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ needs.init.outputs.sanitized_ref_name }}-vllm-placeholder
+          extra_build_args: |
+            BASE_IMAGE=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-runtime
+            CRIU_REPO=${{ inputs.snapshot_criu_repo }}
+            CRIU_REF=${{ inputs.snapshot_criu_ref }}
+
+  snapshot-placeholder-sglang:
+    name: SGLang Snapshot Placeholder
+    needs: [init, sglang-copy-to-acr]
+    if: inputs.build_sglang_placeholder
+    runs-on: prod-default-v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Build and push SGLang snapshot placeholder
+        uses: ./.github/actions/build-deploy-component
+        with:
+          component: snapshot
+          target: placeholder
+          image_tag: ${{ github.sha }}-sglang-placeholder
+          builder_name: ${{ needs.init.outputs.builder_name }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+          extra_tags: |
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-placeholder
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ needs.init.outputs.sanitized_ref_name }}-sglang-placeholder
+          extra_build_args: |
+            BASE_IMAGE=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-runtime
+            CRIU_REPO=${{ inputs.snapshot_criu_repo }}
+            CRIU_REF=${{ inputs.snapshot_criu_ref }}
 
   # ============================================================================
   # OPERATOR (build-only)
@@ -194,7 +300,7 @@ jobs:
     name: Clean K8s builder if exists
     runs-on: prod-default-small-v2
     if: always()
-    needs: [init, vllm-build, sglang-build, trtllm-build, operator]
+    needs: [init, vllm-build, sglang-build, trtllm-build, snapshot-agent, snapshot-placeholder-vllm, snapshot-placeholder-sglang, operator]
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
## Summary

- Add Build On Demand inputs for snapshot-agent, vLLM snapshot-placeholder, and SGLang snapshot-placeholder images.
- Build the snapshot-agent image from `deploy/snapshot/Dockerfile` target `agent`.
- Build vLLM and SGLang snapshot placeholder images from target `placeholder` after the corresponding runtime image is built and copied to ACR.
- Allow workflow dispatch users to override `CRIU_REPO` and `CRIU_REF` for snapshot-agent and placeholder image builds.

## Validation

- `git diff --check -- .github/workflows/build-on-demand.yml`
- Parsed `.github/workflows/build-on-demand.yml` with `yq -o=json`.
- Ran a structural workflow check for the new inputs, runtime prerequisite conditions, snapshot jobs, placeholder `BASE_IMAGE` build args, CRIU build args, and cleanup dependencies.
