### PR TITLE
docs: add agent quickstart and surface it from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Most inference engines optimize a single GPU or a single node. Dynamo is the **o
 ### New in 1.0
 
 - **Zero-config deploy ([DGDR](https://docs.nvidia.com/dynamo/kubernetes-deployment/deploy-models/dgdr-reference))** *(beta):* Specify model, HW, and SLA in one YAML — AIConfigurator auto-profiles the workload, Planner optimizes the topology, and Dynamo deploys
-- **Agentic inference:** Per-request hints for priority, expected output length, and speculative prefill, plus session metadata for tracing and SGLang subagent KV isolation. [LangChain](https://docs.langchain.com/oss/python/integrations/chat/nvidia_ai_endpoints#use-with-nvidia-dynamo) + [NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) integrations
+- **Agentic inference:** Per-request hints for priority, expected output length, and speculative prefill, plus session metadata for tracing and SGLang subagent KV isolation. Start with the [Agent Quickstart](docs/agents/quickstart.md); [LangChain](https://docs.langchain.com/oss/python/integrations/chat/nvidia_ai_endpoints#use-with-nvidia-dynamo) + [NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) integrations
 - **Multimodal E/P/D:** Disaggregated encode/prefill/decode with embedding cache — 30% faster TTFT on image workloads
 - **Video generation:** Native [FastVideo](https://github.com/hao-ai-lab/FastVideo) + [SGLang Diffusion](https://lmsys.org/blog/2026-02-16-sglang-diffusion-advanced-optimizations/) support — real-time 1080p on single B200
 - **K8s Inference Gateway plugin:** KV-aware routing inside the standard Kubernetes gateway
@@ -122,6 +122,8 @@ In **standalone** mode, request flow is `client → Frontend → Router → work
 See the [Inference Gateway (GAIE) guide](docs/kubernetes/inference-gateway.md) for the full setup, supported features, and configuration of gateway mode.
 
 ## Quick Start
+
+> **Serving an agent or agentic harness?** Add per-request priority, output-length, and tracing metadata to any request — see the [Agent Quickstart](docs/agents/quickstart.md).
 
 ### Option A: Container (fastest)
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -14,6 +14,7 @@ telemetry, routing hints, and backend-specific cache behavior.
 
 | Concept | Purpose |
 |---------|---------|
+| [Agent Quickstart](quickstart.md) | The fastest path: send a normal request, then add `agent_context` and `agent_hints` to it with curl — no harness or SDK required. |
 | [Agent Tracing](agent-tracing.md) | Passive `session_id`/`trajectory_id` metadata plus Dynamo-owned request timing, token, cache, worker-placement, and harness tool-event traces. |
 | [Agent Hints](agent-hints.md) | Optional per-request hints such as priority, expected output length, and speculative prefill. |
 | [Priority Scheduling](priority-scheduling.md) | Request priority semantics across the router queue, backend engines, and cache policy. |

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -1,0 +1,120 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Agent Quickstart
+subtitle: Send your first agent-aware request to a running Dynamo deployment
+---
+
+This is the fastest path to an agent-aware request. You start an ordinary Dynamo
+deployment, send a normal OpenAI-compatible request, then add Dynamo's agent
+metadata to that same request. The metadata is plain JSON under `nvext` - no SDK,
+client library, or harness changes required. For a full coding-agent harness
+wired end to end, see [Use Pi-Mono with Dynamo](pi-mono.md).
+
+## Prerequisites
+
+A running Dynamo frontend and worker. If you don't have one, start the smallest
+possible deployment (same as the [main Quick Start](https://github.com/ai-dynamo/dynamo#quick-start)):
+
+```bash
+python3 -m dynamo.frontend --http-port 8000 --discovery-backend file > /dev/null 2>&1 &
+python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B --discovery-backend file &
+```
+
+Agent metadata is backend-agnostic - substitute `dynamo.vllm` or `dynamo.trtllm`
+and the requests below work unchanged.
+
+## 1. Send a Normal Request
+
+Confirm the deployment answers a plain request first:
+
+```bash
+curl -s localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{
+  "model": "Qwen/Qwen3-0.6B",
+  "messages": [{"role": "user", "content": "Hello!"}],
+  "max_tokens": 100
+}' | jq
+```
+
+## 2. Add Agent Context (Trace Identity)
+
+`agent_context` is passive identity that ties every LLM call in a run to a
+session and a trajectory. It does not change routing or output - it tags the
+request so traces can be joined later, across LLM calls, tool calls, and external
+trajectory files.
+
+```bash
+curl -s localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{
+  "model": "Qwen/Qwen3-0.6B",
+  "messages": [{"role": "user", "content": "Plan the next step."}],
+  "max_tokens": 100,
+  "nvext": {
+    "agent_context": {
+      "session_type_id": "deep_research",
+      "session_id": "research-run-42",
+      "trajectory_id": "research-run-42:researcher"
+    }
+  }
+}' | jq
+```
+
+The three context fields are required when you send `agent_context`. See
+[Agent Tracing](agent-tracing.md#adding-trace-context-to-each-llm-call) for the
+full field reference, including `parent_trajectory_id` for subagents.
+
+## 3. Add Agent Hints (Serving Intent)
+
+`agent_hints` is active intent the deployment can act on - request `priority`,
+expected output length (`osl`), and `speculative_prefill`. Send hints alongside
+the same context:
+
+```bash
+curl -s localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{
+  "model": "Qwen/Qwen3-0.6B",
+  "messages": [{"role": "user", "content": "Continue the report."}],
+  "max_tokens": 1024,
+  "nvext": {
+    "agent_context": {
+      "session_type_id": "deep_research",
+      "session_id": "research-run-42",
+      "trajectory_id": "research-run-42:writer"
+    },
+    "agent_hints": {
+      "priority": 5,
+      "osl": 1024
+    }
+  }
+}' | jq
+```
+
+Hints are accepted on any deployment, but each one only takes effect where the
+matching feature is enabled - for example, `priority` needs router and backend
+priority support, and `osl` needs `--router-track-output-blocks`. See
+[Agent Hints](agent-hints.md) for the full hint list and the per-backend support
+matrix, and [Priority Scheduling](priority-scheduling.md) for priority semantics.
+
+## 4. (Optional) Capture a Trace
+
+To see what Dynamo measured for these requests, enable tracing **before** you
+start the worker:
+
+```bash
+export DYN_AGENT_TRACE=1
+python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B --discovery-backend file &
+```
+
+Dynamo writes one `request_end` record per request - carrying your
+`agent_context`, output tokens, and autodetected tool-call and finish metadata -
+to `/tmp/dynamo-agent-trace.*.jsonl.gz`. From there you can visualize the run in
+Perfetto. See [Agent Tracing → Enable output](agent-tracing.md#enable-output) for
+the sink options and the Perfetto converter.
+
+## Next Steps
+
+| Go deeper | Page |
+|-----------|------|
+| The full hint list and backend support matrix | [Agent Hints](agent-hints.md) |
+| The trace protocol, `request_end` schema, and Perfetto view | [Agent Tracing](agent-tracing.md) |
+| Priority semantics across router, engine, and cache | [Priority Scheduling](priority-scheduling.md) |
+| A real coding agent wired through Dynamo end to end | [Use Pi-Mono with Dynamo](pi-mono.md) |
+| Backend-specific behavior (SGLang) | [SGLang for Agentic Workloads](../backends/sglang/agents.md) |

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Agent Quickstart
 subtitle: Send your first agent-aware request to a running Dynamo deployment
@@ -21,8 +21,11 @@ python3 -m dynamo.frontend --http-port 8000 --discovery-backend file > /dev/null
 python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B --discovery-backend file &
 ```
 
-Agent metadata is backend-agnostic - substitute `dynamo.vllm` or `dynamo.trtllm`
-and the requests below work unchanged.
+Agent metadata is backend-agnostic, so the requests below work unchanged against
+a vLLM or TensorRT-LLM worker. The launch flags differ by backend, though - for
+example, vLLM uses `python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B`. See the
+[installation guide](../getting-started/local-installation.md) for each backend's
+exact launch command.
 
 ## 1. Send a Normal Request
 
@@ -95,19 +98,20 @@ matrix, and [Priority Scheduling](priority-scheduling.md) for priority semantics
 
 ## 4. (Optional) Capture a Trace
 
-To see what Dynamo measured for these requests, enable tracing **before** you
-start the worker:
+To see what Dynamo measured for these requests, export the trace switch **before**
+you start the deployment, so the process recording traces picks it up:
 
 ```bash
-export DYN_AGENT_TRACE=1
-python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B --discovery-backend file &
+export DYN_REQUEST_TRACE=1
+# then start the frontend and worker as in Prerequisites
 ```
 
-Dynamo writes one `request_end` record per request - carrying your
-`agent_context`, output tokens, and autodetected tool-call and finish metadata -
-to `/tmp/dynamo-agent-trace.*.jsonl.gz`. From there you can visualize the run in
-Perfetto. See [Agent Tracing → Enable output](agent-tracing.md#enable-output) for
-the sink options and the Perfetto converter.
+With the default sink, Dynamo writes one `request_end` record per request -
+carrying your `agent_context`, output tokens, and autodetected tool-call and
+finish metadata - to `/tmp/dynamo-request-trace.*.jsonl.gz`. From there you can
+visualize the run in Perfetto. See
+[Agent Tracing → Enable output](agent-tracing.md#enable-output) for the sink
+options and the Perfetto converter.
 
 ## Next Steps
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -297,6 +297,8 @@ navigation:
             slug: agents
             path: agents/README.md
             contents:
+              - page: Agent Quickstart
+                path: agents/quickstart.md
               - page: Agent Tracing
                 path: agents/agent-tracing.md
               - page: Agent Hints


### PR DESCRIPTION
## Overview

Adds a lightweight **Agent Quickstart** for serving agentic workloads, and makes the existing `docs/agents/` material discoverable from the README front door.

The agent-serving features (per-request hints, tracing, priority scheduling) are a headline 1.0 capability, but nothing in the README pointed at the docs — the one "Agentic inference" bullet linked out to LangChain/NeMo, not to our own guides. This closes that gap and gives a copy-paste on-ramp that sits below the full Pi-Mono walkthrough.

## Changes

- **`docs/agents/quickstart.md`** (new): curl-only quickstart. Send a normal OpenAI-compatible request, then add `nvext.agent_context` and `nvext.agent_hints` to the same request. No harness or SDK required. Honest about which hints only take effect when the matching feature is enabled, with links to the per-feature pages. Optional tracing step ties into `agent-tracing.md`.
- **`docs/agents/README.md`**: add the quickstart as the entry-point row in Core Concepts.
- **`docs/index.yml`**: register the quickstart as the first page under the Agents nav section.
- **`README.md`**: Quick Start pointer + link in the "New in 1.0" agentic-inference bullet (relative paths).

## Notes

- Reuses the exact frontend/worker launch from the README Quick Start (`Qwen/Qwen3-0.6B`, port 8000); metadata is backend-agnostic.
- `pi-mono.md` stays as the full end-to-end harness walkthrough.
- All cross-links verified to resolve.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Agent Quickstart guide with step-by-step instructions for sending agent-aware requests via HTTP, including metadata configuration
  * Provided guidance on agent context fields, hints (priority, output length, speculative prefill), and optional tracing
  * Updated documentation navigation and main README to highlight Agent Quickstart resources
  * Included reference links to related agent configuration and deployment guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->