### PR TITLE
fix(operator): make Tilt apply patched CRDs

### DIFF
--- a/deploy/operator/Tiltfile
+++ b/deploy/operator/Tiltfile
@@ -169,8 +169,9 @@ local(helm_cmd + ' repo add --force-update bitnami https://charts.bitnami.com/bi
 local(helm_cmd + ' repo update', quiet=True)
 
 # Initial sync at load time so render_helm() can succeed on a fresh checkout.
-# Keep this lock-file based; the Tilt resource below performs full updates.
-local(helm_cmd + ' dependency build ' + HELM_CHART, quiet=True)
+# Chart.lock and packaged charts are ignored local artifacts, so refresh them
+# here before rendering instead of trusting stale workspace state.
+local(helm_cmd + ' dependency update ' + HELM_CHART, quiet=True)
 
 # Re-run when the local operator subchart or dependency list changes.
 local_resource(

--- a/deploy/operator/Tiltfile
+++ b/deploy/operator/Tiltfile
@@ -142,7 +142,12 @@ local_resource(
 # CRDs — regenerate & apply via server-side apply on change
 # ---------------------------------------------------------------------------
 SKIP_CODEGEN = settings['skip_codegen']
-_crd_cmd = kubectl_cmd + ' apply --server-side --force-conflicts -f ' + CRD_DIR
+_crd_cmd = (
+    'go run ./cmd/crd-apply --crds-dir=' + CRD_DIR +
+    ' --version=' + OPERATOR_VERSION +
+    ' --conversion-webhook-service-name=dynamo-dynamo-operator-webhook-service' +
+    ' --conversion-webhook-service-namespace=' + NAMESPACE
+)
 if not SKIP_CODEGEN:
     _crd_cmd = 'make generate && make manifests && ' + _crd_cmd
 


### PR DESCRIPTION
Summary
- Make the Tilt CRD resource run `cmd/crd-apply`, so local kind/Tilt installs patch CRD conversion webhook service coordinates before applying CRDs.
- Refresh Helm dependencies with `helm dependency update` during Tiltfile load, because `Chart.lock` and packaged chart archives are ignored local artifacts and can be stale before `render_helm()` runs.

Commit structure
- `deploy/operator: refresh helm deps in tilt` isolates the Helm lock-file behavior change. `helm dependency build` trusts an existing `Chart.lock`; in this repo that lock is ignored local state, so Tilt must refresh from `Chart.yaml` before rendering.
- `deploy/operator: run crd apply in tilt` switches the CRD local resource from raw `kubectl apply` to the existing `cmd/crd-apply` helper with hard-coded Tilt service coordinates.

Validation
- `git diff --check -- deploy/operator/Tiltfile`
- `go test ./cmd/crd-apply`