### PR TITLE
fix: scope KV router cancellation to router lifetime

### DIFF
--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -7,6 +7,7 @@ use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 
 use dashmap::DashMap;
 use dynamo_kv_router::protocols::ActiveLoad;
@@ -398,6 +399,18 @@ pub struct KvWorkerMonitor {
     thresholds: Arc<RwLock<LoadThresholdConfig>>,
     /// Guard to ensure start_monitoring() only runs once across clones
     started: Arc<AtomicBool>,
+    /// Cancels the background monitoring task when the last monitor clone is dropped.
+    cancellation: Arc<MonitorCancellation>,
+}
+
+struct MonitorCancellation {
+    token: CancellationToken,
+}
+
+impl Drop for MonitorCancellation {
+    fn drop(&mut self) {
+        self.token.cancel();
+    }
 }
 
 impl KvWorkerMonitor {
@@ -422,6 +435,9 @@ impl KvWorkerMonitor {
             worker_load_states: Arc::new(DashMap::new()),
             thresholds: Arc::new(RwLock::new(config)),
             started: Arc::new(AtomicBool::new(false)),
+            cancellation: Arc::new(MonitorCancellation {
+                token: CancellationToken::new(),
+            }),
         }
     }
 
@@ -536,7 +552,15 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
         let endpoint = &self.client.endpoint;
         let component = endpoint.component();
 
-        let cancellation_token = component.drt().child_token();
+        let cancellation_token = self.cancellation.token.child_token();
+        let runtime_cancellation = component.drt().child_token();
+        let cancellation_bridge = cancellation_token.clone();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = runtime_cancellation.cancelled() => cancellation_bridge.cancel(),
+                _ = cancellation_bridge.cancelled() => {}
+            }
+        });
 
         // Watch for runtime config updates from model deployment cards via discovery interface
         let discovery = component.drt().discovery();

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -225,12 +225,13 @@ where
         let kv_router_config = kv_router_config.unwrap_or_default();
         kv_router_config.validate()?;
         let component = endpoint.component();
-        let cancellation_token = component.drt().primary_token();
+        let cancellation_token = component.drt().child_token();
         let min_initial_workers = min_initial_workers_from_env()?;
 
         let indexer = Indexer::new(
             component,
             &kv_router_config,
+            cancellation_token.clone(),
             block_size,
             model_name.as_deref(),
         )
@@ -269,6 +270,7 @@ where
             overlap_scores_refresh,
             Some(overloaded_worker_provider),
             worker_type,
+            cancellation_token.clone(),
         )
         .await?;
 
