### PR TITLE
feat(replay): expose the goodput SLA on the plain trace-replay binding

### DIFF
--- a/components/src/dynamo/mocker/__init__.py
+++ b/components/src/dynamo/mocker/__init__.py
@@ -50,6 +50,9 @@ else:
         trace_format="mooncake",
         trace_shared_prefix_ratio=0.0,
         trace_num_prefix_groups=0,
+        sla_ttft_ms=None,
+        sla_itl_ms=None,
+        sla_e2e_ms=None,
     ):
         return _run_mocker_trace_replay(
             trace_file,
@@ -64,6 +67,10 @@ else:
             trace_format=trace_format,
             trace_shared_prefix_ratio=trace_shared_prefix_ratio,
             trace_num_prefix_groups=trace_num_prefix_groups,
+            # Goodput SLA (offline only): report carries goodput_* when set.
+            sla_ttft_ms=sla_ttft_ms,
+            sla_itl_ms=sla_itl_ms,
+            sla_e2e_ms=sla_e2e_ms,
         )
 
 

--- a/components/src/dynamo/replay/api.py
+++ b/components/src/dynamo/replay/api.py
@@ -28,6 +28,9 @@ def run_trace_replay(
     trace_num_prefix_groups=0,
     report_jsonl_path=None,
     max_sim_time_ms=None,
+    sla_ttft_ms=None,
+    sla_itl_ms=None,
+    sla_e2e_ms=None,
 ):
     return _run_mocker_trace_replay(
         trace_file,
@@ -49,6 +52,11 @@ def run_trace_replay(
         trace_num_prefix_groups=trace_num_prefix_groups,
         report_jsonl_path=report_jsonl_path,
         max_sim_time_ms=max_sim_time_ms,
+        # Goodput SLA (offline replay only): when set, the report carries
+        # goodput_* keys classifying SLA-satisfying requests.
+        sla_ttft_ms=sla_ttft_ms,
+        sla_itl_ms=sla_itl_ms,
+        sla_e2e_ms=sla_e2e_ms,
     )
 
 

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -734,7 +734,7 @@ impl MockEngineArgs {
 }
 
 #[pyfunction]
-#[pyo3(signature = (trace_file, extra_engine_args=None, prefill_engine_args=None, decode_engine_args=None, router_config=None, aic_perf_config=None, num_workers=1, num_prefill_workers=1, num_decode_workers=1, replay_concurrency=None, replay_mode="offline", router_mode="round_robin", arrival_speedup_ratio=1.0, trace_block_size=512, trace_format="mooncake", trace_shared_prefix_ratio=0.0, trace_num_prefix_groups=0, report_jsonl_path=None, max_sim_time_ms=None))]
+#[pyo3(signature = (trace_file, extra_engine_args=None, prefill_engine_args=None, decode_engine_args=None, router_config=None, aic_perf_config=None, num_workers=1, num_prefill_workers=1, num_decode_workers=1, replay_concurrency=None, replay_mode="offline", router_mode="round_robin", arrival_speedup_ratio=1.0, trace_block_size=512, trace_format="mooncake", trace_shared_prefix_ratio=0.0, trace_num_prefix_groups=0, report_jsonl_path=None, max_sim_time_ms=None, sla_ttft_ms=None, sla_itl_ms=None, sla_e2e_ms=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn run_mocker_trace_replay(
     py: Python<'_>,
@@ -757,6 +757,9 @@ pub fn run_mocker_trace_replay(
     trace_num_prefix_groups: usize,
     report_jsonl_path: Option<PathBuf>,
     max_sim_time_ms: Option<f64>,
+    sla_ttft_ms: Option<f64>,
+    sla_itl_ms: Option<f64>,
+    sla_e2e_ms: Option<f64>,
 ) -> PyResult<PyObject> {
     let args_selection = load_replay_args_selection(
         py,
@@ -796,6 +799,17 @@ pub fn run_mocker_trace_replay(
             ));
         }
     }
