### PR TITLE
fix(sglang): warm up snapshot engine before capture

### DIFF
--- a/components/src/dynamo/sglang/snapshot.py
+++ b/components/src/dynamo/sglang/snapshot.py
@@ -24,6 +24,17 @@ logger = logging.getLogger(__name__)
 
 async def warmup_engine(engine: sgl.Engine, server_args: Any) -> None:
     """Warm up the direct SGLang Engine generation path before snapshot capture."""
+    DUMMY_WARMUP_MAX_NEW_TOKENS = 8
+    DUMMY_WARMUP_TEMPERATURE = 0
+    DUMMY_WARMUP_INPUT_IDS = [10, 11, 12]
+    DUMMY_WARMUP_PROMPT = "The capital city of France is"
+    DUMMY_DEBUG_TENSOR_MAX_NEW_TOKENS = 0
+    DUMMY_DISAGG_WARMUP_TEMPERATURE = 0.0
+    DUMMY_DISAGG_WARMUP_INPUT_IDS = [10, 11, 12, 13]
+    DUMMY_BOOTSTRAP_ROOM_RANGE = 2**63
+    DEFAULT_WARMUP_TIMEOUT = 600
+    DEFAULT_DISAGG_WARMUP_TIMEOUT = 1800
+
     # The direct Engine API does not run SGLang's HTTP server warmup. Snapshot
     # mode only needs to warm the generation path before the engine is frozen.
     if getattr(server_args, "skip_server_warmup", False):
@@ -38,16 +49,18 @@ async def warmup_engine(engine: sgl.Engine, server_args: Any) -> None:
 
     warmup_args: dict[str, Any] = {
         "sampling_params": {
-            "temperature": 0,
-            "max_new_tokens": 8,
+            "temperature": DUMMY_WARMUP_TEMPERATURE,
+            "max_new_tokens": DUMMY_WARMUP_MAX_NEW_TOKENS,
         }
     }
     if server_args.skip_tokenizer_init:
-        warmup_args["input_ids"] = [[10, 11, 12] for _ in range(server_args.dp_size)]
+        warmup_args["input_ids"] = [
+            DUMMY_WARMUP_INPUT_IDS for _ in range(server_args.dp_size)
+        ]
         if server_args.dp_size == 1:
             warmup_args["input_ids"] = warmup_args["input_ids"][0]
     else:
-        warmup_args["prompt"] = ["The capital city of France is"] * server_args.dp_size
+        warmup_args["prompt"] = [DUMMY_WARMUP_PROMPT] * server_args.dp_size
         if server_args.dp_size == 1:
             warmup_args["prompt"] = warmup_args["prompt"][0]
 
@@ -58,7 +71,9 @@ async def warmup_engine(engine: sgl.Engine, server_args: Any) -> None:
         warmup_args["input_ids"] = np.load(
             server_args.debug_tensor_dump_input_file
         ).tolist()
-        warmup_args["sampling_params"]["max_new_tokens"] = 0
+        warmup_args["sampling_params"][
+            "max_new_tokens"
+        ] = DUMMY_DEBUG_TENSOR_MAX_NEW_TOKENS
 
     is_disaggregated = server_args.disaggregation_mode != "null"
     if is_disaggregated:
