### PR TITLE
fix(router): preserve session affinity through migration

### DIFF
--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -13,7 +13,10 @@ use crate::{
     model_card::ModelDeploymentCard,
     protocols::{
         TokenIdType,
-        common::llm_backend::{BackendOutput, LLMEngineOutput, PreprocessedRequest},
+        common::{
+            extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
+            llm_backend::{BackendOutput, LLMEngineOutput, PreprocessedRequest},
+        },
     },
 };
 
@@ -146,6 +149,10 @@ where
         let (preprocessed_request, context) = request.transfer(());
         let engine_ctx = context.context();
         let engine_ctx_ = engine_ctx.clone();
+        let session_affinity = context
+            .get_optional::<SessionAffinityId>(SESSION_AFFINITY_CONTEXT_KEY)
+            .map_err(Error::msg)?
+            .map(|session_id| session_id.as_ref().clone());
         let retry_manager = RetryManager::build(
             engine_ctx,
             context.metadata().clone(),
@@ -155,6 +162,7 @@ where
             self.max_seq_len,
             self.model_name.clone(),
             self.metrics.clone(),
+            session_affinity,
         )
         .await?;
         let response_stream = stream::unfold(retry_manager, move |mut retry_manager| async move {
@@ -175,6 +183,7 @@ where
     context: Arc<dyn AsyncEngineContext>,
     metadata: BTreeMap<String, String>,
     request: PreprocessedRequest,
+    session_affinity: Option<SessionAffinityId>,
     next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<Resp>>,
     next_stream: Option<ManyOut<Annotated<Resp>>>,
     retries_left: u32,
@@ -200,6 +209,7 @@ where
         max_seq_len: Option<u32>,
         model_name: Arc<String>,
         metrics: Arc<Metrics>,
+        session_affinity: Option<SessionAffinityId>,
     ) -> Result<Self> {
         // Disable migration for structured-output (guided-decoding) requests.
         // Inference backends initialize the guided-decoding FSM (finite state machine) fresh
@@ -233,6 +243,7 @@ where
             context,
             metadata,
             request: preprocessed_request,
+            session_affinity,
             next_generate: next,
             next_stream: None,
             retries_left: retries_left + 1, // +1 to account for the initial attempt
@@ -286,11 +297,14 @@ where
             if let Some(link) = self.last_worker_link.as_ref() {
                 self.request.migration_link = Some(link.clone());
             }
-            let request = Context::with_id_and_metadata(
+            let mut request = Context::with_id_and_metadata(
                 self.request.clone(),
                 self.context.id().to_string(),
                 self.metadata.clone(),
             );
+            if let Some(session_affinity) = self.session_affinity.as_ref() {
+                request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_affinity.clone());
+            }
             self.context.link_child(request.context());
             if self.context.is_stopped() || self.context.is_killed() {
                 tracing::debug!("Abort creating new stream after context is stopped or killed");
@@ -434,12 +448,19 @@ mod tests {
         Success,
         /// Fails on first call with NoResponders error, then succeeds on subsequent calls
         FailThenSuccess,
+        FailThenSuccessWithAffinity,
         /// Succeeds initially, fails mid-stream with specific error, then succeeds on retry
-        MidStreamFail { fail_after: usize },
+        MidStreamFail {
+            fail_after: usize,
+        },
         /// Succeeds initially, fails mid-stream with specific error, then always fails on retry attempts
-        MidStreamFailAlways { fail_after: usize },
+        MidStreamFailAlways {
+            fail_after: usize,
+        },
         /// Succeeds initially, fails mid-stream, then always fails with stream error on retry attempts
-        MidStreamFailAlwaysStreamError { fail_after: usize },
+        MidStreamFailAlwaysStreamError {
+            fail_after: usize,
+        },
         /// Always fails with NoResponders error (same as FailThenSuccess first call)
         AlwaysFail,
     }
@@ -480,6 +501,12 @@ mod tests {
             request: SingleIn<PreprocessedRequest>,
         ) -> Result<ManyOut<Annotated<BackendOutput>>> {
             let call_num = self.call_count.fetch_add(1, Ordering::SeqCst);
+            if matches!(self.behavior, MockBehavior::FailThenSuccessWithAffinity) {
+                let actual = request
+                    .get::<SessionAffinityId>(SESSION_AFFINITY_CONTEXT_KEY)
+                    .expect("session affinity context missing after migration wrapper");
+                assert_eq!(actual.as_str(), "session-123");
+            }
             let (preprocessed_request, context) = request.transfer(());
 
             // Assert that the context_id matches the expected one
@@ -515,7 +542,7 @@ mod tests {
                     self.send_responses(responses_already_generated, self.num_responses)
                         .await
                 }
-                MockBehavior::FailThenSuccess => {
+                MockBehavior::FailThenSuccess | MockBehavior::FailThenSuccessWithAffinity => {
                     if call_num == 0 {
                         // First call - return "No responders available" error to trigger retry
                         return Err(anyhow::anyhow!(
@@ -738,6 +765,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await
         .expect("Failed to build RetryManager");
@@ -757,6 +785,30 @@ mod tests {
 
         assert_eq!(metrics.get_migration_new_request_count(TEST_MODEL), 0);
         assert_eq!(metrics.get_migration_ongoing_request_count(TEST_MODEL), 0);
+    }
+
+    #[tokio::test]
+    async fn test_migration_preserves_session_affinity_across_retry() {
+        let context_id = uuid::Uuid::new_v4().to_string();
+        let mock_engine = Arc::new(MockEngine::new(
+            MockBehavior::FailThenSuccessWithAffinity,
+            1,
+            100,
+            context_id.clone(),
+        ));
+        let calls = mock_engine.call_count.clone();
+        let mut request =
+            Context::with_id_and_metadata(create_mock_request(1), context_id, BTreeMap::new());
+        request.insert(
+            SESSION_AFFINITY_CONTEXT_KEY,
+            SessionAffinityId::new("session-123"),
+        );
+
+        let migration = Migration::new(1, None, TEST_MODEL.to_string(), Arc::new(Metrics::new()));
+        let mut stream = migration.generate(request, mock_engine).await.unwrap();
+        while stream.next().await.is_some() {}
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     /// Test case 2: New request migration
@@ -790,6 +842,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await
         .expect("Failed to build RetryManager");
@@ -843,6 +896,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await
         .expect("Failed to build RetryManager");
@@ -897,6 +951,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await;
 
@@ -938,6 +993,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         ) // 3 retries
         .await
         .expect("Failed to build RetryManager");
@@ -998,6 +1054,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         ) // 3 retries
         .await
         .expect("Failed to build RetryManager");
@@ -1063,6 +1120,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await;
 
@@ -1143,6 +1201,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await
         .expect("Failed to build RetryManager");
@@ -1221,6 +1280,7 @@ mod tests {
             Some(5), // prompt(3) + 3 generated = 6 > 5 → disables migration
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await
         .expect("Failed to build RetryManager");
@@ -1293,6 +1353,7 @@ mod tests {
             Some(5), // prompt(3) + 2 generated = 5 == max_seq_len → still migratable
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await
         .expect("Failed to build RetryManager");
@@ -1359,6 +1420,7 @@ mod tests {
             Some(2), // prompt(3) > max_seq_len(2) → migration disabled at build time
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await
         .expect("Failed to build RetryManager");
@@ -1439,6 +1501,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics,
+            None,
         )
         .await
         .expect("Failed to build RetryManager");
@@ -1568,6 +1631,7 @@ mod tests {
             None,
             Arc::new(TEST_MODEL.to_string()),
             metrics.clone(),
+            None,
         )
         .await
         .expect("Failed to build RetryManager");


### PR DESCRIPTION
## Summary

This preserves `SessionAffinityId` while the migration wrapper reconstructs request contexts for initial and retried backend attempts. Without it, header-based affinity from #10875 is silently discarded before routing, so one session can move between workers.

## Root Cause

`Migration::generate` retained the request controller and string metadata, but `RetryManager::new_stream` rebuilt a fresh `Context` with an empty typed registry. That dropped the `SessionAffinityId` inserted by the HTTP handler even when `migration_limit=0`.

## How This Was Implemented

- Capture the optional `SessionAffinityId` before the migration wrapper separates the request from its context.
- Store it on `RetryManager` and reinsert it into every reconstructed request context.
- Add a regression test that forces an initial backend failure and verifies that both attempts retain the affinity ID.

<details>
<summary>Walkthrough</summary>

- `Migration::generate`: extracts affinity from the incoming typed context registry.
- `RetryManager::new_stream`: restores affinity before handing the request to routing.
- `test_migration_preserves_session_affinity_across_retry`: checks initial and retry propagation.

</details>

## Reproduction Steps

The following reproduces the failure on `codex/header-session-affinity` and validates this branch.

### 1. Build Dynamo

```bash
git checkout codex/header-session-affinity
uv venv --python 3.12
uv pip install maturin

cd lib/bindings/python
maturin develop --uv
cd ../../..
uv pip install -e .
```

### 2. Start discovery services

```bash
nats-server -js >/tmp/dynamo-affinity-nats.log 2>&1 &
NATS_PID=$!

etcd --data-dir /tmp/dynamo-affinity-etcd \
  --listen-client-urls http://127.0.0.1:2379 \
  --advertise-client-urls http://127.0.0.1:2379 \
  >/tmp/dynamo-affinity-etcd.log 2>&1 &
ETCD_PID=$!
```

### 3. Start one KV frontend and three mock workers

```bash
DYN_REPO=$PWD \
NUM_WORKERS=3 \
OTHER_CORES=4-15 \
DYN_ENABLE_FRONTEND_NVEXT=true \
DYN_ROUTER_SESSION_AFFINITY_TTL_SECS=300 \
bash .agents/skills/dynamo-frontend-benchmark/scripts/start.sh
```

### 4. Minimal curl reproduction

```bash
rm -f /tmp/dynamo-affinity-workers
for turn in $(seq 1 10); do
  curl -sfS http://127.0.0.1:8000/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -H 'X-Dynamo-Session-ID: repro-session' \
    -d "{\"model\":\"Qwen/Qwen3-0.6B\",\"messages\":[{\"role\":\"user\",\"content\":\"unique turn ${turn}\"}],\"max_tokens\":4,\"stream\":false,\"nvext\":{\"extra_fields\":[\"worker_id\"]}}" \
    | jq -r '.nvext.worker_id.decode_worker_id' \
    | tee -a /tmp/dynamo-affinity-workers
done

sort -u /tmp/dynamo-affinity-workers
```

Before this fix, the same session returns multiple worker IDs. With this fix, all ten requests return one worker ID.

### 5. AIPerf multi-session validation

From an AIPerf checkout with the header transport from `ajcasagrande/aiperf#3`:

```bash
AIPERF_DYNAMO_SESSION_TRANSPORT=headers aiperf profile \
  --url http://127.0.0.1:8000 \
  --model Qwen/Qwen3-0.6B \
  --endpoint-type chat \
  --input-file tests/fixtures/weka_traces_small \
  --custom-dataset-type weka-trace \
  --no-fixed-schedule \
  --ignore-trace-delays \
  --concurrency 4 \
  --request-count 30 \
  --use-dynamo-conv-aware-routing \
  --extra-inputs '{"nvext":{"extra_fields":["worker_id"]}}' \
  --export-level raw \
  --output-artifact-dir /tmp/aiperf-10875-header
```

Verify every session used exactly one decode worker:

```bash
python - <<'PY'
import json
from collections import defaultdict

sessions = defaultdict(set)
with open('/tmp/aiperf-10875-header/profile_export_raw.jsonl') as records:
    for line in records:
        record = json.loads(line)
        session_id = record['request_headers']['X-Dynamo-Session-ID']
        response = json.loads(record['responses'][-1]['text'])
        worker_id = response['nvext']['worker_id']['decode_worker_id']
        sessions[session_id].add(worker_id)

assert all(len(workers) == 1 for workers in sessions.values()), sessions
print(f'{len(sessions)} sessions remained sticky')
PY
```

Observed before the fix: 4 of 9 sessions crossed workers. Observed after the fix: 0 of 9 crossed workers; all three mock workers received traffic.

### 6. Cleanup

```bash
DYN_REPO=$PWD bash .agents/skills/dynamo-frontend-benchmark/scripts/stop.sh
kill "$ETCD_PID" "$NATS_PID"
rm -rf /tmp/dynamo-affinity-etcd
```

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/ephemeral/dynamo/target cargo test -p dynamo-llm --lib --no-default-features migration::tests` — 14 passed
- `CARGO_TARGET_DIR=/ephemeral/dynamo/target cargo test -p dynamo-llm --lib --no-default-features session_affinity` — 27 passed
- `maturin develop --uv`
- AIPerf header mode: 30/30 HTTP 200; 9 sessions; 0 session crossings; 3 workers used
