### PR TITLE
docs(operator): align Go prerequisite with go.mod

### DIFF
--- a/deploy/operator/README.md
+++ b/deploy/operator/README.md
@@ -22,7 +22,7 @@ Built with [Kubebuilder](https://book.kubebuilder.io/), it follows Kubernetes be
 
 ### Pre-requisites
 
-- [Go](https://go.dev/doc/install) >= 1.25
+- [Go](https://go.dev/doc/install) >= 1.26.3
 - [Kubebuilder](https://book.kubebuilder.io/quick-start.html)
 
 ### Build
@@ -41,7 +41,7 @@ The following tools must be installed and available in your `PATH` before runnin
 
 | Tool | Version | Purpose | Install |
 |------|---------|---------|---------|
-| [Go](https://go.dev/doc/install) | ≥ 1.25 | Compiles the manager binary locally | [go.dev/doc/install](https://go.dev/doc/install) |
+| [Go](https://go.dev/doc/install) | ≥ 1.26.3 | Compiles the manager binary locally | [go.dev/doc/install](https://go.dev/doc/install) |
 | [Tilt](https://docs.tilt.dev/install.html) | latest | Live-reload dev loop orchestrator | [docs.tilt.dev/install](https://docs.tilt.dev/install.html) |
 | [Helm](https://helm.sh/docs/intro/install/) | v3 | Renders the platform Helm chart | [helm.sh/docs/intro/install](https://helm.sh/docs/intro/install/) |
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | ≥ 1.29 | Applies CRDs and creates the namespace | [kubernetes.io/docs/tasks/tools](https://kubernetes.io/docs/tasks/tools/) |

--- a/deploy/operator/Tiltfile
+++ b/deploy/operator/Tiltfile
@@ -18,7 +18,7 @@
 #      running container — no full image rebuild needed.
 #
 # Prerequisites:
-#   - Go >= 1.25        — compiles the manager binary locally
+#   - Go >= 1.26.3      — compiles the manager binary locally
 #   - tilt              — live-reload orchestrator (https://docs.tilt.dev/install.html)
 #   - docker            — builds the live-update container image
 #   - A Kubernetes cluster reachable via your current kubeconfig context

--- a/deploy/operator/test/e2e/dgdr/README.md
+++ b/deploy/operator/test/e2e/dgdr/README.md
@@ -15,7 +15,7 @@ Go, Ginkgo v2, and typed CRD structs.
      --set operator.image.tag=<your-branch-tag>
    ```
 2. `kubectl` configured for the cluster
-3. Go 1.25+
+3. Go 1.26.3+
 
 ## Image Override
 

--- a/docs/kubernetes/tilt-dev-setup.md
+++ b/docs/kubernetes/tilt-dev-setup.md
@@ -33,7 +33,7 @@ workloads — while iterating on controller logic with sub-second feedback.
 |------|---------|---------|
 | [Tilt](https://docs.tilt.dev/install.html) | v0.33+ | Development orchestration |
 | [Helm](https://helm.sh/docs/intro/install/) | v3 | Chart rendering |
-| [Go](https://go.dev/dl/) | 1.25+ | Compiling the operator |
+| [Go](https://go.dev/dl/) | 1.26.3+ | Compiling the operator |
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | — | Cluster access |
 | A Kubernetes cluster | — | kind, minikube, or remote cluster |
 


### PR DESCRIPTION
## Overview:

Follow up on https://github.com/ai-dynamo/dynamo/pull/10058 by syncing the
operator-facing Go prerequisite docs with the `go 1.26.3` directive.

## Details:

- Update operator README, Tiltfile, DGDR e2e README, and Tilt docs from Go 1.25
  to Go 1.26.3.
- Keep unrelated `1.25` references unchanged.

This follows https://github.com/ai-dynamo/dynamo/pull/10058, which pinned Go
build references to 1.26.3 to match `go.mod`, and mirrors the doc-sync pattern
from https://github.com/ai-dynamo/dynamo/pull/5241.

## Where should the reviewer start?

`deploy/operator/README.md`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Go version requirements from 1.25 to 1.26.3 across development prerequisites documentation and local development configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->