### PR TITLE
fix(profiler): clamp vLLM Mamba align token floor

### DIFF
--- a/components/src/dynamo/profiler/interpolation.py
+++ b/components/src/dynamo/profiler/interpolation.py
@@ -81,12 +81,17 @@ async def run_interpolation(
 
     config_modifier = CONFIG_MODIFIERS[backend]
     model_name, model_path = config_modifier.get_model_name(disagg_config)
+    convert_kwargs = {}
+    if backend == "vllm":
+        convert_kwargs["model_name_or_path"] = model_path or model_name
 
     best_prefill_gpus = best_prefill_config.num_gpus
     best_decode_gpus = best_decode_config.num_gpus
 
     # --- Prefill interpolation ---
-    prefill_config = config_modifier.convert_config(disagg_config, EngineType.PREFILL)
+    prefill_config = config_modifier.convert_config(
+        disagg_config, EngineType.PREFILL, **convert_kwargs
+    )
     if job_tolerations:
         prefill_config = inject_tolerations_into_dgd(prefill_config, job_tolerations)
 
@@ -143,7 +148,9 @@ async def run_interpolation(
     deployment_clients.remove(client)
 
     # --- Decode interpolation ---
-    decode_config = config_modifier.convert_config(disagg_config, EngineType.DECODE)
+    decode_config = config_modifier.convert_config(
+        disagg_config, EngineType.DECODE, **convert_kwargs
+    )
     if job_tolerations:
         decode_config = inject_tolerations_into_dgd(decode_config, job_tolerations)
 

--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -27,6 +27,7 @@ from deploy.utils.dynamo_deployment import cleanup_remaining_deployments
 from dynamo.profiler.interpolation import run_interpolation
 from dynamo.profiler.rapid import run_rapid
 from dynamo.profiler.thorough import run_thorough
+from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
 from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
     PickedParallelConfig,
 )
@@ -73,6 +74,29 @@ def _apply_tolerations_to_final_config(final_config: Any, tolerations: list) -> 
         result[-1] = inject_tolerations_into_dgd(result[-1], tolerations)
         return result
     return inject_tolerations_into_dgd(final_config, tolerations)
+
+
+def _apply_model_runtime_constraints_to_final_config(
+    final_config: Any,
+    backend: str,
+    model_name_or_path: str,
+) -> Any:
+    if backend != "vllm" or not final_config:
+        return final_config
+
+    config_modifier = CONFIG_MODIFIERS[backend]
+    if not hasattr(config_modifier, "apply_model_runtime_constraints"):
+        return final_config
+
+    if isinstance(final_config, list):
+        final_config[-1] = config_modifier.apply_model_runtime_constraints(
+            final_config[-1], model_name_or_path
+        )
+    elif isinstance(final_config, dict):
+        final_config = config_modifier.apply_model_runtime_constraints(
+            final_config, model_name_or_path
+        )
+    return final_config
 
 
 def _check_auto_backend_support(model: str, system: str) -> bool:
@@ -536,6 +560,12 @@ async def run_profile(
             elif isinstance(final_config, dict):
                 final_config = apply_dgd_overrides(final_config, dgdr.overrides.dgd)
             logger.info("Applied DGD overrides to the final config.")
+
+        final_config = _apply_model_runtime_constraints_to_final_config(
+            final_config,
+            resolved_backend,
+            resolve_model_path(dgdr),
+        )
 
         # Propagate profiling-job tolerations to the final DGD (covers any
         # services added by assemble_final_config, e.g. Planner).

--- a/components/src/dynamo/profiler/tests/unit/test_model_info.py
+++ b/components/src/dynamo/profiler/tests/unit/test_model_info.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for profiler model-info helpers."""
+
+import json
+
+import pytest
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+try:
+    from dynamo.profiler.utils.model_info import get_mamba_cache_align_block_size
+except ImportError as e:
+    pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
+
+
+def test_mamba_cache_align_block_size_from_local_config(tmp_path) -> None:
+    """Mamba align floor follows vLLM's Mamba/attention page size."""
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "mamba_num_heads": 128,
+                "mamba_head_dim": 64,
+                "ssm_state_size": 128,
+            }
+        )
+    )
+
+    assert get_mamba_cache_align_block_size(tmp_path) == 8320

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -178,6 +178,101 @@ def test_sglang_set_prefill_config_uses_effective_mrr_override() -> None:
     assert args[args.index("--cuda-graph-bs") + 1] == "2"
 
 
