### PR TITLE
fix(logging): allow exporting OTLP traces without logs

### DIFF
--- a/docs/fern/pages/reference/observability/environment-variables.mdx
+++ b/docs/fern/pages/reference/observability/environment-variables.mdx
@@ -114,6 +114,10 @@ Every Dynamo process reads its own environment at startup, so set these on each 
   Master switch for OTLP export. Gates both traces and runtime logs. Request trace records require the separate `otel` request-trace sink.
 </ParamField>
 
+<ParamField path="OTEL_EXPORT_LOGS_ENABLED" type="boolean" default="true">
+  Export runtime logs when `OTEL_EXPORT_ENABLED` is enabled. Set this to a falsy value (`false`, `0`, `off`, or `no`) to export traces without creating the OTLP log exporter.
+</ParamField>
+
 <ParamField path="OTEL_EXPORTER_OTLP_ENDPOINT" type="string">
   Generic endpoint for traces and logs. For `grpc`, Dynamo uses it as-is. For `http/protobuf`, Dynamo appends `/v1/traces` or `/v1/logs`. When unset, each signal uses its protocol default.
 </ParamField>

--- a/docs/fern/pages/reference/observability/logging.mdx
+++ b/docs/fern/pages/reference/observability/logging.mdx
@@ -65,8 +65,8 @@ export DYN_LOG='info,dynamo_runtime::system_status_server=trace'
 
 ## OTLP Export
 
-`OTEL_EXPORT_ENABLED=true` is the master switch for runtime trace and log export. Configure a
-generic endpoint for both signals:
+`OTEL_EXPORT_ENABLED=true` is the master switch for runtime trace and log export. Logs are exported
+by default. Configure a generic endpoint for both signals:
 
 ```bash
 export DYN_LOGGING_CONSOLE_FORMAT=readable
@@ -78,6 +78,13 @@ export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 Console formatting does not affect OTLP export; use `jsonl` instead if the local stderr stream also
 needs machine-readable records.
 
+To export traces without runtime logs, disable only the log exporter:
+
+```bash
+export OTEL_EXPORT_ENABLED=true
+export OTEL_EXPORT_LOGS_ENABLED=false
+```
+
 Use `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` for signal-specific
 destinations. Signal-specific endpoints are used as-is. For a generic `http/protobuf` endpoint,
 Dynamo appends `/v1/traces` or `/v1/logs`.
@@ -86,6 +93,7 @@ Dynamo appends `/v1/traces` or `/v1/logs`.
 `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` does not fall back to
 `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. If only the traces endpoint is set, logs use the generic
 endpoint or the protocol default and can be silently dropped when no collector is listening there.
+Set `OTEL_EXPORT_LOGS_ENABLED=false` when the collector accepts traces only.
 </Warning>
 
 Set these variables on every process whose telemetry you want to export. Use

--- a/docs/fern/pages/reference/observability/logging.mdx
+++ b/docs/fern/pages/reference/observability/logging.mdx
@@ -60,14 +60,21 @@ export DYN_LOG='info,dynamo_runtime::system_status_server=trace'
 
 ## OTLP Export
 
-`OTEL_EXPORT_ENABLED=true` is the master switch for runtime trace and log export. Configure a
-generic endpoint for both signals:
+`OTEL_EXPORT_ENABLED=true` is the master switch for runtime trace and log export. Logs are exported
+by default. Configure a generic endpoint for both signals:
 
 ```bash
 export DYN_LOGGING_JSONL=true
 export OTEL_EXPORT_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+To export traces without runtime logs, disable only the log exporter:
+
+```bash
+export OTEL_EXPORT_ENABLED=true
+export OTEL_EXPORT_LOGS_ENABLED=false
 ```
 
 Use `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` for signal-specific
@@ -78,6 +85,7 @@ Dynamo appends `/v1/traces` or `/v1/logs`.
 `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` does not fall back to
 `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. If only the traces endpoint is set, logs use the generic
 endpoint or the protocol default and can be silently dropped when no collector is listening there.
