### PR TITLE
fix(trace): infer tool slices from request finish metadata

### DIFF
--- a/benchmarks/request_trace/README.md
+++ b/benchmarks/request_trace/README.md
@@ -24,6 +24,9 @@ glob pattern. The converter emits Chrome Trace Event JSON:
 - one tool slice per harness `tool_end`/`tool_error`; explicit
   `started_at_unix_ms`/`ended_at_unix_ms` are preferred, then `duration_ms`,
   then paired `tool_start` timing when both records are present
+- inferred tool slices from request `finish_reason_metadata.tool_calls` when
+  no matching tool event was traced; these span the gap from the tool-call LLM
+  response end to the next LLM request start in the same trajectory
 - finish metadata on request slices, including final finish reason, backend
   finish reason, stop reason, per-choice finish summaries, and complete
   tool-call names

--- a/benchmarks/request_trace/README.md
+++ b/benchmarks/request_trace/README.md
@@ -27,7 +27,8 @@ glob pattern. The converter emits Chrome Trace Event JSON:
 - inferred tool slices from request `finish_reason_metadata.tool_calls` when
   no matching tool event was traced; when the next same-trajectory request
   starts after the tool-call response, the slice spans that gap, otherwise the
-  converter emits a short `duration_unknown` synthetic slice at the response end
+  converter emits a short `duration_unknown` synthetic slice at the response
+  end, including when there is no following same-trajectory request
 - finish metadata on request slices, including final finish reason, backend
   finish reason, stop reason, per-choice finish summaries, and complete
   tool-call names

--- a/benchmarks/request_trace/README.md
+++ b/benchmarks/request_trace/README.md
@@ -25,8 +25,9 @@ glob pattern. The converter emits Chrome Trace Event JSON:
   `started_at_unix_ms`/`ended_at_unix_ms` are preferred, then `duration_ms`,
   then paired `tool_start` timing when both records are present
 - inferred tool slices from request `finish_reason_metadata.tool_calls` when
-  no matching tool event was traced; these span the gap from the tool-call LLM
-  response end to the next LLM request start in the same trajectory
+  no matching tool event was traced; when the next same-trajectory request
+  starts after the tool-call response, the slice spans that gap, otherwise the
+  converter emits a short `duration_unknown` synthetic slice at the response end
 - finish metadata on request slices, including final finish reason, backend
   finish reason, stop reason, per-choice finish summaries, and complete
   tool-call names

--- a/benchmarks/request_trace/convert_to_perfetto.py
+++ b/benchmarks/request_trace/convert_to_perfetto.py
@@ -16,6 +16,7 @@ import gzip
 import heapq
 import json
 import sys
