### PR TITLE
fix(operator): avoid duplicate PVC volumes for repeated mounts

### DIFF
--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1677,6 +1677,9 @@ func appendMissingPVCVolumesForMounts(volumes []corev1.Volume, mounts []corev1.V
 		if mount.Name == "" {
 			continue
 		}
+		if _, ok := seen[mount.Name]; ok {
+			continue
+		}
 		if volume, ok := volumesByName[mount.Name]; ok {
 			ordered = append(ordered, volume)
 			seen[mount.Name] = struct{}{}

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -854,6 +854,23 @@ func TestAppendMissingPVCVolumesForMountsAddsMissingPVCs(t *testing.T) {
 	assert.Equal(t, "config", got[2].Name)
 }
 
+func TestAppendMissingPVCVolumesForMountsKeepsRepeatedVolumeMountsUnique(t *testing.T) {
+	volumes := []corev1.Volume{
+		{Name: "shared-model", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "model-cache-pvc"}}},
+	}
+	mounts := []corev1.VolumeMount{
+		{Name: "shared-model", MountPath: "/model-store", SubPath: "models/glm"},
+		{Name: "shared-model", MountPath: "/cache/sglang", SubPath: "cache/sglang/glm"},
+	}
+
+	got := appendMissingPVCVolumesForMounts(volumes, mounts)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "shared-model", got[0].Name)
+	require.NotNil(t, got[0].PersistentVolumeClaim)
+	assert.Equal(t, "model-cache-pvc", got[0].PersistentVolumeClaim.ClaimName)
+}
+
 func TestGenerateDynamoComponentsDeployments_PropagatesPreservedAlphaServiceAnnotations(t *testing.T) {
 	className := "nginx"
 	alpha := &v1alpha1.DynamoGraphDeployment{


### PR DESCRIPTION
## Description

Fixes #10822.

Dynamo currently auto-adds PVC volumes for user-provided `volumeMounts`, but `appendMissingPVCVolumesForMounts` can append the same volume more than once when a container mounts one volume multiple times with different `mountPath`/`subPath` values.

That pattern is valid Kubernetes Pod semantics and is useful for large model serving deployments backed by shared storage such as Ceph/CPFS/NFS. A single RWX PVC may contain both model weights and runtime cache directories, for example:

- `/model-store` from `subPath: models/...`
- `/cache/sglang` from `subPath: cache/sglang/...`

Before this change, the generated Grove `PodCliqueSet` could contain duplicate `podSpec.volumes` entries and fail validation with a duplicate volume name error.

## Changes

- Skip already-seen volume names while synthesizing missing PVC volumes from volume mounts.
- Add a regression test for repeated mounts of the same PVC-backed volume with different subPaths.

## Validation

```bash
cd deploy/operator
go test ./internal/dynamo -run 'TestAppendMissingPVCVolumesForMounts'
go test ./internal/dynamo
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate storage volumes from being added when multiple mount points reference the same name.
  * Improved consistency in volume handling so repeated mounts no longer create redundant entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->