### PR TITLE
feat(recipes): add aggregated CustomEncoder K8s deploy + smoke-test recipe

### DIFF
--- a/recipes/custom-encoder/README.md
+++ b/recipes/custom-encoder/README.md
@@ -1,0 +1,189 @@
+# CustomEncoder — pluggable in-process vision encoder (aggregated)
+
+K8s recipe that deploys and smoke-tests the Dynamo + vLLM **`CustomEncoder`**
+feature from [ai-dynamo/dynamo#10832](https://github.com/ai-dynamo/dynamo/pull/10832):
+a custom image encoder that runs **in-process inside a single aggregated
+`dynamo.vllm` worker** — no separate encode worker, no NIXL transfer.
+
+This is a **correctness / feature demo**, not a throughput benchmark. It runs
+the example `HitchhikersCustomEncoder` on a text-only LM (`Qwen2.5-1.5B-Instruct`)
+that fakes an "image" as the embeddings of a fixed phrase, so the assembled
+prompt answers **"42"**. Swap `--custom-encoder-class` (and `--model`) for a real
+encoder + LM to use it for real.
+
+> **Depends on PR #10832.** The feature code and the `examples/custom_encoder`
+> package are not in any published image yet, so this recipe runs against a
+> **custom image built from the PR branch** (see [Build the image](#build-the-image)).
+
+## How it works
+
+```
+client ── /v1/chat/completions ──▶ Frontend (dynamo.frontend)
+                                      │  rewrites image_url → image,
+                                      │  minimal jinja emits <|image_pad|>
+                                      ▼
+                              VllmWorker (dynamo.vllm, 1 GPU)
+                                ├─ CustomEncoder.encode(image_urls) → image embeds
+                                ├─ assemble mixed token-ids/embeds EmbedsPrompt
+                                │    (vLLM embeds text; image embeds spliced in)
+                                └─ vLLM engine runs the transformer
+```
+
+The encoder never needs the LM's text-embedding table; vLLM embeds the text
+positions with the real table and substitutes only the image positions. The
+example encoder ignores the image bytes and returns the embeddings of a fixed
+phrase, which makes the spliced prompt read as one coherent sentence — a
+**semantic** check, not just a shape check.
+
+## Prerequisites
+
+1. Kubectl context pointing at a cluster with **one free GPU** on a node.
+2. A namespace you have write access to (`$NAMESPACE` below).
+3. A `shared-model-cache` PVC (RWX) in that namespace. Platform-managed
+   AWS / FSx clusters pre-provision it; otherwise see [Storage](#storage).
+4. `envsubst` on the laptop driving the recipe (Ubuntu: `apt install
+   gettext-base`; macOS: `brew install gettext`).
+5. **No HuggingFace token** — `Qwen/Qwen2.5-1.5B-Instruct` is public.
+6. A **custom image built from PR #10832** — see below.
+
+## Build the image
+
+The published `vllm-runtime` images don't have the `--custom-encoder-class`
+handler, the `examples/custom_encoder` package, or vLLM 0.21+. Build one from
+the PR branch (`examples/` is `COPY`'d into the image, so the example encoder +
+jinja template are baked in):
+
+```bash
+cd ~/workspace/dynamo
+git fetch origin pull/10832/head:custom-encoder-pr
+git checkout custom-encoder-pr
+
+# Render + build the vLLM runtime image (build context = repo root, so
+# examples/custom_encoder lands at /workspace/examples/custom_encoder).
+python3 container/render.py --framework vllm --target runtime \
+        --platform linux/amd64 --output-short-filename     # -> container/rendered.Dockerfile
+docker build -t nvcr.io/nvstaging/ai-dynamo/vllm-runtime:qiwa-custom-encoder \
+             -f container/rendered.Dockerfile .
+docker push nvcr.io/nvstaging/ai-dynamo/vllm-runtime:qiwa-custom-encoder
+```
+
+The base image must ship **vLLM >= 0.21** (`EmbedsPrompt.prompt_is_token_ids`);
+the PR's base already does. (`/build-image` is a convenience wrapper for the same
+render + build.)
+
+## Quick start
+
+```bash
+export NAMESPACE=<your-namespace>
+export IMAGE=nvcr.io/nvstaging/ai-dynamo/vllm-runtime:qiwa-custom-encoder
+
+# pvc check → model download → deploy (Frontend + 1 GPU worker) → smoke ("42")
+./run.sh -n "$NAMESPACE" --image "$IMAGE" --step all
+
+# Optionally pin both pods to a specific node:
+./run.sh -n "$NAMESPACE" --image "$IMAGE" --node ip-100-66-1-2.ec2.internal --step all
+```
+
+Granular steps: `--step {pvc|download|deploy|smoke|encoder-log|clean}`.
+`encoder-log` greps the worker log for the `Loaded CustomEncoder` line to confirm
+the plugin loaded in-process.
+
+## Smoke-test details
+
+`smoke.yaml` runs a small CPU pod that hits the auto-created Frontend Service
+(`custom-encoder-agg-frontend:8000`) over ClusterIP and POSTs:
+
+```jsonc
+{
+  "model": "Qwen/Qwen2.5-1.5B-Instruct",
+  "max_tokens": 32, "temperature": 0,
+  "messages": [{"role": "user", "content": [
+    {"type": "text",      "text": "Based on The Hitchhiker's Guide to the Galaxy, The Answer to"},
+    {"type": "image_url", "image_url": {"url": "data:image/png;base64,<1x1 png>"}},
+    {"type": "text",      "text": " is?"}
+  ]}]
+}
+```
+
+The completion must contain **"42"** → the pod echoes `SMOKE PASS` (else
+`SMOKE FAIL`), which `run.sh` polls for. The `data:` image is self-contained
+(the example encoder ignores image content). For a **real** encoder, override
+the `IMAGE_URL` env in `smoke.yaml` with a reachable image — `DYN_MM_ALLOW_INTERNAL=1`
+on the deploy permits `data:` and localhost URLs.
+
+## Plugging in a real encoder
+
+1. Implement a `CustomEncoder` subclass (load your ViT + projector in `load()`;
+   return one `(n_visual_tokens, lm_hidden_dim)` tensor per image in `encode()`).
+   See `components/src/dynamo/vllm/multimodal_utils/custom_encoder.py`.
+2. Bake your module into the image (or a sibling layer on top of it) so its
+   dotted path is importable with `PYTHONPATH=/workspace`.
+3. Edit `deploy.yaml`: set `ENCODER_CLASS` to your dotted `module.ClassName`,
+   `MODEL_NAME` to your LM, and (if your model defines `<|image_pad|>` itself)
+   drop `DYN_IMAGE_PLACEHOLDER_TOKEN_ID` to let the encoder auto-resolve it.
+4. Replace the demo's minimal `--custom-jinja-template` if your LM's own chat
+   template already renders image content parts.
+
+## Storage
+
+The recipe expects a `shared-model-cache` PVC (RWX), mounted at the HF cache
+root (`/home/dynamo/.cache/huggingface`) on the download Job and the worker —
+no subPath (the DGD `volumeMounts` grammar has none). If your cluster doesn't
+pre-provision it, create it first, picking an RWX storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-model-cache
+spec:
+  accessModes: [ReadWriteMany]
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: <your-rwx-storage-class>   # e.g. dgxc-enterprise-file / FSx Lustre — not ebs
+```
+
+## Cleanup
+
+```bash
+./run.sh -n "$NAMESPACE" --step clean    # deletes the DGD + smoke pod; keeps the PVC
+```
+
+The PVC (model cache) is intentionally retained. To wipe it:
+`kubectl -n "$NAMESPACE" delete pvc shared-model-cache`.
+
+## Directory layout
+
+```text
+custom-encoder/
+├── README.md
+├── run.sh                      # driver: pvc | download | deploy | smoke | encoder-log | clean | all
+├── deploy.yaml                 # DGD: Frontend + 1 aggregated VllmWorker (custom encoder)
+├── smoke.yaml                  # Pod: curl the frontend, assert "42"
+└── model-cache/
+    └── model-download.yaml     # Job: HF download for Qwen2.5-1.5B-Instruct
+```
+
+## Naming & ownership
+
+All resources carry the label `app.kubernetes.io/name: custom-encoder`:
+
+```bash
+kubectl -n "$NAMESPACE" get pvc,job,pod,dynamographdeployment \
+  -l app.kubernetes.io/name=custom-encoder
+```
+
+## Notes
+
+- **Aggregated, single GPU.** The encoder runs in the same process as the worker
+  (no encode worker, no NIXL). The PR validates `--custom-encoder-class` as
+  agg-only + multimodal; it is rejected under disagg or `--use-vllm-tokenizer`.
+- **`--enforce-eager`** skips cudagraph capture for a fast smoke startup and
+  sidesteps the un-persistable compilation cache (DGD has no subPath mount).
+  Remove it for the realistic engine path.
+- **"42" is the deterministic contract** of the example encoder at
+  `temperature=0` — it splices the model's own `embed_tokens` embeddings of a
+  fixed phrase. If you swap in a real encoder, change the smoke assertion to
+  match your model's expected output (or assert pipeline health only).
+- Recipes are **local / on-demand reproducers**, not CI artifacts.

--- a/recipes/custom-encoder/deploy.yaml
+++ b/recipes/custom-encoder/deploy.yaml
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated Dynamo + vLLM serving with a pluggable in-process CustomEncoder
+# (ai-dynamo/dynamo#10832). A SINGLE aggregated worker loads a CustomEncoder
+# subclass in-process via --custom-encoder-class; there is NO separate encode
+# worker and NO NIXL transfer. For each multimodal request the worker calls
+# encoder.encode(image_urls) and assembles a mixed token-ids/embeds EmbedsPrompt
+# (vLLM embeds the text positions itself; the encoder's image embeds are spliced
+# at the placeholder span).
+#
+# This demo runs the example HitchhikersCustomEncoder on a TEXT-ONLY LM
+# (Qwen2.5-1.5B-Instruct): the encoder fakes an "image" as the embeddings of a
+# fixed phrase so the spliced prompt answers "42". Swap --custom-encoder-class
+# (and --model) for a real encoder + LM in production.
+#
+# REQUIRES a custom image built from PR #10832 (see README → "Build the image"):
+#   - dynamo.vllm with the --custom-encoder-class handler,
+#   - examples/custom_encoder baked at /workspace/examples/custom_encoder,
+#   - vLLM >= 0.21 (EmbedsPrompt.prompt_is_token_ids).
+#
+# The operator auto-creates a Service `custom-encoder-agg-frontend` on port 8000
+# which smoke.yaml targets. ${VLLM_IMAGE} / ${HW_NODE_SELECTOR} are filled by
+# run.sh via envsubst; ${MODEL_NAME} / ${ENCODER_CLASS} stay literal (pod env).
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: custom-encoder-agg
+  labels:
+    app.kubernetes.io/name: custom-encoder
+    app.kubernetes.io/component: agg-custom-encoder
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  pvcs:
+    - create: false
+      name: shared-model-cache
+  services:
+    Frontend:
+      componentType: frontend
+      envs:
+        - name: HF_HOME
+          value: /home/dynamo/.cache/huggingface
+        - name: DYN_REQUEST_PLANE
+          value: tcp
+        # Large request-plane + HTTP body limits so a real (non-fake) encoder
+        # can receive multi-MB base64 images. Harmless for the demo's tiny image.
+        - name: DYN_TCP_MAX_MESSAGE_SIZE
+          value: "209715200"
+        - name: DYN_HTTP_BODY_LIMIT_MB
+          value: "200"
+        # Permit non-public (localhost / data:) image references.
+        - name: DYN_MM_ALLOW_INTERNAL
+          value: "1"
+      extraPodSpec:
+        # nodeSelector comes from `run.sh --node <host>` (envsubst); `{}`
+        # (match any node) when --node is omitted.
+        nodeSelector: ${HW_NODE_SELECTOR}
+        mainContainer:
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+      replicas: 1
+      resources:
+        requests:
+          cpu: "2"
+          memory: 8Gi
+        limits:
+          cpu: "4"
+          memory: 16Gi
+      subComponentType: null
+
+    VllmWorker:
+      componentType: worker
+      extraPodSpec:
+        nodeSelector: ${HW_NODE_SELECTOR}
+        mainContainer:
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              ulimit -l unlimited
+              python3 -m dynamo.vllm \
+                --model "${MODEL_NAME}" \
+                --custom-encoder-class "${ENCODER_CLASS}" \
+                --custom-jinja-template /workspace/examples/custom_encoder/templates/qwen_vl.jinja \
+                --enable-multimodal \
+                --enable-prompt-embeds \
+                --max-model-len 16384 \
+                --gpu-memory-utilization 0.8 \
+                --enforce-eager \
+                --no-enable-log-requests
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_NAME
+              value: "Qwen/Qwen2.5-1.5B-Instruct"
+            # Dotted module.ClassName of the CustomEncoder subclass. The example
+            # encoder ships in the image at /workspace/examples/custom_encoder.
+            - name: ENCODER_CLASS
+              value: "examples.custom_encoder.hitchhikers_custom_encoder.HitchhikersCustomEncoder"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            # Weights are pre-pulled by the model-download Job; serve from cache.
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            # /workspace on sys.path so the dotted examples.custom_encoder.*
+            # import in --custom-encoder-class resolves.
+            - name: PYTHONPATH
+              value: /workspace
+            - name: DYN_REQUEST_PLANE
+              value: tcp
+            - name: DYN_TCP_MAX_MESSAGE_SIZE
+              value: "209715200"
+            - name: DYN_HTTP_BODY_LIMIT_MB
+              value: "200"
+            # The example encoder forces <|image_pad|> (151655) via this env;
+            # production encoders usually auto-resolve it from the tokenizer.
+            - name: DYN_IMAGE_PLACEHOLDER_TOKEN_ID
+              value: "151655"
+            - name: DYN_MM_ALLOW_INTERNAL
+              value: "1"
+          workingDir: /workspace
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          gpu: "1"
+      subComponentType: null
+      volumeMounts:
+        # HF cache at the PVC root (DGD volumeMounts grammar has no subPath).
+        # --enforce-eager skips cudagraph capture so we don't need a persisted
+        # compilation cache.
+        - name: shared-model-cache
+          mountPoint: /home/dynamo/.cache/huggingface

--- a/recipes/custom-encoder/model-cache/model-download.yaml
+++ b/recipes/custom-encoder/model-cache/model-download.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pre-downloads the demo LM (Qwen/Qwen2.5-1.5B-Instruct, ~3 GiB, public) into
+# shared-model-cache at the standard HF_HOME path so the weights land at
+# /home/dynamo/.cache/huggingface/hub/models--Qwen--Qwen2.5-1.5B-Instruct/,
+# sharing the HF Hub cache layout with the rest of the namespace.
+#
+# Pre-downloading lets the worker run HF_HUB_OFFLINE=1 (no startup egress
+# stall). The model is tiny + public, so this is fast and needs no HF token.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: custom-encoder-model-download
+  labels:
+    app.kubernetes.io/name: custom-encoder
+    app.kubernetes.io/component: model-download
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: custom-encoder
+        app.kubernetes.io/component: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["sh", "-c"]
+          env:
+            - name: MODEL_NAME
+              value: "Qwen/Qwen2.5-1.5B-Instruct"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.11.0
+              hf download "$MODEL_NAME"
+          resources:
+            requests:
+              cpu: "2"
+              memory: "8Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+          volumeMounts:
+            - name: shared-model-cache
+              mountPath: /home/dynamo/.cache/huggingface
+      volumes:
+        - name: shared-model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/custom-encoder/run.sh
+++ b/recipes/custom-encoder/run.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Driver for the aggregated CustomEncoder demo recipe (ai-dynamo/dynamo#10832).
+# Idempotent — re-running a completed step is a no-op.
+#
+# Usage:
+#   ./run.sh -n <namespace> --image <tag> [--node <hostname>] [--step <step>]
+#
+# Flags:
+#   -n, --namespace  Target namespace (required).
+#   --image          Custom image built from PR #10832 (required except --step clean).
+#                    e.g. nvcr.io/nvstaging/ai-dynamo/vllm-runtime:qiwa-custom-encoder
+#   --node           Pin Frontend + Worker to this kubernetes.io/hostname (optional).
+#   --step           pvc | download | deploy | smoke | encoder-log | clean | all
+#                    (default: all)
+set -euo pipefail
+
+NAMESPACE=""
+IMAGE=""
+NODE=""
+STEP="all"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace) NAMESPACE="$2"; shift 2 ;;
+    --image) IMAGE="$2"; shift 2 ;;
+    --node) NODE="$2"; shift 2 ;;
+    --step) STEP="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -z "$NAMESPACE" ]] && { echo "ERROR: -n <namespace> required" >&2; exit 2; }
+if [[ "$STEP" != "clean" && -z "$IMAGE" ]]; then
+  echo "ERROR: --image <tag> required (custom image built from PR #10832 — see README)" >&2
+  exit 2
+fi
+command -v envsubst >/dev/null 2>&1 || {
+  echo "ERROR: envsubst missing. Install gettext-base (apt) or gettext (brew)." >&2
+  exit 2
+}
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+K="kubectl -n $NAMESPACE"
+
+DGD_NAME="custom-encoder-agg"
+DL_JOB="custom-encoder-model-download"
+SMOKE_POD="custom-encoder-smoke"
+
+export VLLM_IMAGE="$IMAGE"
+if [[ -n "$NODE" ]]; then
+  export HW_NODE_SELECTOR="{\"kubernetes.io/hostname\":\"$NODE\"}"
+else
+  export HW_NODE_SELECTOR="{}"
+fi
+export SMOKE_FRONTEND="${DGD_NAME}-frontend"
+
+# Allow-lists keep pod-side ${MODEL_NAME} / ${ENCODER_CLASS} / ${FRONTEND} /
+# ${IMAGE_URL} literal so they resolve from the container env at runtime.
+DEPLOY_VARS='$VLLM_IMAGE $HW_NODE_SELECTOR'
+SMOKE_VARS='$SMOKE_FRONTEND'
+
+pvc() {
+  if ! $K get pvc shared-model-cache >/dev/null 2>&1; then
+    echo "[pvc] ERROR: PVC 'shared-model-cache' not found in namespace '$NAMESPACE'" >&2
+    echo "[pvc] See README.md → 'Storage' for a copy-pasteable manifest." >&2
+    exit 1
+  fi
+  $K get pvc shared-model-cache
+}
+
+download() {
+  if [[ "$($K get job "$DL_JOB" -o jsonpath='{.status.succeeded}' 2>/dev/null)" == "1" ]]; then
+    echo "[download] already complete"
+    return
+  fi
+  $K delete job "$DL_JOB" --ignore-not-found
+  $K apply -f "$HERE/model-cache/model-download.yaml"
+  $K wait --for=condition=Complete "job/$DL_JOB" --timeout=1800s
+}
+
+encoder_log() {
+  local sel="nvidia.com/dynamo-graph-deployment-name=$DGD_NAME,nvidia.com/dynamo-component-type=worker"
+  if $K logs -l "$sel" --tail=-1 2>/dev/null | grep -m1 "Loaded CustomEncoder"; then
+    echo "[encoder-log] custom encoder loaded in-process"
+  else
+    echo "[encoder-log] 'Loaded CustomEncoder' not seen yet (worker may still be starting)"
+  fi
+}
+
+deploy() {
+  envsubst "$DEPLOY_VARS" < "$HERE/deploy.yaml" | $K apply -f -
+  local sel="nvidia.com/dynamo-graph-deployment-name=$DGD_NAME"
+  # The operator takes a few seconds to reconcile the DGD into pods.
+  # `kubectl wait -l` errors "no matching resources found" if it fires before
+  # any pod exists, so poll for existence (Frontend + Worker = 2) first.
+  echo "[deploy] waiting for operator to stamp DGD pods ..."
+  for _ in $(seq 1 60); do
+    [[ "$($K get pod -l "$sel" --no-headers 2>/dev/null | wc -l | tr -d ' ')" -ge 2 ]] && break
+    sleep 5
+  done
+  echo "[deploy] waiting for Frontend Ready ..."
+  $K wait --for=condition=Ready pod \
+     -l "$sel,nvidia.com/dynamo-component-type=frontend" --timeout=600s
+  echo "[deploy] waiting for VllmWorker Ready ..."
+  $K wait --for=condition=Ready pod \
+     -l "$sel,nvidia.com/dynamo-component-type=worker" --timeout=900s
+  encoder_log || true
+}
+
+smoke() {
+  $K delete pod "$SMOKE_POD" --ignore-not-found
+  envsubst "$SMOKE_VARS" < "$HERE/smoke.yaml" | $K apply -f -
+  echo "[smoke] polling for SMOKE PASS/FAIL marker (pod self-terminates) ..."
+  for _ in $(seq 1 90); do
+    local log
+    log="$($K logs "$SMOKE_POD" 2>/dev/null || true)"
+    if grep -q "SMOKE PASS" <<<"$log"; then echo "$log"; echo "[smoke] PASS"; return 0; fi
+    if grep -q "SMOKE FAIL" <<<"$log"; then echo "$log"; echo "[smoke] FAIL"; return 1; fi
+    local phase
+    phase="$($K get pod "$SMOKE_POD" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    [[ "$phase" == "Failed" ]] && { $K logs "$SMOKE_POD" || true; echo "[smoke] pod Failed"; return 1; }
+    sleep 10
+  done
+  $K logs "$SMOKE_POD" --tail=80 || true
+  echo "[smoke] TIMEOUT: no SMOKE marker in ~15 min" >&2
+  return 1
+}
+
+clean() {
+  $K delete pod "$SMOKE_POD" --ignore-not-found
+  $K delete dynamographdeployment "$DGD_NAME" --ignore-not-found
+  # PVC intentionally retained (model cache). To wipe:
+  #   kubectl -n $NAMESPACE delete pvc shared-model-cache
+}
+
+all() {
+  pvc
+  download
+  deploy
+  smoke
+}
+
+case "$STEP" in
+  encoder-log) encoder_log ;;
+  pvc|download|deploy|smoke|clean|all) "$STEP" ;;
+  *)
+    echo "unknown step: $STEP" >&2
+    echo "Available: pvc download deploy smoke encoder-log clean all" >&2
+    exit 2 ;;
+esac

--- a/recipes/custom-encoder/smoke.yaml
+++ b/recipes/custom-encoder/smoke.yaml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Correctness smoke test for the aggregated CustomEncoder path (PR #10832).
+# Sends the Hitchhiker's prompt with an image content part; the example
+# HitchhikersCustomEncoder splices the embeddings of "the Ultimate Question of
+# Life, the Universe, and Everything" at the image placeholder, so the assembled
+# prompt reads "...The Answer to <that phrase> is?" and the completion must
+# contain "42". The image content is irrelevant — the example encoder ignores
+# the URL — so we send a self-contained 1x1 data: image (no egress needed).
+#
+# run.sh pipes this through `envsubst` (only ${SMOKE_FRONTEND}) before apply;
+# the inline-bash ${FRONTEND}/${MODEL_NAME}/${IMAGE_URL} stay literal and resolve
+# from the pod env. The pod echoes a `SMOKE PASS` / `SMOKE FAIL` marker that
+# run.sh polls for (it terminates itself — do not `kubectl logs -f`).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: custom-encoder-smoke
+  labels:
+    app.kubernetes.io/name: custom-encoder
+    app.kubernetes.io/component: smoke
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  restartPolicy: Never
+  containers:
+    - name: smoke
+      image: python:3.11
+      command:
+        - /bin/bash
+        - -lc
+        - |
+          set -uo pipefail
+          apt-get update -qq && apt-get install -y -qq --no-install-recommends curl jq >/dev/null
+
+          FE="http://${FRONTEND}:8000"
+          echo "Waiting for model '${MODEL_NAME}' at ${FE}/v1/models ..."
+          for i in $(seq 1 60); do
+            if curl -s "${FE}/v1/models" \
+                 | jq -e --arg m "${MODEL_NAME}" '.data[]? | select(.id == $m)' >/dev/null 2>&1; then
+              echo "Model '${MODEL_NAME}' is ready."
+              break
+            fi
+            echo "[$(date '+%H:%M:%S')] not ready ($i/60), sleeping 10s"
+            sleep 10
+          done
+
+          # Build the request with jq so the apostrophe in "Hitchhiker's" and the
+          # data: URL are escaped correctly.
+          REQ="$(jq -nc \
+            --arg m "${MODEL_NAME}" \
+            --arg url "${IMAGE_URL}" \
+            --arg t1 "Based on The Hitchhiker's Guide to the Galaxy, The Answer to" \
+            --arg t2 " is?" \
+            '{model:$m, max_tokens:32, temperature:0, messages:[{role:"user", content:[
+               {type:"text", text:$t1},
+               {type:"image_url", image_url:{url:$url}},
+               {type:"text", text:$t2}]}]}')"
+          echo "REQUEST: ${REQ}"
+
+          RESP="$(curl -sS "${FE}/v1/chat/completions" \
+                    -H 'Content-Type: application/json' -d "${REQ}")" || {
+            echo "SMOKE FAIL: request errored"
+            exit 1
+          }
+          echo "RESPONSE: ${RESP}"
+          ANSWER="$(echo "${RESP}" | jq -r '.choices[0].message.content // empty')"
+          echo "COMPLETION: ${ANSWER}"
+
+          if echo "${ANSWER}" | grep -q "42"; then
+            echo "SMOKE PASS"
+            exit 0
+          fi
+          echo "SMOKE FAIL: '42' not found in completion"
+          exit 1
+      env:
+        - name: FRONTEND
+          value: ${SMOKE_FRONTEND}
+        - name: MODEL_NAME
+          value: "Qwen/Qwen2.5-1.5B-Instruct"
+        # Self-contained 1x1 PNG. The example encoder ignores image content; for
+        # a real encoder, override with a reachable image URL (http(s):// or a
+        # larger data: URL) — DYN_MM_ALLOW_INTERNAL=1 on the deploy permits both.
+        - name: IMAGE_URL
+          value: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+      resources:
+        requests:
+          cpu: "1"
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 2Gi


### PR DESCRIPTION
## Why

PR #10832 adds a `CustomEncoder` escape hatch — a custom image encoder that runs in-process in an aggregated vLLM worker — but ships only a local launch script (`examples/custom_encoder/launch/agg_custom.sh`). There's no way to stand the feature up on Kubernetes or verify it end-to-end on a cluster. This recipe fills that gap: a deployable DGD plus a one-command correctness smoke test, so the path can be exercised on a GPU node and a real encoder dropped in later. It's a feature demo (text-only LM + the example fake encoder), not a throughput benchmark, so it deliberately omits the aiperf machinery the other recipes carry.

## What Change

- DGD: Frontend + one aggregated GPU worker wired with `--custom-encoder-class`
- Smoke pod asserts the example encoder makes the prompt answer "42"
- Idempotent driver + model-download Job; README documents the image build

## Test Plan

- Static: shell syntax, YAML render under `envsubst`, pre-commit — all pass
- Runtime needs a custom image from #10832: `./run.sh -n <ns> --image <tag> --step all`
