### PR TITLE
feat(replay): goodput + provisioned GPU-hours in planner replay

### DIFF
--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -522,23 +522,10 @@ def _run_planner_replay(
                             f"(prefill={len(prefill_fpms)}, decode={len(decode_fpms)})\n"
                         )
 
-    result = adapter.run()
-
-    # Surface true GPU-hours in the JSON report: the time-integrated provisioned
-    # worker-seconds (which already include the startup ramp and drain tail) x
-    # the per-engine GPU count. This is ungated, unlike the diagnostics-only
-    # `_cumulative_gpu_hours` (active-count based). Skipped when the per-engine
-    # GPU counts are not configured — the raw *_worker_seconds remain in the
-    # report for a consumer to scale by its own GPUs-per-worker.
-    gpu_p = planner_config.prefill_engine_num_gpu or 0
-    gpu_d = planner_config.decode_engine_num_gpu or 0
-    if gpu_p or gpu_d:
-        report = result.trace_report
-        result.trace_report["gpu_hours"] = (
-            report.get("prefill_worker_seconds", 0.0) * gpu_p
-            + report.get("decode_worker_seconds", 0.0) * gpu_d
-        ) / 3600.0
-    return result
+    # gpu_hours (and prefill/decode_gpus_per_worker) are computed in the mocker
+    # from its own worker parallelism (aic_tp x aic_attention_dp) and ride the
+    # report dict — no per-engine GPU count from the planner config is needed.
+    return adapter.run()
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -325,8 +325,16 @@ def _run_planner_replay(
     trace_block_size: int,
     planner_config_arg: str,
     benchmark_granularity: int = 8,
+    sla_ttft_ms: float | None = None,
+    sla_itl_ms: float | None = None,
+    sla_e2e_ms: float | None = None,
 ):
     """Run an offline replay with planner-in-the-loop (agg or disagg).
+
+    ``sla_ttft_ms`` / ``sla_itl_ms`` / ``sla_e2e_ms`` are the **goodput** SLA used
+    to classify SLA-satisfying requests in the report. They are independent of
+    the planner's own scaling SLA in ``planner_config`` and are never read from
+    it — pass whatever goodput threshold the caller wants measured.
 
     # TODO(jthomson04): SLA-based scaling (optimization_target="sla") with
     # disagg mode requires planner_profile_data (NPZ) or AIC-backed engine
@@ -355,6 +363,9 @@ def _run_planner_replay(
             router_config=router_config,
             arrival_speedup_ratio=arrival_speedup_ratio,
             trace_block_size=trace_block_size,
+            sla_ttft_ms=sla_ttft_ms,
+            sla_itl_ms=sla_itl_ms,
+            sla_e2e_ms=sla_e2e_ms,
         )
         capabilities = WorkerCapabilities(decode=_engine_caps(extra_engine_args))
 
@@ -373,6 +384,9 @@ def _run_planner_replay(
             router_config=router_config,
             arrival_speedup_ratio=arrival_speedup_ratio,
             trace_block_size=trace_block_size,
+            sla_ttft_ms=sla_ttft_ms,
+            sla_itl_ms=sla_itl_ms,
+            sla_e2e_ms=sla_e2e_ms,
         )
         capabilities = WorkerCapabilities(
             prefill=_engine_caps(prefill_engine_args),
@@ -508,7 +522,23 @@ def _run_planner_replay(
                             f"(prefill={len(prefill_fpms)}, decode={len(decode_fpms)})\n"
                         )
 
-    return adapter.run()
+    result = adapter.run()
+
+    # Surface true GPU-hours in the JSON report: the time-integrated provisioned
+    # worker-seconds (which already include the startup ramp and drain tail) ×
+    # the per-engine GPU count. This is ungated, unlike the diagnostics-only
+    # `_cumulative_gpu_hours` (active-count based). Skipped when the per-engine
+    # GPU counts are not configured — the raw *_worker_seconds remain in the
+    # report for a consumer to scale by its own GPUs-per-worker.
+    gpu_p = planner_config.prefill_engine_num_gpu or 0
+    gpu_d = planner_config.decode_engine_num_gpu or 0
+    if gpu_p or gpu_d:
+        report = result.trace_report
+        result.trace_report["gpu_hours"] = (
+            report.get("prefill_worker_seconds", 0.0) * gpu_p
+            + report.get("decode_worker_seconds", 0.0) * gpu_d
+        ) / 3600.0
+    return result
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -618,6 +648,31 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=None,
         help="optional cap on simulated wall-clock duration for offline replay (disagg and agg); when set, replay stops once the simulated clock would exceed this many seconds, leaving in-flight requests as incomplete in the report",
     )
+    # Goodput SLA — the threshold a request must meet to count toward goodput in
+    # the report. This is INDEPENDENT of the planner's own scaling SLA (in
+    # --planner-config); the two can hold different values and are never read
+    # from each other. Set --sla-ttft-ms + --sla-itl-ms, or --sla-e2e-ms alone.
+    parser.add_argument(
+        "--sla-ttft-ms",
+        type=float,
+        default=None,
+        help="goodput SLA: max time-to-first-token (ms). Independent of the planner's scaling SLA. "
+        "When an SLA is set, the report adds goodput_* (SLA-satisfying throughput).",
+    )
+    parser.add_argument(
+        "--sla-itl-ms",
+        type=float,
+        default=None,
+        help="goodput SLA: max average inter-token latency (ms), per request (e2e - ttft)/(osl - 1) "
+        "(aiperf definition). Independent of the planner's scaling SLA.",
+    )
+    parser.add_argument(
+        "--sla-e2e-ms",
+        type=float,
+        default=None,
+        help="goodput SLA: max end-to-end latency (ms); use instead of --sla-ttft-ms/--sla-itl-ms. "
+        "Independent of the planner's scaling SLA.",
+    )
     args = parser.parse_args(list(sys.argv[1:] if argv is None else argv))
 
     using_trace_file = args.trace_file is not None
@@ -664,6 +719,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser.error(
                 "--max-sim-time-seconds currently only supports trace-file replay"
             )
+    if (
+        any(v is not None for v in (args.sla_ttft_ms, args.sla_itl_ms, args.sla_e2e_ms))
+        and args.planner_config is None
+    ):
+        parser.error(
+            "goodput SLA (--sla-ttft-ms/--sla-itl-ms/--sla-e2e-ms) currently requires --planner-config"
+        )
 
     extra_engine_args = _load_engine_args(args.extra_engine_args)
     prefill_engine_args = _load_engine_args(args.prefill_engine_args)
@@ -701,6 +763,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             trace_block_size=args.trace_block_size,
             planner_config_arg=args.planner_config,
             benchmark_granularity=args.benchmark_granularity,
+            sla_ttft_ms=args.sla_ttft_ms,
+            sla_itl_ms=args.sla_itl_ms,
+            sla_e2e_ms=args.sla_e2e_ms,
         )
         report = planner_report.trace_report
         if planner_report.scaling_events:

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -525,7 +525,7 @@ def _run_planner_replay(
     result = adapter.run()
 
     # Surface true GPU-hours in the JSON report: the time-integrated provisioned
-    # worker-seconds (which already include the startup ramp and drain tail) ×
+    # worker-seconds (which already include the startup ramp and drain tail) x
     # the per-engine GPU count. This is ungated, unlike the diagnostics-only
     # `_cumulative_gpu_hours` (active-count based). Skipped when the per-engine
     # GPU counts are not configured — the raw *_worker_seconds remain in the

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1618,6 +1618,19 @@ fn fpm_snapshots_to_json(
 /// calls `advance_to()` to run the simulation forward, collects FPM/traffic
 /// metrics, feeds them to the planner state machine, then calls
 /// `apply_scaling()` to resize worker pools.
+/// Reject a goodput SLA threshold that is not a finite, non-negative value;
+/// `None` (unset) is allowed and means "do not gate on this dimension".
+fn validate_sla_threshold(name: &str, value: Option<f64>) -> PyResult<()> {
+    if let Some(v) = value {
+        if !v.is_finite() || v < 0.0 {
+            return Err(PyValueError::new_err(format!(
+                "{name} must be a finite, non-negative value, got {v}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[pyclass(unsendable)]
 pub struct PlannerReplayBridge {
     handle: Option<dynamo_mocker::replay::PlannerReplayHandle>,
@@ -1645,6 +1658,9 @@ impl PlannerReplayBridge {
             Python::with_gil(|py| materialize_replay_mocker_args(py, extra_engine_args.clone()))?;
         let router_mode = parse_replay_router_mode(router_mode)?;
         let router_config = load_replay_router_config(router_config);
+        validate_sla_threshold("sla_ttft_ms", sla_ttft_ms)?;
+        validate_sla_threshold("sla_itl_ms", sla_itl_ms)?;
+        validate_sla_threshold("sla_e2e_ms", sla_e2e_ms)?;
         let sla = dynamo_mocker::replay::SlaThresholds {
             ttft_ms: sla_ttft_ms,
             itl_ms: sla_itl_ms,
@@ -1699,6 +1715,9 @@ impl PlannerReplayBridge {
         };
         let router_mode = parse_replay_router_mode(router_mode)?;
         let router_config = load_replay_router_config(router_config);
+        validate_sla_threshold("sla_ttft_ms", sla_ttft_ms)?;
+        validate_sla_threshold("sla_itl_ms", sla_itl_ms)?;
+        validate_sla_threshold("sla_e2e_ms", sla_e2e_ms)?;
         let sla = dynamo_mocker::replay::SlaThresholds {
             ttft_ms: sla_ttft_ms,
             itl_ms: sla_itl_ms,

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1621,12 +1621,12 @@ fn fpm_snapshots_to_json(
 /// Reject a goodput SLA threshold that is not a finite, non-negative value;
 /// `None` (unset) is allowed and means "do not gate on this dimension".
 fn validate_sla_threshold(name: &str, value: Option<f64>) -> PyResult<()> {
-    if let Some(v) = value {
-        if !v.is_finite() || v < 0.0 {
-            return Err(PyValueError::new_err(format!(
-                "{name} must be a finite, non-negative value, got {v}"
-            )));
-        }
+    if let Some(v) = value
+        && (!v.is_finite() || v < 0.0)
+    {
+        return Err(PyValueError::new_err(format!(
+            "{name} must be a finite, non-negative value, got {v}"
+        )));
     }
     Ok(())
 }

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1627,7 +1627,8 @@ pub struct PlannerReplayBridge {
 impl PlannerReplayBridge {
     /// Create a bridge for an aggregated Mooncake-style JSONL trace replay.
     #[new]
-    #[pyo3(signature = (trace_file, extra_engine_args, num_workers, router_mode="round_robin", router_config=None, arrival_speedup_ratio=1.0, trace_block_size=512))]
+    #[pyo3(signature = (trace_file, extra_engine_args, num_workers, router_mode="round_robin", router_config=None, arrival_speedup_ratio=1.0, trace_block_size=512, sla_ttft_ms=None, sla_itl_ms=None, sla_e2e_ms=None))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         trace_file: PathBuf,
         extra_engine_args: &MockEngineArgs,
@@ -1636,11 +1637,19 @@ impl PlannerReplayBridge {
         router_config: Option<KvRouterConfig>,
         arrival_speedup_ratio: f64,
         trace_block_size: usize,
+        sla_ttft_ms: Option<f64>,
+        sla_itl_ms: Option<f64>,
+        sla_e2e_ms: Option<f64>,
     ) -> PyResult<Self> {
         let args =
             Python::with_gil(|py| materialize_replay_mocker_args(py, extra_engine_args.clone()))?;
         let router_mode = parse_replay_router_mode(router_mode)?;
         let router_config = load_replay_router_config(router_config);
+        let sla = dynamo_mocker::replay::SlaThresholds {
+            ttft_ms: sla_ttft_ms,
+            itl_ms: sla_itl_ms,
+            e2e_ms: sla_e2e_ms,
+        };
 
         let handle = dynamo_mocker::replay::PlannerReplayHandle::from_trace_file(
             args,
@@ -1651,6 +1660,7 @@ impl PlannerReplayBridge {
             num_workers,
             arrival_speedup_ratio,
             router_mode,
+            sla,
         )
         .map_err(to_pyerr)?;
 
@@ -1661,7 +1671,7 @@ impl PlannerReplayBridge {
 
     /// Create a bridge for a disaggregated Mooncake-style JSONL trace replay.
     #[staticmethod]
-    #[pyo3(signature = (trace_file, prefill_engine_args, decode_engine_args, num_prefill_workers, num_decode_workers, router_mode="round_robin", router_config=None, arrival_speedup_ratio=1.0, trace_block_size=512))]
+    #[pyo3(signature = (trace_file, prefill_engine_args, decode_engine_args, num_prefill_workers, num_decode_workers, router_mode="round_robin", router_config=None, arrival_speedup_ratio=1.0, trace_block_size=512, sla_ttft_ms=None, sla_itl_ms=None, sla_e2e_ms=None))]
     #[allow(clippy::too_many_arguments)]
     fn create_disagg(
         trace_file: PathBuf,
@@ -1673,6 +1683,9 @@ impl PlannerReplayBridge {
         router_config: Option<KvRouterConfig>,
         arrival_speedup_ratio: f64,
         trace_block_size: usize,
+        sla_ttft_ms: Option<f64>,
+        sla_itl_ms: Option<f64>,
+        sla_e2e_ms: Option<f64>,
     ) -> PyResult<Self> {
         let prefill_args =
             Python::with_gil(|py| materialize_replay_mocker_args(py, prefill_engine_args.clone()))?;
@@ -1686,6 +1699,11 @@ impl PlannerReplayBridge {
         };
         let router_mode = parse_replay_router_mode(router_mode)?;
         let router_config = load_replay_router_config(router_config);
+        let sla = dynamo_mocker::replay::SlaThresholds {
+            ttft_ms: sla_ttft_ms,
+            itl_ms: sla_itl_ms,
+            e2e_ms: sla_e2e_ms,
+        };
 
         let handle = dynamo_mocker::replay::PlannerReplayHandle::from_trace_file_disagg(
             config,
@@ -1695,6 +1713,7 @@ impl PlannerReplayBridge {
             trace_block_size,
             arrival_speedup_ratio,
             router_mode,
+            sla,
         )
         .map_err(to_pyerr)?;
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2307,6 +2307,9 @@ class PlannerReplayBridge:
         router_config: Optional[KvRouterConfig] = None,
         arrival_speedup_ratio: float = 1.0,
         trace_block_size: int = 512,
+        sla_ttft_ms: Optional[float] = None,
+        sla_itl_ms: Optional[float] = None,
+        sla_e2e_ms: Optional[float] = None,
     ) -> None: ...
 
     @staticmethod
@@ -2320,6 +2323,9 @@ class PlannerReplayBridge:
         router_config: Optional[KvRouterConfig] = None,
         arrival_speedup_ratio: float = 1.0,
         trace_block_size: int = 512,
+        sla_ttft_ms: Optional[float] = None,
+        sla_itl_ms: Optional[float] = None,
+        sla_e2e_ms: Optional[float] = None,
     ) -> "PlannerReplayBridge": ...
 
     def advance_to(self, until_ms: float) -> Dict[str, Any]: ...

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -1146,6 +1146,16 @@ impl MockEngineArgs {
         MockEngineArgsBuilder::default()
     }
 
+    /// GPUs occupied by one worker (engine), derived from the AIC parallelism:
+    /// `aic_tp_size × aic_attention_dp_size` (the attention width, which by the
+    /// MoE constraint equals `aic_moe_tp_size × aic_moe_ep_size`). Falls back to
+    /// 1 when AIC parallelism is not configured (non-AIC / polynomial perf
+    /// model, where a worker is a single logical engine). Used to turn
+    /// provisioned worker-seconds into GPU-hours.
+    pub fn aic_gpus_per_worker(&self) -> usize {
+        self.aic_tp_size.unwrap_or(1) * self.aic_attention_dp_size.unwrap_or(1)
+    }
+
     pub fn normalized(mut self) -> anyhow::Result<Self> {
         self.materialize_defaults();
         self.validate_config()?;

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -44,13 +44,15 @@ pub struct TraceThroughputStats {
     pub total_throughput_tok_s: f64,
     /// Provisioned worker-time per role, in **worker-seconds**: the time-integral
     /// of the *provisioned* worker count over the whole simulated run. The
-    /// provisioned count is every worker physically holding a GPU — active +
-    /// starting-up + draining — so this captures the startup ramp and the
+    /// provisioned count is every worker physically holding a GPU (active +
+    /// starting-up + draining), so this captures the startup ramp and the
     /// scale-down drain tail, unlike a snapshot of the active/serving count.
-    /// Set by the runtime via [`TraceSimulationReport::with_worker_seconds`]
-    /// (0.0 until then). Multiply by GPUs-per-worker for GPU-seconds (÷3600 for
-    /// GPU-hours). Aggregated replay reports through `decode_worker_seconds`,
-    /// leaving `prefill_worker_seconds` at 0.0.
+    /// Populated on the collector by the runtime: `add_worker_seconds` accrues
+    /// the integral each clock advance (agg / disagg), and
+    /// `set_static_worker_count` covers the single-worker path; 0.0 otherwise.
+    /// Multiply by GPUs-per-worker for GPU-seconds (/3600 for GPU-hours).
+    /// Aggregated replay reports through `decode_worker_seconds`, leaving
+    /// `prefill_worker_seconds` at 0.0.
     pub prefill_worker_seconds: f64,
     pub decode_worker_seconds: f64,
 }

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -55,6 +55,16 @@ pub struct TraceThroughputStats {
     /// `prefill_worker_seconds` at 0.0.
     pub prefill_worker_seconds: f64,
     pub decode_worker_seconds: f64,
+    /// GPUs per worker per role, derived from the mocker engine parallelism
+    /// (`MockEngineArgs::aic_gpus_per_worker` = aic_tp × aic_attention_dp); the
+    /// runtime sets it on the collector. 0 when not set (e.g. the online path).
+    pub prefill_gpus_per_worker: usize,
+    pub decode_gpus_per_worker: usize,
+    /// GPU-hours = Σ_role `worker_seconds × gpus_per_worker / 3600` — the
+    /// deployment's provisioned GPU-time (already including the startup ramp and
+    /// drain tail, since `*_worker_seconds` do). Computed in `finish()` straight
+    /// from the mocker's own worker parallelism, so it needs no external config.
+    pub gpu_hours: f64,
 }
 
 /// Goodput: throughput restricted to the requests that satisfy the SLA. Present
@@ -183,7 +193,7 @@ impl Serialize for TraceSimulationReport {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(67))?;
+        let mut map = serializer.serialize_map(Some(70))?;
         map.serialize_entry("num_requests", &self.request_counts.num_requests)?;
         map.serialize_entry(
             "completed_requests",
@@ -223,6 +233,15 @@ impl Serialize for TraceSimulationReport {
             "decode_worker_seconds",
             &self.throughput.decode_worker_seconds,
         )?;
+        map.serialize_entry(
+            "prefill_gpus_per_worker",
+            &self.throughput.prefill_gpus_per_worker,
+        )?;
+        map.serialize_entry(
+            "decode_gpus_per_worker",
+            &self.throughput.decode_gpus_per_worker,
+        )?;
+        map.serialize_entry("gpu_hours", &self.throughput.gpu_hours)?;
         if let Some(goodput) = &self.goodput {
             map.serialize_entry("goodput_completed_requests", &goodput.completed_requests)?;
             map.serialize_entry(
@@ -443,6 +462,10 @@ pub(crate) struct TraceCollector {
     /// integrate). When `Some`, `finish()` derives worker-seconds as
     /// `count × duration_s` instead of using the accumulator.
     static_worker_count: Option<(usize, usize)>,
+    /// GPUs per worker per role, from the mocker engine parallelism. Used in
+    /// `finish()` to turn worker-seconds into gpu_hours.
+    prefill_gpus_per_worker: usize,
+    decode_gpus_per_worker: usize,
 }
 
 impl TraceRequestStats {
@@ -508,6 +531,13 @@ impl TraceCollector {
     /// reports `count × duration_s` worker-seconds.
     pub(crate) fn set_static_worker_count(&mut self, prefill: usize, decode: usize) {
         self.static_worker_count = Some((prefill, decode));
+    }
+
+    /// Set GPUs-per-worker per role (from the mocker engine parallelism). Used
+    /// in `finish()` to derive gpu_hours from the worker-seconds.
+    pub(crate) fn set_gpus_per_worker(&mut self, prefill: usize, decode: usize) {
+        self.prefill_gpus_per_worker = prefill;
+        self.decode_gpus_per_worker = decode;
     }
 
     pub(crate) fn on_arrival(
@@ -619,6 +649,8 @@ impl TraceCollector {
         let static_worker_count = self.static_worker_count;
         let accumulated_prefill_worker_seconds = self.prefill_worker_seconds;
         let accumulated_decode_worker_seconds = self.decode_worker_seconds;
+        let prefill_gpus_per_worker = self.prefill_gpus_per_worker;
+        let decode_gpus_per_worker = self.decode_gpus_per_worker;
         let requests = self.requests;
         let request_count = requests.len();
         let mut ttfts = Vec::with_capacity(request_count);
@@ -691,6 +723,11 @@ impl TraceCollector {
                 accumulated_decode_worker_seconds,
             ),
         };
+        // GPU-hours straight from the mocker's own worker parallelism (no
+        // external GPU-count config). 0 when gpus_per_worker was not set.
+        let gpu_hours = (prefill_worker_seconds * prefill_gpus_per_worker as f64
+            + decode_worker_seconds * decode_gpus_per_worker as f64)
+            / 3600.0;
         let itl_distribution = build_distribution_stats(itls);
         // Goodput only when an SLA was supplied; otherwise it is undefined.
         let goodput = sla.is_set().then(|| TraceGoodputStats {
@@ -715,6 +752,9 @@ impl TraceCollector {
                     / duration_s,
                 prefill_worker_seconds,
                 decode_worker_seconds,
+                prefill_gpus_per_worker,
+                decode_gpus_per_worker,
+                gpu_hours,
             },
             prefix_cache_reused_ratio: if total_input_tokens == 0 {
                 0.0
@@ -1147,6 +1187,21 @@ mod tests {
         let report = static_single.finish();
         assert!(report.throughput.prefill_worker_seconds.abs() < 1e-9);
         assert!((report.throughput.decode_worker_seconds - 0.2).abs() < 1e-9);
+    }
+
+    /// gpu_hours derives from worker-seconds x the per-role GPUs/worker that the
+    /// runtime records from the mocker's own parallelism.
+    #[test]
+    fn gpu_hours_from_worker_seconds_and_gpus_per_worker() {
+        let mut collector = TraceCollector::default();
+        collector.set_gpus_per_worker(2, 4); // prefill 2 GPUs/worker, decode 4
+        add_completed(&mut collector, 1, 0.0, 2, &[100.0, 200.0]);
+        collector.add_worker_seconds(10.0, 5.0); // prefill_ws=10, decode_ws=5
+        let report = collector.finish();
+        assert_eq!(report.throughput.prefill_gpus_per_worker, 2);
+        assert_eq!(report.throughput.decode_gpus_per_worker, 4);
+        // gpu_hours = (10*2 + 5*4) / 3600 = 40 / 3600
+        assert!((report.throughput.gpu_hours - 40.0 / 3600.0).abs() < 1e-9);
     }
 
     /// Records emerge in arrival-time order, so the JSONL file produced from

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -14,6 +14,10 @@ pub struct TraceSimulationReport {
     pub prefix_cache_reused_ratio: f64,
     pub first_admission_prefix_cache_reused_ratio: f64,
     pub latency: TraceLatencyStats,
+    /// SLA-goodput stats. `Some` only when an SLA was supplied to the collector
+    /// (via `set_sla_thresholds`); `None` otherwise — goodput is undefined
+    /// without an SLA, so the `goodput_*` keys are omitted from the report.
+    pub goodput: Option<TraceGoodputStats>,
     /// Per-request records, one per admitted request. Populated by
     /// `TraceCollector::finish`. Intentionally NOT serialized into the summary
     /// JSON (see custom `Serialize` impl below) — consumers that want per-
@@ -38,6 +42,31 @@ pub struct TraceThroughputStats {
     pub input_throughput_tok_s: f64,
     pub output_throughput_tok_s: f64,
     pub total_throughput_tok_s: f64,
+    /// Provisioned worker-time per role, in **worker-seconds**: the time-integral
+    /// of the *provisioned* worker count over the whole simulated run. The
+    /// provisioned count is every worker physically holding a GPU — active +
+    /// starting-up + draining — so this captures the startup ramp and the
+    /// scale-down drain tail, unlike a snapshot of the active/serving count.
+    /// Set by the runtime via [`TraceSimulationReport::with_worker_seconds`]
+    /// (0.0 until then). Multiply by GPUs-per-worker for GPU-seconds (÷3600 for
+    /// GPU-hours). Aggregated replay reports through `decode_worker_seconds`,
+    /// leaving `prefill_worker_seconds` at 0.0.
+    pub prefill_worker_seconds: f64,
+    pub decode_worker_seconds: f64,
+}
+
+/// Goodput: throughput restricted to the requests that satisfy the SLA. Present
+/// on the report only when an SLA was supplied to the collector (goodput is
+/// undefined without one). A completed request counts as "good" per
+/// [`SlaThresholds::is_good`].
+#[derive(Debug, Clone)]
+pub struct TraceGoodputStats {
+    /// Completed requests that satisfied the SLA.
+    pub completed_requests: usize,
+    /// Good requests per second, over the simulated `duration_s`.
+    pub request_throughput_rps: f64,
+    /// Output tokens from good requests per second, over `duration_s`.
+    pub output_throughput_tok_s: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -152,7 +181,7 @@ impl Serialize for TraceSimulationReport {
     where
         S: Serializer,
     {
-        let mut map = serializer.serialize_map(Some(62))?;
+        let mut map = serializer.serialize_map(Some(67))?;
         map.serialize_entry("num_requests", &self.request_counts.num_requests)?;
         map.serialize_entry(
             "completed_requests",
@@ -184,6 +213,25 @@ impl Serialize for TraceSimulationReport {
             "total_throughput_tok_s",
             &self.throughput.total_throughput_tok_s,
         )?;
+        map.serialize_entry(
+            "prefill_worker_seconds",
+            &self.throughput.prefill_worker_seconds,
+        )?;
+        map.serialize_entry(
+            "decode_worker_seconds",
+            &self.throughput.decode_worker_seconds,
+        )?;
+        if let Some(goodput) = &self.goodput {
+            map.serialize_entry("goodput_completed_requests", &goodput.completed_requests)?;
+            map.serialize_entry(
+                "goodput_request_throughput_rps",
+                &goodput.request_throughput_rps,
+            )?;
+            map.serialize_entry(
+                "goodput_output_throughput_tok_s",
+                &goodput.output_throughput_tok_s,
+            )?;
+        }
         map.serialize_entry("processed_tokens", &self.processed_tokens())?;
         map.serialize_entry("processed_tokens_per_s", &self.processed_tokens_per_s())?;
         map.serialize_entry(
@@ -322,6 +370,56 @@ pub(crate) struct TraceRequestStatsSnapshot {
     pub first_admission_reused_input_tokens: usize,
 }
 
+/// SLA thresholds used to classify requests for goodput. Mirrors Spica's
+/// `SLATarget` shape: set `ttft_ms` + `itl_ms` together, or `e2e_ms` alone.
+/// Only the thresholds that are set are checked, so an e2e-only SLA gates on
+/// e2e and a ttft+itl SLA gates on both. All-`None` (the default) means "no
+/// SLA", which suppresses goodput entirely.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SlaThresholds {
+    pub ttft_ms: Option<f64>,
+    pub itl_ms: Option<f64>,
+    pub e2e_ms: Option<f64>,
+}
+
+impl SlaThresholds {
+    pub(crate) fn is_set(&self) -> bool {
+        self.ttft_ms.is_some() || self.itl_ms.is_some() || self.e2e_ms.is_some()
+    }
+
+    /// Whether a completed request satisfies the SLA. Each *set* threshold must
+    /// hold; unset thresholds are ignored.
+    ///
+    /// - `ttft_ms`: time-to-first-token ≤ bound.
+    /// - `e2e_ms`: end-to-end latency ≤ bound.
+    /// - `itl_ms`: the per-request **average inter-token latency** ≤ bound,
+    ///   computed the same way as aiperf / genai-perf:
+    ///   `avg_itl = (e2e_ms − ttft_ms) / (output_length − 1)`. When
+    ///   `output_length ≤ 1` there is no inter-token interval, so the ITL check
+    ///   is skipped (treated as satisfied).
+    fn is_good(&self, ttft_ms: f64, e2e_ms: f64, output_length: usize) -> bool {
+        if let Some(bound) = self.e2e_ms
+            && e2e_ms > bound
+        {
+            return false;
+        }
+        if let Some(bound) = self.ttft_ms
+            && ttft_ms > bound
+        {
+            return false;
+        }
+        if let Some(bound) = self.itl_ms
+            && output_length > 1
+        {
+            let avg_itl_ms = (e2e_ms - ttft_ms) / (output_length as f64 - 1.0);
+            if avg_itl_ms > bound {
+                return false;
+            }
+        }
+        true
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct TraceCollector {
     requests: FxHashMap<Uuid, TraceRequestStats>,
@@ -329,6 +427,20 @@ pub(crate) struct TraceCollector {
     /// Default `false` to skip the ~100ms terminal pass + ~30MB allocation
     /// when the caller doesn't need per-request granularity.
     capture_per_request: bool,
+    /// SLA thresholds for goodput classification. All-`None` by default, in
+    /// which case `finish()` leaves `TraceSimulationReport::goodput` as `None`.
+    sla: SlaThresholds,
+    /// Accumulated provisioned worker-seconds per role, integrated by the
+    /// runtime over the sim clock (see `add_worker_seconds`). Used for the
+    /// runtimes that have an event loop (agg / disagg), where the provisioned
+    /// count varies with startup / drain / scaling.
+    prefill_worker_seconds: f64,
+    decode_worker_seconds: f64,
+    /// Static provisioned worker counts `(prefill, decode)` for runtimes with a
+    /// fixed worker (the single-worker path, which has no event loop to
+    /// integrate). When `Some`, `finish()` derives worker-seconds as
+    /// `count × duration_s` instead of using the accumulator.
+    static_worker_count: Option<(usize, usize)>,
 }
 
 impl TraceRequestStats {
@@ -370,6 +482,30 @@ impl TraceCollector {
     /// default; the runtimes flip it on when the caller asks for JSONL output.
     pub(crate) fn set_capture_per_request(&mut self, value: bool) {
         self.capture_per_request = value;
+    }
+
+    /// Set the SLA thresholds used to classify goodput in `finish()`. With no
+    /// SLA set (the default), the report's `goodput` field stays `None`.
+    pub(crate) fn set_sla_thresholds(&mut self, sla: SlaThresholds) {
+        self.sla = sla;
+    }
+
+    /// Add provisioned worker-seconds for the interval just elapsed. The runtime
+    /// calls this each time it advances the sim clock, with
+    /// `provisioned_count × dt_ms / 1000` per role — the time-integral of the
+    /// *provisioned* worker count (active + starting-up + draining), so the
+    /// startup ramp and drain tail are included. Agg replay passes `prefill = 0`
+    /// and reports through `decode`.
+    pub(crate) fn add_worker_seconds(&mut self, prefill: f64, decode: f64) {
+        self.prefill_worker_seconds += prefill;
+        self.decode_worker_seconds += decode;
+    }
+
+    /// Declare a fixed `(prefill, decode)` provisioned worker count for a runtime
+    /// with no event loop to integrate (the single-worker path). `finish()` then
+    /// reports `count × duration_s` worker-seconds.
+    pub(crate) fn set_static_worker_count(&mut self, prefill: usize, decode: usize) {
+        self.static_worker_count = Some((prefill, decode));
     }
 
     pub(crate) fn on_arrival(
@@ -477,6 +613,10 @@ impl TraceCollector {
         } else {
             Vec::new()
         };
+        let sla = self.sla;
+        let static_worker_count = self.static_worker_count;
+        let accumulated_prefill_worker_seconds = self.prefill_worker_seconds;
+        let accumulated_decode_worker_seconds = self.decode_worker_seconds;
         let requests = self.requests;
         let request_count = requests.len();
         let mut ttfts = Vec::with_capacity(request_count);
@@ -491,6 +631,9 @@ impl TraceCollector {
         let mut completed_requests = 0usize;
         let mut total_reused_tokens = 0usize;
         let mut total_first_admission_reused_tokens = 0usize;
+        // Goodput: completed requests (and their output tokens) that satisfy the SLA.
+        let mut goodput_requests = 0usize;
+        let mut goodput_output_tokens = 0usize;
 
         for stats in requests.values() {
             if stats.first_admit_ms.is_none() {
@@ -515,6 +658,12 @@ impl TraceCollector {
             ttfts.push(ttft_ms);
             e2e_latencies.push(e2e_ms);
 
+            // Goodput classification (aiperf avg-ITL; see SlaThresholds::is_good).
+            if sla.is_set() && sla.is_good(ttft_ms, e2e_ms, stats.output_length) {
+                goodput_requests += 1;
+                goodput_output_tokens += stats.output_length;
+            }
+
             if let Some(ttst_ms) = stats.ttst_ms() {
                 ttsts.push(ttst_ms);
             }
@@ -531,7 +680,22 @@ impl TraceCollector {
         }
 
         let duration_s = (duration_ms / 1000.0).max(1e-9);
+        // Provisioned worker-seconds: static count × duration for the
+        // single-worker path, else the runtime-integrated accumulator.
+        let (prefill_worker_seconds, decode_worker_seconds) = match static_worker_count {
+            Some((prefill, decode)) => (prefill as f64 * duration_s, decode as f64 * duration_s),
+            None => (
+                accumulated_prefill_worker_seconds,
+                accumulated_decode_worker_seconds,
+            ),
+        };
         let itl_distribution = build_distribution_stats(itls);
+        // Goodput only when an SLA was supplied; otherwise it is undefined.
+        let goodput = sla.is_set().then(|| TraceGoodputStats {
+            completed_requests: goodput_requests,
+            request_throughput_rps: goodput_requests as f64 / duration_s,
+            output_throughput_tok_s: goodput_output_tokens as f64 / duration_s,
+        });
         TraceSimulationReport {
             request_counts: TraceRequestCounts {
                 num_requests: request_count,
@@ -547,6 +711,8 @@ impl TraceCollector {
                 output_throughput_tok_s: total_output_tokens as f64 / duration_s,
                 total_throughput_tok_s: (total_input_tokens + total_output_tokens) as f64
                     / duration_s,
+                prefill_worker_seconds,
+                decode_worker_seconds,
             },
             prefix_cache_reused_ratio: if total_input_tokens == 0 {
                 0.0
@@ -571,6 +737,7 @@ impl TraceCollector {
                     output_token_throughput_per_user,
                 ),
             },
+            goodput,
             per_request,
         }
     }
@@ -870,6 +1037,114 @@ mod tests {
         assert!(report.per_request.is_empty());
         // Summary stats still work.
         assert_eq!(report.request_counts.completed_requests, 1);
+    }
+
+    /// Register a completed request: arrival, output length (osl), and the
+    /// explicit per-output-token timestamps (first → ttft, last → e2e).
+    fn add_completed(
+        collector: &mut TraceCollector,
+        uuid_n: u128,
+        arrival_ms: f64,
+        output_length: usize,
+        token_times_ms: &[f64],
+    ) {
+        let uuid = Uuid::from_u128(uuid_n);
+        collector.on_arrival(uuid, arrival_ms, 100, output_length);
+        collector.on_admit(uuid, arrival_ms, 0);
+        collector.on_decode_assigned(uuid, 0);
+        for &t in token_times_ms {
+            collector.on_token(uuid, t);
+        }
+    }
+
+    /// Goodput classifies a request "good" using aiperf's average ITL,
+    /// `avg_itl = (e2e − ttft) / (osl − 1)`, and skips the ITL check when
+    /// `osl ≤ 1`.
+    #[test]
+    fn goodput_classifies_by_aiperf_avg_itl() {
+        let mut collector = TraceCollector::default();
+        collector.set_sla_thresholds(SlaThresholds {
+            ttft_ms: Some(150.0),
+            itl_ms: Some(30.0),
+            e2e_ms: None,
+        });
+        // A: ttft=100, e2e=200, osl=3 → avg_itl=(200−100)/2=50 > 30 → BAD.
+        add_completed(&mut collector, 1, 0.0, 3, &[100.0, 150.0, 200.0]);
+        // B: ttft=100, e2e=140, osl=3 → avg_itl=20 ≤ 30, ttft ok → GOOD.
+        add_completed(&mut collector, 2, 0.0, 3, &[100.0, 120.0, 140.0]);
+        // C: osl=1 → ITL check skipped; ttft=100 ≤ 150 → GOOD.
+        add_completed(&mut collector, 3, 0.0, 1, &[100.0]);
+
+        let goodput = collector
+            .finish()
+            .goodput
+            .expect("SLA set → goodput present");
+        assert_eq!(goodput.completed_requests, 2); // B and C
+        // duration = max last token = 200ms → 0.2s; good output tokens = 3 (B) + 1 (C) = 4.
+        assert!((goodput.output_throughput_tok_s - 4.0 / 0.2).abs() < 1e-6);
+        assert!((goodput.request_throughput_rps - 2.0 / 0.2).abs() < 1e-6);
+    }
+
+    /// A request straddling the ITL bound flips good↔bad at the boundary.
+    #[test]
+    fn goodput_itl_boundary_is_inclusive() {
+        let sla = SlaThresholds {
+            ttft_ms: None,
+            itl_ms: Some(50.0),
+            e2e_ms: None,
+        };
+        // avg_itl = (200−100)/(3−1) = 50.0, exactly the bound → good (≤).
+        let mut at_bound = TraceCollector::default();
+        at_bound.set_sla_thresholds(sla);
+        add_completed(&mut at_bound, 1, 0.0, 3, &[100.0, 150.0, 200.0]);
+        assert_eq!(at_bound.finish().goodput.unwrap().completed_requests, 1);
+        // avg_itl = (201−100)/2 = 50.5 > 50 → bad.
+        let mut over = TraceCollector::default();
+        over.set_sla_thresholds(sla);
+        add_completed(&mut over, 1, 0.0, 3, &[100.0, 150.0, 201.0]);
+        assert_eq!(over.finish().goodput.unwrap().completed_requests, 0);
+    }
+
+    /// An e2e-only SLA gates on end-to-end latency alone.
+    #[test]
+    fn goodput_e2e_only_sla() {
+        let mut collector = TraceCollector::default();
+        collector.set_sla_thresholds(SlaThresholds {
+            ttft_ms: None,
+            itl_ms: None,
+            e2e_ms: Some(150.0),
+        });
+        add_completed(&mut collector, 1, 0.0, 2, &[100.0, 200.0]); // e2e=200 > 150 → BAD
+        add_completed(&mut collector, 2, 0.0, 2, &[60.0, 120.0]); // e2e=120 ≤ 150 → GOOD
+        assert_eq!(collector.finish().goodput.unwrap().completed_requests, 1);
+    }
+
+    /// No SLA → goodput is omitted entirely.
+    #[test]
+    fn goodput_absent_without_sla() {
+        let mut collector = TraceCollector::default();
+        add_completed(&mut collector, 1, 0.0, 2, &[10.0, 20.0]);
+        assert!(collector.finish().goodput.is_none());
+    }
+
+    /// Worker-seconds: the accumulator (agg/disagg) sums runtime contributions;
+    /// the static path (single worker) reports `count × duration_s`.
+    #[test]
+    fn worker_seconds_accumulated_and_static() {
+        let mut accumulated = TraceCollector::default();
+        add_completed(&mut accumulated, 1, 0.0, 2, &[10.0, 20.0]);
+        accumulated.add_worker_seconds(1.5, 4.0);
+        accumulated.add_worker_seconds(0.5, 1.0);
+        let report = accumulated.finish();
+        assert!((report.throughput.prefill_worker_seconds - 2.0).abs() < 1e-9);
+        assert!((report.throughput.decode_worker_seconds - 5.0).abs() < 1e-9);
+
+        let mut static_single = TraceCollector::default();
+        static_single.set_static_worker_count(0, 1);
+        add_completed(&mut static_single, 1, 0.0, 2, &[100.0, 200.0]); // duration = 0.2s
+        let report = static_single.finish();
+        assert!(report.throughput.prefill_worker_seconds.abs() < 1e-9);
+        assert!((report.throughput.decode_worker_seconds - 0.2).abs() < 1e-9);
     }
 
     /// Records emerge in arrival-time order, so the JSONL file produced from

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -23,8 +23,9 @@ pub(crate) use collector::TraceCollector;
 #[cfg(test)]
 pub(crate) use collector::TraceRequestStatsSnapshot;
 pub use collector::{
-    PerRequestRecord, TraceDistributionStats, TraceInterTokenLatencyStats, TraceLatencyStats,
-    TraceRequestCounts, TraceSimulationReport, TraceThroughputStats,
+    PerRequestRecord, SlaThresholds, TraceDistributionStats, TraceGoodputStats,
+    TraceInterTokenLatencyStats, TraceLatencyStats, TraceRequestCounts, TraceSimulationReport,
+    TraceThroughputStats,
 };
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReplayRouterMode {

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -137,6 +137,7 @@ impl AggRuntime {
         router_mode: ReplayRouterMode,
     ) -> anyhow::Result<Self> {
         let args = args.clone().normalized()?;
+        let decode_gpus_per_worker = args.aic_gpus_per_worker();
         let progress = ReplayProgress::new(admission.total_requests(), "offline replay");
         let router = match router_mode {
             ReplayRouterMode::RoundRobin => None,
@@ -163,6 +164,11 @@ impl AggRuntime {
         );
         engine.set_scaling_args(args, capture_kv_events);
 
+        // Aggregated replay has a single (decode) pool; record its GPUs/worker
+        // so the report can express GPU-hours from the mocker's own parallelism.
+        let mut collector = TraceCollector::default();
+        collector.set_gpus_per_worker(0, decode_gpus_per_worker);
+
         Ok(Self {
             now_ms: 0.0,
             next_worker_idx: 0,
@@ -170,7 +176,7 @@ impl AggRuntime {
             admission,
             requests: FxHashMap::default(),
             engine,
-            collector: TraceCollector::default(),
+            collector,
             events: BinaryHeap::new(),
             router,
             progress,

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs, OutputSignal};
 use crate::loadgen::{ReplayRequestHashes, WorkloadDriver};
-use crate::replay::{ReplayPrefillLoadEstimator, ReplayRouterMode, TraceCollector};
+use crate::replay::{ReplayPrefillLoadEstimator, ReplayRouterMode, SlaThresholds, TraceCollector};
 use anyhow::bail;
 use dynamo_kv_router::config::KvRouterConfig;
 use dynamo_kv_router::protocols::RouterEvent;
@@ -212,6 +212,12 @@ impl AggRuntime {
     /// it for the calibration use case this exists to serve.
     pub(in crate::replay) fn with_max_sim_time_ms(mut self, ms: Option<f64>) -> Self {
         self.max_sim_time_ms = ms;
+        self
+    }
+
+    /// Set the SLA thresholds used to classify goodput in the final report.
+    pub(in crate::replay) fn with_sla_thresholds(mut self, sla: SlaThresholds) -> Self {
+        self.collector.set_sla_thresholds(sla);
         self
     }
 
@@ -661,12 +667,12 @@ impl AggRuntime {
 
             if next_timestamp_ms > until_ms {
                 if until_ms > self.now_ms {
-                    self.now_ms = until_ms;
+                    self.advance_now_ms(until_ms);
                 }
                 break;
             }
 
-            self.now_ms = next_timestamp_ms;
+            self.advance_now_ms(next_timestamp_ms);
             self.drain_current_timestamp()?;
         }
 
@@ -676,6 +682,21 @@ impl AggRuntime {
     /// Current simulated time in milliseconds.
     pub(in crate::replay) fn now_ms(&self) -> f64 {
         self.now_ms
+    }
+
+    /// Advance the sim clock to `new_now_ms`, integrating provisioned
+    /// worker-seconds over the interval just elapsed. `worker_count()` counts
+    /// active + starting-up + draining workers, so this captures the startup
+    /// ramp and the scale-down drain tail. Aggregated replay has no separate
+    /// prefill pool, so it reports through the decode role (prefill = 0).
+    fn advance_now_ms(&mut self, new_now_ms: f64) {
+        let dt_ms = (new_now_ms - self.now_ms).max(0.0);
+        if dt_ms > 0.0 {
+            let decode_worker_seconds = self.engine.worker_count() as f64 * dt_ms / 1000.0;
+            self.collector
+                .add_worker_seconds(0.0, decode_worker_seconds);
+        }
+        self.now_ms = new_now_ms;
     }
 
     /// Number of active (non-pending-removal) workers.
@@ -787,7 +808,7 @@ impl AggRuntime {
             {
                 break;
             }
-            self.now_ms = next_timestamp_ms;
+            self.advance_now_ms(next_timestamp_ms);
             self.drain_current_timestamp()?;
         }
 
@@ -2449,6 +2470,41 @@ mod tests {
         rt.advance_to(expected_ready_ms).unwrap();
         assert_eq!(rt.active_worker_count(), 2); // now active
         assert_eq!(rt.total_worker_count(), 2);
+    }
+
+    #[test]
+    fn test_worker_seconds_counts_startup_ramp() {
+        // 1 worker over [0, 1s], then scale to 2 with a 5s startup delay and
+        // advance to 3s. The second worker is still *starting up* over [1s, 3s]
+        // but is provisioned (holds a GPU), so worker-seconds must count it:
+        //   1 worker × 1s + 2 workers × 2s = 5.0 worker-seconds.
+        // (If it integrated the *active* count it would wrongly be 3.0.)
+        let args = startup_args(5.0);
+        let requests = simple_requests(20, 1000.0);
+        let mut rt = AggRuntime::new(
+            &args,
+            None,
+            None,
+            requests,
+            1,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        rt.advance_to(1000.0).unwrap();
+        rt.apply_scaling(2).unwrap();
+        assert_eq!(rt.active_worker_count(), 1); // 2nd worker still starting
+        assert_eq!(rt.total_worker_count(), 2); // ...but provisioned
+        rt.advance_to(3000.0).unwrap();
+
+        let report = rt.finalize_report();
+        assert!(
+            (report.throughput.decode_worker_seconds - 5.0).abs() < 1e-6,
+            "expected 5.0 provisioned worker-seconds (startup ramp counted), got {}",
+            report.throughput.decode_worker_seconds
+        );
+        assert_eq!(report.throughput.prefill_worker_seconds, 0.0); // agg: decode role only
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -187,6 +187,14 @@ impl DisaggRuntime {
         );
         decode_engine.set_scaling_args(config.decode_args.clone(), false);
 
+        // Record each pool's GPUs/worker from its engine parallelism so the
+        // report can express GPU-hours from the mocker's own config.
+        let mut collector = TraceCollector::default();
+        collector.set_gpus_per_worker(
+            config.prefill_args.aic_gpus_per_worker(),
+            config.decode_args.aic_gpus_per_worker(),
+        );
+
         Ok(Self {
             now_ms: 0.0,
             next_prefill_worker_idx: 0,
@@ -198,7 +206,7 @@ impl DisaggRuntime {
             prefill_router,
             decode_router,
             requests: HashMap::new(),
-            collector: TraceCollector::default(),
+            collector,
             events: BinaryHeap::new(),
             progress,
             #[cfg(test)]

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -25,7 +25,8 @@ use super::state::{DisaggPhase, DisaggRequestState};
 use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs, OutputSignal};
 use crate::loadgen::{ReplayRequestHashes, WorkloadDriver};
 use crate::replay::{
-    OfflineDisaggReplayConfig, ReplayPrefillLoadEstimator, ReplayRouterMode, TraceCollector,
+    OfflineDisaggReplayConfig, ReplayPrefillLoadEstimator, ReplayRouterMode, SlaThresholds,
+    TraceCollector,
 };
 use crate::scheduler::AdmissionEvent;
 
@@ -235,6 +236,12 @@ impl DisaggRuntime {
     /// it for the calibration use case this exists to serve.
     pub(in crate::replay) fn with_max_sim_time_ms(mut self, ms: Option<f64>) -> Self {
         self.max_sim_time_ms = ms;
+        self
+    }
+
+    /// Set the SLA thresholds used to classify goodput in the final report.
+    pub(in crate::replay) fn with_sla_thresholds(mut self, sla: SlaThresholds) -> Self {
+        self.collector.set_sla_thresholds(sla);
         self
     }
 
@@ -917,12 +924,12 @@ impl DisaggRuntime {
 
             if next_timestamp_ms > until_ms {
                 if until_ms > self.now_ms {
-                    self.now_ms = until_ms;
+                    self.advance_now_ms(until_ms);
                 }
                 break;
             }
 
-            self.now_ms = next_timestamp_ms;
+            self.advance_now_ms(next_timestamp_ms);
             self.drain_current_timestamp()?;
         }
 
@@ -932,6 +939,21 @@ impl DisaggRuntime {
     /// Current simulated time in milliseconds.
     pub(in crate::replay) fn now_ms(&self) -> f64 {
         self.now_ms
+    }
+
+    /// Advance the sim clock to `new_now_ms`, integrating provisioned
+    /// worker-seconds for both pools over the interval just elapsed.
+    /// `worker_count()` counts active + starting-up + draining workers, so this
+    /// captures the startup ramp and the scale-down drain tail.
+    fn advance_now_ms(&mut self, new_now_ms: f64) {
+        let dt_ms = (new_now_ms - self.now_ms).max(0.0);
+        if dt_ms > 0.0 {
+            let prefill_worker_seconds = self.prefill_engine.worker_count() as f64 * dt_ms / 1000.0;
+            let decode_worker_seconds = self.decode_engine.worker_count() as f64 * dt_ms / 1000.0;
+            self.collector
+                .add_worker_seconds(prefill_worker_seconds, decode_worker_seconds);
+        }
+        self.now_ms = new_now_ms;
     }
 
     pub(in crate::replay) fn active_prefill_count(&self) -> usize {
@@ -1074,7 +1096,7 @@ impl DisaggRuntime {
             {
                 break;
             }
-            self.now_ms = next_timestamp_ms;
+            self.advance_now_ms(next_timestamp_ms);
             self.drain_current_timestamp()?;
         }
 

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -65,11 +65,16 @@ impl SingleRuntime {
             AdmissionSource::Requests(pending) => pending.len(),
             AdmissionSource::Workload(driver) => driver.total_turns(),
         };
+        // The single-worker runtime has exactly one (decode) worker for the
+        // whole run and no event loop to integrate, so declare a static count;
+        // `finish()` derives worker-seconds as 1 × duration_s.
+        let mut collector = TraceCollector::default();
+        collector.set_static_worker_count(0, 1);
         Self {
             current_time_ms: 0.0,
             admission,
             worker: ReplayWorkerCore::new(args),
-            collector: TraceCollector::default(),
+            collector,
             mode,
             progress: ReplayProgress::new(total_requests, "offline replay"),
             consecutive_no_progress_passes: 0,

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -70,6 +70,7 @@ impl SingleRuntime {
         // `finish()` derives worker-seconds as 1 × duration_s.
         let mut collector = TraceCollector::default();
         collector.set_static_worker_count(0, 1);
+        collector.set_gpus_per_worker(0, args.aic_gpus_per_worker());
         Self {
             current_time_ms: 0.0,
             admission,

--- a/lib/mocker/src/replay/planner_handle.rs
+++ b/lib/mocker/src/replay/planner_handle.rs
@@ -18,7 +18,8 @@ use super::offline::agg::AggRuntime;
 use super::offline::components::{ReplayMode, TrafficStats};
 use super::offline::disagg::DisaggRuntime;
 use super::{
-    OfflineDisaggReplayConfig, ReplayPrefillLoadEstimator, ReplayRouterMode, TraceSimulationReport,
+    OfflineDisaggReplayConfig, ReplayPrefillLoadEstimator, ReplayRouterMode, SlaThresholds,
+    TraceSimulationReport,
 };
 use crate::common::protocols::{ForwardPassSnapshot, MockEngineArgs};
 use crate::loadgen::Trace;
@@ -74,6 +75,7 @@ impl PlannerReplayHandle {
         num_workers: usize,
         arrival_speedup_ratio: f64,
         router_mode: ReplayRouterMode,
+        sla: SlaThresholds,
     ) -> Result<Self> {
         let args = args.normalized()?;
         let trace = Trace::from_mooncake(trace_path, trace_block_size)?
@@ -87,7 +89,8 @@ impl PlannerReplayHandle {
             num_workers,
             ReplayMode::Trace,
             router_mode,
-        )?;
+        )?
+        .with_sla_thresholds(sla);
         Ok(Self {
             runtime: RuntimeKind::Agg(runtime),
             started_at: Instant::now(),
@@ -95,6 +98,7 @@ impl PlannerReplayHandle {
     }
 
     /// Create a handle for a disaggregated trace-file replay.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_trace_file_disagg(
         config: OfflineDisaggReplayConfig,
         router_config: Option<KvRouterConfig>,
@@ -103,6 +107,7 @@ impl PlannerReplayHandle {
         trace_block_size: usize,
         arrival_speedup_ratio: f64,
         router_mode: ReplayRouterMode,
+        sla: SlaThresholds,
     ) -> Result<Self> {
         let config = config.normalized()?;
         let trace = Trace::from_mooncake(trace_path, trace_block_size)?
@@ -115,7 +120,8 @@ impl PlannerReplayHandle {
             trace.into_trace_driver_with_block_size(config.decode_args.block_size)?,
             ReplayMode::Trace,
             router_mode,
-        )?;
+        )?
+        .with_sla_thresholds(sla);
         Ok(Self {
             runtime: RuntimeKind::Disagg(runtime),
             started_at: Instant::now(),


### PR DESCRIPTION
## What

Adds two metrics the Mocker/replay evaluator did not expose, as first-class fields in the planner-replay report:

### 1. goodput (SLA-satisfying throughput)
The collector classifies each completed request against an optional SLA and emits:
- `goodput_completed_requests`
- `goodput_request_throughput_rps`
- `goodput_output_throughput_tok_s`

A request is *good* when it meets the configured SLA. The **ITL** bound uses the per-request average inter-token latency `(e2e − ttft)/(osl − 1)`, matching **aiperf / genai-perf** (`osl ≤ 1` skips the ITL check); `ttft`/`e2e` bounds are direct. Only the thresholds that are set apply (set `ttft+itl`, or `e2e` alone).

**The goodput SLA is independent of the planner's own scaling SLA** (in `--planner-config`) and is never read from it — they can hold different values.

### 2. provisioned GPU-time
`prefill_worker_seconds` / `decode_worker_seconds` = the time-integral of the **provisioned** worker count (active + starting-up + draining), so it captures the **startup ramp** and the **scale-down drain tail** — unlike an active/serving-count integral. `worker_count()` already counts `pending_startup` + `pending_removal`, so the agg/disagg runtimes accumulate it at each clock advance; the single-worker path reports `count × duration`.

The planner replay CLI multiplies by per-engine GPU counts to surface a first-class **`gpu_hours`** in the report JSON — ungated, unlike the diagnostics-only, active-count `_cumulative_gpu_hours`.

## How
Both fields ride the existing `TraceSimulationReport` struct via `pythonize`, so they appear in the planner bridge's report dict with no per-path Python plumbing. SLA is threaded through the bridge constructors (`PlannerReplayBridge.new` / `create_disagg`) and exposed on the replay CLI as `--sla-ttft-ms` / `--sla-itl-ms` / `--sla-e2e-ms` (independent of `--planner-config`).

## Scope
Wired through the **planner-in-the-loop** path (the consumer path). Plain `run_mocker_trace_replay` SLA is a follow-up — the new `with_sla_thresholds` runtime builder makes it a small addition.

## Tests
- collector goodput: aiperf-ITL classification, ITL boundary (good↔bad at the bound), e2e-only SLA, no-SLA → omitted.
- worker-seconds: accumulated (agg/disagg) + static (single).
- runtime: startup ramp is counted as provisioned (`5.0` worker-seconds, not the active-only `3.0`).
- All 147 replay unit tests pass; `dynamo-mocker` + `dynamo-py3` bindings compile; pre-commit clean.

> Remaining verification (CI / reviewer): rebuild the Python bindings (`maturin`) and run `lib/bindings/python/tests/replay/test_replay_cli.py` + `components/.../planner/tests/offline/test_replay_adapter_fpm.py` against the new `_core` — a worktree rebuild here would clobber the main checkout's editable install, so it's deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SLA threshold configuration for planner replay enabling specification of TTFT, ITL, and E2E latency thresholds via new CLI options.
  * Introduced goodput metrics in replay reports providing visibility into SLA-compliant request counts and throughput rates.
  * Added GPU hours computation in trace reports based on measured worker utilization.

* **Tests**
  * Added comprehensive unit tests for goodput classification and worker-seconds aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->