### PR TITLE
fix(sglang): handle --unified in disagg_same_gpu.sh arg parsing

### DIFF
--- a/examples/backends/sglang/launch/disagg_same_gpu.sh
+++ b/examples/backends/sglang/launch/disagg_same_gpu.sh
@@ -21,6 +21,16 @@ source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 
 MODEL="Qwen/Qwen3-0.6B"
 
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+# Strip --unified via the shared helper, then parse the remaining flags.
+# `--unified` routes workers through dynamo.sglang.unified_main (the Rust
+# backend-common Worker, which owns the prefill drain loop); default stays
+# on the legacy main. Done before the arg loop so it isn't rejected as an
+# unknown option.
+pick_worker_module dynamo.sglang dynamo.sglang.unified_main "$@"
+set -- "${REMAINING_ARGS[@]}"
+
 # --model overrides the default (e.g. a VLM for the multimodal P/D test).
 # --single-gpu is a no-op kept for parity with the other launch scripts.
 while [[ $# -gt 0 ]]; do
@@ -38,9 +48,10 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -h|--help)
-            echo "Usage: $0 [--model <name>] [--single-gpu]"
+            echo "Usage: $0 [--model <name>] [--single-gpu] [--unified]"
             echo "  --model <name>  Model to serve (default: $MODEL)"
             echo "  --single-gpu    Accepted no-op; both workers already share GPU 0"
+            echo "  --unified       Use the unified_main entry point (Rust Worker)"
             exit 0
             ;;
         *)
@@ -70,13 +81,6 @@ MEM_SAVER_ARGS="--enable-memory-saver --delete-ckpt-after-loading"
 if [[ "${DYN_SGLANG_DISABLE_MEMORY_SAVER:-0}" == "1" ]]; then
     MEM_SAVER_ARGS=""
 fi
-
-source "$SCRIPT_DIR/../../../common/launch_utils.sh"
-
-# Select legacy vs unified worker entry point. `--unified` routes workers
-# through dynamo.sglang.unified_main (the Rust backend-common Worker, which
-# owns the prefill drain loop); default stays on the legacy main.
-pick_worker_module dynamo.sglang dynamo.sglang.unified_main "$@"
 
 DISAGG_BOOTSTRAP_PORT="${DYN_DISAGG_BOOTSTRAP_PORT:-12345}"
 


### PR DESCRIPTION
## Overview:

Fixes the post-merge CI break in `sglang-runtime / Test cuda13.0, amd64` where `tests/serve/test_sglang.py::test_prefill_drain_unified` fails with `RuntimeError: Main server process exited with code -15 while waiting for health check` within ~1s of launch.

## Details:

`disagg_same_gpu.sh` ran its `--model`/`--single-gpu` arg-parse `while` loop **before** `pick_worker_module`, so `--unified` fell through to the loop's catch-all (`*) … exit 1`). Combined with `set -e` and `trap 'echo Cleaning up...; kill 0' EXIT`, the failing `exit 1` fired the trap, whose `kill 0` SIGTERM'd the script's own process group — surfacing to the test harness as the server dying with code `-15` before any GPU/model work began.

The test is `@pytest.mark.post_merge` (runs only on `main`, not on the PR), so the break was not caught pre-merge.

Fix: strip `--unified` up front via `pick_worker_module` + `set -- "${REMAINING_ARGS[@]}"` **before** the arg-parse loop (mirroring the existing `disagg.sh` pattern), then parse the remaining flags. Also document `--unified` in `--help`.

## Where should the reviewer start?

- `examples/backends/sglang/launch/disagg_same_gpu.sh` — the only changed file. Compare the new ordering against `examples/backends/sglang/launch/disagg.sh`, which already uses this `pick_worker_module` + `set --` pattern.

Validated on a local RTX 6000 Ada GPU: the pre-fix script exits in ~2s with `Unknown option: --unified`, while the fixed script parses `--unified`, launches the unified prefill+decode workers, and proceeds into model loading / serving as expected.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal launch script argument handling for backend workers to improve configuration routing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->