### PR TITLE
fix(llm): accept generic trajectory identity

### DIFF
--- a/docs/agents/agent-tracing.md
+++ b/docs/agents/agent-tracing.md
@@ -32,8 +32,8 @@ Inject `agent_context` into each LLM request
 
 | Field                  | Required | Meaning                                  |
 | ---------------------- | :------: | ---------------------------------------- |
-| `session_type_id`      |   Yes    | Workload class (e.g. `deep_research`).   |
-| `session_id`           |   Yes    | Whole agent run.                         |
+| `session_type_id`      |    No    | Workload class; defaults to `dynamo`.    |
+| `session_id`           |    No    | Whole agent run; defaults to `trajectory_id`. |
 | `trajectory_id`        |   Yes    | One reasoning/tool chain inside the run. |
 | `parent_trajectory_id` |    No    | Parent trajectory when using subagents.  |
 | `trajectory_final`     |    No    | `true` marks the trajectory's last request — a cleanup hint. |

--- a/docs/agents/agent-tracing.md
+++ b/docs/agents/agent-tracing.md
@@ -32,11 +32,17 @@ Inject `agent_context` into each LLM request
 
 | Field                  | Required | Meaning                                  |
 | ---------------------- | :------: | ---------------------------------------- |
-| `session_type_id`      |    No    | Workload class; defaults to `dynamo`.    |
-| `session_id`           |    No    | Whole agent run; defaults to `trajectory_id`. |
 | `trajectory_id`        |   Yes    | One reasoning/tool chain inside the run. |
+| `session_type_id`      |    No    | Workload class.                          |
+| `session_id`           |    No    | Whole agent run.                         |
 | `parent_trajectory_id` |    No    | Parent trajectory when using subagents.  |
 | `trajectory_final`     |    No    | `true` marks the trajectory's last request — a cleanup hint. |
+
+For generic HTTP clients, `x-dynamo-trajectory-id` is enough to synthesize
+`agent_context`. Dynamo sets `trajectory_id` from the header, sets
+`session_type_id` to `dynamo`, and leaves `session_id`,
+`parent_trajectory_id`, and `trajectory_final` unset. Explicit
+`nvext.agent_context` takes precedence over all identity headers.
 
 `trajectory_final` is an optional terminal marker: set it to `true` to signal that a
 trajectory is finished. Lifecycle-aware backends use it to release whatever

--- a/docs/components/frontend/nvext.md
+++ b/docs/components/frontend/nvext.md
@@ -74,10 +74,16 @@ agentic requests. Dynamo uses this metadata to emit enriched request traces when
 request tracing is enabled. It does not change routing, scheduling, or cache
 behavior.
 
+For generic HTTP clients, `x-dynamo-trajectory-id` is enough to synthesize
+`agent_context`: Dynamo uses that value for both `trajectory_id` and
+`session_id`, sets `session_type_id` to `"dynamo"`, and leaves
+`parent_trajectory_id` and `trajectory_final` unset. Explicit
+`nvext.agent_context` remains the richer/manual path and takes precedence.
+
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `session_type_id` | `string` | Yes | Reusable profile or agent class label. |
-| `session_id` | `string` | Yes | Top-level agent run/session identifier. |
+| `session_type_id` | `string` | No | Reusable profile or agent class label. Defaults to `"dynamo"` when omitted. |
+| `session_id` | `string` | No | Top-level agent run/session identifier. Defaults to `trajectory_id` when omitted. |
 | `trajectory_id` | `string` | Yes | One schedulable reasoning/tool trajectory. |
 | `parent_trajectory_id` | `string` | No | Parent trajectory, typically for subagents. |
 | `trajectory_final` | `bool` | No | Terminal marker for lifecycle-aware consumers; ignored by consumers that do not track trajectory lifecycle. |

--- a/docs/components/frontend/nvext.md
+++ b/docs/components/frontend/nvext.md
@@ -74,17 +74,16 @@ agentic requests. Dynamo uses this metadata to emit enriched request traces when
 request tracing is enabled. It does not change routing, scheduling, or cache
 behavior.
 
-For generic HTTP clients, `x-dynamo-trajectory-id` is enough to synthesize
-`agent_context`: Dynamo uses that value for both `trajectory_id` and
-`session_id`, sets `session_type_id` to `"dynamo"`, and leaves
-`parent_trajectory_id` and `trajectory_final` unset. Explicit
-`nvext.agent_context` remains the richer/manual path and takes precedence.
+Generic HTTP clients can send `x-dynamo-trajectory-id` instead of a body
+`agent_context`; Dynamo synthesizes the passive identity at the HTTP boundary.
+For the full header precedence and tracing contract, see
+[Agent Tracing](../../agents/agent-tracing.md).
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `session_type_id` | `string` | No | Reusable profile or agent class label. Defaults to `"dynamo"` when omitted. |
-| `session_id` | `string` | No | Top-level agent run/session identifier. Defaults to `trajectory_id` when omitted. |
 | `trajectory_id` | `string` | Yes | One schedulable reasoning/tool trajectory. |
