### PR TITLE
[codex] prune unused MX refit route

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1346,9 +1346,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         """Stop accepting new generate requests and quiesce in-flight ones.
 
         Lighter than ``sleep``: keeps the model resident in GPU memory but
-        prevents new requests from racing weight mutations. Used by the
-        trainer-driven MX refit cycle:
-        ``pause → update_weights_via_mx → flush_cache → resume``.
+        prevents new requests from racing weight mutations. This is available
+        for explicit admin flows; NeMo-RL's MX dispatcher currently calls
+        ``update_weights_via_mx`` and ``flush_cache`` directly.
         """
         try:
             await self.engine_client.pause_generation()
@@ -1360,9 +1360,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     async def resume_generation(self, body: dict | None = None) -> dict:
         """Resume accepting new generate requests after a pause.
 
-        Counterpart to :meth:`pause_generation`. The trainer's refit cycle
-        calls this in a ``finally`` block so the worker re-enters service
-        even if the refit itself errored.
+        Counterpart to :meth:`pause_generation`.
         """
         try:
             await self.engine_client.resume_generation()
@@ -1914,28 +1912,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             "workers_ok": sum(1 for r in (results or []) if r),
             "workers_total": len(results or []),
         }
-
-    async def prepare_refit_info(self, request=None):
-        """Forward per-tensor (shape, dtype) info to every worker.
-
-        Called once by the trainer driver before the first refit cycle. The
-        trainer sends ``{tensor_name: [shape_list, dtype_string]}``; we hand
-        it to ``MxRefitWorkerExtension.prepare_refit_info`` on each worker.
-        """
-        if request is None:
-            yield {"status": "error", "message": "state_dict_info dict required"}
-            return
-        state_dict_info = request.get("state_dict_info") or request
-        try:
-            await self.engine_client.collective_rpc(
-                "prepare_refit_info",
-                kwargs={"state_dict_info": state_dict_info},
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.error("[mx] prepare_refit_info collective_rpc failed: %s", exc)
-            yield {"status": "error", "message": str(exc)}
-            return
-        yield {"status": "ok"}
 
     def add_temp_dir(self, temp_dir: tempfile.TemporaryDirectory) -> None:
         """Add a temporary directory to be cleaned up later."""

--- a/components/src/dynamo/vllm/mx_refit/extension.py
+++ b/components/src/dynamo/vllm/mx_refit/extension.py
@@ -16,7 +16,7 @@ import logging
 import os
 import socket
 import traceback
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -34,9 +34,7 @@ class MxConfig:
     same_rank_only: bool = True
     tree_scale_out: bool = True
     moe_expert_filter: bool = True
-    register_self_buffers: list[str] = field(default_factory=list)
     nic_pin: str = "auto"
-    retain_latest_k: int = 1
 
     @classmethod
     def from_dict(cls, d: dict[str, Any] | None) -> "MxConfig":
@@ -49,9 +47,7 @@ class MxConfig:
             same_rank_only=bool(d.get("same_rank_only", True)),
             tree_scale_out=bool(d.get("tree_scale_out", True)),
             moe_expert_filter=bool(d.get("moe_expert_filter", True)),
-            register_self_buffers=list(d.get("register_self_buffers", []) or []),
             nic_pin=str(d.get("nic_pin", "auto")),
-            retain_latest_k=int(d.get("retain_latest_k", 1)),
         )
 
 
