### PR TITLE
fix(test): resolve nightly pipeline test failures (run 27944805290)

### DIFF
--- a/examples/backends/vllm/launch/dsr1_dep.sh
+++ b/examples/backends/vllm/launch/dsr1_dep.sh
@@ -70,6 +70,17 @@ if [ -z "$NUM_NODES" ] || [ -z "$NODE_RANK" ] || [ -z "$GPUS_PER_NODE" ]; then
     exit 1
 fi
 
+# Create the log directory up front (before any `tee` below writes into it).
+# Fall back to a writable temp dir if the chosen location (default ./logs) is
+# not writable, e.g. a read-only working directory in CI. Without this, the
+# failing mkdir would trip `set -e` and fire the EXIT trap's `kill 0`, taking
+# the whole launch down before the workers ever start.
+if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
+    FALLBACK_LOG_DIR="$(mktemp -d)"
+    echo "Warning: cannot create log dir '$LOG_DIR'; using '$FALLBACK_LOG_DIR'" >&2
+    LOG_DIR="$FALLBACK_LOG_DIR"
+fi
+
 # Calculate data parallel size
 DATA_PARALLEL_SIZE=$((NUM_NODES * GPUS_PER_NODE))
 
@@ -103,10 +114,8 @@ trap 'echo Cleaning up...; kill 0' EXIT
 # run ingress if it's node 0
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
 if [ $NODE_RANK -eq 0 ]; then
-    DYN_LOG=debug python -m dynamo.frontend --router-mode kv 2>&1 | tee $LOG_DIR/dsr1_dep_ingress.log &
+    DYN_LOG=debug python -m dynamo.frontend --router-mode kv 2>&1 | tee "$LOG_DIR/dsr1_dep_ingress.log" &
 fi
-
-mkdir -p $LOG_DIR
 
 # Data Parallel Attention / Expert Parallelism
 # Routing to DP workers managed by Dynamo
@@ -139,7 +148,7 @@ python3 -m dynamo.vllm \
 --data-parallel-rpc-port 13345 \
 $GPU_MEM_ARGS \
 --enforce-eager \
---kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:20080\",\"enable_kv_cache_events\":true}" 2>&1 | tee $LOG_DIR/dsr1_dep_${dp_start_rank}.log &
+--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:20080\",\"enable_kv_cache_events\":true}" 2>&1 | tee "$LOG_DIR/dsr1_dep_${dp_start_rank}.log" &
 
 echo "All workers starting. (press Ctrl+C to stop)..."
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -79,16 +79,20 @@ class DynamoWorkerProcess(ManagedProcess):
             "16384",
         ]
         if mode != "prefill_and_decode":
-            with open("test_request_cancellation_trtllm_config.yaml", "w") as f:
+            # Write the engine config under the test's tmp_path (guaranteed
+            # writable, unique per test) rather than the CWD, which is
+            # read-only in CI and raised PermissionError.
+            config_file = str(
+                request.getfixturevalue("tmp_path")
+                / f"trtllm_cancel_config_{system_port}.yaml"
+            )
+            with open(config_file, "w") as f:
                 f.write(
                     "cache_transceiver_config:\n  backend: DEFAULT\n  max_tokens_in_buffer: 16384\n"
                 )
                 f.write("disable_overlap_scheduler: true\n")
                 f.write("kv_cache_config:\n  max_tokens: 16384\n")
