### PR TITLE
chore(deps): bump renderer and tokenizers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c110dcbce894dc72ead3efb1c1795c45ab19e08e64b8ace0573c3b6ce43ff82"
+checksum = "bc6658e06cd0dda37d493ac84d70cb33ea89fbe91056b152174351f7502fb46a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2848,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdeae45f2465f48b0abc980a5745add4bc59be15701f87f604a97e1282c8db77"
+checksum = "801685a07cfbc87d5e3f3ed55b920707b67f31dd660c62d1b3532a651fc9d013"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -3193,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "fastokens"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f38849fadd9e96f872be6549556d26b3e9f5135b6ac8b616205de554fdd4318"
+checksum = "8728655e193e0d08d7a95d63cf1fdb9b768d282cab0a112ecb006615bae9f067"
 dependencies = [
  "daachorse",
  "fancy-regex 0.17.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 dynamo-runtime = { path = "lib/runtime", version = "1.3.0" }
 dynamo-llm = { path = "lib/llm", version = "1.3.0" }
 dynamo-rl = { path = "lib/rl", version = "1.3.0" }
-dynamo-tokenizers = { version = "=1.3.1" }
-dynamo-renderer = { version = "=1.3.3" }
+dynamo-tokenizers = { version = "=1.3.2" }
+dynamo-renderer = { version = "=1.3.4" }
 dynamo-tokens = { path = "lib/tokens", version = "1.3.0" }
 dynamo-data-gen = { path = "lib/data-gen", version = "1.3.0" }
 dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.3.0" }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1736,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c110dcbce894dc72ead3efb1c1795c45ab19e08e64b8ace0573c3b6ce43ff82"
+checksum = "bc6658e06cd0dda37d493ac84d70cb33ea89fbe91056b152174351f7502fb46a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1834,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdeae45f2465f48b0abc980a5745add4bc59be15701f87f604a97e1282c8db77"
+checksum = "801685a07cfbc87d5e3f3ed55b920707b67f31dd660c62d1b3532a651fc9d013"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2080,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "fastokens"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f38849fadd9e96f872be6549556d26b3e9f5135b6ac8b616205de554fdd4318"
+checksum = "8728655e193e0d08d7a95d63cf1fdb9b768d282cab0a112ecb006615bae9f067"
 dependencies = [
  "daachorse",
  "fancy-regex 0.17.0",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2386,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c110dcbce894dc72ead3efb1c1795c45ab19e08e64b8ace0573c3b6ce43ff82"
+checksum = "bc6658e06cd0dda37d493ac84d70cb33ea89fbe91056b152174351f7502fb46a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2485,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdeae45f2465f48b0abc980a5745add4bc59be15701f87f604a97e1282c8db77"
+checksum = "801685a07cfbc87d5e3f3ed55b920707b67f31dd660c62d1b3532a651fc9d013"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2777,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "fastokens"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f38849fadd9e96f872be6549556d26b3e9f5135b6ac8b616205de554fdd4318"
+checksum = "8728655e193e0d08d7a95d63cf1fdb9b768d282cab0a112ecb006615bae9f067"
 dependencies = [
  "daachorse",
  "fancy-regex 0.17.0",


### PR DESCRIPTION
## Summary
- Bump the published `dynamo-renderer` pin from `=1.3.3` to `=1.3.4`.
- Pin `dynamo-tokenizers` from `=1.3.1` to `=1.3.2`.
- Refresh the root, Python binding, and KVBM binding lockfiles; `fastokens` moves to `0.2.1` through the tokenizer update.

## Validation
- `git diff --check origin/main..HEAD`
- `cargo pkgid -p dynamo-renderer` -> `registry+https://github.com/rust-lang/crates.io-index#dynamo-renderer@1.3.4`
- `cargo pkgid -p dynamo-tokenizers` -> `registry+https://github.com/rust-lang/crates.io-index#dynamo-tokenizers@1.3.2`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo metadata --locked --no-deps --format-version 1 --manifest-path lib/bindings/python/Cargo.toml`
- `cargo metadata --locked --no-deps --format-version 1 --manifest-path lib/bindings/kvbm/Cargo.toml`
- `cargo check -p dynamo-llm --no-default-features`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependencies to latest patch versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->