### PR TITLE
feat(router): thread trajectory id into scheduling

### DIFF
--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -226,6 +226,7 @@ where
     ) -> Result<SchedulingResponse, KvSchedulerError> {
         self.schedule_with_block_hashes(
             maybe_request_id,
+            None,
             isl_tokens,
             token_seq,
             None,
@@ -254,6 +255,7 @@ where
     pub async fn schedule_with_block_hashes(
         &self,
         maybe_request_id: Option<String>,
+        trajectory_id: Option<String>,
         isl_tokens: usize,
         token_seq: Option<Vec<SequenceHash>>,
         block_hashes: Option<Vec<LocalBlockHash>>,
@@ -277,6 +279,7 @@ where
             .unwrap_or(self.track_prefill_tokens_default);
         let request = SchedulingRequest {
             maybe_request_id,
+            trajectory_id,
             token_seq,
             isl_tokens,
             tier_overlap_blocks,

--- a/lib/kv-router/src/scheduling/policy.rs
+++ b/lib/kv-router/src/scheduling/policy.rs
@@ -204,6 +204,7 @@ mod tests {
             .collect();
         SchedulingRequest {
             maybe_request_id: None,
+            trajectory_id: None,
             token_seq: None,
             isl_tokens,
             tier_overlap_blocks: Default::default(),

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1269,6 +1269,7 @@ mod tests {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let req = SchedulingRequest {
             maybe_request_id: Some(request_id.to_string()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens,
             tier_overlap_blocks: Default::default(),
@@ -1895,6 +1896,7 @@ mod tests {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let req = SchedulingRequest {
             maybe_request_id: Some("filter-0".to_string()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: isl,
             tier_overlap_blocks: Default::default(),

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -502,6 +502,7 @@ mod tests {
     fn base_request(isl_tokens: usize) -> SchedulingRequest {
         SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens,
             tier_overlap_blocks: Default::default(),
@@ -665,6 +666,7 @@ mod tests {
         ]);
         let request = SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: 16,
             tier_overlap_blocks: Default::default(),
@@ -801,6 +803,7 @@ mod tests {
         )]);
         let request = SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: 16,
             tier_overlap_blocks: Default::default(),
@@ -847,6 +850,7 @@ mod tests {
         ]);
         let request = SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: 16,
             tier_overlap_blocks: Default::default(),
@@ -911,6 +915,7 @@ mod tests {
 
             let request = SchedulingRequest {
                 maybe_request_id: Some("test".into()),
+                trajectory_id: None,
                 token_seq: None,
                 isl_tokens: 16,
                 tier_overlap_blocks: Default::default(),
@@ -973,6 +978,7 @@ mod tests {
 
         let request = SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: 16,
             tier_overlap_blocks: Default::default(),
@@ -1031,6 +1037,7 @@ mod tests {
 
         let request = SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: 16,
             tier_overlap_blocks: Default::default(),
@@ -1105,6 +1112,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::oneshot::channel();
         let request = SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: isl,
             tier_overlap_blocks,
@@ -1170,6 +1178,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::oneshot::channel();
         let request = SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: isl,
             tier_overlap_blocks,
@@ -1318,6 +1327,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::oneshot::channel();
         let request = SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: isl,
             tier_overlap_blocks: Default::default(),
@@ -1368,6 +1378,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::oneshot::channel();
         let request = SchedulingRequest {
             maybe_request_id: Some("test".into()),
+            trajectory_id: None,
             token_seq: None,
             isl_tokens: isl,
             tier_overlap_blocks: Default::default(),

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -85,6 +85,7 @@ pub struct SchedulingResponse {
 pub struct SchedulingRequest {
     // Request identity and payload.
     pub maybe_request_id: Option<String>,
+    pub trajectory_id: Option<String>,
     pub token_seq: Option<Vec<SequenceHash>>,
     pub isl_tokens: usize,
     pub lora_name: Option<String>,

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -644,6 +644,7 @@ impl SelectionCore {
             }
             result = entry.scheduler.schedule_with_block_hashes(
                 scheduler_request_id,
+                None,
                 isl_tokens,
                 Some(sequence_hashes),
                 None,

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -388,6 +388,7 @@ where
     pub async fn find_best_match_details(
         &self,
         context_id: Option<&str>,
+        trajectory_id: Option<String>,
         tokens: &[u32],
         block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
         router_config_override: Option<&RouterConfigOverride>,
@@ -473,6 +474,7 @@ where
             .scheduler
             .schedule_with_block_hashes(
                 context_id.map(|s| s.to_string()),
+                trajectory_id,
                 isl_tokens,
                 maybe_seq_hashes,
                 block_hashes_for_refresh,
@@ -576,6 +578,7 @@ where
         let result = self
             .find_best_match_details(
                 context_id,
+                None,
                 tokens,
                 block_mm_infos,
                 router_config_override,
@@ -1001,6 +1004,7 @@ where
                 match self
                     .find_best_match_details(
                         Some(&context_id),
+                        None,
                         &tokens,
                         block_mm_infos.as_deref(),
                         None,
@@ -1168,6 +1172,7 @@ mod tests {
 
     struct InspectingSelector {
         expected_hits: Option<u32>,
+        expected_trajectory_id: Option<&'static str>,
         selected_worker: WorkerWithDpRank,
     }
 
@@ -1184,6 +1189,10 @@ mod tests {
                 .as_ref()
                 .map(|hits| hits.total_hits);
             assert_eq!(observed_hits, self.expected_hits);
+            assert_eq!(
+                request.trajectory_id.as_deref(),
+                self.expected_trajectory_id
+            );
 
             Ok(dynamo_kv_router::protocols::WorkerSelectionResult {
                 worker: self.selected_worker,
@@ -1269,6 +1278,7 @@ mod tests {
         let router = make_test_router(
             InspectingSelector {
                 expected_hits: Some(2),
+                expected_trajectory_id: None,
                 selected_worker: WorkerWithDpRank::from_worker_id(1),
             },
             Some(Box::new(FakeSharedCache {
@@ -1307,6 +1317,7 @@ mod tests {
         let router = make_test_router(
             InspectingSelector {
                 expected_hits: None,
+                expected_trajectory_id: None,
                 selected_worker: WorkerWithDpRank::from_worker_id(0),
             },
             Some(Box::new(FakeSharedCache {
@@ -1335,6 +1346,41 @@ mod tests {
 
         assert_eq!(worker, WorkerWithDpRank::from_worker_id(0));
         assert_eq!(overlap, 0);
+    }
+
+    #[tokio::test]
+    async fn test_find_best_match_details_passes_trajectory_id_to_scheduler() {
+        let router = make_test_router(
+            InspectingSelector {
+                expected_hits: None,
+                expected_trajectory_id: Some("trajectory-123"),
+                selected_worker: WorkerWithDpRank::from_worker_id(0),
+            },
+            None,
+        )
+        .await;
+
+        let outcome = router
+            .find_best_match_details(
+                None,
+                Some("trajectory-123".to_string()),
+                &[11, 12, 21, 22],
+                None,
+                None,
+                false,
+                false,
+                None,
+                0.0,
+                0,
+                None,
+                None,
+                None,
+                RoutingConstraints::default(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, FindBestMatchOutcome::Routed { .. }));
     }
 
     #[tokio::test]
@@ -1374,6 +1420,7 @@ mod tests {
         let router = make_test_router(
             InspectingSelector {
                 expected_hits: None,
+                expected_trajectory_id: None,
                 selected_worker: WorkerWithDpRank::from_worker_id(0),
             },
             None,
@@ -1383,6 +1430,7 @@ mod tests {
 
         let outcome = router
             .find_best_match_details(
+                None,
                 None,
                 &tokens,
                 None,
@@ -1427,6 +1475,7 @@ mod tests {
         let router = make_test_router(
             InspectingSelector {
                 expected_hits: None,
+                expected_trajectory_id: None,
                 selected_worker: WorkerWithDpRank::from_worker_id(0),
             },
             None,
@@ -1435,6 +1484,7 @@ mod tests {
 
         let outcome = router
             .find_best_match_details(
+                None,
                 None,
                 &[11, 12, 21, 22],
                 None,
@@ -1463,6 +1513,7 @@ mod tests {
         let router = make_test_router(
             InspectingSelector {
                 expected_hits: None,
+                expected_trajectory_id: None,
                 selected_worker: WorkerWithDpRank::from_worker_id(0),
             },
             Some(Box::new(FakeSharedCache {

--- a/lib/llm/src/kv_router/prefill_router/query.rs
+++ b/lib/llm/src/kv_router/prefill_router/query.rs
@@ -40,6 +40,7 @@ impl PrefillRouter {
                     .chooser
                     .find_best_match_details(
                         None,
+                        None,
                         token_ids,
                         block_mm_infos,
                         None,

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -50,8 +50,16 @@ impl<'a> RoutingRequestParts<'a> {
     }
 }
 
+fn scheduler_trajectory_id(request: &PreprocessedRequest) -> Option<String> {
+    request
+        .agent_context
+        .as_ref()
+        .map(|ctx| ctx.trajectory_id.clone())
+}
+
 struct BestMatchArgs<'a> {
     context_id: &'a str,
+    trajectory_id: Option<String>,
     routing_parts: RoutingRequestParts<'a>,
     router_config_override: Option<&'a RouterConfigOverride>,
     update_states: bool,
@@ -72,6 +80,7 @@ impl KvPushRouter {
             .chooser
             .find_best_match_details(
                 Some(args.context_id),
+                args.trajectory_id,
                 args.routing_parts.token_ids,
                 args.routing_parts.block_mm_infos,
                 args.router_config_override,
@@ -139,6 +148,7 @@ impl KvPushRouter {
         let allowed_worker_ids = routing.and_then(|routing| routing.allowed_worker_ids.clone());
         let return_routing_hashes =
             !is_query_only && self.chooser.indexer().records_routing_decisions();
+        let trajectory_id = scheduler_trajectory_id(request);
         let routing_constraints = routing
             .and_then(|routing| routing.routing_constraints.clone())
             .unwrap_or_default();
@@ -147,6 +157,7 @@ impl KvPushRouter {
             let selection = self
                 .select_best_match(BestMatchArgs {
                     context_id,
+                    trajectory_id,
                     routing_parts,
                     router_config_override: request.router_config_override.as_ref(),
                     update_states: !is_query_only,
@@ -216,6 +227,7 @@ impl KvPushRouter {
 
         self.select_best_match(BestMatchArgs {
             context_id,
+            trajectory_id,
             routing_parts,
             router_config_override: request.router_config_override.as_ref(),
             update_states: !is_query_only,
@@ -278,11 +290,49 @@ mod tests {
         scheduling::{RoutingEligibility, WorkerEligibilityError},
     };
 
-    use super::{pinned_worker_hint, resolve_pinned_worker_rank};
+    use super::{pinned_worker_hint, resolve_pinned_worker_rank, scheduler_trajectory_id};
     use crate::{
         local_model::runtime_config::ModelRuntimeConfig,
-        protocols::common::{preprocessor::RoutingHints, timing::RequestPhase},
+        protocols::common::{
+            extensions::AgentContext,
+            preprocessor::{PreprocessedRequest, RoutingHints},
+            timing::RequestPhase,
+        },
     };
+
+    fn test_request(agent_context: Option<AgentContext>) -> PreprocessedRequest {
+        PreprocessedRequest::builder()
+            .model("test".to_string())
+            .token_ids(vec![1, 2, 3])
+            .stop_conditions(Default::default())
+            .sampling_options(Default::default())
+            .output_options(Default::default())
+            .agent_context(agent_context)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn scheduler_trajectory_id_uses_agent_context_trajectory() {
+        let request = test_request(Some(AgentContext {
+            trajectory_id: "trajectory-123".to_string(),
+            parent_trajectory_id: Some("parent-456".to_string()),
+            trajectory_final: Some(true),
+            kv_hints: None,
+        }));
+
+        assert_eq!(
+            scheduler_trajectory_id(&request).as_deref(),
+            Some("trajectory-123")
+        );
+    }
+
+    #[test]
+    fn scheduler_trajectory_id_keeps_anonymous_requests_none() {
+        let request = test_request(None);
+
+        assert_eq!(scheduler_trajectory_id(&request), None);
+    }
 
     #[test]
     fn resolve_pinned_worker_rank_uses_explicit_rank_including_zero() {

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -171,6 +171,7 @@ where
     ) -> Result<SchedulingResponse, KvSchedulerError> {
         self.schedule_with_block_hashes(
             maybe_request_id,
+            None,
             isl_tokens,
             token_seq,
             None,
@@ -198,6 +199,7 @@ where
     pub async fn schedule_with_block_hashes(
         &self,
         maybe_request_id: Option<String>,
+        trajectory_id: Option<String>,
         isl_tokens: usize,
         token_seq: Option<Vec<SequenceHash>>,
         block_hashes: Option<Vec<LocalBlockHash>>,
@@ -219,6 +221,7 @@ where
             .inner
             .schedule_with_block_hashes(
                 maybe_request_id,
+                trajectory_id,
                 isl_tokens,
                 token_seq,
                 block_hashes,

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -161,6 +161,7 @@ impl PendingRequest {
             .collect();
         SchedulingRequest {
             maybe_request_id: Some(self.request_id()),
+            trajectory_id: None,
             token_seq: self.token_seq.clone(),
             isl_tokens: self.isl_tokens,
             tier_overlap_blocks: TierOverlapBlocks::default(),


### PR DESCRIPTION
### Summary
Thread normalized agent trajectory identity from the push router into the native scheduling request without changing routing decisions. This gives the next trajectory-aware queue policy a concrete key while anonymous and advisory paths remain `None`.

CLOSES: DYN-3230

### How This Was Implemented
- Extract `trajectory_id` from `PreprocessedRequest.agent_context` in the push-router selection path.
- Add `trajectory_id: Option<String>` to `SchedulingRequest`.
- Thread the value through `find_best_match_details` and `schedule_with_block_hashes`.
- Keep non-agent and advisory callers behavior-free by passing `None`.
- Add focused tests for extraction and scheduler propagation.

<details>
<summary>Walkthrough</summary>

- `lib/llm/src/kv_router/push_router/selection.rs`: reads the normalized trajectory ID from `agent_context`.
- `lib/llm/src/kv_router.rs`: accepts the optional trajectory ID on the detailed match path and forwards it to scheduling.
- `lib/llm/src/kv_router/scheduler.rs` and `lib/kv-router/src/scheduling/local.rs`: carry the optional value into `SchedulingRequest`.
- `lib/kv-router/src/scheduling/types.rs`: stores `trajectory_id` as request metadata only; no policy consumes it yet.

</details>

### Validation
- `cargo test -p dynamo-llm scheduler_trajectory_id --lib`
- `cargo test -p dynamo-llm test_find_best_match_details_passes_trajectory_id_to_scheduler --lib`
- `cargo test -p dynamo-kv-router --lib scheduling::`