### PR TITLE
refactor(router): consolidate mocker e2e infrastructure

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -24,17 +24,12 @@ from tests.router.helper import (
     poll_for_worker_instances,
     send_inflight_requests,
     send_request_via_python_kv_router,
-    send_request_with_retry,
     verify_response_timing,
     wait_for_frontend_ready,
     wait_for_indexer_workers_active,
     wait_for_workers_ready,
 )
-from tests.router.router_process import (
-    DirectRouterProcess,
-    FrontendRouterProcess,
-    KVRouterProcess,
-)
+from tests.router.router_process import FrontendRouterProcess, KVRouterProcess
 
 if TYPE_CHECKING:
     from tests.conftest import NatsServer
@@ -214,6 +209,9 @@ def _test_router_basic(
                 frontend_url=frontend_url,
                 expected_num_workers=engine_workers.num_workers,
                 timeout=frontend_timeout,
+                engine_workers=engine_workers,
+                store_backend=store_backend,
+                request_plane=request_plane,
             )
         )
 
@@ -313,6 +311,9 @@ def _test_router_override_router_config(
                 frontend_url=frontend_url,
                 expected_num_workers=engine_workers.num_workers,
                 timeout=frontend_timeout,
+                engine_workers=engine_workers,
+                store_backend=store_backend,
+                request_plane=request_plane,
             )
         )
 
@@ -402,6 +403,8 @@ def _test_router_two_routers(
                     frontend_url=frontend_url,
                     expected_num_workers=engine_workers.num_workers,
                     timeout=120,
+                    engine_workers=engine_workers,
+                    store_backend=store_backend,
                 )
             )
         logger.info("Both routers have discovered workers")
@@ -530,17 +533,6 @@ def _test_remote_indexer_decisions(
 ):
     """Validate remote-indexer-backed routing decisions using direct KvRouter instances."""
 