+| `session_type_id` | `string` | No | Reusable profile or agent class label. |
+| `session_id` | `string` | No | Top-level agent run/session identifier. |
 | `parent_trajectory_id` | `string` | No | Parent trajectory, typically for subagents. |
 | `trajectory_final` | `bool` | No | Terminal marker for lifecycle-aware consumers; ignored by consumers that do not track trajectory lifecycle. |
 

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -882,8 +882,8 @@ mod tests {
         assert_eq!(
             nvext.and_then(|ext| ext.agent_context),
             Some(AgentContext {
-                session_type_id: "deep_research:v1".to_string(),
-                session_id: "run-123".to_string(),
+                session_type_id: Some("deep_research:v1".to_string()),
+                session_id: Some("run-123".to_string()),
                 trajectory_id: "run-123:researcher-0".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -539,6 +539,7 @@ fn copy_x_request_id<T: Send + Sync + 'static, U: Send + Sync + 'static>(
 /// Warn (once per request) when nvext data is dropped because the extension is
 /// disabled. Only called from the disabled branch, so the default path is free.
 fn warn_nvext_disabled(endpoint: &str, nvext_present: bool, headers: &HeaderMap) {
+    use crate::protocols::agents::has_agent_headers;
     use crate::protocols::common::extensions::{
         HEADER_DP_RANK, HEADER_DP_RANK_ALIAS, HEADER_PREFILL_DP_RANK, HEADER_PREFILL_INSTANCE_ID,
         HEADER_WORKER_INSTANCE_ID,
@@ -551,7 +552,8 @@ fn warn_nvext_disabled(endpoint: &str, nvext_present: bool, headers: &HeaderMap)
         HEADER_PREFILL_DP_RANK,
     ]
     .iter()
-    .any(|h| headers.contains_key(*h));
+    .any(|h| headers.contains_key(*h))
+        || has_agent_headers(headers);
 
     if nvext_present || header_present {
         tracing::warn!(

--- a/lib/llm/src/protocols.rs
+++ b/lib/llm/src/protocols.rs
@@ -10,6 +10,7 @@
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 
+pub(crate) mod agents;
 pub mod anthropic;
 pub mod codec;
 pub mod common;

--- a/lib/llm/src/protocols.rs
+++ b/lib/llm/src/protocols.rs
@@ -10,7 +10,7 @@
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 
-pub(crate) mod agents;
+pub mod agents;
 pub mod anthropic;
 pub mod codec;
 pub mod common;

--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -10,6 +10,8 @@ pub(crate) const HEADER_CLAUDE_CODE_AGENT_ID: &str = "x-claude-code-agent-id";
 pub(crate) const HEADER_CODEX_SESSION_ID: &str = "session-id";
 pub(crate) const HEADER_OPENCODE_SESSION_ID: &str = "x-session-id";
 pub(crate) const HEADER_OPENCODE_PARENT_SESSION_ID: &str = "x-parent-session-id";
+pub(crate) const HEADER_DYNAMO_TRAJECTORY_ID: &str = "x-dynamo-trajectory-id";
+pub(crate) const DEFAULT_DYNAMO_SESSION_TYPE_ID: &str = "dynamo";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct AgentHeaderMapping {
@@ -81,17 +83,25 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
             parent_trajectory_id,
         });
     }
-    None
+    header_value(headers, HEADER_DYNAMO_TRAJECTORY_ID).map(|trajectory_id| {
+        AgentContextHeaderValues {
+            session_type_id: DEFAULT_DYNAMO_SESSION_TYPE_ID,
+            session_id: trajectory_id.clone(),
+            trajectory_id,
+            parent_trajectory_id: None,
+        }
+    })
 }
 
 pub(crate) fn has_agent_headers(headers: &HeaderMap) -> bool {
-    AGENT_HEADER_MAPPINGS.iter().any(|mapping| {
-        headers.contains_key(mapping.session_header)
-            || mapping
-                .trajectory_header
-                .is_some_and(|trajectory_header| headers.contains_key(trajectory_header))
-            || mapping
-                .parent_session_header
-                .is_some_and(|parent_header| headers.contains_key(parent_header))
-    })
+    headers.contains_key(HEADER_DYNAMO_TRAJECTORY_ID)
+        || AGENT_HEADER_MAPPINGS.iter().any(|mapping| {
+            headers.contains_key(mapping.session_header)
+                || mapping
+                    .trajectory_header
+                    .is_some_and(|trajectory_header| headers.contains_key(trajectory_header))
+                || mapping
+                    .parent_session_header
+                    .is_some_and(|parent_header| headers.contains_key(parent_header))
+        })
 }

--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -49,7 +49,7 @@ const AGENT_HEADER_MAPPINGS: &[AgentHeaderMapping] = &[
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AgentContextHeaderValues {
     pub(crate) session_type_id: &'static str,
-    pub(crate) session_id: String,
+    pub(crate) session_id: Option<String>,
     pub(crate) trajectory_id: String,
     pub(crate) parent_trajectory_id: Option<String>,
 }
@@ -78,7 +78,7 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
 
         return Some(AgentContextHeaderValues {
             session_type_id: mapping.session_type_id,
-            session_id,
+            session_id: Some(session_id),
             trajectory_id,
             parent_trajectory_id,
         });
@@ -86,7 +86,7 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
     header_value(headers, HEADER_DYNAMO_TRAJECTORY_ID).map(|trajectory_id| {
         AgentContextHeaderValues {
             session_type_id: DEFAULT_DYNAMO_SESSION_TYPE_ID,
-            session_id: trajectory_id.clone(),
+            session_id: None,
             trajectory_id,
             parent_trajectory_id: None,
         }

--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Coding-agent request metadata recognized at Dynamo's HTTP boundary.
+
+use axum::http::HeaderMap;
+
+pub(crate) const HEADER_CLAUDE_CODE_SESSION_ID: &str = "x-claude-code-session-id";
+pub(crate) const HEADER_CODEX_SESSION_ID: &str = "session-id";
+pub(crate) const HEADER_OPENCODE_SESSION_ID: &str = "x-session-id";
+pub(crate) const HEADER_OPENCODE_PARENT_SESSION_ID: &str = "x-parent-session-id";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AgentHeaderMapping {
+    session_type_id: &'static str,
+    session_header: &'static str,
+    parent_session_header: Option<&'static str>,
+}
+
+const AGENT_HEADER_MAPPINGS: &[AgentHeaderMapping] = &[
+    AgentHeaderMapping {
+        session_type_id: "claude_code",
+        session_header: HEADER_CLAUDE_CODE_SESSION_ID,
+        parent_session_header: None,
+    },
+    AgentHeaderMapping {
+        session_type_id: "codex",
+        session_header: HEADER_CODEX_SESSION_ID,
+        parent_session_header: None,
+    },
+    AgentHeaderMapping {
+        session_type_id: "opencode",
+        session_header: HEADER_OPENCODE_SESSION_ID,
+        parent_session_header: Some(HEADER_OPENCODE_PARENT_SESSION_ID),
+    },
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentContextHeaderValues {
+    pub(crate) session_type_id: &'static str,
+    pub(crate) session_id: String,
+    pub(crate) parent_trajectory_id: Option<String>,
+}
+
+fn header_value(headers: &HeaderMap, header_name: &str) -> Option<String> {
+    let value = headers.get(header_name)?.to_str().ok()?.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentContextHeaderValues> {
+    for mapping in AGENT_HEADER_MAPPINGS {
+        let Some(session_id) = header_value(headers, mapping.session_header) else {
+            continue;
+        };
+        let parent_trajectory_id = mapping
+            .parent_session_header
+            .and_then(|parent_header| header_value(headers, parent_header));
+
+        return Some(AgentContextHeaderValues {
+            session_type_id: mapping.session_type_id,
+            session_id,
+            parent_trajectory_id,
+        });
+    }
+    None
+}
+
+pub(crate) fn has_agent_headers(headers: &HeaderMap) -> bool {
+    AGENT_HEADER_MAPPINGS.iter().any(|mapping| {
+        headers.contains_key(mapping.session_header)
+            || mapping
+                .parent_session_header
+                .is_some_and(|parent_header| headers.contains_key(parent_header))
+    })
+}

--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -6,6 +6,7 @@
 use axum::http::HeaderMap;
 
 pub(crate) const HEADER_CLAUDE_CODE_SESSION_ID: &str = "x-claude-code-session-id";
+pub(crate) const HEADER_CLAUDE_CODE_AGENT_ID: &str = "x-claude-code-agent-id";
 pub(crate) const HEADER_CODEX_SESSION_ID: &str = "session-id";
 pub(crate) const HEADER_OPENCODE_SESSION_ID: &str = "x-session-id";
 pub(crate) const HEADER_OPENCODE_PARENT_SESSION_ID: &str = "x-parent-session-id";
@@ -14,24 +15,32 @@ pub(crate) const HEADER_OPENCODE_PARENT_SESSION_ID: &str = "x-parent-session-id"
 struct AgentHeaderMapping {
     session_type_id: &'static str,
     session_header: &'static str,
+    trajectory_header: Option<&'static str>,
     parent_session_header: Option<&'static str>,
+    infer_parent_from_session_for_child: bool,
 }
 
 const AGENT_HEADER_MAPPINGS: &[AgentHeaderMapping] = &[
     AgentHeaderMapping {
         session_type_id: "claude_code",
         session_header: HEADER_CLAUDE_CODE_SESSION_ID,
+        trajectory_header: Some(HEADER_CLAUDE_CODE_AGENT_ID),
         parent_session_header: None,
+        infer_parent_from_session_for_child: true,
     },
     AgentHeaderMapping {
         session_type_id: "codex",
         session_header: HEADER_CODEX_SESSION_ID,
+        trajectory_header: None,
         parent_session_header: None,
+        infer_parent_from_session_for_child: false,
     },
     AgentHeaderMapping {
         session_type_id: "opencode",
         session_header: HEADER_OPENCODE_SESSION_ID,
+        trajectory_header: None,
         parent_session_header: Some(HEADER_OPENCODE_PARENT_SESSION_ID),
+        infer_parent_from_session_for_child: false,
     },
 ];
 
@@ -39,6 +48,7 @@ const AGENT_HEADER_MAPPINGS: &[AgentHeaderMapping] = &[
 pub(crate) struct AgentContextHeaderValues {
     pub(crate) session_type_id: &'static str,
     pub(crate) session_id: String,
+    pub(crate) trajectory_id: String,
     pub(crate) parent_trajectory_id: Option<String>,
 }
 
@@ -52,13 +62,22 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
         let Some(session_id) = header_value(headers, mapping.session_header) else {
             continue;
         };
+        let trajectory_id = mapping
+            .trajectory_header
+            .and_then(|trajectory_header| header_value(headers, trajectory_header))
+            .unwrap_or_else(|| session_id.clone());
         let parent_trajectory_id = mapping
             .parent_session_header
-            .and_then(|parent_header| header_value(headers, parent_header));
+            .and_then(|parent_header| header_value(headers, parent_header))
+            .or_else(|| {
+                (mapping.infer_parent_from_session_for_child && trajectory_id != session_id)
+                    .then(|| session_id.clone())
+            });
 
         return Some(AgentContextHeaderValues {
             session_type_id: mapping.session_type_id,
             session_id,
+            trajectory_id,
             parent_trajectory_id,
         });
     }
@@ -68,6 +87,9 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
 pub(crate) fn has_agent_headers(headers: &HeaderMap) -> bool {
     AGENT_HEADER_MAPPINGS.iter().any(|mapping| {
         headers.contains_key(mapping.session_header)
+            || mapping
+                .trajectory_header
+                .is_some_and(|trajectory_header| headers.contains_key(trajectory_header))
             || mapping
                 .parent_session_header
                 .is_some_and(|parent_header| headers.contains_key(parent_header))

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -641,8 +641,8 @@ mod tests {
         assert_eq!(
             chat_req.nvext.and_then(|ext| ext.agent_context),
             Some(AgentContext {
-                session_type_id: "deep_research:v1".to_string(),
-                session_id: "run-123".to_string(),
+                session_type_id: Some("deep_research:v1".to_string()),
+                session_id: Some("run-123".to_string()),
                 trajectory_id: "run-123:researcher-0".to_string(),
                 parent_trajectory_id: Some("run-123:root".to_string()),
                 trajectory_final: Some(false),

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::protocols::TokenIdType;
+use crate::protocols::agents::{AgentContextHeaderValues, agent_context_header_values};
 use crate::protocols::common::llm_backend::PromptLogprobs;
 use crate::protocols::common::timing::TimingInfo;
 
@@ -272,7 +273,34 @@ pub const HEADER_DP_RANK_ALIAS: &str = "x-data-parallel-rank";
 pub const HEADER_PREFILL_DP_RANK: &str = "x-prefill-dp-rank";
 const UNSET_DP_RANK_SENTINEL: u32 = u32::MAX;
 
-/// Apply routing overrides from HTTP headers to nvext.
+impl From<AgentContextHeaderValues> for AgentContext {
+    fn from(values: AgentContextHeaderValues) -> Self {
+        Self {
+            session_type_id: values.session_type_id.to_string(),
+            session_id: values.session_id.clone(),
+            trajectory_id: values.session_id,
+            parent_trajectory_id: values.parent_trajectory_id,
+            trajectory_final: None,
+        }
+    }
+}
+
+/// Apply HTTP header overrides to nvext.
+///
+/// Header mappings:
+/// - `x-worker-instance-id` -> `backend_instance_id` and `decode_worker_id`
+/// - `x-prefill-instance-id` -> `prefill_worker_id`
+/// - `x-dp-rank` -> `dp_rank` (decode worker's DP rank)
+/// - `x-prefill-dp-rank` -> `prefill_dp_rank`
+/// - coding-agent session headers -> `agent_context.session_id` and
+///   `agent_context.trajectory_id`
+/// - coding-agent source -> `agent_context.session_type_id`
+/// - configured coding-agent parent session headers ->
+///   `agent_context.parent_trajectory_id`
+///
+/// Routing headers take priority over existing nvext values when present.
+/// Explicit `nvext.agent_context` takes priority over coding-agent headers.
+/// If no headers are present, returns the original nvext unchanged.
 pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap) -> Option<NvExt> {
     let worker_id = headers
         .get(HEADER_WORKER_INSTANCE_ID)
@@ -296,7 +324,20 @@ pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap)
         .and_then(|s| s.parse::<u32>().ok());
     let prefill_dp_rank = prefill_dp_rank.filter(|rank| *rank != UNSET_DP_RANK_SENTINEL);
 
-    if worker_id.is_none() && prefill_id.is_none() && dp_rank.is_none() && prefill_dp_rank.is_none()
+    let has_agent_context = nvext
+        .as_ref()
+        .is_some_and(|ext| ext.agent_context.is_some());
+    let header_agent_context = if has_agent_context {
+        None
+    } else {
+        agent_context_header_values(headers).map(AgentContext::from)
+    };
+
+    if worker_id.is_none()
+        && prefill_id.is_none()
+        && dp_rank.is_none()
+        && prefill_dp_rank.is_none()
+        && header_agent_context.is_none()
     {
         return nvext;
     }
@@ -314,6 +355,9 @@ pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap)
     }
     if let Some(rank) = prefill_dp_rank {
         ext.prefill_dp_rank = Some(rank);
+    }
+    if ext.agent_context.is_none() {
+        ext.agent_context = header_agent_context;
     }
     Some(ext)
 }
@@ -604,6 +648,10 @@ pub(crate) fn validate_completion_token_ids_single_choice(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocols::agents::{
+        HEADER_CLAUDE_CODE_SESSION_ID, HEADER_CODEX_SESSION_ID, HEADER_OPENCODE_PARENT_SESSION_ID,
+        HEADER_OPENCODE_SESSION_ID,
+    };
 
     #[test]
     fn shared_nvext_builder_default() {
@@ -791,6 +839,113 @@ mod tests {
         assert_eq!(result.prefill_worker_id, Some(456));
         assert_eq!(result.dp_rank, Some(3));
         assert_eq!(result.prefill_dp_rank, Some(5));
+    }
+
+    #[test]
+    fn apply_header_routing_overrides_derives_agent_context_table() {
+        use axum::http::{HeaderMap, HeaderName};
+
+        let cases = [
+            (
+                HEADER_CLAUDE_CODE_SESSION_ID,
+                "claude-run-1",
+                None,
+                "claude_code",
+                None,
+            ),
+            ("Session-ID", "codex-run-1", None, "codex", None),
+            (
+                HEADER_CODEX_SESSION_ID,
+                "codex-run-2",
+                Some("opencode-parent"),
+                "codex",
+                None,
+            ),
+            (
+                HEADER_OPENCODE_SESSION_ID,
+                "opencode-run-1",
+                Some("parent-run-1"),
+                "opencode",
+                Some("parent-run-1"),
+            ),
+        ];
+
+        for (
+            header_name,
+            header_value,
+            parent_header_value,
+            expected_session_type_id,
+            expected_parent_trajectory_id,
+        ) in cases
+        {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                header_name.parse::<HeaderName>().unwrap(),
+                header_value.parse().unwrap(),
+            );
+            if let Some(parent) = parent_header_value {
+                headers.insert(HEADER_OPENCODE_PARENT_SESSION_ID, parent.parse().unwrap());
+            }
+
+            let agent_context = apply_header_routing_overrides(None, &headers)
+                .unwrap()
+                .agent_context
+                .unwrap();
+            assert_eq!(
+                (
+                    agent_context.session_type_id.as_str(),
+                    agent_context.session_id.as_str(),
+                    agent_context.trajectory_id.as_str(),
+                    agent_context.parent_trajectory_id.as_deref(),
+                ),
+                (
+                    expected_session_type_id,
+                    header_value,
+                    header_value,
+                    expected_parent_trajectory_id,
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn apply_header_routing_overrides_ignores_non_identity_session_headers() {
+        use axum::http::{HeaderMap, HeaderName};
+
+        for header_name in ["x-session-affinity", "session_id"] {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                header_name.parse::<HeaderName>().unwrap(),
+                "session-value".parse().unwrap(),
+            );
+
+            assert!(apply_header_routing_overrides(None, &headers).is_none());
+        }
+    }
+
+    #[test]
+    fn apply_header_routing_overrides_explicit_agent_context_wins() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_CODEX_SESSION_ID, "header-run".parse().unwrap());
+        headers.insert(
+            HEADER_OPENCODE_PARENT_SESSION_ID,
+            "header-parent".parse().unwrap(),
+        );
+        let explicit = AgentContext::builder()
+            .session_type_id("native".to_string())
+            .session_id("native-session".to_string())
+            .trajectory_id("native-trajectory".to_string())
+            .parent_trajectory_id("native-parent".to_string())
+            .build()
+            .unwrap();
+        let nvext = NvExt::builder()
+            .agent_context(explicit.clone())
+            .build()
+            .unwrap();
+
+        let result = apply_header_routing_overrides(Some(nvext), &headers).unwrap();
+
+        assert_eq!(result.agent_context, Some(explicit));
     }
 
     #[test]

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::protocols::TokenIdType;
-use crate::protocols::agents::{AgentContextHeaderValues, agent_context_header_values};
+use crate::protocols::agents::{
+    AgentContextHeaderValues, DEFAULT_DYNAMO_SESSION_TYPE_ID, agent_context_header_values,
+};
 use crate::protocols::common::llm_backend::PromptLogprobs;
 use crate::protocols::common::timing::TimingInfo;
 
@@ -60,8 +62,7 @@ where
 }
 
 /// Identity metadata for agentic workloads.
-#[derive(Serialize, Deserialize, Builder, Debug, Clone, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[derive(Serialize, Builder, Debug, Clone, PartialEq, Eq)]
 pub struct AgentContext {
     /// Reusable session/profile class.
     pub session_type_id: String,
@@ -74,19 +75,51 @@ pub struct AgentContext {
 
     /// Optional parent trajectory for subagents.
     #[builder(default, setter(strip_option))]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_trajectory_id: Option<String>,
 
     /// Optional terminal marker: when true, this request signals that the
     /// trajectory is complete.
     #[builder(default, setter(strip_option))]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub trajectory_final: Option<bool>,
 }
 
 impl AgentContext {
     pub fn builder() -> AgentContextBuilder {
         AgentContextBuilder::default()
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentContext {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct AgentContextWire {
+            session_type_id: Option<String>,
+            session_id: Option<String>,
+            trajectory_id: String,
+            #[serde(default)]
+            parent_trajectory_id: Option<String>,
+            #[serde(default)]
+            trajectory_final: Option<bool>,
+        }
+
+        let wire = AgentContextWire::deserialize(deserializer)?;
+        Ok(Self {
+            session_type_id: wire
+                .session_type_id
+                .unwrap_or_else(|| DEFAULT_DYNAMO_SESSION_TYPE_ID.to_string()),
+            session_id: wire
+                .session_id
+                .unwrap_or_else(|| wire.trajectory_id.clone()),
+            trajectory_id: wire.trajectory_id,
+            parent_trajectory_id: wire.parent_trajectory_id,
+            trajectory_final: wire.trajectory_final,
+        })
     }
 }
 
@@ -298,6 +331,8 @@ impl From<AgentContextHeaderValues> for AgentContext {
 /// - coding-agent source -> `agent_context.session_type_id`
 /// - configured coding-agent parent session headers ->
 ///   `agent_context.parent_trajectory_id`
+/// - `x-dynamo-trajectory-id` -> generic `agent_context` with
+///   `session_id=trajectory_id` and `session_type_id=dynamo`
 ///
 /// Routing headers take priority over existing nvext values when present.
 /// Explicit `nvext.agent_context` takes priority over coding-agent headers.
@@ -651,7 +686,7 @@ mod tests {
     use super::*;
     use crate::protocols::agents::{
         HEADER_CLAUDE_CODE_AGENT_ID, HEADER_CLAUDE_CODE_SESSION_ID, HEADER_CODEX_SESSION_ID,
-        HEADER_OPENCODE_PARENT_SESSION_ID, HEADER_OPENCODE_SESSION_ID,
+        HEADER_DYNAMO_TRAJECTORY_ID, HEADER_OPENCODE_PARENT_SESSION_ID, HEADER_OPENCODE_SESSION_ID,
     };
 
     #[test]
@@ -751,11 +786,26 @@ mod tests {
     }
 
     #[test]
-    fn agent_context_serde_missing_required_field_fails() {
+    fn agent_context_serde_defaults_missing_session_fields() {
+        let json = r#"{
+            "agent_context": {
+                "trajectory_id": "run-123:researcher-0"
+            }
+        }"#;
+
+        let nvext = serde_json::from_str::<NvExt>(json).unwrap();
+        let agent_context = nvext.agent_context.unwrap();
+        assert_eq!(agent_context.session_type_id, "dynamo");
+        assert_eq!(agent_context.session_id, "run-123:researcher-0");
+        assert_eq!(agent_context.trajectory_id, "run-123:researcher-0");
+    }
+
+    #[test]
+    fn agent_context_serde_missing_trajectory_id_fails() {
         let json = r#"{
             "agent_context": {
                 "session_type_id": "deep_research:v1",
-                "trajectory_id": "run-123:researcher-0"
+                "session_id": "run-123"
             }
         }"#;
 
@@ -869,6 +919,13 @@ mod tests {
                 "opencode",
                 Some("parent-run-1"),
             ),
+            (
+                HEADER_DYNAMO_TRAJECTORY_ID,
+                "generic-run-1",
+                None,
+                "dynamo",
+                None,
+            ),
         ];
 
         for (
@@ -933,6 +990,22 @@ mod tests {
     }
 
     #[test]
+    fn apply_header_routing_overrides_prefers_first_class_agent_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_CODEX_SESSION_ID, "codex-run".parse().unwrap());
+        headers.insert(HEADER_DYNAMO_TRAJECTORY_ID, "generic-run".parse().unwrap());
+
+        let agent_context = apply_header_routing_overrides(None, &headers)
+            .unwrap()
+            .agent_context
+            .unwrap();
+
+        assert_eq!(agent_context.session_type_id, "codex");
+        assert_eq!(agent_context.session_id, "codex-run");
+        assert_eq!(agent_context.trajectory_id, "codex-run");
+    }
+
+    #[test]
     fn apply_header_routing_overrides_ignores_non_identity_session_headers() {
         use axum::http::{HeaderMap, HeaderName};
 
@@ -955,6 +1028,7 @@ mod tests {
             HEADER_OPENCODE_PARENT_SESSION_ID,
             "header-parent".parse().unwrap(),
         );
+        headers.insert(HEADER_DYNAMO_TRAJECTORY_ID, "generic-run".parse().unwrap());
         let explicit = AgentContext::builder()
             .session_type_id("native".to_string())
             .session_id("native-session".to_string())

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -10,9 +10,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::protocols::TokenIdType;
-use crate::protocols::agents::{
-    AgentContextHeaderValues, DEFAULT_DYNAMO_SESSION_TYPE_ID, agent_context_header_values,
-};
+use crate::protocols::agents::{AgentContextHeaderValues, agent_context_header_values};
 use crate::protocols::common::llm_backend::PromptLogprobs;
 use crate::protocols::common::timing::TimingInfo;
 
@@ -62,13 +60,18 @@ where
 }
 
 /// Identity metadata for agentic workloads.
-#[derive(Serialize, Builder, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Builder, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AgentContext {
     /// Reusable session/profile class.
-    pub session_type_id: String,
+    #[builder(default, setter(strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_type_id: Option<String>,
 
     /// Top-level agent run/session identifier.
-    pub session_id: String,
+    #[builder(default, setter(strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 
     /// Schedulable reasoning/tool trajectory identifier.
     pub trajectory_id: String,
@@ -88,38 +91,6 @@ pub struct AgentContext {
 impl AgentContext {
     pub fn builder() -> AgentContextBuilder {
         AgentContextBuilder::default()
-    }
-}
-
-impl<'de> Deserialize<'de> for AgentContext {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(deny_unknown_fields)]
-        struct AgentContextWire {
-            session_type_id: Option<String>,
-            session_id: Option<String>,
-            trajectory_id: String,
-            #[serde(default)]
-            parent_trajectory_id: Option<String>,
-            #[serde(default)]
-            trajectory_final: Option<bool>,
-        }
-
-        let wire = AgentContextWire::deserialize(deserializer)?;
-        Ok(Self {
-            session_type_id: wire
-                .session_type_id
-                .unwrap_or_else(|| DEFAULT_DYNAMO_SESSION_TYPE_ID.to_string()),
-            session_id: wire
-                .session_id
-                .unwrap_or_else(|| wire.trajectory_id.clone()),
-            trajectory_id: wire.trajectory_id,
-            parent_trajectory_id: wire.parent_trajectory_id,
-            trajectory_final: wire.trajectory_final,
-        })
     }
 }
 
@@ -309,8 +280,8 @@ const UNSET_DP_RANK_SENTINEL: u32 = u32::MAX;
 impl From<AgentContextHeaderValues> for AgentContext {
     fn from(values: AgentContextHeaderValues) -> Self {
         Self {
-            session_type_id: values.session_type_id.to_string(),
-            session_id: values.session_id.clone(),
+            session_type_id: Some(values.session_type_id.to_string()),
+            session_id: values.session_id,
             trajectory_id: values.trajectory_id,
             parent_trajectory_id: values.parent_trajectory_id,
             trajectory_final: None,
@@ -331,8 +302,8 @@ impl From<AgentContextHeaderValues> for AgentContext {
 /// - coding-agent source -> `agent_context.session_type_id`
 /// - configured coding-agent parent session headers ->
 ///   `agent_context.parent_trajectory_id`
-/// - `x-dynamo-trajectory-id` -> generic `agent_context` with
-///   `session_id=trajectory_id` and `session_type_id=dynamo`
+/// - `x-dynamo-trajectory-id` -> generic `agent_context.trajectory_id`
+///   with `session_type_id=dynamo`
 ///
 /// Routing headers take priority over existing nvext values when present.
 /// Explicit `nvext.agent_context` takes priority over coding-agent headers.
@@ -413,11 +384,12 @@ pub fn validate_nvext_semantics(nvext: Option<&NvExt>) -> anyhow::Result<()> {
     };
 
     if let Some(agent_context) = nvext.agent_context.as_ref() {
-        validate_non_empty(
-            &agent_context.session_type_id,
-            "nvext.agent_context.session_type_id",
-        )?;
-        validate_non_empty(&agent_context.session_id, "nvext.agent_context.session_id")?;
+        if let Some(session_type_id) = agent_context.session_type_id.as_ref() {
+            validate_non_empty(session_type_id, "nvext.agent_context.session_type_id")?;
+        }
+        if let Some(session_id) = agent_context.session_id.as_ref() {
+            validate_non_empty(session_id, "nvext.agent_context.session_id")?;
+        }
         validate_non_empty(
             &agent_context.trajectory_id,
             "nvext.agent_context.trajectory_id",
@@ -769,8 +741,8 @@ mod tests {
     fn shared_agent_context_semantics_reject_empty_required_ids() {
         let nvext = NvExt::builder()
             .agent_context(AgentContext {
-                session_type_id: "deep_research:v1".to_string(),
-                session_id: "run-123".to_string(),
+                session_type_id: Some("deep_research:v1".to_string()),
+                session_id: Some("run-123".to_string()),
                 trajectory_id: " ".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,
@@ -786,7 +758,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_context_serde_defaults_missing_session_fields() {
+    fn agent_context_serde_accepts_trajectory_only() {
         let json = r#"{
             "agent_context": {
                 "trajectory_id": "run-123:researcher-0"
@@ -795,8 +767,8 @@ mod tests {
 
         let nvext = serde_json::from_str::<NvExt>(json).unwrap();
         let agent_context = nvext.agent_context.unwrap();
-        assert_eq!(agent_context.session_type_id, "dynamo");
-        assert_eq!(agent_context.session_id, "run-123:researcher-0");
+        assert_eq!(agent_context.session_type_id, None);
+        assert_eq!(agent_context.session_id, None);
         assert_eq!(agent_context.trajectory_id, "run-123:researcher-0");
     }
 
@@ -902,14 +874,23 @@ mod tests {
                 "claude-run-1",
                 None,
                 "claude_code",
+                Some("claude-run-1"),
                 None,
             ),
-            ("Session-ID", "codex-run-1", None, "codex", None),
+            (
+                "Session-ID",
+                "codex-run-1",
+                None,
+                "codex",
+                Some("codex-run-1"),
+                None,
+            ),
             (
                 HEADER_CODEX_SESSION_ID,
                 "codex-run-2",
                 Some("opencode-parent"),
                 "codex",
+                Some("codex-run-2"),
                 None,
             ),
             (
@@ -917,6 +898,7 @@ mod tests {
                 "opencode-run-1",
                 Some("parent-run-1"),
                 "opencode",
+                Some("opencode-run-1"),
                 Some("parent-run-1"),
             ),
             (
@@ -924,6 +906,7 @@ mod tests {
                 "generic-run-1",
                 None,
                 "dynamo",
+                None,
                 None,
             ),
         ];
@@ -933,6 +916,7 @@ mod tests {
             header_value,
             parent_header_value,
             expected_session_type_id,
+            expected_session_id,
             expected_parent_trajectory_id,
         ) in cases
         {
@@ -951,14 +935,14 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 (
-                    agent_context.session_type_id.as_str(),
-                    agent_context.session_id.as_str(),
+                    agent_context.session_type_id.as_deref(),
+                    agent_context.session_id.as_deref(),
                     agent_context.trajectory_id.as_str(),
                     agent_context.parent_trajectory_id.as_deref(),
                 ),
                 (
-                    expected_session_type_id,
-                    header_value,
+                    Some(expected_session_type_id),
+                    expected_session_id,
                     header_value,
                     expected_parent_trajectory_id,
                 )
@@ -980,8 +964,11 @@ mod tests {
             .agent_context
             .unwrap();
 
-        assert_eq!(agent_context.session_type_id, "claude_code");
-        assert_eq!(agent_context.session_id, "claude-session");
+        assert_eq!(
+            agent_context.session_type_id.as_deref(),
+            Some("claude_code")
+        );
+        assert_eq!(agent_context.session_id.as_deref(), Some("claude-session"));
         assert_eq!(agent_context.trajectory_id, "claude-agent");
         assert_eq!(
             agent_context.parent_trajectory_id.as_deref(),
@@ -1000,8 +987,8 @@ mod tests {
             .agent_context
             .unwrap();
 
-        assert_eq!(agent_context.session_type_id, "codex");
-        assert_eq!(agent_context.session_id, "codex-run");
+        assert_eq!(agent_context.session_type_id.as_deref(), Some("codex"));
+        assert_eq!(agent_context.session_id.as_deref(), Some("codex-run"));
         assert_eq!(agent_context.trajectory_id, "codex-run");
     }
 

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -278,7 +278,7 @@ impl From<AgentContextHeaderValues> for AgentContext {
         Self {
             session_type_id: values.session_type_id.to_string(),
             session_id: values.session_id.clone(),
-            trajectory_id: values.session_id,
+            trajectory_id: values.trajectory_id,
             parent_trajectory_id: values.parent_trajectory_id,
             trajectory_final: None,
         }
@@ -294,6 +294,7 @@ impl From<AgentContextHeaderValues> for AgentContext {
 /// - `x-prefill-dp-rank` -> `prefill_dp_rank`
 /// - coding-agent session headers -> `agent_context.session_id` and
 ///   `agent_context.trajectory_id`
+/// - coding-agent child trajectory headers -> `agent_context.trajectory_id`
 /// - coding-agent source -> `agent_context.session_type_id`
 /// - configured coding-agent parent session headers ->
 ///   `agent_context.parent_trajectory_id`
@@ -649,8 +650,8 @@ pub(crate) fn validate_completion_token_ids_single_choice(
 mod tests {
     use super::*;
     use crate::protocols::agents::{
-        HEADER_CLAUDE_CODE_SESSION_ID, HEADER_CODEX_SESSION_ID, HEADER_OPENCODE_PARENT_SESSION_ID,
-        HEADER_OPENCODE_SESSION_ID,
+        HEADER_CLAUDE_CODE_AGENT_ID, HEADER_CLAUDE_CODE_SESSION_ID, HEADER_CODEX_SESSION_ID,
+        HEADER_OPENCODE_PARENT_SESSION_ID, HEADER_OPENCODE_SESSION_ID,
     };
 
     #[test]
@@ -906,6 +907,29 @@ mod tests {
                 )
             );
         }
+    }
+
+    #[test]
+    fn apply_header_routing_overrides_uses_claude_agent_id_as_child_trajectory() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HEADER_CLAUDE_CODE_SESSION_ID,
+            "claude-session".parse().unwrap(),
+        );
+        headers.insert(HEADER_CLAUDE_CODE_AGENT_ID, "claude-agent".parse().unwrap());
+
+        let agent_context = apply_header_routing_overrides(None, &headers)
+            .unwrap()
+            .agent_context
+            .unwrap();
+
+        assert_eq!(agent_context.session_type_id, "claude_code");
+        assert_eq!(agent_context.session_id, "claude-session");
+        assert_eq!(agent_context.trajectory_id, "claude-agent");
+        assert_eq!(
+            agent_context.parent_trajectory_id.as_deref(),
+            Some("claude-session")
+        );
     }
 
     #[test]

--- a/lib/llm/src/request_trace/agent_context.rs
+++ b/lib/llm/src/request_trace/agent_context.rs
@@ -632,8 +632,8 @@ mod tests {
 
         let trace_state = AgentContextTraceState {
             agent_context: AgentContext {
-                session_type_id: "agent_harness".to_string(),
-                session_id: "run-finish".to_string(),
+                session_type_id: Some("agent_harness".to_string()),
+                session_id: Some("run-finish".to_string()),
                 trajectory_id: "run-finish:agent".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,
@@ -748,8 +748,8 @@ mod tests {
 
         let trace_state = AgentContextTraceState {
             agent_context: AgentContext {
-                session_type_id: "agent_harness".to_string(),
-                session_id: "run-completion-finish".to_string(),
+                session_type_id: Some("agent_harness".to_string()),
+                session_id: Some("run-completion-finish".to_string()),
                 trajectory_id: "run-completion-finish:agent".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,

--- a/lib/llm/src/request_trace/integration.rs
+++ b/lib/llm/src/request_trace/integration.rs
@@ -366,8 +366,8 @@ mod tests {
         let state = RequestEndTraceState {
             agent: Some(AgentContextTraceState {
                 agent_context: AgentContext {
-                    session_type_id: "agent_harness".to_string(),
-                    session_id: "run-1".to_string(),
+                    session_type_id: Some("agent_harness".to_string()),
+                    session_id: Some("run-1".to_string()),
                     trajectory_id: "root".to_string(),
                     parent_trajectory_id: None,
                     trajectory_final: None,
@@ -440,8 +440,8 @@ mod tests {
             ..Default::default()
         });
         request.agent_context = Some(AgentContext {
-            session_type_id: "agent_harness".to_string(),
-            session_id: "run-unsupported".to_string(),
+            session_type_id: Some("agent_harness".to_string()),
+            session_id: Some("run-unsupported".to_string()),
             trajectory_id: "root".to_string(),
             parent_trajectory_id: None,
             trajectory_final: None,

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -209,8 +209,8 @@ mod tests {
             event_time_unix_ms: 2_000,
             event_source: Some(RequestTraceEventSource::Harness),
             agent_context: Some(AgentContext {
-                session_type_id: "agent_harness".to_string(),
-                session_id: "run-1".to_string(),
+                session_type_id: Some("agent_harness".to_string()),
+                session_id: Some("run-1".to_string()),
                 trajectory_id: "root".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,

--- a/lib/llm/src/request_trace/tool_relay.rs
+++ b/lib/llm/src/request_trace/tool_relay.rs
@@ -173,8 +173,8 @@ mod tests {
             event_time_unix_ms: 1,
             event_source: Some(RequestTraceEventSource::Harness),
             agent_context: Some(AgentContext {
-                session_type_id: "agent_harness".to_string(),
-                session_id: "run-1".to_string(),
+                session_type_id: Some("agent_harness".to_string()),
+                session_id: Some("run-1".to_string()),
                 trajectory_id: "run-1:agent".to_string(),
                 parent_trajectory_id: None,
                 trajectory_final: None,
@@ -247,7 +247,7 @@ mod tests {
                 assert_eq!(record.event_source, Some(RequestTraceEventSource::Harness));
                 assert_eq!(
                     record.agent_context.expect("agent context").session_id,
-                    "run-1"
+                    Some("run-1".to_string())
                 );
                 assert_eq!(record.tool.unwrap().tool_call_id, "tool-123");
 

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -574,8 +574,11 @@ pub mod openai_preprocessor_tests {
         let agent_context = preprocessed_request
             .agent_context
             .expect("agent_context should propagate");
-        assert_eq!(agent_context.session_type_id, "deep_research:v1");
-        assert_eq!(agent_context.session_id, "run-123");
+        assert_eq!(
+            agent_context.session_type_id.as_deref(),
+            Some("deep_research:v1")
+        );
+        assert_eq!(agent_context.session_id.as_deref(), Some("run-123"));
         assert_eq!(agent_context.trajectory_id, "run-123:researcher-0");
         assert_eq!(
             agent_context.parent_trajectory_id.as_deref(),

--- a/tests/frontend/agent_smoke_inputs.py
+++ b/tests/frontend/agent_smoke_inputs.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static prompts and config writers for frontend coding-agent smoke tests."""
+
+import json
+from pathlib import Path
+
+LIST_DIRECTORY_PROMPT = (
+    "What files exist in the current working directory? Use your shell tool to run "
+    "ls and report each filename verbatim from the output."
+)
+
+
+def write_codex_config(codex_home: Path, frontend_port: int) -> None:
+    """Emit a minimal ~/.codex/config.toml pointing Codex at Dynamo."""
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "config.toml").write_text(
+        f"""
+model_max_output_tokens = 4096
+
+[model_providers.local]
+name = "local-dynamo"
+base_url = "http://localhost:{frontend_port}/v1"
+wire_api = "responses"
+env_key = "LOCAL_API_KEY"
+        """.lstrip()
+    )
+
+
+def write_claude_subagent_config(cwd: Path, subagent_name: str) -> None:
+    """Register a project-local Claude Code subagent for best-effort CI signal."""
+    agents_dir = cwd / ".claude" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / f"{subagent_name}.md").write_text(
+        f"""
+---
+name: {subagent_name}
+description: Dynamo CI smoke subagent that lists the current directory.
+tools: Bash
+---
+
+Use Bash to run `ls -1` in the current working directory. Return only the exact
+filenames from the command output, one per line. Do not explain anything.
+        """.lstrip()
+    )
+
+
+def claude_subagent_prompt(subagent_name: str, marker_filename: str) -> str:
+    return (
+        f"@agent-{subagent_name}\n"
+        f"Invoke the {subagent_name} subagent exactly once. Do not use Bash yourself. "
+        "The subagent must use Bash to run `ls -1` in the current working directory "
+        f"and return the exact filenames. The output must include {marker_filename}."
+    )
+
+
+def write_opencode_config(
+    cwd: Path,
+    frontend_port: int,
+    model: str,
+    subtask_command: str,
+) -> None:
+    config = {
+        "provider": {
+            "dynamo": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "Dynamo",
+                "env": ["DYNAMO_API_KEY"],
+                "models": {
+                    model: {
+                        "id": model,
+                        "name": model,
+                        "limit": {"context": 8192, "output": 512},
+                        "cost": {"input": 0, "output": 0},
+                    }
+                },
+                "options": {"baseURL": f"http://localhost:{frontend_port}/v1"},
+            }
+        },
+        "permission": {"task": "allow"},
+        "command": {
+            subtask_command: {
+                "template": "Reply with exactly OK.",
+                "subtask": True,
+            }
+        },
+    }
+
+    project_config = cwd / ".opencode"
+    project_config.mkdir(parents=True, exist_ok=True)
+    (project_config / "opencode.jsonc").write_text(json.dumps(config, indent=2))

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -371,9 +371,12 @@ def _install_npm_cli(
     the path to the CLI entry point. Shared helper for agent CLIs."""
     install_dir = tools_cache / slot
     cli_bin = install_dir / "node_modules" / ".bin" / binary_name
+    sentinel = install_dir / ".installed"
     with FileLock(str(tools_cache / f"{slot}.lock")):
-        if cli_bin.exists():
+        if sentinel.exists() and cli_bin.exists():
             return cli_bin
+        if install_dir.exists():
+            shutil.rmtree(install_dir)
         install_dir.mkdir(parents=True, exist_ok=True)
         env = {
             **os.environ,
@@ -395,6 +398,7 @@ def _install_npm_cli(
             ),
             description=f"npm install {package}",
         )
+        sentinel.touch()
     return cli_bin
 
 

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -14,14 +14,18 @@ sequentially against one server:
    `/v1/responses`.
 3. `claude -p` smoke — forces the Bash tool-call path through
    `/v1/messages` (Anthropic Messages API).
+4. `opencode run` smoke — sends a real OpenCode request through
+   `/v1/chat/completions`.
 
-All external tooling (bun, node, the OpenResponses suite, and the codex /
-claude CLIs) is installed lazily at test time by session-scoped fixtures
-into a session-shared cache directory. Versions and the OpenResponses
-SHA are pinned as module-level constants. FileLock coordination makes
-concurrent xdist workers share a single install.
+All external tooling (bun, node, the OpenResponses suite, and the coding-agent
+CLIs) is installed lazily at test time by session-scoped fixtures into a
+session-shared cache directory. Versions and the OpenResponses SHA are pinned
+as module-level constants. FileLock coordination makes concurrent xdist
+workers share a single install.
+
 """
 
+import json
 import logging
 import os
 import platform
@@ -50,9 +54,9 @@ sglang_dir = os.environ.get("SGLANG_DIR") or os.path.join(
 COMPLIANCE_MODEL = "Qwen/Qwen3-VL-2B-Instruct"
 
 # Pinned external-tool versions. Bun and node are pinned for reproducibility.
-# The agent CLIs (@openai/codex, @anthropic-ai/claude-code) float to @latest
-# so we automatically pick up protocol fixes — they're client-side harnesses,
-# not Dynamo surface.
+# The agent CLIs (@openai/codex, @anthropic-ai/claude-code, opencode-ai) float
+# to @latest so we automatically pick up protocol fixes — they're client-side
+# harnesses, not Dynamo surface.
 BUN_VERSION = "1.3.12"
 NODE_VERSION = "20.19.0"
 OPENRESPONSES_REPO = "https://github.com/openresponses/openresponses.git"
@@ -101,11 +105,10 @@ _SUBPROCESS_ENV_ALLOWLIST: frozenset[str] = frozenset(
 def _agent_subprocess_env(
     extra_env: dict[str, str], path_prepend: list[Path] | None = None
 ) -> dict[str, str]:
-    """Build a minimal env for codex/claude subprocesses: allowlist from
-    `os.environ` merged with explicit test-scoped vars. Optional
-    `path_prepend` prepends directories to PATH so the fixture-installed
-    node/codex/claude binaries resolve without contaminating the
-    inherited PATH."""
+    """Build a minimal env for agent subprocesses: allowlist from `os.environ`
+    merged with explicit test-scoped vars. Optional `path_prepend` prepends
+    directories to PATH so fixture-installed CLIs resolve without
+    contaminating the inherited PATH."""
     base = {
         k: v for k in _SUBPROCESS_ENV_ALLOWLIST if (v := os.environ.get(k)) is not None
     }
@@ -359,7 +362,7 @@ def _install_npm_cli(
     slot: str,
 ) -> Path:
     """Install `package` into `{tools_cache}/{slot}` via npm and return
-    the path to the CLI entry point. Shared helper for codex + claude."""
+    the path to the CLI entry point. Shared helper for agent CLIs."""
     install_dir = tools_cache / slot
     cli_bin = install_dir / "node_modules" / ".bin" / binary_name
     with FileLock(str(tools_cache / f"{slot}.lock")):
@@ -411,8 +414,19 @@ def _claude_cli(_tools_cache, _node_bin) -> Path:
     )
 
 
+@pytest.fixture(scope="session")
+def _opencode_cli(_tools_cache, _node_bin) -> Path:
+    return _install_npm_cli(
+        _tools_cache,
+        _node_bin,
+        package="opencode-ai",
+        binary_name="opencode",
+        slot="opencode",
+    )
+
+
 # ---------------------------------------------------------------------------
-# Test
+# Live Dynamo frontend compliance test
 # ---------------------------------------------------------------------------
 
 
@@ -425,10 +439,10 @@ def _claude_cli(_tools_cache, _node_bin) -> Path:
 @pytest.mark.requested_sglang_kv_tokens(49152)
 # Budget: tool-install fixtures (~30-60s first session run, near-zero on
 # cache hit) + sglang cold start (30-60s) + bun compliance (up to 180s) +
-# codex exec (up to 180s) + claude exec (up to 180s) + two inter-suite
-# health checks + teardown. 750s leaves headroom for CI variance without
-# masking real hangs.
-@pytest.mark.timeout(750)
+# codex exec (up to 180s) + claude exec (up to 180s) + opencode run (up to
+# 180s) + inter-suite health checks + teardown. 930s leaves headroom for CI
+# variance without masking real hangs.
+@pytest.mark.timeout(930)
 @pytest.mark.frontend_api_surface_compliance
 @pytest.mark.pre_merge
 @pytest.mark.flaky(reruns=2, only_rerun=["did not report the marker file"])
@@ -443,6 +457,7 @@ def test_frontend_api_surface_compliance(
     _openresponses_suite,
     _codex_cli,
     _claude_cli,
+    _opencode_cli,
 ):
     """Assert the frontend passes the upstream OpenResponses compliance suite."""
 
@@ -481,12 +496,19 @@ def test_frontend_api_surface_compliance(
         frontend_port=frontend_port,
     )
 
+    request_trace_path = tmp_path / "request_trace.jsonl"
+    request_trace_path.unlink(missing_ok=True)
     merged_env = {
         "DYN_HTTP_PORT": str(frontend_port),
         "DYN_SYSTEM_PORT": str(system_port),
         # agg.sh doesn't forward frontend args, but the frontend reads this
         # env var directly. Enables /v1/messages for the claude smoke step.
         "DYN_ENABLE_ANTHROPIC_API": "1",
+        "DYN_ENABLE_FRONTEND_NVEXT": "1",
+        "DYN_REQUEST_TRACE": "1",
+        "DYN_REQUEST_TRACE_SINKS": "jsonl",
+        "DYN_REQUEST_TRACE_OUTPUT_PATH": str(request_trace_path),
+        "DYN_REQUEST_TRACE_JSONL_FLUSH_INTERVAL_MS": "10",
     }
 
     codex_home = tmp_path / "codex_home"
@@ -508,6 +530,11 @@ def test_frontend_api_surface_compliance(
     # ~/.claude during CI / local invocation.
     claude_home = tmp_path / "claude_home"
     claude_home.mkdir()
+    opencode_home = tmp_path / "opencode_home"
+    opencode_home.mkdir()
+    opencode_cwd = tmp_path / "opencode_cwd"
+    opencode_cwd.mkdir()
+    _write_opencode_config(opencode_cwd, frontend_port)
 
     with EngineProcess.from_script(config, request, extra_env=merged_env):
         _run_bun_compliance(_bun_binary, _openresponses_suite, frontend_port)
@@ -515,6 +542,7 @@ def test_frontend_api_surface_compliance(
         _run_codex_exec_smoke(
             _codex_cli, _node_bin, codex_home, agent_cwd, marker_filename
         )
+        _assert_agent_context_in_trace(request_trace_path, "codex")
         _wait_for_frontend_healthy(frontend_port)
         _run_claude_exec_smoke(
             _claude_cli,
@@ -524,6 +552,10 @@ def test_frontend_api_surface_compliance(
             marker_filename,
             frontend_port,
         )
+        _assert_agent_context_in_trace(request_trace_path, "claude_code")
+        _wait_for_frontend_healthy(frontend_port)
+        _run_opencode_smoke(_opencode_cli, _node_bin, opencode_home, opencode_cwd)
+        _assert_agent_context_in_trace(request_trace_path, "opencode")
 
 
 def _attach_subprocess_log(
@@ -605,6 +637,49 @@ def _wait_for_frontend_healthy(
     )
 
 
+def _read_request_trace_records(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    records = []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            logger.debug("Skipping partial request-trace line: %r", line)
+    return records
+
+
+def _assert_agent_context_in_trace(
+    trace_path: Path, session_type_id: str, timeout_s: float = 30.0
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_records: list[dict] = []
+    while time.monotonic() < deadline:
+        last_records = _read_request_trace_records(trace_path)
+        for record in last_records:
+            agent_context = record.get("agent_context")
+            if not agent_context:
+                continue
+            if agent_context.get("session_type_id") != session_type_id:
+                continue
+            assert agent_context.get("session_id"), agent_context
+            assert agent_context.get("session_id") == agent_context.get("trajectory_id")
+            return
+        time.sleep(0.2)
+
+    seen = [
+        record.get("agent_context")
+        for record in last_records
+        if record.get("agent_context")
+    ]
+    pytest.fail(
+        f"request trace did not contain agent_context for {session_type_id!r} "
+        f"within {timeout_s}s; saw {seen}"
+    )
+
+
 def _run_bun_compliance(
     bun_binary: Path, openresponses_dir: Path, frontend_port: int
 ) -> None:
@@ -674,6 +749,31 @@ wire_api = "responses"
 env_key = "LOCAL_API_KEY"
 """.lstrip()
     )
+
+
+def _write_opencode_config(cwd: Path, frontend_port: int) -> None:
+    config = {
+        "provider": {
+            "dynamo": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "Dynamo",
+                "env": ["DYNAMO_API_KEY"],
+                "models": {
+                    COMPLIANCE_MODEL: {
+                        "id": COMPLIANCE_MODEL,
+                        "name": COMPLIANCE_MODEL,
+                        "limit": {"context": 8192, "output": 4096},
+                        "cost": {"input": 0, "output": 0},
+                    }
+                },
+                "options": {"baseURL": f"http://localhost:{frontend_port}/v1"},
+            }
+        }
+    }
+
+    project_config = cwd / ".opencode"
+    project_config.mkdir(parents=True, exist_ok=True)
+    (project_config / "opencode.jsonc").write_text(json.dumps(config, indent=2))
 
 
 def _run_codex_exec_smoke(
@@ -826,4 +926,58 @@ def _run_claude_exec_smoke(
             "claude -p did not report the marker file — expected stdout to "
             f"contain {marker_filename!r} (implies the Bash tool was invoked "
             f"and actually ran `ls` in {cwd}). Got:\n{result.stdout}"
+        )
+
+
+def _run_opencode_smoke(
+    opencode_cli: Path,
+    node_bin: Path,
+    opencode_home: Path,
+    cwd: Path,
+) -> None:
+    """Run `opencode run` against the live Dynamo chat/completions endpoint."""
+    logger.info("Running opencode smoke test against cwd=%s", cwd)
+
+    extra_env = {
+        "HOME": str(opencode_home),
+        "DYNAMO_API_KEY": "sk-none",
+        "NO_PROXY": "127.0.0.1,localhost",
+    }
+    env = _agent_subprocess_env(extra_env, path_prepend=[node_bin])
+
+    cmd = [
+        str(opencode_cli),
+        "run",
+        "--dangerously-skip-permissions",
+        "-m",
+        f"dynamo/{COMPLIANCE_MODEL}",
+        "--dir",
+        str(cwd),
+        "Reply with exactly OK. Do not use tools.",
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    _attach_subprocess_log(
+        name="opencode_smoke.log",
+        cmd=cmd,
+        result=result,
+        extra_env=extra_env,
+        cwd=str(cwd),
+    )
+    if result.stdout:
+        logger.info("opencode stdout:\n%s", result.stdout)
+    if result.stderr:
+        logger.info("opencode stderr:\n%s", result.stderr)
+
+    if result.returncode != 0:
+        pytest.fail(
+            f"opencode run failed (exit={result.returncode}).\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
         )

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -16,6 +16,8 @@ sequentially against one server:
    `/v1/messages` (Anthropic Messages API).
 4. `opencode run --command ...` smoke — forces an OpenCode subtask request
    through `/v1/chat/completions`.
+5. Optional `claude -p` subagent smoke — collects CI signal for Claude Code
+   child-agent headers without gating the suite while invocation is calibrated.
 
 All external tooling (bun, node, the OpenResponses suite, and the coding-agent
 CLIs) is installed lazily at test time by session-scoped fixtures into a
@@ -63,6 +65,8 @@ NODE_VERSION = "20.19.0"
 OPENRESPONSES_REPO = "https://github.com/openresponses/openresponses.git"
 OPENRESPONSES_SHA = "fa29df5"
 OPENRESPONSES_MAX_OUTPUT_TOKENS = 512
+CLAUDE_SUBAGENT_NAME = "dynamo-subagent-smoke"
+CLAUDE_SUBAGENT_TIMEOUT_S = 45
 OPENCODE_SUBTASK_COMMAND = "dynamo-subagent-smoke"
 
 # Retry budget for network-touching installs. Exponential backoff starting
@@ -450,10 +454,11 @@ def _opencode_cli(_tools_cache, _node_bin) -> Path:
 @pytest.mark.requested_sglang_kv_tokens(49152)
 # Budget: tool-install fixtures (~30-60s first session run, near-zero on
 # cache hit) + sglang cold start (30-60s) + bun compliance (up to 180s) +
-# codex exec (up to 180s) + claude exec (up to 180s) + opencode run (up to
-# 180s) + inter-suite health checks + teardown. 930s leaves headroom for CI
-# variance without masking real hangs.
-@pytest.mark.timeout(930)
+# codex exec (up to 180s) + claude exec (up to 180s) + optional claude
+# subagent probe (up to 45s) + opencode run (up to 180s) + inter-suite
+# health checks + teardown. 975s leaves headroom for CI variance without
+# masking real hangs.
+@pytest.mark.timeout(975)
 @pytest.mark.frontend_api_surface_compliance
 @pytest.mark.pre_merge
 @pytest.mark.flaky(reruns=2, only_rerun=["did not report the marker file"])
@@ -577,6 +582,15 @@ def test_frontend_api_surface_compliance(
         )
         _assert_agent_context_in_trace(request_trace_path, "opencode")
         _assert_agent_parent_context_in_trace(request_trace_path, "opencode")
+        _try_run_claude_subagent_smoke(
+            _claude_cli,
+            _node_bin,
+            claude_home,
+            agent_cwd,
+            marker_filename,
+            frontend_port,
+            request_trace_path,
+        )
 
 
 def _attach_subprocess_log(
@@ -752,6 +766,27 @@ def _trace_contains_agent_parent_context(
     return False
 
 
+def _trace_contains_claude_subagent_context(records: list[dict]) -> bool:
+    for record in records:
+        agent_context = record.get("agent_context")
+        if not agent_context:
+            continue
+        if agent_context.get("session_type_id") != "claude_code":
+            continue
+
+        session_id = agent_context.get("session_id")
+        trajectory_id = agent_context.get("trajectory_id")
+        parent_trajectory_id = agent_context.get("parent_trajectory_id")
+        if not session_id or not trajectory_id:
+            continue
+        if trajectory_id == session_id:
+            continue
+        if parent_trajectory_id != session_id:
+            continue
+        return True
+    return False
+
+
 def _run_bun_compliance(
     bun_binary: Path, openresponses_dir: Path, frontend_port: int
 ) -> None:
@@ -819,6 +854,24 @@ name = "local-dynamo"
 base_url = "http://localhost:{frontend_port}/v1"
 wire_api = "responses"
 env_key = "LOCAL_API_KEY"
+	""".lstrip()
+    )
+
+
+def _write_claude_subagent_config(cwd: Path) -> None:
+    """Register a project-local Claude Code subagent for best-effort CI signal."""
+    agents_dir = cwd / ".claude" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / f"{CLAUDE_SUBAGENT_NAME}.md").write_text(
+        f"""
+---
+name: {CLAUDE_SUBAGENT_NAME}
+description: Dynamo CI smoke subagent that lists the current directory.
+tools: Bash
+---
+
+Use Bash to run `ls -1` in the current working directory. Return only the exact
+filenames from the command output, one per line. Do not explain anything.
 """.lstrip()
     )
 
@@ -1006,6 +1059,139 @@ def _run_claude_exec_smoke(
             f"contain {marker_filename!r} (implies the Bash tool was invoked "
             f"and actually ran `ls` in {cwd}). Got:\n{result.stdout}"
         )
+
+
+def _try_run_claude_subagent_smoke(
+    claude_cli: Path,
+    node_bin: Path,
+    claude_home: Path,
+    cwd: Path,
+    marker_filename: str,
+    frontend_port: int,
+    request_trace_path: Path,
+) -> None:
+    """Best-effort Claude subagent probe.
+
+    This intentionally does not fail the suite yet. OpenCode gives us a hard
+    `subtask: true` trigger, but Claude subagent invocation is model-mediated,
+    so keep this as CI telemetry until it is stable enough to gate on.
+    """
+    try:
+        _write_claude_subagent_config(cwd)
+        _run_claude_subagent_smoke(
+            claude_cli,
+            node_bin,
+            claude_home,
+            cwd,
+            marker_filename,
+            frontend_port,
+            request_trace_path,
+        )
+    except Exception:
+        logger.warning("Optional Claude subagent smoke failed", exc_info=True)
+
+
+def _run_claude_subagent_smoke(
+    claude_cli: Path,
+    node_bin: Path,
+    claude_home: Path,
+    cwd: Path,
+    marker_filename: str,
+    frontend_port: int,
+    request_trace_path: Path,
+) -> None:
+    base_url = f"http://localhost:{frontend_port}"
+    logger.info("Running optional Claude subagent smoke test against %s", base_url)
+
+    extra_env = {
+        "HOME": str(claude_home),
+        "ANTHROPIC_BASE_URL": base_url,
+        "ANTHROPIC_AUTH_TOKEN": "sk-none",
+        "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "512",
+    }
+    env = _agent_subprocess_env(extra_env, path_prepend=[node_bin])
+
+    prompt = (
+        f"@agent-{CLAUDE_SUBAGENT_NAME}\n"
+        f"Invoke the {CLAUDE_SUBAGENT_NAME} subagent exactly once. Do not use "
+        f"Bash yourself. The subagent must use Bash to run `ls -1` in the "
+        f"current working directory and return the exact filenames. The output "
+        f"must include {marker_filename}."
+    )
+    cmd = [
+        str(claude_cli),
+        "--model",
+        COMPLIANCE_MODEL,
+        "--dangerously-skip-permissions",
+        "-p",
+        prompt,
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=CLAUDE_SUBAGENT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logger.warning(
+            "Optional Claude subagent smoke timed out after %.0fs; stdout=%r stderr=%r",
+            exc.timeout,
+            exc.stdout,
+            exc.stderr,
+        )
+        return
+
+    _attach_subprocess_log(
+        name="claude_subagent_smoke_optional.log",
+        cmd=cmd,
+        result=result,
+        extra_env=extra_env,
+        cwd=str(cwd),
+    )
+    if result.stdout:
+        logger.info("claude subagent stdout:\n%s", result.stdout)
+    if result.stderr:
+        logger.info("claude subagent stderr:\n%s", result.stderr)
+
+    if result.returncode != 0:
+        logger.warning(
+            "Optional Claude subagent smoke exited with %s; stdout=%r stderr=%r",
+            result.returncode,
+            result.stdout,
+            result.stderr,
+        )
+        return
+
+    if marker_filename not in result.stdout:
+        logger.warning(
+            "Optional Claude subagent smoke did not report marker file %r; stdout=%r",
+            marker_filename,
+            result.stdout,
+        )
+        return
+
+    deadline = time.monotonic() + 30.0
+    last_records: list[dict] = []
+    while time.monotonic() < deadline:
+        last_records = _read_request_trace_records(request_trace_path)
+        if _trace_contains_claude_subagent_context(last_records):
+            logger.info("Optional Claude subagent smoke traced child agent_context")
+            return
+        time.sleep(0.2)
+
+    seen = [
+        record.get("agent_context")
+        for record in last_records
+        if record.get("agent_context")
+    ]
+    logger.warning(
+        "Optional Claude subagent smoke did not trace child agent_context; saw %s",
+        seen,
+    )
 
 
 def _run_opencode_smoke(

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -32,6 +32,7 @@ import platform
 import shlex
 import shutil
 import subprocess
+import sys
 import tarfile
 import time
 import uuid
@@ -257,7 +258,7 @@ def _node_bin(_tools_cache) -> Path:
 
 
 @pytest.fixture(scope="session")
-def _openresponses_suite(_tools_cache, _bun_binary) -> Path:
+def _openresponses_suite(_tools_cache, _bun_binary, _node_bin) -> Path:
     """Pinned-SHA clone of the OpenResponses compliance suite with bun
     deps installed. A `.installed` sentinel file marks a completed setup
     so an interrupted prior install forces a clean redo."""
@@ -290,10 +291,15 @@ def _openresponses_suite(_tools_cache, _bun_binary) -> Path:
             text=True,
         )
         _patch_openresponses_suite(install_dir)
+        env = {
+            **os.environ,
+            "PATH": f"{_node_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+        }
         _retry_network_op(
             lambda: subprocess.run(
                 [str(_bun_binary), "install", "--frozen-lockfile"],
                 cwd=str(install_dir),
+                env=env,
                 check=True,
                 capture_output=True,
                 text=True,
@@ -509,6 +515,9 @@ def test_frontend_api_surface_compliance(
         "DYN_REQUEST_TRACE_SINKS": "jsonl",
         "DYN_REQUEST_TRACE_OUTPUT_PATH": str(request_trace_path),
         "DYN_REQUEST_TRACE_JSONL_FLUSH_INTERVAL_MS": "10",
+        # The SGLang launch scripts invoke `python3`; keep them on the same
+        # interpreter environment pytest is running in.
+        "PATH": f"{Path(sys.executable).parent}{os.pathsep}{os.environ.get('PATH', '')}",
     }
 
     codex_home = tmp_path / "codex_home"
@@ -554,7 +563,13 @@ def test_frontend_api_surface_compliance(
         )
         _assert_agent_context_in_trace(request_trace_path, "claude_code")
         _wait_for_frontend_healthy(frontend_port)
-        _run_opencode_smoke(_opencode_cli, _node_bin, opencode_home, opencode_cwd)
+        _run_opencode_smoke(
+            _opencode_cli,
+            _node_bin,
+            opencode_home,
+            opencode_cwd,
+            request_trace_path,
+        )
         _assert_agent_context_in_trace(request_trace_path, "opencode")
 
 
@@ -645,9 +660,13 @@ def _read_request_trace_records(path: Path) -> list[dict]:
         if not line.strip():
             continue
         try:
-            records.append(json.loads(line))
+            record = json.loads(line)
         except json.JSONDecodeError:
             logger.debug("Skipping partial request-trace line: %r", line)
+            continue
+        if isinstance(record.get("event"), dict):
+            record = record["event"]
+        records.append(record)
     return records
 
 
@@ -658,14 +677,7 @@ def _assert_agent_context_in_trace(
     last_records: list[dict] = []
     while time.monotonic() < deadline:
         last_records = _read_request_trace_records(trace_path)
-        for record in last_records:
-            agent_context = record.get("agent_context")
-            if not agent_context:
-                continue
-            if agent_context.get("session_type_id") != session_type_id:
-                continue
-            assert agent_context.get("session_id"), agent_context
-            assert agent_context.get("session_id") == agent_context.get("trajectory_id")
+        if _trace_contains_agent_context(last_records, session_type_id):
             return
         time.sleep(0.2)
 
@@ -678,6 +690,19 @@ def _assert_agent_context_in_trace(
         f"request trace did not contain agent_context for {session_type_id!r} "
         f"within {timeout_s}s; saw {seen}"
     )
+
+
+def _trace_contains_agent_context(records: list[dict], session_type_id: str) -> bool:
+    for record in records:
+        agent_context = record.get("agent_context")
+        if not agent_context:
+            continue
+        if agent_context.get("session_type_id") != session_type_id:
+            continue
+        assert agent_context.get("session_id"), agent_context
+        assert agent_context.get("session_id") == agent_context.get("trajectory_id")
+        return True
+    return False
 
 
 def _run_bun_compliance(
@@ -762,13 +787,13 @@ def _write_opencode_config(cwd: Path, frontend_port: int) -> None:
                     COMPLIANCE_MODEL: {
                         "id": COMPLIANCE_MODEL,
                         "name": COMPLIANCE_MODEL,
-                        "limit": {"context": 8192, "output": 4096},
+                        "limit": {"context": 8192, "output": 512},
                         "cost": {"input": 0, "output": 0},
                     }
                 },
                 "options": {"baseURL": f"http://localhost:{frontend_port}/v1"},
             }
-        }
+        },
     }
 
     project_config = cwd / ".opencode"
@@ -934,8 +959,9 @@ def _run_opencode_smoke(
     node_bin: Path,
     opencode_home: Path,
     cwd: Path,
+    request_trace_path: Path,
 ) -> None:
-    """Run `opencode run` against the live Dynamo chat/completions endpoint."""
+    """Run `opencode run` until Dynamo traces its live chat/completions request."""
     logger.info("Running opencode smoke test against cwd=%s", cwd)
 
     extra_env = {
@@ -955,13 +981,45 @@ def _run_opencode_smoke(
         str(cwd),
         "Reply with exactly OK. Do not use tools.",
     ]
-    result = subprocess.run(
+    process = subprocess.Popen(
         cmd,
         cwd=str(cwd),
         env=env,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        timeout=180,
+    )
+
+    trace_seen = False
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if _trace_contains_agent_context(
+            _read_request_trace_records(request_trace_path), "opencode"
+        ):
+            trace_seen = True
+            break
+        if process.poll() is not None:
+            break
+        time.sleep(0.2)
+
+    if process.poll() is None:
+        process.terminate()
+        try:
+            stdout, stderr = process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+    else:
+        stdout, stderr = process.communicate()
+
+    trace_seen = trace_seen or _trace_contains_agent_context(
+        _read_request_trace_records(request_trace_path), "opencode"
+    )
+    result = subprocess.CompletedProcess(
+        cmd,
+        process.returncode,
+        stdout,
+        stderr,
     )
 
     _attach_subprocess_log(
@@ -976,8 +1034,13 @@ def _run_opencode_smoke(
     if result.stderr:
         logger.info("opencode stderr:\n%s", result.stderr)
 
+    if trace_seen:
+        return
+
     if result.returncode != 0:
         pytest.fail(
             f"opencode run failed (exit={result.returncode}).\n"
             f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
         )
+
+    pytest.fail("opencode run exited before Dynamo traced an opencode agent_context")

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -741,8 +741,13 @@ def _trace_contains_agent_context(records: list[dict], session_type_id: str) -> 
             continue
         if agent_context.get("session_type_id") != session_type_id:
             continue
-        assert agent_context.get("session_id"), agent_context
-        assert agent_context.get("session_id") == agent_context.get("trajectory_id")
+
+        session_id = agent_context.get("session_id")
+        trajectory_id = agent_context.get("trajectory_id")
+        if not session_id or not trajectory_id:
+            continue
+        if session_type_id != "claude_code" and session_id != trajectory_id:
+            continue
         return True
     return False
 
@@ -759,9 +764,15 @@ def _trace_contains_agent_parent_context(
         parent_trajectory_id = agent_context.get("parent_trajectory_id")
         if not parent_trajectory_id:
             continue
-        assert agent_context.get("session_id"), agent_context
-        assert agent_context.get("session_id") == agent_context.get("trajectory_id")
-        assert parent_trajectory_id != agent_context.get("trajectory_id"), agent_context
+
+        session_id = agent_context.get("session_id")
+        trajectory_id = agent_context.get("trajectory_id")
+        if not session_id or not trajectory_id:
+            continue
+        if session_id != trajectory_id:
+            continue
+        if parent_trajectory_id == trajectory_id:
+            continue
         return True
     return False
 
@@ -1232,26 +1243,27 @@ def _run_opencode_smoke(
     )
 
     trace_seen = False
-    deadline = time.monotonic() + 30
-    while time.monotonic() < deadline:
-        if _trace_contains_agent_parent_context(
-            _read_request_trace_records(request_trace_path), "opencode"
-        ):
-            trace_seen = True
-            break
-        if process.poll() is not None:
-            break
-        time.sleep(0.2)
-
-    if process.poll() is None:
-        process.terminate()
-        try:
-            stdout, stderr = process.communicate(timeout=10)
-        except subprocess.TimeoutExpired:
-            process.kill()
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if _trace_contains_agent_parent_context(
+                _read_request_trace_records(request_trace_path), "opencode"
+            ):
+                trace_seen = True
+                break
+            if process.poll() is not None:
+                break
+            time.sleep(0.2)
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                stdout, stderr = process.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout, stderr = process.communicate()
+        else:
             stdout, stderr = process.communicate()
-    else:
-        stdout, stderr = process.communicate()
 
     trace_seen = trace_seen or _trace_contains_agent_parent_context(
         _read_request_trace_records(request_trace_path), "opencode"

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -45,6 +45,13 @@ import pytest
 import requests
 from filelock import FileLock
 
+from tests.frontend.agent_smoke_inputs import (
+    LIST_DIRECTORY_PROMPT,
+    claude_subagent_prompt,
+    write_claude_subagent_config,
+    write_codex_config,
+    write_opencode_config,
+)
 from tests.serve.common import WORKSPACE_DIR
 from tests.utils.engine_process import EngineConfig, EngineProcess
 
@@ -531,7 +538,7 @@ def test_frontend_api_surface_compliance(
     }
 
     codex_home = tmp_path / "codex_home"
-    _write_codex_config(codex_home, frontend_port)
+    write_codex_config(codex_home, frontend_port)
 
     # Marker file that the agents can only "see" by invoking their shell/Bash
     # tool; if a model answers from its prior without actually running `ls`,
@@ -553,7 +560,9 @@ def test_frontend_api_surface_compliance(
     opencode_home.mkdir()
     opencode_cwd = tmp_path / "opencode_cwd"
     opencode_cwd.mkdir()
-    _write_opencode_config(opencode_cwd, frontend_port)
+    write_opencode_config(
+        opencode_cwd, frontend_port, COMPLIANCE_MODEL, OPENCODE_SUBTASK_COMMAND
+    )
 
     with EngineProcess.from_script(config, request, extra_env=merged_env):
         _run_bun_compliance(_bun_binary, _openresponses_suite, frontend_port)
@@ -843,82 +852,6 @@ def _run_bun_compliance(
         )
 
 
-def _write_codex_config(codex_home, frontend_port: int) -> None:
-    """Emit a minimal ~/.codex/config.toml pointing Codex at Dynamo.
-
-    Using a per-test CODEX_HOME keeps the runner's global Codex state
-    (if any) untouched.
-    """
-    codex_home.mkdir(parents=True, exist_ok=True)
-    config_path = codex_home / "config.toml"
-    # Bound the per-request output budget so the smoke test stays well within
-    # the 180s subprocess timeout. Codex omits `max_output_tokens` by default,
-    # and the Dynamo Responses handler forwards `None` to the engine — sglang
-    # then generates up to `max_model_len`, which is far more than this test
-    # needs and easily exceeds the timeout for reasoning models.
-    config_path.write_text(
-        f"""
-model_max_output_tokens = 4096
-
-[model_providers.local]
-name = "local-dynamo"
-base_url = "http://localhost:{frontend_port}/v1"
-wire_api = "responses"
-env_key = "LOCAL_API_KEY"
-	""".lstrip()
-    )
-
-
-def _write_claude_subagent_config(cwd: Path) -> None:
-    """Register a project-local Claude Code subagent for best-effort CI signal."""
-    agents_dir = cwd / ".claude" / "agents"
-    agents_dir.mkdir(parents=True, exist_ok=True)
-    (agents_dir / f"{CLAUDE_SUBAGENT_NAME}.md").write_text(
-        f"""
----
-name: {CLAUDE_SUBAGENT_NAME}
-description: Dynamo CI smoke subagent that lists the current directory.
-tools: Bash
----
-
-Use Bash to run `ls -1` in the current working directory. Return only the exact
-filenames from the command output, one per line. Do not explain anything.
-""".lstrip()
-    )
-
-
-def _write_opencode_config(cwd: Path, frontend_port: int) -> None:
-    config = {
-        "provider": {
-            "dynamo": {
-                "npm": "@ai-sdk/openai-compatible",
-                "name": "Dynamo",
-                "env": ["DYNAMO_API_KEY"],
-                "models": {
-                    COMPLIANCE_MODEL: {
-                        "id": COMPLIANCE_MODEL,
-                        "name": COMPLIANCE_MODEL,
-                        "limit": {"context": 8192, "output": 512},
-                        "cost": {"input": 0, "output": 0},
-                    }
-                },
-                "options": {"baseURL": f"http://localhost:{frontend_port}/v1"},
-            }
-        },
-        "permission": {"task": "allow"},
-        "command": {
-            OPENCODE_SUBTASK_COMMAND: {
-                "template": "Reply with exactly OK.",
-                "subtask": True,
-            }
-        },
-    }
-
-    project_config = cwd / ".opencode"
-    project_config.mkdir(parents=True, exist_ok=True)
-    (project_config / "opencode.jsonc").write_text(json.dumps(config, indent=2))
-
-
 def _run_codex_exec_smoke(
     codex_cli: Path, node_bin: Path, codex_home, cwd, marker_filename: str
 ) -> None:
@@ -955,7 +888,7 @@ def _run_codex_exec_smoke(
         "-c",
         "model_provider=local",
         "exec",
-        "What files exist in the current working directory? Use your shell tool to run ls and report each filename verbatim from the output.",
+        LIST_DIRECTORY_PROMPT,
         "--dangerously-bypass-approvals-and-sandbox",
     ]
     result = subprocess.run(
@@ -1022,7 +955,7 @@ def _run_claude_exec_smoke(
         "ANTHROPIC_BASE_URL": base_url,
         "ANTHROPIC_AUTH_TOKEN": "sk-none",
         # Cap output so reasoning models don't blow the 180s subprocess
-        # timeout. Mirrors the codex cap in `_write_codex_config`.
+        # timeout. Mirrors the codex cap in `write_codex_config`.
         "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "4096",
     }
     # claude shells out to `node` internally; make sure the fixture-installed
@@ -1035,7 +968,7 @@ def _run_claude_exec_smoke(
         COMPLIANCE_MODEL,
         "--dangerously-skip-permissions",
         "-p",
-        "What files exist in the current working directory? Use your shell tool to run ls and report each filename verbatim from the output.",
+        LIST_DIRECTORY_PROMPT,
     ]
     result = subprocess.run(
         cmd,
@@ -1088,7 +1021,7 @@ def _try_run_claude_subagent_smoke(
     so keep this as CI telemetry until it is stable enough to gate on.
     """
     try:
-        _write_claude_subagent_config(cwd)
+        write_claude_subagent_config(cwd, CLAUDE_SUBAGENT_NAME)
         _run_claude_subagent_smoke(
             claude_cli,
             node_bin,
@@ -1122,20 +1055,13 @@ def _run_claude_subagent_smoke(
     }
     env = _agent_subprocess_env(extra_env, path_prepend=[node_bin])
 
-    prompt = (
-        f"@agent-{CLAUDE_SUBAGENT_NAME}\n"
-        f"Invoke the {CLAUDE_SUBAGENT_NAME} subagent exactly once. Do not use "
-        f"Bash yourself. The subagent must use Bash to run `ls -1` in the "
-        f"current working directory and return the exact filenames. The output "
-        f"must include {marker_filename}."
-    )
     cmd = [
         str(claude_cli),
         "--model",
         COMPLIANCE_MODEL,
         "--dangerously-skip-permissions",
         "-p",
-        prompt,
+        claude_subagent_prompt(CLAUDE_SUBAGENT_NAME, marker_filename),
     ]
 
     try:

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -14,8 +14,8 @@ sequentially against one server:
    `/v1/responses`.
 3. `claude -p` smoke — forces the Bash tool-call path through
    `/v1/messages` (Anthropic Messages API).
-4. `opencode run` smoke — sends a real OpenCode request through
-   `/v1/chat/completions`.
+4. `opencode run --command ...` smoke — forces an OpenCode subtask request
+   through `/v1/chat/completions`.
 
 All external tooling (bun, node, the OpenResponses suite, and the coding-agent
 CLIs) is installed lazily at test time by session-scoped fixtures into a
@@ -63,6 +63,7 @@ NODE_VERSION = "20.19.0"
 OPENRESPONSES_REPO = "https://github.com/openresponses/openresponses.git"
 OPENRESPONSES_SHA = "fa29df5"
 OPENRESPONSES_MAX_OUTPUT_TOKENS = 512
+OPENCODE_SUBTASK_COMMAND = "dynamo-subagent-smoke"
 
 # Retry budget for network-touching installs. Exponential backoff starting
 # at 2s; 3 attempts caps the worst-case wait at ~6s before we surface a
@@ -575,6 +576,7 @@ def test_frontend_api_surface_compliance(
             request_trace_path,
         )
         _assert_agent_context_in_trace(request_trace_path, "opencode")
+        _assert_agent_parent_context_in_trace(request_trace_path, "opencode")
 
 
 def _attach_subprocess_log(
@@ -696,6 +698,28 @@ def _assert_agent_context_in_trace(
     )
 
 
+def _assert_agent_parent_context_in_trace(
+    trace_path: Path, session_type_id: str, timeout_s: float = 30.0
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_records: list[dict] = []
+    while time.monotonic() < deadline:
+        last_records = _read_request_trace_records(trace_path)
+        if _trace_contains_agent_parent_context(last_records, session_type_id):
+            return
+        time.sleep(0.2)
+
+    seen = [
+        record.get("agent_context")
+        for record in last_records
+        if record.get("agent_context")
+    ]
+    pytest.fail(
+        f"request trace did not contain parent agent_context for {session_type_id!r} "
+        f"within {timeout_s}s; saw {seen}"
+    )
+
+
 def _trace_contains_agent_context(records: list[dict], session_type_id: str) -> bool:
     for record in records:
         agent_context = record.get("agent_context")
@@ -705,6 +729,25 @@ def _trace_contains_agent_context(records: list[dict], session_type_id: str) -> 
             continue
         assert agent_context.get("session_id"), agent_context
         assert agent_context.get("session_id") == agent_context.get("trajectory_id")
+        return True
+    return False
+
+
+def _trace_contains_agent_parent_context(
+    records: list[dict], session_type_id: str
+) -> bool:
+    for record in records:
+        agent_context = record.get("agent_context")
+        if not agent_context:
+            continue
+        if agent_context.get("session_type_id") != session_type_id:
+            continue
+        parent_trajectory_id = agent_context.get("parent_trajectory_id")
+        if not parent_trajectory_id:
+            continue
+        assert agent_context.get("session_id"), agent_context
+        assert agent_context.get("session_id") == agent_context.get("trajectory_id")
+        assert parent_trajectory_id != agent_context.get("trajectory_id"), agent_context
         return True
     return False
 
@@ -796,6 +839,13 @@ def _write_opencode_config(cwd: Path, frontend_port: int) -> None:
                     }
                 },
                 "options": {"baseURL": f"http://localhost:{frontend_port}/v1"},
+            }
+        },
+        "permission": {"task": "allow"},
+        "command": {
+            OPENCODE_SUBTASK_COMMAND: {
+                "template": "Reply with exactly OK.",
+                "subtask": True,
             }
         },
     }
@@ -965,7 +1015,7 @@ def _run_opencode_smoke(
     cwd: Path,
     request_trace_path: Path,
 ) -> None:
-    """Run `opencode run` until Dynamo traces its live chat/completions request."""
+    """Run `opencode run` until Dynamo traces its live subagent request."""
     logger.info("Running opencode smoke test against cwd=%s", cwd)
 
     extra_env = {
@@ -983,7 +1033,8 @@ def _run_opencode_smoke(
         f"dynamo/{COMPLIANCE_MODEL}",
         "--dir",
         str(cwd),
-        "Reply with exactly OK. Do not use tools.",
+        "--command",
+        OPENCODE_SUBTASK_COMMAND,
     ]
     process = subprocess.Popen(
         cmd,
@@ -997,7 +1048,7 @@ def _run_opencode_smoke(
     trace_seen = False
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
-        if _trace_contains_agent_context(
+        if _trace_contains_agent_parent_context(
             _read_request_trace_records(request_trace_path), "opencode"
         ):
             trace_seen = True
@@ -1016,7 +1067,7 @@ def _run_opencode_smoke(
     else:
         stdout, stderr = process.communicate()
 
-    trace_seen = trace_seen or _trace_contains_agent_context(
+    trace_seen = trace_seen or _trace_contains_agent_parent_context(
         _read_request_trace_records(request_trace_path), "opencode"
     )
     result = subprocess.CompletedProcess(
@@ -1047,4 +1098,7 @@ def _run_opencode_smoke(
             f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
         )
 
-    pytest.fail("opencode run exited before Dynamo traced an opencode agent_context")
+    pytest.fail(
+        "opencode run exited before Dynamo traced an opencode child agent_context "
+        "with parent_trajectory_id"
+    )


### PR DESCRIPTION
## Summary
- Normalize first-class coding agent headers into `agent_context` trajectory IDs.
- Add `x-dynamo-trajectory-id` as the generic fallback path and keep session identity optional unless explicitly supplied.
- Keep the live frontend agent smoke tests, with agent prompts/config fixtures split out of the main test file.

Linear: DYN-3247

## Validation
- `cargo test -p dynamo-llm protocols::common::extensions::tests --lib`
- `cargo test -p dynamo-llm --test preprocessor test_agent_context_propagates_to_preprocessed_request`
- `ruff check tests/frontend/test_frontend_api_surface_compliance.py tests/frontend/agent_smoke_inputs.py`
- `.venv/bin/python -m py_compile tests/frontend/test_frontend_api_surface_compliance.py tests/frontend/agent_smoke_inputs.py`
- `.venv/bin/python -m pytest tests/frontend/test_frontend_api_surface_compliance.py::test_patch_openresponses_suite_adds_output_cap -q`
- `.venv/bin/python -m pytest tests/frontend/test_frontend_api_surface_compliance.py --collect-only -q`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->