### PR TITLE
fix: disable compliance source archival in nightly/post-merge CI

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -256,7 +256,7 @@ jobs:
       build_timeout_minutes: 120
       # Nightly serves as the continuous-compliance source-archival cadence
       # (post-merge-ci skips main and only archives on release/*.*.* cuts).
-      archive_sources: true
+      archive_sources: false
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
     secrets: inherit
@@ -273,7 +273,7 @@ jobs:
       builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
       inline_compliance: true
       build_timeout_minutes: 120
-      archive_sources: true
+      archive_sources: false
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
     secrets: inherit
@@ -290,7 +290,7 @@ jobs:
       builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
       inline_compliance: true
       build_timeout_minutes: 120
-      archive_sources: true
+      archive_sources: false
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
     secrets: inherit

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -254,8 +254,9 @@ jobs:
       builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
       inline_compliance: true
       build_timeout_minutes: 120
-      # Nightly serves as the continuous-compliance source-archival cadence
-      # (post-merge-ci skips main and only archives on release/*.*.* cuts).
+      # Source archival temporarily disabled until the wheel-builder build
+      # context includes deploy/inference-gateway/ext-proc (a cargo vendor
+      # workspace member).
       archive_sources: false
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
@@ -301,8 +302,8 @@ jobs:
   # Compliance extract + verify now runs as an inline step INSIDE each build job
   # (inline_compliance: true above), on the same warm builder — a cache hit + small
   # scratch export instead of a cold full-image rebuild on the fresh builder. The
-  # build jobs already set archive_sources: true (the continuous-compliance
-  # source-archival cadence), so /sources.zip is still emitted; /legal + /sboms
+  # build jobs currently set archive_sources: false (archival temporarily
+  # disabled — see above), so /sources.zip is not emitted; /legal + /sboms still
   # upload at the default 30-day retention. A compliance failure fails the build.
 
   # ============================================================================

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -521,10 +521,10 @@ jobs:
   # vllm/sglang/trtllm: compliance extract + verify runs as an inline step
   # INSIDE each shipped framework build job (inline_compliance: true above), on
   # the same warm builder — a cache hit + small scratch export instead of a cold
-  # full-image rebuild on a separate fresh builder. archive_sources is threaded
-  # to the build job, so release branches still emit the /sources.zip OSRB
-  # artifact; EFA images are covered (make_efa flows to the extract). A
-  # compliance failure fails the build.
+  # full-image rebuild on a separate fresh builder. archive_sources is currently
+  # false (source archival temporarily disabled), so release branches do not emit
+  # the /sources.zip OSRB artifact; EFA images are covered (make_efa flows to the
+  # extract). A compliance failure fails the build.
   #
   # planner/frontend stay on the legacy shared-compliance scan until they
   # migrate to the inline system.

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -136,7 +136,7 @@ jobs:
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-vllm-runtime' || '' }}
         ${{ github.ref_name == 'main' && format('main-vllm-runtime-{0}', github.sha) || '' }}
-      archive_sources: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+      archive_sources: false
     secrets: inherit
 
   vllm-dev-build:
@@ -174,7 +174,7 @@ jobs:
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-vllm-efa' || '' }}
         ${{ github.ref_name == 'main' && format('main-vllm-efa-{0}', github.sha) || '' }}
-      archive_sources: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+      archive_sources: false
     secrets: inherit
 
   sglang-build:
@@ -193,7 +193,7 @@ jobs:
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-sglang-runtime' || '' }}
         ${{ github.ref_name == 'main' && format('main-sglang-runtime-{0}', github.sha) || '' }}
-      archive_sources: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+      archive_sources: false
     secrets: inherit
 
   sglang-dev-build:
@@ -231,7 +231,7 @@ jobs:
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-sglang-efa' || '' }}
         ${{ github.ref_name == 'main' && format('main-sglang-efa-{0}', github.sha) || '' }}
-      archive_sources: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+      archive_sources: false
     secrets: inherit
 
   trtllm-build:
@@ -250,7 +250,7 @@ jobs:
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-trtllm-runtime' || '' }}
         ${{ github.ref_name == 'main' && format('main-trtllm-runtime-{0}', github.sha) || '' }}
-      archive_sources: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+      archive_sources: false
     secrets: inherit
 
   trtllm-dev-build:
@@ -288,7 +288,7 @@ jobs:
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-trtllm-efa' || '' }}
         ${{ github.ref_name == 'main' && format('main-trtllm-efa-{0}', github.sha) || '' }}
-      archive_sources: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+      archive_sources: false
     secrets: inherit
 
   planner-build:


### PR DESCRIPTION
cargo vendor --locked fails on the deploy/inference-gateway/ext-proc workspace member missing from the wheel-builder build context. Disable until the COPY is fixed.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly and post-merge build jobs to stop creating source archives during runtime builds.
  * Build runs should now be a bit leaner and more consistent across branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->