### PR TITLE
feat(multimodal): pluggable vision encoder interface for custom VLMs

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1121,7 +1121,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     def _load_custom_encoder(self, config: Config) -> None:
         """Import, instantiate, and load the --custom-encoder-class encoder."""
-        custom_encoder_class = getattr(config, "custom_encoder_class", None)
+        custom_encoder_class = config.custom_encoder_class
         if not custom_encoder_class:
             return
         # The custom encoder path only ever submits a mixed EmbedsPrompt, so fail
@@ -1144,8 +1144,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 f"VisionEncoderBackend subclass, got {backend_cls!r}."
             )
         # The author writes the VisionEncoderBackend; Dynamo wraps it in the
-        # AsyncVisionEncoder glue, which owns the preprocess pool + actor
-        # thread + micro-batcher. load() runs backend.build() on the actor thread
+        # AsyncVisionEncoder glue, which owns the preprocess pool and actor
+        # thread. load() runs backend.build() on the actor thread
         # (the backend picks its own device) and cleans that thread up on failure.
         encoder = AsyncVisionEncoder(backend_cls())
         encoder.load(config.model)
@@ -2954,9 +2954,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         image_items = mm_map.get(IMAGE_URL_KEY) or []
         image_urls = [
-            item["Url"]
+            item[URL_VARIANT_KEY]
             for item in image_items
-            if isinstance(item, dict) and "Url" in item
+            if isinstance(item, dict) and URL_VARIANT_KEY in item
         ]
         if len(image_urls) != len(image_items):
             # At least one image item was malformed — not a dict with a 'Url'
@@ -2982,9 +2982,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # failure becomes a structured request error instead of escaping the
         # request coroutine and tearing down the stream.
         try:
-            # encode() is async; AsyncVisionEncoder preprocesses off-thread and the
-            # ThreadedMicroBatcher coalesces concurrent calls onto one dedicated
-            # actor thread. The worker holds no lock — batching is the encoder's.
+            # encode() preprocesses off-thread and serializes forwards on one
+            # dedicated actor thread.
             img_tensors: list[torch.Tensor] = await self._custom_encoder.encode(
                 image_urls
             )

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2530,20 +2530,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # intentionally skipped for this path.
         if mixed_embeds is not None:
             prompt_embeds, prompt_token_ids, prompt_is_token_ids = mixed_embeds