+Set `OTEL_EXPORT_LOGS_ENABLED=false` when the collector accepts traces only.
 </Warning>
 
 Set these variables on every process whose telemetry you want to export. Use

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -48,6 +48,11 @@ pub mod logging {
         /// Enable OTLP export for traces and logs (set to "1" to enable)
         pub const OTEL_EXPORT_ENABLED: &str = "OTEL_EXPORT_ENABLED";
 
+        /// Export OTLP logs when OTLP export is enabled. Logs are exported by
+        /// default; set to a falsy value ("0", "false", "off", "no") to export
+        /// traces only, e.g. when the collector accepts traces but not logs.
+        pub const OTEL_EXPORT_LOGS_ENABLED: &str = "OTEL_EXPORT_LOGS_ENABLED";
+
         /// OTLP exporter transport protocol. Supported values: "grpc", "http/protobuf".
         pub const OTEL_EXPORTER_OTLP_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
 

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -51,6 +51,11 @@ pub mod logging {
         /// Enable OTLP export for traces and logs (set to "1" to enable)
         pub const OTEL_EXPORT_ENABLED: &str = "OTEL_EXPORT_ENABLED";
 
+        /// Export OTLP logs when OTLP export is enabled. Logs are exported by
+        /// default; set to a falsy value ("0", "false", "off", "no") to export
+        /// traces only, e.g. when the collector accepts traces but not logs.
+        pub const OTEL_EXPORT_LOGS_ENABLED: &str = "OTEL_EXPORT_LOGS_ENABLED";
+
         /// OTLP exporter transport protocol. Supported values: "grpc", "http/protobuf".
         pub const OTEL_EXPORTER_OTLP_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
 
@@ -835,6 +840,7 @@ mod tests {
             logging::DYN_LOG_USE_LOCAL_TZ,
             logging::DYN_LOGGING_SPAN_EVENTS,
             logging::otlp::OTEL_EXPORT_ENABLED,
+            logging::otlp::OTEL_EXPORT_LOGS_ENABLED,
             logging::otlp::OTEL_EXPORTER_OTLP_PROTOCOL,
             logging::otlp::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
             logging::otlp::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -52,7 +52,7 @@ use tracing_subscriber::{filter::Directive, fmt};
 
 use crate::config::{
     ConsoleLogFormat, console_log_format, disable_ansi_logging, env_is_truthy,
-    legacy_jsonl_logging_enabled, span_events_enabled,
+    legacy_jsonl_logging_enabled, parse_bool_opt, span_events_enabled,
 };
 use async_nats::{HeaderMap, HeaderValue};
 use axum::extract::FromRequestParts;
@@ -145,6 +145,18 @@ impl Default for LoggingConfig {
 /// Check if OTLP trace exporting is enabled (accepts: "1", "true", "on", "yes" - case insensitive)
 fn otlp_exporter_enabled() -> bool {
     env_is_truthy(env_logging::otlp::OTEL_EXPORT_ENABLED)
+}
+
+/// Check if OTLP log exporting is enabled. Logs are exported by default when
+/// OTLP export is on; set `OTEL_EXPORT_LOGS_ENABLED` to a falsy value ("0",
+/// "false", "off", "no") to export traces only. This avoids flooding stderr
+/// with endpoint-unavailable errors when the collector accepts traces but not
+/// logs.
+fn otlp_logs_enabled() -> bool {
+    std::env::var(env_logging::otlp::OTEL_EXPORT_LOGS_ENABLED)
+        .ok()
+        .and_then(|value| parse_bool_opt(&value))
+        .unwrap_or(true)
 }
 
 /// Get the service name from environment or use default
@@ -329,7 +341,8 @@ fn log_otel_init_status(
             protocol = %protocol.as_str(),
             service = %service_name,
             console_format = console_format.as_str(),
-            "OpenTelemetry OTLP export enabled (traces and logs)"
+            logs_enabled = otlp_logs_enabled(),
+            "OpenTelemetry OTLP export enabled"
         );
     } else {
         tracing::info!(
@@ -1329,30 +1342,15 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
                     .as_deref(),
                 env_logging::otlp::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
             );
-            let logs_protocol = resolve_signal_otlp_protocol(
-                protocol,
-                std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL)
-                    .ok()
-                    .as_deref(),
-                env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
-            );
             let generic_endpoint =
                 std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_ENDPOINT).ok();
             let traces_endpoint_env =
                 std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).ok();
-            let logs_endpoint_env =
-                std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).ok();
             let traces_endpoint = resolve_otlp_endpoint(
                 traces_protocol,
                 traces_endpoint_env,
                 generic_endpoint.clone(),
                 "/v1/traces",
-            );
-            let logs_endpoint = resolve_otlp_endpoint(
-                logs_protocol,
-                logs_endpoint_env,
-                generic_endpoint,
-                "/v1/logs",
             );
 
             let resource = opentelemetry_sdk::Resource::builder_empty()
