### PR TITLE
fix(llm): accept generic trajectory identity

### DIFF
--- a/docs/agents/agent-tracing.md
+++ b/docs/agents/agent-tracing.md
@@ -32,8 +32,8 @@ Inject `agent_context` into each LLM request
 
 | Field                  | Required | Meaning                                  |
 | ---------------------- | :------: | ---------------------------------------- |
-| `session_type_id`      |   Yes    | Workload class (e.g. `deep_research`).   |
-| `session_id`           |   Yes    | Whole agent run.                         |
+| `session_type_id`      |    No    | Workload class; defaults to `dynamo`.    |
+| `session_id`           |    No    | Whole agent run; defaults to `trajectory_id`. |
 | `trajectory_id`        |   Yes    | One reasoning/tool chain inside the run. |
 | `parent_trajectory_id` |    No    | Parent trajectory when using subagents.  |
 | `trajectory_final`     |    No    | `true` marks the trajectory's last request — a cleanup hint. |

--- a/docs/agents/agent-tracing.md
+++ b/docs/agents/agent-tracing.md
@@ -32,11 +32,17 @@ Inject `agent_context` into each LLM request
 
 | Field                  | Required | Meaning                                  |
 | ---------------------- | :------: | ---------------------------------------- |
-| `session_type_id`      |    No    | Workload class; defaults to `dynamo`.    |
-| `session_id`           |    No    | Whole agent run; defaults to `trajectory_id`. |
 | `trajectory_id`        |   Yes    | One reasoning/tool chain inside the run. |
+| `session_type_id`      |    No    | Workload class.                          |
+| `session_id`           |    No    | Whole agent run.                         |
 | `parent_trajectory_id` |    No    | Parent trajectory when using subagents.  |
 | `trajectory_final`     |    No    | `true` marks the trajectory's last request — a cleanup hint. |
+
+For generic HTTP clients, `x-dynamo-trajectory-id` is enough to synthesize
+`agent_context`. Dynamo sets `trajectory_id` from the header, sets
+`session_type_id` to `dynamo`, and leaves `session_id`,
+`parent_trajectory_id`, and `trajectory_final` unset. Explicit
+`nvext.agent_context` takes precedence over all identity headers.
 
 `trajectory_final` is an optional terminal marker: set it to `true` to signal that a
 trajectory is finished. Lifecycle-aware backends use it to release whatever

--- a/docs/components/frontend/nvext.md
+++ b/docs/components/frontend/nvext.md
@@ -74,10 +74,16 @@ agentic requests. Dynamo uses this metadata to emit enriched request traces when
 request tracing is enabled. It does not change routing, scheduling, or cache
 behavior.
 
+For generic HTTP clients, `x-dynamo-trajectory-id` is enough to synthesize
+`agent_context`: Dynamo uses that value for both `trajectory_id` and
+`session_id`, sets `session_type_id` to `"dynamo"`, and leaves
+`parent_trajectory_id` and `trajectory_final` unset. Explicit
+`nvext.agent_context` remains the richer/manual path and takes precedence.
+
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `session_type_id` | `string` | Yes | Reusable profile or agent class label. |
-| `session_id` | `string` | Yes | Top-level agent run/session identifier. |
+| `session_type_id` | `string` | No | Reusable profile or agent class label. Defaults to `"dynamo"` when omitted. |
+| `session_id` | `string` | No | Top-level agent run/session identifier. Defaults to `trajectory_id` when omitted. |
 | `trajectory_id` | `string` | Yes | One schedulable reasoning/tool trajectory. |
 | `parent_trajectory_id` | `string` | No | Parent trajectory, typically for subagents. |
 | `trajectory_final` | `bool` | No | Terminal marker for lifecycle-aware consumers; ignored by consumers that do not track trajectory lifecycle. |

--- a/docs/components/frontend/nvext.md
+++ b/docs/components/frontend/nvext.md
@@ -74,17 +74,16 @@ agentic requests. Dynamo uses this metadata to emit enriched request traces when
 request tracing is enabled. It does not change routing, scheduling, or cache
 behavior.
 
