### PR TITLE
feat(vllm): support EAGLE MX refit

### DIFF
--- a/components/src/dynamo/vllm/mx_refit/extension.py
+++ b/components/src/dynamo/vllm/mx_refit/extension.py
@@ -385,7 +385,105 @@ def _torch_dtype(dtype_name: str) -> torch.dtype:
         "half": torch.float16,
         "float32": torch.float32,
         "float": torch.float32,
+        "int64": torch.int64,
+        "long": torch.long,
     }.get(dtype_name, torch.bfloat16)
+
+
+def _split_policy_and_draft_weights(
+    weights: list[tuple[str, torch.Tensor]],
+) -> tuple[list[tuple[str, torch.Tensor]], list[tuple[str, torch.Tensor]]]:
+    policy_weights = []
+    draft_weights = []
+    for name, tensor in weights:
+        if name.startswith("draft."):
+            draft_weights.append((name.removeprefix("draft."), tensor))
+        else:
+            policy_weights.append((name, tensor))
+    return policy_weights, draft_weights
+
+
+def _derive_qwen_llama_hf_names(megatron_name: str, role: str | None) -> list[str]:
+    name = megatron_name.removeprefix("module.")
+
+    if name.startswith("decoder.layers."):
+        parts = name.split(".")
+        if len(parts) < 4:
+            return [name]
+        layer = parts[2]
+        suffix = ".".join(parts[3:])
+        layer_prefix = f"model.layers.{layer}"
+
+        if suffix == "self_attention.linear_qkv.weight":
+            return [
+                f"{layer_prefix}.self_attn.q_proj.weight",
+                f"{layer_prefix}.self_attn.k_proj.weight",
+                f"{layer_prefix}.self_attn.v_proj.weight",
+            ]
+        if suffix == "self_attention.linear_proj.weight":
+            return [f"{layer_prefix}.self_attn.o_proj.weight"]
+        if suffix == "self_attention.q_layernorm.weight":
+            return [f"{layer_prefix}.self_attn.q_norm.weight"]
+        if suffix == "self_attention.k_layernorm.weight":
+            return [f"{layer_prefix}.self_attn.k_norm.weight"]
+        if suffix == "mlp.linear_fc1.weight" and role == "gated_mlp_column":
+            return [
+                f"{layer_prefix}.mlp.gate_proj.weight",
+                f"{layer_prefix}.mlp.up_proj.weight",
+            ]
+        if suffix == "mlp.linear_fc2.weight":
+            return [f"{layer_prefix}.mlp.down_proj.weight"]
+        if suffix == "input_layernorm.weight":
+            return [f"{layer_prefix}.input_layernorm.weight"]
+        if suffix == "pre_mlp_layernorm.weight":
+            return [f"{layer_prefix}.post_attention_layernorm.weight"]
+
+    if name == "decoder.final_layernorm.weight":
+        return ["model.norm.weight"]
+    if name == "embedding.word_embeddings.weight":
+        return ["model.embed_tokens.weight"]
+    if name == "output_layer.weight":
+        return ["lm_head.weight"]
+    return [name]
+
+
+def _resolve_hf_names(
+    megatron_name: str,
+    role: str | None,
+    name_map: dict[str, list[str]],
+) -> list[str]:
+    lookup_name = megatron_name.removeprefix("module.")
+    hf_names = name_map.get(lookup_name, name_map.get(megatron_name))
+    if hf_names is None:
+        return _derive_qwen_llama_hf_names(megatron_name, role)
+
+    hf_names = list(hf_names)
+    if hf_names in ([megatron_name], [lookup_name]):
+        return _derive_qwen_llama_hf_names(megatron_name, role)
+    return [name.removeprefix("module.") for name in hf_names]
+
+
+def _trim_draft_vocab_padding(
+    draft_model: torch.nn.Module,
+    draft_weights: list[tuple[str, torch.Tensor]],
+) -> list[tuple[str, torch.Tensor]]:
+    vocab_sizes = {
+        name: int(module.org_vocab_size)
+        for name, module in draft_model.named_modules()
+        if hasattr(module, "org_vocab_size")
+    }
+    if not vocab_sizes:
+        return draft_weights
+
+    trimmed = []
+    for name, tensor in draft_weights:
+        for module_name, org_vocab_size in vocab_sizes.items():
+            leaf_name = module_name.rsplit(".", 1)[-1]
+            if leaf_name in name and tensor.shape[0] > org_vocab_size:
+                tensor = tensor[:org_vocab_size]
+                break
+        trimmed.append((name, tensor))
+    return trimmed
 
 
 class MxRefitWorkerExtension:
@@ -455,6 +553,7 @@ class MxRefitWorkerExtension:
                 model._do_torchao_reload = old_do_torchao_reload
 
     def _mx_load_weights(self, weights: list[tuple[str, torch.Tensor]]) -> None:
