### PR TITLE
fix(runtime): retry etcd startup connection

### DIFF
--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -85,6 +85,7 @@ impl Client {
         })
     }
 
+    /// Connect to etcd during startup, retrying with exponential backoff for up to 2 minutes.
     async fn connect_with_startup_retry(
         config: &ClientOptions,
         token: CancellationToken,
@@ -97,37 +98,7 @@ impl Client {
                 anyhow::bail!("etcd startup connection cancelled");
             }
 
-            let attempt: Result<(Arc<Connector>, u64)> = async {
-                let connector =
-                    Connector::new(config.etcd_url.clone(), config.etcd_connect_options.clone())
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "Unable to connect to etcd server at {}. Check etcd server status",
-                                config.etcd_url.join(", ")
-                            )
-                        })?;
-
-                let lease_id = if config.attach_lease {
-                    create_lease(connector.clone(), config.lease_ttl, token.clone())
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "Unable to create lease. Check etcd server status at {}",
-                                config.etcd_url.join(", ")
-                            )
-                        })?
-                } else {
-                    0
-                };
-
-                if token.is_cancelled() {
-                    anyhow::bail!("etcd startup connection cancelled");
-                }
-
-                Ok((connector, lease_id))
-            }
-            .await;
+            let attempt = Self::connect_startup_attempt(config, &token).await;
 
             match attempt {
                 Ok(connection) => return Ok(connection),
@@ -139,7 +110,7 @@ impl Client {
 
                     let sleep_duration = backoff.min(deadline.saturating_duration_since(now));
 
-                    tracing::info!(
+                    tracing::warn!(
                         error = %err,
                         retry_in = ?sleep_duration,
                         remaining = ?deadline.saturating_duration_since(now),
@@ -159,6 +130,33 @@ impl Client {
                 }
             }
         }
+    }
+
+    async fn connect_startup_attempt(
+        config: &ClientOptions,
+        token: &CancellationToken,
+    ) -> Result<(Arc<Connector>, u64)> {
+        let connector =
+            Connector::new(config.etcd_url.clone(), config.etcd_connect_options.clone()).await?;
+
+        let lease_id = if config.attach_lease {
+            create_lease(connector.clone(), config.lease_ttl, token.clone())
+                .await
+                .with_context(|| {
+                    format!(
+                        "Unable to create lease. Check etcd server status at {}",
+                        config.etcd_url.join(", ")
+                    )
+                })?
+        } else {
+            0
+        };
+
+        if token.is_cancelled() {
+            anyhow::bail!("etcd startup connection cancelled");
+        }
+
+        Ok((connector, lease_id))
     }
 
     /// Get a clone of the underlying [`etcd_client::Client`] instance.

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -19,7 +19,7 @@ use etcd_client::{
     WatchStream, Watcher,
 };
 pub use etcd_client::{ConnectOptions, KeyValue, LeaseClient};
-use tokio::time::{Duration, interval};
+use tokio::time::{Duration, Instant, interval};
 use tokio_util::sync::CancellationToken;
 
 mod connector;
@@ -32,6 +32,10 @@ pub use lock::*;
 
 use super::utils::build_in_runtime;
 use crate::config::environment_names::etcd as env_etcd;
+
+const STARTUP_CONNECT_TIMEOUT: Duration = Duration::from_secs(120);
+const STARTUP_CONNECT_INITIAL_BACKOFF: Duration = Duration::from_secs(5);
+const STARTUP_CONNECT_MAX_BACKOFF: Duration = Duration::from_secs(30);
 
 /// ETCD Client
 #[derive(Clone)]
@@ -68,22 +72,44 @@ impl Client {
         let token = runtime.primary_token();
 
         let ((connector, lease_id), rt) = build_in_runtime(
-            async move {
-                let etcd_urls = config.etcd_url.clone();
-                let connect_options = config.etcd_connect_options.clone();
+            async move { Self::connect_with_startup_retry(&config, token).await },
+            1,
+        )
+        .await?;
 
-                // Create the connector
-                let connector = Connector::new(etcd_urls, connect_options)
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "Unable to connect to etcd server at {}. Check etcd server status",
-                            config.etcd_url.join(", ")
-                        )
-                    })?;
+        Ok(Client {
+            connector,
+            primary_lease: lease_id,
+            rt,
+            runtime,
+        })
+    }
+
+    async fn connect_with_startup_retry(
+        config: &ClientOptions,
+        token: CancellationToken,
+    ) -> Result<(Arc<Connector>, u64)> {
+        let deadline = Instant::now() + STARTUP_CONNECT_TIMEOUT;
+        let mut backoff = STARTUP_CONNECT_INITIAL_BACKOFF;
+
+        loop {
+            if token.is_cancelled() {
+                anyhow::bail!("etcd startup connection cancelled");
+            }
+
+            let attempt: Result<(Arc<Connector>, u64)> = async {
+                let connector =
+                    Connector::new(config.etcd_url.clone(), config.etcd_connect_options.clone())
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "Unable to connect to etcd server at {}. Check etcd server status",
+                                config.etcd_url.join(", ")
+                            )
+                        })?;
 
                 let lease_id = if config.attach_lease {
-                    create_lease(connector.clone(), config.lease_ttl, token)
+                    create_lease(connector.clone(), config.lease_ttl, token.clone())
                         .await
                         .with_context(|| {
                             format!(
@@ -95,18 +121,44 @@ impl Client {
                     0
                 };
 
-                Ok((connector, lease_id))
-            },
-            1,
-        )
-        .await?;
+                if token.is_cancelled() {
+                    anyhow::bail!("etcd startup connection cancelled");
+                }
 
-        Ok(Client {
-            connector,
-            primary_lease: lease_id,
-            rt,
-            runtime,
-        })
+                Ok((connector, lease_id))
+            }
+            .await;
+
+            match attempt {
+                Ok(connection) => return Ok(connection),
+                Err(err) => {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        return Err(err);
+                    }
+
+                    let sleep_duration = backoff.min(deadline.saturating_duration_since(now));
+
+                    tracing::info!(
+                        error = %err,
+                        retry_in = ?sleep_duration,
+                        remaining = ?deadline.saturating_duration_since(now),
+                        "etcd not reachable yet; retrying startup connection"
+                    );
+
+                    tokio::select! {
+                        biased;
+
+                        _ = token.cancelled() => {
+                            anyhow::bail!("etcd startup connection cancelled");
+                        }
+
+                        _ = tokio::time::sleep(sleep_duration) => {}
+                    }
+                    backoff = backoff.saturating_mul(2).min(STARTUP_CONNECT_MAX_BACKOFF);
+                }
+            }
+        }
     }
 
     /// Get a clone of the underlying [`etcd_client::Client`] instance.

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -34,7 +34,7 @@ use super::utils::build_in_runtime;
 use crate::config::environment_names::etcd as env_etcd;
 
 const STARTUP_CONNECT_TIMEOUT: Duration = Duration::from_secs(120);
