### PR TITLE
fix(operator): propagate DGD annotations to Grove services

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1068,6 +1068,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGroveResources(ctx context.Co
 				DynamoNamespace: dynamoNamespace,
 				ComponentName:   componentName,
 				Labels:          dynamo.GetDGDComponentResourceLabels(renderDeployment, componentName, component),
+				Annotations:     dynamo.GetDGDComponentResourceAnnotations(renderDeployment, componentName, component),
 				IsK8sDiscovery:  isK8sDiscoveryEnabled,
 			})
 			if err != nil {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -2655,6 +2655,73 @@ func Test_reconcileGroveResources_UsesPreservedAlphaServiceIngress(t *testing.T)
 	g.Expect(service.Labels["legacy-label"]).To(gomega.Equal("kept"))
 }
 
+func Test_reconcileGroveResources_PropagatesComponentServiceAnnotations(t *testing.T) {
+	ctx := context.Background()
+	g := gomega.NewGomegaWithT(t)
+
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Annotations: map[string]string{
+				"prometheus.io/probe_skip": "true",
+				"shared":                   "from-dgd",
+			},
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{
+					ComponentName: "VllmDecodeWorker",
+					ComponentType: v1beta1.ComponentTypeDecode,
+					Replicas:      ptr.To(int32(1)),
+					PodTemplate: &corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"component-only": "kept",
+								"shared":         "from-component",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := newDynamoGraphDeploymentControllerTestScheme(t)
+	fakeKubeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dgd).
+		Build()
+
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client:   fakeKubeClient,
+		Recorder: record.NewFakeRecorder(100),
+		Config: &configv1alpha1.OperatorConfiguration{
+			Discovery: configv1alpha1.DiscoveryConfiguration{
+				Backend: configv1alpha1.DiscoveryBackendKubernetes,
+			},
+		},
+		RuntimeConfig: &controller_common.RuntimeConfig{},
+		ScaleClient:   &mockScaleClient{},
+		DockerSecretRetriever: &mockDockerSecretRetriever{
+			GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+				return []string{}, nil
+			},
+		},
+	}
+
+	_, err := reconciler.reconcileGroveResources(ctx, dgd, nil, nil)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	service := &corev1.Service{}
+	serviceName := dynamo.GetDCDResourceName(dgd, "VllmDecodeWorker", "")
+	g.Expect(fakeKubeClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: "default"}, service)).NotTo(gomega.HaveOccurred())
+	g.Expect(service.Annotations["prometheus.io/probe_skip"]).To(gomega.Equal("true"))
+	g.Expect(service.Annotations["component-only"]).To(gomega.Equal("kept"))
+	g.Expect(service.Annotations["shared"]).To(gomega.Equal("from-component"))
+}
+
 func TestDynamoGraphDeploymentReconciler_prepareGroveRenderDeployment_PreservesLegacyWorkerSelectors(t *testing.T) {
 	ctx := context.Background()
 	g := gomega.NewGomegaWithT(t)

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -501,6 +501,18 @@ func GetDGDComponentResourceLabels(dgd *v1beta1.DynamoGraphDeployment, component
 	return labels
 }
 
+// GetDGDComponentResourceAnnotations returns annotations that should be applied
+// to resources created directly for a DGD component.
+func GetDGDComponentResourceAnnotations(dgd *v1beta1.DynamoGraphDeployment, componentName string, component *v1beta1.DynamoComponentDeploymentSharedSpec) map[string]string {
+	annotations := map[string]string{}
+	if dgd != nil {
+		maps.Copy(annotations, dgd.Spec.Annotations)
+		maps.Copy(annotations, getDGDComponentAlphaAnnotations(dgd, componentName))
+	}
+	maps.Copy(annotations, GetPodTemplateAnnotations(component))
+	return annotations
+}
+
 // GetDGDComponentPreservedIngressSpec returns an alpha component ingress spec that
 // was preserved during conversion to v1beta1.
 func GetDGDComponentPreservedIngressSpec(dgd *v1beta1.DynamoGraphDeployment, componentName string) (IngressSpec, bool) {
@@ -2167,10 +2179,7 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 		delete(clique.Labels, commonconsts.KubeLabelDynamoDiscoveryEnabled)
 	}
 
-	annotations, err := generateAnnotations(p.component, p.dynamoDeployment, p.componentName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate annotations: %w", err)
-	}
+	annotations := generateAnnotations(p.component, p.dynamoDeployment, p.componentName)
 	for _, annotationKey := range commonconsts.KubeTopologySourceAnnotationKeys() {
 		delete(annotations, annotationKey)
 	}
@@ -2606,25 +2615,8 @@ func GetDGDPreservedAlphaPVCs(dgd *v1beta1.DynamoGraphDeployment) []v1alpha1.PVC
 	return append([]v1alpha1.PVC(nil), alpha.Spec.PVCs...)
 }
 
