### PR TITLE
feat(frontend): add request priority headers

### DIFF
--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -172,7 +172,7 @@ Set an env value of `0` / `false` / `no` / `off` (case-insensitive) to disable.
 
 | Env Var | Default | Behavior when `false` |
 |---------|---------|------------------------|
-| `DYN_ENABLE_FRONTEND_NVEXT` | `true` | Frontend drops `request.nvext` at handler entry on `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/embeddings`, and `/v1/messages`; ignores routing-override headers (`x-worker-instance-id`, `x-prefill-instance-id`, `x-dp-rank`, `x-data-parallel-rank`, `x-prefill-dp-rank`); silently ignores the response-side `nvext.extra_fields` opt-in. Note: disabling this breaks EPP / GAIE serving, Prime-RL-style training that uses `nvext.cache_salt`, multi-tenant agent platforms that forward `nvext.agent_hints`, and clients that opt into response disclosure via `nvext.extra_fields`. |
+| `DYN_ENABLE_FRONTEND_NVEXT` | `true` | Frontend drops `request.nvext` at handler entry on `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/embeddings`, and `/v1/messages`; ignores routing-override headers (`x-worker-instance-id`, `x-prefill-instance-id`, `x-dp-rank`, `x-data-parallel-rank`, `x-prefill-dp-rank`, `x-dynamo-request-priority`, `x-dynamo-request-strict-priority`); silently ignores the response-side `nvext.extra_fields` opt-in. Note: disabling this breaks EPP / GAIE serving, Prime-RL-style training that uses `nvext.cache_salt`, multi-tenant agent platforms that forward `nvext.agent_hints`, and clients that opt into response disclosure via `nvext.extra_fields`. |
 | `DYN_ENABLE_FRONTEND_ADMIN_API` | `true` | `GET /busy_threshold` and `POST /busy_threshold` are not registered (404 instead of 503). Inference, metrics, models, health, and liveness routes are unaffected. |
 
 ### Endpoint Path Customization

--- a/docs/components/router/priority-scheduling.md
+++ b/docs/components/router/priority-scheduling.md
@@ -10,6 +10,10 @@ Priority scheduling lets a client mark one request as more important than anothe
 - `nvext.agent_hints.priority` is a soft priority used by router policy scoring and supported backend engines.
 - `nvext.agent_hints.strict_priority` is an unsigned router pending-queue tier. Higher tiers always precede lower tiers.
 