+        weights, draft_weights = _split_policy_and_draft_weights(weights)
         tp_size, tp_rank = _target_tp(self)
         uses_fp8_quantization = self._mx_uses_fp8_quantization()
         if tp_size > 1:
@@ -485,6 +584,28 @@ class MxRefitWorkerExtension:
             self._mx_load_fp8_weights(weights)
         else:
             self.model_runner.model.load_weights(weights=weights)
+        self._mx_load_draft_weights(draft_weights)
+
+    def _mx_load_draft_weights(
+        self,
+        draft_weights: list[tuple[str, torch.Tensor]],
+    ) -> None:
+        if not draft_weights:
+            return
+
+        drafter = getattr(self.model_runner, "drafter", None)
+        draft_model = getattr(drafter, "model", None) if drafter is not None else None
+        if draft_model is None:
+            speculator = getattr(self.model_runner, "speculator", None)
+            draft_model = (
+                getattr(speculator, "model", None) if speculator is not None else None
+            )
+        if draft_model is None:
+            raise RuntimeError("Received EAGLE draft weights, but vLLM has no drafter.")
+
+        draft_model.load_weights(
+            weights=_trim_draft_vocab_padding(draft_model, draft_weights),
+        )
 
     def _mx_maybe_process_fp8_kv_cache(self) -> None:
         cache_config = getattr(self.model_runner.vllm_config, "cache_config", None)
@@ -655,15 +776,13 @@ class MxRefitWorkerExtension:
             for td in cand.registry.get("tensors", []):
                 if td.name in receive_specs or not td.megatron_role:
                     continue
