### PR TITLE
ci(snapshot): add SGLang DynamoCheckpoint coverage

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -730,8 +730,6 @@ jobs:
         hf_token: ${{ secrets.HF_TOKEN }}
         dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
         dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-        checkpoint_enabled: 'true'
-        checkpoint_storage_size: 64Gi
 
   deploy-test-vllm:
     needs: [deploy-operator, vllm-copy-to-acr]
@@ -769,12 +767,70 @@ jobs:
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
 
-  deploy-snapshot-agent:
-    name: Snapshot Agent Deploy Setup
-    needs: [deploy-operator, snapshot-agent]
+  deploy-operator-checkpoint-vllm:
+    name: vLLM DynamoCheckpoint Operator Setup
+    needs: [operator]
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: prod-deploy-tester-v1
+    permissions:
+      contents: read
+    outputs:
+      namespace: ${{ steps.setup.outputs.namespace }}
+      vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
+      operator_tag: ${{ steps.setup.outputs.operator_tag }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Setup vCluster and operator
+      id: setup
+      uses: ./.github/actions/setup-dynamo-operator
+      with:
+        vcluster_name: ci-${{ github.run_id }}-checkpoint-vllm
+        vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-vllm-dt
+        registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+        operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
+        hf_token: ${{ secrets.HF_TOKEN }}
+        dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+        dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        checkpoint_enabled: 'true'
+        checkpoint_storage_size: 64Gi
+
+  deploy-operator-checkpoint-sglang:
+    name: SGLang DynamoCheckpoint Operator Setup
+    needs: [operator]
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: prod-deploy-tester-v1
+    permissions:
+      contents: read
+    outputs:
+      namespace: ${{ steps.setup.outputs.namespace }}
+      vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
+      operator_tag: ${{ steps.setup.outputs.operator_tag }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Setup vCluster and operator
+      id: setup
+      uses: ./.github/actions/setup-dynamo-operator
+      with:
+        vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
+        vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
+        registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+        operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
+        hf_token: ${{ secrets.HF_TOKEN }}
+        dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+        dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        checkpoint_enabled: 'true'
+        checkpoint_storage_size: 64Gi
+
+  deploy-snapshot-agent-checkpoint-vllm:
+    name: vLLM DynamoCheckpoint Snapshot Agent Setup
+    needs: [deploy-operator-checkpoint-vllm, snapshot-agent]
     if: |
       github.event_name != 'workflow_dispatch' &&
-      needs.deploy-operator.result == 'success' &&
+      needs.deploy-operator-checkpoint-vllm.result == 'success' &&
       needs.snapshot-agent.result == 'success'
     runs-on: prod-deploy-tester-v1
     timeout-minutes: 15
@@ -789,16 +845,16 @@ jobs:
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-dynamo-operator
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-vllm.outputs.operator_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -808,8 +864,56 @@ jobs:
         id: connect-vcluster
         uses: ./.github/actions/connect-vcluster
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
+      - name: Install snapshot-agent
+        uses: ./.github/actions/setup-snapshot-agent
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+
+  deploy-snapshot-agent-checkpoint-sglang:
+    name: SGLang DynamoCheckpoint Snapshot Agent Setup
+    needs: [deploy-operator-checkpoint-sglang, snapshot-agent]
+    if: |
+      github.event_name != 'workflow_dispatch' &&
+      needs.deploy-operator-checkpoint-sglang.result == 'success' &&
+      needs.snapshot-agent.result == 'success'
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Check if vCluster exists
+        id: vcluster-check
+        uses: ./.github/actions/check-vcluster-exists
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
+      - name: Self-bootstrap vCluster (rerun)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-sglang.outputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+      - name: Connect to vCluster
+        id: connect-vcluster
+        uses: ./.github/actions/connect-vcluster
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Install snapshot-agent
         uses: ./.github/actions/setup-snapshot-agent
         with:
@@ -819,10 +923,10 @@ jobs:
 
   deploy-test-checkpoint-vllm:
     name: vLLM DynamoCheckpoint Deploy Test
-    needs: [deploy-operator, deploy-snapshot-agent, snapshot-placeholder-vllm, frontend-copy-to-acr]
+    needs: [deploy-operator-checkpoint-vllm, deploy-snapshot-agent-checkpoint-vllm, snapshot-placeholder-vllm, frontend-copy-to-acr]
     if: |
       always() && !cancelled() &&
-      needs.deploy-snapshot-agent.result == 'success' &&
+      needs.deploy-snapshot-agent-checkpoint-vllm.result == 'success' &&
       needs.snapshot-placeholder-vllm.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
     runs-on: prod-deploy-tester-v1
@@ -838,16 +942,16 @@ jobs:
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-dynamo-operator
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-vllm.outputs.operator_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -857,8 +961,8 @@ jobs:
         id: connect-vcluster
         uses: ./.github/actions/connect-vcluster
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-snapshot-agent
@@ -872,7 +976,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-vllm.outputs.operator_tag }}
           framework: checkpoint
           profile: dgd_restore
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-placeholder
@@ -885,10 +989,10 @@ jobs:
 
   deploy-test-checkpoint-sglang:
     name: SGLang DynamoCheckpoint Deploy Test
-    needs: [deploy-operator, deploy-snapshot-agent, snapshot-placeholder-sglang, frontend-copy-to-acr]
+    needs: [deploy-operator-checkpoint-sglang, deploy-snapshot-agent-checkpoint-sglang, snapshot-placeholder-sglang, frontend-copy-to-acr]
     if: |
       always() && !cancelled() &&
-      needs.deploy-snapshot-agent.result == 'success' &&
+      needs.deploy-snapshot-agent-checkpoint-sglang.result == 'success' &&
       needs.snapshot-placeholder-sglang.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
     runs-on: prod-deploy-tester-v1
@@ -904,16 +1008,16 @@ jobs:
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-dynamo-operator
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-sglang.outputs.operator_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -923,8 +1027,8 @@ jobs:
         id: connect-vcluster
         uses: ./.github/actions/connect-vcluster
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-snapshot-agent
@@ -938,7 +1042,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-sglang.outputs.operator_tag }}
           framework: checkpoint
           profile: dgd_restore
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-placeholder
@@ -951,7 +1055,7 @@ jobs:
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, deploy-test-checkpoint-vllm, deploy-test-checkpoint-sglang, deploy-test-gaie]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-gaie]
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -963,6 +1067,36 @@ jobs:
       with:
         vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
         vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+