@@ -67,24 +82,27 @@ async def warmup_engine(engine: sgl.Engine, server_args: Any) -> None:
         logger.info("Start of pd disaggregation warmup ...")
         warmup_args = {
             "sampling_params": {
-                "temperature": 0.0,
-                "max_new_tokens": 8,
+                "temperature": DUMMY_DISAGG_WARMUP_TEMPERATURE,
+                "max_new_tokens": DUMMY_WARMUP_MAX_NEW_TOKENS,
                 "ignore_eos": True,
             },
             "bootstrap_host": [FAKE_BOOTSTRAP_HOST] * server_args.dp_size,
             # This is a hack to ensure fake transfer is enabled during
             # prefill warmup and each DP rank has a unique room.
             "bootstrap_room": [
-                i * (2**63 // server_args.dp_size) + (i % server_args.tp_size)
+                i * (DUMMY_BOOTSTRAP_ROOM_RANGE // server_args.dp_size)
+                + (i % server_args.tp_size)
                 for i in range(server_args.dp_size)
             ],
-            "input_ids": [[10, 11, 12, 13]] * server_args.dp_size,
+            "input_ids": [DUMMY_DISAGG_WARMUP_INPUT_IDS] * server_args.dp_size,
         }
 
     warmup_timeout = envs.SGLANG_WARMUP_TIMEOUT.get()
-    timeout = warmup_timeout if warmup_timeout > 0 else 600
+    timeout = warmup_timeout if warmup_timeout > 0 else DEFAULT_WARMUP_TIMEOUT
     if is_disaggregated:
-        timeout = warmup_timeout if warmup_timeout > 0 else 1800
+        timeout = (
+            warmup_timeout if warmup_timeout > 0 else DEFAULT_DISAGG_WARMUP_TIMEOUT
+        )
 
     logger.info("SGLang snapshot warmup starting")
     await asyncio.wait_for(

--- a/components/src/dynamo/sglang/snapshot.py
+++ b/components/src/dynamo/sglang/snapshot.py
@@ -22,6 +22,78 @@ from .pause import SGLangEnginePauseController
 logger = logging.getLogger(__name__)
 
 
+async def warmup_engine(engine: sgl.Engine, server_args: Any) -> None:
+    """Warm up the direct SGLang Engine generation path before snapshot capture."""
+    # The direct Engine API does not run SGLang's HTTP server warmup. Snapshot
+    # mode only needs to warm the generation path before the engine is frozen.
+    if getattr(server_args, "skip_server_warmup", False):
+        return
+
+    tokenizer_manager = engine.tokenizer_manager
+    if not tokenizer_manager.is_generation:
+        logger.info("Skipping SGLang snapshot warmup for non-generation model")
+        return
+
+    from sglang.srt.environ import envs
+
+    warmup_args: dict[str, Any] = {
+        "sampling_params": {
+            "temperature": 0,
+            "max_new_tokens": 8,
+        }
+    }
+    if server_args.skip_tokenizer_init:
+        warmup_args["input_ids"] = [[10, 11, 12] for _ in range(server_args.dp_size)]
+        if server_args.dp_size == 1:
+            warmup_args["input_ids"] = warmup_args["input_ids"][0]
+    else:
+        warmup_args["prompt"] = ["The capital city of France is"] * server_args.dp_size
+        if server_args.dp_size == 1:
+            warmup_args["prompt"] = warmup_args["prompt"][0]
+
+    if server_args.debug_tensor_dump_input_file:
+        import numpy as np
+
+        warmup_args.pop("prompt", None)
+        warmup_args["input_ids"] = np.load(
+            server_args.debug_tensor_dump_input_file
+        ).tolist()
+        warmup_args["sampling_params"]["max_new_tokens"] = 0
+
+    is_disaggregated = server_args.disaggregation_mode != "null"
+    if is_disaggregated:
+        from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+
+        logger.info("Start of pd disaggregation warmup ...")
+        warmup_args = {
+            "sampling_params": {
+                "temperature": 0.0,
+                "max_new_tokens": 8,
+                "ignore_eos": True,
+            },
+            "bootstrap_host": [FAKE_BOOTSTRAP_HOST] * server_args.dp_size,
+            # This is a hack to ensure fake transfer is enabled during
+            # prefill warmup and each DP rank has a unique room.
+            "bootstrap_room": [
+                i * (2**63 // server_args.dp_size) + (i % server_args.tp_size)
+                for i in range(server_args.dp_size)
+            ],
+            "input_ids": [[10, 11, 12, 13]] * server_args.dp_size,
+        }
+
+    warmup_timeout = envs.SGLANG_WARMUP_TIMEOUT.get()
+    timeout = warmup_timeout if warmup_timeout > 0 else 600
+    if is_disaggregated:
+        timeout = warmup_timeout if warmup_timeout > 0 else 1800
+
+    logger.info("SGLang snapshot warmup starting")
+    await asyncio.wait_for(
+        engine.async_generate(**warmup_args),
+        timeout=timeout,
+    )
+    logger.info("SGLang snapshot warmup complete")
+
+
 async def prepare_snapshot_engine(
     server_args,
 ) -> EngineSnapshotController[sgl.Engine] | None:
@@ -63,76 +135,7 @@ async def prepare_snapshot_engine(
     logger.info(
         f"SGLang engine loaded in {time.time() - start_time:.2f}s (snapshot mode)"
     )
-
-    # The direct Engine API does not run SGLang's HTTP server warmup. Snapshot
-    # mode only needs to warm the generation path before the engine is frozen.
-    if not getattr(server_args, "skip_server_warmup", False):
-        tokenizer_manager = engine.tokenizer_manager
-        if not tokenizer_manager.is_generation:
-            logger.info("Skipping SGLang snapshot warmup for non-generation model")
-        else:
-            from sglang.srt.environ import envs
-
-            warmup_args: dict[str, Any] = {
-                "sampling_params": {
-                    "temperature": 0,
-                    "max_new_tokens": 8,
-                }
-            }
-            if server_args.skip_tokenizer_init:
-                warmup_args["input_ids"] = [
-                    [10, 11, 12] for _ in range(server_args.dp_size)
-                ]
-                if server_args.dp_size == 1:
-                    warmup_args["input_ids"] = warmup_args["input_ids"][0]
-            else:
-                warmup_args["prompt"] = [
-                    "The capital city of France is"
-                ] * server_args.dp_size
-                if server_args.dp_size == 1:
-                    warmup_args["prompt"] = warmup_args["prompt"][0]
-
-            if server_args.debug_tensor_dump_input_file:
-                import numpy as np
-
-                warmup_args.pop("prompt", None)
-                warmup_args["input_ids"] = np.load(
-                    server_args.debug_tensor_dump_input_file
-                ).tolist()
-                warmup_args["sampling_params"]["max_new_tokens"] = 0
-
-            is_disaggregated = server_args.disaggregation_mode != "null"
-            if is_disaggregated:
-                from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
-
-                logger.info("Start of pd disaggregation warmup ...")
-                warmup_args = {
-                    "sampling_params": {
-                        "temperature": 0.0,
-                        "max_new_tokens": 8,
-                        "ignore_eos": True,
-                    },
-                    "bootstrap_host": [FAKE_BOOTSTRAP_HOST] * server_args.dp_size,
-                    # This is a hack to ensure fake transfer is enabled during
-                    # prefill warmup and each DP rank has a unique room.
-                    "bootstrap_room": [
-                        i * (2**63 // server_args.dp_size) + (i % server_args.tp_size)
-                        for i in range(server_args.dp_size)
-                    ],
-                    "input_ids": [[10, 11, 12, 13]] * server_args.dp_size,
-                }
-
-            warmup_timeout = envs.SGLANG_WARMUP_TIMEOUT.get()
-            timeout = warmup_timeout if warmup_timeout > 0 else 600
-            if is_disaggregated:
-                timeout = warmup_timeout if warmup_timeout > 0 else 1800
-
-            logger.info("SGLang snapshot warmup starting")
-            await asyncio.wait_for(
-                engine.async_generate(**warmup_args),
-                timeout=timeout,
-            )
-            logger.info("SGLang snapshot warmup complete")
+    await warmup_engine(engine, server_args)
 
     gc.collect()
 

--- a/components/src/dynamo/sglang/snapshot.py
+++ b/components/src/dynamo/sglang/snapshot.py
@@ -3,9 +3,11 @@
 
 """Dynamo Snapshot integration for SGLang workers."""
 
+import asyncio
 import gc
 import logging
 import time
+from typing import Any
 
 import sglang as sgl
 
@@ -61,6 +63,76 @@ async def prepare_snapshot_engine(
     logger.info(
         f"SGLang engine loaded in {time.time() - start_time:.2f}s (snapshot mode)"
     )
+
+    # The direct Engine API does not run SGLang's HTTP server warmup. Snapshot
+    # mode only needs to warm the generation path before the engine is frozen.
+    if not getattr(server_args, "skip_server_warmup", False):
+        tokenizer_manager = engine.tokenizer_manager
+        if not tokenizer_manager.is_generation:
+            logger.info("Skipping SGLang snapshot warmup for non-generation model")
+        else:
+            from sglang.srt.environ import envs
+
+            warmup_args: dict[str, Any] = {
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 8,
+                }
+            }
+            if server_args.skip_tokenizer_init:
+                warmup_args["input_ids"] = [
+                    [10, 11, 12] for _ in range(server_args.dp_size)
+                ]
+                if server_args.dp_size == 1:
+                    warmup_args["input_ids"] = warmup_args["input_ids"][0]
+            else:
+                warmup_args["prompt"] = [
+                    "The capital city of France is"
+                ] * server_args.dp_size
+                if server_args.dp_size == 1:
+                    warmup_args["prompt"] = warmup_args["prompt"][0]
+
+            if server_args.debug_tensor_dump_input_file:
+                import numpy as np
+
+                warmup_args.pop("prompt", None)
+                warmup_args["input_ids"] = np.load(
+                    server_args.debug_tensor_dump_input_file
+                ).tolist()
+                warmup_args["sampling_params"]["max_new_tokens"] = 0
+
+            is_disaggregated = server_args.disaggregation_mode != "null"
+            if is_disaggregated:
+                from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+
+                logger.info("Start of pd disaggregation warmup ...")
+                warmup_args = {
+                    "sampling_params": {
+                        "temperature": 0.0,
+                        "max_new_tokens": 8,
+                        "ignore_eos": True,
+                    },
+                    "bootstrap_host": [FAKE_BOOTSTRAP_HOST] * server_args.dp_size,
+                    # This is a hack to ensure fake transfer is enabled during
+                    # prefill warmup and each DP rank has a unique room.
+                    "bootstrap_room": [
+                        i * (2**63 // server_args.dp_size) + (i % server_args.tp_size)
+                        for i in range(server_args.dp_size)
+                    ],
+                    "input_ids": [[10, 11, 12, 13]] * server_args.dp_size,
+                }
+
+            warmup_timeout = envs.SGLANG_WARMUP_TIMEOUT.get()
+            timeout = warmup_timeout if warmup_timeout > 0 else 600
+            if is_disaggregated:
+                timeout = warmup_timeout if warmup_timeout > 0 else 1800
+
+            logger.info("SGLang snapshot warmup starting")
+            await asyncio.wait_for(
+                engine.async_generate(**warmup_args),
+                timeout=timeout,
+            )
+            logger.info("SGLang snapshot warmup complete")
 
     gc.collect()
 


### PR DESCRIPTION
## Summary
- Add a snapshot-only SGLang generation warmup after direct `sgl.Engine` construction and before the snapshot ready/capture boundary.
- Use SGLang's public `Engine.async_generate(...)` path so Dynamo warms the same engine generation path without requiring the SGLang HTTP server.
- Keep the warmup focused on upstream `/generate` behavior, including tokenizer-skip input IDs, text prompt fallback, debug tensor dump input, disaggregated fake-bootstrap payload, and `SGLANG_WARMUP_TIMEOUT` defaults.
- Annotate the mixed warmup kwargs for mypy while preserving runtime behavior.


Note: SGLang doesn't expose any reusable warmup function for us to use, so we are implementing it ourselves.

## Validation
- `black --check components/src/dynamo/sglang/snapshot.py`
- `ruff check components/src/dynamo/sglang/snapshot.py`
- `python -m py_compile components/src/dynamo/sglang/snapshot.py`
- `git diff --check`
- CI mypy failure root-caused to local dict inference; local mypy unavailable in this environment, PR CI will rerun after push.