### PR TITLE
docs: pin compatible pi provider revision

### DIFF
--- a/docs/agents/pi-mono.md
+++ b/docs/agents/pi-mono.md
@@ -51,6 +51,8 @@ Build from source and install it into Pi:
 ```bash
 git clone git@github.com:ai-dynamo/pi-dynamo-provider.git
 cd pi-dynamo-provider
+# Use provider main at 5c237a1 or newer for DYN_REQUEST_TRACE support.
+git checkout 5c237a1577b1e4bcfe3785c52b6a73d1aa4ee716
 npm install && npm run build
 pi install /absolute/path/to/pi-dynamo-provider
 ```


### PR DESCRIPTION
## Summary
- Pin the Pi mono quickstart to ai-dynamo/pi-dynamo-provider commit 5c237a1, the provider main revision with DYN_REQUEST_TRACE support.
- Follow-up to #10701 after ai-dynamo/pi-dynamo-provider#6 merged.

## Validation
- git diff --check origin/main...HEAD

Linear: DYN-3229
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Pi-Mono provider installation instructions to reference the latest compatible version with improved feature support and provided updated installation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->