### PR TITLE
fix(test): tolerate transient first-request 503 in router overload probe

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1140,6 +1140,15 @@ def _probe_overload_503_and_assert(
 
     async def exhaust_resources_and_verify_503():
         stop_event = asyncio.Event()
+        # Set once any request has been accepted (200). A 503 only ends the probe
+        # after this is set. Some configs (notably decode-blocks, where a single
+        # request's own footprint can momentarily exceed the block threshold) can
+        # emit a transient 503 for the very first request before any request is
+        # accepted; stopping on that 503 would leave num_succeeded == 0 and fail
+        # the "at least one success" assertion. Continuing past it lets a later
+        # request land on the (now drained) worker and be accepted, which is the
+        # 200-then-503 behavior the test is meant to verify.
+        accepted_event = asyncio.Event()
 
         async with aiohttp.ClientSession() as session:
             tasks = []
@@ -1149,13 +1158,20 @@ def _probe_overload_503_and_assert(
                     async with session.post(url, json=payload) as response:
                         if response.status == 200:
                             logger.info(f"Request {req_id} accepted")
+                            accepted_event.set()
                             await stop_event.wait()
                             return response.status
 
                         if response.status == 503:
                             body = await response.text()
                             logger.info(f"Request {req_id} got expected 503: {body}")
-                            stop_event.set()
+                            if accepted_event.is_set():
+                                stop_event.set()
+                            else:
+                                logger.info(
+                                    f"Request {req_id} got a transient 503 before any "
+                                    "request was accepted; continuing to probe"
+                                )
                             return response.status
 
                         body = await response.text()


### PR DESCRIPTION
tests/router/test_router_e2e_with_mockers.py::
test_mocker_disagg_router_overload_503[decode-blocks-nondurable] failed
intermittently with "Expected at least 1 success, but got 0".

The probe sends staggered requests and stops on the first 503, expecting
earlier requests to have been accepted (200) and held open. In the
decode-blocks config a single request's own footprint can momentarily
exceed the block threshold, so the very first request can get a transient
503 before any request is accepted. Stopping there leaves
num_succeeded == 0 and fails the "at least one success" assertion, even
though the router behaved correctly.

Only let a 503 end the probe once at least one request has been accepted.
A transient pre-acceptance 503 now lets the loop keep probing; a later
request lands on the (drained) worker and is accepted, producing the
200-then-503 sequence the test verifies. Passing configs are unaffected
(their first request is accepted immediately). The rejection-metric
assertion still holds since every received 503 was emitted by the
frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced overload scenario validation to properly handle transient responses and ensure comprehensive test coverage of overload conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->