### PR TITLE
feat(parsers): require outer DSML wrapper for DeepSeek tool calls

### DIFF
--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -183,6 +183,16 @@ pub struct DsmlParserConfig {
     /// leave this `false`.
     #[serde(default)]
     pub allow_eof_recovery: bool,
+
+    /// Require the outer DSML block wrapper (`<｜DSML｜function_calls>` /
+    /// `<｜DSML｜tool_calls>`) before an `<｜DSML｜invoke>` is treated as a tool
+    /// call. The DeepSeek DSML spec (DeepSeek-V4 `encoding/README.md`) defines a
+    /// tool call AS a wrapper block, so a bare invoke without the wrapper is not
+    /// conformant. When `true`, wrapper-less invokes are NOT recovered: they
+    /// yield no calls and the orphan markup is suppressed from `normal_text`.
+    /// Defaults to `false` (lenient bare-invoke recovery) for back-compat.
+    #[serde(default)]
+    pub require_wrapper: bool,
 }
 
 impl Default for DsmlParserConfig {
@@ -195,6 +205,7 @@ impl Default for DsmlParserConfig {
             parameter_prefix: "<｜DSML｜parameter name=".to_string(),
             parameter_end: "</｜DSML｜parameter>".to_string(),
             allow_eof_recovery: false,
+            require_wrapper: false,
         }
     }
 }
