### PR TITLE
feat(kv-router): share core indexer metrics

### DIFF
--- a/docs/components/router/standalone-indexer.md
+++ b/docs/components/router/standalone-indexer.md
@@ -160,6 +160,14 @@ curl http://localhost:8090/metrics
 | `dynamo_kvindexer_models` | Gauge | — | Number of active model+tenant indexers |
 | `dynamo_kvindexer_workers` | Gauge | — | Number of registered worker instances |
 | `dynamo_kvindexer_listeners` | Gauge | `status` | Number of ZMQ listeners by status (`pending`, `active`, `paused`, `failed`) |
+| `dynamo_kvrouter_kv_cache_events_applied` | Counter | `event_type`, `status` | Primary device-tier KV events applied, partitioned by event type and result |
+| `dynamo_kvrouter_kv_cache_event_warnings` | Counter | `warning_kind` | Suspicious-but-valid primary device-tier events, including duplicate STORE content |
+
+The core event counters aggregate process-wide across model and tenant indexers and
+across all indexer threads. A `duplicate_store` warning is not necessarily an error:
+peer recovery replay can reapply content already restored from a snapshot. Lower-tier
+events and listener transport or replay failures are not represented by these core
+event counters; use the standalone service metrics and logs for those paths.
 
 ### `POST /register` — Register an endpoint
 

--- a/lib/kv-router/src/indexer/metrics.rs
+++ b/lib/kv-router/src/indexer/metrics.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "runtime-protocols")]
+#[cfg(any(feature = "metrics", feature = "runtime-protocols"))]
 use std::sync::Arc;
 #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
 use std::sync::OnceLock;
@@ -154,21 +154,53 @@ pub const METRIC_WARNING_DUPLICATE_STORE: &str = "duplicate_store";
 const KV_CACHE_EVENTS_APPLIED_SUFFIX: &str = "kv_cache_events_applied";
 #[cfg(feature = "metrics")]
 const KV_CACHE_EVENTS_APPLIED_NAME: &str = "dynamo_kvrouter_kv_cache_events_applied";
+#[cfg(feature = "metrics")]
+const KV_CACHE_EVENTS_APPLIED_HELP: &str = "Total number of KV cache events applied to index";
+#[cfg(feature = "metrics")]
+const KV_CACHE_EVENTS_APPLIED_LABELS: &[&str] = &["event_type", "status"];
 #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
 const KV_CACHE_EVENT_WARNINGS_SUFFIX: &str = "kv_cache_event_warnings";
 #[cfg(feature = "metrics")]
 const KV_CACHE_EVENT_WARNINGS_NAME: &str = "dynamo_kvrouter_kv_cache_event_warnings";