@@ -1372,16 +1370,42 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
             }
             let tracer_provider = tracer_provider_builder.build();
 
-            let log_exporter = build_log_exporter(logs_protocol, &logs_endpoint)?;
+            // Build the OTLP log exporter, unless log export is disabled
+            // (traces-only mode for collectors that accept traces but not
+            // logs). Logs protocol/endpoint resolution also lives inside the
+            // branch so a misconfigured logs protocol cannot warn when log
+            // export is off.
+            let logger_provider_opt = if otlp_logs_enabled() {
+                let logs_protocol = resolve_signal_otlp_protocol(
+                    protocol,
+                    std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL)
+                        .ok()
+                        .as_deref(),
+                    env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
+                );
+                let logs_endpoint_env =
+                    std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).ok();
+                let logs_endpoint = resolve_otlp_endpoint(
+                    logs_protocol,
+                    logs_endpoint_env,
+                    generic_endpoint,
+                    "/v1/logs",
+                );
+                let log_exporter = build_log_exporter(logs_protocol, &logs_endpoint)?;
 
-            let logger_provider = SdkLoggerProvider::builder()
-                .with_batch_exporter(log_exporter)
-                .with_resource(resource)
-                .build();
+                Some(
+                    SdkLoggerProvider::builder()
+                        .with_batch_exporter(log_exporter)
+                        .with_resource(resource)
+                        .build(),
+                )
+            } else {
+                None
+            };
 
             (
                 tracer_provider,
-                Some(logger_provider),
+                logger_provider_opt,
                 Some((traces_protocol, traces_endpoint)),
             )
         } else {
@@ -3238,6 +3262,85 @@ pub mod tests {
         }
 
         Ok(())
+    }
+
+    /// Verify `otlp_logs_enabled()` defaults to enabled when `OTEL_EXPORT_LOGS_ENABLED`
+    /// is unset, disables logs for falsy values, and keeps logs enabled for truthy
+    /// or unrecognized values.
+    #[test]
+    fn test_otlp_logs_enabled() {
+        use env_logging::otlp::OTEL_EXPORT_LOGS_ENABLED;
+
+        // Default (unset): logs are exported alongside traces.
+        temp_env::with_vars(vec![(OTEL_EXPORT_LOGS_ENABLED, None::<&str>)], || {
+            assert!(otlp_logs_enabled());
+        });
+
+        // Falsy values export traces only.
+        for val in ["0", "false", "off", "no", "OFF", "No"] {
+            temp_env::with_vars(vec![(OTEL_EXPORT_LOGS_ENABLED, Some(val))], || {
+                assert!(!otlp_logs_enabled(), "expected logs disabled for {val:?}");
+            });
+        }
+
+        // Truthy, empty, or unrecognized values keep logs enabled.
+        for val in ["1", "true", "on", "yes", "", "  ", "anything"] {
+            temp_env::with_vars(vec![(OTEL_EXPORT_LOGS_ENABLED, Some(val))], || {
+                assert!(otlp_logs_enabled(), "expected logs enabled for {val:?}");
+            });
+        }
+    }
+
+    #[test]
+    fn test_otlp_export_logs_disabled_ignores_invalid_protocol() {
+        use std::process::Command;
+
+        let output = Command::new("cargo")
+            .args([
+                "test",
+                "-p",
+                "dynamo-runtime",
+                "logging::tests::test_otlp_export_logs_disabled_ignores_invalid_protocol_subprocess",
+                "--",
+                "--exact",
+                "--nocapture",
+            ])
+            .env("OTEL_EXPORT_ENABLED", "1")
+            .env("OTEL_EXPORT_LOGS_ENABLED", "false")
+            .env("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "invalid")
+            .env_remove("OTEL_EXPORTER_OTLP_PROTOCOL")
+            .env_remove("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
+            .env_remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+            .env_remove("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
+            .env_remove("DYN_LOGGING_CONSOLE_FORMAT")
+            .env_remove("DYN_LOGGING_JSONL")
+            .output()
+            .expect("Failed to execute subprocess test");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "Subprocess test failed with exit code {:?}: {stderr}",
+            output.status.code()
+        );
+        assert!(
+            stderr.contains("OpenTelemetry OTLP export enabled"),
+            "OTLP trace export should initialize: {stderr}"
+        );
+        assert!(
+            !stderr.contains("unsupported OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"),
+            "disabled log export must not resolve the logs protocol: {stderr}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_otlp_export_logs_disabled_ignores_invalid_protocol_subprocess() {
+        if std::env::var("OTEL_EXPORT_LOGS_ENABLED").is_err() {
+            return;
+        }
+
+        // `init` exercises the real setup_logging path in a fresh process.
+        init();
     }
 
     /// Comprehensive test for span events covering:

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -49,7 +49,7 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{filter::Directive, fmt};
 
 use crate::config::{
-    disable_ansi_logging, env_is_truthy, jsonl_logging_enabled, span_events_enabled,
+    disable_ansi_logging, env_is_truthy, jsonl_logging_enabled, parse_bool_opt, span_events_enabled,
 };
 use async_nats::{HeaderMap, HeaderValue};
 use axum::extract::FromRequestParts;
@@ -142,6 +142,18 @@ impl Default for LoggingConfig {
 /// Check if OTLP trace exporting is enabled (accepts: "1", "true", "on", "yes" - case insensitive)
 fn otlp_exporter_enabled() -> bool {
     env_is_truthy(env_logging::otlp::OTEL_EXPORT_ENABLED)
+}
+
+/// Check if OTLP log exporting is enabled. Logs are exported by default when
+/// OTLP export is on; set `OTEL_EXPORT_LOGS_ENABLED` to a falsy value ("0",
+/// "false", "off", "no") to export traces only. This avoids flooding stderr
+/// with endpoint-unavailable errors when the collector accepts traces but not
+/// logs.
+fn otlp_logs_enabled() -> bool {
+    std::env::var(env_logging::otlp::OTEL_EXPORT_LOGS_ENABLED)
+        .ok()
+        .and_then(|value| parse_bool_opt(&value))
+        .unwrap_or(true)
 }
 
 /// Get the service name from environment or use default
@@ -303,7 +315,8 @@ fn log_otel_init_status(service_name: &str, endpoint_opt: Option<(OtlpProtocol, 
             endpoint = %endpoint,
             protocol = %protocol.as_str(),
             service = %service_name,
-            "OpenTelemetry OTLP export enabled (traces and logs)"
+            logs_enabled = otlp_logs_enabled(),
+            "OpenTelemetry OTLP export enabled"
         );
     } else {
         tracing::info!(
@@ -1291,30 +1304,15 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
                     .as_deref(),
                 env_logging::otlp::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
             );
-            let logs_protocol = resolve_signal_otlp_protocol(
-                protocol,
-                std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL)
-                    .ok()
-                    .as_deref(),
-                env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
-            );
             let generic_endpoint =
                 std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_ENDPOINT).ok();
             let traces_endpoint_env =
                 std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).ok();
-            let logs_endpoint_env =
-                std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).ok();
             let traces_endpoint = resolve_otlp_endpoint(
                 traces_protocol,
                 traces_endpoint_env,
                 generic_endpoint.clone(),
                 "/v1/traces",
-            );
-            let logs_endpoint = resolve_otlp_endpoint(
-                logs_protocol,
-                logs_endpoint_env,
-                generic_endpoint,
-                "/v1/logs",
             );
 
             let resource = opentelemetry_sdk::Resource::builder_empty()
@@ -1334,16 +1332,42 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
             }
             let tracer_provider = tracer_provider_builder.build();
 
