### PR TITLE
feat(operator): preserve worker ratios during rollouts

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -18,6 +18,7 @@
 package controller
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -1119,6 +1120,290 @@ func resolveRollingUpdateParams(annotations map[string]string, desiredReplicas i
 	return int32(surge), int32(unavail)
 }
 
+type workerRollingUpdateConfig struct {
+	maxSurge       int32
+	maxUnavailable int32
+}
+
+type workerRolloutComponent struct {
+	name    string
+	desired int32
+	old     dcdComponentState
+	new     dcdComponentState
+	config  workerRollingUpdateConfig
+}
+
+func workerRolloutBatchSize(config workerRollingUpdateConfig) int32 {
+	if config.maxSurge > 0 {
+		return config.maxSurge
+	}
+	return max(int32(1), config.maxUnavailable)
+}
+
+func ceilDivInt32(numerator, denominator int32) int32 {
+	if denominator <= 0 {
+		return 0
+	}
+	return (numerator + denominator - 1) / denominator
+}
+
+func computeWorkerRolloutTotalSteps(
+	initialOld []int32,
+	targetNew []int32,
+	configs []workerRollingUpdateConfig,
+) int32 {
+	var totalSteps int32
+	for i := range initialOld {
+		maxReplicas := max(initialOld[i], targetNew[i], int32(0))
+		totalSteps = max(totalSteps, ceilDivInt32(maxReplicas, workerRolloutBatchSize(configs[i])))
+	}
+	return totalSteps
+}
+
+func computeNextWorkerNewReplicas(targetNew, currentNew []int32, totalSteps int32) []int32 {
+	result := make([]int32, len(targetNew))
+	if totalSteps == 0 {
+		copy(result, targetNew)
+		return result
+	}
+
+	stepIndex := func(current, target int32) int32 {
+		if target == 0 {
+			return totalSteps
+		}
+		return current * totalSteps / target
+	}
+
+	minStepIndex := totalSteps
+	for i := range targetNew {
+		minStepIndex = min(minStepIndex, stepIndex(currentNew[i], targetNew[i]))
+	}
+	nextStepIndex := minStepIndex + 1
+
+	for i := range targetNew {
+		next := ceilDivInt32(nextStepIndex*targetNew[i], totalSteps)
+		result[i] = max(min(next, targetNew[i]), currentNew[i])
+	}
+	return result
+}
+
+func computeNextWorkerOldReplicas(initialOld, currentOld []int32, totalSteps int32) []int32 {
+	result := make([]int32, len(initialOld))
+	if totalSteps == 0 {
+		return result
+	}
+
+	stepIndex := func(removed, source int32) int32 {
+		if source == 0 {
+			return 0
+		}
+		return removed * totalSteps / source
+	}
+
+	var maxStepIndex int32
+	for i := range initialOld {
+		if initialOld[i] == 0 {
+			continue
+		}
+		removed := initialOld[i] - currentOld[i]
+		maxStepIndex = max(maxStepIndex, stepIndex(removed, initialOld[i]))
+	}
+	nextStepIndex := maxStepIndex + 1
+
+	for i := range initialOld {
+		next := initialOld[i] - (nextStepIndex * initialOld[i] / totalSteps)
+		result[i] = min(max(int32(0), next), currentOld[i])
+	}
+	return result
+}
+
+func workerRolloutComplete(currentOld, currentNew, targetNew []int32) bool {
+	for i := range currentOld {
+		if currentOld[i] != 0 || currentNew[i] < targetNew[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func workerNewAtTarget(currentNew, targetNew []int32) bool {
+	for i := range currentNew {
+		if currentNew[i] < targetNew[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func workerCanScaleUp(
+	currentOld []int32,
+	nextNew []int32,
+	targetNew []int32,
+	configs []workerRollingUpdateConfig,
+) bool {
+	for i := range currentOld {
+		if targetNew[i] == 0 {
+			continue
+		}
+		if currentOld[i]+nextNew[i] > targetNew[i]+configs[i].maxSurge {
+			return false
+		}
+	}
+	return true
+}
+
+func computeWorkerMinOld(
+	initialOld []int32,
+	currentNew []int32,
+	targetNew []int32,
+	configs []workerRollingUpdateConfig,
+) []int32 {
+	minOld := make([]int32, len(initialOld))
+	for i := range initialOld {
+		if initialOld[i] >= targetNew[i] {
+			minOld[i] = max(int32(0), targetNew[i]-configs[i].maxUnavailable-currentNew[i])
+		}
+	}
+	return minOld
+}
+
+func workerCanDrainAllToZero(
+	currentNew []int32,
+	initialOld []int32,
+	targetNew []int32,
+	configs []workerRollingUpdateConfig,
+) bool {
+	for i := range targetNew {
+		if initialOld[i] >= targetNew[i] {
+			minRequired := targetNew[i] - configs[i].maxUnavailable
+			if currentNew[i] < minRequired {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func applyWorkerOrphanPrevention(
+	nextOld []int32,
+	currentNew []int32,
+	initialOld []int32,
+	targetNew []int32,
+	configs []workerRollingUpdateConfig,
+) {
+	anyDrainsToZero := false
+	allDrainToZero := true
+	for i := range nextOld {
+		if initialOld[i] == 0 {
+			continue
+		}
+		if nextOld[i] == 0 {
+			anyDrainsToZero = true
+		} else {
+			allDrainToZero = false
+		}
+	}
+
+	if !anyDrainsToZero || allDrainToZero {
+		return
+	}
+
+	if workerCanDrainAllToZero(currentNew, initialOld, targetNew, configs) {
+		for i := range nextOld {
+			nextOld[i] = 0
+		}
+		return
+	}
+
+	for i := range nextOld {
+		if nextOld[i] == 0 && initialOld[i] > 0 {
+			nextOld[i] = 1
+		}
+	}
+}
+
+func computeNextWorkerRolloutStep(
+	initialOld []int32,
+	currentOld []int32,
+	currentNew []int32,
+	targetNew []int32,
+	configs []workerRollingUpdateConfig,
+) ([]int32, []int32) {
+	oldTargets := slices.Clone(currentOld)
+	newTargets := slices.Clone(currentNew)
+	if workerRolloutComplete(currentOld, currentNew, targetNew) {
+		return oldTargets, newTargets
+	}
+
+	totalSteps := computeWorkerRolloutTotalSteps(initialOld, targetNew, configs)
+	if totalSteps == 0 {
+		return oldTargets, newTargets
+	}
+
+	if workerNewAtTarget(currentNew, targetNew) {
+		return make([]int32, len(initialOld)), newTargets
+	}
+
+	nextNew := computeNextWorkerNewReplicas(targetNew, currentNew, totalSteps)
+	needsScaleUp := false
+	for i := range currentNew {
+		if nextNew[i] > currentNew[i] {
+			needsScaleUp = true
+			break
+		}
+	}
+	if needsScaleUp && workerCanScaleUp(currentOld, nextNew, targetNew, configs) {
+		return oldTargets, nextNew
+	}
+
+	minOld := computeWorkerMinOld(initialOld, currentNew, targetNew, configs)
+	nextOld := computeNextWorkerOldReplicas(initialOld, currentOld, totalSteps)
+	for i := range nextOld {
+		nextOld[i] = max(nextOld[i], minOld[i])
+	}
+	applyWorkerOrphanPrevention(nextOld, currentNew, initialOld, targetNew, configs)
+
+	needsScaleDown := false
+	for i := range nextOld {
+		if nextOld[i] < currentOld[i] {
+			needsScaleDown = true
+			break
+		}
+	}
+	if needsScaleDown {
+		return nextOld, newTargets
+	}
+
+	drainedOld := make([]int32, len(currentOld))
+	needsForceDrain := false
+	for i := range currentOld {
+		maxOld := targetNew[i] + configs[i].maxSurge - nextNew[i]
+		drainedOld[i] = max(int32(0), min(currentOld[i], maxOld))
+		if initialOld[i] >= targetNew[i] {
+			minOldForRole := max(int32(0), targetNew[i]-configs[i].maxUnavailable-nextNew[i])
+			drainedOld[i] = max(drainedOld[i], minOldForRole)
+		}
+		if drainedOld[i] < currentOld[i] {
+			needsForceDrain = true
+		}
+	}
+	if needsForceDrain {
+		applyWorkerOrphanPrevention(drainedOld, nextNew, initialOld, targetNew, configs)
+		return drainedOld, nextNew
+	}
+
+	return oldTargets, newTargets
+}
+
+func newWorkerGenerationAvailable(components []workerRolloutComponent) bool {
+	for i := range components {
+		if components[i].new.Available < components[i].new.Spec {
+			return false
+		}
+	}
+	return true
+}
+
 // buildRollingUpdateContext creates a RollingUpdateContext.
 func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 	ctx context.Context,
@@ -1147,10 +1432,7 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 		return dynamo.RollingUpdateContext{}, fmt.Errorf("failed to get old worker component states: %w", err)
 	}
 
-	oldWorkerComponentReplicas := make(map[string]int32)
-	oldWorkerDCDReplicas := make(map[string]int32)
-	newWorkerReplicas := make(map[string]int32)
-
+	components := make([]workerRolloutComponent, 0)
 	for i := range dgd.Spec.Components {
 		spec := &dgd.Spec.Components[i]
 		componentName := spec.ComponentName
@@ -1164,7 +1446,6 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 		}
 
 		maxSurge, maxUnavailable := resolveRollingUpdateParams(dynamo.GetPodTemplateAnnotations(spec), desired)
-		minAvailable := desired - maxUnavailable
 
 		var newState dcdComponentState
 		newDCDName := dynamo.GetDCDResourceName(dgd, componentName, newWorkerHash)
@@ -1175,35 +1456,64 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 			return dynamo.RollingUpdateContext{}, fmt.Errorf("failed to get new worker DCD %s: %w", newDCDName, err)
 		}
 
-		oldState := oldStates[componentName]
+		components = append(components, workerRolloutComponent{
+			name:    componentName,
+			desired: desired,
+			old:     oldStates[componentName],
+			new:     newState,
+			config: workerRollingUpdateConfig{
+				maxSurge:       maxSurge,
+				maxUnavailable: maxUnavailable,
+			},
+		})
+	}
 
-		newUnavailable := max(int32(0), newState.Spec-newState.Available)
-		// maxScaledDown is the maximum number of old replicas that can be scaled down
-		maxScaledDown := max(int32(0), (oldState.Spec+newState.Spec)-minAvailable-newUnavailable)
-		oldUnhealthy := max(int32(0), oldState.Spec-oldState.Available)
-		// availableSurplus is how many extra available replicas we have above minAvailable (min 0)
-		availableSurplus := max(int32(0), (oldState.Available+newState.Available)-minAvailable)
-		oldTarget := max(int32(0), oldState.Spec-min(maxScaledDown, oldUnhealthy+availableSurplus))
+	slices.SortFunc(components, func(a, b workerRolloutComponent) int {
+		return cmp.Compare(a.name, b.name)
+	})
 
-		// Surge budget uses Spec (declared intent) like K8s Deployment controller; scheduler enforces actual resource constraints.
-		scaleUpBudget := max(int32(0), desired+maxSurge-oldState.Spec-newState.Spec)
-		newTarget := min(desired, newState.Spec+scaleUpBudget)
+	initialOld := make([]int32, len(components))
+	currentOld := make([]int32, len(components))
+	currentNew := make([]int32, len(components))
+	targetNew := make([]int32, len(components))
+	configs := make([]workerRollingUpdateConfig, len(components))
+	for i := range components {
+		component := components[i]
+		initialOld[i] = max(component.desired, component.old.Spec)
+		currentOld[i] = component.old.Spec
+		currentNew[i] = component.new.Spec
+		targetNew[i] = component.desired
+		configs[i] = component.config
+	}
 
-		oldWorkerComponentReplicas[componentName] = oldTarget
-		newWorkerReplicas[componentName] = newTarget
+	oldTargets := slices.Clone(currentOld)
+	newTargets := slices.Clone(currentNew)
+	if newWorkerGenerationAvailable(components) {
+		oldTargets, newTargets = computeNextWorkerRolloutStep(initialOld, currentOld, currentNew, targetNew, configs)
+	}
 
-		for dcdName, target := range allocateOldWorkerDCDReplicas(oldDCDsByComponent[componentName], oldTarget) {
+	oldWorkerComponentReplicas := make(map[string]int32)
+	oldWorkerDCDReplicas := make(map[string]int32)
+	newWorkerReplicas := make(map[string]int32)
+	for i := range components {
+		component := components[i]
+		oldTarget := oldTargets[i]
+		newTarget := newTargets[i]
+
+		oldWorkerComponentReplicas[component.name] = oldTarget
+		newWorkerReplicas[component.name] = newTarget
+
+		for dcdName, target := range allocateOldWorkerDCDReplicas(oldDCDsByComponent[component.name], oldTarget) {
 			oldWorkerDCDReplicas[dcdName] = target
 		}
 
 		logger.V(1).Info("Rolling update replica calculation",
-			"component", componentName,
-			"desired", desired,
-			"maxSurge", maxSurge,
-			"maxUnavailable", maxUnavailable,
-			"minAvailable", minAvailable,
-			"old", oldState,
-			"new", newState,
+			"component", component.name,
+			"desired", component.desired,
+			"maxSurge", component.config.maxSurge,
+			"maxUnavailable", component.config.maxUnavailable,
+			"old", component.old,
+			"new", component.new,
 			"oldTarget", oldTarget,
 			"newTarget", newTarget)
 	}

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -2786,9 +2786,9 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerationsPreservesAvailableReplicas(t *
 
 	rollingUpdateCtx, err := r.buildRollingUpdateContext(ctx, dgd)
 	require.NoError(t, err)
-	assert.Equal(t, int32(15), rollingUpdateCtx.OldWorkerReplicaTargetsByComponent["worker"])
+	assert.Equal(t, int32(20), rollingUpdateCtx.OldWorkerReplicaTargetsByComponent["worker"])
 	assert.Equal(t, int32(15), rollingUpdateCtx.OldWorkerReplicaTargetsByDCD["test-dgd-worker-hashaaaa"])
-	assert.Equal(t, int32(0), rollingUpdateCtx.OldWorkerReplicaTargetsByDCD["test-dgd-worker-hashbbbb"])
+	assert.Equal(t, int32(5), rollingUpdateCtx.OldWorkerReplicaTargetsByDCD["test-dgd-worker-hashbbbb"])
 	assert.Equal(t, int32(0), rollingUpdateCtx.NewWorkerReplicaTargetsByComponent["worker"])
 
 	err = r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
@@ -2797,12 +2797,12 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerationsPreservesAvailableReplicas(t *
 	updatedA := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{})
 	err = r.Get(ctx, types.NamespacedName{Name: "test-dgd-worker-hashaaaa", Namespace: "default"}, updatedA)
 	require.NoError(t, err)
-	assert.Equal(t, int32(15), *updatedA.Spec.Replicas, "Healthy old DCD should continue serving minAvailable")
+	assert.Equal(t, int32(15), *updatedA.Spec.Replicas, "Healthy old DCD should continue serving")
 
 	updatedB := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{})
 	err = r.Get(ctx, types.NamespacedName{Name: "test-dgd-worker-hashbbbb", Namespace: "default"}, updatedB)
 	require.NoError(t, err)
-	assert.Equal(t, int32(0), *updatedB.Spec.Replicas, "Unavailable newer old DCD should be drained first")
+	assert.Equal(t, int32(5), *updatedB.Spec.Replicas, "Unavailable newer old DCD should absorb the remaining old target")
 }
 
 func TestAggregateOldWorkerServiceStatuses_MultipleOldGenerations(t *testing.T) {
@@ -3497,9 +3497,11 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			expectedNew: map[string]int32{"worker": 2}, // budget from Spec: 10+0-8-0=2
 		},
 		{
-			name: "old fleet degraded - should protect healthy old pods",
+			name: "old fleet degraded - scale up before draining old",
 			// desired=10, maxSurge=3, maxUnavailable=2
 			// old: spec=8, available=4, actual=8 | new: spec=3, available=3, actual=3
+			// Vector planning advances by one scale-up step first; unhealthy old pods are not
+			// independently drained ahead of the shared rollout progression.
 			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				"worker": {
 					ComponentType: consts.ComponentTypeWorker,
@@ -3517,7 +3519,7 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 3, 3, 3),
 				}
 			},
-			expectedOld: map[string]int32{"worker": 5},
+			expectedOld: map[string]int32{"worker": 8},
 			expectedNew: map[string]int32{"worker": 5},
 		},
 		{
@@ -3536,7 +3538,7 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 				}
 			},
 			newDCDs:     func(_ string) []runtime.Object { return nil },
-			expectedOld: map[string]int32{"worker": 8},
+			expectedOld: map[string]int32{"worker": 10},
 			expectedNew: map[string]int32{"worker": 3},
 		},
 		{
@@ -3562,15 +3564,17 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 5, 5, 5),
 				}
 			},
-			expectedOld: map[string]int32{"worker": 3},
+			expectedOld: map[string]int32{"worker": 5},
 			expectedNew: map[string]int32{"worker": 8},
 		},
 		{
-			name: "multi-service independence - prefill done, decode mid-rollout",
+			name: "multi-service vector gate - prefill done, decode new pods unavailable",
 			// prefill: desired=4, maxSurge=1, maxUnavailable=1
 			//   old: spec=0, available=0, actual=0 | new: spec=4, available=4, actual=4
 			// decode: desired=8, maxSurge=2, maxUnavailable=2
 			//   old: spec=6, available=6, actual=6 | new: spec=2, available=0, actual=2
+			// Because decode's new generation is not available yet, the vector planner holds all
+			// worker targets instead of advancing decode independently.
 			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				"prefill": {
 					ComponentType: consts.ComponentTypePrefill,
@@ -3594,7 +3598,76 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 				}
 			},
 			expectedOld: map[string]int32{"prefill": 0, "decode": 6},