+from itertools import pairwise
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -453,7 +454,7 @@ def _prepare_inferred_tool_items(
 
     for requests in by_trajectory.values():
         requests.sort(key=lambda item: item["ts_us"])
-        for request_item, next_request_item in zip(requests, requests[1:]):
+        for request_item, next_request_item in pairwise(requests):
             tool_calls = _inferred_tool_calls(request_item["request"])
             if not tool_calls:
                 continue

--- a/benchmarks/request_trace/convert_to_perfetto.py
+++ b/benchmarks/request_trace/convert_to_perfetto.py
@@ -461,8 +461,7 @@ def _prepare_inferred_tool_items(
 
             start_us = request_item["ts_us"] + request_item["dur_us"]
             end_us = next_request_item["ts_us"]
-            if end_us <= start_us:
-                continue
+            duration_unknown = end_us <= start_us
 
             for tool_call in tool_calls:
                 tool_call_id = tool_call.get("id")
@@ -487,15 +486,36 @@ def _prepare_inferred_tool_items(
                     "inferred": True,
                     "host_execution": False,
                     "source_request_id": request_item["request"].get("request_id"),
-                    "next_request_id": next_request_item["request"].get("request_id"),
                     "tool_call_id": tool_call_id,
                     "tool_call_index": tool_call.get("tool_call_index"),
                     "choice_index": tool_call.get("choice_index"),
                     "tool_class": tool_name,
                     "started_at_unix_ms": start_us / 1000.0,
-                    "ended_at_unix_ms": end_us / 1000.0,
-                    "duration_ms": (end_us - start_us) / 1000.0,
                 }
+                if duration_unknown:
+                    args.update(
+                        {
+                            "duration_unknown": True,
+                            "synthetic_duration": True,
+                            "visual_duration_ms": _SYNTHETIC_TOOL_DURATION_US / 1000.0,
+                            "overlapping_request_id": next_request_item["request"].get(
+                                "request_id"
+                            ),
+                        }
+                    )
+                    dur_us = _SYNTHETIC_TOOL_DURATION_US
+                else:
+                    args.update(
+                        {
+                            "next_request_id": next_request_item["request"].get(
+                                "request_id"
+                            ),
+                            "ended_at_unix_ms": end_us / 1000.0,
+                            "duration_ms": (end_us - start_us) / 1000.0,
+                        }
+                    )
+                    dur_us = end_us - start_us
+
                 items.append(
                     {
                         "kind": "inferred_tool",
@@ -506,7 +526,7 @@ def _prepare_inferred_tool_items(
                             if value is not None
                         },
                         "ts_us": start_us,
-                        "dur_us": end_us - start_us,
+                        "dur_us": dur_us,
                         "session_id": request_item["session_id"],
                         "trajectory_id": request_item["trajectory_id"],
                     }

--- a/benchmarks/request_trace/convert_to_perfetto.py
+++ b/benchmarks/request_trace/convert_to_perfetto.py
@@ -216,9 +216,16 @@ def _flatten_tool_args(
     return {key: value for key, value in args.items() if value is not None}
 
 
+def _inferred_tool_calls(request: dict[str, Any]) -> list[dict[str, Any]]:
+    finish = request.get("finish_reason_metadata")
+    tool_calls = finish.get("tool_calls") if isinstance(finish, dict) else None
+    if not isinstance(tool_calls, list):
+        return []
+    return [call for call in tool_calls if isinstance(call, dict)]
+
+
 class TrackTable:
     def __init__(self) -> None:
-        self._session_pids: dict[str, int] = {}
         self._track_tids: dict[tuple[str, str, int, str], int] = {}
         self._active_lanes: dict[tuple[str, str], list[tuple[int, int]]] = {}
         self._max_lanes: dict[tuple[str, str], int] = {}
@@ -231,9 +238,6 @@ class TrackTable:
         start_us: int,
         end_us: int,
     ) -> int:
-        if session_id not in self._session_pids:
-            self._session_pids[session_id] = len(self._session_pids) + 1
-
         trajectory_key = (session_id, trajectory_id)
         active = self._active_lanes.setdefault(trajectory_key, [])
         while active and active[0][0] <= start_us:
@@ -256,36 +260,26 @@ class TrackTable:
         lane: int,
         track_kind: str,
     ) -> tuple[int, int]:
-        if session_id not in self._session_pids:
-            self._session_pids[session_id] = len(self._session_pids) + 1
-        pid = self._session_pids[session_id]
-
         track_key = (session_id, trajectory_id, lane, track_kind)
         if track_key not in self._track_tids:
-            self._track_tids[track_key] = (
-                len([1 for existing in self._track_tids if existing[0] == session_id])
-                + 1
-            )
-        return pid, self._track_tids[track_key]
+            self._track_tids[track_key] = len(self._track_tids) + 1
+        return 1, self._track_tids[track_key]
 
     def metadata_events(self) -> list[dict[str, Any]]:
         events: list[dict[str, Any]] = []
-        for session_id, pid in sorted(
-            self._session_pids.items(), key=lambda item: item[1]
-        ):
+        if self._track_tids:
             events.append(
                 {
                     "name": "process_name",
                     "ph": "M",
-                    "pid": pid,
-                    "args": {"name": f"session: {session_id}"},
+                    "pid": 1,
+                    "args": {"name": "Dynamo request trace"},
                 }
             )
         for (session_id, trajectory_id, lane, track_kind), tid in sorted(
             self._track_tids.items(),
-            key=lambda item: (self._session_pids[item[0][0]], item[1]),
+            key=lambda item: item[1],
         ):
-            pid = self._session_pids[session_id]
             lane_count = self._max_lanes.get((session_id, trajectory_id), 1)
             track_name = trajectory_id
             if lane_count > 1:
@@ -296,7 +290,7 @@ class TrackTable:
                 {
                     "name": "thread_name",
                     "ph": "M",
-                    "pid": pid,
+                    "pid": 1,
                     "tid": tid,
                     "args": {"name": track_name},
                 }
@@ -435,6 +429,91 @@ def _prepare_tool_items(tool_records: list[dict[str, Any]]) -> list[dict[str, An
     return items
 
 
+def _prepare_inferred_tool_items(
+    request_items: list[dict[str, Any]],
+    tool_records: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    real_tool_keys = {
+        (
+            record["session_id"],
+            record["trajectory_id"],
+            _safe_label(record["tool"].get("tool_call_id"), ""),
+        )
+        for record in tool_records
+        if record["event_type"] in {"tool_end", "tool_error"}
+        and record["tool"].get("tool_call_id")
+    }
+
+    by_trajectory: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for item in request_items:
+        by_trajectory.setdefault(
+            (item["session_id"], item["trajectory_id"]), []
+        ).append(item)
+
+    for requests in by_trajectory.values():
+        requests.sort(key=lambda item: item["ts_us"])
+        for request_item, next_request_item in zip(requests, requests[1:]):
+            tool_calls = _inferred_tool_calls(request_item["request"])
+            if not tool_calls:
+                continue
+
+            start_us = request_item["ts_us"] + request_item["dur_us"]
+            end_us = next_request_item["ts_us"]
+            if end_us <= start_us:
+                continue
+
+            for tool_call in tool_calls:
+                tool_call_id = tool_call.get("id")
+                if (
+                    request_item["session_id"],
+                    request_item["trajectory_id"],
+                    _safe_label(tool_call_id, ""),
+                ) in real_tool_keys:
+                    continue
+
+                tool_name = _safe_label(tool_call.get("name"), "unknown-tool")
+                args = {
+                    "session_type_id": request_item["args"].get("session_type_id"),
+                    "session_id": request_item["session_id"],
+                    "trajectory_id": request_item["trajectory_id"],
+                    "parent_trajectory_id": request_item["args"].get(
+                        "parent_trajectory_id"
+                    ),
+                    "event_type": "inferred_tool_call",
+                    "event_source": "dynamo",
+                    "source": "request.finish_reason_metadata.tool_calls",
+                    "inferred": True,
+                    "host_execution": False,
+                    "source_request_id": request_item["request"].get("request_id"),
+                    "next_request_id": next_request_item["request"].get("request_id"),
+                    "tool_call_id": tool_call_id,
+                    "tool_call_index": tool_call.get("tool_call_index"),
+                    "choice_index": tool_call.get("choice_index"),
+                    "tool_class": tool_name,
+                    "started_at_unix_ms": start_us / 1000.0,
+                    "ended_at_unix_ms": end_us / 1000.0,
+                    "duration_ms": (end_us - start_us) / 1000.0,
+                }
+                items.append(
+                    {
+                        "kind": "inferred_tool",
+                        "tool_class": tool_name,
+                        "args": {
+                            key: value
+                            for key, value in args.items()
+                            if value is not None
+                        },
+                        "ts_us": start_us,
+                        "dur_us": end_us - start_us,
+                        "session_id": request_item["session_id"],
+                        "trajectory_id": request_item["trajectory_id"],
+                    }
+                )
+
+    return items
+
+
 def convert_records(
     records: Iterable[dict[str, Any]],
     *,
@@ -443,6 +522,7 @@ def convert_records(
     separate_stage_tracks: bool = False,
 ) -> tuple[dict[str, Any], int]:
     prepared: list[dict[str, Any]] = []
+    request_items: list[dict[str, Any]] = []
     tool_records: list[dict[str, Any]] = []
 
     for record in records:
@@ -474,17 +554,17 @@ def convert_records(
             if ts_us is None or dur_us is None:
                 continue
 
-            prepared.append(
-                {
-                    "kind": "request",
-                    "request": request,
-                    "args": _flatten_args(event, agent_context, request),
-                    "ts_us": ts_us,
-                    "dur_us": max(1, dur_us),
-                    "session_id": session_id,
-                    "trajectory_id": trajectory_id,
-                }
-            )
+            item = {
+                "kind": "request",
+                "request": request,
+                "args": _flatten_args(event, agent_context, request),
+                "ts_us": ts_us,
+                "dur_us": max(1, dur_us),
+                "session_id": session_id,
+                "trajectory_id": trajectory_id,
+            }
+            prepared.append(item)
+            request_items.append(item)
             continue
 
         if event_type in _TOOL_EVENT_TYPES:
@@ -510,6 +590,7 @@ def convert_records(
                 }
             )
 
+    prepared.extend(_prepare_inferred_tool_items(request_items, tool_records))
     prepared.extend(_prepare_tool_items(tool_records))
 
     tracks = TrackTable()
@@ -571,6 +652,27 @@ def convert_records(
                     pid=tool_pid,
                     tid=tool_tid,
                     ts_us=ts_us,
+                    args=args,
+                )
+            )
+            converted += 1
+            continue
+
+        if item["kind"] == "inferred_tool":
+            tool_pid, tool_tid = tracks.track_for(
+                item["session_id"],
+                item["trajectory_id"],
+                lane,
+                "tools",
+            )
+            trace_events.append(
+                _make_complete_event(
+                    name="Tool: " + item["tool_class"],
+                    category="dynamo.agent.tool",
+                    pid=tool_pid,
+                    tid=tool_tid,
+                    ts_us=ts_us,
+                    dur_us=dur_us,
                     args=args,
                 )
             )

--- a/benchmarks/request_trace/convert_to_perfetto.py
+++ b/benchmarks/request_trace/convert_to_perfetto.py
@@ -16,7 +16,6 @@ import gzip
 import heapq
 import json
 import sys
-from itertools import pairwise
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -454,14 +453,17 @@ def _prepare_inferred_tool_items(
 
     for requests in by_trajectory.values():
         requests.sort(key=lambda item: item["ts_us"])
-        for request_item, next_request_item in pairwise(requests):
+        for index, request_item in enumerate(requests):
+            next_request_item = (
+                requests[index + 1] if index + 1 < len(requests) else None
+            )
             tool_calls = _inferred_tool_calls(request_item["request"])
             if not tool_calls:
                 continue
 
             start_us = request_item["ts_us"] + request_item["dur_us"]
-            end_us = next_request_item["ts_us"]
-            duration_unknown = end_us <= start_us
+            end_us = next_request_item["ts_us"] if next_request_item else start_us
+            duration_unknown = next_request_item is None or end_us <= start_us
 
             for tool_call in tool_calls:
                 tool_call_id = tool_call.get("id")
@@ -498,8 +500,10 @@ def _prepare_inferred_tool_items(
                             "duration_unknown": True,
                             "synthetic_duration": True,
                             "visual_duration_ms": _SYNTHETIC_TOOL_DURATION_US / 1000.0,
-                            "overlapping_request_id": next_request_item["request"].get(
-                                "request_id"
+                            "overlapping_request_id": (
+                                next_request_item["request"].get("request_id")
+                                if next_request_item
+                                else None
                             ),
                         }
                     )

--- a/benchmarks/request_trace/validate_convert_to_perfetto.py
+++ b/benchmarks/request_trace/validate_convert_to_perfetto.py
@@ -76,7 +76,7 @@ def check_convert_records_emits_request_stages_and_metadata():
         include_markers=True,
     )
 
-    assert converted == 1
+    assert converted == 2
     events = trace["traceEvents"]
     assert [event for event in events if event["ph"] == "M"]
 
@@ -549,6 +549,35 @@ def check_convert_records_infers_tool_slices_between_requests():
     assert "next_request_id" not in tool_event["args"]
     assert "ended_at_unix_ms" not in tool_event["args"]
     assert "duration_ms" not in tool_event["args"]
+
+    trace, converted = convert_records(
+        [
+            request(
+                "req-terminal-tool-call",
+                1000,
+                100,
+                {
+                    "finish_reason": "tool_calls",
+                    "tool_calls": [{"id": "call-1", "name": "exec_command"}],
+                },
+            ),
+        ],
+        include_stages=False,
+        include_markers=False,
+    )
+
+    assert converted == 2
+    tool_event = next(
+        event
+        for event in trace["traceEvents"]
+        if event.get("cat") == "dynamo.agent.tool"
+    )
+    assert tool_event["ts"] == 1_100_000
+    assert tool_event["dur"] == 1_000
+    assert tool_event["args"]["duration_unknown"] is True
+    assert tool_event["args"]["synthetic_duration"] is True
+    assert "next_request_id" not in tool_event["args"]
+    assert "overlapping_request_id" not in tool_event["args"]
 
     trace, converted = convert_records(
         [

--- a/benchmarks/request_trace/validate_convert_to_perfetto.py
+++ b/benchmarks/request_trace/validate_convert_to_perfetto.py
@@ -346,6 +346,41 @@ def check_convert_records_splits_overlapping_trajectory_requests_into_lanes():
     assert request_tids["req-1"] != request_tids["req-2"]
 
 
+def check_convert_records_uses_one_process_for_all_sessions():
+    def record(session_id: str):
+        return {
+            "event": {
+                "schema": "dynamo.request.trace.v1",
+                "event_type": "request_end",
+                "event_time_unix_ms": 1050,
+                "agent_context": {
+                    "session_id": session_id,
+                    "trajectory_id": session_id,
+                },
+                "request": {
+                    "request_id": session_id,
+                    "model": "test-model",
+                    "request_received_ms": 1000,
+                    "total_time_ms": 50,
+                },
+            }
+        }
+
+    trace, converted = convert_records(
+        [record("session-1"), record("session-2")],
+        include_stages=False,
+        include_markers=False,
+    )
+
+    assert converted == 2
+    pids = {
+        event["pid"]
+        for event in trace["traceEvents"]
+        if event.get("cat") == "dynamo.llm"
+    }
+    assert pids == {1}
+
+
 def check_convert_records_emits_tool_duration_slices():
     trace, converted = convert_records(
         [
@@ -398,6 +433,135 @@ def check_convert_records_emits_tool_duration_slices():
         if event.get("name") == "thread_name"
     ]
     assert thread_names == ["session-1:searcher tools"]
+
+
+def check_convert_records_infers_tool_slices_between_requests():
+    def request(
+        request_id: str,
+        start_ms: int,
+        total_ms: int,
+        finish_reason_metadata: dict | None = None,
+    ):
+        return {
+            "event": {
+                "schema": "dynamo.request.trace.v1",
+                "event_type": "request_end",
+                "event_time_unix_ms": start_ms + total_ms,
+                "event_source": "dynamo",
+                "agent_context": {
+                    "session_type_id": "codex",
+                    "session_id": "codex-session",
+                    "trajectory_id": "codex-session",
+                    "parent_trajectory_id": "parent-session",
+                },
+                "request": {
+                    "request_id": request_id,
+                    "model": "test-model",
+                    "request_received_ms": start_ms,
+                    "total_time_ms": total_ms,
+                    **(
+                        {"finish_reason_metadata": finish_reason_metadata}
+                        if finish_reason_metadata
+                        else {}
+                    ),
+                },
+            }
+        }
+
+    trace, converted = convert_records(
+        [
+            request(
+                "req-tool-call",
+                1000,
+                50,
+                {
+                    "finish_reason": "tool_calls",
+                    "tool_calls": [
+                        {
+                            "choice_index": 0,
+                            "tool_call_index": 0,
+                            "id": "call-1",
+                            "name": "exec_command",
+                        }
+                    ],
+                },
+            ),
+            request("req-after-tool", 1200, 40),
+        ],
+        include_stages=False,
+        include_markers=False,
+    )
+
+    assert converted == 3
+    tool_event = next(
+        event
+        for event in trace["traceEvents"]
+        if event.get("cat") == "dynamo.agent.tool"
+    )
+    assert tool_event["name"] == "Tool: exec_command"
+    assert tool_event["ts"] == 1_050_000
+    assert tool_event["dur"] == 150_000
+    assert tool_event["args"]["event_type"] == "inferred_tool_call"
+    assert tool_event["args"]["inferred"] is True
+    assert tool_event["args"]["host_execution"] is False
+    assert tool_event["args"]["source_request_id"] == "req-tool-call"
+    assert tool_event["args"]["next_request_id"] == "req-after-tool"
+    assert tool_event["args"]["tool_call_id"] == "call-1"
+    assert tool_event["args"]["parent_trajectory_id"] == "parent-session"
+
+    thread_names = [
+        event["args"]["name"]
+        for event in trace["traceEvents"]
+        if event.get("name") == "thread_name"
+    ]
+    assert thread_names == ["codex-session", "codex-session tools"]
+
+    trace, converted = convert_records(
+        [
+            request(
+                "req-tool-call",
+                1000,
+                50,
+                {
+                    "finish_reason": "tool_calls",
+                    "tool_calls": [{"id": "call-1", "name": "exec_command"}],
+                },
+            ),
+            request("req-after-tool", 1200, 40),
+            {
+                "event": {
+                    "schema": "dynamo.request.trace.v1",
+                    "event_type": "tool_end",
+                    "event_time_unix_ms": 1175,
+                    "event_source": "harness",
+                    "agent_context": {
+                        "session_type_id": "codex",
+                        "session_id": "codex-session",
+                        "trajectory_id": "codex-session",
+                    },
+                    "tool": {
+                        "tool_call_id": "call-1",
+                        "tool_class": "exec_command",
+                        "started_at_unix_ms": 1060,
+                        "ended_at_unix_ms": 1175,
+                    },
+                }
+            },
+        ],
+        include_stages=False,
+        include_markers=False,
+    )
+
+    assert converted == 3
+    tool_events = [
+        event
+        for event in trace["traceEvents"]
+        if event.get("cat") == "dynamo.agent.tool"
+    ]
+    assert len(tool_events) == 1
+    assert "inferred" not in tool_events[0]["args"]
+    assert tool_events[0]["ts"] == 1_060_000
+    assert tool_events[0]["dur"] == 115_000
 
 
 def check_convert_records_pairs_tool_start_and_end_without_duration():
@@ -526,7 +690,9 @@ CHECKS = [
     check_convert_records_accepts_context_free_request_trace_schema,
     check_convert_records_clamps_stage_rounding_overlap,
     check_convert_records_splits_overlapping_trajectory_requests_into_lanes,
+    check_convert_records_uses_one_process_for_all_sessions,
     check_convert_records_emits_tool_duration_slices,
+    check_convert_records_infers_tool_slices_between_requests,
     check_convert_records_pairs_tool_start_and_end_without_duration,
     check_convert_records_renders_zero_duration_tool_as_synthetic_span,
 ]

--- a/benchmarks/request_trace/validate_convert_to_perfetto.py
+++ b/benchmarks/request_trace/validate_convert_to_perfetto.py
@@ -521,6 +521,40 @@ def check_convert_records_infers_tool_slices_between_requests():
             request(
                 "req-tool-call",
                 1000,
+                100,
+                {
+                    "finish_reason": "tool_calls",
+                    "tool_calls": [{"id": "call-1", "name": "exec_command"}],
+                },
+            ),
+            request("req-overlap", 1050, 40),
+            request("req-later", 1200, 40),
+        ],
+        include_stages=False,
+        include_markers=False,
+    )
+
+    assert converted == 4
+    tool_event = next(
+        event
+        for event in trace["traceEvents"]
+        if event.get("cat") == "dynamo.agent.tool"
+    )
+    assert tool_event["ts"] == 1_100_000
+    assert tool_event["dur"] == 1_000
+    assert tool_event["args"]["duration_unknown"] is True
+    assert tool_event["args"]["synthetic_duration"] is True
+    assert tool_event["args"]["visual_duration_ms"] == 1.0
+    assert tool_event["args"]["overlapping_request_id"] == "req-overlap"
+    assert "next_request_id" not in tool_event["args"]
+    assert "ended_at_unix_ms" not in tool_event["args"]
+    assert "duration_ms" not in tool_event["args"]
+
+    trace, converted = convert_records(
+        [
+            request(
+                "req-tool-call",
+                1000,
                 50,
                 {
                     "finish_reason": "tool_calls",


### PR DESCRIPTION
<!-- codex-pr-description:start -->
### Summary

The request-trace Perfetto converter now renders decoded model tool-call intent as normal `dynamo.agent.tool` slices when explicit harness tool events are absent. This restores the expected request/prefill/decode/tool visual shape for coding-agent traces on current `main`.

CLOSES: DYN-3244

### How This Was Implemented

- Infer tool slices from `request.finish_reason_metadata.tool_calls` when the same trajectory has a following request.
- Prefer real `tool_end`/`tool_error` timing when explicit tool events exist.
- Keep flat coding-agent identity intact; no synthetic `:turn:*` trajectory IDs.
- Emit one Perfetto process with trajectory/tool rows as threads so traces open expanded and readable in Perfetto.
- Preserve `parent_trajectory_id` on inferred tool slice args for child-agent traces.

<details>
<summary>Walkthrough</summary>

- `benchmarks/request_trace/convert_to_perfetto.py`: adds inferred tool slices, overlapping-request lanes, and one-process Perfetto metadata.
- `benchmarks/request_trace/validate_convert_to_perfetto.py`: covers inferred tools, real-tool precedence, overlapping lanes, and one-process rendering.
- `benchmarks/request_trace/README.md`: documents the default converter behavior and inferred timing semantics.

</details>

### Validation

- `python3 benchmarks/request_trace/validate_convert_to_perfetto.py`
- `python3 -m py_compile benchmarks/request_trace/convert_to_perfetto.py benchmarks/request_trace/validate_convert_to_perfetto.py`
- `git diff --check`
- Live Codex smoke against `examples/backends/sglang/launch/agg_agent.sh` with GLM-4.7: inferred `exec_command` tool slices rendered in Perfetto.
- Live Claude Code smoke/subagent probe against the same endpoint: inferred `Tool: Agent` and child `Tool: Bash` slices rendered in Perfetto.

### Examples

Artifacts gist: https://gist.github.com/ishandhanani/1f79a1c85b4185319cd4587b2fd81207

Claude Code subagent:

![Claude Code subagent Perfetto](https://gist.githubusercontent.com/ishandhanani/1f79a1c85b4185319cd4587b2fd81207/raw/claude-code-subagent-perfetto.svg)

Codex:

![Codex Perfetto](https://gist.githubusercontent.com/ishandhanani/1f79a1c85b4185319cd4587b2fd81207/raw/codex-perfetto.svg)
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool call timeline slices are now automatically inferred when indicated in LLM responses but not explicitly traced.

* **Improvements**
  * Simplified trace metadata and thread/process mapping to use consistent process identification across all sessions.

* **Documentation**
  * Updated documentation to describe tool slice inference behavior.

* **Tests**
  * Added validation tests for process mapping and tool call inference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->