### PR TITLE
fix(operator): preserve empty DGDR status conversion

### DIFF
--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -1168,6 +1168,9 @@ func dgdrAlphaDeploymentNeedsSave(state DGDRState, deployment *DeploymentStatus)
 	if deployment == nil {
 		return false
 	}
+	if apiequality.Semantic.DeepEqual(*deployment, DeploymentStatus{}) {
+		return true
+	}
 	if deployment.Namespace != "" || deployment.State != "" || deployment.Created {
 		return true
 	}

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,6 +168,29 @@ func TestBugDGDRStaleAlphaDeploymentDeletedRequiresDGDNameMatch(t *testing.T) {
 	}
 	if dst.Status.Deployment.Created {
 		t.Fatal("deployment.created = true, want false")
+	}
+}
+
+func TestBugDGDREmptyAlphaDeploymentStatusRoundTrips(t *testing.T) {
+	original := &DynamoGraphDeploymentRequest{
+		Status: DynamoGraphDeploymentRequestStatus{
+			State:      DGDRStateReady,
+			Deployment: &DeploymentStatus{},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := original.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	restored := &DynamoGraphDeploymentRequest{}
+	if err := restored.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+
+	if diff := cmp.Diff(original.Status, restored.Status); diff != "" {
+		t.Fatalf("status mismatch after round-trip (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve empty v1alpha1 DGDR deployment status during v1alpha1 -> v1beta1 -> v1alpha1 conversion.
- Add a regression test for `status.deployment: {}`.

## Reproduction and Impact

Before this fix, a v1alpha1 DGDR with `status.deployment: {}` round-trips back with `status.deployment == nil`. This is a narrow conversion fidelity bug: it drops the distinction between an absent deployment status and an explicitly present empty deployment status.

## Merge Order

This fix unblocks https://github.com/ai-dynamo/dynamo/pull/10793 (operator Kubernetes deps bump to v0.36.2). The dependency bump exercises a conversion round-trip path that surfaces this pre-existing bug, so #10793's `operator` CI job fails until this PR is merged and #10793 is rebased onto the updated `main`. Please merge this PR first.

## Validation

- `cd deploy/operator && GOCACHE=/tmp/dynamo-go-cache go test ./api/v1alpha1 -count=1`
- `cd deploy/operator && GOCACHE=/tmp/dynamo-go-cache go test ./api -run TestFuzzRoundTripMutability/DGDR -count=1`

## Related Issues

- No related issue.
