### PR TITLE
fix(llm): fall back to tokenizer.json for eos/bos token ids

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -1743,7 +1743,10 @@ fn resolve_token_id_from_tokenizer_files(model_dir: &Path, token_key: &str) -> O
 }
 
 /// Read `<token_key>` from `tokenizer_config.json` (a string or
-/// `{"content": ...}` object) and look it up in `added_tokens_decoder`.
+/// `{"content": ...}` object) and resolve its id via `added_tokens_decoder`,
+/// falling back to `tokenizer.json:added_tokens`. Some models (e.g.
+/// jina-embeddings-v5-omni) ship the token only as a bare string with no
+/// `added_tokens_decoder`, keeping the id mapping solely in `tokenizer.json`.
 fn resolve_token_id_from_tokenizer_config(
     path: &Path,
     token_key: &str,
@@ -1751,13 +1754,20 @@ fn resolve_token_id_from_tokenizer_config(
     let config = read_json(path)
         .with_context(|| format!("Failed to read or parse tokenizer_config.json: {:?}", path))?;
     let token_str = extract_token_string(config.get(token_key), token_key)?;
-    let added_tokens = config
+    if let Some(added_tokens) = config
         .get("added_tokens_decoder")
         .and_then(|v| v.as_object())
-        .ok_or_else(|| {
-            anyhow::anyhow!("added_tokens_decoder not found in tokenizer_config.json")
-        })?;
-    lookup_id_in_added_tokens_decoder(added_tokens, &token_str)
+        && let Ok(id) = lookup_id_in_added_tokens_decoder(added_tokens, &token_str)
+    {
+        return Ok(id);
+    }
+    let model_dir = path.parent().unwrap_or_else(|| Path::new(""));
+    lookup_id_in_tokenizer_json(model_dir, &token_str).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{token_key} '{token_str}' from tokenizer_config.json not found in \
+             added_tokens_decoder or tokenizer.json added_tokens"
+        )
+    })
 }
 
 /// Read and JSON-parse a file, returning `None` if it is missing or invalid.
@@ -2111,6 +2121,31 @@ mod tests {
         assert!(
             eos.contains(&200),
             "eos should resolve to 200 from special_tokens_map"
+        );
+        Ok(())
+    }
+
+    /// Rung 3, `tokenizer.json` fallback: `tokenizer_config.json` names the
+    /// eos token as a bare string but ships NO `added_tokens_decoder`, so the
+    /// string->id mapping lives only in `tokenizer.json:added_tokens`. With
+    /// `generation_config.json` and `special_tokens_map.json` both absent, this
+    /// is the only path that can recover the id. (bos is null in this model, so
+    /// only eos is exercised here.)
+    ///
+    /// Models in the wild that need this: `jinaai/jina-embeddings-v5-omni-small`
+    /// (https://huggingface.co/jinaai/jina-embeddings-v5-omni-small), reported
+    /// in https://github.com/ai-dynamo/dynamo/issues/10805: its eos `<|im_end|>`
+    /// resolves to 151645 from `tokenizer.json` alone. The fixture mirrors that
+    /// layout (ids/strings kept identical to the real model).
+    #[test]
+    fn test_config_json_eos_bos_from_tokenizer_json_fallback() -> anyhow::Result<()> {
+        let config_file = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-tokenizer-json-fallback/config.json");
+        let config = HFConfig::from_json_file(&config_file)?;
+        let eos: HashSet<_> = config.eos_token_ids().iter().cloned().collect();
+        assert!(
+            eos.contains(&151645),
+            "eos should resolve to 151645 (<|im_end|>) from tokenizer.json"
         );
         Ok(())
     }

--- a/lib/llm/tests/data/sample-models/mock-tokenizer-json-fallback/config.json
+++ b/lib/llm/tests/data/sample-models/mock-tokenizer-json-fallback/config.json
@@ -1,0 +1,5 @@
+{
+  "architectures": ["JinaEmbeddingsV5OmniModel"],
+  "model_type": "jina_embeddings_v5_omni",
+  "special_token_ids": [151652, 151653, 151655, 151656, 151669, 151670, 151671]
+}

--- a/lib/llm/tests/data/sample-models/mock-tokenizer-json-fallback/tokenizer.json
+++ b/lib/llm/tests/data/sample-models/mock-tokenizer-json-fallback/tokenizer.json
@@ -1,0 +1,6 @@
+{
+  "added_tokens": [
+    {"id": 151643, "content": "<|endoftext|>", "special": true},
+    {"id": 151645, "content": "<|im_end|>", "special": true}
+  ]
+}

--- a/lib/llm/tests/data/sample-models/mock-tokenizer-json-fallback/tokenizer_config.json
+++ b/lib/llm/tests/data/sample-models/mock-tokenizer-json-fallback/tokenizer_config.json
@@ -1,0 +1,10 @@
+{
+  "add_prefix_space": false,
+  "bos_token": null,
+  "clean_up_tokenization_spaces": false,
+  "eos_token": "<|im_end|>",
+  "model_max_length": 131072,
+  "pad_token": "<|endoftext|>",
+  "tokenizer_class": "Qwen2Tokenizer",
+  "unk_token": null
+}


### PR DESCRIPTION
#### Overview
Some models store their end-of-sequence token only as a name in `tokenizer_config.json` (e.g. `"eos_token": "<|im_end|>"`) and keep the name→id mapping solely in `tokenizer.json`. They ship no `generation_config.json` and no `special_tokens_map.json`. The frontend's model card builder could not find the eos id for these models and refused to register them, even though the inference engine loaded them fine. This makes the eos/bos lookup fall back to `tokenizer.json` so those models register.

**Repro** (the model from the issue, `jinaai/jina-embeddings-v5-omni-small`): deploy it behind the dynamo frontend + vllm backend. The backend comes up, but the frontend rejects the model during discovery.

Before:
```
WARN  Missing eos_token_id in generation_config.json
ERROR Error adding model from discovery:
 missing eos_token_id in config.json and
 generation_config.json, cannot load
```

After: the model registers and serves; eos resolves to `151645` (`<|im_end|>`) from `tokenizer.json`.

#### Details
The eos/bos id is resolved through a four-source fallback chain in `lib/llm/src/model_card.rs`: `generation_config.json` → `config.json` → `tokenizer_config.json` → `special_tokens_map.json`. The third rung, `resolve_token_id_from_tokenizer_config`, read the token *name* from `tokenizer_config.json` but could only turn that name into an id via an `added_tokens_decoder` map in the same file. When that map is absent, the only other place the id exists is `tokenizer.json`, and the code that reads it was reachable only through the fourth rung, which first requires a `special_tokens_map.json` to be present. A model missing both files fell through every rung.

The fix lets the third rung consult `tokenizer.json:added_tokens` directly when `added_tokens_decoder` is missing or does not contain the token. This is the same source the tokenizer itself uses, which is why the backend already worked. bos flows through the same helper, so it benefits identically.

Added a CI test plus a small fixture (`mock-tokenizer-json-fallback`) mirroring the real model's file layout, with the offending model linked in the test doc comment.

#### Where should the reviewer start?
`resolve_token_id_from_tokenizer_config` in `lib/llm/src/model_card.rs`, the added `tokenizer.json` fallback is the whole fix.

#### Related Issues
- Resolves #10805

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced special token resolution to support models with incomplete tokenizer metadata, improving compatibility with a broader range of model configurations.

* **Tests**
  * Added test coverage for special token resolution fallback behavior in tokenizer configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->