+  deploy-cleanup-checkpoint-vllm:
+    name: vLLM DynamoCheckpoint Cleanup
+    if: always() && github.event_name != 'workflow_dispatch'
+    needs: [deploy-operator-checkpoint-vllm, deploy-snapshot-agent-checkpoint-vllm, deploy-test-checkpoint-vllm]
+    runs-on: prod-deploy-tester-v1
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Teardown vCluster
+      uses: ./.github/actions/teardown-dynamo-operator
+      with:
+        vcluster_name: ci-${{ github.run_id }}-checkpoint-vllm
+        vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-vllm-dt
+
+  deploy-cleanup-checkpoint-sglang:
+    name: SGLang DynamoCheckpoint Cleanup
+    if: always() && github.event_name != 'workflow_dispatch'
+    needs: [deploy-operator-checkpoint-sglang, deploy-snapshot-agent-checkpoint-sglang, deploy-test-checkpoint-sglang]
+    runs-on: prod-deploy-tester-v1
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Teardown vCluster
+      uses: ./.github/actions/teardown-dynamo-operator
+      with:
+        vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
+        vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
 
   # ============================================================================
   # GAIE DEPLOY TEST
@@ -1027,7 +1161,24 @@ jobs:
 
   deploy-status-check:
     runs-on: ubuntu-latest
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, snapshot-placeholder-vllm, snapshot-placeholder-sglang, frontend-copy-to-acr, deploy-test-checkpoint-vllm, deploy-test-checkpoint-sglang, deploy-test-gaie, deploy-cleanup]
+    needs:
+      - deploy-operator
+      - deploy-test-vllm
+      - deploy-test-sglang
+      - deploy-test-trtllm
+      - deploy-operator-checkpoint-vllm
+      - deploy-operator-checkpoint-sglang
+      - deploy-snapshot-agent-checkpoint-vllm
+      - deploy-snapshot-agent-checkpoint-sglang
+      - snapshot-placeholder-vllm
+      - snapshot-placeholder-sglang
+      - frontend-copy-to-acr
+      - deploy-test-checkpoint-vllm
+      - deploy-test-checkpoint-sglang
+      - deploy-test-gaie
+      - deploy-cleanup
+      - deploy-cleanup-checkpoint-vllm
+      - deploy-cleanup-checkpoint-sglang
     if: always()
     steps:
       - name: "Check all deploy test jobs"

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -780,8 +780,6 @@ jobs:
       operator_tag: ${{ steps.setup.outputs.operator_tag }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        persist-credentials: false
     - name: Setup vCluster and operator
       id: setup
       uses: ./.github/actions/setup-dynamo-operator
@@ -809,8 +807,6 @@ jobs:
       operator_tag: ${{ steps.setup.outputs.operator_tag }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        persist-credentials: false
     - name: Setup vCluster and operator
       id: setup
       uses: ./.github/actions/setup-dynamo-operator
@@ -839,8 +835,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Check if vCluster exists
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
@@ -887,8 +881,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Check if vCluster exists
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
@@ -936,8 +928,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Check if vCluster exists
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
@@ -1002,8 +992,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Check if vCluster exists
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
@@ -1075,8 +1063,6 @@ jobs:
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        persist-credentials: false
     - name: Teardown vCluster
       uses: ./.github/actions/teardown-dynamo-operator
       with:
@@ -1090,8 +1076,6 @@ jobs:
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        persist-credentials: false
     - name: Teardown vCluster
       uses: ./.github/actions/teardown-dynamo-operator
       with:

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -581,8 +581,8 @@ jobs:
       copy_timeout_minutes: 20
     secrets: inherit
 
-  snapshot-placeholder:
-    name: Snapshot Placeholder
+  snapshot-placeholder-vllm:
+    name: vLLM Snapshot Placeholder
     needs: [vllm-copy-to-acr]
     if: github.event_name != 'workflow_dispatch'
     runs-on: prod-default-v2
@@ -628,6 +628,33 @@ jobs:
       cuda_version: '["13.0"]' # Deploy tests only use CUDA 13
       copy_timeout_minutes: 20
     secrets: inherit
+
+  snapshot-placeholder-sglang:
+    name: SGLang Snapshot Placeholder
+    needs: [sglang-copy-to-acr]
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: prod-default-v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build and push snapshot placeholder
+        uses: ./.github/actions/build-deploy-component
+        with:
+          component: snapshot
+          target: placeholder
+          image_tag: ${{ github.sha }}-sglang-placeholder
+          builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+          extra_tags: |
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-placeholder
+          extra_build_args: |
+            BASE_IMAGE=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-runtime
 
   sglang-dev-copy-to-acr:
     name: sglang-dev # This name overlaps with other sglang jobs to group them in the UI
@@ -790,13 +817,13 @@ jobs:
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
 
-  deploy-test-checkpoint:
-    name: DynamoCheckpoint Deploy Test
-    needs: [deploy-operator, deploy-snapshot-agent, snapshot-placeholder, frontend-copy-to-acr]
+  deploy-test-checkpoint-vllm:
+    name: vLLM DynamoCheckpoint Deploy Test
+    needs: [deploy-operator, deploy-snapshot-agent, snapshot-placeholder-vllm, frontend-copy-to-acr]
     if: |
       always() && !cancelled() &&
       needs.deploy-snapshot-agent.result == 'success' &&
-      needs.snapshot-placeholder.result == 'success' &&
+      needs.snapshot-placeholder-vllm.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
     runs-on: prod-deploy-tester-v1
     timeout-minutes: 30
@@ -849,15 +876,82 @@ jobs:
           framework: checkpoint
           profile: dgd_restore
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-placeholder
-          test_name: checkpoint_dgd_restore
+          test_name: checkpoint_dgd_restore_vllm
           test_file: tests/deploy/test_dynamocheckpoint.py
           extra_pytest_args: >-
             -m dynamocheckpoint
+            --checkpoint-backend=vllm
+            --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-dynamo-frontend
+
+  deploy-test-checkpoint-sglang:
+    name: SGLang DynamoCheckpoint Deploy Test
+    needs: [deploy-operator, deploy-snapshot-agent, snapshot-placeholder-sglang, frontend-copy-to-acr]
+    if: |
+      always() && !cancelled() &&
+      needs.deploy-snapshot-agent.result == 'success' &&
+      needs.snapshot-placeholder-sglang.result == 'success' &&
+      needs.frontend-copy-to-acr.result == 'success'
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Check if vCluster exists
+        id: vcluster-check
+        uses: ./.github/actions/check-vcluster-exists
+        with:
+          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+      - name: Self-bootstrap vCluster (rerun)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+      - name: Connect to vCluster
+        id: connect-vcluster
+        uses: ./.github/actions/connect-vcluster
+        with:
+          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+      - name: Install snapshot-agent (rerun bootstrap)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-snapshot-agent
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+      - name: Run DynamoCheckpoint Deploy Test
+        uses: ./.github/actions/dynamo-deploy-test
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          framework: checkpoint
+          profile: dgd_restore
+          image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-placeholder
+          test_name: checkpoint_dgd_restore_sglang
+          test_file: tests/deploy/test_dynamocheckpoint.py
+          extra_pytest_args: >-
+            -m dynamocheckpoint
+            --checkpoint-backend=sglang
             --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-dynamo-frontend
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, deploy-test-checkpoint, deploy-test-gaie]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, deploy-test-checkpoint-vllm, deploy-test-checkpoint-sglang, deploy-test-gaie]
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -933,7 +1027,7 @@ jobs:
 
   deploy-status-check:
     runs-on: ubuntu-latest
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, snapshot-placeholder, frontend-copy-to-acr, deploy-test-checkpoint, deploy-test-gaie, deploy-cleanup]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, snapshot-placeholder-vllm, snapshot-placeholder-sglang, frontend-copy-to-acr, deploy-test-checkpoint-vllm, deploy-test-checkpoint-sglang, deploy-test-gaie, deploy-cleanup]
     if: always()
     steps:
       - name: "Check all deploy test jobs"
