### PR TITLE
fix(frontend): emit SGLang metrics annotations

### DIFF
--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -6,6 +6,7 @@
 #
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -44,6 +45,16 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _cached_tokens_from_usage(usage: dict[str, Any] | None) -> int | None:
+    if not isinstance(usage, dict):
+        return None
+    prompt_details = usage.get("prompt_tokens_details")
+    if not isinstance(prompt_details, dict):
+        return None
+    cached_tokens = prompt_details.get("cached_tokens")
+    return cached_tokens if isinstance(cached_tokens, int) else None
 
 
 def _load_tokenizer(source_path: str, trust_remote_code: bool):
@@ -496,6 +507,8 @@ class SglangProcessor:
             pending_token_ids: list[int] = []
             pending_usage: dict[str, Any] | None = None
             first_chunk = True
+            input_tokens = len(tokens)
+            cumulative_output_tokens = 0
 
             async for dynamo_response in dynamo_stream:
                 if dynamo_response.is_error():
@@ -523,6 +536,8 @@ class SglangProcessor:
                     break
 
                 new_ids = engine_response["token_ids"]
+                chunk_tokens = len(new_ids)
+                cumulative_output_tokens += chunk_tokens
                 raw_finish = engine_response.get("finish_reason")
                 finish_reason = _map_finish_reason(raw_finish)
                 stop_reason = engine_response.get("stop_reason")
@@ -552,6 +567,7 @@ class SglangProcessor:
                         post_proc_total_ms += (t_pp1 - t_pp0) * 1000.0
                         token_count += len(pending_token_ids)
 
