### PR TITLE
fix(examples): make dsr1_dep.sh log dir creation robust

### DIFF
--- a/examples/backends/vllm/launch/dsr1_dep.sh
+++ b/examples/backends/vllm/launch/dsr1_dep.sh
@@ -75,7 +75,7 @@ fi
 # not writable, e.g. a read-only working directory in CI. Without this, the
 # failing mkdir would trip `set -e` and fire the EXIT trap's `kill 0`, taking
 # the whole launch down before the workers ever start.
-if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
+if ! mkdir -p "$LOG_DIR" 2>/dev/null || [ ! -w "$LOG_DIR" ]; then
     FALLBACK_LOG_DIR="$(mktemp -d)"
     echo "Warning: cannot create log dir '$LOG_DIR'; using '$FALLBACK_LOG_DIR'" >&2
     LOG_DIR="$FALLBACK_LOG_DIR"

--- a/examples/backends/vllm/launch/dsr1_dep.sh
+++ b/examples/backends/vllm/launch/dsr1_dep.sh
@@ -70,6 +70,17 @@ if [ -z "$NUM_NODES" ] || [ -z "$NODE_RANK" ] || [ -z "$GPUS_PER_NODE" ]; then
     exit 1
 fi
 
+# Create the log directory up front (before any `tee` below writes into it).
+# Fall back to a writable temp dir if the chosen location (default ./logs) is
+# not writable, e.g. a read-only working directory in CI. Without this, the
+# failing mkdir would trip `set -e` and fire the EXIT trap's `kill 0`, taking
+# the whole launch down before the workers ever start.
+if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
+    FALLBACK_LOG_DIR="$(mktemp -d)"
+    echo "Warning: cannot create log dir '$LOG_DIR'; using '$FALLBACK_LOG_DIR'" >&2
+    LOG_DIR="$FALLBACK_LOG_DIR"
+fi
+
 # Calculate data parallel size
 DATA_PARALLEL_SIZE=$((NUM_NODES * GPUS_PER_NODE))
 
@@ -103,10 +114,8 @@ trap 'echo Cleaning up...; kill 0' EXIT
 # run ingress if it's node 0
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
 if [ $NODE_RANK -eq 0 ]; then
-    DYN_LOG=debug python -m dynamo.frontend --router-mode kv 2>&1 | tee $LOG_DIR/dsr1_dep_ingress.log &
+    DYN_LOG=debug python -m dynamo.frontend --router-mode kv 2>&1 | tee "$LOG_DIR/dsr1_dep_ingress.log" &
 fi
-
-mkdir -p $LOG_DIR
 
 # Data Parallel Attention / Expert Parallelism
 # Routing to DP workers managed by Dynamo
@@ -139,7 +148,7 @@ python3 -m dynamo.vllm \
 --data-parallel-rpc-port 13345 \
 $GPU_MEM_ARGS \
 --enforce-eager \
---kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:20080\",\"enable_kv_cache_events\":true}" 2>&1 | tee $LOG_DIR/dsr1_dep_${dp_start_rank}.log &
+--kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:20080\",\"enable_kv_cache_events\":true}" 2>&1 | tee "$LOG_DIR/dsr1_dep_${dp_start_rank}.log" &
 
 echo "All workers starting. (press Ctrl+C to stop)..."
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest


### PR DESCRIPTION
tests/serve/test_vllm.py::test_serve_deployment[deepep-2] failed in the
nightly pipeline with "Main server process exited with code -15 while
waiting for health check". The launch script logs showed:

  tee: ./logs/dsr1_dep_ingress.log: No such file or directory
  mkdir: cannot create directory './logs': Permission denied
  + echo Cleaning up...; + kill 0

Two problems: the frontend was piped through `tee $LOG_DIR/...` before
`mkdir -p $LOG_DIR` ran, and the mkdir failed outright because the CWD
was not writable in CI. Under `set -e` that failure fired the EXIT
trap's `kill 0`, SIGTERMing the whole process group before any worker
started.

Create the log directory up front (before the first tee) and fall back
to a writable temp dir when the chosen location is not writable, so a
read-only CWD no longer takes the launch down. Also quote the $LOG_DIR
tee paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced launch script reliability to ensure logs are properly created, with automatic fallback to a temporary directory if the default log location is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->