### PR TITLE
perf: optimize active sequence load projection

### DIFF
--- a/lib/bench/kv_router/active_sequences_shared.rs
+++ b/lib/bench/kv_router/active_sequences_shared.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use dynamo_kv_router::protocols::{PrefillLoadHint, WorkerWithDpRank};
-use dynamo_kv_router::{ActiveSequencesMultiWorker, PrefillTokenDeltas, SequenceRequest};
+use dynamo_kv_router::{ActiveSequencesMultiWorker, SequenceRequest};
 use dynamo_mocker::loadgen::Trace;
 use dynamo_tokens::SequenceHash;
 use tokio::time::{Duration, Instant};
@@ -136,7 +136,7 @@ pub async fn generate_sequence_events(
 }
 
 /// Run the benchmark: replay sequence trace entries against a shared
-/// ActiveSequencesMultiWorker, measuring potential_blocks_and_tokens /
+/// ActiveSequencesMultiWorker, measuring project_worker_loads /
 /// add_request / mark_prefill_completed / free latency.
 pub async fn run_benchmark(
     traces: &[Vec<SequenceTrace>],
@@ -243,7 +243,7 @@ pub async fn run_benchmark(
     );
 
     println!(
-        "Ops Throughput: offered={} ops/s achieved={} ops/s (potential_blocks_and_tokens + add + prefill_complete + free)",
+        "Ops Throughput: offered={} ops/s achieved={} ops/s (project_worker_loads + add + prefill_complete + free)",
         run.results.offered_ops_throughput, run.results.ops_throughput
     );
     println!(
@@ -301,10 +301,7 @@ async fn apply_entry(
             isl,
             output_length,
         } => {
-            let _ = multi.potential_blocks_and_tokens::<false>(
-                Some(&block_hashes),
-                &PrefillTokenDeltas::uniform(isl),
-            );
+            let _ = multi.project_worker_loads(Some(&block_hashes), decay_now);
             let _ = multi.add_request(
                 SequenceRequest {
                     request_id,

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -98,6 +98,8 @@ impl WorkerLoadSlot {
 
 #[derive(Debug, Default)]
 struct WorkerLoadTable {
+    // Admission projects every registered worker's load. Keep that hot scan as a dense Vec walk;
+    // the hash index is only for point updates/removes when worker state changes.
     slots: Vec<WorkerLoadSlot>,
     index: FxHashMap<WorkerWithDpRank, usize>,
 }

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dashmap::DashMap;
 use dynamo_tokens::SequenceHash;
+use parking_lot::RwLock;
 #[cfg(test)]
 use rustc_hash::FxHashSet;
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -73,6 +73,85 @@ impl WorkerLoadSnapshot {
     }
 }
 
+#[derive(Debug)]
+struct WorkerLoadSlot {
+    worker: WorkerWithDpRank,
+    load: RwLock<WorkerLoadSnapshot>,
+}
+
+impl WorkerLoadSlot {
+    fn new(worker: WorkerWithDpRank, load: WorkerLoadSnapshot) -> Self {
+        Self {
+            worker,
+            load: RwLock::new(load),
+        }
+    }
+
+    fn snapshot(&self) -> WorkerLoadSnapshot {
+        *self.load.read()
+    }
+
+    fn replace(&self, load: WorkerLoadSnapshot) {
+        *self.load.write() = load;
+    }
+}
+
+#[derive(Debug, Default)]
+struct WorkerLoadTable {
+    slots: Vec<WorkerLoadSlot>,
+    index: FxHashMap<WorkerWithDpRank, usize>,
+}
+
+impl WorkerLoadTable {
+    fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &WorkerLoadSlot> + '_ {
+        self.slots.iter()
+    }
+
+    fn ensure_worker(&mut self, worker: WorkerWithDpRank) {
+        if self.index.contains_key(&worker) {
+            return;
+        }
+        self.insert(worker, WorkerLoadSnapshot::default());
+    }
+
+    fn update(&self, worker: WorkerWithDpRank, load: WorkerLoadSnapshot) -> bool {
+        let Some(&idx) = self.index.get(&worker) else {
+            return false;
+        };
+        self.slots[idx].replace(load);
+        true
+    }
+
+    fn upsert(&mut self, worker: WorkerWithDpRank, load: WorkerLoadSnapshot) {
+        if let Some(&idx) = self.index.get(&worker) {
+            self.slots[idx].replace(load);
+        } else {
+            self.insert(worker, load);
+        }
+    }
+
+    fn remove(&mut self, worker: WorkerWithDpRank) {
+        let Some(idx) = self.index.remove(&worker) else {
+            return;
+        };
+
+        self.slots.swap_remove(idx);
+        if idx < self.slots.len() {
+            self.index.insert(self.slots[idx].worker, idx);
+        }
+    }
+
+    fn insert(&mut self, worker: WorkerWithDpRank, load: WorkerLoadSnapshot) {
+        let idx = self.slots.len();
+        self.slots.push(WorkerLoadSlot::new(worker, load));
+        self.index.insert(worker, idx);
+    }
+}
+
 pub(super) struct PromptRegistry {
     // WARNING: prompt membership and worker load are only eventually consistent.
     // Each mutation still starts from one worker-local source of truth: we mutate the chosen
@@ -81,7 +160,7 @@ pub(super) struct PromptRegistry {
     // after the write finishes, but reads can still observe a mixed membership/load state that
     // never existed atomically and make a suboptimal routing choice.
     membership: PromptMembershipTrie,
-    loads: DashMap<WorkerWithDpRank, WorkerLoadSnapshot, FxBuildHasher>,
+    loads: RwLock<WorkerLoadTable>,
     #[cfg(test)]
     cleanup_attempts: AtomicUsize,
 }
@@ -90,7 +169,7 @@ impl Default for PromptRegistry {
     fn default() -> Self {
         Self {
             membership: PromptMembershipTrie::new(),
-            loads: DashMap::with_hasher(FxBuildHasher),
+            loads: RwLock::new(WorkerLoadTable::default()),
             #[cfg(test)]
             cleanup_attempts: AtomicUsize::new(0),
         }
@@ -100,9 +179,11 @@ impl Default for PromptRegistry {
 impl PromptRegistry {
     pub(super) fn new(workers: impl IntoIterator<Item = WorkerWithDpRank>) -> Self {
         let registry = Self::default();
+        let mut loads = registry.loads.write();
         for worker in workers {
-            registry.loads.entry(worker).or_default();
+            loads.ensure_worker(worker);
         }
+        drop(loads);
         registry
     }
 
@@ -111,7 +192,7 @@ impl PromptRegistry {
         worker: WorkerWithDpRank,
         load: WorkerLoadSnapshot,
     ) {
-        self.loads.insert(worker, load);
+        self.upsert_worker_load(worker, load);
     }
 
     pub(super) fn apply_membership_delta_and_load(
@@ -139,7 +220,14 @@ impl PromptRegistry {
             self.membership
                 .store_chain(worker, lookup, store.parent, &store.hashes);
         }
-        self.loads.insert(worker, load);
+        self.upsert_worker_load(worker, load);
+    }
+
+    fn upsert_worker_load(&self, worker: WorkerWithDpRank, load: WorkerLoadSnapshot) {
+        if self.loads.read().update(worker, load) {
+            return;
+        }
+        self.loads.write().upsert(worker, load);
     }
 
     pub(super) fn maybe_cleanup(&self) {
@@ -157,11 +245,11 @@ impl PromptRegistry {
         for removed in change.removed {
             self.membership
                 .remove_worker(removed.worker, &removed.trie_lookup);
-            self.loads.remove(&removed.worker);
+            self.loads.write().remove(removed.worker);
         }
 
         for worker in change.added {
-            self.loads.entry(worker).or_default();
+            self.loads.write().ensure_worker(worker);
         }
         self.membership.maybe_cleanup();
     }
@@ -173,16 +261,15 @@ impl PromptRegistry {
         prefill_token_deltas: &PrefillTokenDeltas,
         decay_now: Instant,
     ) -> PotentialLoadMaps {
-        let mut potential_blocks =
-            FxHashMap::with_capacity_and_hasher(self.loads.len(), FxBuildHasher);
-        let mut potential_tokens =
-            FxHashMap::with_capacity_and_hasher(self.loads.len(), FxBuildHasher);
+        let loads = self.loads.read();
+        let mut potential_blocks = FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher);
+        let mut potential_tokens = FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher);
         let mut active_requests = INCLUDE_ACTIVE_REQUESTS
-            .then(|| FxHashMap::with_capacity_and_hasher(self.loads.len(), FxBuildHasher));
+            .then(|| FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher));
 
-        for entry in &self.loads {
-            let worker = *entry.key();
-            let load = *entry.value();
+        for entry in loads.iter() {
+            let worker = entry.worker;
+            let load = entry.snapshot();
             let overlap_depth = matched_depth.get(&worker).copied().unwrap_or(0);
             let new_blocks = query_len.saturating_sub(overlap_depth);
             let active_tokens = load.active_tokens(decay_now);
@@ -221,11 +308,12 @@ impl PromptRegistry {
     ) -> FxHashMap<WorkerWithDpRank, WorkerLoadProjection> {
         let query_len = token_sequence.map_or(0, |query| query.len());
         let matched_depth = self.membership.compute_overlap_depths(token_sequence);
-        let mut projections = FxHashMap::with_capacity_and_hasher(self.loads.len(), FxBuildHasher);
+        let loads = self.loads.read();
+        let mut projections = FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher);
 
-        for entry in &self.loads {
-            let worker = *entry.key();
-            let load = *entry.value();
+        for entry in loads.iter() {
+            let worker = entry.worker;
+            let load = entry.snapshot();
             let overlap_depth = matched_depth.get(&worker).copied().unwrap_or(0);
             projections.insert(
                 worker,
@@ -242,22 +330,25 @@ impl PromptRegistry {
 
     pub(super) fn active_blocks(&self) -> HashMap<WorkerWithDpRank, usize> {
         self.loads
+            .read()
             .iter()
-            .map(|entry| (*entry.key(), entry.value().active_blocks))
+            .map(|entry| (entry.worker, entry.snapshot().active_blocks))
             .collect()
     }
 
     pub(super) fn active_request_counts(&self) -> HashMap<WorkerWithDpRank, usize> {
         self.loads
+            .read()
             .iter()
-            .map(|entry| (*entry.key(), entry.value().active_requests))
+            .map(|entry| (entry.worker, entry.snapshot().active_requests))
             .collect()
     }
 
     pub(super) fn active_tokens(&self, decay_now: Instant) -> HashMap<WorkerWithDpRank, usize> {
         self.loads
+            .read()
             .iter()
-            .map(|entry| (*entry.key(), entry.value().active_tokens(decay_now)))
+            .map(|entry| (entry.worker, entry.snapshot().active_tokens(decay_now)))
             .collect()
     }
 
@@ -266,12 +357,11 @@ impl PromptRegistry {
         now: Instant,
     ) -> HashMap<WorkerWithDpRank, Result<u64, PrefillTimeLoadError>> {
         self.loads
+            .read()
             .iter()
             .map(|entry| {
-                (
-                    *entry.key(),
-                    entry.value().modeled_remaining_prefill_time_ms(now),
-                )
+                let load = entry.snapshot();
+                (entry.worker, load.modeled_remaining_prefill_time_ms(now))
             })
             .collect()
     }
@@ -282,8 +372,9 @@ impl PromptRegistry {
         mut predicate: impl FnMut(WorkerWithDpRank, usize) -> bool,
     ) -> bool {
         self.loads
+            .read()
             .iter()
-            .any(|entry| predicate(*entry.key(), entry.value().active_tokens(decay_now)))
+            .any(|entry| predicate(entry.worker, entry.snapshot().active_tokens(decay_now)))
     }
 
     #[cfg(test)]
@@ -294,8 +385,9 @@ impl PromptRegistry {
     ) {
         let actual_loads: FxHashMap<_, _> = self
             .loads
+            .read()
             .iter()
-            .map(|entry| (*entry.key(), *entry.value()))
+            .map(|entry| (entry.worker, entry.snapshot()))
             .collect();
         let actual_blocks = self.membership.worker_hashes();
         assert_eq!(

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -264,24 +264,15 @@ impl ActiveSequences {
 
         let _ = request_state.expected_output_tokens;
         let mut membership_delta = PromptMembershipDelta::default();
-        let mut first_absent_prompt_idx = None;
-        let prompt_hashes: Vec<_> = request_state
-            .prompt_blocks
-            .iter()
-            .map(|(hash, _)| *hash)
-            .collect();
+        let mut prompt_remove = Vec::new();
 
-        for (idx, (block_hash, rc)) in request_state.prompt_blocks.into_iter().enumerate() {
+        for (block_hash, rc) in request_state.prompt_blocks {
             drop(rc);
-            if self.blocks.try_remove_block(&block_hash) && first_absent_prompt_idx.is_none() {
-                first_absent_prompt_idx = Some(idx);
+            if self.blocks.try_remove_block(&block_hash) || !prompt_remove.is_empty() {
+                prompt_remove.push(block_hash);
             }
         }
-
-        if let Some(first_absent_prompt_idx) = first_absent_prompt_idx {
-            let prompt_remove = prompt_hashes[first_absent_prompt_idx..].to_vec();
-            membership_delta.push_remove(prompt_remove);
-        }
+        membership_delta.push_remove(prompt_remove);
 
         for (block_hash, rc) in request_state.output_blocks {
             drop(rc);


### PR DESCRIPTION
## Summary
- Avoid building a full prompt hash copy before freeing active sequences.
- Replace the prompt registry load `DashMap` with a dense worker load table for hot read-path projection.
- Keep per-worker load updates isolated behind each worker slot load lock, while topology changes still update the table shape under the registry table lock.
- Update `active_sequences_bench` to measure the production `project_worker_loads` path instead of the legacy `potential_blocks_and_tokens` path.

## Why
The active sequence profile showed the scheduler admission path dominated by all-worker load projection. The previous map-backed load table paid substantial overhead in map iteration/shared-lock mechanics, then the scheduler consumed the projected loads immediately. This PR removes the duplicate free-path suffix allocation and makes the scheduler read path iterate a compact worker-load table instead of a sharded map.

The prompt membership trie semantics and the advisory/eventually-consistent registry model are unchanged.

## Benchmark
`active_sequences_bench` A/B from the base before this PR (`d9b5ed60c9`) to the PR tip (`b1982b6a16`). The base run used the same production-path benchmark harness locally so the comparison measures the implementation changes rather than the benchmark-path switch.

Config: `mooncake_trace_1000.jsonl`, `--benchmark-duration-ms 20`, `--num-unique-inference-workers 10`, `--inference-worker-duplication-factor 20`, `--trace-duplication-factor 50`, `--num-gpu-blocks 16384`, `--block-size 128`.

| version | achieved ops/s runs | avg ops/s | avg block ops/s | avg p99 |
| --- | ---: | ---: | ---: | ---: |
| PR base `d9b5ed60c9` | 1.765M, 1.775M, 1.763M | 1.768M | 11.599M | 48.63 us |
| PR tip `b1982b6a16` | 2.683M, 2.666M, 2.671M | 2.673M | 17.542M | 58.70 us |

Net throughput change: +51.2% ops/s, about 1.51x. Each run still warned that the synthetic offered rate was too high, so treat these as saturated hot-path throughput numbers; p99 is noisier under this overload setup.

## Validation
- `cargo fmt --all --check`
- `cargo test -p dynamo-kv-router --lib sequences::`
- `cargo test -p dynamo-kv-router --lib`
- `cargo test -p dynamo-bench --test active_sequences_trace`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of worker load tracking during topology changes, helping keep routing state in sync.
  * Fixed sequence cleanup so related prompt blocks are removed more consistently, reducing stale state and mismatched memberships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->