### PR TITLE
perf(kv-router): avoid redundant CRTC suffix invalidation

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node_state.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node_state.rs
@@ -46,9 +46,13 @@ impl NodeState {
             || matches!(self.worker_cutoffs.get(&worker), Some(&cutoff) if pos < cutoff)
     }
 
-    fn uncovered_suffix_hashes(&self, cutoff: usize) -> Vec<ExternalSequenceBlockHash> {
-        debug_assert!(cutoff <= self.edge.len());
-        self.edge[cutoff..].iter().map(|&(_, hash)| hash).collect()
+    fn uncovered_suffix_hashes(&self, start: usize, end: usize) -> Vec<ExternalSequenceBlockHash> {
+        debug_assert!(start <= end);
+        debug_assert!(end <= self.edge.len());
+        self.edge[start..end]
+            .iter()
+            .map(|&(_, hash)| hash)
+            .collect()
     }
 
     #[inline]
@@ -183,7 +187,7 @@ impl NodeState {
         }
 
         let new_cutoff = pos;
-        let stale_hashes = self.uncovered_suffix_hashes(new_cutoff);
+        let stale_hashes = self.uncovered_suffix_hashes(new_cutoff, current_cutoff);
 
         if new_cutoff == 0 {
             self.drop_worker(worker);
@@ -197,5 +201,63 @@ impl NodeState {
 
     pub(super) fn has_any_workers(&self) -> bool {
         !self.full_edge_workers.is_empty() || !self.worker_cutoffs.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worker() -> WorkerWithDpRank {
+        WorkerWithDpRank::new(1, 0)
+    }
+
+    fn ext(hash: u64) -> ExternalSequenceBlockHash {
+        ExternalSequenceBlockHash(hash)
+    }
+
+    fn state_with_full_worker() -> NodeState {
+        let edge = vec![
+            (LocalBlockHash(1), ext(10)),
+            (LocalBlockHash(2), ext(20)),
+            (LocalBlockHash(3), ext(30)),
+            (LocalBlockHash(4), ext(40)),
+        ];
+        let mut full_edge_workers = FxHashSet::default();
+        full_edge_workers.insert(worker());
+        NodeState {
+            edge_index: NodeState::edge_index_for(&edge),
+            edge,
+            worker_cutoffs: FxHashMap::default(),
+            full_edge_workers,
+        }
+    }
+
+    #[test]
+    fn reverse_order_removes_only_report_newly_uncovered_hashes() {
+        let mut state = state_with_full_worker();
+        let worker = worker();
+
+        let outcome = state.remove_worker_at_pos(worker, 3, ext(40));
+        assert_eq!(outcome.stale_hashes, vec![ext(40)]);
+        assert_eq!(state.current_cutoff(worker), 3);
+
+        let outcome = state.remove_worker_at_pos(worker, 2, ext(30));
+        assert_eq!(outcome.stale_hashes, vec![ext(30)]);
+        assert_eq!(state.current_cutoff(worker), 2);
+
+        let outcome = state.remove_worker_at_pos(worker, 1, ext(20));
+        assert_eq!(outcome.stale_hashes, vec![ext(20)]);
+        assert_eq!(state.current_cutoff(worker), 1);
+    }
+
+    #[test]
+    fn head_remove_still_reports_full_newly_uncovered_suffix() {
+        let mut state = state_with_full_worker();
+        let worker = worker();
+
+        let outcome = state.remove_worker_at_pos(worker, 1, ext(20));
+        assert_eq!(outcome.stale_hashes, vec![ext(20), ext(30), ext(40)]);
+        assert_eq!(state.current_cutoff(worker), 1);
     }
 }


### PR DESCRIPTION

## Summary
- Limit CRTC worker lookup invalidation on partial removes to the newly uncovered suffix instead of the whole remaining edge.
- Avoid repeatedly removing lookup entries for suffix blocks that were already uncovered by earlier leaf-to-root remove events.
- Add unit coverage for reverse-order removes and head removes.

## Benchmark
AgentX 060526, block size 1, one frontend on cores 0-3, four mockers plus AIPerf on cores 4-23, request plane TCP/msgpack, event plane NATS/msgpack.

No TTL side indexer:
- c128: 31.16 -> 37.59 req/s (+20.6%), 0% errors both; frontend CPU 72.2% -> 32.7%.
- c144: 31.61 -> 38.23 req/s (+20.9%), 0% errors both; frontend CPU 75.9% -> 35.1%.
- c160/c192: baseline hit 18-20% errors; patched stayed at 0% errors.

With --router-predicted-ttl-secs 5:
- c96: baseline 17.79 req/s with 9.0% errors; patched 28.99 req/s with 0% errors.
- c128 remained invalid in both paths, so TTL mode still needs additional side-indexer/prune work.

## Validation
- cargo test -p dynamo-kv-router concurrent_radix_tree_compressed --lib
- cargo test -p dynamo-kv-router --lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of hash tracking in the indexer when removing worker coverage. The system now correctly identifies only newly uncovered hashes rather than reporting the entire uncovered range, resulting in more precise state reporting.

* **Tests**
  * Added tests to validate hash reporting behavior during worker removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->