### PR TITLE
fix(docs): flip recipe card background in dark mode

### DIFF
--- a/fern/components/RecipeStyles.tsx
+++ b/fern/components/RecipeStyles.tsx
@@ -416,6 +416,13 @@ const RECIPE_CSS = `
     text-decoration: none;
 }
 
+/* --nv-color-bg-default does not flip in the dark theme (stays #FFFFFF), so
+   in dark mode the card would be a white tile with light text. Flip the
+   surface to match the other dark-aware components (chip, search box, etc.). */
+.dark .dynamo-model-card {
+    background: var(--nv-dark-grey-2);
+}
+
 .dynamo-model-card:hover {
     border-color: var(--nv-color-green);
     text-decoration: none;


### PR DESCRIPTION
## Problem

On the [Recipes browse page](https://docs.nvidia.com/dynamo/dev/recipes/browse), every model card rendered as a **white tile with invisible light-gray text** in dark mode. Reported post-launch by Tanmay Verma and Abhishek Kumar Gupta.

## Root cause

The theme variable `--nv-color-bg-default` does **not** flip in the dark theme — it stays `#FFFFFF`. The component CSS works around this with per-surface `.dark` overrides (chip, search box, traffic facts, benchmark cards, target picker all switch to `--nv-dark-grey-2`). `.dynamo-model-card` was the **one surface that was missed**, so in dark mode it kept the white background while its text flipped to `#eee` → unreadable.

## Fix

One rule, matching the existing convention:

```css
.dark .dynamo-model-card {
    background: var(--nv-dark-grey-2);
}
```

## Verification

Audited all four page types in forced dark mode on live prod (recipes browse, recipe detail, benchmarks landing, benchmark detail). The white-tile bug existed **only** on the recipes browse model cards; every other surface (filter chips, "Features Under Test" technique guide, variant tables, column headers) already reads correctly. After this change, the cards flip to `--nv-dark-grey-2` like the rest. Will confirm on the hosted preview before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark theme compatibility with enhanced background color contrast for better visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->