### PR TITLE
feat(vllm): elastic EP scaling and headless on unified backend

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -353,8 +353,34 @@ jobs:
       platform: '["amd64"]' # No ARM GPUs available
       enable_coverage: true
       run_sanity_check: false
-      gpu_test_markers: vllm and (gpu_2 or gpu_4)
+      # elastic_ep runs in its own dedicated job (vllm-elastic-ep-test) below.
+      gpu_test_markers: vllm and (gpu_2 or gpu_4) and not elastic_ep
       gpu_test_timeout_minutes: 45
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
+  vllm-elastic-ep-test:
+    name: vllm-runtime # Groups with other vllm jobs in the UI
+    needs: [vllm-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: vllm
+      test_type: Elastic EP Scaling Test
+      amd_runner: prod-tester-amd-gpu-4-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      enable_coverage: true
+      run_sanity_check: false
+      # Dedicated job: live scale_elastic_ep up/down over the Ray DP backend.
+      # Needs 4 GPUs (start DP=2, scale to 4) and a longer budget than the
+      # general suite (MoE weights + two engine-core reconfigures).
+      gpu_test_markers: vllm and elastic_ep
+      gpu_test_timeout_minutes: 60
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
     secrets: inherit

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -353,34 +353,11 @@ jobs:
       platform: '["amd64"]' # No ARM GPUs available
       enable_coverage: true
       run_sanity_check: false
-      # elastic_ep runs in its own dedicated job (vllm-elastic-ep-test) below.
-      gpu_test_markers: vllm and (gpu_2 or gpu_4) and not elastic_ep
+      # Includes elastic_ep, locally validated DP=2->4->2 on H200 GPUs with
+      # vLLM 0.24.0. That test remains pytest-skipped because this runner has
+      # 24 GiB/GPU, while its unquantized EPLB model needs >=80 GiB/GPU.
+      gpu_test_markers: vllm and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 45
-      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
-      image_tag_suffix: '-nightly'
-    secrets: inherit
-
-  vllm-elastic-ep-test:
-    name: vllm-runtime # Groups with other vllm jobs in the UI
-    needs: [vllm-build, resolve-source-sha, compute-release-mode]
-    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      dd_env: nightly
-      dd_flaky_retry_enabled: 'false'
-      test_suite_name: vllm
-      test_type: Elastic EP Scaling Test
-      amd_runner: prod-tester-amd-gpu-4-v2
-      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
-      cuda_version: '["13.0"]'
-      platform: '["amd64"]' # No ARM GPUs available
-      enable_coverage: true
-      run_sanity_check: false
-      # Dedicated job: live scale_elastic_ep up/down over the Ray DP backend.
-      # Needs 4 GPUs (start DP=2, scale to 4) and a longer budget than the
-      # general suite (MoE weights + two engine-core reconfigures).
-      gpu_test_markers: vllm and elastic_ep
-      gpu_test_timeout_minutes: 60
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
     secrets: inherit

--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -529,6 +529,29 @@ Lifecycle and runtime:
     unchanged.
   - Loaded adapters appear in `GET /v1/models`; inference selects an
     adapter by sending `"model": "<lora_name>"`.
+- **Sleep/wake (vLLM)** — `sleep` / `wake_up` controls via
+  `VllmEnginePauseController` (discovery unregister before sleep,
+  re-register after wake; `worker.rs` `engine_control_policy`)
+- **Elastic EP scaling (vLLM)** — `scale_elastic_ep` control at parity
+  with the legacy handler: `new_data_parallel_size` validation, a
+  single-flight lock (concurrent scales rejected, not queued), and the
+  `ray.util.state.list_nodes` → GCS shim for ray `--minimal`. Served at
+  `/engine/control/scale_elastic_ep` on the system port (the unified
+  Worker namespaces controls under `/engine/control/<name>`, matching the
+  legacy backend). Requires the Ray DP backend
+  (`--data-parallel-backend ray`, `nnodes == 1`) **and `ray` installed**
+  (the vLLM runtime image does not ship it). The single head-node backend
+  drives `add_dp_placement_groups` to place DP-worker Ray actors across
+  the Ray cluster, so multi-node is a Ray-cluster-membership concern
+  (operator-managed `ray start`), not a per-node backend concern.
+  GPU-validated on 4×H100: scale-**up** (2→4) returns `status:ok` and keeps
+  serving; scale-**down** (4→2) currently hangs in vLLM's
+  `_scale_down_elastic_ep` (track upstream).
+- **Headless multi-node (vLLM)** — `--headless` secondary nodes run
+  vLLM workers only (multi-node TP/PP with `--data-parallel-backend mp`),
+  bypassing DistributedRuntime; `unified_main` routes them to
+  `run_dynamo_headless` before the Worker/engine path. Distinct from
+  elastic EP, which uses the Ray backend above.
 - **Disaggregated serving** (`agg`/`prefill`/`decode`) — KV transfer
   uses NIXL across all three engines; SGLang exchanges a Dynamo-level
   bootstrap address, vLLM and TRT-LLM use an engine-internal handshake.
@@ -594,15 +617,12 @@ Request handling:
 
 | Feature | Description |
 |---------|-------------|
-| Sleep/wake | 3-level vLLM engine lifecycle control (`VllmEnginePauseController`) with shutdown-delay tags |
-| Elastic EP scaling | `scale_elastic_ep` endpoint with Ray node management |
 | GMS shadow mode | GPU Memory Service integration with failover lock (`--gms-shadow-mode`, `configure_gms_lock_mode`) |
 | ModelExpress P2P | Distributed model loading via P2P (`--model-express-url`, `register_modelexpress_loaders`, `mx-source` / `mx-target` load formats) |
 | KV block clearing | Prefix cache reset endpoint |
 | `VllmEngineMonitor` | Background `EngineDeadError` detection task |
 | Instrumented scheduler + FPM relay | Per-forward-pass `ForwardPassMetrics` ZMQ telemetry |
 | `KvConnectorProtocol` abstraction | Legacy abstracts NIXL pull / Mooncake push; unified uses vLLM's internal connector only |
-| `--headless` multi-node mode | Secondary-node TP/PP worker mode (`run_dynamo_headless`); unified requires every node to run the backend |
 | `--benchmark-mode` family | The `--benchmark-*` flag family (mode, prefill/decode granularities, warmup, output path, timeout) injects into `vllm_config.additional_config` |
 | "Omni" alternative entry point | `dynamo.vllm.omni.*` parallel mode for alternative tensor workflows |
 | Multimodal (vLLM) | NIXL embedding transfer (`EmbeddingTransferMode`, `--embedding-transfer-mode`), embedding LRU cache (`--multimodal-embedding-cache-capacity-gb`), Qwen VL mRoPE, `EncodeWorkerHandler`, `--route-to-encoder` |
@@ -655,9 +675,10 @@ For users picking what to land next on the unified path:
    (engine updates `/engine/update/load_lora|unload_lora|list_loras` + a
    `/v1/loras` compatibility alias; see [What works today](#what-works-today)).
    Remaining: SGLang and TRT-LLM, which advertise no LoRA updates yet.
-3. **Engine routes / lifecycle endpoints** — sleep/wake, profile
-   start/stop, weight updates, KV block clearing, prefix cache
-   reset. Visible in operator workflows.
+3. **Engine routes / lifecycle endpoints** — weight updates, KV block
+   clearing, prefix cache reset. (Profiling, sleep/wake, elastic-EP
+   scaling, and headless multi-node already landed.) Visible in operator
+   workflows.
 4. **Snapshot / CRIU** — production checkpoint support.
 5. **Multimodal / diffusion / video / DLLM** — biggest functional
    gap, but largest scope. Best parallelized across modality leads.

--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -544,9 +544,12 @@ Lifecycle and runtime:
   drives `add_dp_placement_groups` to place DP-worker Ray actors across
   the Ray cluster, so multi-node is a Ray-cluster-membership concern
   (operator-managed `ray start`), not a per-node backend concern.
-  GPU-validated on 4×H100: scale-**up** (2→4) returns `status:ok` and keeps
-  serving; scale-**down** (4→2) currently hangs in vLLM's
-  `_scale_down_elastic_ep` (track upstream).
+  Locally GPU-validated on H200 GPUs with vLLM 0.24.0: scale-**up** (2→4)
+  and scale-**down** (4→2) return `status:ok`, and serving continues after
+  each transition. The integration test remains skipped in CI because each
+  unquantized Qwen3-30B-A3B replica needs about 57 GiB for weights at TP=1,
+  while CI's four-GPU runner has only 24 GiB per GPU; the test requires at
+  least 80 GiB per GPU for weights and runtime headroom.
 - **Headless multi-node (vLLM)** — `--headless` secondary nodes run
   vLLM workers only (multi-node TP/PP with `--data-parallel-backend mp`),
   bypassing DistributedRuntime; `unified_main` routes them to

--- a/components/src/dynamo/common/backend/run.py
+++ b/components/src/dynamo/common/backend/run.py
@@ -13,34 +13,40 @@ Each backend's ``unified_main.py`` calls :func:`run` with its
         run(VllmLLMEngine)
 """
 
+from collections.abc import Awaitable, Callable
+
 import uvloop
 
 from .engine import BaseEngine
-from .worker import Worker
+from .worker import Worker, WorkerConfig
+
+EngineFactory = Callable[[list[str] | None], Awaitable[tuple[BaseEngine, WorkerConfig]]]
 
 
 async def _start(
-    engine_cls: type[BaseEngine], argv: list[str] | None = None, config=None
+    engine_cls: type[BaseEngine],
+    argv: list[str] | None = None,
+    engine_factory: EngineFactory | None = None,
 ):
-    # Forward a pre-parsed config only when supplied, so engines whose
-    # from_args doesn't accept `config` keep their original call shape.
-    if config is not None:
-        engine, worker_config = await engine_cls.from_args(argv, config=config)
-    else:
-        engine, worker_config = await engine_cls.from_args(argv)
+    from_args = engine_factory or engine_cls.from_args
+    engine, worker_config = await from_args(argv)
     w = Worker(engine, worker_config)
     await w.run()
 
 
-def run(engine_cls: type[BaseEngine], argv: list[str] | None = None, config=None):
+def run(
+    engine_cls: type[BaseEngine],
+    argv: list[str] | None = None,
+    engine_factory: EngineFactory | None = None,
+):
     """Entry point for per-backend unified_main.py files.
 
     ``engine_cls`` may be an :class:`LLMEngine` or a :class:`DiffusionEngine`
     subclass; both share the ``from_args -> (engine, WorkerConfig)`` contract.
 
-    ``config`` lets an entry point that already parsed args (e.g. the vLLM
-    headless check in ``unified_main``) thread the parsed config through so
-    ``from_args`` does not re-parse; engines whose ``from_args`` does not
-    accept ``config`` are only ever called without it.
+    ``engine_factory`` lets an entry point that already parsed args construct
+    its engine without parsing again. The default remains
+    ``engine_cls.from_args(argv)`` so backend-specific arguments do not leak
+    into the shared :class:`BaseEngine` contract.
     """
-    uvloop.run(_start(engine_cls, argv, config))
+    uvloop.run(_start(engine_cls, argv, engine_factory))

--- a/components/src/dynamo/common/backend/run.py
+++ b/components/src/dynamo/common/backend/run.py
@@ -19,16 +19,28 @@ from .engine import BaseEngine
 from .worker import Worker
 
 
-async def _start(engine_cls: type[BaseEngine], argv: list[str] | None = None):
-    engine, worker_config = await engine_cls.from_args(argv)
+async def _start(
+    engine_cls: type[BaseEngine], argv: list[str] | None = None, config=None
+):
+    # Forward a pre-parsed config only when supplied, so engines whose
+    # from_args doesn't accept `config` keep their original call shape.
+    if config is not None:
+        engine, worker_config = await engine_cls.from_args(argv, config=config)
+    else:
+        engine, worker_config = await engine_cls.from_args(argv)
     w = Worker(engine, worker_config)
     await w.run()
 
 
-def run(engine_cls: type[BaseEngine], argv: list[str] | None = None):
+def run(engine_cls: type[BaseEngine], argv: list[str] | None = None, config=None):
     """Entry point for per-backend unified_main.py files.
 
     ``engine_cls`` may be an :class:`LLMEngine` or a :class:`DiffusionEngine`
     subclass; both share the ``from_args -> (engine, WorkerConfig)`` contract.
+
+    ``config`` lets an entry point that already parsed args (e.g. the vLLM
+    headless check in ``unified_main``) thread the parsed config through so
+    ``from_args`` does not re-parse; engines whose ``from_args`` does not
+    accept ``config`` are only ever called without it.
     """
-    uvloop.run(_start(engine_cls, argv))
+    uvloop.run(_start(engine_cls, argv, config))

--- a/components/src/dynamo/common/backend/tests/test_run.py
+++ b/components/src/dynamo/common/backend/tests/test_run.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the shared unified-backend runner."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip(
+    "dynamo._core.backend",
+    reason="dynamo._core.backend not built — run `maturin develop` first",
+    exc_type=ImportError,
+)
+
+import dynamo.common.backend.run as run_module  # noqa: E402
+from dynamo.common.backend.worker import WorkerConfig  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+
+
+async def test_start_uses_engine_from_args_by_default():
+    engine_cls = MagicMock()
+    engine = MagicMock()
+    worker_config = WorkerConfig(namespace="test")
+    engine_cls.from_args = AsyncMock(return_value=(engine, worker_config))
+    worker = MagicMock()
+    worker.run = AsyncMock()
+
+    with patch.object(run_module, "Worker", return_value=worker) as worker_cls:
+        await run_module._start(engine_cls, ["--model", "test-model"])
+
+    engine_cls.from_args.assert_awaited_once_with(["--model", "test-model"])
+    worker_cls.assert_called_once_with(engine, worker_config)
+    worker.run.assert_awaited_once_with()
+
+
+async def test_start_uses_supplied_engine_factory():
+    engine_cls = MagicMock()
+    engine_cls.from_args = AsyncMock()
+    engine = MagicMock()
+    worker_config = WorkerConfig(namespace="test")
+    engine_factory = AsyncMock(return_value=(engine, worker_config))
+    worker = MagicMock()
+    worker.run = AsyncMock()
+
+    with patch.object(run_module, "Worker", return_value=worker) as worker_cls:
+        await run_module._start(
+            engine_cls,
+            ["--model", "test-model"],
+            engine_factory=engine_factory,
+        )
+
+    engine_factory.assert_awaited_once_with(["--model", "test-model"])
+    engine_cls.from_args.assert_not_called()
+    worker_cls.assert_called_once_with(engine, worker_config)
+    worker.run.assert_awaited_once_with()

--- a/components/src/dynamo/vllm/headless.py
+++ b/components/src/dynamo/vllm/headless.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Headless multi-node worker mode for the vLLM backend.
+
+Shared by the legacy entry point (``dynamo.vllm.main``) and the unified
+entry point (``dynamo.vllm.unified_main``). Secondary nodes in a multi-node
+TP/PP (or ``mp`` data-parallel) deployment run vLLM workers only — no engine
+core, no scheduler, no Dynamo endpoints — bypassing DistributedRuntime
+entirely (no NATS/etcd).
+
+``--headless`` is the multi-node mechanism for ``--data-parallel-backend mp``
+(vLLM asserts ``nnodes > 1`` only with the ``mp`` backend). It is distinct
+from — and mutually exclusive with — elastic-EP scaling, which requires the
+Ray DP backend (``--data-parallel-backend ray``) with ``nnodes == 1``; there
+the head node's engine schedules DP-worker Ray actors across the Ray cluster,
+so secondary nodes run neither this headless mode nor the backend at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from .args import Config
+
+
+def build_headless_namespace(config: Config) -> argparse.Namespace:
+    """Build an argparse Namespace from engine_args for vLLM's run_headless().
+
+    run_headless() expects the raw CLI namespace. We reconstruct it from
+    the already-parsed AsyncEngineArgs so parse_args() doesn't need to
+    leak transport details.
+    """
+    ns = argparse.Namespace(**vars(config.engine_args))
+    # run_headless() reads api_server_count; default to 0 (no API server)
+    if not hasattr(ns, "api_server_count"):
+        ns.api_server_count = 0
+    return ns
+
+
+def run_dynamo_headless(config: Config) -> None:
+    """Run in headless mode for multi-node TP/PP.
+
+    Secondary nodes spawn vLLM workers only — no engine core, no scheduler,
+    no Dynamo endpoints. Bypasses DistributedRuntime entirely (no NATS/etcd).
+    """
+    # Propagate worker_cls for custom load formats so headless workers use
+    # the same model loader settings as the leader node.
+    if config.engine_args.load_format == "gms":
+        config.engine_args.worker_cls = (
+            "gpu_memory_service.integrations.vllm.worker.GMSWorker"
+        )
+
+        if config.gms_shadow_mode:
+            from gpu_memory_service.integrations.vllm.utils import (
+                configure_gms_lock_mode,
+                configure_mx_ports,
+            )
+
+            os.environ["DYN_GMS_SCRATCH_KV_ENABLED"] = "1"
+            configure_gms_lock_mode(config.engine_args)
+            configure_mx_ports(config.engine_args)
+
+    # ModelExpress uses vLLM's plugin path with --load-format=modelexpress.
+    # Dynamo does not set a custom worker class here.
+
+    # Keep the upstream CLI import local so tests that only exercise
+    # build_headless_namespace() do not pull in vLLM's full CLI import graph.
+    from vllm.entrypoints.cli.serve import run_headless
+
+    args = build_headless_namespace(config)
+    run_headless(args)

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -241,7 +241,7 @@ class VllmLLMEngine(LLMEngine):
         # headless config reaching here means run() was driven directly,
         # bypassing the entry point. Fail loud rather than booting a full
         # backend on what should be a vLLM-workers-only secondary node.
-        if getattr(config, "headless", False):
+        if config.headless:
             raise NotImplementedError(
                 "--headless must be launched via `python -m dynamo.vllm.unified_main` "
                 "(or the legacy `python -m dynamo.vllm`); it is not supported when "

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -237,6 +237,17 @@ class VllmLLMEngine(LLMEngine):
                 "use `python -m dynamo.vllm` for multimodal encode workers"
             )
 
+        # Headless is handled by unified_main before engine construction; a
+        # headless config reaching here means run() was driven directly,
+        # bypassing the entry point. Fail loud rather than booting a full
+        # backend on what should be a vLLM-workers-only secondary node.
+        if config.headless:
+            raise NotImplementedError(
+                "--headless must be launched via `python -m dynamo.vllm.unified_main` "
+                "(or the legacy `python -m dynamo.vllm`); it is not supported when "
+                "driving the unified Worker directly"
+            )
+
         if not config.served_model_name:
             config.served_model_name = (
                 config.engine_args.served_model_name

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -64,7 +64,7 @@ from dynamo.llm import (
     unregister_model,
 )
 from dynamo.runtime import Endpoint
-from dynamo.vllm.args import configure_rl_logprobs_mode, parse_args
+from dynamo.vllm.args import Config, configure_rl_logprobs_mode, parse_args
 from dynamo.vllm.cache_info import (
     configure_kv_event_block_size,
     get_configured_kv_event_block_size,
@@ -227,9 +227,13 @@ class VllmLLMEngine(LLMEngine):
 
     @classmethod
     async def from_args(
-        cls, argv: list[str] | None = None
+        cls, argv: list[str] | None = None, config: Config | None = None
     ) -> tuple[VllmLLMEngine, WorkerConfig]:
-        config = parse_args(argv)
+        # `config` lets unified_main thread its already-parsed args through so we
+        # don't re-parse (idempotent, but avoids a duplicate argparse + doubled
+        # vLLM deprecation warnings at startup).
+        if config is None:
+            config = parse_args(argv)
 
         if config.disaggregation_mode == DisaggregationMode.ENCODE:
             raise NotImplementedError(

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -241,7 +241,7 @@ class VllmLLMEngine(LLMEngine):
         # headless config reaching here means run() was driven directly,
         # bypassing the entry point. Fail loud rather than booting a full
         # backend on what should be a vLLM-workers-only secondary node.
-        if config.headless:
+        if getattr(config, "headless", False):
             raise NotImplementedError(
                 "--headless must be launched via `python -m dynamo.vllm.unified_main` "
                 "(or the legacy `python -m dynamo.vllm`); it is not supported when "

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import argparse
 import asyncio
 import json
 import logging
@@ -61,6 +60,7 @@ from .capacity import (
 )
 from .constants import DisaggregationMode
 from .handlers import get_dp_range_for_worker
+from .headless import run_dynamo_headless
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
 from .snapshot import prepare_snapshot_engine
@@ -107,54 +107,6 @@ def _register_model_source_path(config: Config, vllm_config: VllmConfig) -> str:
     if getattr(vllm_config.model_config, "model_weights", ""):
         return vllm_config.model_config.model
     return config.model
-
-
-def build_headless_namespace(config: Config) -> argparse.Namespace:
-    """Build an argparse Namespace from engine_args for vLLM's run_headless().
-
-    run_headless() expects the raw CLI namespace. We reconstruct it from
-    the already-parsed AsyncEngineArgs so parse_args() doesn't need to
-    leak transport details.
-    """
-    ns = argparse.Namespace(**vars(config.engine_args))
-    # run_headless() reads api_server_count; default to 0 (no API server)
-    if not hasattr(ns, "api_server_count"):
-        ns.api_server_count = 0
-    return ns
-
-
-def run_dynamo_headless(config: Config) -> None:
-    """Run in headless mode for multi-node TP/PP.
-
-    Secondary nodes spawn vLLM workers only — no engine core, no scheduler,
-    no Dynamo endpoints. Bypasses DistributedRuntime entirely (no NATS/etcd).
-    """
-    # Propagate worker_cls for custom load formats so headless workers use
-    # the same model loader settings as the leader node.
-    if config.engine_args.load_format == "gms":
-        config.engine_args.worker_cls = (
-            "gpu_memory_service.integrations.vllm.worker.GMSWorker"
-        )
-
-        if config.gms_shadow_mode:
-            from gpu_memory_service.integrations.vllm.utils import (
-                configure_gms_lock_mode,
-                configure_mx_ports,
-            )
-
-            os.environ["DYN_GMS_SCRATCH_KV_ENABLED"] = "1"
-            configure_gms_lock_mode(config.engine_args)
-            configure_mx_ports(config.engine_args)
-
-    # ModelExpress uses vLLM's plugin path with --load-format=modelexpress.
-    # Dynamo does not set a custom worker class here.
-
-    # Keep the upstream CLI import local so tests that only exercise
-    # build_headless_namespace() do not pull in vLLM's full CLI import graph.
-    from vllm.entrypoints.cli.serve import run_headless
-
-    args = build_headless_namespace(config)
-    run_headless(args)
 
 
 async def worker(argv: list[str] | None = None) -> None:

--- a/components/src/dynamo/vllm/tests/test_vllm_engine_routes.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine_routes.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -38,6 +39,7 @@ def _make_engine(include_scale: bool = False) -> VllmLLMEngine:
     engine._pause_controller = VllmEnginePauseController(engine_client)
     engine._pause_lock = asyncio.Lock()
     engine._scale_ep_lock = asyncio.Lock()
+    engine._scale_ep_in_progress = False
     return engine
 
 
@@ -115,3 +117,78 @@ async def test_scale_elastic_ep_validates_required_size_before_ray_import():
         "message": "Missing required field: new_data_parallel_size",
     }
     engine.engine_client.scale_elastic_ep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scale_elastic_ep_rejects_size_below_two():
+    engine = _make_engine(include_scale=True)
+
+    result = await engine.engine_control(
+        "scale_elastic_ep", {"new_data_parallel_size": 1}
+    )
+
+    assert result["status"] == "error"
+    assert ">= 2" in result["message"]
+    engine.engine_client.scale_elastic_ep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scale_elastic_ep_rejects_non_integer():
+    engine = _make_engine(include_scale=True)
+
+    result = await engine.engine_control(
+        "scale_elastic_ep", {"new_data_parallel_size": "four"}
+    )
+
+    assert result["status"] == "error"
+    assert "must be an integer" in result["message"]
+    engine.engine_client.scale_elastic_ep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scale_elastic_ep_rejects_concurrent_call():
+    engine = _make_engine(include_scale=True)
+    # Simulate a scale already running: the second caller must be rejected
+    # rather than queued (a queued caller GCs the first caller's TCPStore).
+    engine._scale_ep_in_progress = True
+
+    result = await engine.engine_control(
+        "scale_elastic_ep", {"new_data_parallel_size": 4}
+    )
+
+    assert result["status"] == "error"
+    assert "already in progress" in result["message"]
+    engine.engine_client.scale_elastic_ep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scale_elastic_ep_patches_and_restores_ray_list_nodes(monkeypatch):
+    engine = _make_engine(include_scale=True)
+
+    # The success path imports ray and swaps ray.util.state.list_nodes for a
+    # GCS-backed shim (works around ray --minimal lacking the dashboard HTTP
+    # server). Inject fakes so the path runs without a real cluster and assert
+    # the original list_nodes is restored afterward.
+    def sentinel_list_nodes(**kw):
+        return []
+
+    fake_state = SimpleNamespace(list_nodes=sentinel_list_nodes)
+    fake_util = SimpleNamespace(state=fake_state)
+    fake_ray = SimpleNamespace(nodes=lambda: [], util=fake_util)
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setitem(sys.modules, "ray.util", fake_util)
+    monkeypatch.setitem(sys.modules, "ray.util.state", fake_state)
+
+    result = await engine.engine_control(
+        "scale_elastic_ep", {"new_data_parallel_size": 4}
+    )
+
+    assert result == {
+        "status": "ok",
+        "message": "Scaled to data_parallel_size=4",
+        "new_data_parallel_size": 4,
+    }
+    engine.engine_client.scale_elastic_ep.assert_awaited_once_with(4)
+    # Patch must be restored even on the success path.
+    assert fake_state.list_nodes is sentinel_list_nodes
+    assert engine._scale_ep_in_progress is False

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("vllm.v1.engine.async_llm")
+pytest.importorskip("vllm.usage.usage_lib")
+
+import dynamo.vllm.unified_main as unified_main  # noqa: E402
+from dynamo.common.constants import DisaggregationMode  # noqa: E402
+from dynamo.vllm.llm_engine import VllmLLMEngine  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+]
+
+
+def test_main_routes_headless_to_run_dynamo_headless():
+    """A headless secondary node must bypass the Worker/engine path entirely
+    and hand off to vLLM's run_headless via run_dynamo_headless."""
+    config = SimpleNamespace(headless=True)
+    with (
+        patch.object(unified_main, "parse_args", return_value=config) as parse_args,
+        patch.object(unified_main, "run_dynamo_headless") as run_headless,
+        patch.object(unified_main, "run") as run,
+    ):
+        unified_main.main()
+
+    parse_args.assert_called_once()
+    run_headless.assert_called_once_with(config)
+    run.assert_not_called()
+
+
+def test_main_routes_normal_node_to_run():
+    """A non-headless node drives the unified Worker via run(VllmLLMEngine)."""
+    config = SimpleNamespace(headless=False)
+    with (
+        patch.object(unified_main, "parse_args", return_value=config) as parse_args,
+        patch.object(unified_main, "run_dynamo_headless") as run_headless,
+        patch.object(unified_main, "run") as run,
+    ):
+        unified_main.main()
+
+    parse_args.assert_called_once()
+    run_headless.assert_not_called()
+    run.assert_called_once_with(unified_main.VllmLLMEngine)
+
+
+@pytest.mark.asyncio
+async def test_from_args_rejects_headless_reaching_engine_path():
+    """Defense in depth: if a headless config reaches from_args (run() driven
+    directly, bypassing unified_main), fail loud instead of booting a full
+    backend on a workers-only node."""
+    config = SimpleNamespace(
+        headless=True,
+        disaggregation_mode=DisaggregationMode.AGGREGATED,
+    )
+    with patch("dynamo.vllm.llm_engine.parse_args", return_value=config):
+        with pytest.raises(NotImplementedError, match="headless"):
+            await VllmLLMEngine.from_args([])

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
@@ -48,7 +48,7 @@ def test_main_routes_normal_node_to_run():
 
     parse_args.assert_called_once()
     run_headless.assert_not_called()
-    run.assert_called_once_with(unified_main.VllmLLMEngine)
+    run.assert_called_once_with(unified_main.VllmLLMEngine, config=config)
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -36,7 +36,8 @@ def test_main_routes_headless_to_run_dynamo_headless():
     run.assert_not_called()
 
 
-def test_main_routes_normal_node_to_run():
+@pytest.mark.asyncio
+async def test_main_routes_normal_node_to_run():
     """A non-headless node drives the unified Worker via run(VllmLLMEngine)."""
     config = SimpleNamespace(headless=False)
     with (
@@ -48,7 +49,20 @@ def test_main_routes_normal_node_to_run():
 
     parse_args.assert_called_once()
     run_headless.assert_not_called()
-    run.assert_called_once_with(unified_main.VllmLLMEngine, config=config)
+    run.assert_called_once()
+    assert run.call_args.args == (unified_main.VllmLLMEngine,)
+
+    engine_factory = run.call_args.kwargs["engine_factory"]
+    expected = (MagicMock(), MagicMock())
+    with patch.object(
+        unified_main.VllmLLMEngine,
+        "from_args",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as from_args:
+        assert await engine_factory(["--model", "test-model"]) == expected
+
+    from_args.assert_awaited_once_with(["--model", "test-model"], config=config)
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -281,7 +281,7 @@ def test_headless_namespace_has_required_fields(mock_vllm_cli):
     config = parse_args()
     assert config.headless is True
 
-    from dynamo.vllm.main import build_headless_namespace
+    from dynamo.vllm.headless import build_headless_namespace
 
     ns = build_headless_namespace(config)
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -27,6 +27,7 @@ from dynamo.vllm.args import (
     update_engine_config_with_dynamo,
 )
 from dynamo.vllm.constants import DisaggregationMode
+from dynamo.vllm.headless import build_headless_namespace
 from dynamo.vllm.tests.conftest import make_cli_args_fixture
 
 # Get path relative to this test file
@@ -281,8 +282,6 @@ def test_headless_namespace_has_required_fields(mock_vllm_cli):
     config = parse_args()
     assert config.headless is True
 
-    from dynamo.vllm.headless import build_headless_namespace
-
     ns = build_headless_namespace(config)
 
     # Required by run_headless()
@@ -344,6 +343,7 @@ def test_unified_from_args_applies_rl_logprobs_default(monkeypatch):
         served_model_name="Qwen/Qwen3-0.6B",
         model="Qwen/Qwen3-0.6B",
         disaggregation_mode=CommonDisaggregationMode.AGGREGATED,
+        headless=False,
         component="backend",
         dyn_tool_call_parser=None,
         dyn_reasoning_parser=None,

--- a/components/src/dynamo/vllm/unified_main.py
+++ b/components/src/dynamo/vllm/unified_main.py
@@ -11,10 +11,20 @@ and feature gap details.
 """
 
 from dynamo.common.backend.run import run
+from dynamo.vllm.args import parse_args
+from dynamo.vllm.headless import run_dynamo_headless
 from dynamo.vllm.llm_engine import VllmLLMEngine
 
 
 def main():
+    # Headless secondary nodes (multi-node TP/PP with --data-parallel-backend
+    # mp) run vLLM workers only and never touch the DistributedRuntime, so they
+    # bypass the Worker/engine lifecycle entirely. Intercept before run() —
+    # which would otherwise build the full backend and register an endpoint.
+    config = parse_args()
+    if config.headless:
+        run_dynamo_headless(config)
+        return
     run(VllmLLMEngine)
 
 

--- a/components/src/dynamo/vllm/unified_main.py
+++ b/components/src/dynamo/vllm/unified_main.py
@@ -11,6 +11,7 @@ and feature gap details.
 """
 
 from dynamo.common.backend.run import run
+from dynamo.common.backend.worker import WorkerConfig
 from dynamo.vllm.args import parse_args
 from dynamo.vllm.headless import run_dynamo_headless
 from dynamo.vllm.llm_engine import VllmLLMEngine
@@ -25,8 +26,15 @@ def main():
     if config.headless:
         run_dynamo_headless(config)
         return
-    # Thread the already-parsed config through so from_args doesn't re-parse.
-    run(VllmLLMEngine, config=config)
+
+    async def from_parsed_args(
+        argv: list[str] | None = None,
+    ) -> tuple[VllmLLMEngine, WorkerConfig]:
+        return await VllmLLMEngine.from_args(argv, config=config)
+
+    # Construct from the already-parsed config without widening BaseEngine's
+    # generic from_args(argv) contract with vLLM-specific arguments.
+    run(VllmLLMEngine, engine_factory=from_parsed_args)
 
 
 if __name__ == "__main__":

--- a/components/src/dynamo/vllm/unified_main.py
+++ b/components/src/dynamo/vllm/unified_main.py
@@ -25,7 +25,8 @@ def main():
     if config.headless:
         run_dynamo_headless(config)
         return
-    run(VllmLLMEngine)
+    # Thread the already-parsed config through so from_args doesn't re-parse.
+    run(VllmLLMEngine, config=config)
 
 
 if __name__ == "__main__":

--- a/examples/backends/vllm/launch/elastic_ep.sh
+++ b/examples/backends/vllm/launch/elastic_ep.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Elastic Expert Parallelism (ePLB) on the unified vLLM backend.
+#
+# Brings up a single head-node backend with the Ray DP backend so the live
+# `scale_elastic_ep` control can spin DP-worker Ray actors up/down without a
+# pod restart. Elastic EP requires `--data-parallel-backend ray` (vLLM asserts
+# nnodes == 1 for the ray backend); for multi-node, join secondary nodes to the
+# Ray cluster out-of-band with `ray start --address=<head>` before launching —
+# the head node's engine schedules new DP ranks onto whichever cluster nodes
+# have free GPUs. This is distinct from `--headless` (mp-backend multi-node).
+#
+# Scale at runtime (control surface is served on DYN_SYSTEM_PORT):
+#   curl -X POST localhost:${DYN_SYSTEM_PORT:-8081}/engine/control/scale_elastic_ep \
+#        -H 'Content-Type: application/json' \
+#        -d '{"new_data_parallel_size": 4}'
+
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+
+# ---- Tunables (override via env vars) ----
+# Small MoE that exercises expert parallelism; override for larger models.
+MODEL="${MODEL:-Qwen/Qwen3-30B-A3B}"
+DP_SIZE="${DP_SIZE:-2}"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}"
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        --dp-size)
+            DP_SIZE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo "Options:"
+            echo "  --model <name>     Model (default: $MODEL)"
+            echo "  --dp-size <n>      Initial data-parallel size (default: $DP_SIZE)"
+            echo "  -h, --help         Show this help message"
+            echo ""
+            echo "Any additional options are passed through to unified_main."
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+print_launch_banner "Launching Elastic EP / ePLB (unified, DP=$DP_SIZE)" "$MODEL" "$HTTP_PORT"
+
+# Elastic EP requires vLLM's Ray DP backend (--data-parallel-backend ray), but
+# the vLLM runtime image does not ship ray. Ensure it is importable.
+python3 -c 'import ray' 2>/dev/null || { echo "ray not found; installing (required for elastic EP)..."; pip install -q ray; }
+
+# run ingress
+python -m dynamo.frontend --router-mode kv &
+
+# Elastic-EP head node on the unified backend.
+# --data-parallel-backend ray is required for scale_elastic_ep.
+# --enforce-eager is for quick deployment; remove for production.
+DYN_SYSTEM_PORT="$SYSTEM_PORT" \
+python3 -m dynamo.vllm.unified_main \
+    --model "$MODEL" \
+    --data-parallel-backend ray \
+    --data-parallel-size "$DP_SIZE" \
+    --enable-expert-parallel \
+    --enable-eplb \
+    --enable-elastic-ep \
+    --enforce-eager \
+    "${EXTRA_ARGS[@]}" &
+
+echo "All workers starting. (press Ctrl+C to stop)..."
+# Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
+wait_any_exit

--- a/examples/backends/vllm/launch/elastic_ep.sh
+++ b/examples/backends/vllm/launch/elastic_ep.sh
@@ -21,6 +21,7 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"    # build_vllm_gpu_mem_args
 source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
 
 # ---- Tunables (override via env vars) ----
@@ -58,11 +59,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# KV-cache sizing for VRAM-profiled CI runs (empty unless the profiling env var is set).
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+
 print_launch_banner "Launching Elastic EP / ePLB (unified, DP=$DP_SIZE)" "$MODEL" "$HTTP_PORT"
 
 # Elastic EP requires vLLM's Ray DP backend (--data-parallel-backend ray), but
-# the vLLM runtime image does not ship ray. Ensure it is importable.
-python3 -c 'import ray' 2>/dev/null || { echo "ray not found; installing (required for elastic EP)..."; pip install -q ray; }
+# the vLLM runtime image does not ship ray. Ensure it is importable. Pin to the
+# project's declared minimum (pyproject ai-dynamo[vllm]: ray>=2.55.0).
+python3 -c 'import ray' 2>/dev/null || { echo "ray not found; installing (required for elastic EP)..."; pip install -q "ray>=2.55.0"; }
 
 # run ingress
 python -m dynamo.frontend --router-mode kv &
@@ -79,6 +84,7 @@ python3 -m dynamo.vllm.unified_main \
     --enable-eplb \
     --enable-elastic-ep \
     --enforce-eager \
+    $GPU_MEM_ARGS \
     "${EXTRA_ARGS[@]}" &
 
 echo "All workers starting. (press Ctrl+C to stop)..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,6 +304,7 @@ markers = [
     "framework_with_gaie: marks tests for GAIE (Gateway API Inference Extension) deployment",
     "dynamocheckpoint: marks tests for the DynamoCheckpoint controller deploy path",
     "unified: marks unified-backend e2e tests (LLMEngine ABC + Worker, DEP #8251)",
+    "elastic_ep: marks vLLM elastic expert-parallelism (ePLB) scaling tests (scale_elastic_ep over the Ray DP backend)",
     # Built-in markers
     "skip: skip this test",
     "skipif: skip if condition is true",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,6 +222,15 @@ logging.basicConfig(
 
 def pytest_configure(config: pytest.Config) -> None:
     """Configure session: validate --models-dir and detect GPUs for --max-vram-gib."""
+    # Dual-register custom markers (also declared in pyproject
+    # [tool.pytest.ini_options].markers) so --strict-markers recognizes them
+    # regardless of config-load order. See .ai/pytest-guidelines.md.
+    config.addinivalue_line(
+        "markers",
+        "elastic_ep: marks vLLM elastic expert-parallelism (ePLB) scaling tests "
+        "(scale_elastic_ep over the Ray DP backend)",
+    )
+
     models_dir = config.getoption("--models-dir", default=None)
     if models_dir and not Path(models_dir).is_dir():
         pytest.exit(

--- a/tests/serve/launch/multi_node_tp_headless.sh
+++ b/tests/serve/launch/multi_node_tp_headless.sh
@@ -11,6 +11,16 @@ set -e
 trap 'echo "Cleaning up..."; kill 0' EXIT
 
 MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+WORKER_MODULE="dynamo.vllm"
+
+# --unified switches both nodes to the unified backend entry point
+# (dynamo.vllm.unified_main), exercising the unified headless code path.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --unified) WORKER_MODULE="dynamo.vllm.unified_main"; shift ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
 
 KV_BYTES="${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:-}"
 GPU_MEM_ARGS=""
@@ -21,8 +31,8 @@ fi
 echo "Starting Dynamo frontend..."
 python3 -m dynamo.frontend &
 
-echo "Starting dynamo.vllm head node (TP=2, nnodes=2, node-rank=0, GPU 0)..."
-CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
+echo "Starting ${WORKER_MODULE} head node (TP=2, nnodes=2, node-rank=0, GPU 0)..."
+CUDA_VISIBLE_DEVICES=0 python3 -m "${WORKER_MODULE}" \
   --model "${MODEL}" \
   --tensor-parallel-size 2 \
   --nnodes 2 \
@@ -31,8 +41,8 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
   --enforce-eager \
   $GPU_MEM_ARGS &
 
-echo "Starting dynamo.vllm headless worker (TP=2, nnodes=2, node-rank=1, GPU 1)..."
-CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
+echo "Starting ${WORKER_MODULE} headless worker (TP=2, nnodes=2, node-rank=1, GPU 1)..."
+CUDA_VISIBLE_DEVICES=1 python3 -m "${WORKER_MODULE}" \
   --model "${MODEL}" \
   --tensor-parallel-size 2 \
   --nnodes 2 \

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -195,24 +195,34 @@ vllm_configs = {
             # ceiling over model download + engine-core respawn.
             pytest.mark.timeout(1800),
             pytest.mark.model("Qwen/Qwen3-30B-A3B"),
-            # VRAM carve-out (.ai/test-model-size-guardrails.md): the 30B MoE is
-            # required to exercise real expert parallelism, and this runs on the
-            # dedicated gpu_4 nightly tier (large-VRAM, whole-node), not the
-            # 24 GiB bin-packed standard tier. profiled_vram_gib is omitted
-            # pending a profiling run; the test is not bin-packed by --max-vram-gib.
+            # DISABLED pending CI hardware. Elastic EP needs a real MoE with EPLB
+            # (`--enable-elastic-ep` requires `--enable-eplb`), and vLLM's EPLB
+            # only supports unquantized or FP8 experts — GPTQ/AWQ raise
+            # `NotImplementedError: EPLB is not supported ...`. The smallest
+            # EPLB-capable MoE (Qwen3-30B-A3B, bf16) needs ~57 GiB of weights per
+            # replica at TP=1, and DP=2->4 puts a full replica on each GPU, so it
+            # requires ~80 GiB/GPU. CI's only 4-GPU runner
+            # (prod-tester-amd-gpu-4-v2) has 24 GiB GPUs and OOMs at model load.
+            # Locally validated end-to-end on H200 GPUs with the pinned vLLM
+            # 0.24.0: initial serving, DP=2->4->2, and inference after each scale
+            # transition all pass. Keep this skipped until CI has a >=80 GiB
+            # 4-GPU runner.
+            pytest.mark.skip(
+                reason="Locally passes DP=2->4->2 on H200 with vLLM 0.24.0, but "
+                "needs a >=80 GiB 4-GPU runner (real EPLB MoE is ~57 GiB/GPU at "
+                "TP=1); CI's only 4-GPU runner is 24 GiB and OOMs at model load."
+            ),
         ],
-        # Small MoE that exercises expert parallelism; must match elastic_ep.sh's
+        # MoE that exercises real expert parallelism; must match elastic_ep.sh's
         # default so payload model-name injection resolves to the served model.
         model="Qwen/Qwen3-30B-A3B",
         request_payloads=[
             # Serving works at the initial DP size...
             chat_payload_default(repeat_count=1),
-            # ...scale up to 4 DP ranks and confirm generation survives.
-            # Scale-DOWN (4->2) is intentionally omitted: validated on 4xH100,
-            # scale-UP returns status:ok and keeps serving, but scale-DOWN never
-            # returns (hangs in vLLM 0.22.1's ray DP `_scale_down_elastic_ep`).
-            # Re-add a downscale payload once that's fixed upstream.
+            # ...scale up to 4 DP ranks and confirm generation survives...
             elastic_ep_scale_payload(new_data_parallel_size=4),
+            # ...then scale back down to 2 and confirm generation survives again.
+            elastic_ep_scale_payload(new_data_parallel_size=2),
         ],
     ),
     "aggregated_logprobs": VLLMConfig(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -195,6 +195,11 @@ vllm_configs = {
             # ceiling over model download + engine-core respawn.
             pytest.mark.timeout(1800),
             pytest.mark.model("Qwen/Qwen3-30B-A3B"),
+            # VRAM carve-out (.ai/test-model-size-guardrails.md): the 30B MoE is
+            # required to exercise real expert parallelism, and this runs on the
+            # dedicated gpu_4 nightly tier (large-VRAM, whole-node), not the
+            # 24 GiB bin-packed standard tier. profiled_vram_gib is omitted
+            # pending a profiling run; the test is not bin-packed by --max-vram-gib.
         ],
         # Small MoE that exercises expert parallelism; must match elastic_ep.sh's
         # default so payload model-name injection resolves to the served model.
@@ -639,7 +644,12 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.pre_merge,
             pytest.mark.unified,
-            # TODO: profile to get max_vram
+            # Conservative budget from the single-GPU Qwen3-0.6B profile
+            # (aggregated config); TP=2 splits weights across 2 GPUs so per-GPU
+            # peak is <= this. requested_vllm_kv_cache_bytes pins the KV cap for
+            # deterministic, bin-packable runs.
+            pytest.mark.profiled_vram_gib(3.8),
+            pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000),
             pytest.mark.timeout(300),
         ],
         model="Qwen/Qwen3-0.6B",

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -626,6 +626,28 @@ vllm_configs = {
             completion_payload_default(),
         ],
     ),
+    "multi_node_tp_headless_unified": VLLMConfig(
+        name="multi_node_tp_headless_unified",
+        directory=os.path.join(WORKSPACE_DIR, "tests/serve"),
+        script_name="multi_node_tp_headless.sh",
+        # --unified runs both nodes via dynamo.vllm.unified_main, so the
+        # headless worker exercises unified_main -> run_dynamo_headless (the
+        # unified backend's headless path, mock-only in unit tests).
+        script_args=["--unified"],
+        marks=[
+            pytest.mark.core,
+            pytest.mark.gpu_2,
+            pytest.mark.pre_merge,
+            pytest.mark.unified,
+            # TODO: profile to get max_vram
+            pytest.mark.timeout(300),
+        ],
+        model="Qwen/Qwen3-0.6B",
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+        ],
+    ),
     "guided_decoding": VLLMConfig(
         name="guided_decoding",
         directory=vllm_dir,

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -32,6 +32,7 @@ from tests.utils.payload_builder import (
     chat_payload_with_logprobs,
     completion_payload_default,
     completion_payload_with_logprobs,
+    elastic_ep_scale_payload,
     embedding_payload,
     embedding_payload_default,
     kv_events_metrics_payload,
@@ -175,6 +176,38 @@ vllm_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+        ],
+    ),
+    "elastic_ep_unified": VLLMConfig(
+        name="elastic_ep_unified",
+        directory=vllm_dir,
+        script_name="elastic_ep.sh",
+        # Start at DP=2 on a 4-GPU node so scale-up to 4 has headroom; the Ray
+        # DP backend places the new DP-worker actors on the free GPUs.
+        script_args=["--dp-size", "2"],
+        marks=[
+            pytest.mark.vllm,
+            pytest.mark.gpu_4,
+            pytest.mark.elastic_ep,
+            pytest.mark.unified,
+            pytest.mark.nightly,
+            # MoE weights + two live reconfigures (scale up then down); generous
+            # ceiling over model download + engine-core respawn.
+            pytest.mark.timeout(1800),
+            pytest.mark.model("Qwen/Qwen3-30B-A3B"),
+        ],
+        # Small MoE that exercises expert parallelism; must match elastic_ep.sh's
+        # default so payload model-name injection resolves to the served model.
+        model="Qwen/Qwen3-30B-A3B",
+        request_payloads=[
+            # Serving works at the initial DP size...
+            chat_payload_default(repeat_count=1),
+            # ...scale up to 4 DP ranks and confirm generation survives.
+            # Scale-DOWN (4->2) is intentionally omitted: validated on 4xH100,
+            # scale-UP returns status:ok and keeps serving, but scale-DOWN never
+            # returns (hangs in vLLM 0.22.1's ray DP `_scale_down_elastic_ep`).
+            # Re-add a downscale payload once that's fixed upstream.
+            elastic_ep_scale_payload(new_data_parallel_size=4),
         ],
     ),
     "aggregated_logprobs": VLLMConfig(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -644,12 +644,14 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.pre_merge,
             pytest.mark.unified,
-            # Conservative budget from the single-GPU Qwen3-0.6B profile
-            # (aggregated config); TP=2 splits weights across 2 GPUs so per-GPU
-            # peak is <= this. requested_vllm_kv_cache_bytes pins the KV cap for
-            # deterministic, bin-packable runs.
-            pytest.mark.profiled_vram_gib(3.8),
-            pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000),
+            # No profiled_vram_gib / requested_vllm_kv_cache_bytes here: the
+            # single-GPU Qwen3-0.6B values do not transfer to this TP=2 worker.
+            # requested_vllm_kv_cache_bytes forces --kv-cache-memory-bytes +
+            # --gpu-memory-utilization 0.01 onto BOTH ranks, which hangs the
+            # headless multi-node startup past the timeout (CI confirmed). Matches
+            # the legacy multi_node_tp_headless sibling, which is also unprofiled;
+            # real TP=2 profiling is needed before VRAM markers can be added.
+            # TODO: profile to get max_vram for the TP=2 headless topology.
             pytest.mark.timeout(300),
         ],
         model="Qwen/Qwen3-0.6B",

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -13,6 +13,7 @@ from tests.utils.payloads import (
     ChatPayloadWithLogprobs,
     CompletionPayload,
     CompletionPayloadWithLogprobs,
+    ElasticEPScalePayload,
     EmbeddingPayload,
     GuidedDecodingChatPayload,
     ImagesPayload,
@@ -766,4 +767,28 @@ def anthropic_messages_stream_payload_default(
         expected_log=expected_log or [],
         expected_response=expected_response
         or ["AI", "knock", "joke", "think", "artificial", "intelligence"],
+    )
+
+
+def elastic_ep_scale_payload(
+    new_data_parallel_size: int,
+    content: str = TEXT_PROMPT,
+    max_tokens: int = 64,
+    expected_response: Optional[List[str]] = None,
+    system_port: int = DefaultPort.SYSTEM1.value,
+    timeout: int = 300,
+) -> ElasticEPScalePayload:
+    """Scale the live data-parallel size, then verify a chat still completes."""
+    return ElasticEPScalePayload(
+        body={
+            "messages": [{"role": "user", "content": content}],
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "stream": False,
+        },
+        new_data_parallel_size=new_data_parallel_size,
+        system_port=system_port,
+        expected_response=expected_response
+        or ["AI", "knock", "joke", "think", "artificial", "intelligence"],
+        timeout=timeout,
     )

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -685,6 +685,71 @@ class LoraTestChatPayload(ChatPayload):
 
 
 @dataclass
+class ElasticEPScalePayload(ChatPayload):
+    """Scales the vLLM data-parallel size live, then verifies the worker still
+    serves a chat request post-scale.
+
+    POSTs ``/engine/control/scale_elastic_ep`` on the worker's system port
+    before the chat request (mirroring LoraTestChatPayload's admin-then-infer
+    pattern), so a single payload exercises both the scale control and that
+    generation survives the reconfigure. Requires a worker started with the Ray
+    DP backend + ePLB (see ``examples/backends/vllm/launch/elastic_ep.sh``).
+    """
+
+    def __init__(
+        self,
+        body: dict,
+        new_data_parallel_size: int,
+        system_port: int = DefaultPort.SYSTEM1.value,
+        repeat_count: int = 1,
+        expected_response: Optional[list] = None,
+        expected_log: Optional[list] = None,
+        timeout: int = 300,
+    ):
+        super().__init__(
+            body=body,
+            repeat_count=repeat_count,
+            expected_response=expected_response or [],
+            expected_log=expected_log or [],
+            timeout=timeout,
+        )
+        self.system_ports = [system_port]
+        self.new_data_parallel_size = new_data_parallel_size
+        self._scaled = False
+
+    def _ensure_scaled(self) -> None:
+        """Drive the scale control once before the first chat request."""
+        if self._scaled:
+            return
+        scale_url = (
+            f"http://{self.host}:{self.system_ports[0]}"
+            "/engine/control/scale_elastic_ep"
+        )
+        logger.info(
+            "Scaling elastic EP to data_parallel_size=%s via %s",
+            self.new_data_parallel_size,
+            scale_url,
+        )
+        response = requests.post(
+            scale_url,
+            json={"new_data_parallel_size": self.new_data_parallel_size},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        result = response.json()
+        assert result.get("status") == "ok", f"scale_elastic_ep failed: {result}"
+        assert (
+            result.get("new_data_parallel_size") == self.new_data_parallel_size
+        ), f"unexpected scale_elastic_ep result: {result}"
+        self._scaled = True
+
+    def url(self) -> str:
+        """Scale before the first chat request, then return the chat URL."""
+        self._ensure_scaled()
+        return super().url()
+
+
+@dataclass
 class CompletionPayload(BasePayload):
     """Payload for completions endpoint."""
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -737,10 +737,10 @@ class ElasticEPScalePayload(ChatPayload):
         )
         response.raise_for_status()
         result = response.json()
-        assert result.get("status") == "ok", f"scale_elastic_ep failed: {result}"
-        assert (
-            result.get("new_data_parallel_size") == self.new_data_parallel_size
-        ), f"unexpected scale_elastic_ep result: {result}"
+        if result.get("status") != "ok":
+            raise RuntimeError(f"scale_elastic_ep failed: {result}")
+        if result.get("new_data_parallel_size") != self.new_data_parallel_size:
+            raise RuntimeError(f"unexpected scale_elastic_ep result: {result}")
         self._scaled = True
 
     def url(self) -> str:

--- a/tests/utils/test_elastic_ep_scale_payload.py
+++ b/tests/utils/test_elastic_ep_scale_payload.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from tests.utils import payloads as payloads_mod
+from tests.utils.constants import DefaultPort
 from tests.utils.payloads import ElasticEPScalePayload
 
 pytestmark = [
@@ -25,7 +26,9 @@ pytestmark = [
 ]
 
 
-def _make_payload(*, new_dp: int = 4, system_port: int = 8081) -> ElasticEPScalePayload:
+def _make_payload(
+    *, new_dp: int = 4, system_port: int = DefaultPort.SYSTEM1.value
+) -> ElasticEPScalePayload:
     return ElasticEPScalePayload(
         body={
             "model": "m",
@@ -62,14 +65,14 @@ def capture_post(monkeypatch):
 def test_url_triggers_scale_then_returns_chat_url(capture_post):
     """url() POSTs to the control route on the system port, then returns the
     chat-completions URL on the frontend port."""
-    payload = _make_payload(new_dp=4, system_port=8081)
+    payload = _make_payload(new_dp=4, system_port=DefaultPort.SYSTEM1.value)
 
     url = payload.url()
 
     assert len(capture_post) == 1
     assert (
         capture_post[0]["url"]
-        == "http://localhost:8081/engine/control/scale_elastic_ep"
+        == f"http://localhost:{DefaultPort.SYSTEM1.value}/engine/control/scale_elastic_ep"
     )
     assert capture_post[0]["json"] == {"new_data_parallel_size": 4}
     assert url.endswith("/v1/chat/completions")
@@ -87,7 +90,7 @@ def test_scale_runs_once_across_repeats(capture_post):
 
 
 def test_scale_error_status_raises(monkeypatch):
-    """A non-ok scale response surfaces as an assertion, not a silent pass."""
+    """A non-ok scale response surfaces as an error, not a silent pass."""
 
     def fake_post(url: str, json: Any = None, timeout: float = 0) -> Any:
         resp = MagicMock()
@@ -98,5 +101,5 @@ def test_scale_error_status_raises(monkeypatch):
     monkeypatch.setattr(payloads_mod.requests, "post", fake_post)
     payload = _make_payload()
 
-    with pytest.raises(AssertionError, match="scale_elastic_ep failed"):
+    with pytest.raises(RuntimeError, match="scale_elastic_ep failed"):
         payload.url()

--- a/tests/utils/test_elastic_ep_scale_payload.py
+++ b/tests/utils/test_elastic_ep_scale_payload.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``ElasticEPScalePayload``.
+
+Exercise the scale-control POST + chat-url handoff without a GPU or a real
+worker. We monkeypatch ``requests.post`` to mimic the
+``/engine/control/scale_elastic_ep`` response and assert the payload POSTs the
+right body to the right route, scales exactly once across repeats, and then
+yields the chat-completions URL on the frontend port.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.utils import payloads as payloads_mod
+from tests.utils.payloads import ElasticEPScalePayload
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+def _make_payload(*, new_dp: int = 4, system_port: int = 8081) -> ElasticEPScalePayload:
+    return ElasticEPScalePayload(
+        body={
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 4,
+        },
+        new_data_parallel_size=new_dp,
+        system_port=system_port,
+        expected_response=["hello"],
+    )
+
+
+@pytest.fixture
+def capture_post(monkeypatch):
+    """Install a fake ``requests.post`` that echoes a successful scale response
+    and records each call."""
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(url: str, json: Any = None, timeout: float = 0) -> Any:
+        calls.append({"url": url, "json": json})
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {
+            "status": "ok",
+            "message": f"Scaled to data_parallel_size={json['new_data_parallel_size']}",
+            "new_data_parallel_size": json["new_data_parallel_size"],
+        }
+        return resp
+
+    monkeypatch.setattr(payloads_mod.requests, "post", fake_post)
+    return calls
+
+
+def test_url_triggers_scale_then_returns_chat_url(capture_post):
+    """url() POSTs to the control route on the system port, then returns the
+    chat-completions URL on the frontend port."""
+    payload = _make_payload(new_dp=4, system_port=8081)
+
+    url = payload.url()
+
+    assert len(capture_post) == 1
+    assert (
+        capture_post[0]["url"]
+        == "http://localhost:8081/engine/control/scale_elastic_ep"
+    )
+    assert capture_post[0]["json"] == {"new_data_parallel_size": 4}
+    assert url.endswith("/v1/chat/completions")
+
+
+def test_scale_runs_once_across_repeats(capture_post):
+    """The _scaled guard means repeated url() calls scale only once."""
+    payload = _make_payload(new_dp=4)
+
+    payload.url()
+    payload.url()
+    payload.url()
+
+    assert len(capture_post) == 1
+
+
+def test_scale_error_status_raises(monkeypatch):
+    """A non-ok scale response surfaces as an assertion, not a silent pass."""
+
+    def fake_post(url: str, json: Any = None, timeout: float = 0) -> Any:
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"status": "error", "message": "boom"}
+        return resp
+
+    monkeypatch.setattr(payloads_mod.requests, "post", fake_post)
+    payload = _make_payload()
+
+    with pytest.raises(AssertionError, match="scale_elastic_ep failed"):
+        payload.url()


### PR DESCRIPTION
## Overview:

Brings two vLLM features to the **unified backend** (`unified_main` / `LLMEngine` + Rust `Worker`) at parity with the legacy path: **headless multi-node** workers and live **elastic EP (ePLB) scaling**. Also corrects the unified-backend README parity table, adds a launch example, and wires unit + GPU integration tests through the existing nightly multi-GPU job.

## Details:

**Headless multi-node**
- `unified_main` routes `--headless` to `run_dynamo_headless` before the Worker/engine path; the helpers (`build_headless_namespace` + `run_dynamo_headless`) are extracted to a shared `dynamo/vllm/headless.py` and reused by legacy `main.py` (no behavior change).
- `VllmLLMEngine.from_args` gains a defense-in-depth guard that fails loud if a headless config reaches the engine path.

**Elastic EP scaling**
- `scale_elastic_ep` control at parity with the legacy handler: `new_data_parallel_size` validation, a single-flight lock (concurrent scales rejected, not queued), and the `ray.util.state.list_nodes` → `ray.nodes()` shim for ray `--minimal`. Served at `/engine/control/scale_elastic_ep`.
- Requires vLLM's Ray DP backend (`--data-parallel-backend ray`) and `ray` installed — which is **not** in the vLLM runtime image, so `examples/backends/vllm/launch/elastic_ep.sh` installs it if missing.
- Scale-**up** (2→4) and scale-**down** (4→2) are locally validated end-to-end on H200 GPUs with vLLM 0.24.0; serving continues after both transitions. The CI test remains skipped because the available four-GPU runner has 24 GiB per GPU, while the unquantized Qwen3-30B-A3B EPLB test needs at least 80 GiB per GPU for weights and runtime headroom.

**Docs & tooling**
- Corrected the unified-backend README parity table (sleep/wake, elastic EP, and `--headless` are no longer listed as gaps).
- New `elastic_ep` pytest marker; the test is collected by the existing nightly `vllm-multi-gpu-test` job. The integration test remains pytest-skipped until CI has a runner with at least 80 GiB per GPU.

**Testing** (locally GPU-validated)
- Unit (pre-merge): headless routing, `from_args` guard, `scale_elastic_ep` validation / lock / Ray-patch parity, and `ElasticEPScalePayload` — **15 passed**.
- Unified-headless e2e (`gpu_2` / pre-merge, `multi_node_tp_headless_unified`): head + headless worker rendezvous at TP=2 and serve a chat completion — **validated**.
- Elastic-EP e2e (local H200, vLLM 0.24.0, `elastic_ep_unified`): DP 2→4→2 returns `status:ok` and serving continues after both transitions — **1 passed in 191.74s**. The CI configuration remains skipped because its 24 GiB GPUs cannot run this unquantized EPLB model at TP=1.

## Where should the reviewer start?

- `components/src/dynamo/vllm/unified_main.py` + `components/src/dynamo/vllm/headless.py` — headless routing and the shared extraction.
- `components/src/dynamo/vllm/llm_engine.py` — the `from_args` headless guard.
- `examples/backends/vllm/launch/elastic_ep.sh` — elastic-EP launch flags (Ray DP backend, ePLB, `--enable-elastic-ep`, ray precheck).
- `tests/serve/test_vllm.py` and `tests/utils/payloads.py` (`ElasticEPScalePayload`) — integration configs, including the locally validated 2→4→2 sequence and the CI hardware skip.
- `.github/workflows/nightly-ci.yml` — Elastic EP collection in the existing `vllm-multi-gpu-test` job.

## Related Issues

Relates to [DIS-2036: vLLM — add elastic EP scaling support](https://linear.app/nvidia/issue/DIS-2036/vllm-add-elastic-ep-scaling-support)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Elastic Expert Parallelism (ePLB) with Ray-based data-parallel scaling and dynamic cluster resizing
  * Enabled headless multi-node deployment configurations for distributed vLLM workloads

* **Tests**
  * Added comprehensive test coverage for elastic data-parallel scaling operations
  * Extended test suite to validate headless worker execution paths
  * Added unified execution mode testing for multi-node deployments

* **Documentation**
  * Updated feature documentation to reflect newly supported capabilities: sleep/wake, elastic EP scaling, and headless multi-node deployments

* **Chores**
  * Integrated Elastic EP test collection into the existing multi-GPU workflow
  * Added pytest markers for elastic EP test categorization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->