-			expectedNew: map[string]int32{"prefill": 4, "decode": 4},
+			expectedNew: map[string]int32{"prefill": 4, "decode": 2},
+		},
+		{
+			name: "awkward ratio initial scale-up uses shared interpolation",
+			// decode:prefill desired=7:3, maxSurge=1, maxUnavailable=0 for both.
+			// The shared interpolation uses totalSteps=7 and starts with +1D/+1P.
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"decode": {
+					ComponentType: consts.ComponentTypeDecode,
+					Replicas:      ptr.To(int32(7)),
+					Annotations: map[string]string{
+						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "1",
+						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "0",
+					},
+				},
+				"prefill": {
+					ComponentType: consts.ComponentTypePrefill,
+					Replicas:      ptr.To(int32(3)),
+					Annotations: map[string]string{
+						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "1",
+						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "0",
+					},
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "decode", consts.ComponentTypeDecode, "", 7, 7, 7),
+					makeOldDCD("test-dgd", "prefill", consts.ComponentTypePrefill, "", 3, 3, 3),
+				}
+			},
+			newDCDs:     func(_ string) []runtime.Object { return nil },
+			expectedOld: map[string]int32{"decode": 7, "prefill": 3},
+			expectedNew: map[string]int32{"decode": 1, "prefill": 1},
+		},
+		{
+			name: "awkward ratio next step drains only decode",
+			// After +1D/+1P is available, surge budget blocks the next +1D, so the
+			// shared interpolation drains one old decode and keeps prefill unchanged.
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"decode": {
+					ComponentType: consts.ComponentTypeDecode,
+					Replicas:      ptr.To(int32(7)),
+					Annotations: map[string]string{
+						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "1",
+						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "0",
+					},
+				},
+				"prefill": {
+					ComponentType: consts.ComponentTypePrefill,
+					Replicas:      ptr.To(int32(3)),
+					Annotations: map[string]string{
+						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "1",
+						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "0",
+					},
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "decode", consts.ComponentTypeDecode, "", 7, 7, 7),
+					makeOldDCD("test-dgd", "prefill", consts.ComponentTypePrefill, "", 3, 3, 3),
+				}
+			},
+			newDCDs: func(newHash string) []runtime.Object {
+				return []runtime.Object{
+					makeNewDCD("test-dgd", "decode", consts.ComponentTypeDecode, newHash, 1, 1, 1),
+					makeNewDCD("test-dgd", "prefill", consts.ComponentTypePrefill, newHash, 1, 1, 1),
+				}
+			},
+			expectedOld: map[string]int32{"decode": 6, "prefill": 3},
+			expectedNew: map[string]int32{"decode": 1, "prefill": 1},
 		},
 		{
 			name: "new pods unavailable - hold old until new becomes Ready",
@@ -3616,8 +3689,8 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 4, 4, 0),
 				}
 			},