+                    envelope: dict[str, Any] = {"_dynamo_annotated": True}
                     if choice:
                         dynamo_out: dict[str, Any] = {
                             "id": request_id,
@@ -574,7 +590,20 @@ class SglangProcessor:
                         if response_nvext:
                             dynamo_out["nvext"] = response_nvext
 
-                        yield dynamo_out
+                        envelope["data"] = dynamo_out
+
+                    metrics: dict[str, Any] = {
+                        "input_tokens": input_tokens,
+                        "output_tokens": cumulative_output_tokens,
+                        "chunk_tokens": len(pending_token_ids),
+                    }
+                    cached_tokens = _cached_tokens_from_usage(pending_usage)
+                    if cached_tokens is not None:
+                        metrics["cached_tokens"] = cached_tokens
+                    envelope["event"] = "llm_metrics"
+                    envelope["comment"] = [json.dumps(metrics)]
+
+                    yield envelope
 
                     pending_token_ids = []
                     pending_usage = None

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_metrics_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_metrics_unit.py
@@ -1,0 +1,174 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+"""Metrics-focused SGLang processor tests with lightweight SGLang stubs."""
+
+import asyncio
+import importlib
+import json
+import sys
+import types
+
+import pytest
+from _routed_engine_fakes import FakeRoutedEngine
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def _install_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _install_sglang_stubs():
+    class _Function:
+        pass
+
+    class _Tool:
+        pass
+
+    class _ToolChoice:
+        pass
+
+    class _ToolChoiceFuncName:
+        pass
+
+    class _ToolCallItem:
+        pass
+
+    class _FunctionCallParser:
+        pass
+
+    class _JsonArrayParser:
+        pass
+
+    class _ReasoningParser:
+        pass
+
+    _install_module("sglang")
+    _install_module("sglang.srt")
+    _install_module("sglang.srt.entrypoints")
+    _install_module("sglang.srt.entrypoints.openai")
+    _install_module(
+        "sglang.srt.entrypoints.openai.protocol",
+        Function=_Function,
+        Tool=_Tool,
+        ToolChoice=_ToolChoice,
+        ToolChoiceFuncName=_ToolChoiceFuncName,
+    )
+    _install_module("sglang.srt.function_call")
+    _install_module("sglang.srt.function_call.core_types", ToolCallItem=_ToolCallItem)
+    _install_module(
+        "sglang.srt.function_call.function_call_parser",
+        FunctionCallParser=_FunctionCallParser,
+    )
+    _install_module(
+        "sglang.srt.function_call.json_array_parser",
+        JsonArrayParser=_JsonArrayParser,
+    )
+    _install_module(
+        "sglang.srt.function_call.utils",
+        get_json_schema_constraint=lambda *args, **kwargs: None,
+    )
+    _install_module("sglang.srt.parser")
+    _install_module(
+        "sglang.srt.parser.jinja_template_utils",
+        detect_jinja_template_content_format=lambda *args, **kwargs: "string",
+        process_content_for_template_format=lambda content, *_args, **_kwargs: content,
+    )
+    _install_module(
+        "sglang.srt.parser.reasoning_parser",
+        ReasoningParser=_ReasoningParser,
+    )
+    _install_module("sglang.srt.utils")
+    _install_module(
+        "sglang.srt.utils.hf_transformers_utils",
+        get_tokenizer=lambda *args, **kwargs: None,
+    )
+
+
+class _PostProcessor:
+    def process_output(self, mapped_response):
+        return {
+            "index": 0,
+            "delta": {"content": "x"},
+            "finish_reason": mapped_response["finish_reason"],
+        }
+
+
+def _load_processor_module():
+    _install_sglang_stubs()
+    _install_module("dynamo._internal", ModelDeploymentCard=object)
+    _install_module("dynamo.frontend.frontend_args", FrontendConfig=object)
+    _install_module(
+        "dynamo.llm",
+        ModelCardInstanceId=object,
+        PythonAsyncEngine=object,
+        RoutedEngine=object,
+    )
+    _install_module(
+        "dynamo.llm.exceptions",
+        InvalidArgument=type("InvalidArgument", (Exception,), {}),
+        Unknown=type("Unknown", (Exception,), {}),
+    )
+    return importlib.import_module("dynamo.frontend.sglang_processor")
+
+
+def test_stream_emits_llm_metrics_annotation():
+    module = _load_processor_module()
+    completion_usage = {
+        "prompt_tokens": 10,
+        "completion_tokens": 3,
+        "total_tokens": 13,
+        "prompt_tokens_details": {"cached_tokens": 4},
+    }
+    processor = module.SglangProcessor(
+        tokenizer=None,
+        routed_engine=FakeRoutedEngine(
+            items=[
+                {
+                    "token_ids": [101, 102, 103],
+                    "finish_reason": "stop",
+                    "completion_usage": completion_usage,
+                }
+            ]
+        ),
+        tool_call_parser_name=None,
+        reasoning_parser_name=None,
+        eos_token_id=None,
+    )
+
+    async def collect():
+        return [
+            item
+            async for item in processor._generate_and_stream(
+                "req-metrics",
+                {"model": "test-model"},
+                {},
+                list(range(10)),
+                _PostProcessor(),
+            )
+        ]
+
+    items = asyncio.run(collect())
+    metric_items = [item for item in items if item.get("event") == "llm_metrics"]
+
+    assert len(metric_items) == 1
+    envelope = metric_items[0]
+    assert envelope["_dynamo_annotated"] is True
+    assert envelope["data"]["usage"] == completion_usage
+    metrics = json.loads(envelope["comment"][0])
+    assert metrics == {
+        "input_tokens": 10,
+        "output_tokens": 3,
+        "chunk_tokens": 3,
+        "cached_tokens": 4,
+    }

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_metrics_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_metrics_unit.py
@@ -19,16 +19,43 @@ pytestmark = [
     pytest.mark.pre_merge,
 ]
 
-
-def _install_module(name: str, **attrs):
-    module = types.ModuleType(name)
-    for key, value in attrs.items():
-        setattr(module, key, value)
-    sys.modules[name] = module
-    return module
+_MISSING = object()
 
 
-def _install_sglang_stubs():
+@pytest.fixture
+def module_stubs():
+    original_modules = {}
+
+    def remember(name: str):
+        if name not in original_modules:
+            original_modules[name] = sys.modules.get(name, _MISSING)
+
+    def install_module(name: str, **attrs):
+        remember(name)
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        sys.modules[name] = module
+        return module
+
+    def remove_module(name: str):
+        remember(name)
+        sys.modules.pop(name, None)
+
+    yield install_module, remove_module
+
+    for name, module in original_modules.items():
+        if module is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+def _install_module(install_module, name: str, **attrs):
+    return install_module(name, **attrs)
+
+
+def _install_sglang_stubs(install_module):
     class _Function:
         pass
 
@@ -53,43 +80,54 @@ def _install_sglang_stubs():
     class _ReasoningParser:
         pass
 
-    _install_module("sglang")
-    _install_module("sglang.srt")
-    _install_module("sglang.srt.entrypoints")
-    _install_module("sglang.srt.entrypoints.openai")
+    _install_module(install_module, "sglang")
+    _install_module(install_module, "sglang.srt")
+    _install_module(install_module, "sglang.srt.entrypoints")
+    _install_module(install_module, "sglang.srt.entrypoints.openai")
     _install_module(
+        install_module,
         "sglang.srt.entrypoints.openai.protocol",
         Function=_Function,
         Tool=_Tool,
         ToolChoice=_ToolChoice,
         ToolChoiceFuncName=_ToolChoiceFuncName,
     )
-    _install_module("sglang.srt.function_call")
-    _install_module("sglang.srt.function_call.core_types", ToolCallItem=_ToolCallItem)
+    _install_module(install_module, "sglang.srt.function_call")
     _install_module(
+        install_module,
+        "sglang.srt.function_call.core_types",
+        ToolCallItem=_ToolCallItem,
+    )
+    _install_module(
+        install_module,
         "sglang.srt.function_call.function_call_parser",
         FunctionCallParser=_FunctionCallParser,
     )
     _install_module(
+        install_module,
         "sglang.srt.function_call.json_array_parser",
         JsonArrayParser=_JsonArrayParser,
     )
     _install_module(
+        install_module,
         "sglang.srt.function_call.utils",
         get_json_schema_constraint=lambda *args, **kwargs: None,
     )
-    _install_module("sglang.srt.parser")
+    _install_module(install_module, "sglang.srt.parser")
     _install_module(
+        install_module,
         "sglang.srt.parser.jinja_template_utils",
         detect_jinja_template_content_format=lambda *args, **kwargs: "string",
         process_content_for_template_format=lambda content, *_args, **_kwargs: content,
     )
     _install_module(
+        install_module,
         "sglang.srt.parser.reasoning_parser",
         ReasoningParser=_ReasoningParser,
     )
-    _install_module("sglang.srt.utils")
+    _install_module(install_module, "sglang.srt.utils")
     _install_module(
+        install_module,
         "sglang.srt.utils.hf_transformers_utils",
         get_tokenizer=lambda *args, **kwargs: None,
     )
@@ -104,26 +142,34 @@ class _PostProcessor:
         }
 
 
