### PR TITLE
docs: fix llms.txt agent directive and backfill page subtitles

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: How to Build and Publish Dynamo Docs
+subtitle: Branch model, sync workflow, and publishing pipeline for the Fern-powered Dynamo documentation site.
 sidebar-title: Building and Publishing
 ---
 

--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: SGLang
+subtitle: SGLang engines run in Dynamo's distributed runtime with disaggregated serving, KV-aware routing, and request cancellation.
 ---
 
 ## Use the Latest Release

--- a/docs/backends/sglang/sglang-diffusion.md
+++ b/docs/backends/sglang/sglang-diffusion.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Diffusion
+subtitle: SGLang supports LLM diffusion, image diffusion, and text-to-video generation through dedicated worker flags.
 ---
 
 Dynamo SGLang supports three types of diffusion-based generation: **LLM diffusion** (text generation via iterative refinement), **image diffusion** (text-to-image), and **video generation** (text-to-video). Each uses a different worker flag and handler, but all integrate with SGLang's `DiffGenerator`.

--- a/docs/backends/sglang/sglang-disaggregation.md
+++ b/docs/backends/sglang/sglang-disaggregation.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Disaggregation
+subtitle: SGLang runs prefill and decode as separate workers in Dynamo, coordinated by a bootstrap handshake with RDMA-based KV cache transfer.
 ---
 
 This document explains how SGLang's disaggregated prefill-decode architecture works, both standalone and within Dynamo.

--- a/docs/backends/sglang/sglang-examples.md
+++ b/docs/backends/sglang/sglang-examples.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Examples
+subtitle: Launch scripts cover aggregated, disaggregated, KV-routed, multimodal, and diffusion deployments on the SGLang backend.
 ---
 
 For quick start instructions, see the [SGLang README](README.md). This document provides all deployment patterns for running SGLang with Dynamo, including LLMs, multimodal, and diffusion models, and Kubernetes deployment.

--- a/docs/backends/sglang/sglang-logits-processing.md
+++ b/docs/backends/sglang/sglang-logits-processing.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Logits Processing
+subtitle: Custom logits processors plug into SGLang's per-step callback through Dynamo's backend-agnostic spec adapter.
 ---
 
 For general SGLang features and configuration, see the [Reference Guide](sglang-reference-guide.md).

--- a/docs/backends/sglang/sglang-observability.md
+++ b/docs/backends/sglang/sglang-observability.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Observability
+subtitle: Prometheus metrics, forward pass telemetry, distributed tracing, and Grafana dashboards for SGLang workers in Dynamo.
 ---
 
 This guide covers metrics, tracing, and visualization for SGLang deployments running through Dynamo.

--- a/docs/backends/trtllm/README.md
+++ b/docs/backends/trtllm/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: TensorRT-LLM
+subtitle: TensorRT-LLM engines run in Dynamo's distributed runtime with disaggregated serving, KV-aware routing, and multinode support.
 ---
 
 ## Use the Latest Release

--- a/docs/backends/trtllm/trtllm-diffusion.md
+++ b/docs/backends/trtllm/trtllm-diffusion.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Video Diffusion Support (Experimental)
+subtitle: Experimental text-to-video and text-to-image diffusion in TensorRT-LLM using the visual_gen module and Diffusers pipelines.
 ---
 
 For general TensorRT-LLM features and configuration, see the [Reference Guide](trtllm-reference-guide.md).

--- a/docs/backends/trtllm/trtllm-examples.md
+++ b/docs/backends/trtllm/trtllm-examples.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Examples
+subtitle: Launch scripts cover aggregated, disaggregated, KV-routed, and multinode deployment patterns for the TensorRT-LLM backend.
 ---
 
 For quick start instructions, see the [TensorRT-LLM README](README.md). This document provides all deployment patterns for running TensorRT-LLM with Dynamo, including single-node, multi-node, and Kubernetes deployments.

--- a/docs/backends/trtllm/trtllm-known-issues.md
+++ b/docs/backends/trtllm/trtllm-known-issues.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Known Issues and Mitigations
+subtitle: Known issues for TensorRT-LLM in Dynamo, including disaggregated KV cache exhaustion and driver mismatch errors, with mitigations.
 ---
 
 For general TensorRT-LLM features and configuration, see the [Reference Guide](trtllm-reference-guide.md).

