### PR TITLE
feat(mocker): add atomic source hold primitive [DYN-3278]

### DIFF
--- a/lib/mocker/src/common/handoff.rs
+++ b/lib/mocker/src/common/handoff.rs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Stable identifier for one prefill-to-decode handoff attempt.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct HandoffId(Uuid);
+
+impl HandoffId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for HandoffId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<Uuid> for HandoffId {
+    fn from(value: Uuid) -> Self {
+        Self(value)
+    }
+}
+
+impl From<HandoffId> for Uuid {
+    fn from(value: HandoffId) -> Self {
+        value.0
+    }
+}

--- a/lib/mocker/src/common/mod.rs
+++ b/lib/mocker/src/common/mod.rs
@@ -5,6 +5,7 @@
 
 #[cfg(feature = "aic-forward-pass")]
 pub mod engine_perf;
+pub mod handoff;
 pub mod kv_cache_trace;
 pub mod perf_model;
 pub mod protocols;

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -131,6 +131,23 @@ pub struct DecodeBlockReservation {
     blocks: Vec<MutableBlock<G1>>,
 }
 
+pub struct VllmDestinationReservation {
+    cached_prefix: Vec<(SequenceHash, ImmutableBlock<G1>)>,
+    unpublished_blocks: Vec<MutableBlock<G1>>,
+    layout: Option<MoveBlock>,
+}
+
+#[cfg(test)]
+impl VllmDestinationReservation {
+    pub(crate) fn block_ids(&self) -> Vec<usize> {
+        self.cached_prefix
+            .iter()
+            .map(|(_, block)| block.block_id())
+            .chain(self.unpublished_blocks.iter().map(MutableBlock::block_id))
+            .collect()
+    }
+}
+
 impl DecodeBlockReservation {
     fn take(&mut self) -> Option<MutableBlock<G1>> {
         self.blocks.pop()
@@ -711,6 +728,14 @@ impl KvManager {
     }
 
     pub fn reserve_decode_blocks(&mut self, count: usize) -> Option<DecodeBlockReservation> {
+        let blocks = self.allocate_unpublished_blocks(count)?;
+        Some(DecodeBlockReservation { blocks })
+    }
+
+    fn allocate_unpublished_blocks(&mut self, count: usize) -> Option<Vec<MutableBlock<G1>>> {
+        if count == 0 {
+            return Some(Vec::new());
+        }
         let (blocks, evicted_plhs) = self.block_manager.allocate_blocks_with_evictions(count)?;
         if self.should_block_on_g1_offload(&evicted_plhs) {
             self.handle_evictions_with_source_slots(evicted_plhs, blocks);
@@ -718,7 +743,148 @@ impl KvManager {
         }
 
         self.handle_evictions(evicted_plhs);
-        Some(DecodeBlockReservation { blocks })
+        Some(blocks)
+    }
+
+    pub(crate) fn reserve_destination(
+        &mut self,
+        sequence: &ActiveSequence,
+    ) -> Option<VllmDestinationReservation> {
+        let layout = sequence.prepare_allocation(sequence.num_input_tokens());
+        let Some(MoveBlock::Use(blocks, _, plhs, _, _)) = layout.as_ref() else {
+            return Some(VllmDestinationReservation {
+                cached_prefix: Vec::new(),
+                unpublished_blocks: Vec::new(),
+                layout,
+            });
+        };
+
+        let mut cached_prefix = Vec::new();
+        for (plh_idx, block) in blocks.iter().enumerate() {
+            let UniqueBlock::FullBlock(seq_hash) = block else {
+                break;
+            };
+            let plh = plhs[plh_idx];
+            if let Some(active) = self.active_full.get(seq_hash) {
+                cached_prefix.push((*seq_hash, active[0].clone()));
+                continue;
+            }
+            let Some(handle) = self.block_manager.match_blocks(&[plh]).into_iter().next() else {
+                break;
+            };
+            cached_prefix.push((*seq_hash, handle));
+        }
+
+        let unpublished_blocks =
+            self.allocate_unpublished_blocks(blocks.len() - cached_prefix.len())?;
+        Some(VllmDestinationReservation {
+            cached_prefix,
+            unpublished_blocks,
+            layout,
+        })
+    }
+
+    pub(crate) fn activate_destination(&mut self, reservation: VllmDestinationReservation) {
+        let VllmDestinationReservation {
+            cached_prefix,
+            unpublished_blocks,
+            layout,
+        } = reservation;
+        let Some(MoveBlock::Use(blocks, local_hashes, plhs, token_ids, parent)) = layout else {
+            debug_assert!(cached_prefix.is_empty());
+            debug_assert!(unpublished_blocks.is_empty());
+            return;
+        };
+
+        let prefix_len = cached_prefix.len();
+        let mut cached_prefix = cached_prefix.into_iter();
+        let mut unpublished_blocks = unpublished_blocks.into_iter();
+        let mut stored_seq_hashes = Vec::new();
+        let mut stored_local_hashes = Vec::new();
+        let mut stored_token_ids = token_ids.as_ref().map(|_| Vec::new());
+        let mut first_store_parent = None;
+        let mut metadata_parent_hash = match parent {
+            Some(UniqueBlock::FullBlock(hash)) => Some(hash),
+            Some(UniqueBlock::PartialBlock(_)) => panic!("parent block cannot be partial"),
+            None => None,
+        };
+        let mut plh_idx = 0usize;
+
+        for (block_idx, block) in blocks.into_iter().enumerate() {
+            match block {
+                UniqueBlock::FullBlock(seq_hash) => {
+                    let full_idx = plh_idx;
+                    let plh = plhs[plh_idx];
+                    plh_idx += 1;
+                    if block_idx < prefix_len {
+                        let (reserved_hash, handle) = cached_prefix
+                            .next()
+                            .expect("reserved prefix handle must exist");
+                        debug_assert_eq!(reserved_hash, seq_hash);
+                        self.active_full.entry(seq_hash).or_default().push(handle);
+                        metadata_parent_hash = Some(seq_hash);
+                        continue;
+                    }
+
+                    let mutable = unpublished_blocks
+                        .next()
+                        .expect("reserved destination block must exist");
+                    let complete = mutable
+                        .stage(plh, self.block_size)
+                        .expect("destination stage failed");
+                    let immutable = self.block_manager.register_block(complete);
+                    let block_id = immutable.block_id();
+                    self.active_full
+                        .entry(seq_hash)
+                        .or_default()
+                        .push(immutable);
+                    if stored_seq_hashes.is_empty() {
+                        first_store_parent = metadata_parent_hash;
+                    }
+                    let local_hash = local_hashes.get(full_idx).copied();
+                    let block_token_ids = token_ids
+                        .as_ref()
+                        .and_then(|all_ids| all_ids.get(full_idx).cloned());
+                    self.registered_blocks.insert(
+                        plh,
+                        RegisteredBlockInfo {
+                            seq_hash,
+                            block_id,
+                            parent_hash: metadata_parent_hash,
+                            local_hash,
+                            token_ids: block_token_ids.clone(),
+                        },
+                    );
+                    stored_seq_hashes.push(seq_hash);
+                    if let Some(local_hash) = local_hash {
+                        stored_local_hashes.push(local_hash);
+                    }
+                    if let (Some(stored), Some(block_token_ids)) =
+                        (stored_token_ids.as_mut(), block_token_ids)
+                    {
+                        stored.push(block_token_ids);
+                    }
+                    metadata_parent_hash = Some(seq_hash);
+                }
+                UniqueBlock::PartialBlock(uuid) => {
+                    let mutable = unpublished_blocks
+                        .next()
+                        .expect("reserved destination partial block must exist");
+                    let previous = self.active_partial.insert(uuid, mutable);
+                    debug_assert!(previous.is_none());
+                }
+            }
+        }
+
+        debug_assert!(cached_prefix.next().is_none());
+        debug_assert!(unpublished_blocks.next().is_none());
+        self.publish_kv_event(
+            stored_seq_hashes,
+            &stored_local_hashes,
+            first_store_parent,
+            true,
+            stored_token_ids,
+        );
     }
 
     pub fn process_decode_signal(
@@ -1292,6 +1458,24 @@ impl KvManager {
     /// Shared-prefix reuse inflates this above the distinct-block count.
     pub fn num_active_block_refs(&self) -> usize {
         self.active_partial.len() + self.active_full.values().map(|v| v.len()).sum::<usize>()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_block_ids(&self, sequence: &ActiveSequence) -> Vec<usize> {
+        sequence
+            .unique_blocks()
+            .iter()
+            .filter_map(|block| match block {
+                UniqueBlock::FullBlock(hash) => self
+                    .active_full
+                    .get(hash)
+                    .and_then(|handles| handles.last())
+                    .map(ImmutableBlock::block_id),
+                UniqueBlock::PartialBlock(uuid) => {
+                    self.active_partial.get(uuid).map(MutableBlock::block_id)
+                }
+            })
+            .collect()
     }
 
     pub fn get_active_perc(&self) -> f64 {

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -969,6 +969,18 @@ impl KvManager {
                         },
                     );
                     if commit == FullBlockCommit::Reused {
+                        if !stored_seq_hashes.is_empty() {
+                            let local_hashes = std::mem::take(&mut stored_local_hashes);
+                            self.publish_kv_event(
+                                std::mem::take(&mut stored_seq_hashes),
+                                &local_hashes,
+                                first_store_parent,
+                                true,
+                                stored_token_ids.take(),
+                            );
+                            first_store_parent = None;
+                            stored_token_ids = token_ids.as_ref().map(|_| Vec::new());
+                        }
                         metadata_parent_hash = Some(seq_hash);
                         continue;
                     }
@@ -2315,6 +2327,57 @@ mod tests {
         assert_eq!(metadata.parent_hash, None);
         assert_eq!(metadata.local_hash, Some(local_hash));
         assert_eq!(metadata.token_ids.as_deref(), Some(token_ids.as_slice()));
+    }
+
+    #[test]
+    fn destination_activation_splits_stores_across_reused_middle_block() {
+        let (mut mgr, sink) = make_mgr_capturing(8, 4);
+        let sequence = ActiveSequence::new((0..12).collect(), 1, Some(4), true, true);
+        let reservation = mgr
+            .reserve_destination(&sequence)
+            .expect("destination reservation should fit");
+        let signal = sequence
+            .prepare_allocation(sequence.num_input_tokens())
+            .expect("full prompt should require allocation");
+        let MoveBlock::Use(blocks, _, plhs, _, _) = &signal else {
+            panic!("expected full prompt allocation");
+        };
+        let [
+            UniqueBlock::FullBlock(first),
+            UniqueBlock::FullBlock(middle),
+            UniqueBlock::FullBlock(last),
+        ] = blocks.as_slice()
+        else {
+            panic!("expected three full prompt blocks");
+        };
+
+        use_full(&mut mgr, *middle, plhs[1]);
+        sink.events.lock().unwrap().clear();
+
+        mgr.activate_destination(reservation);
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        let KvCacheEventData::Stored(first_store) = &events[0].data else {
+            panic!("expected first Stored event");
+        };
+        assert_eq!(first_store.blocks.len(), 1);
+        assert_eq!(
+            first_store.blocks[0].block_hash,
+            ExternalSequenceBlockHash(*first)
+        );
+        let KvCacheEventData::Stored(last_store) = &events[1].data else {
+            panic!("expected second Stored event");
+        };
+        assert_eq!(last_store.blocks.len(), 1);
+        assert_eq!(
+            last_store.blocks[0].block_hash,
+            ExternalSequenceBlockHash(*last)
+        );
+        assert_eq!(
+            last_store.parent_hash,
+            Some(ExternalSequenceBlockHash(*middle))
+        );
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -40,6 +40,7 @@ use dynamo_kv_router::protocols::{
 };
 use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{BlockHash, PositionalLineageHash, SequenceHash};
+use kvbm_logical::blocks::BlockDuplicationPolicy;
 use kvbm_logical::registry::BlockRegistry;
 use kvbm_logical::tinylfu::TinyLFUTracker;
 use kvbm_logical::{BlockManager, ImmutableBlock, MutableBlock};
@@ -171,6 +172,20 @@ struct RegisteredBlockInfo {
     token_ids: Option<Vec<u32>>,
 }
 
+struct FullBlockMetadata {
+    seq_hash: SequenceHash,
+    plh: PositionalLineageHash,
+    parent_hash: Option<SequenceHash>,
+    local_hash: Option<BlockHash>,
+    token_ids: Option<Vec<u32>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FullBlockCommit {
+    Reused,
+    Stored,
+}
+
 /// Synchronous G1 KV block manager backed by `kvbm-logical::BlockManager<G1>`.
 pub struct KvManager {
     block_manager: BlockManager<G1>,
@@ -248,7 +263,17 @@ impl KvManager {
         let mut mgr_builder = BlockManager::builder()
             .block_count(max_capacity)
             .block_size(block_size)
-            .registry(registry);
+            .registry(registry)
+            .duplication_policy(BlockDuplicationPolicy::Reject);
+
+        // Intentional vLLM drift: upstream permits duplicate physical blocks
+        // for append-only request block tables. The mocker has one canonical
+        // registered_blocks entry per PLH and no request-owned physical block
+        // tables or duplicate-reset events, so Allow would make offload metadata
+        // and KV-event cleanup unsafe. Reject may discard a reserved block,
+        // adopt an existing block ID, reduce occupancy, and omit duplicate Stored.
+        // Revisit Allow only with per-request physical ownership, duplicate-aware
+        // offload metadata, and balanced duplicate Stored/Removed lifecycle events.
         mgr_builder = match eviction_backend {
             MockerEvictionBackend::Lineage => mgr_builder.with_lineage_backend(),
             MockerEvictionBackend::Lru => mgr_builder.with_lru_backend(),
@@ -757,6 +782,57 @@ impl KvManager {
         self.block_manager.match_blocks(&[plh]).into_iter().next()
     }
 
+    fn commit_active_full(
+        &mut self,
+        candidate: MutableBlock<G1>,
+        metadata: FullBlockMetadata,
+    ) -> FullBlockCommit {
+        let FullBlockMetadata {
+            seq_hash,
+            plh,
+            parent_hash,
+            local_hash,
+            token_ids,
+        } = metadata;
+
+        if let Some(canonical) = self.acquire_existing_full(seq_hash, plh) {
+            drop(candidate);
+            self.active_full
+                .entry(seq_hash)
+                .or_default()
+                .push(canonical);
+            return FullBlockCommit::Reused;
+        }
+
+        let candidate_block_id = candidate.block_id();
+        let complete = candidate
+            .stage(plh, self.block_size)
+            .expect("full block stage failed");
+        let canonical = self.block_manager.register_block(complete);
+        let canonical_block_id = canonical.block_id();
+        self.active_full
+            .entry(seq_hash)
+            .or_default()
+            .push(canonical);
+
+        if canonical_block_id != candidate_block_id {
+            return FullBlockCommit::Reused;
+        }
+
+        let previous = self.registered_blocks.insert(
+            plh,
+            RegisteredBlockInfo {
+                seq_hash,
+                block_id: canonical_block_id,
+                parent_hash,
+                local_hash,
+                token_ids,
+            },
+        );
+        debug_assert!(previous.is_none());
+        FullBlockCommit::Stored
+    }
+
     pub(crate) fn reserve_destination(
         &mut self,
         sequence: &ActiveSequence,
@@ -809,6 +885,44 @@ impl KvManager {
         };
 
         let prefix_len = cached_prefix.len();
+        let full_blocks = blocks
+            .iter()
+            .filter(|block| matches!(block, UniqueBlock::FullBlock(_)))
+            .count();
+        assert_eq!(
+            plhs.len(),
+            full_blocks,
+            "destination PLH count must match full block count"
+        );
+        assert!(
+            local_hashes.is_empty() || local_hashes.len() == full_blocks,
+            "destination local hash count must be empty or match full block count"
+        );
+        assert!(
+            token_ids
+                .as_ref()
+                .is_none_or(|all_ids| all_ids.len() == full_blocks),
+            "destination token metadata count must match full block count"
+        );
+        assert!(
+            prefix_len <= blocks.len(),
+            "destination cached prefix exceeds block layout"
+        );
+        assert_eq!(
+            unpublished_blocks.len(),
+            blocks.len() - prefix_len,
+            "destination unpublished block count must cover the uncached layout"
+        );
+        for (block, (reserved_hash, _)) in blocks.iter().zip(&cached_prefix) {
+            let UniqueBlock::FullBlock(layout_hash) = block else {
+                panic!("destination cached prefix cannot contain a partial block");
+            };
+            assert_eq!(
+                layout_hash, reserved_hash,
+                "destination cached prefix hash must match block layout"
+            );
+        }
+
         let mut cached_prefix = cached_prefix.into_iter();
         let mut unpublished_blocks = unpublished_blocks.into_iter();
         let mut stored_seq_hashes = Vec::new();
@@ -829,10 +943,9 @@ impl KvManager {
                     let plh = plhs[plh_idx];
                     plh_idx += 1;
                     if block_idx < prefix_len {
-                        let (reserved_hash, handle) = cached_prefix
+                        let (_, handle) = cached_prefix
                             .next()
                             .expect("reserved prefix handle must exist");
-                        debug_assert_eq!(reserved_hash, seq_hash);
                         self.active_full.entry(seq_hash).or_default().push(handle);
                         metadata_parent_hash = Some(seq_hash);
                         continue;
@@ -841,38 +954,27 @@ impl KvManager {
                     let mutable = unpublished_blocks
                         .next()
                         .expect("reserved destination block must exist");
-                    if let Some(handle) = self.acquire_existing_full(seq_hash, plh) {
-                        drop(mutable);
-                        self.active_full.entry(seq_hash).or_default().push(handle);
-                        metadata_parent_hash = Some(seq_hash);
-                        continue;
-                    }
-                    let complete = mutable
-                        .stage(plh, self.block_size)
-                        .expect("destination stage failed");
-                    let immutable = self.block_manager.register_block(complete);
-                    let block_id = immutable.block_id();
-                    self.active_full
-                        .entry(seq_hash)
-                        .or_default()
-                        .push(immutable);
-                    if stored_seq_hashes.is_empty() {
-                        first_store_parent = metadata_parent_hash;
-                    }
                     let local_hash = local_hashes.get(full_idx).copied();
                     let block_token_ids = token_ids
                         .as_ref()
                         .and_then(|all_ids| all_ids.get(full_idx).cloned());
-                    self.registered_blocks.insert(
-                        plh,
-                        RegisteredBlockInfo {
+                    let commit = self.commit_active_full(
+                        mutable,
+                        FullBlockMetadata {
                             seq_hash,
-                            block_id,
+                            plh,
                             parent_hash: metadata_parent_hash,
                             local_hash,
                             token_ids: block_token_ids.clone(),
                         },
                     );
+                    if commit == FullBlockCommit::Reused {
+                        metadata_parent_hash = Some(seq_hash);
+                        continue;
+                    }
+                    if stored_seq_hashes.is_empty() {
+                        first_store_parent = metadata_parent_hash;
+                    }
                     stored_seq_hashes.push(seq_hash);
                     if let Some(local_hash) = local_hash {
                         stored_local_hashes.push(local_hash);
@@ -894,8 +996,6 @@ impl KvManager {
             }
         }
 
-        debug_assert!(cached_prefix.next().is_none());
-        debug_assert!(unpublished_blocks.next().is_none());
         self.publish_kv_event(
             stored_seq_hashes,
             &stored_local_hashes,
@@ -1415,33 +1515,18 @@ impl KvManager {
             .remove(&uuid)
             .expect("Promote: partial block not found");
 
-        // Detect collision: seq_hash already has registered handles (active or inactive).
-        let is_new = if let Some(existing) = self.acquire_existing_full(seq_hash, plh) {
-            drop(mutable);
-            self.active_full.entry(seq_hash).or_default().push(existing);
-            false
-        } else {
-            // Fresh registration.
-            let complete = mutable
-                .stage(plh, self.block_size)
-                .expect("stage failed during promote");
-            let immutable = self.block_manager.register_block(complete);
-            let block_id = immutable.block_id();
-            self.active_full.insert(seq_hash, vec![immutable]);
-            self.registered_blocks.insert(
+        let commit = self.commit_active_full(
+            mutable,
+            FullBlockMetadata {
+                seq_hash,
                 plh,
-                RegisteredBlockInfo {
-                    seq_hash,
-                    block_id,
-                    parent_hash,
-                    local_hash,
-                    token_ids: token_ids.clone(),
-                },
-            );
-            true
-        };
+                parent_hash,
+                local_hash,
+                token_ids: token_ids.clone(),
+            },
+        );
 
-        if is_new {
+        if commit == FullBlockCommit::Stored {
             let local_hashes = local_hash.into_iter().collect::<Vec<_>>();
             self.publish_kv_event(
                 vec![seq_hash],
@@ -2181,6 +2266,10 @@ mod tests {
     #[test]
     fn destination_activation_collision_reuses_canonical_block_and_offload_metadata() {
         let (mut mgr, sink) = make_mgr_capturing(2, 4);
+        assert_eq!(
+            mgr.block_manager.duplication_policy(),
+            &BlockDuplicationPolicy::Reject
+        );
         let sequence = ActiveSequence::new(vec![1, 2, 3, 4], 1, Some(4), true, true);
         let reservation = mgr
             .reserve_destination(&sequence)
@@ -2226,6 +2315,34 @@ mod tests {
         assert_eq!(metadata.parent_hash, None);
         assert_eq!(metadata.local_hash, Some(local_hash));
         assert_eq!(metadata.token_ids.as_deref(), Some(token_ids.as_slice()));
+    }
+
+    #[test]
+    fn destination_activation_validates_layout_before_committing_blocks() {
+        let mut mgr = make_mgr(4, 4);
+        let unpublished_blocks = mgr
+            .allocate_unpublished_blocks(2)
+            .expect("destination capacity should be available");
+        let reservation = VllmDestinationReservation {
+            cached_prefix: Vec::new(),
+            unpublished_blocks,
+            layout: Some(MoveBlock::Use(
+                vec![UniqueBlock::FullBlock(1), UniqueBlock::FullBlock(2)],
+                Vec::new(),
+                vec![plh(1)],
+                None,
+                None,
+            )),
+        };
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            mgr.activate_destination(reservation);
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(mgr.num_active_blocks(), 0);
+        assert!(mgr.active_full.is_empty());
+        assert!(mgr.registered_blocks.is_empty());
     }
 
     /// After reusing a prefix [A, B] and storing a new suffix [C], the

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -746,6 +746,17 @@ impl KvManager {
         Some(blocks)
     }
 
+    fn acquire_existing_full(
+        &mut self,
+        seq_hash: SequenceHash,
+        plh: PositionalLineageHash,
+    ) -> Option<ImmutableBlock<G1>> {
+        if let Some(active) = self.active_full.get(&seq_hash) {
+            return Some(active[0].clone());
+        }
+        self.block_manager.match_blocks(&[plh]).into_iter().next()
+    }
+
     pub(crate) fn reserve_destination(
         &mut self,
         sequence: &ActiveSequence,
@@ -765,11 +776,7 @@ impl KvManager {
                 break;
             };
             let plh = plhs[plh_idx];
-            if let Some(active) = self.active_full.get(seq_hash) {
-                cached_prefix.push((*seq_hash, active[0].clone()));
-                continue;
-            }
-            let Some(handle) = self.block_manager.match_blocks(&[plh]).into_iter().next() else {
+            let Some(handle) = self.acquire_existing_full(*seq_hash, plh) else {
                 break;
             };
             cached_prefix.push((*seq_hash, handle));
@@ -784,6 +791,11 @@ impl KvManager {
         })
     }
 
+    /// Publish transferred destination blocks while reconciling any cache entry
+    /// that appeared after reservation. Unlike upstream vLLM, a collision may
+    /// replace the reserved block ID and reduce occupancy during activation;
+    /// the mocker acquires the canonical handle instead of strictly moving the
+    /// originally reserved handle.
     pub(crate) fn activate_destination(&mut self, reservation: VllmDestinationReservation) {
         let VllmDestinationReservation {
             cached_prefix,
@@ -829,6 +841,12 @@ impl KvManager {
                     let mutable = unpublished_blocks
                         .next()
                         .expect("reserved destination block must exist");
+                    if let Some(handle) = self.acquire_existing_full(seq_hash, plh) {
+                        drop(mutable);
+                        self.active_full.entry(seq_hash).or_default().push(handle);
+                        metadata_parent_hash = Some(seq_hash);
+                        continue;
+                    }
                     let complete = mutable
                         .stage(plh, self.block_size)
                         .expect("destination stage failed");
@@ -1398,16 +1416,9 @@ impl KvManager {
             .expect("Promote: partial block not found");
 
         // Detect collision: seq_hash already has registered handles (active or inactive).
-        let is_new = if let Some(vec) = self.active_full.get_mut(&seq_hash) {
-            // Collision on active pool — drop MutableBlock, clone existing handle.
+        let is_new = if let Some(existing) = self.acquire_existing_full(seq_hash, plh) {
             drop(mutable);
-            let existing = vec[0].clone();
-            vec.push(existing);
-            false
-        } else if let Some(immutable) = self.block_manager.match_blocks(&[plh]).into_iter().next() {
-            // Collision on inactive pool — reactivate existing handle.
-            drop(mutable);
-            self.active_full.insert(seq_hash, vec![immutable]);
+            self.active_full.entry(seq_hash).or_default().push(existing);
             false
         } else {
             // Fresh registration.
@@ -2165,6 +2176,56 @@ mod tests {
             .count();
         assert_eq!(stored_count, 1, "reactivation must not re-emit Stored");
         assert_eq!(removed_count, 0, "Deref must not emit Removed");
+    }
+
+    #[test]
+    fn destination_activation_collision_reuses_canonical_block_and_offload_metadata() {
+        let (mut mgr, sink) = make_mgr_capturing(2, 4);
+        let sequence = ActiveSequence::new(vec![1, 2, 3, 4], 1, Some(4), true, true);
+        let reservation = mgr
+            .reserve_destination(&sequence)
+            .expect("destination reservation should fit");
+        let reserved_block_id = reservation.block_ids()[0];
+        assert_eq!(mgr.num_active_blocks(), 1);
+
+        let signal = sequence
+            .prepare_allocation(sequence.num_input_tokens())
+            .expect("full prompt should require allocation");
+        let MoveBlock::Use(blocks, local_hashes, plhs, token_ids, _) = &signal else {
+            panic!("expected full prompt allocation");
+        };
+        let UniqueBlock::FullBlock(seq_hash) = blocks[0] else {
+            panic!("expected a full prompt block");
+        };
+        let plh = plhs[0];
+        let local_hash = local_hashes[0];
+        let token_ids = token_ids.as_ref().expect("token metadata enabled")[0].clone();
+
+        assert_eq!(mgr.process(&signal), 1);
+        let canonical_block_id = mgr.active_block_ids(&sequence)[0];
+        assert_ne!(reserved_block_id, canonical_block_id);
+        assert_eq!(mgr.num_active_blocks(), 2);
+        sink.events.lock().unwrap().clear();
+
+        mgr.activate_destination(reservation);
+
+        assert_eq!(mgr.num_active_blocks(), 1);
+        assert_eq!(mgr.active_block_ids(&sequence), vec![canonical_block_id]);
+        assert!(
+            sink.events.lock().unwrap().is_empty(),
+            "collision must not emit another Stored"
+        );
+
+        // handle_evictions consumes this entry when it later creates offload metadata.
+        let metadata = mgr
+            .registered_blocks
+            .get(&plh)
+            .expect("canonical registry metadata must remain available for offload");
+        assert_eq!(metadata.seq_hash, seq_hash);
+        assert_eq!(metadata.block_id, canonical_block_id);
+        assert_eq!(metadata.parent_hash, None);
+        assert_eq!(metadata.local_hash, Some(local_hash));
+        assert_eq!(metadata.token_ids.as_deref(), Some(token_ids.as_slice()));
     }
 
     /// After reusing a prefix [A, B] and storing a new suffix [C], the

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -46,6 +46,25 @@ pub struct DecodeTokenReservation {
     indices: VecDeque<usize>,
 }
 
+pub struct SglangDestinationReservation {
+    pub(crate) prefix_len: usize,
+    prefix_indices: Vec<usize>,
+    last_node: NodeId,
+    unpublished_indices: Vec<usize>,
+    pub(crate) allocated_tokens: usize,
+}
+
+#[cfg(test)]
+impl SglangDestinationReservation {
+    pub(crate) fn indices(&self) -> Vec<usize> {
+        self.prefix_indices
+            .iter()
+            .chain(&self.unpublished_indices)
+            .copied()
+            .collect()
+    }
+}
+
 impl DecodeTokenReservation {
     pub fn take(&mut self) -> usize {
         self.indices
@@ -179,9 +198,10 @@ impl SglangKvManager {
         // Find the new deepest node after insert
         let (_, new_last_node) = self.cache.match_prefix(token_ids);
 
-        // Transfer lock: release old path, protect new path
-        self.cache.dec_lock_ref(last_node);
+        // Acquire the extended path before releasing the old prefix so
+        // destination activation never leaves valid transferred KV unprotected.
         self.cache.inc_lock_ref(new_last_node);
+        self.cache.dec_lock_ref(last_node);
 
         new_last_node
     }
@@ -204,6 +224,75 @@ impl SglangKvManager {
             })
     }
 
+    pub(crate) fn reserve_destination(
+        &mut self,
+        token_ids: &[u64],
+    ) -> Option<SglangDestinationReservation> {
+        let (prefix_len, last_node) = self.cache.match_prefix(token_ids);
+        let mut prefix_indices = self.collect_path_indices(last_node);
+        prefix_indices.truncate(prefix_len);
+        self.cache.inc_lock_ref(last_node);
+
+        let allocated_tokens = if token_ids.is_empty() {
+            0
+        } else {
+            token_ids.len().div_ceil(self.cache.page_size()) * self.cache.page_size()
+        };
+        let fresh_tokens = allocated_tokens.saturating_sub(prefix_len);
+        let reservable = self.cache.token_pool.available() + self.cache.evictable_size;
+        if fresh_tokens > reservable {
+            self.cache.dec_lock_ref(last_node);
+            return None;
+        }
+        let available = self.cache.token_pool.available();
+        if fresh_tokens > available {
+            self.evict(fresh_tokens - available);
+        }
+        let Some(unpublished_indices) = self.cache.token_pool.allocate(fresh_tokens) else {
+            self.cache.dec_lock_ref(last_node);
+            return None;
+        };
+        self.log_trace("reserve_destination", fresh_tokens);
+        Some(SglangDestinationReservation {
+            prefix_len,
+            prefix_indices,
+            last_node,
+            unpublished_indices,
+            allocated_tokens,
+        })
+    }
+
+    pub(crate) fn activate_destination(
+        &mut self,
+        reservation: SglangDestinationReservation,
+        token_ids: &[u64],
+    ) -> AllocResult {
+        let SglangDestinationReservation {
+            prefix_len,
+            mut prefix_indices,
+            last_node,
+            mut unpublished_indices,
+            allocated_tokens: _,
+        } = reservation;
+        let missing_tokens = token_ids.len().saturating_sub(prefix_len);
+        let surplus = unpublished_indices.split_off(missing_tokens);
+        self.release_unpublished_indices(surplus);
+        prefix_indices.append(&mut unpublished_indices);
+        let new_last_node =
+            self.cache_unfinished_req(token_ids, &prefix_indices, last_node, prefix_len);
+        self.log_trace("activate_destination", missing_tokens);
+        AllocResult {
+            prefix_len,
+            kv_indices: prefix_indices,
+            last_node: new_last_node,
+        }
+    }
+
+    pub(crate) fn cancel_destination(&mut self, reservation: SglangDestinationReservation) {
+        self.cache.dec_lock_ref(reservation.last_node);
+        self.release_unpublished_indices(reservation.unpublished_indices);
+    }
+
     pub fn publish_decode_token(&mut self, idx: usize, last_idx: Option<usize>) {
         let _ = (idx, last_idx);
         self.log_trace("allocation", 1);
@@ -211,6 +300,10 @@ impl SglangKvManager {
 
     pub fn release_decode_reservation(&mut self, reservation: DecodeTokenReservation) {
         let indices = reservation.indices.into_iter().collect::<Vec<_>>();
+        self.release_unpublished_indices(indices);
+    }
+
+    fn release_unpublished_indices(&mut self, indices: Vec<usize>) {
         if indices.is_empty() {
             return;
         }

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -16,7 +16,10 @@ pub(crate) use kv_event_sink::{
     CapturedRouterEventBuffer, DeferredFpmBuffer, capture_deferred_kv_publish_sink,
     capture_router_event_sink, publish_deferred_fpm, publish_deferred_kv_events,
 };
-pub(crate) use source_holds::{RemovedSource, SchedulerCommand, SourceCompletion, SourceHolds};
+pub(crate) use source_holds::{
+    DestinationHolds, RemovedSource, SchedulerCommand, SchedulerCommandResult, SourceCompletion,
+    SourceHolds,
+};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -189,6 +192,25 @@ impl EngineCore {
         match self {
             Self::Vllm(core) => core.is_empty(),
             Self::Sglang(core) => core.is_empty(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_drained(&self) -> bool {
+        match self {
+            Self::Vllm(core) => core.is_drained(),
+            Self::Sglang(core) => core.is_drained(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn apply_command(
+        &mut self,
+        command: SchedulerCommand,
+    ) -> anyhow::Result<SchedulerCommandResult> {
+        match self {
+            Self::Vllm(core) => core.apply_command(command),
+            Self::Sglang(core) => core.apply_command(command),
         }
     }
 
@@ -393,6 +415,37 @@ pub(crate) mod test_utils;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::handoff::HandoffId;
+    use crate::common::protocols::{EngineType, MockEngineArgs, WorkerType};
+
+    fn core(engine_type: EngineType, worker_type: WorkerType, blocks: usize) -> EngineCore {
+        let args = MockEngineArgs::builder()
+            .engine_type(engine_type)
+            .block_size(4)
+            .num_gpu_blocks(blocks)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(1))
+            .enable_prefix_caching(true)
+            .worker_type(worker_type)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        match engine_type {
+            EngineType::Vllm | EngineType::Trtllm => EngineCore::Vllm(VllmCore::new(args)),
+            EngineType::Sglang => EngineCore::Sglang(SglangCore::new(args)),
+        }
+    }
+
+    fn request(uuid: Uuid, tokens: Vec<u32>) -> DirectRequest {
+        DirectRequest {
+            tokens,
+            max_output_tokens: 2,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn welford_acc_empty() {
@@ -442,6 +495,87 @@ mod tests {
             "expected {expected}, got {}",
             acc.variance()
         );
+    }
+
+    #[test]
+    fn unavailable_destination_keeps_source_held_until_both_owners_are_cancelled() {
+        for (case, engine_type) in [EngineType::Vllm, EngineType::Sglang]
+            .into_iter()
+            .enumerate()
+        {
+            let mut source = core(engine_type, WorkerType::Prefill, 8);
+            let mut destination = core(engine_type, WorkerType::Decode, 2);
+            let held_handoff = HandoffId::from(Uuid::from_u128(30_000 + case as u128));
+            let capacity_handoff = HandoffId::from(Uuid::from_u128(30_100 + case as u128));
+            let request_id = Uuid::from_u128(30_200 + case as u128);
+
+            assert!(matches!(
+                destination
+                    .apply_command(SchedulerCommand::ReserveDestination {
+                        handoff_id: capacity_handoff,
+                        request: request(
+                            Uuid::from_u128(30_300 + case as u128),
+                            (100..108).collect(),
+                        ),
+                    })
+                    .unwrap(),
+                SchedulerCommandResult::DestinationReserved { .. }
+            ));
+            source
+                .apply_command(SchedulerCommand::SubmitHandoffPrefill {
+                    handoff_id: held_handoff,
+                    request: request(request_id, (0..8).collect()),
+                })
+                .unwrap();
+            let mut now_ms = 0.0;
+            for _ in 0..8 {
+                let pass = source.execute_hidden_pass(now_ms);
+                now_ms = pass.end_ms;
+                if source.is_empty() {
+                    break;
+                }
+            }
+            assert!(source.is_empty());
+            assert!(!source.is_drained());
+
+            assert_eq!(
+                destination
+                    .apply_command(SchedulerCommand::ReserveDestination {
+                        handoff_id: held_handoff,
+                        request: request(request_id, (0..4).collect()),
+                    })
+                    .unwrap(),
+                SchedulerCommandResult::DestinationUnavailable
+            );
+            assert_eq!(
+                destination
+                    .apply_command(SchedulerCommand::CancelDestination {
+                        handoff_id: held_handoff,
+                    })
+                    .unwrap(),
+                SchedulerCommandResult::Noop
+            );
+            assert_eq!(
+                destination
+                    .apply_command(SchedulerCommand::CancelDestination {
+                        handoff_id: capacity_handoff,
+                    })
+                    .unwrap(),
+                SchedulerCommandResult::Applied
+            );
+            assert_eq!(
+                source
+                    .apply_command(SchedulerCommand::CancelSource {
+                        handoff_id: held_handoff,
+                    })
+                    .unwrap(),
+                SchedulerCommandResult::Applied
+            );
+            assert!(source.is_empty());
+            assert!(source.is_drained());
+            assert!(destination.is_empty());
+            assert!(destination.is_drained());
+        }
     }
 }
 

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -6,6 +6,7 @@
 mod kv_event_sink;
 #[path = "sglang/mod.rs"]
 pub mod sglang;
+mod source_holds;
 pub mod vllm;
 
 pub use crate::common::protocols::ForwardPassSnapshot;
@@ -15,6 +16,7 @@ pub(crate) use kv_event_sink::{
     CapturedRouterEventBuffer, DeferredFpmBuffer, capture_deferred_kv_publish_sink,
     capture_router_event_sink, publish_deferred_fpm, publish_deferred_kv_events,
 };
+pub(crate) use source_holds::{RemovedSource, SchedulerCommand, SourceCompletion, SourceHolds};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;

--- a/lib/mocker/src/scheduler/sglang/config.rs
+++ b/lib/mocker/src/scheduler/sglang/config.rs
@@ -26,6 +26,7 @@ pub enum SchedulePolicy {
 pub(super) struct SglangConfig {
     pub(super) schedule_policy: SchedulePolicy,
     pub(super) max_prefill_tokens: usize,
+    pub(super) max_running_requests: usize,
     pub(super) chunked_prefill_size: usize,
     pub(super) clip_max_new_tokens: usize,
     pub(super) init_new_token_ratio: f64,
@@ -68,6 +69,7 @@ impl SglangConfig {
 
         Self {
             schedule_policy,
+            max_running_requests: args.max_num_seqs.unwrap_or(usize::MAX),
             max_prefill_tokens: sglang
                 .and_then(|s| s.max_prefill_tokens)
                 .unwrap_or(DEFAULT_MAX_PREFILL_TOKENS),

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -7,19 +7,23 @@ use std::time::Duration;
 use dynamo_kv_router::protocols::WorkerId;
 use uuid::Uuid;
 
+use crate::common::handoff::HandoffId;
 use crate::common::protocols::{DirectRequest, KvEventPublishers, MockEngineArgs, WorkerType};
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
 use crate::kv_manager::SglangKvManager;
 use crate::replay::TraceCollector;
 
 use super::config::SglangConfig;
-use super::decode::{cache_materialized_prefix, simulate_decode_step_with_sampler};
+use super::decode::{
+    cache_materialized_prefix, cleanup_completed_request, simulate_decode_step_with_sampler,
+};
 use super::policy::apply_schedule_policy;
 use super::prefill::get_new_batch_prefill;
 use super::request::SglangRequest;
 use crate::scheduler::{
-    CapturedRouterEventBuffer, EnginePassResult, MockerMetrics, RouterEventVisibility,
-    accept_length_sample, build_fpm_snapshot, capture_router_event_sink,
+    CapturedRouterEventBuffer, EnginePassResult, MockerMetrics, RemovedSource,
+    RouterEventVisibility, SchedulerCommand, SourceCompletion, SourceHolds, accept_length_sample,
+    build_fpm_snapshot, capture_router_event_sink,
 };
 
 pub(crate) struct SglangCore {
@@ -31,6 +35,11 @@ pub(crate) struct SglangCore {
     pub(super) kv_manager: SglangKvManager,
     speculative_sampler: Option<SpeculativeDecodeSampler>,
     kv_event_buffer: Option<CapturedRouterEventBuffer>,
+    source_holds: SourceHolds<HeldSglangPrefill>,
+}
+
+struct HeldSglangPrefill {
+    request: SglangRequest,
 }
 
 impl SglangCore {
@@ -92,15 +101,82 @@ impl SglangCore {
             ),
             speculative_sampler,
             kv_event_buffer,
+            source_holds: SourceHolds::default(),
         }
     }
 
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
+        self.apply_command(SchedulerCommand::Submit(request))
+            .expect("ordinary request submission is infallible")
+            .expect("submit command must return a request ID")
+    }
+
+    pub(crate) fn apply_command(
+        &mut self,
+        command: SchedulerCommand,
+    ) -> anyhow::Result<Option<Uuid>> {
+        match command {
+            SchedulerCommand::Submit(request) => Ok(Some(self.submit(request))),
+            SchedulerCommand::SubmitHandoffPrefill {
+                handoff_id,
+                mut request,
+            } => {
+                let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+                request.uuid = Some(uuid);
+                self.source_holds.register(uuid, handoff_id)?;
+                let submitted = self.submit(request);
+                debug_assert_eq!(submitted, uuid);
+                Ok(Some(uuid))
+            }
+            SchedulerCommand::ReleaseSource { handoff_id }
+            | SchedulerCommand::CancelSource { handoff_id } => {
+                self.remove_source(handoff_id);
+                Ok(None)
+            }
+        }
+    }
+
+    fn submit(&mut self, request: DirectRequest) -> Uuid {
         let request = SglangRequest::from(request);
         request.debug_assert_invariants(self.config.block_size);
         let uuid = request.uuid;
         self.waiting.push_back(request);
         uuid
+    }
+
+    fn complete_source(&mut self, request: SglangRequest) {
+        let uuid = request.uuid;
+        let payload = HeldSglangPrefill { request };
+        if let SourceCompletion::Release(payload) = self.source_holds.complete_source(uuid, payload)
+        {
+            self.cleanup_completed_prefill(payload);
+        }
+    }
+
+    fn remove_source(&mut self, handoff_id: HandoffId) -> bool {
+        match self.source_holds.remove(handoff_id) {
+            RemovedSource::Held(payload) => {
+                self.cleanup_completed_prefill(payload);
+                true
+            }
+            RemovedSource::Pending => true,
+            RemovedSource::Missing => false,
+        }
+    }
+
+    fn cleanup_completed_prefill(&mut self, payload: HeldSglangPrefill) {
+        let mut request = payload.request;
+        cleanup_completed_request(&mut request, &mut self.kv_manager, self.config.block_size);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn source_is_held(&self, handoff_id: HandoffId) -> bool {
+        self.source_holds.is_held(handoff_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn source_is_registered(&self, handoff_id: HandoffId) -> bool {
+        self.source_holds.is_registered(handoff_id)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -190,6 +266,10 @@ impl SglangCore {
             decode_start_ms,
             true,
         );
+
+        for request in decode.completed_requests.drain(..) {
+            self.complete_source(request);
+        }
 
         if let Some(collector) = collector {
             for signal in &decode.output_signals {

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -54,10 +54,8 @@ impl ReservedSglangDecode {
     fn activate(self, kv_manager: &mut SglangKvManager, block_size: usize) -> SglangRequest {
         let Self { mut request, kv } = self;
         let allocated_tokens = kv.allocated_tokens;
-        let prefix_len = kv.prefix_len;
         let prompt_tokens = request.prompt_tokens.clone();
         let alloc = kv_manager.activate_destination(kv, &prompt_tokens);
-        debug_assert_eq!(alloc.prefix_len, prefix_len);
         request.last_node = Some(alloc.last_node);
         request.kv_indices = alloc.kv_indices;
         request.materialized_tokens = request.prompt_len();
@@ -164,8 +162,7 @@ impl SglangCore {
                 request.uuid = Some(uuid);
                 self.source_holds.register(uuid, handoff_id)?;
                 let submitted = self.submit(request);
-                debug_assert_eq!(submitted, uuid);
-                Ok(SchedulerCommandResult::Submitted(uuid))
+                Ok(SchedulerCommandResult::Submitted(submitted))
             }
             SchedulerCommand::ReleaseSource { handoff_id }
             | SchedulerCommand::CancelSource { handoff_id } => {

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -11,6 +11,7 @@ use crate::common::handoff::HandoffId;
 use crate::common::protocols::{DirectRequest, KvEventPublishers, MockEngineArgs, WorkerType};
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
 use crate::kv_manager::SglangKvManager;
+use crate::kv_manager::sglang_backend::SglangDestinationReservation;
 use crate::replay::TraceCollector;
 
 use super::config::SglangConfig;
@@ -21,25 +22,55 @@ use super::policy::apply_schedule_policy;
 use super::prefill::get_new_batch_prefill;
 use super::request::SglangRequest;
 use crate::scheduler::{
-    CapturedRouterEventBuffer, EnginePassResult, MockerMetrics, RemovedSource,
-    RouterEventVisibility, SchedulerCommand, SourceCompletion, SourceHolds, accept_length_sample,
-    build_fpm_snapshot, capture_router_event_sink,
+    CapturedRouterEventBuffer, DestinationHolds, EnginePassResult, MockerMetrics, RemovedSource,
+    RouterEventVisibility, SchedulerCommand, SchedulerCommandResult, SourceCompletion, SourceHolds,
+    accept_length_sample, build_fpm_snapshot, capture_router_event_sink,
 };
 
 pub(crate) struct SglangCore {
     pub(super) config: SglangConfig,
     dp_rank: u32,
     pub(super) waiting: VecDeque<SglangRequest>,
+    prebuilt_ready: VecDeque<SglangRequest>,
     pub(super) running: Vec<SglangRequest>,
     pub(super) new_token_ratio: f64,
     pub(super) kv_manager: SglangKvManager,
     speculative_sampler: Option<SpeculativeDecodeSampler>,
     kv_event_buffer: Option<CapturedRouterEventBuffer>,
     source_holds: SourceHolds<HeldSglangPrefill>,
+    destination_holds: DestinationHolds<ReservedSglangDecode>,
 }
 
 struct HeldSglangPrefill {
     request: SglangRequest,
+}
+
+struct ReservedSglangDecode {
+    request: SglangRequest,
+    kv: SglangDestinationReservation,
+}
+
+impl ReservedSglangDecode {
+    fn activate(self, kv_manager: &mut SglangKvManager, block_size: usize) -> SglangRequest {
+        let Self { mut request, kv } = self;
+        let allocated_tokens = kv.allocated_tokens;
+        let prefix_len = kv.prefix_len;
+        let prompt_tokens = request.prompt_tokens.clone();
+        let alloc = kv_manager.activate_destination(kv, &prompt_tokens);
+        debug_assert_eq!(alloc.prefix_len, prefix_len);
+        request.last_node = Some(alloc.last_node);
+        request.kv_indices = alloc.kv_indices;
+        request.materialized_tokens = request.prompt_len();
+        request.cached_tokens = request.page_aligned_materialized_tokens(block_size);
+        request.allocated_tokens = allocated_tokens;
+        request.debug_assert_invariants(block_size);
+        request
+    }
+
+    fn cancel(self, kv_manager: &mut SglangKvManager) {
+        let Self { request: _, kv } = self;
+        kv_manager.cancel_destination(kv);
+    }
 }
 
 impl SglangCore {
@@ -91,6 +122,7 @@ impl SglangCore {
             config,
             dp_rank,
             waiting: VecDeque::new(),
+            prebuilt_ready: VecDeque::new(),
             running: Vec::new(),
             new_token_ratio: SglangConfig::from_args(&args).init_new_token_ratio,
             kv_manager: SglangKvManager::new(
@@ -102,21 +134,28 @@ impl SglangCore {
             speculative_sampler,
             kv_event_buffer,
             source_holds: SourceHolds::default(),
+            destination_holds: DestinationHolds::default(),
         }
     }
 
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
-        self.apply_command(SchedulerCommand::Submit(request))
+        match self
+            .apply_command(SchedulerCommand::Submit(request))
             .expect("ordinary request submission is infallible")
-            .expect("submit command must return a request ID")
+        {
+            SchedulerCommandResult::Submitted(uuid) => uuid,
+            _ => unreachable!("submit command must return a request ID"),
+        }
     }
 
     pub(crate) fn apply_command(
         &mut self,
         command: SchedulerCommand,
-    ) -> anyhow::Result<Option<Uuid>> {
+    ) -> anyhow::Result<SchedulerCommandResult> {
         match command {
-            SchedulerCommand::Submit(request) => Ok(Some(self.submit(request))),
+            SchedulerCommand::Submit(request) => {
+                Ok(SchedulerCommandResult::Submitted(self.submit(request)))
+            }
             SchedulerCommand::SubmitHandoffPrefill {
                 handoff_id,
                 mut request,
@@ -126,14 +165,62 @@ impl SglangCore {
                 self.source_holds.register(uuid, handoff_id)?;
                 let submitted = self.submit(request);
                 debug_assert_eq!(submitted, uuid);
-                Ok(Some(uuid))
+                Ok(SchedulerCommandResult::Submitted(uuid))
             }
             SchedulerCommand::ReleaseSource { handoff_id }
             | SchedulerCommand::CancelSource { handoff_id } => {
-                self.remove_source(handoff_id);
-                Ok(None)
+                Ok(if self.remove_source(handoff_id) {
+                    SchedulerCommandResult::Applied
+                } else {
+                    SchedulerCommandResult::Noop
+                })
+            }
+            SchedulerCommand::ReserveDestination {
+                handoff_id,
+                mut request,
+            } => {
+                let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+                request.uuid = Some(uuid);
+                if self.request_is_active(uuid) {
+                    anyhow::bail!("request {uuid} is already active");
+                }
+                self.destination_holds.validate(uuid, handoff_id)?;
+                let request = SglangRequest::from(request);
+                let Some(kv) = self.kv_manager.reserve_destination(&request.prompt_tokens) else {
+                    return Ok(SchedulerCommandResult::DestinationUnavailable);
+                };
+                self.destination_holds.insert(
+                    uuid,
+                    handoff_id,
+                    ReservedSglangDecode { request, kv },
+                );
+                Ok(SchedulerCommandResult::DestinationReserved { request_id: uuid })
+            }
+            SchedulerCommand::ActivateDestination { handoff_id } => {
+                let Some((_, reservation)) = self.destination_holds.remove(handoff_id) else {
+                    return Ok(SchedulerCommandResult::Noop);
+                };
+                let request = reservation.activate(&mut self.kv_manager, self.config.block_size);
+                self.prebuilt_ready.push_back(request);
+                Ok(SchedulerCommandResult::Applied)
+            }
+            SchedulerCommand::CancelDestination { handoff_id } => {
+                let Some((_, reservation)) = self.destination_holds.remove(handoff_id) else {
+                    return Ok(SchedulerCommandResult::Noop);
+                };
+                reservation.cancel(&mut self.kv_manager);
+                Ok(SchedulerCommandResult::Applied)
             }
         }
+    }
+
+    fn request_is_active(&self, uuid: Uuid) -> bool {
+        self.waiting.iter().any(|request| request.uuid == uuid)
+            || self
+                .prebuilt_ready
+                .iter()
+                .any(|request| request.uuid == uuid)
+            || self.running.iter().any(|request| request.uuid == uuid)
     }
 
     fn submit(&mut self, request: DirectRequest) -> Uuid {
@@ -180,11 +267,44 @@ impl SglangCore {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.waiting.is_empty() && self.running.is_empty()
+        self.waiting.is_empty() && self.prebuilt_ready.is_empty() && self.running.is_empty()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_drained(&self) -> bool {
+        self.is_empty() && self.source_holds.is_empty() && self.destination_holds.is_empty()
     }
 
     pub(crate) fn num_requests(&self) -> usize {
-        self.waiting.len() + self.running.len()
+        self.waiting.len() + self.prebuilt_ready.len() + self.running.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn destination_is_held(&self, handoff_id: HandoffId) -> bool {
+        self.destination_holds.contains(handoff_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn destination_indices(&self, handoff_id: HandoffId) -> Vec<usize> {
+        self.destination_holds
+            .get(handoff_id)
+            .map(|reservation| reservation.kv.indices())
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub(super) fn prebuilt_request(&self, uuid: Uuid) -> Option<&SglangRequest> {
+        self.prebuilt_ready
+            .iter()
+            .find(|request| request.uuid == uuid)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn drain_kv_events(&self) -> Vec<dynamo_kv_router::protocols::RouterEvent> {
+        self.kv_event_buffer
+            .as_ref()
+            .map(CapturedRouterEventBuffer::drain)
+            .unwrap_or_default()
     }
 
     pub(crate) fn execute_pass(
@@ -204,6 +324,7 @@ impl SglangCore {
         mut collector: Option<&mut TraceCollector>,
         now_ms: f64,
     ) -> EnginePassResult {
+        self.promote_prebuilt_ready();
         apply_schedule_policy(&mut self.waiting, &self.kv_manager, &self.config);
 
         let admit = get_new_batch_prefill(
@@ -334,7 +455,7 @@ impl SglangCore {
                 active_decode_blocks,
                 self.config.total_kv_tokens.div_ceil(self.config.block_size) as u64,
                 self.running.len() as u64,
-                self.waiting.len() as u64,
+                (self.waiting.len() + self.prebuilt_ready.len()) as u64,
                 0,
                 sglang_cache_hit_tokens,
                 sglang_cache_total_tokens,
@@ -358,6 +479,11 @@ impl SglangCore {
             .map(SglangRequest::extra_reserved_tokens)
             .sum::<usize>()
             + self
+                .prebuilt_ready
+                .iter()
+                .map(SglangRequest::extra_reserved_tokens)
+                .sum::<usize>()
+            + self
                 .running
                 .iter()
                 .map(SglangRequest::extra_reserved_tokens)
@@ -365,6 +491,15 @@ impl SglangCore {
         let actual_used =
             self.kv_manager.cache().total_tokens() - self.kv_manager.cache().available_tokens();
         (actual_used + active_reserved).div_ceil(self.config.block_size) as u64
+    }
+
+    fn promote_prebuilt_ready(&mut self) {
+        while self.running.len() < self.config.max_running_requests {
+            let Some(request) = self.prebuilt_ready.pop_front() else {
+                break;
+            };
+            self.running.push(request);
+        }
     }
 }
 

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -139,7 +139,7 @@ impl SglangCore {
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
         match self
             .apply_command(SchedulerCommand::Submit(request))
-            .expect("ordinary request submission is infallible")
+            .expect("ordinary request ID must be unique")
         {
             SchedulerCommandResult::Submitted(uuid) => uuid,
             _ => unreachable!("submit command must return a request ID"),
@@ -151,8 +151,11 @@ impl SglangCore {
         command: SchedulerCommand,
     ) -> anyhow::Result<SchedulerCommandResult> {
         match command {
-            SchedulerCommand::Submit(request) => {
-                Ok(SchedulerCommandResult::Submitted(self.submit(request)))
+            SchedulerCommand::Submit(mut request) => {
+                let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+                request.uuid = Some(uuid);
+                self.validate_request_id(uuid)?;
+                Ok(SchedulerCommandResult::Submitted(self.submit(request)?))
             }
             SchedulerCommand::SubmitHandoffPrefill {
                 handoff_id,
@@ -160,8 +163,11 @@ impl SglangCore {
             } => {
                 let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
                 request.uuid = Some(uuid);
+                self.validate_request_id(uuid)?;
                 self.source_holds.register(uuid, handoff_id)?;
-                let submitted = self.submit(request);
+                let submitted = self
+                    .submit(request)
+                    .expect("prevalidated handoff request must submit");
                 Ok(SchedulerCommandResult::Submitted(submitted))
             }
             SchedulerCommand::ReleaseSource { handoff_id }
@@ -178,9 +184,7 @@ impl SglangCore {
             } => {
                 let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
                 request.uuid = Some(uuid);
-                if self.request_is_active(uuid) {
-                    anyhow::bail!("request {uuid} is already active");
-                }
+                self.validate_request_id(uuid)?;
                 self.destination_holds.validate(uuid, handoff_id)?;
                 let request = SglangRequest::from(request);
                 let Some(kv) = self.kv_manager.reserve_destination(&request.prompt_tokens) else {
@@ -211,6 +215,16 @@ impl SglangCore {
         }
     }
 
+    fn validate_request_id(&self, uuid: Uuid) -> anyhow::Result<()> {
+        if self.request_is_active(uuid)
+            || self.source_holds.contains_request(uuid)
+            || self.destination_holds.contains_request(uuid)
+        {
+            anyhow::bail!("request {uuid} is already active");
+        }
+        Ok(())
+    }
+
     fn request_is_active(&self, uuid: Uuid) -> bool {
         self.waiting.iter().any(|request| request.uuid == uuid)
             || self
@@ -220,12 +234,15 @@ impl SglangCore {
             || self.running.iter().any(|request| request.uuid == uuid)
     }
 
-    fn submit(&mut self, request: DirectRequest) -> Uuid {
+    fn submit(&mut self, request: DirectRequest) -> anyhow::Result<Uuid> {
         let request = SglangRequest::from(request);
+        if self.request_is_active(request.uuid) {
+            anyhow::bail!("request {} is already active", request.uuid);
+        }
         request.debug_assert_invariants(self.config.block_size);
         let uuid = request.uuid;
         self.waiting.push_back(request);
-        uuid
+        Ok(uuid)
     }
 
     fn complete_source(&mut self, request: SglangRequest) {
@@ -321,10 +338,10 @@ impl SglangCore {
         mut collector: Option<&mut TraceCollector>,
         now_ms: f64,
     ) -> EnginePassResult {
-        self.promote_prebuilt_ready();
+        let mut admissions = self.promote_prebuilt_ready();
         apply_schedule_policy(&mut self.waiting, &self.kv_manager, &self.config);
 
-        let admit = get_new_batch_prefill(
+        let mut admit = get_new_batch_prefill(
             &mut self.waiting,
             &mut self.kv_manager,
             &self.config,
@@ -336,7 +353,8 @@ impl SglangCore {
             self.new_token_ratio = self.config.init_new_token_ratio;
         }
 
-        for admission in &admit.admissions {
+        admissions.append(&mut admit.admissions);
+        for admission in &admissions {
             if let Some(collector) = collector.as_deref_mut() {
                 collector.on_admit(admission.uuid, now_ms, admission.reused_input_tokens);
             }
@@ -446,7 +464,7 @@ impl SglangCore {
                 .filter(|signal| signal.completed)
                 .count(),
             output_signals: decode.output_signals,
-            admissions: admit.admissions,
+            admissions,
             mocker_metrics: MockerMetrics::from_parts(
                 self.dp_rank,
                 active_decode_blocks,
@@ -490,13 +508,19 @@ impl SglangCore {
         (actual_used + active_reserved).div_ceil(self.config.block_size) as u64
     }
 
-    fn promote_prebuilt_ready(&mut self) {
+    fn promote_prebuilt_ready(&mut self) -> Vec<crate::scheduler::AdmissionEvent> {
+        let mut admissions = Vec::new();
         while self.running.len() < self.config.max_running_requests {
             let Some(request) = self.prebuilt_ready.pop_front() else {
                 break;
             };
+            admissions.push(crate::scheduler::AdmissionEvent {
+                uuid: request.uuid,
+                reused_input_tokens: 0,
+            });
             self.running.push(request);
         }
+        admissions
     }
 }
 

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -14,6 +14,7 @@ use super::request::SglangRequest;
 #[derive(Default)]
 pub(super) struct DecodeResult {
     pub(super) requests: Vec<SglangRequest>,
+    pub(super) completed_requests: Vec<SglangRequest>,
     pub(super) output_signals: Vec<OutputSignal>,
     pub(super) retracted_any: bool,
     pub(super) end_ms: f64,
@@ -151,14 +152,44 @@ pub(super) fn simulate_decode_step(
     current_time_ms: f64,
     apply_speedup: bool,
 ) -> DecodeResult {
-    simulate_decode_step_with_sampler(
+    let mut result = simulate_decode_step_with_sampler(
         running,
         kv_manager,
         config,
         None,
         current_time_ms,
         apply_speedup,
-    )
+    );
+    for mut request in result.completed_requests.drain(..) {
+        cleanup_completed_request(&mut request, kv_manager, config.block_size);
+    }
+    result
+}
+
+pub(super) fn cleanup_completed_request(
+    request: &mut SglangRequest,
+    kv_manager: &mut SglangKvManager,
+    block_size: usize,
+) {
+    let sequence = request.sequence_tokens();
+    let tokens_to_cache = floor_to_block(sequence.len(), block_size);
+    if request.kv_indices.len() > tokens_to_cache {
+        kv_manager.free_indices(&request.kv_indices[tokens_to_cache..]);
+    }
+
+    let Some(last_node) = request.last_node.take() else {
+        return;
+    };
+    if tokens_to_cache > 0 {
+        kv_manager.cache_finished_req(
+            &sequence[..tokens_to_cache],
+            &request.kv_indices[..tokens_to_cache],
+            last_node,
+            request.cached_tokens,
+        );
+    } else {
+        kv_manager.free_request(last_node);
+    }
 }
 
 pub(super) fn simulate_decode_step_with_sampler(
@@ -278,25 +309,6 @@ pub(super) fn simulate_decode_step_with_sampler(
             });
 
             if is_complete {
-                let sequence = req.sequence_tokens();
-                let tokens_to_cache = floor_to_block(sequence.len(), config.block_size);
-                if req.kv_indices.len() > tokens_to_cache {
-                    kv_manager.free_indices(&req.kv_indices[tokens_to_cache..]);
-                }
-
-                if let Some(last_node) = req.last_node.take() {
-                    if tokens_to_cache > 0 {
-                        kv_manager.cache_finished_req(
-                            &sequence[..tokens_to_cache],
-                            &req.kv_indices[..tokens_to_cache],
-                            last_node,
-                            req.cached_tokens,
-                        );
-                    } else {
-                        kv_manager.free_request(last_node);
-                    }
-                }
-
                 completed_indices.push(idx);
                 break;
             }
@@ -312,12 +324,15 @@ pub(super) fn simulate_decode_step_with_sampler(
     );
     kv_manager.release_decode_reservation(reservation);
 
+    let mut completed_requests = Vec::with_capacity(completed_indices.len());
     for &idx in completed_indices.iter().rev() {
-        running.remove(idx);
+        completed_requests.push(running.remove(idx));
     }
+    completed_requests.reverse();
 
     DecodeResult {
         requests: retracted,
+        completed_requests,
         output_signals,
         retracted_any,
         end_ms: current_time_ms + total_time.as_secs_f64() * 1000.0,

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -65,7 +65,10 @@ pub(super) fn get_new_batch_prefill(
     let mut total_isl = 0usize;
     let mut total_prefix = 0usize;
 
-    while let Some(mut req) = waiting.pop_front() {
+    let available_running_slots = config.max_running_requests.saturating_sub(running.len());
+    while can_run.len() < available_running_slots
+        && let Some(mut req) = waiting.pop_front()
+    {
         let extend_input = req.extend_input_len();
         if extend_input == 0 {
             rejected.push_back(req);

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -28,7 +28,8 @@ use crate::scheduler::test_utils::{
     RouterIndexerHarness, nth_stored_hashes, removed_event_count, stored_hashes,
 };
 use crate::scheduler::{
-    RouterEventVisibility, SchedulerCommand, SchedulerHandle, capture_router_event_sink,
+    RouterEventVisibility, SchedulerCommand, SchedulerCommandResult, SchedulerHandle,
+    capture_router_event_sink,
 };
 
 const ROUTER_TEST_WORKER_ID: WorkerId = 17;
@@ -212,6 +213,186 @@ mod source_holds {
 
         assert!(terminal.output_signals[0].completed);
         assert_eq!(occupied_tokens(&core), 8);
+    }
+}
+
+mod destination_lifecycle {
+    use super::*;
+    use crate::common::protocols::WorkerType;
+
+    fn args(worker_type: WorkerType) -> MockEngineArgs {
+        MockEngineArgs::builder()
+            .engine_type(EngineType::Sglang)
+            .num_gpu_blocks(16)
+            .block_size(4)
+            .max_num_seqs(Some(1))
+            .worker_type(worker_type)
+            .speedup_ratio(0.0)
+            .sglang(Some(SglangArgs {
+                page_size: Some(4),
+                chunked_prefill_size: Some(16),
+                ..Default::default()
+            }))
+            .build()
+            .unwrap()
+    }
+
+    fn request(uuid: Uuid, tokens: Vec<u32>, max_output_tokens: usize) -> DirectRequest {
+        DirectRequest {
+            tokens,
+            max_output_tokens,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+            ..Default::default()
+        }
+    }
+
+    fn execute(core: &mut SglangCore, now_ms: f64) -> crate::scheduler::EnginePassResult {
+        let mut collector = crate::replay::TraceCollector::default();
+        core.execute_pass(&mut collector, now_ms)
+    }
+
+    fn assert_no_republished_stores(
+        activation: &[dynamo_kv_router::protocols::LocalBlockHash],
+        later: &[dynamo_kv_router::protocols::LocalBlockHash],
+    ) {
+        assert!(later.iter().all(|hash| !activation.contains(hash)));
+    }
+
+    fn occupied_tokens(core: &SglangCore) -> usize {
+        core.kv_manager.cache().total_tokens() - core.kv_manager.cache().available_tokens()
+    }
+
+    fn drive_source_to_hold(core: &mut SglangCore, handoff_id: HandoffId, req: DirectRequest) {
+        assert!(matches!(
+            core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+                handoff_id,
+                request: req,
+            })
+            .unwrap(),
+            SchedulerCommandResult::Submitted(_)
+        ));
+        let mut now_ms = 0.0;
+        for _ in 0..8 {
+            let pass = execute(core, now_ms);
+            now_ms = pass.end_ms;
+            if core.is_empty() {
+                break;
+            }
+        }
+        assert!(core.is_empty());
+        assert!(core.source_is_held(handoff_id));
+        assert!(!core.is_drained());
+    }
+
+    #[test]
+    fn handoff_prefill_to_reserved_decode_owns_kv_until_prebuilt_admission() {
+        let logical_uuid = Uuid::from_u128(20_001);
+        let handoff_id = HandoffId::from(Uuid::from_u128(20_002));
+        let logical_tokens = (0..8).collect::<Vec<_>>();
+
+        let mut source = SglangCore::new_with_kv_capture(args(WorkerType::Prefill), 41);
+        let mut destination = SglangCore::new_with_kv_capture(args(WorkerType::Decode), 42);
+
+        destination.receive(request(Uuid::from_u128(20_003), (0..4).collect(), 1));
+        execute(&mut destination, 0.0);
+        assert!(destination.is_empty());
+        destination.drain_kv_events();
+
+        let blocker_uuid = Uuid::from_u128(20_004);
+        destination.receive(request(blocker_uuid, (100..104).collect(), 3));
+        let blocker_first = execute(&mut destination, 1.0);
+        assert_eq!(destination.running.len(), 1);
+        destination.drain_kv_events();
+
+        drive_source_to_hold(
+            &mut source,
+            handoff_id,
+            request(logical_uuid, logical_tokens.clone(), 2),
+        );
+
+        let usage_before_reservation = occupied_tokens(&destination);
+        assert_eq!(
+            destination
+                .apply_command(SchedulerCommand::ReserveDestination {
+                    handoff_id,
+                    request: request(logical_uuid, logical_tokens, 2),
+                })
+                .unwrap(),
+            SchedulerCommandResult::DestinationReserved {
+                request_id: logical_uuid
+            }
+        );
+        assert!(destination.destination_is_held(handoff_id));
+        assert!(!destination.is_drained());
+        assert_eq!(destination.running.len(), 1);
+        assert!(occupied_tokens(&destination) > usage_before_reservation);
+        assert!(stored_hashes(&destination.drain_kv_events()).is_empty());
+
+        let reserved_indices = destination.destination_indices(handoff_id);
+        let protected_before_activation = destination.kv_manager.cache().protected_size;
+        assert!(!reserved_indices.is_empty());
+        assert_eq!(
+            destination
+                .apply_command(SchedulerCommand::ActivateDestination { handoff_id })
+                .unwrap(),
+            SchedulerCommandResult::Applied
+        );
+        let ready = destination
+            .prebuilt_request(logical_uuid)
+            .expect("activated request must be prebuilt-ready");
+        assert_eq!(ready.kv_indices, reserved_indices);
+        assert_eq!(destination.running.len(), 1);
+        assert!(destination.kv_manager.cache().protected_size >= protected_before_activation);
+        let activation_stores = stored_hashes(&destination.drain_kv_events());
+        assert!(!activation_stores.is_empty());
+
+        assert_eq!(
+            source
+                .apply_command(SchedulerCommand::ReleaseSource { handoff_id })
+                .unwrap(),
+            SchedulerCommandResult::Applied
+        );
+        assert!(source.is_empty());
+        assert!(source.is_drained());
+
+        let blocked = execute(&mut destination, blocker_first.end_ms);
+        let ready = destination
+            .prebuilt_request(logical_uuid)
+            .expect("full running batch must keep request ready");
+        assert_eq!(ready.kv_indices, reserved_indices);
+        assert_no_republished_stores(&activation_stores, &stored_hashes(&blocked.kv_events));
+
+        let blocker_terminal = execute(&mut destination, blocked.end_ms);
+        assert!(
+            blocker_terminal
+                .output_signals
+                .iter()
+                .any(|signal| signal.uuid == blocker_uuid && signal.completed)
+        );
+        assert!(destination.prebuilt_request(logical_uuid).is_some());
+
+        let admitted = execute(&mut destination, blocker_terminal.end_ms);
+        let running = destination
+            .running
+            .iter()
+            .find(|request| request.uuid == logical_uuid)
+            .expect("prebuilt request must enter the running batch");
+        assert!(running.kv_indices.starts_with(&reserved_indices));
+        assert_no_republished_stores(&activation_stores, &stored_hashes(&admitted.kv_events));
+
+        let terminal = execute(&mut destination, admitted.end_ms);
+        assert!(
+            terminal
+                .output_signals
+                .iter()
+                .any(|signal| signal.uuid == logical_uuid && signal.completed)
+        );
+        assert!(destination.is_empty());
+        assert!(destination.is_drained());
+        assert!(!destination.destination_is_held(handoff_id));
+        assert_eq!(destination.kv_manager.cache().protected_size, 0);
     }
 }
 

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -18,6 +18,7 @@ use super::live::SglangScheduler;
 use super::policy::apply_schedule_policy;
 use super::prefill::get_new_batch_prefill;
 use super::request::SglangRequest;
+use crate::common::handoff::HandoffId;
 use crate::common::protocols::{
     DirectRequest, EngineType, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
     SglangArgs,
@@ -26,7 +27,9 @@ use crate::kv_manager::SglangKvManager;
 use crate::scheduler::test_utils::{
     RouterIndexerHarness, nth_stored_hashes, removed_event_count, stored_hashes,
 };
-use crate::scheduler::{RouterEventVisibility, SchedulerHandle, capture_router_event_sink};
+use crate::scheduler::{
+    RouterEventVisibility, SchedulerCommand, SchedulerHandle, capture_router_event_sink,
+};
 
 const ROUTER_TEST_WORKER_ID: WorkerId = 17;
 
@@ -82,6 +85,134 @@ fn make_decoded_request(
     let result = simulate_decode_step(&mut running, kv_manager, config, 0.0, false);
     assert_eq!(result.output_signals.len(), 1);
     running.pop().unwrap()
+}
+
+mod source_holds {
+    use super::*;
+
+    fn args() -> MockEngineArgs {
+        MockEngineArgs::builder()
+            .engine_type(EngineType::Sglang)
+            .num_gpu_blocks(16)
+            .block_size(4)
+            .max_num_seqs(Some(1))
+            .worker_type(crate::common::protocols::WorkerType::Prefill)
+            .speedup_ratio(0.0)
+            .sglang(Some(SglangArgs {
+                page_size: Some(4),
+                chunked_prefill_size: Some(16),
+                ..Default::default()
+            }))
+            .build()
+            .unwrap()
+    }
+
+    fn request(uuid: Uuid) -> DirectRequest {
+        DirectRequest {
+            tokens: (0..8).collect(),
+            max_output_tokens: 2,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+            ..Default::default()
+        }
+    }
+
+    fn execute(core: &mut SglangCore, now_ms: f64) -> crate::scheduler::EnginePassResult {
+        let mut collector = crate::replay::TraceCollector::default();
+        core.execute_pass(&mut collector, now_ms)
+    }
+
+    fn occupied_tokens(core: &SglangCore) -> usize {
+        core.kv_manager.cache().total_tokens() - core.kv_manager.cache().available_tokens()
+    }
+
+    #[test]
+    fn terminal_completion_holds_source_without_running_cleanup() {
+        let mut core = SglangCore::new(args());
+        let request_id = Uuid::from_u128(301);
+        let handoff_id = HandoffId::from(Uuid::from_u128(401));
+        core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+            handoff_id,
+            request: request(request_id),
+        })
+        .unwrap();
+
+        let first = execute(&mut core, 0.0);
+        assert!(!first.output_signals[0].completed);
+        let terminal = execute(&mut core, first.end_ms);
+        assert!(terminal.output_signals[0].completed);
+        assert!(core.source_is_held(handoff_id));
+        assert!(core.running.is_empty());
+        let held_tokens = occupied_tokens(&core);
+
+        core.apply_command(SchedulerCommand::ReleaseSource { handoff_id })
+            .unwrap();
+        assert!(!core.source_is_held(handoff_id));
+        let released_tokens = occupied_tokens(&core);
+        assert!(released_tokens < held_tokens);
+
+        core.apply_command(SchedulerCommand::ReleaseSource { handoff_id })
+            .unwrap();
+        assert_eq!(occupied_tokens(&core), released_tokens);
+    }
+
+    #[test]
+    fn cancel_and_early_release_cleanup_exactly_once() {
+        let mut core = SglangCore::new(args());
+        let first_id = HandoffId::from(Uuid::from_u128(402));
+        core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+            handoff_id: first_id,
+            request: request(Uuid::from_u128(302)),
+        })
+        .unwrap();
+        let first = execute(&mut core, 0.0);
+        execute(&mut core, first.end_ms);
+        let held_tokens = occupied_tokens(&core);
+
+        core.apply_command(SchedulerCommand::CancelSource {
+            handoff_id: first_id,
+        })
+        .unwrap();
+        let cancelled_tokens = occupied_tokens(&core);
+        assert!(cancelled_tokens < held_tokens);
+        core.apply_command(SchedulerCommand::CancelSource {
+            handoff_id: first_id,
+        })
+        .unwrap();
+        assert_eq!(occupied_tokens(&core), cancelled_tokens);
+
+        core.kv_manager.evict(cancelled_tokens);
+        let second_id = first_id;
+        core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+            handoff_id: second_id,
+            request: request(Uuid::from_u128(303)),
+        })
+        .unwrap();
+        assert!(core.source_is_registered(second_id));
+        core.apply_command(SchedulerCommand::ReleaseSource {
+            handoff_id: second_id,
+        })
+        .unwrap();
+        assert!(!core.source_is_registered(second_id));
+
+        let first = execute(&mut core, 0.0);
+        let terminal = execute(&mut core, first.end_ms);
+        assert!(terminal.output_signals[0].completed);
+        assert!(!core.source_is_held(second_id));
+    }
+
+    #[test]
+    fn ordinary_completion_keeps_default_cleanup() {
+        let mut core = SglangCore::new(args());
+        core.receive(request(Uuid::from_u128(306)));
+
+        let first = execute(&mut core, 0.0);
+        let terminal = execute(&mut core, first.end_ms);
+
+        assert!(terminal.output_signals[0].completed);
+        assert_eq!(occupied_tokens(&core), 8);
+    }
 }
 
 mod scheduling {

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -214,6 +214,28 @@ mod source_holds {
         assert!(terminal.output_signals[0].completed);
         assert_eq!(occupied_tokens(&core), 8);
     }
+
+    #[test]
+    fn active_request_id_is_rejected_before_source_hold_registration() {
+        let mut core = SglangCore::new(args());
+        let request_id = Uuid::from_u128(307);
+        let handoff_id = HandoffId::from(Uuid::from_u128(407));
+        core.receive(request(request_id));
+
+        assert!(
+            core.apply_command(SchedulerCommand::Submit(request(request_id)))
+                .is_err()
+        );
+        assert!(
+            core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+                handoff_id,
+                request: request(request_id),
+            })
+            .is_err()
+        );
+        assert!(!core.source_is_registered(handoff_id));
+        assert_eq!(core.num_requests(), 1);
+    }
 }
 
 mod destination_lifecycle {
@@ -358,6 +380,12 @@ mod destination_lifecycle {
         assert!(source.is_drained());
 
         let blocked = execute(&mut destination, blocker_first.end_ms);
+        assert!(
+            blocked
+                .admissions
+                .iter()
+                .all(|admission| admission.uuid != logical_uuid)
+        );
         let ready = destination
             .prebuilt_request(logical_uuid)
             .expect("full running batch must keep request ready");
@@ -367,6 +395,12 @@ mod destination_lifecycle {
         let blocker_terminal = execute(&mut destination, blocked.end_ms);
         assert!(
             blocker_terminal
+                .admissions
+                .iter()
+                .all(|admission| admission.uuid != logical_uuid)
+        );
+        assert!(
+            blocker_terminal
                 .output_signals
                 .iter()
                 .any(|signal| signal.uuid == blocker_uuid && signal.completed)
@@ -374,6 +408,13 @@ mod destination_lifecycle {
         assert!(destination.prebuilt_request(logical_uuid).is_some());
 
         let admitted = execute(&mut destination, blocker_terminal.end_ms);
+        let logical_admissions = admitted
+            .admissions
+            .iter()
+            .filter(|admission| admission.uuid == logical_uuid)
+            .collect::<Vec<_>>();
+        assert_eq!(logical_admissions.len(), 1);
+        assert_eq!(logical_admissions[0].reused_input_tokens, 0);
         let running = destination
             .running
             .iter()

--- a/lib/mocker/src/scheduler/source_holds.rs
+++ b/lib/mocker/src/scheduler/source_holds.rs
@@ -77,15 +77,8 @@ impl<T> SourceHolds<T> {
     }
 
     pub(crate) fn register(&mut self, request_id: Uuid, handoff_id: HandoffId) -> Result<()> {
-        if self.pending_by_request.contains_key(&request_id) {
-            bail!("source hold already registered for request {request_id}");
-        }
-        if self
-            .held_prefills
-            .values()
-            .any(|(held_request_id, _)| *held_request_id == request_id)
-        {
-            bail!("source hold already held for request {request_id}");
+        if self.contains_request(request_id) {
+            bail!("source hold already active for request {request_id}");
         }
         if self.pending_by_handoff.contains_key(&handoff_id)
             || self.held_prefills.contains_key(&handoff_id)
@@ -96,6 +89,14 @@ impl<T> SourceHolds<T> {
         self.pending_by_request.insert(request_id, handoff_id);
         self.pending_by_handoff.insert(handoff_id, request_id);
         Ok(())
+    }
+
+    pub(crate) fn contains_request(&self, request_id: Uuid) -> bool {
+        self.pending_by_request.contains_key(&request_id)
+            || self
+                .held_prefills
+                .values()
+                .any(|(held_request_id, _)| *held_request_id == request_id)
     }
 
     pub(crate) fn complete_source(&mut self, request_id: Uuid, payload: T) -> SourceCompletion<T> {
@@ -169,6 +170,10 @@ impl<T> DestinationHolds<T> {
             bail!("destination handoff {handoff_id:?} is already active");
         }
         Ok(())
+    }
+
+    pub(crate) fn contains_request(&self, request_id: Uuid) -> bool {
+        self.by_request.contains_key(&request_id)
     }
 
     pub(crate) fn insert(&mut self, request_id: Uuid, handoff_id: HandoffId, payload: T) {

--- a/lib/mocker/src/scheduler/source_holds.rs
+++ b/lib/mocker/src/scheduler/source_holds.rs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Result, bail};
+use rustc_hash::FxHashMap;
+use uuid::Uuid;
+
+use crate::common::handoff::HandoffId;
+use crate::common::protocols::DirectRequest;
+
+#[allow(dead_code)]
+pub(crate) enum SchedulerCommand {
+    Submit(DirectRequest),
+    SubmitHandoffPrefill {
+        handoff_id: HandoffId,
+        request: DirectRequest,
+    },
+    ReleaseSource {
+        handoff_id: HandoffId,
+    },
+    CancelSource {
+        handoff_id: HandoffId,
+    },
+}
+
+pub(crate) enum SourceCompletion<T> {
+    Release(T),
+    Held,
+}
+
+pub(crate) enum RemovedSource<T> {
+    Held(T),
+    Pending,
+    Missing,
+}
+
+pub(crate) struct SourceHolds<T> {
+    pending_by_request: FxHashMap<Uuid, HandoffId>,
+    pending_by_handoff: FxHashMap<HandoffId, Uuid>,
+    held_prefills: FxHashMap<HandoffId, (Uuid, T)>,
+}
+
+impl<T> Default for SourceHolds<T> {
+    fn default() -> Self {
+        Self {
+            pending_by_request: FxHashMap::default(),
+            pending_by_handoff: FxHashMap::default(),
+            held_prefills: FxHashMap::default(),
+        }
+    }
+}
+
+impl<T> SourceHolds<T> {
+    pub(crate) fn register(&mut self, request_id: Uuid, handoff_id: HandoffId) -> Result<()> {
+        if self.pending_by_request.contains_key(&request_id) {
+            bail!("source hold already registered for request {request_id}");
+        }
+        if self
+            .held_prefills
+            .values()
+            .any(|(held_request_id, _)| *held_request_id == request_id)
+        {
+            bail!("source hold already held for request {request_id}");
+        }
+        if self.pending_by_handoff.contains_key(&handoff_id)
+            || self.held_prefills.contains_key(&handoff_id)
+        {
+            bail!("handoff {handoff_id:?} is already active");
+        }
+
+        self.pending_by_request.insert(request_id, handoff_id);
+        self.pending_by_handoff.insert(handoff_id, request_id);
+        Ok(())
+    }
+
+    pub(crate) fn complete_source(&mut self, request_id: Uuid, payload: T) -> SourceCompletion<T> {
+        let Some(handoff_id) = self.pending_by_request.remove(&request_id) else {
+            return SourceCompletion::Release(payload);
+        };
+
+        let registered_request = self
+            .pending_by_handoff
+            .remove(&handoff_id)
+            .expect("validated source-hold registration must be bidirectional");
+        debug_assert_eq!(registered_request, request_id);
+
+        let previous = self.held_prefills.insert(handoff_id, (request_id, payload));
+        debug_assert!(previous.is_none());
+        SourceCompletion::Held
+    }
+
+    pub(crate) fn remove(&mut self, handoff_id: HandoffId) -> RemovedSource<T> {
+        if let Some((_, payload)) = self.held_prefills.remove(&handoff_id) {
+            return RemovedSource::Held(payload);
+        }
+
+        let Some(request_id) = self.pending_by_handoff.remove(&handoff_id) else {
+            return RemovedSource::Missing;
+        };
+        let removed = self.pending_by_request.remove(&request_id);
+        debug_assert_eq!(removed, Some(handoff_id));
+        RemovedSource::Pending
+    }
+
+    pub(crate) fn remove_request(&mut self, request_id: Uuid) {
+        let Some(handoff_id) = self.pending_by_request.remove(&request_id) else {
+            return;
+        };
+        let removed = self.pending_by_handoff.remove(&handoff_id);
+        debug_assert_eq!(removed, Some(request_id));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_held(&self, handoff_id: HandoffId) -> bool {
+        self.held_prefills.contains_key(&handoff_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_registered(&self, handoff_id: HandoffId) -> bool {
+        self.pending_by_handoff.contains_key(&handoff_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completion_atomically_moves_registered_payload_to_held() {
+        let request_id = Uuid::from_u128(1);
+        let handoff_id = HandoffId::from(Uuid::from_u128(2));
+        let mut holds = SourceHolds::default();
+
+        holds.register(request_id, handoff_id).unwrap();
+        assert!(holds.is_registered(handoff_id));
+
+        let completion = holds.complete_source(request_id, "payload");
+        assert!(matches!(completion, SourceCompletion::Held));
+        assert!(!holds.is_registered(handoff_id));
+        assert!(holds.is_held(handoff_id));
+        assert!(
+            holds
+                .register(request_id, HandoffId::from(Uuid::from_u128(7)))
+                .is_err()
+        );
+        assert!(matches!(
+            holds.remove(handoff_id),
+            RemovedSource::Held("payload")
+        ));
+        assert!(matches!(holds.remove(handoff_id), RemovedSource::Missing));
+    }
+
+    #[test]
+    fn active_ids_are_rejected_but_released_ids_can_be_reused() {
+        let request_id = Uuid::from_u128(3);
+        let handoff_id = HandoffId::from(Uuid::from_u128(4));
+        let mut holds = SourceHolds::<()>::default();
+
+        holds.register(request_id, handoff_id).unwrap();
+        assert!(holds.register(Uuid::from_u128(5), handoff_id).is_err());
+        assert!(holds.register(request_id, HandoffId::new()).is_err());
+        assert!(matches!(holds.remove(handoff_id), RemovedSource::Pending));
+
+        holds.register(Uuid::from_u128(5), handoff_id).unwrap();
+    }
+
+    #[test]
+    fn unregistered_completion_releases_payload() {
+        let mut holds = SourceHolds::default();
+        let payload = String::from("payload");
+
+        assert!(matches!(
+            holds.complete_source(Uuid::from_u128(6), payload),
+            SourceCompletion::Release(value) if value == "payload"
+        ));
+    }
+}

--- a/lib/mocker/src/scheduler/source_holds.rs
+++ b/lib/mocker/src/scheduler/source_holds.rs
@@ -21,6 +21,25 @@ pub(crate) enum SchedulerCommand {
     CancelSource {
         handoff_id: HandoffId,
     },
+    ReserveDestination {
+        handoff_id: HandoffId,
+        request: DirectRequest,
+    },
+    ActivateDestination {
+        handoff_id: HandoffId,
+    },
+    CancelDestination {
+        handoff_id: HandoffId,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SchedulerCommandResult {
+    Submitted(Uuid),
+    DestinationReserved { request_id: Uuid },
+    DestinationUnavailable,
+    Applied,
+    Noop,
 }
 
 pub(crate) enum SourceCompletion<T> {
@@ -51,6 +70,12 @@ impl<T> Default for SourceHolds<T> {
 }
 
 impl<T> SourceHolds<T> {
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        debug_assert_eq!(self.pending_by_request.len(), self.pending_by_handoff.len());
+        self.pending_by_request.is_empty() && self.held_prefills.is_empty()
+    }
+
     pub(crate) fn register(&mut self, request_id: Uuid, handoff_id: HandoffId) -> Result<()> {
         if self.pending_by_request.contains_key(&request_id) {
             bail!("source hold already registered for request {request_id}");
@@ -118,6 +143,63 @@ impl<T> SourceHolds<T> {
     #[cfg(test)]
     pub(crate) fn is_registered(&self, handoff_id: HandoffId) -> bool {
         self.pending_by_handoff.contains_key(&handoff_id)
+    }
+}
+
+pub(crate) struct DestinationHolds<T> {
+    by_handoff: FxHashMap<HandoffId, (Uuid, T)>,
+    by_request: FxHashMap<Uuid, HandoffId>,
+}
+
+impl<T> Default for DestinationHolds<T> {
+    fn default() -> Self {
+        Self {
+            by_handoff: FxHashMap::default(),
+            by_request: FxHashMap::default(),
+        }
+    }
+}
+
+impl<T> DestinationHolds<T> {
+    pub(crate) fn validate(&self, request_id: Uuid, handoff_id: HandoffId) -> Result<()> {
+        if self.by_request.contains_key(&request_id) {
+            bail!("destination reservation already exists for request {request_id}");
+        }
+        if self.by_handoff.contains_key(&handoff_id) {
+            bail!("destination handoff {handoff_id:?} is already active");
+        }
+        Ok(())
+    }
+
+    pub(crate) fn insert(&mut self, request_id: Uuid, handoff_id: HandoffId, payload: T) {
+        debug_assert!(self.validate(request_id, handoff_id).is_ok());
+        let previous = self.by_handoff.insert(handoff_id, (request_id, payload));
+        debug_assert!(previous.is_none());
+        let previous = self.by_request.insert(request_id, handoff_id);
+        debug_assert!(previous.is_none());
+    }
+
+    pub(crate) fn remove(&mut self, handoff_id: HandoffId) -> Option<(Uuid, T)> {
+        let (request_id, payload) = self.by_handoff.remove(&handoff_id)?;
+        let removed = self.by_request.remove(&request_id);
+        debug_assert_eq!(removed, Some(handoff_id));
+        Some((request_id, payload))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        debug_assert_eq!(self.by_handoff.len(), self.by_request.len());
+        self.by_handoff.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, handoff_id: HandoffId) -> bool {
+        self.by_handoff.contains_key(&handoff_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get(&self, handoff_id: HandoffId) -> Option<&T> {
+        self.by_handoff.get(&handoff_id).map(|(_, payload)| payload)
     }
 }
 

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -27,16 +27,19 @@ use crate::common::utils::compute_prefill_handoff_delay_ms;
 use crate::kv_manager::KvManager;
 #[cfg(feature = "kvbm-offload")]
 use crate::kv_manager::kvbm_backend::SwapInRegistrationBlock;
+use crate::kv_manager::kvbm_backend::VllmDestinationReservation;
 use crate::replay::TraceCollector;
 use crate::scheduler::vllm::policy::{self, AdmissionDecision};
 use crate::scheduler::{
-    AdmissionEvent, CapturedRouterEventBuffer, EnginePassResult, ForwardPassSnapshot,
-    MockerMetrics, RemovedSource, RouterEventVisibility, SchedulerCommand, SourceCompletion,
-    SourceHolds, accept_length_sample, build_fpm_snapshot, capture_router_event_sink,
+    AdmissionEvent, CapturedRouterEventBuffer, DestinationHolds, EnginePassResult,
+    ForwardPassSnapshot, MockerMetrics, RemovedSource, RouterEventVisibility, SchedulerCommand,
+    SchedulerCommandResult, SourceCompletion, SourceHolds, accept_length_sample,
+    build_fpm_snapshot, capture_router_event_sink,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RequestStatus {
+    WaitingForRemoteKv,
     Waiting,
     Running,
     Preempted,
@@ -137,6 +140,12 @@ impl SchedulerState {
             return;
         }
         self.waiting.push_back(uuid);
+    }
+
+    fn insert_waiting(&mut self, uuid: Uuid, request: VllmRequestState) {
+        debug_assert!(!self.requests.contains_key(&uuid));
+        self.requests.insert(uuid, request);
+        self.push_waiting(uuid);
     }
 
     fn prepend_waiting(&mut self, uuid: Uuid) {
@@ -365,6 +374,7 @@ pub(crate) struct VllmCore {
     speculative_sampler: Option<SpeculativeDecodeSampler>,
     kv_event_buffer: Option<CapturedRouterEventBuffer>,
     source_holds: SourceHolds<HeldVllmPrefill>,
+    destination_holds: DestinationHolds<ReservedVllmDecode>,
 
     /// Requests parked on pending G2→G1 swap-ins. Populated by the
     /// admission path when a request's remaining prefix matches G2 only
@@ -381,6 +391,28 @@ pub(crate) struct VllmCore {
 struct HeldVllmPrefill {
     request: VllmRequestState,
     deferred_deref: Vec<MoveBlock>,
+}
+
+struct ReservedVllmDecode {
+    request: VllmRequestState,
+    kv: VllmDestinationReservation,
+}
+
+impl ReservedVllmDecode {
+    fn activate(self, kv_manager: &mut KvManager) -> VllmRequestState {
+        let Self { mut request, kv } = self;
+        kv_manager.activate_destination(kv);
+        let prompt_len = request.sequence.num_input_tokens();
+        request.sequence.commit_allocation(prompt_len);
+        request.num_computed_tokens = prompt_len;
+        request.status = RequestStatus::Waiting;
+        request
+    }
+
+    fn cancel(self, _kv_manager: &mut KvManager) {
+        let Self { request: _, kv } = self;
+        drop(kv);
+    }
 }
 
 struct VllmTerminalEffects {
@@ -448,6 +480,7 @@ impl VllmCore {
             speculative_sampler,
             kv_event_buffer,
             source_holds: SourceHolds::default(),
+            destination_holds: DestinationHolds::default(),
             #[cfg(feature = "kvbm-offload")]
             requests_awaiting_swap_in: Vec::new(),
         }
@@ -473,17 +506,23 @@ impl VllmCore {
     }
 
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
-        self.apply_command(SchedulerCommand::Submit(request))
+        match self
+            .apply_command(SchedulerCommand::Submit(request))
             .expect("ordinary request submission is infallible")
-            .expect("submit command must return a request ID")
+        {
+            SchedulerCommandResult::Submitted(uuid) => uuid,
+            _ => unreachable!("submit command must return a request ID"),
+        }
     }
 
     pub(crate) fn apply_command(
         &mut self,
         command: SchedulerCommand,
-    ) -> anyhow::Result<Option<Uuid>> {
+    ) -> anyhow::Result<SchedulerCommandResult> {
         match command {
-            SchedulerCommand::Submit(request) => Ok(Some(self.submit(request))),
+            SchedulerCommand::Submit(request) => {
+                Ok(SchedulerCommandResult::Submitted(self.submit(request)))
+            }
             SchedulerCommand::SubmitHandoffPrefill {
                 handoff_id,
                 mut request,
@@ -493,17 +532,68 @@ impl VllmCore {
                 self.source_holds.register(uuid, handoff_id)?;
                 let submitted = self.submit(request);
                 debug_assert_eq!(submitted, uuid);
-                Ok(Some(uuid))
+                Ok(SchedulerCommandResult::Submitted(uuid))
             }
             SchedulerCommand::ReleaseSource { handoff_id }
             | SchedulerCommand::CancelSource { handoff_id } => {
-                self.remove_source(handoff_id);
-                Ok(None)
+                Ok(if self.remove_source(handoff_id) {
+                    SchedulerCommandResult::Applied
+                } else {
+                    SchedulerCommandResult::Noop
+                })
+            }
+            SchedulerCommand::ReserveDestination {
+                handoff_id,
+                mut request,
+            } => {
+                let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+                request.uuid = Some(uuid);
+                if self.state.requests.contains_key(&uuid) {
+                    anyhow::bail!("request {uuid} is already active");
+                }
+                self.destination_holds.validate(uuid, handoff_id)?;
+                let request = self.make_request_state(request, RequestStatus::WaitingForRemoteKv);
+                let Some(kv) = self.kv_manager.reserve_destination(&request.sequence) else {
+                    return Ok(SchedulerCommandResult::DestinationUnavailable);
+                };
+                self.destination_holds
+                    .insert(uuid, handoff_id, ReservedVllmDecode { request, kv });
+                Ok(SchedulerCommandResult::DestinationReserved { request_id: uuid })
+            }
+            SchedulerCommand::ActivateDestination { handoff_id } => {
+                let Some((uuid, reservation)) = self.destination_holds.remove(handoff_id) else {
+                    return Ok(SchedulerCommandResult::Noop);
+                };
+                let request = reservation.activate(&mut self.kv_manager);
+                self.state.insert_waiting(uuid, request);
+                Ok(SchedulerCommandResult::Applied)
+            }
+            SchedulerCommand::CancelDestination { handoff_id } => {
+                let Some((_, reservation)) = self.destination_holds.remove(handoff_id) else {
+                    return Ok(SchedulerCommandResult::Noop);
+                };
+                reservation.cancel(&mut self.kv_manager);
+                Ok(SchedulerCommandResult::Applied)
             }
         }
     }
 
-    fn submit(&mut self, request: DirectRequest) -> Uuid {
+    fn submit(&mut self, mut request: DirectRequest) -> Uuid {
+        let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+        request.uuid = Some(uuid);
+        let request = self.make_request_state(request, RequestStatus::Waiting);
+        self.state.insert_waiting(uuid, request);
+        if let Some(request) = self.state.requests.get(&uuid) {
+            request.debug_assert_progress(uuid);
+        }
+        uuid
+    }
+
+    fn make_request_state(
+        &self,
+        request: DirectRequest,
+        status: RequestStatus,
+    ) -> VllmRequestState {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
         let mut max_output_tokens = request.max_output_tokens;
         if let Some(clamped) = policy::normalize_max_output_tokens(
@@ -529,20 +619,12 @@ impl VllmCore {
             self.args.enable_prefix_caching,
             self.args.zmq_kv_events_port.is_some(),
         );
-        self.state.requests.insert(
-            uuid,
-            VllmRequestState {
-                sequence,
-                status: RequestStatus::Waiting,
-                num_computed_tokens: 0,
-                num_preemptions: 0,
-            },
-        );
-        self.state.push_waiting(uuid);
-        if let Some(request) = self.state.requests.get(&uuid) {
-            request.debug_assert_progress(uuid);
+        VllmRequestState {
+            sequence,
+            status,
+            num_computed_tokens: 0,
+            num_preemptions: 0,
         }
-        uuid
     }
 
     fn remove_source(&mut self, handoff_id: HandoffId) -> bool {
@@ -594,6 +676,52 @@ impl VllmCore {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.state.is_empty()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_drained(&self) -> bool {
+        if !self.is_empty() || !self.source_holds.is_empty() || !self.destination_holds.is_empty() {
+            return false;
+        }
+        #[cfg(feature = "kvbm-offload")]
+        {
+            self.requests_awaiting_swap_in.is_empty()
+                && self.kv_manager.earliest_offload_deadline().is_none()
+        }
+        #[cfg(not(feature = "kvbm-offload"))]
+        {
+            true
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn destination_is_held(&self, handoff_id: HandoffId) -> bool {
+        self.destination_holds.contains(handoff_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn destination_block_ids(&self, handoff_id: HandoffId) -> Vec<usize> {
+        self.destination_holds
+            .get(handoff_id)
+            .map(|reservation| reservation.kv.block_ids())
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn request_block_ids(&self, uuid: Uuid) -> Vec<usize> {
+        self.state
+            .requests
+            .get(&uuid)
+            .map(|request| self.kv_manager.active_block_ids(&request.sequence))
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn drain_kv_events(&self) -> Vec<dynamo_kv_router::protocols::RouterEvent> {
+        self.kv_event_buffer
+            .as_ref()
+            .map(CapturedRouterEventBuffer::drain)
+            .unwrap_or_default()
     }
 
     pub(crate) fn num_requests(&self) -> usize {
@@ -931,15 +1059,30 @@ impl VllmCore {
                     .iter()
                     .filter_map(|running_uuid| self.state.requests.get(running_uuid))
                     .map(|request| &request.sequence);
-                policy::decide_waiting_admission(
-                    scheduling_policy,
-                    &request.sequence,
-                    request.status == RequestStatus::Waiting,
-                    running_seqs,
-                    self.args.num_gpu_blocks,
-                    self.args.block_size,
-                    &self.kv_manager,
-                )
+                let prompt_is_prebuilt = request.num_computed_tokens
+                    >= request.sequence.num_input_tokens()
+                    && request.sequence.num_allocated_tokens()
+                        >= request.sequence.num_input_tokens();
+                if prompt_is_prebuilt {
+                    AdmissionDecision::Admit {
+                        prefill_cost: PrefillCost {
+                            new_blocks: 0,
+                            new_tokens: 0,
+                            cached_tokens: request.sequence.num_input_tokens(),
+                            active_cached_tokens: request.sequence.num_input_tokens(),
+                        },
+                    }
+                } else {
+                    policy::decide_waiting_admission(
+                        scheduling_policy,
+                        &request.sequence,
+                        request.status == RequestStatus::Waiting,
+                        running_seqs,
+                        self.args.num_gpu_blocks,
+                        self.args.block_size,
+                        &self.kv_manager,
+                    )
+                }
             };
             let prefill_cost = match decision {
                 AdmissionDecision::Admit { prefill_cost } => prefill_cost,

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -18,8 +18,8 @@ use crate::common::handoff::HandoffId;
 #[cfg(feature = "kvbm-offload")]
 use crate::common::protocols::G1;
 use crate::common::protocols::{
-    DirectRequest, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal, PreemptionMode,
-    PrefillCost, WorkerType,
+    DirectRequest, EngineType, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal,
+    PreemptionMode, PrefillCost, WorkerType,
 };
 use crate::common::sequence::ActiveSequence;
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
@@ -546,6 +546,9 @@ impl VllmCore {
                 handoff_id,
                 mut request,
             } => {
+                if self.args.engine_type == EngineType::Trtllm {
+                    anyhow::bail!("destination reservation is not supported for TRT-LLM");
+                }
                 let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
                 request.uuid = Some(uuid);
                 if self.state.requests.contains_key(&uuid) {

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -14,6 +14,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+use crate::common::handoff::HandoffId;
 #[cfg(feature = "kvbm-offload")]
 use crate::common::protocols::G1;
 use crate::common::protocols::{
@@ -30,8 +31,8 @@ use crate::replay::TraceCollector;
 use crate::scheduler::vllm::policy::{self, AdmissionDecision};
 use crate::scheduler::{
     AdmissionEvent, CapturedRouterEventBuffer, EnginePassResult, ForwardPassSnapshot,
-    MockerMetrics, RouterEventVisibility, accept_length_sample, build_fpm_snapshot,
-    capture_router_event_sink,
+    MockerMetrics, RemovedSource, RouterEventVisibility, SchedulerCommand, SourceCompletion,
+    SourceHolds, accept_length_sample, build_fpm_snapshot, capture_router_event_sink,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -202,9 +203,13 @@ impl SchedulerState {
     }
 
     pub(crate) fn complete(&mut self, uuid: &Uuid) {
+        self.take_completed(uuid);
+    }
+
+    pub(crate) fn take_completed(&mut self, uuid: &Uuid) -> Option<VllmRequestState> {
         self.waiting_members.remove(uuid);
         self.running_members.remove(uuid);
-        self.requests.remove(uuid);
+        self.requests.remove(uuid)
     }
 
     pub(crate) fn running_sequence_mut(&mut self, uuid: Uuid) -> Option<&mut ActiveSequence> {
@@ -359,6 +364,7 @@ pub(crate) struct VllmCore {
     pub(super) kv_manager: KvManager,
     speculative_sampler: Option<SpeculativeDecodeSampler>,
     kv_event_buffer: Option<CapturedRouterEventBuffer>,
+    source_holds: SourceHolds<HeldVllmPrefill>,
 
     /// Requests parked on pending G2→G1 swap-ins. Populated by the
     /// admission path when a request's remaining prefix matches G2 only
@@ -370,6 +376,16 @@ pub(crate) struct VllmCore {
     /// uuid↔handle mapping.
     #[cfg(feature = "kvbm-offload")]
     pub(super) requests_awaiting_swap_in: Vec<AwaitingSwapIn>,
+}
+
+struct HeldVllmPrefill {
+    request: VllmRequestState,
+    deferred_deref: Vec<MoveBlock>,
+}
+
+struct VllmTerminalEffects {
+    immediate: Vec<MoveBlock>,
+    cleanup: Vec<MoveBlock>,
 }
 
 impl VllmCore {
@@ -431,6 +447,7 @@ impl VllmCore {
             state: SchedulerState::default(),
             speculative_sampler,
             kv_event_buffer,
+            source_holds: SourceHolds::default(),
             #[cfg(feature = "kvbm-offload")]
             requests_awaiting_swap_in: Vec::new(),
         }
@@ -456,6 +473,37 @@ impl VllmCore {
     }
 
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
+        self.apply_command(SchedulerCommand::Submit(request))
+            .expect("ordinary request submission is infallible")
+            .expect("submit command must return a request ID")
+    }
+
+    pub(crate) fn apply_command(
+        &mut self,
+        command: SchedulerCommand,
+    ) -> anyhow::Result<Option<Uuid>> {
+        match command {
+            SchedulerCommand::Submit(request) => Ok(Some(self.submit(request))),
+            SchedulerCommand::SubmitHandoffPrefill {
+                handoff_id,
+                mut request,
+            } => {
+                let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+                request.uuid = Some(uuid);
+                self.source_holds.register(uuid, handoff_id)?;
+                let submitted = self.submit(request);
+                debug_assert_eq!(submitted, uuid);
+                Ok(Some(uuid))
+            }
+            SchedulerCommand::ReleaseSource { handoff_id }
+            | SchedulerCommand::CancelSource { handoff_id } => {
+                self.remove_source(handoff_id);
+                Ok(None)
+            }
+        }
+    }
+
+    fn submit(&mut self, request: DirectRequest) -> Uuid {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
         let mut max_output_tokens = request.max_output_tokens;
         if let Some(clamped) = policy::normalize_max_output_tokens(
@@ -495,6 +543,53 @@ impl VllmCore {
             request.debug_assert_progress(uuid);
         }
         uuid
+    }
+
+    fn remove_source(&mut self, handoff_id: HandoffId) -> bool {
+        match self.source_holds.remove(handoff_id) {
+            RemovedSource::Held(payload) => {
+                self.cleanup_completed_prefill(payload);
+                true
+            }
+            RemovedSource::Pending => true,
+            RemovedSource::Missing => false,
+        }
+    }
+
+    fn complete_source(&mut self, uuid: Uuid, deferred_deref: Vec<MoveBlock>) {
+        let request = self
+            .state
+            .take_completed(&uuid)
+            .expect("completed request must remain scheduler-owned");
+        let payload = HeldVllmPrefill {
+            request,
+            deferred_deref,
+        };
+        if let SourceCompletion::Release(payload) = self.source_holds.complete_source(uuid, payload)
+        {
+            self.cleanup_completed_prefill(payload);
+        }
+    }
+
+    fn cleanup_completed_prefill(&mut self, payload: HeldVllmPrefill) {
+        let HeldVllmPrefill {
+            request,
+            deferred_deref,
+        } = payload;
+        for signal in deferred_deref {
+            self.kv_manager.process(&signal);
+        }
+        drop(request);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn source_is_held(&self, handoff_id: HandoffId) -> bool {
+        self.source_holds.is_held(handoff_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn source_is_registered(&self, handoff_id: HandoffId) -> bool {
+        self.source_holds.is_registered(handoff_id)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -966,6 +1061,7 @@ impl VllmCore {
         for signal in request.sequence.free_signal() {
             self.kv_manager.process(&signal);
         }
+        self.source_holds.remove_request(uuid);
         self.state.complete(&uuid);
     }
 
@@ -1262,20 +1358,30 @@ impl VllmCore {
         for uuid in ready {
             let mut emitted = false;
             let mut completed = false;
+            let mut deferred_deref = Vec::new();
             loop {
                 self.state.debug_assert_ready_to_decode(uuid);
                 let Some(sequence) = self.state.running_sequence_mut(uuid) else {
                     break;
                 };
                 let signals = sequence.generate();
-                if signals.is_empty() || process_signals(&mut self.kv_manager, &signals) {
-                    if !signals.is_empty()
-                        && sequence.generated_tokens() < sequence.max_output_tokens()
-                    {
+                completed = sequence.generated_tokens() >= sequence.max_output_tokens();
+                let effects = if completed {
+                    split_terminal_effects(signals)
+                } else {
+                    VllmTerminalEffects {
+                        immediate: signals,
+                        cleanup: Vec::new(),
+                    }
+                };
+                if effects.immediate.is_empty()
+                    || process_signals(&mut self.kv_manager, &effects.immediate)
+                {
+                    if !effects.immediate.is_empty() && !completed {
                         sequence.commit_allocation(sequence.len());
                     }
                     emitted = true;
-                    completed = sequence.generated_tokens() >= sequence.max_output_tokens();
+                    deferred_deref = effects.cleanup;
                     break;
                 }
                 sequence.pop();
@@ -1295,9 +1401,6 @@ impl VllmCore {
                 continue;
             }
 
-            if let Some(collector) = collector.as_deref_mut() {
-                collector.on_token(uuid, decode_end_ms);
-            }
             let handoff_delay_ms = self.state.requests.get(&uuid).and_then(|request| {
                 request.debug_assert_progress(uuid);
                 compute_prefill_handoff_delay_ms(
@@ -1308,16 +1411,20 @@ impl VllmCore {
                     self.args.kv_bytes_per_token,
                 )
             });
-            output_signals.push(OutputSignal {
+            let output_signal = OutputSignal {
                 uuid,
                 completed,
                 rejected: false,
                 handoff_delay_ms,
-            });
+            };
             if completed {
-                self.state.complete(&uuid);
+                self.complete_source(uuid, deferred_deref);
                 running_changed = true;
             }
+            if let Some(collector) = collector.as_deref_mut() {
+                collector.on_token(uuid, decode_end_ms);
+            }
+            output_signals.push(output_signal);
         }
 
         if output_signals.is_empty() {
@@ -1453,16 +1560,28 @@ impl VllmCore {
             Vec::with_capacity(sampled_bursts.iter().map(|(_, burst)| *burst).sum());
         for (uuid, burst) in sampled_bursts {
             let mut completed = false;
+            let mut deferred_deref = Vec::new();
             for _ in 0..burst {
-                let signals = {
+                let (signals, is_complete) = {
                     let request = self
                         .state
                         .requests
                         .get_mut(&uuid)
                         .expect("sampled request must remain active");
-                    request.sequence.generate()
+                    let signals = request.sequence.generate();
+                    let is_complete =
+                        request.sequence.generated_tokens() >= request.sequence.max_output_tokens();
+                    (signals, is_complete)
                 };
-                for signal in &signals {
+                let effects = if is_complete {
+                    split_terminal_effects(signals)
+                } else {
+                    VllmTerminalEffects {
+                        immediate: signals,
+                        cleanup: Vec::new(),
+                    }
+                };
+                for signal in &effects.immediate {
                     self.kv_manager
                         .process_decode_signal(signal, &mut reservation);
                 }
@@ -1494,12 +1613,13 @@ impl VllmCore {
                 });
                 if is_complete {
                     completed = true;
+                    deferred_deref = effects.cleanup;
                     break;
                 }
             }
 
             if completed {
-                self.state.complete(&uuid);
+                self.complete_source(uuid, deferred_deref);
                 running_changed = true;
                 continue;
             }
@@ -1560,6 +1680,13 @@ fn scale_decode_time(decode_ms: f64, args: &MockEngineArgs) -> Duration {
         return unscaled;
     }
     Duration::from_secs_f64(unscaled.as_secs_f64() / effective_ratio)
+}
+
+fn split_terminal_effects(signals: Vec<MoveBlock>) -> VllmTerminalEffects {
+    let (cleanup, immediate) = signals
+        .into_iter()
+        .partition(|signal| matches!(signal, MoveBlock::Deref(_)));
+    VllmTerminalEffects { immediate, cleanup }
 }
 
 fn process_signals(kv_manager: &mut KvManager, signals: &[MoveBlock]) -> bool {

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -531,8 +531,7 @@ impl VllmCore {
                 request.uuid = Some(uuid);
                 self.source_holds.register(uuid, handoff_id)?;
                 let submitted = self.submit(request);
-                debug_assert_eq!(submitted, uuid);
-                Ok(SchedulerCommandResult::Submitted(uuid))
+                Ok(SchedulerCommandResult::Submitted(submitted))
             }
             SchedulerCommand::ReleaseSource { handoff_id }
             | SchedulerCommand::CancelSource { handoff_id } => {

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -18,8 +18,8 @@ use crate::common::handoff::HandoffId;
 #[cfg(feature = "kvbm-offload")]
 use crate::common::protocols::G1;
 use crate::common::protocols::{
-    DirectRequest, EngineType, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal,
-    PreemptionMode, PrefillCost, WorkerType,
+    DirectRequest, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal, PreemptionMode,
+    PrefillCost, WorkerType,
 };
 use crate::common::sequence::ActiveSequence;
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
@@ -508,7 +508,7 @@ impl VllmCore {
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
         match self
             .apply_command(SchedulerCommand::Submit(request))
-            .expect("ordinary request submission is infallible")
+            .expect("ordinary request ID must be unique")
         {
             SchedulerCommandResult::Submitted(uuid) => uuid,
             _ => unreachable!("submit command must return a request ID"),
@@ -520,8 +520,11 @@ impl VllmCore {
         command: SchedulerCommand,
     ) -> anyhow::Result<SchedulerCommandResult> {
         match command {
-            SchedulerCommand::Submit(request) => {
-                Ok(SchedulerCommandResult::Submitted(self.submit(request)))
+            SchedulerCommand::Submit(mut request) => {
+                let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+                request.uuid = Some(uuid);
+                self.validate_request_id(uuid)?;
+                Ok(SchedulerCommandResult::Submitted(self.submit(request)?))
             }
             SchedulerCommand::SubmitHandoffPrefill {
                 handoff_id,
@@ -529,8 +532,11 @@ impl VllmCore {
             } => {
                 let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
                 request.uuid = Some(uuid);
+                self.validate_request_id(uuid)?;
                 self.source_holds.register(uuid, handoff_id)?;
-                let submitted = self.submit(request);
+                let submitted = self
+                    .submit(request)
+                    .expect("prevalidated handoff request must submit");
                 Ok(SchedulerCommandResult::Submitted(submitted))
             }
             SchedulerCommand::ReleaseSource { handoff_id }
@@ -545,14 +551,12 @@ impl VllmCore {
                 handoff_id,
                 mut request,
             } => {
-                if self.args.engine_type == EngineType::Trtllm {
+                if !policy::supports_destination_reservation(self.args.scheduling_policy()) {
                     anyhow::bail!("destination reservation is not supported for TRT-LLM");
                 }
                 let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
                 request.uuid = Some(uuid);
-                if self.state.requests.contains_key(&uuid) {
-                    anyhow::bail!("request {uuid} is already active");
-                }
+                self.validate_request_id(uuid)?;
                 self.destination_holds.validate(uuid, handoff_id)?;
                 let request = self.make_request_state(request, RequestStatus::WaitingForRemoteKv);
                 let Some(kv) = self.kv_manager.reserve_destination(&request.sequence) else {
@@ -580,15 +584,28 @@ impl VllmCore {
         }
     }
 
-    fn submit(&mut self, mut request: DirectRequest) -> Uuid {
+    fn validate_request_id(&self, uuid: Uuid) -> anyhow::Result<()> {
+        if self.state.requests.contains_key(&uuid)
+            || self.source_holds.contains_request(uuid)
+            || self.destination_holds.contains_request(uuid)
+        {
+            anyhow::bail!("request {uuid} is already active");
+        }
+        Ok(())
+    }
+
+    fn submit(&mut self, mut request: DirectRequest) -> anyhow::Result<Uuid> {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
         request.uuid = Some(uuid);
+        if self.state.requests.contains_key(&uuid) {
+            anyhow::bail!("request {uuid} is already active");
+        }
         let request = self.make_request_state(request, RequestStatus::Waiting);
         self.state.insert_waiting(uuid, request);
         if let Some(request) = self.state.requests.get(&uuid) {
             request.debug_assert_progress(uuid);
         }
-        uuid
+        Ok(uuid)
     }
 
     fn make_request_state(

--- a/lib/mocker/src/scheduler/vllm/policy.rs
+++ b/lib/mocker/src/scheduler/vllm/policy.rs
@@ -128,6 +128,10 @@ pub(super) fn allows_preemption(policy: SchedulingPolicy) -> bool {
     policy == SchedulingPolicy::Vllm
 }
 
+pub(super) fn supports_destination_reservation(policy: SchedulingPolicy) -> bool {
+    policy == SchedulingPolicy::Vllm
+}
+
 /// TRT-LLM enqueue normalization: a no-evict request's `prompt + output` can
 /// reserve at most the whole KV pool. Returns `max_output_tokens` clamped to the
 /// room left after the prompt, or `None` if the prompt alone leaves no decode

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -179,6 +179,28 @@ mod source_holds {
         assert!(!core.source_is_held(second_id));
         assert_eq!(core.kv_manager.num_active_blocks(), 0);
     }
+
+    #[test]
+    fn active_request_id_is_rejected_before_source_hold_registration() {
+        let mut core = VllmCore::new(args());
+        let request_id = Uuid::from_u128(104);
+        let handoff_id = HandoffId::from(Uuid::from_u128(204));
+        core.receive(request(request_id));
+
+        assert!(
+            core.apply_command(SchedulerCommand::Submit(request(request_id)))
+                .is_err()
+        );
+        assert!(
+            core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+                handoff_id,
+                request: request(request_id),
+            })
+            .is_err()
+        );
+        assert!(!core.source_is_registered(handoff_id));
+        assert_eq!(core.num_requests(), 1);
+    }
 }
 
 mod destination_lifecycle {

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -13,8 +13,8 @@ use uuid::Uuid;
 
 use crate::common::handoff::HandoffId;
 use crate::common::protocols::{
-    DirectRequest, FpmPublisher, KvCacheEventSink, KvEventPublishers, MockEngineArgs, OutputSignal,
-    PreemptionMode, RawKvEvent, RawKvEventSink,
+    DirectRequest, EngineType, FpmPublisher, KvCacheEventSink, KvEventPublishers, MockEngineArgs,
+    OutputSignal, PreemptionMode, RawKvEvent, RawKvEventSink,
 };
 use crate::common::sequence::ActiveSequence;
 use crate::scheduler::SchedulerHandle;
@@ -378,6 +378,39 @@ mod destination_lifecycle {
         assert!(destination.is_drained());
         assert!(!destination.destination_is_held(handoff_id));
         assert_eq!(destination.kv_manager.num_active_blocks(), 0);
+    }
+
+    #[test]
+    fn trtllm_destination_reservation_fails_without_acquiring_kv() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Trtllm)
+            .block_size(4)
+            .num_gpu_blocks(12)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(1))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(true)
+            .worker_type(WorkerType::Decode)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut destination = VllmCore::new(args);
+        let handoff_id = HandoffId::from(Uuid::from_u128(10_005));
+
+        let error = destination
+            .apply_command(SchedulerCommand::ReserveDestination {
+                handoff_id,
+                request: request(Uuid::from_u128(10_006), (0..8).collect(), 2),
+            })
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "destination reservation is not supported for TRT-LLM"
+        );
+        assert!(!destination.destination_is_held(handoff_id));
+        assert_eq!(destination.kv_manager.num_active_blocks(), 0);
+        assert!(destination.is_drained());
     }
 }
 

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -11,14 +11,15 @@ use tokio::sync::mpsc;
 use tokio::time::interval;
 use uuid::Uuid;
 
+use crate::common::handoff::HandoffId;
 use crate::common::protocols::{
     DirectRequest, FpmPublisher, KvCacheEventSink, KvEventPublishers, MockEngineArgs, OutputSignal,
     PreemptionMode, RawKvEvent, RawKvEventSink,
 };
 use crate::common::sequence::ActiveSequence;
-use crate::scheduler::RouterEventVisibility;
 use crate::scheduler::SchedulerHandle;
 use crate::scheduler::test_utils::{RouterIndexerHarness, removed_event_count, stored_hashes};
+use crate::scheduler::{RouterEventVisibility, SchedulerCommand};
 
 use super::core::{RequestStatus, VllmCore, VllmRequestState};
 use super::live::{MockerMetrics, Scheduler};
@@ -67,6 +68,117 @@ fn router_args() -> MockEngineArgs {
         .speedup_ratio(0.0)
         .build()
         .unwrap()
+}
+
+mod source_holds {
+    use super::*;
+
+    fn args() -> MockEngineArgs {
+        MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(8)
+            .max_num_batched_tokens(Some(8))
+            .max_num_seqs(Some(1))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(false)
+            .worker_type(crate::common::protocols::WorkerType::Prefill)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap()
+    }
+
+    fn request(uuid: Uuid) -> DirectRequest {
+        DirectRequest {
+            tokens: (0..8).collect(),
+            max_output_tokens: 2,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+            ..Default::default()
+        }
+    }
+
+    fn execute(core: &mut VllmCore, now_ms: f64) -> crate::scheduler::EnginePassResult {
+        let mut collector = crate::replay::TraceCollector::default();
+        core.execute_pass(&mut collector, now_ms)
+    }
+
+    #[test]
+    fn terminal_completion_holds_source_without_freeing_kv() {
+        let mut core = VllmCore::new(args());
+        let request_id = Uuid::from_u128(101);
+        let handoff_id = HandoffId::from(Uuid::from_u128(201));
+        core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+            handoff_id,
+            request: request(request_id),
+        })
+        .unwrap();
+
+        let first = execute(&mut core, 0.0);
+        assert!(!first.output_signals[0].completed);
+        let active_before_terminal = core.kv_manager.num_active_blocks();
+        assert!(active_before_terminal > 0);
+
+        let terminal = execute(&mut core, first.end_ms);
+        assert!(terminal.output_signals[0].completed);
+        assert!(core.source_is_held(handoff_id));
+        assert!(!core.state.requests.contains_key(&request_id));
+        assert_eq!(core.kv_manager.num_active_blocks(), active_before_terminal);
+
+        core.apply_command(SchedulerCommand::ReleaseSource { handoff_id })
+            .unwrap();
+        assert!(!core.source_is_held(handoff_id));
+        assert_eq!(core.kv_manager.num_active_blocks(), 0);
+
+        core.apply_command(SchedulerCommand::ReleaseSource { handoff_id })
+            .unwrap();
+        assert_eq!(core.kv_manager.num_active_blocks(), 0);
+    }
+
+    #[test]
+    fn cancel_and_early_release_cleanup_exactly_once() {
+        let mut core = VllmCore::new(args());
+        let first_id = HandoffId::from(Uuid::from_u128(202));
+        core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+            handoff_id: first_id,
+            request: request(Uuid::from_u128(102)),
+        })
+        .unwrap();
+        let first = execute(&mut core, 0.0);
+        execute(&mut core, first.end_ms);
+        let held_blocks = core.kv_manager.num_active_blocks();
+
+        core.apply_command(SchedulerCommand::CancelSource {
+            handoff_id: first_id,
+        })
+        .unwrap();
+        assert_eq!(core.kv_manager.num_active_blocks(), 0);
+        core.apply_command(SchedulerCommand::CancelSource {
+            handoff_id: first_id,
+        })
+        .unwrap();
+        assert_eq!(core.kv_manager.num_active_blocks(), 0);
+        assert!(held_blocks > 0);
+
+        let second_id = first_id;
+        core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+            handoff_id: second_id,
+            request: request(Uuid::from_u128(103)),
+        })
+        .unwrap();
+        assert!(core.source_is_registered(second_id));
+        core.apply_command(SchedulerCommand::ReleaseSource {
+            handoff_id: second_id,
+        })
+        .unwrap();
+        assert!(!core.source_is_registered(second_id));
+
+        let first = execute(&mut core, 0.0);
+        let terminal = execute(&mut core, first.end_ms);
+        assert!(terminal.output_signals[0].completed);
+        assert!(!core.source_is_held(second_id));
+        assert_eq!(core.kv_manager.num_active_blocks(), 0);
+    }
 }
 
 mod core_behavior {

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -19,7 +19,7 @@ use crate::common::protocols::{
 use crate::common::sequence::ActiveSequence;
 use crate::scheduler::SchedulerHandle;
 use crate::scheduler::test_utils::{RouterIndexerHarness, removed_event_count, stored_hashes};
-use crate::scheduler::{RouterEventVisibility, SchedulerCommand};
+use crate::scheduler::{RouterEventVisibility, SchedulerCommand, SchedulerCommandResult};
 
 use super::core::{RequestStatus, VllmCore, VllmRequestState};
 use super::live::{MockerMetrics, Scheduler};
@@ -178,6 +178,206 @@ mod source_holds {
         assert!(terminal.output_signals[0].completed);
         assert!(!core.source_is_held(second_id));
         assert_eq!(core.kv_manager.num_active_blocks(), 0);
+    }
+}
+
+mod destination_lifecycle {
+    use super::*;
+    use crate::common::protocols::WorkerType;
+
+    fn args(worker_type: WorkerType) -> MockEngineArgs {
+        MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(12)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(1))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(true)
+            .worker_type(worker_type)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap()
+    }
+
+    fn request(uuid: Uuid, tokens: Vec<u32>, max_output_tokens: usize) -> DirectRequest {
+        DirectRequest {
+            tokens,
+            max_output_tokens,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+            ..Default::default()
+        }
+    }
+
+    fn execute(core: &mut VllmCore, now_ms: f64) -> crate::scheduler::EnginePassResult {
+        let mut collector = crate::replay::TraceCollector::default();
+        core.execute_pass(&mut collector, now_ms)
+    }
+
+    fn assert_no_republished_stores(
+        activation: &[dynamo_kv_router::protocols::LocalBlockHash],
+        later: &[dynamo_kv_router::protocols::LocalBlockHash],
+    ) {
+        assert!(later.iter().all(|hash| !activation.contains(hash)));
+    }
+
+    fn drive_source_to_hold(core: &mut VllmCore, handoff_id: HandoffId, req: DirectRequest) {
+        assert!(matches!(
+            core.apply_command(SchedulerCommand::SubmitHandoffPrefill {
+                handoff_id,
+                request: req,
+            })
+            .unwrap(),
+            SchedulerCommandResult::Submitted(_)
+        ));
+        let mut now_ms = 0.0;
+        for _ in 0..8 {
+            let pass = execute(core, now_ms);
+            now_ms = pass.end_ms;
+            if core.is_empty() {
+                break;
+            }
+        }
+        assert!(core.is_empty());
+        assert!(core.source_is_held(handoff_id));
+        assert!(!core.is_drained());
+    }
+
+    #[test]
+    fn handoff_prefill_to_reserved_decode_owns_kv_until_normal_admission() {
+        let logical_uuid = Uuid::from_u128(10_001);
+        let handoff_id = HandoffId::from(Uuid::from_u128(10_002));
+        let logical_tokens = (0..8).collect::<Vec<_>>();
+
+        let mut source = VllmCore::new_with_kv_capture(args(WorkerType::Prefill), 31);
+        let mut destination = VllmCore::new_with_kv_capture(args(WorkerType::Decode), 32);
+
+        destination.receive(request(Uuid::from_u128(10_003), (0..4).collect(), 1));
+        execute(&mut destination, 0.0);
+        assert!(destination.is_empty());
+        destination.drain_kv_events();
+
+        let blocker_uuid = Uuid::from_u128(10_004);
+        destination.receive(request(blocker_uuid, (100..104).collect(), 3));
+        let blocker_first = execute(&mut destination, 1.0);
+        assert_eq!(destination.state.running.len(), 1);
+        destination.drain_kv_events();
+
+        drive_source_to_hold(
+            &mut source,
+            handoff_id,
+            request(logical_uuid, logical_tokens.clone(), 2),
+        );
+
+        let usage_before_reservation = destination.kv_manager.num_active_blocks();
+        assert_eq!(
+            destination
+                .apply_command(SchedulerCommand::ReserveDestination {
+                    handoff_id,
+                    request: request(logical_uuid, logical_tokens, 2),
+                })
+                .unwrap(),
+            SchedulerCommandResult::DestinationReserved {
+                request_id: logical_uuid
+            }
+        );
+        assert!(destination.destination_is_held(handoff_id));
+        assert!(!destination.is_drained());
+        assert_eq!(destination.state.running.len(), 1);
+        assert!(destination.kv_manager.num_active_blocks() > usage_before_reservation);
+        assert!(stored_hashes(&destination.drain_kv_events()).is_empty());
+
+        let reserved_block_ids = destination.destination_block_ids(handoff_id);
+        let occupancy_before_activation = destination.kv_manager.num_active_blocks();
+        assert!(!reserved_block_ids.is_empty());
+        assert_eq!(
+            destination
+                .apply_command(SchedulerCommand::ActivateDestination { handoff_id })
+                .unwrap(),
+            SchedulerCommandResult::Applied
+        );
+        assert!(!destination.destination_is_held(handoff_id));
+        assert_eq!(
+            destination.kv_manager.num_active_blocks(),
+            occupancy_before_activation
+        );
+        assert_eq!(
+            destination.state.requests[&logical_uuid].status,
+            RequestStatus::Waiting
+        );
+        assert_eq!(destination.state.running.len(), 1);
+        assert_eq!(
+            destination.request_block_ids(logical_uuid),
+            reserved_block_ids
+        );
+        let activation_stores = stored_hashes(&destination.drain_kv_events());
+        assert!(!activation_stores.is_empty());
+
+        assert_eq!(
+            source
+                .apply_command(SchedulerCommand::ReleaseSource { handoff_id })
+                .unwrap(),
+            SchedulerCommandResult::Applied
+        );
+        assert!(source.is_empty());
+        assert!(source.is_drained());
+
+        let blocked = execute(&mut destination, blocker_first.end_ms);
+        assert_eq!(
+            destination.state.requests[&logical_uuid].status,
+            RequestStatus::Waiting
+        );
+        assert_eq!(
+            destination.request_block_ids(logical_uuid),
+            reserved_block_ids
+        );
+        let blocked_stores = stored_hashes(&blocked.kv_events);
+        assert_no_republished_stores(&activation_stores, &blocked_stores);
+
+        let blocker_terminal = execute(&mut destination, blocked.end_ms);
+        assert!(
+            blocker_terminal
+                .output_signals
+                .iter()
+                .any(|signal| signal.uuid == blocker_uuid && signal.completed)
+        );
+        assert_eq!(
+            destination.state.requests[&logical_uuid].status,
+            RequestStatus::Waiting
+        );
+
+        let admitted = execute(&mut destination, blocker_terminal.end_ms);
+        assert_eq!(
+            destination.state.requests[&logical_uuid].status,
+            RequestStatus::Running
+        );
+        assert!(
+            destination
+                .request_block_ids(logical_uuid)
+                .starts_with(&reserved_block_ids)
+        );
+        assert!(
+            destination.state.requests[&logical_uuid]
+                .sequence
+                .num_allocated_tokens()
+                >= destination.state.requests[&logical_uuid]
+                    .sequence
+                    .num_input_tokens()
+        );
+        assert_no_republished_stores(&activation_stores, &stored_hashes(&admitted.kv_events));
+
+        let terminal = execute(&mut destination, admitted.end_ms);
+        assert!(
+            terminal
+                .output_signals
+                .iter()
+                .any(|signal| signal.uuid == logical_uuid && signal.completed)
+        );
+        assert!(destination.is_empty());
+        assert!(destination.is_drained());
+        assert!(!destination.destination_is_held(handoff_id));
+        assert_eq!(destination.kv_manager.num_active_blocks(), 0);
     }
 }
 


### PR DESCRIPTION
## Summary

- Add a stable `HandoffId` and scheduler-owned source-hold registry.
- Let vLLM retain completed request state and defer terminal `Deref` cleanup.
- Let SGLang retain completed request state and defer cache/free/unlock cleanup.
- Make release and cancel perform deferred cleanup exactly once, including early and duplicate commands.
- Preserve existing replay, live, admission, and KV-accounting behavior when no source hold is registered.

Related to #10736.

## Validation

- `cargo clippy --no-deps --all-targets -- -D warnings` from `lib/mocker`
- `cargo fmt` from `lib/mocker`
- `cargo test -p dynamo-mocker --lib` (375 passed, 1 ignored)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved scheduling and handoff lifecycle handling so source and destination KV ownership can be held across prefill/decode transitions, with safer activation/cancellation behavior and fewer redundant KV store emissions.
  * Enhanced cache block handling to avoid duplicate physical registrations and to ensure canonical reuse during collisions.
* **Configuration**
  * Added `max_running_requests` to the SGLang scheduler config (defaults to unlimited when unset).
* **Tests**
  * Expanded end-to-end and lifecycle tests covering held-source/destination semantics and invalid reservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->