### PR TITLE
perf(kv-router): batch CRTC removals by compressed node

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use super::types::*;
-use crate::indexer::compressed_radix::{NodeState, RemoveOutcome};
+use crate::indexer::compressed_radix::NodeState;
 use crate::protocols::*;
 
 type NodeChildren = DashMap<LocalBlockHash, SharedNode, FxBuildHasher>;
@@ -660,18 +660,32 @@ impl Node {
         &self,
         worker: WorkerWithDpRank,
         block_hashes: &[ExternalSequenceBlockHash],
-    ) -> Option<RemoveOutcome> {
+    ) -> Option<RemoveBatchOutcome> {
         let _gate = self.shape_gate.write();
         let mut state = self.state.write();
-        let (pos, block_hash) = block_hashes
-            .iter()
-            .filter_map(|&hash| state.edge_index.get(&hash).copied().map(|pos| (pos, hash)))
-            .min_by_key(|&(pos, _)| pos)?;
+        let mut min_match = None;
+        let mut unmatched_hashes = Vec::new();
+
+        for &hash in block_hashes {
+            match state.edge_index.get(&hash).copied() {
+                Some(pos) => {
+                    if min_match.is_none_or(|(min_pos, _)| pos < min_pos) {
+                        min_match = Some((pos, hash));
+                    }
+                }
+                None => unmatched_hashes.push(hash),
+            }
+        }
+
+        let (pos, block_hash) = min_match?;
         let outcome = state.remove_worker_at_pos(worker, pos, block_hash);
         let should_clear_children = state.full_edge_workers.is_empty();
         drop(state);
         self.clear_children_if_unreachable(should_clear_children);
-        Some(outcome)
+        Some(RemoveBatchOutcome {
+            stale_hashes: outcome.stale_hashes,
+            unmatched_hashes,
+        })
     }
 
     #[cfg_attr(feature = "profile", inline(never))]

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -656,14 +656,17 @@ impl Node {
         SplitLookupData { suffix }
     }
 
