### PR TITLE
docs(build): explain patchelf extra in follow-up docs

### DIFF
--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -53,6 +53,8 @@ git clone https://github.com/sgl-project/sglang.git
 cd sglang && uv pip install -e "python"
 ```
 
+[Maturin](https://github.com/PyO3/maturin) is the Rust-Python bindings build tool. The `patchelf` extra lets maturin patch native extension library paths during the build.
+
 This is the ideal way for agents to develop. You can provide the path to both repos and the virtual environment and have it rerun these commands as it makes changes
 </Accordion>
 

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -258,6 +258,8 @@ pip install /tmp/wheels/*.whl       # ai-dynamo-runtime
 pip install /path/to/dynamo         # ai-dynamo (components/ tree)
 ```
 
+[Maturin](https://github.com/PyO3/maturin) is the Rust-Python bindings build tool. The `patchelf` extra lets maturin patch native extension library paths during the build.
+
 Building the wheel needs a Rust toolchain plus `clang`, `cmake`,
 `protobuf-compiler`, and `libssl-dev`.
 


### PR DESCRIPTION
Summary
- Add the existing maturin/patchelf explanation to the SGLang development install docs.
- Add the same explanation to the unified backends runtime wheel build docs.
- Follow-up to #10792 review feedback.

cc @dagil-nvidia

Validation
- Pre-commit hooks run during commit: codespell and basic formatting checks passed.
- `pytest-marker-report` was skipped on retry because the local environment fails collection with `ImportError: cannot import name 'MultimodalEmbeddingCachePublisher' from 'dynamo._core'`; this is unrelated to the docs-only change.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification about Maturin, the Rust-Python bindings build tool.
  * Added explanation of the patchelf extra's role in patching native extension library paths during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->