+def test_vllm_mamba_align_raises_max_num_batched_tokens() -> None:
+    """vLLM Mamba align requires the scheduler token cap to cover block size."""
+    modifier = CONFIG_MODIFIERS["vllm"]
+    args = [
+        "--enable-prefix-caching",
+        "--mamba-cache-mode",
+        "align",
+        "--max-num-batched-tokens",
+        "1024",
+    ]
+
+    with patch(
+        "dynamo.profiler.utils.config_modifiers.vllm.get_mamba_cache_align_block_size",
+        return_value=8320,
+    ):
+        result = modifier._apply_mamba_cache_align_token_floor(args, "nemotron")
+
+    assert result[result.index("--max-num-batched-tokens") + 1] == "8320"
+
+
+def test_vllm_mamba_align_skips_without_explicit_align_mode() -> None:
+    """Do not probe model metadata for ordinary prefix-caching decode workers."""
+    modifier = CONFIG_MODIFIERS["vllm"]
+    args = [
+        "--enable-prefix-caching",
+        "--max-num-batched-tokens",
+        "1024",
+    ]
+
+    with patch(
+        "dynamo.profiler.utils.config_modifiers.vllm.get_mamba_cache_align_block_size"
+    ) as mock_floor:
+        result = modifier._apply_mamba_cache_align_token_floor(args, "llama")
+
+    mock_floor.assert_not_called()
+    assert result == args
+
+
+def test_vllm_model_runtime_constraints_update_decode_config() -> None:
+    """Candidate-level vLLM postprocessing fixes generated decode worker args."""
+    modifier = CONFIG_MODIFIERS["vllm"]
+    config = {
+        "metadata": {"name": "test"},
+        "spec": {
+            "services": {
+                "Frontend": {},
+                "VllmDecodeWorker": {
+                    "subComponentType": "decode",
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "args": [
+                                "--mamba-cache-mode",
+                                "align",
+                                "--max-num-batched-tokens",
+                                "1024",
+                            ]
+                        }
+                    },
+                },
+            }
+        },
+    }
+
+    with patch(
+        "dynamo.profiler.utils.config_modifiers.vllm.get_mamba_cache_align_block_size",
+        return_value=8320,
+    ):
+        result = modifier.apply_model_runtime_constraints(config, "nemotron")
+
+    args = result["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"][
+        "mainContainer"
+    ]["args"]
+    assert args[args.index("--max-num-batched-tokens") + 1] == "8320"
+
+
+def test_vllm_model_runtime_constraints_skip_partial_decode_config() -> None:
+    """Final DGD postprocessing should tolerate partial mocked configs."""
+    modifier = CONFIG_MODIFIERS["vllm"]
+    config = {
+        "metadata": {"name": "test"},
+        "spec": {
+            "services": {
+                "Frontend": {},
+                "VllmDecodeWorker": {"subComponentType": "decode"},
+            }
+        },
+    }
+
+    result = modifier.apply_model_runtime_constraints(config, "nemotron")
+
+    decode_service = result["spec"]["services"]["VllmDecodeWorker"]
+    assert decode_service["subComponentType"] == "decode"
+    assert decode_service["extraPodSpec"] is None
+
+
 def test_build_dgd_config_multinode_when_tp_exceeds_node() -> None:
     """Single instances that exceed node capacity still get multinode config."""
     modifier = CONFIG_MODIFIERS["sglang"]
