### PR TITLE
ci(checkpoint): add TRTLLM DynamoCheckpoint coverage

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -743,6 +743,33 @@ jobs:
       copy_timeout_minutes: 20
     secrets: inherit
 
+  snapshot-placeholder-trtllm:
+    name: TRTLLM Snapshot Placeholder
+    needs: [trtllm-copy-to-acr]
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: prod-default-v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build and push snapshot placeholder
+        uses: ./.github/actions/build-deploy-component
+        with:
+          component: snapshot
+          target: placeholder
+          image_tag: ${{ github.sha }}-trtllm-placeholder
+          builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+          extra_tags: |
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-trtllm-placeholder
+          extra_build_args: |
+            BASE_IMAGE=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-trtllm-runtime
+
   trtllm-dev-copy-to-acr:
     name: trtllm-dev # This name overlaps with other trtllm jobs to group them in the UI
     needs: [trtllm-dev-build]
@@ -884,6 +911,33 @@ jobs:
         checkpoint_enabled: 'true'
         checkpoint_storage_size: 64Gi
 
+  deploy-operator-checkpoint-trtllm:
+    name: TRTLLM DynamoCheckpoint Operator Setup
+    needs: [operator]
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: prod-deploy-tester-v1
+    permissions:
+      contents: read
+    outputs:
+      namespace: ${{ steps.setup.outputs.namespace }}
+      vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
+      operator_tag: ${{ steps.setup.outputs.operator_tag }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: Setup vCluster and operator
+      id: setup
+      uses: ./.github/actions/setup-dynamo-operator
+      with:
+        vcluster_name: ci-${{ github.run_id }}-checkpoint-trtllm
+        vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-trtllm-dt
+        registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+        operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
+        hf_token: ${{ secrets.HF_TOKEN }}
+        dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+        dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        checkpoint_enabled: 'true'
+        checkpoint_storage_size: 64Gi
+
   deploy-snapshot-agent-checkpoint-vllm:
     name: vLLM DynamoCheckpoint Snapshot Agent Setup
     needs: [deploy-operator-checkpoint-vllm, snapshot-agent]
@@ -969,6 +1023,52 @@ jobs:
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
+      - name: Install snapshot-agent
+        uses: ./.github/actions/setup-snapshot-agent
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+
+  deploy-snapshot-agent-checkpoint-trtllm:
+    name: TRTLLM DynamoCheckpoint Snapshot Agent Setup
+    needs: [deploy-operator-checkpoint-trtllm, snapshot-agent]
+    if: |
+      github.event_name != 'workflow_dispatch' &&
+      needs.deploy-operator-checkpoint-trtllm.result == 'success' &&
+      needs.snapshot-agent.result == 'success'
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Check if vCluster exists
+        id: vcluster-check
+        uses: ./.github/actions/check-vcluster-exists
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+      - name: Self-bootstrap vCluster (rerun)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+      - name: Connect to vCluster
+        id: connect-vcluster
+        uses: ./.github/actions/connect-vcluster
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Install snapshot-agent
         uses: ./.github/actions/setup-snapshot-agent
         with:
@@ -1104,6 +1204,70 @@ jobs:
             --checkpoint-backend=sglang
             --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-dynamo-frontend
 
+  deploy-test-checkpoint-trtllm:
+    name: TRTLLM DynamoCheckpoint Deploy Test
+    needs: [deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, snapshot-placeholder-trtllm, frontend-copy-to-acr]
+    if: |
+      always() && !cancelled() &&
+      needs.deploy-snapshot-agent-checkpoint-trtllm.result == 'success' &&
+      needs.snapshot-placeholder-trtllm.result == 'success' &&
+      needs.frontend-copy-to-acr.result == 'success'
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Check if vCluster exists
+        id: vcluster-check
+        uses: ./.github/actions/check-vcluster-exists
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+      - name: Self-bootstrap vCluster (rerun)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+      - name: Connect to vCluster
+        id: connect-vcluster
+        uses: ./.github/actions/connect-vcluster
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+      - name: Install snapshot-agent (rerun bootstrap)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-snapshot-agent
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+      - name: Run DynamoCheckpoint Deploy Test
+        uses: ./.github/actions/dynamo-deploy-test
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.operator_tag }}
+          framework: checkpoint
+          profile: dgd_restore
+          image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-trtllm-placeholder
+          test_name: checkpoint_dgd_restore_trtllm
+          test_file: tests/deploy/test_dynamocheckpoint.py
+          extra_pytest_args: >-
+            -m dynamocheckpoint
+            --checkpoint-backend=trtllm
+            --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-dynamo-frontend
+
   deploy-cleanup:
     if: always()
     needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-gaie]
