### PR TITLE
docs(benchmarks): frame Kimi-K2.5 feature-stack page as the agentic coding stack

### DIFF
--- a/docs/benchmarks/kimi-k2-5-feature-stack.mdx
+++ b/docs/benchmarks/kimi-k2-5-feature-stack.mdx
@@ -1,7 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: "Kimi-K2.5 Feature-Stack Benchmark"
+title: "Agentic Coding Throughput Stack - Kimi-K2.5"
 subtitle: "How much throughput and interactivity do we gain as KV routing, Eagle3, disaggregation, and KV offload are composed?"
 ---
 
@@ -9,9 +9,9 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-<p className="dynamo-recipe-eyebrow">Feature composition · Agentic coding throughput stack</p>
+<p className="dynamo-recipe-eyebrow">Feature composition</p>
 
-This is the **agentic coding throughput stack**: four configurations run Dynamo + TensorRT-LLM on 6x GB200 nodes (24 GPUs, MNNVL) against a Mooncake-style agentic coding trace (~200K-token context, multi-turn), starting from plain aggregated round-robin serving and adding one feature at a time — KV routing, Eagle3 speculation, disaggregation, and KV offload — up to the full disaggregated stack. The full stack delivers roughly **3x the per-GPU throughput** of the baseline while also improving per-user token speed.
+Four configurations run Dynamo + TensorRT-LLM on 6x GB200 nodes (24 GPUs, MNNVL) against a Mooncake-style agentic coding trace (~200K-token context, multi-turn), starting from plain aggregated round-robin serving and adding one feature at a time — KV routing, Eagle3 speculation, disaggregation, and KV offload — up to the full disaggregated stack. The full stack delivers roughly **3x the per-GPU throughput** of the baseline while also improving per-user token speed.
 
 <div className="dynamo-target-picker static">
 <p className="dynamo-target-picker-title">Benchmark setup</p>

--- a/docs/benchmarks/kimi-k2-5-feature-stack.mdx
+++ b/docs/benchmarks/kimi-k2-5-feature-stack.mdx
@@ -9,7 +9,9 @@ import { RecipeStyles } from "@/components/RecipeStyles";
 
 <RecipeStyles />
 
-Four configurations run Dynamo + TensorRT-LLM on 6x GB200 nodes (24 GPUs, MNNVL), starting from plain aggregated round-robin serving and adding one feature at a time up to the full disaggregated stack. The full stack delivers roughly **3x the per-GPU throughput** of the baseline while also improving per-user token speed.
+<p className="dynamo-recipe-eyebrow">Feature composition · Agentic coding throughput stack</p>
+
+This is the **agentic coding throughput stack**: four configurations run Dynamo + TensorRT-LLM on 6x GB200 nodes (24 GPUs, MNNVL) against a Mooncake-style agentic coding trace (~200K-token context, multi-turn), starting from plain aggregated round-robin serving and adding one feature at a time — KV routing, Eagle3 speculation, disaggregation, and KV offload — up to the full disaggregated stack. The full stack delivers roughly **3x the per-GPU throughput** of the baseline while also improving per-user token speed.
 
 <div className="dynamo-target-picker static">
 <p className="dynamo-target-picker-title">Benchmark setup</p>

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -70,7 +70,7 @@ navigation:
             path: benchmarks/qwen3-32b-kv-routing.mdx
             slug: qwen3-32b-kv-routing
             hidden: true
-          - page: Kimi-K2.5 Feature Stack
+          - page: Agentic Coding Throughput Stack - Kimi-K2.5
             path: benchmarks/kimi-k2-5-feature-stack.mdx
             slug: kimi-k2-5-feature-stack
             hidden: true


### PR DESCRIPTION
The Feature Benchmarks landing card frames this benchmark as the **"Agentic coding throughput stack"** (feature composition), but the detail page led with a Kimi-K2.5 / feature-stack framing and never made the agentic-stack purpose explicit.

This adds a `Feature composition · Agentic coding throughput stack` eyebrow at the top of the page and opens the lead paragraph with that framing (plus the Mooncake agentic coding trace), so the sub-page matches its landing-card identity.

Content/wording only — happy to adjust on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark documentation with improved formatting and clearer presentation of feature composition and agentic coding performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->