+#[cfg(feature = "metrics")]
+const KV_CACHE_EVENT_WARNINGS_HELP: &str =
+    "Total number of suspicious KV cache events seen by the router indexer";
+#[cfg(feature = "metrics")]
+const KV_CACHE_EVENT_WARNINGS_LABELS: &[&str] = &["warning_kind"];
 
 #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
 static KV_INDEXER_METRICS: OnceLock<Arc<KvIndexerMetrics>> = OnceLock::new();
 
 impl KvIndexerMetrics {
-    #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
+    #[cfg(feature = "metrics")]
     fn new(kv_cache_events_applied: IntCounterVec, kv_cache_event_warnings: IntCounterVec) -> Self {
         Self {
             kv_cache_events_applied,
             kv_cache_event_warnings,
         }
+    }
+
+    #[cfg(feature = "metrics")]
+    fn new_prometheus() -> Result<Self, prometheus::Error> {
+        Ok(Self::new(
+            IntCounterVec::new(
+                Opts::new(KV_CACHE_EVENTS_APPLIED_NAME, KV_CACHE_EVENTS_APPLIED_HELP),
+                KV_CACHE_EVENTS_APPLIED_LABELS,
+            )?,
+            IntCounterVec::new(
+                Opts::new(KV_CACHE_EVENT_WARNINGS_NAME, KV_CACHE_EVENT_WARNINGS_HELP),
+                KV_CACHE_EVENT_WARNINGS_LABELS,
+            )?,
+        ))
+    }
+
+    /// Creates and registers a shared metrics instance in `registry`.
+    #[cfg(feature = "metrics")]
+    pub fn new_registered(registry: &prometheus::Registry) -> Result<Arc<Self>, prometheus::Error> {
+        let metrics = Arc::new(Self::new_prometheus()?);
+        registry.register(Box::new(metrics.kv_cache_events_applied.clone()))?;
+        registry.register(Box::new(metrics.kv_cache_event_warnings.clone()))?;
+        Ok(metrics)
     }
 
     /// Creates a new KvIndexerMetrics from a Component, memoizing the result in
@@ -182,14 +214,14 @@ impl KvIndexerMetrics {
                     match (
                         component.metrics().create_intcountervec(
                             KV_CACHE_EVENTS_APPLIED_SUFFIX,
-                            "Total number of KV cache events applied to index",
-                            &["event_type", "status"],
+                            KV_CACHE_EVENTS_APPLIED_HELP,
+                            KV_CACHE_EVENTS_APPLIED_LABELS,
                             &[],
                         ),
                         component.metrics().create_intcountervec(
                             KV_CACHE_EVENT_WARNINGS_SUFFIX,
-                            "Total number of suspicious KV cache events seen by the router indexer",
-                            &["warning_kind"],
+                            KV_CACHE_EVENT_WARNINGS_HELP,
+                            KV_CACHE_EVENT_WARNINGS_LABELS,
                             &[],
                         ),
                     ) {
@@ -216,24 +248,7 @@ impl KvIndexerMetrics {
     /// This may be used for tests or as a fallback for when a MetricsRegistry is not available / has errored.
     #[cfg(feature = "metrics")]
     pub fn new_unregistered() -> Self {
-        Self {
-            kv_cache_events_applied: IntCounterVec::new(
-                Opts::new(
-                    KV_CACHE_EVENTS_APPLIED_NAME,
-                    "Total number of KV cache events applied to index",
-                ),
-                &["event_type", "status"],
-            )
-            .unwrap(),
-            kv_cache_event_warnings: IntCounterVec::new(
-                Opts::new(
-                    KV_CACHE_EVENT_WARNINGS_NAME,
-                    "Total number of suspicious KV cache events seen by the router indexer",
-                ),
-                &["warning_kind"],
-            )
-            .unwrap(),
-        }
+        Self::new_prometheus().expect("valid KV indexer metric definitions")
     }
 
     /// Creates a no-op metrics instance when Prometheus support is disabled.

--- a/lib/kv-router/src/services/indexer/backend.rs
+++ b/lib/kv-router/src/services/indexer/backend.rs
@@ -470,12 +470,25 @@ mod tests {
 }
 
 pub fn create_indexer(block_size: u32, num_threads: usize) -> Indexer {
+    create_indexer_with_metrics(
+        block_size,
+        num_threads,
+        Arc::new(KvIndexerMetrics::new_unregistered()),
+    )
+}
+
+pub fn create_indexer_with_metrics(
+    block_size: u32,
+    num_threads: usize,
+    metrics: Arc<KvIndexerMetrics>,
+) -> Indexer {
     if num_threads > 1 {
         Indexer::Concurrent {
-            primary: Arc::new(ThreadPoolIndexer::new(
+            primary: Arc::new(ThreadPoolIndexer::new_with_metrics(
                 ConcurrentRadixTreeCompressed::new(),
                 num_threads,
                 block_size,
+                Some(metrics),
             )),
             lower_tier: LowerTierIndexers::new(num_threads, block_size),
         }
@@ -484,7 +497,7 @@ pub fn create_indexer(block_size: u32, num_threads: usize) -> Indexer {
             primary: KvIndexer::new_with_pruning(
                 CancellationToken::new(),
                 block_size,
-                Arc::new(KvIndexerMetrics::new_unregistered()),
+                metrics,
                 None,
             ),
             lower_tier: LowerTierIndexers::new(1, block_size),

--- a/lib/kv-router/src/services/indexer/mod.rs
+++ b/lib/kv-router/src/services/indexer/mod.rs
@@ -128,8 +128,8 @@ pub async fn run_server(config: IndexerConfig) -> anyhow::Result<()> {
         "Starting standalone KV cache indexer (HTTP-only mode)"
     );
 
-    let registry = Arc::new(WorkerRegistry::new(config.threads));
-    run_common(&config, &registry, cancel_token).await
+    let state = Arc::new(AppState::new(config.threads)?);
+    run_common(&config, state, cancel_token).await
 }
 
 async fn wait_for_min_initial_workers(
@@ -161,9 +161,11 @@ async fn wait_for_min_initial_workers(
 
 async fn run_common(
     config: &IndexerConfig,
-    registry: &Arc<WorkerRegistry>,
+    state: Arc<AppState>,
     cancel_token: CancellationToken,
 ) -> anyhow::Result<()> {
+    let registry = &state.registry;
+
     if let Some(ref workers_str) = config.workers {
         let block_size = config.block_size.ok_or_else(|| {
             anyhow::anyhow!("--block-size is required when --workers is specified")
@@ -208,19 +210,6 @@ async fn run_common(
 
     wait_for_min_initial_workers(registry, &cancel_token).await?;
     registry.signal_ready();
-
-    #[cfg(feature = "metrics")]
-    let prom_registry = {
-        let r = prometheus::Registry::new();
-        metrics::register(&r).expect("failed to register indexer metrics");
-        r
-    };
-
-    let state = Arc::new(AppState {
-        registry: registry.clone(),
-        #[cfg(feature = "metrics")]
-        prom_registry,
-    });
 
     let app = create_router(state);
     let listener = TcpListener::bind(("0.0.0.0", config.port)).await?;

--- a/lib/kv-router/src/services/indexer/registry.rs
+++ b/lib/kv-router/src/services/indexer/registry.rs
@@ -14,9 +14,10 @@ use serde::Serialize;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
+use crate::indexer::KvIndexerMetrics;
 use crate::protocols::WorkerId;
 
-use super::backend::{Indexer, create_indexer};
+use super::backend::{Indexer, create_indexer_with_metrics};
 use super::listener::spawn_zmq_listener;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -314,12 +315,20 @@ pub struct WorkerRegistry {
     peers: DashMap<String, ()>,
     watermarks: DashMap<(WorkerId, u32), Arc<AtomicU64>>,
     num_threads: usize,
+    indexer_metrics: Arc<KvIndexerMetrics>,
     ready_tx: watch::Sender<bool>,
     ready_rx: watch::Receiver<bool>,
 }
 
 impl WorkerRegistry {
     pub fn new(num_threads: usize) -> Self {
+        Self::new_with_indexer_metrics(num_threads, Arc::new(KvIndexerMetrics::new_unregistered()))
+    }
+
+    pub fn new_with_indexer_metrics(
+        num_threads: usize,
+        indexer_metrics: Arc<KvIndexerMetrics>,
+    ) -> Self {
         let (ready_tx, ready_rx) = watch::channel(false);
         Self {
             workers: DashMap::new(),
@@ -327,6 +336,7 @@ impl WorkerRegistry {
             peers: DashMap::new(),
             watermarks: DashMap::new(),
             num_threads,
+            indexer_metrics,
             ready_tx,
             ready_rx,
         }
@@ -405,7 +415,11 @@ impl WorkerRegistry {
                 "Creating new indexer"
             );
             IndexerEntry {
-                indexer: create_indexer(block_size, self.num_threads),
+                indexer: create_indexer_with_metrics(
+                    block_size,
+                    self.num_threads,
+                    self.indexer_metrics.clone(),
+                ),
                 block_size,
             }
         });
@@ -710,7 +724,11 @@ impl WorkerRegistry {
                 "Creating indexer from recovery dump"
             );
             IndexerEntry {
-                indexer: create_indexer(block_size, self.num_threads),
+                indexer: create_indexer_with_metrics(
+                    block_size,
+                    self.num_threads,
+                    self.indexer_metrics.clone(),
+                ),
                 block_size,
             }
         });

--- a/lib/kv-router/src/services/indexer/server.rs
+++ b/lib/kv-router/src/services/indexer/server.rs
@@ -13,6 +13,8 @@ use axum::{Json, Router};
 use prometheus::Encoder;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "metrics")]
+use crate::indexer::KvIndexerMetrics;
 use crate::indexer::TieredMatchDetails;
 #[cfg(test)]
 use crate::protocols::StorageTier;
@@ -44,6 +46,29 @@ pub struct AppState {
     pub registry: Arc<WorkerRegistry>,
     #[cfg(feature = "metrics")]
     pub prom_registry: prometheus::Registry,
+}
+
+impl AppState {
+    pub fn new(indexer_threads: usize) -> anyhow::Result<Self> {
+        #[cfg(feature = "metrics")]
+        {
+            let prom_registry = prometheus::Registry::new();
+            super::metrics::register(&prom_registry)?;
+            let indexer_metrics = KvIndexerMetrics::new_registered(&prom_registry)?;
+            return Ok(Self {
+                registry: Arc::new(WorkerRegistry::new_with_indexer_metrics(
+                    indexer_threads,
+                    indexer_metrics,
+                )),
+                prom_registry,
+            });
+        }
+
+        #[cfg(not(feature = "metrics"))]
+        Ok(Self {
+            registry: Arc::new(WorkerRegistry::new(indexer_threads)),
+        })
+    }
 }
 
 fn default_tenant() -> String {

--- a/lib/kv-router/tests/standalone_indexer_http.rs
+++ b/lib/kv-router/tests/standalone_indexer_http.rs
@@ -309,6 +309,58 @@ async fn health_returns_ok() {
     task.await.expect("server task join");
 }
 
+#[cfg(feature = "metrics")]
+#[tokio::test]
+async fn duplicate_store_warning_is_exported() {
+    const BLOCK_SIZE: u32 = 4;
+    const MODEL: &str = "test-model";
+    const TENANT: &str = "default";
+
+    let state = Arc::new(AppState::new(4).expect("create app state"));
+    state.registry.signal_ready();
+
+    let key = IndexerKey {
+        model_name: MODEL.to_string(),
+        tenant_id: TENANT.to_string(),
+    };
+    let indexer = state
+        .registry
+        .get_or_create_indexer(key.clone(), BLOCK_SIZE);
+    indexer
+        .apply_event_routed(store_event(7, 0, 1, &[], &[11, 12], StorageTier::Device))
+        .await;
+    indexer
+        .apply_event_routed(store_event(7, 0, 2, &[], &[11, 12], StorageTier::Device))
+        .await;
+
+    let entry = state
+        .registry
+        .get_indexer(&key)
+        .expect("indexer should exist");
+    drop(entry.indexer.dump_events().await.expect("dump events"));
+    drop(entry);
+
+    let (base_url, cancel, task) = spawn_indexer_http(state).await;
+    let body = reqwest::Client::new()
+        .get(format!("{base_url}/metrics"))
+        .send()
+        .await
+        .expect("GET /metrics")
+        .text()
+        .await
+        .expect("read metrics body");
+
+    assert!(
+        body.lines().any(|line| {
+            line == "dynamo_kvrouter_kv_cache_event_warnings{warning_kind=\"duplicate_store\"} 1"
+        }),
+        "duplicate-store warning metric missing from /metrics:\n{body}"
+    );
+
+    cancel.cancel();
+    task.await.expect("server task join");
+}
+
 // =============================================================================
 // ZMQ-publisher e2e — drive a real PUB socket through the listener path
 // =============================================================================


### PR DESCRIPTION
## Summary

- Register the existing core `KvIndexerMetrics` collectors in the standalone indexer's Prometheus registry.
- Inject one process-wide metrics handle into primary device-tier indexers created through registration and peer recovery, while keeping native runtime plumbing unchanged.
- Add a Rust HTTP integration test that applies duplicate STORE content and verifies the warning counter through `/metrics`.
- Document process-wide aggregation, device-tier scope, and recovery replay semantics.

Previously, standalone indexers constructed unregistered core metrics before the HTTP Prometheus registry existed, so event warnings and errors were not exported even though the native Dynamo path exposed them.

## Validation

- `(cd lib/kv-router && cargo clippy --no-deps --all-targets -- -D warnings && cargo fmt)`
- `cargo test -p dynamo-kv-router --no-default-features --features metrics test_duplicate_store_replay_warns_without_error -- --nocapture`
- `cargo test -p dynamo-kv-router --no-default-features --features "standalone-indexer,metrics" --test standalone_indexer_http`
- `cargo test -p dynamo-kv-router --no-default-features --features standalone-indexer --test standalone_indexer_http`
- `cargo test -p dynamo-kv-router --no-default-features --features "metrics,runtime-protocols" --lib test_duplicate_store_replay_warns_without_error -- --nocapture`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Prometheus metrics documentation for KV indexer standalone monitoring.

* **New Features**
  * Added new Prometheus metrics for enhanced monitoring: counters for applied KV cache events (partitioned by event type and result status) and counters for suspicious-but-valid KV event warnings, enabling better operational visibility and diagnostic capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->