### PR TITLE
ci: wait for DynamoGraphDeployment CRD before checkpoint tests

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -302,6 +302,16 @@ runs:
           rollout status deployment -n default --watch --timeout=900s
         echo "::endgroup::"
 
+    - name: Wait for CRDs to be established
+      shell: bash
+      run: |
+        echo "::group::Wait for DynamoGraphDeployment CRD"
+        kubectl --kubeconfig=${{ github.workspace }}/.kubeconfig-vcluster \
+          wait --for=condition=established \
+          crd/dynamographdeployments.nvidia.com \
+          --timeout=120s
+        echo "::endgroup::"
+
     - name: Debug deployment failure
       if: failure()
       shell: bash


### PR DESCRIPTION
## Summary
- Add `kubectl wait --for=condition=established crd/dynamographdeployments.nvidia.com --timeout=120s` after operator rollout in `setup-dynamo-operator/action.yml`
- Fixes intermittent 404 on DynamoCheckpoint Deploy Test introduced in #10186

## Root cause
`rollout status deployment` returns as soon as the controller-manager pod is Running/Ready, but the Dynamo operator registers its CRDs asynchronously after the pod starts. Tests that immediately POST a `DynamoGraphDeployment` resource receive a 404 because the CRD isn't in the API server yet.

## Test plan
- [ ] DynamoCheckpoint Deploy Test passes on this PR
- [ ] No regression in existing deploy/operator tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow reliability by adding a validation check to ensure system components are fully initialized before proceeding with automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->