@@ -948,7 +1042,7 @@ jobs:
     name: Clean K8s builder if exists
     runs-on: prod-default-small-v2
     if: always()
-    needs: [vllm-build, sglang-build, trtllm-build, vllm-dev-build, sglang-dev-build, trtllm-dev-build, vllm-efa-build, sglang-efa-build, trtllm-efa-build, operator, snapshot-agent, snapshot-placeholder, frontend-build, planner-build]
+    needs: [vllm-build, sglang-build, trtllm-build, vllm-dev-build, sglang-dev-build, trtllm-dev-build, vllm-efa-build, sglang-efa-build, trtllm-efa-build, operator, snapshot-agent, snapshot-placeholder-vllm, snapshot-placeholder-sglang, frontend-build, planner-build]
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -859,8 +859,6 @@ jobs:
       operator_tag: ${{ steps.setup.outputs.operator_tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Setup vCluster and operator
         id: setup
         uses: ./.github/actions/setup-dynamo-operator
@@ -893,8 +891,6 @@ jobs:
       operator_tag: ${{ steps.setup.outputs.operator_tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Setup vCluster and operator
         id: setup
         uses: ./.github/actions/setup-dynamo-operator
@@ -926,8 +922,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Check if vCluster exists
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
@@ -977,8 +971,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Check if vCluster exists
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
@@ -1029,8 +1021,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Check if vCluster exists
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
@@ -1098,8 +1088,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Check if vCluster exists
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
@@ -1175,8 +1163,6 @@ jobs:
     runs-on: prod-deploy-tester-v1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Teardown vCluster
         uses: ./.github/actions/teardown-dynamo-operator
         with:
@@ -1194,8 +1180,6 @@ jobs:
     runs-on: prod-deploy-tester-v1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
       - name: Teardown vCluster
         uses: ./.github/actions/teardown-dynamo-operator
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -89,7 +89,23 @@ jobs:
 
   deploy-status-check:
     runs-on: ubuntu-latest
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, snapshot-placeholder-vllm, snapshot-placeholder-sglang, frontend-copy-to-acr, deploy-test-checkpoint-vllm, deploy-test-checkpoint-sglang, deploy-cleanup]
+    needs:
+      - deploy-operator
+      - deploy-test-vllm
+      - deploy-test-sglang
+      - deploy-test-trtllm
+      - deploy-operator-checkpoint-vllm
+      - deploy-operator-checkpoint-sglang
+      - deploy-snapshot-agent-checkpoint-vllm
+      - deploy-snapshot-agent-checkpoint-sglang
+      - snapshot-placeholder-vllm
+      - snapshot-placeholder-sglang
+      - frontend-copy-to-acr
+      - deploy-test-checkpoint-vllm
+      - deploy-test-checkpoint-sglang
+      - deploy-cleanup
+      - deploy-cleanup-checkpoint-vllm
+      - deploy-cleanup-checkpoint-sglang
     if: always()
     steps:
       - name: Check all deploy test jobs
@@ -753,8 +769,6 @@ jobs:
       (needs.changed-files.outputs.vllm == 'true' ||
        needs.changed-files.outputs.sglang == 'true' ||
        needs.changed-files.outputs.trtllm == 'true' ||
-       needs.changed-files.outputs.operator == 'true' ||
-       needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.deploy == 'true') &&
       (needs.operator.result == 'success' || needs.operator.result == 'skipped')
     needs: [changed-files, operator]
@@ -778,8 +792,6 @@ jobs:
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-          checkpoint_enabled: ${{ (needs.changed-files.outputs.operator == 'true' || needs.changed-files.outputs.snapshot == 'true' || needs.changed-files.outputs.deploy == 'true') && 'true' || 'false' }}
-          checkpoint_storage_size: 64Gi
 
   deploy-test-vllm:
     name: vllm Deploy Test
@@ -829,15 +841,83 @@ jobs:
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
 
-  deploy-snapshot-agent:
-    name: Snapshot Agent Deploy Setup
-    needs: [changed-files, deploy-operator, snapshot-agent]
+  deploy-operator-checkpoint-vllm:
+    name: vLLM DynamoCheckpoint Operator Setup
     if: |
       always() && !cancelled() &&
       (needs.changed-files.outputs.operator == 'true' ||
        needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.deploy == 'true') &&
-      needs.deploy-operator.result == 'success' &&
+      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
+    needs: [changed-files, operator]
+    runs-on: prod-deploy-tester-v1
+    permissions:
+      contents: read
+    outputs:
+      namespace: ${{ steps.setup.outputs.namespace }}
+      vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
+      operator_tag: ${{ steps.setup.outputs.operator_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup vCluster and operator
+        id: setup
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ci-${{ github.run_id }}-checkpoint-vllm
+          vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-vllm-dt
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.operator.result == 'success' && needs.operator.outputs.operator_default_tag || 'main-operator' }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+
+  deploy-operator-checkpoint-sglang:
+    name: SGLang DynamoCheckpoint Operator Setup
+    if: |
+      always() && !cancelled() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true') &&
+      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
+    needs: [changed-files, operator]
+    runs-on: prod-deploy-tester-v1
+    permissions:
+      contents: read
+    outputs:
+      namespace: ${{ steps.setup.outputs.namespace }}
+      vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
+      operator_tag: ${{ steps.setup.outputs.operator_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup vCluster and operator
+        id: setup
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
+          vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.operator.result == 'success' && needs.operator.outputs.operator_default_tag || 'main-operator' }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+
+  deploy-snapshot-agent-checkpoint-vllm:
+    name: vLLM DynamoCheckpoint Snapshot Agent Setup
+    needs: [changed-files, deploy-operator-checkpoint-vllm, snapshot-agent]
+    if: |
+      always() && !cancelled() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true') &&
+      needs.deploy-operator-checkpoint-vllm.result == 'success' &&
       needs.snapshot-agent.result == 'success'
     runs-on: prod-deploy-tester-v1
     timeout-minutes: 15
@@ -852,16 +932,16 @@ jobs:
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-dynamo-operator
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-vllm.outputs.operator_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -871,8 +951,59 @@ jobs:
         id: connect-vcluster
         uses: ./.github/actions/connect-vcluster
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
+      - name: Install snapshot-agent
+        uses: ./.github/actions/setup-snapshot-agent
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+
+  deploy-snapshot-agent-checkpoint-sglang:
+    name: SGLang DynamoCheckpoint Snapshot Agent Setup
+    needs: [changed-files, deploy-operator-checkpoint-sglang, snapshot-agent]
+    if: |
+      always() && !cancelled() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true') &&
+      needs.deploy-operator-checkpoint-sglang.result == 'success' &&
+      needs.snapshot-agent.result == 'success'
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Check if vCluster exists
+        id: vcluster-check
+        uses: ./.github/actions/check-vcluster-exists
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
+      - name: Self-bootstrap vCluster (rerun)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-sglang.outputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+      - name: Connect to vCluster
+        id: connect-vcluster
+        uses: ./.github/actions/connect-vcluster
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Install snapshot-agent
         uses: ./.github/actions/setup-snapshot-agent
         with:
@@ -882,13 +1013,13 @@ jobs:
 
   deploy-test-checkpoint-vllm:
     name: vLLM DynamoCheckpoint Deploy Test
-    needs: [changed-files, deploy-operator, deploy-snapshot-agent, snapshot-placeholder-vllm, frontend-copy-to-acr]
+    needs: [changed-files, deploy-operator-checkpoint-vllm, deploy-snapshot-agent-checkpoint-vllm, snapshot-placeholder-vllm, frontend-copy-to-acr]
     if: |
       always() && !cancelled() &&
       (needs.changed-files.outputs.operator == 'true' ||
        needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.deploy == 'true') &&
-      needs.deploy-snapshot-agent.result == 'success' &&
+      needs.deploy-snapshot-agent-checkpoint-vllm.result == 'success' &&
       needs.snapshot-placeholder-vllm.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
     runs-on: prod-deploy-tester-v1
@@ -904,16 +1035,16 @@ jobs:
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-dynamo-operator
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-vllm.outputs.operator_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -923,8 +1054,8 @@ jobs:
         id: connect-vcluster
         uses: ./.github/actions/connect-vcluster
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-vllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-vllm.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-snapshot-agent
@@ -938,7 +1069,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-vllm.outputs.operator_tag }}
           framework: checkpoint
           profile: dgd_restore
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-placeholder
@@ -951,13 +1082,13 @@ jobs:
 
   deploy-test-checkpoint-sglang:
     name: SGLang DynamoCheckpoint Deploy Test
-    needs: [changed-files, deploy-operator, deploy-snapshot-agent, snapshot-placeholder-sglang, frontend-copy-to-acr]
+    needs: [changed-files, deploy-operator-checkpoint-sglang, deploy-snapshot-agent-checkpoint-sglang, snapshot-placeholder-sglang, frontend-copy-to-acr]
     if: |
       always() && !cancelled() &&
       (needs.changed-files.outputs.operator == 'true' ||
        needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.deploy == 'true') &&
-      needs.deploy-snapshot-agent.result == 'success' &&
+      needs.deploy-snapshot-agent-checkpoint-sglang.result == 'success' &&
       needs.snapshot-placeholder-sglang.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
     runs-on: prod-deploy-tester-v1
@@ -973,16 +1104,16 @@ jobs:
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-dynamo-operator
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-sglang.outputs.operator_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -992,8 +1123,8 @@ jobs:
         id: connect-vcluster
         uses: ./.github/actions/connect-vcluster
         with:
-          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
-          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
       - name: Install snapshot-agent (rerun bootstrap)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-snapshot-agent
@@ -1007,7 +1138,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-sglang.outputs.operator_tag }}
           framework: checkpoint
           profile: dgd_restore
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-placeholder
@@ -1020,7 +1151,7 @@ jobs:
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, deploy-test-checkpoint-vllm, deploy-test-checkpoint-sglang]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm]
     runs-on: prod-deploy-tester-v1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1032,6 +1163,44 @@ jobs:
         with:
           vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+
