### PR TITLE
fix(llm): jamba never-leaks tool-call markup in streaming jail

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -919,18 +919,18 @@ impl JailedStream {
     ///
     /// The real source of truth is `dynamo-parsers`'
     /// `JsonParserConfig::discard_unparseable_wrapper`, set by that crate's
-    /// `hermes()` / `qwen25()` configs (ai-dynamo/frontend-crates,
+    /// `hermes()` / `qwen25()` / `jamba()` configs (ai-dynamo/frontend-crates,
     /// `parsers/src/tool_calling/config.rs`) and already honored by the batch
     /// parser. We allowlist by name here only because the pinned `dynamo-parsers`
     /// version predates that exported field, so it can't be read yet; extend the
     /// list when a new family opts into the never-leak contract.
     // TODO: read `discard_unparseable_wrapper` from the parser config and drop
-    // this name allowlist once the `dynamo-parsers` dependency is bumped to a
-    // version that exports the field.
+    // this name allowlist (hermes/qwen25/jamba) once the `dynamo-parsers`
+    // dependency is bumped to a version that exports the field.
     fn suppresses_tool_call_markup(&self) -> bool {
         matches!(
             self.tool_call_parser.as_deref(),
-            Some("hermes") | Some("qwen25")
+            Some("hermes") | Some("qwen25") | Some("jamba")
         )
     }
 


### PR DESCRIPTION
#### Overview
Extends the streaming-jail never-leak suppression added for hermes/qwen25 to AI21 Jamba. When a jamba tool-call stream ends on a truncated body or arrives as a bare inner body followed by orphan `</tool_calls>` close markers, the jail previously surfaced the raw `<tool_calls>`/`</tool_calls>` markup as user-visible content. Jamba uses the same wrapped-JSON shape, so it belongs on the same allowlist. Pairs with the batch-side fix in frontend-crates#69; this closes the streaming path. Stacked on #10833.

#### Details
- Add `Some("jamba")` to `suppresses_tool_call_markup()` in `jail.rs`. `build()` already auto-populates the jail's start/end sequences from the parser config, so jamba's `<tool_calls>`/`</tool_calls>` markers are picked up with no further wiring. The existing finalize logic then keeps only the prose before the opening marker (truncated/unparseable wrapper) or removes every orphan close marker, instead of re-emitting the raw buffer.
- Update the allowlist TODO to name jamba alongside hermes/qwen25. The follow-up to read `discard_unparseable_wrapper` from the parser config once the `dynamo-parsers` dep is bumped (and drop the name allowlist) still stands.

#### Before / After
```
truncated  (<tool_calls>[{"name": "get_weather", "arguments": {"loc , finish=stop)
  before: <tool_calls>[{"name": "get_weather", "arguments": {"loc
  after:  (empty)
orphan     ([{...NYC}}]</tool_calls></tool_calls></tool_calls> , finish=length)
  before: [{...}]</tool_calls></tool_calls></tool_calls>
  after:  [{"name": "get_weather", "arguments": {"location": "NYC"}}]
```

#### Cross-impl
```
jamba stream truncated  Dynamo jail: leak -> suppressed (empty)
jamba stream orphan     Dynamo jail: leak -> close markers stripped, inner JSON kept
                        (identical handling to hermes/qwen25 from #10833)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tool call markup suppression to ensure consistent safety protections across all supported parser types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->