### PR TITLE
fix(docs): make recipe/benchmark components readable in real dark mode

### DIFF
--- a/fern/components/RecipeStyles.tsx
+++ b/fern/components/RecipeStyles.tsx
@@ -19,6 +19,24 @@
  * recipe/benchmark page (and the two landing READMEs).
  */
 const RECIPE_CSS = `
+/* Dark-mode variable re-bind.
+   The shared NVIDIA theme defines the dark values of --pst-color-text-base,
+   --pst-color-text-muted, and --pst-color-surface only under
+   html[data-theme="dark"], but Fern's theme toggle flips dark mode with the
+   .dark *class* and does NOT set data-theme. So in real dark mode these three
+   resolve to their LIGHT values (#1a1a1a text, #666 muted, #f7f7f7 surface),
+   which our components use for text/panels — rendering dark-on-dark. Re-bind
+   them under .dark so they track the class. !important is required: the
+   theme's light-default selector outranks a bare .dark. Scoped safely because
+   this stylesheet only loads on recipe/benchmark pages. (--nv-color-bg-default
+   never flips even with data-theme; those surfaces keep their own .dark
+   background overrides below.) */
+.dark {
+    --pst-color-text-base: #eee !important;
+    --pst-color-text-muted: #999 !important;
+    --pst-color-surface: #1a1a1a !important;
+}
+
 /* Recipe catalog */
 .dynamo-recipe-selector {
     margin: 24px 0;


### PR DESCRIPTION
## Problem

In **real** dark mode on every recipe and Feature Benchmark page, component text and panels render **dark-on-dark** — e.g. the "Features Under Test" titles measured **1.2:1 contrast** (effectively invisible).

## Root cause

Fern's theme toggle flips dark mode with the **`.dark` class** and does **not** set `data-theme`. But the shared NVIDIA theme binds the *dark* values of `--pst-color-text-base`, `--pst-color-text-muted`, and `--pst-color-surface` only under `html[data-theme="dark"]`. So in real (class-only) dark mode those three stay at their **light** values (`#1a1a1a` text, `#666` muted, `#f7f7f7` surface). Every `.dynamo-*` component colors its text/panels with them → dark-on-dark.

(Other vars — `--nv-dark-grey-*`, `--grayscale-a*` — *do* flip under `.dark`, which is why the bug was easy to miss when testing with `data-theme` forced on.)

## Fix

Re-bind the three vars under `.dark` (with `!important` — a bare `.dark` is outranked by the theme's light-default selector). Scoped safely: this stylesheet only loads on the recipe/benchmark pages.

## Verification

Injected the rebind into the **live prod** page and re-measured (the hosted preview uses a newer theme build that already flips these, so it can't reproduce the prod bug):

| element | before | after |
|---|---|---|
| "Features Under Test" titles | 1.21:1 | **18:1** |
| benchmark card titles | — | **15:1** |

Completes the earlier model-card fix (#10763), which corrected card backgrounds but left title text at the unflipped `#1a1a1a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dark mode display issues on recipe and benchmark pages, ensuring text and background colors render correctly when dark mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->