### PR TITLE
fix(mocker): keep cached chunked-prefill replay progressing

### DIFF
--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -283,15 +283,8 @@ impl RadixCache {
             self.nodes[parent_id].children.insert(original_ck, inter_id);
         }
 
-        // Size tracking: intermediate inherits child's lock_ref, so
-        // protected_size is unchanged (split_pos + remainder = original).
-        // For evictable: intermediate is NOT a leaf (has child), so only
-        // the child's contribution changes.
-        if self.evictable_leaves.contains(&child_id) {
-            let old_tokens = child_key.len();
-            let new_tokens = child_key.len() - split_pos;
-            self.evictable_size = self.evictable_size - old_tokens + new_tokens;
-        }
+        // Both size totals are unchanged: the intermediate and suffix split
+        // the original edge without changing its lock state or token count.
 
         inter_id
     }
@@ -308,10 +301,7 @@ impl RadixCache {
         let ck = self.child_key(key);
         let new_id = self.nodes.insert(new_node);
 
-        if self.evictable_leaves.remove(&parent_id) {
-            let parent_tokens = self.nodes[parent_id].key.len();
-            self.evictable_size -= parent_tokens;
-        }
+        self.evictable_leaves.remove(&parent_id);
 
         self.nodes[parent_id].children.insert(ck, new_id);
 
@@ -333,9 +323,8 @@ impl RadixCache {
             let tokens = node.key.len();
             node.lock_ref += 1;
             if node.lock_ref == 1 {
-                if self.evictable_leaves.remove(&id) {
-                    self.evictable_size -= tokens;
-                }
+                self.evictable_leaves.remove(&id);
+                self.evictable_size -= tokens;
                 self.protected_size += tokens;
             }
             current = self.nodes[id].parent;
@@ -357,9 +346,9 @@ impl RadixCache {
             if node.lock_ref == 0 {
                 let tokens = node.key.len();
                 self.protected_size -= tokens;
+                self.evictable_size += tokens;
                 if self.is_leaf(id) {
                     self.evictable_leaves.insert(id);
-                    self.evictable_size += tokens;
                 }
             }
             current = self.nodes[id].parent;
@@ -403,9 +392,7 @@ impl RadixCache {
                     && self.nodes[pid].children.is_empty()
                     && self.nodes[pid].lock_ref == 0
                 {
-                    let parent_tokens = self.nodes[pid].key.len();
                     self.evictable_leaves.insert(pid);
-                    self.evictable_size += parent_tokens;
                 }
             }
 
@@ -591,6 +578,20 @@ mod tests {
             "should evict unlocked [4,5,6] indices"
         );
         assert_eq!(cache.match_prefix(&[1, 2, 3]).0, 3);
+    }
+
+    #[test]
+    fn test_evictable_size_includes_unlocked_internal_prefix() {
+        let mut cache = RadixCache::new(16, 4);
+        let first = cache.token_pool.allocate(8).unwrap();
+        cache.insert(&[1; 8], &first);
+        let mut branch = first[..4].to_vec();
+        branch.extend(cache.token_pool.allocate(4).unwrap());
+        cache.insert(&[1, 1, 1, 1, 2, 2, 2, 2], &branch);
+
+        assert_eq!(cache.evictable_size, 12);
+        assert_eq!(cache.evict(12).0, 12);
+        assert_eq!(cache.available_tokens(), 16);
     }
 
     #[test]

--- a/lib/mocker/src/common/perf_model.rs
+++ b/lib/mocker/src/common/perf_model.rs
@@ -220,6 +220,9 @@ impl PerfModel {
     /// - Aiconfigurator: passes (batch_size, isl - prefix, prefix) to the AIC SDK
     pub fn predict_prefill_time(&self, batch_size: usize, isl: usize, prefix: usize) -> f64 {
         let new_tokens_per_req = isl.saturating_sub(prefix);
+        if batch_size == 0 || new_tokens_per_req == 0 {
+            return 0.0;
+        }
         let time = match self {
             PerfModel::Polynomial => {
                 // Total tokens across the batch — GPU processes them in parallel
@@ -276,5 +279,15 @@ impl PerfModel {
             "Decode time prediction: batch_size={batch_size}, active_kv_tokens={active_kv_tokens}, context_length={context_length}, time={result:.2}ms"
         );
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PerfModel;
+
+    #[test]
+    fn fully_cached_prompt_skips_prefill() {
+        assert_eq!(PerfModel::default().predict_prefill_time(1, 128, 128), 0.0);
     }
 }

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -11,11 +11,15 @@ use super::super::runtime_utils::WorkerCompletionPayload;
 use super::super::state::OfflineWorkerSnapshot;
 use super::super::state::OfflineWorkerState;
 use super::{EngineEffects, EnginePassMode, ScheduledWorkerCompletion};
-use crate::common::protocols::{DirectRequest, MockEngineArgs};
+use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs};
 use crate::replay::TraceCollector;
 use crate::scheduler::RouterEventVisibility;
 #[cfg(feature = "kvbm-offload")]
 use dynamo_kv_router::protocols::RouterEvent;
+
+fn fpm_has_scheduled_work(snapshot: &ForwardPassSnapshot) -> bool {
+    snapshot.num_prefill_requests > 0 || snapshot.num_decode_requests > 0
+}
 
 pub(in crate::replay::offline) struct EngineComponent {
     stage: SimulationWorkerStage,
@@ -250,6 +254,18 @@ impl EngineComponent {
             };
 
             if executed.end_ms == now_ms {
+                let made_progress = !effects.admissions.is_empty()
+                    || !effects.pass_start_kv_events.is_empty()
+                    || payload.completed_requests > 0
+                    || !payload.output_signals.is_empty()
+                    || !payload.kv_events.is_empty()
+                    || effects
+                        .fpm_snapshots
+                        .iter()
+                        .any(|(_, snapshot)| fpm_has_scheduled_work(snapshot));
+                if !made_progress {
+                    continue;
+                }
                 effects.immediate_completions.push(payload);
                 return Ok(effects);
             }
@@ -428,6 +444,22 @@ mod tests {
         assert_eq!(engine.active_worker_ids().len(), 1);
         assert!(engine.mark_worker_ready(new_id));
         assert_eq!(engine.active_worker_ids().len(), 2);
+    }
+
+    #[test]
+    fn queued_only_fpm_is_not_zero_duration_progress() {
+        let queued = ForwardPassSnapshot {
+            num_queued_prefill: 1,
+            sum_queued_prefill_tokens: 128,
+            ..ForwardPassSnapshot::default()
+        };
+        assert!(!fpm_has_scheduled_work(&queued));
+
+        let scheduled = ForwardPassSnapshot {
+            num_prefill_requests: 1,
+            ..ForwardPassSnapshot::default()
+        };
+        assert!(fpm_has_scheduled_work(&scheduled));
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -75,12 +75,6 @@ pub(super) fn get_new_batch_prefill(
             break;
         }
 
-        let total_needed = req.total_tokens_needed(config.clip_max_new_tokens) as f64;
-        if total_needed >= rem_total_tokens {
-            rejected.push_back(req);
-            break;
-        }
-
         let chunk_tokens = if extend_input <= config.chunked_prefill_size {
             extend_input
         } else {
@@ -93,6 +87,16 @@ pub(super) fn get_new_batch_prefill(
         };
 
         let charged_input_tokens = ceil_to_block(chunk_tokens, config.block_size) as f64;
+        let output_reserve = if chunk_tokens < extend_input {
+            0
+        } else {
+            req.remaining_output_tokens()
+                .min(config.clip_max_new_tokens)
+        };
+        if charged_input_tokens + output_reserve as f64 >= rem_total_tokens {
+            rejected.push_back(req);
+            break;
+        }
         if charged_input_tokens > rem_input_tokens || charged_input_tokens > rem_chunk_tokens {
             rejected.push_back(req);
             break;
@@ -141,14 +145,6 @@ pub(super) fn get_new_batch_prefill(
         req.materialized_tokens = chunk_end;
         req.allocated_tokens = ceil_to_block(chunk_end, config.block_size);
         req.debug_assert_invariants(config.block_size);
-
-        let is_truncated = chunk_end < req.current_sequence_len();
-        let output_reserve = if is_truncated {
-            0
-        } else {
-            req.remaining_output_tokens()
-                .min(config.clip_max_new_tokens)
-        };
 
         admissions.push(AdmissionEvent {
             uuid: req.uuid,

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -40,12 +40,6 @@ impl SglangRequest {
             .saturating_sub(self.materialized_tokens)
     }
 
-    pub(super) fn total_tokens_needed(&self, clip_max_new_tokens: usize) -> usize {
-        let remaining_input = self.extend_input_len();
-        let remaining_output = self.remaining_output_tokens().min(clip_max_new_tokens);
-        remaining_input + remaining_output
-    }
-
     pub(super) fn remaining_output_tokens(&self) -> usize {
         self.max_output_tokens.saturating_sub(self.output_len())
     }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -626,6 +626,36 @@ mod core_behavior {
     }
 
     #[test]
+    fn test_chunked_prefill_admits_next_chunk_when_full_prompt_does_not_fit() {
+        let config = SglangConfig {
+            chunked_prefill_size: 8,
+            ..SglangConfig::from_args(
+                &MockEngineArgs::builder()
+                    .block_size(4)
+                    .speedup_ratio(1.0)
+                    .build()
+                    .unwrap(),
+            )
+        };
+        let mut kv_manager = SglangKvManager::new(12, 4, KvEventPublishers::default(), 0);
+        let mut waiting = VecDeque::from([SglangRequest {
+            uuid: Uuid::new_v4(),
+            prompt_tokens: vec![1; 16],
+            max_output_tokens: 2,
+            output_ids: Vec::new(),
+            last_node: None,
+            kv_indices: Vec::new(),
+            materialized_tokens: 0,
+            cached_tokens: 0,
+            allocated_tokens: 0,
+        }]);
+
+        let admit = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[]);
+        assert_eq!(admit.can_run.len(), 1);
+        assert_eq!(admit.can_run[0].materialized_tokens, 8);
+    }
+
+    #[test]
     fn test_chunked_prefill_subpage_budget_defers_next_request() {
         let config = SglangConfig {
             chunked_prefill_size: 8,


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Fix four correctness gaps that can stall or mis-account SGLang offline replay with cached, chunked prompts. Together these changes let long traces continue under KV pressure without inventing zero-duration work or undercounting evictable cache capacity.

### How This Was Implemented
- Return zero prefill duration when a batch has no uncached prompt tokens, avoiding invalid performance-model calls.
- Ignore zero-duration engine passes that report queued state but make no scheduling progress.
- Admit chunked prefill based on the next chunk's allocation and reserve output KV only on the final chunk.
- Count every unlocked radix node as evictable while retaining leaf-only victim selection.

<details>
<summary>Walkthrough</summary>

- `PerfModel::predict_prefill_time` handles empty and fully cached work before selecting a backend.
- `EngineComponent::step` distinguishes scheduled work from queued-only forward-pass metrics.
- SGLang prefill admission charges the current chunk instead of requiring the full remaining prompt to fit.
- Radix-cache size accounting follows lock state independently from the eviction-candidate leaf set.

</details>

### Validation
- `cargo test -p dynamo-mocker --release` — 395 passed, 1 ignored.
- `git diff --check`
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt and cache accounting so partially cached or chunked requests are handled more accurately.
  * Fixed scheduling behavior to better admit requests when only part of a prompt fits, and to avoid counting idle work as progress.
  * Corrected cache size tracking so unlocked internal prefix data is reflected properly during eviction.
  * Prefill timing now returns zero for fully cached prompts or empty batches, improving prediction accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->