+    // Goodput SLA: when set, the collector classifies SLA-satisfying requests and
+    // the report carries goodput_* keys. Offline replay only (the online/live
+    // entrypoints do not take it); with none set, goodput is omitted as before.
+    validate_sla_threshold("sla_ttft_ms", sla_ttft_ms)?;
+    validate_sla_threshold("sla_itl_ms", sla_itl_ms)?;
+    validate_sla_threshold("sla_e2e_ms", sla_e2e_ms)?;
+    let sla = dynamo_mocker::replay::SlaThresholds {
+        ttft_ms: sla_ttft_ms,
+        itl_ms: sla_itl_ms,
+        e2e_ms: sla_e2e_ms,
+    };
     let report = py.allow_threads(move || {
         let replay_concurrency = parse_replay_concurrency(replay_concurrency)?;
         if trace_format == dynamo_mocker::loadgen::TraceFileFormat::AppliedComputeAgentic
@@ -823,6 +837,7 @@ pub fn run_mocker_trace_replay(
                             trace_shared_prefix_ratio,
                             trace_num_prefix_groups,
                             record_per_request, max_sim_time_ms,
+                            sla,
                         )
                     }
                     ("offline", None) => {
@@ -839,6 +854,7 @@ pub fn run_mocker_trace_replay(
                             trace_shared_prefix_ratio,
                             trace_num_prefix_groups,
                             record_per_request, max_sim_time_ms,
+                            sla,
                         )
                     }
                     ("online", Some(max_in_flight)) => {
@@ -892,6 +908,7 @@ pub fn run_mocker_trace_replay(
                         trace_shared_prefix_ratio,
                         trace_num_prefix_groups,
                         record_per_request, max_sim_time_ms,
+                        sla,
                     )
                 }
                 ("offline", None) => {
@@ -907,6 +924,7 @@ pub fn run_mocker_trace_replay(
                         trace_shared_prefix_ratio,
                         trace_num_prefix_groups,
                         record_per_request, max_sim_time_ms,
+                        sla,
                     )
                 }
                 ("online", _) => anyhow::bail!("disagg replay only supports replay_mode='offline'"),

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -801,10 +801,19 @@ pub fn run_mocker_trace_replay(
     }
     // Goodput SLA: when set, the collector classifies SLA-satisfying requests and
     // the report carries goodput_* keys. Offline replay only (the online/live
-    // entrypoints do not take it); with none set, goodput is omitted as before.
+    // entrypoints don't take it) — reject it for non-offline modes rather than
+    // silently dropping it, matching report_jsonl_path / max_sim_time_ms. With none
+    // set, goodput is omitted as before.
     validate_sla_threshold("sla_ttft_ms", sla_ttft_ms)?;
     validate_sla_threshold("sla_itl_ms", sla_itl_ms)?;
     validate_sla_threshold("sla_e2e_ms", sla_e2e_ms)?;
+    if replay_mode != "offline"
+        && (sla_ttft_ms.is_some() || sla_itl_ms.is_some() || sla_e2e_ms.is_some())
+    {
+        return Err(PyValueError::new_err(
+            "sla_ttft_ms, sla_itl_ms, and sla_e2e_ms only support replay_mode='offline'",
+        ));
+    }
     let sla = dynamo_mocker::replay::SlaThresholds {
         ttft_ms: sla_ttft_ms,
         itl_ms: sla_itl_ms,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2337,6 +2337,9 @@ def run_mocker_trace_replay(
     trace_num_prefix_groups: int = 0,
     report_jsonl_path: Optional[str | os.PathLike[str]] = None,
     max_sim_time_ms: Optional[float] = None,
+    sla_ttft_ms: Optional[float] = None,
+    sla_itl_ms: Optional[float] = None,
+    sla_e2e_ms: Optional[float] = None,
 ) -> Dict[str, Any]:
     """Replay a mocker trace file and return the simulation report for aggregated vLLM or SGLang configs.
 
@@ -2344,6 +2347,10 @@ def run_mocker_trace_replay(
     JSON object per request is written to that path. Each line includes
     arrival/admit/token timestamps, input/output lengths, the full per-token
     ITL series, and prefill/decode worker indices.
+
+    ``sla_ttft_ms`` / ``sla_itl_ms`` / ``sla_e2e_ms`` are the goodput SLA bounds
+    (offline replay only). When any is set, the report carries ``goodput_*`` keys
+    classifying SLA-satisfying requests; with none set, goodput is omitted.
     """
     ...
 

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -14,7 +14,7 @@ use super::validate::{
 };
 use super::{
     OfflineDisaggReplayConfig, ReplayPrefillLoadEstimator, ReplayRouterMode, ReplayWorkerArtifacts,
-    TraceSimulationReport,
+    SlaThresholds, TraceSimulationReport,
 };
 use crate::common::protocols::{DirectRequest, MockEngineArgs};
 use crate::loadgen::{AgenticTrace, Trace, TraceFileFormat};
@@ -162,6 +162,7 @@ pub fn simulate_trace_file_with_router_mode(
         0,
         false,
         None,
+        SlaThresholds::default(),
     )
 }
 
@@ -180,6 +181,7 @@ pub fn simulate_trace_file_with_router_mode_and_format(
     trace_num_prefix_groups: usize,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let args = args.normalized()?;
     validate_offline_replay_args(&args, num_workers, router_mode)?;
@@ -193,6 +195,7 @@ pub fn simulate_trace_file_with_router_mode_and_format(
             trace,
             num_workers,
             router_mode,
+            sla,
         );
     }
     if trace_format == TraceFileFormat::AppliedComputeAgentic {
@@ -220,6 +223,7 @@ pub fn simulate_trace_file_with_router_mode_and_format(
             router_mode,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )?
     } else if trace_accumulates_session_deltas(trace_format) {
         crate::replay::offline::simulate_trace_workload_accumulating_deltas(
@@ -231,6 +235,7 @@ pub fn simulate_trace_file_with_router_mode_and_format(
             router_mode,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )?
     } else {
         crate::replay::offline::simulate_trace_workload(
@@ -242,6 +247,7 @@ pub fn simulate_trace_file_with_router_mode_and_format(
             router_mode,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )?
     };
     Ok(report)
@@ -269,6 +275,7 @@ pub fn simulate_trace_file_disagg_with_router_mode(
         0,
         false,
         None,
+        SlaThresholds::default(),
     )
 }
 
@@ -286,6 +293,7 @@ pub fn simulate_trace_file_disagg_with_router_mode_and_format(
     trace_num_prefix_groups: usize,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let config = config.normalized()?;
     validate_offline_disagg_replay_args(&config, router_mode)?;
@@ -319,6 +327,7 @@ pub fn simulate_trace_file_disagg_with_router_mode_and_format(
             router_mode,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )?
     } else {
         crate::replay::offline::simulate_trace_workload_disagg(
@@ -329,6 +338,7 @@ pub fn simulate_trace_file_disagg_with_router_mode_and_format(
             router_mode,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )?
     };
     Ok(report)
@@ -479,6 +489,7 @@ pub fn simulate_trace_requests_with_router_mode(
         router_mode,
         false,
         None,
+        SlaThresholds::default(),
     )?;
     Ok(report)
 }
@@ -506,6 +517,7 @@ pub fn simulate_trace_requests_disagg_with_router_mode(
         router_mode,
         false,
         None,
+        SlaThresholds::default(),
     )?;
     Ok(report)
 }
@@ -597,6 +609,7 @@ pub fn simulate_concurrency_file_with_router_mode(
         0,
         false,
         None,
+        SlaThresholds::default(),
     )
 }
 
