### PR TITLE
chore: bump aiconfigurator-core rev to pick up pyo3 abi3-py310 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.9.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=12866ed0a961d7934969ab473ec6692ff7ea89f4#12866ed0a961d7934969ab473ec6692ff7ea89f4"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=ffbab15797d3a3f14c382e937c0ab0c1c5cbc530#ffbab15797d3a3f14c382e937c0ab0c1c5cbc530"
 dependencies = [
  "bincode 1.3.3",
  "parquet",
@@ -6786,7 +6786,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -6806,7 +6806,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ kvbm-physical = { path = "lib/kvbm-physical", version = "1.3.0" }
 velo = { version = "0.1.0" }
 
 # External dependencies
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "12866ed0a961d7934969ab473ec6692ff7ea89f4", package = "aiconfigurator-core" }
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "ffbab15797d3a3f14c382e937c0ab0c1c5cbc530", package = "aiconfigurator-core" }
 anyhow = { version = "1" }
 lru = { version = "0.16" }
 async-nats = { version = "0.49.1", features = ["service"] }

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.9.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=12866ed0a961d7934969ab473ec6692ff7ea89f4#12866ed0a961d7934969ab473ec6692ff7ea89f4"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=ffbab15797d3a3f14c382e937c0ab0c1c5cbc530#ffbab15797d3a3f14c382e937c0ab0c1c5cbc530"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -46,7 +46,7 @@ mm-routing = ["dynamo-llm/mm-routing"]
 # own interpreter is used; build_aic_engine() crosses into Python once at
 # startup while AicEngine::{prefill,decode}_latency_ms() are pure Rust (no GIL)
 # on the predict hot path.
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "12866ed0a961d7934969ab473ec6692ff7ea89f4", package = "aiconfigurator-core", optional = true }
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "ffbab15797d3a3f14c382e937c0ab0c1c5cbc530", package = "aiconfigurator-core", optional = true }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
 dynamo-parsers = { version = "1.4.1" }


### PR DESCRIPTION
## Overview

Bump the `aiconfigurator-core` git pin from `12866ed` → `ffbab15` (merge commit of [ai-dynamo/aiconfigurator#1225](https://github.com/ai-dynamo/aiconfigurator/pull/1225)).

## Details

The nightly Kitmaker release broke for `ai_dynamo_runtime`: wheels were built as `cp39-abi3` but the package declares `requires-python = ">=3.10"`, so Kitmaker's validator rejected both architectures (kvbm was unaffected).

**Root cause:** A previous bump of the `aiconfigurator-core` rev pulled in a version where `aiconfigurator-core` added `pyo3` tagged `abi3-py39`. `dynamo-py3` wants `abi3-py310`; cargo feature unification enables both and pyo3 picks the lower (`abi3-py39`), so wheels were tagged `cp39-abi3` instead of `cp310-abi3`.

**Fix:** aiconfigurator#1225 aligns the `pyo3` abi to `abi3-py310`, matching aiconfigurator's own `requires-python = ">=3.10"`. This PR bumps the Dynamo pin to that merge commit.

## Files changed
- `Cargo.toml` (workspace dep)
- `lib/bindings/python/Cargo.toml` (optional `aic-forward-pass` dep)
- `Cargo.lock`, `lib/bindings/python/Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to incorporate latest improvements and optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->