### PR TITLE
feat: route Qwen3-Coder + DeepSeek-V4 tool calls through dynamo-parsers-v2 (DYN_ENABLE_EXPERIMENTAL_PARSERS_V2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
  "dynamo-memory",
  "dynamo-mocker",
  "dynamo-parsers",
+ "dynamo-parsers-v2",
  "dynamo-protocols",
  "dynamo-renderer",
  "dynamo-rl",
@@ -2721,6 +2722,22 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "dynamo-parsers-v2"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ed5c413c09fd40cfb214a1e8cdcc8c7f536186f3bc5e433accfe24721b927c"
+dependencies = [
+ "anyhow",
+ "dynamo-parsers",
+ "openai-harmony",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ dynamo-mocker = { path = "lib/mocker", version = "1.3.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.3.0", features = ["metrics", "runtime-protocols"] }
 dynamo-protocols = { version = "=2.0.0" }
 dynamo-parsers = { version = "2.1.2" }
+# Published on crates.io. To see all available versions:
+#   web:          https://crates.io/crates/dynamo-parsers-v2/versions
+#   sparse index: curl https://index.crates.io/dy/na/dynamo-parsers-v2   (one JSON line per release; read the "vers" field)
+dynamo-parsers-v2 = { version = "0.1.10" }
 dynamo-backend-common = { path = "lib/backend-common", version = "1.3.0" }
 fastokens = { version = "0.2.0" }
 

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1591,6 +1591,7 @@ dependencies = [
  "dynamo-memory",
  "dynamo-mocker",
  "dynamo-parsers",
+ "dynamo-parsers-v2",
  "dynamo-protocols",
  "dynamo-renderer",
  "dynamo-rl",
@@ -1715,6 +1716,22 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "dynamo-parsers-v2"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ed5c413c09fd40cfb214a1e8cdcc8c7f536186f3bc5e433accfe24721b927c"
+dependencies = [
+ "anyhow",
+ "dynamo-parsers",
+ "openai-harmony",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tracing",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2194,6 +2194,7 @@ dependencies = [
  "dynamo-memory",
  "dynamo-mocker",
  "dynamo-parsers",
+ "dynamo-parsers-v2",
  "dynamo-protocols",
  "dynamo-renderer",
  "dynamo-rl",
@@ -2328,6 +2329,22 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "dynamo-parsers-v2"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ed5c413c09fd40cfb214a1e8cdcc8c7f536186f3bc5e433accfe24721b927c"
+dependencies = [
+ "anyhow",
+ "dynamo-parsers",
+ "openai-harmony",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tracing",
 ]
 
 [[package]]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -72,6 +72,7 @@ aho-corasick = "1.1"
 anyhow = { workspace = true }
 dynamo-protocols = { workspace = true }
 dynamo-parsers = { workspace = true }
+dynamo-parsers-v2 = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 async-nats = { workspace = true }

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -333,6 +333,14 @@ async fn anthropic_messages(
 
     let request = context.map(|_req| chat_request);
 
+    // Gate the experimental v2 batch finalize on the request's tool_choice, mirroring the
+    // streaming gate (required/named + structural-tag stay on the v1 finalize path).
+    let parsing_options = parsing_options.with_experimental_v2_batch_eligible(
+        crate::protocols::openai::chat_completions::tool_parser_v2::batch_tool_choice_eligible(
+            request.inner.tool_choice.as_ref(),
+        ),
+    );
+
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
     // Create inflight_guard early to ensure all errors are counted

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1684,6 +1684,14 @@ async fn chat_completions(
             err_response
         })?;
 
+    // Gate the experimental v2 batch finalize on the request's tool_choice, mirroring the
+    // streaming gate (required/named + structural-tag stay on the v1 finalize path).
+    let parsing_options = parsing_options.with_experimental_v2_batch_eligible(
+        crate::protocols::openai::chat_completions::tool_parser_v2::batch_tool_choice_eligible(
+            request.inner.tool_choice.as_ref(),
+        ),
+    );
+
     let mut response_collector = state
         .metrics_clone()
         .create_response_collector(&metric_model);
@@ -2154,6 +2162,14 @@ async fn responses(
             inflight_guard.mark_error(extract_error_type_from_response(&err_response));
             err_response
         })?;
+
+    // Gate the experimental v2 batch finalize on the request's tool_choice, mirroring the
+    // streaming gate (required/named + structural-tag stay on the v1 finalize path).
+    let parsing_options = parsing_options.with_experimental_v2_batch_eligible(
+        crate::protocols::openai::chat_completions::tool_parser_v2::batch_tool_choice_eligible(
+            request.inner.tool_choice.as_ref(),
+        ),
+    );
 
     let mut response_collector = state
         .metrics_clone()

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1998,18 +1998,43 @@ impl OpenAIPreprocessor {
                 .collect()
         });
 
+        // When DYN_ENABLE_EXPERIMENTAL_PARSERS_V2 is set, supported families
+        // (Qwen3-Coder, DeepSeek-V4) stream through the dynamo-parsers-v2 parser
+        // instead of the jail, which is never built for them on this path.
+        // tool_choice=required/named and structural-tag still use the jail's
+        // Immediate mode, since those rely on guided-decoded JSON rather than the
+        // native markup the v2 parser reads. See tool_parser_v2::apply_stream.
+        use crate::protocols::openai::chat_completions::tool_parser_v2;
+        let parser_name = self.tool_call_parser.as_deref();
+        let use_parsers_v2 = tool_parser_v2::enabled()
+            && parser_name.is_some_and(tool_parser_v2::supports_family)
+            && !uses_tool_call_structural_tag
+            && matches!(
+                request.inner.tool_choice.as_ref(),
+                None | Some(dynamo_protocols::types::ChatCompletionToolChoiceOption::Auto)
+            );
+
         // Apply jail conditionally
-        let transformed_stream: Pin<Box<dyn Stream<Item = _> + Send>> = if should_jail {
-            Box::pin(Self::apply_tool_calling_jail(
-                self.tool_call_parser.clone(),
-                request.inner.tool_choice.clone(),
-                tool_definitions,
-                uses_tool_call_structural_tag,
-                stream,
-            ))
-        } else {
-            Box::pin(stream)
-        };
+        let transformed_stream: Pin<Box<dyn Stream<Item = _> + Send>> =
+            if should_jail && use_parsers_v2 {
+                Box::pin(tool_parser_v2::apply_stream(
+                    stream,
+                    tool_definitions,
+                    parser_name
+                        .expect("use_parsers_v2 implies a parser name")
+                        .to_string(),
+                ))
+            } else if should_jail {
+                Box::pin(Self::apply_tool_calling_jail(
+                    self.tool_call_parser.clone(),
+                    request.inner.tool_choice.clone(),
+                    tool_definitions,
+                    uses_tool_call_structural_tag,
+                    stream,
+                ))
+            } else {
+                Box::pin(stream)
+            };
 
         Ok(transformed_stream)
     }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -324,6 +324,15 @@ pub struct ParsingOptions {
     pub tool_call_parser: Option<String>,
 
     pub reasoning_parser: Option<String>,
+
+    /// Request-side gate for routing the batch tool-call finalize through
+    /// `dynamo-parsers-v2` (see
+    /// `chat_completions::tool_parser_v2::batch_tool_choice_eligible`). Defaults `false`
+    /// so any path that does not explicitly opt in stays on the v1 finalize path; the
+    /// chat HTTP handlers set it from the request's tool_choice. The env flag and family
+    /// support are checked separately in the aggregator.
+    #[serde(default)]
+    pub experimental_v2_batch_eligible: bool,
 }
 
 impl ParsingOptions {
@@ -331,6 +340,15 @@ impl ParsingOptions {
         Self {
             tool_call_parser,
             reasoning_parser,
+            experimental_v2_batch_eligible: false,
         }
+    }
+
+    /// Set whether this request is eligible for the experimental v2 batch parser
+    /// (request-side tool_choice gate). See
+    /// `chat_completions::tool_parser_v2::batch_tool_choice_eligible`.
+    pub fn with_experimental_v2_batch_eligible(mut self, eligible: bool) -> Self {
+        self.experimental_v2_batch_eligible = eligible;
+        self
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -23,6 +23,7 @@ use crate::protocols::common::extensions::{
 pub mod aggregator;
 mod delta;
 pub mod jail;
+pub mod tool_parser_v2;
 
 pub use aggregator::DeltaAggregator;
 pub use delta::DeltaGenerator;

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -381,20 +381,33 @@ impl DeltaAggregator {
                     continue;
                 }
 
-                let (tool_calls, content) =
-                    match try_tool_call_parse_aggregate_finalize(&choice.text, Some(parser), None)
-                        .await
-                    {
-                        Ok(result) => result,
-                        Err(error) => {
-                            tracing::debug!(
-                                error = %error,
-                                parser,
-                                "failed to parse aggregated chat tool calls"
-                            );
-                            continue;
-                        }
-                    };
+                // With DYN_ENABLE_EXPERIMENTAL_PARSERS_V2, supported families use the
+                // v2 parser for batch too (no jail / no aggregate-finalize):
+                // parse_complete drops a value truncated at EOF instead of guessing it.
+                // Other families, the flag off, and guided-decoded requests
+                // (tool_choice=required/named or structural-tag, gated by
+                // experimental_v2_batch_eligible — see tool_parser_v2::batch_tool_choice_eligible)
+                // keep the v1 finalize path.
+                let parse_result = if super::tool_parser_v2::enabled()
+                    && super::tool_parser_v2::supports_family(parser)
+                    && parsing_options.experimental_v2_batch_eligible
+                {
+                    super::tool_parser_v2::parse_complete(&choice.text, None, parser)
+                        .map(|(calls, normal)| (calls, Some(normal)))
+                } else {
+                    try_tool_call_parse_aggregate_finalize(&choice.text, Some(parser), None).await
+                };
+                let (tool_calls, content) = match parse_result {
+                    Ok(result) => result,
+                    Err(error) => {
+                        tracing::debug!(
+                            error = %error,
+                            parser,
+                            "failed to parse aggregated chat tool calls"
+                        );
+                        continue;
+                    }
+                };
 
                 if !tool_calls.is_empty() {
                     choice.tool_calls = Some(

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -1,0 +1,537 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tool calls routed through the `dynamo-parsers-v2` streaming parser, bypassing the jail.
+//!
+//! Gated behind
+//! [`DYN_ENABLE_EXPERIMENTAL_PARSERS_V2`](dynamo_runtime::config::environment_names::llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2).
+//! When enabled, the families in [`V2_FAMILIES`] (Qwen3-Coder, DeepSeek-V4) stream
+//! straight through their `dynamo_parsers_v2` parser instead of
+//! [`JailedStream`](super::jail::JailedStream): the v2 parser owns incremental
+//! tool-call emission and drops a parameter value truncated at EOF rather than
+//! guessing it. The jail is never built for these families in either path
+//! (`apply_stream` for streaming, `parse_complete` for batch). Other families, and
+//! non-`auto` tool_choice, keep the v1 jail / aggregate-finalize path. The parser is
+//! selected by family name via `dynamo_parsers_v2::create_tool_parser_for_family`, so
+//! adding a family is a one-line change here plus support in that crate.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use async_stream::stream;
+use dynamo_protocols::types::{
+    ChatCompletionMessageContent, ChatCompletionMessageToolCallChunk,
+    ChatCompletionToolChoiceOption, FinishReason, FunctionCallStream, FunctionType,
+};
+use dynamo_runtime::config::{env_is_truthy, environment_names::llm as env_llm};
+use dynamo_runtime::protocols::annotated::Annotated;
+use futures::{Stream, StreamExt};
+use uuid::Uuid;
+
+use dynamo_parsers::tool_calling::{
+    CalledFunction, ToolCallResponse, ToolCallType, ToolDefinition,
+};
+use dynamo_parsers_v2::{Tool as ToolV2, ToolCallDelta, ToolParser, create_tool_parser_for_family};
+
+use super::NvCreateChatCompletionStreamResponse;
+
+/// Tool-call families with a `dynamo-parsers-v2` parser wired into both the batch and
+/// the streaming path. Must stay a subset of the families
+/// `dynamo_parsers_v2::create_tool_parser_for_family` accepts; the strings match
+/// dynamo's `tool_call_parser` names so a parser name maps straight to a v2 family.
+pub(crate) const V2_FAMILIES: &[&str] = &["qwen3_coder", "deepseek_v4"];
+
+/// Whether the experimental v2 tool-parser routing is enabled. Read once from
+/// [`DYN_ENABLE_EXPERIMENTAL_PARSERS_V2`](env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2) —
+/// env vars are fixed for the process lifetime, so the result is cached.
+pub(crate) fn enabled() -> bool {
+    static ENABLED: LazyLock<bool> =
+        LazyLock::new(|| env_is_truthy(env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2));
+    *ENABLED
+}
+
+/// Whether `family` has a v2 parser and should bypass the v1 jail when [`enabled`].
+pub(crate) fn supports_family(family: &str) -> bool {
+    V2_FAMILIES.contains(&family)
+}
+
+/// Request-side gate for routing the **batch** finalize through v2, mirroring the
+/// streaming gate's tool_choice clause (see `preprocessor.rs`): only an unset or `auto`
+/// tool_choice is eligible. `tool_choice=required`/named and structural-tag mode are
+/// guided-decoded JSON, not the native markup the v2 parser reads, so they stay on the
+/// v1 finalize path.
+///
+/// The streaming gate's `!uses_tool_call_structural_tag` clause is intentionally not
+/// re-checked here. That flag is computed in the worker preprocessor and isn't visible
+/// to the frontend aggregator; but any request that gets structural-tag/guided decoding
+/// is parsed upstream (the worker jails it and emits `tool_calls`), so it never reaches
+/// the batch finalize with raw text. The request's tool_choice is the reachable guard.
+pub(crate) fn batch_tool_choice_eligible(
+    tool_choice: Option<&ChatCompletionToolChoiceOption>,
+) -> bool {
+    matches!(
+        tool_choice,
+        None | Some(ChatCompletionToolChoiceOption::Auto)
+    )
+}
+
+/// Map dynamo's v1 `ToolDefinition`s onto the v2 parser's `Tool` shape.
+fn to_v2_tools(tools: Option<&[ToolDefinition]>) -> Vec<ToolV2> {
+    tools
+        .unwrap_or(&[])
+        .iter()
+        .map(|t| ToolV2 {
+            name: t.name.clone(),
+            description: None,
+            parameters: t.parameters.clone().unwrap_or(serde_json::Value::Null),
+            strict: t.strict,
+        })
+        .collect()
+}
+
+/// Batch (non-streaming) path: run the whole response text through the `family` v2
+/// parser's complete lifecycle and map the coalesced calls back onto the v1
+/// `(tool_calls, normal_text)` tuple the aggregator consumes. No jail involved; a
+/// call truncated mid parameter value is dropped (returns zero calls, empty text).
+pub(crate) fn parse_complete(
+    content: &str,
+    tools: Option<&[ToolDefinition]>,
+    family: &str,
+) -> anyhow::Result<(Vec<ToolCallResponse>, String)> {
+    let v2_tools = to_v2_tools(tools);
+    let mut parser = create_tool_parser_for_family(family, &v2_tools)?;
+    let result = parser.parse_complete(content)?;
+
+    let tool_calls = result
+        .calls
+        .into_iter()
+        .map(|call| ToolCallResponse {
+            id: format!("call-{}", Uuid::new_v4()),
+            tp: ToolCallType::Function,
+            function: CalledFunction {
+                name: call.name.unwrap_or_default(),
+                arguments: call.arguments,
+            },
+        })
+        .collect();
+
+    Ok((tool_calls, result.normal_text))
+}
+
+/// Per-choice streaming state: one parser plus the set of tool indices whose
+/// opening delta (id + type + function name) has already been emitted.
+struct ChoiceState {
+    parser: Box<dyn ToolParser>,
+    opened: HashSet<usize>,
+}
+
+impl ChoiceState {
+    fn new(family: &str, tools: &[ToolV2]) -> anyhow::Result<Self> {
+        Ok(Self {
+            parser: create_tool_parser_for_family(family, tools)?,
+            opened: HashSet::new(),
+        })
+    }
+
+    /// Map v2 per-chunk deltas onto OpenAI streaming tool-call chunks. The first
+    /// delta for a given tool index carries the minted id, type and function name;
+    /// later deltas for that index carry only argument fragments (`id`/`type`/`name`
+    /// `None`), matching the OpenAI streaming tool-call contract.
+    fn emit_chunks(
+        &mut self,
+        calls: Vec<ToolCallDelta>,
+    ) -> Option<Vec<ChatCompletionMessageToolCallChunk>> {
+        if calls.is_empty() {
+            return None;
+        }
+        let chunks = calls
+            .into_iter()
+            .map(|delta| {
+                let first = self.opened.insert(delta.tool_index);
+                ChatCompletionMessageToolCallChunk {
+                    index: delta.tool_index as u32,
+                    id: first.then(|| format!("call-{}", Uuid::new_v4())),
+                    r#type: first.then_some(FunctionType::Function),
+                    function: Some(FunctionCallStream {
+                        name: delta.name,
+                        arguments: Some(delta.arguments),
+                    }),
+                }
+            })
+            .collect();
+        Some(chunks)
+    }
+}
+
+/// Streaming path: replace the jail with the `family` v2 parser. Each upstream text
+/// delta is pushed into the parser; the parser's `normal_text` becomes the emitted
+/// content and its tool-call deltas become OpenAI tool-call chunks. The jail is never
+/// built. `finish()` runs on a choice's terminating chunk (and again at stream end as
+/// a backstop) so a value truncated mid-stream is dropped instead of leaking markup.
+pub(crate) fn apply_stream<S>(
+    stream_in: S,
+    tool_definitions: Option<Vec<ToolDefinition>>,
+    family: String,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    let v2_tools = to_v2_tools(tool_definitions.as_deref());
+    stream! {
+        // The caller only routes supported families here, but if a parser cannot be
+        // built we pass every chunk through untouched rather than dropping output.
+        if create_tool_parser_for_family(&family, &v2_tools).is_err() {
+            tracing::warn!(family = %family, "no dynamo-parsers-v2 parser for family; passing stream through unchanged");
+            tokio::pin!(stream_in);
+            while let Some(response) = stream_in.next().await {
+                yield response;
+            }
+            return;
+        }
+
+        let mut states: HashMap<u32, ChoiceState> = HashMap::new();
+        // Choice indices whose finish() has already run (terminating chunk seen).
+        let mut finished: HashSet<u32> = HashSet::new();
+        // Choice indices that have emitted at least one tool-call chunk; used to flip a
+        // `Stop` terminating reason to `ToolCalls` (OpenAI contract — see below).
+        let mut tool_emitted: HashSet<u32> = HashSet::new();
+        // Last data response, kept (with choices cleared) as a template for the
+        // end-of-stream flush when no finish_reason chunk arrived.
+        let mut template: Option<NvCreateChatCompletionStreamResponse> = None;
+
+        tokio::pin!(stream_in);
+
+        while let Some(mut response) = stream_in.next().await {
+            let Some(chat_response) = response.data.as_mut() else {
+                // Non-data annotations (errors, comments) pass through untouched.
+                yield response;
+                continue;
+            };
+
+            {
+                let mut t = chat_response.clone();
+                t.inner.choices.clear();
+                template = Some(t);
+            }
+
+            for choice in chat_response.inner.choices.iter_mut() {
+                let state = states.entry(choice.index).or_insert_with(|| {
+                    // Family validated above; construction is deterministic in-process.
+                    ChoiceState::new(&family, &v2_tools)
+                        .expect("dynamo-parsers-v2 parser construction validated above")
+                });
+
+                // Only text content feeds the parser; multimodal parts pass through.
+                let text = match choice.delta.content.as_ref() {
+                    Some(ChatCompletionMessageContent::Text(t)) => Some(t.clone()),
+                    _ => None,
+                };
+
+                let mut result = dynamo_parsers_v2::ToolParseResult::default();
+                let mut parsed_any = false;
+                if let Some(text) = text.as_deref() {
+                    match state.parser.push(text) {
+                        Ok(r) => {
+                            result.append(r);
+                            parsed_any = true;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, family = %family, "v2 stream push failed; passing chunk through");
+                        }
+                    }
+                }
+                // Flush on the terminating chunk so a value truncated at EOF is dropped.
+                if choice.finish_reason.is_some() && finished.insert(choice.index) {
+                    match state.parser.finish() {
+                        Ok(r) => {
+                            result.append(r);
+                            parsed_any = true;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, family = %family, "v2 stream finish failed");
+                        }
+                    }
+                }
+
+                if parsed_any {
+                    let tool_calls = state.emit_chunks(result.calls);
+                    if tool_calls.is_some() {
+                        tool_emitted.insert(choice.index);
+                    }
+                    // The parser consumed text input, so replace content with its
+                    // normal_text (None when the input was all tool markup) — raw tool
+                    // markup must never reach the client. Role, reasoning and logprobs
+                    // are preserved as-is.
+                    choice.delta.content = if result.normal_text.is_empty() {
+                        None
+                    } else {
+                        Some(ChatCompletionMessageContent::Text(result.normal_text))
+                    };
+                    choice.delta.tool_calls = tool_calls;
+                }
+
+                // OpenAI streaming contract: once a choice has emitted tool calls, a
+                // `Stop` terminating reason must be reported as `ToolCalls` (mirrors the
+                // v1 jail's fix_finish_reason). Length/ContentFilter are preserved as-is.
+                // Runs regardless of parsed_any so a role-only terminating chunk that
+                // still carries finish_reason gets fixed.
+                if choice.finish_reason == Some(FinishReason::Stop)
+                    && tool_emitted.contains(&choice.index)
+                {
+                    choice.finish_reason = Some(FinishReason::ToolCalls);
+                }
+            }
+
+            yield response;
+        }
+
+        // Backstop: the stream ended without a finish_reason for some choice. Flush
+        // each unfinished parser; emit a trailing chunk only when it yields output.
+        if let Some(template) = template {
+            for (index, state) in states.iter_mut() {
+                if finished.contains(index) {
+                    continue;
+                }
+                let Ok(result) = state.parser.finish() else {
+                    continue;
+                };
+                let tool_calls = state.emit_chunks(result.calls);
+                if result.normal_text.is_empty() && tool_calls.is_none() {
+                    continue;
+                }
+                let mut response = template.clone();
+                #[allow(deprecated)]
+                let choice = dynamo_protocols::types::ChatChoiceStream {
+                    index: *index,
+                    delta: dynamo_protocols::types::ChatCompletionStreamResponseDelta {
+                        role: None,
+                        content: (!result.normal_text.is_empty())
+                            .then_some(ChatCompletionMessageContent::Text(result.normal_text)),
+                        tool_calls,
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: None,
+                    logprobs: None,
+                };
+                response.inner.choices = vec![choice];
+                yield Annotated {
+                    data: Some(response),
+                    id: None,
+                    event: None,
+                    comment: None,
+                    error: None,
+                };
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_protocols::types::{
+        ChatChoiceStream, ChatCompletionStreamResponseDelta, FinishReason, Role,
+    };
+    use futures::stream;
+
+    const QWEN3_GET_WEATHER: &str = "<tool_call>\n<function=get_weather>\n<parameter=location>\nParis\n</parameter>\n</function>\n</tool_call>";
+
+    // DeepSeek-V4 DSML: one get_weather(location="NYC") call. The `｜` glyphs are the
+    // fullwidth vertical bars the DSML markers use (see dynamo_parsers_v2::dsml).
+    const DSV4_GET_WEATHER: &str = "<｜DSML｜tool_calls> <｜DSML｜invoke name=\"get_weather\"> <｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter> </｜DSML｜invoke> </｜DSML｜tool_calls>";
+
+    fn chunk(text: &str, finish: bool) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        #[allow(deprecated)]
+        let response = NvCreateChatCompletionStreamResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test".to_string(),
+                choices: vec![ChatChoiceStream {
+                    index: 0,
+                    delta: ChatCompletionStreamResponseDelta {
+                        role: Some(Role::Assistant),
+                        content: Some(ChatCompletionMessageContent::Text(text.to_string())),
+                        tool_calls: None,
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: finish.then_some(FinishReason::Stop),
+                    logprobs: None,
+                }],
+                created: 0,
+                model: "test".to_string(),
+                system_fingerprint: None,
+                service_tier: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+            },
+            nvext: None,
+        };
+        Annotated {
+            data: Some(response),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// Reassemble the streamed tool-call deltas into (name, arguments) per index and
+    /// collect all emitted content, mirroring how an OpenAI client reconstructs a
+    /// streamed tool call.
+    fn reassemble(
+        responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> (Vec<(String, String)>, String) {
+        let mut calls: Vec<(String, String)> = Vec::new();
+        let mut content = String::new();
+        for r in responses {
+            let Some(data) = r.data.as_ref() else {
+                continue;
+            };
+            for choice in &data.inner.choices {
+                if let Some(ChatCompletionMessageContent::Text(t)) = &choice.delta.content {
+                    content.push_str(t);
+                }
+                let Some(tcs) = &choice.delta.tool_calls else {
+                    continue;
+                };
+                for tc in tcs {
+                    let idx = tc.index as usize;
+                    if calls.len() <= idx {
+                        calls.resize(idx + 1, (String::new(), String::new()));
+                    }
+                    if let Some(f) = &tc.function {
+                        if let Some(name) = &f.name {
+                            calls[idx].0 = name.clone();
+                        }
+                        if let Some(args) = &f.arguments {
+                            calls[idx].1.push_str(args);
+                        }
+                    }
+                }
+            }
+        }
+        (calls, content)
+    }
+
+    /// The last `finish_reason` emitted across the stream (the terminating reason a
+    /// client sees). `None` if the stream never carried one.
+    fn final_finish_reason(
+        responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Option<FinishReason> {
+        responses
+            .iter()
+            .filter_map(|r| r.data.as_ref())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter_map(|c| c.finish_reason)
+            .next_back()
+    }
+
+    // Feed a Qwen3-Coder tool call split across many small chunks (incremental
+    // streaming) and confirm the bypass reconstructs exactly one call with the
+    // right arguments and never leaks raw markup into content.
+    #[tokio::test]
+    async fn qwen3_bypass_streams_incrementally_without_leaking_markup() {
+        // Split into 8-char chunks to force partial markers across push() calls.
+        let mut chunks: Vec<_> = QWEN3_GET_WEATHER
+            .as_bytes()
+            .chunks(8)
+            .map(|b| chunk(std::str::from_utf8(b).unwrap(), false))
+            .collect();
+        chunks.push(chunk("", true));
+
+        let out: Vec<_> = apply_stream(stream::iter(chunks), None, "qwen3_coder".to_string())
+            .collect::<Vec<_>>()
+            .await;
+
+        let (calls, content) = reassemble(&out);
+        assert_eq!(calls.len(), 1, "expected exactly one tool call: {calls:?}");
+        assert_eq!(calls[0].0, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        assert_eq!(args["location"], "Paris");
+        for marker in ["<tool_call>", "<function=", "<parameter="] {
+            assert!(
+                !content.contains(marker),
+                "raw markup {marker:?} leaked into content: {content:?}"
+            );
+        }
+        // A choice that emitted tool calls must report finish_reason=ToolCalls, not the
+        // upstream Stop (OpenAI streaming contract; mirrors the v1 jail).
+        assert_eq!(
+            final_finish_reason(&out),
+            Some(FinishReason::ToolCalls),
+            "finish_reason must flip Stop->ToolCalls when tool calls are emitted"
+        );
+    }
+
+    // A parameter value truncated at EOF must be dropped (no guessed argument),
+    // and no markup may leak — the reason qwen3 uses the v2 parser, not the jail.
+    #[tokio::test]
+    async fn qwen3_bypass_drops_value_truncated_at_eof() {
+        let truncated = "<tool_call>\n<function=get_weather>\n<parameter=location>\nPar";
+        let chunks = vec![chunk(truncated, false), chunk("", true)];
+
+        let out: Vec<_> = apply_stream(stream::iter(chunks), None, "qwen3_coder".to_string())
+            .collect::<Vec<_>>()
+            .await;
+
+        let (calls, content) = reassemble(&out);
+        let complete: Vec<_> = calls.iter().filter(|(n, _)| !n.is_empty()).collect();
+        assert!(
+            complete.is_empty(),
+            "truncated value must not produce a finished call: {calls:?}"
+        );
+        assert!(
+            !content.contains("<function="),
+            "raw markup leaked into content: {content:?}"
+        );
+        // No call was emitted (truncated value dropped), so the terminating reason must
+        // stay Stop — the flip only fires when tool calls were actually emitted.
+        assert_eq!(
+            final_finish_reason(&out),
+            Some(FinishReason::Stop),
+            "no tool calls emitted -> finish_reason stays Stop"
+        );
+    }
+
+    // Same family-agnostic bypass for DeepSeek-V4 DSML: incremental streaming
+    // reconstructs exactly one call and never leaks DSML markup into content.
+    #[tokio::test]
+    async fn dsv4_bypass_streams_incrementally_without_leaking_markup() {
+        // DSML markers contain the multibyte `｜` glyph; chunk by chars (not bytes) so
+        // a small chunk size still splits markers across push() calls without slicing
+        // a UTF-8 character.
+        let glyphs: Vec<char> = DSV4_GET_WEATHER.chars().collect();
+        let mut chunks: Vec<_> = glyphs
+            .chunks(6)
+            .map(|c| chunk(&c.iter().collect::<String>(), false))
+            .collect();
+        chunks.push(chunk("", true));
+
+        let out: Vec<_> = apply_stream(stream::iter(chunks), None, "deepseek_v4".to_string())
+            .collect::<Vec<_>>()
+            .await;
+
+        let (calls, content) = reassemble(&out);
+        let complete: Vec<_> = calls.iter().filter(|(n, _)| !n.is_empty()).collect();
+        assert_eq!(
+            complete.len(),
+            1,
+            "expected exactly one tool call: {calls:?}"
+        );
+        assert_eq!(complete[0].0, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&complete[0].1).unwrap();
+        assert_eq!(args["location"], "NYC");
+        assert!(
+            !content.contains("DSML"),
+            "raw DSML markup leaked into content: {content:?}"
+        );
+        assert_eq!(
+            final_finish_reason(&out),
+            Some(FinishReason::ToolCalls),
+            "finish_reason must flip Stop->ToolCalls when tool calls are emitted"
+        );
+    }
+}

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1541,6 +1541,50 @@ async fn tool_choice_deepseek_v4_required_prompt_injected_bare_json_recovers() {
     );
 }
 
+/// Exercises the experimental parsers-v2 gate end-to-end. `tool_choice=Auto` + a v2
+/// family (`qwen3_coder`) is the only combination the gate routes to
+/// `tool_parser_v2::apply_stream`; `required`/`named` (above) always stay on the v1
+/// jail. The flag is read once at process startup, so a single test covers BOTH
+/// paths via the startup switch: run with `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2` unset
+/// and this goes through the v1 jail; set it and the identical stream goes through
+/// the v2 parser. A complete tool call must extract cleanly with no raw markup
+/// leaking into content on either path, so the same assertion validates both.
+#[tokio::test]
+async fn tool_calls_qwen3_coder_auto_routes_through_experimental_gate() {
+    let xml = "<tool_call>\n<function=get_weather>\n<parameter=location>\nSan Francisco\n</parameter>\n</function>\n</tool_call>";
+    let preprocessor = build_preprocessor(None, Some("qwen3_coder"));
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Auto);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(xml), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        content,
+        tool_calls,
+        finish_reasons,
+        ..
+    } = drain_stream(output_stream).await;
+
+    let path = if std::env::var("DYN_ENABLE_EXPERIMENTAL_PARSERS_V2")
+        .is_ok_and(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
+    {
+        "qwen3_coder auto -> dynamo-parsers-v2 (DYN_ENABLE_EXPERIMENTAL_PARSERS_V2 on)"
+    } else {
+        "qwen3_coder auto -> v1 jail (flag off)"
+    };
+    assert_clean_tool_call(path, &content, &tool_calls, "San Francisco");
+    // Both paths must honor the OpenAI contract: a tool-call stream terminates with
+    // finish_reason=ToolCalls — v1 via the jail's fix_finish_reason, v2 via apply_stream.
+    assert!(
+        finish_reasons.contains(&FinishReason::ToolCalls),
+        "{path}: expected ToolCalls finish_reason, got: {finish_reasons:?}"
+    );
+}
+
 /// DeepSeek V4/GLM + required + `prompt_injected_reasoning=true` +
 /// reasoning-close-marker JSON. This is not bare JSON; the reasoning parser
 /// must strip the pre-`</think>` prefix before the immediate jail sees JSON.

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -333,6 +333,12 @@ pub mod llm {
     pub const DYN_ENABLE_STREAMING_REASONING_DISPATCH: &str =
         "DYN_ENABLE_STREAMING_REASONING_DISPATCH";
 
+    /// \[EXPERIMENTAL\] Route supported tool-call families (Qwen3-Coder, DeepSeek-V4)
+    /// through the `dynamo-parsers-v2` streaming parser for BOTH the batch and the
+    /// streaming path, bypassing the v1 tool-call jail. Off by default; when set, the
+    /// v2 parser owns incremental tool-call emission and drops values truncated at EOF.
+    pub const DYN_ENABLE_EXPERIMENTAL_PARSERS_V2: &str = "DYN_ENABLE_EXPERIMENTAL_PARSERS_V2";
+
     /// Backend stream inactivity timeout in seconds.
     ///
     /// When set to a positive integer, the frontend will kill the engine context
@@ -696,6 +702,7 @@ mod tests {
             llm::DYN_STRIP_ANTHROPIC_PREAMBLE,
             llm::DYN_ENABLE_STREAMING_TOOL_DISPATCH,
             llm::DYN_ENABLE_STREAMING_REASONING_DISPATCH,
+            llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2,
             llm::DYN_LORA_ALLOCATION_ENABLED,
             llm::DYN_LORA_ALLOCATION_ALGORITHM,
             llm::DYN_LORA_ALLOCATION_TIMESTEP_SECS,


### PR DESCRIPTION
## Overview

Routes Qwen3-Coder **and** DeepSeek-V4 tool calls through the `dynamo-parsers-v2` streaming parser, gated behind a new `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2` env flag. When the flag is set, both the batch and the streaming path bypass the v1 tool-call jail and use the v2 parser — which owns incremental tool-call emission and drops a parameter value truncated at EOF instead of guessing it. Off by default; the v1 jail / aggregate-finalize path is unchanged.

## Changes

- New `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2` flag (const + registry in `environment_names.rs`), read once via a cached `LazyLock<bool>`.
- Generalized the Qwen3-Coder-only module `qwen3_coder_v2.rs` into a family-agnostic `tool_parser_v2.rs`: `enabled()`, `supports_family()` = `{qwen3_coder, deepseek_v4}`, and `apply_stream` / `parse_complete` built on `dynamo_parsers_v2::create_tool_parser_for_family(family, …)` returning `Box<dyn ToolParser>`. Adding a family is a one-line change here plus support in the crate.
- Both dispatch sites gated on `enabled() && supports_family(parser)`: streaming (`preprocessor.rs`) and batch (`aggregator.rs`).
- Adds the published `dynamo-parsers-v2 0.1.10` dep. The `dynamo-parsers 2.1.2` bump merged separately in #10899; this branch is rebased onto `main` on top of it.

## Behavior

- Flag **unset** (default): no change — every family uses the v1 jail.
- Flag **set**: `qwen3_coder` and `deepseek_v4` route through v2 for both batch and streaming.

## Tests

- New `tool_parser_v2` unit tests: Qwen3-Coder incremental stream + truncated-at-EOF drop, plus a DeepSeek-V4 DSML incremental stream (reconstructs one `get_weather(location=NYC)` call, no markup leak).
- `cargo test -p dynamo-llm`: 3 unit + 149 integration (test_jail 69, streaming 36, tool_choice 36, parallel 8) pass — the env-gating leaves the v1 path unchanged.

## Enabling the experimental v2 path

Off by default. Set `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2` (truthy: `1`/`true`/`yes`/`on`) **at process startup** to route the supported families (`qwen3_coder`, `deepseek_v4`) through the v2 parser instead of the v1 jail, for **both** batch and streaming. The flag is read once per process via `LazyLock`, so it's a startup switch (not toggleable mid-run). Other families, and non-`auto` tool_choice (`required`/`named`), always stay on v1.

**In fixture / Rust tests** — prefix the test run with the env var (applies to the whole test binary):

```
# v1 (default)
cargo test -p dynamo-llm --test postprocessor_parsing_stream tool_calls_qwen3_coder_auto_routes_through_experimental_gate
# v2 (experimental)
DYN_ENABLE_EXPERIMENTAL_PARSERS_V2=1 cargo test -p dynamo-llm --test postprocessor_parsing_stream tool_calls_qwen3_coder_auto_routes_through_experimental_gate
```

`tool_calls_qwen3_coder_auto_routes_through_experimental_gate` is the gate test: it routes a `qwen3_coder` + `auto` tool-call stream through the dispatch, so the same assertion exercises v1 with the flag off and v2 with it on. CI runs with the flag off.

**In real Dynamo** — export it for the frontend process:

```
DYN_ENABLE_EXPERIMENTAL_PARSERS_V2=1 python -m dynamo.frontend --http-port 8000
```

## Related

[DIS-2228](https://linear.app/nvidia/issue/DIS-2228) — Qwen3-Coder v2 parser + env-gated Dynamo routing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental support for improved tool-call parsing in streaming and non-streaming chat responses for select model families.
  * Introduced a new opt-in setting to enable the experimental parser path.

* **Bug Fixes**
  * Reduced the chance of malformed tool-call output leaking into visible text.
  * Improved handling of incomplete responses at the end of a stream so tool calls are finalized more safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->