### PR TITLE
docs(recipes): provider picker mockup on Qwen3-235B (design review, do not merge)

### DIFF
--- a/docs/recipes/qwen3-235b-a22b-fp8.mdx
+++ b/docs/recipes/qwen3-235b-a22b-fp8.mdx
@@ -178,7 +178,7 @@ kv_backend: LIBFABRIC                   # the one non-UCX fabric -- select per e
 securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): append `env`, apply the image rule (+verify the `-efa` tag), set LIBFABRIC for your engine. After deploy, confirm `NIXL ... Backend LIBFABRIC was instantiated` — UCX is a *silent* slow fallback, not an error.
+**To apply:** append the `env`, apply the image rule (verify the `-efa` tag exists), and set LIBFABRIC for your engine; after deploy, confirm `NIXL ... Backend LIBFABRIC was instantiated` (UCX is a *silent* slow fallback). Full step-by-step: [AGENTS.md →](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md).
 
 </div>
 
@@ -195,7 +195,7 @@ kv_backend:  UCX                        # default -- nothing to select
 securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): the `device` RDMA networks and the `interfaces` annotation must match your A4X pool. The GKE GIB driver host-mounts stay in the base recipe.
+**To apply:** the `device` RDMA networks and the `interfaces` annotation must match your A4X pool; the GKE GIB driver host-mounts stay in the base recipe. Full step-by-step: [AGENTS.md →](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md).
 
 </div>
 
@@ -212,7 +212,7 @@ kv_backend: UCX                         # default -- nothing to select
 securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): `UCX_NET_DEVICES` is load-bearing — omit it and UCX binds a side NIC, giving degraded BW + a zeroed KV counter. Prefill + decode must share **one agentpool** (per-agentpool IB pkeys) — pin via `nodeSelector` in the base DGD.
+**To apply:** `UCX_NET_DEVICES` is load-bearing — omit it and UCX binds a side NIC (degraded BW + a zeroed KV counter); prefill + decode must share **one agentpool** (per-agentpool IB pkeys), pinned via `nodeSelector` in the base DGD. Full step-by-step: [AGENTS.md →](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md).
 
 </div>
 
@@ -228,7 +228,7 @@ kv_backend: UCX                         # default -- nothing to select
 securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): the simplest IB case — base image + the IB device slot; no NIC list to derive.
+**To apply:** the simplest IB case — base image + the IB device slot; no NIC list to derive. Full step-by-step: [AGENTS.md →](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md).
 
 </div>
 
@@ -245,7 +245,7 @@ kv_backend: UCX                         # default -- nothing to select
 securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): Nscale nodes expose a **mixed** fabric — list only the compute NICs (`mlx5_0..5,10,11`) and exclude the side fabric (`mlx5_6..9`), or the first KV transfer fails with `NIXL_ERR_REMOTE_DISCONNECT`.
+**To apply:** list only the compute NICs (`mlx5_0..5,10,11`) and exclude the side fabric (`mlx5_6..9`) — Nscale exposes a *mixed* fabric, and mixing them fails the first KV transfer with `NIXL_ERR_REMOTE_DISCONNECT`. Full step-by-step: [AGENTS.md →](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md).
 
 </div>
 

--- a/docs/recipes/qwen3-235b-a22b-fp8.mdx
+++ b/docs/recipes/qwen3-235b-a22b-fp8.mdx
@@ -155,142 +155,97 @@ kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml -n
 
 <div data-provider="generic">
 