@@ -615,6 +628,7 @@ pub fn simulate_concurrency_file_with_router_mode_and_format(
     trace_num_prefix_groups: usize,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let args = args.normalized()?;
     validate_offline_concurrency_args(&args, num_workers, max_in_flight, router_mode)?;
@@ -639,6 +653,7 @@ pub fn simulate_concurrency_file_with_router_mode_and_format(
             router_mode,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )?
     } else {
         crate::replay::offline::simulate_concurrency_workload(
@@ -651,6 +666,7 @@ pub fn simulate_concurrency_file_with_router_mode_and_format(
             router_mode,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )?
     };
     Ok(report)
@@ -678,6 +694,7 @@ pub fn simulate_concurrency_file_disagg_with_router_mode(
         0,
         false,
         None,
+        SlaThresholds::default(),
     )
 }
 
@@ -695,6 +712,7 @@ pub fn simulate_concurrency_file_disagg_with_router_mode_and_format(
     trace_num_prefix_groups: usize,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let config = config.normalized()?;
     validate_offline_disagg_concurrency_args(&config, max_in_flight, router_mode)?;
@@ -720,6 +738,7 @@ pub fn simulate_concurrency_file_disagg_with_router_mode_and_format(
         router_mode,
         record_per_request,
         max_sim_time_ms,
+        sla,
     )?;
     Ok(report)
 }