-def _load_processor_module():
-    _install_sglang_stubs()
-    _install_module("dynamo._internal", ModelDeploymentCard=object)
-    _install_module("dynamo.frontend.frontend_args", FrontendConfig=object)
+def _load_processor_module(module_stubs):
+    install_module, remove_module = module_stubs
+    _install_sglang_stubs(install_module)
+    _install_module(install_module, "dynamo._internal", ModelDeploymentCard=object)
     _install_module(
+        install_module,
+        "dynamo.frontend.frontend_args",
+        FrontendConfig=object,
+    )
+    _install_module(
+        install_module,
         "dynamo.llm",
         ModelCardInstanceId=object,
         PythonAsyncEngine=object,
         RoutedEngine=object,
     )
     _install_module(
+        install_module,
         "dynamo.llm.exceptions",
         InvalidArgument=type("InvalidArgument", (Exception,), {}),
         Unknown=type("Unknown", (Exception,), {}),
     )
+    remove_module("dynamo.frontend.sglang_processor")
     return importlib.import_module("dynamo.frontend.sglang_processor")
 
 
-def test_stream_emits_llm_metrics_annotation():
-    module = _load_processor_module()
+def test_stream_emits_llm_metrics_annotation(module_stubs):
+    module = _load_processor_module(module_stubs)
     completion_usage = {
         "prompt_tokens": 10,
         "completion_tokens": 3,

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -1888,8 +1888,9 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         items = asyncio.run(collect())
 
         assert len(items) == 1
-        assert items[0]["nvext"]["stop_reason"] == "END"
-        assert "stop_reason" not in items[0]["choices"][0]
+        chunk = items[0]["data"]
+        assert chunk["nvext"]["stop_reason"] == "END"
+        assert "stop_reason" not in chunk["choices"][0]
 
     def _run_stream(self, tokenizer, items):
         processor = SglangProcessor(
@@ -1904,11 +1905,17 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         )
 
         async def collect():
-            return [
+            raw_items = [
                 item
                 async for item in processor._generate_and_stream(
                     "req-err", {"model": "test-model"}, {}, [], post
                 )
+            ]
+            return [
+                item["data"]
+                if item.get("_dynamo_annotated") and "data" in item
+                else item
+                for item in raw_items
             ]
 
         return asyncio.run(collect())


### PR DESCRIPTION
## Summary

- Emit `llm_metrics` annotations from the SGLang chat processor so frontend token, TTFT, ITL, and cached-token metrics can be observed.
- Preserve SGLang response usage while wrapping streamed output and metrics in a Dynamo annotated envelope.
- Add focused unit coverage for SGLang metrics annotations and update existing SGLang processor tests to unwrap annotated envelopes.

Part of #10778.

## Validation

- `PYTHONPATH=components/src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -o filterwarnings=default components/src/dynamo/frontend/tests/test_sglang_processor_metrics_unit.py`
- `python -m py_compile components/src/dynamo/frontend/sglang_processor.py components/src/dynamo/frontend/tests/test_sglang_processor_metrics_unit.py components/src/dynamo/frontend/tests/test_sglang_processor_unit.py`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token usage tracking to include cached tokens and per-chunk metrics during streaming.
  * Improved metrics reporting with structured output containing input tokens, output tokens, and cached tokens.

* **Tests**
  * Added comprehensive unit tests for metrics emission and token tracking validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->