-            if not self.config.engine_args.enable_prompt_embeds:
-                msg = (
-                    "CustomEncoder requires `--enable-prompt-embeds`; the "
-                    "assembled EmbedsPrompt cannot be submitted without it."
-                )
-                logger.error("Request %s: %s", request_id, msg)
-                return (
-                    None,
-                    None,
-                    {
-                        "finish_reason": f"error: {msg}",
-                        "token_ids": [],
-                    },
-                )
             seq_len = prompt_embeds.shape[0]
             return (
                 EmbedsPrompt(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1141,8 +1141,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 f"--custom-encoder-class {custom_encoder_class!r} must resolve to a "
                 f"VisionEncoderBackend subclass, got {backend_cls!r}."
             )
-        # The author writes the VisionEncoderBackend (L2); Dynamo wraps it in the
-        # AsyncVisionEncoder glue (L3), which owns the preprocess pool + actor
+        # The author writes the VisionEncoderBackend; Dynamo wraps it in the
+        # AsyncVisionEncoder glue, which owns the preprocess pool + actor
         # thread + micro-batcher. load() runs backend.build() on the actor thread
         # (the backend picks its own device — the worker pins it via
         # CUDA_VISIBLE_DEVICES) and cleans that thread up on failure.

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2916,7 +2916,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         request: Dict[str, Any],
         request_id: str,
         context,
-        mm_processor_kwargs: Dict[str, Any] | None = None,
     ) -> tuple[
         tuple[torch.Tensor, list[int], list[bool]] | None,
         Dict[str, Any] | None,
@@ -2927,8 +2926,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         The CustomEncoder consumes image URLs directly and emits embeds. Returns
         ``(mixed_embeds, multi_modal_data, error)``:
         - images present: ``(mixed_embeds, None, None)``,
-        - no image content: ``(None, multi_modal_data, None)`` — text-only request
-          loaded via the normal aggregated path,
+        - no image content: ``(None, None, None)`` — text-only request, nothing
+          to assemble or extract (non-image modalities are rejected above),
         - failure: ``(None, None, error_dict)`` for the caller to yield.
         """
         # Internal invariant: callers guard on `self._custom_encoder is not None`
@@ -2967,11 +2966,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
 
         if not image_urls:
-            # No image content at all → normal aggregated load (text-only).
-            multi_modal_data = await self._extract_multimodal_data(
-                request, request_id, context, mm_processor_kwargs=mm_processor_kwargs
-            )
-            return None, multi_modal_data, None
+            # No usable image URLs, and non-image modalities were already
+            # rejected above, so there is nothing for the CustomEncoder to
+            # assemble and nothing to extract → text-only request.
+            return None, None, None
 
         token_ids: list[int] = request.get("token_ids") or []
         # encode() is user-supplied code (any exception) and
@@ -3038,7 +3036,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 request,
                 request_id,
                 context,
-                None,
             )
             if assemble_error is not None:
                 yield assemble_error

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2955,20 +2955,21 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             for item in image_items
             if isinstance(item, dict) and "Url" in item
         ]
-        if image_items and not image_urls:
-            # Image data is present but no usable URL could be extracted.
+        if len(image_urls) != len(image_items):
+            # At least one image item was malformed — not a dict with a 'Url'
+            # key (e.g. a pre-'Decoded' variant the CustomEncoder can't take).
+            # Reject the whole request instead of silently dropping images.
             msg = (
-                "CustomEncoder received image multimodal data but could not "
-                f"extract any URLs from {len(image_items)} item(s); each item "
-                "must be a dict with a 'Url' key"
+                "CustomEncoder received image multimodal data but only "
+                f"{len(image_urls)} of {len(image_items)} item(s) had a usable "
+                "'Url'; each item must be a dict with a 'Url' key"
             )
             logger.error("Request %s: %s", request_id, msg)
             return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
 
         if not image_urls:
-            # No usable image URLs, and non-image modalities were already
-            # rejected above, so there is nothing for the CustomEncoder to
-            # assemble and nothing to extract → text-only request.
+            # No image items at all — and non-image modalities were already
+            # rejected above — so there is nothing to assemble → text-only.
             return None, None, None
 
         token_ids: list[int] = request.get("token_ids") or []

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1144,8 +1144,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # The author writes the VisionEncoderBackend; Dynamo wraps it in the
         # AsyncVisionEncoder glue, which owns the preprocess pool + actor
         # thread + micro-batcher. load() runs backend.build() on the actor thread
-        # (the backend picks its own device — the worker pins it via
-        # CUDA_VISIBLE_DEVICES) and cleans that thread up on failure.
+        # (the backend picks its own device) and cleans that thread up on failure.
         encoder = AsyncVisionEncoder(backend_cls())
         encoder.load(config.model)
         # Assign only after a successful load so a failed load (which already shut

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import base64
+import importlib
 import inspect
 import logging
 import math
@@ -86,11 +87,16 @@ from dynamo.vllm.kv_connector_protocols import (
 from .args import Config
 from .constants import DisaggregationMode, EmbeddingTransferMode
 from .engine_monitor import VllmEngineMonitor
+from .multimodal_utils.async_vision_encoder import AsyncVisionEncoder
+from .multimodal_utils.embed_assembler import build_mixed_embeds
 from .multimodal_utils.prefill_worker_utils import MultiModalEmbeddingLoader
 from .multimodal_utils.request_processor import (
+    IMAGE_URL_KEY,
+    URL_VARIANT_KEY,
     MissingMultimodalHandoffError,
     VllmMultimodalRequestProcessor,
 )
+from .multimodal_utils.vision_encoder_backend import VisionEncoderBackend
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
@@ -1056,6 +1062,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
         embedding_loader = self.init_embedding_loader(config, encode_worker_client)
 
+        # Aggregated partial encoder. The attribute is set here so cleanup() is
+        # always safe, but the encoder is loaded last in __init__ (it starts a
+        # thread) — see _load_custom_encoder below — so a failure in the rest of
+        # init does not leak the batcher thread.
+        self._custom_encoder: Optional[AsyncVisionEncoder] = None
+
         self.use_vllm_tokenizer = use_vllm_tokenizer
 
         self.dp_range = get_dp_range_for_worker(self.engine_client.vllm_config)
@@ -1099,6 +1111,51 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # Request-plane RL method map served by rl_dispatch on
         # dyn://<namespace>.<component>.rl when --enable-rl / DYN_ENABLE_RL is set.
         self.rl_route_registry = RLRouteRegistry(self.runtime, logger_=logger)
+
+        # Load the custom encoder last: it starts a batcher thread, so deferring
+        # it until all other (fallible) setup is done means an earlier init
+        # failure cannot leave that thread orphaned.
+        self._load_custom_encoder(config)
+
+    def _load_custom_encoder(self, config: Config) -> None:
+        """Import, instantiate, and load the --custom-encoder-class encoder."""
+        custom_encoder_class = getattr(config, "custom_encoder_class", None)
+        if not custom_encoder_class:
+            return
+        # The custom encoder path only ever submits a mixed EmbedsPrompt, so fail
+        # fast here if prompt-embeds are disabled rather than loading the encoder
+        # and then rejecting every image request at runtime.
+        if not config.engine_args.enable_prompt_embeds:
+            raise ValueError(
+                "--custom-encoder-class requires --enable-prompt-embeds: the "
+                "custom encoder submits a mixed EmbedsPrompt, which the engine "
+                "cannot accept without prompt-embeds enabled."
+            )
+        module_path, _, class_name = custom_encoder_class.rpartition(".")
+        backend_cls = getattr(importlib.import_module(module_path), class_name)
+        if not (
+            isinstance(backend_cls, type)
+            and issubclass(backend_cls, VisionEncoderBackend)
+        ):
+            raise TypeError(
+                f"--custom-encoder-class {custom_encoder_class!r} must resolve to a "
+                f"VisionEncoderBackend subclass, got {backend_cls!r}."
+            )
+        # The author writes the VisionEncoderBackend (L2); Dynamo wraps it in the
+        # AsyncVisionEncoder glue (L3), which owns the preprocess pool + actor
+        # thread + micro-batcher. load() runs backend.build() on the actor thread
+        # (the backend picks its own device — the worker pins it via
+        # CUDA_VISIBLE_DEVICES) and cleans that thread up on failure.
+        encoder = AsyncVisionEncoder(backend_cls())
+        encoder.load(config.model)
+        # Assign only after a successful load so a failed load (which already shut
+        # its own thread down) leaves _custom_encoder None.
+        self._custom_encoder = encoder
+        logger.info(
+            "Loaded CustomEncoder %s from %s",
+            custom_encoder_class,
+            config.model,
+        )
 
     def _shutdown_on_engine_dead(self, e: EngineDeadError) -> NoReturn:
         logger.error(f"vLLM EngineDeadError: {e}")
@@ -2362,6 +2419,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     def cleanup(self):
         """Clean up resources including temporary directories."""
+        if self._custom_encoder is not None:
+            # Stop the in-process encoder's batcher thread on teardown.
+            self._custom_encoder.shutdown()
         for temp_dir in self.temp_dirs:
             try:
                 temp_dir.cleanup()
@@ -2440,6 +2500,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         multi_modal_data: Dict[str, Any] | None,
         log_prefix: str = "",
         mm_processor_kwargs: Dict[str, Any] | None = None,
+        mixed_embeds: tuple[torch.Tensor, list[int], list[bool]] | None = None,
     ) -> tuple[TokensPrompt | EmbedsPrompt | None, int | None, Dict[str, Any] | None]:
         """
         Build a prompt from request, handling both prompt_embeds and token_ids.
@@ -2451,6 +2512,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             log_prefix: Prefix for log messages (e.g., "Prefill " for prefill requests)
             mm_processor_kwargs: Optional multimodal processor kwargs (e.g.
                 use_audio_in_video) forwarded to the vLLM engine.
+            mixed_embeds: Optional ``(prompt_embeds, prompt_token_ids,
+                prompt_is_token_ids)`` assembled by the aggregated CustomEncoder
+                path. When present, takes the EmbedsPrompt fast path below.
 
         Returns:
             Tuple of (prompt, embedding_sequence_length, error_dict) where:
@@ -2458,6 +2522,39 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             - On failure: (None, None, error_dict to yield)
         """
         embedding_sequence_length = None
+
+        # Fast path: mixed token-ids/embeds prompt from the aggregated
+        # CustomEncoder path, assembled in _generate_token_mode and passed in
+        # explicitly. The image embeds ride on the EmbedsPrompt itself and the
+        # request carries no multi_modal_data, so there is nothing to bind
+        # mm_uuids to here — the normal token path's MM-routing logic below is
+        # intentionally skipped for this path.
+        if mixed_embeds is not None:
+            prompt_embeds, prompt_token_ids, prompt_is_token_ids = mixed_embeds
+            if not self.config.engine_args.enable_prompt_embeds:
+                msg = (
+                    "CustomEncoder requires `--enable-prompt-embeds`; the "
+                    "assembled EmbedsPrompt cannot be submitted without it."
+                )
+                logger.error("Request %s: %s", request_id, msg)
+                return (
+                    None,
+                    None,
+                    {
+                        "finish_reason": f"error: {msg}",
+                        "token_ids": [],
+                    },
+                )
+            seq_len = prompt_embeds.shape[0]
+            return (
+                EmbedsPrompt(
+                    prompt_embeds=prompt_embeds,
+                    prompt_token_ids=prompt_token_ids,
+                    prompt_is_token_ids=prompt_is_token_ids,
+                ),
+                seq_len,
+                None,
+            )
 
         if "prompt_embeds" in request and request["prompt_embeds"]:
             if not self.config.engine_args.enable_prompt_embeds:
@@ -2501,6 +2598,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "token_ids": [],
                     },
                 )
+        # Text-only PD + encoder-worker path.
         # Normal path: use token IDs.
         # Prefer frontend-forwarded mm_hashes for hash consistency with the
         # routing layer. Fall back to computing from loaded image data when
@@ -2828,6 +2926,99 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     first_token = False
                 yield chunk
 
+    async def _assemble_custom_encoder_prompt(
+        self,
+        request: Dict[str, Any],
+        request_id: str,
+        context,
+        mm_processor_kwargs: Dict[str, Any] | None = None,
+    ) -> tuple[
+        tuple[torch.Tensor, list[int], list[bool]] | None,
+        Dict[str, Any] | None,
+        Dict[str, Any] | None,
+    ]:
+        """Run the in-process CustomEncoder and assemble a mixed EmbedsPrompt.
+
+        The CustomEncoder consumes image URLs directly and emits embeds. Returns
+        ``(mixed_embeds, multi_modal_data, error)``:
+        - images present: ``(mixed_embeds, None, None)``,
+        - no image content: ``(None, multi_modal_data, None)`` — text-only request
+          loaded via the normal aggregated path,
+        - failure: ``(None, None, error_dict)`` for the caller to yield.
+        """
+        # Internal invariant: callers guard on `self._custom_encoder is not None`
+        # before reaching here. Use an explicit raise (not assert, which is
+        # stripped under `python -O`) so a future mis-wire fails loudly.
+        if self._custom_encoder is None:
+            raise RuntimeError(
+                "_assemble_custom_encoder_prompt called without a CustomEncoder"
+            )
+        mm_map = request.get("multi_modal_data") or {}
+        # CustomEncoder handles images only. Reject any non-image modality
+        # (video/audio/...) explicitly instead of silently dropping it.
+        unsupported = sorted(k for k in mm_map if k != IMAGE_URL_KEY and mm_map.get(k))
+        if unsupported:
+            msg = (
+                "CustomEncoder supports image inputs only; got "
+                f"unsupported multimodal data: {unsupported}"
+            )
+            logger.error("Request %s: %s", request_id, msg)
+            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
+
+        image_items = mm_map.get(IMAGE_URL_KEY) or []
+        image_urls = [
+            item["Url"]
+            for item in image_items
+            if isinstance(item, dict) and "Url" in item
+        ]
+        if image_items and not image_urls:
+            # Image data is present but no usable URL could be extracted.
+            msg = (
+                "CustomEncoder received image multimodal data but could not "
+                f"extract any URLs from {len(image_items)} item(s); each item "
+                "must be a dict with a 'Url' key"
+            )
+            logger.error("Request %s: %s", request_id, msg)
+            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
+
+        if not image_urls:
+            # No image content at all → normal aggregated load (text-only).
+            multi_modal_data = await self._extract_multimodal_data(
+                request, request_id, context, mm_processor_kwargs=mm_processor_kwargs
+            )
+            return None, multi_modal_data, None
+
+        token_ids: list[int] = request.get("token_ids") or []
+        # encode() is user-supplied code (any exception) and
+        # get_image_placeholder_token_id() can raise (unknown model family), so
+        # keep encode -> placeholder lookup -> assembly inside one guard: a
+        # failure becomes a structured request error instead of escaping the
+        # request coroutine and tearing down the stream.
+        try:
+            # encode() is async; AsyncVisionEncoder preprocesses off-thread and the
+            # ThreadedMicroBatcher coalesces concurrent calls onto one dedicated
+            # actor thread. The worker holds no lock — batching is the encoder's.
+            img_tensors: list[torch.Tensor] = await self._custom_encoder.encode(
+                image_urls
+            )
+            placeholder_id = self._custom_encoder.get_image_placeholder_token_id()
+            prompt_embeds, mixed_token_ids, is_token_ids = build_mixed_embeds(
+                token_ids, img_tensors, placeholder_id
+            )
+        except Exception as exc:
+            msg = f"CustomEncoder failed: {exc}"
+            logger.exception("Request %s: %s", request_id, msg)
+            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
+
+        logger.debug(
+            "Request %s: CustomEncoder assembled %d image(s) → seq_len=%d dtype=%s",
+            request_id,
+            len(img_tensors),
+            prompt_embeds.shape[0],
+            prompt_embeds.dtype,
+        )
+        return (prompt_embeds, mixed_token_ids, is_token_ids), None, None
+
     async def _generate_token_mode(self, request, context, request_id):
         """Generate tokens using internal protocol format (token-in-token-out)."""
         # Firstly extract disaggregated params from prefill result if available
@@ -2842,28 +3033,54 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         else:
             kv_params = None
 
-        is_decode_only = self.config.disaggregation_mode == DisaggregationMode.DECODE
-        try:
-            mode = cast(DisaggregationMode, self.config.disaggregation_mode)
-            prepared_input = await self._multimodal_request_processor.prepare_input(
+        mode = cast(DisaggregationMode, self.config.disaggregation_mode)
+        is_decode_only = mode == DisaggregationMode.DECODE
+        has_mm_data = request.get("multi_modal_data") is not None
+        mixed_embeds: tuple[torch.Tensor, list[int], list[bool]] | None = None
+
+        if (
+            mode == DisaggregationMode.AGGREGATED
+            and self._custom_encoder is not None
+            and has_mm_data
+        ):
+            # A configured CustomEncoder owns the aggregated image path. Bypass
+            # the normal NIXL/HF request processor and assemble an EmbedsPrompt.
+            (
+                mixed_embeds,
+                multi_modal_data,
+                assemble_error,
+            ) = await self._assemble_custom_encoder_prompt(
                 request,
                 request_id,
                 context,
-                mode,
+                None,
             )
-        except MissingMultimodalHandoffError as exc:
-            logger.error("Request %s: %s", request_id, exc)
-            yield {
-                "finish_reason": f"error: {exc}",
-                "index": 0,
-                "token_ids": [],
-            }
-            return
+            if assemble_error is not None:
+                yield assemble_error
+                return
+            mm_processor_kwargs = None
+            pre_rendered = None
+        else:
+            try:
+                prepared_input = await self._multimodal_request_processor.prepare_input(
+                    request,
+                    request_id,
+                    context,
+                    mode,
+                )
+            except MissingMultimodalHandoffError as exc:
+                logger.error("Request %s: %s", request_id, exc)
+                yield {
+                    "finish_reason": f"error: {exc}",
+                    "index": 0,
+                    "token_ids": [],
+                }
+                return
 
-        request = prepared_input.request
-        multi_modal_data = prepared_input.multi_modal_data
-        mm_processor_kwargs = prepared_input.mm_processor_kwargs
-        pre_rendered = prepared_input.pre_rendered_prompt
+            request = prepared_input.request
+            multi_modal_data = prepared_input.multi_modal_data
+            mm_processor_kwargs = prepared_input.mm_processor_kwargs
+            pre_rendered = prepared_input.pre_rendered_prompt
 
         # Build prompt from request. `prompt` is either a pre-rendered
         # MultiModalInput dict (fast path) or a TokensPrompt/EmbedsPrompt from
@@ -2892,6 +3109,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     request_id,
                     multi_modal_data,
                     mm_processor_kwargs=mm_processor_kwargs,
+                    mixed_embeds=mixed_embeds,
                 )
         if error is not None:
             yield error

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1063,9 +1063,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         embedding_loader = self.init_embedding_loader(config, encode_worker_client)
 
         # Aggregated partial encoder. The attribute is set here so cleanup() is
-        # always safe, but the encoder is loaded last in __init__ (it starts a
-        # thread) — see _load_custom_encoder below — so a failure in the rest of
-        # init does not leak the batcher thread.
+        # always safe; the encoder itself is loaded last in __init__ (it starts
+        # the actor thread) — see _load_custom_encoder below for why.
         self._custom_encoder: Optional[AsyncVisionEncoder] = None
 
         self.use_vllm_tokenizer = use_vllm_tokenizer
@@ -1112,9 +1111,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # dyn://<namespace>.<component>.rl when --enable-rl / DYN_ENABLE_RL is set.
         self.rl_route_registry = RLRouteRegistry(self.runtime, logger_=logger)
 
-        # Load the custom encoder last: it starts a batcher thread, so deferring
-        # it until all other (fallible) setup is done means an earlier init
-        # failure cannot leave that thread orphaned.
+        # Load the custom encoder last. If a later init step raised, executor
+        # GC would eventually reap the idle actor thread — but only once the
+        # exception's traceback stops pinning `self` (unbounded while the
+        # failure is handled upstream), and GC never runs backend.close() or
+        # frees the encoder's GPU memory in the meantime. Ordering the encoder
+        # after all other fallible setup removes that window by construction.
         self._load_custom_encoder(config)
 
     def _load_custom_encoder(self, config: Config) -> None:
@@ -2419,7 +2421,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     def cleanup(self):
         """Clean up resources including temporary directories."""
         if self._custom_encoder is not None:
-            # Stop the in-process encoder's batcher thread on teardown.
+            # Run backend.close() on the actor thread, then stop it — executor
+            # GC would only end the thread, never call close().
             self._custom_encoder.shutdown()
         for temp_dir in self.temp_dirs:
             try:

--- a/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
@@ -185,14 +185,21 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
     def shutdown(self) -> None:
         """Run ``backend.close`` on the actor thread, then stop both pools. Safe
         before ``load`` and idempotent."""
-        if self._actor is not None:
+        # Detach both executors before teardown so a repeated cleanup is a no-op,
+        # including when backend.close() itself raises.
+        actor = self._actor
+        pool = self._pool
+        self._actor = None
+        self._pool = None
+
+        if actor is not None:
             try:
-                self._actor.submit(self._backend.close).result(timeout=10)
+                actor.submit(self._backend.close).result(timeout=10)
             except BaseException:  # noqa: BLE001 — teardown best-effort
                 logger.exception(
                     "AsyncVisionEncoder(%s): backend.close raised during teardown",
                     self._name,
                 )
-            self._actor.shutdown(wait=False)
-        if self._pool is not None:
-            self._pool.shutdown(wait=False)
+            actor.shutdown(wait=False)
+        if pool is not None:
+            pool.shutdown(wait=False)

--- a/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Serial async glue (L3) between the worker's event loop and a ``VisionEncoderBackend``.
+"""Serial async glue between the worker's event loop and a ``VisionEncoderBackend``.
 
-This is the **eager-milestone** glue: it proves the splice path end to end with a
+This is the **eager** glue: it proves the splice path end to end with a
 **direct call — no micro-batcher**. Per request it preprocesses the images off the
 event loop, enforces request-level atomicity, and runs the author's
 ``forward_batch`` on a single dedicated **actor thread**, serialized — there is no
@@ -17,7 +17,7 @@ Why a single actor thread (not ``asyncio.to_thread``): build and every
 graph in ``build`` can replay it from ``forward_batch`` — the affinity the batched
 version also guarantees. ``max_workers=1`` serializes forwards (FIFO).
 
-Request-level atomicity (design A5): a gather-barrier sits between preprocess and
+Request-level atomicity: a gather-barrier sits between preprocess and
 the forward — ``encode`` waits for *every* image's preprocess to settle and runs
 the forward only if **all** succeed; on any failure it does no GPU work and raises
 the request-level error, so a text-only LM never sees a partial result.
@@ -135,7 +135,8 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
         preprocessed: List[Preprocessed] = list(settled)  # type: ignore[arg-type]
         items = [p.item for p in preprocessed]
         # Direct, serialized forward on the actor thread (eager; target_bucket
-        # defaults to None — there is no graph ladder in this milestone).
+        # defaults to None — there is no graph ladder until CUDA-graph batching
+        # is supported).
         return await loop.run_in_executor(
             self._actor, self._backend.forward_batch, items
         )

--- a/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
@@ -49,6 +49,12 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
     request; ``shutdown`` on teardown. All model knowledge lives in ``backend``;
     this class owns the optional preprocess pool, the request-atomicity barrier,
     and the single actor thread that runs ``build`` / ``forward_batch`` / ``close``.
+
+    ``preprocess_concurrency`` (backend-declared, constructor-overridable) is not
+    just a pool size — it gates the whole preprocess **phase**: ``0`` means
+    ``preprocess`` is never called and raws go straight to ``forward_batch``. A
+    backend that overrides ``preprocess`` while the effective concurrency is ``0``
+    is rejected at construction (the override would silently never run).
     """
 
     def __init__(
@@ -59,8 +65,9 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
         name: str = "vision-encoder",
     ) -> None:
         # The backend declares whether it needs off-loop preprocessing; the
-        # explicit arg is an override for tuning. 0 ⇒ no pool (raws pass straight
-        # to forward_batch).
+        # explicit arg is an override for tuning. Not just a pool size: 0 ⇒ no
+        # preprocess phase at all — preprocess() is never called and raws pass
+        # straight to forward_batch.
         conc = (
             backend.preprocess_concurrency
             if preprocess_concurrency is None
@@ -68,6 +75,19 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
         )
         if conc < 0:
             raise ValueError("preprocess_concurrency must be >= 0")
+        # Fail fast on the silent mismatch: an overridden preprocess that the
+        # effective concurrency of 0 would skip forever.
+        overrides_preprocess = (
+            type(backend).preprocess is not VisionEncoderBackend.preprocess
+        )
+        if conc == 0 and overrides_preprocess:
+            raise ValueError(
+                f"{type(backend).__name__} overrides preprocess() but the "
+                "effective preprocess_concurrency is 0, so preprocess would never "
+                "run (raws go straight to forward_batch). Set "
+                "preprocess_concurrency > 0 to enable the preprocess phase, or "
+                "drop the override and do the prep inside forward_batch."
+            )
         self._backend = backend
         self._preprocess_concurrency = conc
         self._name = name

--- a/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Serial async glue between the worker's event loop and a ``VisionEncoderBackend``.

--- a/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
@@ -47,24 +47,32 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
 
     The worker calls ``load`` once at startup and ``await``s ``encode`` per
     request; ``shutdown`` on teardown. All model knowledge lives in ``backend``;
-    this class owns the preprocess pool, the A5 barrier, and the single actor
-    thread that runs ``build`` / ``forward_batch`` / ``close``.
+    this class owns the optional preprocess pool, the A5 barrier, and the single
+    actor thread that runs ``build`` / ``forward_batch`` / ``close``.
     """
 
     def __init__(
         self,
         backend: VisionEncoderBackend[RawT, ItemT],
         *,
-        preprocess_concurrency: int = 4,
+        preprocess_concurrency: int | None = None,
         name: str = "vision-encoder",
     ) -> None:
-        if preprocess_concurrency < 1:
-            raise ValueError("preprocess_concurrency must be >= 1")
+        # The backend declares whether it needs off-loop preprocessing; the
+        # explicit arg is an override for tuning. 0 ⇒ no pool (raws pass straight
+        # to forward_batch).
+        conc = (
+            backend.preprocess_concurrency
+            if preprocess_concurrency is None
+            else preprocess_concurrency
+        )
+        if conc < 0:
+            raise ValueError("preprocess_concurrency must be >= 0")
         self._backend = backend
-        self._preprocess_concurrency = preprocess_concurrency
+        self._preprocess_concurrency = conc
         self._name = name
         self._actor: ThreadPoolExecutor | None = None  # build + every forward
-        self._pool: ThreadPoolExecutor | None = None  # off-loop preprocess
+        self._pool: ThreadPoolExecutor | None = None  # off-loop preprocess (or None)
 
     # ---- lifecycle ---------------------------------------------------------
 
@@ -75,7 +83,7 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
         so a misconfigured encoder errors at startup. Single-shot: a second
         ``load()`` raises rather than orphaning the first actor thread and model.
         """
-        if self._actor is not None or self._pool is not None:
+        if self._actor is not None:
             raise RuntimeError("AsyncVisionEncoder.load() called twice")
         try:
             # One actor thread so build + every forward share a thread; a single
@@ -83,9 +91,14 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
             self._actor = ThreadPoolExecutor(
                 max_workers=1, thread_name_prefix=f"{self._name}-actor"
             )
-            self._pool = ThreadPoolExecutor(
-                max_workers=self._preprocess_concurrency,
-                thread_name_prefix=f"{self._name}-pre",
+            # No pool when concurrency is 0 — preprocess is skipped (passthrough).
+            self._pool = (
+                ThreadPoolExecutor(
+                    max_workers=self._preprocess_concurrency,
+                    thread_name_prefix=f"{self._name}-pre",
+                )
+                if self._preprocess_concurrency > 0
+                else None
             )
             self._actor.submit(self._backend.build, model_id).result()
             self.validate()
@@ -110,30 +123,38 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
     # ---- request path ------------------------------------------------------
 
     async def encode(self, raws: List[RawT]) -> List[torch.Tensor]:
-        """Preprocess (off-loop, A5 barrier) then run a single serial forward.
+        """Optionally preprocess (off-loop, A5 barrier) then run a single serial
+        forward.
 
-        Returns one ``(n_visual_tokens, lm_hidden_dim)`` CPU tensor per raw input,
-        in order. Raises if any image's preprocess fails (no GPU work) or if the
-        forward fails.
+        With no preprocess pool (``preprocess_concurrency == 0``) raws go straight
+        to ``forward_batch`` (the backend folds any prep in there). Returns one
+        ``(n_visual_tokens, lm_hidden_dim)`` CPU tensor per raw input, in order.
+        Raises if any image's preprocess fails (no GPU work) or if the forward
+        fails.
         """
-        if self._actor is None or self._pool is None:
+        if self._actor is None:
             raise RuntimeError("AsyncVisionEncoder.encode() called before load()")
         if not raws:
             return []
         loop = asyncio.get_running_loop()
-        # A5 barrier: preprocess all images concurrently, wait for EVERY one to
-        # settle, and run the forward only if all succeeded. return_exceptions=True
-        # makes the gather a true barrier (no short-circuit).
-        tasks = [
-            loop.run_in_executor(self._pool, self._backend.preprocess, raw)
-            for raw in raws
-        ]
-        settled = await asyncio.gather(*tasks, return_exceptions=True)
-        errors = [r for r in settled if isinstance(r, BaseException)]
-        if errors:
-            raise errors[0]
-        preprocessed: List[Preprocessed] = list(settled)  # type: ignore[arg-type]
-        items = [p.item for p in preprocessed]
+        if self._pool is None:
+            # No preprocess phase: raw IS the item. No A5 barrier needed — the
+            # single forward is already all-or-nothing for the request.
+            items: List[ItemT] = list(raws)  # type: ignore[arg-type]  # ItemT==RawT
+        else:
+            # A5 barrier: preprocess all images concurrently, wait for EVERY one to
+            # settle, run the forward only if all succeeded. return_exceptions=True
+            # makes the gather a true barrier (no short-circuit).
+            tasks = [
+                loop.run_in_executor(self._pool, self._backend.preprocess, raw)
+                for raw in raws
+            ]
+            settled = await asyncio.gather(*tasks, return_exceptions=True)
+            errors = [r for r in settled if isinstance(r, BaseException)]
+            if errors:
+                raise errors[0]
+            preprocessed: List[Preprocessed] = list(settled)  # type: ignore[arg-type]
+            items = [p.item for p in preprocessed]
         # Direct, serialized forward on the actor thread (eager; target_bucket
         # defaults to None — there is no graph ladder until CUDA-graph batching
         # is supported).

--- a/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
@@ -47,8 +47,8 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
 
     The worker calls ``load`` once at startup and ``await``s ``encode`` per
     request; ``shutdown`` on teardown. All model knowledge lives in ``backend``;
-    this class owns the optional preprocess pool, the A5 barrier, and the single
-    actor thread that runs ``build`` / ``forward_batch`` / ``close``.
+    this class owns the optional preprocess pool, the request-atomicity barrier,
+    and the single actor thread that runs ``build`` / ``forward_batch`` / ``close``.
     """
 
     def __init__(
@@ -123,8 +123,8 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
     # ---- request path ------------------------------------------------------
 
     async def encode(self, raws: List[RawT]) -> List[torch.Tensor]:
-        """Optionally preprocess (off-loop, A5 barrier) then run a single serial
-        forward.
+        """Optionally preprocess (off-loop, with a request-atomicity barrier) then
+        run a single serial forward.
 
         With no preprocess pool (``preprocess_concurrency == 0``) raws go straight
         to ``forward_batch`` (the backend folds any prep in there). Returns one
@@ -138,13 +138,13 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
             return []
         loop = asyncio.get_running_loop()
         if self._pool is None:
-            # No preprocess phase: raw IS the item. No A5 barrier needed — the
+            # No preprocess phase: raw IS the item. No barrier needed — the
             # single forward is already all-or-nothing for the request.
             items: List[ItemT] = list(raws)  # type: ignore[arg-type]  # ItemT==RawT
         else:
-            # A5 barrier: preprocess all images concurrently, wait for EVERY one to
-            # settle, run the forward only if all succeeded. return_exceptions=True
-            # makes the gather a true barrier (no short-circuit).
+            # Request-atomicity barrier: preprocess all images concurrently, wait
+            # for EVERY one to settle, run the forward only if all succeeded.
+            # return_exceptions=True makes the gather a true barrier (no short-circuit).
             tasks = [
                 loop.run_in_executor(self._pool, self._backend.preprocess, raw)
                 for raw in raws

--- a/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serial async glue (L3) between the worker's event loop and a ``VisionEncoderBackend``.
+
+This is the **eager-milestone** glue: it proves the splice path end to end with a
+**direct call — no micro-batcher**. Per request it preprocesses the images off the
+event loop, enforces request-level atomicity, and runs the author's
+``forward_batch`` on a single dedicated **actor thread**, serialized — there is no
+cross-request coalescing. A follow-up swaps this body for a
+``ThreadedMicroBatcher`` (cross-request batching); the public surface
+(``load`` / ``encode`` / ``get_image_placeholder_token_id`` / ``shutdown``) is
+identical, so the worker integration does not change.
+
+Why a single actor thread (not ``asyncio.to_thread``): build and every
+``forward_batch`` run on the **same** thread, so an author that captures a CUDA
+graph in ``build`` can replay it from ``forward_batch`` — the affinity the batched
+version also guarantees. ``max_workers=1`` serializes forwards (FIFO).
+
+Request-level atomicity (design A5): a gather-barrier sits between preprocess and
+the forward — ``encode`` waits for *every* image's preprocess to settle and runs
+the forward only if **all** succeed; on any failure it does no GPU work and raises
+the request-level error, so a text-only LM never sees a partial result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Generic, List
+
+import torch
+
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
+    ItemT,
+    Preprocessed,
+    RawT,
+    VisionEncoderBackend,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncVisionEncoder(Generic[RawT, ItemT]):
+    """Drive a ``VisionEncoderBackend`` from the async request path, serially.
+
+    The worker calls ``load`` once at startup and ``await``s ``encode`` per
+    request; ``shutdown`` on teardown. All model knowledge lives in ``backend``;
+    this class owns the preprocess pool, the A5 barrier, and the single actor
+    thread that runs ``build`` / ``forward_batch`` / ``close``.
+    """
+
+    def __init__(
+        self,
+        backend: VisionEncoderBackend[RawT, ItemT],
+        *,
+        preprocess_concurrency: int = 4,
+        name: str = "vision-encoder",
+    ) -> None:
+        if preprocess_concurrency < 1:
+            raise ValueError("preprocess_concurrency must be >= 1")
+        self._backend = backend
+        self._preprocess_concurrency = preprocess_concurrency
+        self._name = name
+        self._actor: ThreadPoolExecutor | None = None  # build + every forward
+        self._pool: ThreadPoolExecutor | None = None  # off-loop preprocess
+
+    # ---- lifecycle ---------------------------------------------------------
+
+    def load(self, model_id: str) -> None:
+        """Run ``backend.build`` on the actor thread and fail fast.
+
+        Re-raises any build error, then ``validate``s the hardcoded image token id
+        so a misconfigured encoder errors at startup. Single-shot: a second
+        ``load()`` raises rather than orphaning the first actor thread and model.
+        """
+        if self._actor is not None or self._pool is not None:
+            raise RuntimeError("AsyncVisionEncoder.load() called twice")
+        try:
+            # One actor thread so build + every forward share a thread; a single
+            # worker also serializes forwards (FIFO) — no cross-request batching.
+            self._actor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix=f"{self._name}-actor"
+            )
+            self._pool = ThreadPoolExecutor(
+                max_workers=self._preprocess_concurrency,
+                thread_name_prefix=f"{self._name}-pre",
+            )
+            self._actor.submit(self._backend.build, model_id).result()
+            self.validate()
+        except BaseException:
+            self.shutdown()
+            raise
+
+    def validate(self) -> None:
+        """Fail-fast check run by ``load`` after ``build``: the author hardcoded a
+        usable ``image_token_id``."""
+        tid = getattr(self._backend, "image_token_id", None)
+        if not isinstance(tid, int) or isinstance(tid, bool):
+            raise ValueError(
+                "VisionEncoderBackend.image_token_id must be a hardcoded int (the "
+                f"image placeholder token id); got {tid!r}"
+            )
+
+    def get_image_placeholder_token_id(self) -> int:
+        """The token id marking image positions (the backend's hardcoded value)."""
+        return self._backend.image_token_id
+
+    # ---- request path ------------------------------------------------------
+
+    async def encode(self, raws: List[RawT]) -> List[torch.Tensor]:
+        """Preprocess (off-loop, A5 barrier) then run a single serial forward.
+
+        Returns one ``(n_visual_tokens, lm_hidden_dim)`` CPU tensor per raw input,
+        in order. Raises if any image's preprocess fails (no GPU work) or if the
+        forward fails.
+        """
+        if self._actor is None or self._pool is None:
+            raise RuntimeError("AsyncVisionEncoder.encode() called before load()")
+        if not raws:
+            return []
+        loop = asyncio.get_running_loop()
+        # A5 barrier: preprocess all images concurrently, wait for EVERY one to
+        # settle, and run the forward only if all succeeded. return_exceptions=True
+        # makes the gather a true barrier (no short-circuit).
+        tasks = [
+            loop.run_in_executor(self._pool, self._backend.preprocess, raw)
+            for raw in raws
+        ]
+        settled = await asyncio.gather(*tasks, return_exceptions=True)
+        errors = [r for r in settled if isinstance(r, BaseException)]
+        if errors:
+            raise errors[0]
+        preprocessed: List[Preprocessed] = list(settled)  # type: ignore[arg-type]
+        items = [p.item for p in preprocessed]
+        # Direct, serialized forward on the actor thread (eager; target_bucket
+        # defaults to None — there is no graph ladder in this milestone).
+        return await loop.run_in_executor(
+            self._actor, self._backend.forward_batch, items
+        )
+
+    def shutdown(self) -> None:
+        """Run ``backend.close`` on the actor thread, then stop both pools. Safe
+        before ``load`` and idempotent."""
+        if self._actor is not None:
+            try:
+                self._actor.submit(self._backend.close).result(timeout=10)
+            except BaseException:  # noqa: BLE001 — teardown best-effort
+                logger.exception(
+                    "AsyncVisionEncoder(%s): backend.close raised during teardown",
+                    self._name,
+                )
+            self._actor.shutdown(wait=False)
+        if self._pool is not None:
+            self._pool.shutdown(wait=False)

--- a/components/src/dynamo/vllm/multimodal_utils/vision_encoder_backend.py
+++ b/components/src/dynamo/vllm/multimodal_utils/vision_encoder_backend.py
@@ -29,7 +29,9 @@ Division of labour (author vs. Dynamo):
   it fails only that image, before any GPU work. **Off by default:** override
   ``preprocess`` *and* set ``preprocess_concurrency > 0`` together to enable this
   pool. With the defaults (identity passthrough, ``preprocess_concurrency = 0``)
-  there is no preprocess phase — raws go straight to ``forward_batch``.
+  there is no preprocess phase — ``preprocess`` is never called and raws go
+  straight to ``forward_batch``. A mismatch (overridden ``preprocess`` with
+  ``preprocess_concurrency`` left at ``0``) fails fast at startup.
 - ``forward_batch(items, target_bucket=None) -> list[torch.Tensor]`` — **actor
   thread, serialized.** ``items`` are a cost-bounded batch (summed ``cost`` within
   the budget). Fence (stream event + sync) and **copy outputs to CPU** before
@@ -118,10 +120,12 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
     #: until CUDA-graph batching is supported. ``None``/empty ⇒ eager.
     buckets: Optional[Sequence[int]] = None
 
-    #: Off-loop preprocess pool size Dynamo runs ``preprocess`` on. ``0`` (the
-    #: **default**) ⇒ **no preprocess phase**: raws go straight to ``forward_batch``
+    #: Off-loop preprocess pool size Dynamo runs ``preprocess`` on. Not just a
+    #: pool size — it gates the preprocess **phase**: ``0`` (the **default**) ⇒
+    #: ``preprocess`` is never called and raws go straight to ``forward_batch``
     #: (``raw`` is the item; do any prep there). Set ``> 0`` (with an overridden
-    #: ``preprocess``) to fetch / resize / patchify off the actor thread. Whether an
+    #: ``preprocess``) to fetch / resize / patchify off the actor thread; overriding
+    #: ``preprocess`` while leaving this at ``0`` fails fast at startup. Whether an
     #: encoder needs off-loop prep is a property of the encoder, so it lives here;
     #: the driver takes an optional override for tuning.
     preprocess_concurrency: int = 0
@@ -146,6 +150,8 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
         fetch + HF processing **and** set ``preprocess_concurrency > 0`` to run it
         on the pool — it must then be deterministic, thread-safe, and CUDA-free.
         Raise to reject a bad input — it fails only that image, before submit.
+        With ``preprocess_concurrency == 0`` this method is **never called**;
+        overriding it without raising the concurrency fails fast at startup.
         """
         return Preprocessed(item=raw)  # type: ignore[arg-type]  # ItemT == RawT
 

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
@@ -4,7 +4,7 @@
 """Unit tests for the serial dynamo.vllm.multimodal_utils.async_vision_encoder.
 
 Pin the serial-glue contract: build / forward / close run on one actor thread;
-encode returns one tensor per raw; the A5 preprocess barrier fails a request
+encode returns one tensor per raw; the preprocess barrier fails a request
 atomically (no GPU work) if any image's preprocess fails; concurrent encodes are
 **not** coalesced (one forward_batch call each — the batched version's job, added
 later); load fails fast on a build error or a missing/invalid image_token_id.
@@ -78,7 +78,7 @@ async def test_encode_returns_one_tensor_per_raw():
         enc.shutdown()
 
 
-async def test_a5_barrier_fails_atomically_with_no_gpu_work():
+async def test_preprocess_barrier_fails_atomically_with_no_gpu_work():
     be = _FakeBackend(fail_on={"bad"})
     enc = AsyncVisionEncoder(be)
     enc.load("m")
@@ -190,7 +190,7 @@ def test_shutdown_before_load_is_safe():
 
 async def test_passthrough_skips_preprocess_when_no_pool():
     """With no pool (preprocess_concurrency=0) preprocess is skipped and raws go
-    straight to forward_batch — no A5 barrier, no pool thread."""
+    straight to forward_batch — no barrier, no pool thread."""
 
     class _PassthroughBackend(_FakeBackend):
         preprocess_concurrency = 0

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
@@ -35,6 +35,9 @@ class _FakeBackend(VisionEncoderBackend):
     """A CPU-only fake backend; records its threads and forward-call boundaries."""
 
     image_token_id = 151655
+    # This fake overrides preprocess, so opt into the off-loop pool (the default
+    # is 0 ⇒ no pool); the passthrough path is covered by its own test below.
+    preprocess_concurrency = 4
 
     def __init__(self, *, fail_on=None):
         self.fail_on = set(fail_on or ())
@@ -185,6 +188,37 @@ def test_shutdown_before_load_is_safe():
     AsyncVisionEncoder(_FakeBackend()).shutdown()  # no-op, no raise
 
 
-def test_preprocess_concurrency_must_be_positive():
+async def test_passthrough_skips_preprocess_when_no_pool():
+    """With no pool (preprocess_concurrency=0) preprocess is skipped and raws go
+    straight to forward_batch — no A5 barrier, no pool thread."""
+
+    class _PassthroughBackend(_FakeBackend):
+        preprocess_concurrency = 0
+
+        def preprocess(self, raw):
+            raise AssertionError("preprocess must not run in passthrough mode")
+
+    be = _PassthroughBackend()
+    enc = AsyncVisionEncoder(be)
+    enc.load("m")
+    try:
+        assert enc._pool is None  # no pool created
+        out = await enc.encode(["a", "bb"])
+        assert len(out) == 2
+        assert be.forward_calls == [["a", "bb"]]  # raws passed straight through
+    finally:
+        enc.shutdown()
+
+
+def test_preprocess_concurrency_zero_disables_pool():
+    enc = AsyncVisionEncoder(_FakeBackend(), preprocess_concurrency=0)
+    enc.load("m")
+    try:
+        assert enc._pool is None
+    finally:
+        enc.shutdown()
+
+
+def test_preprocess_concurrency_rejects_negative():
     with pytest.raises(ValueError, match="preprocess_concurrency"):
-        AsyncVisionEncoder(_FakeBackend(), preprocess_concurrency=0)
+        AsyncVisionEncoder(_FakeBackend(), preprocess_concurrency=-1)

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the serial dynamo.vllm.multimodal_utils.async_vision_encoder.
+
+Pin the serial-glue contract: build / forward / close run on one actor thread;
+encode returns one tensor per raw; the A5 preprocess barrier fails a request
+atomically (no GPU work) if any image's preprocess fails; concurrent encodes are
+**not** coalesced (one forward_batch call each — the batched version's job, added
+later); load fails fast on a build error or a missing/invalid image_token_id.
+"""
+
+import asyncio
+import threading
+
+import pytest
+import torch
+
+from dynamo.vllm.multimodal_utils.async_vision_encoder import AsyncVisionEncoder
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
+    Preprocessed,
+    VisionEncoderBackend,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+
+class _FakeBackend(VisionEncoderBackend):
+    """A CPU-only fake backend; records its threads and forward-call boundaries."""
+
+    image_token_id = 151655
+
+    def __init__(self, *, fail_on=None):
+        self.fail_on = set(fail_on or ())
+        self.build_thread = None
+        self.close_thread = None
+        self.closed = False
+        self.model_id = None
+        self.forward_threads: list[int] = []
+        self.forward_calls: list[list] = []  # one entry per forward_batch call
+
+    def build(self, model_id):
+        self.build_thread = threading.get_ident()
+        self.model_id = model_id
+
+    def preprocess(self, raw):
+        if raw in self.fail_on:
+            raise ValueError(f"bad input {raw}")
+        return Preprocessed(item=raw, cost=1)
+
+    def forward_batch(self, items, target_bucket=None):
+        self.forward_threads.append(threading.get_ident())
+        self.forward_calls.append(list(items))
+        return [torch.full((2, 4), float(len(str(it)))) for it in items]
+
+    def close(self):
+        self.close_thread = threading.get_ident()
+        self.closed = True
+
+
+async def test_encode_returns_one_tensor_per_raw():
+    enc = AsyncVisionEncoder(_FakeBackend())
+    enc.load("m")
+    try:
+        out = await enc.encode(["a", "bb", "ccc"])
+        assert len(out) == 3
+        assert all(t.shape == (2, 4) for t in out)
+    finally:
+        enc.shutdown()
+
+
+async def test_a5_barrier_fails_atomically_with_no_gpu_work():
+    be = _FakeBackend(fail_on={"bad"})
+    enc = AsyncVisionEncoder(be)
+    enc.load("m")
+    try:
+        with pytest.raises(ValueError, match="bad input"):
+            await enc.encode(["good", "bad"])
+        assert be.forward_calls == []  # nothing ran
+    finally:
+        enc.shutdown()
+
+
+async def test_build_and_forward_share_one_non_main_thread():
+    be = _FakeBackend()
+    enc = AsyncVisionEncoder(be)
+    enc.load("m")
+    try:
+        await enc.encode(["x"])
+        assert be.build_thread is not None
+        assert set(be.forward_threads) == {be.build_thread}
+        assert be.build_thread != threading.get_ident()
+    finally:
+        enc.shutdown()
+
+
+async def test_concurrent_encodes_are_not_coalesced():
+    """Serial glue: each encode runs its own forward_batch — no cross-request
+    batching (that is the batched version's job, added in a later PR)."""
+    be = _FakeBackend()
+    enc = AsyncVisionEncoder(be)
+    enc.load("m")
+    try:
+        await asyncio.gather(enc.encode(["a"]), enc.encode(["b"]), enc.encode(["c"]))
+        assert len(be.forward_calls) == 3
+        assert all(len(call) == 1 for call in be.forward_calls)
+    finally:
+        enc.shutdown()
+
+
+async def test_load_resolves_placeholder_and_passes_model_id():
+    be = _FakeBackend()
+    enc = AsyncVisionEncoder(be)
+    enc.load("my-model")
+    try:
+        assert enc.get_image_placeholder_token_id() == 151655
+        assert be.model_id == "my-model"
+    finally:
+        enc.shutdown()
+
+
+async def test_encode_empty_returns_empty():
+    enc = AsyncVisionEncoder(_FakeBackend())
+    enc.load("m")
+    try:
+        assert await enc.encode([]) == []
+    finally:
+        enc.shutdown()
+
+
+async def test_encode_before_load_raises():
+    enc = AsyncVisionEncoder(_FakeBackend())
+    with pytest.raises(RuntimeError, match="before load"):
+        await enc.encode(["a"])
+
+
+def test_load_twice_raises():
+    enc = AsyncVisionEncoder(_FakeBackend())
+    enc.load("m")
+    try:
+        with pytest.raises(RuntimeError, match="called twice"):
+            enc.load("m")
+    finally:
+        enc.shutdown()
+
+
+def test_shutdown_runs_backend_close_on_actor_thread():
+    be = _FakeBackend()
+    enc = AsyncVisionEncoder(be)
+    enc.load("m")
+    enc.shutdown()
+    assert be.closed is True
+    assert be.close_thread == be.build_thread
+
+
+def test_load_fails_fast_on_build_error_and_reaps_threads():
+    class _BadBuild(_FakeBackend):
+        def build(self, model_id):
+            raise RuntimeError("build failed")
+
+    enc = AsyncVisionEncoder(_BadBuild())
+    with pytest.raises(RuntimeError, match="build failed"):
+        enc.load("m")
+    assert enc._actor is not None and enc._actor._shutdown is True
+    assert enc._pool is not None and enc._pool._shutdown is True
+
+
+def test_load_fails_fast_on_missing_image_token_id():
+    class _NoTokenId(_FakeBackend):
+        image_token_id = None
+
+    enc = AsyncVisionEncoder(_NoTokenId())
+    with pytest.raises(ValueError, match="image_token_id"):
+        enc.load("m")
+    assert enc._actor is not None and enc._actor._shutdown is True
+
+
+def test_shutdown_before_load_is_safe():
+    AsyncVisionEncoder(_FakeBackend()).shutdown()  # no-op, no raise
+
+
+def test_preprocess_concurrency_must_be_positive():
+    with pytest.raises(ValueError, match="preprocess_concurrency"):
+        AsyncVisionEncoder(_FakeBackend(), preprocess_concurrency=0)

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
@@ -44,6 +44,7 @@ class _FakeBackend(VisionEncoderBackend):
         self.build_thread = None
         self.close_thread = None
         self.closed = False
+        self.close_calls = 0
         self.model_id = None
         self.forward_threads: list[int] = []
         self.forward_calls: list[list] = []  # one entry per forward_batch call
@@ -65,6 +66,7 @@ class _FakeBackend(VisionEncoderBackend):
     def close(self):
         self.close_thread = threading.get_ident()
         self.closed = True
+        self.close_calls += 1
 
 
 async def test_encode_returns_one_tensor_per_raw():
@@ -162,6 +164,17 @@ def test_shutdown_runs_backend_close_on_actor_thread():
     assert be.close_thread == be.build_thread
 
 
+def test_shutdown_is_idempotent():
+    be = _FakeBackend()
+    enc = AsyncVisionEncoder(be)
+    enc.load("m")
+    enc.shutdown()
+    enc.shutdown()
+    assert be.close_calls == 1
+    assert enc._actor is None
+    assert enc._pool is None
+
+
 def test_load_fails_fast_on_build_error_and_reaps_threads():
     class _BadBuild(_FakeBackend):
         def build(self, model_id):
@@ -170,8 +183,8 @@ def test_load_fails_fast_on_build_error_and_reaps_threads():
     enc = AsyncVisionEncoder(_BadBuild())
     with pytest.raises(RuntimeError, match="build failed"):
         enc.load("m")
-    assert enc._actor is not None and enc._actor._shutdown is True
-    assert enc._pool is not None and enc._pool._shutdown is True
+    assert enc._actor is None
+    assert enc._pool is None
 
 
 def test_load_fails_fast_on_missing_image_token_id():
@@ -181,7 +194,8 @@ def test_load_fails_fast_on_missing_image_token_id():
     enc = AsyncVisionEncoder(_NoTokenId())
     with pytest.raises(ValueError, match="image_token_id"):
         enc.load("m")
-    assert enc._actor is not None and enc._actor._shutdown is True
+    assert enc._actor is None
+    assert enc._pool is None
 
 
 def test_shutdown_before_load_is_safe():

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
@@ -188,17 +188,32 @@ def test_shutdown_before_load_is_safe():
     AsyncVisionEncoder(_FakeBackend()).shutdown()  # no-op, no raise
 
 
+class _PassthroughBackend(VisionEncoderBackend):
+    """Keeps the base identity preprocess (no override) — the legal passthrough
+    shape at preprocess_concurrency=0."""
+
+    image_token_id = 151655
+
+    def __init__(self):
+        self.forward_calls: list[list] = []
+
+    def build(self, model_id):
+        pass
+
+    def forward_batch(self, items, target_bucket=None):
+        self.forward_calls.append(list(items))
+        return [torch.zeros(2, 4) for _ in items]
+
+
 async def test_passthrough_skips_preprocess_when_no_pool():
-    """With no pool (preprocess_concurrency=0) preprocess is skipped and raws go
-    straight to forward_batch — no barrier, no pool thread."""
-
-    class _PassthroughBackend(_FakeBackend):
-        preprocess_concurrency = 0
-
-        def preprocess(self, raw):
-            raise AssertionError("preprocess must not run in passthrough mode")
-
+    """With no pool (preprocess_concurrency=0) the preprocess phase is skipped
+    entirely and raws go straight to forward_batch — no barrier, no pool thread."""
     be = _PassthroughBackend()
+    # Instance-level boom (invisible to the class-override check) proves the
+    # phase is never entered, not merely run through an identity hook.
+    be.preprocess = lambda raw: (_ for _ in ()).throw(  # type: ignore[method-assign]
+        AssertionError("preprocess must not run in passthrough mode")
+    )
     enc = AsyncVisionEncoder(be)
     enc.load("m")
     try:
@@ -211,12 +226,30 @@ async def test_passthrough_skips_preprocess_when_no_pool():
 
 
 def test_preprocess_concurrency_zero_disables_pool():
-    enc = AsyncVisionEncoder(_FakeBackend(), preprocess_concurrency=0)
+    enc = AsyncVisionEncoder(_PassthroughBackend(), preprocess_concurrency=0)
     enc.load("m")
     try:
         assert enc._pool is None
     finally:
         enc.shutdown()
+
+
+def test_overridden_preprocess_with_zero_concurrency_raises():
+    """A backend that overrides preprocess but declares no pool would silently
+    never run it — rejected at construction."""
+
+    class _MismatchedBackend(_FakeBackend):
+        preprocess_concurrency = 0
+
+    with pytest.raises(ValueError, match="never run"):
+        AsyncVisionEncoder(_MismatchedBackend())
+
+
+def test_driver_override_to_zero_with_overriding_backend_raises():
+    """The constructor override participates in the same check: forcing the
+    effective concurrency to 0 must not silently skip an overridden preprocess."""
+    with pytest.raises(ValueError, match="never run"):
+        AsyncVisionEncoder(_FakeBackend(), preprocess_concurrency=0)
 
 
 def test_preprocess_concurrency_rejects_negative():

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -651,6 +651,9 @@ def _make_decode_handler(
         use_unified_vision_chunk=False,
     )
     handler._deferred_aborts = {}
+    # Real BaseWorkerHandler.__init__ (patched out above) sets this; the
+    # aggregated branch in _generate_token_mode reads it, so mirror the default.
+    handler._custom_encoder = None
     return handler
 
 

--- a/examples/custom_encoder/__init__.py
+++ b/examples/custom_encoder/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/custom_encoder/__init__.py
+++ b/examples/custom_encoder/__init__.py
@@ -1,2 +1,2 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/examples/custom_encoder/hitchhikers_vision_encoder.py
+++ b/examples/custom_encoder/hitchhikers_vision_encoder.py
@@ -44,7 +44,6 @@ import torch
 from safetensors import safe_open
 from transformers.utils import cached_file
 
-from dynamo.vllm.multimodal_utils.vision_encoder_backend import Preprocessed
 from examples.custom_encoder.qwen_vision_encoder import QwenVisionEncoderBackend
 
 logger = logging.getLogger(__name__)
@@ -97,7 +96,9 @@ class HitchhikersVisionEncoder(QwenVisionEncoderBackend):
     so the spliced prompt reads as a coherent sentence.
     """
 
-    # Eager: no graph ladder. Count-based budget (cost == 1 per image).
+    # Eager: no graph ladder. Count-based budget (cost == 1 per image). The URL is
+    # ignored, so there is nothing to preprocess: it inherits the identity-default
+    # preprocess + preprocess_concurrency=0, and raws go straight to forward_batch.
     buckets = None
     max_batch_cost = 8
 
@@ -111,12 +112,6 @@ class HitchhikersVisionEncoder(QwenVisionEncoderBackend):
             self._embed_weight.dtype,
             _PHRASE,
         )
-
-    def preprocess(self, image_url: str) -> Preprocessed[str]:
-        """Pass-through: the URL is ignored, so there is nothing to fetch/decode.
-
-        cost=1 (count-based)."""
-        return Preprocessed(item=image_url, cost=1)
 
     def forward_batch(
         self, items: List[str], target_bucket: Optional[int] = None

--- a/examples/custom_encoder/hitchhikers_vision_encoder.py
+++ b/examples/custom_encoder/hitchhikers_vision_encoder.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example ``VisionEncoderBackend`` that fakes an image as a known text phrase.
+
+Instead of a real vision encoder, ``forward_batch()`` returns the LM's
+``embed_tokens`` embeddings of a fixed phrase (default: *"the Ultimate Question
+of Life, the Universe, and Everything"*). Splicing those embeddings in at the
+image placeholder makes the assembled prompt read as one coherent sentence, so
+the mixed-embeds path can be checked for **semantic** correctness, not just
+shape:
+
+    "Based on The Hitchhiker's Guide to the Galaxy, The Answer to"
+        + <image>            # → embeds of " the Ultimate Question of Life, ..."
+        + " is?"
+    → the model answers "42".
+
+The image URL is ignored — any URL yields the same phrase embeddings. This is an
+**eager** backend: ``buckets`` stays ``None`` (no CUDA graphs), ``cost`` is 1 per
+image, and ``preprocess`` is a pass-through (no fetch / decode), so it isolates
+the splice + contract + LM path from any real vision compute.
+
+Subclasses ``QwenVisionEncoderBackend``: the default model is a Qwen-family LM
+(Qwen2.5), so the base loads the tokenizer and resolves the ``<|image_pad|>``
+placeholder id; this class only loads the ``embed_tokens`` weight and implements
+``preprocess`` + the synchronous ``forward_batch``.
+
+Usage (via agg_custom.sh):
+    DYN_ENCODER_CLASS=examples.custom_encoder.hitchhikers_vision_encoder.HitchhikersVisionEncoder
+    DYN_MODEL=Qwen/Qwen2.5-1.5B-Instruct
+    DYN_CUSTOM_PHRASE=" the Ultimate Question of Life, the Universe, and Everything"
+    ./agg_custom.sh
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional
+
+import torch
+from safetensors import safe_open
+from transformers.utils import cached_file
+
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import Preprocessed
+from examples.custom_encoder.qwen_vision_encoder import QwenVisionEncoderBackend
+
+logger = logging.getLogger(__name__)
+
+# The Answer to the Ultimate Question of Life, the Universe, and Everything is 42.
+_PHRASE = os.environ.get(
+    "DYN_CUSTOM_PHRASE",
+    " the Ultimate Question of Life, the Universe, and Everything",
+)
+
+
+def _load_embed_tokens_weight(model_id: str) -> torch.Tensor:
+    """Load only ``embed_tokens.weight`` from a HF checkpoint (lazy safetensors read).
+
+    Works for both local directories and HF hub model IDs (resolved through the
+    HF cache), and for sharded and single-file checkpoints.
+    """
+    try:
+        index_path = cached_file(model_id, "model.safetensors.index.json")
+        model_dir = Path(index_path).parent
+        weight_map = json.loads(Path(index_path).read_text())["weight_map"]
+        embed_key = next(
+            (k for k in weight_map if k.endswith("embed_tokens.weight")), None
+        )
+        if embed_key is None:
+            raise FileNotFoundError(
+                f"No embed_tokens.weight key in safetensors index for {model_id}"
+            )
+        shard_path = model_dir / weight_map[embed_key]
+    except (OSError, StopIteration):
+        # Fallback: single-file safetensors model.
+        shard_path = Path(cached_file(model_id, "model.safetensors"))
+        embed_key = None  # scanned below
+
+    with safe_open(str(shard_path), framework="pt", device="cpu") as f:
+        if embed_key is None:
+            embed_key = next(
+                (k for k in f.keys() if k.endswith("embed_tokens.weight")), None
+            )
+        if embed_key is None:
+            raise FileNotFoundError(f"embed_tokens.weight not found in {shard_path}")
+        return f.get_tensor(embed_key)
+
+
+class HitchhikersVisionEncoder(QwenVisionEncoderBackend):
+    """Backend that returns the LM embeddings of a fixed phrase for any image URL.
+
+    A test/example backend, not a production vision encoder: it loads the LM's
+    ``embed_tokens`` weight and returns the embeddings of ``DYN_CUSTOM_PHRASE``
+    so the spliced prompt reads as a coherent sentence.
+    """
+
+    # Eager: no graph ladder. Count-based budget (cost == 1 per image).
+    buckets = None
+    max_batch_cost = 8
+
+    def build(self, model_id: str) -> None:
+        """Load the tokenizer (via the Qwen base) and the LM ``embed_tokens`` weight."""
+        super().build(model_id)  # loads self.tokenizer
+        self._embed_weight = _load_embed_tokens_weight(model_id)
+        logger.info(
+            "[HitchhikersVisionEncoder] ready: embed_weight=%s dtype=%s phrase=%r",
+            tuple(self._embed_weight.shape),
+            self._embed_weight.dtype,
+            _PHRASE,
+        )
+
+    def preprocess(self, image_url: str) -> Preprocessed[str]:
+        """Pass-through: the URL is ignored, so there is nothing to fetch/decode.
+
+        cost=1 (count-based)."""
+        return Preprocessed(item=image_url, cost=1)
+
+    def forward_batch(
+        self, items: List[str], target_bucket: Optional[int] = None
+    ) -> List[torch.Tensor]:
+        """Return the ``embed_tokens`` embeddings of the phrase for each item.
+
+        Synchronous batched forward — the AsyncVisionEncoder runs it on the
+        dedicated actor thread, one batch at a time. Eager (``target_bucket`` is
+        always ``None`` here since ``buckets`` is ``None``)."""
+        # Explicit check (not assert): asserts are stripped under `python -O`,
+        # which would turn a missing build() into an opaque None-index crash.
+        if (
+            getattr(self, "_embed_weight", None) is None
+            or getattr(self, "tokenizer", None) is None
+        ):
+            raise RuntimeError(
+                "HitchhikersVisionEncoder.forward_batch() called before "
+                "build(); load the encoder first."
+            )
+        ids = self.tokenizer.encode(_PHRASE, add_special_tokens=False)
+        phrase_embeds = self._embed_weight[torch.tensor(ids, dtype=torch.long)]
+        logger.debug(
+            "[HitchhikersVisionEncoder] phrase tokens=%d → shape=%s",
+            len(ids),
+            tuple(phrase_embeds.shape),
+        )
+        return [phrase_embeds.clone() for _ in items]

--- a/examples/custom_encoder/hitchhikers_vision_encoder.py
+++ b/examples/custom_encoder/hitchhikers_vision_encoder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Example ``VisionEncoderBackend`` that fakes an image as a known text phrase.

--- a/examples/custom_encoder/launch/agg_custom.sh
+++ b/examples/custom_encoder/launch/agg_custom.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Aggregated serving with a CustomEncoder.

--- a/examples/custom_encoder/launch/agg_custom.sh
+++ b/examples/custom_encoder/launch/agg_custom.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated serving with a CustomEncoder.
+#
+# Architecture: single aggregated worker
+#   - Frontend: dynamo.frontend (OpenAI-compatible HTTP gateway)
+#   - Worker:   dynamo.vllm with a CustomEncoder loaded in-process
+#
+# The CustomEncoder is called for each multimodal request:
+#   1. encoder.encode(image_urls) → list[(n_visual_tokens, lm_hidden_dim)]
+#   2. Dynamo builds a mixed token-ids/embeds EmbedsPrompt: vLLM embeds the text
+#      itself and substitutes the encoder's image embeds at the placeholder span.
+#   3. vLLM engine runs transformer layers on the EmbedsPrompt.
+#
+# No separate encode worker, no NIXL inter-process transfer.
+#
+# The default model is a text-only LM (Qwen2.5-1.5B-Instruct) — the standard
+# topology for this feature (custom encoder + stock LM), served with a minimal
+# custom chat template that emits the image placeholder. The default encoder
+# (HitchhikersVisionEncoder) fakes an image as the embeddings of a fixed phrase
+# so the path can be checked for semantic correctness; replace it with a real
+# CustomEncoder subclass for production.
+#
+# Usage:
+#   ./agg_custom.sh [--model <hf_id>] [--encoder-class <dotted.ClassName>]
+#                    [--gpu <index>]
+#
+# Defaults:
+#   --model:         Qwen/Qwen2.5-1.5B-Instruct
+#   --encoder-class: examples.custom_encoder.hitchhikers_vision_encoder.HitchhikersVisionEncoder
+#   --gpu:           0
+
+set -e
+trap 'echo "Cleaning up..."; kill 0' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../common/launch_utils.sh"
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+MODEL="${DYN_MODEL:-Qwen/Qwen2.5-1.5B-Instruct}"
+ENCODER_CLASS="${DYN_ENCODER_CLASS:-examples.custom_encoder.hitchhikers_vision_encoder.HitchhikersVisionEncoder}"
+# Precedence: explicit DYN_WORKER_GPU/--gpu > harness-set CUDA_VISIBLE_DEVICES
+# (e.g. the pytest profile runner) > device 0 (portable default; on a generic
+# host or single-GPU container, GPU 0 is the natural choice).
+WORKER_GPU="${DYN_WORKER_GPU:-${CUDA_VISIBLE_DEVICES:-0}}"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+MAX_MODEL_LEN="${DYN_MAX_MODEL_LEN:-16384}"
+# A text-only LM's own chat template can't render image content parts, so default
+# to the bundled minimal template that emits the <|image_pad|> placeholder.
+CUSTOM_JINJA_TEMPLATE="${DYN_CUSTOM_JINJA_TEMPLATE:-$SCRIPT_DIR/../templates/qwen_vl.jinja}"
+EXTRA_ARGS=()
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL=$2; shift 2 ;;
+        --encoder-class)
+            ENCODER_CLASS=$2; shift 2 ;;
+        --gpu)
+            WORKER_GPU=$2; shift 2 ;;
+        -h|--help)
+            cat <<'EOF'
+Usage: agg_custom.sh [OPTIONS]
+
+Aggregated serving with a CustomEncoder (no separate encode worker).
+
+Options:
+  --model <id>           LLM checkpoint (default: Qwen/Qwen2.5-1.5B-Instruct)
+  --encoder-class <path> Dotted module.ClassName for CustomEncoder subclass
+  --gpu <index>          GPU index for the worker (default: 0)
+  -h, --help             Show this help
+
+Environment variables:
+  DYN_MODEL                      LLM model checkpoint
+  DYN_ENCODER_CLASS              Dotted class path for the CustomEncoder subclass
+  DYN_WORKER_GPU                 GPU index (default: 0)
+  DYN_CUSTOM_JINJA_TEMPLATE      Path to a .jinja chat template (defaults to the
+                                 bundled templates/qwen_vl.jinja)
+  DYN_CUSTOM_PHRASE             Phrase the HitchhikersEncoder embeds as the "image"
+EOF
+            exit 0 ;;
+        *)
+            EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+# VRAM sizing: honors the profiler/test-harness override
+# (_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES) when set, else falls back to a sane
+# local default. Required for VRAM-safe parallel test scheduling.
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+[[ -z "$GPU_MEM_ARGS" ]] && GPU_MEM_ARGS="--gpu-memory-utilization 0.8"
+
+print_launch_banner --no-curl "CustomEncoder — Aggregated Serving" "$MODEL" "$HTTP_PORT" \
+    "Worker GPU:  $WORKER_GPU" \
+    "Encoder:     $ENCODER_CLASS" \
+    "Jinja tmpl:  ${CUSTOM_JINJA_TEMPLATE:-(model default)}" \
+    "NOTE: HitchhikersVisionEncoder fakes an image as a fixed-phrase embedding;" \
+    "      replace with a real CustomEncoder subclass for production use."
+
+export DYN_REQUEST_PLANE=tcp
+export DYN_TCP_MAX_MESSAGE_SIZE=209715200
+export DYN_HTTP_BODY_LIMIT_MB=200
+
+# ── Frontend ──────────────────────────────────────────────────────────────────
+echo "[1/2] Starting frontend (port $HTTP_PORT)..."
+python -m dynamo.frontend &
+
+# ── Aggregated worker ─────────────────────────────────────────────────────────
+echo "[2/2] Starting aggregated worker (model=$MODEL, GPU=$WORKER_GPU)..."
+JINJA_ARG=()
+[[ -n "$CUSTOM_JINJA_TEMPLATE" ]] && JINJA_ARG=(--custom-jinja-template "$CUSTOM_JINJA_TEMPLATE")
+CUDA_VISIBLE_DEVICES=$WORKER_GPU \
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+python -m dynamo.vllm \
+    --model "$MODEL" \
+    --custom-encoder-class "$ENCODER_CLASS" \
+    --enable-multimodal \
+    --enable-prompt-embeds \
+    --max-model-len "$MAX_MODEL_LEN" \
+    $GPU_MEM_ARGS \
+    "${JINJA_ARG[@]}" \
+    "${EXTRA_ARGS[@]}" &
+
+echo "=================================================================="
+echo "All components started. Waiting for initialization (~30-60s)..."
+echo "=================================================================="
+
+wait_any_exit

--- a/examples/custom_encoder/qwen_vision_encoder.py
+++ b/examples/custom_encoder/qwen_vision_encoder.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable example base for Qwen-family ``VisionEncoderBackend`` authors.
+
+Hardcodes the Qwen ``<|image_pad|>`` placeholder id and loads the model tokenizer
+(handy for subclasses that tokenize text). A concrete Qwen-family encoder
+subclasses this and implements only ``preprocess`` + ``forward_batch``.
+
+    class MyQwenEncoder(QwenVisionEncoderBackend):
+        def build(self, model_id):
+            super().build(model_id)             # loads self.tokenizer
+            # ... load ViT + projector (pick the device yourself) ...
+        def preprocess(self, raw):
+            ...                                 # off-thread, returns Preprocessed
+        def forward_batch(self, items, target_bucket=None):
+            ...                                 # actor thread, batched forward (CPU out)
+"""
+
+from __future__ import annotations
+
+from transformers import AutoTokenizer
+
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import VisionEncoderBackend
+
+
+class QwenVisionEncoderBackend(VisionEncoderBackend):
+    """``VisionEncoderBackend`` base for Qwen-family models (Qwen2-VL / Qwen3-VL /
+    Qwen3.5).
+
+    Hardcodes ``image_token_id`` to Qwen3-VL's ``<|image_pad|>`` (151655) — override
+    it for other versions (e.g. 248056 for Qwen3.5). ``build`` loads the model
+    tokenizer; ``preprocess`` and ``forward_batch`` stay abstract, so this class
+    cannot be instantiated directly — subclass it and implement them.
+    """
+
+    # Qwen3-VL <|image_pad|>; override for other Qwen versions.
+    image_token_id = 151655
+
+    def build(self, model_id: str) -> None:
+        """Load the model tokenizer. Subclasses extend this (call super) to also
+        load their encoder weights (picking the device themselves)."""
+        self.tokenizer = AutoTokenizer.from_pretrained(model_id)

--- a/examples/custom_encoder/qwen_vision_encoder.py
+++ b/examples/custom_encoder/qwen_vision_encoder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Reusable example base for Qwen-family ``VisionEncoderBackend`` authors.

--- a/examples/custom_encoder/qwen_vision_encoder.py
+++ b/examples/custom_encoder/qwen_vision_encoder.py
@@ -5,9 +5,11 @@
 
 Hardcodes the Qwen ``<|image_pad|>`` placeholder id and loads the model tokenizer
 (handy for subclasses that tokenize text). A concrete Qwen-family encoder
-subclasses this and implements only ``preprocess`` + ``forward_batch``.
+subclasses this and implements ``forward_batch`` — plus ``preprocess`` (and
+``preprocess_concurrency > 0``) only when it needs off-loop fetch/resize.
 
     class MyQwenEncoder(QwenVisionEncoderBackend):
+        preprocess_concurrency = 4              # enable the off-loop pool
         def build(self, model_id):
             super().build(model_id)             # loads self.tokenizer
             # ... load ViT + projector (pick the device yourself) ...
@@ -30,8 +32,9 @@ class QwenVisionEncoderBackend(VisionEncoderBackend):
 
     Hardcodes ``image_token_id`` to Qwen3-VL's ``<|image_pad|>`` (151655) — override
     it for other versions (e.g. 248056 for Qwen3.5). ``build`` loads the model
-    tokenizer; ``preprocess`` and ``forward_batch`` stay abstract, so this class
-    cannot be instantiated directly — subclass it and implement them.
+    tokenizer; ``forward_batch`` stays abstract, so this class cannot be
+    instantiated directly — subclass it and implement ``forward_batch`` (and
+    ``preprocess`` only if it needs off-loop prep).
     """
 
     # Qwen3-VL <|image_pad|>; override for other Qwen versions.

--- a/examples/custom_encoder/templates/qwen_vl.jinja
+++ b/examples/custom_encoder/templates/qwen_vl.jinja
@@ -1,0 +1,26 @@
+{#- Minimal chat template for a text-only LM that hosts a custom image encoder. -#}
+{#- Renders text content normally and emits one bare <|image_pad|> placeholder -#}
+{#- per image content part. The CustomEncoder replaces each placeholder token -#}
+{#- with the encoder's image embeddings before the prompt reaches the engine. -#}
+{#- The frontend rewrites each {"type":"image_url",...} part to a bare -#}
+{#- {"type":"image"} before this template runs, so match on type == 'image'. -#}
+{#- The assembler maps one placeholder token to one image tensor, so -#}
+{#- consecutive images need no separator. -#}
+{%- for message in messages %}
+    {{- '<|im_start|>' + message.role + '\n' }}
+    {%- if message.content is string %}
+        {{- message.content }}
+    {%- else %}
+        {%- for content in message.content %}
+            {%- if content.type == 'image' %}
+                {{- '<|image_pad|>' }}
+            {%- elif content.type == 'text' %}
+                {{- content.text }}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -625,9 +625,8 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 timeout_s=300,
                 directory=os.path.join(WORKSPACE_DIR, "examples/custom_encoder"),
                 env={
-                    # The single-GPU test container remaps its host GPU to
-                    # device 0, so pin the worker there (agg_custom.sh also
-                    # honors an externally-set CUDA_VISIBLE_DEVICES).
+                    # The single-GPU test container exposes its GPU at device 0,
+                    # so pin the worker there.
                     "DYN_WORKER_GPU": "0",
                     "DYN_ENCODER_CLASS": (
                         "examples.custom_encoder.hitchhikers_vision_encoder."

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -1,13 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
+from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.utils.multimodal import (
     MmCase,
     MultimodalModelProfile,
     TopologyConfig,
     make_audio_payload,
+    make_custom_encoder_payload,
     make_image_payload,
     make_image_payload_b64,
     make_image_payload_cached_tokens,
@@ -56,6 +60,10 @@ VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "epd_video": "disagg_multimodal_epd.sh",
     "p_d": "disagg_multimodal_p_d.sh",
     "p_d_unified": "disagg_multimodal_p_d.sh",
+    # CustomEncoder: a custom in-process vision encoder on a text-only LM
+    # (no separate encode worker, no NIXL). Lives in examples/custom_encoder,
+    # not examples/backends/vllm — the TopologyConfig sets `directory` to match.
+    "agg_custom": "agg_custom.sh",
 }
 
 VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
@@ -598,6 +606,40 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                         )
                     )
                 ],
+            ),
+        },
+    ),
+    # CustomEncoder coverage. NOTE: Qwen2.5-1.5B-Instruct is a TEXT-ONLY LM —
+    # it sits in the multimodal profiles because the in-process CustomEncoder
+    # *plugin* (a custom vision encoder) gives it the image->embeds serving
+    # path; the multimodality comes from the encoder, not the model. The
+    # `agg_custom` topology launches examples/custom_encoder/launch/agg_custom.sh
+    # (hence the `directory` override) with the example HitchhikersVisionEncoder,
+    # which fakes an image as a fixed phrase so the spliced prompt answers "42".
+    MultimodalModelProfile(
+        name="Qwen/Qwen2.5-1.5B-Instruct",
+        short_name="custom-encoder",
+        topologies={
+            "agg_custom": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=300,
+                directory=os.path.join(WORKSPACE_DIR, "examples/custom_encoder"),
+                env={
+                    # The single-GPU test container remaps its host GPU to
+                    # device 0, so pin the worker there (agg_custom.sh also
+                    # honors an externally-set CUDA_VISIBLE_DEVICES).
+                    "DYN_WORKER_GPU": "0",
+                    "DYN_ENCODER_CLASS": (
+                        "examples.custom_encoder.hitchhikers_vision_encoder."
+                        "HitchhikersVisionEncoder"
+                    ),
+                    "DYN_CUSTOM_JINJA_TEMPLATE": os.path.join(
+                        WORKSPACE_DIR,
+                        "examples/custom_encoder/templates/qwen_vl.jinja",
+                    ),
+                    "PYTHONPATH": str(WORKSPACE_DIR),
+                },
+                tests=[MmCase(payload=make_custom_encoder_payload())],
             ),
         },
     ),

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -255,6 +255,32 @@ def make_audio_payload(expected_response: list[str]) -> ChatPayload:
     )
 
 
+def make_custom_encoder_payload() -> ChatPayload:
+    """Semantic check for the aggregated CustomEncoder path.
+
+    The example HitchhikersVisionEncoder splices the embeddings of "the
+    Ultimate Question of Life, the Universe, and Everything" at the image
+    placeholder, so the assembled prompt must answer "42". The served image
+    content is irrelevant (the encoder ignores the URL). ``expected_log``
+    asserts the encoder loaded in-process at worker startup.
+    """
+    return chat_payload(
+        [
+            {
+                "type": "text",
+                "text": "Based on The Hitchhiker's Guide to the Galaxy, The Answer to",
+            },
+            {"type": "image_url", "image_url": {"url": MULTIMODAL_IMG_URL}},
+            {"type": "text", "text": " is?"},
+        ],
+        repeat_count=1,
+        expected_response=["42"],
+        expected_log=["Loaded CustomEncoder"],
+        max_tokens=32,
+        temperature=0.0,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Config dataclasses
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Main just landed the CustomEncoder foundation (#10910: the `VisionEncoderBackend` ABC, `build_mixed_embeds`, and the `--custom-encoder-class` flag), but nothing wires it into serving — a configured encoder is never loaded or run. This PR closes that gap: an aggregated `dynamo.vllm` worker resolves a user-supplied `VisionEncoderBackend`, runs it in-process on image URLs, and splices the resulting image embeds into a mixed embeds-prompt — so custom or vLLM-unsupported VLMs serve without a separate encode worker or NIXL transfer. The encoder glue is deliberately serial (no micro-batcher): it proves the splice path end to end behind a stable surface (`load` / `encode` / `get_image_placeholder_token_id` / `shutdown`), so a follow-up adding cross-request batching swaps only internals and leaves the worker integration untouched.

## Effect

```
python -m dynamo.vllm --model Qwen/Qwen2.5-1.5B-Instruct --enable-multimodal \
    --custom-encoder-class examples.custom_encoder.hitchhikers_vision_encoder.HitchhikersVisionEncoder
```

## What Change

- Add `AsyncVisionEncoder`: serial async driver — off-loop preprocess, request-atomicity barrier, one actor thread for build/forward.
- Wire the aggregated handler to load the configured encoder and assemble a mixed embeds-prompt from image URLs; text-only requests fall through.
- Add a runnable example encoder (Qwen) + launcher + chat template.

## Test Plan

- Unit tests: preprocess-barrier atomicity, serial forward, load/shutdown lifecycle, handler wiring.
- `pytest components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