-const STARTUP_CONNECT_INITIAL_BACKOFF: Duration = Duration::from_secs(5);
+const STARTUP_CONNECT_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const STARTUP_CONNECT_MAX_BACKOFF: Duration = Duration::from_secs(30);
 
 /// ETCD Client

--- a/lib/runtime/src/transports/etcd/lease.rs
+++ b/lib/runtime/src/transports/etcd/lease.rs
@@ -17,10 +17,25 @@ pub async fn create_lease(
     ttl: u64,
     token: CancellationToken,
 ) -> anyhow::Result<u64> {
+    if token.is_cancelled() {
+        anyhow::bail!("lease creation cancelled");
+    }
+
     let mut lease_client = connector.get_client().lease_client();
     let lease = lease_client.grant(ttl as i64, None).await?;
 
     let id = lease.id() as u64;
+    if token.is_cancelled() {
+        if let Err(e) = lease_client.revoke(id as i64).await {
+            tracing::warn!(
+                lease_id = id,
+                error = %e,
+                "Failed to revoke lease after cancellation during creation"
+            );
+        }
+        anyhow::bail!("lease creation cancelled");
+    }
+
     let ttl = lease.ttl() as u64;
     let child = token.child_token();
 


### PR DESCRIPTION
## Summary
- Add startup-only retry handling for the initial etcd connector and primary lease creation path.
- Retry for up to 120s with exponential backoff from 5s to 30s, logging transient startup failures at info level.
- Keep runtime watch/reconnect behavior unchanged.

Fixes #10798

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p dynamo-runtime`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved etcd client connection startup reliability by adding a cancellable, configurable retry loop with exponential backoff capped by a maximum delay.
  * Enhanced connection and lease error handling with clearer contextual messaging during failure and retry scenarios.
  * Improved lease creation responsiveness to shutdown/cancellation by preventing stale lease state and revoking the newly created lease when cancellation occurs mid-creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->