@@ -276,8 +278,13 @@ where
         if kv_router_config.use_remote_indexer {
             tracing::info!("Skipping KV event subscription (using remote indexer)");
         } else if kv_router_config.should_subscribe_to_kv_events() {
-            indexer::start_subscriber(component.clone(), &kv_router_config, indexer.clone())
-                .await?;
+            indexer::start_subscriber(
+                component.clone(),
+                &kv_router_config,
+                indexer.clone(),
+                cancellation_token.clone(),
+            )
+            .await?;
         } else {
             tracing::info!(
                 "Skipping KV event subscription (use_kv_events={}, overlap_score_credit={})",

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -20,8 +20,9 @@ use dynamo_kv_router::{
 pub(crate) use dynamo_kv_router::indexer::TieredMatchDetails;
 #[allow(unused_imports)]
 pub(crate) use dynamo_kv_router::indexer::WireTieredMatchDetails;
-use dynamo_runtime::{component::Component, traits::DistributedRuntimeProvider};
+use dynamo_runtime::component::Component;
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 
 mod lookup;
 mod recording;
@@ -69,6 +70,7 @@ impl Indexer {
     pub async fn new(
         component: &Component,
         kv_router_config: &KvRouterConfig,
+        cancellation_token: CancellationToken,
         block_size: u32,
         model_name: Option<&str>,
     ) -> Result<Self> {
@@ -97,7 +99,12 @@ impl Indexer {
             );
             let remote =
                 RemoteIndexer::new(component, model_name, kv_router_config.use_kv_events).await?;
-            let approx = SideIndexer::new_predict_on_route(component, kv_router_config, block_size);
+            let approx = SideIndexer::new_predict_on_route(
+                component,
+                kv_router_config,
+                cancellation_token,
+                block_size,
+            );
             return Ok(Self::Remote {
                 primary: Arc::new(remote),
                 approx,
@@ -128,7 +135,6 @@ impl Indexer {
                 });
             }
 
-            let cancellation_token = component.drt().primary_token();
             return Ok(Self::KvIndexer {
                 primary: KvIndexer::new_with_pruning(
                     cancellation_token,
@@ -142,7 +148,12 @@ impl Indexer {
             });
         }
 
-        let approx = SideIndexer::new_predict_on_route(component, kv_router_config, block_size);
+        let approx = SideIndexer::new_predict_on_route(
+            component,
+            kv_router_config,
+            cancellation_token.clone(),
+            block_size,
+        );
 
         if kv_router_config.router_event_threads > 1 {
             let kv_indexer_metrics = KvIndexerMetrics::from_component(component);
@@ -163,8 +174,6 @@ impl Indexer {
         }
 
         let kv_indexer_metrics = KvIndexerMetrics::from_component(component);
-        let cancellation_token = component.drt().primary_token();
-
         Ok(Self::KvIndexer {
             primary: KvIndexer::new_with_pruning(
                 cancellation_token,

--- a/lib/llm/src/kv_router/indexer/recovery/jetstream.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/jetstream.rs
@@ -227,8 +227,8 @@ pub(crate) async fn start_kv_router_background(
     consumer_id: String,
     indexer: Indexer,
     kv_router_config: &KvRouterConfig,
+    cancellation_token: CancellationToken,
 ) -> Result<()> {
-    let cancellation_token = component.drt().primary_token();
     let router_snapshot_threshold = kv_router_config.router_snapshot_threshold;
     let router_reset_states = kv_router_config.router_reset_states;
     // Set up NATS connections

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -12,6 +12,7 @@ use dynamo_runtime::{
     component::Component, discovery::EventTransportKind, prelude::*,
     transports::event_plane::EventSubscriber,
 };
+use tokio_util::sync::CancellationToken;
 
 /// Start a simplified background task for event consumption using the event plane.
 ///
@@ -27,9 +28,8 @@ async fn start_kv_router_background_event_plane(
     component: Component,
     indexer: Indexer,
     transport_kind: EventTransportKind,
+    cancellation_token: CancellationToken,
 ) -> Result<()> {
-    let cancellation_token = component.drt().primary_token();
-
     // Subscribe to KV events BEFORE spawning the discovery/recovery loop.
     // This ensures no events are lost between the initial dump fetch and the
     // subscription becoming active — the tree state at fetch time is guaranteed
@@ -45,7 +45,8 @@ async fn start_kv_router_background_event_plane(
 
     // WorkerQueryClient handles its own discovery loop for lifecycle + initial recovery.
     // No blocking wait — recovery happens asynchronously as endpoints are discovered.
-    let worker_query_client = WorkerQueryClient::spawn(component.clone(), indexer).await?;
+    let worker_query_client =
+        WorkerQueryClient::spawn(component.clone(), indexer, cancellation_token.clone()).await?;
     let kv_event_subject = format!(
         "namespace.{}.component.{}.{}",
         component.namespace().name(),
@@ -116,6 +117,7 @@ pub async fn start_subscriber(
     component: Component,
     kv_router_config: &KvRouterConfig,
     indexer: Indexer,
+    cancellation_token: CancellationToken,
 ) -> Result<()> {
     let transport_kind = component.drt().default_event_transport_kind();
 
@@ -140,6 +142,7 @@ pub async fn start_subscriber(
             consumer_id,
             indexer,
             kv_router_config,
+            cancellation_token,
         )
         .await
     } else {
@@ -156,6 +159,12 @@ pub async fn start_subscriber(
             tracing::info!("Using NATS Core subscription (local_indexer mode)");
         }
 
-        start_kv_router_background_event_plane(component, indexer, transport_kind).await
+        start_kv_router_background_event_plane(
+            component,
+            indexer,
+            transport_kind,
+            cancellation_token,
+        )
+        .await
     }
 }

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -87,12 +87,15 @@ impl WorkerQueryClient {
     /// The background loop watches `ComponentEndpoints` discovery for query endpoints,
     /// recovers each `(worker_id, dp_rank)` as it appears, and sends worker removal
     /// events when all dp_ranks for a worker disappear.
-    pub async fn spawn(component: Component, indexer: Indexer) -> Result<Arc<Self>> {
+    pub async fn spawn(
+        component: Component,
+        indexer: Indexer,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) -> Result<Arc<Self>> {
         let transport = Arc::new(RuntimeWorkerQueryTransport::new(&component).await?);
         let client = Self::new(component.clone(), indexer, transport);
 
         let client_bg = client.clone();
-        let cancel_token = component.drt().primary_token();
         tokio::spawn(async move {
             if let Err(e) = client_bg.run_discovery_loop(cancel_token).await {
                 tracing::error!("WorkerQueryClient discovery loop failed: {e}");

--- a/lib/llm/src/kv_router/indexer/side.rs
+++ b/lib/llm/src/kv_router/indexer/side.rs
@@ -14,7 +14,8 @@ use dynamo_kv_router::{
     },
     protocols::{DpRank, OverlapScores, WorkerId, WorkerWithDpRank},
 };
-use dynamo_runtime::{component::Component, traits::DistributedRuntimeProvider};
+use dynamo_runtime::component::Component;
+use tokio_util::sync::CancellationToken;
 
 use super::lookup::HashInput;
 
@@ -28,6 +29,7 @@ impl SideIndexer {
     pub(super) fn new_predict_on_route(
         component: &Component,
         kv_router_config: &KvRouterConfig,
+        cancellation_token: CancellationToken,
         block_size: u32,
     ) -> Option<Self> {
         let ttl_secs = kv_router_config.router_predicted_ttl_secs?;
@@ -51,7 +53,6 @@ impl SideIndexer {
             )));
         }
 
-        let cancellation_token = component.drt().primary_token();
         Some(Self::KvIndexer(KvIndexer::new_with_pruning(
             cancellation_token,
             block_size,

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -31,6 +31,7 @@ use dynamo_tokens::SequenceHash;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
 pub struct KvScheduler<Sel = DefaultWorkerSelector, RF = NoopOverlapScoresRefresh>
 where
@@ -66,6 +67,7 @@ where
         overlap_scores_refresh: Option<Arc<RF>>,
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
         worker_type: &'static str,
+        cancellation_token: CancellationToken,
     ) -> Result<Self, KvSchedulerError> {
         let initial_workers: HashMap<WorkerId, ModelRuntimeConfig> =
             workers_with_configs.borrow().clone();
@@ -107,13 +109,13 @@ where
             overloaded_worker_provider,
             kv_router_config.router_queue_recheck_interval(),
             kv_router_config.router_track_prefill_tokens,
-            component.drt().child_token(),
+            cancellation_token.clone(),
             worker_type,
             watch_worker_configs,
         ));
 
         let metrics_scheduler = Arc::clone(&inner);
-        let metrics_cancel_token = component.drt().child_token();
+        let metrics_cancel_token = cancellation_token;
         let mut queue_updates = inner.subscribe_queue_updates();
         tokio::spawn(async move {
             let mut recheck_interval = tokio::time::interval(Duration::from_secs(60));
@@ -358,6 +360,7 @@ mod tests {
             None::<Arc<NoopOverlapScoresRefresh>>,
             None,
             "decode",
+            CancellationToken::new(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

This scopes KV-router and worker-monitor background work to the lifetime of the owner that created it, instead of using process/runtime-level cancellation for WorkerSet-scoped work.

Refs #10729.

## What changed

- Create a router-owned cancellation token in `KvRouter::new` using `component.drt().child_token()`.
- Pass the router token through indexer construction, scheduler startup, event-plane / JetStream subscriber startup, and `WorkerQueryClient` recovery/discovery.
- Stop deriving `component.drt().primary_token()` inside router-owned indexer/subscriber/recovery paths.
- Use the router token for scheduler queue metrics and scheduler worker monitoring work.
- Give `KvWorkerMonitor` an owned cancellation token that is canceled when the last monitor handle is dropped, while still bridging runtime shutdown into that owned token.

## Why

On LoRA-enabled KV-router deployments, frontend RSS and thread count can grow until OOM. The suspected root cause is that WorkerSet/router-scoped background tasks survive WorkerSet/router removal because they are tied to runtime/process cancellation instead of owner lifetime.

LoRA deployments make this especially visible because model-card/adapter churn repeatedly exercises WorkerSet/router teardown and rebuild.

## Validation

Passed locally on current `origin/main` after rebase:

```bash
git diff --check origin/main..HEAD
PATH=/Users/ameenp/.cargo/bin:$PATH cargo fmt --all --check
PATH=/Users/ameenp/.cargo/bin:$PATH cargo check -p dynamo-llm --no-default-features --locked
PATH=/Users/ameenp/.cargo/bin:$PATH cargo clippy -p dynamo-llm --no-default-features --locked -- -D warnings
```

## Follow-up validation

- Deploy under Freyr-like LoRA churn and compare frontend RSS/thread count/discovery stream count before and after this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced cancellation and shutdown coordination across KV router and monitoring components for improved consistency in lifecycle management and graceful termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->