### PR TITLE
refactor(runtime): remove deprecated Context::with_id

### DIFF
--- a/lib/runtime/src/pipeline/context.rs
+++ b/lib/runtime/src/pipeline/context.rs
@@ -51,22 +51,6 @@ impl<T: Send + Sync + 'static> Context<T> {
         }
     }
 
-    #[deprecated(
-        since = "1.1.2",
-        note = "Use `Context::with_id_and_metadata` instead; pass `Default::default()` \
-                when you have no metadata to propagate. `with_id` will be removed once \
-                all call sites have been migrated."
-    )]
-    pub fn with_id(current: T, id: String) -> Self {
-        Context {
-            current,
-            controller: Arc::new(Controller::new(id)),
-            registry: Registry::new(),
-            stages: Vec::new(),
-            metadata: BTreeMap::new(),
-        }
-    }
-
     pub fn with_id_and_metadata(
         current: T,
         id: String,


### PR DESCRIPTION
## Summary
- Remove the deprecated `Context::with_id` constructor from `dynamo-runtime`.
- Keep `Context::with_id_and_metadata` as the metadata-aware constructor, using `Default::default()` for callers without metadata.

This follows the deprecation added in #9726 after the in-tree call sites were migrated. I also checked public usage before opening this: GitHub code search did not find external `Context::with_id(` callers, and the crates.io reverse dependencies for `dynamo-runtime` are Dynamo-owned crates.

## Validation
- `rg "with_id\\(" -n` only finds the unrelated `Endpoint::name_with_id()` comment.
- `cargo check -p dynamo-runtime`
- `cargo test -p dynamo-runtime test_with_id_and_metadata_constructor`
- `cargo fmt --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated constructor method that only accepted an identifier parameter. Use the alternative constructor that accepts both identifier and metadata instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->