@@ -561,6 +572,10 @@ impl ToolCallConfig {
         let dsml_config = DsmlParserConfig {
             block_start: format!("<｜DSML｜{}>", block_name),
             block_end: format!("</｜DSML｜{}>", block_name),
+            // DeepSeek DSML spec: the outer block wrapper is mandatory; a bare
+            // invoke without it is not a conformant tool call. Both V3.2 and V4
+            // inherit this from the shared helper.
+            require_wrapper: true,
             ..Default::default()
         };
         let structural_tag = StructuralTagBuilder::DsmlToolCalls(DsmlToolCallsConfig {

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -86,7 +86,8 @@ pub fn try_tool_call_parse_dsml(
     let Some(start_idx) = trimmed.find(&config.block_start) else {
         if let Some(marker_idx) = first_orphan_dsml_marker_index(trimmed, config) {
             let marker_tail = &trimmed[marker_idx..];
-            if marker_tail.starts_with(config.invoke_start_prefix.as_str())
+            if !config.require_wrapper
+                && marker_tail.starts_with(config.invoke_start_prefix.as_str())
                 && (marker_tail.contains(config.block_end.as_str()) || config.allow_eof_recovery)
             {
                 let tool_calls = extract_invokes(marker_tail, config)?;
@@ -232,6 +233,11 @@ fn recover_orphan_invokes_in_span(
     span: &str,
     config: &DsmlParserConfig,
 ) -> anyhow::Result<Option<(String, Vec<ToolCallResponse>)>> {
+    // Spec-strict configs require the outer wrapper, so a bare invoke (with no
+    // enclosing block, even one preceding a later block) is not recovered.
+    if config.require_wrapper {
+        return Ok(None);
+    }
     let Some(marker_idx) = first_orphan_dsml_marker_index(span, config) else {
         return Ok(None);
     };
@@ -1098,6 +1104,81 @@ mod tests {
         assert_eq!(args1["x"], "1");
         assert_eq!(name2, "b");
         assert_eq!(args2["y"], "2");
+    }
+
+    /// Strict config (`require_wrapper: true`, as the deepseek_v3_2 / deepseek_v4
+    /// factories set) drops the EOF-recovery `allow_eof_recovery` lever on top of
+    /// the recovery test config, so this exercises the production finalize shape.
+    fn get_v4_strict_test_config() -> DsmlParserConfig {
+        DsmlParserConfig {
+            require_wrapper: true,
+            ..get_v4_recovery_test_config()
+        }
+    }
+
+    /// DeepSeek DSML spec: the outer `<｜DSML｜tool_calls>` wrapper is mandatory.
+    /// A complete but wrapper-less `<｜DSML｜invoke>` is NOT a conformant tool
+    /// call, so a strict config recovers nothing and suppresses the orphan
+    /// markup (no leak into normal_text). Mirrors fixture
+    /// deepseek_v4/TOOLCALLING.stream.4.c. Even with `allow_eof_recovery`,
+    /// `require_wrapper` wins.
+    #[test] // TOOLCALLING.stream.4.c, TOOLCALLING.batch.5.c (strict)
+    fn test_parse_deepseek_v4_strict_bare_invoke_without_wrapper_rejected() {
+        let input = "<｜DSML｜invoke name=\"get_weather\">\n\
+<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+</｜DSML｜invoke>\n\
+</｜DSML｜invoke>";
+
+        let config = get_v4_strict_test_config();
+        let (calls, normal_text) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 0, "bare invoke without wrapper is not a call");
+        assert_eq!(
+            normal_text.as_deref(),
+            Some(""),
+            "orphan DSML markup must be suppressed, not leaked into normal_text"
+        );
+    }
+
+    /// Strict config still parses a properly wrapped tool call — strictness only
+    /// rejects the missing wrapper, it does not break the conformant path.
+    #[test]
+    fn test_parse_deepseek_v4_strict_wrapped_invoke_still_parsed() {
+        let input = "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"get_weather\">\n\
+<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+</｜DSML｜tool_calls>";
+
+        let config = get_v4_strict_test_config();
+        let (calls, _) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 1);
+        let (name, args) = extract_name_and_args(calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+    }
+
+    /// Strict config: a bare invoke preceding a properly wrapped block is dropped
+    /// (and its markup suppressed), while the wrapped block is still parsed.
+    #[test]
+    fn test_parse_deepseek_v4_strict_bare_invoke_before_block_dropped() {
+        let input = "<｜DSML｜invoke name=\"orphan\">\n\
+<｜DSML｜parameter name=\"x\" string=\"true\">1</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"wrapped\">\n\
+<｜DSML｜parameter name=\"y\" string=\"true\">2</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+</｜DSML｜tool_calls>";
+
+        let config = get_v4_strict_test_config();
+        let (calls, _) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 1, "only the wrapped invoke is a tool call");
+        let (name, _) = extract_name_and_args(calls[0].clone());
+        assert_eq!(name, "wrapped");
     }
 
     /// `TOOLCALLING.batch.4` — malformed JSON in a `string="false"` parameter value falls back

--- a/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
@@ -52,14 +52,15 @@ cases:
     tools:
     - *id001
     expected:
+      # DSML strict-wrapper (spec): a closing </｜DSML｜function_calls> with no matching open means
+      # the invoke never had its mandatory wrapper. Per the DeepSeek DSML spec
+      # this is not a tool call; Dynamo now emits no call and suppresses the
+      # orphan markup (cleaner than vLLM/SGLang, which leak it into content).
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
+        calls: []
         normal_text: ''
       vllm: &d_5_b
-        reason: "vLLM and SGLang preserve orphan DSML markers as content when the opening <｜DSML｜function_calls> wrapper is missing; Dynamo recovers the complete bare <｜DSML｜invoke> call and strips the orphan marker tail."
+        reason: "vLLM and SGLang preserve orphan DSML markers as content when the opening <｜DSML｜function_calls> wrapper is missing; Dynamo also emits no call (spec requires the wrapper) but suppresses the orphan markup instead of leaking it."
         calls: []
         normal_text: |-
           <｜DSML｜invoke name="get_weather">

--- a/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.stream.4.yaml
@@ -82,11 +82,12 @@ cases:
           location:
             type: string
     expected:
+      # DSML strict-wrapper (spec): the DeepSeek DSML spec defines a tool call AS a
+      # <｜DSML｜function_calls> wrapper block; a bare <｜DSML｜invoke> with no
+      # wrapper is not a conformant tool call. Dynamo now requires the wrapper,
+      # so this yields no call and the orphan markup is suppressed (not leaked).
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
+        calls: []
         normal_text: ''
       vllm:
         calls:
@@ -99,9 +100,11 @@ cases:
           </｜DSML｜invoke>
           </｜DSML｜invoke>
           </｜DSML｜invoke>
+        reason: "vLLM (<0.23) recovers the wrapper-less invoke and leaks the markup into normal_text; Dynamo requires the outer <｜DSML｜function_calls> wrapper and emits no call. vLLM 0.23 also becomes strict here (see #10723)."
       sglang:
         calls:
         - arguments:
             location: NYC
           name: get_weather
         normal_text: ''
+        reason: "SGLang stays lenient and recovers the wrapper-less bare <｜DSML｜invoke>; Dynamo requires the outer <｜DSML｜function_calls> wrapper per the DeepSeek DSML spec and emits no call."

--- a/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -48,14 +48,15 @@ cases:
     tools:
     - *id001
     expected:
+      # DSML strict-wrapper (spec): a closing </｜DSML｜tool_calls> with no matching open means the
+      # invoke never had its mandatory wrapper. Per the DeepSeek DSML spec this
+      # is not a tool call; Dynamo now emits no call and suppresses the orphan
+      # markup (cleaner than vLLM, which leaks it into content).
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
+        calls: []
         normal_text: ''
       vllm:
-        reason: "vLLM leaks the DSML envelope into normal_text on missing/orphan end marker recovery; Dynamo recovers the complete bare <｜DSML｜invoke> call and strips the orphan DSML marker tail."
+        reason: "vLLM leaks the DSML envelope into normal_text on missing/orphan end-marker recovery; Dynamo also emits no call (spec requires the wrapper) but suppresses the orphan markup instead of leaking it."
         calls: []
         normal_text: |-
           <｜DSML｜invoke name="get_weather">
@@ -175,11 +176,12 @@ cases:
     tools:
     - *id001
     expected:
+      # DSML strict-wrapper (spec): the first invoke has no <｜DSML｜tool_calls> wrapper, so per the
+      # DeepSeek DSML spec it is not a tool call. Dynamo now drops the bare
+      # invoke (suppressing its markup) and keeps only the wrapped Boston call,
+      # converging with vLLM on calls.
       dynamo:
         calls:
-        - name: get_weather
-          arguments:
-            location: NYC
         - name: get_weather
           arguments:
             location: Boston
@@ -194,7 +196,7 @@ cases:
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
           </｜DSML｜invoke>
           </｜DSML｜tool_calls>
-        reason: "vLLM preserves the bare DSML invoke before the first <｜DSML｜tool_calls> as content, including the trailing newline; Dynamo recovers it as the first structured call before parsing the wrapped call."
+        reason: "vLLM preserves the bare DSML invoke before the first <｜DSML｜tool_calls> as content; Dynamo also drops it as a call (spec requires the wrapper) but suppresses its markup instead of leaking it, keeping only the wrapped call."
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.5.g:
@@ -208,11 +210,12 @@ cases:
     tools:
     - *id001
     expected:
+      # DSML strict-wrapper (spec): the invoke after the prose has no <｜DSML｜tool_calls> wrapper,
+      # so per the DeepSeek DSML spec it is not a tool call. Dynamo now keeps
+      # only the prefix prose, emits no call, and suppresses the orphan markup
+      # (vLLM leaks the markup into content).
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
+        calls: []
         normal_text: I will check that.
       vllm:
         calls: []
@@ -221,6 +224,6 @@ cases:
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
           </｜DSML｜invoke>
           </｜DSML｜tool_calls>
-        reason: "vLLM leaks the DSML envelope into normal_text on orphan close-marker recovery; Dynamo preserves the prefix prose, recovers the complete bare <｜DSML｜invoke> call, and strips the orphan DSML marker tail."
+        reason: "vLLM leaks the DSML envelope into normal_text on orphan close-marker recovery; Dynamo also emits no call (spec requires the wrapper), keeps the prefix prose, and suppresses the orphan markup instead of leaking it."
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'

--- a/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.stream.4.yaml
@@ -80,11 +80,12 @@ cases:
           location:
             type: string
     expected:
+      # DSML strict-wrapper (spec): the DeepSeek DSML spec defines a tool call AS a
+      # <｜DSML｜tool_calls> wrapper block; a bare <｜DSML｜invoke> with no wrapper
+      # is not a conformant tool call. Dynamo now requires the wrapper, so this
+      # yields no call and the orphan markup is suppressed (not leaked).
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
+        calls: []
         normal_text: ''
       vllm:
         calls:
@@ -97,6 +98,6 @@ cases:
           </｜DSML｜invoke>
           </｜DSML｜invoke>
           </｜DSML｜invoke>
-        reason: "vLLM accepts a bare <｜DSML｜invoke> body without the outer <｜DSML｜tool_calls> wrapper and leaks the markup into normal_text on the recovery path"
+        reason: "vLLM (<0.23) accepts a bare <｜DSML｜invoke> without the outer <｜DSML｜tool_calls> wrapper and leaks the markup into normal_text; Dynamo requires the wrapper and emits no call. vLLM 0.23 also becomes strict here (see #10723)."
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'


### PR DESCRIPTION
#### Overview:

This PR makes Dynamo's DeepSeek DSML tool-call parser require the outer wrapper (`<｜DSML｜function_calls>` for V3.2, `<｜DSML｜tool_calls>` for V4) before an `<｜DSML｜invoke>` is treated as a tool call, matching the DeepSeek DSML spec.

#### Details:

- **How is this done?** Add `require_wrapper: bool` to `DsmlParserConfig` (default `false`, preserving current behavior), set once in the shared `deepseek_dsml()` helper so V3.2 and V4 both inherit it. When set, the three bare-invoke recovery sites in `dsml/parser.rs` are skipped: a wrapper-less `<｜DSML｜invoke>` yields no call and the orphan markup is suppressed from `normal_text`.
- Spec basis: DeepSeek-V4 `encoding/README.md` defines a tool call AS a wrapper block ("invoke tools by writing a `<｜DSML｜tool_calls>` block"; "You MUST strictly follow the above defined ... schemas"). A bare `<｜DSML｜invoke>` without the wrapper is not conformant.
- Behavior change: previously Dynamo recovered bare invokes (lenient, beyond spec). It now rejects them, converging with the spec and with vLLM 0.23 — and is cleaner than vLLM 0.23, which leaks the raw DSML markup into `content` (Dynamo suppresses it).
- Fixtures: updated the 6 affected deepseek parity cases — `stream.4.c` + `batch.5.b` (both families), `batch.5.f` + `batch.5.g` (V4) — with the spec rationale in each `reason:`. `stream.4.b` is unaffected (it has the wrapper; that case is incomplete-call truncation, not a missing wrapper).
- Added strict-config unit tests in `dsml/parser.rs`.
- Overlaps with #10723 (vLLM 0.23 bump) on the two `deepseek_*/TOOLCALLING.stream.4.yaml` files (different blocks within the same cases); trivial rebase whenever either lands.

#### Verification:

`cargo test -p dynamo-parsers --lib` -> 609 passed. Dynamo-side parity 739 passed; full toolcalling parity (dynamo + vLLM 0.22 + SGLang) 1367 passed, 0 failed. Also confirmed the wrapped (conformant) path still parses.

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/config.rs` (the `require_wrapper` flag + `deepseek_dsml()`), then `lib/parsers/src/tool_calling/dsml/parser.rs` (the three gated recovery sites).

#### Related Issues:

Relates to DIS-2237. Relates to #10723.

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DSML tool-call parsing for DeepSeek V3.2+ models to prevent malformed tool-call blocks from appearing in text content.

* **Tests**
  * Updated test fixtures to validate stricter tool-call parsing behavior across DeepSeek model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->