@@ -648,10 +743,9 @@ def test_build_dgd_config_pvc_with_model_path_uses_pvc_path(backend) -> None:
             continue
         args = svc.get("extraPodSpec", {}).get("mainContainer", {}).get("args", [])
         flat_args = " ".join(args) if args else ""
-        assert model_path in flat_args, (
-            f"Worker '{svc_name}' should use PVC model path '{model_path}'. "
-            f"args={args}"
-        )
+        assert (
+            model_path in flat_args
+        ), f"Worker '{svc_name}' should use PVC model path '{model_path}'. args={args}"
 
 
 def test_build_dgd_config_pvc_without_model_path_sets_hf_home() -> None:

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -409,6 +409,24 @@ async def run_thorough(
             len(decode_candidates),
         )
 
+    config_modifier = CONFIG_MODIFIERS[backend]
+    if backend == "vllm" and hasattr(
+        config_modifier, "apply_model_runtime_constraints"
+    ):
+        for candidate in prefill_candidates:
+            candidate.dgd_config = config_modifier.apply_model_runtime_constraints(
+                candidate.dgd_config, local_or_hf_model
+            )
+        for candidate in decode_candidates:
+            candidate.dgd_config = config_modifier.apply_model_runtime_constraints(
+                candidate.dgd_config, local_or_hf_model
+            )
+        logger.info(
+            "Applied vLLM model runtime constraints to %d prefill + %d decode candidates.",
+            len(prefill_candidates),
+            len(decode_candidates),
+        )
+
     # Propagate profiling-job tolerations to candidate DGDs
     job_tolerations = get_profiling_job_tolerations(dgdr)
     if job_tolerations:
@@ -426,8 +444,6 @@ async def run_thorough(
             len(prefill_candidates),
             len(decode_candidates),
         )
-
-    config_modifier = CONFIG_MODIFIERS[backend]
 
     # --- Stage 2: Benchmarking ---
     ops.current_phase = ProfilingPhase.SweepingPrefill

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -6,6 +6,7 @@ from typing import Tuple
 from uuid import uuid4
 
 import yaml