-			expectedOld: map[string]int32{"worker": 8}, // newUnavailable shrinks scale-down budget; hold unhealthy old
-			expectedNew: map[string]int32{"worker": 4}, // no surge: actual already at desired+maxSurge-1
+			expectedOld: map[string]int32{"worker": 10}, // new generation is not available; hold old targets
+			expectedNew: map[string]int32{"worker": 4},
 		},
 		{
 			name: "multiple old generations - aggregate state across hashes",
@@ -3640,8 +3713,8 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 2, 2, 2),
 				}
 			},
-			expectedOld: map[string]int32{"worker": 6}, // aggregated across both old gens
-			expectedNew: map[string]int32{"worker": 5},
+			expectedOld: map[string]int32{"worker": 8}, // aggregated across both old gens
+			expectedNew: map[string]int32{"worker": 3},
 		},
 	}
 
@@ -3729,8 +3802,8 @@ func TestBuildRollingUpdateContext_NoNewDCDExists(t *testing.T) {
 
 	assert.NoError(t, err, "IsNotFound on the new-hash DCD must not produce an error")
 	assert.Equal(t, newHash, result.NewWorkerHash)
-	// Math runs with newState={0,0,0}: drain old to minAvailable, surge new from zero.
-	assert.Equal(t, int32(8), result.OldWorkerReplicaTargetsByComponent["worker"])
+	// Math runs with newState={0,0,0}: the vector planner scales new up before draining old.
+	assert.Equal(t, int32(10), result.OldWorkerReplicaTargetsByComponent["worker"])
 	assert.Equal(t, int32(3), result.NewWorkerReplicaTargetsByComponent["worker"])
 }
 


