### PR TITLE
chore: removed outdated warning

### DIFF
--- a/lib/llm/build.rs
+++ b/lib/llm/build.rs
@@ -12,7 +12,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Declare our custom cfg flag to avoid unexpected_cfgs warnings
     println!("cargo:rustc-check-cfg=cfg(have_vec_copy_fatbin)");
 
-    println!("cargo:warning=Building with CUDA KV off");
     build_protos()?;
 
     // Get FATBIN path and copy it to OUT_DIR for embedding


### PR DESCRIPTION
Removed warning which is apparently an artifact left over from a feature that has been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a build warning message from the compilation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->