### PR TITLE
feat(mocker): model cache-aware KV transfer timing [DYN-3277]

### DIFF
--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -545,6 +545,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "For intra-node NVLink, typical value is ~450.",
     )
     parser.add_argument(
+        "--kv-transfer-timing-mode",
+        choices=("full_prompt", "destination_missing"),
+        default="full_prompt",
+        help="Physical KV footprint used for coordinated disaggregated transfer timing.",
+    )
+    parser.add_argument(
         "--kv-cache-dtype",
         type=str,
         default="auto",

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -296,6 +296,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         enable_local_indexer=not getattr(args, "durable_kv_events", False),
         kv_bytes_per_token=getattr(args, "kv_bytes_per_token", None),
         kv_transfer_bandwidth=getattr(args, "kv_transfer_bandwidth", None),
+        kv_transfer_timing_mode=getattr(args, "kv_transfer_timing_mode", "full_prompt"),
         num_g2_blocks=getattr(args, "num_g2_blocks", None),
         num_g3_blocks=getattr(args, "num_g3_blocks", None),
         enable_g4_storage=getattr(args, "enable_g4_storage", False),

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -46,6 +46,7 @@ def make_args(**overrides):
         "startup_time": None,
         "durable_kv_events": False,
         "kv_transfer_bandwidth": 64.0,
+        "kv_transfer_timing_mode": "full_prompt",
         "reasoning": None,
         "sglang_schedule_policy": None,
         "sglang_page_size": None,
@@ -273,6 +274,7 @@ def test_build_mocker_engine_args_preserves_cli_mapped_fields(tmp_path):
         durable_kv_events=False,
         kv_bytes_per_token=131072,
         kv_transfer_bandwidth=123.0,
+        kv_transfer_timing_mode="destination_missing",
         num_g2_blocks=8192,
         num_g3_blocks=16384,
         offload_batch_size=32,
@@ -322,6 +324,7 @@ def test_build_mocker_engine_args_preserves_cli_mapped_fields(tmp_path):
     assert engine_args.aic_moe_ep_size is None
     assert engine_args.aic_attention_dp_size is None
     assert engine_args.bootstrap_port is None
+    assert engine_args.kv_transfer_timing_mode == "destination_missing"
     assert engine_args.num_g2_blocks == 8192
     assert engine_args.num_g3_blocks == 16384
     assert engine_args.offload_batch_size == 32

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -171,7 +171,7 @@ impl MockEngineArgs {
 #[pymethods]
 impl MockEngineArgs {
     #[new]
-    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=42, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, handoff_session_timeout_ms=300000, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
+    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=42, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, handoff_session_timeout_ms=300000, kv_bytes_per_token=None, kv_transfer_bandwidth=None, kv_transfer_timing_mode="full_prompt", reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         engine_type: &str,
@@ -206,6 +206,7 @@ impl MockEngineArgs {
         handoff_session_timeout_ms: u64,
         kv_bytes_per_token: Option<usize>,
         kv_transfer_bandwidth: Option<f64>,
+        kv_transfer_timing_mode: &str,
         reasoning: Option<ReasoningConfig>,
         zmq_kv_events_port: Option<u16>,
         zmq_replay_port: Option<u16>,
@@ -227,6 +228,9 @@ impl MockEngineArgs {
         let engine_type = parse_mocker_engine_type(engine_type)?;
         let worker_type = parse_worker_type(worker_type)?;
         let preemption_mode = parse_preemption_mode(preemption_mode)?;
+        let kv_transfer_timing_mode = kv_transfer_timing_mode
+            .parse()
+            .map_err(|error: String| PyException::new_err(error))?;
         let router_queue_policy = router_queue_policy
             .map(|value| {
                 value.parse().map_err(|e: String| {
@@ -267,6 +271,7 @@ impl MockEngineArgs {
             .handoff_session_timeout_ms(handoff_session_timeout_ms)
             .kv_bytes_per_token(kv_bytes_per_token)
             .kv_transfer_bandwidth(kv_transfer_bandwidth)
+            .kv_transfer_timing_mode(kv_transfer_timing_mode)
             .num_g2_blocks(num_g2_blocks)
             .num_g3_blocks(num_g3_blocks)
             .enable_g4_storage(enable_g4_storage)
@@ -386,6 +391,16 @@ impl MockEngineArgs {
     #[getter]
     fn handoff_session_timeout_ms(&self) -> u64 {
         self.inner.handoff_session_timeout_ms
+    }
+
+    #[getter]
+    fn kv_transfer_timing_mode(&self) -> &'static str {
+        match self.inner.kv_transfer_timing_mode {
+            dynamo_mocker::common::protocols::KvTransferTimingMode::FullPrompt => "full_prompt",
+            dynamo_mocker::common::protocols::KvTransferTimingMode::DestinationMissing => {
+                "destination_missing"
+            }
+        }
     }
 
     #[getter]

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1998,6 +1998,7 @@ class MockEngineArgs:
         handoff_session_timeout_ms: int = 300000,
         kv_bytes_per_token: Optional[int] = None,
         kv_transfer_bandwidth: Optional[float] = None,
+        kv_transfer_timing_mode: str = "full_prompt",
         reasoning: Optional[ReasoningConfig] = None,
         zmq_kv_events_port: Optional[int] = None,
         zmq_replay_port: Optional[int] = None,
@@ -2056,6 +2057,9 @@ class MockEngineArgs:
 
     @property
     def handoff_session_timeout_ms(self) -> int: ...
+
+    @property
+    def kv_transfer_timing_mode(self) -> str: ...
 
     @property
     def engine_type(self) -> str: ...

--- a/lib/llm/src/mocker/handoff.rs
+++ b/lib/llm/src/mocker/handoff.rs
@@ -10,10 +10,10 @@ use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use dynamo_mocker::common::handoff::{
     HandoffAction, HandoffActionId, HandoffActionOutcome, HandoffCoordinatorCore, HandoffFact,
-    HandoffId, HandoffOrder, IssuedHandoffAction, NormalizedHandoffEvent,
-    validate_transfer_delay_ms,
+    HandoffId, HandoffOrder, HandoffTransferTiming, IssuedHandoffAction, NormalizedHandoffEvent,
+    validate_transfer_delay_ms, validate_transfer_timing,
 };
-use dynamo_mocker::common::protocols::{DirectRequest, EngineType};
+use dynamo_mocker::common::protocols::{DirectRequest, EngineType, KvTransferTimingMode};
 use dynamo_mocker::scheduler::{
     SchedulerCommand, SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerCommandResult,
     SchedulerLifecycleEvent,
@@ -37,6 +37,18 @@ fn session_deadline_with_transfer(
     Ok(session_started
         + session_timeout
         + Duration::from_secs_f64(transfer_delay_ms.unwrap_or_default() / 1000.0))
+}
+
+fn transfer_timeout_delay(
+    transfer_timing: HandoffTransferTiming,
+    destination_missing_tokens: Option<usize>,
+) -> Option<Option<f64>> {
+    match transfer_timing.mode {
+        KvTransferTimingMode::FullPrompt => Some(transfer_timing.full_prompt_delay_ms()),
+        KvTransferTimingMode::DestinationMissing => {
+            destination_missing_tokens.map(|tokens| transfer_timing.delay_ms(tokens))
+        }
+    }
 }
 
 pub(crate) fn order_for_engine(engine_type: EngineType) -> Result<HandoffOrder> {
@@ -742,17 +754,17 @@ fn apply_source_held(
     observer: &Option<mpsc::UnboundedSender<NormalizedHandoffEvent>>,
     observed_source_held: &mut bool,
     handoff_id: HandoffId,
-    transfer_delay_ms: Option<f64>,
+    transfer_timing: HandoffTransferTiming,
 ) -> Result<()> {
     let next = coordinator.on_fact(HandoffFact::SourceHeld {
         handoff_id,
-        transfer_delay_ms,
+        transfer_timing,
     })?;
     queue_source_message(
         outbound_tx,
         BootstrapMessage::Fact(HandoffFact::SourceHeld {
             handoff_id,
-            transfer_delay_ms,
+            transfer_timing,
         }),
     )?;
     actions.extend(next);
@@ -817,6 +829,8 @@ async fn run_source_session(
     let mut observed_destination_reserved = false;
     let mut pending_submit_action = None;
     let mut pending_source_held = None;
+    let mut source_transfer_timing = None;
+    let mut destination_transferable_prompt_tokens = None;
 
     tasks.spawn(run_source_transport(
         connection,
@@ -1015,26 +1029,31 @@ async fn run_source_session(
             match event {
                 SourceSessionEvent::Scheduler(SchedulerLifecycleEvent::SourceHeld {
                     handoff_id: observed,
-                    transfer_delay_ms,
+                    transfer_timing,
                     ..
                 }) if observed == handoff_id => {
-                    if transfer_delay_ms.is_some() {
+                    validate_transfer_timing(transfer_timing)?;
+                    source_transfer_timing = Some(transfer_timing);
+                    if let Some(Some(timeout_delay)) = transfer_timeout_delay(
+                        transfer_timing,
+                        destination_transferable_prompt_tokens,
+                    ) {
                         session_deadline = session_deadline_with_transfer(
                             session_started,
                             session_timeout,
-                            transfer_delay_ms,
+                            Some(timeout_delay),
                         )?;
                         deadline.as_mut().reset(session_deadline);
                     }
                     if pending_submit_action.is_some() {
                         if let Some(previous) = pending_source_held
-                            && previous != transfer_delay_ms
+                            && previous != transfer_timing
                         {
                             bail!(
-                                "source changed its modeled transfer delay before submission ACK"
+                                "source changed its modeled transfer timing before submission ACK"
                             );
                         }
-                        pending_source_held = Some(transfer_delay_ms);
+                        pending_source_held = Some(transfer_timing);
                         continue;
                     }
                     apply_source_held(
@@ -1044,7 +1063,7 @@ async fn run_source_session(
                         &observer,
                         &mut observed_source_held,
                         handoff_id,
-                        transfer_delay_ms,
+                        transfer_timing,
                     )?;
                 }
                 SourceSessionEvent::Scheduler(SchedulerLifecycleEvent::SourceHeld { .. }) => {
@@ -1066,15 +1085,31 @@ async fn run_source_session(
                 SourceSessionEvent::Remote(Ok(Some(BootstrapMessage::Fact(
                     HandoffFact::DestinationReserved {
                         handoff_id: observed,
+                        transferable_prompt_tokens,
                     },
                 )))) if observed == handoff_id => {
+                    destination_transferable_prompt_tokens = Some(transferable_prompt_tokens);
                     if !observed_destination_reserved {
                         observe_handoff(&observer, NormalizedHandoffEvent::DestinationReserved);
                         observed_destination_reserved = true;
                     }
-                    actions.extend(
-                        coordinator.on_fact(HandoffFact::DestinationReserved { handoff_id })?,
-                    );
+                    if let Some(Some(timeout_delay)) = source_transfer_timing
+                        .filter(|timing| timing.mode == KvTransferTimingMode::DestinationMissing)
+                        .and_then(|timing| {
+                            transfer_timeout_delay(timing, Some(transferable_prompt_tokens))
+                        })
+                    {
+                        session_deadline = session_deadline_with_transfer(
+                            session_started,
+                            session_timeout,
+                            Some(timeout_delay),
+                        )?;
+                        deadline.as_mut().reset(session_deadline);
+                    }
+                    actions.extend(coordinator.on_fact(HandoffFact::DestinationReserved {
+                        handoff_id,
+                        transferable_prompt_tokens,
+                    })?);
                 }
                 SourceSessionEvent::Remote(Ok(Some(BootstrapMessage::Abort { message })))
                 | SourceSessionEvent::Remote(Ok(Some(BootstrapMessage::ProtocolError {
@@ -1095,7 +1130,7 @@ async fn run_source_session(
                     actions.extend(coordinator.on_action_outcome(action_id, outcome)?);
                     if completes_submit {
                         pending_submit_action = None;
-                        if let Some(transfer_delay_ms) = pending_source_held.take() {
+                        if let Some(transfer_timing) = pending_source_held.take() {
                             if !submitted {
                                 bail!("source was held after its submission failed");
                             }
@@ -1106,7 +1141,7 @@ async fn run_source_session(
                                 &observer,
                                 &mut observed_source_held,
                                 handoff_id,
-                                transfer_delay_ms,
+                                transfer_timing,
                             )?;
                         }
                     }
@@ -1170,14 +1205,15 @@ pub(crate) async fn run_destination_session(
     let mut complete = false;
     let mut session_started = None;
     let mut session_deadline = tokio::time::Instant::now() + PARTICIPANT_RENDEZVOUS_TIMEOUT;
-    let mut transfer_delay_ms = None;
+    let mut transfer_timing: Option<HandoffTransferTiming> = None;
+    let mut transferable_prompt_tokens = None;
     let action_stop = CancellationToken::new();
     let action_tasks = TaskTracker::new();
     let (action_result_tx, mut action_result_rx) =
         mpsc::channel::<(IssuedHandoffAction, HandoffActionOutcome)>(1);
     let mut pending_action: Option<IssuedHandoffAction> = None;
     let mut reserve_ack_sent = false;
-    let mut pending_destination_reserved = false;
+    let mut pending_destination_reserved = None;
     let mut destination_reserved_sent = false;
     let deadline = tokio::time::sleep_until(session_deadline);
     tokio::pin!(deadline);
@@ -1216,16 +1252,16 @@ pub(crate) async fn run_destination_session(
                 }).await?;
                 if accepted_reservation {
                     reserve_ack_sent = true;
-                    if pending_destination_reserved {
+                    if let Some(transferable_prompt_tokens) = pending_destination_reserved.take() {
                         connection
                             .send(BootstrapMessage::Fact(HandoffFact::DestinationReserved {
                                 handoff_id,
+                                transferable_prompt_tokens,
                             }))
                             .await?;
-                        pending_destination_reserved = false;
                         destination_reserved_sent = true;
                     }
-                } else if pending_destination_reserved
+                } else if pending_destination_reserved.is_some()
                     && matches!(action.action, HandoffAction::ReserveDestination { .. })
                 {
                     bail!("destination reservation lifecycle accompanied a failed reservation");
@@ -1236,16 +1272,43 @@ pub(crate) async fn run_destination_session(
                     break;
                 };
                 match event {
-                    SchedulerLifecycleEvent::DestinationReserved { handoff_id: observed, .. }
+                    SchedulerLifecycleEvent::DestinationReserved {
+                        handoff_id: observed,
+                        transferable_prompt_tokens: observed_transferable_prompt_tokens,
+                        ..
+                    }
                         if observed == handoff_id =>
                     {
-                        if destination_reserved_sent || pending_destination_reserved {
+                        if destination_reserved_sent || pending_destination_reserved.is_some() {
                             continue;
+                        }
+                        transferable_prompt_tokens = Some(observed_transferable_prompt_tokens);
+                        if let Some(Some(timeout_delay)) = transfer_timing
+                            .filter(|timing| {
+                                timing.mode == KvTransferTimingMode::DestinationMissing
+                            })
+                            .and_then(|timing| {
+                                transfer_timeout_delay(
+                                    timing,
+                                    Some(observed_transferable_prompt_tokens),
+                                )
+                            })
+                        {
+                            session_deadline = session_deadline_with_transfer(
+                                session_started.ok_or_else(|| {
+                                    anyhow!("destination reserved before source registration")
+                                })?,
+                                session_timeout,
+                                Some(timeout_delay),
+                            )?;
+                            deadline.as_mut().reset(session_deadline);
                         }
                         if reserve_ack_sent {
                             connection
                                 .send(BootstrapMessage::Fact(HandoffFact::DestinationReserved {
                                     handoff_id,
+                                    transferable_prompt_tokens:
+                                        observed_transferable_prompt_tokens,
                                 }))
                                 .await?;
                             destination_reserved_sent = true;
@@ -1253,7 +1316,8 @@ pub(crate) async fn run_destination_session(
                             pending_action.map(|action| action.action),
                             Some(HandoffAction::ReserveDestination { .. })
                         ) {
-                            pending_destination_reserved = true;
+                            pending_destination_reserved =
+                                Some(observed_transferable_prompt_tokens);
                         } else {
                             bail!("destination reserved before its action was pending");
                         }
@@ -1280,21 +1344,25 @@ pub(crate) async fn run_destination_session(
                     }
                     BootstrapMessage::Fact(HandoffFact::SourceHeld {
                         handoff_id: observed,
-                        transfer_delay_ms: observed_delay,
+                        transfer_timing: observed_timing,
                     }) if observed == handoff_id => {
-                        if let Some(previous) = transfer_delay_ms
-                            && previous != observed_delay
+                        validate_transfer_timing(observed_timing)?;
+                        if let Some(previous) = transfer_timing
+                            && previous != observed_timing
                         {
-                            bail!("source changed the modeled transfer delay");
+                            bail!("source changed the modeled transfer timing");
                         }
-                        transfer_delay_ms = Some(observed_delay);
-                        if observed_delay.is_some() {
+                        transfer_timing = Some(observed_timing);
+                        if let Some(Some(timeout_delay)) = transfer_timeout_delay(
+                            observed_timing,
+                            transferable_prompt_tokens,
+                        ) {
                             session_deadline = session_deadline_with_transfer(
                                 session_started.ok_or_else(|| {
                                     anyhow!("source fact arrived before registration")
                                 })?,
                                 session_timeout,
-                                observed_delay,
+                                Some(timeout_delay),
                             )?;
                             deadline.as_mut().reset(session_deadline);
                         }

--- a/lib/llm/src/mocker/handoff_tests.rs
+++ b/lib/llm/src/mocker/handoff_tests.rs
@@ -4,10 +4,11 @@
 use super::*;
 use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData};
 use dynamo_mocker::common::handoff::{
-    HandoffCompletion, NormalizedHandoffConformance, NormalizedStoredTiming,
+    HandoffCompletion, HandoffTransferTiming, NormalizedHandoffConformance, NormalizedStoredTiming,
 };
 use dynamo_mocker::common::protocols::{
-    FpmPublisher, KvCacheEventSink, KvEventPublishers, MockEngineArgs, OutputSignal, WorkerType,
+    FpmPublisher, KvCacheEventSink, KvEventPublishers, KvTransferTimingMode, MockEngineArgs,
+    OutputSignal, WorkerType,
 };
 use dynamo_mocker::engine::create_engine;
 use dynamo_mocker::scheduler::{MockerMetrics, SchedulerHandle};
@@ -18,6 +19,14 @@ use dynamo_mocker::services::bootstrap::{
 use uuid::Uuid;
 
 fn args(engine_type: EngineType, worker_type: WorkerType) -> MockEngineArgs {
+    args_with_mode(engine_type, worker_type, KvTransferTimingMode::FullPrompt)
+}
+
+fn args_with_mode(
+    engine_type: EngineType,
+    worker_type: WorkerType,
+    transfer_timing_mode: KvTransferTimingMode,
+) -> MockEngineArgs {
     let mut builder = MockEngineArgs::builder()
         .engine_type(engine_type)
         .block_size(4)
@@ -28,7 +37,8 @@ fn args(engine_type: EngineType, worker_type: WorkerType) -> MockEngineArgs {
         .speedup_ratio(1000.0)
         .decode_speedup_ratio(1000.0)
         .kv_transfer_bandwidth(Some(1.0))
-        .kv_bytes_per_token(Some(1_000_000));
+        .kv_bytes_per_token(Some(1_000_000))
+        .kv_transfer_timing_mode(transfer_timing_mode);
     if engine_type == EngineType::Sglang {
         builder = builder.sglang(Some(Default::default()));
     }
@@ -42,6 +52,33 @@ fn request(uuid: Uuid, output_tokens: usize) -> DirectRequest {
         uuid: Some(uuid),
         ..Default::default()
     }
+}
+
+fn transfer_timing(delay_ms: Option<f64>) -> HandoffTransferTiming {
+    HandoffTransferTiming {
+        mode: KvTransferTimingMode::FullPrompt,
+        full_prompt_tokens: 1,
+        kv_bytes_per_token: delay_ms.map(|delay_ms| (delay_ms * 1_000_000.0) as usize),
+        bandwidth_gb_s: delay_ms.map(|_| 1.0),
+    }
+}
+
+#[test]
+fn timeout_delay_resolves_at_the_mode_specific_boundary() {
+    let full = HandoffTransferTiming {
+        mode: KvTransferTimingMode::FullPrompt,
+        full_prompt_tokens: 8,
+        kv_bytes_per_token: Some(1_000_000),
+        bandwidth_gb_s: Some(1.0),
+    };
+    assert_eq!(transfer_timeout_delay(full, None), Some(Some(8.0)));
+
+    let missing = HandoffTransferTiming {
+        mode: KvTransferTimingMode::DestinationMissing,
+        ..full
+    };
+    assert_eq!(transfer_timeout_delay(missing, None), None);
+    assert_eq!(transfer_timeout_delay(missing, Some(4)), Some(Some(4.0)));
 }
 
 fn start_scheduler(
@@ -64,6 +101,27 @@ fn start_scheduler(
     (scheduler, output_rx)
 }
 
+fn start_scheduler_with_mode(
+    engine_type: EngineType,
+    worker_type: WorkerType,
+    transfer_timing_mode: KvTransferTimingMode,
+    cancel: CancellationToken,
+) -> (
+    Box<dyn SchedulerHandle>,
+    mpsc::UnboundedReceiver<Vec<OutputSignal>>,
+) {
+    let (output_tx, output_rx) = mpsc::unbounded_channel();
+    let scheduler = create_engine(
+        args_with_mode(engine_type, worker_type, transfer_timing_mode),
+        0,
+        Some(output_tx),
+        KvEventPublishers::default(),
+        Some(cancel),
+        FpmPublisher::default(),
+    );
+    (scheduler, output_rx)
+}
+
 #[derive(Clone)]
 struct CapturingKvSink {
     tx: mpsc::UnboundedSender<KvCacheEvent>,
@@ -77,9 +135,10 @@ impl KvCacheEventSink for CapturingKvSink {
     }
 }
 
-fn start_scheduler_with_kv_events(
+fn start_scheduler_with_kv_events_and_mode(
     engine_type: EngineType,
     worker_type: WorkerType,
+    transfer_timing_mode: KvTransferTimingMode,
     cancel: CancellationToken,
 ) -> (
     Box<dyn SchedulerHandle>,
@@ -89,7 +148,7 @@ fn start_scheduler_with_kv_events(
     let (output_tx, output_rx) = mpsc::unbounded_channel();
     let (event_tx, event_rx) = mpsc::unbounded_channel();
     let scheduler = create_engine(
-        args(engine_type, worker_type),
+        args_with_mode(engine_type, worker_type, transfer_timing_mode),
         0,
         Some(output_tx),
         KvEventPublishers::new(Some(Arc::new(CapturingKvSink { tx: event_tx })), None),
@@ -245,6 +304,7 @@ async fn destination_reservation_ack_precedes_an_early_lifecycle_fact() {
         .deliver_and_wait(SchedulerLifecycleEvent::DestinationReserved {
             handoff_id,
             request_id,
+            transferable_prompt_tokens: 1,
         })
         .await;
     envelope
@@ -267,6 +327,7 @@ async fn destination_reservation_ack_precedes_an_early_lifecycle_fact() {
         source.recv().await.unwrap(),
         Some(BootstrapMessage::Fact(HandoffFact::DestinationReserved {
             handoff_id: observed,
+            ..
         })) if observed == handoff_id
     ));
 
@@ -277,7 +338,10 @@ async fn destination_reservation_ack_precedes_an_early_lifecycle_fact() {
             .is_empty()
     );
     let submit = coordinator
-        .on_fact(HandoffFact::DestinationReserved { handoff_id })
+        .on_fact(HandoffFact::DestinationReserved {
+            handoff_id,
+            transferable_prompt_tokens: 1,
+        })
         .unwrap()
         .pop()
         .unwrap();
@@ -291,7 +355,7 @@ async fn destination_reservation_ack_precedes_an_early_lifecycle_fact() {
     let transfer = coordinator
         .on_fact(HandoffFact::SourceHeld {
             handoff_id,
-            transfer_delay_ms: Some(0.0),
+            transfer_timing: transfer_timing(Some(0.0)),
         })
         .unwrap()
         .pop()
@@ -418,6 +482,7 @@ async fn premature_complete_keeps_destination_cleanup_active() {
         .deliver_and_wait(SchedulerLifecycleEvent::DestinationReserved {
             handoff_id,
             request_id,
+            transferable_prompt_tokens: 1,
         })
         .await;
     assert!(matches!(
@@ -438,7 +503,10 @@ async fn premature_complete_keeps_destination_cleanup_active() {
         .on_action_outcome(reserve.id, HandoffActionOutcome::Accepted)
         .unwrap();
     let submit = coordinator
-        .on_fact(HandoffFact::DestinationReserved { handoff_id })
+        .on_fact(HandoffFact::DestinationReserved {
+            handoff_id,
+            transferable_prompt_tokens: 1,
+        })
         .unwrap()
         .pop()
         .unwrap();
@@ -448,7 +516,7 @@ async fn premature_complete_keeps_destination_cleanup_active() {
     let transfer = coordinator
         .on_fact(HandoffFact::SourceHeld {
             handoff_id,
-            transfer_delay_ms: None,
+            transfer_timing: transfer_timing(None),
         })
         .unwrap()
         .pop()
@@ -571,7 +639,7 @@ async fn source_held_waits_for_submit_outcome_before_progressing() {
         .deliver_and_wait(SchedulerLifecycleEvent::SourceHeld {
             handoff_id,
             request_id,
-            transfer_delay_ms: Some(0.0),
+            transfer_timing: transfer_timing(Some(0.0)),
         })
         .await;
     submit
@@ -587,8 +655,9 @@ async fn source_held_waits_for_submit_outcome_before_progressing() {
         destination.recv().await.unwrap(),
         Some(BootstrapMessage::Fact(HandoffFact::SourceHeld {
             handoff_id: observed,
-            transfer_delay_ms: Some(0.0),
+            transfer_timing: observed_timing,
         })) if observed == handoff_id
+            && observed_timing == transfer_timing(Some(0.0))
     ));
     let reserve = match destination.recv().await.unwrap().unwrap() {
         BootstrapMessage::Action(
@@ -609,6 +678,7 @@ async fn source_held_waits_for_submit_outcome_before_progressing() {
     destination
         .send(BootstrapMessage::Fact(HandoffFact::DestinationReserved {
             handoff_id,
+            transferable_prompt_tokens: 1,
         }))
         .await
         .unwrap();
@@ -850,6 +920,7 @@ fn destination_command_proxy(
 
 async fn run_live_handoff_conformance(
     engine_type: EngineType,
+    transfer_timing_mode: KvTransferTimingMode,
     source_arrives_first: bool,
     case: usize,
 ) -> NormalizedHandoffConformance {
@@ -868,10 +939,19 @@ async fn run_live_handoff_conformance(
     let manager =
         SourceHandoffManager::start(incoming, 2, Duration::from_secs(2), shutdown.clone());
 
-    let (mut source_scheduler, mut source_output) =
-        start_scheduler(engine_type, WorkerType::Prefill, shutdown.clone());
+    let (mut source_scheduler, mut source_output) = start_scheduler_with_mode(
+        engine_type,
+        WorkerType::Prefill,
+        transfer_timing_mode,
+        shutdown.clone(),
+    );
     let (mut destination_scheduler, mut destination_output, destination_kv_events) =
-        start_scheduler_with_kv_events(engine_type, WorkerType::Decode, shutdown.clone());
+        start_scheduler_with_kv_events_and_mode(
+            engine_type,
+            WorkerType::Decode,
+            transfer_timing_mode,
+            shutdown.clone(),
+        );
     let (destination_command_tx, destination_kv_observer) = destination_command_proxy(
         destination_scheduler.command_sender(),
         destination_kv_events,
@@ -1036,18 +1116,32 @@ async fn run_live_handoff_conformance(
 
 #[tokio::test]
 async fn live_and_offline_handoff_surfaces_share_one_conformance_report() {
-    for (case, (engine_type, source_arrives_first)) in [
-        (EngineType::Vllm, true),
-        (EngineType::Vllm, false),
-        (EngineType::Sglang, true),
-        (EngineType::Sglang, false),
-    ]
-    .into_iter()
-    .enumerate()
-    {
-        let live = run_live_handoff_conformance(engine_type, source_arrives_first, case).await;
-        let offline = dynamo_mocker::replay::run_offline_handoff_conformance(engine_type).unwrap();
-        assert_eq!(live, offline);
+    let mut case = 0;
+    for transfer_timing_mode in [
+        KvTransferTimingMode::FullPrompt,
+        KvTransferTimingMode::DestinationMissing,
+    ] {
+        for (engine_type, source_arrives_first) in [
+            (EngineType::Vllm, true),
+            (EngineType::Vllm, false),
+            (EngineType::Sglang, true),
+            (EngineType::Sglang, false),
+        ] {
+            let live = run_live_handoff_conformance(
+                engine_type,
+                transfer_timing_mode,
+                source_arrives_first,
+                case,
+            )
+            .await;
+            let offline = dynamo_mocker::replay::run_offline_handoff_conformance(
+                engine_type,
+                transfer_timing_mode,
+            )
+            .unwrap();
+            assert_eq!(live, offline);
+            case += 1;
+        }
     }
 }
 
@@ -1190,7 +1284,7 @@ async fn assert_destination_disconnect_cleans_ownership(
             coordinator
                 .on_fact(HandoffFact::SourceHeld {
                     handoff_id,
-                    transfer_delay_ms: None,
+                    transfer_timing: transfer_timing(None),
                 })
                 .unwrap()
                 .pop()
@@ -1213,6 +1307,7 @@ async fn assert_destination_disconnect_cleans_ownership(
             }
             BootstrapMessage::Fact(HandoffFact::DestinationReserved {
                 handoff_id: observed,
+                ..
             }) if observed == handoff_id => reserved = true,
             other => panic!("unexpected destination message: {other:?}"),
         }
@@ -1222,7 +1317,10 @@ async fn assert_destination_disconnect_cleans_ownership(
             .on_action_outcome(reserve.id, HandoffActionOutcome::Accepted)
             .unwrap();
         let after_reserved = coordinator
-            .on_fact(HandoffFact::DestinationReserved { handoff_id })
+            .on_fact(HandoffFact::DestinationReserved {
+                handoff_id,
+                transferable_prompt_tokens: 1,
+            })
             .unwrap();
         let transfer = match order {
             HandoffOrder::SourceFirst => after_reserved.into_iter().next().unwrap(),
@@ -1234,7 +1332,7 @@ async fn assert_destination_disconnect_cleans_ownership(
                 coordinator
                     .on_fact(HandoffFact::SourceHeld {
                         handoff_id,
-                        transfer_delay_ms: None,
+                        transfer_timing: transfer_timing(None),
                     })
                     .unwrap()
                     .pop()
@@ -1353,7 +1451,7 @@ async fn lost_reserve_or_activation_ack_cleans_ambiguous_destination_ownership()
         let reserve = coordinator
             .on_fact(HandoffFact::SourceHeld {
                 handoff_id,
-                transfer_delay_ms: None,
+                transfer_timing: transfer_timing(None),
             })
             .unwrap()
             .pop()
@@ -1377,7 +1475,10 @@ async fn lost_reserve_or_activation_ack_cleans_ambiguous_destination_ownership()
                 ))
             ));
             let transfer = coordinator
-                .on_fact(HandoffFact::DestinationReserved { handoff_id })
+                .on_fact(HandoffFact::DestinationReserved {
+                    handoff_id,
+                    transferable_prompt_tokens: 1,
+                })
                 .unwrap()
                 .pop()
                 .unwrap();
@@ -1450,7 +1551,7 @@ async fn duplicate_lifecycle_route_does_not_replace_the_active_route() {
         .deliver(SchedulerLifecycleEvent::SourceHeld {
             handoff_id,
             request_id,
-            transfer_delay_ms: None,
+            transfer_timing: transfer_timing(None),
         })
         .await;
 
@@ -1951,6 +2052,7 @@ async fn expired_destination_session_deadline_still_cleans_reserved_ownership() 
             }
             BootstrapMessage::Fact(HandoffFact::DestinationReserved {
                 handoff_id: observed,
+                ..
             }) if observed == handoff_id => reserved = true,
             other => panic!("unexpected destination message: {other:?}"),
         }

--- a/lib/mocker/src/common/handoff.rs
+++ b/lib/mocker/src/common/handoff.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::protocols::EngineType;
+use super::protocols::{EngineType, KvTransferTimingMode};
 
 /// Stable identifier for one prefill-to-decode handoff attempt.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
@@ -43,14 +43,49 @@ pub enum HandoffOrder {
     DestinationFirst,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HandoffTransferTiming {
+    pub mode: KvTransferTimingMode,
+    pub full_prompt_tokens: usize,
+    pub kv_bytes_per_token: Option<usize>,
+    pub bandwidth_gb_s: Option<f64>,
+}
+
+impl HandoffTransferTiming {
+    pub fn delay_ms(self, destination_missing_tokens: usize) -> Option<f64> {
+        let tokens = match self.mode {
+            KvTransferTimingMode::FullPrompt => self.full_prompt_tokens,
+            KvTransferTimingMode::DestinationMissing => destination_missing_tokens,
+        };
+        let (Some(bytes_per_token), Some(bandwidth_gb_s)) =
+            (self.kv_bytes_per_token, self.bandwidth_gb_s)
+        else {
+            return None;
+        };
+        if bandwidth_gb_s <= 0.0 {
+            return None;
+        }
+        Some(tokens as f64 * bytes_per_token as f64 / (bandwidth_gb_s * 1e9) * 1000.0)
+    }
+
+    pub fn full_prompt_delay_ms(self) -> Option<f64> {
+        let full_prompt = Self {
+            mode: KvTransferTimingMode::FullPrompt,
+            ..self
+        };
+        full_prompt.delay_ms(0)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum HandoffFact {
     SourceHeld {
         handoff_id: HandoffId,
-        transfer_delay_ms: Option<f64>,
+        transfer_timing: HandoffTransferTiming,
     },
     DestinationReserved {
         handoff_id: HandoffId,
+        transferable_prompt_tokens: usize,
     },
     TransferCompleted {
         handoff_id: HandoffId,
@@ -70,7 +105,7 @@ impl HandoffFact {
     fn handoff_id(&self) -> HandoffId {
         match *self {
             Self::SourceHeld { handoff_id, .. }
-            | Self::DestinationReserved { handoff_id }
+            | Self::DestinationReserved { handoff_id, .. }
             | Self::TransferCompleted { handoff_id }
             | Self::Failed { handoff_id }
             | Self::TimedOut { handoff_id }
@@ -284,7 +319,7 @@ struct SourceProgress {
     submit_issued: bool,
     submitted: bool,
     held: bool,
-    delay_ms: Option<f64>,
+    transfer_timing: Option<HandoffTransferTiming>,
     release_issued: bool,
     cancel_issued: bool,
     cleanup_done: bool,
@@ -295,6 +330,7 @@ struct DestinationProgress {
     reserve_issued: bool,
     accepted: bool,
     reserved: bool,
+    transferable_prompt_tokens: Option<usize>,
     activation_issued: bool,
     activation_applied: bool,
     cancel_issued: bool,
@@ -358,7 +394,7 @@ impl HandoffCoordinatorCore {
 
         match fact {
             HandoffFact::SourceHeld {
-                transfer_delay_ms, ..
+                transfer_timing, ..
             } => {
                 if self.source.held {
                     return Ok(Vec::new());
@@ -366,12 +402,15 @@ impl HandoffCoordinatorCore {
                 if !self.source.submitted {
                     bail!("source held before prefill submission was acknowledged");
                 }
-                validate_transfer_delay_ms(transfer_delay_ms)?;
+                validate_transfer_timing(transfer_timing)?;
                 self.source.held = true;
-                self.source.delay_ms = transfer_delay_ms;
+                self.source.transfer_timing = Some(transfer_timing);
                 self.advance_active()
             }
-            HandoffFact::DestinationReserved { .. } => {
+            HandoffFact::DestinationReserved {
+                transferable_prompt_tokens,
+                ..
+            } => {
                 if self.destination.reserved {
                     return Ok(Vec::new());
                 }
@@ -379,6 +418,7 @@ impl HandoffCoordinatorCore {
                     bail!("destination reserved before ownership was accepted");
                 }
                 self.destination.reserved = true;
+                self.destination.transferable_prompt_tokens = Some(transferable_prompt_tokens);
                 self.advance_active()
             }
             HandoffFact::TransferCompleted { .. } => {
@@ -497,10 +537,22 @@ impl HandoffCoordinatorCore {
         }
         if self.source.held && self.destination.reserved && !self.transfer.issued {
             self.transfer.issued = true;
-            return Ok(vec![self.issue(HandoffAction::StartTransfer {
-                handoff_id: self.handoff_id,
-                delay_ms: self.source.delay_ms.unwrap_or_default(),
-            })]);
+            let transfer_timing = self
+                .source
+                .transfer_timing
+                .expect("held source must retain transfer timing");
+            let transferable_prompt_tokens = self
+                .destination
+                .transferable_prompt_tokens
+                .expect("reserved destination must report its transferable footprint");
+            return Ok(vec![
+                self.issue(HandoffAction::StartTransfer {
+                    handoff_id: self.handoff_id,
+                    delay_ms: transfer_timing
+                        .delay_ms(transferable_prompt_tokens)
+                        .unwrap_or_default(),
+                }),
+            ]);
         }
         if self.transfer.completed && !self.destination.activation_issued {
             self.destination.activation_issued = true;
@@ -611,6 +663,15 @@ pub fn validate_transfer_delay_ms(transfer_delay_ms: Option<f64>) -> Result<()> 
         bail!("invalid handoff transfer delay {delay_ms}");
     }
     Ok(())
+}
+
+pub fn validate_transfer_timing(transfer_timing: HandoffTransferTiming) -> Result<()> {
+    if let Some(bandwidth_gb_s) = transfer_timing.bandwidth_gb_s
+        && (!bandwidth_gb_s.is_finite() || bandwidth_gb_s < 0.0)
+    {
+        bail!("invalid handoff transfer bandwidth {bandwidth_gb_s}");
+    }
+    validate_transfer_delay_ms(transfer_timing.full_prompt_delay_ms())
 }
 
 fn require_outcome(outcome: &HandoffActionOutcome, allowed: &[HandoffActionOutcome]) -> Result<()> {

--- a/lib/mocker/src/common/handoff.rs
+++ b/lib/mocker/src/common/handoff.rs
@@ -667,7 +667,7 @@ pub fn validate_transfer_delay_ms(transfer_delay_ms: Option<f64>) -> Result<()> 
 
 pub fn validate_transfer_timing(transfer_timing: HandoffTransferTiming) -> Result<()> {
     if let Some(bandwidth_gb_s) = transfer_timing.bandwidth_gb_s
-        && (!bandwidth_gb_s.is_finite() || bandwidth_gb_s < 0.0)
+        && (!bandwidth_gb_s.is_finite() || bandwidth_gb_s <= 0.0)
     {
         bail!("invalid handoff transfer bandwidth {bandwidth_gb_s}");
     }

--- a/lib/mocker/src/common/handoff_tests.rs
+++ b/lib/mocker/src/common/handoff_tests.rs
@@ -20,6 +20,22 @@ fn acknowledge(
     coordinator.on_action_outcome(action.id, outcome).unwrap()
 }
 
+fn transfer_timing(delay_ms: Option<f64>) -> HandoffTransferTiming {
+    HandoffTransferTiming {
+        mode: KvTransferTimingMode::FullPrompt,
+        full_prompt_tokens: 1,
+        kv_bytes_per_token: delay_ms.map(|delay_ms| (delay_ms * 1_000_000.0) as usize),
+        bandwidth_gb_s: delay_ms.map(|_| 1.0),
+    }
+}
+
+fn destination_reserved(handoff_id: HandoffId) -> HandoffFact {
+    HandoffFact::DestinationReserved {
+        handoff_id,
+        transferable_prompt_tokens: 1,
+    }
+}
+
 fn drive_success(order: HandoffOrder) {
     let id = handoff_id();
     let mut coordinator = HandoffCoordinatorCore::new(id, order);
@@ -34,7 +50,7 @@ fn drive_success(order: HandoffOrder) {
             one(coordinator
                 .on_fact(HandoffFact::SourceHeld {
                     handoff_id: id,
-                    transfer_delay_ms: Some(2.5),
+                    transfer_timing: transfer_timing(Some(2.5)),
                 })
                 .unwrap())
         }
@@ -47,9 +63,7 @@ fn drive_success(order: HandoffOrder) {
         }
     };
     assert!(acknowledge(&mut coordinator, reserve, HandoffActionOutcome::Accepted).is_empty());
-    let after_reserved = coordinator
-        .on_fact(HandoffFact::DestinationReserved { handoff_id: id })
-        .unwrap();
+    let after_reserved = coordinator.on_fact(destination_reserved(id)).unwrap();
 
     let transfer = match order {
         HandoffOrder::SourceFirst => one(after_reserved),
@@ -62,7 +76,7 @@ fn drive_success(order: HandoffOrder) {
             one(coordinator
                 .on_fact(HandoffFact::SourceHeld {
                     handoff_id: id,
-                    transfer_delay_ms: Some(2.5),
+                    transfer_timing: transfer_timing(Some(2.5)),
                 })
                 .unwrap())
         }
@@ -102,6 +116,72 @@ fn backend_orders_reach_the_same_safe_completion_sequence() {
 }
 
 #[test]
+fn timing_mode_selects_full_or_destination_missing_footprint() {
+    for (mode, expected_delay_ms) in [
+        (KvTransferTimingMode::FullPrompt, 8.0),
+        (KvTransferTimingMode::DestinationMissing, 4.0),
+    ] {
+        let id = handoff_id();
+        let mut coordinator = HandoffCoordinatorCore::new(id, HandoffOrder::SourceFirst);
+        let submit = one(coordinator.start().unwrap());
+        acknowledge(&mut coordinator, submit, HandoffActionOutcome::Submitted);
+        let reserve = one(coordinator
+            .on_fact(HandoffFact::SourceHeld {
+                handoff_id: id,
+                transfer_timing: HandoffTransferTiming {
+                    mode,
+                    full_prompt_tokens: 8,
+                    kv_bytes_per_token: Some(1_000_000),
+                    bandwidth_gb_s: Some(1.0),
+                },
+            })
+            .unwrap());
+        acknowledge(&mut coordinator, reserve, HandoffActionOutcome::Accepted);
+        let transfer = one(coordinator
+            .on_fact(HandoffFact::DestinationReserved {
+                handoff_id: id,
+                transferable_prompt_tokens: 4,
+            })
+            .unwrap());
+        assert!(matches!(
+            transfer.action,
+            HandoffAction::StartTransfer { delay_ms, .. }
+                if delay_ms == expected_delay_ms
+        ));
+    }
+}
+
+#[test]
+fn full_destination_hit_keeps_zero_delay_transfer_transition() {
+    let id = handoff_id();
+    let mut coordinator = HandoffCoordinatorCore::new(id, HandoffOrder::SourceFirst);
+    let submit = one(coordinator.start().unwrap());
+    acknowledge(&mut coordinator, submit, HandoffActionOutcome::Submitted);
+    let reserve = one(coordinator
+        .on_fact(HandoffFact::SourceHeld {
+            handoff_id: id,
+            transfer_timing: HandoffTransferTiming {
+                mode: KvTransferTimingMode::DestinationMissing,
+                full_prompt_tokens: 8,
+                kv_bytes_per_token: Some(1_000_000),
+                bandwidth_gb_s: Some(1.0),
+            },
+        })
+        .unwrap());
+    acknowledge(&mut coordinator, reserve, HandoffActionOutcome::Accepted);
+    let transfer = one(coordinator
+        .on_fact(HandoffFact::DestinationReserved {
+            handoff_id: id,
+            transferable_prompt_tokens: 0,
+        })
+        .unwrap());
+    assert!(matches!(
+        transfer.action,
+        HandoffAction::StartTransfer { delay_ms: 0.0, .. }
+    ));
+}
+
+#[test]
 fn cancellation_cleans_actions_that_may_have_been_applied() {
     let id = handoff_id();
     let mut coordinator = HandoffCoordinatorCore::new(id, HandoffOrder::SourceFirst);
@@ -110,7 +190,7 @@ fn cancellation_cleans_actions_that_may_have_been_applied() {
     let reserve = one(coordinator
         .on_fact(HandoffFact::SourceHeld {
             handoff_id: id,
-            transfer_delay_ms: None,
+            transfer_timing: transfer_timing(None),
         })
         .unwrap());
 
@@ -159,16 +239,14 @@ fn drive_to_activation(order: HandoffOrder) -> (HandoffCoordinatorCore, IssuedHa
             one(coordinator
                 .on_fact(HandoffFact::SourceHeld {
                     handoff_id: id,
-                    transfer_delay_ms: None,
+                    transfer_timing: transfer_timing(None),
                 })
                 .unwrap())
         }
         HandoffOrder::DestinationFirst => first,
     };
     acknowledge(&mut coordinator, reserve, HandoffActionOutcome::Accepted);
-    let after_reserved = coordinator
-        .on_fact(HandoffFact::DestinationReserved { handoff_id: id })
-        .unwrap();
+    let after_reserved = coordinator.on_fact(destination_reserved(id)).unwrap();
     let transfer = match order {
         HandoffOrder::SourceFirst => one(after_reserved),
         HandoffOrder::DestinationFirst => {
@@ -177,7 +255,7 @@ fn drive_to_activation(order: HandoffOrder) -> (HandoffCoordinatorCore, IssuedHa
             one(coordinator
                 .on_fact(HandoffFact::SourceHeld {
                     handoff_id: id,
-                    transfer_delay_ms: None,
+                    transfer_timing: transfer_timing(None),
                 })
                 .unwrap())
         }
@@ -243,7 +321,7 @@ fn invalid_same_handoff_ordering_is_rejected() {
         coordinator
             .on_fact(HandoffFact::SourceHeld {
                 handoff_id: id,
-                transfer_delay_ms: None,
+                transfer_timing: transfer_timing(None),
             })
             .is_err()
     );
@@ -259,8 +337,8 @@ fn invalid_same_handoff_ordering_is_rejected() {
 }
 
 #[test]
-fn invalid_transfer_delays_are_rejected_before_scheduling() {
-    for delay_ms in [-1.0, f64::NAN, f64::INFINITY] {
+fn invalid_transfer_timing_is_rejected_before_scheduling() {
+    for bandwidth_gb_s in [-1.0, f64::NAN, f64::INFINITY] {
         let id = handoff_id();
         let mut coordinator = HandoffCoordinatorCore::new(id, HandoffOrder::SourceFirst);
         let submit = one(coordinator.start().unwrap());
@@ -269,10 +347,17 @@ fn invalid_transfer_delays_are_rejected_before_scheduling() {
         let error = coordinator
             .on_fact(HandoffFact::SourceHeld {
                 handoff_id: id,
-                transfer_delay_ms: Some(delay_ms),
+                transfer_timing: HandoffTransferTiming {
+                    bandwidth_gb_s: Some(bandwidth_gb_s),
+                    ..transfer_timing(Some(1.0))
+                },
             })
             .unwrap_err();
-        assert!(error.to_string().contains("invalid handoff transfer delay"));
+        assert!(
+            error
+                .to_string()
+                .contains("invalid handoff transfer bandwidth")
+        );
     }
 }
 
@@ -323,9 +408,7 @@ fn destination_first_unacknowledged_prefill_is_cleaned_as_ambiguous_ownership() 
     let mut coordinator = HandoffCoordinatorCore::new(id, HandoffOrder::DestinationFirst);
     let reserve = one(coordinator.start().unwrap());
     acknowledge(&mut coordinator, reserve, HandoffActionOutcome::Accepted);
-    let submit = one(coordinator
-        .on_fact(HandoffFact::DestinationReserved { handoff_id: id })
-        .unwrap());
+    let submit = one(coordinator.on_fact(destination_reserved(id)).unwrap());
     assert!(matches!(submit.action, HandoffAction::SubmitPrefill { .. }));
 
     let cleanup = coordinator
@@ -366,16 +449,14 @@ fn timeout_after_transfer_is_scheduled_cleans_both_owners() {
                 one(coordinator
                     .on_fact(HandoffFact::SourceHeld {
                         handoff_id: id,
-                        transfer_delay_ms: None,
+                        transfer_timing: transfer_timing(None),
                     })
                     .unwrap())
             }
             HandoffOrder::DestinationFirst => first,
         };
         acknowledge(&mut coordinator, reserve, HandoffActionOutcome::Accepted);
-        let after_reserved = coordinator
-            .on_fact(HandoffFact::DestinationReserved { handoff_id: id })
-            .unwrap();
+        let after_reserved = coordinator.on_fact(destination_reserved(id)).unwrap();
         let transfer = match order {
             HandoffOrder::SourceFirst => one(after_reserved),
             HandoffOrder::DestinationFirst => {
@@ -384,7 +465,7 @@ fn timeout_after_transfer_is_scheduled_cleans_both_owners() {
                 one(coordinator
                     .on_fact(HandoffFact::SourceHeld {
                         handoff_id: id,
-                        transfer_delay_ms: None,
+                        transfer_timing: transfer_timing(None),
                     })
                     .unwrap())
             }
@@ -454,7 +535,7 @@ fn duplicates_are_idempotent_but_conflicts_are_rejected() {
 
     let fact = HandoffFact::SourceHeld {
         handoff_id: id,
-        transfer_delay_ms: None,
+        transfer_timing: transfer_timing(None),
     };
     assert_eq!(coordinator.on_fact(fact.clone()).unwrap().len(), 1);
     assert!(coordinator.on_fact(fact).unwrap().is_empty());
@@ -462,6 +543,7 @@ fn duplicates_are_idempotent_but_conflicts_are_rejected() {
         coordinator
             .on_fact(HandoffFact::DestinationReserved {
                 handoff_id: HandoffId::from(Uuid::from_u128(99)),
+                transferable_prompt_tokens: 1,
             })
             .is_err()
     );

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -378,6 +378,31 @@ impl FromStr for WorkerType {
     }
 }
 
+/// Physical KV footprint used to model a coordinated disaggregated transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum KvTransferTimingMode {
+    /// Charge the source request's full logical prompt length.
+    #[default]
+    FullPrompt,
+    /// Charge only the physical prompt footprint missing at the destination.
+    DestinationMissing,
+}
+
+impl FromStr for KvTransferTimingMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "full_prompt" => Ok(Self::FullPrompt),
+            "destination_missing" => Ok(Self::DestinationMissing),
+            _ => Err(format!(
+                "Invalid kv_transfer_timing_mode '{value}'. Must be 'full_prompt' or 'destination_missing'."
+            )),
+        }
+    }
+}
+
 /// Configuration for reasoning/thinking token output in the mocker.
 ///
 /// When set, the mocker wraps the first portion of each response in thinking
@@ -521,6 +546,7 @@ struct MockEngineArgsSerde {
     handoff_session_timeout_ms: OptionalConfigValue<u64>,
     kv_bytes_per_token: OptionalConfigValue<usize>,
     kv_transfer_bandwidth: OptionalConfigValue<f64>,
+    kv_transfer_timing_mode: OptionalConfigValue<String>,
     num_g2_blocks: OptionalConfigValue<usize>,
     num_g3_blocks: OptionalConfigValue<usize>,
     enable_g4_storage: OptionalConfigValue<bool>,
@@ -736,6 +762,11 @@ pub struct MockEngineArgs {
     #[builder(default = "None")]
     #[validate(range(min = 0.0))]
     pub kv_transfer_bandwidth: Option<f64>,
+
+    /// Selects whether disaggregated transfer timing charges the full prompt
+    /// or only the physical prompt footprint missing at the destination.
+    #[builder(default = "KvTransferTimingMode::FullPrompt")]
+    pub kv_transfer_timing_mode: KvTransferTimingMode,
 
     /// KVBM G2 (host DRAM) block capacity. When the `kvbm-offload`
     /// feature is enabled, setting this explicitly opts the mocker into
@@ -1075,6 +1106,12 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         if let Some(kv_transfer_bandwidth) = compat.kv_transfer_bandwidth.into_nullable() {
             builder = builder.kv_transfer_bandwidth(kv_transfer_bandwidth);
         }
+        if let Some(mode) = compat
+            .kv_transfer_timing_mode
+            .into_non_null("kv_transfer_timing_mode")?
+        {
+            builder = builder.kv_transfer_timing_mode(mode.parse()?);
+        }
         if let Some(num_g2_blocks) = compat.num_g2_blocks.into_nullable() {
             builder = builder.num_g2_blocks(num_g2_blocks);
         }
@@ -1364,6 +1401,7 @@ mod tests {
             "handoff_session_timeout_ms": args.handoff_session_timeout_ms,
             "kv_bytes_per_token": args.kv_bytes_per_token,
             "kv_transfer_bandwidth": args.kv_transfer_bandwidth,
+            "kv_transfer_timing_mode": "full_prompt",
             "num_g2_blocks": args.num_g2_blocks,
             "num_g3_blocks": args.num_g3_blocks,
             "enable_g4_storage": args.enable_g4_storage,
@@ -1388,6 +1426,10 @@ mod tests {
         assert_eq!(restored.worker_type, WorkerType::Decode);
         assert_eq!(restored.max_num_seqs, None);
         assert_eq!(restored.max_num_batched_tokens, None);
+        assert_eq!(
+            restored.kv_transfer_timing_mode,
+            KvTransferTimingMode::FullPrompt
+        );
     }
 
     #[test]

--- a/lib/mocker/src/common/utils.rs
+++ b/lib/mocker/src/common/utils.rs
@@ -3,7 +3,22 @@
 
 use std::time::{Duration, Instant};
 
-use crate::common::protocols::{MockEngineArgs, WorkerType};
+use crate::common::handoff::HandoffTransferTiming;
+use crate::common::protocols::{KvTransferTimingMode, MockEngineArgs, WorkerType};
+
+pub fn prefill_handoff_transfer_timing(
+    num_input_tokens: usize,
+    kv_transfer_bandwidth: Option<f64>,
+    kv_bytes_per_token: Option<usize>,
+    mode: KvTransferTimingMode,
+) -> HandoffTransferTiming {
+    HandoffTransferTiming {
+        mode,
+        full_prompt_tokens: num_input_tokens,
+        kv_bytes_per_token,
+        bandwidth_gb_s: kv_transfer_bandwidth,
+    }
+}
 
 /// Compute the modeled handoff delay after a prefill worker emits its terminal token.
 ///
@@ -21,23 +36,23 @@ pub fn compute_prefill_handoff_delay_ms(
     if worker_type != WorkerType::Prefill || !completed {
         return None;
     }
-
-    match (kv_transfer_bandwidth, kv_bytes_per_token) {
-        (Some(bw), Some(bpt)) if bw > 0.0 => {
-            // TODO(disagg): Keep full-prompt timing until destination-cache-aware sizing is
-            // optional across backends: https://github.com/ai-dynamo/dynamo/issues/10911
-            let kv_bytes = num_input_tokens as f64 * bpt as f64;
-            let delay_ms = kv_bytes / (bw * 1e9) * 1000.0;
+    let timing = prefill_handoff_transfer_timing(
+        num_input_tokens,
+        kv_transfer_bandwidth,
+        kv_bytes_per_token,
+        KvTransferTimingMode::FullPrompt,
+    );
+    match timing.full_prompt_delay_ms() {
+        Some(delay_ms) => {
             tracing::debug!(
                 num_input_tokens,
-                kv_bytes,
-                bandwidth_gb_s = bw,
+                bandwidth_gb_s = kv_transfer_bandwidth,
                 delay_ms = format!("{delay_ms:.2}"),
                 "KV handoff delay for prefill completion"
             );
             Some(delay_ms)
         }
-        _ => None,
+        None => None,
     }
 }
 

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -138,8 +138,12 @@ pub struct VllmDestinationReservation {
     layout: Option<MoveBlock>,
 }
 
-#[cfg(test)]
 impl VllmDestinationReservation {
+    pub(crate) fn transferable_prompt_tokens(&self, block_size: usize) -> usize {
+        self.unpublished_blocks.len().saturating_mul(block_size)
+    }
+
+    #[cfg(test)]
     pub(crate) fn block_ids(&self) -> Vec<usize> {
         self.cached_prefix
             .iter()
@@ -2344,6 +2348,42 @@ mod tests {
         assert_eq!(metadata.parent_hash, None);
         assert_eq!(metadata.local_hash, Some(local_hash));
         assert_eq!(metadata.token_ids.as_deref(), Some(token_ids.as_slice()));
+    }
+
+    #[test]
+    fn destination_transfer_footprint_uses_missing_physical_blocks() {
+        let (mut mgr, _) = make_mgr_capturing(16, 4);
+
+        let cold = ActiveSequence::new((0..10).collect(), 1, Some(4), true, true);
+        let cold_reservation = mgr
+            .reserve_destination_at(&cold, None)
+            .expect("cold destination reservation should fit");
+        assert_eq!(cold_reservation.transferable_prompt_tokens(4), 12);
+        drop(cold_reservation);
+
+        let mut prefix = ActiveSequence::new((0..4).collect(), 1, Some(4), true, true);
+        let prefix_allocation = prefix
+            .prepare_allocation(prefix.num_input_tokens())
+            .expect("prefix should require one full block");
+        assert_eq!(mgr.process(&prefix_allocation), 1);
+        prefix.commit_allocation(prefix.num_input_tokens());
+
+        let partial = mgr
+            .reserve_destination_at(&cold, None)
+            .expect("partially cached destination reservation should fit");
+        assert_eq!(partial.transferable_prompt_tokens(4), 8);
+        drop(partial);
+
+        let mut aligned = ActiveSequence::new((20..28).collect(), 1, Some(4), true, true);
+        let aligned_allocation = aligned
+            .prepare_allocation(aligned.num_input_tokens())
+            .expect("aligned prompt should require two full blocks");
+        assert_eq!(mgr.process(&aligned_allocation), 2);
+        aligned.commit_allocation(aligned.num_input_tokens());
+        let full_hit = mgr
+            .reserve_destination_at(&aligned, None)
+            .expect("fully cached destination reservation should fit");
+        assert_eq!(full_hit.transferable_prompt_tokens(4), 0);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -54,8 +54,12 @@ pub struct SglangDestinationReservation {
     pub(crate) allocated_tokens: usize,
 }
 
-#[cfg(test)]
 impl SglangDestinationReservation {
+    pub(crate) fn transferable_prompt_tokens(&self) -> usize {
+        self.unpublished_indices.len()
+    }
+
+    #[cfg(test)]
     pub(crate) fn indices(&self) -> Vec<usize> {
         self.prefix_indices
             .iter()
@@ -648,6 +652,49 @@ mod tests {
         assert_eq!(r2.prefix_len, 5);
         assert_eq!(r2.kv_indices.len(), 7); // 5 reused + 2 new pages
         assert_eq!(mgr.cache().token_pool.available(), 93); // 100 - 5 - 2
+    }
+
+    #[test]
+    fn destination_transfer_footprint_uses_missing_physical_pages() {
+        let mut mgr = SglangKvManager::new(64, 4, KvEventPublishers::default(), 0);
+        let prompt = (0..10).collect::<Vec<_>>();
+
+        let cold = mgr
+            .reserve_destination(&prompt)
+            .expect("cold destination reservation should fit");
+        assert_eq!(cold.transferable_prompt_tokens(), 12);
+        mgr.cancel_destination(cold);
+
+        let prefix_tokens = &prompt[..4];
+        let prefix = mgr
+            .allocate_for_request(prefix_tokens)
+            .expect("prefix allocation should fit");
+        mgr.cache_finished_req(
+            prefix_tokens,
+            &prefix.kv_indices,
+            prefix.last_node,
+            prefix.prefix_len,
+        );
+        let partial = mgr
+            .reserve_destination(&prompt)
+            .expect("partially cached destination reservation should fit");
+        assert_eq!(partial.transferable_prompt_tokens(), 8);
+        mgr.cancel_destination(partial);
+
+        let aligned_tokens = (20..28).collect::<Vec<_>>();
+        let aligned = mgr
+            .allocate_for_request(&aligned_tokens)
+            .expect("aligned prompt allocation should fit");
+        mgr.cache_finished_req(
+            &aligned_tokens,
+            &aligned.kv_indices,
+            aligned.last_node,
+            aligned.prefix_len,
+        );
+        let full_hit = mgr
+            .reserve_destination(&aligned_tokens)
+            .expect("fully cached destination reservation should fit");
+        assert_eq!(full_hit.transferable_prompt_tokens(), 0);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -748,6 +748,7 @@ mod tests {
             SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id: observed,
                 request_id,
+                ..
             } if *observed == handoff_id && *request_id == Uuid::from_u128(2)
         )));
         assert_eq!(engine.worker_count(), 1);
@@ -853,6 +854,7 @@ mod tests {
             SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id: observed,
                 request_id,
+                ..
             } if *observed == handoff_id && *request_id == Uuid::from_u128(103)
         )));
     }

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -990,7 +990,7 @@ impl DisaggRuntime {
                 SchedulerLifecycleEvent::SourceHeld {
                     handoff_id,
                     request_id,
-                    transfer_delay_ms,
+                    transfer_timing,
                 } => {
                     let uuid = self.uuid_for_handoff(handoff_id)?;
                     if uuid != request_id {
@@ -1008,13 +1008,14 @@ impl DisaggRuntime {
                         uuid,
                         HandoffFact::SourceHeld {
                             handoff_id,
-                            transfer_delay_ms,
+                            transfer_timing,
                         },
                     )?;
                 }
                 SchedulerLifecycleEvent::DestinationReserved {
                     handoff_id,
                     request_id,
+                    transferable_prompt_tokens,
                 } => {
                     let uuid = self.uuid_for_handoff(handoff_id)?;
                     if uuid != request_id {
@@ -1030,7 +1031,13 @@ impl DisaggRuntime {
                             .push(NormalizedHandoffEvent::DestinationReserved);
                     }
                     self.collector.on_destination_reserved(uuid, self.now_ms);
-                    self.apply_handoff_fact(uuid, HandoffFact::DestinationReserved { handoff_id })?;
+                    self.apply_handoff_fact(
+                        uuid,
+                        HandoffFact::DestinationReserved {
+                            handoff_id,
+                            transferable_prompt_tokens,
+                        },
+                    )?;
                 }
             }
         }

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -8,7 +8,9 @@ use super::super::entrypoints::{
     run_trace_workload_collect,
 };
 use super::*;
-use crate::common::protocols::{EngineType, MockEngineArgs, SglangArgs, WorkerType};
+use crate::common::protocols::{
+    EngineType, KvTransferTimingMode, MockEngineArgs, SglangArgs, WorkerType,
+};
 use crate::loadgen::{SessionTrace, Trace, TurnTrace};
 use crate::replay::TraceSimulationReport;
 
@@ -65,10 +67,46 @@ fn sglang_disagg_config() -> OfflineDisaggReplayConfig {
     }
 }
 
+fn forced_chunked_handoff_config(engine_type: EngineType) -> OfflineDisaggReplayConfig {
+    let mut config = match engine_type {
+        EngineType::Vllm => disagg_config(),
+        EngineType::Sglang => sglang_disagg_config(),
+        EngineType::Trtllm => unreachable!(),
+    };
+    config.num_prefill_workers = 1;
+    config.num_decode_workers = 1;
+    config.prefill_args.speedup_ratio = 1.0;
+    config.prefill_args.max_num_batched_tokens = Some(64);
+    if let Some(sglang) = config.prefill_args.sglang.as_mut() {
+        sglang.chunked_prefill_size = Some(64);
+        sglang.max_prefill_tokens = Some(64);
+    }
+    config
+}
+
 fn disagg_config_with_handoff_delay() -> OfflineDisaggReplayConfig {
     let mut config = disagg_config();
     config.prefill_args.kv_transfer_bandwidth = Some(1.0);
     config.prefill_args.kv_bytes_per_token = Some(1_000_000);
+    config
+}
+
+fn transfer_timing_config(
+    engine_type: EngineType,
+    mode: KvTransferTimingMode,
+    decode_workers: usize,
+) -> OfflineDisaggReplayConfig {
+    let mut config = match engine_type {
+        EngineType::Vllm => disagg_config(),
+        EngineType::Sglang => sglang_disagg_config(),
+        EngineType::Trtllm => unreachable!(),
+    };
+    config.num_prefill_workers = 1;
+    config.num_decode_workers = decode_workers;
+    config.prefill_args.kv_transfer_bandwidth = Some(1.0);
+    config.prefill_args.kv_bytes_per_token = Some(1_000_000);
+    config.prefill_args.kv_transfer_timing_mode = mode;
+    config.decode_args.kv_transfer_timing_mode = mode;
     config
 }
 
@@ -566,6 +604,107 @@ fn test_source_release_waits_for_destination_activation() {
     }
 }
 
+#[rstest::rstest]
+#[case(EngineType::Vllm)]
+#[case(EngineType::Sglang)]
+fn chunked_prefill_handoff_waits_for_full_materialization(#[case] engine_type: EngineType) {
+    let config = forced_chunked_handoff_config(engine_type);
+    let uuid = Uuid::from_u128(1);
+    let pending =
+        crate::replay::normalize_trace_requests(vec![request(uuid.as_u128(), 192, 2, 0.0)], 1.0)
+            .unwrap();
+    let mut runtime = DisaggRuntime::new(
+        &config,
+        None,
+        None,
+        pending,
+        ReplayMode::Trace,
+        ReplayRouterMode::RoundRobin,
+    )
+    .unwrap()
+    .with_per_request_records(true);
+
+    let mut prefill_fpm = Vec::new();
+    for _ in 0..32 {
+        if runtime
+            .stats
+            .transition_log
+            .contains(&DisaggTransition::SourceHeld { uuid })
+        {
+            break;
+        }
+        let next = runtime
+            .next_timestamp()
+            .expect("chunked source must retain scheduled work");
+        runtime.advance_to(next).unwrap();
+        prefill_fpm.extend(runtime.drain_prefill_fpm());
+    }
+
+    assert!(
+        runtime
+            .stats
+            .transition_log
+            .contains(&DisaggTransition::SourceHeld { uuid }),
+        "source must reach terminal hold"
+    );
+    let prefill_chunks = prefill_fpm
+        .iter()
+        .filter(|(_, snapshot)| snapshot.sum_prefill_tokens > 0)
+        .collect::<Vec<_>>();
+    assert!(
+        prefill_chunks.len() >= 3,
+        "192 prompt tokens with a 64-token budget must span at least three passes"
+    );
+    assert_eq!(
+        prefill_chunks
+            .iter()
+            .map(|(_, snapshot)| snapshot.sum_prefill_tokens)
+            .sum::<u64>(),
+        192
+    );
+
+    assert!(runtime.advance_to(f64::MAX).unwrap());
+    let decode_fpm = runtime.drain_decode_fpm();
+    runtime.finish_test_stats();
+
+    let transitions = &runtime.stats.transition_log;
+    let held = transition_index(transitions, DisaggTransition::SourceHeld { uuid });
+    let activated = transition_index(transitions, DisaggTransition::DestinationActivated { uuid });
+    let admitted = transition_index(transitions, DisaggTransition::DecodeAdmitted { uuid });
+    let released = transition_index(transitions, DisaggTransition::SourceReleased { uuid });
+    assert!(held < activated);
+    assert!(activated < admitted);
+    assert!(activated < released);
+    assert!(
+        decode_fpm
+            .iter()
+            .all(|(_, snapshot)| snapshot.num_prefill_requests == 0
+                && snapshot.sum_prefill_tokens == 0),
+        "activated destination must not recompute prompt chunks"
+    );
+    assert!(
+        decode_fpm
+            .iter()
+            .any(|(_, snapshot)| snapshot.num_decode_requests > 0)
+    );
+    assert!(runtime.prefill_engine.is_drained());
+    assert!(runtime.decode_engine.is_drained());
+    assert!(runtime.action_queues.is_empty());
+    assert_eq!(
+        runtime.stats.request_snapshots[&uuid].phase,
+        DisaggPhase::Done
+    );
+
+    let report = runtime.collector.finish();
+    assert_eq!(report.request_counts.completed_requests, 1);
+    assert_eq!(report.request_counts.total_input_tokens, 192);
+    assert_eq!(report.request_counts.total_output_tokens, 2);
+    assert_eq!(
+        report.per_request[0].terminal_status,
+        ReplayTerminalStatus::Completed
+    );
+}
+
 #[test]
 fn per_request_handoff_detail_preserves_backend_causality_and_stage_reuse() {
     for (engine_type, config) in [
@@ -726,63 +865,179 @@ fn handoff_delay_is_applied_once_to_decode_visible_ttft() {
 }
 
 #[test]
-fn test_cancellation_during_transfer_ignores_retired_completion_event() {
-    let config = disagg_config_with_handoff_delay();
-    let uuid = Uuid::from_u128(1);
-    let mut runtime = DisaggRuntime::new(
-        &config,
-        None,
-        None,
-        VecDeque::from([request(1, 128, 2, 0.0)]),
-        ReplayMode::Trace,
-        ReplayRouterMode::RoundRobin,
-    )
-    .unwrap()
-    .with_per_request_records(true);
+fn destination_missing_timing_uses_isolated_destination_cache_state() {
+    for engine_type in [EngineType::Vllm, EngineType::Sglang] {
+        for (seed_tokens, measured_tokens, expected_missing_ms) in [
+            (None, 128, 128.0),
+            (Some(64), 128, 64.0),
+            (Some(64), 64, 0.0),
+        ] {
+            let requests = seed_tokens
+                .map(|tokens| request(1, tokens, 1, 0.0))
+                .into_iter()
+                .chain(std::iter::once(request(2, measured_tokens, 2, 1_000.0)))
+                .collect::<Vec<_>>();
+            let full = run_trace_with_details(
+                &transfer_timing_config(engine_type, KvTransferTimingMode::FullPrompt, 1),
+                requests.clone(),
+                None,
+                ReplayRouterMode::RoundRobin,
+            );
+            let missing = run_trace_with_details(
+                &transfer_timing_config(engine_type, KvTransferTimingMode::DestinationMissing, 1),
+                requests,
+                None,
+                ReplayRouterMode::RoundRobin,
+            );
+            let full_record = full
+                .per_request
+                .iter()
+                .find(|record| {
+                    record.input_length == measured_tokens && record.arrival_time_ms > 0.0
+                })
+                .or_else(|| {
+                    full.per_request
+                        .iter()
+                        .find(|record| record.input_length == measured_tokens)
+                })
+                .unwrap();
+            let missing_record = missing
+                .per_request
+                .iter()
+                .find(|record| {
+                    record.input_length == measured_tokens && record.arrival_time_ms > 0.0
+                })
+                .or_else(|| {
+                    missing
+                        .per_request
+                        .iter()
+                        .find(|record| record.input_length == measured_tokens)
+                })
+                .unwrap();
+            let full_transfer_span = full_record.destination_activated_ms.unwrap()
+                - full_record.destination_reserved_ms.unwrap();
+            let missing_transfer_span = missing_record.destination_activated_ms.unwrap()
+                - missing_record.destination_reserved_ms.unwrap();
 
-    runtime.drain_current_timestamp().unwrap();
-    for _ in 0..16 {
-        if runtime.state(uuid).unwrap().phase == DisaggPhase::TransferPending {
-            break;
+            let expected_reduction = measured_tokens as f64 - expected_missing_ms;
+            assert!(
+                ((full_transfer_span - missing_transfer_span) - expected_reduction).abs() < 1e-6,
+                "{engine_type:?} seed={seed_tokens:?} measured={measured_tokens}: full span {full_transfer_span}, missing span {missing_transfer_span}"
+            );
+            assert!(
+                missing_transfer_span >= expected_missing_ms
+                    && missing_transfer_span - expected_missing_ms < 1.0,
+                "{engine_type:?} seed={seed_tokens:?} measured={measured_tokens}: missing span {missing_transfer_span}"
+            );
+            assert_eq!(full_record.terminal_status, ReplayTerminalStatus::Completed);
+            assert_eq!(
+                missing_record.terminal_status,
+                ReplayTerminalStatus::Completed
+            );
+            assert!(
+                missing_record.source_held_ms.unwrap()
+                    <= missing_record.destination_activated_ms.unwrap()
+            );
+            assert!(
+                missing_record.destination_reserved_ms.unwrap()
+                    <= missing_record.destination_activated_ms.unwrap()
+            );
+            assert!(
+                missing_record.destination_activated_ms.unwrap()
+                    <= missing_record.source_released_ms.unwrap()
+            );
         }
-        let next = runtime.next_timestamp().unwrap();
-        runtime.advance_now_ms(next);
-        runtime.drain_current_timestamp().unwrap();
     }
-    assert_eq!(
-        runtime.state(uuid).unwrap().phase,
-        DisaggPhase::TransferPending
-    );
-    let handoff_id = runtime.state(uuid).unwrap().handoff_id;
-    runtime.apply_scaling(0, 0).unwrap();
-    assert_eq!(runtime.total_prefill_count(), 1);
-    assert_eq!(runtime.total_decode_count(), 1);
-    runtime
-        .apply_handoff_fact(uuid, HandoffFact::Canceled { handoff_id })
-        .unwrap();
+}
 
-    runtime.drain_current_timestamp().unwrap();
-    assert!(runtime.events.iter().all(|event| !matches!(
-        &event.kind,
-        crate::replay::offline::events::SimulationEventKind::TransferComplete { .. }
-    )));
-    while !runtime.is_done() {
-        let next = runtime.next_timestamp().unwrap();
-        runtime.advance_now_ms(next);
-        runtime.drain_current_timestamp().unwrap();
+#[test]
+fn source_only_reuse_does_not_reduce_destination_missing_transfer() {
+    for engine_type in [EngineType::Vllm, EngineType::Sglang] {
+        let report = run_trace_with_details(
+            &transfer_timing_config(engine_type, KvTransferTimingMode::DestinationMissing, 2),
+            vec![request(1, 64, 1, 0.0), request(2, 64, 2, 1_000.0)],
+            None,
+            ReplayRouterMode::RoundRobin,
+        );
+        let measured = report
+            .per_request
+            .iter()
+            .find(|record| record.arrival_time_ms > 0.0)
+            .unwrap();
+        let transfer_span =
+            measured.destination_activated_ms.unwrap() - measured.destination_reserved_ms.unwrap();
+
+        assert!(measured.reused_input_tokens > 0);
+        assert_eq!(measured.decode_reused_input_tokens, Some(0));
+        assert!(transfer_span >= 64.0 && transfer_span - 64.0 < 1.0);
     }
-    assert_eq!(runtime.state(uuid).unwrap().phase, DisaggPhase::Done);
-    assert_eq!(runtime.total_prefill_count(), 0);
-    assert_eq!(runtime.total_decode_count(), 0);
-    assert!(
-        !runtime
-            .stats
-            .transition_log
-            .contains(&DisaggTransition::DestinationActivated { uuid })
-    );
-    let records = runtime.collector.per_request_records();
-    assert_eq!(records.len(), 1);
-    assert_eq!(records[0].terminal_status, ReplayTerminalStatus::Canceled);
+}
+
+#[test]
+fn test_cancellation_during_transfer_ignores_retired_completion_event() {
+    for mode in [
+        KvTransferTimingMode::FullPrompt,
+        KvTransferTimingMode::DestinationMissing,
+    ] {
+        let mut config = disagg_config_with_handoff_delay();
+        config.prefill_args.kv_transfer_timing_mode = mode;
+        config.decode_args.kv_transfer_timing_mode = mode;
+        let uuid = Uuid::from_u128(1);
+        let mut runtime = DisaggRuntime::new(
+            &config,
+            None,
+            None,
+            VecDeque::from([request(1, 128, 2, 0.0)]),
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap()
+        .with_per_request_records(true);
+
+        runtime.drain_current_timestamp().unwrap();
+        for _ in 0..16 {
+            if runtime.state(uuid).unwrap().phase == DisaggPhase::TransferPending {
+                break;
+            }
+            let next = runtime.next_timestamp().unwrap();
+            runtime.advance_now_ms(next);
+            runtime.drain_current_timestamp().unwrap();
+        }
+        assert_eq!(
+            runtime.state(uuid).unwrap().phase,
+            DisaggPhase::TransferPending
+        );
+        let handoff_id = runtime.state(uuid).unwrap().handoff_id;
+        runtime.apply_scaling(0, 0).unwrap();
+        assert_eq!(runtime.total_prefill_count(), 1);
+        assert_eq!(runtime.total_decode_count(), 1);
+        runtime
+            .apply_handoff_fact(uuid, HandoffFact::Canceled { handoff_id })
+            .unwrap();
+
+        runtime.drain_current_timestamp().unwrap();
+        assert!(runtime.events.iter().all(|event| !matches!(
+            &event.kind,
+            crate::replay::offline::events::SimulationEventKind::TransferComplete { .. }
+        )));
+        while !runtime.is_done() {
+            let next = runtime.next_timestamp().unwrap();
+            runtime.advance_now_ms(next);
+            runtime.drain_current_timestamp().unwrap();
+        }
+        assert_eq!(runtime.state(uuid).unwrap().phase, DisaggPhase::Done);
+        assert_eq!(runtime.total_prefill_count(), 0);
+        assert_eq!(runtime.total_decode_count(), 0);
+        assert!(
+            !runtime
+                .stats
+                .transition_log
+                .contains(&DisaggTransition::DestinationActivated { uuid })
+        );
+        let records = runtime.collector.per_request_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].terminal_status, ReplayTerminalStatus::Canceled);
+    }
 }
 
 #[test]

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -58,6 +58,7 @@ fn use_single_runtime(num_workers: usize, router_mode: ReplayRouterMode) -> bool
 #[doc(hidden)]
 pub fn run_offline_handoff_conformance(
     engine_type: EngineType,
+    transfer_timing_mode: crate::common::protocols::KvTransferTimingMode,
 ) -> Result<NormalizedHandoffConformance> {
     if engine_type == EngineType::Trtllm {
         anyhow::bail!("TRT-LLM does not support destination handoff");
@@ -74,7 +75,8 @@ pub fn run_offline_handoff_conformance(
             .speedup_ratio(1000.0)
             .decode_speedup_ratio(1000.0)
             .kv_transfer_bandwidth(Some(1.0))
-            .kv_bytes_per_token(Some(1_000_000));
+            .kv_bytes_per_token(Some(1_000_000))
+            .kv_transfer_timing_mode(transfer_timing_mode);
         if engine_type == EngineType::Sglang {
             builder = builder.sglang(Some(SglangArgs {
                 page_size: Some(4),

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -385,6 +385,7 @@ mod tests {
                     .push(SchedulerLifecycleEvent::DestinationReserved {
                         handoff_id: HandoffId::from(Uuid::from_u128(2)),
                         request_id: Uuid::from_u128(3),
+                        transferable_prompt_tokens: 4,
                     });
             }
             Ok(effects)
@@ -425,6 +426,7 @@ mod tests {
             lifecycle_events: vec![SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id: HandoffId::from(Uuid::from_u128(2)),
                 request_id,
+                transferable_prompt_tokens: 4,
             }],
             mocker_metrics: MockerMetrics::default(),
             router_event_visibility: RouterEventVisibility::PassEnd,

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -752,6 +752,7 @@ mod tests {
                 [SchedulerLifecycleEvent::DestinationReserved {
                     handoff_id,
                     request_id,
+                    ..
                 }] if *handoff_id == second_handoff && *request_id == second_request
             ));
         }
@@ -919,6 +920,7 @@ mod tests {
                 [SchedulerLifecycleEvent::DestinationReserved {
                     handoff_id,
                     request_id,
+                    ..
                 }] if *handoff_id == pending_handoff && *request_id == pending_request
             ));
             assert_eq!(
@@ -1004,6 +1006,7 @@ mod tests {
             [SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id,
                 request_id,
+                ..
             }] if *handoff_id == pending_handoff && *request_id == pending_request
         ));
         assert_eq!(

--- a/lib/mocker/src/scheduler/sglang/config.rs
+++ b/lib/mocker/src/scheduler/sglang/config.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use crate::common::perf_model::PerfModel;
-use crate::common::protocols::{MockEngineArgs, WorkerType};
+use crate::common::protocols::{KvTransferTimingMode, MockEngineArgs, WorkerType};
 
 const DEFAULT_MAX_PREFILL_TOKENS: usize = 16384;
 const DEFAULT_CHUNKED_PREFILL_SIZE: usize = 8192;
@@ -40,6 +40,7 @@ pub(super) struct SglangConfig {
     pub(super) total_kv_tokens: usize,
     pub(super) kv_bytes_per_token: Option<usize>,
     pub(super) kv_transfer_bandwidth: Option<f64>,
+    pub(super) kv_transfer_timing_mode: KvTransferTimingMode,
     pub(super) speculative_max_tokens: Option<usize>,
 }
 
@@ -90,6 +91,7 @@ impl SglangConfig {
             total_kv_tokens: args.num_gpu_blocks * args.block_size,
             kv_bytes_per_token: args.kv_bytes_per_token,
             kv_transfer_bandwidth: args.kv_transfer_bandwidth,
+            kv_transfer_timing_mode: args.kv_transfer_timing_mode,
             speculative_max_tokens: args.aic_nextn.map(|nextn| nextn + 1),
         }
     }

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use crate::common::handoff::HandoffId;
 use crate::common::protocols::{DirectRequest, KvEventPublishers, MockEngineArgs, WorkerType};
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
-use crate::common::utils::compute_prefill_handoff_delay_ms;
+use crate::common::utils::prefill_handoff_transfer_timing;
 use crate::kv_manager::SglangKvManager;
 use crate::kv_manager::sglang_backend::SglangDestinationReservation;
 use crate::replay::TraceCollector;
@@ -313,6 +313,7 @@ impl SglangCore {
         let Some(kv) = reservation else {
             return Vec::new();
         };
+        let transferable_prompt_tokens = kv.transferable_prompt_tokens();
         let (handoff_id, request_id, request) = self
             .pending_destinations
             .pop_front()
@@ -322,6 +323,7 @@ impl SglangCore {
         vec![SchedulerLifecycleEvent::DestinationReserved {
             handoff_id,
             request_id,
+            transferable_prompt_tokens,
         }]
     }
 
@@ -359,12 +361,11 @@ impl SglangCore {
 
     fn complete_source(&mut self, request: SglangRequest) {
         let uuid = request.uuid;
-        let transfer_delay_ms = compute_prefill_handoff_delay_ms(
-            self.config.worker_type,
-            true,
+        let transfer_timing = prefill_handoff_transfer_timing(
             request.prompt_len(),
             self.config.kv_transfer_bandwidth,
             self.config.kv_bytes_per_token,
+            self.config.kv_transfer_timing_mode,
         );
         let payload = HeldSglangPrefill { request };
         let released = match self.source_holds.complete_source(uuid, payload) {
@@ -377,7 +378,7 @@ impl SglangCore {
                     .push(SchedulerLifecycleEvent::SourceHeld {
                         handoff_id,
                         request_id: uuid,
-                        transfer_delay_ms,
+                        transfer_timing,
                     });
                 false
             }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -364,6 +364,35 @@ mod destination_lifecycle {
         assert_eq!(core.mocker_metrics().waiting_requests, 0);
     }
 
+    #[test]
+    fn destination_transfer_footprint_excludes_decode_headroom() {
+        let footprint = |max_output_tokens| {
+            let mut core = SglangCore::new(args(WorkerType::Decode));
+            let effects = core
+                .apply_command_effects(
+                    SchedulerCommand::ReserveDestination {
+                        handoff_id: HandoffId::new(),
+                        request: request(Uuid::new_v4(), (0..10).collect(), max_output_tokens),
+                    },
+                    true,
+                )
+                .unwrap();
+            let [
+                SchedulerLifecycleEvent::DestinationReserved {
+                    transferable_prompt_tokens,
+                    ..
+                },
+            ] = effects.lifecycle_events.as_slice()
+            else {
+                panic!("destination reservation should complete immediately");
+            };
+            *transferable_prompt_tokens
+        };
+
+        assert_eq!(footprint(1), 12);
+        assert_eq!(footprint(128), 12);
+    }
+
     async fn send_live_command(
         scheduler: &SglangScheduler,
         command: SchedulerCommand,
@@ -534,17 +563,29 @@ mod destination_lifecycle {
         );
 
         let usage_before_reservation = occupied_tokens(&destination);
-        assert_eq!(
-            destination
-                .apply_command(SchedulerCommand::ReserveDestination {
+        let reserved = destination
+            .apply_command_effects(
+                SchedulerCommand::ReserveDestination {
                     handoff_id,
                     request: request(logical_uuid, logical_tokens, 2),
-                })
-                .unwrap(),
+                },
+                true,
+            )
+            .unwrap();
+        assert_eq!(
+            reserved.result,
             SchedulerCommandResult::DestinationAccepted {
                 request_id: logical_uuid
             }
         );
+        assert!(matches!(
+            reserved.lifecycle_events.as_slice(),
+            [SchedulerLifecycleEvent::DestinationReserved {
+                handoff_id: reserved_handoff,
+                request_id: reserved_request,
+                transferable_prompt_tokens: 4,
+            }] if *reserved_handoff == handoff_id && *reserved_request == logical_uuid
+        ));
         assert!(destination.destination_is_held(handoff_id));
         assert!(!destination.is_drained());
         assert_eq!(destination.running.len(), 1);
@@ -736,6 +777,7 @@ mod destination_lifecycle {
             [SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id,
                 request_id,
+                ..
             }] if *handoff_id == follower_handoff && *request_id == follower_request
         ));
 

--- a/lib/mocker/src/scheduler/source_holds.rs
+++ b/lib/mocker/src/scheduler/source_holds.rs
@@ -7,7 +7,7 @@ use anyhow::{Result, bail};
 use rustc_hash::FxHashMap;
 use uuid::Uuid;
 
-use crate::common::handoff::HandoffId;
+use crate::common::handoff::{HandoffId, HandoffTransferTiming};
 use crate::common::protocols::DirectRequest;
 
 #[allow(dead_code)]
@@ -48,11 +48,12 @@ pub enum SchedulerLifecycleEvent {
     SourceHeld {
         handoff_id: HandoffId,
         request_id: Uuid,
-        transfer_delay_ms: Option<f64>,
+        transfer_timing: HandoffTransferTiming,
     },
     DestinationReserved {
         handoff_id: HandoffId,
         request_id: Uuid,
+        transferable_prompt_tokens: usize,
     },
 }
 

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -23,7 +23,7 @@ use crate::common::protocols::{
 };
 use crate::common::sequence::ActiveSequence;
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
-use crate::common::utils::compute_prefill_handoff_delay_ms;
+use crate::common::utils::{compute_prefill_handoff_delay_ms, prefill_handoff_transfer_timing};
 use crate::kv_manager::KvManager;
 #[cfg(feature = "kvbm-offload")]
 use crate::kv_manager::kvbm_backend::SwapInRegistrationBlock;
@@ -737,6 +737,7 @@ impl VllmCore {
         let Some(kv) = reservation else {
             return Vec::new();
         };
+        let transferable_prompt_tokens = kv.transferable_prompt_tokens(self.args.block_size);
         let (handoff_id, request_id, request) = self
             .pending_destinations
             .pop_front()
@@ -746,6 +747,7 @@ impl VllmCore {
         vec![SchedulerLifecycleEvent::DestinationReserved {
             handoff_id,
             request_id,
+            transferable_prompt_tokens,
         }]
     }
 
@@ -850,13 +852,12 @@ impl VllmCore {
     }
 
     fn complete_source(&mut self, uuid: Uuid, deferred_deref: Vec<MoveBlock>) {
-        let transfer_delay_ms = self.state.requests.get(&uuid).and_then(|request| {
-            compute_prefill_handoff_delay_ms(
-                self.args.worker_type,
-                true,
+        let transfer_timing = self.state.requests.get(&uuid).map(|request| {
+            prefill_handoff_transfer_timing(
                 request.sequence.num_input_tokens(),
                 self.args.kv_transfer_bandwidth,
                 self.args.kv_bytes_per_token,
+                self.args.kv_transfer_timing_mode,
             )
         });
         let request = self
@@ -876,7 +877,8 @@ impl VllmCore {
                     .push(SchedulerLifecycleEvent::SourceHeld {
                         handoff_id,
                         request_id: uuid,
-                        transfer_delay_ms,
+                        transfer_timing: transfer_timing
+                            .expect("completed source request must retain transfer timing"),
                     });
             }
         }

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -741,6 +741,7 @@ mod tests {
             SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id: observed,
                 request_id: observed_request,
+                ..
             } if observed == handoff_id && observed_request == request_id
         ));
         let host_stores = || {

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -391,6 +391,35 @@ mod destination_lifecycle {
     }
 
     #[test]
+    fn destination_transfer_footprint_excludes_decode_headroom() {
+        let footprint = |max_output_tokens| {
+            let mut core = VllmCore::new(args(WorkerType::Decode));
+            let effects = core
+                .apply_command_effects(
+                    SchedulerCommand::ReserveDestination {
+                        handoff_id: HandoffId::new(),
+                        request: request(Uuid::new_v4(), (0..10).collect(), max_output_tokens),
+                    },
+                    true,
+                )
+                .unwrap();
+            let [
+                SchedulerLifecycleEvent::DestinationReserved {
+                    transferable_prompt_tokens,
+                    ..
+                },
+            ] = effects.lifecycle_events.as_slice()
+            else {
+                panic!("destination reservation should complete immediately");
+            };
+            *transferable_prompt_tokens
+        };
+
+        assert_eq!(footprint(1), 12);
+        assert_eq!(footprint(128), 12);
+    }
+
+    #[test]
     fn handoff_prefill_to_reserved_decode_owns_kv_until_normal_admission() {
         let logical_uuid = Uuid::from_u128(10_001);
         let handoff_id = HandoffId::from(Uuid::from_u128(10_002));
@@ -464,7 +493,9 @@ mod destination_lifecycle {
             [SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id: reserved_handoff,
                 request_id: reserved_request,
+                transferable_prompt_tokens,
             }] if *reserved_handoff == handoff_id && *reserved_request == logical_uuid
+                && *transferable_prompt_tokens == 4
         ));
         assert!(destination.kv_manager.num_active_blocks() > usage_before_physical_reservation);
         let reserved_block_ids = destination.destination_block_ids(handoff_id);
@@ -658,6 +689,7 @@ mod destination_lifecycle {
             [SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id,
                 request_id,
+                ..
             }] if *handoff_id == pending_handoff && *request_id == pending_request
         ));
         assert_eq!(
@@ -2501,6 +2533,7 @@ mod offload {
             SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id: observed,
                 request_id,
+                ..
             } if *observed == handoff_id && *request_id == Uuid::from_u128(2)
         )));
         assert!(!core.destination_block_ids(handoff_id).is_empty());
@@ -2916,6 +2949,7 @@ mod offload {
             SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id,
                 request_id,
+                ..
             } if *handoff_id == follower_handoff && *request_id == follower_uuid
         )));
 
@@ -3400,6 +3434,7 @@ mod offload {
             SchedulerLifecycleEvent::DestinationReserved {
                 handoff_id: observed_handoff,
                 request_id: observed_request,
+                ..
             } if *observed_handoff == handoff_id && *observed_request == request_id
         )));
         assert!(core.destination_is_held(handoff_id));


### PR DESCRIPTION
## Summary

Stacked on #10915. Implements #10911.

- Adds `kv_transfer_timing_mode` with `full_prompt` as the behavior-preserving default.
- Adds opt-in `destination_missing` timing based on the destination reservation's authoritative physical footprint:
  - vLLM charges missing block-rounded prompt KV.
  - SGLang charges missing page-rounded prompt KV.
- Carries the reservation footprint through the existing bootstrap v1 fact and shared offline/live coordinator path without changing the protocol version or ownership lifecycle.
- Preserves the current full-prompt timeout extension at `SourceHeld`; missing-mode timeout extension waits for successful destination reservation.
- Excludes destination-cached prefix, source-only reuse, output/decode headroom, and unused reserved capacity from cache-aware transfer bytes.

Ordinary requests and default `full_prompt` behavior are unchanged.

## Validation

Local:

- `cargo test -p dynamo-mocker --lib` — 457 passed, 1 ignored.
- `cargo test -p dynamo-llm --no-default-features mocker::handoff` — 18 passed.
- `.venv/bin/python -m pytest components/src/dynamo/mocker/tests/unit/test_config.py -q` — 25 passed.
- Clippy and format passed for `lib/mocker`, `lib/llm`, and `lib/bindings/python`; Ruff passed for touched Python files.

SC-01 isolated replay validation against the exact final stacked base:

- Deterministic 1-prefill/1-decode timing at 1 MB/token and 1 GB/s:
  - vLLM cold `128→128 ms`, partial `128→64 ms`, full `128→0 ms`, source-only `128→128 ms`.
  - SGLang modeled reductions were identical, with 0.006–0.024 ms of normal scheduler overhead in the measured reservation-to-activation span.
- Base versus candidate `full_prompt` had equivalent normalized request JSONL and model-time reports for both backends. Assignments, completion order, reuse, outcomes, and token totals matched; only host wall-clock execution rates varied.
- 2-prefill/2-decode KV-router runs completed 100/100 requests per backend with 25,600 input and 800 output tokens. Under `destination_missing`, 44 requests activated 128 ms earlier and 56 were unchanged. All lifecycle rows were causal and terminal-completed; the resulting completion-order changes followed the earlier readiness boundary.
- Focused KVBM busy-worker offload/admission regression passed. The full Linux feature suite reached 529 passed / 1 ignored / 2 failed; both failing live-offload fixtures reproduce on the stacked base. A constrained KVBM replay stall also reproduced on base and candidate. G2→G1 prefix restore remains unexercised because destination reservation currently matches G1 cache only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new transfer timing option for disaggregated KV handoff behavior, with selectable modes for full-prompt or destination-missing timing.
  * Exposed transfer timing settings across configuration and Python bindings.

* **Bug Fixes**
  * Improved handoff timing calculations to better reflect destination cache state and missing prompt footprint.
  * Updated scheduler and replay flows so destination reservations report transferable prompt tokens more accurately.
  * Refined offline replay and conformance behavior to handle both timing modes consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->