### PR TITLE
fix(test): use matching 2B model for trtllm disagg multimodal test

### DIFF
--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -260,7 +260,12 @@ trtllm_configs = {
             pytest.mark.multimodal,
             pytest.mark.nightly,
         ],
-        model="Qwen/Qwen2-VL-7B-Instruct",
+        # Must match the disagg engine configs shipped in disagg_multimodal.sh
+        # (engine_configs/qwen3-vl-2b-instruct/{prefill,decode}.yaml). Qwen2-VL-7B
+        # only ships an agg.yaml, so loading it against the 2B disagg configs
+        # crashes the worker during multimodal KV-cache profiling
+        # ("Number of mm_embeds does not match expected total").
+        model="Qwen/Qwen3-VL-2B-Instruct",
         frontend_port=DefaultPort.FRONTEND.value,
         timeout=900,
         delayed_start=60,


### PR DESCRIPTION
tests/serve/test_trtllm.py::test_deployment[disaggregated_multimodal-2]
failed in the nightly pipeline with the decode worker crashing during
TRT-LLM startup multimodal KV-cache profiling:

  AssertionError: Number of mm_embeds (2) does not match expected total (810)
  -> RuntimeError: Main server process exited with code 1

test_deployment injects MODEL_PATH/SERVED_MODEL_NAME from config.model,
so the config's model="Qwen/Qwen2-VL-7B-Instruct" was loaded against the
engine configs hardcoded in disagg_multimodal.sh, which point at
engine_configs/qwen3-vl-2b-instruct/{prefill,decode}.yaml. The
qwen2-vl-7b-instruct config dir only ships agg.yaml (no disagg configs),
so the 7B weights ran with 2B vision settings and the placeholder counts
mismatched.

Use Qwen3-VL-2B-Instruct, matching both the launch script's default and
its disagg engine configs (and consistent with the other multimodal
serve cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated disaggregated multimodal TRT-LLM test configuration to use an updated model version for better compatibility.
  * Enhanced test documentation to clarify model constraints and prevent worker issues during multimodal profiling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->