--- a/docs/backends/trtllm/trtllm-observability.md
+++ b/docs/backends/trtllm/trtllm-observability.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Prometheus
+subtitle: TensorRT-LLM exposes request, latency, and KV cache transfer metrics through Dynamo's Prometheus /metrics endpoint.
 ---
 
 For general TensorRT-LLM features and configuration, see the [Reference Guide](trtllm-reference-guide.md).

--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: vLLM
+subtitle: vLLM engines run in Dynamo's distributed runtime with disaggregated serving, NIXL KV transfer, and KV-aware routing.
 ---
 
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.

--- a/docs/backends/vllm/vllm-examples.md
+++ b/docs/backends/vllm/vllm-examples.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Examples
+subtitle: Launch scripts cover aggregated, disaggregated, KV-routed, and expert-parallel deployment patterns for the vLLM backend.
 ---
 
 For quick start instructions, see the [vLLM README](README.md). This document provides all deployment patterns for running vLLM with Dynamo, including aggregated, disaggregated, KV-routed, and expert-parallel configurations.

--- a/docs/backends/vllm/vllm-logits-processing.md
+++ b/docs/backends/vllm/vllm-logits-processing.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Logits Processing
+subtitle: Custom logits processors plug into vLLM through Dynamo's engine-loaded adapter and per-request SamplingParams.extra_args.
 ---
 
 For general vLLM features and configuration, see the [Reference Guide](vllm-reference-guide.md).

--- a/docs/backends/vllm/vllm-observability.md
+++ b/docs/backends/vllm/vllm-observability.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Prometheus
+subtitle: vLLM exposes request, latency, scheduler, and disaggregation metrics through Dynamo's Prometheus /metrics endpoint.
 ---
 
 ## Overview

