### PR TITLE
fix(runtime): fix OTLP http/protobuf exporter crashing at startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,6 @@ opentelemetry-otlp = { version = "0.31.0", features = [
     "logs",
     "grpc-tonic",
     "http-proto",
-    "reqwest-client",
     "reqwest-rustls",
 ] }
 opentelemetry-appender-tracing = { version = "0.31.0" }


### PR DESCRIPTION
## What

Fixes a startup crash introduced by #10576 when the new OTLP `http/protobuf` transport is selected.

## Why

#10576 added the async `reqwest-client` feature to `opentelemetry-otlp`, but the crate already enables `reqwest-blocking-client` by default. Its HTTP exporter selects a default HTTP client through mutually-exclusive `cfg` gates:

- the `reqwest-client` branch requires `not(feature = "reqwest-blocking-client")`
- the `reqwest-blocking-client` branch requires `not(feature = "reqwest-client")`

With **both** features active, neither branch compiles, so no default HTTP client is installed. At runtime, any process started with `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` fails logging init with `no http client specified` and exits (`std::process::exit(1)` in `logging.rs`).

Forcing the async client instead (`default-features = false` + keep `reqwest-client`) does compile, but then panics the OTel batch processor with `there is no reactor running, must be called from the context of a Tokio 1.x runtime`, because the batch processor runs on a dedicated non-Tokio thread. The async `reqwest::Client` requires a Tokio reactor; the blocking client does not. This is exactly why `reqwest-blocking-client` is the crate's default.

## Fix

Drop `reqwest-client` and rely on the default blocking client; keep `reqwest-rustls` only for TLS roots.

## Testing

Verified in a local container (frontend + mock worker → OTLP collector):

| Transport | Before | After |
|-----------|--------|-------|
| `grpc` (default) | ✅ works | ✅ works |
| `http/protobuf` | ❌ crash at startup (`no http client specified`, exit 1) | ✅ frontend + worker start cleanly, no panic |

With the fix, both **traces and logs** export over `http/protobuf` to the collector, and the generic-endpoint resolution (`OTEL_EXPORTER_OTLP_ENDPOINT` → `…/v1/traces`, `…/v1/logs`) works as intended. gRPC transport is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency configuration for improved stability and compatibility. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->