### PR TITLE
fix(snapshot): use fast worker probes when checkpointing

### DIFF
--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1404,6 +1404,26 @@ func AddStandardEnvVars(container *corev1.Container, operatorConfig *configv1alp
 	container.Env = MergeEnvs(standardEnvVars, container.Env)
 }
 
+func applyCheckpointProbeCadence(
+	container *corev1.Container,
+	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+	operatorConfig *configv1alpha1.OperatorConfiguration,
+	checkpointInfo *checkpoint.CheckpointInfo,
+) {
+	if operatorConfig.Checkpoint.Enabled &&
+		checkpointInfo != nil &&
+		checkpointInfo.Enabled &&
+		checkpointInfo.Ready &&
+		IsWorkerComponent(string(component.ComponentType)) {
+		if container.ReadinessProbe != nil {
+			container.ReadinessProbe.PeriodSeconds = 1
+		}
+		if container.StartupProbe != nil {
+			container.StartupProbe.PeriodSeconds = 1
+		}
+	}
+}
+
 // applyDefaultSecurityContext sets secure defaults for pod security context.
 // Currently only sets fsGroup to solve volume permission issues.
 // Does NOT set runAsUser/runAsGroup/runAsNonRoot to maintain backward compatibility
@@ -1485,18 +1505,7 @@ func GenerateBasePodSpec(
 		return nil, fmt.Errorf("unsupported backend framework: %s", backendFramework)
 	}
 	backend.UpdateContainer(&container, numberOfNodes, role, component, serviceName, multinodeDeployer)
-	if operatorConfig.Checkpoint.Enabled &&
-		checkpointInfo != nil &&
-		checkpointInfo.Enabled &&
-		checkpointInfo.Ready &&
-		IsWorkerComponent(string(component.ComponentType)) {
-		if container.ReadinessProbe != nil {
-			container.ReadinessProbe.PeriodSeconds = 1
-		}
-		if container.StartupProbe != nil {
-			container.StartupProbe.PeriodSeconds = 1
-		}
-	}
+	applyCheckpointProbeCadence(&container, component, operatorConfig, checkpointInfo)
 
 	// get base podspec from component
 	podSpec, err := componentDefaults.GetBasePodSpec(componentContext)

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1485,6 +1485,18 @@ func GenerateBasePodSpec(
 		return nil, fmt.Errorf("unsupported backend framework: %s", backendFramework)
 	}
 	backend.UpdateContainer(&container, numberOfNodes, role, component, serviceName, multinodeDeployer)
+	if operatorConfig.Checkpoint.Enabled &&
+		checkpointInfo != nil &&
+		checkpointInfo.Enabled &&
+		checkpointInfo.Ready &&
+		IsWorkerComponent(string(component.ComponentType)) {
+		if container.ReadinessProbe != nil {
+			container.ReadinessProbe.PeriodSeconds = 1
+		}
+		if container.StartupProbe != nil {
+			container.StartupProbe.PeriodSeconds = 1
+		}
+	}
 
 	// get base podspec from component
 	podSpec, err := componentDefaults.GetBasePodSpec(componentContext)

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -6,7 +6,6 @@ package protocol
 import (
 	"context"
 	"fmt"
-	"math"
 	"path/filepath"
 	"strings"
 
@@ -36,7 +35,8 @@ const (
 	// context and sleep instead of cold-starting the workload. Generic
 	// images that do not honor this env must still provide their own inert
 	// restore command.
-	RestoreStandbyModeEnv = "DYN_SNAPSHOT_RESTORE_STANDBY"
+	RestoreStandbyModeEnv          = "DYN_SNAPSHOT_RESTORE_STANDBY"
+	restoreStartupFailureThreshold = 1800 // 30 minutes at 1s cadence.
 )
 
 // NewRestorePod shapes every annotated target container for restore.
@@ -141,7 +141,7 @@ func ensureRestoreStartupProbe(container *corev1.Container) {
 			},
 			TimeoutSeconds:   1,
 			PeriodSeconds:    1,
-			FailureThreshold: math.MaxInt32,
+			FailureThreshold: restoreStartupFailureThreshold,
 			SuccessThreshold: 1,
 		}
 		return
@@ -150,7 +150,7 @@ func ensureRestoreStartupProbe(container *corev1.Container) {
 	startup = startup.DeepCopy()
 	startup.InitialDelaySeconds = 0
 	startup.PeriodSeconds = 1
-	startup.FailureThreshold = math.MaxInt32
+	startup.FailureThreshold = restoreStartupFailureThreshold
 	startup.SuccessThreshold = 1
 	container.StartupProbe = startup
 }

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -5,7 +5,6 @@ package protocol
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"testing"
 
@@ -461,15 +460,17 @@ func TestPrepareRestorePodSpecFallsBackToSentinelWhenNoProbe(t *testing.T) {
 }
 
 // assertRestoreStartupGate verifies the load-bearing invariants every restore
-// StartupProbe must satisfy: effectively infinite retries during CRIU restore
-// and SuccessThreshold=1.
+// StartupProbe must satisfy: 30 minutes at 1s cadence and SuccessThreshold=1.
 func assertRestoreStartupGate(t *testing.T, probe *corev1.Probe) {
 	t.Helper()
 	if probe == nil {
 		t.Fatalf("expected non-nil startup probe")
 	}
-	if got := probe.FailureThreshold; got != math.MaxInt32 {
-		t.Fatalf("expected startup failure threshold %d, got %d", math.MaxInt32, got)
+	if got := probe.FailureThreshold; got != restoreStartupFailureThreshold {
+		t.Fatalf("expected startup failure threshold %d, got %d", restoreStartupFailureThreshold, got)
+	}
+	if got := probe.PeriodSeconds; got != 1 {
+		t.Fatalf("expected startup period 1, got %d", got)
 	}
 	if got := probe.SuccessThreshold; got != 1 {
 		t.Fatalf("expected startup success threshold 1, got %d", got)
@@ -575,7 +576,7 @@ func TestValidateRestorePodSpec(t *testing.T) {
 	okSpec.Containers[0].StartupProbe = &corev1.Probe{
 		ProbeHandler:     corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/livez"}},
 		PeriodSeconds:    5,
-		FailureThreshold: math.MaxInt32,
+		FailureThreshold: restoreStartupFailureThreshold,
 		SuccessThreshold: 1,
 	}
 	if err := ValidateRestorePodSpec(okSpec, annotations, storage, DefaultSeccompLocalhostProfile); err != nil {


### PR DESCRIPTION
Summary
- Preserve the existing 2h worker startup budget before checkpoint capture by only using fast worker probes once checkpointInfo is Ready.
- Set worker readiness/startup probe periods to 1s for restore-ready checkpointed workers.
- Bound restore startup probes to 30 minutes at 1s cadence.

Validation
- cd dynamo/deploy/operator && go test ./internal/dynamo -count=1
- cd dynamo/deploy/operator && go test ../snapshot/protocol -count=1