+  deploy-cleanup-checkpoint-vllm:
+    name: vLLM DynamoCheckpoint Cleanup
+    if: |
+      always() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true')
+    needs: [changed-files, deploy-operator-checkpoint-vllm, deploy-snapshot-agent-checkpoint-vllm, deploy-test-checkpoint-vllm]
+    runs-on: prod-deploy-tester-v1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Teardown vCluster
+        uses: ./.github/actions/teardown-dynamo-operator
+        with:
+          vcluster_name: ci-${{ github.run_id }}-checkpoint-vllm
+          vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-vllm-dt
+
+  deploy-cleanup-checkpoint-sglang:
+    name: SGLang DynamoCheckpoint Cleanup
+    if: |
+      always() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true')
+    needs: [changed-files, deploy-operator-checkpoint-sglang, deploy-snapshot-agent-checkpoint-sglang, deploy-test-checkpoint-sglang]
+    runs-on: prod-deploy-tester-v1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Teardown vCluster
+        uses: ./.github/actions/teardown-dynamo-operator
+        with:
+          vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
+          vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
 
   clean-k8s-builder:
     name: Clean K8s builder if exists

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,7 +57,8 @@ jobs:
       - operator
       - helm-chart-tests
       - snapshot-agent
-      - snapshot-placeholder
+      - snapshot-placeholder-vllm
+      - snapshot-placeholder-sglang
       - vllm-build
       - vllm-dev-build
       - vllm-test