-            command += [
-                "--extra-engine-args",
-                "test_request_cancellation_trtllm_config.yaml",
-            ]
+            command += ["--extra-engine-args", config_file]
 
         health_check_urls = [
             (f"http://localhost:{frontend_port}/v1/models", check_models_api),

--- a/tests/fault_tolerance/etcd_ha/test_trtllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_trtllm.py
@@ -61,13 +61,17 @@ class DynamoWorkerProcess(ManagedProcess):
 
         # Add disaggregation-specific configuration
         if mode != "prefill_and_decode":
-            with open("test_etcd_ha_trtllm_config.yaml", "w") as f:
+            # Write the engine config under the test's tmp_path (guaranteed
+            # writable, unique per test) rather than the CWD, which is
+            # read-only in CI and raised PermissionError.
+            config_file = str(
+                request.getfixturevalue("tmp_path")
+                / f"trtllm_etcd_ha_config_{mode}.yaml"
+            )
+            with open(config_file, "w") as f:
                 f.write("cache_transceiver_config:\n  backend: DEFAULT\n")
                 f.write("disable_overlap_scheduler: true\n")
-            command += [
-                "--extra-engine-args",
-                "test_etcd_ha_trtllm_config.yaml",
-            ]
+            command += ["--extra-engine-args", config_file]
 
         health_check_urls = [
             (f"http://localhost:{FRONTEND_PORT}/v1/models", check_models_api),

--- a/tests/fault_tolerance/etcd_ha/utils.py
+++ b/tests/fault_tolerance/etcd_ha/utils.py
@@ -37,16 +37,21 @@ class DynamoFrontendProcess(BaseDynamoFrontendProcess):
             "DYN_LOG": "debug",
             "ETCD_ENDPOINTS": ",".join(etcd_endpoints),
         }
-        # WARNING: terminate_all_matching_process_names=True is NOT pytest-xdist safe!
-        # DANGER: Kills ALL dynamo-frontend processes system-wide, including other parallel tests.
-        # For parallel-safe alternative, use terminate_all_matching_process_names=False.
-        # See tests/kvbm_integration/common.py:llm_server_kvbm for example.
-        # TODO: Switch to terminate_all_matching_process_names=False with dynamic ports
+        # terminate_all_matching_process_names=False is required here: the frontend
+        # is launched as `python -m dynamo.frontend`, so its _command_name is the
+        # generic "python". With True, ManagedProcess.__enter__ would SIGTERM/SIGKILL
+        # every "python" process on the host on startup — including this test's own
+        # etcd cluster and vLLM worker (and sibling framework jobs). That orphans
+        # etcd ("connection refused"), so the HA failover the test waits for never
+        # completes and the test hangs until the 600s pytest-timeout fires.
+        # Each test manages its frontend via a `with` block (cleaned up on exit) and
+        # runs in its own container on the fixed FRONTEND_PORT, so the system-wide
+        # name-based sweep is both unnecessary and unsafe here.
         super().__init__(
             request,
             router_mode="round-robin",
             extra_env=extra_env,
-            terminate_all_matching_process_names=True,  # TODO: Change to False
+            terminate_all_matching_process_names=False,
         )
 
 

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -110,8 +110,12 @@ class DynamoWorkerProcess(ManagedProcess):
             "0.15",  # avoid validation error on TRT-LLM available memory checks
         ]
         if mode != "prefill_and_decode":