--- a/docs/backends/vllm/vllm-omni.md
+++ b/docs/backends/vllm/vllm-omni.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: vLLM-Omni
+subtitle: vLLM-Omni serves text-to-image, text-to-video, image-to-video, and text-to-speech models through OpenAI-compatible endpoints.
 ---
 
 Dynamo supports multimodal generation through the [vLLM-Omni](https://github.com/vllm-project/vllm-omni) backend. This integration exposes text-to-image, text-to-video, image-to-video, and text-to-audio (TTS) capabilities via OpenAI-compatible API endpoints.

--- a/docs/components/frontend/README.md
+++ b/docs/components/frontend/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Frontend
+subtitle: API gateway that exposes OpenAI HTTP and KServe gRPC endpoints and handles request preprocessing, routing, and response formatting.
 ---
 
 The Dynamo Frontend is the API gateway for serving LLM inference requests. It provides OpenAI-compatible HTTP endpoints and KServe gRPC endpoints, handling request preprocessing, routing, and response formatting.

--- a/docs/components/frontend/Tokenizer.md
+++ b/docs/components/frontend/Tokenizer.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Tokenizer
+subtitle: Selects between the default HuggingFace and fastokens tokenizer backends for BPE models served through the Dynamo Frontend.
 ---
 
 The Dynamo Frontend supports multiple tokenizer backends for BPE-based `tokenizer.json` models. `BPE` is the underlying tokenization algorithm, not a backend-specific feature: both the default HuggingFace path and the `fastokens` path can serve these models. The backend choice controls which implementation performs tokenization before requests are sent to the inference engine.

--- a/docs/components/frontend/frontend-guide.md
+++ b/docs/components/frontend/frontend-guide.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Frontend Guide
+subtitle: Configures the KServe gRPC frontend, including supported endpoints, gRPC tuning, and registering OpenAI or tensor-based backends.
 ---
 
 This guide covers the KServe gRPC frontend configuration and integration for the Dynamo Frontend.

--- a/docs/components/kvbm/README.md
+++ b/docs/components/kvbm/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: KVBM
+subtitle: Unified memory layer and write-through KV cache spanning GPU, host, SSD, and remote storage via NIXL for TensorRT-LLM and vLLM.
 ---
 
 <p align="left">

--- a/docs/components/planner/README.md
+++ b/docs/components/planner/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Planner
+subtitle: Autoscaler that adjusts prefill and decode replicas using engine performance models and traffic prediction to meet TTFT and ITL SLAs.
 ---
 
 ## Why LLM Inference Needs a Different Autoscaler

--- a/docs/components/planner/global-planner.md
+++ b/docs/components/planner/global-planner.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Global Planner Deployment Guide
+subtitle: Deploys GlobalPlanner as the centralized scaling layer for multi-DGD policy enforcement and single-endpoint multi-pool deployments.
 ---
 
 This guide explains how to deploy `GlobalPlanner` and when to use it. `GlobalPlanner` is the centralized scaling execution layer for deployments where multiple DGDs should delegate scaling through one component, whether those DGDs expose separate endpoints or sit behind one shared endpoint.

--- a/docs/components/planner/planner-examples.md
+++ b/docs/components/planner/planner-examples.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Planner Examples
+subtitle: Examples for custom load predictors and the VirtualConnector for non-Kubernetes scaling environments.
 ---
 
 Planner-specific examples for advanced configuration and non-Kubernetes

--- a/docs/components/planner/planner-guide.md
+++ b/docs/components/planner/planner-guide.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Planner Guide
+subtitle: Configures Planner optimization targets, scaling modes, and PlannerConfig fields for production deployments.
 ---
 
 <p align="left">

--- a/docs/components/profiler/README.md
+++ b/docs/components/profiler/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Profiler
+subtitle: Automated performance analysis that finds optimal prefill and decode parallelism and generates SLA-driven deployment configurations.
 ---
 
 The Dynamo Profiler is an automated performance analysis tool that measures model inference characteristics to optimize deployment configurations. It determines optimal tensor parallelism (TP) settings for prefill and decode phases, generates performance interpolation data, and enables SLA-driven autoscaling through the Planner.

--- a/docs/components/profiler/profiler-examples.md
+++ b/docs/components/profiler/profiler-examples.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Profiler Examples
+subtitle: Complete DGDR profiling examples for dense and MoE models across rapid and thorough search strategies.
 ---
 
 Complete examples for profiling with DGDRs.

--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Profiler Guide
+subtitle: Runs the AI Configurator-driven profiling pipeline that turns a model, SLA targets, and backend into a ready-to-deploy DGD.
 ---
 
 ## Overview

--- a/docs/components/router/README.md
+++ b/docs/components/router/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Router
+subtitle: KV cache-aware router that picks workers by combined prefill and decode cost to maximize throughput and minimize latency.
 ---
 
 <p align="left">

--- a/docs/components/router/router-examples.md
+++ b/docs/components/router/router-examples.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Router Examples
+subtitle: Worked examples for the KvRouter Python API, Kubernetes deployments, and custom routing patterns.
 ---
 
 For quick start instructions, see the [Router README](README.md). This document provides further examples for using the Dynamo Router, including Python API usage, Kubernetes deployments, and custom routing patterns.

--- a/docs/dynosim/mocker.md
+++ b/docs/dynosim/mocker.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Live Simulation with Mocker
+subtitle: Mocker simulates production engine scheduling, KV cache, and timing so you can exercise Dynamo's frontend, router, and planner without GPUs.
 ---
 
 Mocker is the live simulated engine in DynoSim. It runs as a Dynamo backend, registers workers, publishes KV events, and exercises the real frontend/router/planner path without requiring GPUs.

--- a/docs/fault-tolerance/graceful-shutdown.md
+++ b/docs/fault-tolerance/graceful-shutdown.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Graceful Shutdown
+subtitle: Coordinates SIGTERM and SIGINT handling so endpoints drain, in-flight requests finish, and pods restart cleanly.
 ---
 
 This document describes how Dynamo components handle shutdown signals to ensure in-flight requests complete successfully and resources are properly cleaned up.

--- a/docs/fault-tolerance/request-cancellation.md
+++ b/docs/fault-tolerance/request-cancellation.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Request Cancellation
+subtitle: Cancels in-flight requests across frontend and workers when clients disconnect, freeing GPU resources end to end.
 ---
 
 This document describes how Dynamo implements request cancellation to cancel in-flight requests between Dynamo workers. Request cancellation allows in-flight requests to terminate early, saving computational resources that would otherwise be spent on responses that are no longer needed.

--- a/docs/fault-tolerance/request-migration.md
+++ b/docs/fault-tolerance/request-migration.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Request Migration
+subtitle: Preserves token state and reissues in-flight requests on healthy workers when their original worker fails.
 ---
 
 <p align="left">

--- a/docs/fault-tolerance/request-rejection.md
+++ b/docs/fault-tolerance/request-rejection.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Request Rejection
+subtitle: Sheds load with HTTP 503 when all workers exceed admission-control thresholds, preventing cascading failures and OOMs.
 ---
 
 This document describes how Dynamo implements request rejection to prevent system overload and maintain service stability under high load conditions.

--- a/docs/fault-tolerance/testing.md
+++ b/docs/fault-tolerance/testing.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Testing
+subtitle: Pytest framework for validating Dynamo's cancellation, migration, etcd HA, and hardware fault-injection paths under induced failures.
 ---
 
 This document describes the test infrastructure for validating Dynamo's fault tolerance mechanisms. The testing framework supports request cancellation, migration, etcd HA, and hardware fault injection scenarios.

--- a/docs/features/diffusion/fastvideo.md
+++ b/docs/features/diffusion/fastvideo.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: FastVideo
+subtitle: Deploys FastVideo text-to-video generation on Dynamo through a custom worker that serves the /v1/videos endpoint.
 sidebar-title: FastVideo
 ---
 

--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Examples
+subtitle: Reference deployments for the SGLang, TensorRT-LLM, and vLLM backends, plus a Hello World walkthrough.
 ---
 
 The examples below assume you build the latest image yourself from source. If using a prebuilt image, follow the examples from the corresponding branch.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Introduction to Dynamo
+subtitle: Overview of Dynamo's design principles, performance techniques, and production features for distributed LLM inference.
 sidebar-title: Introduction
 ---
 

--- a/docs/integrations/flexkv-integration.md
+++ b/docs/integrations/flexkv-integration.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: FlexKV
+subtitle: Integrate FlexKV with Dynamo's vLLM backend for multi-level KV cache offloading across CPU, SSD, and cloud storage.
 ---
 
 ## Introduction

--- a/docs/integrations/lmcache-integration.md
+++ b/docs/integrations/lmcache-integration.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: LMCache
+subtitle: Integrate LMCache with Dynamo's vLLM backend for prefill-once, reuse-everywhere KV cache across requests.
 ---
 
 ## Introduction

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Kubernetes Quickstart
+subtitle: Quickstart for deploying a model on Kubernetes with Helm and the Dynamo operator.
 ---
 
 Get a model running on Kubernetes in minutes.

--- a/docs/kubernetes/autoscaling.md
+++ b/docs/kubernetes/autoscaling.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Autoscaling
+subtitle: Scales DGD services with the DynamoGraphDeploymentScalingAdapter using KEDA, Kubernetes HPA, or the Dynamo Planner.
 ---
 
 This guide explains how to configure autoscaling for DynamoGraphDeployment (DGD) services using the `sglang-agg` example from `examples/backends/sglang/deploy/agg.yaml`.

--- a/docs/kubernetes/cloud-providers/ecs/ecs.md
+++ b/docs/kubernetes/cloud-providers/ecs/ecs.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Amazon Elastic Container Service (ECS)
+subtitle: Runs Dynamo on Amazon ECS with EC2 GPU clusters for vLLM workers and Fargate tasks for etcd and NATS.
 ---
 
 ## 1. EC2 Cluster Setup (for vLLM workloads)

--- a/docs/kubernetes/cloud-providers/eks/efa.md
+++ b/docs/kubernetes/cloud-providers/eks/efa.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: EFA (RDMA over AWS Fabric) on EKS
+subtitle: Enables GPU-Direct RDMA over AWS Elastic Fabric Adapter so disaggregated workers transfer KV cache across EKS nodes without TCP.
 ---
 
 This guide covers setting up RDMA over AWS Elastic Fabric Adapter (EFA) on EKS for high-performance disaggregated inference with Dynamo. EFA is the only RDMA fabric available on AWS — InfiniBand and RoCE are not offered. With EFA, Dynamo's prefill and decode workers transfer KV cache directly between GPUs across nodes via GPU-Direct RDMA, bypassing CPU and TCP/IP stacks.

--- a/docs/kubernetes/cloud-providers/eks/efs.md
+++ b/docs/kubernetes/cloud-providers/eks/efs.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Amazon EFS Setup for EKS
+subtitle: Creates an Amazon EFS file system so Dynamo workers on EKS share model weights and compilation cache across nodes.
 ---
 
 This guide walks through creating an Amazon EFS file system and connecting it to your EKS cluster. The EFS CSI Driver was already installed as an addon via `eksctl.yaml` during cluster creation. Now we need to create the actual file system and make it available to Kubernetes workloads.

--- a/docs/kubernetes/cloud-providers/eks/eks.md
+++ b/docs/kubernetes/cloud-providers/eks/eks.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Amazon Elastic Kubernetes Service (EKS)
+subtitle: Deploys the Dynamo platform on Amazon EKS, including cluster creation, GPU node groups, and add-ons.
 ---
 
 This guide demonstrates the Dynamo platform on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/kubernetes/deployment/dynamomodel-guide.md
+++ b/docs/kubernetes/deployment/dynamomodel-guide.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Managing Models with DynamoModel
+subtitle: Deploys LoRA adapters and tracks model endpoints with the DynamoModel custom resource alongside DGDs.
 ---
 
 ## Overview

--- a/docs/kubernetes/deployment/minikube.md
+++ b/docs/kubernetes/deployment/minikube.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Minikube Setup
+subtitle: Sets up a local Minikube cluster with GPU support and Istio for running the Dynamo Kubernetes Platform.
 ---
 
 Don't have a Kubernetes cluster? No problem! You can set up a local development environment using Minikube. This guide walks through the set up of everything you need to run Dynamo Kubernetes Platform locally.

--- a/docs/kubernetes/deployment/multinode-deployment.md
+++ b/docs/kubernetes/deployment/multinode-deployment.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Multinode Deployments
+subtitle: Scales Dynamo inference across multiple GPU nodes with Grove and KAI-Scheduler for large-model tensor parallelism.
 ---
 
 This guide explains how to deploy Dynamo workloads across multiple nodes. Multinode deployments enable you to scale compute-intensive LLM workloads across multiple physical machines, maximizing GPU utilization and supporting larger models.

--- a/docs/kubernetes/dgdr-examples.md
+++ b/docs/kubernetes/dgdr-examples.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: DGDR Examples
+subtitle: Practical DynamoGraphDeploymentRequest examples covering AIC estimates, online profiling, and SLA-driven generation.
 ---
 
 Practical examples for deploying with `DynamoGraphDeploymentRequest` (DGDR).

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: DGDR Reference
+subtitle: Field reference for DynamoGraphDeploymentRequest, the deploy-by-intent generator that profiles and produces a DGD.
 ---
 
 A `DynamoGraphDeploymentRequest` (DGDR) is Dynamo's deploy-by-intent generator

--- a/docs/kubernetes/dynamo-operator.md
+++ b/docs/kubernetes/dynamo-operator.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Dynamo Operator
+subtitle: Reference for the Dynamo Kubernetes operator covering its controllers, deployment modes, and reconciliation workflow.
 ---
 
 ## Overview

--- a/docs/kubernetes/grove.md
+++ b/docs/kubernetes/grove.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Grove
+subtitle: Kubernetes API for orchestrating disaggregated inference with gang scheduling, multi-level autoscaling, and topology-aware placement.
 ---
 
 Grove is a Kubernetes API specifically designed to address the orchestration challenges of modern AI workloads, particularly disaggregated inference systems. Grove provides seamless integration with NVIDIA Dynamo for comprehensive AI infrastructure management.

--- a/docs/kubernetes/installation-guide.md
+++ b/docs/kubernetes/installation-guide.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Installation Guide
+subtitle: Installs the GPU Operator and Dynamo Platform Helm charts along with optional Grove, RDMA, and Prometheus add-ons.
 ---
 
 This guide walks you through installing everything needed to deploy models with Dynamo on Kubernetes. Follow the steps in order — each builds on the previous one.

--- a/docs/kubernetes/observability/logging.md
+++ b/docs/kubernetes/observability/logging.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Logging
+subtitle: Aggregates Dynamo logs on Kubernetes with Grafana Loki and Alloy for cluster-wide log querying.
 ---
 
 This guide demonstrates how to set up logging for Dynamo in Kubernetes using Grafana Loki and Alloy. This setup provides a simple reference logging setup that can be followed in Kubernetes clusters including Minikube and MicroK8s.

--- a/docs/kubernetes/observability/metrics.md
+++ b/docs/kubernetes/observability/metrics.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Metrics
+subtitle: Collects and visualizes Dynamo component metrics on Kubernetes with kube-prometheus-stack PodMonitors and Grafana.
 ---
 
 ## Overview

--- a/docs/kubernetes/observability/operator-metrics.md
+++ b/docs/kubernetes/observability/operator-metrics.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Operator Metrics
+subtitle: Monitors Dynamo operator health with Prometheus metrics for controller reconciliation, webhooks, and managed resources.
 ---
 
 ## Overview

--- a/docs/kubernetes/rolling-update.md
+++ b/docs/kubernetes/rolling-update.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Rolling Updates
+subtitle: Updates DGD worker images, resources, and arguments with managed rolling updates across Deployment, Grove, and LWS backends.
 ---
 
 This guide covers how rolling updates work for `DynamoGraphDeployment` (DGD) resources. Rolling updates allow you to update worker configurations (images, resources, environment variables, etc.) with minimal downtime by gradually replacing old pods with new ones.

--- a/docs/kubernetes/service-discovery.md
+++ b/docs/kubernetes/service-discovery.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Service Discovery
+subtitle: Lets Dynamo frontends, workers, and planners locate each other on Kubernetes via native CRDs and EndpointSlices, or via etcd.
 ---
 
 Dynamo components (frontends, workers, planner) need to be able to discover each other and their capabilities at runtime. We refer to this as service discovery. There are 2 kinds of service discovery backends supported on Kubernetes.

--- a/docs/kubernetes/shadow-engine-failover.md
+++ b/docs/kubernetes/shadow-engine-failover.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Shadow Engine Failover
+subtitle: Keeps a standby engine attached to GPU-resident model weights so process failures recover without reloading the model.
 ---
 
 > ⚠️ **Experimental Feature**: Shadow Engine Failover is an opt-in preview

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Snapshotting GPU Workers
+subtitle: Checkpoints initialized GPU workers with CRIU and cuda-checkpoint so later pods warm-start in seconds instead of minutes.
 ---
 
 > ⚠️ **Experimental Feature**: Dynamo Snapshot is currently in preview and may only be functional in some cluster setups. The `snapshot-agent` DaemonSet runs in privileged mode to perform CRIU operations. See [Limitations](#limitations) for details.

--- a/docs/kubernetes/topology-aware-scheduling.md
+++ b/docs/kubernetes/topology-aware-scheduling.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Topology Aware Scheduling
+subtitle: Packs prefill, decode, and routing pods within the same rack or zone to reduce inter-node latency.
 ---
 
 Topology Aware Scheduling (TAS) lets you control where Dynamo places inference workload pods relative to the cluster's network topology. By packing related pods within the same rack, block, or other topology domain, you reduce inter-node latency and improve throughput — especially for disaggregated serving where prefill, decode, and routing components communicate frequently.

--- a/docs/kubernetes/webhooks.md
+++ b/docs/kubernetes/webhooks.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Webhooks
+subtitle: Dynamo operator admission webhooks that validate and default Dynamo custom resources before persistence.
 ---
 
 This document describes the webhook functionality in the Dynamo Operator, including validation webhooks, certificate management, and troubleshooting.

--- a/docs/observability/health-checks.md
+++ b/docs/observability/health-checks.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Health Checks
+subtitle: HTTP health and liveness endpoints Dynamo components expose locally for wiring startup, liveness, and readiness probes.
 ---
 
 ## Overview

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Logging
+subtitle: Structured text and JSONL logging for local Dynamo processes, with optional OTLP export to Loki via the OpenTelemetry Collector.
 ---
 
 > [!IMPORTANT]

--- a/docs/observability/metrics-developer-guide.md
+++ b/docs/observability/metrics-developer-guide.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Metrics Developer Guide
+subtitle: Reference for creating counters, gauges, and histograms with Dynamo's metrics API, surfaced on the local /metrics endpoint.
 ---
 
 This guide explains how to create and use custom metrics in Dynamo components using the Dynamo metrics API.

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Metrics
+subtitle: Reference for the Prometheus metrics Dynamo's runtime, frontend, and workers expose on the local system metrics endpoint.
 ---
 
 ## Overview

--- a/docs/observability/prometheus-grafana.md
+++ b/docs/observability/prometheus-grafana.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Prometheus + Grafana Setup
+subtitle: Single-machine setup for collecting Dynamo metrics in Prometheus and visualizing them in Grafana for local development and demos.
 ---
 
 ## Overview

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Tracing
+subtitle: OpenTelemetry distributed tracing for Dynamo running locally via Docker Compose, exporting spans to Tempo and visualizing them in Grafana.
 ---
 
 ## Overview

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Feature Matrix
+subtitle: Compatibility matrix for Dynamo features across the SGLang, TensorRT-LLM, and vLLM backends.
 ---
 
 This document provides a comprehensive compatibility matrix for key Dynamo features across the supported backends.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Glossary
+subtitle: Definitions of core Dynamo terms covering disaggregated serving, KV cache, components, and the distributed runtime.
 ---
 
 ## B

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -22,7 +22,7 @@ instances:
 title: NVIDIA Dynamo Documentation
 
 agents:
-  page-directive: "For clean Markdown content of this page, append .md to this URL. For the complete documentation index, see https://docs.nvidia.com/dynamo/llms.txt. For full content including API reference and SDK examples, see https://docs.nvidia.com/dynamo/llms-full.txt."
+  page-directive: "For clean Markdown content of this page, append .md to this URL. For the complete documentation index, see https://docs.nvidia.com/dynamo/latest/llms.txt. For section-specific indexes, append /llms.txt to any section URL."
 
 
 products:


### PR DESCRIPTION
## Summary

The `agents.page-directive` in `fern/docs.yml` is injected into every page's Markdown output and is the canonical entry point we advertise to AI agents (Cursor, Claude Code, etc.). It currently points them at `https://docs.nvidia.com/dynamo/llms.txt`.

That bare product-root URL is a Fern-generated **stub** — it lists only the first 5 Getting Started pages (linked under `/latest/`) and omits the other ~165 pages (Kubernetes, components, backends, integrations, digest, recipes). So an agent that follows our own directive to "the complete documentation index" gets a near-empty map of the docs.

This is maximal-blast-radius because the directive is injected into **every** page, so any page an agent reads actively routes it to the stub.

## What this changes

One line in `fern/docs.yml`:

- **Repoint** the directive at the healthy per-version index — `https://docs.nvidia.com/dynamo/latest/llms.txt` (~170 entries, each with a one-line description) instead of the 5-page root stub.
- **Surface the working escape hatch** — "append `/llms.txt` to any section URL" (verified: section indexes like `/dynamo/dev/kubernetes-deployment/llms.txt` return full content).
- **Drop the `llms-full.txt` clause** — Fern [deprecated full-site concatenation](https://buildwithfern.com/learn/docs/ai-features/llms-txt), so that URL now returns the same stub rather than full page content. The old directive promised "full content including API reference and SDK examples" there, which is a dead end.

## Why not a redirect / root override

Fern flags unversioned→versioned redirects as an anti-pattern, and redirects aren't documented to fire for generated `.txt` artifacts. Repointing the directive is a one-line, in-config fix with no routing side effects. A follow-up could add a curated custom root `llms.txt` via `agents.llms-txt`, plus backfilling `description` frontmatter on the ~dozen pages still missing it.

## Verification

| URL | Entries |
|---|---|
| `/dynamo/llms.txt` (old target — stub) | 5 |
| `/dynamo/latest/llms.txt` (new target) | ~170 |
| `/dynamo/dev/llms.txt` | ~187 |

No code paths touched; docs-config only. The directive change takes effect on the next docs build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation indexing to direct users to the latest version of complete documentation.
  * Improved section-specific documentation index organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->