@@ -1144,6 +1308,19 @@ jobs:
       with:
         vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
         vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
+
+  deploy-cleanup-checkpoint-trtllm:
+    name: TRTLLM DynamoCheckpoint Cleanup
+    if: always() && github.event_name != 'workflow_dispatch'
+    needs: [deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, deploy-test-checkpoint-trtllm]
+    runs-on: prod-deploy-tester-v1
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: Teardown vCluster
+      uses: ./.github/actions/teardown-dynamo-operator
+      with:
+        vcluster_name: ci-${{ github.run_id }}-checkpoint-trtllm
+        vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-trtllm-dt
 
   # ============================================================================
   # GAIE DEPLOY TEST
@@ -1215,17 +1392,22 @@ jobs:
       - deploy-test-trtllm
       - deploy-operator-checkpoint-vllm
       - deploy-operator-checkpoint-sglang
+      - deploy-operator-checkpoint-trtllm
       - deploy-snapshot-agent-checkpoint-vllm
       - deploy-snapshot-agent-checkpoint-sglang
+      - deploy-snapshot-agent-checkpoint-trtllm
       - snapshot-placeholder-vllm
       - snapshot-placeholder-sglang
+      - snapshot-placeholder-trtllm
       - frontend-copy-to-acr
       - deploy-test-checkpoint-vllm
       - deploy-test-checkpoint-sglang
+      - deploy-test-checkpoint-trtllm
       - deploy-test-gaie
       - deploy-cleanup
       - deploy-cleanup-checkpoint-vllm
       - deploy-cleanup-checkpoint-sglang
+      - deploy-cleanup-checkpoint-trtllm
     if: always()
     steps:
       - name: "Check all deploy test jobs"
@@ -1240,7 +1422,7 @@ jobs:
     name: Clean K8s builder if exists
     runs-on: prod-default-small-v2
     if: always()
-    needs: [vllm-build, sglang-build, trtllm-build, vllm-dev-build, sglang-dev-build, trtllm-dev-build, vllm-efa-build, sglang-efa-build, trtllm-efa-build, operator, snapshot-agent, snapshot-placeholder-vllm, snapshot-placeholder-sglang, power-agent, frontend-build, planner-build]
+    needs: [vllm-build, sglang-build, trtllm-build, vllm-dev-build, sglang-dev-build, trtllm-dev-build, vllm-efa-build, sglang-efa-build, trtllm-efa-build, operator, snapshot-agent, snapshot-placeholder-vllm, snapshot-placeholder-sglang, snapshot-placeholder-trtllm, power-agent, frontend-build, planner-build]
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -863,9 +863,7 @@ jobs:
     needs: [changed-files, trtllm-copy-to-acr]
     if: |
       always() && !cancelled() &&
-      (needs.changed-files.outputs.operator == 'true' ||
-       needs.changed-files.outputs.snapshot == 'true' ||
-       needs.changed-files.outputs.deploy == 'true')
+      (needs.changed-files.outputs.snapshot == 'true')
     runs-on: prod-default-v2
     steps:
       - name: Checkout code
@@ -1042,10 +1040,8 @@ jobs:
     name: TRTLLM DynamoCheckpoint Operator Setup
     if: |
       always() && !cancelled() &&
-      (needs.changed-files.outputs.operator == 'true' ||
-       needs.changed-files.outputs.snapshot == 'true' ||
-       needs.changed-files.outputs.deploy == 'true') &&
-      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
+      (needs.changed-files.outputs.snapshot == 'true') &&
+      needs.operator.result == 'success'
     needs: [changed-files, operator]
     runs-on: prod-deploy-tester-v1
     permissions:
@@ -1169,9 +1165,7 @@ jobs:
     needs: [changed-files, deploy-operator-checkpoint-trtllm, snapshot-agent]
     if: |
       always() && !cancelled() &&
