### PR TITLE
fix(test): write trtllm fault-tolerance engine configs to tmp_path

### DIFF
--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -79,16 +79,20 @@ class DynamoWorkerProcess(ManagedProcess):
             "16384",
         ]
         if mode != "prefill_and_decode":
-            with open("test_request_cancellation_trtllm_config.yaml", "w") as f:
+            # Write the engine config under the test's tmp_path (guaranteed
+            # writable, unique per test) rather than the CWD, which is
+            # read-only in CI and raised PermissionError.
+            config_file = str(
+                request.getfixturevalue("tmp_path")
+                / f"trtllm_cancel_config_{system_port}.yaml"
+            )
+            with open(config_file, "w") as f:
                 f.write(
                     "cache_transceiver_config:\n  backend: DEFAULT\n  max_tokens_in_buffer: 16384\n"
                 )
                 f.write("disable_overlap_scheduler: true\n")
                 f.write("kv_cache_config:\n  max_tokens: 16384\n")
-            command += [
-                "--extra-engine-args",
-                "test_request_cancellation_trtllm_config.yaml",
-            ]
+            command += ["--extra-engine-args", config_file]
 
         health_check_urls = [
             (f"http://localhost:{frontend_port}/v1/models", check_models_api),

--- a/tests/fault_tolerance/etcd_ha/test_trtllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_trtllm.py
@@ -61,13 +61,17 @@ class DynamoWorkerProcess(ManagedProcess):
 
         # Add disaggregation-specific configuration
         if mode != "prefill_and_decode":
-            with open("test_etcd_ha_trtllm_config.yaml", "w") as f:
+            # Write the engine config under the test's tmp_path (guaranteed
+            # writable, unique per test) rather than the CWD, which is
+            # read-only in CI and raised PermissionError.
+            config_file = str(
+                request.getfixturevalue("tmp_path")
+                / f"trtllm_etcd_ha_config_{mode}.yaml"
+            )
+            with open(config_file, "w") as f:
                 f.write("cache_transceiver_config:\n  backend: DEFAULT\n")
                 f.write("disable_overlap_scheduler: true\n")
-            command += [
-                "--extra-engine-args",
-                "test_etcd_ha_trtllm_config.yaml",
-            ]
+            command += ["--extra-engine-args", config_file]
 
         health_check_urls = [
             (f"http://localhost:{FRONTEND_PORT}/v1/models", check_models_api),

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -110,8 +110,12 @@ class DynamoWorkerProcess(ManagedProcess):
             "0.15",  # avoid validation error on TRT-LLM available memory checks
         ]
         if mode != "prefill_and_decode":
-            config_file = (
-                f"test_request_migration_trtllm_config_{self.system_port}.yaml"
+            # Write the engine config under the test's tmp_path (guaranteed
+            # writable, unique per test) rather than the CWD, which is
+            # read-only in CI and raised PermissionError.
+            config_file = str(
+                request.getfixturevalue("tmp_path")
+                / f"trtllm_migration_config_{self.system_port}.yaml"
             )
             with open(config_file, "w") as f:
                 f.write(


### PR DESCRIPTION
The trtllm cancellation, etcd_ha, and migration fault-tolerance tests
wrote their disagg engine config (--extra-engine-args) to a relative
path in the current working directory. In CI the CWD is read-only, so
every disaggregated case failed at setup with:

  PermissionError: [Errno 13] Permission denied: 'test_*_config.yaml'

This is the real root cause of the original nightly trtllm decode_cancel
failure: it fast-failed in <1s (before any worker started) writing the
config, which previously looked like a flake because it only reproduces
when the CWD is not writable. It stayed hidden for the other trtllm
fault-tolerance tests because the shard was terminated (143) at the
etcd_ha test before they ran; with the etcd_ha fix the shard runs to
completion and all 28 disagg cases surfaced the same PermissionError.

Write the config under the test's pytest tmp_path instead (guaranteed
writable, unique per test, auto-cleaned). Validated on GPU by running
decode_cancel from a read-only CWD: passes, and no file is written to
the CWD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved fault tolerance test infrastructure for TensorRT-LLM integration, including cancellation, high-availability, and migration test suites, to enhance reliability in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->