+from pydantic import ValidationError
 
 from dynamo.planner.config.defaults import SubComponentType
 from dynamo.profiler.utils.config import (
@@ -26,6 +27,7 @@ from dynamo.profiler.utils.defaults import (
     EngineType,
     resolve_deploy_path,
 )
+from dynamo.profiler.utils.model_info import get_mamba_cache_align_block_size
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -43,6 +45,26 @@ DEFAULT_VLLM_DISAGG_CONFIG_PATH = resolve_deploy_path(
 DEFAULT_VLLM_AGG_CONFIG_PATH = resolve_deploy_path(
     "examples/backends/vllm/deploy/agg.yaml"
 )
+
+
+def _get_valued_arg(args: list[str], key: str) -> str | None:
+    for i, arg in enumerate(args):
+        if arg == key and i + 1 < len(args):
+            return args[i + 1]
+        if isinstance(arg, str) and arg.startswith(f"{key}="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+def _set_valued_arg(args: list[str], key: str, value: str) -> list[str]:
+    for i, arg in enumerate(args):
+        if arg == key and i + 1 < len(args):
+            args[i + 1] = value
+            return args
+        if isinstance(arg, str) and arg.startswith(f"{key}="):
+            args[i] = f"{key}={value}"
+            return args
+    return set_argument_value(args, key, value)
 
 
 class VllmV1ConfigModifier(BaseConfigModifier):
@@ -71,6 +93,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         config: dict,
         target: EngineType,
         is_moe_model: bool = False,
+        model_name_or_path: str | None = None,
     ) -> dict:
         cfg = Config.model_validate(config)
 
@@ -151,6 +174,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             if "--no-enable-prefix-caching" in args:
                 args.remove("--no-enable-prefix-caching")
 
+            args = cls._apply_mamba_cache_align_token_floor(args, model_name_or_path)
             worker_service.extraPodSpec.mainContainer.args = args
 
         # set num workers to 1
@@ -161,6 +185,75 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         decode_worker_config = cfg.spec.services[final_decode_service_name]
         decode_worker_config.replicas = 1
 
+        return cfg.model_dump()
+
+    @classmethod
+    def _apply_mamba_cache_align_token_floor(
+        cls, args: list[str], model_name_or_path: str | None
+    ) -> list[str]:
+        if not model_name_or_path:
+            return args
+
+        mamba_cache_mode = _get_valued_arg(args, "--mamba-cache-mode")
+        if mamba_cache_mode:
+            mamba_cache_mode = mamba_cache_mode.lower()
+        if mamba_cache_mode != "align":
+            return args
+
+        try:
+            mamba_align_floor = get_mamba_cache_align_block_size(model_name_or_path)
+        except (OSError, ValueError, TypeError):
+            logger.debug(
+                "Could not derive Mamba cache align token floor for %s",
+                model_name_or_path,
+                exc_info=True,
+            )
+            return args
+        if not mamba_align_floor:
+            return args
+
+        current = _get_valued_arg(args, "--max-num-batched-tokens")
+        try:
+            current_value = int(current) if current is not None else 0
+        except ValueError:
+            current_value = 0
+        if current_value >= mamba_align_floor:
+            return args
+
+        logger.info(
+            "Raising vLLM --max-num-batched-tokens from %s to Mamba align floor %d",
+            current if current is not None else "unset",
+            mamba_align_floor,
+        )
+        return _set_valued_arg(args, "--max-num-batched-tokens", str(mamba_align_floor))
+
+    @classmethod
+    def apply_model_runtime_constraints(
+        cls, config: dict, model_name_or_path: str | None
+    ) -> dict:
+        try:
+            cfg = Config.model_validate(config)
+        except ValidationError:
+            logger.debug(
+                "Skipping vLLM model runtime constraints for partial config",
+                exc_info=True,
+            )
+            return config
+        for component_type in (SubComponentType.DECODE,):
+            try:
+                worker_service = get_worker_service_from_config(
+                    cfg, backend="vllm", sub_component_type=component_type
+                )
+                args = validate_and_get_worker_args(worker_service, backend="vllm")
+                args = break_arguments(args)
+            except (KeyError, ValueError):
+                logger.debug(
+                    "Skipping vLLM model runtime constraints for partial worker config",
+                    exc_info=True,
+                )
+                continue
+            args = cls._apply_mamba_cache_align_token_floor(args, model_name_or_path)
+            worker_service.extraPodSpec.mainContainer.args = args
         return cfg.model_dump()
 
     @classmethod

--- a/components/src/dynamo/profiler/utils/model_info.py
+++ b/components/src/dynamo/profiler/utils/model_info.py
@@ -1,12 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from pathlib import Path
 from typing import Optional, Union
 
 from huggingface_hub import model_info
 from pydantic import BaseModel
 from transformers import AutoConfig
+
+try:
+    from aiconfigurator.sdk.utils import get_model_config_from_model_path
+except ImportError:
+    get_model_config_from_model_path = None
 
 DTYPE_BYTES_MAP = {
     "F32": 4,  # FP32: 4 bytes per parameter
@@ -121,6 +127,62 @@ class ModelInfo(BaseModel):
     intermediate_size: Optional[int] = None
     num_kv_heads: Optional[int] = None
     quantization_block_size: Optional[int] = None
+
+
+def _get_config_value(config: object, attr: str) -> object:
+    if isinstance(config, dict):
+        return config.get(attr)
+    return getattr(config, attr, None)
+
+
+def _positive_int_config_value(config: object, attr: str) -> Optional[int]:
+    value = _get_config_value(config, attr)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _load_model_config_for_mamba(
+    model_name_or_path: Union[str, Path],
+    trust_remote_code: bool = False,
+) -> object:
+    path = Path(model_name_or_path)
+    config_path = path / "config.json"
+    if path.is_dir() and config_path.is_file():
+        with open(config_path) as f:
+            return json.load(f)
+
+    if get_model_config_from_model_path is not None:
+        model_config = get_model_config_from_model_path(str(model_name_or_path))
+        raw_config = model_config.get("raw_config")
+        if raw_config is not None:
+            return raw_config
+
+    return AutoConfig.from_pretrained(
+        model_name_or_path,
+        trust_remote_code=trust_remote_code,
+    )
+
+
+def get_mamba_cache_align_block_size(
+    model_name_or_path: Union[str, Path],
+    trust_remote_code: bool = False,
+) -> Optional[int]:
+    """Return vLLM's Mamba cache align token floor when derivable.
+
+    vLLM requires ``max_num_batched_tokens`` to be at least this block size
+    when Mamba cache mode is ``align``. Nemotron-H configs expose the fields
+    needed to compute it directly.
+    """
+    config = _load_model_config_for_mamba(model_name_or_path, trust_remote_code)
+    mamba_num_heads = _positive_int_config_value(config, "mamba_num_heads")
+    mamba_head_dim = _positive_int_config_value(config, "mamba_head_dim")
+    ssm_state_size = _positive_int_config_value(config, "ssm_state_size")
+    if not (mamba_num_heads and mamba_head_dim and ssm_state_size):
+        return None
+    return mamba_num_heads * mamba_head_dim + ssm_state_size
 
 
 def get_model_info(


### PR DESCRIPTION
## Summary
- Add a profiler helper to derive the vLLM Mamba cache align token floor from model config fields: `mamba_num_heads * mamba_head_dim + ssm_state_size`.
- Clamp vLLM `--max-num-batched-tokens` for explicit Mamba align decode configs so generated sweep, interpolation, and final DGD configs do not violate vLLM's scheduler/cache constraint.
- Address CodeRabbit/Devin feedback by avoiding silent broad exception handlers, skipping partial final configs safely, and avoiding model metadata probes for ordinary prefix-caching decode workers.

## Validation
- `PYTHONPATH=/home/hongkuanz/Projects/dynamo/components/src:/home/hongkuanz/Projects/dynamo/aiconfigurator/src ./.venv/bin/pytest -q components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py components/src/dynamo/profiler/tests/unit/test_model_info.py::test_mamba_cache_align_block_size_from_local_config components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py::TestRunProfileSkipsInterpolationForAggConfig::test_run_profile_calls_interpolation_with_resolved_backend_for_disagg`
- `PYTHONPATH=/home/hongkuanz/Projects/dynamo/components/src ./.venv/bin/python -c "import dynamo.profiler.utils.model_info as m; print(m.get_model_config_from_model_path)"`
- `./.venv/bin/pre-commit run isort --files components/src/dynamo/profiler/utils/model_info.py components/src/dynamo/profiler/utils/config_modifiers/vllm.py components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py`
- `./.venv/bin/pre-commit run black --files components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py components/src/dynamo/profiler/utils/config_modifiers/vllm.py components/src/dynamo/profiler/utils/model_info.py`
- `./.venv/bin/pre-commit run ruff --files components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py components/src/dynamo/profiler/tests/unit/test_model_info.py components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py components/src/dynamo/profiler/utils/config_modifiers/vllm.py components/src/dynamo/profiler/utils/model_info.py components/src/dynamo/profiler/profile_sla.py components/src/dynamo/profiler/interpolation.py components/src/dynamo/profiler/thorough.py`

Note: `./.venv/bin/pre-commit run --all-files` gets past black locally but the marker-report hook cannot collect `tests/kvbm_integration/test_consolidator_config_unit.py` in this workstation because `kvbm.trtllm_integration` is not installed. CI marker-report is the source of truth for that hook.