-    async def wait_for_worker_ids(endpoint, expected_num_workers: int) -> list[int]:
-        client = await endpoint.client()
-
-        for _ in range(120):
-            worker_ids = sorted(set(client.instance_ids()))
-            if len(worker_ids) >= expected_num_workers:
-                return worker_ids
-            await asyncio.sleep(1)
-
-        raise TimeoutError("Timed out waiting for backend worker IDs")
-
     async def wait_for_served_indexer(
         runtime,
         expected_query_instances: int,
@@ -650,8 +642,10 @@ def _test_remote_indexer_decisions(
             router_predicted_ttl_secs=router_predicted_ttl_secs,
         )
 
-        worker_ids = await wait_for_worker_ids(
-            serving_endpoints[0], expected_num_instances
+        worker_ids = sorted(
+            await poll_for_worker_instances(
+                serving_endpoints[0], expected_num_instances, max_wait_time=120
+            )
         )
         if len(worker_ids) >= 2:
             worker_a_id = worker_ids[0]
@@ -762,7 +756,9 @@ def _test_remote_indexer_decisions(
                 f"(longest prefix match), got {req5['prefill_dp_rank']}"
             )
 
-        await wait_for_worker_ids(consumer_endpoint, expected_num_instances)
+        await poll_for_worker_instances(
+            consumer_endpoint, expected_num_instances, max_wait_time=120
+        )
 
     asyncio.run(test_sync())
 
@@ -930,9 +926,16 @@ def _test_router_query_instance_id(
 
         url = f"http://localhost:{frontend_port}/v1/chat/completions"
 
-        # Send a warming request first to ensure system is ready
-        logger.info("Sending warming request without annotations...")
-        asyncio.run(send_request_with_retry(url, test_payload))
+        asyncio.run(
+            wait_for_frontend_ready(
+                frontend_url=f"http://localhost:{frontend_port}",
+                expected_num_workers=engine_workers.num_workers,
+                timeout=120,
+                test_payload=test_payload,
+                engine_workers=engine_workers,
+                store_backend=store_backend,
+            )
+        )
 
         # Test payload with query_instance_id annotation
         # Format: "query_instance_id:" (colon with empty value) for GAIE aggregated mode
@@ -1298,8 +1301,9 @@ def _test_router_overload_503(
         asyncio.run(
             wait_for_frontend_ready(
                 frontend_url=frontend_url,
-                expected_num_workers=1,
+                expected_num_workers=engine_workers.num_workers,
                 timeout=60,
+                engine_workers=engine_workers,
             )
         )
 
@@ -1307,6 +1311,7 @@ def _test_router_overload_503(
 
 
 def _test_disagg_router_overload_503(
+    prefill_workers,
     decode_workers,
     block_size: int,
     request,
@@ -1369,8 +1374,13 @@ def _test_disagg_router_overload_503(
         asyncio.run(
             wait_for_frontend_ready(
                 frontend_url=frontend_url,
-                expected_num_workers=decode_workers.num_workers,
+                expected_num_workers=(
+                    prefill_workers.num_workers + decode_workers.num_workers
+                ),
                 timeout=120,
+                engine_workers=[prefill_workers, decode_workers],
+                store_backend=store_backend,
+                request_plane=request_plane,
             )
         )
 
@@ -1430,8 +1440,9 @@ def _test_router_threshold_none_disables_rejection(
         asyncio.run(
             wait_for_frontend_ready(
                 frontend_url=frontend_url,
-                expected_num_workers=1,
+                expected_num_workers=engine_workers.num_workers,
                 timeout=60,
+                engine_workers=engine_workers,
             )
         )
 
@@ -2186,8 +2197,13 @@ def _test_router_decisions_disagg(
         asyncio.run(
             wait_for_frontend_ready(
                 frontend_url=frontend_url,
-                expected_num_workers=decode_workers.num_workers,
+                expected_num_workers=(
+                    prefill_workers.num_workers + decode_workers.num_workers
+                ),
                 timeout=120,
+                engine_workers=[prefill_workers, decode_workers],
+                store_backend=store_backend,
+                request_plane=request_plane,
             )
         )
 
@@ -2429,8 +2445,13 @@ def _test_disagg_background_prefill_sticky_routing(
         async def test_sync():
             await wait_for_frontend_ready(
                 frontend_url=frontend_url,
-                expected_num_workers=decode_workers.num_workers,
+                expected_num_workers=(
+                    prefill_workers.num_workers + decode_workers.num_workers
+                ),
                 timeout=120,
+                engine_workers=[prefill_workers, decode_workers],
+                store_backend=store_backend,
+                request_plane=request_plane,
             )
 
             runtime = get_runtime(
@@ -2567,13 +2588,13 @@ def _test_disagg_topology_required_prefill_pin_match_and_mismatch(
                 frontend_url=frontend_url,
                 expected_num_workers=decode_workers.num_workers,
                 timeout=120,
+                engine_workers=decode_workers,
+                request_plane=request_plane,
             )
 
             runtime = get_runtime(request_plane=request_plane)
-            decode_endpoint = runtime.endpoint(f"{shared_namespace}.backend.generate")
             prefill_endpoint = runtime.endpoint(f"{shared_namespace}.prefill.generate")
 
-            await poll_for_worker_instances(decode_endpoint, decode_workers.num_workers)
             await poll_for_worker_instances(
                 prefill_endpoint, decode_workers.num_workers
             )
@@ -2636,6 +2657,8 @@ def _test_disagg_topology_required_prefill_pin_match_and_mismatch(
                 expected_num_workers=decode_workers.num_workers,
                 timeout=120,
                 test_payload=topology_ready_payload,
+                engine_workers=decode_workers,
+                request_plane=request_plane,
             )
 
             async with aiohttp.ClientSession() as session:
@@ -2698,8 +2721,13 @@ def _test_router_decisions_disagg_round_robin_prefill_dp_rank(
             chat_url = f"{frontend_url}/v1/chat/completions"
             await wait_for_frontend_ready(
                 frontend_url=frontend_url,
-                expected_num_workers=decode_workers.num_workers,
+                expected_num_workers=(
+                    prefill_workers.num_workers + decode_workers.num_workers
+                ),
                 timeout=120,
+                engine_workers=[prefill_workers, decode_workers],
+                store_backend=store_backend,
+                request_plane=request_plane,
             )
 
             runtime = get_runtime(
@@ -2726,18 +2754,11 @@ def _test_router_decisions_disagg_round_robin_prefill_dp_rank(
                 engine_workers=prefill_workers,
             )
 
-            client = await prefill_endpoint.client()
-            worker_ids: list[int] = []
-            deadline = asyncio.get_running_loop().time() + 60
-            while asyncio.get_running_loop().time() < deadline:
-                worker_ids = sorted(set(client.instance_ids()))
-                if len(worker_ids) >= prefill_workers.num_workers:
-                    break
-                await asyncio.sleep(1.0)
-
-            assert len(worker_ids) == prefill_workers.num_workers, (
-                f"Timed out waiting for prefill workers. "
-                f"Found {worker_ids}, expected {prefill_workers.num_workers}"
+            worker_ids = sorted(
+                await poll_for_worker_instances(
+                    prefill_endpoint,
+                    prefill_workers.num_workers,
+                )
             )
             prefill_worker_id = worker_ids[0]
 
@@ -3242,6 +3263,9 @@ def _test_busy_threshold_endpoint(
                 frontend_url=frontend_url,
                 expected_num_workers=engine_workers.num_workers,
                 timeout=120,
+                engine_workers=engine_workers,
+                store_backend=store_backend,
+                request_plane=request_plane,
             )
         )
 
@@ -3517,40 +3541,17 @@ def _test_disagg_direct_mode(
         test_payload: Base test payload for /v1/chat/completions.
         request_plane: Transport for request plane ("nats" or "tcp").
     """
-    with DirectRouterProcess(
+    with FrontendRouterProcess(
         request,
+        BLOCK_SIZE,
         frontend_port,
         decode_workers.namespace,
         enforce_disagg=True,
         request_plane=request_plane,
+        router_mode="direct",
     ):
         frontend_url = f"http://localhost:{frontend_port}"
         chat_url = f"{frontend_url}/v1/chat/completions"
-
-        logger.info("Waiting for models to appear in Direct-mode frontend...")
-
-        async def wait_for_models():
-            models_url = f"{frontend_url}/v1/models"
-            for _ in range(120):
-                try:
-                    async with aiohttp.ClientSession() as session:
-                        async with session.get(models_url) as response:
-                            if response.status == 200:
-                                data = await response.json()
-                                models = data.get("data", [])
-                                if models:
-                                    logger.info(
-                                        f"Models registered: {[m.get('id') for m in models]}"
-                                    )
-                                    return
-                except Exception as e:
-                    logger.debug(f"Error checking models endpoint: {e}")
-                await asyncio.sleep(1)
-            raise TimeoutError("Timeout waiting for models in Direct-mode frontend")
-
-        asyncio.run(wait_for_models())
-
-        # Phase 2: Discover worker IDs via the runtime
         runtime = get_runtime(request_plane=request_plane)
         prefill_endpoint = runtime.endpoint(
             f"{decode_workers.namespace}.prefill.generate"
@@ -3559,21 +3560,30 @@ def _test_disagg_direct_mode(
             f"{decode_workers.namespace}.backend.generate"
         )
 
-        async def discover_workers():
-            prefill_client = await prefill_endpoint.client()
-            decode_client = await decode_endpoint.client()
-
-            for _ in range(60):
-                p_ids = prefill_client.instance_ids()
-                d_ids = decode_client.instance_ids()
-                if p_ids and d_ids:
-                    return p_ids, d_ids
-                await asyncio.sleep(0.5)
-            raise TimeoutError(
-                f"Timeout discovering workers: prefill={p_ids}, decode={d_ids}"
+        async def wait_for_direct_frontend():
+            prefill_ids = await poll_for_worker_instances(
+                prefill_endpoint,
+                prefill_workers.num_workers,
             )
+            decode_ids = await poll_for_worker_instances(
+                decode_endpoint,
+                decode_workers.num_workers,
+            )
+            headers = {
+                "x-worker-instance-id": str(decode_ids[0]),
+                "x-prefill-instance-id": str(prefill_ids[0]),
+                "x-dp-rank": "0",
+                "x-prefill-dp-rank": "0",
+            }
+            await wait_for_frontend_ready(
+                frontend_url=frontend_url,
+                timeout=120,
+                test_payload={**test_payload, "stream": False},
+                request_headers=headers,
+            )
+            return prefill_ids, decode_ids
 
-        prefill_ids, decode_ids = asyncio.run(discover_workers())
+        prefill_ids, decode_ids = asyncio.run(wait_for_direct_frontend())
         logger.info(f"Discovered prefill workers: {prefill_ids}")
         logger.info(f"Discovered decode workers: {decode_ids}")
 
@@ -3599,34 +3609,18 @@ def _test_disagg_direct_mode(
             }
 
             async with aiohttp.ClientSession() as session:
-                # Retry a few times to allow the pipeline to warm up
-                for attempt in range(10):
-                    async with session.post(
-                        chat_url, json=payload, headers=headers
-                    ) as response:
-                        if response.status == 200:
-                            data = await response.json()
-                            logger.info(
-                                f"Direct-mode response (attempt {attempt + 1}): "
-                                f"status=200, model={data.get('model')}"
-                            )
-                            assert (
-                                "choices" in data
-                            ), "Expected 'choices' in response data"
-                            assert (
-                                len(data["choices"]) > 0
-                            ), "Expected at least one choice in response"
-                            break
-                        else:
-                            logger.info(
-                                f"Direct-mode attempt {attempt + 1} returned "
-                                f"status {response.status}, retrying..."
-                            )
-                            await asyncio.sleep(2)
-                else:
-                    raise AssertionError(
-                        "Direct-mode request with headers never returned 200"
+                async with session.post(
+                    chat_url, json=payload, headers=headers
+                ) as response:
+                    assert response.status == 200, (
+                        "Direct-mode request with headers failed: "
+                        f"status={response.status}, body={await response.text()}"
                     )
+                    data = await response.json()
+                    assert "choices" in data, "Expected 'choices' in response data"
+                    assert (
+                        len(data["choices"]) > 0
+                    ), "Expected at least one choice in response"
 
                 # Test 2: Request WITHOUT headers should fail (Direct mode
                 # rejects requests that have no worker ID)

--- a/tests/router/e2e_harness.py
+++ b/tests/router/e2e_harness.py
@@ -4,7 +4,7 @@
 import logging
 import os
 import time
-from typing import Any
+from typing import Any, Callable, ContextManager
 
 from tests.router.common import (
     _test_router_basic,
@@ -161,6 +161,29 @@ def get_engine_endpoint(engine_workers, request_plane: str, component_name: str)
     return runtime.endpoint(f"{engine_workers.namespace}.{component_name}.generate")
 
 
+def _create_engine_process(
+    *,
+    engine_process_cls,
+    engine_args_name: str,
+    engine_args: dict[str, Any],
+    request,
+    request_plane: str,
+    default_process_kwargs: dict[str, Any],
+    engine_process_kwargs: dict[str, Any] | None,
+):
+    process_kwargs = (
+        default_process_kwargs
+        if engine_process_kwargs is None
+        else engine_process_kwargs
+    )
+    return engine_process_cls(
+        request,
+        request_plane=request_plane,
+        **{engine_args_name: engine_args},
+        **process_kwargs,
+    )
+
+
 def run_basic_router_test(
     *,
     engine_process_cls,
@@ -173,25 +196,38 @@ def run_basic_router_test(
     block_size: int,
     model_name: str,
     frontend_timeout: int = 180,
+    engine_process_kwargs: dict[str, Any] | None = None,
+    test_payload: dict[str, Any] | None = None,
+    num_requests: int = 10,
+    router_mode: str = "kv",
+    min_initial_workers: int | None = None,
 ):
-    with engine_process_cls(
-        request,
-        num_workers=num_workers,
-        single_gpu=single_gpu,
+    process = _create_engine_process(
+        engine_process_cls=engine_process_cls,
+        engine_args_name=engine_args_name,
+        engine_args=engine_args,
+        request=request,
         request_plane=request_plane,
-        **{engine_args_name: engine_args},
-    ) as engine_workers:
+        default_process_kwargs={
+            "num_workers": num_workers,
+            "single_gpu": single_gpu,
+        },
+        engine_process_kwargs=engine_process_kwargs,
+    )
+    with process as engine_workers:
         frontend_port = allocate_frontend_ports(request, 1)[0]
         _test_router_basic(
             engine_workers=engine_workers,
             block_size=block_size,
             request=request,
             frontend_port=frontend_port,
-            test_payload=build_test_payload(model_name),
-            num_requests=10,
+            test_payload=test_payload or build_test_payload(model_name),
+            num_requests=num_requests,
             frontend_timeout=frontend_timeout,
             store_backend="etcd",
             request_plane=request_plane,
+            router_mode=router_mode,
+            min_initial_workers=min_initial_workers,
         )
 
 
@@ -210,17 +246,33 @@ def run_router_decisions_test(
     test_dp_rank: bool,
     extra_process_kwargs: dict[str, Any] | None = None,
     initial_wait: float = 0.25,
+    engine_process_kwargs: dict[str, Any] | None = None,
+    test_kwargs: dict[str, Any] | None = None,
 ):
-    process_kwargs = extra_process_kwargs or {}
-    with engine_process_cls(
-        request,
-        num_workers=num_workers,
-        single_gpu=single_gpu,
+    default_process_kwargs = {
+        "num_workers": num_workers,
+        "single_gpu": single_gpu,
+        **(extra_process_kwargs or {}),
+    }
+    process = _create_engine_process(
+        engine_process_cls=engine_process_cls,
+        engine_args_name=engine_args_name,
+        engine_args=engine_args,
+        request=request,
         request_plane=request_plane,
-        **{engine_args_name: engine_args},
-        **process_kwargs,
-    ) as engine_workers:
+        default_process_kwargs=default_process_kwargs,
+        engine_process_kwargs=engine_process_kwargs,
+    )
+    with process as engine_workers:
         endpoint = get_engine_endpoint(engine_workers, request_plane, component_name)
+        scenario_kwargs = dict(test_kwargs or {})
+        for argument, attribute in (
+            ("standalone_indexer_url", "standalone_indexer_url"),
+            ("standalone_selector_url", "standalone_selector_url"),
+        ):
+            value = getattr(engine_workers, attribute, None)
+            if value is not None:
+                scenario_kwargs.setdefault(argument, value)
         _test_router_decisions(
             engine_workers,
             endpoint,
@@ -229,6 +281,7 @@ def run_router_decisions_test(
             test_dp_rank=test_dp_rank,
             block_size=block_size,
             initial_wait=initial_wait,
+            **scenario_kwargs,
         )
 
 
@@ -245,6 +298,10 @@ def run_disagg_router_decisions_test(
     num_decode_workers: int,
     prefill_process_kwargs: dict[str, Any] | None = None,
     decode_process_kwargs: dict[str, Any] | None = None,
+    worker_context_factory: Callable[[str], ContextManager[tuple[Any, Any]]]
+    | None = None,
+    test_payload: dict[str, Any] | None = None,
+    test_kwargs: dict[str, Any] | None = None,
 ):
     shared_namespace = f"test-namespace-{generate_random_suffix()}"
     frontend_port = allocate_frontend_ports(request, 1)[0]
@@ -257,6 +314,23 @@ def run_disagg_router_decisions_test(
         "namespace": shared_namespace,
         **(decode_process_kwargs or {}),
     }
+
+    def run_test(prefill_workers, decode_workers):
+        _test_router_decisions_disagg(
+            prefill_workers=prefill_workers,
+            decode_workers=decode_workers,
+            block_size=block_size,
+            request=request,
+            frontend_port=frontend_port,
+            test_payload=test_payload or build_test_payload(model_name),
+            request_plane=request_plane,
+            **(test_kwargs or {}),
+        )
+
+    if worker_context_factory is not None:
+        with worker_context_factory(shared_namespace) as workers:
+            run_test(*workers)
+        return
 
     with engine_process_cls(
         request,
@@ -272,15 +346,7 @@ def run_disagg_router_decisions_test(
             **{engine_args_name: engine_args},
             **decode_kwargs,
         ) as decode_workers:
-            _test_router_decisions_disagg(
-                prefill_workers=prefill_workers,
-                decode_workers=decode_workers,
-                block_size=block_size,
-                request=request,
-                frontend_port=frontend_port,
-                test_payload=build_test_payload(model_name),
-                request_plane=request_plane,
-            )
+            run_test(prefill_workers, decode_workers)
 
 
 def run_indexers_sync_test(
@@ -297,20 +363,27 @@ def run_indexers_sync_test(
     model_name: str,
     num_workers: int,
     extra_process_kwargs: dict[str, Any] | None = None,
+    engine_process_kwargs: dict[str, Any] | None = None,
 ):
     nats_process, _etcd_process = runtime_services_dynamic_ports
     process_kwargs = extra_process_kwargs or {}
 
-    with engine_process_cls(
-        request,
-        num_workers=num_workers,
-        single_gpu=True,
+    process = _create_engine_process(
+        engine_process_cls=engine_process_cls,
+        engine_args_name=engine_args_name,
+        engine_args=engine_args,
+        request=request,
         request_plane=request_plane,
-        store_backend=store_backend,
-        durable_kv_events=durable_kv_events,
-        **{engine_args_name: engine_args},
-        **process_kwargs,
-    ) as engine_workers:
+        default_process_kwargs={
+            "num_workers": num_workers,
+            "single_gpu": True,
+            "store_backend": store_backend,
+            "durable_kv_events": durable_kv_events,
+            **process_kwargs,
+        },
+        engine_process_kwargs=engine_process_kwargs,
+    )
+    with process as engine_workers:
         _test_router_indexers_sync(
             engine_workers=engine_workers,
             block_size=block_size,

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -275,7 +275,7 @@ async def wait_for_frontend_ready(
                             logger.debug(
                                 f"No models registered yet (elapsed: {elapsed:.1f}s)"
                             )
-        except Exception as e:
+        except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as e:
             logger.debug(f"Error checking models endpoint: {e}")
 
         # Wait before next poll
@@ -316,7 +316,7 @@ async def wait_for_frontend_ready(
                         logger.debug(
                             f"Chat completions not ready yet, status {response.status} (elapsed: {elapsed:.1f}s)"
                         )
-        except Exception as e:
+        except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as e:
             logger.debug(f"Error testing chat completions: {e}")
 
         # Wait before next poll

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -176,38 +176,78 @@ def verify_response_timing(timing_info: dict[str, Any], disagg: bool = False) ->
 
 async def wait_for_frontend_ready(
     frontend_url: str,
-    expected_num_workers: int = 2,
+    expected_num_workers: int | None = None,
     timeout: int = 120,
     test_payload: dict[str, Any] | None = None,
+    engine_workers=None,
+    store_backend: str = "etcd",
+    request_plane: str = "nats",
+    request_headers: dict[str, str] | None = None,
 ):
     """Wait for backend worker(s) to be ready via the HTTP frontend (OpenAI API).
 
-    This function performs a two-phase readiness check through the frontend HTTP server:
-        1. Polls GET /v1/models until at least one model is registered (workers connected)
-        2. Sends a test POST to /v1/chat/completions to verify the request pipeline is functional
+    This function performs a three-phase readiness check:
+        1. Polls discovery for every expected worker when engine_workers is provided.
+        2. Polls GET /v1/models until at least one model is registered.
+        3. Sends a test POST to /v1/chat/completions to verify the request pipeline is functional.
 
     Use this when testing through the HTTP frontend server (dynamo.frontend).
     For direct Python API testing with KvRouter, use wait_for_workers_ready() instead.
 
     Args:
         frontend_url: Base URL of the frontend HTTP server (e.g., "http://localhost:8000")
-        expected_num_workers: Number of workers to wait for (currently logs but doesn't enforce)
-        timeout: Maximum time to wait in seconds for both phases combined
-        test_payload: Optional chat completions payload for the phase 2 readiness probe.
+        expected_num_workers: Exact total worker count to enforce through discovery.
+        timeout: Maximum time to wait in seconds for each readiness phase.
+        test_payload: Optional chat completions payload for the final readiness probe.
             Use this when readiness must satisfy the same routing constraints as the test.
+        engine_workers: Worker process object, or a list of process objects, exposing
+            namespace, component_name, and num_workers.
+        store_backend: Discovery backend used by the workers.
+        request_plane: Request transport used by the workers.
+        request_headers: Optional headers for the chat-completions readiness probe.
 
     Raises:
         TimeoutError: If workers don't register or pipeline doesn't become ready within timeout
         aiohttp.ClientError: If HTTP requests fail unexpectedly
     """
 
+    if expected_num_workers is not None:
+        if engine_workers is None:
+            raise ValueError(
+                "engine_workers is required when expected_num_workers is set"
+            )
+
+        worker_groups = (
+            list(engine_workers)
+            if isinstance(engine_workers, (list, tuple))
+            else [engine_workers]
+        )
+        configured_workers = sum(group.num_workers for group in worker_groups)
+        if configured_workers != expected_num_workers:
+            raise ValueError(
+                "expected_num_workers does not match configured workers: "
+                f"expected={expected_num_workers}, configured={configured_workers}"
+            )
+
+        runtime = get_runtime(
+            store_backend=store_backend,
+            request_plane=request_plane,
+        )
+        for group in worker_groups:
+            endpoint = runtime.endpoint(
+                f"{group.namespace}.{group.component_name}.generate"
+            )
+            await poll_for_worker_instances(
+                endpoint,
+                group.num_workers,
+                max_wait_time=timeout,
+            )
+
     models_url = f"{frontend_url}/v1/models"
     chat_url = f"{frontend_url}/v1/chat/completions"
     start_time = asyncio.get_event_loop().time()
 
-    logger.info(
-        f"Waiting for {expected_num_workers} workers to register on HTTP frontend (timeout={timeout}s)..."
-    )
+    logger.info("Waiting for HTTP frontend readiness (timeout=%ss)...", timeout)
 
     # Phase 1: Wait for models to appear in /v1/models
     model_name = None
@@ -264,7 +304,11 @@ async def wait_for_frontend_ready(
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.post(chat_url, json=test_payload) as response:
+                async with session.post(
+                    chat_url,
+                    json=test_payload,
+                    headers=request_headers,
+                ) as response:
                     if response.status == 200:
                         logger.info("Chat completions pipeline ready!")
                         return

--- a/tests/router/mocker_process.py
+++ b/tests/router/mocker_process.py
@@ -651,15 +651,18 @@ def _wait_for_disagg_workers(
     request_plane: str,
     event_plane: Optional[str],
 ) -> None:
-    runtime = get_runtime(
-        store_backend=store_backend,
-        request_plane=request_plane,
-        event_plane=event_plane,
-    )
-    endpoint = runtime.endpoint(
-        f"{workers.namespace}.{workers.component_name}.generate"
-    )
-    asyncio.run(poll_for_worker_instances(endpoint, workers.num_workers))
+    async def wait_for_workers() -> None:
+        runtime = get_runtime(
+            store_backend=store_backend,
+            request_plane=request_plane,
+            event_plane=event_plane,
+        )
+        endpoint = runtime.endpoint(
+            f"{workers.namespace}.{workers.component_name}.generate"
+        )
+        await poll_for_worker_instances(endpoint, workers.num_workers)
+
+    asyncio.run(wait_for_workers())
 
 
 @contextmanager

--- a/tests/router/mocker_process.py
+++ b/tests/router/mocker_process.py
@@ -14,7 +14,9 @@ from tests.router.helper import (
     generate_random_suffix,
     get_kv_indexer_command,
     get_kv_indexer_test_env,
+    get_runtime,
     get_select_service_command,
+    poll_for_worker_instances,
     wait_for_indexer_workers_active,
     wait_for_selection_service_ready,
 )
@@ -643,6 +645,23 @@ class DisaggMockerProcess:
             self._zmq_kv_events_ports = []
 
 
+def _wait_for_disagg_workers(
+    workers: DisaggMockerProcess,
+    store_backend: str,
+    request_plane: str,
+    event_plane: Optional[str],
+) -> None:
+    runtime = get_runtime(
+        store_backend=store_backend,
+        request_plane=request_plane,
+        event_plane=event_plane,
+    )
+    endpoint = runtime.endpoint(
+        f"{workers.namespace}.{workers.component_name}.generate"
+    )
+    asyncio.run(poll_for_worker_instances(endpoint, workers.num_workers))
+
+
 @contextmanager
 def launch_disagg_workers(
     request,
@@ -677,6 +696,9 @@ def launch_disagg_workers(
             zmq_kv_events=zmq_kv_events,
         ) as prefill_workers:
             logger.info("Prefill workers using endpoint: %s", prefill_workers.endpoint)
+            _wait_for_disagg_workers(
+                prefill_workers, store_backend, request_plane, event_plane
+            )
             logger.info(
                 "Starting %s decode mocker instances (second)", num_decode_mockers
             )
@@ -694,6 +716,9 @@ def launch_disagg_workers(
                 logger.info(
                     "Decode workers using endpoint: %s", decode_workers.endpoint
                 )
+                _wait_for_disagg_workers(
+                    decode_workers, store_backend, request_plane, event_plane
+                )
                 yield prefill_workers, decode_workers
         return
 
@@ -710,6 +735,9 @@ def launch_disagg_workers(
         zmq_kv_events=zmq_kv_events,
     ) as decode_workers:
         logger.info("Decode workers using endpoint: %s", decode_workers.endpoint)
+        _wait_for_disagg_workers(
+            decode_workers, store_backend, request_plane, event_plane
+        )
         logger.info(
             "Starting %s prefill mocker instances (second)", num_prefill_mockers
         )
@@ -726,7 +754,7 @@ def launch_disagg_workers(
             zmq_kv_events=zmq_kv_events,
         ) as prefill_workers:
             logger.info("Prefill workers using endpoint: %s", prefill_workers.endpoint)
+            _wait_for_disagg_workers(
+                prefill_workers, store_backend, request_plane, event_plane
+            )
             yield prefill_workers, decode_workers
-
-
-_launch_disagg_workers = launch_disagg_workers

--- a/tests/router/router_process.py
+++ b/tests/router/router_process.py
@@ -159,61 +159,6 @@ class FrontendRouterProcess(ManagedProcess):
         super().__exit__(exc_type, exc_val, exc_tb)
 
 
-class DirectRouterProcess(ManagedProcess):
-    """Manages a process in Direct routing mode for EPP-style disagg tests.
-
-    In Direct mode, the router does not select workers itself — worker IDs
-    must be supplied via x-worker-instance-id and x-prefill-instance-id headers.
-    """
-
-    def __init__(
-        self,
-        request,
-        frontend_port: int,
-        namespace: str,
-        enforce_disagg: bool = True,
-        request_plane: str = "nats",
-    ):
-        command = [
-            sys.executable,
-            "-m",
-            "dynamo.frontend",
-            "--router-mode",
-            "direct",
-            "--http-port",
-            str(frontend_port),
-            "--namespace",
-            namespace,
-        ]
-
-        if enforce_disagg:
-            command.append("--enforce-disagg")
-
-        env = os.environ.copy()
-        env["DYN_REQUEST_PLANE"] = request_plane
-
-        super().__init__(
-            command=command,
-            env=env,
-            timeout=60,
-            display_output=True,
-            health_check_ports=[frontend_port],
-            health_check_urls=[
-                (f"http://localhost:{frontend_port}/v1/models", self._check_ready)
-            ],
-            log_dir=request.node.name,
-            terminate_all_matching_process_names=False,
-            display_name="dynamo-frontend-direct",
-        )
-        self.port = frontend_port
-
-    def _check_ready(self, response):
-        return response.status_code == 200
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        super().__exit__(exc_type, exc_val, exc_tb)
-
-
 # Backward-compatible alias so existing callers that import KVRouterProcess
 # continue to work without changes.
 KVRouterProcess = FrontendRouterProcess

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -13,7 +13,6 @@ import logging
 import os
 import sys
 import tempfile
-import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -27,16 +26,20 @@ from tests.router.common import (
     _test_disagg_topology_required_prefill_pin_match_and_mismatch,
     _test_python_router_bindings,
     _test_remote_indexer_decisions,
-    _test_router_basic,
-    _test_router_decisions,
-    _test_router_decisions_disagg,
     _test_router_decisions_disagg_round_robin_prefill_dp_rank,
-    _test_router_indexers_sync,
     _test_router_overload_503,
     _test_router_override_router_config,
     _test_router_query_instance_id,
     _test_router_threshold_none_disables_rejection,
     _test_router_two_routers,
+)
+from tests.router.e2e_harness import (
+    allocate_frontend_ports,
+    build_test_payload,
+    run_basic_router_test,
+    run_disagg_router_decisions_test,
+    run_indexers_sync_test,
+    run_router_decisions_test,
 )
 from tests.router.helper import (
     generate_random_suffix,
@@ -47,12 +50,11 @@ from tests.router.helper import (
 from tests.router.mocker_process import (
     DisaggMockerProcess,
     MockerProcess,
-    _launch_disagg_workers,
+    launch_disagg_workers,
 )
 from tests.router.router_process import FrontendRouterProcess
 from tests.utils.constants import ROUTER_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
-from tests.utils.port_utils import allocate_ports, deallocate_ports
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +70,6 @@ pytestmark = [
 ]
 NUM_MOCKERS = 2
 SPEEDUP_RATIO = 10.0
-BASE_PORT = 9100  # Base port for general test allocations (frontend, system, etc.)
 NUM_REQUESTS = 100
 BLOCK_SIZE = 16
 ROUTER_OVERLOAD_DEBUG_DYN_LOG = (
@@ -180,42 +181,7 @@ def _require_router_aic() -> dict[str, Any]:
     return ROUTER_AIC_CONFIG.copy()
 
 
-def get_unique_ports(
-    request,
-    num_ports: int = 1,
-    store_backend: str = "etcd",
-    request_plane: str = "nats",
-    registration_order: str = "prefill_first",
-) -> list[int]:
-    """Allocate random free ports for xdist-safe router tests.
-
-    This replaces the previous "test-name offset" scheme with the shared flock-backed
-    allocator from `tests.utils.port_utils`, which avoids collisions across pytest-xdist
-    worker processes.
-
-    Notes:
-    - The extra parameters are kept for call-site compatibility (they no longer affect
-      the chosen ports).
-    - Ports are released at the end of the test via a pytest finalizer.
-    """
-    _ = (store_backend, request_plane, registration_order)
-    ports = allocate_ports(num_ports, BASE_PORT)
-    request.addfinalizer(lambda: deallocate_ports(ports))
-    return ports
-
-
-# Shared test payload for all tests
-TEST_PAYLOAD: Dict[str, Any] = {
-    "model": MODEL_NAME,
-    "messages": [
-        {
-            "role": "user",
-            "content": "In a quiet meadow tucked between rolling hills, a plump gray rabbit nibbled on clover beneath the shade of a gnarled oak tree. Its ears twitched at the faint rustle of leaves, but it remained calm, confident in the safety of its burrow just a few hops away. The late afternoon sun warmed its fur, and tiny dust motes danced in the golden light as bees hummed lazily nearby. Though the rabbit lived a simple life, every day was an adventure of scents, shadows, and snacks—an endless search for the tastiest patch of greens and the softest spot to nap.",
-        }
-    ],
-    "stream": True,
-    "max_tokens": 10,
-}
+TEST_PAYLOAD = build_test_payload(MODEL_NAME)
 SOAK_TEST_PAYLOAD: Dict[str, Any] = {
     "model": MODEL_NAME,
     "messages": [
@@ -393,33 +359,22 @@ def test_mocker_router(
     }
     mocker_args.update(mocker_args_override)
 
-    with MockerProcess(
-        request,
-        mocker_args=mocker_args,
-        num_mockers=NUM_MOCKERS,
+    run_basic_router_test(
+        engine_process_cls=MockerProcess,
+        engine_args_name="mocker_args",
+        engine_args=mocker_args,
+        num_workers=NUM_MOCKERS,
+        single_gpu=False,
+        request=request,
         request_plane=request_plane,
-    ) as mockers:
-        # Start mocker instances with the new CLI interface
-        logger.info(f"Starting {NUM_MOCKERS} mocker instances")
-        logger.info(f"All mockers using endpoint: {mockers.endpoint}")
-
-        # Get unique port for this test
-        frontend_port = get_unique_ports(
-            request, num_ports=1, request_plane=request_plane
-        )[0]
-
-        # Run basic router test (starts router internally and waits for workers to be ready)
-        _test_router_basic(
-            engine_workers=mockers,
-            block_size=BLOCK_SIZE,
-            request=request,
-            frontend_port=frontend_port,
-            test_payload=TEST_PAYLOAD,
-            num_requests=NUM_REQUESTS,
-            request_plane=request_plane,
-            router_mode=router_mode,
-            min_initial_workers=mockers.num_workers,
-        )
+        block_size=BLOCK_SIZE,
+        model_name=MODEL_NAME,
+        engine_process_kwargs={"num_mockers": NUM_MOCKERS},
+        test_payload=TEST_PAYLOAD,
+        num_requests=NUM_REQUESTS,
+        router_mode=router_mode,
+        min_initial_workers=NUM_MOCKERS,
+    )
 
 
 @pytest.mark.timeout(180)
@@ -442,27 +397,22 @@ def test_mocker_router_soak(
         "durable_kv_events": durable_kv_events,
     }
 
-    with MockerProcess(
-        request,
-        mocker_args=mocker_args,
-        num_mockers=2,
+    run_basic_router_test(
+        engine_process_cls=MockerProcess,
+        engine_args_name="mocker_args",
+        engine_args=mocker_args,
+        num_workers=NUM_MOCKERS,
+        single_gpu=False,
+        request=request,
         request_plane=request_plane,
-    ) as mockers:
-        frontend_port = get_unique_ports(
-            request, num_ports=1, request_plane=request_plane
-        )[0]
-
-        _test_router_basic(
-            engine_workers=mockers,
-            block_size=BLOCK_SIZE,
-            request=request,
-            frontend_port=frontend_port,
-            test_payload=SOAK_TEST_PAYLOAD,
-            num_requests=1024,
-            request_plane=request_plane,
-            router_mode=router_mode,
-            min_initial_workers=mockers.num_workers,
-        )
+        block_size=BLOCK_SIZE,
+        model_name=MODEL_NAME,
+        engine_process_kwargs={"num_mockers": NUM_MOCKERS},
+        test_payload=SOAK_TEST_PAYLOAD,
+        num_requests=1024,
+        router_mode=router_mode,
+        min_initial_workers=NUM_MOCKERS,
+    )
 
 
 @pytest.mark.parametrize("store_backend", ["etcd", "file"])
@@ -507,9 +457,7 @@ def test_mocker_two_kv_router(
         logger.info(f"All mockers using endpoint: {mockers.endpoint}")
 
         # Get unique ports for this test (2 ports for two routers)
-        router_ports = get_unique_ports(
-            request, num_ports=2, store_backend=store_backend
-        )
+        router_ports = allocate_frontend_ports(request, 2)
 
         # Run two-router test (starts KV routers internally and manages their lifecycle)
         _test_router_two_routers(
@@ -554,7 +502,7 @@ def test_mocker_kv_router_overload_503(
         logger.info(f"Mocker using endpoint: {mockers.endpoint}")
 
         # Get unique port for this test
-        frontend_port = get_unique_ports(request, num_ports=1)[0]
+        frontend_port = allocate_frontend_ports(request, 1)[0]
 
         # Run overload 503 test
         _test_router_overload_503(
@@ -587,7 +535,7 @@ def test_mocker_kv_router_threshold_none_disables_rejection(
         logger.info("Starting single mocker instance with limited resources")
         logger.info(f"Mocker using endpoint: {mockers.endpoint}")
 
-        frontend_port = get_unique_ports(request, num_ports=1)[0]
+        frontend_port = allocate_frontend_ports(request, 1)[0]
 
         _test_router_threshold_none_disables_rejection(
             engine_workers=mockers,
@@ -688,9 +636,6 @@ def test_indexers_sync(
         f"durable_kv_events={durable_kv_events}, request_plane={request_plane}"
     )
 
-    # Use the dynamic-port fixture to avoid hardcoded localhost:4222/2379 in parallel runs.
-    nats_process, _etcd_process = runtime_services_dynamic_ports
-
     # Create mocker args dictionary
     # Use 2 DP ranks to test per-dp_rank event ID tracking and recovery
     mocker_args = {
@@ -700,40 +645,27 @@ def test_indexers_sync(
         "dp_size": 2,
     }
 
-    with MockerProcess(
-        request,
-        mocker_args=mocker_args,
-        num_mockers=NUM_MOCKERS,
+    run_indexers_sync_test(
+        engine_process_cls=MockerProcess,
+        engine_args_name="mocker_args",
+        engine_args=mocker_args,
+        request=request,
+        runtime_services_dynamic_ports=runtime_services_dynamic_ports,
         store_backend=store_backend,
+        durable_kv_events=durable_kv_events,
         request_plane=request_plane,
-        zmq_kv_events=True,
-        zmq_replay=True,
-        standalone_indexer=True,
+        block_size=BLOCK_SIZE,
         model_name=MODEL_NAME,
-    ) as mockers:
-        # Start mocker instances (2 workers x 2 DP ranks = 4 independent event streams)
-        logger.info(f"Starting {NUM_MOCKERS} mocker instances with dp_size=2")
-        logger.info(f"All mockers using endpoint: {mockers.endpoint}")
-
-        # Use the common test implementation (creates its own runtimes for each router)
-        # Note: Consumer verification is done inside _test_router_indexers_sync while routers are alive
-        # When using durable_kv_events=True, use JetStream mode for the router
-        _test_router_indexers_sync(
-            engine_workers=mockers,
-            block_size=BLOCK_SIZE,
-            model_name=MODEL_NAME,
-            num_workers=NUM_MOCKERS,
-            store_backend=store_backend,
-            request_plane=request_plane,
-            test_nats_interruption=not durable_kv_events,
-            nats_server=nats_process if not durable_kv_events else None,
-            durable_kv_events=durable_kv_events,
-            standalone_indexer_url=mockers.standalone_indexer_url,
-            standalone_indexer_b_url=mockers.standalone_indexer_b_url,
-            test_zmq_replay=True,
-        )
-
-        logger.info("Indexers sync test completed successfully")
+        num_workers=NUM_MOCKERS,
+        engine_process_kwargs={
+            "num_mockers": NUM_MOCKERS,
+            "store_backend": store_backend,
+            "zmq_kv_events": True,
+            "zmq_replay": True,
+            "standalone_indexer": True,
+            "model_name": MODEL_NAME,
+        },
+    )
 
 
 @pytest.mark.timeout(120)  # bumped for xdist contention (was 42s; ~13.80s serial avg)
@@ -760,7 +692,7 @@ def test_query_instance_id_returns_worker_and_tokens(
         logger.info(f"All mockers using endpoint: {mockers.endpoint}")
 
         # Get unique port for this test
-        frontend_port = get_unique_ports(request, num_ports=1)[0]
+        frontend_port = allocate_frontend_ports(request, 1)[0]
 
         # Run query_instance_id annotation test
         _test_router_query_instance_id(
@@ -849,19 +781,20 @@ def test_router_decisions(
         "durable_kv_events": durable_kv_events and use_kv_events,
     }
 
-    with MockerProcess(
-        request,
-        mocker_args=mocker_args,
-        num_mockers=2,
-        request_plane=request_plane,
-        zmq_kv_events=zmq_kv_events,
-        standalone_indexer=zmq_kv_events,
-        standalone_selector=zmq_kv_events,
-        model_name=MODEL_NAME,
-    ) as mockers:
-        logger.info(f"All mockers using endpoint: {mockers.endpoint}")
-
-        if use_remote_indexer:
+    process_kwargs = {
+        "num_mockers": NUM_MOCKERS,
+        "zmq_kv_events": zmq_kv_events,
+        "standalone_indexer": zmq_kv_events,
+        "standalone_selector": zmq_kv_events,
+        "model_name": MODEL_NAME,
+    }
+    if use_remote_indexer:
+        with MockerProcess(
+            request,
+            mocker_args=mocker_args,
+            request_plane=request_plane,
+            **process_kwargs,
+        ) as mockers:
             _test_remote_indexer_decisions(
                 mockers,
                 MODEL_NAME,
@@ -871,23 +804,27 @@ def test_router_decisions(
                 request_plane=request_plane,
                 router_predicted_ttl_secs=router_predicted_ttl_secs,
             )
-            return
+        return
 
-        runtime = get_runtime(request_plane=request_plane)
-        endpoint = runtime.endpoint(f"{mockers.namespace}.mocker.generate")
-
-        _test_router_decisions(
-            mockers,
-            endpoint,
-            MODEL_NAME,
-            request,
-            test_dp_rank=True,
-            use_kv_events=use_kv_events,
-            durable_kv_events=durable_kv_events,
-            standalone_indexer_url=mockers.standalone_indexer_url,
-            standalone_selector_url=mockers.standalone_selector_url,
-            router_predicted_ttl_secs=router_predicted_ttl_secs,
-        )
+    run_router_decisions_test(
+        engine_process_cls=MockerProcess,
+        engine_args_name="mocker_args",
+        engine_args=mocker_args,
+        request=request,
+        request_plane=request_plane,
+        model_name=MODEL_NAME,
+        block_size=8,
+        component_name="mocker",
+        num_workers=NUM_MOCKERS,
+        single_gpu=False,
+        test_dp_rank=True,
+        engine_process_kwargs=process_kwargs,
+        test_kwargs={
+            "use_kv_events": use_kv_events,
+            "durable_kv_events": durable_kv_events,
+            "router_predicted_ttl_secs": router_predicted_ttl_secs,
+        },
+    )
 
 
 @pytest.mark.timeout(300)
@@ -909,26 +846,28 @@ def test_router_decisions_router_aic(
         "durable_kv_events": False,
     }
 
-    with MockerProcess(
-        request,
-        mocker_args=mocker_args,
-        num_mockers=2,
+    run_router_decisions_test(
+        engine_process_cls=MockerProcess,
+        engine_args_name="mocker_args",
+        engine_args=mocker_args,
+        request=request,
         request_plane=request_plane,
         model_name=MODEL_NAME,
-    ) as mockers:
-        runtime = get_runtime(request_plane=request_plane)
-        endpoint = runtime.endpoint(f"{mockers.namespace}.mocker.generate")
-
-        _test_router_decisions(
-            mockers,
-            endpoint,
-            MODEL_NAME,
-            request,
-            test_dp_rank=True,
-            use_kv_events=True,
-            durable_kv_events=False,
-            router_aic_config=router_aic_config,
-        )
+        block_size=8,
+        component_name="mocker",
+        num_workers=NUM_MOCKERS,
+        single_gpu=False,
+        test_dp_rank=True,
+        engine_process_kwargs={
+            "num_mockers": NUM_MOCKERS,
+            "model_name": MODEL_NAME,
+        },
+        test_kwargs={
+            "use_kv_events": True,
+            "durable_kv_events": False,
+            "router_aic_config": router_aic_config,
+        },
+    )
 
 
 @pytest.mark.parametrize("registration_order", ["prefill_first", "decode_first"])
@@ -958,10 +897,6 @@ def test_router_decisions_disagg(
         f"(registration_order={registration_order}, bootstrap={enable_disagg_bootstrap})"
     )
 
-    # Generate shared namespace for prefill and decode workers
-    namespace_suffix = generate_random_suffix()
-    shared_namespace = f"test-namespace-{namespace_suffix}"
-
     # Create mocker args - use NATS Core with local indexer (default mode)
     mocker_args = {
         "speedup_ratio": SPEEDUP_RATIO,
@@ -969,29 +904,29 @@ def test_router_decisions_disagg(
         # durable_kv_events defaults to False (NATS Core mode)
     }
 
-    with _launch_disagg_workers(
-        request,
-        shared_namespace,
-        registration_order,
-        prefill_mocker_args=mocker_args,
-        decode_mocker_args=mocker_args,
-        num_prefill_mockers=4,
-        num_decode_mockers=4,
-        enable_disagg_bootstrap=enable_disagg_bootstrap,
-    ) as (prefill_workers, decode_workers):
-        frontend_port = get_unique_ports(
-            request, num_ports=1, registration_order=registration_order
-        )[0]
-        _test_router_decisions_disagg(
-            prefill_workers=prefill_workers,
-            decode_workers=decode_workers,
-            block_size=BLOCK_SIZE,
-            request=request,
-            frontend_port=frontend_port,
-            test_payload=TEST_PAYLOAD,
-            request_plane="nats",
-            enable_bootstrap=enable_disagg_bootstrap,
-        )
+    run_disagg_router_decisions_test(
+        engine_process_cls=DisaggMockerProcess,
+        engine_args_name="mocker_args",
+        engine_args=mocker_args,
+        request=request,
+        request_plane="nats",
+        model_name=MODEL_NAME,
+        block_size=BLOCK_SIZE,
+        num_prefill_workers=4,
+        num_decode_workers=4,
+        worker_context_factory=lambda namespace: launch_disagg_workers(
+            request,
+            namespace,
+            registration_order,
+            prefill_mocker_args=mocker_args,
+            decode_mocker_args=mocker_args,
+            num_prefill_mockers=4,
+            num_decode_mockers=4,
+            enable_disagg_bootstrap=enable_disagg_bootstrap,
+        ),
+        test_payload=TEST_PAYLOAD,
+        test_kwargs={"enable_bootstrap": enable_disagg_bootstrap},
+    )
 
 
 @pytest.mark.parametrize(
@@ -1032,7 +967,7 @@ def test_mocker_disagg_router_overload_503(
             "durable_kv_events": durable_kv_events,
         }
 
-    with _launch_disagg_workers(
+    with launch_disagg_workers(
         request,
         shared_namespace,
         registration_order="prefill_first",
@@ -1041,9 +976,10 @@ def test_mocker_disagg_router_overload_503(
         num_prefill_mockers=overload_case["num_prefill"],
         num_decode_mockers=overload_case["num_decode"],
         enable_disagg_bootstrap=False,
-    ) as (_prefill_workers, decode_workers):
-        frontend_port = get_unique_ports(request, num_ports=1)[0]
+    ) as (prefill_workers, decode_workers):
+        frontend_port = allocate_frontend_ports(request, 1)[0]
         _test_disagg_router_overload_503(
+            prefill_workers=prefill_workers,
             decode_workers=decode_workers,
             block_size=4,
             request=request,
@@ -1083,12 +1019,7 @@ def test_disagg_background_prefill_sticky(
         "block_size": BLOCK_SIZE,
     }
 
-    frontend_port = get_unique_ports(
-        request,
-        num_ports=1,
-        store_backend=discovery_backend,
-        request_plane=request_plane,
-    )[0]
+    frontend_port = allocate_frontend_ports(request, 1)[0]
     with FrontendRouterProcess(
         request,
         BLOCK_SIZE,
@@ -1100,8 +1031,7 @@ def test_disagg_background_prefill_sticky(
         event_plane="nats",
         durable_kv_events=False,
     ):
-        time.sleep(1.0)
-        with _launch_disagg_workers(
+        with launch_disagg_workers(
             request,
             shared_namespace,
             "prefill_first",
@@ -1201,7 +1131,7 @@ def test_disagg_topology_required_prefill_pin_match_and_mismatch(
                 )
                 logger.info("Decode zone-a worker ids: %s", decode_ids)
 
-                frontend_port = get_unique_ports(request, num_ports=1)[0]
+                frontend_port = allocate_frontend_ports(request, 1)[0]
                 _test_disagg_topology_required_prefill_pin_match_and_mismatch(
                     decode_workers=decode_workers,
                     block_size=BLOCK_SIZE,
@@ -1248,9 +1178,7 @@ def test_router_decisions_disagg_round_robin_prefill_dp_rank(
     }
 
     def run_case(prefill_workers, decode_workers):
-        frontend_port = get_unique_ports(
-            request, num_ports=1, registration_order=registration_order
-        )[0]
+        frontend_port = allocate_frontend_ports(request, 1)[0]
         _test_router_decisions_disagg_round_robin_prefill_dp_rank(
             prefill_workers=prefill_workers,
             decode_workers=decode_workers,
@@ -1262,7 +1190,7 @@ def test_router_decisions_disagg_round_robin_prefill_dp_rank(
             request_plane="nats",
         )
 
-    with _launch_disagg_workers(
+    with launch_disagg_workers(
         request,
         shared_namespace,
         registration_order,
@@ -1285,48 +1213,34 @@ def test_router_decisions_disagg_router_aic(
     logger.info("Starting disaggregated router prefix reuse test with router-side AIC")
 
     router_aic_config = _require_router_aic()
-    namespace_suffix = generate_random_suffix()
-    shared_namespace = f"test-namespace-{namespace_suffix}"
     mocker_args = {
         "speedup_ratio": SPEEDUP_RATIO,
         "block_size": BLOCK_SIZE,
     }
 
-    with DisaggMockerProcess(
-        request,
-        namespace=shared_namespace,
-        worker_type="prefill",
-        mocker_args=mocker_args,
-        num_mockers=4,
+    run_disagg_router_decisions_test(
+        engine_process_cls=DisaggMockerProcess,
+        engine_args_name="mocker_args",
+        engine_args=mocker_args,
+        request=request,
         request_plane="nats",
-        enable_bootstrap=False,
-    ) as prefill_workers:
-        logger.info(f"Prefill workers using endpoint: {prefill_workers.endpoint}")
-
-        with DisaggMockerProcess(
+        model_name=MODEL_NAME,
+        block_size=BLOCK_SIZE,
+        num_prefill_workers=4,
+        num_decode_workers=4,
+        worker_context_factory=lambda namespace: launch_disagg_workers(
             request,
-            namespace=shared_namespace,
-            worker_type="decode",
-            mocker_args=mocker_args,
-            num_mockers=4,
-            request_plane="nats",
-        ) as decode_workers:
-            logger.info(f"Decode workers using endpoint: {decode_workers.endpoint}")
-
-            frontend_port = get_unique_ports(
-                request, num_ports=1, registration_order="prefill_first"
-            )[0]
-
-            _test_router_decisions_disagg(
-                prefill_workers=prefill_workers,
-                decode_workers=decode_workers,
-                block_size=BLOCK_SIZE,
-                request=request,
-                frontend_port=frontend_port,
-                test_payload=TEST_PAYLOAD,
-                request_plane="nats",
-                router_aic_config=router_aic_config,
-            )
+            namespace,
+            registration_order="prefill_first",
+            prefill_mocker_args=mocker_args,
+            decode_mocker_args=mocker_args,
+            num_prefill_mockers=4,
+            num_decode_mockers=4,
+            enable_disagg_bootstrap=False,
+        ),
+        test_payload=TEST_PAYLOAD,
+        test_kwargs={"router_aic_config": router_aic_config},
+    )
 
 
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
@@ -1371,9 +1285,7 @@ def test_busy_threshold_endpoint(
         logger.info(f"Starting {NUM_MOCKERS} mocker instances")
         logger.info(f"All mockers using endpoint: {mockers.endpoint}")
 
-        frontend_port = get_unique_ports(
-            request, num_ports=1, request_plane=request_plane
-        )[0]
+        frontend_port = allocate_frontend_ports(request, 1)[0]
 
         _test_busy_threshold_endpoint(
             engine_workers=mockers,
@@ -1411,36 +1323,25 @@ def test_disagg_direct_mode_epp_headers(
         "block_size": BLOCK_SIZE,
     }
 
-    with DisaggMockerProcess(
+    with launch_disagg_workers(
         request,
-        namespace=shared_namespace,
-        worker_type="prefill",
-        mocker_args=mocker_args,
-        num_mockers=2,
-        request_plane="nats",
-    ) as prefill_workers:
-        logger.info(f"Prefill workers using endpoint: {prefill_workers.endpoint}")
-
-        with DisaggMockerProcess(
-            request,
-            namespace=shared_namespace,
-            worker_type="decode",
-            mocker_args=mocker_args,
-            num_mockers=2,
+        shared_namespace,
+        registration_order="prefill_first",
+        prefill_mocker_args=mocker_args,
+        decode_mocker_args=mocker_args,
+        num_prefill_mockers=2,
+        num_decode_mockers=2,
+        enable_disagg_bootstrap=False,
+    ) as (prefill_workers, decode_workers):
+        frontend_port = allocate_frontend_ports(request, 1)[0]
+        _test_disagg_direct_mode(
+            prefill_workers=prefill_workers,
+            decode_workers=decode_workers,
+            request=request,
+            frontend_port=frontend_port,
+            test_payload=TEST_PAYLOAD,
             request_plane="nats",
-        ) as decode_workers:
-            logger.info(f"Decode workers using endpoint: {decode_workers.endpoint}")
-
-            frontend_port = get_unique_ports(request, num_ports=1)[0]
-
-            _test_disagg_direct_mode(
-                prefill_workers=prefill_workers,
-                decode_workers=decode_workers,
-                request=request,
-                frontend_port=frontend_port,
-                test_payload=TEST_PAYLOAD,
-                request_plane="nats",
-            )
+        )
 
 
 def test_router_per_worker_config(
@@ -1459,7 +1360,7 @@ def test_router_per_worker_config(
     logger.info("Starting per-worker router config override test")
 
     with CounterWorkerProcess(request) as workers:
-        frontend_port = get_unique_ports(request, num_ports=1)[0]
+        frontend_port = allocate_frontend_ports(request, 1)[0]
         _test_router_override_router_config(
             endpoint=workers.endpoint_path,
             engine_workers=workers,


### PR DESCRIPTION
## Summary

- reuse the shared router E2E harness for standard mocker scenarios
- enforce disaggregated worker registration order and exact worker-count readiness
- consolidate frontend/disaggregated process lifecycle, port allocation, and payload setup
- replace readiness sleeps and unchecked warmup retries with explicit polling

## Validation

- repository pre-commit hooks (`isort`, `black`, `flake8`, `ruff`, marker validation, and standard file checks)
- `.venv/bin/python -m py_compile` on all changed Python modules
- `git diff --check`
- E2E tests not run locally, as requested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved router test synchronization and readiness verification.
  * Refactored test infrastructure utilities for better maintainability and configurability.
  * Streamlined test harness to reduce custom per-test orchestration and improve test reliability.
  * Deprecated test infrastructure components removed and replaced with unified implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->