-      (needs.changed-files.outputs.operator == 'true' ||
-       needs.changed-files.outputs.snapshot == 'true' ||
-       needs.changed-files.outputs.deploy == 'true') &&
+      (needs.changed-files.outputs.snapshot == 'true') &&
       needs.deploy-operator-checkpoint-trtllm.result == 'success' &&
       needs.snapshot-agent.result == 'success'
     runs-on: prod-deploy-tester-v1
@@ -1348,9 +1342,7 @@ jobs:
     needs: [changed-files, deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, snapshot-placeholder-trtllm, frontend-copy-to-acr]
     if: |
       always() && !cancelled() &&
-      (needs.changed-files.outputs.operator == 'true' ||
-       needs.changed-files.outputs.snapshot == 'true' ||
-       needs.changed-files.outputs.deploy == 'true') &&
+      (needs.changed-files.outputs.snapshot == 'true') &&
       needs.deploy-snapshot-agent-checkpoint-trtllm.result == 'success' &&
       needs.snapshot-placeholder-trtllm.result == 'success' &&
       needs.frontend-copy-to-acr.result == 'success'
@@ -1459,9 +1451,7 @@ jobs:
     name: TRTLLM DynamoCheckpoint Cleanup
     if: |
       always() &&
-      (needs.changed-files.outputs.operator == 'true' ||
-       needs.changed-files.outputs.snapshot == 'true' ||
-       needs.changed-files.outputs.deploy == 'true')
+      (needs.changed-files.outputs.snapshot == 'true')
     needs: [changed-files, deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, deploy-test-checkpoint-trtllm]
     runs-on: prod-deploy-tester-v1
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1059,7 +1059,7 @@ jobs:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-trtllm
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-trtllm-dt
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.operator.result == 'success' && needs.operator.outputs.operator_default_tag || 'main-operator' }}
+          operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -60,6 +60,7 @@ jobs:
       - snapshot-agent
       - snapshot-placeholder-vllm
       - snapshot-placeholder-sglang
+      - snapshot-placeholder-trtllm
       - power-agent
       - vllm-build
       - vllm-dev-build
@@ -98,16 +99,21 @@ jobs:
       - deploy-test-trtllm
       - deploy-operator-checkpoint-vllm
       - deploy-operator-checkpoint-sglang
+      - deploy-operator-checkpoint-trtllm
       - deploy-snapshot-agent-checkpoint-vllm
       - deploy-snapshot-agent-checkpoint-sglang
+      - deploy-snapshot-agent-checkpoint-trtllm
       - snapshot-placeholder-vllm
       - snapshot-placeholder-sglang
+      - snapshot-placeholder-trtllm
       - frontend-copy-to-acr
       - deploy-test-checkpoint-vllm
       - deploy-test-checkpoint-sglang
+      - deploy-test-checkpoint-trtllm
       - deploy-cleanup
       - deploy-cleanup-checkpoint-vllm
       - deploy-cleanup-checkpoint-sglang
+      - deploy-cleanup-checkpoint-trtllm
     if: always()
     steps:
       - name: Check all deploy test jobs
@@ -353,12 +359,14 @@ jobs:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
     needs: [changed-files]
     # `operator` is here because operator changes run the deploy tests, which
-    # deploy the CI-built runtime image.
+    # deploy the CI-built runtime image. `snapshot` is here because
+    # DynamoCheckpoint deploy tests build a snapshot placeholder from it.
     if: |
       needs.changed-files.outputs.core == 'true' ||
       needs.changed-files.outputs.trtllm == 'true' ||
       needs.changed-files.outputs.deploy == 'true' ||
-      needs.changed-files.outputs.operator == 'true'
+      needs.changed-files.outputs.operator == 'true' ||
+      needs.changed-files.outputs.snapshot == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
@@ -839,7 +847,8 @@ jobs:
       (needs.changed-files.outputs.core == 'true' ||
        needs.changed-files.outputs.trtllm == 'true' ||
        needs.changed-files.outputs.deploy == 'true' ||
-       needs.changed-files.outputs.operator == 'true') &&
+       needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true') &&
       needs.trtllm-build.result == 'success'
     uses: ./.github/workflows/shared-copy.yml
     with:
