### PR TITLE
fix(operator): continue startup when docker secret index refresh fails

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -585,11 +585,8 @@ func main() {
 			case <-mainCtx.Done():
 				return
 			case <-ticker.C:
-				setupLog.Info("refreshing docker secrets index...")
 				if err := dockerSecretRetriever.RefreshIndex(mainCtx); err != nil {
-					setupLog.Error(err, "unable to refresh docker secrets index")
-				} else {
-					setupLog.Info("docker secrets index refreshed")
+					setupLog.Error(err, "failed to refresh docker secrets index")
 				}
 			}
 		}

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -572,10 +572,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err := dockerSecretRetriever.RefreshIndex(mainCtx); err != nil {
-		setupLog.Error(err, "initial docker secrets index refresh failed")
-		os.Exit(1)
+		setupLog.Error(err, "initial docker secrets index refresh completed with errors; continuing startup")
+	} else {
+		setupLog.Info("initial docker secrets index refreshed")
 	}
-	setupLog.Info("initial docker secrets index refreshed")
 	// launch a goroutine to refresh the docker secret indexer in any case every minute
 	go func() {
 		ticker := time.NewTicker(60 * time.Second)
@@ -588,8 +588,9 @@ func main() {
 				setupLog.Info("refreshing docker secrets index...")
 				if err := dockerSecretRetriever.RefreshIndex(mainCtx); err != nil {
 					setupLog.Error(err, "unable to refresh docker secrets index")
+				} else {
+					setupLog.Info("docker secrets index refreshed")
 				}
-				setupLog.Info("docker secrets index refreshed")
 			}
 		}
 	}()

--- a/deploy/operator/internal/secrets/docker.go
+++ b/deploy/operator/internal/secrets/docker.go
@@ -87,10 +87,7 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.secrets = tmpSecrets
-	if len(refreshErrors) > 0 {
-		return errors.Join(refreshErrors...)
-	}
-	return nil
+	return errors.Join(refreshErrors...)
 }
 
 func (i *DockerSecretIndexer) listOptions() []client.ListOption {

--- a/deploy/operator/internal/secrets/docker.go
+++ b/deploy/operator/internal/secrets/docker.go
@@ -3,6 +3,7 @@ package secrets
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -51,6 +52,7 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 		return 0
 	})
 	tmpSecrets := make(map[string]map[string][]string)
+	var refreshErrors []error
 	for _, secret := range secrets.Items {
 		if secret.Type == corev1.SecretTypeDockerConfigJson {
 			// unmarshal the secret data
@@ -58,7 +60,8 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 				Auths map[string]any `json:"auths"`
 			}{}
 			if err := json.Unmarshal(secret.Data[corev1.DockerConfigJsonKey], dockerConfig); err != nil {
-				return fmt.Errorf("unable to unmarshal docker config json for secret %s: %w", secret.Name, err)
+				refreshErrors = append(refreshErrors, fmt.Errorf("unable to unmarshal docker config json for secret %s/%s: %w", secret.Namespace, secret.Name, err))
+				continue
 			}
 			namespace := secret.Namespace
 			if _, ok := tmpSecrets[namespace]; !ok {
@@ -68,7 +71,8 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 				// retrieve the registry host
 				registry, err := common.GetHost(auth)
 				if err != nil {
-					return fmt.Errorf("unable to get host for registry %s for secret %s: %w", auth, secret.Name, err)
+					refreshErrors = append(refreshErrors, fmt.Errorf("unable to get host for registry %q for secret %s/%s: %w", auth, secret.Namespace, secret.Name, err))
+					continue
 				}
 				tmpSecrets[namespace][registry] = append(tmpSecrets[namespace][registry], secret.Name)
 			}
@@ -83,6 +87,9 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.secrets = tmpSecrets
+	if len(refreshErrors) > 0 {
+		return errors.Join(refreshErrors...)
+	}
 	return nil
 }
 

--- a/deploy/operator/internal/secrets/docker_test.go
+++ b/deploy/operator/internal/secrets/docker_test.go
@@ -146,6 +146,59 @@ func TestDockerSecretIndexer_DeterministicSecrets(t *testing.T) {
 	}
 }
 
+func TestDockerSecretIndexer_RefreshIndexSkipsMalformedSecrets(t *testing.T) {
+	mockSecrets := []corev1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "good-secret",
+				Namespace: "default",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`{"auths":{"docker.io":{}}}`),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bad-secret",
+				Namespace: "default",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`not-json`),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "invalid-registry-secret",
+				Namespace: "default",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`{"auths":{"pip install torch --index-url https:":{}}}`),
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&mockSecrets[0], &mockSecrets[1], &mockSecrets[2]).
+		Build()
+
+	i := NewDockerSecretIndexer(fakeClient, "")
+	if err := i.RefreshIndex(t.Context()); err == nil {
+		t.Fatal("DockerSecretIndexer.RefreshIndex() error = nil, want errors for malformed secrets")
+	}
+
+	secrets, err := i.GetSecrets("default", "docker.io")
+	if err != nil {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() error = %v", err)
+	}
+	if got, want := secrets, []string{"good-secret"}; !slices.Equal(got, want) {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() = %v, want %v", got, want)
+	}
+}
+
 func TestDockerSecretIndexer_RefreshIndexRespectsNamespaceScope(t *testing.T) {
 	mockSecrets := []corev1.Secret{
 		{


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

The controller manager will crash and exit when the initial docker secrets index refresh encounters malformed secrets.

## Details:

<!-- Describe the changes made in this PR. -->

- Stop exiting the controller manager when the initial docker secrets index refresh encounters malformed secrets.
- Skip invalid `kubernetes.io/dockerconfigjson` secrets during `RefreshIndex` and continue indexing valid ones, logging aggregated errors instead of failing the whole refresh.
- Only log periodic refresh success when the refresh actually succeeds.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #10790 

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

