### PR TITLE
chore: bump dynamo-parsers to 2.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,7 +1563,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2302,7 +2302,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2707,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.4.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53929c7ac7cfc7696a936600bbe1e53b32aaf1279564ca93baa7bb6c8967d0ab"
+checksum = "2577dd23a85f6108a628580e2f7f0ec7c149c21d2fe280210e4be7752e6dee03"
 dependencies = [
  "anyhow",
  "num-traits",
@@ -3079,7 +3079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4058,7 +4058,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -4394,7 +4394,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5768,7 +5768,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6931,8 +6931,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -6951,8 +6951,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6973,7 +6973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6986,7 +6986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7176,7 +7176,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7213,9 +7213,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7860,7 +7860,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8894,7 +8894,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10716,7 +10716,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ dynamo-memory = { path = "lib/memory", version = "1.3.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.3.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.3.0", features = ["metrics", "runtime-protocols"] }
 dynamo-protocols = { version = "=2.0.0" }
-dynamo-parsers = { version = "1.4.1" }
+dynamo-parsers = { version = "2.1.2" }
 dynamo-backend-common = { path = "lib/backend-common", version = "1.3.0" }
 fastokens = { version = "0.2.0" }
 

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.4.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53929c7ac7cfc7696a936600bbe1e53b32aaf1279564ca93baa7bb6c8967d0ab"
+checksum = "2577dd23a85f6108a628580e2f7f0ec7c149c21d2fe280210e4be7752e6dee03"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2314,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "1.4.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53929c7ac7cfc7696a936600bbe1e53b32aaf1279564ca93baa7bb6c8967d0ab"
+checksum = "2577dd23a85f6108a628580e2f7f0ec7c149c21d2fe280210e4be7752e6dee03"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -49,7 +49,7 @@ mm-routing = ["dynamo-llm/mm-routing"]
 aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "ffbab15797d3a3f14c382e937c0ab0c1c5cbc530", package = "aiconfigurator-core", optional = true }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
-dynamo-parsers = { version = "1.4.1" }
+dynamo-parsers = { version = "2.1.2" }
 dynamo-protocols = { version = "=2.0.0" }
 dynamo-backend-common = { path = "../../backend-common" }
 

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -1382,6 +1382,32 @@ mod tests {
             inner.inner.created, 1234567890,
             "Inner response created should carry forward from real stream chunks, not be 0"
         );
+
+        // The hermes parser (dynamo-parsers 2.0.1, PR #63) never surfaces tool-call
+        // markup to the client: a call truncated at stream end is recovered as a real
+        // tool call and the raw `<tool_call>` markup is stripped, rather than leaking
+        // the buffer as text. So the released chunk carries the recovered call with
+        // empty content (the metadata-preservation checks above are the test's subject).
+        let content = &inner.inner.choices[0].delta.content;
+        assert_eq!(
+            content.as_ref().map(test_utils::extract_text),
+            Some(""),
+            "Released chunk must not leak raw tool-call markup as content"
+        );
+        let tool_calls = inner.inner.choices[0].delta.tool_calls.as_ref();
+        assert_eq!(
+            tool_calls.map(|tc| tc.len()),
+            Some(1),
+            "Truncated call must be recovered as a tool call, not leaked as text"
+        );
+        assert_eq!(
+            tool_calls.unwrap()[0]
+                .function
+                .as_ref()
+                .and_then(|f| f.name.as_deref()),
+            Some("incomplete_call"),
+            "Recovered tool call should carry the parsed function name"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
#### Overview:

This PR bumps the published `dynamo-parsers` dependency from 1.4.1 to 2.1.2 (workspace root + python bindings) so Dynamo runs on the 2.1.x parser line; no Dynamo code changes. 2.1.x carries the Qwen3-Coder v2 streaming parser (frontend-crates #53) and the truncated-mid-value drop fix (frontend-crates #72).

#### Details:

- `dynamo-parsers` 1.4.1 -> 2.1.2 in `Cargo.toml` and `lib/bindings/python/Cargo.toml`; `Cargo.lock` regenerated.
- Updates `test_jailed_stream_preserves_metadata_on_stream_end` to the 2.x hermes contract: at stream end the truncated call is recovered with empty content rather than the raw `<tool_call>` markup leaking, so the test asserts the recovered tool call instead of a leaked start marker (metadata-preservation checks unchanged).

#### Verification:

`cargo test -p dynamo-llm --test test_jail --test tool_choice --test test_streaming_tool_parsers --test parallel_tool_call_integration` — 149 passed, 0 failed against published 2.1.2 (no test-contract change needed beyond the one carried from the 2.0.x bump).

#### Where should the reviewer start?

`Cargo.toml`, then `lib/llm/tests/test_jail.rs`

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace Python bindings to use a newer `dynamo-parsers` version.

* **Tests**
  * Strengthened stream-end coverage to verify metadata is preserved, no tool-call markup leaks into output, and recovered tool-call details remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->