### PR TITLE
feat(mocker): add output token replay

### DIFF
--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -411,6 +411,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "start_thinking_token_id (u32), end_thinking_token_id (u32), thinking_ratio (0.0-1.0). "
         'Example: \'{"start_thinking_token_id": 123, "end_thinking_token_id": 456, "thinking_ratio": 0.6}\'',
     )
+    parser.add_argument(
+        "--response-replay-trace-path",
+        type=str,
+        default=None,
+        help=(
+            "Optional Mooncake JSONL trace containing output_token_ids for "
+            "output_replay_id annotation lookup."
+        ),
+    )
 
     # Engine type selection
     parser.add_argument(

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -217,9 +217,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
     worker_type = (
         "prefill"
         if getattr(args, "is_prefill_worker", False)
-        else "decode"
-        if getattr(args, "is_decode_worker", False)
-        else "aggregated"
+        else "decode" if getattr(args, "is_decode_worker", False) else "aggregated"
     )
     aic_backend = None
     aic_system = None

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -308,7 +308,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         bandwidth_g2_to_g4_gbps=getattr(args, "bandwidth_g2_to_g4_gbps", None),
         bandwidth_g4_to_g2_gbps=getattr(args, "bandwidth_g4_to_g2_gbps", None),
         reasoning=_parse_reasoning_config(getattr(args, "reasoning", None)),
-        response_replay_trace_path=getattr(args, "response_replay_trace_path", None),
+        response_replay_trace_path=args.response_replay_trace_path,
         sglang=_build_sglang_args(args),
         trtllm=_build_trtllm_args(args),
         preemption_mode=getattr(args, "preemption_mode", "lifo"),

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -308,6 +308,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         bandwidth_g2_to_g4_gbps=getattr(args, "bandwidth_g2_to_g4_gbps", None),
         bandwidth_g4_to_g2_gbps=getattr(args, "bandwidth_g4_to_g2_gbps", None),
         reasoning=_parse_reasoning_config(getattr(args, "reasoning", None)),
+        response_replay_trace_path=getattr(args, "response_replay_trace_path", None),
         sglang=_build_sglang_args(args),
         trtllm=_build_trtllm_args(args),
         preemption_mode=getattr(args, "preemption_mode", "lifo"),
@@ -361,6 +362,7 @@ def build_runtime_config(
         engine_args.enable_local_indexer and not engine_args.is_decode()
     )
     rc.data_parallel_size = engine_args.dp_size
+    rc.set_engine_specific("output_replay_consumer", "true")
 
     bootstrap_port = engine_args.bootstrap_port
     if engine_args.is_prefill() and bootstrap_port is not None:

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -217,7 +217,9 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
     worker_type = (
         "prefill"
         if getattr(args, "is_prefill_worker", False)
-        else "decode" if getattr(args, "is_decode_worker", False) else "aggregated"
+        else "decode"
+        if getattr(args, "is_decode_worker", False)
+        else "aggregated"
     )
     aic_backend = None
     aic_system = None

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -90,7 +90,7 @@ def test_build_runtime_config_uses_normalized_sglang_page_size_alias():
     assert runtime_config.total_kv_blocks == 16384
     assert runtime_config.max_num_seqs == 256
     assert runtime_config.max_num_batched_tokens == 8192
-    assert runtime_config.runtime_data["output_replay_consumer"] is True
+    assert runtime_config.runtime_data["output_replay_consumer"] == "true"
 
 
 def test_build_mocker_engine_args_rejects_mismatched_sglang_sizes():

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -48,6 +48,7 @@ def make_args(**overrides):
         "kv_transfer_bandwidth": 64.0,
         "kv_transfer_timing_mode": "full_prompt",
         "reasoning": None,
+        "response_replay_trace_path": None,
         "sglang_schedule_policy": None,
         "sglang_page_size": None,
         "sglang_max_prefill_tokens": None,
@@ -89,6 +90,7 @@ def test_build_runtime_config_uses_normalized_sglang_page_size_alias():
     assert runtime_config.total_kv_blocks == 16384
     assert runtime_config.max_num_seqs == 256
     assert runtime_config.max_num_batched_tokens == 8192
+    assert runtime_config.runtime_data["output_replay_consumer"] is True
 
 
 def test_build_mocker_engine_args_rejects_mismatched_sglang_sizes():

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -277,6 +277,7 @@ def test_build_mocker_engine_args_preserves_cli_mapped_fields(tmp_path):
         kv_bytes_per_token=131072,
         kv_transfer_bandwidth=123.0,
         kv_transfer_timing_mode="destination_missing",
+        response_replay_trace_path=None,
         num_g2_blocks=8192,
         num_g3_blocks=16384,
         offload_batch_size=32,

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -171,7 +171,7 @@ impl MockEngineArgs {
 #[pymethods]
 impl MockEngineArgs {
     #[new]
-    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=42, aic_gemm_dtype=None, aic_moe_dtype=None, aic_fmha_dtype=None, aic_kv_cache_dtype=None, aic_comm_dtype=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, handoff_session_timeout_ms=300000, kv_bytes_per_token=None, kv_transfer_bandwidth=None, kv_transfer_timing_mode="full_prompt", reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
+    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=42, aic_gemm_dtype=None, aic_moe_dtype=None, aic_fmha_dtype=None, aic_kv_cache_dtype=None, aic_comm_dtype=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, handoff_session_timeout_ms=300000, kv_bytes_per_token=None, kv_transfer_bandwidth=None, kv_transfer_timing_mode="full_prompt", reasoning=None, response_replay_trace_path=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         engine_type: &str,
@@ -213,6 +213,7 @@ impl MockEngineArgs {
         kv_transfer_bandwidth: Option<f64>,
         kv_transfer_timing_mode: &str,
         reasoning: Option<ReasoningConfig>,
+        response_replay_trace_path: Option<PathBuf>,
         zmq_kv_events_port: Option<u16>,
         zmq_replay_port: Option<u16>,
         preemption_mode: &str,
@@ -293,6 +294,7 @@ impl MockEngineArgs {
             .bandwidth_g2_to_g4_gbps(bandwidth_g2_to_g4_gbps)
             .bandwidth_g4_to_g2_gbps(bandwidth_g4_to_g2_gbps)
             .reasoning(reasoning.map(|config| config.inner()))
+            .response_replay_trace_path(response_replay_trace_path)
             .zmq_kv_events_port(zmq_kv_events_port)
             .zmq_replay_port(zmq_replay_port)
             .preemption_mode(preemption_mode)
@@ -425,6 +427,11 @@ impl MockEngineArgs {
     #[getter]
     fn kv_bytes_per_token(&self) -> Option<usize> {
         self.inner.kv_bytes_per_token
+    }
+
+    #[getter]
+    fn response_replay_trace_path(&self) -> Option<PathBuf> {
+        self.inner.response_replay_trace_path.clone()
     }
 
     #[getter]

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1940,6 +1940,7 @@ class MockEngineArgs:
         kv_transfer_bandwidth: Optional[float] = None,
         kv_transfer_timing_mode: str = "full_prompt",
         reasoning: Optional[ReasoningConfig] = None,
+        response_replay_trace_path: Optional[str | os.PathLike[str]] = None,
         zmq_kv_events_port: Optional[int] = None,
         zmq_replay_port: Optional[int] = None,
         preemption_mode: str = "lifo",
@@ -2003,6 +2004,9 @@ class MockEngineArgs:
 
     @property
     def engine_type(self) -> str: ...
+
+    @property
+    def response_replay_trace_path(self) -> Optional[os.PathLike[str]]: ...
 
     @property
     def num_g2_blocks(self) -> Optional[int]: ...

--- a/lib/data-gen/src/mooncake.rs
+++ b/lib/data-gen/src/mooncake.rs
@@ -611,6 +611,36 @@ mod tests {
     }
 
     #[test]
+    fn row_replay_fields_round_trip_canonical_and_alias_inputs() {
+        let canonical = r#"{"request_id":"r1","session_id":"s","input_length":8,"output_length":3,"output_token_ids":[101,102,103],"hash_ids":[0,1],"timestamp":12.5,"delay":3.0}"#;
+        let row: MooncakeRow = serde_json::from_str(canonical).unwrap();
+        assert_eq!(row.request_id.as_deref(), Some("r1"));
+        assert_eq!(row.output_length, Some(3));
+        assert_eq!(row.output_token_ids, Some(vec![101, 102, 103]));
+
+        let rendered: Value = serde_json::to_value(&row).unwrap();
+        assert_eq!(rendered["request_id"], json!("r1"));
+        assert_eq!(rendered["output_token_ids"], json!([101, 102, 103]));
+        let decoded: MooncakeRow = serde_json::from_value(rendered).unwrap();
+        assert_eq!(decoded.request_id.as_deref(), Some("r1"));
+        assert_eq!(decoded.output_token_ids, Some(vec![101, 102, 103]));
+
+        let aliased = r#"{"request_id":"r2","input_tokens":4,"output_tokens":2,"output_token_ids":[201,202],"hash_ids":[7],"created_time":1.5,"delay_ms":0.5}"#;
+        let row: MooncakeRow = serde_json::from_str(aliased).unwrap();
+        assert_eq!(row.request_id.as_deref(), Some("r2"));
+        assert_eq!(row.input_length, Some(4));
+        assert_eq!(row.output_length, Some(2));
+        assert_eq!(row.output_token_ids, Some(vec![201, 202]));
+
+        let rendered: Value = serde_json::to_value(&row).unwrap();
+        assert_eq!(rendered["input_length"], json!(4));
+        assert_eq!(rendered["output_length"], json!(2));
+        assert_eq!(rendered["output_token_ids"], json!([201, 202]));
+        assert!(rendered.get("input_tokens").is_none());
+        assert!(rendered.get("output_tokens").is_none());
+    }
+
+    #[test]
     fn row_canonical_input_round_trips_without_renaming() {
         let raw = r#"{"input_length":8,"output_length":2,"timestamp":12.5,"delay":3.0}"#;
         let mut row: MooncakeRow = serde_json::from_str(raw).unwrap();
@@ -648,6 +678,8 @@ mod tests {
         assert!(rendered.get("priority").is_none());
         assert!(rendered.get("strict_priority").is_none());
         assert!(rendered.get("policy_class").is_none());
+        assert!(rendered.get("request_id").is_none());
+        assert!(rendered.get("output_token_ids").is_none());
     }
 
     #[test]
@@ -688,6 +720,37 @@ mod tests {
         assert!(rendered.get("priority").is_none());
         assert!(rendered.get("strict_priority").is_none());
         assert!(rendered.get("policy_class").is_none());
+        assert!(rendered.get("output_token_ids").is_none());
+    }
+
+    #[test]
+    fn agentic_row_replay_fields_round_trip_canonical_and_alias_inputs() {
+        let canonical = r#"{"request_id":"r1","session_id":"s","input_length":8,"output_length":3,"output_token_ids":[101,102,103],"hash_ids":[0,1],"timestamp":12.5,"delay":3.0}"#;
+        let row: AgenticMooncakeRow = serde_json::from_str(canonical).unwrap();
+        assert_eq!(row.request_id, "r1");
+        assert_eq!(row.output_length, Some(3));
+        assert_eq!(row.output_token_ids, Some(vec![101, 102, 103]));
+
+        let rendered: Value = serde_json::to_value(&row).unwrap();
+        assert_eq!(rendered["request_id"], json!("r1"));
+        assert_eq!(rendered["output_token_ids"], json!([101, 102, 103]));
+        let decoded: AgenticMooncakeRow = serde_json::from_value(rendered).unwrap();
+        assert_eq!(decoded.request_id, "r1");
+        assert_eq!(decoded.output_token_ids, Some(vec![101, 102, 103]));
+
+        let aliased = r#"{"request_id":"r2","input_tokens":4,"output_tokens":2,"output_token_ids":[201,202],"hash_ids":[7],"created_time":1.5,"delay_ms":0.5}"#;
+        let row: AgenticMooncakeRow = serde_json::from_str(aliased).unwrap();
+        assert_eq!(row.request_id, "r2");
+        assert_eq!(row.input_length, Some(4));
+        assert_eq!(row.output_length, Some(2));
+        assert_eq!(row.output_token_ids, Some(vec![201, 202]));
+
+        let rendered: Value = serde_json::to_value(&row).unwrap();
+        assert_eq!(rendered["input_length"], json!(4));
+        assert_eq!(rendered["output_length"], json!(2));
+        assert_eq!(rendered["output_token_ids"], json!([201, 202]));
+        assert!(rendered.get("input_tokens").is_none());
+        assert!(rendered.get("output_tokens").is_none());
     }
 
     #[test]

--- a/lib/data-gen/src/mooncake.rs
+++ b/lib/data-gen/src/mooncake.rs
@@ -37,11 +37,15 @@ use std::path::Path;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MooncakeRow {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
     #[serde(default, alias = "input_tokens")]
     pub input_length: Option<usize>,
     #[serde(default, alias = "output_tokens")]
     pub output_length: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_token_ids: Option<Vec<u32>>,
     #[serde(default)]
     pub hash_ids: Option<Vec<u64>>,
     #[serde(
@@ -77,6 +81,8 @@ pub struct AgenticMooncakeRow {
     pub input_length: Option<usize>,
     #[serde(default, alias = "output_tokens")]
     pub output_length: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_token_ids: Option<Vec<u32>>,
     #[serde(default)]
     pub hash_ids: Option<Vec<u64>>,
     #[serde(

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -36,6 +36,9 @@ use cancellation::{cancel_on_stop, cancelled_error};
 use request_guard::RequestGuard;
 use selection::{RoutingRequestParts, SelectionOptions, WorkerSelection};
 
+const OUTPUT_REPLAY_ID_ANNOTATION_KEY: &str = "output_replay_id";
+const OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY: &str = "output_replay_consumer";
+
 pub struct KvPushRouter {
     inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     pub chooser: Arc<KvRouter>,
@@ -277,6 +280,7 @@ impl KvPushRouter {
             .unwrap_or(RequestPhase::Aggregated);
         let phase_label = phase.to_string();
         guard.start_dispatch(&phase_label);
+        self.warn_if_output_replay_annotation_ignored(&request, &selection);
 
         let (mut backend_input, context) = request.into_parts();
         backend_input.routing_mut().dp_rank = Some(selection.dp_rank);
@@ -344,6 +348,38 @@ impl KvPushRouter {
             guard.finish().await;
         });
         Ok(ResponseStream::new(wrapped_stream, stream_context))
+    }
+
+    fn warn_if_output_replay_annotation_ignored(
+        &self,
+        request: &SingleIn<PreprocessedRequest>,
+        selection: &WorkerSelection,
+    ) {
+        let Some(replay_key) = request.get_annotation_value(OUTPUT_REPLAY_ID_ANNOTATION_KEY) else {
+            return;
+        };
+        let consumes_replay = self
+            .chooser
+            .workers_with_configs
+            .borrow()
+            .get(&selection.instance_id)
+            .and_then(|config| {
+                config
+                    .get_engine_specific::<bool>(OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY)
+                    .ok()
+                    .flatten()
+            })
+            .unwrap_or(false);
+        if consumes_replay {
+            return;
+        }
+
+        tracing::warn!(
+            replay_key,
+            worker_id = selection.instance_id,
+            dp_rank = selection.dp_rank,
+            "request has output token replay annotation but selected worker has not declared replay-token consumption"
+        );
     }
 
     pub(crate) async fn select_and_dispatch_prefill<M, F>(

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -9,6 +9,10 @@
 mod handoff;
 mod metrics;
 
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
@@ -17,7 +21,7 @@ use crate::backend::ExecutionContext;
 use crate::kv_router::publisher::{KvEventPublisher, KvEventSourceConfig, WorkerMetricsPublisher};
 use crate::protocols::TokenIdType;
 use crate::protocols::common::llm_backend::{LLMEngineOutput, PreprocessedRequest};
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use dashmap::DashMap;
 use dynamo_kv_router::protocols::{KvCacheEvent, StorageTier};
 use dynamo_mocker::common::handoff::HandoffId;
@@ -26,6 +30,7 @@ use dynamo_mocker::common::protocols::{
     RawKvEventSink,
 };
 use dynamo_mocker::engine::create_engine;
+use dynamo_mocker::loadgen::{OUTPUT_REPLAY_ID_ANNOTATION_KEY, effective_replay_key};
 use dynamo_mocker::scheduler::{SchedulerCommandEnvelope, SchedulerHandle};
 use dynamo_mocker::services::bootstrap::{
     BootstrapIdentity, BootstrapParticipantRole, BootstrapServer, BootstrapServerConfig,
@@ -42,7 +47,7 @@ use dynamo_runtime::{
     traits::DistributedRuntimeProvider,
 };
 use futures::StreamExt;
-use rand::Rng;
+use serde::Deserialize;
 use tokio::sync::{Notify, OnceCell, Semaphore, mpsc, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
@@ -56,6 +61,107 @@ use self::handoff::{
 use self::metrics::NativeMockerMetrics;
 
 pub const MOCKER_COMPONENT: &str = "mocker";
+
+#[derive(Debug, Clone, Deserialize)]
+struct ResponseReplayTraceRow {
+    #[serde(default)]
+    request_id: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default, alias = "output_tokens")]
+    output_length: Option<usize>,
+    #[serde(default)]
+    output_token_ids: Option<Vec<TokenIdType>>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ResponseReplayTable {
+    rows: HashMap<String, Vec<TokenIdType>>,
+}
+
+impl ResponseReplayTable {
+    fn from_path(path: &Path) -> Result<Self> {
+        let file = File::open(path)
+            .with_context(|| format!("failed to open response replay trace {}", path.display()))?;
+        let reader = BufReader::new(file);
+        let mut rows = HashMap::new();
+        let mut session_turns: HashMap<String, usize> = HashMap::new();
+
+        for (line_index, line) in reader.lines().enumerate() {
+            let line = line.with_context(|| {
+                format!(
+                    "failed to read line {} from response replay trace {}",
+                    line_index + 1,
+                    path.display()
+                )
+            })?;
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let row: ResponseReplayTraceRow = serde_json::from_str(&line).with_context(|| {
+                format!(
+                    "failed to parse line {} from response replay trace {}",
+                    line_index + 1,
+                    path.display()
+                )
+            })?;
+            let turn_index = row
+                .session_id
+                .as_ref()
+                .map(|session_id| {
+                    let entry = session_turns.entry(session_id.clone()).or_default();
+                    let turn_index = *entry;
+                    *entry += 1;
+                    turn_index
+                })
+                .unwrap_or(0);
+
+            let Some(output_token_ids) = row.output_token_ids else {
+                continue;
+            };
+            let output_length = row.output_length.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "response replay trace line {} has output_token_ids but no output_length",
+                    line_index + 1
+                )
+            })?;
+            if output_length != output_token_ids.len() {
+                bail!(
+                    "response replay trace line {} output_length {} does not match output_token_ids length {}",
+                    line_index + 1,
+                    output_length,
+                    output_token_ids.len()
+                );
+            }
+
+            let key = effective_replay_key(
+                row.request_id.as_deref(),
+                row.session_id.as_deref(),
+                turn_index,
+                line_index,
+            );
+            if rows.insert(key.clone(), output_token_ids).is_some() {
+                bail!(
+                    "response replay trace line {} duplicates output_replay_id key {}",
+                    line_index + 1,
+                    key
+                );
+            }
+        }
+
+        Ok(Self { rows })
+    }
+
+    fn get(&self, key: &str) -> Option<Vec<TokenIdType>> {
+        self.rows.get(key).cloned()
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.rows.len()
+    }
+}
 
 /// Wrapper to adapt KvEventPublisher to the KvCacheEventSink trait
 struct KvEventSinkAdapter(KvEventPublisher);
@@ -113,6 +219,7 @@ pub struct MockEngine {
     handoff_session_permits: OnceCell<Vec<Arc<Semaphore>>>,
     senders_ready: Notify,
     engine_args: MockEngineArgs,
+    response_replay_table: Option<ResponseReplayTable>,
     unset_dp_rank_counter: AtomicU32,
     /// Bootstrap server for prefill workers in disaggregated mode
     bootstrap_server: Arc<OnceCell<Arc<BootstrapServer>>>,
@@ -139,6 +246,23 @@ impl MockEngine {
     pub fn new(engine_args: MockEngineArgs) -> Self {
         let native_metrics = NativeMockerMetrics::new(engine_args.engine_type, engine_args.dp_size)
             .expect("mocker native metrics collectors should be valid");
+        let response_replay_table = engine_args
+            .response_replay_trace_path
+            .as_deref()
+            .map(|path| {
+                ResponseReplayTable::from_path(path).unwrap_or_else(|error| {
+                    panic!(
+                        "failed to load response replay trace {}: {error:#}",
+                        path.display()
+                    )
+                })
+            });
+        if let Some(table) = response_replay_table.as_ref() {
+            tracing::info!(
+                rows = table.rows.len(),
+                "loaded response replay token table"
+            );
+        }
         Self {
             active_requests: Arc::new(DashMap::new()),
             request_senders: OnceCell::new(),
@@ -146,6 +270,7 @@ impl MockEngine {
             handoff_session_permits: OnceCell::new(),
             senders_ready: Notify::new(),
             engine_args,
+            response_replay_table,
             unset_dp_rank_counter: AtomicU32::new(0),
             bootstrap_server: Arc::new(OnceCell::new()),
             source_handoff_manager: OnceCell::new(),
@@ -630,7 +755,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
 
         let request_uuid = ctx.id().parse().unwrap_or(Uuid::new_v4());
         let is_prefill = self.engine_args.is_prefill();
-        let max_output_tokens = if is_prefill {
+        let requested_max_output_tokens = if is_prefill {
             1
         } else {
             request
@@ -639,6 +764,32 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                 .ok_or_else(|| Error::msg("max_output_tokens must be specified for mocker"))?
                 as usize
         };
+        let replay_key = (!is_prefill)
+            .then(|| request.get_annotation_value(OUTPUT_REPLAY_ID_ANNOTATION_KEY))
+            .flatten();
+        let planned_output_token_ids = replay_key.as_deref().and_then(|key| {
+            let Some(table) = self.response_replay_table.as_ref() else {
+                tracing::warn!(
+                    replay_key = key,
+                    "request asked for output token replay but mocker has no response replay trace"
+                );
+                return None;
+            };
+            match table.get(key) {
+                Some(tokens) => Some(tokens),
+                None => {
+                    tracing::warn!(
+                        replay_key = key,
+                        "request asked for output token replay but key was not found"
+                    );
+                    None
+                }
+            }
+        });
+        let has_planned_output_tokens = planned_output_token_ids.is_some();
+        let max_output_tokens = planned_output_token_ids
+            .as_ref()
+            .map_or(requested_max_output_tokens, Vec::len);
         let native_timing = self
             .native_metrics
             .request_timing(&request.model, dp_rank, is_prefill, request_start)
@@ -648,6 +799,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
         let direct_request = DirectRequest {
             tokens: request.token_ids.clone(),
             max_output_tokens,
+            output_token_ids: planned_output_token_ids.clone(),
             uuid: Some(request_uuid),
             dp_rank,
             arrival_timestamp_ms: request.request_timestamp_ms,
@@ -873,7 +1025,9 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                         }
 
                         // Generate a token (with thinking boundaries if configured)
-                        let token_id = if token_count == 0 && think_len > 0 {
+                        let token_id = if has_planned_output_tokens {
+                            signal.token_id.unwrap_or_else(generate_random_token)
+                        } else if token_count == 0 && think_len > 0 {
                             reasoning.as_ref().unwrap().start_thinking_token_id
                         } else if think_len > 0 && token_count == think_len - 1 {
                             reasoning.as_ref().unwrap().end_thinking_token_id
@@ -1059,12 +1213,13 @@ pub async fn make_mocker_engine(
 
 #[cfg(test)]
 mod tests {
-    use super::MockEngine;
+    use super::*;
     use crate::protocols::common::llm_backend::PreprocessedRequest;
     use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
     use dynamo_mocker::common::protocols::{MockEngineArgs, OutputSignal, WorkerType};
     use dynamo_runtime::pipeline::{AsyncEngine, SingleIn};
     use futures::StreamExt;
+    use std::io::Write;
     use std::time::Duration;
 
     fn prefill_request() -> PreprocessedRequest {
@@ -1105,6 +1260,7 @@ mod tests {
             .unwrap()
             .send(OutputSignal {
                 uuid: request_id,
+                token_id: None,
                 completed: true,
                 rejected: false,
                 handoff_delay_ms: Some(100.0),
@@ -1175,5 +1331,51 @@ mod tests {
             .expect("released bootstrap port must be reusable");
         engine.handoff_shutdown.cancel();
         prepared.server.wait_closed().await;
+    }
+
+    fn write_replay_trace(lines: &[serde_json::Value]) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        for line in lines {
+            writeln!(file, "{}", serde_json::to_string(line).unwrap()).unwrap();
+        }
+        file
+    }
+
+    #[test]
+    fn response_replay_table_derives_keys_and_validates_lengths() {
+        let file = write_replay_trace(&[
+            serde_json::json!({
+                "request_id": "explicit",
+                "session_id": "s",
+                "output_length": 2,
+                "output_token_ids": [7, 8],
+            }),
+            serde_json::json!({
+                "session_id": "s",
+                "output_length": 1,
+                "output_token_ids": [9],
+            }),
+            serde_json::json!({
+                "output_length": 1,
+                "output_token_ids": [10],
+            }),
+        ]);
+
+        let table = ResponseReplayTable::from_path(file.path()).unwrap();
+        assert_eq!(table.len(), 3);
+        assert_eq!(table.get("explicit").as_deref(), Some(&[7, 8][..]));
+        assert_eq!(table.get("s:1").as_deref(), Some(&[9][..]));
+        assert_eq!(table.get("line:2").as_deref(), Some(&[10][..]));
+
+        let invalid = write_replay_trace(&[serde_json::json!({
+            "output_length": 2,
+            "output_token_ids": [1],
+        })]);
+        let err = ResponseReplayTable::from_path(invalid.path()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("output_length 2 does not match output_token_ids length 1"),
+            "{err:#}"
+        );
     }
 }

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -47,6 +47,7 @@ use dynamo_runtime::{
     traits::DistributedRuntimeProvider,
 };
 use futures::StreamExt;
+use rand::Rng;
 use serde::Deserialize;
 use tokio::sync::{Notify, OnceCell, Semaphore, mpsc, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -211,6 +211,8 @@ pub enum MoveBlockResponse {
 pub struct DirectRequest {
     pub tokens: Vec<Token>,
     pub max_output_tokens: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_token_ids: Option<Vec<Token>>,
     pub uuid: Option<Uuid>,
     pub dp_rank: u32,
     pub arrival_timestamp_ms: Option<f64>,
@@ -269,6 +271,8 @@ impl PrefillCost {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutputSignal {
     pub uuid: Uuid,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_id: Option<Token>,
     /// Terminal flag: the request's lifecycle has ended. Replay drivers free
     /// resources and advance/notify on this.
     pub completed: bool,
@@ -563,6 +567,7 @@ struct MockEngineArgsSerde {
     bandwidth_g2_to_g4_gbps: OptionalConfigValue<f64>,
     bandwidth_g4_to_g2_gbps: OptionalConfigValue<f64>,
     reasoning: OptionalConfigValue<ReasoningConfig>,
+    response_replay_trace_path: OptionalConfigValue<PathBuf>,
     zmq_kv_events_port: OptionalConfigValue<u16>,
     zmq_replay_port: OptionalConfigValue<u16>,
     preemption_mode: OptionalConfigValue<String>,
@@ -864,6 +869,12 @@ pub struct MockEngineArgs {
     /// When set, the mocker wraps output in thinking boundary tokens.
     #[builder(default = "None")]
     pub reasoning: Option<ReasoningConfig>,
+
+    /// Optional Mooncake trace with exact output token IDs keyed by
+    /// `output_replay_id` annotations. Direct replay paths carry the same token
+    /// IDs on `DirectRequest` and do not need this lookup.
+    #[builder(default = "None")]
+    pub response_replay_trace_path: Option<PathBuf>,
 
     /// ZMQ port for publishing KV events in vLLM's native wire format.
     /// When set, the scheduler publishes to a ZMQ PUB socket instead of directly to NATS.
@@ -1192,6 +1203,10 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         }
         if let Some(reasoning) = compat.reasoning.into_nullable() {
             builder = builder.reasoning(reasoning);
+        }
+        if let Some(response_replay_trace_path) = compat.response_replay_trace_path.into_nullable()
+        {
+            builder = builder.response_replay_trace_path(response_replay_trace_path);
         }
         if let Some(zmq_kv_events_port) = compat.zmq_kv_events_port.into_nullable() {
             builder = builder.zmq_kv_events_port(zmq_kv_events_port);

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -64,6 +64,8 @@ pub struct ActiveSequence {
     #[getter(copy)]
     generated_tokens: usize,
 
+    planned_output_ids: Option<Vec<u32>>,
+
     #[getter(copy)]
     num_input_tokens: usize,
 
@@ -86,6 +88,24 @@ impl ActiveSequence {
         enable_prefix_caching: bool,
         emit_token_ids: bool,
     ) -> Self {
+        Self::new_with_planned_output_ids(
+            tokens,
+            max_output_tokens,
+            block_size,
+            enable_prefix_caching,
+            emit_token_ids,
+            None,
+        )
+    }
+
+    pub fn new_with_planned_output_ids(
+        tokens: Vec<u32>,
+        max_output_tokens: usize,
+        block_size: Option<usize>,
+        enable_prefix_caching: bool,
+        emit_token_ids: bool,
+        planned_output_ids: Option<Vec<u32>>,
+    ) -> Self {
         let block_size = block_size.unwrap_or(64);
         let num_input_tokens = tokens.len();
 
@@ -101,6 +121,7 @@ impl ActiveSequence {
             block_size,
             max_output_tokens,
             generated_tokens: 0,
+            planned_output_ids,
             num_input_tokens,
             num_allocated_tokens: 0,
             enable_prefix_caching,
@@ -318,14 +339,24 @@ impl ActiveSequence {
     /// Always check `generated_tokens < max_output_tokens` before calling this method.
     #[cfg_attr(feature = "profile", inline(never))]
     pub fn generate(&mut self) -> Vec<MoveBlock> {
+        self.generate_token().1
+    }
+
+    /// Generate the next output token, push it to the sequence, and return the
+    /// token alongside any KV movement signals.
+    #[cfg_attr(feature = "profile", inline(never))]
+    pub fn generate_token(&mut self) -> (u32, Vec<MoveBlock>) {
         // Assert that we haven't reached the maximum output tokens
         assert!(
             self.generated_tokens < self.max_output_tokens,
             "Cannot generate more tokens: reached max_output_tokens limit"
         );
 
-        // Generate a random token
-        let token = random::<u32>();
+        let token = self
+            .planned_output_ids
+            .as_ref()
+            .and_then(|ids| ids.get(self.generated_tokens).copied())
+            .unwrap_or_else(random::<u32>);
 
         // Collect signals
         let mut signals = Vec::new();
@@ -337,12 +368,12 @@ impl ActiveSequence {
 
         // Check if we've reached the limit after pushing
         if self.generated_tokens != self.max_output_tokens {
-            return signals;
+            return (token, signals);
         }
 
         // Free all blocks when we reach max tokens
         signals.extend(self.free_signal_for_tokens(self.len()));
-        signals
+        (token, signals)
     }
 
     fn free_signal_for_tokens(&self, active_tokens: usize) -> Vec<MoveBlock> {

--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -63,8 +63,10 @@ struct SessionRuntime {
 #[derive(Debug)]
 struct TurnRuntime {
     request_id: Option<String>,
+    replay_key: Option<String>,
     tokens: Vec<u32>,
     max_output_tokens: usize,
+    output_token_ids: Option<Vec<u32>>,
     delay_after_previous_ms: f64,
     priority: i32,
     strict_priority: u32,
@@ -326,8 +328,10 @@ impl WorkloadDriver {
                 session_id: turn.session_id,
                 turns: vec![TurnRuntime {
                     request_id: Some(turn.request_id),
+                    replay_key: turn.replay_key,
                     tokens,
                     max_output_tokens: turn.max_output_tokens,
+                    output_token_ids: turn.output_token_ids,
                     delay_after_previous_ms: turn.delay_after_dependencies_ms,
                     priority: turn.priority,
                     strict_priority: turn.strict_priority,
@@ -401,7 +405,9 @@ impl WorkloadDriver {
                         Ok(TurnRuntime {
                             request_id: None,
                             tokens: turn.synthesize_tokens(trace_block_size)?,
+                            replay_key: turn.replay_key,
                             max_output_tokens: turn.max_output_tokens,
+                            output_token_ids: turn.output_token_ids,
                             delay_after_previous_ms: turn.delay_after_previous_ms,
                             priority: turn.priority,
                             strict_priority: turn.strict_priority,
@@ -517,6 +523,7 @@ impl WorkloadDriver {
             let request = DirectRequest {
                 tokens: request_tokens,
                 max_output_tokens: turn.max_output_tokens,
+                output_token_ids: turn.output_token_ids.clone(),
                 uuid: Some(request_uuid),
                 dp_rank: 0,
                 arrival_timestamp_ms,
@@ -537,6 +544,7 @@ impl WorkloadDriver {
                 request_uuid,
                 session_id: session.session_id.clone(),
                 turn_index,
+                replay_key: turn.replay_key.clone(),
                 scheduled_ready_at_ms,
                 replay_hashes: Some(replay_hashes),
                 request,
@@ -1059,6 +1067,8 @@ mod tests {
                     TurnTrace {
                         input_length: 6,
                         max_output_tokens: 1,
+                        output_token_ids: None,
+                        replay_key: None,
                         hash_ids: vec![10, 11],
                         delay_after_previous_ms: 0.0,
                         priority: 3,
@@ -1068,6 +1078,8 @@ mod tests {
                     TurnTrace {
                         input_length: 3,
                         max_output_tokens: 1,
+                        output_token_ids: None,
+                        replay_key: None,
                         hash_ids: vec![12],
                         delay_after_previous_ms: 5.0,
                         priority: -2,

--- a/lib/mocker/src/loadgen/mod.rs
+++ b/lib/mocker/src/loadgen/mod.rs
@@ -9,8 +9,10 @@ pub use driver::WorkloadDriver;
 pub use trace::validate_trace_files;
 pub use types::{
     AgenticTrace, AgenticTurnTrace, ArrivalSpec, DelaySpec, DynamoRequestTrace, LengthSpec,
-    ReadyTurn, ReplayRequestHashes, RouterSequence, SequenceHashMode, SessionPartitionSpec,
-    SessionTrace, SyntheticTraceSpec, Trace, TraceFileFormat, TurnTrace,
+    OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY, OUTPUT_REPLAY_ID_ANNOTATION_KEY, ReadyTurn,
+    ReplayRequestHashes, RouterSequence, SequenceHashMode, SessionPartitionSpec, SessionTrace,
+    SyntheticTraceSpec, Trace, TraceFileFormat, TurnTrace, effective_replay_key,
+    output_replay_id_annotation,
 };
 
 #[cfg(test)]

--- a/lib/mocker/src/loadgen/tests.rs
+++ b/lib/mocker/src/loadgen/tests.rs
@@ -141,6 +141,77 @@ fn test_from_mooncake_single_turn_preserves_fields() {
 }
 
 #[test]
+fn test_from_mooncake_preserves_output_token_replay_keys() {
+    let file = write_trace(&[
+        serde_json::json!({
+            "request_id": "explicit",
+            "session_id": "s",
+            "input_length": 4,
+            "output_length": 2,
+            "output_token_ids": [10, 11],
+            "hash_ids": [1],
+        }),
+        serde_json::json!({
+            "session_id": "s",
+            "input_length": 4,
+            "output_length": 1,
+            "output_token_ids": [12],
+            "hash_ids": [2],
+        }),
+        serde_json::json!({
+            "input_length": 4,
+            "output_length": 1,
+            "output_token_ids": [13],
+            "hash_ids": [3],
+        }),
+    ]);
+
+    let trace = Trace::from_mooncake(file.path(), 4).unwrap();
+    assert_eq!(
+        trace.sessions[0].turns[0].replay_key.as_deref(),
+        Some("explicit")
+    );
+    assert_eq!(
+        trace.sessions[0].turns[0].output_token_ids.as_deref(),
+        Some(&[10, 11][..])
+    );
+    assert_eq!(
+        trace.sessions[0].turns[1].replay_key.as_deref(),
+        Some("s:1")
+    );
+    assert_eq!(
+        trace.sessions[0].turns[1].output_token_ids.as_deref(),
+        Some(&[12][..])
+    );
+    assert_eq!(
+        trace.sessions[1].turns[0].replay_key.as_deref(),
+        Some("line:2")
+    );
+
+    let request = trace.sessions[0].turns[0]
+        .to_direct_request(4, Uuid::from_u128(1), None)
+        .unwrap();
+    assert_eq!(request.output_token_ids.as_deref(), Some(&[10, 11][..]));
+}
+
+#[test]
+fn test_from_mooncake_rejects_output_token_length_mismatch() {
+    let file = write_trace(&[serde_json::json!({
+        "input_length": 4,
+        "output_length": 2,
+        "output_token_ids": [10],
+        "hash_ids": [1],
+    })]);
+
+    let err = Trace::from_mooncake(file.path(), 4).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("output_length 2 does not match output_token_ids length 1"),
+        "{err:#}"
+    );
+}
+
+#[test]
 fn test_from_mooncake_multi_turn_uses_session_id_and_delay() {
     let file = write_trace(&[
         serde_json::json!({
@@ -337,6 +408,8 @@ fn test_turn_to_direct_request_repeats_hash_ids_by_block_size() {
     let turn = TurnTrace {
         input_length: 6,
         max_output_tokens: 3,
+        output_token_ids: None,
+        replay_key: None,
         hash_ids: vec![1, 2],
         delay_after_previous_ms: 0.0,
         priority: -2,

--- a/lib/mocker/src/loadgen/tests.rs
+++ b/lib/mocker/src/loadgen/tests.rs
@@ -212,6 +212,32 @@ fn test_from_mooncake_rejects_output_token_length_mismatch() {
 }
 
 #[test]
+fn test_trace_validate_rejects_programmatic_output_token_length_mismatch() {
+    let trace = Trace {
+        block_size: 4,
+        sessions: vec![SessionTrace {
+            session_id: "s".to_string(),
+            first_arrival_timestamp_ms: Some(0.0),
+            turns: vec![TurnTrace {
+                input_length: 4,
+                max_output_tokens: 2,
+                output_token_ids: Some(vec![10]),
+                hash_ids: vec![1],
+                delay_after_previous_ms: 0.0,
+                ..Default::default()
+            }],
+        }],
+    };
+
+    let err = trace.validate_for_trace_mode().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("max_output_tokens 2 does not match output_token_ids length 1"),
+        "{err:#}"
+    );
+}
+
+#[test]
 fn test_from_mooncake_multi_turn_uses_session_id_and_delay() {
     let file = write_trace(&[
         serde_json::json!({

--- a/lib/mocker/src/loadgen/trace.rs
+++ b/lib/mocker/src/loadgen/trace.rs
@@ -1024,6 +1024,17 @@ impl Trace {
             }
 
             for (turn_idx, turn) in session.turns.iter().enumerate() {
+                if let Some(output_token_ids) = turn.output_token_ids.as_ref()
+                    && output_token_ids.len() != turn.max_output_tokens
+                {
+                    bail!(
+                        "session {} turn {} max_output_tokens {} does not match output_token_ids length {}",
+                        session.session_id,
+                        turn_idx,
+                        turn.max_output_tokens,
+                        output_token_ids.len()
+                    );
+                }
                 if turn.input_length == 0 {
                     bail!(
                         "session {} turn {} must have a positive input_length",

--- a/lib/mocker/src/loadgen/trace.rs
+++ b/lib/mocker/src/loadgen/trace.rs
@@ -27,7 +27,7 @@ use super::driver::WorkloadDriver;
 use super::types::{
     AgenticTrace, AgenticTurnTrace, ArrivalSpec, DelaySpec, DynamoRequestTrace, LengthSpec,
     ReplayRequestHashes, RouterSequence, SequenceHashMode, SessionPartitionSpec, SessionTrace,
-    SyntheticTraceSpec, Trace, TraceFileFormat, TurnTrace,
+    SyntheticTraceSpec, Trace, TraceFileFormat, TurnTrace, effective_replay_key,
 };
 use crate::common::protocols::DirectRequest;
 
@@ -176,6 +176,7 @@ impl TurnTrace {
         Ok(DirectRequest {
             tokens,
             max_output_tokens: self.max_output_tokens,
+            output_token_ids: self.output_token_ids.clone(),
             uuid: Some(request_uuid),
             dp_rank: 0,
             arrival_timestamp_ms,
@@ -240,8 +241,10 @@ impl MooncakeTraceBuilder {
     }
 
     fn push(&mut self, line_idx: usize, raw: MooncakeRow) -> Result<()> {
-        let session_id = raw
-            .session_id
+        let request_id = raw.request_id;
+        let raw_session_id = raw.session_id;
+        let session_id = raw_session_id
+            .clone()
             .unwrap_or_else(|| format!("request_{}", line_idx + 1));
         let hash_ids = raw
             .hash_ids
@@ -260,6 +263,17 @@ impl MooncakeTraceBuilder {
         let output_length = raw
             .output_length
             .ok_or_else(|| anyhow!("trace line {} is missing output_length", line_idx + 1))?;
+        let output_token_ids = raw.output_token_ids;
+        if let Some(output_token_ids) = output_token_ids.as_ref()
+            && output_token_ids.len() != output_length
+        {
+            bail!(
+                "trace line {} output_length {} does not match output_token_ids length {}",
+                line_idx + 1,
+                output_length,
+                output_token_ids.len()
+            );
+        }
         let timestamp_ms = raw.timestamp;
         let explicit_delay_ms = raw.delay;
         let priority = raw.priority.unwrap_or(0);
@@ -285,6 +299,14 @@ impl MooncakeTraceBuilder {
             .get_mut(session_index)
             .expect("newly inserted session must exist");
         let turn_idx = session.turns.len();
+        let replay_key = output_token_ids.as_ref().map(|_| {
+            effective_replay_key(
+                request_id.as_deref(),
+                raw_session_id.as_deref(),
+                turn_idx,
+                line_idx,
+            )
+        });
         let delay_after_previous_ms = if turn_idx == 0 {
             let delay = explicit_delay_ms.unwrap_or(0.0);
             if delay != 0.0 {
@@ -330,6 +352,8 @@ impl MooncakeTraceBuilder {
         session.turns.push(TurnTrace {
             input_length,
             max_output_tokens: output_length,
+            output_token_ids,
+            replay_key,
             hash_ids,
             delay_after_previous_ms,
             priority,
@@ -1100,6 +1124,17 @@ impl AgenticTraceBuilder {
         let output_length = raw
             .output_length
             .ok_or_else(|| anyhow!("trace line {} is missing output_length", line_idx + 1))?;
+        let output_token_ids = raw.output_token_ids;
+        if let Some(output_token_ids) = output_token_ids.as_ref()
+            && output_token_ids.len() != output_length
+        {
+            bail!(
+                "trace line {} output_length {} does not match output_token_ids length {}",
+                line_idx + 1,
+                output_length,
+                output_token_ids.len()
+            );
+        }
         if !delay_after_dependencies_ms.is_finite() || delay_after_dependencies_ms < 0.0 {
             bail!(
                 "trace line {} has invalid dependency delay {}",
@@ -1117,13 +1152,23 @@ impl AgenticTraceBuilder {
             );
         }
 
+        let replay_key = output_token_ids.as_ref().map(|_| {
+            effective_replay_key(
+                Some(raw.request_id.as_str()),
+                raw.session_id.as_deref(),
+                0,
+                line_idx,
+            )
+        });
         self.turns.push(AgenticTurnTrace {
+            replay_key,
             request_id: raw.request_id,
             session_id: raw
                 .session_id
                 .unwrap_or_else(|| format!("request_{}", line_idx + 1)),
             input_length,
             max_output_tokens: output_length,
+            output_token_ids,
             hash_ids,
             first_ready_timestamp_ms: raw.timestamp,
             delay_after_dependencies_ms,

--- a/lib/mocker/src/loadgen/types.rs
+++ b/lib/mocker/src/loadgen/types.rs
@@ -11,6 +11,28 @@ use uuid::Uuid;
 
 use crate::common::protocols::DirectRequest;
 
+pub const OUTPUT_REPLAY_ID_ANNOTATION_KEY: &str = "output_replay_id";
+pub const OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY: &str = "output_replay_consumer";
+
+pub fn output_replay_id_annotation(replay_key: &str) -> String {
+    format!("{OUTPUT_REPLAY_ID_ANNOTATION_KEY}:{replay_key}")
+}
+
+pub fn effective_replay_key(
+    request_id: Option<&str>,
+    session_id: Option<&str>,
+    turn_index: usize,
+    line_index: usize,
+) -> String {
+    if let Some(request_id) = request_id.map(str::trim).filter(|value| !value.is_empty()) {
+        return request_id.to_string();
+    }
+    if let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) {
+        return format!("{session_id}:{turn_index}");
+    }
+    format!("line:{line_index}")
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Trace {
     pub block_size: usize,
@@ -69,6 +91,8 @@ pub struct SessionTrace {
 pub struct TurnTrace {
     pub input_length: usize,
     pub max_output_tokens: usize,
+    pub output_token_ids: Option<Vec<u32>>,
+    pub replay_key: Option<String>,
     pub hash_ids: Vec<u64>,
     pub delay_after_previous_ms: f64,
     pub priority: i32,
@@ -82,6 +106,8 @@ pub struct AgenticTurnTrace {
     pub session_id: String,
     pub input_length: usize,
     pub max_output_tokens: usize,
+    pub output_token_ids: Option<Vec<u32>>,
+    pub replay_key: Option<String>,
     pub hash_ids: Vec<u64>,
     pub first_ready_timestamp_ms: Option<f64>,
     pub delay_after_dependencies_ms: f64,
@@ -170,6 +196,7 @@ pub struct ReadyTurn {
     pub request_uuid: Uuid,
     pub session_id: String,
     pub turn_index: usize,
+    pub replay_key: Option<String>,
     pub scheduled_ready_at_ms: f64,
     pub replay_hashes: Option<ReplayRequestHashes>,
     pub request: DirectRequest,

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -1434,6 +1434,7 @@ mod tests {
         let request = DirectRequest {
             tokens: vec![1; 8],
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: Some(0.0),

--- a/lib/mocker/src/replay/loader.rs
+++ b/lib/mocker/src/replay/loader.rs
@@ -83,6 +83,7 @@ pub(super) fn load_trace_requests(
         requests.push(DirectRequest {
             tokens,
             max_output_tokens: output_length,
+            output_token_ids: None,
             uuid: Some(Uuid::new_v4()),
             dp_rank: 0,
             arrival_timestamp_ms,

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -186,6 +186,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1; 4],
                 max_output_tokens: 1,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(1)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(100.0),
@@ -194,6 +195,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![2; 4],
                 max_output_tokens: 1,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(2)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(200.0),

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -1092,6 +1092,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1; 4],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(11)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(100.0),
@@ -1100,6 +1101,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![2; 8],
                 max_output_tokens: 4,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(22)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(101.0),
@@ -1108,6 +1110,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![3; 12],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(33)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(500.0),
@@ -1368,6 +1371,7 @@ mod tests {
         DirectRequest {
             tokens: (base..base + prompt_tokens).collect(),
             max_output_tokens: max_output,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(uuid)),
             dp_rank: 0,
             arrival_timestamp_ms: Some(0.0),
@@ -1582,6 +1586,7 @@ mod tests {
             DirectRequest {
                 tokens: [vec![11; 64], vec![21; 32]].concat(),
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(111)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.0),
@@ -1590,6 +1595,7 @@ mod tests {
             DirectRequest {
                 tokens: [vec![11; 64], vec![22; 32]].concat(),
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(222)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(500.0),
@@ -1680,6 +1686,7 @@ mod tests {
                     DirectRequest {
                         tokens: vec![11; 64],
                         max_output_tokens: 8,
+                        output_token_ids: None,
                         uuid: Some(Uuid::from_u128(11)),
                         dp_rank: 0,
                         arrival_timestamp_ms: Some(0.0),
@@ -1688,6 +1695,7 @@ mod tests {
                     DirectRequest {
                         tokens: vec![22; 64],
                         max_output_tokens: 8,
+                        output_token_ids: None,
                         uuid: Some(Uuid::from_u128(22)),
                         dp_rank: 0,
                         arrival_timestamp_ms: Some(0.0),
@@ -1696,6 +1704,7 @@ mod tests {
                     DirectRequest {
                         tokens: vec![11; 64],
                         max_output_tokens: 2,
+                        output_token_ids: None,
                         uuid: Some(Uuid::from_u128(33)),
                         dp_rank: 0,
                         arrival_timestamp_ms: Some(0.1),
@@ -1774,6 +1783,7 @@ mod tests {
                     DirectRequest {
                         tokens: vec![11; 64],
                         max_output_tokens: 8,
+                        output_token_ids: None,
                         uuid: Some(Uuid::from_u128(1)),
                         dp_rank: 0,
                         arrival_timestamp_ms: Some(0.0),
@@ -1782,6 +1792,7 @@ mod tests {
                     DirectRequest {
                         tokens: vec![22; 64],
                         max_output_tokens: 8,
+                        output_token_ids: None,
                         uuid: Some(Uuid::from_u128(2)),
                         dp_rank: 0,
                         arrival_timestamp_ms: Some(0.0),
@@ -1826,6 +1837,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
                     max_output_tokens: 4,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(11)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(100.0),
@@ -1834,6 +1846,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(22)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(100.0),
@@ -1842,6 +1855,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![5, 5, 5, 5, 6, 6, 6, 6],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(33)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(101.0),
@@ -1850,6 +1864,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![7, 7, 7, 7, 8, 8, 8, 8],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(44)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(101.0),
@@ -1889,6 +1904,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![1; 8],
                     max_output_tokens: 1,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(1)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -1897,6 +1913,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![2; 8],
                     max_output_tokens: 1,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(2)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -1905,6 +1922,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![3; 8],
                     max_output_tokens: 1,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(3)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -1913,6 +1931,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![4; 8],
                     max_output_tokens: 1,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(4)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -1921,6 +1940,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![5; 8],
                     max_output_tokens: 1,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(5)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -1943,6 +1963,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![1; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(901)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -1951,6 +1972,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![2; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(902)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(5.0),
@@ -1976,6 +1998,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![7; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(911)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -1984,6 +2007,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![7; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(912)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(500.0),
@@ -2013,6 +2037,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(11)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(900.0),
@@ -2021,6 +2046,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![3, 3, 3, 3, 4, 4, 4, 4],
                     max_output_tokens: 4,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(22)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(1000.0),
@@ -2029,6 +2055,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![5, 5, 5, 5, 6, 6, 6, 6],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(33)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(100.0),
@@ -2065,6 +2092,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![11; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(11)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -2073,6 +2101,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![22; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(22)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -2081,6 +2110,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![11; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(33)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(2.0),
@@ -2089,6 +2119,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![22; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(44)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(2.0),
@@ -2118,6 +2149,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![9; 64],
                     max_output_tokens: 1,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(9)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -2126,6 +2158,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![8; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(8)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -2149,6 +2182,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![1; 64],
                     max_output_tokens: 8,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(1)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -2157,6 +2191,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![2; 64],
                     max_output_tokens: 8,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(2)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.0),
@@ -2165,6 +2200,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![3; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(3)),
                     dp_rank: 0,
                     arrival_timestamp_ms: Some(0.1),
@@ -2195,6 +2231,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![10; 64],
                 max_output_tokens: 8,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(10)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.0),
@@ -2203,6 +2240,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![20; 64],
                 max_output_tokens: 8,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(20)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.0),
@@ -2211,6 +2249,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![30; 64],
                 max_output_tokens: 1,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(30)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.1),
@@ -2219,6 +2258,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![40; 64],
                 max_output_tokens: 1,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(40)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.2),
@@ -2261,6 +2301,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![10; 64],
                 max_output_tokens: 8,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(10)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.0),
@@ -2269,6 +2310,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![20; 128],
                 max_output_tokens: 8,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(20)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.0),
@@ -2277,6 +2319,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![30; 64],
                 max_output_tokens: 1,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(30)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.1),
@@ -2285,6 +2328,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![40; 64],
                 max_output_tokens: 1,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(40)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.2),
@@ -2327,6 +2371,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![1; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(1)),
                     dp_rank: 0,
                     arrival_timestamp_ms: None,
@@ -2335,6 +2380,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![2; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(2)),
                     dp_rank: 0,
                     arrival_timestamp_ms: None,
@@ -2343,6 +2389,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![1; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(3)),
                     dp_rank: 0,
                     arrival_timestamp_ms: None,
@@ -2351,6 +2398,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![2; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(4)),
                     dp_rank: 0,
                     arrival_timestamp_ms: None,
@@ -2374,6 +2422,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![1; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(11)),
                     dp_rank: 0,
                     arrival_timestamp_ms: None,
@@ -2382,6 +2431,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![2; 64],
                     max_output_tokens: 4,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(22)),
                     dp_rank: 0,
                     arrival_timestamp_ms: None,
@@ -2390,6 +2440,7 @@ mod tests {
                 DirectRequest {
                     tokens: vec![3; 64],
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(Uuid::from_u128(33)),
                     dp_rank: 0,
                     arrival_timestamp_ms: None,
@@ -2437,6 +2488,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(11)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(100.0),
@@ -2445,6 +2497,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(22)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(101.0),
@@ -2453,6 +2506,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![9, 9, 9, 9, 8, 8, 8, 8],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(33)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(500.0),
@@ -2566,6 +2620,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(11)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(900.0),
@@ -2574,6 +2629,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![3, 3, 3, 3, 4, 4, 4, 4],
                 max_output_tokens: 4,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(22)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(1000.0),
@@ -2582,6 +2638,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![5, 5, 5, 5, 6, 6, 6, 6],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(33)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(100.0),
@@ -2629,6 +2686,7 @@ mod tests {
             .map(|i| DirectRequest {
                 tokens: vec![1; 64],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(i as u128 + 1)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(i as f64 * arrival_interval_ms),
@@ -2718,6 +2776,7 @@ mod tests {
         let requests = VecDeque::from([DirectRequest {
             tokens: vec![1; 64],
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: Some(1000.0),
@@ -3044,6 +3103,7 @@ mod tests {
         DirectRequest {
             tokens: vec![1; 64],
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(uuid)),
             dp_rank: 0,
             arrival_timestamp_ms: Some(arrival_ms),

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -750,6 +750,7 @@ mod tests {
         DirectRequest {
             tokens: vec![token; input_tokens],
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(uuid)),
             dp_rank: 0,
             arrival_timestamp_ms: Some(0.0),

--- a/lib/mocker/src/replay/offline/runtime_utils.rs
+++ b/lib/mocker/src/replay/offline/runtime_utils.rs
@@ -262,6 +262,7 @@ mod tests {
         DirectRequest {
             tokens: vec![1; 8],
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(uuid)),
             dp_rank: 0,
             arrival_timestamp_ms,
@@ -325,6 +326,7 @@ mod tests {
                 completed_requests: 1,
                 output_signals: vec![OutputSignal {
                     uuid: Uuid::from_u128(7),
+                    token_id: None,
                     completed: true,
                     rejected: false,
                     handoff_delay_ms: None,
@@ -346,6 +348,7 @@ mod tests {
                 completed_requests: 2,
                 output_signals: vec![OutputSignal {
                     uuid: Uuid::from_u128(8),
+                    token_id: None,
                     completed: false,
                     rejected: false,
                     handoff_delay_ms: None,

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -401,6 +401,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(11)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(100.0),
@@ -409,6 +410,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1, 1, 1, 1, 2, 2, 2, 2],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(22)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(101.0),
@@ -417,6 +419,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![9, 9, 9, 9, 8, 8, 8, 8],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(33)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(500.0),
@@ -859,6 +862,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1, 2, 3, 4, 5, 6, 7, 8],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(11)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(900.0),
@@ -867,6 +871,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1, 2, 3, 4, 5, 9, 10, 11],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(22)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(1000.0),
@@ -875,6 +880,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![12, 13, 14, 15, 16, 17, 18, 19],
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(33)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(100.0),
@@ -988,6 +994,7 @@ mod tests {
         DirectRequest {
             tokens: vec![1; 4],
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(uuid)),
             dp_rank: 0,
             arrival_timestamp_ms: Some(arrival_ms),

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -468,6 +468,7 @@ mod tests {
             DirectRequest {
                 tokens: vec![1; 8],
                 max_output_tokens: 12,
+                output_token_ids: None,
                 uuid: Some(Uuid::from_u128(1)),
                 dp_rank: 0,
                 arrival_timestamp_ms: Some(0.0),

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -411,6 +411,7 @@ mod tests {
         DirectRequest {
             tokens: vec![uuid as u32; 64],
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(uuid)),
             dp_rank: 0,
             arrival_timestamp_ms: Some(0.0),

--- a/lib/mocker/src/replay/online/tests.rs
+++ b/lib/mocker/src/replay/online/tests.rs
@@ -52,6 +52,7 @@ fn request(uuid: u128, token: u32, arrival_timestamp_ms: Option<f64>) -> DirectR
     DirectRequest {
         tokens: vec![token; 64],
         max_output_tokens: 2,
+        output_token_ids: None,
         uuid: Some(Uuid::from_u128(uuid)),
         dp_rank: 0,
         arrival_timestamp_ms,
@@ -79,6 +80,7 @@ fn reject_request(uuid: u128, prompt_tokens: u32, max_output: usize) -> DirectRe
     DirectRequest {
         tokens: (base..base + prompt_tokens).collect(),
         max_output_tokens: max_output,
+        output_token_ids: None,
         uuid: Some(Uuid::from_u128(uuid)),
         dp_rank: 0,
         arrival_timestamp_ms: None,
@@ -568,6 +570,7 @@ fn test_online_trace_replay_kv_router_marks_prefill_and_free_once() {
     let requests = vec![DirectRequest {
         tokens: vec![9; 64],
         max_output_tokens: 1,
+        output_token_ids: None,
         uuid: Some(Uuid::from_u128(9)),
         dp_rank: 0,
         arrival_timestamp_ms: Some(0.0),

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -415,6 +415,7 @@ mod tests {
             completed_requests: 1,
             output_signals: vec![OutputSignal {
                 uuid: request_id,
+                token_id: None,
                 completed: true,
                 rejected: false,
                 handoff_delay_ms: None,

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -291,12 +291,14 @@ pub(super) fn simulate_decode_step_with_sampler(
             if crossing_page_boundary {
                 req.allocated_tokens += config.block_size;
             }
-            req.append_output_token(req.next_output_token());
+            let token_id = req.next_output_token();
+            req.append_output_token(token_id);
             req.debug_assert_invariants(config.block_size);
 
             let is_complete = req.output_len() >= req.max_output_tokens;
             output_signals.push(OutputSignal {
                 uuid: req.uuid,
+                token_id: Some(token_id),
                 completed: is_complete,
                 rejected: false,
                 handoff_delay_ms: compute_prefill_handoff_delay_ms(

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -14,6 +14,7 @@ pub(super) struct SglangRequest {
     pub(super) uuid: Uuid,
     pub(super) prompt_tokens: Vec<u64>,
     pub(super) max_output_tokens: usize,
+    pub(super) planned_output_ids: Option<Vec<u32>>,
     pub(super) output_ids: Vec<u32>,
     pub(super) last_node: Option<NodeId>,
     pub(super) kv_indices: Vec<usize>,
@@ -74,6 +75,14 @@ impl SglangRequest {
     }
 
     pub(super) fn next_output_token(&self) -> u32 {
+        if let Some(token_id) = self
+            .planned_output_ids
+            .as_ref()
+            .and_then(|ids| ids.get(self.output_len()))
+        {
+            return *token_id;
+        }
+
         let mut hasher = DefaultHasher::new();
         self.uuid.hash(&mut hasher);
         self.output_len().hash(&mut hasher);
@@ -162,7 +171,11 @@ impl From<DirectRequest> for SglangRequest {
         Self {
             uuid: req.uuid.unwrap_or_else(Uuid::new_v4),
             prompt_tokens: req.tokens.iter().map(|&t| t as u64).collect(),
-            max_output_tokens: req.max_output_tokens,
+            max_output_tokens: req
+                .output_token_ids
+                .as_ref()
+                .map_or(req.max_output_tokens, Vec::len),
+            planned_output_ids: req.output_token_ids,
             output_ids: Vec::new(),
             last_node: None,
             kv_indices: Vec::new(),

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -77,6 +77,7 @@ fn make_decoded_request(
         uuid: Uuid::new_v4(),
         prompt_tokens,
         max_output_tokens,
+        planned_output_ids: None,
         output_ids: Vec::new(),
         last_node: Some(alloc.last_node),
         kv_indices: alloc.kv_indices,
@@ -827,6 +828,7 @@ mod scheduling {
             scheduler.receive(crate::common::protocols::DirectRequest {
                 tokens: vec![i as u32; 10],
                 max_output_tokens: max_output,
+                output_token_ids: None,
                 uuid: None,
                 dp_rank: 0,
                 arrival_timestamp_ms: None,
@@ -879,6 +881,7 @@ mod scheduling {
                 uuid: no_match_uuid,
                 prompt_tokens: vec![9, 8, 7],
                 max_output_tokens: 1,
+                planned_output_ids: None,
                 output_ids: Vec::new(),
                 last_node: None,
                 kv_indices: Vec::new(),
@@ -890,6 +893,7 @@ mod scheduling {
                 uuid: match_uuid,
                 prompt_tokens: vec![1, 2, 3, 4, 5],
                 max_output_tokens: 1,
+                planned_output_ids: None,
                 output_ids: vec![6, 7],
                 last_node: None,
                 kv_indices: Vec::new(),
@@ -924,6 +928,7 @@ mod scheduling {
                 uuid: Uuid::new_v4(),
                 prompt_tokens: duplicate_prefix.clone(),
                 max_output_tokens: 1,
+                planned_output_ids: None,
                 output_ids: Vec::new(),
                 last_node: None,
                 kv_indices: Vec::new(),
@@ -937,6 +942,7 @@ mod scheduling {
             uuid: unique_uuid,
             prompt_tokens: (100..132).collect(),
             max_output_tokens: 1,
+            planned_output_ids: None,
             output_ids: Vec::new(),
             last_node: None,
             kv_indices: Vec::new(),
@@ -957,6 +963,37 @@ mod core_behavior {
     use super::*;
 
     #[test]
+    fn test_planned_output_tokens_are_emitted_exactly() {
+        let mut core = SglangCore::new(test_args(100, 4, 8));
+        let uuid = Uuid::from_u128(0xB0B);
+        let planned = vec![111, 222, 333];
+        core.receive(DirectRequest {
+            tokens: vec![1, 2],
+            max_output_tokens: planned.len(),
+            output_token_ids: Some(planned.clone()),
+            uuid: Some(uuid),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+            ..Default::default()
+        });
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let mut emitted = Vec::new();
+        for step in 0..planned.len() {
+            let pass = core.execute_pass(&mut collector, step as f64);
+            emitted.extend(
+                pass.output_signals
+                    .into_iter()
+                    .filter(|signal| signal.uuid == uuid)
+                    .map(|signal| signal.token_id.expect("planned token should be present")),
+            );
+        }
+
+        assert_eq!(emitted, planned);
+        assert!(core.is_empty());
+    }
+
+    #[test]
     fn test_chunked_prefill_budget_is_page_aware() {
         let config = SglangConfig {
             chunked_prefill_size: 8,
@@ -973,6 +1010,7 @@ mod core_behavior {
             uuid: Uuid::new_v4(),
             prompt_tokens: vec![1; 6],
             max_output_tokens: 3,
+            planned_output_ids: None,
             output_ids: Vec::new(),
             last_node: None,
             kv_indices: Vec::new(),
@@ -1038,6 +1076,7 @@ mod core_behavior {
                 uuid: first_uuid,
                 prompt_tokens: vec![1; 7],
                 max_output_tokens: 3,
+                planned_output_ids: None,
                 output_ids: Vec::new(),
                 last_node: None,
                 kv_indices: Vec::new(),
@@ -1049,6 +1088,7 @@ mod core_behavior {
                 uuid: second_uuid,
                 prompt_tokens: vec![2; 8],
                 max_output_tokens: 3,
+                planned_output_ids: None,
                 output_ids: Vec::new(),
                 last_node: None,
                 kv_indices: Vec::new(),
@@ -1083,6 +1123,7 @@ mod core_behavior {
             uuid: Uuid::new_v4(),
             prompt_tokens: vec![1, 2, 3, 4, 5, 6],
             max_output_tokens: 4,
+            planned_output_ids: None,
             output_ids: Vec::new(),
             last_node: Some(alloc.last_node),
             kv_indices: alloc.kv_indices,
@@ -1128,6 +1169,7 @@ mod core_behavior {
             uuid: Uuid::new_v4(),
             prompt_tokens: vec![1, 2, 3, 4],
             max_output_tokens: 4,
+            planned_output_ids: None,
             output_ids: Vec::new(),
             last_node: Some(base_alloc.last_node),
             kv_indices: base_alloc.kv_indices,
@@ -1142,6 +1184,7 @@ mod core_behavior {
             uuid: Uuid::new_v4(),
             prompt_tokens: vec![1, 2, 3, 4],
             max_output_tokens: 4,
+            planned_output_ids: None,
             output_ids: Vec::new(),
             last_node: Some(fast_alloc.last_node),
             kv_indices: fast_alloc.kv_indices,
@@ -1192,6 +1235,7 @@ mod core_behavior {
                 uuid: Uuid::new_v4(),
                 prompt_tokens: vec![1, 2, 3, 4],
                 max_output_tokens: 10,
+                planned_output_ids: None,
                 output_ids: vec![11, 12, 13],
                 last_node: None,
                 kv_indices: first,
@@ -1203,6 +1247,7 @@ mod core_behavior {
                 uuid: Uuid::new_v4(),
                 prompt_tokens: vec![9, 8, 7, 6],
                 max_output_tokens: 10,
+                planned_output_ids: None,
                 output_ids: vec![21],
                 last_node: None,
                 kv_indices: second,
@@ -1235,6 +1280,7 @@ mod core_behavior {
             uuid: Uuid::new_v4(),
             prompt_tokens: vec![1, 2, 3, 4],
             max_output_tokens: 4,
+            planned_output_ids: None,
             output_ids: Vec::new(),
             last_node: Some(alloc.last_node),
             kv_indices: alloc.kv_indices,
@@ -1266,6 +1312,7 @@ mod core_behavior {
         core.receive(crate::common::protocols::DirectRequest {
             tokens: vec![1; 6],
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: None,
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1531,6 +1578,7 @@ mod router_events {
             uuid,
             prompt_tokens: prompt_tokens.iter().map(|&token| token as u64).collect(),
             max_output_tokens: 2,
+            planned_output_ids: None,
             output_ids: Vec::new(),
             last_node: None,
             kv_indices: Vec::new(),
@@ -1632,6 +1680,7 @@ mod router_events {
             uuid: Uuid::new_v4(),
             prompt_tokens: vec![1, 2, 3, 4, 5, 6],
             max_output_tokens: 3,
+            planned_output_ids: None,
             output_ids: Vec::new(),
             last_node: None,
             kv_indices: Vec::new(),
@@ -1852,6 +1901,7 @@ mod router_events {
         core.receive(DirectRequest {
             tokens: vec![1; 8],
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(91)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1896,6 +1946,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1927,6 +1978,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 3,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1944,6 +1996,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (100..104).collect(),
             max_output_tokens: 3,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(2)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1970,6 +2023,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1984,6 +2038,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(2)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2039,6 +2094,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2047,6 +2103,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (100..108).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(2)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2092,6 +2149,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..4).collect(), // prompt_len = 4
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2100,6 +2158,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (100..112).collect(), // prompt_len = 12
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(2)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2143,6 +2202,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..16).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2206,6 +2266,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 20,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2214,6 +2275,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (100..104).collect(),
             max_output_tokens: 20,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(2)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2229,6 +2291,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (200..212).collect(), // 12 tokens
             max_output_tokens: 10,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(3)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2297,6 +2360,7 @@ mod forward_pass_metrics {
         scheduler.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -1042,6 +1042,7 @@ mod core_behavior {
             uuid: Uuid::new_v4(),
             prompt_tokens: vec![1; 16],
             max_output_tokens: 2,
+            planned_output_ids: None,
             output_ids: Vec::new(),
             last_node: None,
             kv_indices: Vec::new(),

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -793,6 +793,18 @@ impl VllmCore {
     ) -> VllmRequestState {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
         let mut max_output_tokens = request.max_output_tokens;
+        let planned_output_ids = request.output_token_ids;
+        if let Some(planned_output_ids) = planned_output_ids.as_ref()
+            && planned_output_ids.len() != max_output_tokens
+        {
+            tracing::warn!(
+                %uuid,
+                requested = max_output_tokens,
+                planned = planned_output_ids.len(),
+                "planned output token count differs from max_output_tokens; using planned count"
+            );
+            max_output_tokens = planned_output_ids.len();
+        }
         if let Some(clamped) = policy::normalize_max_output_tokens(
             self.args.scheduling_policy(),
             request.tokens.len(),
@@ -809,12 +821,13 @@ impl VllmCore {
         // The `None` case (a TRT-LLM prompt alone leaves no decode room) is
         // unchanged here. The waiting-admission policy owns terminal rejection
         // because that path can emit the lifecycle signal.
-        let sequence = ActiveSequence::new(
+        let sequence = ActiveSequence::new_with_planned_output_ids(
             request.tokens,
             max_output_tokens,
             Some(self.args.block_size),
             self.args.enable_prefix_caching,
             self.args.zmq_kv_events_port.is_some(),
+            planned_output_ids,
         );
         VllmRequestState {
             sequence,
@@ -1442,6 +1455,7 @@ impl VllmCore {
         for uuid in rejected_uuids {
             output_signals.push(OutputSignal {
                 uuid,
+                token_id: None,
                 completed: true,
                 rejected: true,
                 handoff_delay_ms: None,
@@ -1824,6 +1838,7 @@ impl VllmCore {
         let mut running_changed = false;
         for uuid in ready {
             let mut emitted = false;
+            let mut emitted_token_id = None;
             let mut completed = false;
             let mut deferred_deref = Vec::new();
             loop {
@@ -1831,7 +1846,7 @@ impl VllmCore {
                 let Some(sequence) = self.state.running_sequence_mut(uuid) else {
                     break;
                 };
-                let signals = sequence.generate();
+                let (token_id, signals) = sequence.generate_token();
                 completed = sequence.generated_tokens() >= sequence.max_output_tokens();
                 let effects = if completed {
                     split_terminal_effects(signals)
@@ -1848,6 +1863,7 @@ impl VllmCore {
                         sequence.commit_allocation(sequence.len());
                     }
                     emitted = true;
+                    emitted_token_id = Some(token_id);
                     deferred_deref = effects.cleanup;
                     break;
                 }
@@ -1880,6 +1896,7 @@ impl VllmCore {
             });
             let output_signal = OutputSignal {
                 uuid,
+                token_id: emitted_token_id,
                 completed,
                 rejected: false,
                 handoff_delay_ms,
@@ -2029,16 +2046,16 @@ impl VllmCore {
             let mut completed = false;
             let mut deferred_deref = Vec::new();
             for _ in 0..burst {
-                let (signals, is_complete) = {
+                let (token_id, signals, is_complete) = {
                     let request = self
                         .state
                         .requests
                         .get_mut(&uuid)
                         .expect("sampled request must remain active");
-                    let signals = request.sequence.generate();
+                    let (token_id, signals) = request.sequence.generate_token();
                     let is_complete =
                         request.sequence.generated_tokens() >= request.sequence.max_output_tokens();
-                    (signals, is_complete)
+                    (token_id, signals, is_complete)
                 };
                 let effects = if is_complete {
                     split_terminal_effects(signals)
@@ -2053,21 +2070,20 @@ impl VllmCore {
                         .process_decode_signal(signal, &mut reservation);
                 }
 
-                let (is_complete, prompt_tokens) = {
+                let prompt_tokens = {
                     let request = self
                         .state
                         .requests
                         .get_mut(&uuid)
                         .expect("sampled request must remain active");
-                    let is_complete =
-                        request.sequence.generated_tokens() >= request.sequence.max_output_tokens();
                     if !is_complete {
                         request.sequence.commit_allocation(request.sequence.len());
                     }
-                    (is_complete, request.sequence.num_input_tokens())
+                    request.sequence.num_input_tokens()
                 };
                 output_signals.push(OutputSignal {
                     uuid,
+                    token_id: Some(token_id),
                     completed: is_complete,
                     rejected: false,
                     handoff_delay_ms: compute_prefill_handoff_delay_ms(

--- a/lib/mocker/src/scheduler/vllm/policy/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/policy/tests.rs
@@ -155,6 +155,7 @@ mod trtllm {
         core.receive(DirectRequest {
             tokens: tokens.collect(),
             max_output_tokens: max_output,
+            output_token_ids: None,
             uuid: Some(uuid),
             dp_rank: 0,
             arrival_timestamp_ms: None,

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -739,6 +739,37 @@ mod core_behavior {
     use super::*;
 
     #[test]
+    fn test_planned_output_tokens_are_emitted_exactly() {
+        let mut core = VllmCore::new(make_args());
+        let uuid = Uuid::from_u128(0xA11CE);
+        let planned = vec![101, 202, 303];
+        core.receive(DirectRequest {
+            tokens: vec![1, 2],
+            max_output_tokens: planned.len(),
+            output_token_ids: Some(planned.clone()),
+            uuid: Some(uuid),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+            ..Default::default()
+        });
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let mut emitted = Vec::new();
+        for step in 0..planned.len() {
+            let pass = core.execute_pass(&mut collector, step as f64);
+            emitted.extend(
+                pass.output_signals
+                    .into_iter()
+                    .filter(|signal| signal.uuid == uuid)
+                    .map(|signal| signal.token_id.expect("planned token should be present")),
+            );
+        }
+
+        assert_eq!(emitted, planned);
+        assert!(core.is_empty());
+    }
+
+    #[test]
     fn test_unified_pass_keeps_partial_prefill_in_running() {
         let args = MockEngineArgs::builder()
             .block_size(4)
@@ -756,6 +787,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(r1),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -764,6 +796,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (100..108).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(r2),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -821,6 +854,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(r1),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -829,6 +863,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (100..108).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(r2),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -866,6 +901,7 @@ mod core_behavior {
             core.receive(DirectRequest {
                 tokens,
                 max_output_tokens: 1,
+                output_token_ids: None,
                 uuid: Some(uuid),
                 dp_rank: 0,
                 arrival_timestamp_ms: None,
@@ -926,6 +962,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: vec![1; 8],
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(81)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -950,6 +987,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(uuid),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -993,6 +1031,7 @@ mod core_behavior {
             core.receive(DirectRequest {
                 tokens: range.collect(),
                 max_output_tokens: 8,
+                output_token_ids: None,
                 uuid: Some(uuid),
                 dp_rank: 0,
                 arrival_timestamp_ms: None,
@@ -1039,6 +1078,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (0..16).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(holder),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1047,6 +1087,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (100..112).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(blocked),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1055,6 +1096,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (200..204).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(follower),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1126,6 +1168,7 @@ mod core_behavior {
             core.receive(DirectRequest {
                 tokens: range.collect(),
                 max_output_tokens: 1,
+                output_token_ids: None,
                 uuid: Some(uuid),
                 dp_rank: 0,
                 arrival_timestamp_ms: None,
@@ -1215,6 +1258,7 @@ mod core_behavior {
             core.receive(DirectRequest {
                 tokens: (0..8).collect(),
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(uuid),
                 dp_rank: 0,
                 arrival_timestamp_ms: None,
@@ -1251,6 +1295,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 5,
+            output_token_ids: None,
             uuid: Some(short),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1259,6 +1304,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (100..104).collect(),
             max_output_tokens: 8,
+            output_token_ids: None,
             uuid: Some(long),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1313,6 +1359,7 @@ mod core_behavior {
         core.receive(DirectRequest {
             tokens: (0..3).collect(),
             max_output_tokens: 5,
+            output_token_ids: None,
             uuid: Some(uuid),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1342,6 +1389,7 @@ mod router_events {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(71)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1371,6 +1419,7 @@ mod router_events {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 4,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(41)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1415,6 +1464,7 @@ mod router_events {
             core.receive(DirectRequest {
                 tokens: range.collect(),
                 max_output_tokens: 8,
+                output_token_ids: None,
                 uuid: Some(uuid),
                 dp_rank: 0,
                 arrival_timestamp_ms: None,
@@ -1492,6 +1542,7 @@ mod router_events {
             core.receive(DirectRequest {
                 tokens: tokens.collect(),
                 max_output_tokens: 7,
+                output_token_ids: None,
                 uuid: Some(uuid),
                 dp_rank: 0,
                 arrival_timestamp_ms: None,
@@ -1753,6 +1804,7 @@ mod live_scheduler {
         scheduler.receive(DirectRequest {
             tokens: (0..256).collect(),
             max_output_tokens: 200,
+            output_token_ids: None,
             uuid: None,
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1812,6 +1864,7 @@ mod live_scheduler {
         scheduler.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(72)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1869,6 +1922,7 @@ mod live_scheduler {
             scheduler.receive(DirectRequest {
                 tokens: vec![42; 8],
                 max_output_tokens: 4,
+                output_token_ids: None,
                 uuid: None,
                 dp_rank: 0,
                 arrival_timestamp_ms: None,
@@ -1930,6 +1984,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1958,6 +2013,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 3,
+            output_token_ids: None,
             uuid: Some(r1),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -1977,6 +2033,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (100..104).collect(),
             max_output_tokens: 3,
+            output_token_ids: None,
             uuid: Some(r2),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2007,6 +2064,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(r1),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2047,6 +2105,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(r1),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2092,6 +2151,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(r1),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2100,6 +2160,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (100..108).collect(),
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(r2),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2138,6 +2199,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..4).collect(), // prompt_len = 4
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2146,6 +2208,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (100..112).collect(), // prompt_len = 12
             max_output_tokens: 1,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(2)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2185,6 +2248,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..16).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2255,6 +2319,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 20,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2270,6 +2335,7 @@ mod forward_pass_metrics {
         core.receive(DirectRequest {
             tokens: (100..116).collect(), // 16 tokens — will pressure KV
             max_output_tokens: 5,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(2)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2331,6 +2397,7 @@ mod forward_pass_metrics {
         scheduler.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(Uuid::from_u128(1)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2568,6 +2635,7 @@ mod offload {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(uuid),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2643,6 +2711,7 @@ mod offload {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(hit_uuid),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2652,6 +2721,7 @@ mod offload {
         core.receive(DirectRequest {
             tokens: (4..8).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(cold_uuid),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2733,6 +2803,7 @@ mod offload {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(uuid),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -2803,6 +2874,7 @@ mod offload {
         core.receive(DirectRequest {
             tokens: (0..(block_size * 3) as u32).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(uuid),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -3012,6 +3084,7 @@ mod offload {
         core.receive(DirectRequest {
             tokens: (0..4).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(first_hit),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -3021,6 +3094,7 @@ mod offload {
         core.receive(DirectRequest {
             tokens: (4..8).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(second_hit),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -3030,6 +3104,7 @@ mod offload {
         core.receive(DirectRequest {
             tokens: (8..12).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(cold),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -3122,6 +3197,7 @@ mod offload {
         core.receive(DirectRequest {
             tokens: (0..(block_size * 4) as u32).collect(),
             max_output_tokens: 2,
+            output_token_ids: None,
             uuid: Some(uuid),
             dp_rank: 0,
             arrival_timestamp_ms: None,
@@ -3263,6 +3339,7 @@ mod offload {
                 core.receive(DirectRequest {
                     tokens: shared_tokens.clone(),
                     max_output_tokens: 2,
+                    output_token_ids: None,
                     uuid: Some(uuid),
                     dp_rank: 0,
                     arrival_timestamp_ms: None,
@@ -3274,6 +3351,7 @@ mod offload {
             core.receive(DirectRequest {
                 tokens: ((TOKENS_PER_REQ as u32)..(2 * TOKENS_PER_REQ as u32)).collect(),
                 max_output_tokens: 2,
+                output_token_ids: None,
                 uuid: Some(r4),
                 dp_rank: 0,
                 arrival_timestamp_ms: None,

--- a/tests/router/mocker_process.py
+++ b/tests/router/mocker_process.py
@@ -114,6 +114,13 @@ def _build_mocker_command(
         command.extend(["--zmq-kv-events-ports", mocker_args["zmq_kv_events_ports"]])
     if "zmq_replay_ports" in mocker_args:
         command.extend(["--zmq-replay-ports", mocker_args["zmq_replay_ports"]])
+    if "response_replay_trace_path" in mocker_args:
+        command.extend(
+            [
+                "--response-replay-trace-path",
+                str(mocker_args["response_replay_trace_path"]),
+            ]
+        )
 
     return command
 
@@ -378,9 +385,9 @@ class MockerProcess:
                         ),
                     }
                     if replay_base is not None:
-                        payload[
-                            "replay_endpoint"
-                        ] = f"tcp://127.0.0.1:{replay_base + dp_rank}"
+                        payload["replay_endpoint"] = (
+                            f"tcp://127.0.0.1:{replay_base + dp_rank}"
+                        )
                     async with session.post(register_url, json=payload) as response:
                         if response.status != 201:
                             body = await response.text()

--- a/tests/router/mocker_process.py
+++ b/tests/router/mocker_process.py
@@ -385,9 +385,9 @@ class MockerProcess:
                         ),
                     }
                     if replay_base is not None:
-                        payload["replay_endpoint"] = (
-                            f"tcp://127.0.0.1:{replay_base + dp_rank}"
-                        )
+                        payload[
+                            "replay_endpoint"
+                        ] = f"tcp://127.0.0.1:{replay_base + dp_rank}"
                     async with session.post(register_url, json=payload) as response:
                         if response.status != 201:
                             body = await response.text()

--- a/tests/router/test_mocker_output_replay_e2e.py
+++ b/tests/router/test_mocker_output_replay_e2e.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dynamo.llm import KvRouter, KvRouterConfig
+from tests.router.common import _create_kv_router_with_timeout
+from tests.router.helper import get_runtime, wait_for_workers_ready
+from tests.router.mocker_process import MockerProcess
+from tests.utils.constants import ROUTER_MODEL_NAME
+
+logger = logging.getLogger(__name__)
+
+MODEL_NAME = ROUTER_MODEL_NAME
+BLOCK_SIZE = 16
+NUM_MOCKERS = 1
+SPEEDUP_RATIO = 100.0
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.integration,
+    pytest.mark.router,
+    pytest.mark.model(MODEL_NAME),
+]
+
+
+def _write_response_replay_trace(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as trace:
+        for row in rows:
+            trace.write(json.dumps(row))
+            trace.write("\n")
+
+
+def _preprocessed_request(
+    *,
+    token_ids: list[int],
+    max_tokens: int,
+    replay_key: str,
+) -> dict[str, Any]:
+    return {
+        "model": MODEL_NAME,
+        "token_ids": token_ids,
+        "stop_conditions": {
+            "ignore_eos": True,
+            "max_tokens": max_tokens,
+        },
+        "sampling_options": {},
+        "output_options": {},
+        "eos_token_ids": [],
+        "annotations": [f"output_replay_id:{replay_key}"],
+        "routing": {
+            "expected_output_tokens": max_tokens,
+        },
+    }
+
+
+async def _collect_output_token_ids(
+    router: KvRouter,
+    request: dict[str, Any],
+) -> tuple[list[int], dict[str, Any]]:
+    stream = await router.generate_from_request(request)
+    output_token_ids: list[int] = []
+    terminal: dict[str, Any] | None = None
+
+    async for response in stream:
+        if not isinstance(response, dict):
+            continue
+
+        token_ids = response.get("token_ids")
+        if isinstance(token_ids, list):
+            output_token_ids.extend(token_ids)
+
+        if response.get("finish_reason") is not None:
+            terminal = response
+
+    assert terminal is not None, (
+        "generate_from_request stream did not emit terminal chunk"
+    )
+    return output_token_ids, terminal
+
+
+def _terminal_kv_hit_rate(terminal: dict[str, Any]) -> float:
+    routing_data = terminal.get("routing_data")
+    assert isinstance(routing_data, dict), f"missing routing_data: {terminal}"
+
+    timing = routing_data.get("timing")
+    assert isinstance(timing, dict), f"missing routing_data.timing: {terminal}"
+
+    kv_hit_rate = timing.get("kv_hit_rate")
+    assert isinstance(kv_hit_rate, (int, float)), f"missing kv_hit_rate: {terminal}"
+    return float(kv_hit_rate)
+
+
+async def _wait_for_overlap_blocks(
+    router: KvRouter,
+    token_ids: list[int],
+    expected_overlap_blocks: int,
+) -> None:
+    last_overlap: float | None = None
+    for _ in range(40):
+        _, _, overlap_blocks = await router.best_worker(token_ids)
+        last_overlap = float(overlap_blocks)
+        if math.isclose(last_overlap, expected_overlap_blocks, abs_tol=1e-9):
+            return
+        await asyncio.sleep(0.25)
+
+    raise AssertionError(
+        f"expected {expected_overlap_blocks} overlap blocks, got {last_overlap}"
+    )
+
+
+async def _run_multi_turn_replay(
+    *,
+    endpoint,
+    router: KvRouter,
+    first_output_token_ids: list[int],
+    second_output_token_ids: list[int],
+) -> None:
+    await wait_for_workers_ready(endpoint, router, NUM_MOCKERS, MODEL_NAME)
+
+    first_input_token_ids = list(range(100_001, 100_001 + BLOCK_SIZE))
+    first_request = _preprocessed_request(
+        token_ids=first_input_token_ids,
+        max_tokens=len(first_output_token_ids),
+        replay_key="conversation:0",
+    )
+    returned_first_ids, _ = await _collect_output_token_ids(router, first_request)
+    assert returned_first_ids == first_output_token_ids
+
+    block_aligned_suffix = list(range(400_001, 400_001 + BLOCK_SIZE))
+    second_input_token_ids = (
+        first_input_token_ids + returned_first_ids + block_aligned_suffix
+    )
+    assert len(second_input_token_ids) % BLOCK_SIZE == 0
+
+    expected_overlap_blocks = (
+        len(first_input_token_ids) + len(returned_first_ids)
+    ) // BLOCK_SIZE
+    expected_total_blocks = len(second_input_token_ids) // BLOCK_SIZE
+    expected_hit_rate = expected_overlap_blocks / expected_total_blocks
+
+    await _wait_for_overlap_blocks(
+        router,
+        second_input_token_ids,
+        expected_overlap_blocks,
+    )
+
+    second_request = _preprocessed_request(
+        token_ids=second_input_token_ids,
+        max_tokens=len(second_output_token_ids),
+        replay_key="conversation:1",
+    )
+    returned_second_ids, terminal = await _collect_output_token_ids(
+        router, second_request
+    )
+    assert returned_second_ids == second_output_token_ids
+    assert math.isclose(
+        _terminal_kv_hit_rate(terminal),
+        expected_hit_rate,
+        abs_tol=1e-9,
+    )
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+@pytest.mark.parametrize(
+    "durable_kv_events", [False], ids=["nondurable"], indirect=True
+)
+def test_mocker_output_replay_generate_from_request_multi_turn(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_tokenizers,
+    request_plane,
+    durable_kv_events,
+    tmp_path,
+):
+    replay_trace_path = tmp_path / "response-replay.jsonl"
+    first_output_token_ids = list(range(200_001, 200_001 + BLOCK_SIZE))
+    second_output_token_ids = [300_001, 300_002, 300_003, 300_004]
+    _write_response_replay_trace(
+        replay_trace_path,
+        [
+            {
+                "session_id": "conversation",
+                "output_length": len(first_output_token_ids),
+                "output_token_ids": first_output_token_ids,
+            },
+            {
+                "session_id": "conversation",
+                "output_length": len(second_output_token_ids),
+                "output_token_ids": second_output_token_ids,
+            },
+        ],
+    )
+
+    mocker_args = {
+        "speedup_ratio": SPEEDUP_RATIO,
+        "block_size": BLOCK_SIZE,
+        "durable_kv_events": durable_kv_events,
+        "response_replay_trace_path": replay_trace_path,
+    }
+
+    with MockerProcess(
+        request,
+        mocker_args=mocker_args,
+        num_mockers=NUM_MOCKERS,
+        request_plane=request_plane,
+    ) as mockers:
+        logger.info("Started mocker replay test endpoint: %s", mockers.endpoint)
+        runtime = get_runtime(request_plane=request_plane)
+        endpoint = runtime.endpoint(
+            f"{mockers.namespace}.{mockers.component_name}.generate"
+        )
+        router_config = KvRouterConfig(router_track_output_blocks=True)
+        router = _create_kv_router_with_timeout(
+            router_factory=lambda: KvRouter(
+                endpoint=endpoint,
+                block_size=BLOCK_SIZE,
+                kv_router_config=router_config,
+            ),
+            num_workers=NUM_MOCKERS,
+            engine_workers=mockers,
+        )
+
+        asyncio.run(
+            _run_multi_turn_replay(
+                endpoint=endpoint,
+                router=router,
+                first_output_token_ids=first_output_token_ids,
+                second_output_token_ids=second_output_token_ids,
+            )
+        )

--- a/tests/router/test_mocker_output_replay_e2e.py
+++ b/tests/router/test_mocker_output_replay_e2e.py
@@ -81,9 +81,9 @@ async def _collect_output_token_ids(
         if response.get("finish_reason") is not None:
             terminal = response
 
-    assert terminal is not None, (
-        "generate_from_request stream did not emit terminal chunk"
-    )
+    assert (
+        terminal is not None
+    ), "generate_from_request stream did not emit terminal chunk"
     return output_token_ids, terminal
 
 

--- a/tests/router/test_mocker_output_replay_e2e.py
+++ b/tests/router/test_mocker_output_replay_e2e.py
@@ -135,9 +135,9 @@ async def _run_multi_turn_replay(
     returned_first_ids, _ = await _collect_output_token_ids(router, first_request)
     assert returned_first_ids == first_output_token_ids
 
-    block_aligned_suffix = list(range(400_001, 400_001 + BLOCK_SIZE))
+    second_turn_suffix_token_ids = list(range(400_001, 400_001 + BLOCK_SIZE - 1))
     second_input_token_ids = (
-        first_input_token_ids + returned_first_ids + block_aligned_suffix
+        first_input_token_ids + returned_first_ids + second_turn_suffix_token_ids
     )
     assert len(second_input_token_ids) % BLOCK_SIZE == 0
 
@@ -183,7 +183,9 @@ def test_mocker_output_replay_generate_from_request_multi_turn(
     tmp_path,
 ):
     replay_trace_path = tmp_path / "response-replay.jsonl"
-    first_output_token_ids = list(range(200_001, 200_001 + BLOCK_SIZE))
+    # The final generated token does not have KV yet. Generate one extra token
+    # so the first full output block is actually cached for the next turn.
+    first_output_token_ids = list(range(200_001, 200_001 + BLOCK_SIZE + 1))
     second_output_token_ids = [300_001, 300_002, 300_003, 300_004]
     _write_response_replay_trace(
         replay_trace_path,


### PR DESCRIPTION
## Overview

Adds deterministic output-token replay for Dynamo mockers. Enriched Mooncake traces can now provide exact `output_token_ids`, and live requests can select the replay row with an `output_replay_id:<key>` annotation while preserving the existing random-token fallback when no replay plan is present.

## Details

- Add optional `output_token_ids` and optional `request_id` support to Mooncake trace rows.
- Derive stable replay keys from `request_id`, `session_id:<turn_index>`, or `line:<row_index>`.
- Carry planned output tokens through `DirectRequest`, `OutputSignal`, and the VLLM/SGLang mocker schedulers.
- Load live response replay tables from `--response-replay-trace-path`.
- Mark mocker workers as output replay consumers and warn when replay annotations route to non-consumer workers.
- Add validation for `output_token_ids.len() == output_length/max_output_tokens`.
- Add a live multi-turn `KvRouter.generate_from_request()` router/mocker E2E covering exact replayed IDs and terminal `routing_data.timing.kv_hit_rate`.

## Where should the reviewer start

- `lib/llm/src/mocker.rs` for live response replay table loading and request annotation lookup.
- `lib/mocker/src/common/sequence.rs` and `lib/mocker/src/scheduler/{vllm,sglang}` for planned-token emission.
- `lib/mocker/src/loadgen/{trace.rs,types.rs,driver.rs}` for trace parsing, key derivation, and direct replay plumbing.
- `tests/router/test_mocker_output_replay_e2e.py` for the live multi-turn router/mocker coverage.

## Related Issues

No linked issue.

## Validation

- `cargo fmt --all --check`
- `cargo test -p dynamo-data-gen --lib`
- `cargo test -p dynamo-mocker --lib`
- `cargo test -p dynamo-llm --lib response_replay_table`
- `uvx ruff format components/src/dynamo/mocker/config.py components/src/dynamo/mocker/tests/unit/test_config.py tests/router/mocker_process.py tests/router/test_mocker_output_replay_e2e.py`
- `uvx ruff check components/src/dynamo/mocker/config.py components/src/dynamo/mocker/tests/unit/test_config.py tests/router/mocker_process.py tests/router/test_mocker_output_replay_e2e.py`
- `git diff --check`

## Notes

- `python3 -m pytest components/src/dynamo/mocker/tests/unit/test_config.py -q` and `.venv/bin/python -m pytest components/src/dynamo/mocker/tests/unit/test_config.py -q` are blocked locally because `pytest` is not installed in either interpreter.
- `uv run pytest components/src/dynamo/mocker/tests/unit/test_config.py -q` is still blocked by the repo extras resolver conflict between `ai-dynamo[sglang]` and `ai-dynamo[vllm]` over `nixl[cu13]`.