@@ -848,6 +857,37 @@ jobs:
       override_arch: amd64 # We are using AMD64 images only on the rest of the clusters.
       copy_timeout_minutes: 10
     secrets: inherit
+
+  snapshot-placeholder-trtllm:
+    name: TRTLLM Snapshot Placeholder
+    needs: [changed-files, trtllm-copy-to-acr]
+    if: |
+      always() && !cancelled() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true')
+    runs-on: prod-default-v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build and push snapshot placeholder
+        uses: ./.github/actions/build-deploy-component
+        with:
+          component: snapshot
+          target: placeholder
+          image_tag: ${{ github.sha }}-trtllm-placeholder
+          builder_name: ${{ needs.changed-files.outputs.builder_name }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+          extra_tags: |
+            ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-trtllm-placeholder
+          extra_build_args: |
+            BASE_IMAGE=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-trtllm-runtime
 
   # ============================================================================
   # DEPLOY TEST PIPELINES
@@ -998,6 +1038,38 @@ jobs:
           checkpoint_enabled: 'true'
           checkpoint_storage_size: 64Gi
 
+  deploy-operator-checkpoint-trtllm:
+    name: TRTLLM DynamoCheckpoint Operator Setup
+    if: |
+      always() && !cancelled() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true') &&
+      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
+    needs: [changed-files, operator]
+    runs-on: prod-deploy-tester-v1
+    permissions:
+      contents: read
+    outputs:
+      namespace: ${{ steps.setup.outputs.namespace }}
+      vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
+      operator_tag: ${{ steps.setup.outputs.operator_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Setup vCluster and operator
+        id: setup
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ci-${{ github.run_id }}-checkpoint-trtllm
+          vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-trtllm-dt
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.operator.result == 'success' && needs.operator.outputs.operator_default_tag || 'main-operator' }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+
   deploy-snapshot-agent-checkpoint-vllm:
     name: vLLM DynamoCheckpoint Snapshot Agent Setup
     needs: [changed-files, deploy-operator-checkpoint-vllm, snapshot-agent]
@@ -1085,6 +1157,55 @@ jobs:
         with:
           vcluster_name: ${{ needs.deploy-operator-checkpoint-sglang.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator-checkpoint-sglang.outputs.namespace }}
+      - name: Install snapshot-agent
+        uses: ./.github/actions/setup-snapshot-agent
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+
+  deploy-snapshot-agent-checkpoint-trtllm:
+    name: TRTLLM DynamoCheckpoint Snapshot Agent Setup
+    needs: [changed-files, deploy-operator-checkpoint-trtllm, snapshot-agent]
+    if: |
+      always() && !cancelled() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true') &&
+      needs.deploy-operator-checkpoint-trtllm.result == 'success' &&
+      needs.snapshot-agent.result == 'success'
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Check if vCluster exists
+        id: vcluster-check
+        uses: ./.github/actions/check-vcluster-exists
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+      - name: Self-bootstrap vCluster (rerun)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+      - name: Connect to vCluster
+        id: connect-vcluster
+        uses: ./.github/actions/connect-vcluster
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
       - name: Install snapshot-agent
         uses: ./.github/actions/setup-snapshot-agent
         with:
@@ -1222,6 +1343,73 @@ jobs:
             --checkpoint-backend=sglang
             --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-dynamo-frontend
 
+  deploy-test-checkpoint-trtllm:
+    name: TRTLLM DynamoCheckpoint Deploy Test
+    needs: [changed-files, deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, snapshot-placeholder-trtllm, frontend-copy-to-acr]
+    if: |
+      always() && !cancelled() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true') &&
+      needs.deploy-snapshot-agent-checkpoint-trtllm.result == 'success' &&
+      needs.snapshot-placeholder-trtllm.result == 'success' &&
+      needs.frontend-copy-to-acr.result == 'success'
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Check if vCluster exists
+        id: vcluster-check
+        uses: ./.github/actions/check-vcluster-exists
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+      - name: Self-bootstrap vCluster (rerun)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          checkpoint_enabled: 'true'
+          checkpoint_storage_size: 64Gi
+      - name: Connect to vCluster
+        id: connect-vcluster
+        uses: ./.github/actions/connect-vcluster
+        with:
+          vcluster_name: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.vcluster_name }}
+          vcluster_namespace: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.namespace }}
+      - name: Install snapshot-agent (rerun bootstrap)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-snapshot-agent
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+      - name: Run DynamoCheckpoint Deploy Test
+        uses: ./.github/actions/dynamo-deploy-test
+        with:
+          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+          namespace: default
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ needs.deploy-operator-checkpoint-trtllm.outputs.operator_tag }}
+          framework: checkpoint
+          profile: dgd_restore
+          image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-trtllm-placeholder
+          test_name: checkpoint_dgd_restore_trtllm
+          test_file: tests/deploy/test_dynamocheckpoint.py
+          extra_pytest_args: >-
+            -m dynamocheckpoint
+            --checkpoint-backend=trtllm
+            --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-dynamo-frontend
+
   deploy-cleanup:
     if: always()
     needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm]