+For HTTP requests, send the same values in `x-dynamo-request-priority` and
+`x-dynamo-request-strict-priority`. Header values override the corresponding `nvext.agent_hints`
+fields.
+
 ```json
 {
     "model": "my-model",

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -531,7 +531,7 @@ fn copy_context_metadata<T: Send + Sync + 'static, U: Send + Sync + 'static>(
 fn warn_nvext_disabled(endpoint: &str, nvext_present: bool, headers: &HeaderMap) {
     use crate::protocols::common::extensions::{
         HEADER_DP_RANK, HEADER_DP_RANK_ALIAS, HEADER_PREFILL_DP_RANK, HEADER_PREFILL_INSTANCE_ID,
-        HEADER_WORKER_INSTANCE_ID,
+        HEADER_REQUEST_PRIORITY, HEADER_REQUEST_STRICT_PRIORITY, HEADER_WORKER_INSTANCE_ID,
     };
     let header_present = [
         HEADER_WORKER_INSTANCE_ID,
@@ -539,6 +539,8 @@ fn warn_nvext_disabled(endpoint: &str, nvext_present: bool, headers: &HeaderMap)
         HEADER_DP_RANK,
         HEADER_DP_RANK_ALIAS,
         HEADER_PREFILL_DP_RANK,
+        HEADER_REQUEST_PRIORITY,
+        HEADER_REQUEST_STRICT_PRIORITY,
     ]
     .iter()
     .any(|h| headers.contains_key(*h));

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -240,6 +240,8 @@ pub const HEADER_DP_RANK: &str = "x-dp-rank";
 /// Alias for data-parallel rank routing.
 pub const HEADER_DP_RANK_ALIAS: &str = "x-data-parallel-rank";
 pub const HEADER_PREFILL_DP_RANK: &str = "x-prefill-dp-rank";
+pub const HEADER_REQUEST_PRIORITY: &str = "x-dynamo-request-priority";
+pub const HEADER_REQUEST_STRICT_PRIORITY: &str = "x-dynamo-request-strict-priority";
 const UNSET_DP_RANK_SENTINEL: u32 = u32::MAX;
 
 impl From<AgentContextHeaderValues> for AgentContext {
@@ -269,6 +271,8 @@ pub fn agent_context_from_headers(headers: &HeaderMap) -> Option<AgentContext> {
 /// - `x-prefill-instance-id` -> `prefill_worker_id`
 /// - `x-dp-rank` -> `dp_rank` (decode worker's DP rank)
 /// - `x-prefill-dp-rank` -> `prefill_dp_rank`
+/// - `x-dynamo-request-priority` -> `agent_hints.priority`
+/// - `x-dynamo-request-strict-priority` -> `agent_hints.strict_priority`
 ///
 /// Routing headers take priority over existing nvext values when present.
 /// If no headers are present, returns the original nvext unchanged.
@@ -295,7 +299,22 @@ pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap)
         .and_then(|s| s.parse::<u32>().ok());
     let prefill_dp_rank = prefill_dp_rank.filter(|rank| *rank != UNSET_DP_RANK_SENTINEL);
 
-    if worker_id.is_none() && prefill_id.is_none() && dp_rank.is_none() && prefill_dp_rank.is_none()
+    let priority = headers
+        .get(HEADER_REQUEST_PRIORITY)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<i32>().ok());
+
+    let strict_priority = headers
+        .get(HEADER_REQUEST_STRICT_PRIORITY)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u32>().ok());
+
+    if worker_id.is_none()
+        && prefill_id.is_none()
+        && dp_rank.is_none()
+        && prefill_dp_rank.is_none()
+        && priority.is_none()
+        && strict_priority.is_none()
     {
         return nvext;
     }
@@ -313,6 +332,15 @@ pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap)
     }
     if let Some(rank) = prefill_dp_rank {
         ext.prefill_dp_rank = Some(rank);
+    }
+    if priority.is_some() || strict_priority.is_some() {
+        let hints = ext.agent_hints.get_or_insert_with(AgentHints::default);
+        if let Some(priority) = priority {
+            hints.priority = Some(priority);
+        }
+        if let Some(strict_priority) = strict_priority {
+            hints.strict_priority = Some(strict_priority);
+        }
     }
     Some(ext)
 }
@@ -707,6 +735,40 @@ mod tests {
         assert_eq!(result.prefill_worker_id, Some(456));
         assert_eq!(result.dp_rank, Some(3));
         assert_eq!(result.prefill_dp_rank, Some(5));
+    }
+
+    #[test]
+    fn apply_header_routing_overrides_sets_priorities() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_REQUEST_PRIORITY, "-3".parse().unwrap());
+        headers.insert(HEADER_REQUEST_STRICT_PRIORITY, "7".parse().unwrap());
+
+        let hints = apply_header_routing_overrides(None, &headers)
+            .unwrap()
+            .agent_hints
+            .unwrap();
+
+        assert_eq!(hints.priority, Some(-3));
+        assert_eq!(hints.strict_priority, Some(7));
+
+        headers.remove(HEADER_REQUEST_STRICT_PRIORITY);
+        let nvext = NvExt {
+            agent_hints: Some(AgentHints {
+                priority: Some(1),
+                strict_priority: Some(2),
+                osl: Some(99),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let hints = apply_header_routing_overrides(Some(nvext), &headers)
+            .unwrap()
+            .agent_hints
+            .unwrap();
+
+        assert_eq!(hints.priority, Some(-3));
+        assert_eq!(hints.strict_priority, Some(2));
+        assert_eq!(hints.osl, Some(99));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `x-dynamo-request-priority` and `x-dynamo-request-strict-priority` as HTTP alternatives to `nvext.agent_hints`. This lets OpenAI and Anthropic clients set scheduling priority without modifying request bodies.

CLOSES: DYN-3263

## How This Was Implemented

- Parse signed soft priority and unsigned strict priority in the shared request-header override path.
- Create agent hints when absent, override matching body fields, and preserve unrelated hints.
- Keep the headers behind `DYN_ENABLE_FRONTEND_NVEXT` and document their behavior.

<details>
<summary>Walkthrough</summary>

- `apply_header_routing_overrides` maps both headers into `NvExt.agent_hints` for OpenAI and Anthropic requests.
- The frontend warning path recognizes the headers when NVIDIA request extensions are disabled.
- Priority scheduling and frontend configuration docs cover precedence and feature-switch behavior.

</details>

## Validation

- `cargo test -p dynamo-llm apply_header_routing_overrides --lib`
- `cargo fmt -p dynamo-llm -- --check`
- `fern check`
- `fern docs broken-links`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new HTTP headers to enable clients to set and override request priority values in routing decisions.

* **Documentation**
  * Updated configuration documentation to clarify feature switch behavior with priority header handling.
  * Added guidance on how HTTP clients can set request priority using the new headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->