-            config_file = (
-                f"test_request_migration_trtllm_config_{self.system_port}.yaml"
+            # Write the engine config under the test's tmp_path (guaranteed
+            # writable, unique per test) rather than the CWD, which is
+            # read-only in CI and raised PermissionError.
+            config_file = str(
+                request.getfixturevalue("tmp_path")
+                / f"trtllm_migration_config_{self.system_port}.yaml"
             )
             with open(config_file, "w") as f:
                 f.write(

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -338,34 +338,6 @@ def validate_response(
     )
 
 
-def verify_migration_occurred(frontend_process: DynamoFrontendProcess) -> None:
-    """
-    Verify that migration occurred by checking frontend logs for stream disconnection message.
-
-    Args:
-        frontend_process: The frontend process to check logs for
-    """
-    log_path = frontend_process.log_path
-    log_content = ""
-    for i in range(10):
-        try:
-            with open(log_path, "r") as f:
-                log_content = f.read()
-        except Exception as e:
-            pytest.fail(f"Could not read frontend log file {log_path}: {e}")
-        # Make sure this message is captured if any with the polling
-        if "Cannot recreate stream: " in log_content:
-            break
-        time.sleep(0.005)
-
-    assert (
-        "Stream disconnected... recreating stream..." in log_content
-    ), "'Stream disconnected... recreating stream...' message not found in logs"
-    assert (
-        "Cannot recreate stream: " not in log_content
-    ), "'Cannot recreate stream: ...' error found in logs"
-
-
 def _parse_migration_metric(
     metrics_text: str, model_name: str, migration_type: str
 ) -> int:
@@ -532,31 +504,27 @@ def run_migration_test(
         )
         terminate_process_tree(worker.get_pid(), immediate_kill=False, timeout=10)
 
-    # Step 5: Validate response and verify migration occurred.
-    # migration_enabled and not max_seq_len_exceeded -> migration should succeed
+    # Step 5: Validate the request outcome via its response (the user-facing
+    # contract), not by parsing frontend logs. Migration is expected to succeed
+    # only when it is enabled and the request does not exceed the migration
+    # seq-len cap; otherwise the in-flight request must fail.
     if migration_limit > 0 and migration_max_seq_len != 1:
         validate_response(request_thread, response_list, validate_delay=stream)
-        verify_migration_occurred(frontend)
     else:
-        try:
+        # openai.APIError covers both mid-stream structured error frames
+        # (DIS-1768 contract) and HTTP non-200 responses. A typed check is more
+        # robust than matching the exception's stringified message against a
+        # specific wire-format prefix.
+        with pytest.raises(APIError):
             validate_response(request_thread, response_list, validate_delay=stream)
-            pytest.fail(
-                "Request succeeded unexpectedly when migration should have failed"
-            )
-        except APIError as e:
-            # Expected: openai.APIError covers mid-stream structured error
-            # frames (DIS-1768 contract) and HTTP non-200 responses. A typed
-            # check is more robust than matching the exception's stringified
-            # message against a specific wire-format prefix.
-            logger.info(f"Got expected APIError: {e}")
 
-        try:
-            verify_migration_occurred(frontend)
-            pytest.fail("Migration unexpectedly succeeded")
-        except AssertionError as e:
-            assert "'Cannot recreate stream: ...' error found in logs" in str(e)
-
-    # Step 6: Verify migration metrics
+    # Step 6: Verify that migration behaved as expected via the frontend's
+    # Prometheus metrics (a stable structured surface) instead of asserting on
+    # log strings. `ongoing_request` is incremented at the same point the
+    # migration layer detects a disconnect and recreates the stream, so it is
+    # the structured equivalent of the old "Stream disconnected, recreating
+    # stream" log assertion; `max_seq_len_exceeded` records hitting the
+    # migration seq-len cap.
     verify_migration_metrics(
         frontend.frontend_port,
         expected_ongoing_request_count=1 if migration_limit > 0 else 0,

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1140,6 +1140,15 @@ def _probe_overload_503_and_assert(
 
     async def exhaust_resources_and_verify_503():
         stop_event = asyncio.Event()
+        # Set once any request has been accepted (200). A 503 only ends the probe
+        # after this is set. Some configs (notably decode-blocks, where a single
+        # request's own footprint can momentarily exceed the block threshold) can
+        # emit a transient 503 for the very first request before any request is
+        # accepted; stopping on that 503 would leave num_succeeded == 0 and fail
+        # the "at least one success" assertion. Continuing past it lets a later
+        # request land on the (now drained) worker and be accepted, which is the
+        # 200-then-503 behavior the test is meant to verify.
+        accepted_event = asyncio.Event()
 
         async with aiohttp.ClientSession() as session:
             tasks = []
@@ -1149,13 +1158,20 @@ def _probe_overload_503_and_assert(
                     async with session.post(url, json=payload) as response:
                         if response.status == 200:
                             logger.info(f"Request {req_id} accepted")
+                            accepted_event.set()
                             await stop_event.wait()
                             return response.status
 
                         if response.status == 503:
                             body = await response.text()
                             logger.info(f"Request {req_id} got expected 503: {body}")
-                            stop_event.set()
+                            if accepted_event.is_set():
+                                stop_event.set()
+                            else:
+                                logger.info(
+                                    f"Request {req_id} got a transient 503 before any "
+                                    "request was accepted; continuing to probe"
+                                )
                             return response.status
 
                         body = await response.text()

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -364,7 +364,9 @@ def test_router_decisions_trtllm_disagg(
 @pytest.mark.nightly
 @pytest.mark.profiled_vram_gib(7.8)
 @pytest.mark.requested_trtllm_kv_tokens(2592)
-@pytest.mark.timeout(150)  # ~3x average (~45s/test), rounded up
+# This test syncs two indexers and routinely runs ~120-160s in nightly (observed
+# 118s, 141s, 159s across runs), so the old 150s cap flaked. Give ~2x headroom.
+@pytest.mark.timeout(300)
 @pytest.mark.parametrize(
     "store_backend,durable_kv_events,request_plane",
     [

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -260,7 +260,12 @@ trtllm_configs = {
             pytest.mark.multimodal,
             pytest.mark.nightly,
         ],
-        model="Qwen/Qwen2-VL-7B-Instruct",
+        # Must match the disagg engine configs shipped in disagg_multimodal.sh
+        # (engine_configs/qwen3-vl-2b-instruct/{prefill,decode}.yaml). Qwen2-VL-7B
+        # only ships an agg.yaml, so loading it against the 2B disagg configs
+        # crashes the worker during multimodal KV-cache profiling
+        # ("Number of mm_embeds does not match expected total").
+        model="Qwen/Qwen3-VL-2B-Instruct",
         frontend_port=DefaultPort.FRONTEND.value,
         timeout=900,
         delayed_start=60,


### PR DESCRIPTION
## Summary

Resolves the framework test failures in nightly run [27944805290](https://github.com/ai-dynamo/dynamo/actions/runs/27944805290). The 7 failed jobs had distinct root causes (not one shared failure). Five focused commits, one per root cause.

## Failures and fixes

| Failing test(s) | Root cause | Fix |
|---|---|---|
| `migration/test_sglang.py::..._decode` (26) | `verify_migration_occurred()` asserted on frontend log strings that drifted from the Rust source (`migration.rs`) | Drop log parsing; verify via response outcome (success vs `APIError`) + Prometheus migration metrics (per `tests/CLAUDE.md`) |
| `etcd_ha/test_vllm.py` (4 timeouts) + sglang mGPU 143 + trtllm sGPU 143 | Frontend runs as `python`, so `terminate_all_matching_process_names=True` SIGKILLs every `python` process on startup — orphaning the test's own etcd/worker → failover hangs to 600s / shard reclaimed (143) | Set the flag to `False` (already the file's own TODO) |
| `serve/test_trtllm.py::test_deployment[disaggregated_multimodal-2]` | Test injected `MODEL_PATH=Qwen2-VL-7B` but the launch script hardcodes `qwen3-vl-2b-instruct` disagg engine configs (7B ships only `agg.yaml`) → mm_embeds mismatch crash | Use `Qwen3-VL-2B-Instruct`, matching the disagg configs |
| `serve/test_vllm.py::test_serve_deployment[deepep-2]` | `dsr1_dep.sh` runs `tee $LOG_DIR/...` before `mkdir`; mkdir fails on a read-only CWD under `set -e` → EXIT trap `kill 0` kills the server | Create log dir up front + fall back to a writable temp dir |
| `router/test_router_e2e_with_mockers.py::..._overload_503[decode-blocks-nondurable]` | Flaky race: a single decode request self-overloads, so the first request can 503 before any is accepted → 0 successes (product is correct) | Only stop the probe once ≥1 request has been accepted |

`trtllm decode_cancel[nats,tcp]` was also reported failing, but it passes reliably on real hardware (4/4) — it was collateral of the shard the etcd_ha bug destabilized (fast-fail in <1s, no traceback; shard killed 143 at the etcd_ha test). No code change; the etcd_ha fix removes the instability.

## Validation

Built `ai-dynamo-runtime` from this branch in the `*-local-dev` images and ran the failing tests on a local GPU:

- router `decode-blocks-nondurable`: **6/6 pass** (was flaky)
- all 4 `etcd_ha/test_vllm.py`: **4/4 pass** in 316s (was timing out at 600s)
- migration (metrics/response): **3/3 trtllm aggregated cases** (enabled, seq-len-exceeded, disabled) pass on GPU; shared helper covers sglang/vLLM
- trtllm `decode_cancel[tcp]`+`[nats]`: pass on GPU

The two `gpu_2`/`h100` fixes (trtllm multimodal model, deepep launch script) are config/shell-level and ride on this nightly run to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multimodal KV-cache profiling issue with TRTLLM models.

* **Tests**
  * Improved fault tolerance and router test reliability.
  * Enhanced migration testing with Prometheus metrics verification.

* **Chores**
  * Improved logging directory initialization and fallback handling in deployment scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->