### PR TITLE
feat: experimental squeeze_evolve (multi-model evolutionary test-time scaling)

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -118,6 +118,7 @@ core:
   # TODO(will): Move TokenSpeed to a dedicated framework filter once CI has
   # TokenSpeed Docker images and backend-specific build/test jobs.
   - 'components/src/dynamo/tokenspeed/**'
+  - 'components/src/dynamo/squeeze_evolve/**'
   - '*.toml'
   - '*.lock'
   - '*.py'

--- a/components/src/dynamo/squeeze_evolve/README.md
+++ b/components/src/dynamo/squeeze_evolve/README.md
@@ -1,0 +1,80 @@
+<!-- # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 -->
+
+# `dynamo.squeeze_evolve` (experimental)
+
+> **Experimental: not a released component.** Run it from a source checkout (see [Install](#install)); the CLI flags and `--tiers` schema are unstable and will change.
+
+A standalone Dynamo component for **multi-model orchestration**: it serves [Squeeze-Evolve](https://arxiv.org/abs/2604.07725) (verifier-free evolutionary test-time scaling) as a chat model backed by any number of model tiers, from small cheap models up to large expensive ones. Each `/v1/chat/completions` request becomes one Squeeze-Evolve *problem*: an evolutionary loop generates a population of candidates and, each round, routes every group to the cheapest tier that can still handle it. Easy groups stay on the cheap models and only the hardest reach the most expensive, so the fleet matches or beats single-model accuracy at a fraction of the cost.
+
+## How it works
+
+Each tier is a separate `dynamo.vllm` deployment, ordered cheapest to most expensive, and the component owns one `KvRouter` per tier.
+
+- **Loop 0**: the most expensive tier generates `--population` candidates.
+- **Loops 1..T**: select `--groups` random `--k`-subsets, score each by answer diversity (number of unique answers), route each group to one of the tiers by its diversity (lowest-diversity consensus groups to the cheapest tier, highest-diversity to the most expensive), then recombine each tier's groups in parallel and replace the population.
+
+The first candidate of the final population is the answer.
+
+## Install
+
+Run it from a source checkout. Squeeze-Evolve is experimental and ships no wheel extra, so install its two dependencies (`numpy` for the percentile routing thresholds, `uvloop` for the entrypoint's event loop) explicitly, alongside the vLLM extra for the tier workers:
+
+```bash
+git clone https://github.com/ai-dynamo/dynamo
+cd dynamo
+(cd lib/bindings/python && maturin develop --uv)   # build the Rust bindings
+uv pip install -e '.[vllm]' numpy uvloop
+```
+
+## Usage
+
+Each command below is a long-running process, so run them in separate terminals (or background them with `&` as shown). Start one `dynamo.vllm` worker per tier, each pinned to its own GPU with `CUDA_VISIBLE_DEVICES`, then the orchestrator, then the frontend. This example uses two tiers; add more tier processes and `--tiers` entries for N tiers (and pass N-1 `--confidence-percentiles`).
+
+```bash
+# Tier 0 (cheap) on GPU 0
+CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm --model Qwen/Qwen3-4B-Instruct-2507 \
+    --endpoint dynamo.tier1.generate \
+    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
+
+# Tier 1 (expensive) on GPU 1
+CUDA_VISIBLE_DEVICES=1 python -m dynamo.vllm --model Qwen/Qwen3-30B-A3B-Instruct-2507 \
+    --endpoint dynamo.tier2.generate \
+    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}' &
+
+# Orchestrator: registers the chat model "squeeze-evolve/aime25"
+python -m dynamo.squeeze_evolve \
+    --tiers '[{"endpoint":"dynamo.tier1.generate","model":"Qwen/Qwen3-4B-Instruct-2507"},
+              {"endpoint":"dynamo.tier2.generate","model":"Qwen/Qwen3-30B-A3B-Instruct-2507"}]' \
+    --model-name squeeze-evolve/aime25 --confidence-percentiles 50 &
+
+# Frontend
+python -m dynamo.frontend --http-port 8000 --router-mode round-robin
+```
+
+`--tiers` is a JSON array, cheapest first; each entry needs `endpoint` and `model`, plus optional `temperature` / `top_p` / `max_tokens` / `block_size` / `tokenizer` / `trust_remote_code`. For N tiers, pass N-1 `--confidence-percentiles`. The model card served to clients defaults to the most expensive tier's model; pass `--model-path` to override. Run `python -m dynamo.squeeze_evolve --help` for the other knobs.
+
+Then call `--model-name` like any chat model:
+
+```bash
+curl localhost:8000/v1/chat/completions -H 'content-type: application/json' -d '{
+  "model": "squeeze-evolve/aime25",
+  "messages": [{"role": "user", "content": "Find the remainder when 7^100 is divided by 13."}]
+}'
+```
+
+## Citation
+
+If you use this package for research, please cite the Squeeze-Evolve paper:
+
+```bibtex
+@misc{maheswaran2026squeezeevolveunifiedmultimodel,
+      title={Squeeze Evolve: Unified Multi-Model Orchestration for Verifier-Free Evolution},
+      author={Monishwaran Maheswaran and Leon Lakhani and Zhongzhu Zhou and Shijia Yang and Junxiong Wang and Coleman Hooper and Yuezhou Hu and Rishabh Tiwari and Jue Wang and Harman Singh and Qingyang Wu and Yuqing Jian and Ce Zhang and Kurt Keutzer and Tri Dao and Xiaoxia Wu and Ben Athiwaratkun and James Zou and Chenfeng Xu},
+      year={2026},
+      eprint={2604.07725},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2604.07725},
+}
+```

--- a/components/src/dynamo/squeeze_evolve/__init__.py
+++ b/components/src/dynamo/squeeze_evolve/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Squeeze-Evolve evolutionary test-time-scaling as a native Dynamo component.
+
+Native port of the Squeeze-Evolve diversity loop (https://arxiv.org/abs/2604.07725):
+runs the evolutionary loop as a chat model, routing candidate groups across model
+tiers via one ``KvRouter`` per tier. See README.md.
+"""
+
+from dynamo.squeeze_evolve.orchestrator import (
+    SqueezeEvolveConfig,
+    SqueezeEvolveOrchestrator,
+    Tier,
+)
+
+__all__ = ["SqueezeEvolveConfig", "SqueezeEvolveOrchestrator", "Tier"]

--- a/components/src/dynamo/squeeze_evolve/__main__.py
+++ b/components/src/dynamo/squeeze_evolve/__main__.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone Squeeze-Evolve Dynamo component (experimental).
+
+Usage (tiers cheapest-first; see README.md for the full per-tier schema):
+    python -m dynamo.squeeze_evolve \\
+        --tiers '[{"endpoint":"dynamo.cheap.generate","model":"Qwen/cheap"},
+                  {"endpoint":"dynamo.expensive.generate","model":"Qwen/big"}]' \\
+        --model-name squeeze-evolve/aime25 --confidence-percentiles 50 --loops 5
+
+Registers as a chat model (``ModelInput.Text`` + ``ModelType.Chat``) so the
+frontend routes ``/v1/chat/completions`` for ``--model-name`` to this service.
+Each request becomes one Squeeze-Evolve problem; the evolutionary loop runs,
+fanning generation across the tiers (each a per-tier ``KvRouter``), and the final
+evolved candidate is streamed back as the assistant message.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any, AsyncIterator
+
+import uvloop
+
+from dynamo.llm import (
+    AicPerfConfig,
+    KvRouterConfig,
+    ModelInput,
+    ModelType,
+    WorkerType,
+    register_model,
+)
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime.logging import configure_dynamo_logging
+from dynamo.squeeze_evolve.args import parse_args
+from dynamo.squeeze_evolve.orchestrator import SqueezeEvolveOrchestrator
+
+configure_dynamo_logging()
+logger = logging.getLogger(__name__)
+
+
+def _content_to_text(content: Any) -> str:
+    """Flatten OpenAI message content (string or list of parts) to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            part["text"]
+            for part in content
+            if isinstance(part, dict)
+            and part.get("type") == "text"
+            and isinstance(part.get("text"), str)
+        ]
+        return "\n".join(parts)
+    return ""
+
+
+def extract_messages(request: dict[str, Any]) -> list[dict[str, str]]:
+    """Normalize an OpenAI chat request to role/text messages.
+
+    Preserves the full conversation (system, user, assistant, ...) so the tier
+    tokenizer's chat template sees it intact instead of only the user turns;
+    multimodal content parts are flattened to their text. A non-list ``messages``
+    payload yields an empty list rather than raising.
+    """
+    raw = request.get("messages")
+    if not isinstance(raw, list):
+        return []
+    messages: list[dict[str, str]] = []
+    for msg in raw:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if not isinstance(role, str) or not role:
+            continue
+        text = _content_to_text(msg.get("content"))
+        if text:
+            messages.append({"role": role, "content": text})
+    return messages
+
+
+def chat_chunk(
+    model: str,
+    req_id: str,
+    *,
+    content: str | None = None,
+    finish: str | None = None,
+) -> dict[str, Any]:
+    """Build one OpenAI ``chat.completion.chunk``."""
+    delta: dict[str, Any] = {}
+    if content is not None:
+        delta = {"role": "assistant", "content": content}
+    return {
+        "id": req_id,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+    }
+
+
+class SqueezeEvolveHandler:
+    """One Squeeze-Evolve problem per chat request against a shared orchestrator."""
+
+    def __init__(
+        self, model_name: str, orchestrator: SqueezeEvolveOrchestrator
+    ) -> None:
+        self._model_name = model_name
+        self._orchestrator = orchestrator
+
+    async def generate(self, request: dict[str, Any]) -> AsyncIterator[dict[str, Any]]:
+        model = self._model_name
+        req_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+        messages = extract_messages(request)
+        if not messages:
+            yield chat_chunk(model, req_id, content="")
+            yield chat_chunk(model, req_id, finish="stop")
+            return
+
+        answer = await self._orchestrator.run(messages)
+        yield chat_chunk(model, req_id, content=answer)
+        yield chat_chunk(model, req_id, finish="stop")
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime) -> None:
+    config = parse_args()
+    tiers = config.tiers
+    model_name = config.model_name
+    if tiers is None or model_name is None:
+        # config.validate() already rejects both; recheck to narrow the Optionals.
+        raise ValueError("--tiers and --model-name are required")
+    logger.info(
+        "Squeeze-Evolve starting (model=%s, tiers=%d, loops=%d)",
+        model_name,
+        len(tiers),
+        config.loops,
+    )
+
+    orchestrator = SqueezeEvolveOrchestrator(
+        cfg=config.to_algo_config(),
+        tiers=tiers,
+        runtime=runtime,
+        # Parity with dynamo.router.args.build_kv_router_config /
+        # build_aic_perf_config, which are typed for DynamoRouterConfig
+        # (single --endpoint); this config inherits the shared bases directly.
+        kv_router_config=KvRouterConfig(**config.kv_router_kwargs()),
+        aic_perf_config=(
+            AicPerfConfig(**config.aic_perf_kwargs())
+            if config.router_prefill_load_model == "aic"
+            else None
+        ),
+        default_block_size=config.default_block_size,
+    )
+    handler = SqueezeEvolveHandler(model_name, orchestrator)
+
+    generate_endpoint = runtime.endpoint(f"{config.namespace}.squeeze_evolve.generate")
+    await register_model(
+        model_input=ModelInput.Text,
+        model_type=ModelType.Chat,
+        endpoint=generate_endpoint,
+        model_path=config.model_path or tiers[-1].model,
+        model_name=model_name,
+        worker_type=WorkerType.Aggregated,
+    )
+
+    logger.info(
+        "Serving %s at %s.squeeze_evolve.generate", model_name, config.namespace
+    )
+    await generate_endpoint.serve_endpoint(
+        handler.generate,
+        graceful_shutdown=True,
+        metrics_labels=[("service", "squeeze_evolve")],
+    )
+
+
+def main() -> None:
+    uvloop.run(worker())
+
+
+if __name__ == "__main__":
+    main()

--- a/components/src/dynamo/squeeze_evolve/args.py
+++ b/components/src/dynamo/squeeze_evolve/args.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Squeeze-Evolve component CLI parsing and config assembly.
+
+Dynamo-native: CLI flags + env vars (no Pydantic, no YAML). Model tiers come from
+a single ``--tiers`` JSON array; the shared per-tier ``KvRouter`` knobs are the
+standard ``--router-*`` flags (reused via ``KvRouterArgGroup``).
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+from dynamo.common.configuration.arg_group import ArgGroup
+from dynamo.common.configuration.groups.aic_perf_args import (
+    AicPerfArgGroup,
+    AicPerfConfigBase,
+)
+from dynamo.common.configuration.groups.kv_router_args import (
+    KvRouterArgGroup,
+    KvRouterConfigBase,
+)
+from dynamo.common.configuration.utils import add_argument
+from dynamo.squeeze_evolve.orchestrator import SqueezeEvolveConfig, Tier, parse_tiers
+
+_TIERS_EXAMPLE = (
+    '[{"endpoint":"dynamo.cheap.generate","model":"Qwen/Qwen3-30B-A3B-Instruct-2507",'
+    '"temperature":0.7,"top_p":0.8,"max_tokens":8192,"block_size":64},'
+    '{"endpoint":"dynamo.expensive.generate","model":"Qwen/Qwen3-235B-A22B-Instruct-2507"}]'
+)
+
+
+def _nullable_int(raw: str) -> Optional[int]:
+    if raw is None or str(raw).lower() in ("", "none", "null"):
+        return None
+    return int(raw)
+
+
+class SqueezeEvolveRunConfig(KvRouterConfigBase, AicPerfConfigBase):
+    """Squeeze-Evolve config: the SE knobs + the shared per-tier KvRouter knobs.
+
+    Inherits the KvRouter/AicPerf bases directly (NOT ``DynamoRouterConfig``) so we
+    reuse ``kv_router_kwargs()`` / ``aic_perf_kwargs()`` + the load-aware preset
+    without ``DynamoRouterConfig``'s single-``--endpoint`` requirement — Squeeze-Evolve
+    has N tier endpoints (in ``--tiers``).
+    """
+
+    namespace: str = "dynamo"
+    tiers: Optional[list[Tier]] = None
+    k: int = 4
+    population: int = 16
+    groups: int = 0  # 0 -> follow --population
+    loops: int = 5
+    confidence_percentiles: list[float] = [50.0]
+    task: str = "math"
+    seed: Optional[int] = None
+    tier_concurrency: int = 32
+    default_block_size: int = 64
+    model_name: Optional[str] = None
+    model_path: Optional[str] = None
+
+    def to_algo_config(self) -> SqueezeEvolveConfig:
+        return SqueezeEvolveConfig(
+            k=self.k,
+            population=self.population,
+            groups=self.groups or self.population,
+            loops=self.loops,
+            confidence_percentiles=[float(p) for p in self.confidence_percentiles],
+            task=self.task,
+            seed=self.seed,
+            tier_concurrency=self.tier_concurrency,
+        )
+
+    def validate(self) -> None:  # type: ignore[override]
+        self.apply_load_aware_preset()  # shared KvRouter preset (KvRouterConfigBase)
+        if not self.tiers:
+            raise ValueError("--tiers is required (JSON array, cheapest first)")
+        self.confidence_percentiles = [float(p) for p in self.confidence_percentiles]
+        n = len(self.tiers)
+        if n > 1 and len(self.confidence_percentiles) != n - 1:
+            raise ValueError(
+                f"{n} tiers require {n - 1} --confidence-percentiles, "
+                f"got {len(self.confidence_percentiles)}"
+            )
+        if not self.model_name:
+            raise ValueError("--model-name is required")
+        if not 1 <= self.k <= self.population:
+            raise ValueError("--k must be in [1, --population]")
+        if self.population < 1 or self.loops < 1:
+            raise ValueError("--population and --loops must be >= 1")
+        if self.groups < 0:
+            raise ValueError("--groups must be >= 0 (0 follows --population)")
+        if self.tier_concurrency < 1:
+            raise ValueError("--tier-concurrency must be >= 1")
+        # After Loop 1 the population shrinks to --groups, so later loops select
+        # --k from it; guard --groups < --k when >1 recombination loop runs.
+        effective_groups = self.groups or self.population
+        if self.loops > 2 and effective_groups < self.k:
+            raise ValueError(
+                "--groups must be >= --k when --loops > 2 "
+                "(population shrinks to --groups after Loop 1)"
+            )
+
+
+class SqueezeEvolveArgGroup(ArgGroup):
+    name = "squeeze-evolve"
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        g = parser.add_argument_group("Squeeze-Evolve Options")
+        add_argument(
+            g,
+            flag_name="--tiers",
+            env_var="DYN_SQUEEZE_TIERS",
+            default=None,
+            arg_type=parse_tiers,
+            help="JSON array of model tiers, cheapest first. Each entry: "
+            "{endpoint (3-part namespace.component.endpoint), model (HF id), "
+            "temperature?, top_p?, max_tokens?, block_size?, tokenizer?, "
+            "trust_remote_code?}. "
+            f"Example: {_TIERS_EXAMPLE}",
+        )
+        add_argument(
+            g,
+            flag_name="--model-name",
+            env_var="DYN_SQUEEZE_MODEL_NAME",
+            default=None,
+            arg_type=str,
+            help="Frontend-visible model name clients call (e.g. squeeze-evolve/aime25).",
+        )
+        add_argument(
+            g,
+            flag_name="--model-path",
+            env_var="DYN_SQUEEZE_MODEL_PATH",
+            default=None,
+            arg_type=str,
+            help="HF repo id / path for the model card used by register_model. "
+            "Defaults to the most expensive tier's model.",
+        )
+        add_argument(
+            g,
+            flag_name="--namespace",
+            env_var="DYN_NAMESPACE",
+            default="dynamo",
+            arg_type=str,
+            help="Dynamo namespace to serve under (default: dynamo).",
+        )
+        add_argument(
+            g,
+            flag_name="--k",
+            env_var="DYN_SQUEEZE_K",
+            default=4,
+            arg_type=int,
+            help="Group size for selection (default: 4).",
+        )
+        add_argument(
+            g,
+            flag_name="--population",
+            env_var="DYN_SQUEEZE_POPULATION",
+            default=16,
+            arg_type=int,
+            help="Candidates per problem, generated in Loop 0 (default: 16).",
+        )
+        add_argument(
+            g,
+            flag_name="--groups",
+            env_var="DYN_SQUEEZE_GROUPS",
+            default=0,
+            arg_type=int,
+            help="Groups per loop (default: 0 = follow --population).",
+        )
+        add_argument(
+            g,
+            flag_name="--loops",
+            env_var="DYN_SQUEEZE_LOOPS",
+            default=5,
+            arg_type=int,
+            help="Evolutionary iterations including Loop 0 (default: 5).",
+        )
+        add_argument(
+            g,
+            flag_name="--confidence-percentiles",
+            env_var="DYN_SQUEEZE_CONFIDENCE_PERCENTILES",
+            default=[50.0],
+            arg_type=float,
+            nargs="+",
+            help="N-1 percentile thresholds for N tiers (default: 50).",
+        )
+        add_argument(
+            g,
+            flag_name="--task",
+            env_var="DYN_SQUEEZE_TASK",
+            default="math",
+            arg_type=str,
+            choices=["math", "gpqa_diamond", "generic"],
+            help="Task type for answer extraction (default: math).",
+        )
+        add_argument(
+            g,
+            flag_name="--seed",
+            env_var="DYN_SQUEEZE_SEED",
+            default=None,
+            arg_type=_nullable_int,
+            help="RNG seed. Leave unset for serving (per-request independence).",
+        )
+        add_argument(
+            g,
+            flag_name="--tier-concurrency",
+            env_var="DYN_SQUEEZE_TIER_CONCURRENCY",
+            default=32,
+            arg_type=int,
+            help="Max concurrent generations per tier (default: 32).",
+        )
+        add_argument(
+            g,
+            flag_name="--default-block-size",
+            env_var="DYN_SQUEEZE_DEFAULT_BLOCK_SIZE",
+            default=64,
+            arg_type=int,
+            help="KvRouter block size for tiers that omit block_size (default: 64).",
+        )
+        # Shared per-tier KvRouter knobs (--router-*) + AIC perf model flags.
+        KvRouterArgGroup().add_arguments(parser)
+        AicPerfArgGroup().add_arguments(parser)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> SqueezeEvolveRunConfig:
+    parser = argparse.ArgumentParser(
+        description="Dynamo Squeeze-Evolve: verifier-free evolutionary test-time "
+        "scaling that routes candidate groups across model tiers, served as a "
+        "chat model.",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    SqueezeEvolveArgGroup().add_arguments(parser)
+    args = parser.parse_args(argv)
+    config = SqueezeEvolveRunConfig.from_cli_args(args)
+    config.validate()
+    return config
+
+
+__all__ = [
+    "SqueezeEvolveArgGroup",
+    "SqueezeEvolveRunConfig",
+    "parse_args",
+]

--- a/components/src/dynamo/squeeze_evolve/operators.py
+++ b/components/src/dynamo/squeeze_evolve/operators.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evolutionary operators for the Squeeze-Evolve diversity loop.
+
+Native port of the operator set from Squeeze-Evolve (https://arxiv.org/abs/2604.07725):
+selection, group fitness (diversity), percentile routing thresholds, route
+assignment, the aggregate recombination prompt, population update, and math
+answer extraction. Plain functions — no registry, no plugin system, no Pydantic.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from typing import Sequence
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Answer extraction (math)
+# ---------------------------------------------------------------------------
+
+
+def strip_think_blocks(text: str) -> str:
+    """Remove ``<think>...</think>`` chain-of-thought wrappers."""
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+    text = re.sub(r"^.*?</think>", "", text, flags=re.DOTALL).strip()
+    return text
+
+
+def _extract_boxed_content(text: str) -> str | None:
+    """Return the content of the last balanced ``\\boxed{...}``, or None."""
+    marker = r"\boxed{"
+    start = text.rfind(marker)
+    if start == -1:
+        return None
+    idx = start + len(marker)
+    depth = 1
+    chars: list[str] = []
+    while idx < len(text):
+        char = text[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return "".join(chars).strip()
+        chars.append(char)
+        idx += 1
+    return None
+
+
+def _extract_tagged_answer(text: str) -> str | None:
+    """Return the content of an ``<answer>...</answer>`` tag, or None."""
+    match = re.search(
+        r"<answer>\s*(.*?)\s*</answer>", text, flags=re.DOTALL | re.IGNORECASE
+    )
+    return match.group(1).strip() if match else None
+
+
+def _extract_final_answer_line(text: str) -> str | None:
+    """Return the ``final answer:`` value, else the last non-empty line."""
+    match = re.search(r"final answer\s*:\s*(.+)", text, flags=re.IGNORECASE | re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return lines[-1] if lines else None
+
+
+def _normalize_math_answer(text: str) -> str:
+    """Canonicalize a math answer (strip LaTeX/`$`/commas, int-normalize)."""
+    stripped = text.strip()
+    stripped = stripped.replace("\\(", "").replace("\\)", "")
+    stripped = stripped.replace("\\[", "").replace("\\]", "")
+    if stripped.startswith("$") and stripped.endswith("$") and len(stripped) >= 2:
+        stripped = stripped[1:-1]
+    stripped = stripped.strip().replace(",", "")
+    stripped = re.sub(r"\s+", "", stripped).strip(".")
+    if stripped.startswith("\\text{") and stripped.endswith("}"):
+        stripped = stripped[6:-1].strip()
+    if re.fullmatch(r"[-+]?\d+", stripped):
+        return str(int(stripped))
+    return stripped.lower()
+
+
+def extract_boxed_math_answer(candidate: str) -> str:
+    """Extract a normalized final answer from a candidate solution."""
+    text = strip_think_blocks(candidate or "")
+    boxed = _extract_boxed_content(text)
+    if boxed is not None:
+        return _normalize_math_answer(boxed)
+    tagged = _extract_tagged_answer(text)
+    if tagged is not None:
+        return _normalize_math_answer(tagged)
+    final_line = _extract_final_answer_line(text)
+    if final_line is None:
+        return ""
+    inline_boxed = _extract_boxed_content(final_line)
+    if inline_boxed is not None:
+        return _normalize_math_answer(inline_boxed)
+    number_match = re.search(r"[-+]?\d+", final_line.replace(",", ""))
+    if number_match:
+        return str(int(number_match.group(0)))
+    return _normalize_math_answer(final_line)
+
+
+def extract_answer(candidate: str, task: str) -> str:
+    """Task-aware answer extraction used for the diversity fitness signal."""
+    if task in ("math", "gpqa_diamond"):
+        return extract_boxed_math_answer(candidate)
+    answer = extract_boxed_math_answer(candidate)
+    return answer if answer else strip_think_blocks(candidate or "")
+
+
+# ---------------------------------------------------------------------------
+# Selection / fitness / routing
+# ---------------------------------------------------------------------------
+
+
+def select_uniform(
+    candidates: Sequence[str], k: int, m: int, rng: random.Random | None = None
+) -> list[list[int]]:
+    """Return ``m`` uniform-random index subsets of size ``k`` from ``candidates``.
+
+    ``rng`` is a request-local ``random.Random`` for per-request isolation and
+    reproducibility; it defaults to the shared ``random`` module.
+    """
+    n = len(candidates)
+    sampler = rng or random
+    return [sampler.sample(range(n), k) for _ in range(m)]
+
+
+def group_diversity(answers: Sequence[str]) -> float:
+    """Answer diversity: count of unique final answers (higher = more disagreement)."""
+    return float(len(set(answers)))
+
+
+def compute_thresholds(
+    fitnesses: Sequence[float], percentiles: Sequence[float]
+) -> list[float]:
+    """Per-problem routing thresholds from ``percentiles`` (sorted ascending)."""
+    results: list[float] = []
+    for p in sorted(percentiles):
+        if p >= 100:
+            results.append(float(max(fitnesses)) + 1.0)
+        elif p <= 0:
+            results.append(float(min(fitnesses)) - 1.0)
+        else:
+            results.append(float(np.percentile(fitnesses, p)))
+    return results
+
+
+def assign_routes(
+    fitnesses: Sequence[float], thresholds: list[float], n_tiers: int
+) -> list[int]:
+    """Map each group's fitness to a tier index (0=cheapest .. n_tiers-1=most expensive).
+
+    Low fitness (hard/uncertain) routes to the most expensive tier; high fitness
+    (easy/consensus) to the cheapest. With N-1 ascending thresholds, a fitness at
+    or below ``thresholds[i]`` goes to tier ``n_tiers-1-i``; anything above all
+    thresholds goes to tier 0.
+    """
+    routes: list[int] = []
+    for f in fitnesses:
+        tier = 0
+        for i, t in enumerate(thresholds):
+            if f <= t:
+                tier = n_tiers - 1 - i
+                break
+        routes.append(tier)
+    return routes
+
+
+# ---------------------------------------------------------------------------
+# Recombination prompt / population update / lite aggregation
+# ---------------------------------------------------------------------------
+
+
+def make_aggregate_prompt(query: str, candidates: list[str], answer_format: str) -> str:
+    """Build a task-aware aggregate recombination prompt for a group of candidates."""
+    if not candidates:
+        return query
+
+    parts: list[str] = []
+    if len(candidates) == 1:
+        parts.append(
+            "You are given a problem and a candidate solution. The candidate may "
+            "be incomplete or contain errors. Refine this trajectory and produce "
+            "an improved, higher-quality solution. If it is entirely wrong, "
+            "attempt a new strategy. End with the final result in "
+            f"{answer_format}.\n"
+        )
+    else:
+        parts.append(
+            "You are given a problem and several candidate solutions. Some "
+            "candidates may be incorrect or contain errors. Aggregate the useful "
+            "ideas and produce a single, high-quality solution. Reason carefully; "
+            "if candidates disagree, choose the correct path. If all are "
+            f"incorrect, attempt a different strategy. End with the final result "
+            f"in {answer_format}.\n"
+        )
+
+    parts.append("Problem:\n")
+    parts.append(query.strip() + "\n")
+    if len(candidates) == 1:
+        parts.append("Candidate solution (may contain mistakes):\n")
+        parts.append(f"---- Candidate ----\n{(candidates[0] or '').strip()}\n")
+        parts.append(
+            "Now refine the candidate into an improved solution. Provide clear "
+            f"reasoning and end with the final answer in {answer_format}."
+        )
+    else:
+        parts.append("Candidate solutions (may contain mistakes):\n")
+        for i, ans in enumerate(candidates, 1):
+            parts.append(f"---- Solution {i} ----\n{(ans or '').strip()}\n")
+        parts.append(
+            "Now write a single improved solution. Provide clear reasoning and "
+            f"end with the final answer in {answer_format}."
+        )
+    return "\n".join(parts)
+
+
+def update_replace(old: list[str], new: list[str]) -> list[str]:
+    """Population update: replace the old population with the new candidates."""
+    return new
+
+
+__all__ = [
+    "assign_routes",
+    "compute_thresholds",
+    "extract_answer",
+    "extract_boxed_math_answer",
+    "group_diversity",
+    "make_aggregate_prompt",
+    "select_uniform",
+    "strip_think_blocks",
+    "update_replace",
+]

--- a/components/src/dynamo/squeeze_evolve/orchestrator.py
+++ b/components/src/dynamo/squeeze_evolve/orchestrator.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Squeeze-Evolve evolutionary orchestrator: native port for Dynamo.
+
+Native re-implementation of the Squeeze-Evolve diversity loop
+(https://arxiv.org/abs/2604.07725) as a Dynamo component. The orchestrator owns
+one ``KvRouter`` (and one tokenizer) per model tier and runs the evolutionary
+loop per chat request: a population is initialized on the most expensive tier,
+then each loop selects candidate groups, scores them by answer diversity, routes
+each group to the cheapest capable tier, recombines, and updates the population.
+
+No external ``squeeze_evolve`` package, no Pydantic, no operator registry, no
+storage/checkpoint/metrics machinery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from dynamo.squeeze_evolve.operators import (
+    assign_routes,
+    compute_thresholds,
+    extract_answer,
+    group_diversity,
+    make_aggregate_prompt,
+    select_uniform,
+    update_replace,
+)
+
+try:  # Rust bindings: absent in binding-free unit-test envs (tests inject fakes).
+    from dynamo.llm import KvRouter
+except ImportError:  # pragma: no cover
+    KvRouter = None  # type: ignore[assignment,misc]
+
+try:  # core dependency, but fail gracefully if the wheel is missing.
+    from transformers import AutoTokenizer
+except ImportError:  # pragma: no cover
+    AutoTokenizer = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+# Recombination answer format requested of the models (math/boxed).
+_ANSWER_FORMAT = "\\boxed{}"
+
+
+# ---------------------------------------------------------------------------
+# Config dataclasses (plain — no Pydantic)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Tier:
+    """One model tier = a dynamo:// worker endpoint + its model/tokenizer + sampling."""
+
+    endpoint: str  # 3-part "namespace.component.endpoint"
+    model: str  # HF repo id; served model name + tokenizer source
+    temperature: float = 1.0
+    top_p: float = 1.0
+    max_tokens: int = 8192
+    block_size: int = 0  # 0 -> use the component default block size
+    tokenizer: Optional[str] = None  # defaults to `model`
+    trust_remote_code: bool = False  # opt-in per tier; runs the model repo's code
+
+
+def parse_tiers(raw: str) -> list[Tier]:
+    """Parse the ``--tiers`` JSON array (cheapest first) into Tier objects.
+
+    Raises ``ValueError`` on malformed input (argparse surfaces it as a usage error).
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"--tiers is not valid JSON: {exc}") from exc
+    if not isinstance(data, list) or not data:
+        raise ValueError("--tiers must be a non-empty JSON array")
+    tiers: list[Tier] = []
+    for i, entry in enumerate(data):
+        if (
+            not isinstance(entry, dict)
+            or "endpoint" not in entry
+            or "model" not in entry
+        ):
+            raise ValueError(
+                f"--tiers[{i}] must be an object with 'endpoint' and 'model'"
+            )
+        parts = str(entry["endpoint"]).split(".")
+        if len(parts) != 3 or any(not part for part in parts):
+            raise ValueError(
+                f"--tiers[{i}].endpoint must be 'namespace.component.endpoint', "
+                f"got {entry['endpoint']!r}"
+            )
+        try:
+            tiers.append(Tier(**entry))
+        except TypeError as exc:
+            raise ValueError(f"--tiers[{i}]: {exc}") from exc
+    return tiers
+
+
+@dataclass
+class SqueezeEvolveConfig:
+    """Plain algorithm config consumed by the orchestrator."""
+
+    k: int = 4
+    population: int = 16
+    groups: int = 16
+    loops: int = 5
+    confidence_percentiles: list[float] = field(default_factory=lambda: [50.0])
+    task: str = "math"
+    seed: Optional[int] = None
+    tier_concurrency: int = 32
+
+
+# ---------------------------------------------------------------------------
+# Per-tier transport (one KvRouter + tokenizer per tier)
+# ---------------------------------------------------------------------------
+
+
+class TierTransport:
+    """Generates over the Dynamo runtime for one model tier.
+
+    Tokenizes a prompt with the tier's tokenizer (token-in / token-out worker
+    path), dispatches via the tier's ``KvRouter``, and detokenizes the streamed
+    output. ``dynamo.llm`` / ``transformers`` imports are lazy so the orchestrator
+    module imports without the bindings (tests inject fakes instead).
+    """
+
+    def __init__(
+        self,
+        runtime: Any,
+        tier: Tier,
+        kv_router_config: Any,
+        aic_perf_config: Any,
+        default_block_size: int,
+        concurrency: int = 32,
+    ) -> None:
+        self._runtime = runtime
+        self._tier = tier
+        self._kv_router_config = kv_router_config
+        self._aic_perf_config = aic_perf_config
+        self._block_size = tier.block_size or default_block_size
+        self._semaphore = asyncio.Semaphore(concurrency)
+        self._router: Any = None
+        self._tokenizer: Any = None
+        self._eos_ids: Optional[list[int]] = None
+
+    def _get_router(self) -> Any:
+        if self._router is None:
+            if KvRouter is None:
+                raise RuntimeError(
+                    "dynamo.llm bindings are unavailable; build them with "
+                    "`maturin develop` before serving."
+                )
+            endpoint = self._runtime.endpoint(self._tier.endpoint)
+            self._router = KvRouter(
+                endpoint=endpoint,
+                block_size=self._block_size,
+                kv_router_config=self._kv_router_config,
+                aic_perf_config=self._aic_perf_config,
+            )
+        return self._router
+
+    def _get_tokenizer(self) -> Any:
+        if self._tokenizer is None:
+            if AutoTokenizer is None:
+                raise RuntimeError("transformers is required to tokenize tier prompts.")
+            self._tokenizer = AutoTokenizer.from_pretrained(
+                self._tier.tokenizer or self._tier.model,
+                trust_remote_code=self._tier.trust_remote_code,
+            )
+        return self._tokenizer
+
+    def _get_eos_token_ids(self, tokenizer: Any) -> list[int]:
+        """EOS token id(s) from the tier tokenizer so generation stops at turn end."""
+        if self._eos_ids is None:
+            ids: list[int] = []
+            eos = getattr(tokenizer, "eos_token_id", None)
+            if isinstance(eos, int):
+                ids.append(eos)
+            elif isinstance(eos, (list, tuple)):
+                ids.extend(int(x) for x in eos if isinstance(x, int))
+            self._eos_ids = ids
+        return self._eos_ids
+
+    async def generate(self, messages: list[dict[str, str]]) -> str:
+        """Generate one completion for a chat message list on this tier."""
+        tokenizer = self._get_tokenizer()
+        encoded = tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+        # transformers >=5 returns a BatchEncoding (dict-like); <5 returns a
+        # plain list[int]. Pull out input_ids so token_ids is always list[int].
+        if hasattr(encoded, "input_ids"):
+            encoded = encoded.input_ids
+        token_ids = [int(t) for t in encoded]
+        # Schema mirrors lib/llm/src/protocols/common/preprocessor.rs.
+        request = {
+            "model": self._tier.model,
+            "token_ids": token_ids,
+            "stop_conditions": {"max_tokens": self._tier.max_tokens},
+            "sampling_options": {
+                "temperature": self._tier.temperature,
+                "top_p": self._tier.top_p,
+            },
+            "output_options": {},
+            "eos_token_ids": self._get_eos_token_ids(tokenizer),
+            "annotations": [],
+        }
+        router = self._get_router()
+        out_tokens: list[int] = []
+        async with self._semaphore:
+            async for chunk in await router.generate_from_request(request):
+                if not isinstance(chunk, dict):
+                    continue
+                finish = chunk.get("finish_reason")
+                if chunk.get("status") == "error" or (
+                    isinstance(finish, str) and finish.startswith("error")
+                ):
+                    raise RuntimeError(
+                        f"tier {self._tier.endpoint} generation failed: "
+                        f"{chunk.get('err_msg') or finish or 'unknown error'}"
+                    )
+                out_tokens.extend(chunk.get("token_ids") or [])
+        return tokenizer.decode(out_tokens, skip_special_tokens=True)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+class SqueezeEvolveOrchestrator:
+    """Runs the Squeeze-Evolve diversity loop for one problem per chat request."""
+
+    def __init__(
+        self,
+        *,
+        cfg: SqueezeEvolveConfig,
+        tiers: Optional[list[Tier]] = None,
+        runtime: Any = None,
+        kv_router_config: Any = None,
+        aic_perf_config: Any = None,
+        default_block_size: int = 64,
+        transports: Optional[list[Any]] = None,
+    ) -> None:
+        self._cfg = cfg
+        # tiers[0] = cheapest, tiers[-1] = most expensive (Loop 0 generator).
+        if transports is not None:
+            if not transports:
+                raise ValueError("transports must be a non-empty list")
+            self._transports = transports  # injected (tests)
+        else:
+            if not tiers:
+                raise ValueError("tiers required when transports are not injected")
+            self._transports = [
+                TierTransport(
+                    runtime,
+                    tier,
+                    kv_router_config,
+                    aic_perf_config,
+                    default_block_size,
+                    concurrency=cfg.tier_concurrency,
+                )
+                for tier in tiers
+            ]
+        self._percentiles = list(cfg.confidence_percentiles)
+
+    async def run(self, messages: list[dict[str, str]]) -> str:
+        """Run the evolutionary loop for one chat request; return the final answer."""
+        cfg = self._cfg
+        # Request-local RNG: a process-global seed would let concurrent requests
+        # overwrite each other's selection sequence. seed=None -> nondeterministic.
+        rng = random.Random(cfg.seed)
+
+        n_tiers = len(self._transports)
+        # Plain-text problem statement (rendered from the chat history) that each
+        # recombination prompt embeds.
+        question_text = "\n\n".join(
+            m["content"] for m in messages if isinstance(m, dict) and m.get("content")
+        )
+
+        # -- Loop 0: most expensive tier generates the initial population --------
+        candidates = list(
+            await asyncio.gather(
+                *(
+                    self._transports[-1].generate(messages)
+                    for _ in range(cfg.population)
+                )
+            )
+        )
+        logger.info("Loop 0: %d candidates from tier %d", len(candidates), n_tiers - 1)
+
+        # -- Loops 1..T-1: score -> select -> route -> recombine -> update -------
+        for t in range(1, cfg.loops):
+            indices = select_uniform(candidates, cfg.k, cfg.groups, rng)
+            # Routing fitness is NEGATIVE answer diversity: a group whose candidates
+            # agree (low diversity = easy) scores high and routes to the cheap tier;
+            # one that disagrees (high diversity = hard) scores low and routes to the
+            # expensive tier. (assign_routes sends low fitness to the expensive end,
+            # same as the confidence signal, where high confidence = easy = cheap.)
+            gf = [
+                -group_diversity([extract_answer(candidates[i], cfg.task) for i in grp])
+                for grp in indices
+            ]
+            thresholds = (
+                compute_thresholds(gf, self._percentiles) if n_tiers > 1 else []
+            )
+            routes = assign_routes(gf, thresholds, n_tiers)
+
+            # Bucket each group's recombination prompt by its routed tier,
+            # remembering original order so we can un-interleave the responses.
+            tier_prompts: dict[int, list[str]] = {i: [] for i in range(n_tiers)}
+            order: list[tuple[int, int]] = []
+            for g_idx, grp in enumerate(indices):
+                group_cands = [candidates[i] for i in grp]
+                tier = routes[g_idx]
+                order.append((tier, len(tier_prompts[tier])))
+                tier_prompts[tier].append(
+                    make_aggregate_prompt(question_text, group_cands, _ANSWER_FORMAT)
+                )
+
+            async def _agg(i: int, prompts: list[str]) -> list[str]:
+                if not prompts:
+                    return []
+                return list(
+                    await asyncio.gather(
+                        *(
+                            self._transports[i].generate(
+                                [{"role": "user", "content": p}]
+                            )
+                            for p in prompts
+                        )
+                    )
+                )
+
+            tier_resps = await asyncio.gather(
+                *(_agg(i, tier_prompts[i]) for i in range(n_tiers))
+            )
+
+            cursors = {i: 0 for i in range(n_tiers)}
+            merged: list[str] = []
+            for tier, _ in order:
+                merged.append(tier_resps[tier][cursors[tier]])
+                cursors[tier] += 1
+            candidates = update_replace(candidates, merged)
+
+            counts = {i: routes.count(i) for i in range(n_tiers)}
+            logger.info("Loop %d: routes=%s", t, counts)
+
+        # -- Final answer: first candidate of the evolved population -------------
+        return candidates[0] if candidates else ""
+
+
+__all__ = [
+    "SqueezeEvolveConfig",
+    "SqueezeEvolveOrchestrator",
+    "Tier",
+    "TierTransport",
+    "parse_tiers",
+]

--- a/components/src/dynamo/squeeze_evolve/tests/__init__.py
+++ b/components/src/dynamo/squeeze_evolve/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/components/src/dynamo/squeeze_evolve/tests/test_operators.py
+++ b/components/src/dynamo/squeeze_evolve/tests/test_operators.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Squeeze-Evolve operators (binding-free)."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from dynamo.squeeze_evolve.operators import (
+    assign_routes,
+    compute_thresholds,
+    extract_answer,
+    extract_boxed_math_answer,
+    group_diversity,
+    make_aggregate_prompt,
+    select_uniform,
+    strip_think_blocks,
+    update_replace,
+)
+
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
+# -- answer extraction ------------------------------------------------------
+
+
+def test_extract_boxed_basic_and_normalized():
+    assert extract_boxed_math_answer("the answer is \\boxed{42}") == "42"
+    assert extract_boxed_math_answer("\\boxed{1,000}") == "1000"  # comma stripped
+    assert extract_boxed_math_answer("\\boxed{007}") == "7"  # int-canonicalized
+
+
+def test_extract_boxed_nested_braces():
+    assert extract_boxed_math_answer("\\boxed{\\frac{1}{2}}") == "\\frac{1}{2}".lower()
+
+
+def test_extract_falls_back_to_tag_then_final_line():
+    assert extract_boxed_math_answer("<answer> 13 </answer>") == "13"
+    assert extract_boxed_math_answer("blah\nFinal answer: 99") == "99"
+
+
+def test_extract_strips_think_blocks():
+    assert extract_boxed_math_answer("<think>lots</think>\\boxed{5}") == "5"
+    assert strip_think_blocks("<think>x</think>done") == "done"
+
+
+def test_extract_empty():
+    assert extract_boxed_math_answer("") == ""
+    assert extract_boxed_math_answer(None) == ""  # type: ignore[arg-type]
+
+
+def test_extract_answer_task_aware():
+    assert extract_answer("\\boxed{7}", "math") == "7"
+    # generic: the boxed/normalized extraction is used when it yields something
+    assert extract_answer("answer: 7", "generic") == "7"
+    # only falls back to strip_think when extraction yields nothing (empty input)
+    assert extract_answer("", "generic") == ""
+
+
+# -- fitness / selection / thresholds / routing -----------------------------
+
+
+def test_group_diversity_counts_unique():
+    assert group_diversity(["1", "1", "2"]) == 2.0
+    assert group_diversity(["3", "3", "3"]) == 1.0
+
+
+def test_select_uniform_seeded_shapes():
+    random.seed(0)
+    groups = select_uniform(list("abcdefgh"), k=3, m=5)
+    assert len(groups) == 5
+    assert all(len(g) == 3 for g in groups)
+    assert all(all(0 <= i < 8 for i in g) for g in groups)
+    assert all(len(set(g)) == 3 for g in groups)  # sampled without replacement
+    # determinism under the same seed
+    random.seed(0)
+    assert select_uniform(list("abcdefgh"), 3, 5) == groups
+
+
+def test_select_uniform_request_local_rng():
+    # A request-local Random is reproducible and independent of global RNG state.
+    out = select_uniform(list("abcdefgh"), 3, 5, random.Random(123))
+    assert out == select_uniform(list("abcdefgh"), 3, 5, random.Random(123))
+
+
+def test_compute_thresholds_edges_and_sorted():
+    gf = [1.0, 2.0, 3.0, 4.0]
+    assert compute_thresholds(gf, [100]) == [max(gf) + 1.0]
+    assert compute_thresholds(gf, [0]) == [min(gf) - 1.0]
+    thr = compute_thresholds(gf, [66, 33])
+    assert thr == sorted(thr)  # ascending regardless of input order
+
+
+def test_assign_routes_low_fitness_to_expensive():
+    # 2 tiers, threshold [2.0]: f<=2 -> tier 1 (expensive), f>2 -> tier 0 (cheap)
+    routes = assign_routes([1.0, 2.0, 3.0, 4.0], [2.0], n_tiers=2)
+    assert routes == [1, 1, 0, 0]
+
+
+def test_assign_routes_three_tiers():
+    # thresholds [2,3]: f<=2 -> tier 2; 2<f<=3 -> tier 1; f>3 -> tier 0
+    routes = assign_routes([1.0, 2.5, 3.0, 4.0], [2.0, 3.0], n_tiers=3)
+    assert routes == [2, 1, 1, 0]
+
+
+def test_diversity_routing_sends_consensus_to_cheap():
+    # Routing fitness is negative diversity (as the orchestrator computes it):
+    # a consensus group (low diversity) routes to the cheap tier, a diverse group
+    # (high diversity) to the expensive tier. Easy goes cheap, hard goes expensive.
+    gf = [-group_diversity(["7", "7"]), -group_diversity(["1", "2"])]  # div 1, 2
+    routes = assign_routes(gf, compute_thresholds(gf, [50.0]), n_tiers=2)
+    assert routes == [0, 1]  # consensus -> cheap (0), diverse -> expensive (1)
+
+
+# -- recombination / update -------------------------------------------------
+
+
+def test_make_aggregate_prompt_branches():
+    assert make_aggregate_prompt("Q?", [], "\\boxed{}") == "Q?"  # no candidates
+    one = make_aggregate_prompt("Q?", ["sol"], "\\boxed{}")
+    assert "candidate solution" in one.lower() and "\\boxed{}" in one
+    many = make_aggregate_prompt("Q?", ["a", "b"], "\\boxed{}")
+    assert "Solution 1" in many and "Solution 2" in many and "\\boxed{}" in many
+
+
+def test_update_replace():
+    assert update_replace(["old"], ["new1", "new2"]) == ["new1", "new2"]

--- a/components/src/dynamo/squeeze_evolve/tests/test_orchestrator.py
+++ b/components/src/dynamo/squeeze_evolve/tests/test_orchestrator.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Orchestrator loop tests with fake tier transports (no bindings/tokenizer)."""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+
+import pytest
+
+from dynamo.squeeze_evolve.orchestrator import (
+    SqueezeEvolveConfig,
+    SqueezeEvolveOrchestrator,
+    parse_tiers,
+)
+
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
+
+class FakeTier:
+    """Records calls; returns a fixed boxed answer."""
+
+    def __init__(self, answer: str) -> None:
+        self._answer = answer
+        self.calls = 0
+
+    async def generate(self, messages: list[dict[str, str]]) -> str:
+        self.calls += 1
+        return f"reasoning... \\boxed{{{self._answer}}}"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _msgs(text: str) -> list[dict[str, str]]:
+    return [{"role": "user", "content": text}]
+
+
+def test_loop0_uses_most_expensive_tier_only():
+    cheap, exp = FakeTier("1"), FakeTier("2")
+    cfg = SqueezeEvolveConfig(
+        k=2, population=4, groups=4, loops=1, confidence_percentiles=[50.0], seed=0
+    )
+    orch = SqueezeEvolveOrchestrator(cfg=cfg, transports=[cheap, exp])
+    answer = _run(orch.run(_msgs("solve x")))
+    # loops=1 -> only Loop 0: population candidates from the expensive tier.
+    assert exp.calls == 4
+    assert cheap.calls == 0
+    assert answer == "reasoning... \\boxed{2}"  # candidates[0]
+
+
+def test_uniform_diversity_routes_all_to_expensive():
+    # Loop 0 fills the population from the expensive tier (all answer "2"), so in
+    # Loop 1 every group has diversity 1 -> all equal -> all route to the
+    # expensive tier (f <= threshold).
+    cheap, exp = FakeTier("1"), FakeTier("2")
+    cfg = SqueezeEvolveConfig(
+        k=2, population=4, groups=4, loops=2, confidence_percentiles=[50.0], seed=0
+    )
+    orch = SqueezeEvolveOrchestrator(cfg=cfg, transports=[cheap, exp])
+    _run(orch.run(_msgs("solve x")))
+    assert exp.calls == 8 and cheap.calls == 0  # 4 (loop0) + 4 (loop1)
+
+
+def test_total_generations_equals_population_plus_groups_per_loop():
+    answers = itertools.cycle(["1", "2", "3", "4"])
+
+    class VariedTier:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def generate(self, messages: list[dict[str, str]]) -> str:
+            self.calls += 1
+            return f"\\boxed{{{next(answers)}}}"
+
+    t0, t1 = VariedTier(), VariedTier()
+    cfg = SqueezeEvolveConfig(
+        k=2, population=6, groups=6, loops=3, confidence_percentiles=[50.0], seed=1
+    )
+    orch = SqueezeEvolveOrchestrator(cfg=cfg, transports=[t0, t1])
+    _run(orch.run(_msgs("q")))
+    # Loop 0 = population (6); Loops 1 & 2 = groups each (6 + 6).
+    assert t0.calls + t1.calls == 6 + 6 + 6
+
+
+def test_single_tier_runs_with_no_thresholds():
+    only = FakeTier("9")
+    cfg = SqueezeEvolveConfig(
+        k=2, population=4, groups=4, loops=2, confidence_percentiles=[], seed=0
+    )
+    orch = SqueezeEvolveOrchestrator(cfg=cfg, transports=[only])
+    answer = _run(orch.run("q"))
+    assert only.calls == 8  # 4 (loop0) + 4 (loop1), all to the one tier
+    assert answer == "reasoning... \\boxed{9}"
+
+
+# -- tier JSON parsing ------------------------------------------------------
+
+
+def test_parse_tiers_basic():
+    tiers = parse_tiers(
+        '[{"endpoint":"dynamo.cheap.generate","model":"Q/c"},'
+        '{"endpoint":"dynamo.exp.generate","model":"Q/e","temperature":0.5}]'
+    )
+    assert len(tiers) == 2
+    assert tiers[0].endpoint == "dynamo.cheap.generate" and tiers[0].model == "Q/c"
+    assert tiers[1].temperature == 0.5
+    assert tiers[0].block_size == 0  # default
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not json",
+        "[]",
+        '[{"endpoint":"a.b.c"}]',  # missing model
+        '[{"endpoint":"two.parts","model":"m"}]',  # endpoint not 3-part
+        '[{"endpoint":"a..b","model":"m"}]',  # empty endpoint segment
+        '[{"endpoint":"a.b.c","model":"m","bogus":1}]',  # unknown key
+        '{"endpoint":"a.b.c","model":"m"}',  # not a list
+    ],
+)
+def test_parse_tiers_rejects_bad_input(raw):
+    with pytest.raises(ValueError):
+        parse_tiers(raw)


### PR DESCRIPTION
## Summary

Adds `components/src/dynamo/squeeze_evolve/`, a standalone Dynamo service that serves [Squeeze-Evolve](https://arxiv.org/abs/2604.07725) (verifier-free evolutionary test-time scaling) as a chat model for **multi-model orchestration**. A single `/v1/chat/completions` request becomes one Squeeze-Evolve problem: an evolutionary loop generates a population of candidates and, each round, scores candidate groups by answer diversity and routes them across N model tiers, so easy groups run on the cheap models and only the hard ones reach the expensive models, for single-model or better accuracy at lower cost.

- **N single-model routers:** each tier is its own `dynamo.vllm` deployment and the service owns one `KvRouter` per tier. Dynamo does the within-tier worker selection (KV-aware); Squeeze-Evolve does the across-tier selection (by fitness). One model per router.
- **Dynamo-native:** registers as `ModelInput.Text` + `ModelType.Chat` behind `dynamo.frontend`, tokenizes per tier itself, and dispatches via each tier's `KvRouter.generate_from_request` (token-in / token-out). Plain functions + asyncio; no external package, Pydantic, operator registry, or storage. Styled after `thunderagent_router`.
- **Routing direction:** a group whose candidates agree (low answer diversity, "easy") routes to the cheap tier; one that disagrees (high diversity, "hard") routes to the expensive tier. Implemented as negative-diversity fitness so it matches the paper's confidence signal (high confidence = easy = cheap).
- **Config:** tiers via a single `--tiers` JSON flag (cheapest first); per-tier `KvRouter` knobs reuse `dynamo.router`'s `--router-*` flags.
- Status is **experimental:** opt-in service, no default frontend wiring, `--tiers` schema still scoped for review.

## Status

Experimental. Not wired into any default frontend path. Opt-in: start one `dynamo.vllm` worker per tier, then `python -m dynamo.squeeze_evolve --tiers '[...]' --model-name <name>`, then point `dynamo.frontend` at it. Only the registered `--model-name` is affected; other models on the frontend are untouched.

## Validation

End-to-end smoke validated on a 4x H100 box against this branch (main `c2bc9f805c` + vLLM 0.23.0) with a real capability gap, both tiers from the paper's Qwen3-Instruct-2507 family: `dynamo.frontend` + cheap tier `Qwen3-4B-Instruct-2507` (GPU 4) + expensive tier `Qwen3-30B-A3B-Instruct-2507`.

## Design Notes

The component `README.md` is the entry point (what it is, how it works, install, usage). Parity with the paper:

- Implements the **diversity-fitness** path: group fitness = count of unique final answers; per-problem percentile thresholds (`--confidence-percentiles`) split groups across the N tiers. The routing fitness is the negation of diversity so consensus routes to the cheap tier, matching the confidence signal's direction.
- The **confidence (GC)** fitness is intentionally out of scope; it needs a vLLM logprobs path. The diversity path is self-contained and needs no engine changes.
- `compute_thresholds` / `assign_routes` / `group_diversity` follow the upstream Squeeze-Evolve operators.
- Alternative considered: a single multi-model router via `KvRouterConfig(use_remote_indexer=true)`. I kept the N-router fan-out so each tier stays a standard single-model `dynamo.vllm` deployment; happy to switch if the remote indexer is the preferred path.

## Test Plan

- [x] `pytest components/src/dynamo/squeeze_evolve/tests/`: 26/26 pass (binding-free; operators + orchestrator loop with a fake transport, including a routing-direction test)
- [x] Live end-to-end smoke on 4x H100 (main `c2bc9f805c` + vLLM 0.23.0): correct boxed answer through the full evolutionary loop across a 4B to 30B tier gap
- [x] pre-commit clean (ruff, black, isort, codespell); Apache-2.0 SPDX headers on all files
- [ ] Reviewer feedback on `--tiers` schema + knob naming for promotion out of experimental

## Notes

- New, additive component. One `pyproject.toml` change: a `squeeze_evolve = ["numpy>=1.26.0"]` optional-dependency extra.
- All commits DCO signed.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced experimental Squeeze-Evolve component for multi-model orchestration and test-time scaling via tiered evolutionary strategies and group routing.

* **Documentation**
  * Added detailed documentation for installation and configuration of the Squeeze-Evolve component.

* **Tests**
  * Added unit tests covering Squeeze-Evolve operators and orchestration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->