@@ -1267,6 +1455,23 @@ jobs:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
 
+  deploy-cleanup-checkpoint-trtllm:
+    name: TRTLLM DynamoCheckpoint Cleanup
+    if: |
+      always() &&
+      (needs.changed-files.outputs.operator == 'true' ||
+       needs.changed-files.outputs.snapshot == 'true' ||
+       needs.changed-files.outputs.deploy == 'true')
+    needs: [changed-files, deploy-operator-checkpoint-trtllm, deploy-snapshot-agent-checkpoint-trtllm, deploy-test-checkpoint-trtllm]
+    runs-on: prod-deploy-tester-v1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Teardown vCluster
+        uses: ./.github/actions/teardown-dynamo-operator
+        with:
+          vcluster_name: ci-${{ github.run_id }}-checkpoint-trtllm
+          vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-trtllm-dt
+
   clean-k8s-builder:
     name: Clean K8s builder if exists
     runs-on: prod-default-small-v2
@@ -1277,6 +1482,7 @@ jobs:
       - snapshot-agent
       - snapshot-placeholder-vllm
       - snapshot-placeholder-sglang
+      - snapshot-placeholder-trtllm
       - power-agent
       - planner-test
       - vllm-copy-to-acr
@@ -1332,6 +1538,7 @@ jobs:
       - deploy-test-trtllm
       - deploy-test-checkpoint-vllm
       - deploy-test-checkpoint-sglang
+      - deploy-test-checkpoint-trtllm
     if: false
     # Disabled: gh-pages branch bloated to ~1GB after 72 commits of Allure reports
     # if: ${{ !cancelled() }}

--- a/tests/deploy/conftest.py
+++ b/tests/deploy/conftest.py
@@ -50,7 +50,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--checkpoint-backend",
         type=str,
         default="vllm",
-        choices=("vllm", "sglang"),
+        choices=("vllm", "sglang", "trtllm"),
         help="DynamoCheckpoint backend to test.",
     )
 