@@ -894,6 +913,7 @@ pub fn simulate_concurrency_requests_with_router_mode(
         router_mode,
         false,
         None,
+        SlaThresholds::default(),
     )
 }
 
@@ -920,6 +940,7 @@ pub fn simulate_concurrency_requests_disagg_with_router_mode(
         router_mode,
         false,
         None,
+        SlaThresholds::default(),
     )
 }
 
@@ -957,6 +978,7 @@ pub fn simulate_trace_workload_with_router_mode(
         router_mode,
         false,
         None,
+        SlaThresholds::default(),
     )?;
     Ok(report)
 }
@@ -978,6 +1000,7 @@ pub fn simulate_trace_workload_disagg_with_router_mode(
         router_mode,
         false,
         None,
+        SlaThresholds::default(),
     )?;
     Ok(report)
 }
@@ -1055,6 +1078,7 @@ pub fn simulate_concurrency_workload_with_router_mode(
         router_mode,
         false,
         None,
+        SlaThresholds::default(),
     )
 }
 
@@ -1077,6 +1101,7 @@ pub fn simulate_concurrency_workload_disagg_with_router_mode(
         router_mode,
         false,
         None,
+        SlaThresholds::default(),
     )
 }
 

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -22,7 +22,8 @@ use crate::loadgen::{AgenticTrace, Trace, WorkloadDriver};
 use crate::replay::OfflineDisaggReplayConfig;
 use crate::replay::{
     ReplayPrefillLoadEstimator, ReplayRouterMode, ReplayTimedKvEvent, ReplayTimedOutputSignal,
-    ReplayTimedRequest, ReplayWorkerArtifacts, TraceCollector, TraceSimulationReport,
+    ReplayTimedRequest, ReplayWorkerArtifacts, SlaThresholds, TraceCollector,
+    TraceSimulationReport,
 };
 use crate::scheduler::RouterEventVisibility;
 