### PR DESCRIPTION
#### Summary:

Preserves worker ratios during Deployment-backed DGD rolling updates by planning all worker components as one shared worker rollout vector instead of independently rolling each component.

When any worker component changes, the operator already creates a new worker hash. This PR makes that hash behave like a coherent worker boundary for `worker`, `decode`, and `prefill`: new worker DCDs advance together, and old worker DCDs drain through a shared old/new pool while respecting each component's Deployment rolling-update budget.

This is intentionally scoped to the Deployment-backed path:

- `minAvailable` remains Grove-only and is not used for Deployment-backed DCD rollout planning.
- Frontend/router/EPP components remain outside the worker boundary unless they independently change through their existing path.
- Pod readiness is the rollout gate, relying on the worker readiness contract that Ready means registered and ready to serve.
- Autoscaling, failure handling, rollback, and roll-forward behavior remain out of scope for this change.

#### Details:

- Adds a worker-vector planner in `buildRollingUpdateContext` across all DGD worker components.
- Uses desired worker replicas as the target ratio and existing Deployment rolling-update annotations as per-component budget constraints.
- Advances the vector only when the current new worker target is Available for every worker component.
- Uses DisaggregatedSet-inspired linear interpolation across old/new pools for uneven ratios such as decode `7` and prefill `3`.
- Preserves existing old-worker DCD allocation logic so multiple old worker generations still drain through concrete per-DCD targets.
- Prevents orphaning one worker role at zero before the rest of the worker vector can complete.
- Adds regression coverage for uneven worker ratios, vector readiness gating, and existing old-generation allocation behavior.

