### PR TITLE
fix: reduce dev image layers

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -309,7 +309,7 @@ jobs:
       cuda_version: '["13.1"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
-      push_image: true
+      push_image: false
       build_timeout_minutes: 60
     secrets: inherit
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -309,7 +309,7 @@ jobs:
       cuda_version: '["13.1"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
-      push_image: false
+      push_image: true
       build_timeout_minutes: 60
     secrets: inherit
 

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -290,18 +290,16 @@ SHELL ["/bin/bash", "-l", "-o", "pipefail", "-c"]
 # We stash the pre-tools python3 (which may be a real binary or a symlink we created earlier for vLLM/TRTLLM)
 # and restore it after copying toolchains from dynamo_tools.
 RUN if [ -e /usr/bin/python3 ]; then cp -a /usr/bin/python3 /tmp/python3.pretools; fi
-COPY --from=dynamo_tools /usr/bin/ /usr/bin/
-COPY --from=dynamo_tools /usr/sbin/ /usr/sbin/
-COPY --from=dynamo_tools /usr/lib/ /usr/lib/
-COPY --from=dynamo_tools /usr/libexec/ /usr/libexec/
-COPY --from=dynamo_tools /usr/include/ /usr/include/
-COPY --from=dynamo_tools /lib/ /lib/
-COPY --from=dynamo_tools /usr/share/ /usr/share/
+# Pull the developer toolchain from dynamo_tools in as few COPY layers as
+# possible (overlay2 caps a downstream image at ~128 layers). The six /usr/*
+# subtrees collapse into one COPY; --exclude=local skips the multi-GB /usr/local
+# (CUDA, etc.) the dev image already inherits from its own base.
+COPY --from=dynamo_tools --exclude=local /usr/ /usr/
+COPY --from=dynamo_tools /opt/nvidia/ /opt/nvidia/
 COPY --from=dynamo_tools /etc/alternatives/ /etc/alternatives/
 COPY --from=dynamo_tools /etc/bash_completion.d/ /etc/bash_completion.d/
 COPY --from=dynamo_tools /etc/sudoers /etc/sudoers
 COPY --from=dynamo_tools /etc/sudoers.d/ /etc/sudoers.d/
-COPY --from=dynamo_tools /opt/nvidia/ /opt/nvidia/
 
 # Restore the pre-tools python3 (keeps SGLang system python intact and avoids venv symlink loops).
 RUN if [ -e /tmp/python3.pretools ]; then cp -af /tmp/python3.pretools /usr/bin/python3; fi
@@ -398,9 +396,6 @@ RUN if [ ! -d /opt/dynamo/venv ]; then \
     fi
 {% endif %}
 
-# Initialize Git LFS for the dynamo user (required for requirements with lfs=true)
-RUN git lfs install
-
 # Install only the ADDITIONAL dev/test dependencies.
 # Runtime deps (common, framework, planner, benchmark) are already installed
 # in the parent runtime image — re-resolving them here would risk version drift.
@@ -411,6 +406,8 @@ RUN --mount=type=bind,source=./container/deps/requirements.dev.txt,target=/tmp/r
     # Cache uv downloads; uv handles its own locking for this cache.
     --mount=type=cache,target=/root/.cache/uv \
     export UV_CACHE_DIR=/root/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    # Git LFS init (needed for requirements with lfs=true); folded in to save a layer.
+    git lfs install && \
 {% if device == "xpu" and framework == "sglang" %}
     uv pip install \
         --python ${VIRTUAL_ENV}/bin/python \
@@ -471,10 +468,8 @@ ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
 RUN --mount=type=bind,source=./container/launch_message/dev.txt,target=/opt/dynamo/launch_message.txt \
     sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen && \
     chmod 755 /opt/dynamo/.launch_screen && \
-    (grep -q 'launch_screen' /etc/bash.bashrc || echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc)
-
-# Warn on interactive entry if /workspace is not bind-mounted from the host
-RUN printf '%s\n' \
+    (grep -q 'launch_screen' /etc/bash.bashrc || echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc) && \
+    printf '%s\n' \
     'if [ ! -f /workspace/Cargo.toml ]; then' \
     '    echo ""' \
     '    echo "  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"' \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -28,9 +28,10 @@ COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
 COPY --from=dynamo_base /bin/uv /usr/bin/uv
 COPY --from=dynamo_base /bin/uvx /usr/bin/uvx
 
-{% if target == "runtime" %}
+{% if target in ("runtime", "dev", "local-dev") %}
 # Renamed `runtime` → `runtime_full` so the final stage can re-FROM upstream
-# and overlay our changes as a single layer (cuts depth for downstream wrappers).
+# and overlay our changes as a single layer (cuts depth for downstream wrappers,
+# incl. the dev image, which otherwise overflows overlay2's ~128-layer cap).
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime_full
 {% else %}
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
@@ -181,7 +182,7 @@ ENV DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
 ENTRYPOINT []
 CMD ["/bin/bash"]
 
-{% if target == "runtime" %}
+{% if target in ("runtime", "dev", "local-dev") %}
 # Rebase on upstream so this stage inherits upstream's image config
 # (ENV/WORKDIR/USER/CMD) and then overlay runtime_full's filesystem as a
 # single layer. Only Dynamo-specific env needs redeclaring below.
@@ -194,6 +195,16 @@ COPY --from=runtime_full / /
 
 # Mirrors runtime_full's ENV — must stay in sync. Re-declaration is required
 # because `FROM ${RUNTIME_IMAGE}` here does not inherit runtime_full's config.
+# dev/local-dev create their own venv in a later stage, so the venv ENV is left
+# out for them — keeps this config identical to the unsquashed dev path.
+{% if target in ("dev", "local-dev") %}
+ENV DYNAMO_HOME=/workspace \
+    HOME=/home/dynamo \
+    PATH=/usr/local/bin/etcd:${PATH} \
+    IMAGEIO_FFMPEG_EXE=/usr/local/bin/ffmpeg \
+    LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
+    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins
+{% else %}
 ENV DYNAMO_HOME=/workspace \
     HOME=/home/dynamo \
     VIRTUAL_ENV=/opt/dynamo/venv \
@@ -201,6 +212,7 @@ ENV DYNAMO_HOME=/workspace \
     IMAGEIO_FFMPEG_EXE=/usr/local/bin/ffmpeg \
     LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
     NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins
+{% endif %}
 
 WORKDIR /workspace
 


### PR DESCRIPTION
The trtllm dev image overflowed overlay2's ~128-layer limit, so docker pull failed with "failed to register layer: max depth exceeded". Measured on a real build, the image was ~130 layers; it is now 118.

- Extend the existing runtime_full squash to the dev/local-dev targets so  the dev image's runtime stage collapses from 6 layers to 2 (rm whiteout  + COPY / /). The post-squash ENV is split so dev keeps its current env
  (no venv prefix, which dev creates itself), leaving the runtime image  unchanged.
- Collapse the six /usr/* dynamo_tools copies in the dev stage into one  COPY --exclude=local /usr/ /usr/ (skips the multi-GB /usr/local the dev  image already inherits), and fold git-lfs init plus the two bashrc  appends into existing layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image build process through consolidated developer toolchain dependencies and streamlined copying mechanisms.
  * Enhanced runtime environment variable configuration for multiple build targets and different deployment scenarios.
  * Integrated Git LFS initialization directly with dependency installation workflows for improved efficiency.
  * Refined interactive shell launch screen banner setup and Bash shell configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->