-    pub(super) fn remove_worker_for_hash(
+    pub(super) fn remove_worker_for_hashes(
         &self,
         worker: WorkerWithDpRank,
-        block_hash: ExternalSequenceBlockHash,
+        block_hashes: &[ExternalSequenceBlockHash],
     ) -> Option<RemoveOutcome> {
         let _gate = self.shape_gate.write();
         let mut state = self.state.write();
-        let pos = state.edge_index.get(&block_hash).copied()?;
+        let (pos, block_hash) = block_hashes
+            .iter()
+            .filter_map(|&hash| state.edge_index.get(&hash).copied().map(|pos| (pos, hash)))
+            .min_by_key(|&(pos, _)| pos)?;
         let outcome = state.remove_worker_at_pos(worker, pos, block_hash);
         let should_clear_children = state.full_edge_workers.is_empty();
         drop(state);

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -141,9 +141,12 @@ impl ConcurrentRadixTreeCompressed {
         block_hash: ExternalSequenceBlockHash,
         id: u64,
     ) {
-        let Some(mut cur_node) =
-            self.resolve_lookup(lookup, worker, block_hash, LookupRepairDirection::TowardHead)
-        else {
+        let Some(mut cur_node) = self.resolve_lookup(
+            lookup,
+            worker,
+            block_hash,
+            LookupRepairDirection::TowardHead,
+        ) else {
             tracing::debug!(
                 worker_id = worker.worker_id.to_string(),
                 dp_rank = worker.dp_rank,

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -61,11 +61,12 @@ impl ConcurrentRadixTreeCompressed {
         let mut group_hashes: Vec<ExternalSequenceBlockHash> = Vec::new();
 
         for block_hash in op.block_hashes {
-            if let Some(node) = group_node.as_ref() {
-                if node.contains_edge_hash(block_hash) {
-                    group_hashes.push(block_hash);
-                    continue;
-                }
+            if group_node
+                .as_ref()
+                .is_some_and(|node| node.contains_edge_hash(block_hash))
+            {
+                group_hashes.push(block_hash);
+                continue;
             }
 
             self.apply_removed_group(
@@ -103,7 +104,7 @@ impl ConcurrentRadixTreeCompressed {
         Ok(())
     }
 
-    fn apply_removed_group(
+    pub(super) fn apply_removed_group(
         &self,
         lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
         worker: WorkerWithDpRank,
@@ -111,12 +112,48 @@ impl ConcurrentRadixTreeCompressed {
         block_hashes: Vec<ExternalSequenceBlockHash>,
         id: u64,
     ) {
-        let Some(mut cur_node) = node else {
+        let Some(cur_node) = node else {
             return;
         };
         if block_hashes.is_empty() {
             return;
         }
+
+        match cur_node.remove_worker_for_hashes(worker, &block_hashes) {
+            Some(outcome) => {
+                Self::remove_lookup_hashes(lookup, worker, outcome.stale_hashes);
+                for block_hash in outcome.unmatched_hashes {
+                    self.apply_removed_hash(lookup, worker, block_hash, id);
+                }
+            }
+            None => {
+                for block_hash in block_hashes {
+                    self.apply_removed_hash(lookup, worker, block_hash, id);
+                }
+            }
+        }
+    }
+
+    fn apply_removed_hash(
+        &self,
+        lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
+        worker: WorkerWithDpRank,
+        block_hash: ExternalSequenceBlockHash,
+        id: u64,
+    ) {
+        let Some(mut cur_node) =
+            self.resolve_lookup(lookup, worker, block_hash, LookupRepairDirection::TowardHead)
+        else {
+            tracing::debug!(
+                worker_id = worker.worker_id.to_string(),
+                dp_rank = worker.dp_rank,
+                id,
+                block_hash = ?block_hash,
+                "Block not found during batched remove fallback; skipping"
+            );
+            Self::remove_lookup_hashes(lookup, worker, [block_hash]);
+            return;
+        };
 
         loop {
             // TODO(CORRECTNESS): Invalidate this worker throughout the descendant
@@ -125,17 +162,13 @@ impl ConcurrentRadixTreeCompressed {
             // reactivated by restoring only the removed block, or emitted by dumps
             // without a valid worker-specific parent. Preserve CRTC's locking and
             // snapshot guarantees when implementing the traversal.
-            match cur_node.remove_worker_for_hashes(worker, &block_hashes) {
+            match cur_node.remove_worker_for_hashes(worker, std::slice::from_ref(&block_hash)) {
                 Some(outcome) => {
-                    if let Some(wl) = lookup.get_mut(&worker) {
-                        for hash in outcome.stale_hashes {
-                            wl.remove(&hash);
-                        }
-                    }
+                    debug_assert!(outcome.unmatched_hashes.is_empty());
+                    Self::remove_lookup_hashes(lookup, worker, outcome.stale_hashes);
                     return;
                 }
                 None => {
-                    let block_hash = block_hashes[0];
                     // Hash was moved to a descendant by a concurrent split.
                     match Self::find_in_subtree(&cur_node, block_hash) {
                         Some(resolved) => {
@@ -153,23 +186,31 @@ impl ConcurrentRadixTreeCompressed {
                             // Retry the loop with the resolved node.
                         }
                         None => {
-                            // Hashes not found anywhere -- evicted by a concurrent clear.
+                            // Hash not found anywhere -- evicted by a concurrent clear.
                             tracing::debug!(
                                 worker_id = worker.worker_id.to_string(),
                                 dp_rank = worker.dp_rank,
                                 id,
                                 block_hash = ?block_hash,
-                                "Block not found in subtree during batched remove; skipping group"
+                                "Block not found in subtree during batched remove; skipping"
                             );
-                            if let Some(wl) = lookup.get_mut(&worker) {
-                                for hash in block_hashes {
-                                    wl.remove(&hash);
-                                }
-                            }
+                            Self::remove_lookup_hashes(lookup, worker, [block_hash]);
                             return;
                         }
                     }
                 }
+            }
+        }
+    }
+
+    fn remove_lookup_hashes(
+        lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
+        worker: WorkerWithDpRank,
+        hashes: impl IntoIterator<Item = ExternalSequenceBlockHash>,
+    ) {
+        if let Some(wl) = lookup.get_mut(&worker) {
+            for hash in hashes {
+                wl.remove(&hash);
             }
         }
     }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -69,13 +69,8 @@ impl ConcurrentRadixTreeCompressed {
                 continue;
             }
 
-            self.apply_removed_group(
-                lookup,
-                worker,
-                group_node.take(),
-                std::mem::take(&mut group_hashes),
-                id,
-            );
+            self.apply_removed_group(lookup, worker, group_node.take(), &group_hashes, id);
+            group_hashes.clear();
 
             match self.resolve_lookup(
                 lookup,
@@ -99,7 +94,7 @@ impl ConcurrentRadixTreeCompressed {
             }
         }
 
-        self.apply_removed_group(lookup, worker, group_node, group_hashes, id);
+        self.apply_removed_group(lookup, worker, group_node, &group_hashes, id);
 
         Ok(())
     }
@@ -109,7 +104,7 @@ impl ConcurrentRadixTreeCompressed {
         lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
         worker: WorkerWithDpRank,
         node: Option<SharedNode>,
-        block_hashes: Vec<ExternalSequenceBlockHash>,
+        block_hashes: &[ExternalSequenceBlockHash],
         id: u64,
     ) {
         let Some(cur_node) = node else {
@@ -127,7 +122,7 @@ impl ConcurrentRadixTreeCompressed {
                 }
             }
             None => {
-                for block_hash in block_hashes {
+                for &block_hash in block_hashes {
                     self.apply_removed_hash(lookup, worker, block_hash, id);
                 }
             }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -114,7 +114,7 @@ impl ConcurrentRadixTreeCompressed {
             return;
         }
 
-        match cur_node.remove_worker_for_hashes(worker, &block_hashes) {
+        match cur_node.remove_worker_for_hashes(worker, block_hashes) {
             Some(outcome) => {
                 Self::remove_lookup_hashes(lookup, worker, outcome.stale_hashes);
                 for block_hash in outcome.unmatched_hashes {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -57,14 +57,35 @@ impl ConcurrentRadixTreeCompressed {
             return Err(KvCacheEventError::BlockNotFound);
         }
 
-        'outer: for block_hash in op.block_hashes {
-            let mut cur_node = match self.resolve_lookup(
+        let mut group_node: Option<SharedNode> = None;
+        let mut group_hashes: Vec<ExternalSequenceBlockHash> = Vec::new();
+
+        for block_hash in op.block_hashes {
+            if let Some(node) = group_node.as_ref() {
+                if node.contains_edge_hash(block_hash) {
+                    group_hashes.push(block_hash);
+                    continue;
+                }
+            }
+
+            self.apply_removed_group(
+                lookup,
+                worker,
+                group_node.take(),
+                std::mem::take(&mut group_hashes),
+                id,
+            );
+
+            match self.resolve_lookup(
                 lookup,
                 worker,
                 block_hash,
                 LookupRepairDirection::TowardHead,
             ) {
-                Some(n) => n,
+                Some(node) => {
+                    group_node = Some(node);
+                    group_hashes.push(block_hash);
+                }
                 None => {
                     tracing::debug!(
                         worker_id = worker.worker_id.to_string(),
@@ -73,64 +94,84 @@ impl ConcurrentRadixTreeCompressed {
                         block_hash = ?block_hash,
                         "Block not found during remove; skipping"
                     );
-                    continue;
                 }
-            };
+            }
+        }
 
-            loop {
-                // TODO(CORRECTNESS): Invalidate this worker throughout the descendant
-                // subtree when a mid-edge removal leaves the node alive for another
-                // worker. Otherwise stale descendants can be reused as store parents,
-                // reactivated by restoring only the removed block, or emitted by dumps
-                // without a valid worker-specific parent. Preserve CRTC's locking and
-                // snapshot guarantees when implementing the traversal.
-                match cur_node.remove_worker_for_hash(worker, block_hash) {
-                    Some(outcome) => {
-                        if let Some(wl) = lookup.get_mut(&worker) {
-                            for hash in outcome.stale_hashes {
-                                wl.remove(&hash);
-                            }
+        self.apply_removed_group(lookup, worker, group_node, group_hashes, id);
+
+        Ok(())
+    }
+
+    fn apply_removed_group(
+        &self,
+        lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
+        worker: WorkerWithDpRank,
+        node: Option<SharedNode>,
+        block_hashes: Vec<ExternalSequenceBlockHash>,
+        id: u64,
+    ) {
+        let Some(mut cur_node) = node else {
+            return;
+        };
+        if block_hashes.is_empty() {
+            return;
+        }
+
+        loop {
+            // TODO(CORRECTNESS): Invalidate this worker throughout the descendant
+            // subtree when a mid-edge removal leaves the node alive for another
+            // worker. Otherwise stale descendants can be reused as store parents,
+            // reactivated by restoring only the removed block, or emitted by dumps
+            // without a valid worker-specific parent. Preserve CRTC's locking and
+            // snapshot guarantees when implementing the traversal.
+            match cur_node.remove_worker_for_hashes(worker, &block_hashes) {
+                Some(outcome) => {
+                    if let Some(wl) = lookup.get_mut(&worker) {
+                        for hash in outcome.stale_hashes {
+                            wl.remove(&hash);
                         }
-                        continue 'outer;
                     }
-                    None => {
-                        // Hash was moved to a descendant by a concurrent split.
-                        match Self::find_in_subtree(&cur_node, block_hash) {
-                            Some(resolved) => {
-                                self.repair_lookup_for_resolved_node(
-                                    lookup,
-                                    block_hash,
-                                    &resolved,
-                                    LookupRepairDirection::TowardHead,
-                                );
-                                #[cfg(feature = "bench")]
-                                self.bench_metrics
-                                    .lookup_repair_scans
-                                    .fetch_add(1, Ordering::Relaxed);
-                                cur_node = resolved;
-                                // Retry the inner loop with the resolved node.
-                            }
-                            None => {
-                                // Hash not found anywhere -- evicted by a concurrent clear.
-                                tracing::debug!(
-                                    worker_id = worker.worker_id.to_string(),
-                                    dp_rank = worker.dp_rank,
-                                    id,
-                                    block_hash = ?block_hash,
-                                    "Block not found in subtree during remove; skipping"
-                                );
-                                if let Some(wl) = lookup.get_mut(&worker) {
-                                    wl.remove(&block_hash);
+                    return;
+                }
+                None => {
+                    let block_hash = block_hashes[0];
+                    // Hash was moved to a descendant by a concurrent split.
+                    match Self::find_in_subtree(&cur_node, block_hash) {
+                        Some(resolved) => {
+                            self.repair_lookup_for_resolved_node(
+                                lookup,
+                                block_hash,
+                                &resolved,
+                                LookupRepairDirection::TowardHead,
+                            );
+                            #[cfg(feature = "bench")]
+                            self.bench_metrics
+                                .lookup_repair_scans
+                                .fetch_add(1, Ordering::Relaxed);
+                            cur_node = resolved;
+                            // Retry the loop with the resolved node.
+                        }
+                        None => {
+                            // Hashes not found anywhere -- evicted by a concurrent clear.
+                            tracing::debug!(
+                                worker_id = worker.worker_id.to_string(),
+                                dp_rank = worker.dp_rank,
+                                id,
+                                block_hash = ?block_hash,
+                                "Block not found in subtree during batched remove; skipping group"
+                            );
+                            if let Some(wl) = lookup.get_mut(&worker) {
+                                for hash in block_hashes {
+                                    wl.remove(&hash);
                                 }
-                                continue 'outer;
                             }
+                            return;
                         }
                     }
                 }
             }
         }
-
-        Ok(())
     }
 
     pub(super) fn remove_or_clear_worker_blocks(

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -299,7 +299,6 @@ mod race_tests {
             assert_direct_score(&index, &[1, 2, 3, 4], worker2, 1);
             assert_direct_score(&index, &[1, 2, 3, 4, 7, 8], worker3, 6);
         }
-
     }
 
     mod cleanup {
@@ -539,7 +538,10 @@ mod remove_tests {
             index.edge_topology_for_test(),
             vec![edge_topology(
                 &[1, 2, 3],
-                vec![edge_topology(&[4, 5, 6], vec![]), edge_topology(&[7], vec![])],
+                vec![
+                    edge_topology(&[4, 5, 6], vec![]),
+                    edge_topology(&[7], vec![])
+                ],
             )],
         );
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -37,6 +37,19 @@ fn local_hashes(query: &[u64]) -> Vec<LocalBlockHash> {
     query.iter().copied().map(LocalBlockHash).collect()
 }
 
+fn remove_hashes_with_parent(
+    prefix_hashes: &[u64],
+    local_hashes: &[u64],
+) -> Vec<ExternalSequenceBlockHash> {
+    match make_remove_event_with_parent(0, prefix_hashes, local_hashes)
+        .event
+        .data
+    {
+        KvCacheEventData::Removed(op) => op.block_hashes,
+        _ => unreachable!("make_remove_event_with_parent must create a remove event"),
+    }
+}
+
 fn apply_direct(
     index: &ConcurrentRadixTreeCompressed,
     lookup: &mut DirectLookup,
@@ -287,46 +300,6 @@ mod race_tests {
             assert_direct_score(&index, &[1, 2, 3, 4, 7, 8], worker3, 6);
         }
 
-        #[test]
-        fn remove_multiple_hashes_from_same_compressed_edge() {
-            let index = Arc::new(ConcurrentRadixTreeCompressed::new());
-            let worker0 = worker(0);
-            let worker1 = worker(1);
-            let mut lookup0 = direct_lookup();
-            let mut lookup1 = direct_lookup();
-
-            apply_direct(
-                &index,
-                &mut lookup0,
-                make_store_event(0, &[1, 2, 3, 4, 5, 6]),
-            );
-            apply_direct(
-                &index,
-                &mut lookup1,
-                make_store_event(1, &[1, 2, 3, 4, 5, 6]),
-            );
-
-            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
-            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
-
-            apply_direct(
-                &index,
-                &mut lookup0,
-                make_remove_event_with_parent(0, &[1, 2], &[3, 4, 5]),
-            );
-
-            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 2);
-            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
-
-            apply_direct(
-                &index,
-                &mut lookup0,
-                make_store_event_with_parent(0, &[1, 2], &[3, 4, 5, 6]),
-            );
-
-            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
-            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
-        }
     }
 
     mod cleanup {
@@ -485,6 +458,104 @@ mod race_tests {
                 }
             }
         }
+    }
+}
+
+mod remove_tests {
+    use super::*;
+
+    #[test]
+    fn remove_multiple_hashes_from_same_compressed_edge() {
+        let index = Arc::new(ConcurrentRadixTreeCompressed::new());
+        let worker0 = worker(0);
+        let worker1 = worker(1);
+        let mut lookup0 = direct_lookup();
+        let mut lookup1 = direct_lookup();
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event(0, &[1, 2, 3, 4, 5, 6]),
+        );
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_remove_event_with_parent(0, &[1, 2], &[3, 4, 5]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 2);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event_with_parent(0, &[1, 2], &[3, 4, 5, 6]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+    }
+
+    #[test]
+    fn batched_remove_processes_hashes_moved_by_split_before_restore() {
+        let index = ConcurrentRadixTreeCompressed::new();
+        let worker0 = worker(0);
+        let worker1 = worker(1);
+        let mut lookup0 = direct_lookup();
+        let mut lookup1 = direct_lookup();
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event(0, &[1, 2, 3, 4, 5, 6]),
+        );
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+        );
+        let remove_hashes = remove_hashes_with_parent(&[1, 2], &[3, 4, 5]);
+        let group_node = lookup0
+            .get(&worker0)
+            .and_then(|worker_lookup| worker_lookup.get(&remove_hashes[0]))
+            .cloned()
+            .expect("remove hash should point to the pre-split group node");
+
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event_with_parent(1, &[1, 2, 3], &[7]),
+        );
+        assert_eq!(
+            index.edge_topology_for_test(),
+            vec![edge_topology(
+                &[1, 2, 3],
+                vec![edge_topology(&[4, 5, 6], vec![]), edge_topology(&[7], vec![])],
+            )],
+        );
+
+        index.apply_removed_group(&mut lookup0, worker0, Some(group_node), remove_hashes, 42);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 2);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event_with_parent(0, &[1, 2], &[3]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 3);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(3));
     }
 }
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::indexer::{KvIndexerInterface, ThreadPoolIndexer};
 use crate::test_utils::{
     assert_score, flush_and_settle, make_remove_event_with_parent, make_store_event,
-    make_store_event_with_parent, snapshot_events, snapshot_tree,
+    make_store_event_with_parent, remove_event, snapshot_events, snapshot_tree,
 };
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -505,6 +505,48 @@ mod remove_tests {
     }
 
     #[test]
+    fn batched_remove_uses_minimum_edge_position_not_event_order() {
+        let index = ConcurrentRadixTreeCompressed::new();
+        let worker0 = worker(0);
+        let worker1 = worker(1);
+        let mut lookup0 = direct_lookup();
+        let mut lookup1 = direct_lookup();
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event(0, &[1, 2, 3, 4, 5, 6]),
+        );
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+        );
+
+        let remove_hashes = remove_hashes_with_parent(&[1, 2], &[3, 4, 5]);
+        let out_of_order_hashes = vec![remove_hashes[2], remove_hashes[0], remove_hashes[1]];
+        apply_direct(
+            &index,
+            &mut lookup0,
+            remove_event(0, 0, 0, out_of_order_hashes),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 2);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(2));
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event_with_parent(0, &[1, 2], &[3, 4, 5, 6]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(6));
+    }
+
+    #[test]
     fn batched_remove_processes_hashes_moved_by_split_before_restore() {
         let index = ConcurrentRadixTreeCompressed::new();
         let worker0 = worker(0);
@@ -558,6 +600,63 @@ mod remove_tests {
         assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 3);
         assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
         assert_eq!(worker_lookup_len(&lookup0, worker0), Some(3));
+    }
+
+    #[test]
+    fn batched_remove_falls_back_when_all_grouped_hashes_move_before_restore() {
+        let index = ConcurrentRadixTreeCompressed::new();
+        let worker0 = worker(0);
+        let worker1 = worker(1);
+        let mut lookup0 = direct_lookup();
+        let mut lookup1 = direct_lookup();
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event(0, &[1, 2, 3, 4, 5, 6]),
+        );
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+        );
+        let remove_hashes = remove_hashes_with_parent(&[1, 2, 3], &[4, 5]);
+        let group_node = lookup0
+            .get(&worker0)
+            .and_then(|worker_lookup| worker_lookup.get(&remove_hashes[0]))
+            .cloned()
+            .expect("remove hash should point to the pre-split group node");
+
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event_with_parent(1, &[1, 2, 3], &[7]),
+        );
+        assert_eq!(
+            index.edge_topology_for_test(),
+            vec![edge_topology(
+                &[1, 2, 3],
+                vec![
+                    edge_topology(&[4, 5, 6], vec![]),
+                    edge_topology(&[7], vec![])
+                ],
+            )],
+        );
+
+        index.apply_removed_group(&mut lookup0, worker0, Some(group_node), remove_hashes, 42);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 3);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(3));
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event_with_parent(0, &[1, 2, 3], &[4]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 4);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(4));
     }
 }
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -587,7 +587,7 @@ mod remove_tests {
             )],
         );
 
-        index.apply_removed_group(&mut lookup0, worker0, Some(group_node), remove_hashes, 42);
+        index.apply_removed_group(&mut lookup0, worker0, Some(group_node), &remove_hashes, 42);
         assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 2);
         assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
 
@@ -643,7 +643,7 @@ mod remove_tests {
             )],
         );
 
-        index.apply_removed_group(&mut lookup0, worker0, Some(group_node), remove_hashes, 42);
+        index.apply_removed_group(&mut lookup0, worker0, Some(group_node), &remove_hashes, 42);
         assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 3);
         assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
         assert_eq!(worker_lookup_len(&lookup0, worker0), Some(3));

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -286,6 +286,47 @@ mod race_tests {
             assert_direct_score(&index, &[1, 2, 3, 4], worker2, 1);
             assert_direct_score(&index, &[1, 2, 3, 4, 7, 8], worker3, 6);
         }
+
+        #[test]
+        fn remove_multiple_hashes_from_same_compressed_edge() {
+            let index = Arc::new(ConcurrentRadixTreeCompressed::new());
+            let worker0 = worker(0);
+            let worker1 = worker(1);
+            let mut lookup0 = direct_lookup();
+            let mut lookup1 = direct_lookup();
+
+            apply_direct(
+                &index,
+                &mut lookup0,
+                make_store_event(0, &[1, 2, 3, 4, 5, 6]),
+            );
+            apply_direct(
+                &index,
+                &mut lookup1,
+                make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+            );
+
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+
+            apply_direct(
+                &index,
+                &mut lookup0,
+                make_remove_event_with_parent(0, &[1, 2], &[3, 4, 5]),
+            );
+
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 2);
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+
+            apply_direct(
+                &index,
+                &mut lookup0,
+                make_store_event_with_parent(0, &[1, 2], &[3, 4, 5, 6]),
+            );
+
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        }
     }
 
     mod cleanup {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
@@ -106,6 +106,11 @@ pub(super) struct SplitLookupData {
     pub(super) suffix: SharedNode,
 }
 
+pub(super) struct RemoveBatchOutcome {
+    pub(super) stale_hashes: Vec<ExternalSequenceBlockHash>,
+    pub(super) unmatched_hashes: Vec<ExternalSequenceBlockHash>,
+}
+
 #[derive(Clone, Copy)]
 pub(super) enum LookupRepairDirection {
     TowardTail,


### PR DESCRIPTION
## Summary
- batch CRTC remove handling for hashes that live on the same compressed edge
- keep the fast grouped path split-safe by falling back to per-hash lookup repair for hashes that move during a concurrent split
- add focused coverage for both the same-edge happy path and a white-box split-before-restore regression

## Related Issues
- [x] Confirmed — no related issue

## Benchmark / profiling evidence

Clean c256 frontend benchmark reruns using the block-size-1 workload reproduce the frontend CPU reduction. Throughput remains flat because this c256 setup is not frontend-throughput-bound, so CPU time is the relevant signal:

| Run | Throughput | Frontend CPU | CRTC bucket | Lookup repair |
| --- | ---: | ---: | ---: | ---: |
| Baseline, no TTL | 21.12 rps | 35.6% | 45.0% | 25.9% |
| Batched remove, no TTL | 21.23 rps | 27.5% | 16.9% | ~0.0% |
| Baseline, TTL=5 | 21.31 rps | 53.3% | 36.9% | 19.1% |
| Batched remove, TTL=5 | 20.81 rps | 46.9% | 17.9% | 1.2% |

## Validation
- `cargo test -p dynamo-kv-router concurrent_radix_tree_compressed --lib`
- `cargo clippy --no-deps --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the batch removal operation to process multiple hashes more efficiently, reducing unnecessary iterations and improving overall performance of the eviction path.

* **Tests**
  * Added comprehensive test coverage for batch removal operations to ensure correct behavior under concurrent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
