### PR TITLE
fix(operator): Ensure DGD annotations are applied to component services

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -20,7 +20,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"maps"
 	"sort"
 	"strings"
 
@@ -1087,7 +1086,22 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGroveResources(ctx context.Co
 				if syncedMainComponentService.Annotations == nil {
 					syncedMainComponentService.Annotations = make(map[string]string)
 				}
-				maps.Copy(syncedMainComponentService.Annotations, dynamo.GetDGDComponentResourceAnnotations(renderDeployment, componentName, component))
+				desiredAnnotations := dynamo.GetDGDComponentResourceAnnotations(renderDeployment, componentName, component)
+				var updateAnnotations bool
+				for key, value := range desiredAnnotations {
+					if val, ok := syncedMainComponentService.Annotations[key]; !ok || val != value {
+						syncedMainComponentService.Annotations[key] = value
+						updateAnnotations = true
+					}
+				}
+				if updateAnnotations {
+					err = r.Update(ctx, syncedMainComponentService)
+					if err != nil {
+						logger.Error(err, fmt.Sprintf("Failed to update main component service %s.", componentName))
+						r.GetRecorder().Eventf(dynamoDeployment, corev1.EventTypeWarning, "UpdateService", "Failed to update Service %s: %s", componentName, err)
+						return ReconcileResult{}, fmt.Errorf("failed to update main component service %s: %w", componentName, err)
+					}
+				}
 				mainComponentServiceAsResource, err := commoncontroller.NewResource(syncedMainComponentService,
 					func() (bool, string) {
 						return true, ""

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1068,6 +1068,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGroveResources(ctx context.Co
 				DynamoNamespace: dynamoNamespace,
 				ComponentName:   componentName,
 				Labels:          dynamo.GetDGDComponentResourceLabels(renderDeployment, componentName, component),
+				Annotations:     dynamo.GetDGDComponentResourceAnnotations(renderDeployment, componentName, component),
 				IsK8sDiscovery:  isK8sDiscoveryEnabled,
 			})
 			if err != nil {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -1083,6 +1084,10 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGroveResources(ctx context.Co
 				return ReconcileResult{}, fmt.Errorf("failed to sync the main component service: %w", err)
 			}
 			if syncedMainComponentService != nil {
+				if syncedMainComponentService.Annotations == nil {
+					syncedMainComponentService.Annotations = make(map[string]string)
+				}
+				maps.Copy(syncedMainComponentService.Annotations, dynamo.GetDGDComponentResourceAnnotations(renderDeployment, componentName, component))
 				mainComponentServiceAsResource, err := commoncontroller.NewResource(syncedMainComponentService,
 					func() (bool, string) {
 						return true, ""

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -2765,6 +2765,7 @@ func TestDynamoGraphDeploymentReconciler_prepareGroveRenderDeployment_PreservesL
 		DynamoNamespace: renderDGD.GetDynamoNamespaceForComponent(decode),
 		ComponentName:   "VllmDecodeWorker",
 		Labels:          dynamo.GetDGDComponentResourceLabels(renderDGD, "VllmDecodeWorker", decode),
+		Annotations:     dynamo.GetDGDComponentResourceAnnotations(renderDGD, "VllmDecodeWorker", decode),
 		IsK8sDiscovery:  true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -2597,11 +2597,13 @@ func Test_reconcileGroveResources_UsesPreservedAlphaServiceIngress(t *testing.T)
 		Spec: v1alpha1.DynamoGraphDeploymentSpec{
 			BackendFramework: "vllm",
 			Labels:           map[string]string{"graph-label": "kept"},
+			Annotations:      map[string]string{"graph-annotation": "kept"},
 			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 				"frontend": {
 					ComponentType: commonconsts.ComponentTypeFrontend,
 					Replicas:      ptr.To(int32(1)),
 					Labels:        map[string]string{"legacy-label": "kept"},
+					Annotations:   map[string]string{"legacy-annotation": "kept"},
 					Ingress: &v1alpha1.IngressSpec{
 						Enabled:                    true,
 						Host:                       "legacy-frontend",
@@ -2653,6 +2655,8 @@ func Test_reconcileGroveResources_UsesPreservedAlphaServiceIngress(t *testing.T)
 	g.Expect(fakeKubeClient.Get(ctx, types.NamespacedName{Name: "test-dgd-frontend", Namespace: "default"}, service)).NotTo(gomega.HaveOccurred())
 	g.Expect(service.Labels["graph-label"]).To(gomega.Equal("kept"))
 	g.Expect(service.Labels["legacy-label"]).To(gomega.Equal("kept"))
+	g.Expect(service.Annotations["graph-annotation"]).To(gomega.Equal("kept"))
+	g.Expect(service.Annotations["legacy-annotation"]).To(gomega.Equal("kept"))
 }
 
 func TestDynamoGraphDeploymentReconciler_prepareGroveRenderDeployment_PreservesLegacyWorkerSelectors(t *testing.T) {

--- a/deploy/operator/internal/controller/upgrade_test.go
+++ b/deploy/operator/internal/controller/upgrade_test.go
@@ -829,6 +829,7 @@ spec:
 						DynamoNamespace: renderDGD.GetDynamoNamespaceForComponent(decodeComponent),
 						ComponentName:   "VllmDecodeWorker",
 						Labels:          dynamo.GetDGDComponentResourceLabels(renderDGD, "VllmDecodeWorker", decodeComponent),
+						Annotations:     dynamo.GetDGDComponentResourceAnnotations(renderDGD, "VllmDecodeWorker", decodeComponent),
 						IsK8sDiscovery:  true,
 					})
 					require.NoError(t, err)

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -501,6 +501,18 @@ func GetDGDComponentResourceLabels(dgd *v1beta1.DynamoGraphDeployment, component
 	return labels
 }
 
+// GetDGDComponentResourceAnnotations returns annotations that should be applied to resources
+// created directly for a DGD component.
+func GetDGDComponentResourceAnnotations(dgd *v1beta1.DynamoGraphDeployment, componentName string, component *v1beta1.DynamoComponentDeploymentSharedSpec) map[string]string {
+	annotations := map[string]string{}
+	if dgd != nil {
+		maps.Copy(annotations, dgd.Spec.Annotations)
+		maps.Copy(annotations, getDGDComponentAlphaAnnotations(dgd, componentName))
+	}
+	maps.Copy(annotations, GetPodTemplateAnnotations(component))
+	return annotations
+}
+
 // GetDGDComponentPreservedIngressSpec returns an alpha component ingress spec that
 // was preserved during conversion to v1beta1.
 func GetDGDComponentPreservedIngressSpec(dgd *v1beta1.DynamoGraphDeployment, componentName string) (IngressSpec, bool) {

--- a/deploy/operator/internal/dynamo/model_service.go
+++ b/deploy/operator/internal/dynamo/model_service.go
@@ -96,6 +96,25 @@ func ReconcileModelServicesForComponents(
 			return fmt.Errorf("failed to sync headless service for model %s: %w", baseModelName, err)
 		}
 
+		if syncedService.Annotations == nil {
+			syncedService.Annotations = make(map[string]string)
+		}
+		var updateAnnotations bool
+		for key, value := range annotations {
+			if val, ok := syncedService.Annotations[key]; !ok || val != value {
+				syncedService.Annotations[key] = value
+				updateAnnotations = true
+			}
+		}
+		if updateAnnotations {
+			err = reconciler.Update(ctx, syncedService)
+			if err != nil {
+				logger.Error(err, fmt.Sprintf("Failed to update model service %s.", componentName))
+				reconciler.GetRecorder().Eventf(owner, corev1.EventTypeWarning, "UpdateService", "Failed to update model Service %s: %s", componentName, err)
+				return fmt.Errorf("failed to update main component service %s: %w", componentName, err)
+			}
+		}
+
 		logger.Info("Synced headless service for model",
 			"serviceName", syncedService.GetName(),
 			"baseModelName", baseModelName,

--- a/deploy/operator/internal/dynamo/model_service.go
+++ b/deploy/operator/internal/dynamo/model_service.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
@@ -68,7 +69,7 @@ func ReconcileModelServicesForComponents(
 		annotations := make(map[string]string)
 		if dgd, ok := owner.(*v1beta1.DynamoGraphDeployment); ok {
 			if dgd.Spec.Annotations != nil {
-				annotations = dgd.Spec.Annotations
+				maps.Copy(annotations, dgd.Spec.Annotations)
 			}
 		}
 
@@ -121,8 +122,12 @@ func generateHeadlessServiceForModel(
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
+	serviceAnnotations := make(map[string]string)
+	if annotations != nil {
+		serviceAnnotations = maps.Clone(annotations)
+	}
 	// Original name for humans
-	annotations[commonconsts.KubeAnnotationDynamoBaseModel] = baseModelName
+	serviceAnnotations[commonconsts.KubeAnnotationDynamoBaseModel] = baseModelName
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -132,7 +137,7 @@ func generateHeadlessServiceForModel(
 				commonconsts.KubeLabelDynamoBaseModelHash: modelHash,
 				"nvidia.com/managed-by":                   "dynamo-operator",
 			},
-			Annotations: annotations,
+			Annotations: serviceAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
 			// Headless service - no ClusterIP, no load balancing

--- a/deploy/operator/internal/dynamo/model_service.go
+++ b/deploy/operator/internal/dynamo/model_service.go
@@ -67,7 +67,9 @@ func ReconcileModelServicesForComponents(
 
 		annotations := make(map[string]string)
 		if dgd, ok := owner.(*v1beta1.DynamoGraphDeployment); ok {
-			annotations = GetDGDComponentResourceAnnotations(dgd, componentName, component)
+			if dgd.Spec.Annotations != nil {
+				annotations = dgd.Spec.Annotations
+			}
 		}
 
 		// Generate headless service with deterministic name based on model name

--- a/deploy/operator/internal/dynamo/model_service.go
+++ b/deploy/operator/internal/dynamo/model_service.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	corev1 "k8s.io/api/core/v1"
@@ -65,10 +66,25 @@ func ReconcileModelServicesForComponents(
 		}
 		seenBaseModels[baseModelName] = true
 
+		annotations := make(map[string]string)
+		if owner.GetObjectKind().GroupVersionKind().Kind == "DynamoGraphDeployment" {
+			dgd, ok := owner.(*nvidiacomv1beta1.DynamoGraphDeployment)
+			if !ok {
+				err := fmt.Errorf("failed to sync headless service annotations for model %s", baseModelName)
+				logger.Error(err, "Failed to get DGD for model services",
+					"kind", owner.GetObjectKind().GroupVersionKind().Kind,
+					"componentName", componentName,
+					"baseModelName", baseModelName)
+				return err
+			}
+			annotations = GetDGDComponentResourceAnnotations(dgd, componentName, component)
+		}
+
 		// Generate headless service with deterministic name based on model name
 		headlessService := generateHeadlessServiceForModel(
 			namespace,
 			baseModelName,
+			annotations,
 		)
 
 		// Sync the service (create or update)
@@ -103,12 +119,18 @@ func ReconcileModelServicesForComponents(
 func generateHeadlessServiceForModel(
 	namespace string,
 	baseModelName string,
+	annotations map[string]string,
 ) *corev1.Service {
 	// Generate deterministic service name from model name
 	serviceName := GenerateServiceName(baseModelName)
 
 	// Hash the base model name for use in labels (no length or character restrictions)
 	modelHash := HashModelName(baseModelName)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	// Original name for humans
+	annotations[commonconsts.KubeAnnotationDynamoBaseModel] = baseModelName
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -118,9 +140,7 @@ func generateHeadlessServiceForModel(
 				commonconsts.KubeLabelDynamoBaseModelHash: modelHash,
 				"nvidia.com/managed-by":                   "dynamo-operator",
 			},
-			Annotations: map[string]string{
-				commonconsts.KubeAnnotationDynamoBaseModel: baseModelName, // Original name for humans
-			},
+			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			// Headless service - no ClusterIP, no load balancing

--- a/deploy/operator/internal/dynamo/model_service.go
+++ b/deploy/operator/internal/dynamo/model_service.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	corev1 "k8s.io/api/core/v1"
@@ -67,16 +66,7 @@ func ReconcileModelServicesForComponents(
 		seenBaseModels[baseModelName] = true
 
 		annotations := make(map[string]string)
-		if owner.GetObjectKind().GroupVersionKind().Kind == "DynamoGraphDeployment" {
-			dgd, ok := owner.(*nvidiacomv1beta1.DynamoGraphDeployment)
-			if !ok {
-				err := fmt.Errorf("failed to sync headless service annotations for model %s", baseModelName)
-				logger.Error(err, "Failed to get DGD for model services",
-					"kind", owner.GetObjectKind().GroupVersionKind().Kind,
-					"componentName", componentName,
-					"baseModelName", baseModelName)
-				return err
-			}
+		if dgd, ok := owner.(*v1beta1.DynamoGraphDeployment); ok {
 			annotations = GetDGDComponentResourceAnnotations(dgd, componentName, component)
 		}
 


### PR DESCRIPTION
## Overview:

Attempt to ensure DGD annotations are applied to component Service objects.

## Details:

Pass DGD `spec.annotations` down to Service objects managed by the DGD.

## Where should the reviewer start?

The DGD controller was not passing any `Annotations` value in `ComponentServiceParams` that was sent to `GenerateComponentService`.

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #10813

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed service annotation propagation to ensure component-level annotations from DynamoGraphDeployment configurations are correctly applied to generated Kubernetes Service resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->