### PR TITLE
chore: bump dynamo-parsers to 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.4.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53929c7ac7cfc7696a936600bbe1e53b32aaf1279564ca93baa7bb6c8967d0ab"
+checksum = "5bb23fb9321c93a16e4299457fb113c9c4d2851de1eba6cf5dff37cb2434849a"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ dynamo-memory = { path = "lib/memory", version = "1.3.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.3.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.3.0", features = ["metrics", "runtime-protocols"] }
 dynamo-protocols = { path = "lib/protocols", version = "1.3.0" }
-dynamo-parsers = { version = "1.4.1" }
+dynamo-parsers = { version = "2.0.1" }
 dynamo-backend-common = { path = "lib/backend-common", version = "1.3.0" }
 fastokens = { version = "0.2.0" }
 

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -49,7 +49,7 @@ mm-routing = ["dynamo-llm/mm-routing"]
 aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "ffbab15797d3a3f14c382e937c0ab0c1c5cbc530", package = "aiconfigurator-core", optional = true }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
-dynamo-parsers = { version = "1.4.1" }
+dynamo-parsers = { version = "2.0.1" }
 dynamo-protocols = { path = "../../protocols" }
 dynamo-backend-common = { path = "../../backend-common" }
 

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -1382,6 +1382,32 @@ mod tests {
             inner.inner.created, 1234567890,
             "Inner response created should carry forward from real stream chunks, not be 0"
         );
+
+        // The hermes parser (dynamo-parsers 2.0.1, PR #63) never surfaces tool-call
+        // markup to the client: a call truncated at stream end is recovered as a real
+        // tool call and the raw `<tool_call>` markup is stripped, rather than leaking
+        // the buffer as text. So the released chunk carries the recovered call with
+        // empty content (the metadata-preservation checks above are the test's subject).
+        let content = &inner.inner.choices[0].delta.content;
+        assert_eq!(
+            content.as_ref().map(test_utils::extract_text).as_deref(),
+            Some(""),
+            "Released chunk must not leak raw tool-call markup as content"
+        );
+        let tool_calls = inner.inner.choices[0].delta.tool_calls.as_ref();
+        assert_eq!(
+            tool_calls.map(|tc| tc.len()),
+            Some(1),
+            "Truncated call must be recovered as a tool call, not leaked as text"
+        );
+        assert_eq!(
+            tool_calls.unwrap()[0]
+                .function
+                .as_ref()
+                .and_then(|f| f.name.as_deref()),
+            Some("incomplete_call"),
+            "Recovered tool call should carry the parsed function name"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
> [!NOTE]
> **Next priority.** This pins the current published `dynamo-parsers` 2.0.1. Once #53 (Qwen3-Coder v2 streaming parser) and #72 (truncation-drop fix) land in `frontend-crates` and a new `dynamo-parsers` is published, this PR will bump to that latest published version. The stacked PR #10853 (Qwen3-Coder routing through `dynamo-parsers-v2`) is a POC for now and becomes real once this lands.

#### Overview:

This PR bumps the published `dynamo-parsers` dependency from 1.4.1 to 2.0.1 (workspace root + python bindings) so Dynamo runs on the 2.0.x parser line; no Dynamo code changes.

#### Details:

- `dynamo-parsers` 1.4.1 -> 2.0.1 in `Cargo.toml` and `lib/bindings/python/Cargo.toml`; `Cargo.lock` regenerated.
- Updates `test_jailed_stream_preserves_metadata_on_stream_end` to 2.0.1's hermes contract: at stream end the truncated call is now recovered with empty content rather than the raw `<tool_call>` markup leaking, so the test asserts the recovered tool call instead of a leaked start marker (metadata-preservation checks unchanged).

#### Verification:

`cargo test -p dynamo-llm --test test_jail --test tool_choice --test test_streaming_tool_parsers --test parallel_tool_call_integration` — 143 passed, 0 failed against published 2.0.1.

#### Where should the reviewer start?

`Cargo.toml`, then `lib/llm/tests/test_jail.rs`

/coderabbit profile chill