@@ -37,10 +38,13 @@ fn timestamp_us_from_ms(timestamp_ms: f64) -> u64 {
 fn finish_with_replay_wall_time(
     collector: TraceCollector,
     started_at: Instant,
+    sla: SlaThresholds,
 ) -> TraceSimulationReport {
     // Capture elapsed time before final report aggregation so bookkeeping such
     // as latency sorting is not counted as replay execution.
     let wall_time_ms = started_at.elapsed().as_secs_f64() * 1000.0;
+    let mut collector = collector;
+    collector.set_sla_thresholds(sla);
     collector.finish().with_wall_time_ms(wall_time_ms)
 }
 
@@ -142,6 +146,7 @@ pub(crate) fn simulate_trace(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     if use_single_runtime(num_workers, router_mode) {
         simulate_trace_single(
@@ -150,6 +155,7 @@ pub(crate) fn simulate_trace(
             arrival_speedup_ratio,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )
     } else {
         simulate_trace_multi(
@@ -162,6 +168,7 @@ pub(crate) fn simulate_trace(
             router_mode,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )
     }
 }
@@ -177,6 +184,7 @@ pub(crate) fn simulate_concurrency(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     if use_single_runtime(num_workers, router_mode) {
         simulate_concurrency_single(
@@ -185,6 +193,7 @@ pub(crate) fn simulate_concurrency(
             max_in_flight,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )
     } else {
         simulate_concurrency_multi(
@@ -197,6 +206,7 @@ pub(crate) fn simulate_concurrency(
             router_mode,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )
     }
 }
@@ -211,6 +221,7 @@ pub(crate) fn simulate_trace_workload(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     simulate_trace_workload_with_delta_mode(
         args,
@@ -222,6 +233,7 @@ pub(crate) fn simulate_trace_workload(
         false,
         record_per_request,
         max_sim_time_ms,
+        sla,
     )
 }
 
@@ -232,9 +244,10 @@ pub(crate) fn simulate_agentic_trace_workload(
     trace: AgenticTrace,
     num_workers: usize,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     if use_single_runtime(num_workers, router_mode) {
-        simulate_agentic_trace_workload_single(args, trace)
+        simulate_agentic_trace_workload_single(args, trace, sla)
     } else {
         simulate_agentic_trace_workload_multi(
             args,
@@ -243,6 +256,7 @@ pub(crate) fn simulate_agentic_trace_workload(
             trace,
             num_workers,
             router_mode,
+            sla,
         )
     }
 }
@@ -257,6 +271,7 @@ pub(crate) fn simulate_trace_workload_accumulating_deltas(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     simulate_trace_workload_with_delta_mode(
         args,
@@ -268,6 +283,7 @@ pub(crate) fn simulate_trace_workload_accumulating_deltas(
         true,
         record_per_request,
         max_sim_time_ms,
+        sla,
     )
 }
 
@@ -282,6 +298,7 @@ fn simulate_trace_workload_with_delta_mode(
     accumulate_session_deltas: bool,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     if use_single_runtime(num_workers, router_mode) {
         simulate_trace_workload_single(
@@ -290,6 +307,7 @@ fn simulate_trace_workload_with_delta_mode(
             accumulate_session_deltas,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )
     } else {
         simulate_trace_workload_multi(
@@ -302,6 +320,7 @@ fn simulate_trace_workload_with_delta_mode(
             accumulate_session_deltas,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )
     }
 }
@@ -317,6 +336,7 @@ pub(crate) fn simulate_concurrency_workload(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     simulate_concurrency_workload_with_delta_mode(
         args,
@@ -329,6 +349,7 @@ pub(crate) fn simulate_concurrency_workload(
         false,
         record_per_request,
         max_sim_time_ms,
+        sla,
     )
 }
 
@@ -343,6 +364,7 @@ pub(crate) fn simulate_concurrency_workload_accumulating_deltas(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     simulate_concurrency_workload_with_delta_mode(
         args,
@@ -355,6 +377,7 @@ pub(crate) fn simulate_concurrency_workload_accumulating_deltas(
         true,
         record_per_request,
         max_sim_time_ms,
+        sla,
     )
 }
 
@@ -370,6 +393,7 @@ fn simulate_concurrency_workload_with_delta_mode(
     accumulate_session_deltas: bool,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     if use_single_runtime(num_workers, router_mode) {
         simulate_concurrency_workload_single(
@@ -379,6 +403,7 @@ fn simulate_concurrency_workload_with_delta_mode(
             accumulate_session_deltas,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )
     } else {
         simulate_concurrency_workload_multi(
@@ -392,6 +417,7 @@ fn simulate_concurrency_workload_with_delta_mode(
             accumulate_session_deltas,
             record_per_request,
             max_sim_time_ms,
+            sla,
         )
     }
 }
@@ -406,6 +432,7 @@ pub(crate) fn simulate_trace_disagg(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let pending = normalize_trace_requests(requests, arrival_speedup_ratio)?;
@@ -420,7 +447,7 @@ pub(crate) fn simulate_trace_disagg(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -433,6 +460,7 @@ pub(crate) fn simulate_concurrency_disagg(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let pending = VecDeque::from(requests);
@@ -447,9 +475,10 @@ pub(crate) fn simulate_concurrency_disagg(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn simulate_trace_workload_disagg(
     config: OfflineDisaggReplayConfig,
     router_config: Option<KvRouterConfig>,
@@ -458,6 +487,7 @@ pub(crate) fn simulate_trace_workload_disagg(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let driver = WorkloadDriver::new_trace(trace, config.prefill_args.block_size)?;
@@ -472,7 +502,7 @@ pub(crate) fn simulate_trace_workload_disagg(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -485,6 +515,7 @@ pub(crate) fn simulate_concurrency_workload_disagg(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let driver =
@@ -500,7 +531,7 @@ pub(crate) fn simulate_concurrency_workload_disagg(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 pub(crate) fn simulate_trace_single(
@@ -509,6 +540,7 @@ pub(crate) fn simulate_trace_single(
     arrival_speedup_ratio: f64,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
@@ -517,7 +549,7 @@ pub(crate) fn simulate_trace_single(
         .with_per_request_records(record_per_request)
         .with_max_sim_time_ms(max_sim_time_ms)
         .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 pub(crate) fn simulate_concurrency_single(
@@ -526,6 +558,7 @@ pub(crate) fn simulate_concurrency_single(
     max_in_flight: usize,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
@@ -538,7 +571,7 @@ pub(crate) fn simulate_concurrency_single(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 pub(crate) fn simulate_trace_workload_single(
@@ -547,6 +580,7 @@ pub(crate) fn simulate_trace_workload_single(
     accumulate_session_deltas: bool,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
@@ -560,19 +594,20 @@ pub(crate) fn simulate_trace_workload_single(
         .with_per_request_records(record_per_request)
         .with_max_sim_time_ms(max_sim_time_ms)
         .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 pub(crate) fn simulate_agentic_trace_workload_single(
     args: MockEngineArgs,
     trace: AgenticTrace,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
     let engine_block_size = args.block_size;
     let driver = trace.into_trace_driver_with_block_size(engine_block_size)?;
     let collector = SingleRuntime::new_workload(args, driver, SingleReplayMode::Trace).run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 pub(crate) fn simulate_concurrency_workload_single(
@@ -582,6 +617,7 @@ pub(crate) fn simulate_concurrency_workload_single(
     accumulate_session_deltas: bool,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
@@ -602,7 +638,7 @@ pub(crate) fn simulate_concurrency_workload_single(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -616,6 +652,7 @@ pub(crate) fn simulate_trace_multi(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
@@ -632,7 +669,7 @@ pub(crate) fn simulate_trace_multi(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -646,6 +683,7 @@ pub(crate) fn simulate_concurrency_multi(
     router_mode: ReplayRouterMode,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
@@ -662,7 +700,7 @@ pub(crate) fn simulate_concurrency_multi(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -676,6 +714,7 @@ pub(crate) fn simulate_trace_workload_multi(
     accumulate_session_deltas: bool,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
@@ -696,7 +735,7 @@ pub(crate) fn simulate_trace_workload_multi(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 pub(crate) fn simulate_agentic_trace_workload_multi(
@@ -706,6 +745,7 @@ pub(crate) fn simulate_agentic_trace_workload_multi(
     trace: AgenticTrace,
     num_workers: usize,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
@@ -720,7 +760,7 @@ pub(crate) fn simulate_agentic_trace_workload_multi(
         router_mode,
     )?
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -735,6 +775,7 @@ pub(crate) fn simulate_concurrency_workload_multi(
     accumulate_session_deltas: bool,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
@@ -758,7 +799,7 @@ pub(crate) fn simulate_concurrency_workload_multi(
     .with_per_request_records(record_per_request)
     .with_max_sim_time_ms(max_sim_time_ms)
     .run()?;
-    Ok(finish_with_replay_wall_time(collector, started_at))
+    Ok(finish_with_replay_wall_time(collector, started_at, sla))
 }
 
 #[cfg(test)]

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -769,8 +769,15 @@ mod tests {
     ) {
         let args = replay_args(enable_prefix_caching, enable_chunked_prefill);
         let manual = run_trace_manually(&args, replay_fixture());
-        let replay_report =
-            simulate_trace_single(args, replay_fixture(), 1.0, false, None).unwrap();
+        let replay_report = simulate_trace_single(
+            args,
+            replay_fixture(),
+            1.0,
+            false,
+            None,
+            crate::replay::SlaThresholds::default(),
+        )
+        .unwrap();
 
         let request_1 = manual.snapshots.get(&Uuid::from_u128(11)).unwrap();
         let request_2 = manual.snapshots.get(&Uuid::from_u128(22)).unwrap();
@@ -797,6 +804,44 @@ mod tests {
         }
 
         assert_report_close(&replay_report, &manual.report);
+    }
+
+    #[test]
+    fn test_trace_replay_emits_goodput_only_with_sla() {
+        // Threading regression: the plain (non-planner) trace replay computes
+        // goodput iff an SLA is supplied. A loose SLA -> every request qualifies.
+        let with_sla = simulate_trace_single(
+            replay_args(false, false),
+            replay_fixture(),
+            1.0,
+            false,
+            None,
+            crate::replay::SlaThresholds {
+                ttft_ms: Some(1.0e9),
+                itl_ms: Some(1.0e9),
+                e2e_ms: Some(1.0e9),
+            },
+        )
+        .unwrap();
+        assert!(
+            with_sla.goodput.is_some(),
+            "goodput should be present when an SLA is supplied"
+        );
+
+        // No SLA (the default) -> goodput stays absent (unchanged behavior).
+        let no_sla = simulate_trace_single(
+            replay_args(false, false),
+            replay_fixture(),
+            1.0,
+            false,
+            None,
+            crate::replay::SlaThresholds::default(),
+        )
+        .unwrap();
+        assert!(
+            no_sla.goodput.is_none(),
+            "goodput should be omitted without an SLA"
+        );
     }
 
     #[test]
@@ -829,7 +874,15 @@ mod tests {
             },
         ];
         let manual = run_concurrency_manually(&args, requests.clone(), 2);
-        let replay_report = simulate_concurrency_single(args, requests, 2, false, None).unwrap();
+        let replay_report = simulate_concurrency_single(
+            args,
+            requests,
+            2,
+            false,
+            None,
+            crate::replay::SlaThresholds::default(),
+        )
+        .unwrap();
 
         let request_1 = manual.snapshots.get(&Uuid::from_u128(11)).unwrap();
         let request_2 = manual.snapshots.get(&Uuid::from_u128(22)).unwrap();
@@ -914,6 +967,7 @@ mod tests {
             1,
             false,
             None,
+            crate::replay::SlaThresholds::default(),
         )
         .unwrap();
 


### PR DESCRIPTION
## What

`run_mocker_trace_replay` / `dynamo.replay.api.run_trace_replay` (and the `dynamo.mocker` convenience wrapper) now accept `sla_ttft_ms` / `sla_itl_ms` / `sla_e2e_ms`. When any is set, the **offline** replay threads them to the `TraceCollector`'s SLA classification and the report carries the `goodput_*` keys (`goodput_output_throughput_tok_s`, `goodput_completed_requests`, `goodput_request_throughput_rps`).

## Why

Goodput requires an SLA to classify SLA-satisfying requests. Until now, only the planner-bridge path (`_run_planner_replay` → `PlannerReplayBridge`) accepted an SLA, so a **plain / static** trace replay (no planner) reported no goodput at all — the collector left `goodput` as `None` and the keys were omitted. That blocks measuring the goodput of a static (non-autoscaling) deployment. This exposes the same SLA entry the bridge already had, on the plain binding.

## How

The SLA threads through the offline `simulate_*` entrypoints (agg **and** disagg, trace **and** concurrency) down to `finish_with_replay_wall_time`, which calls `collector.set_sla_thresholds(sla)` before `finish()`.

- **lib/mocker**: `sla: SlaThresholds` added (last param) to the offline entrypoints + the finish chokepoint; the default-format / synthetic shims pass `SlaThresholds::default()` (unchanged behavior).
- **lib/bindings**: `run_mocker_trace_replay` validates the three thresholds (`validate_sla_threshold`), builds `SlaThresholds`, and forwards it to the offline agg/disagg arms. Online/live arms are unchanged (goodput is an offline-report concept). `_core.pyi` updated.
- **components**: `run_trace_replay` + the `dynamo.mocker` wrapper expose the three params.

With no SLA set, goodput is omitted exactly as before — fully backward compatible.

## Test

- New `replay::offline::single` unit test: the plain trace replay emits goodput iff an SLA is supplied (and omits it otherwise).
- `cargo check` (bindings crate) + `cargo clippy` (mocker + bindings) + `cargo fmt` clean; existing collector/replay tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional SLA (Service Level Agreement) threshold parameters to trace replay, enabling users to define performance targets for time-to-first-token, inter-token latency, and end-to-end latency.
  * Simulation reports now include goodput metrics that classify which requests meet the specified SLA criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related Issues

_No related GitHub issue_ — internal enablement so the plain/static (non-planner) replay can report goodput; consumed by the Spica smart-sweeper for static-deployment goodput.