#### Where should the reviewer start?

- `deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go`
- `deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go`

#### Validation:

- `go test ./internal/controller -run 'Test(BuildRollingUpdateContext|ResolveRollingUpdateParams|ScaleOldWorkerDCDs|AllocateOldWorker|AggregateOldWorker)' -count=1`
- `go test ./internal/dynamo -count=1`
- Local mocker e2e on minikube, no GPUs:
  - built the operator image locally and loaded it into minikube without pushing
  - installed CRDs/operator plus local `nats:2.11.4`
  - deployed a Deployment-backed DGD with Grove disabled, frontend `1`, decode `7`, prefill `3`, and both workers set to `maxSurge=1`, `maxUnavailable=0`
  - patched only the Decode pod-template annotation
  - observed Kubernetes events for new Decode/Prefill DCD creation, Deployment scale-up, old pod deletion, and rollout completion
  - final state: DGD Ready=True, old worker DCDs deleted, new Decode `7/7` Available, new Prefill `3/3` Available

Captured local evidence:

- `/home/tmontfort/runs/dynamo/2026-06-24-dep983-worker-ratio-rollout/README.md`
- `/home/tmontfort/runs/dynamo/2026-06-24-dep983-worker-ratio-rollout/events-after.txt`
- `/home/tmontfort/runs/dynamo/2026-06-24-dep983-worker-ratio-rollout/rollout-summary-samples.tsv`
- `/home/tmontfort/runs/dynamo/2026-06-24-dep983-worker-ratio-rollout/dgd-final.yaml`
- `/home/tmontfort/runs/dynamo/2026-06-24-dep983-worker-ratio-rollout/dcd-final.yaml`

Full `go test ./internal/controller -count=1` is blocked locally because envtest cannot find `../../bin/k8s/1.29.0-linux-amd64/etcd`.

#### Related Issues:

- Linear: https://linear.app/nvidia/issue/DEP-983/make-deployment-backed-rolling-updates-preserve-configured-worker
- Follows the Grove-only `minAvailable` API work in https://github.com/ai-dynamo/dynamo/pull/10532