@@ -88,7 +89,7 @@ jobs:
 
   deploy-status-check:
     runs-on: ubuntu-latest
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, snapshot-placeholder, frontend-copy-to-acr, deploy-test-checkpoint, deploy-cleanup]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, snapshot-placeholder-vllm, snapshot-placeholder-sglang, frontend-copy-to-acr, deploy-test-checkpoint-vllm, deploy-test-checkpoint-sglang, deploy-cleanup]
     if: always()
     steps:
       - name: Check all deploy test jobs
@@ -234,7 +235,14 @@ jobs:
   sglang-build:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
     needs: [changed-files]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true'
+    # `operator` and `snapshot` are here because DynamoCheckpoint deploy tests
+    # build a snapshot placeholder from the CI-built SGLang runtime image.
+    if: |
+      needs.changed-files.outputs.core == 'true' ||
+      needs.changed-files.outputs.sglang == 'true' ||
+      needs.changed-files.outputs.deploy == 'true' ||
+      needs.changed-files.outputs.operator == 'true' ||
+      needs.changed-files.outputs.snapshot == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: sglang
@@ -639,8 +647,8 @@ jobs:
       copy_timeout_minutes: 10
     secrets: inherit
 
-  snapshot-placeholder:
-    name: Snapshot Placeholder
+  snapshot-placeholder-vllm:
+    name: vLLM Snapshot Placeholder
     needs: [changed-files, vllm-copy-to-acr]
     if: |
       always() && !cancelled() &&
@@ -675,7 +683,11 @@ jobs:
     needs: [changed-files, sglang-build]
     if: |
       always() && !cancelled() &&
-      (needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true') &&
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.sglang == 'true' ||
+       needs.changed-files.outputs.deploy == 'true' ||
+       needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true') &&
       needs.sglang-build.result == 'success'
     uses: ./.github/workflows/shared-copy.yml
     with:
@@ -684,6 +696,37 @@ jobs:
       override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
       copy_timeout_minutes: 10
     secrets: inherit
+
+  snapshot-placeholder-sglang:
+    name: SGLang Snapshot Placeholder
+    needs: [changed-files, sglang-copy-to-acr]
+    if: |
+      always() && !cancelled() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true')
+    runs-on: prod-default-v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build and push snapshot placeholder
+        uses: ./.github/actions/build-deploy-component
+        with:
+          component: snapshot
+          target: placeholder
+          image_tag: ${{ github.sha }}-sglang-placeholder
+          builder_name: ${{ needs.changed-files.outputs.builder_name }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+          extra_tags: |
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-placeholder
+          extra_build_args: |
+            BASE_IMAGE=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-runtime
 
   trtllm-copy-to-acr:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
@@ -837,16 +880,16 @@ jobs:
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
 
-  deploy-test-checkpoint:
-    name: DynamoCheckpoint Deploy Test
-    needs: [changed-files, deploy-operator, deploy-snapshot-agent, snapshot-placeholder, frontend-copy-to-acr]
+  deploy-test-checkpoint-vllm:
+    name: vLLM DynamoCheckpoint Deploy Test
+    needs: [changed-files, deploy-operator, deploy-snapshot-agent, snapshot-placeholder-vllm, frontend-copy-to-acr]
     if: |
       always() && !cancelled() &&
       (needs.changed-files.outputs.operator == 'true' ||
        needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.deploy == 'true') &&
       needs.deploy-snapshot-agent.result == 'success' &&
-      needs.snapshot-placeholder.result == 'success' &&
+      needs.snapshot-placeholder-vllm.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
     runs-on: prod-deploy-tester-v1
     timeout-minutes: 30
@@ -899,15 +942,85 @@ jobs:
           framework: checkpoint
           profile: dgd_restore
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-placeholder
-          test_name: checkpoint_dgd_restore
+          test_name: checkpoint_dgd_restore_vllm
           test_file: tests/deploy/test_dynamocheckpoint.py
           extra_pytest_args: >-
             -m dynamocheckpoint
+            --checkpoint-backend=vllm
+            --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-dynamo-frontend
+
+  deploy-test-checkpoint-sglang:
+    name: SGLang DynamoCheckpoint Deploy Test
+    needs: [changed-files, deploy-operator, deploy-snapshot-agent, snapshot-placeholder-sglang, frontend-copy-to-acr]
+    if: |
+      always() && !cancelled() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true') &&
+      needs.deploy-snapshot-agent.result == 'success' &&
+      needs.snapshot-placeholder-sglang.result == 'success' &&
+      needs.frontend-copy-to-acr.result == 'success'
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Check if vCluster exists
+        id: vcluster-check
+        uses: ./.github/actions/check-vcluster-exists
+        with:
+          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+      - name: Self-bootstrap vCluster (rerun)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+      - name: Connect to vCluster
+        id: connect-vcluster
+        uses: ./.github/actions/connect-vcluster
+        with:
+          vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
+      - name: Install snapshot-agent (rerun bootstrap)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-snapshot-agent
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+      - name: Run DynamoCheckpoint Deploy Test
+        uses: ./.github/actions/dynamo-deploy-test
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+          framework: checkpoint
+          profile: dgd_restore
+          image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-sglang-placeholder
+          test_name: checkpoint_dgd_restore_sglang
+          test_file: tests/deploy/test_dynamocheckpoint.py
+          extra_pytest_args: >-
+            -m dynamocheckpoint
+            --checkpoint-backend=sglang
             --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-dynamo-frontend
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, deploy-test-checkpoint]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-snapshot-agent, deploy-test-checkpoint-vllm, deploy-test-checkpoint-sglang]
     runs-on: prod-deploy-tester-v1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -928,7 +1041,8 @@ jobs:
       - changed-files
       - operator
       - snapshot-agent