--- a/tests/deploy/test_dynamocheckpoint.py
+++ b/tests/deploy/test_dynamocheckpoint.py
@@ -141,28 +141,23 @@ CHECKPOINT_BACKENDS = {
         frontend_component=FRONTEND_COMPONENT,
         target_container=TARGET_CONTAINER,
         model=CHECKPOINT_MODEL,
+        # Only the CI-sizing overrides that differ from TensorRT-LLM defaults
+        # are passed. The remaining single-GPU snapshot settings from
+        # examples/backends/trtllm/engine_configs/qwen3/snapshot.yaml are already
+        # defaults or no-ops for dense Qwen3-0.6B: tensor/pipeline parallel = 1,
+        # no expert parallel or attention DP, pytorch backend (forced by the
+        # worker), and chunked prefill (inert at max-batch-size 1).
         args=(
             "--model-path",
             CHECKPOINT_MODEL,
             "--served-model-name",
             CHECKPOINT_MODEL,
-            "--tensor-parallel-size",
-            "1",
             "--max-num-tokens",
             "1024",
             "--max-batch-size",
             "1",
             "--free-gpu-memory-fraction",
             "0.10",
-            "--expert-parallel-size",
-            "1",
-            "--no-enable-attention-dp",
-            "--trtllm.trust_remote_code",
-            "true",
-            "--trtllm.backend",
-            "pytorch",
-            "--trtllm.enable_chunked_prefill",
-            "false",
         ),
         # Keep the raw DGD PVC-free: the checkpoint operator mounts
         # snapshot-pvc at /checkpoints for checkpoint/restore pods, so HF_HOME
@@ -223,22 +218,6 @@ def _component(spec: dict[str, Any], name: str) -> dict[str, Any]:
     raise AssertionError(f"component {name!r} not found in DGD spec")
 
 
-def _merge_named_items(
-    items: list[dict[str, Any]], extras: tuple[dict[str, Any], ...]
-) -> None:
-    items_by_name = {item.get("name"): item for item in items if item.get("name")}
-    for extra in extras:
-        name = extra.get("name")
-        if not name:
-            raise AssertionError(f"extra pod item must have a name: {extra!r}")
-        if name in items_by_name:
-            items_by_name[name].update(copy.deepcopy(extra))
-        else:
-            item = copy.deepcopy(extra)
-            items.append(item)
-            items_by_name[name] = item
-
-
 def _new_checkpoint_spec(
     backend: CheckpointBackendConfig,
     name: str,
@@ -271,10 +250,12 @@ def _new_checkpoint_spec(
     if backend.container_resources:
         container["resources"] = copy.deepcopy(backend.container_resources)
     if backend.extra_volumes:
-        _merge_named_items(pod_spec.setdefault("volumes", []), backend.extra_volumes)
+        pod_spec.setdefault("volumes", []).extend(
+            copy.deepcopy(volume) for volume in backend.extra_volumes
+        )
     if backend.extra_volume_mounts:
-        _merge_named_items(
-            container.setdefault("volumeMounts", []), backend.extra_volume_mounts
+        container.setdefault("volumeMounts", []).extend(
+            copy.deepcopy(mount) for mount in backend.extra_volume_mounts
         )
     if backend.env:
         env = container.setdefault("env", [])

--- a/tests/deploy/test_dynamocheckpoint.py
+++ b/tests/deploy/test_dynamocheckpoint.py
@@ -4,6 +4,7 @@
 """Live-cluster DGD checkpoint/restore deploy test."""
 
 import asyncio
+import copy
 import logging
 import time
 from dataclasses import dataclass
@@ -36,6 +37,8 @@ CHECKPOINT_PLURAL = "dynamocheckpoints"
 FRONTEND_COMPONENT = "Frontend"
 TARGET_CONTAINER = "main"
 CHECKPOINT_MODEL = "Qwen/Qwen3-0.6B"
+CHECKPOINT_STORAGE_MOUNT_PATH = "/checkpoints"
+TRTLLM_HF_HOME = f"{CHECKPOINT_STORAGE_MOUNT_PATH}/trtllm-hf-cache"
 
 CHECKPOINT_ID_LABEL = "nvidia.com/snapshot-checkpoint-id"
 CHECKPOINT_SOURCE_LABEL = "nvidia.com/snapshot-is-checkpoint-source"
@@ -72,6 +75,12 @@ class CheckpointBackendConfig:
     target_container: str
     model: str
     args: tuple[str, ...]
+    env: tuple[tuple[str, str], ...] = ()
+    extra_volumes: tuple[dict[str, Any], ...] = ()
+    extra_volume_mounts: tuple[dict[str, Any], ...] = ()
+    pod_spec_updates: dict[str, Any] | None = None
+    container_resources: dict[str, Any] | None = None
+    checkpoint_startup_policy: str | None = None
 
 
 CHECKPOINT_BACKENDS = {
@@ -118,6 +127,82 @@ CHECKPOINT_BACKENDS = {
             "--skip-tokenizer-init",
         ),
     ),
+    "trtllm": CheckpointBackendConfig(
+        name="trtllm",
+        manifest=(
+            "examples",
+            "backends",
+            "trtllm",
+            "deploy",
+            "v1beta1",
+            "agg.yaml",
+        ),
+        decode_component="TRTLLMWorker",
+        frontend_component=FRONTEND_COMPONENT,
+        target_container=TARGET_CONTAINER,
+        model=CHECKPOINT_MODEL,
+        args=(
+            "--model-path",
+            CHECKPOINT_MODEL,
+            "--served-model-name",
+            CHECKPOINT_MODEL,
+            "--tensor-parallel-size",
+            "1",
+            "--max-num-tokens",
+            "1024",
+            "--max-batch-size",
+            "1",
+            "--free-gpu-memory-fraction",
+            "0.10",
+            "--expert-parallel-size",
+            "1",
+            "--no-enable-attention-dp",
+            "--trtllm.trust_remote_code",
+            "true",
+            "--trtllm.backend",
+            "pytorch",
+            "--trtllm.enable_chunked_prefill",
+            "false",
+        ),
+        # Keep the raw DGD PVC-free: the checkpoint operator mounts
+        # snapshot-pvc at /checkpoints for checkpoint/restore pods, so HF_HOME
+        # there preserves model files across restore without a model-cache PVC.
+        env=(("UCX_TLS", "tcp,self"), ("HF_HOME", TRTLLM_HF_HOME)),
+        # Match the base TRTLLM snapshot recipe and avoid cold-worker/restore
+        # rollout overlap during initial DGD startup.
+        checkpoint_startup_policy="WaitForCheckpoint",
+        pod_spec_updates={
+            "runtimeClassName": "nvidia",
+            "securityContext": {
+                "fsGroup": 1000,
+                "fsGroupChangePolicy": "OnRootMismatch",
+            },
+        },
+        container_resources={
+            "requests": {
+                "cpu": "4",
+                "memory": "16Gi",
+                "nvidia.com/gpu": "1",
+                "ephemeral-storage": "10Gi",
+            },
+            "limits": {
+                "cpu": "8",
+                "memory": "32Gi",
+                "nvidia.com/gpu": "1",
+            },
+        },
+        extra_volumes=(
+            {"name": "criu-work", "emptyDir": {}},
+            {
+                "name": "dev-net-tun",
+                "hostPath": {"path": "/dev/net/tun", "type": "CharDevice"},
+            },
+        ),
+        extra_volume_mounts=(
+            {"name": "criu-work", "mountPath": "/var/criu-work"},
+            {"name": "dev-net-tun", "mountPath": "/dev/net/tun"},
+        ),
+    ),
 }
 
 
@@ -138,6 +223,22 @@ def _component(spec: dict[str, Any], name: str) -> dict[str, Any]:
     raise AssertionError(f"component {name!r} not found in DGD spec")
 
 
+def _merge_named_items(
+    items: list[dict[str, Any]], extras: tuple[dict[str, Any], ...]
+) -> None:
+    items_by_name = {item.get("name"): item for item in items if item.get("name")}
+    for extra in extras:
+        name = extra.get("name")
+        if not name:
+            raise AssertionError(f"extra pod item must have a name: {extra!r}")
+        if name in items_by_name:
+            items_by_name[name].update(copy.deepcopy(extra))
+        else:
+            item = copy.deepcopy(extra)
+            items.append(item)
+            items_by_name[name] = item
+
+
 def _new_checkpoint_spec(
     backend: CheckpointBackendConfig,
     name: str,
@@ -156,19 +257,40 @@ def _new_checkpoint_spec(
     raw_spec = deployment_spec.spec()
     decode = _component(raw_spec, backend.decode_component)
     pod_spec = decode.setdefault("podTemplate", {}).setdefault("spec", {})
-    pod_spec["nodeSelector"] = dict(GPU_NODE_SELECTOR)
-    pod_spec["tolerations"] = list(GPU_TOLERATIONS)
     containers = pod_spec.setdefault("containers", [])
     if not containers:
         raise AssertionError(
             f"component {backend.decode_component!r} has no containers"
         )
-    containers[0]["args"] = list(backend.args)
+    pod_spec["nodeSelector"] = dict(GPU_NODE_SELECTOR)
+    pod_spec["tolerations"] = list(GPU_TOLERATIONS)
+    if backend.pod_spec_updates:
+        pod_spec.update(copy.deepcopy(backend.pod_spec_updates))
+    container = containers[0]
+    container["args"] = list(backend.args)
+    if backend.container_resources:
+        container["resources"] = copy.deepcopy(backend.container_resources)
+    if backend.extra_volumes:
+        _merge_named_items(pod_spec.setdefault("volumes", []), backend.extra_volumes)
+    if backend.extra_volume_mounts:
+        _merge_named_items(
+            container.setdefault("volumeMounts", []), backend.extra_volume_mounts
+        )
+    if backend.env:
+        env = container.setdefault("env", [])
+        for name, value in backend.env:
+            for item in env:
+                if item.get("name") == name:
+                    item["value"] = value
+                    break
+            else:
+                env.append({"name": name, "value": value})
 
-    decode.setdefault("experimental", {})["checkpoint"] = {
-        "enabled": True,
-        "targetContainerName": backend.target_container,
-    }
+    checkpoint = decode.setdefault("experimental", {}).setdefault("checkpoint", {})
+    checkpoint["enabled"] = True
+    checkpoint["targetContainerName"] = backend.target_container
+    if backend.checkpoint_startup_policy is not None:
+        checkpoint["startupPolicy"] = backend.checkpoint_startup_policy
     return deployment_spec
 
 


### PR DESCRIPTION
## Summary
- Add TRTLLM to the DynamoCheckpoint deploy-test matrix alongside the existing vLLM and SGLang coverage.
- Keep TRTLLM aligned with the vLLM/SGLang checkpoint test pattern by using the standard `agg.yaml` manifest, enabling checkpointing in the shared deploy test helper, and specifying CI-sized TRTLLM args inline instead of referencing `snapshot.yaml`/engine config files.
- Set TRTLLM-specific checkpoint env, including `UCX_TLS=tcp,self` from the base TRTLLM snapshot recipe and `HF_HOME=/checkpoints/trtllm-hf-cache` so restore pods can reuse model files from the operator-provided checkpoint storage without introducing a separate model-cache PVC.
- Mirror the base TRTLLM snapshot recipe's non-PVC/non-engine-config restore settings for checkpoint restore: `startupPolicy: WaitForCheckpoint`, `runtimeClassName: nvidia`, pod `fsGroup`/`fsGroupChangePolicy`, TRTLLM resource requests/limits, `/var/criu-work`, and `/dev/net/tun`.
- Continue to avoid `model-cache`/`hf-cache`/manual `checkpoint-storage` PVC wiring and `--extra-engine-args`/`snapshot.yaml`.

## Validation
- `git diff --check origin/schwinns/trtllm-snapshot-recipe...HEAD`
- Parsed `.github/workflows/pr.yaml` and `.github/workflows/post-merge-ci.yml`.
- `python3 -m py_compile tests/deploy/conftest.py tests/deploy/test_dynamocheckpoint.py`
- Verified generated checkpoint specs keep vLLM/SGLang unchanged and generate TRTLLM from `examples/backends/trtllm/deploy/v1beta1/agg.yaml` with inline `--model-path` args, `UCX_TLS=tcp,self`, `HF_HOME=/checkpoints/trtllm-hf-cache`, `startupPolicy: WaitForCheckpoint`, `runtimeClassName: nvidia`, pod `fsGroup`/`fsGroupChangePolicy`, TRTLLM resource requests/limits, `criu-work` mounted at `/var/criu-work`, `/dev/net/tun` mounted from a CharDevice hostPath, and no `model-cache`/`hf-cache`/manual `checkpoint-storage` PVC wiring or `snapshot.yaml`/`--extra-engine-args`.
- Read-only review approved the latest non-PVC TRTLLM recipe-settings update.
- Read-only tester passed local/static validation for the latest commit.
- CI on `e3d8e9156482be4596ad1ede47e6b594f04cf22c` passed all three DynamoCheckpoint deploy tests in PR workflow run https://github.com/ai-dynamo/dynamo/actions/runs/28127259751:
  - vLLM: https://github.com/ai-dynamo/dynamo/actions/runs/28127259751/job/83296121816
  - SGLang: https://github.com/ai-dynamo/dynamo/actions/runs/28127259751/job/83296121751
  - TRTLLM: https://github.com/ai-dynamo/dynamo/actions/runs/28127259751/job/83296288190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TRTLLM support to the DynamoCheckpoint workflow, including checkpoint deploy, restore, and cleanup coverage.
  * Expanded PR reporting and status checks to include the new TRTLLM checkpoint pipeline.

* **Bug Fixes**
  * Improved checkpoint configuration handling for TRTLLM runs, including environment, volume, and resource updates.
  * Allowed the checkpoint backend selector to accept TRTLLM for deploy tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->