-Select a cloud provider in the picker above for fabric-specific networking setup. These overlays apply to the **disaggregated** topology, where KV transfer crosses the cluster network.
+Pick a cloud provider to fold its **RDMA fabric profile** into the disaggregated deployment above. The profiles ([`recipes/addons/providers/`](https://github.com/ai-dynamo/dynamo/pull/10979)) are **model-agnostic** — an agent (or you) materializes one onto the prefill + decode workers, resolving the per-cluster `@param` values rather than copying them. Step-by-step: [`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md).
 
 </div>
 
 <div className="dynamo-provider-agg-note">
 
-Provider overlays apply to the **disaggregated** topology only — aggregated serving keeps KV transfer on-node, so no fabric overrides are needed. Switch **Topology** to **Disaggregated** to see the provider setup.
+Fabric profiles apply to the **disaggregated** topology only — aggregated serving keeps KV transfer on-node, so no fabric layer is needed. Switch **Topology** to **Disaggregated** to see the provider setup.
 
 </div>
 
 <div data-provider="aws" data-variant="disagg">
 
-**AWS · EFA** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+**AWS · EFA** — fabric profile [`aws-efa.yaml`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/aws-efa.yaml). LIBFABRIC KV backend; arch-suffixed image. Materialize onto the prefill + decode workers:
 
 ```yaml
-# provider-overlay: aws-efa
-status: unverified            # validated on qwen3-32b, not this model
-applies_to: topology=disaggregated
-apply:                        # add to prefill + decode worker spec
-  resources.limits:
-    vpc.amazonaws.com/efa: "32"
-  env:
-    DYN_KVBM_NIXL_BACKEND_LIBFABRIC: "true"
-    DYN_KVBM_NIXL_BACKEND_UCX: "false"
-    FI_PROVIDER: efa
-    FI_EFA_USE_DEVICE_RDMA: "1"
-    FI_EFA_ENABLE_SHM_TRANSFER: "0"
-  libraries: in-image (/opt/amazon/efa/lib*)   # no extra mounts
-derive_per_cluster: none      # EFA does not use UCX_NET_DEVICES
-caveats: []
-reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-aws-efa/deploy.yaml
+# recipes/addons/providers/aws-efa.yaml  ->  merge onto prefill + decode workers
+image:    {base_tag}-efa-{arch}        # @param arch: amd64 (H100/B200) | arm64 (GB200); verify the tag exists
+device:   vpc.amazonaws.com/efa: {{ gpus_per_worker * 4 }}   # @param from base GPU count (p5 = 4/GPU)
+env:      FI_PROVIDER=efa, FI_EFA_USE_DEVICE_RDMA=1, FI_EFA_ENABLE_SHM_TRANSFER=0
+kv_backend: LIBFABRIC                   # the one non-UCX fabric -- select per engine (vLLM / TRT-LLM / SGLang)
+securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-[Reference deploy.yaml — disagg-1p1d-aws-efa](https://github.com/ai-dynamo/dynamo/pull/10202)
+**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): append `env`, apply the image rule (+verify the `-efa` tag), set LIBFABRIC for your engine. After deploy, confirm `NIXL ... Backend LIBFABRIC was instantiated` — UCX is a *silent* slow fallback, not an error.
 
 </div>
 
 <div data-provider="gke" data-variant="disagg">
 
-**GCP GKE · RoCE** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+**GCP GKE · RoCE** (A4X) — fabric profile [`gke-roce.yaml`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/gke-roce.yaml). UCX over RoCEv2; NIC auto-probe. Materialize onto the prefill + decode workers:
 
 ```yaml
-# provider-overlay: gke-roce
-status: unverified            # validated on qwen3-32b, not this model
-applies_to: topology=disaggregated
-apply:                        # add to prefill + decode worker spec
-  metadata.annotations:
-    networking.gke.io/networks: [rdma-0 ... rdma-3]   # + .IP, interfaces, per-net tolerations
-  volumes:                    # hostPath
-    /usr/local/gib: gib
-    /nvidia: nvidia
-  nixl_backend: ucx           # default
-derive_per_cluster:
-  UCX_NET_DEVICES:
-    from: ibv_devinfo         # tested: mlx5_0:1..3
-caveats: []
-reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-gke-roce/deploy.yaml
+# recipes/addons/providers/gke-roce.yaml  ->  merge onto prefill + decode workers
+device:      networking.gke.io.networks/rdma-0..3 (+ .IP)    # @param RDMA network names/count for your A4X pool
+annotations: networking.gke.io/interfaces  [eth2->rdma-0 ... eth5->rdma-3]   # webhook attaches the NICs
+env:         NCCL_SOCKET_IFNAME=eth0, NCCL_CROSS_NIC=0       # no UCX_NET_DEVICES -- UCX auto-probes the RoCE NICs
+kv_backend:  UCX                        # default -- nothing to select
+securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-[Reference deploy.yaml — disagg-1p1d-gke-roce](https://github.com/ai-dynamo/dynamo/pull/10202)
+**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): the `device` RDMA networks and the `interfaces` annotation must match your A4X pool. The GKE GIB driver host-mounts stay in the base recipe.
 
 </div>
 
 <div data-provider="aks" data-variant="disagg">
 
-**Azure AKS · IB** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+**Azure AKS · InfiniBand** — fabric profile [`aks-ib.yaml`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/aks-ib.yaml). UCX over IB; **NIC pin required**. Materialize onto the prefill + decode workers:
 
 ```yaml
-# provider-overlay: aks-ib
-status: unverified            # validated on qwen3-32b, not this model
-applies_to: topology=disaggregated
-apply:
-  resources.limits:
-    rdma/shared_ib: "1"       # NOT rdma/ib
-  volumes:
-    - /dev/infiniband
-derive_per_cluster:
-  UCX_NET_DEVICES:
-    from: ibv_devinfo
-caveats:
-  - "rdma/shared_ib, not rdma/ib -- wrong key => pod gets no RDMA resource"
-reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-aks-ib/deploy.yaml
+# recipes/addons/providers/aks-ib.yaml  ->  merge onto prefill + decode workers
+device:   rdma/ib: "1"                  # device-plugin slot (grants all HCAs) -- keep "1", not GPU-derived
+env:      UCX_NET_DEVICES: <compute IB NICs>   # @param from ibv_devinfo (default mlx5_0..3 on ND_H100_v5)
+          NCCL_SOCKET_IFNAME: eth0
+kv_backend: UCX                         # default -- nothing to select
+securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-[Reference deploy.yaml — disagg-1p1d-aks-ib](https://github.com/ai-dynamo/dynamo/pull/10202)
+**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): `UCX_NET_DEVICES` is load-bearing — omit it and UCX binds a side NIC, giving degraded BW + a zeroed KV counter. Prefill + decode must share **one agentpool** (per-agentpool IB pkeys) — pin via `nodeSelector` in the base DGD.
 
 </div>
 
 <div data-provider="nebius" data-variant="disagg">
 
-**Nebius · IB** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+**Nebius · InfiniBand** — fabric profile [`nebius-ib.yaml`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/nebius-ib.yaml). UCX over IB; NIC auto-probe. Materialize onto the prefill + decode workers:
 
 ```yaml
-# provider-overlay: nebius-ib
-status: unverified            # validated on qwen3-32b, not this model
-applies_to: topology=disaggregated
-apply:
-  resources.limits:
-    rdma/ib: "1"
-  volumes:
-    - /dev/infiniband
-    - /dev/shm
-derive_per_cluster:
-  UCX_NET_DEVICES:
-    from: ibv_devinfo         # tested: mlx5_0:1..7 (8 ports)
-caveats: []
-reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-nebius-ib/deploy.yaml
+# recipes/addons/providers/nebius-ib.yaml  ->  merge onto prefill + decode workers
+device:   rdma/ib: "1"                  # slot count (grants all 8 HCAs) -- keep "1"
+env:      NCCL_SOCKET_IFNAME: eth0       # no UCX_NET_DEVICES -- all 8 CX-7 HCAs are compute fabric, UCX auto-probes
+kv_backend: UCX                         # default -- nothing to select
+securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-[Reference deploy.yaml — disagg-1p1d-nebius-ib](https://github.com/ai-dynamo/dynamo/pull/10202)
+**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): the simplest IB case — base image + the IB device slot; no NIC list to derive.
 
 </div>
 
 <div data-provider="nscale" data-variant="disagg">
 
-**Nscale · IB** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+**Nscale · InfiniBand** — fabric profile [`nscale-ib.yaml`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/nscale-ib.yaml). UCX over IB; **NIC pin required** (mixed fabric). Materialize onto the prefill + decode workers:
 
 ```yaml
-# provider-overlay: nscale-ib
-status: unverified            # validated on qwen3-32b, not this model
-applies_to: topology=disaggregated
-apply:
-  resources.limits:
-    rdma/ib: "1"
-  volumes:
-    - /dev/infiniband
-    - /dev/shm
-derive_per_cluster:
-  UCX_NET_DEVICES:
-    from: ibv_devinfo         # tested: mlx5_0..5,10,11 (non-contiguous subset)
-caveats:
-  - "non-contiguous subset; mlx5_0..7 hits the side fabric and breaks the cross-rank handshake"
-reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-nscale-ib/deploy.yaml
+# recipes/addons/providers/nscale-ib.yaml  ->  merge onto prefill + decode workers
+device:   rdma/ib: "1"                  # slot count (grants all HCAs) -- keep "1"
+env:      UCX_NET_DEVICES: <COMPUTE NICs only>   # @param from ibv_devinfo (default mlx5_0..5,10,11)
+          NCCL_SOCKET_IFNAME: eth0
+kv_backend: UCX                         # default -- nothing to select
+securityContext: privileged + IPC_LOCK, SYS_PTRACE
 ```
 
-[Reference deploy.yaml — disagg-1p1d-nscale-ib](https://github.com/ai-dynamo/dynamo/pull/10202)
+**Merge** ([`AGENTS.md`](https://github.com/ai-dynamo/dynamo/blob/jihao/csp-kustomize-addons/recipes/addons/providers/AGENTS.md)): Nscale nodes expose a **mixed** fabric — list only the compute NICs (`mlx5_0..5,10,11`) and exclude the side fabric (`mlx5_6..9`), or the first KV transfer fails with `NIXL_ERR_REMOTE_DISCONNECT`.
 
 </div>
 

--- a/docs/recipes/qwen3-235b-a22b-fp8.mdx
+++ b/docs/recipes/qwen3-235b-a22b-fp8.mdx
@@ -9,7 +9,7 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Each target below is a validated TensorRT-LLM deployment of Qwen3-235B-A22B-FP8 — a 235B-parameter Mixture-of-Experts model with ~22B active parameters per token — on 16 GPUs with KV-aware routing, benchmarked at 4K ISL / 200 OSL. Hopper and Blackwell need different MoE backends, and you can serve aggregated or with prefill/decode disaggregation. Pick your GPU architecture and serving topology; every command on this page updates to match.
+Each target below is a validated TensorRT-LLM deployment of Qwen3-235B-A22B-FP8 — a 235B-parameter Mixture-of-Experts model with ~22B active parameters per token — on 16 GPUs with KV-aware routing, benchmarked at 4K ISL / 200 OSL. Hopper and Blackwell need different MoE backends, and you can serve aggregated or with prefill/decode disaggregation. Pick your GPU architecture, serving topology, and (on the disaggregated topology) cloud provider; every command on this page updates to match.
 
 <div className="dynamo-target-picker">
 <p className="dynamo-target-picker-title">Choose your deployment target</p>
@@ -26,6 +26,21 @@ Each target below is a validated TensorRT-LLM deployment of Qwen3-235B-A22B-FP8 
 <label htmlFor="recipe-variant-agg">Aggregated</label>
 <input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
 <label htmlFor="recipe-variant-disagg">Disaggregated</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Provider</span>
+<input type="radio" id="recipe-provider-generic" name="recipe-provider" value="generic" defaultChecked />
+<label htmlFor="recipe-provider-generic">Generic</label>
+<input type="radio" id="recipe-provider-aws" name="recipe-provider" value="aws" />
+<label htmlFor="recipe-provider-aws">AWS · EFA</label>
+<input type="radio" id="recipe-provider-gke" name="recipe-provider" value="gke" />
+<label htmlFor="recipe-provider-gke">GCP · RoCE</label>
+<input type="radio" id="recipe-provider-aks" name="recipe-provider" value="aks" />
+<label htmlFor="recipe-provider-aks">Azure · IB</label>
+<input type="radio" id="recipe-provider-nebius" name="recipe-provider" value="nebius" />
+<label htmlFor="recipe-provider-nebius">Nebius · IB</label>
+<input type="radio" id="recipe-provider-nscale" name="recipe-provider" value="nscale" />
+<label htmlFor="recipe-provider-nscale">Nscale · IB</label>
 </div>
 <div className="dynamo-target-picker-summary" data-sku="blackwell" data-variant="agg">
 <span><b>Checkpoint</b> Qwen/Qwen3-235B-A22B-FP8</span>
@@ -133,6 +148,149 @@ kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/deploy.yaml -n ${
 ```bash
 kubectl apply -f recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml -n ${NAMESPACE}
 ```
+
+</div>
+
+## Provider-specific setup
+
+<div data-provider="generic">
+
+Select a cloud provider in the picker above for fabric-specific networking setup. These overlays apply to the **disaggregated** topology, where KV transfer crosses the cluster network.
+
+</div>
+
+<div className="dynamo-provider-agg-note">
+
+Provider overlays apply to the **disaggregated** topology only — aggregated serving keeps KV transfer on-node, so no fabric overrides are needed. Switch **Topology** to **Disaggregated** to see the provider setup.
+
+</div>
+
+<div data-provider="aws" data-variant="disagg">
+
+**AWS · EFA** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+
+```yaml
+# provider-overlay: aws-efa
+status: unverified            # validated on qwen3-32b, not this model
+applies_to: topology=disaggregated
+apply:                        # add to prefill + decode worker spec
+  resources.limits:
+    vpc.amazonaws.com/efa: "32"
+  env:
+    DYN_KVBM_NIXL_BACKEND_LIBFABRIC: "true"
+    DYN_KVBM_NIXL_BACKEND_UCX: "false"
+    FI_PROVIDER: efa
+    FI_EFA_USE_DEVICE_RDMA: "1"
+    FI_EFA_ENABLE_SHM_TRANSFER: "0"
+  libraries: in-image (/opt/amazon/efa/lib*)   # no extra mounts
+derive_per_cluster: none      # EFA does not use UCX_NET_DEVICES
+caveats: []
+reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-aws-efa/deploy.yaml
+```
+
+[Reference deploy.yaml — disagg-1p1d-aws-efa](https://github.com/ai-dynamo/dynamo/pull/10202)
+
+</div>
+
+<div data-provider="gke" data-variant="disagg">
+
+**GCP GKE · RoCE** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+
+```yaml
+# provider-overlay: gke-roce
+status: unverified            # validated on qwen3-32b, not this model
+applies_to: topology=disaggregated
+apply:                        # add to prefill + decode worker spec
+  metadata.annotations:
+    networking.gke.io/networks: [rdma-0 ... rdma-3]   # + .IP, interfaces, per-net tolerations
+  volumes:                    # hostPath
+    /usr/local/gib: gib
+    /nvidia: nvidia
+  nixl_backend: ucx           # default
+derive_per_cluster:
+  UCX_NET_DEVICES:
+    from: ibv_devinfo         # tested: mlx5_0:1..3
+caveats: []
+reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-gke-roce/deploy.yaml
+```
+
+[Reference deploy.yaml — disagg-1p1d-gke-roce](https://github.com/ai-dynamo/dynamo/pull/10202)
+
+</div>
+
+<div data-provider="aks" data-variant="disagg">
+
+**Azure AKS · IB** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+
+```yaml
+# provider-overlay: aks-ib
+status: unverified            # validated on qwen3-32b, not this model
+applies_to: topology=disaggregated
+apply:
+  resources.limits:
+    rdma/shared_ib: "1"       # NOT rdma/ib
+  volumes:
+    - /dev/infiniband
+derive_per_cluster:
+  UCX_NET_DEVICES:
+    from: ibv_devinfo
+caveats:
+  - "rdma/shared_ib, not rdma/ib -- wrong key => pod gets no RDMA resource"
+reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-aks-ib/deploy.yaml
+```
+
+[Reference deploy.yaml — disagg-1p1d-aks-ib](https://github.com/ai-dynamo/dynamo/pull/10202)
+
+</div>
+
+<div data-provider="nebius" data-variant="disagg">
+
+**Nebius · IB** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+
+```yaml
+# provider-overlay: nebius-ib
+status: unverified            # validated on qwen3-32b, not this model
+applies_to: topology=disaggregated
+apply:
+  resources.limits:
+    rdma/ib: "1"
+  volumes:
+    - /dev/infiniband
+    - /dev/shm
+derive_per_cluster:
+  UCX_NET_DEVICES:
+    from: ibv_devinfo         # tested: mlx5_0:1..7 (8 ports)
+caveats: []
+reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-nebius-ib/deploy.yaml
+```
+
+[Reference deploy.yaml — disagg-1p1d-nebius-ib](https://github.com/ai-dynamo/dynamo/pull/10202)
+
+</div>
+
+<div data-provider="nscale" data-variant="disagg">
+
+**Nscale · IB** · `unverified` — validated on Qwen3-32B; the fabric plumbing is model-agnostic. Apply to the prefill + decode worker spec before deploying:
+
+```yaml
+# provider-overlay: nscale-ib
+status: unverified            # validated on qwen3-32b, not this model
+applies_to: topology=disaggregated
+apply:
+  resources.limits:
+    rdma/ib: "1"
+  volumes:
+    - /dev/infiniband
+    - /dev/shm
+derive_per_cluster:
+  UCX_NET_DEVICES:
+    from: ibv_devinfo         # tested: mlx5_0..5,10,11 (non-contiguous subset)
+caveats:
+  - "non-contiguous subset; mlx5_0..7 hits the side fabric and breaks the cross-rank handshake"
+reference: recipes/qwen3-32b/vllm/cloud-providers/disagg-1p1d-nscale-ib/deploy.yaml
+```
+
+[Reference deploy.yaml — disagg-1p1d-nscale-ib](https://github.com/ai-dynamo/dynamo/pull/10202)
 
 </div>
 

--- a/fern/components/RecipeStyles.tsx
+++ b/fern/components/RecipeStyles.tsx
@@ -2190,6 +2190,31 @@ body:has(input[name="recipe-sku"][value="blackwell"]:checked):has(input[name="re
     position: relative;
     z-index: 1;
 }
+
+/* ---------------------------------------------------------------------------
+   Provider axis (cloud-fabric overlays). Generic is the default; selecting a
+   provider reveals its [data-provider] block. Overlay blocks also carry
+   data-variant="disagg" so the existing topology gating only surfaces them on
+   the disaggregated topology (where KV transfer crosses the provider fabric).
+--------------------------------------------------------------------------- */
+body:has(input[name="recipe-provider"][value="generic"]:checked) [data-provider]:not([data-provider~="generic"]),
+body:has(input[name="recipe-provider"][value="aws"]:checked) [data-provider]:not([data-provider~="aws"]),
+body:has(input[name="recipe-provider"][value="gke"]:checked) [data-provider]:not([data-provider~="gke"]),
+body:has(input[name="recipe-provider"][value="aks"]:checked) [data-provider]:not([data-provider~="aks"]),
+body:has(input[name="recipe-provider"][value="nebius"]:checked) [data-provider]:not([data-provider~="nebius"]),
+body:has(input[name="recipe-provider"][value="nscale"]:checked) [data-provider]:not([data-provider~="nscale"]) {
+    display: none;
+}
+
+/* "Not applicable to aggregated" note — shown only when a non-generic provider
+   is selected while the aggregated topology is active. */
+.dynamo-provider-agg-note {
+    display: none;
+}
+
+body:has(input[name="recipe-variant"][value="agg"]:checked):has(input[name="recipe-provider"]:checked:not([value="generic"])) .dynamo-provider-agg-note {
+    display: block;
+}
 `;
 
 export function RecipeStyles() {


### PR DESCRIPTION
**Draft / mockup for design review — not for merge.**

Prototype of a **Provider** picker on the Qwen3-235B-A22B FP8 recipe, ported into the real Fern page so it can be reviewed in-product.

## What it does
- Adds a third picker dimension — **Provider** (`Generic` default + AWS·EFA, GCP·RoCE, Azure·IB, Nebius·IB, Nscale·IB) — alongside the existing GPU and Topology pickers, via a `recipe-provider` axis in the shared `RecipeStyles` CSS.
- Selecting a provider reveals that CSP's **fabric profile** plus a short **"how an agent merges it"** pointer — not a one-command `apply -k`. The load-bearing per-cluster values (`UCX_NET_DEVICES` from `ibv_devinfo`, EFA count from the GPU count, image arch) can't be templated, so the design is *show the profile + point at the merge procedure*, not a kustomize apply.
- **Gated to the disaggregated topology** (where KV transfer actually crosses the provider fabric); aggregated shows a "not applicable" note.

## Provenance (updated since the first draft)
Now sourced from **Jie Hao's #10979** (`recipes/addons/providers/*.yaml` + `README.md` + `AGENTS.md`) — **generic, model-agnostic** RDMA fabric profiles that **supersede** the earlier per-recipe #10202 set. Each provider block shows the real profile and links the file plus `AGENTS.md` (the step-by-step merge procedure).

## Open question — resolved
"How model-specific are these overlays?" → **model-agnostic by construction.** A profile is a fabric-layer spec an agent materializes onto *any* base `DynamoGraphDeployment` (resolving the per-cluster `@param`s), so there's no per-model overlay to maintain. This is exactly what #10979 establishes, and it addresses the one-recipe-per-deployment concern raised in review.

## Depends on
#10979 — profile/`AGENTS.md` links currently point at its `jihao/csp-kustomize-addons` branch; repoint to `main` blob URLs once it merges.

## Still to converge (not in this PR)
"Show-the-DGD": render this recipe's base DGD inline (command up top + collapsible full manifest) so the merge *target* is visible next to the profile. Needs a build-time codegen step (`fern/`-scoped `<Markdown src>` can't reach `recipes/*/deploy.yaml`); piggybacks on the catalog-publish work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