-      - snapshot-placeholder
+      - snapshot-placeholder-vllm
+      - snapshot-placeholder-sglang
       - planner-test
       - vllm-copy-to-acr
       - vllm-multi-gpu-test
@@ -981,7 +1095,8 @@ jobs:
       - deploy-test-vllm
       - deploy-test-sglang
       - deploy-test-trtllm
-      - deploy-test-checkpoint
+      - deploy-test-checkpoint-vllm
+      - deploy-test-checkpoint-sglang
     if: false
     # Disabled: gh-pages branch bloated to ~1GB after 72 commits of Allure reports
     # if: ${{ !cancelled() }}

--- a/tests/deploy/conftest.py
+++ b/tests/deploy/conftest.py
@@ -46,6 +46,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help="Frontend container image (used by GAIE and checkpoint deploy tests).",
     )
+    parser.addoption(
+        "--checkpoint-backend",
+        type=str,
+        default="vllm",
+        choices=("vllm", "sglang"),
+        help="DynamoCheckpoint backend to test.",
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/deploy/test_dynamocheckpoint.py
+++ b/tests/deploy/test_dynamocheckpoint.py
@@ -6,6 +6,7 @@
 import asyncio
 import logging
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -32,18 +33,14 @@ TRANSIENT_K8S_EXCEPTIONS = (
 DGD_PLURAL = "dynamographdeployments"
 CHECKPOINT_PLURAL = "dynamocheckpoints"
 
-DECODE_COMPONENT = "VllmDecodeWorker"
 FRONTEND_COMPONENT = "Frontend"
 TARGET_CONTAINER = "main"
-VLLM_MODEL = "Qwen/Qwen3-0.6B"
-VLLM_MAX_MODEL_LEN = "2048"
-VLLM_GPU_MEMORY_UTILIZATION = "0.30"
+CHECKPOINT_MODEL = "Qwen/Qwen3-0.6B"
 
 CHECKPOINT_ID_LABEL = "nvidia.com/snapshot-checkpoint-id"
 CHECKPOINT_SOURCE_LABEL = "nvidia.com/snapshot-is-checkpoint-source"
 RESTORE_TARGET_LABEL = "nvidia.com/snapshot-is-restore-target"
 TARGET_CONTAINERS_ANNOTATION = "nvidia.com/snapshot-target-containers"
-RESTORE_STATUS_ANNOTATION = f"nvidia.com/snapshot-restore-status.{TARGET_CONTAINER}"
 
 # CUDA checkpointing can OOM on 10GB MIG slices; run this test on full GPUs.
 GPU_NODE_SELECTOR = {
@@ -66,6 +63,74 @@ DGD_READY_TIMEOUT = 300
 TEST_TIMEOUT = 1200
 
 
+@dataclass(frozen=True)
+class CheckpointBackendConfig:
+    name: str
+    manifest: tuple[str, ...]
+    decode_component: str
+    frontend_component: str
+    target_container: str
+    model: str
+    args: tuple[str, ...]
+
+
+CHECKPOINT_BACKENDS = {
+    "vllm": CheckpointBackendConfig(
+        name="vllm",
+        manifest=("examples", "backends", "vllm", "deploy", "v1beta1", "agg.yaml"),
+        decode_component="VllmDecodeWorker",
+        frontend_component=FRONTEND_COMPONENT,
+        target_container=TARGET_CONTAINER,
+        model=CHECKPOINT_MODEL,
+        args=(
+            "--model",
+            CHECKPOINT_MODEL,
+            "--max-model-len",
+            "2048",
+            "--gpu-memory-utilization",
+            "0.30",
+        ),
+    ),
+    "sglang": CheckpointBackendConfig(
+        name="sglang",
+        manifest=(
+            "examples",
+            "backends",
+            "sglang",
+            "deploy",
+            "v1beta1",
+            "agg.yaml",
+        ),
+        decode_component="decode",
+        frontend_component=FRONTEND_COMPONENT,
+        target_container=TARGET_CONTAINER,
+        model=CHECKPOINT_MODEL,
+        args=(
+            "--model-path",
+            CHECKPOINT_MODEL,
+            "--served-model-name",
+            CHECKPOINT_MODEL,
+            "--page-size",
+            "16",
+            "--tp",
+            "1",
+            "--trust-remote-code",
+            "--skip-tokenizer-init",
+        ),
+    ),
+}
+
+
+def _checkpoint_backend(request: pytest.FixtureRequest) -> CheckpointBackendConfig:
+    backend_name = request.config.getoption("--checkpoint-backend")
+    try:
+        return CHECKPOINT_BACKENDS[backend_name]
+    except KeyError as exc:
+        raise AssertionError(
+            f"unsupported checkpoint backend {backend_name!r}"
+        ) from exc
+
+
 def _component(spec: dict[str, Any], name: str) -> dict[str, Any]:
     for component in spec["spec"].get("components", []):
         if component.get("name") == name:
@@ -73,45 +138,36 @@ def _component(spec: dict[str, Any], name: str) -> dict[str, Any]:
     raise AssertionError(f"component {name!r} not found in DGD spec")
 
 
-def _new_vllm_checkpoint_spec(
-    name: str, namespace: str, image: str, frontend_image: str
+def _new_checkpoint_spec(
+    backend: CheckpointBackendConfig,
+    name: str,
+    namespace: str,
+    image: str,
+    frontend_image: str,
 ) -> DeploymentSpec:
-    spec_path = (
-        Path(_get_workspace_dir())
-        / "examples"
-        / "backends"
-        / "vllm"
-        / "deploy"
-        / "v1beta1"
-        / "agg.yaml"
-    )
+    spec_path = Path(_get_workspace_dir()).joinpath(*backend.manifest)
     deployment_spec = DeploymentSpec(str(spec_path))
     deployment_spec.name = name
     deployment_spec.namespace = namespace
-    deployment_spec.set_image(frontend_image, FRONTEND_COMPONENT)
-    deployment_spec.set_image(image, DECODE_COMPONENT)
-    deployment_spec.set_model(VLLM_MODEL, DECODE_COMPONENT)
+    deployment_spec.set_image(frontend_image, backend.frontend_component)
+    deployment_spec.set_image(image, backend.decode_component)
+    deployment_spec.set_model(backend.model, backend.decode_component)
 
     raw_spec = deployment_spec.spec()
-    decode = _component(raw_spec, DECODE_COMPONENT)
+    decode = _component(raw_spec, backend.decode_component)
     pod_spec = decode.setdefault("podTemplate", {}).setdefault("spec", {})
     pod_spec["nodeSelector"] = dict(GPU_NODE_SELECTOR)
     pod_spec["tolerations"] = list(GPU_TOLERATIONS)
     containers = pod_spec.setdefault("containers", [])
     if not containers:
-        raise AssertionError(f"component {DECODE_COMPONENT!r} has no containers")
-    containers[0]["args"] = [
-        "--model",
-        VLLM_MODEL,
-        "--max-model-len",
-        VLLM_MAX_MODEL_LEN,
-        "--gpu-memory-utilization",
-        VLLM_GPU_MEMORY_UTILIZATION,
-    ]
+        raise AssertionError(
+            f"component {backend.decode_component!r} has no containers"
+        )
+    containers[0]["args"] = list(backend.args)
 
     decode.setdefault("experimental", {})["checkpoint"] = {
         "enabled": True,
-        "targetContainerName": TARGET_CONTAINER,
+        "targetContainerName": backend.target_container,
     }
     return deployment_spec
 
@@ -173,10 +229,15 @@ async def _get_checkpoint(
 
 async def _wait_for_checkpoint_ready(
     deployment: ManagedDeployment,
+    backend: CheckpointBackendConfig,
 ) -> tuple[str, str]:
     async def fetch_status() -> dict[str, Any]:
         dgd = await _get_dgd(deployment)
-        status = dgd.get("status", {}).get("checkpoints", {}).get(DECODE_COMPONENT, {})
+        status = (
+            dgd.get("status", {})
+            .get("checkpoints", {})
+            .get(backend.decode_component, {})
+        )
         checkpoint_name = status.get("checkpointName")
         checkpoint = None
         if checkpoint_name:
@@ -184,7 +245,7 @@ async def _wait_for_checkpoint_ready(
         return {"dgd_status": status, "checkpoint": checkpoint}
 
     value = await _wait_for(
-        "DGD auto checkpoint to become Ready",
+        f"{backend.name} DGD auto checkpoint to become Ready",
         fetch_status,
         _checkpoint_is_ready,
         timeout_s=CHECKPOINT_READY_TIMEOUT,
@@ -213,8 +274,12 @@ def _checkpoint_is_ready(result: dict[str, Any]) -> bool:
     return phase == "Ready" and bool(status.get("identityHash"))
 
 
-def _runtime_decode_pods(deployment: ManagedDeployment) -> list[Any]:
-    pods = deployment.get_pods([DECODE_COMPONENT]).get(DECODE_COMPONENT, [])
+def _runtime_decode_pods(
+    deployment: ManagedDeployment, backend: CheckpointBackendConfig
+) -> list[Any]:
+    pods = deployment.get_pods([backend.decode_component]).get(
+        backend.decode_component, []
+    )
     return [
         pod
         for pod in pods
@@ -223,17 +288,19 @@ def _runtime_decode_pods(deployment: ManagedDeployment) -> list[Any]:
     ]
 
 
-async def _scale_decode_component(deployment: ManagedDeployment, replicas: int) -> None:
+async def _scale_decode_component(
+    deployment: ManagedDeployment, backend: CheckpointBackendConfig, replicas: int
+) -> None:
     if deployment._custom_api is None:
         raise RuntimeError("Kubernetes API not initialized")
     dgd = await _get_dgd(deployment)
     components = dgd["spec"]["components"]
     for component in components:
-        if component.get("name") == DECODE_COMPONENT:
+        if component.get("name") == backend.decode_component:
             component["replicas"] = replicas
             break
     else:
-        raise AssertionError(f"component {DECODE_COMPONENT!r} not found")
+        raise AssertionError(f"component {backend.decode_component!r} not found")
 
     await deployment._custom_api.patch_namespaced_custom_object(
         group="nvidia.com",
@@ -247,11 +314,14 @@ async def _scale_decode_component(deployment: ManagedDeployment, replicas: int) 
 
 
 async def _wait_for_decode_runtime_pod_count(
-    deployment: ManagedDeployment, expected: int, timeout_s: int
+    deployment: ManagedDeployment,
+    backend: CheckpointBackendConfig,
+    expected: int,
+    timeout_s: int,
 ) -> list[Any]:
     return await _wait_for(
-        f"{expected} decode runtime pod(s)",
-        lambda: _runtime_decode_pods(deployment),
+        f"{expected} {backend.name} decode runtime pod(s)",
+        lambda: _runtime_decode_pods(deployment, backend),
         lambda pods: len(pods) == expected,
         timeout_s=timeout_s,
         interval_s=2,
@@ -260,11 +330,16 @@ async def _wait_for_decode_runtime_pod_count(
 
 async def _wait_for_restored_decode_pod(
     deployment: ManagedDeployment,
+    backend: CheckpointBackendConfig,
     old_pod_names: set[str],
     checkpoint_hash: str,
 ) -> Any:
+    restore_status_annotation = (
+        f"nvidia.com/snapshot-restore-status.{backend.target_container}"
+    )
+
     def find_restored() -> Any:
-        pods = _runtime_decode_pods(deployment)
+        pods = _runtime_decode_pods(deployment, backend)
         last_seen: list[dict[str, Any]] = []
         for pod in pods:
             metadata = pod.raw.get("metadata", {})
@@ -275,7 +350,7 @@ async def _wait_for_restored_decode_pod(
                 {
                     "name": name,
                     "checkpoint": labels.get(CHECKPOINT_ID_LABEL),
-                    "restore": annotations.get(RESTORE_STATUS_ANNOTATION),
+                    "restore": annotations.get(restore_status_annotation),
                     "phase": pod.raw.get("status", {}).get("phase"),
                     "node": pod.raw.get("spec", {}).get("nodeName"),
                 }
@@ -286,19 +361,22 @@ async def _wait_for_restored_decode_pod(
                 continue
             if labels.get(RESTORE_TARGET_LABEL) != "true":
                 continue
-            if annotations.get(TARGET_CONTAINERS_ANNOTATION) != TARGET_CONTAINER:
+            if (
+                annotations.get(TARGET_CONTAINERS_ANNOTATION)
+                != backend.target_container
+            ):
                 continue
-            if annotations.get(RESTORE_STATUS_ANNOTATION) == "failed":
+            if annotations.get(restore_status_annotation) == "failed":
                 raise AssertionError(
                     f"restore failed for decode pod {name}: {last_seen[-1]}"
                 )
-            if annotations.get(RESTORE_STATUS_ANNOTATION) != "completed":
+            if annotations.get(restore_status_annotation) != "completed":
                 continue
             return pod
         return last_seen
 
     restored = await _wait_for(
-        "replacement decode pod to restore from checkpoint",
+        f"replacement {backend.name} decode pod to restore from checkpoint",
         find_restored,
         lambda result: not isinstance(result, list),
         timeout_s=RESTORE_READY_TIMEOUT,
@@ -381,10 +459,11 @@ async def test_dgd_checkpoint_restore_deploy(
     request: pytest.FixtureRequest,
 ) -> None:
     """Verify a DGD worker can be checkpointed, restored, and still serve."""
+    backend = _checkpoint_backend(request)
     if not image:
         pytest.fail(
             "--image is required for the checkpoint deploy test "
-            "(expected the CI-built vLLM checkpoint placeholder image)",
+            f"(expected the CI-built {backend.name} checkpoint placeholder image)",
             pytrace=False,
         )
     frontend_image = request.config.getoption("--frontend-image")
@@ -396,8 +475,9 @@ async def test_dgd_checkpoint_restore_deploy(
         )
 
     suffix = str(int(time.time() * 1000))
-    deployment_name = f"vllm-checkpoint-{suffix}"
-    deployment_spec = _new_vllm_checkpoint_spec(
+    deployment_name = f"{backend.name}-checkpoint-{suffix}"
+    deployment_spec = _new_checkpoint_spec(
+        backend=backend,
         name=deployment_name,
         namespace=namespace,
         image=image,
@@ -410,8 +490,8 @@ async def test_dgd_checkpoint_restore_deploy(
         namespace=namespace,
         skip_service_restart=skip_service_restart,
     ) as deployment:
-        frontend_pods = deployment.get_pods([FRONTEND_COMPONENT]).get(
-            FRONTEND_COMPONENT, []
+        frontend_pods = deployment.get_pods([backend.frontend_component]).get(
+            backend.frontend_component, []
         )
         if not frontend_pods:
             pytest.fail(f"No frontend pods found for {deployment_name}", pytrace=False)
@@ -421,28 +501,35 @@ async def test_dgd_checkpoint_restore_deploy(
         base_url = f"http://localhost:{port_forward.local_port}"
 
         logger.info("Validating inference before restore")
-        _assert_inference(base_url, deployment_spec.endpoint, VLLM_MODEL)
+        _assert_inference(base_url, deployment_spec.endpoint, backend.model)
 
-        _, checkpoint_hash = await _wait_for_checkpoint_ready(deployment)
+        _, checkpoint_hash = await _wait_for_checkpoint_ready(deployment, backend)
 
         old_decode_pods = await _wait_for_decode_runtime_pod_count(
-            deployment, expected=1, timeout_s=DECODE_SCALE_TIMEOUT
+            deployment,
+            backend=backend,
+            expected=1,
+            timeout_s=DECODE_SCALE_TIMEOUT,
         )
         old_pod_names = {pod.name for pod in old_decode_pods}
         logger.info("Scaling decode down from pods: %s", sorted(old_pod_names))
-        await _scale_decode_component(deployment, replicas=0)
+        await _scale_decode_component(deployment, backend, replicas=0)
         await _wait_for_decode_runtime_pod_count(
-            deployment, expected=0, timeout_s=DECODE_SCALE_TIMEOUT
+            deployment,
+            backend=backend,
+            expected=0,
+            timeout_s=DECODE_SCALE_TIMEOUT,
         )
 
         logger.info("Scaling decode back up to trigger restore")
-        await _scale_decode_component(deployment, replicas=1)
+        await _scale_decode_component(deployment, backend, replicas=1)
         await _wait_for_restored_decode_pod(
             deployment,
+            backend=backend,
             old_pod_names=old_pod_names,
             checkpoint_hash=checkpoint_hash,
         )
         await deployment._wait_for_ready(timeout=DGD_READY_TIMEOUT)
 
         logger.info("Validating inference after restore")
-        _assert_inference(base_url, deployment_spec.endpoint, VLLM_MODEL)
+        _assert_inference(base_url, deployment_spec.endpoint, backend.model)


### PR DESCRIPTION
Summary
- Add backend-aware DynamoCheckpoint deploy test support for vLLM and SGLang while preserving vLLM as the default.
- Split checkpoint placeholder image builds into vLLM and SGLang variants backed by their respective runtime images.
- Add separate vLLM and SGLang DynamoCheckpoint deploy jobs. Each backend gets its own checkpoint-enabled operator/vCluster and snapshot-agent installation while sharing the built operator/snapshot-agent images.
- Extend SGLang runtime build/copy triggers for operator and snapshot changes so SGLang checkpoint placeholders can be built for existing checkpoint CI triggers.

Validation
- python -m py_compile tests/deploy/conftest.py tests/deploy/test_dynamocheckpoint.py
- git diff --check
- yq '.' .github/workflows/pr.yaml
- yq '.' .github/workflows/post-merge-ci.yml
- Local workflow needs-graph sanity check for both modified workflows
- PR CI: vLLM DynamoCheckpoint Deploy Test passed on run 27980359422
- PR CI: SGLang DynamoCheckpoint Deploy Test passed on run 27980359422