-For generic HTTP clients, `x-dynamo-trajectory-id` is enough to synthesize
-`agent_context`: Dynamo uses that value for both `trajectory_id` and
-`session_id`, sets `session_type_id` to `"dynamo"`, and leaves
-`parent_trajectory_id` and `trajectory_final` unset. Explicit
-`nvext.agent_context` remains the richer/manual path and takes precedence.
+Generic HTTP clients can send `x-dynamo-trajectory-id` instead of a body
+`agent_context`; Dynamo synthesizes the passive identity at the HTTP boundary.
+For the full header precedence and tracing contract, see
+[Agent Tracing](../../agents/agent-tracing.md).
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `session_type_id` | `string` | No | Reusable profile or agent class label. Defaults to `"dynamo"` when omitted. |
-| `session_id` | `string` | No | Top-level agent run/session identifier. Defaults to `trajectory_id` when omitted. |
 | `trajectory_id` | `string` | Yes | One schedulable reasoning/tool trajectory. |
+| `session_type_id` | `string` | No | Reusable profile or agent class label. |
+| `session_id` | `string` | No | Top-level agent run/session identifier. |
 | `parent_trajectory_id` | `string` | No | Parent trajectory, typically for subagents. |
 | `trajectory_final` | `bool` | No | Terminal marker for lifecycle-aware consumers; ignored by consumers that do not track trajectory lifecycle. |
 

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -882,8 +882,8 @@ mod tests {
         assert_eq!(
             nvext.and_then(|ext| ext.agent_context),
             Some(AgentContext {
-                session_type_id: "deep_research:v1".to_string(),
-                session_id: "run-123".to_string(),
+                session_type_id: Some("deep_research:v1".to_string()),
+                session_id: Some("run-123".to_string()),
                 trajectory_id: "run-123:researcher-0".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,

--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -10,6 +10,8 @@ pub(crate) const HEADER_CLAUDE_CODE_AGENT_ID: &str = "x-claude-code-agent-id";
 pub(crate) const HEADER_CODEX_SESSION_ID: &str = "session-id";
 pub(crate) const HEADER_OPENCODE_SESSION_ID: &str = "x-session-id";
 pub(crate) const HEADER_OPENCODE_PARENT_SESSION_ID: &str = "x-parent-session-id";
+pub(crate) const HEADER_DYNAMO_TRAJECTORY_ID: &str = "x-dynamo-trajectory-id";
+pub(crate) const DEFAULT_DYNAMO_SESSION_TYPE_ID: &str = "dynamo";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct AgentHeaderMapping {
@@ -81,17 +83,25 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
             parent_trajectory_id,
         });
     }
-    None
+    header_value(headers, HEADER_DYNAMO_TRAJECTORY_ID).map(|trajectory_id| {
+        AgentContextHeaderValues {
+            session_type_id: DEFAULT_DYNAMO_SESSION_TYPE_ID,
+            session_id: trajectory_id.clone(),
+            trajectory_id,
+            parent_trajectory_id: None,
+        }
+    })
 }
 
 pub(crate) fn has_agent_headers(headers: &HeaderMap) -> bool {
-    AGENT_HEADER_MAPPINGS.iter().any(|mapping| {
-        headers.contains_key(mapping.session_header)
-            || mapping
-                .trajectory_header
-                .is_some_and(|trajectory_header| headers.contains_key(trajectory_header))
-            || mapping
-                .parent_session_header
-                .is_some_and(|parent_header| headers.contains_key(parent_header))
-    })
+    headers.contains_key(HEADER_DYNAMO_TRAJECTORY_ID)
+        || AGENT_HEADER_MAPPINGS.iter().any(|mapping| {
+            headers.contains_key(mapping.session_header)
+                || mapping
+                    .trajectory_header
+                    .is_some_and(|trajectory_header| headers.contains_key(trajectory_header))
+                || mapping
+                    .parent_session_header
+                    .is_some_and(|parent_header| headers.contains_key(parent_header))
+        })
 }

--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -49,7 +49,7 @@ const AGENT_HEADER_MAPPINGS: &[AgentHeaderMapping] = &[
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AgentContextHeaderValues {
     pub(crate) session_type_id: &'static str,
-    pub(crate) session_id: String,
+    pub(crate) session_id: Option<String>,
     pub(crate) trajectory_id: String,
     pub(crate) parent_trajectory_id: Option<String>,
 }
@@ -78,7 +78,7 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
 
         return Some(AgentContextHeaderValues {
             session_type_id: mapping.session_type_id,
-            session_id,
+            session_id: Some(session_id),
             trajectory_id,
             parent_trajectory_id,
         });
@@ -86,7 +86,7 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
     header_value(headers, HEADER_DYNAMO_TRAJECTORY_ID).map(|trajectory_id| {
         AgentContextHeaderValues {
             session_type_id: DEFAULT_DYNAMO_SESSION_TYPE_ID,
-            session_id: trajectory_id.clone(),
+            session_id: None,
             trajectory_id,
             parent_trajectory_id: None,
         }

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -641,8 +641,8 @@ mod tests {
         assert_eq!(
             chat_req.nvext.and_then(|ext| ext.agent_context),
             Some(AgentContext {
-                session_type_id: "deep_research:v1".to_string(),
-                session_id: "run-123".to_string(),
+                session_type_id: Some("deep_research:v1".to_string()),
+                session_id: Some("run-123".to_string()),
                 trajectory_id: "run-123:researcher-0".to_string(),
                 parent_trajectory_id: Some("run-123:root".to_string()),
                 trajectory_final: Some(false),

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::protocols::TokenIdType;
-use crate::protocols::agents::{AgentContextHeaderValues, agent_context_header_values};
+use crate::protocols::agents::{
+    AgentContextHeaderValues, DEFAULT_DYNAMO_SESSION_TYPE_ID, agent_context_header_values,
+};
 use crate::protocols::common::llm_backend::PromptLogprobs;
 use crate::protocols::common::timing::TimingInfo;
 
@@ -60,8 +62,7 @@ where
 }
 
 /// Identity metadata for agentic workloads.
-#[derive(Serialize, Deserialize, Builder, Debug, Clone, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[derive(Serialize, Builder, Debug, Clone, PartialEq, Eq)]
 pub struct AgentContext {
     /// Reusable session/profile class.
     pub session_type_id: String,
@@ -74,19 +75,51 @@ pub struct AgentContext {
 
     /// Optional parent trajectory for subagents.
     #[builder(default, setter(strip_option))]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_trajectory_id: Option<String>,
 
     /// Optional terminal marker: when true, this request signals that the
     /// trajectory is complete.
     #[builder(default, setter(strip_option))]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub trajectory_final: Option<bool>,
 }
 
 impl AgentContext {
     pub fn builder() -> AgentContextBuilder {
         AgentContextBuilder::default()
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentContext {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct AgentContextWire {
+            session_type_id: Option<String>,
+            session_id: Option<String>,
+            trajectory_id: String,
+            #[serde(default)]
+            parent_trajectory_id: Option<String>,
+            #[serde(default)]
+            trajectory_final: Option<bool>,
+        }
+
+        let wire = AgentContextWire::deserialize(deserializer)?;
+        Ok(Self {
+            session_type_id: wire
+                .session_type_id
+                .unwrap_or_else(|| DEFAULT_DYNAMO_SESSION_TYPE_ID.to_string()),
+            session_id: wire
+                .session_id
+                .unwrap_or_else(|| wire.trajectory_id.clone()),
+            trajectory_id: wire.trajectory_id,
+            parent_trajectory_id: wire.parent_trajectory_id,
+            trajectory_final: wire.trajectory_final,
+        })
     }
 }
 
@@ -298,6 +331,8 @@ impl From<AgentContextHeaderValues> for AgentContext {
 /// - coding-agent source -> `agent_context.session_type_id`
 /// - configured coding-agent parent session headers ->
 ///   `agent_context.parent_trajectory_id`
+/// - `x-dynamo-trajectory-id` -> generic `agent_context` with
+///   `session_id=trajectory_id` and `session_type_id=dynamo`
 ///
 /// Routing headers take priority over existing nvext values when present.
 /// Explicit `nvext.agent_context` takes priority over coding-agent headers.
@@ -651,7 +686,7 @@ mod tests {
     use super::*;
     use crate::protocols::agents::{
         HEADER_CLAUDE_CODE_AGENT_ID, HEADER_CLAUDE_CODE_SESSION_ID, HEADER_CODEX_SESSION_ID,
-        HEADER_OPENCODE_PARENT_SESSION_ID, HEADER_OPENCODE_SESSION_ID,
+        HEADER_DYNAMO_TRAJECTORY_ID, HEADER_OPENCODE_PARENT_SESSION_ID, HEADER_OPENCODE_SESSION_ID,
     };
 
     #[test]
@@ -751,11 +786,26 @@ mod tests {
     }
 
     #[test]
-    fn agent_context_serde_missing_required_field_fails() {
+    fn agent_context_serde_defaults_missing_session_fields() {
+        let json = r#"{
+            "agent_context": {
+                "trajectory_id": "run-123:researcher-0"
+            }
+        }"#;
+
+        let nvext = serde_json::from_str::<NvExt>(json).unwrap();
+        let agent_context = nvext.agent_context.unwrap();
+        assert_eq!(agent_context.session_type_id, "dynamo");
+        assert_eq!(agent_context.session_id, "run-123:researcher-0");
+        assert_eq!(agent_context.trajectory_id, "run-123:researcher-0");
+    }
+
+    #[test]
+    fn agent_context_serde_missing_trajectory_id_fails() {
         let json = r#"{
             "agent_context": {
                 "session_type_id": "deep_research:v1",
-                "trajectory_id": "run-123:researcher-0"
+                "session_id": "run-123"
             }
         }"#;
 
@@ -869,6 +919,13 @@ mod tests {
                 "opencode",
                 Some("parent-run-1"),
             ),
+            (
+                HEADER_DYNAMO_TRAJECTORY_ID,
+                "generic-run-1",
+                None,
+                "dynamo",
+                None,
+            ),
         ];
 
         for (
@@ -933,6 +990,22 @@ mod tests {
     }
 
     #[test]
+    fn apply_header_routing_overrides_prefers_first_class_agent_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_CODEX_SESSION_ID, "codex-run".parse().unwrap());
+        headers.insert(HEADER_DYNAMO_TRAJECTORY_ID, "generic-run".parse().unwrap());
+
+        let agent_context = apply_header_routing_overrides(None, &headers)
+            .unwrap()
+            .agent_context
+            .unwrap();
+
+        assert_eq!(agent_context.session_type_id, "codex");
+        assert_eq!(agent_context.session_id, "codex-run");
+        assert_eq!(agent_context.trajectory_id, "codex-run");
+    }
+
+    #[test]
     fn apply_header_routing_overrides_ignores_non_identity_session_headers() {
         use axum::http::{HeaderMap, HeaderName};
 
@@ -955,6 +1028,7 @@ mod tests {
             HEADER_OPENCODE_PARENT_SESSION_ID,
             "header-parent".parse().unwrap(),
         );
+        headers.insert(HEADER_DYNAMO_TRAJECTORY_ID, "generic-run".parse().unwrap());
         let explicit = AgentContext::builder()
             .session_type_id("native".to_string())
             .session_id("native-session".to_string())

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -10,9 +10,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::protocols::TokenIdType;
-use crate::protocols::agents::{
-    AgentContextHeaderValues, DEFAULT_DYNAMO_SESSION_TYPE_ID, agent_context_header_values,
-};
+use crate::protocols::agents::{AgentContextHeaderValues, agent_context_header_values};
 use crate::protocols::common::llm_backend::PromptLogprobs;
 use crate::protocols::common::timing::TimingInfo;
 
@@ -62,13 +60,18 @@ where
 }
 
 /// Identity metadata for agentic workloads.
-#[derive(Serialize, Builder, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Builder, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AgentContext {
     /// Reusable session/profile class.
-    pub session_type_id: String,
+    #[builder(default, setter(strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_type_id: Option<String>,
 
     /// Top-level agent run/session identifier.
-    pub session_id: String,
+    #[builder(default, setter(strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 
     /// Schedulable reasoning/tool trajectory identifier.
     pub trajectory_id: String,
@@ -88,38 +91,6 @@ pub struct AgentContext {
 impl AgentContext {
     pub fn builder() -> AgentContextBuilder {
         AgentContextBuilder::default()
-    }
-}
-
-impl<'de> Deserialize<'de> for AgentContext {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct AgentContextWire {
-            session_type_id: Option<String>,
-            session_id: Option<String>,
-            trajectory_id: String,
-            #[serde(default)]
-            parent_trajectory_id: Option<String>,
-            #[serde(default)]
-            trajectory_final: Option<bool>,
-        }
-
-        let wire = AgentContextWire::deserialize(deserializer)?;
-        Ok(Self {
-            session_type_id: wire
-                .session_type_id
-                .unwrap_or_else(|| DEFAULT_DYNAMO_SESSION_TYPE_ID.to_string()),
-            session_id: wire
-                .session_id
-                .unwrap_or_else(|| wire.trajectory_id.clone()),
-            trajectory_id: wire.trajectory_id,
-            parent_trajectory_id: wire.parent_trajectory_id,
-            trajectory_final: wire.trajectory_final,
-        })
     }
 }
 
@@ -309,8 +280,8 @@ const UNSET_DP_RANK_SENTINEL: u32 = u32::MAX;
 impl From<AgentContextHeaderValues> for AgentContext {
     fn from(values: AgentContextHeaderValues) -> Self {
         Self {
-            session_type_id: values.session_type_id.to_string(),
-            session_id: values.session_id.clone(),
+            session_type_id: Some(values.session_type_id.to_string()),
+            session_id: values.session_id,
             trajectory_id: values.trajectory_id,
             parent_trajectory_id: values.parent_trajectory_id,
             trajectory_final: None,
@@ -331,8 +302,8 @@ impl From<AgentContextHeaderValues> for AgentContext {
 /// - coding-agent source -> `agent_context.session_type_id`
 /// - configured coding-agent parent session headers ->
 ///   `agent_context.parent_trajectory_id`
-/// - `x-dynamo-trajectory-id` -> generic `agent_context` with
-///   `session_id=trajectory_id` and `session_type_id=dynamo`
+/// - `x-dynamo-trajectory-id` -> generic `agent_context.trajectory_id`
+///   with `session_type_id=dynamo`
 ///
 /// Routing headers take priority over existing nvext values when present.
 /// Explicit `nvext.agent_context` takes priority over coding-agent headers.
@@ -413,11 +384,12 @@ pub fn validate_nvext_semantics(nvext: Option<&NvExt>) -> anyhow::Result<()> {
     };
 
     if let Some(agent_context) = nvext.agent_context.as_ref() {
-        validate_non_empty(
-            &agent_context.session_type_id,
-            "nvext.agent_context.session_type_id",
-        )?;
-        validate_non_empty(&agent_context.session_id, "nvext.agent_context.session_id")?;
+        if let Some(session_type_id) = agent_context.session_type_id.as_ref() {
+            validate_non_empty(session_type_id, "nvext.agent_context.session_type_id")?;
+        }
+        if let Some(session_id) = agent_context.session_id.as_ref() {
+            validate_non_empty(session_id, "nvext.agent_context.session_id")?;
+        }
         validate_non_empty(
             &agent_context.trajectory_id,
             "nvext.agent_context.trajectory_id",
@@ -769,8 +741,8 @@ mod tests {
     fn shared_agent_context_semantics_reject_empty_required_ids() {
         let nvext = NvExt::builder()
             .agent_context(AgentContext {
-                session_type_id: "deep_research:v1".to_string(),
-                session_id: "run-123".to_string(),
+                session_type_id: Some("deep_research:v1".to_string()),
+                session_id: Some("run-123".to_string()),
                 trajectory_id: " ".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,
@@ -786,7 +758,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_context_serde_defaults_missing_session_fields() {
+    fn agent_context_serde_accepts_trajectory_only() {
         let json = r#"{
             "agent_context": {
                 "trajectory_id": "run-123:researcher-0"
@@ -795,8 +767,8 @@ mod tests {
 
         let nvext = serde_json::from_str::<NvExt>(json).unwrap();
         let agent_context = nvext.agent_context.unwrap();
-        assert_eq!(agent_context.session_type_id, "dynamo");
-        assert_eq!(agent_context.session_id, "run-123:researcher-0");
+        assert_eq!(agent_context.session_type_id, None);
+        assert_eq!(agent_context.session_id, None);
         assert_eq!(agent_context.trajectory_id, "run-123:researcher-0");
     }
 
@@ -902,14 +874,23 @@ mod tests {
                 "claude-run-1",
                 None,
                 "claude_code",
+                Some("claude-run-1"),
                 None,
             ),
-            ("Session-ID", "codex-run-1", None, "codex", None),
+            (
+                "Session-ID",
+                "codex-run-1",
+                None,
+                "codex",
+                Some("codex-run-1"),
+                None,
+            ),
             (
                 HEADER_CODEX_SESSION_ID,
                 "codex-run-2",
                 Some("opencode-parent"),
                 "codex",
+                Some("codex-run-2"),
                 None,
             ),
             (
@@ -917,6 +898,7 @@ mod tests {
                 "opencode-run-1",
                 Some("parent-run-1"),
                 "opencode",
+                Some("opencode-run-1"),
                 Some("parent-run-1"),
             ),
             (
@@ -924,6 +906,7 @@ mod tests {
                 "generic-run-1",
                 None,
                 "dynamo",
+                None,
                 None,
             ),
         ];
@@ -933,6 +916,7 @@ mod tests {
             header_value,
             parent_header_value,
             expected_session_type_id,
+            expected_session_id,
             expected_parent_trajectory_id,
         ) in cases
         {
@@ -951,14 +935,14 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 (
-                    agent_context.session_type_id.as_str(),
-                    agent_context.session_id.as_str(),
+                    agent_context.session_type_id.as_deref(),
+                    agent_context.session_id.as_deref(),
                     agent_context.trajectory_id.as_str(),
                     agent_context.parent_trajectory_id.as_deref(),
                 ),
                 (
-                    expected_session_type_id,
-                    header_value,
+                    Some(expected_session_type_id),
+                    expected_session_id,
                     header_value,
                     expected_parent_trajectory_id,
                 )
@@ -980,8 +964,11 @@ mod tests {
             .agent_context
             .unwrap();
 
-        assert_eq!(agent_context.session_type_id, "claude_code");
-        assert_eq!(agent_context.session_id, "claude-session");
+        assert_eq!(
+            agent_context.session_type_id.as_deref(),
+            Some("claude_code")
+        );
+        assert_eq!(agent_context.session_id.as_deref(), Some("claude-session"));
         assert_eq!(agent_context.trajectory_id, "claude-agent");
         assert_eq!(
             agent_context.parent_trajectory_id.as_deref(),
@@ -1000,8 +987,8 @@ mod tests {
             .agent_context
             .unwrap();
 
-        assert_eq!(agent_context.session_type_id, "codex");
-        assert_eq!(agent_context.session_id, "codex-run");
+        assert_eq!(agent_context.session_type_id.as_deref(), Some("codex"));
+        assert_eq!(agent_context.session_id.as_deref(), Some("codex-run"));
         assert_eq!(agent_context.trajectory_id, "codex-run");
     }
 

--- a/lib/llm/src/request_trace/agent_context.rs
+++ b/lib/llm/src/request_trace/agent_context.rs
@@ -632,8 +632,8 @@ mod tests {
 
         let trace_state = AgentContextTraceState {
             agent_context: AgentContext {
-                session_type_id: "agent_harness".to_string(),
-                session_id: "run-finish".to_string(),
+                session_type_id: Some("agent_harness".to_string()),
+                session_id: Some("run-finish".to_string()),
                 trajectory_id: "run-finish:agent".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,
@@ -748,8 +748,8 @@ mod tests {
 
         let trace_state = AgentContextTraceState {
             agent_context: AgentContext {
-                session_type_id: "agent_harness".to_string(),
-                session_id: "run-completion-finish".to_string(),
+                session_type_id: Some("agent_harness".to_string()),
+                session_id: Some("run-completion-finish".to_string()),
                 trajectory_id: "run-completion-finish:agent".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,

--- a/lib/llm/src/request_trace/integration.rs
+++ b/lib/llm/src/request_trace/integration.rs
@@ -366,8 +366,8 @@ mod tests {
         let state = RequestEndTraceState {
             agent: Some(AgentContextTraceState {
                 agent_context: AgentContext {
-                    session_type_id: "agent_harness".to_string(),
-                    session_id: "run-1".to_string(),
+                    session_type_id: Some("agent_harness".to_string()),
+                    session_id: Some("run-1".to_string()),
                     trajectory_id: "root".to_string(),
                     parent_trajectory_id: None,
                     trajectory_final: None,
@@ -440,8 +440,8 @@ mod tests {
             ..Default::default()
         });
         request.agent_context = Some(AgentContext {
-            session_type_id: "agent_harness".to_string(),
-            session_id: "run-unsupported".to_string(),
+            session_type_id: Some("agent_harness".to_string()),
+            session_id: Some("run-unsupported".to_string()),
             trajectory_id: "root".to_string(),
             parent_trajectory_id: None,
             trajectory_final: None,

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -209,8 +209,8 @@ mod tests {
             event_time_unix_ms: 2_000,
             event_source: Some(RequestTraceEventSource::Harness),
             agent_context: Some(AgentContext {
-                session_type_id: "agent_harness".to_string(),
-                session_id: "run-1".to_string(),
+                session_type_id: Some("agent_harness".to_string()),
+                session_id: Some("run-1".to_string()),
                 trajectory_id: "root".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,

--- a/lib/llm/src/request_trace/tool_relay.rs
+++ b/lib/llm/src/request_trace/tool_relay.rs
@@ -173,8 +173,8 @@ mod tests {
             event_time_unix_ms: 1,
             event_source: Some(RequestTraceEventSource::Harness),
             agent_context: Some(AgentContext {
-                session_type_id: "agent_harness".to_string(),
-                session_id: "run-1".to_string(),
+                session_type_id: Some("agent_harness".to_string()),
+                session_id: Some("run-1".to_string()),
                 trajectory_id: "run-1:agent".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,
@@ -247,7 +247,7 @@ mod tests {
                 assert_eq!(record.event_source, Some(RequestTraceEventSource::Harness));
                 assert_eq!(
                     record.agent_context.expect("agent context").session_id,
-                    "run-1"
+                    Some("run-1".to_string())
                 );
                 assert_eq!(record.tool.unwrap().tool_call_id, "tool-123");
 

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -574,8 +574,11 @@ pub mod openai_preprocessor_tests {
         let agent_context = preprocessed_request
             .agent_context
             .expect("agent_context should propagate");
-        assert_eq!(agent_context.session_type_id, "deep_research:v1");
-        assert_eq!(agent_context.session_id, "run-123");
+        assert_eq!(
+            agent_context.session_type_id.as_deref(),
+            Some("deep_research:v1")
+        );
+        assert_eq!(agent_context.session_id.as_deref(), Some("run-123"));
         assert_eq!(agent_context.trajectory_id, "run-123:researcher-0");
         assert_eq!(
             agent_context.parent_trajectory_id.as_deref(),


### PR DESCRIPTION
<!-- codex-pr-description:start -->
### Summary
Adds the generic `x-dynamo-trajectory-id` HTTP fallback and makes `trajectory_id` the only required `agent_context` identity field. This lets generic/non-first-class agents provide one trajectory header while keeping `session_id` absent unless the caller or a first-class agent supplies it.

Linear: DYN-3247

### How This Was Implemented
- Added `x-dynamo-trajectory-id` with generic `session_type_id="dynamo"` and no synthesized `session_id`.
- Kept precedence as explicit `nvext.agent_context` > first-class coding-agent headers > generic Dynamo header > absent context.
- Removed the custom `AgentContext` deserializer and made `session_type_id` / `session_id` optional fields directly.
- Moved the detailed tracing contract into agent tracing docs and kept the nvext reference brief.

<details>
<summary>Walkthrough</summary>

- `lib/llm/src/protocols/agents.rs`: adds the generic fallback header after first-class agent mappings and leaves generic `session_id` unset.
- `lib/llm/src/protocols/common/extensions.rs`: makes only `trajectory_id` required, validates optional IDs when present, and covers precedence/default behavior in unit tests.
- `docs/agents/agent-tracing.md`: puts `trajectory_id` first and documents generic header synthesis.
- `docs/components/frontend/nvext.md`: links to agent tracing instead of duplicating the full contract.

</details>

### Validation
- `cargo test -p dynamo-llm protocols::common::extensions::tests --lib` (30 passed).
- `cargo test -p dynamo-llm --test preprocessor test_agent_context_propagates_to_preprocessed_request` (1 passed).
<!-- codex-pr-description:end -->