-func generateAnnotations(component *v1beta1.DynamoComponentDeploymentSharedSpec, dynamoDeployment *v1beta1.DynamoGraphDeployment, componentName string) (map[string]string, error) {
-	annotations := make(map[string]string)
-	if dynamoDeployment.Spec.Annotations != nil {
-		if err := mergo.Merge(&annotations, dynamoDeployment.Spec.Annotations, mergo.WithOverride); err != nil {
-			return nil, fmt.Errorf("failed to merge DGD annotations: %w", err)
-		}
-	}
-	if componentAnnotations := getDGDComponentAlphaAnnotations(dynamoDeployment, componentName); componentAnnotations != nil {
-		if err := mergo.Merge(&annotations, componentAnnotations, mergo.WithOverride); err != nil {
-			return nil, fmt.Errorf("failed to merge preserved component annotations: %w", err)
-		}
-	}
-	if podTemplateAnnotations := GetPodTemplateAnnotations(component); podTemplateAnnotations != nil {
-		err := mergo.Merge(&annotations, podTemplateAnnotations, mergo.WithOverride)
-		if err != nil {
-			return nil, fmt.Errorf("failed to merge annotations: %w", err)
-		}
-	}
-	return annotations, nil
+func generateAnnotations(component *v1beta1.DynamoComponentDeploymentSharedSpec, dynamoDeployment *v1beta1.DynamoGraphDeployment, componentName string) map[string]string {
+	return GetDGDComponentResourceAnnotations(dynamoDeployment, componentName, component)
 }
 
 // detectBackendFrameworkFromArgs detects the backend framework from command/args

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -1222,6 +1222,8 @@ func TestGenerateGrovePodCliqueSet_ProjectsClusterTopologyDomainsToWorkerCliques
 	assert.False(t, hasTopologyLabelVolume(cliques["frontend"].Spec.PodSpec.Volumes))
 }
 
+const testPodTemplateAnnotationValue = "from-pod-template"
+
 func TestGenerateLabelsAndAnnotations_UsePreservedAlphaDGDServiceMetadata(t *testing.T) {
 	alpha := &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1250,18 +1252,58 @@ func TestGenerateLabelsAndAnnotations_UsePreservedAlphaDGDServiceMetadata(t *tes
 	service := beta.GetComponentByName("worker")
 	require.NotNil(t, service)
 	component := service
-	ensurePodTemplate(component).Annotations["pod-template-annotation"] = "from-pod-template"
+	ensurePodTemplate(component).Annotations["pod-template-annotation"] = testPodTemplateAnnotationValue
 
 	labels, err := generateLabels(component, beta, "worker", DiscoveryContext{})
 	require.NoError(t, err)
 	assert.Equal(t, "kept", labels["legacy-label"])
 	assert.Equal(t, "legacy-sub", labels[commonconsts.KubeLabelDynamoSubComponentType])
 
-	annotations, err := generateAnnotations(component, beta, "worker")
-	require.NoError(t, err)
+	annotations := generateAnnotations(component, beta, "worker")
 	assert.Equal(t, "from-dgd", annotations["dgd-annotation"])
 	assert.Equal(t, "kept", annotations["legacy-annotation"])
-	assert.Equal(t, "from-pod-template", annotations["pod-template-annotation"])
+	assert.Equal(t, testPodTemplateAnnotationValue, annotations["pod-template-annotation"])
+}
+
+func TestGetDGDComponentResourceAnnotations(t *testing.T) {
+	alpha := &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			Annotations: map[string]string{
+				"dgd-only": "from-dgd",
+				"shared":   "from-dgd",
+			},
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					Annotations: map[string]string{
+						"legacy-only": "from-legacy",
+						"shared":      "from-legacy",
+					},
+				},
+			},
+		},
+	}
+	beta := &v1beta1.DynamoGraphDeployment{}
+	require.NoError(t, alpha.ConvertTo(beta))
+
+	component := beta.GetComponentByName("worker")
+	require.NotNil(t, component)
+	podTemplate := ensurePodTemplate(component)
+	podTemplate.Annotations["pod-template-only"] = testPodTemplateAnnotationValue
+	podTemplate.Annotations["shared"] = testPodTemplateAnnotationValue
+
+	annotations := GetDGDComponentResourceAnnotations(beta, "worker", component)
+
+	assert.Equal(t, map[string]string{
+		"dgd-only":          "from-dgd",
+		"legacy-only":       "from-legacy",
+		"pod-template-only": testPodTemplateAnnotationValue,
+		"shared":            testPodTemplateAnnotationValue,
+	}, annotations)
 }
 
 // TestGenerateComponentContext tests the generateComponentContext function


### PR DESCRIPTION
## Summary

Fixes #10813.

- Propagates DGD component resource annotations onto Grove-managed component Services.
- Preserves expected precedence: DGD `spec.annotations` < preserved alpha component annotations < component `podTemplate.metadata.annotations`.
- Simplifies annotation merging for flat metadata maps and removes the now-unneeded error path.
- Adds regression coverage for Grove Service annotation propagation and precedence.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced annotation handling for component services in deployments, ensuring that component-specific and deployment-level annotations are properly merged and applied to generated Kubernetes resources.

* **Tests**
  * Added test coverage for annotation propagation to verify that component and deployment-level annotations are correctly merged and applied to services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->