-            let log_exporter = build_log_exporter(logs_protocol, &logs_endpoint)?;
+            // Build the OTLP log exporter, unless log export is disabled
+            // (traces-only mode for collectors that accept traces but not
+            // logs). Logs protocol/endpoint resolution also lives inside the
+            // branch so a misconfigured logs protocol cannot warn when log
+            // export is off.
+            let logger_provider_opt = if otlp_logs_enabled() {
+                let logs_protocol = resolve_signal_otlp_protocol(
+                    protocol,
+                    std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL)
+                        .ok()
+                        .as_deref(),
+                    env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
+                );
+                let logs_endpoint_env =
+                    std::env::var(env_logging::otlp::OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).ok();
+                let logs_endpoint = resolve_otlp_endpoint(
+                    logs_protocol,
+                    logs_endpoint_env,
+                    generic_endpoint,
+                    "/v1/logs",
+                );
+                let log_exporter = build_log_exporter(logs_protocol, &logs_endpoint)?;
 
-            let logger_provider = SdkLoggerProvider::builder()
-                .with_batch_exporter(log_exporter)
-                .with_resource(resource)
-                .build();
+                Some(
+                    SdkLoggerProvider::builder()
+                        .with_batch_exporter(log_exporter)
+                        .with_resource(resource)
+                        .build(),
+                )
+            } else {
+                None
+            };
 
             (
                 tracer_provider,
-                Some(logger_provider),
+                logger_provider_opt,
                 Some((traces_protocol, traces_endpoint)),
             )
         } else {
@@ -2849,6 +2873,33 @@ pub mod tests {
     #[tracing::instrument(level = "info", target = "other_module", skip_all)]
     async fn other_target_info_span() {
         tracing::info!(target: "other_module", "inside other target span");
+    }
+
+    /// Verify `otlp_logs_enabled()` defaults to enabled when `OTEL_EXPORT_LOGS_ENABLED`
+    /// is unset, disables logs for falsy values, and keeps logs enabled for truthy
+    /// or unrecognized values.
+    #[test]
+    fn test_otlp_logs_enabled() {
+        use env_logging::otlp::OTEL_EXPORT_LOGS_ENABLED;
+
+        // Default (unset): logs are exported alongside traces.
+        temp_env::with_vars(vec![(OTEL_EXPORT_LOGS_ENABLED, None::<&str>)], || {
+            assert!(otlp_logs_enabled());
+        });
+
+        // Falsy values export traces only.
+        for val in ["0", "false", "off", "no", "OFF", "No"] {
+            temp_env::with_vars(vec![(OTEL_EXPORT_LOGS_ENABLED, Some(val))], || {
+                assert!(!otlp_logs_enabled(), "expected logs disabled for {val:?}");
+            });
+        }
+
+        // Truthy, empty, or unrecognized values keep logs enabled.
+        for val in ["1", "true", "on", "yes", "", "  ", "anything"] {
+            temp_env::with_vars(vec![(OTEL_EXPORT_LOGS_ENABLED, Some(val))], || {
+                assert!(otlp_logs_enabled(), "expected logs enabled for {val:?}");
+            });
+        }
     }
 
     /// Comprehensive test for span events covering:


### PR DESCRIPTION
## Summary

Closes #10781.

When `OTEL_EXPORT_ENABLED` is set, Dynamo installs both the OTLP span exporter
and the OTLP log exporter. Collectors that accept traces but not logs therefore
produce repeated log-endpoint errors.

This adds the backward-compatible `OTEL_EXPORT_LOGS_ENABLED` opt-out:

- Unset, truthy, empty, or unrecognized values keep the existing traces-and-logs behavior.
- Falsy values (`0`, `false`, `off`, or `no`, case-insensitive) keep trace export enabled while skipping log-specific protocol and endpoint resolution, the log exporter/provider, and the logs bridge layer.

Trace protocol and endpoint resolution, sampling, the persistent exporter runtime,
the global tracer provider, console formatting, and legacy trace-context behavior are
unchanged.

### Usage

```bash
OTEL_EXPORT_ENABLED=1 OTEL_EXPORT_LOGS_ENABLED=0
```

### Docs

The new flag and traces-only usage are documented in:

- `docs/fern/pages/reference/observability/environment-variables.mdx`
- `docs/fern/pages/reference/observability/logging.mdx`

## Validation

- `cargo test -p dynamo-runtime --lib logging` — 44 passed.
- The exact subprocess regression initializes real OTLP tracing with logs disabled and proves an invalid logs protocol is not resolved.
- `OTEL_EXPORT_LOGS_ENABLED=false cargo test -p dynamo-runtime logging::tests::otlp_sync_init_connects_without_ambient_runtime -- --exact --nocapture` proves the trace exporter connects in both legacy JSONL modes.
- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-runtime --lib --tests`
- `git diff --check origin/main...HEAD`

Rebuilt directly on current main `a3e69aba61586afbe88915fadcf38d1a6f7432ae` as `4609907c0e32717c36d0c0d96b97411efd9ad591`.