@@ -488,11 +484,6 @@ def _trim_draft_vocab_padding(
 
 class MxRefitWorkerExtension:
     """Methods injected into vLLM's Worker via ``worker_extension_cls``."""
-
-    def prepare_refit_info(self, state_dict_info: dict[str, Any]) -> None:
-        self._mx_state_dict_info = state_dict_info
-        if not hasattr(self, "state_dict_info"):
-            self.state_dict_info = state_dict_info
 
     def _mx_uses_fp8_quantization(self) -> bool:
         vllm_config = getattr(self.model_runner, "vllm_config", None)

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -432,12 +432,7 @@ class WorkerFactory:
             mx_refit_endpoint = runtime.endpoint(
                 f"{config.namespace}.{config.component}.update_weights_via_mx"
             )
-            prepare_refit_endpoint = runtime.endpoint(
-                f"{config.namespace}.{config.component}.prepare_refit_info"
-            )
-            shutdown_endpoints.extend(
-                [mx_refit_endpoint, prepare_refit_endpoint]
-            )
+            shutdown_endpoints.append(mx_refit_endpoint)
 
         # Use pre-created engine if provided (checkpoint mode), otherwise create new
         fpm_worker_id = str(generate_endpoint.connection_id())
@@ -680,10 +675,6 @@ class WorkerFactory:
                     [
                         mx_refit_endpoint.serve_endpoint(
                             handler.update_weights_via_mx,
-                            metrics_labels=model_metrics_labels,
-                        ),
-                        prepare_refit_endpoint.serve_endpoint(
-                            handler.prepare_refit_info,
                             metrics_labels=model_metrics_labels,
                         ),
                     ]

--- a/docs/components/frontend/Tokenizer.md
+++ b/docs/components/frontend/Tokenizer.md
@@ -45,6 +45,86 @@ export DYN_TOKENIZER=fastokens
 python -m dynamo.frontend
 ```
 
+## HTTP Endpoints
+
+The frontend exposes tokenizer utilities at the root OpenAI service:
+
+- `POST /tokenize`
+- `POST /detokenize`
+
+These routes use the same model card, prompt formatter, tokenizer backend, and
+chat-template behavior as normal inference requests. `model` is optional when
+the frontend is serving exactly one model.
+
+### Completion Tokenization
+
+Use `prompt` for completion-style tokenization:
+
+```json
+{
+  "model": "Qwen/Qwen3-4B-Thinking-2507",
+  "prompt": "Solve 2 + 2.",
+  "add_special_tokens": true,
+  "return_token_strs": true
+}
+```
+
+The response includes the token IDs, token count, model context length, and
+optional token strings:
+
+```json
+{
+  "count": 5,
+  "max_model_len": 32768,
+  "tokens": [50, 12435, 220, 17, 13],
+  "token_strs": ["Solve", " 2", " +", " 2", "."]
+}
+```
+
+### Chat Tokenization
+
+Use `messages` for chat-template tokenization:
+
+```json
+{
+  "model": "Qwen/Qwen3-4B-Thinking-2507",
+  "messages": [
+    {"role": "user", "content": "Solve 2 + 2."}
+  ],
+  "add_generation_prompt": true,
+  "return_token_strs": false,
+  "chat_template_kwargs": {
+    "enable_thinking": true
+  }
+}
+```
+
+Supported chat-tokenization fields include `tools`, `chat_template`,
+`chat_template_kwargs`, `continue_final_message`, `add_special_tokens`,
+`media_io_kwargs`, `mm_processor_kwargs`, and `required_prefix_token_ids`.
+`continue_final_message` and `add_generation_prompt` cannot both be true.
+
+`required_prefix_token_ids` is useful for prefix-reuse workflows: the frontend
+renders the chat prompt and replaces the reusable prefix token span with the
+provided token IDs using the model's prefix-reuse EOS metadata.
+
+### Detokenization
+
+Use `/detokenize` to convert token IDs back to text:
+
+```json
+{
+  "model": "Qwen/Qwen3-4B-Thinking-2507",
+  "tokens": [50, 12435, 220, 17, 13]
+}
+```
+
+```json
+{
+  "prompt": "Solve 2 + 2."
+}
+```
+
 ## Dynamo Frontend Behavior
 
 When `DYN_TOKENIZER=fastokens` is set:

--- a/docs/components/frontend/nvext.md
+++ b/docs/components/frontend/nvext.md
@@ -35,7 +35,7 @@ Include `nvext` as a top-level field alongside standard OpenAI-compatible fields
 | `backend_instance_id` | `u64` | `None` | Router | Routes the request to a specific backend instance. |
 | `token_data` | `u32[]` | `None` | Preprocessor | Pre-tokenized prompt tokens. When provided with `backend_instance_id`, tokenization is skipped. |
 | `max_thinking_tokens` | `u32` | `None` | Backend | Maximum thinking tokens allowed (passed through to backends). |
-| `extra_fields` | `string[]` | `None` | Response builder | Fields to include in the response `nvext`. Supported: `"worker_id"`, `"timing"`, `"routed_experts"`, `"engine_data"`, `"stop_reason"`. |
+| `extra_fields` | `string[]` | `None` | Response builder | Fields to include in the response `nvext`. Supported: `"worker_id"`, `"timing"`, `"routed_experts"`, `"engine_data"`, `"stop_reason"`, `"completion_token_ids"`, `"prompt_logprobs"`. |
 | `prefill_worker_id` | `u64` | `None` | Router | Routes the request to a specific prefill worker (disaggregated serving). |
 | `decode_worker_id` | `u64` | `None` | Router | Routes the request to a specific decode worker (disaggregated serving). |
 | `agent_context` | object | `None` | Preprocessor | Passive session and trajectory identity for agent traces. See [Agent Context](#agent-context) below and [Agent Tracing](../../agents/agent-tracing.md). |
@@ -211,7 +211,14 @@ When the client requests response metadata via `extra_fields`, the response incl
 | `routed_experts` | `extra_fields: ["routed_experts"]` | Routed expert capture payload returned by SGLang-backed requests. |
 | `engine_data` | `extra_fields: ["engine_data"]` | Opaque backend-provided engine metadata. |
 | `stop_reason` | `extra_fields: ["stop_reason"]` | Backend-specific matched stop condition, returned under `nvext` because it is not part of the OpenAI completions schema. Dynamo currently serves this as a response-level field for single-choice requests; supporting `n > 1` will require an indexed per-choice shape. |
+| `completion_token_ids` | `extra_fields: ["completion_token_ids"]` | Generated token IDs emitted by the backend. Streaming chunks carry delta token IDs; aggregated responses concatenate them. This field requires exactly one generated choice. |
+| `prompt_logprobs` | `extra_fields: ["prompt_logprobs"]` | Prompt-token logprobs emitted on the final chunk when the backend provides them. |
 | `token_ids` | Automatic (GAIE Stage 1) | Tokenized prompt for reuse in Stage 2 query-only mode. |
+
+`completion_token_ids` is separate from `return_tokens_as_token_ids`.
+`return_tokens_as_token_ids` changes logprob token display strings, while
+`completion_token_ids` returns the generated token ID sequence under response
+`nvext`.
 
 ### Example response `nvext`
 
@@ -227,7 +234,8 @@ When the client requests response metadata via `extra_fields`, the response incl
         "timing": {
             "ttft_ms": 45.2,
             "itl_ms": 12.1
-        }
+        },
+        "completion_token_ids": [9906, 0]
     }
 }
 ```

--- a/docs/kubernetes/modelexpress.md
+++ b/docs/kubernetes/modelexpress.md
@@ -61,9 +61,80 @@ services:
             value: modelexpress
 ```
 
-<Note>
-Use the load format supported by your runtime image. ModelExpress v0.3 and newer document the unified `mx` loader. Some older Dynamo images expose `mx-source` and `mx-target` loader names instead.
-</Note>
+> [!NOTE]
+> Use the load format supported by your runtime image. ModelExpress v0.3 and
+> newer document the unified `mx` loader. Some older Dynamo images expose
+> `mx-source` and `mx-target` loader names instead.
+
+## Mid-Training Weight Refit
+
+Dynamo's vLLM backend can also receive trainer-published weights from
+ModelExpress during an RL training run. This is separate from cold-start model
+distribution: the worker is already running, and an external trainer publishes a
+new version of model weights to the ModelExpress server.
+
+Use a runtime image that includes:
+
+- `modelexpress`
+- NIXL with the UCX backend required by the cluster fabric
+- `dynamo.vllm.mx_refit.extension.MxRefitWorkerExtension`
+
+Enable the receiver in the DGD worker with `DYN_MX_REFIT_ENABLED=1` and use the
+ModelExpress target load format supported by that image:
+
+```yaml
+services:
+  VllmWorker:
+    extraPodSpec:
+      mainContainer:
+        image: <vllm-runtime-image-with-modelexpress-refit>
+        command: ["python3", "-m", "dynamo.vllm"]
+        args:
+          - --model
+          - Qwen/Qwen3-4B-Thinking-2507
+          - --load-format
+          - mx-target
+        env:
+          - name: DYN_MX_REFIT_ENABLED
+            value: "1"
+          - name: MODEL_EXPRESS_URL
+            value: modelexpress-server.default.svc.cluster.local:8001
+          - name: UCX_TLS
+            value: rc,cuda_copy
+          - name: NIXL_UCX_TLS
+            value: rc,cuda_copy
+          - name: UCX_IB_GPU_DIRECT_RDMA
+            value: "yes"
+          - name: UCX_CUDA_COPY_DMABUF
+            value: "yes"
+          - name: MX_RDMA_NIC_PIN
+            value: auto
+```
+
+When `DYN_MX_REFIT_ENABLED=1`, Dynamo registers an engine admin route named
+`update_weights_via_mx`. A trainer or orchestration layer can call:
+
+```http
+POST /engine/update_weights_via_mx
+Content-Type: application/json
+
+{
+  "version": 12,
+  "mx_config": {
+    "mx_server_url": "modelexpress-server.default.svc.cluster.local:8001",
+    "timeout_seconds": 300.0,
+    "same_rank_only": true,
+    "tree_scale_out": true,
+    "moe_expert_filter": false,
+    "nic_pin": "auto"
+  }
+}
+```
+
+After a successful refit, call `POST /engine/flush_cache` so prefix-cache entries
+created with the old weights are discarded. There is no separate prepare step;
+the refit receiver reads the versioned tensor metadata published through
+ModelExpress.
 
 ## Stream Without Shared Storage
 


### PR DESCRIPTION
## Summary

- Remove the unused `prepare_refit_info` MX endpoint and worker-extension method.
- Drop inactive `register_self_buffers` and `retain_latest_k` fields from the vLLM MX config shim.
- Document `/tokenize`, `/detokenize`, `nvext.completion_token_ids`, and the current ModelExpress mid-training refit flow.

## Validation

- `python -m py_compile components/src/dynamo/vllm/mx_refit/extension.py components/src/dynamo/vllm/handlers.py components/src/dynamo/vllm/worker_factory.py`
- `python -m pytest components/src/dynamo/vllm/tests/test_vllm_engine_routes.py components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py` did not reach collection because the environment is missing `pytest_benchmark` from the repo warning filters.
- `python -m pytest -c /dev/null -rs components/src/dynamo/vllm/tests/test_vllm_engine_routes.py components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py` imported the test modules but skipped both because `vllm` is not installed.

## Notes

This targets `jthomson04/tokenize-endpoint-merge-main-06-09` and keeps pause/resume admin routes intact; only the unexercised refit-info preparation route is removed.
