### PR TITLE
docs: add OpenClaw agent harness setup

### DIFF
--- a/docs/agents/agent-harnesses.md
+++ b/docs/agents/agent-harnesses.md
@@ -87,6 +87,61 @@ opencode -m dynamo/zai-org/GLM-4.7-Flash
 
 Dynamo maps OpenCode's `x-session-id` header to `session_id` and `x-parent-session-id` to `parent_session_id`.
 
+## OpenClaw
+
+OpenClaw can use Dynamo through its OpenAI-compatible Responses endpoint. Install the
+Dynamo provider plugin:
+
+```bash
+git clone https://github.com/ai-dynamo/agent-plugins.git ~/agent-plugins
+openclaw plugins install --link ~/agent-plugins/openclaw-plugin
+openclaw plugins enable dynamo
+```
+
+Add a Dynamo-backed model to `~/.openclaw/openclaw.json`:
+
+```jsonc
+{
+  "models": {
+    "providers": {
+      "dynamo": {
+        "baseUrl": "http://localhost:8000/v1",
+        "apiKey": "dynamo-local",
+        "api": "openai-responses",
+        "models": [
+          {
+            "id": "zai-org/GLM-4.7-Flash",
+            "name": "Dynamo GLM 4.7 Flash",
+            "reasoning": true,
+            "contextWindow": 128000,
+            "maxTokens": 8192
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "dynamo/zai-org/GLM-4.7-Flash"
+      }
+    }
+  }
+}
+```
+
+Run a local agent turn:
+
+```bash
+openclaw agent --local --message "Reply exactly ok."
+```
+
+The plugin copies OpenClaw's current `sessionId` into `x-dynamo-session-id` on each
+request. Native subagents receive their own `session_id` and the immediate parent is
+recorded as `parent_session_id`. The ID is stable during ordinary turns; OpenClaw can
+rotate it after compaction when
+`agents.defaults.compaction.truncateAfterCompaction` is enabled.
+
 ## Hermes Agent
 
 Hermes uses an OpenAI-compatible custom endpoint. Configure Hermes with the served model name and Dynamo `/v1` base URL:

--- a/docs/agents/agent-harnesses.md
+++ b/docs/agents/agent-harnesses.md
@@ -130,17 +130,15 @@ Add a Dynamo-backed model to `~/.openclaw/openclaw.json`:
 }
 ```
 
-Run a local agent turn:
+Run OpenClaw:
 
 ```bash
-openclaw agent --local --message "Reply exactly ok."
+openclaw chat
 ```
 
 The plugin copies OpenClaw's current `sessionId` into `x-dynamo-session-id` on each
 request. Native subagents receive their own `session_id` and the immediate parent is
-recorded as `parent_session_id`. The ID is stable during ordinary turns; OpenClaw can
-rotate it after compaction when
-`agents.defaults.compaction.truncateAfterCompaction` is enabled.
+recorded as `parent_session_id`.
 
 ## Hermes Agent
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This adds an OpenClaw section to the Dynamo agent-harness guide with provider installation, Responses configuration, and a local invocation example. It documents how the provider plugin maps root and native subagent lineage into Dynamo session fields.

Depends on [ai-dynamo/agent-plugins#9](https://github.com/ai-dynamo/agent-plugins/pull/9).

### How This Was Implemented
- Document plugin installation and a minimal `openai-responses` provider configuration.
- Describe root `session_id`, immediate `parent_session_id`, and the optional compaction rotation caveat.

<details>
<summary>Walkthrough</summary>

- `docs/agents/agent-harnesses.md`: add the OpenClaw setup and session-identity contract beside the existing harness sections.

</details>

### Validation
- `fern check` (0 errors).
- `git diff --check`.
<!-- codex-pr-description:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new OpenClaw section with setup and usage guidance for connecting to Dynamo through an OpenAI-compatible endpoint.
  * Included example configuration details, startup instructions, and notes on how session IDs are handled for tracing and parent-child request tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->