-                lookup_name = (
-                    td.name[len("module.") :]
-                    if td.name.startswith("module.")
-                    else td.name
-                )
-                hf_names = name_map.get(lookup_name, name_map.get(td.name, [td.name]))
                 receive_specs[td.name] = ReceiveSpec(
                     megatron_name=td.name,
-                    hf_names=list(hf_names),
+                    hf_names=_resolve_hf_names(
+                        td.name,
+                        td.megatron_role,
+                        name_map,
+                    ),
                     role=td.megatron_role,
                     target_shape=tuple(int(s) for s in td.global_shape),
                     target_dtype=td.dtype,

--- a/components/src/dynamo/vllm/tests/test_mx_refit_eagle.py
+++ b/components/src/dynamo/vllm/tests/test_mx_refit_eagle.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from dynamo.vllm.mx_refit import extension
+
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class RecordingModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.loaded_weights = None
+
+    def load_weights(self, *, weights):
+        self.loaded_weights = list(weights)
+
+
+class RecordingDraftModel(RecordingModel):
+    def __init__(self, *, org_vocab_size: int | None = None):
+        super().__init__()
+        self._org_vocab_size = org_vocab_size
+
+    def named_modules(self):
+        if self._org_vocab_size is None:
+            return []
+        return [
+            (
+                "lm_head",
+                SimpleNamespace(org_vocab_size=self._org_vocab_size),
+            )
+        ]
+
+
+def _worker_with(model_runner):
+    worker = object.__new__(extension.MxRefitWorkerExtension)
+    worker.model_runner = model_runner
+    return worker
+
+
+def test_torch_dtype_handles_draft_d2t_int64():
+    assert extension._torch_dtype("int64") is torch.int64
+    assert extension._torch_dtype("torch.int64") is torch.int64
+
+
+def test_derives_qwen_llama_qkv_hf_names_without_sidecar_map():
+    assert extension._derive_qwen_llama_hf_names(
+        "module.decoder.layers.0.self_attention.linear_qkv.weight",
+        "qkv_column",
+    ) == [
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.self_attn.k_proj.weight",
+        "model.layers.0.self_attn.v_proj.weight",
+    ]
+
+
+def test_derives_qwen_llama_gated_mlp_hf_names_without_sidecar_map():
+    assert extension._derive_qwen_llama_hf_names(
+        "module.decoder.layers.1.mlp.linear_fc1.weight",
+        "gated_mlp_column",
+    ) == [
+        "model.layers.1.mlp.gate_proj.weight",
+        "model.layers.1.mlp.up_proj.weight",
+    ]
+
+
+def test_resolves_identity_megatron_name_map_with_derived_hf_name():
+    assert extension._resolve_hf_names(
+        "module.decoder.layers.2.input_layernorm.weight",
+        "replicated",
+        {
+            "decoder.layers.2.input_layernorm.weight": [
+                "module.decoder.layers.2.input_layernorm.weight"
+            ]
+        },
+    ) == ["model.layers.2.input_layernorm.weight"]
+
+
+def test_resolves_module_prefixed_hf_name_map_without_wrapper_prefix():
+    assert extension._resolve_hf_names(
+        "module.decoder.layers.2.input_layernorm.weight",
+        "replicated",
+        {
+            "decoder.layers.2.input_layernorm.weight": [
+                "module.model.layers.2.input_layernorm.weight"
+            ]
+        },
+    ) == ["model.layers.2.input_layernorm.weight"]
+
+
+def test_derives_fallback_name_without_module_wrapper_prefix():
+    assert extension._derive_qwen_llama_hf_names(
+        "module.decoder.layers.2.unhandled.weight",
+        "replicated",
+    ) == ["decoder.layers.2.unhandled.weight"]
+
+
+def test_mx_load_weights_routes_draft_weights_to_drafter():
+    policy_model = RecordingModel()
+    draft_model = RecordingDraftModel(org_vocab_size=2)
+    worker = _worker_with(
+        SimpleNamespace(
+            model=policy_model,
+            drafter=SimpleNamespace(model=draft_model),
+        )
+    )
+
+    policy_tensor = torch.ones(2, 2)
+    draft_tensor = torch.arange(8).reshape(4, 2)
+
+    worker._mx_load_weights(
+        [
+            ("model.layers.0.weight", policy_tensor),
+            ("draft.lm_head.weight", draft_tensor),
+        ]
+    )
+
+    assert len(policy_model.loaded_weights) == 1
+    policy_name, loaded_policy_tensor = policy_model.loaded_weights[0]
+    assert policy_name == "model.layers.0.weight"
+    assert loaded_policy_tensor is policy_tensor
+    assert len(draft_model.loaded_weights) == 1
+    draft_name, loaded_draft_tensor = draft_model.loaded_weights[0]
+    assert draft_name == "lm_head.weight"
+    assert torch.equal(loaded_draft_tensor, draft_tensor[:2])
+
+
+def test_mx_load_weights_routes_draft_weights_to_speculator_model():
+    policy_model = RecordingModel()
+    draft_model = RecordingDraftModel(org_vocab_size=2)
+    worker = _worker_with(
+        SimpleNamespace(
+            model=policy_model,
+            speculator=SimpleNamespace(model=draft_model),
+        )
+    )
+
+    draft_tensor = torch.arange(8).reshape(4, 2)
+
+    worker._mx_load_weights([("draft.lm_head.weight", draft_tensor)])
+
+    assert policy_model.loaded_weights == []
+    assert len(draft_model.loaded_weights) == 1
+    draft_name, loaded_draft_tensor = draft_model.loaded_weights[0]
+    assert draft_name == "lm_head.weight"
+    assert torch.equal(loaded_draft_tensor, draft_tensor[:2])
+
+
+def test_mx_load_weights_rejects_draft_weights_without_drafter():
+    policy_model = RecordingModel()
+    worker = _worker_with(SimpleNamespace(model=policy_model))
+
+    with pytest.raises(RuntimeError, match="vLLM has no drafter"):
+        worker._mx_load_weights([("draft.eagle_module.fc.weight", torch.ones(2, 2))])
+
+    assert policy_model.loaded_weights == []


### PR DESCRIPTION
## Summary

Adds EAGLE/specdec handling to Dynamo's native vLLM ModelExpress refit extension, stacked on the FP8 MX refit branch from PR #10845.

- splits `draft.*` tensors from policy tensors during MX refit
- loads EAGLE draft tensors into vLLM's `drafter.model`, with V1 `speculator.model` support
- trims padded draft vocab tensors before draft load
- supports `int64`/`long` MX tensor allocation for draft metadata tensors such as `d2t`
- derives Qwen/Llama HF names for Megatron tensors when the sidecar map is missing or identity-mapped
- adds focused EAGLE MX refit unit tests

## Validation

- `python -m py_compile components/src/dynamo/vllm/mx_refit/extension.py components/src/dynamo/vllm/tests/test_mx_refit_eagle.py`
- `PYTHONPATH=components/src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -c /dev/null components/src/dynamo/vllm/tests/test_mx_refit_eagle.py -q` (`9 passed`)
- `python -m ruff check components/src/dynamo/vllm/mx_refit/extension.py components/src/dynamo/vllm/tests/test_mx_refit_eagle.py`
- `python -m ruff format --check components/src/dynamo/vllm/mx_refit/extension.py components/src/dynamo/vllm/tests/test_mx_refit_eagle.py`
- NeMo-RL Qwen3-1.7B Megatron EAGLE3 Dynamo + MX e2e using mounted Dynamo source:
  - Run ID: `qwen3-eagle3-mx-e2e-dynamo-mounted-20260623-030028`
  - Ray job: `0d000000`, status `SUCCEEDED`
  - Completed 2 GRPO steps
  - Trainer published 14 EAGLE draft tensors on both steps
  - DGD refit transferred 239 policy tensors, 3.09 GB, on both steps

## Notes

The combined local FP8 test command could not run on host Python because `vllm` is not installed locally; the E2E used the same mounted-source pattern as PR #10845 testing.