### PR TITLE
Back prompt membership trie with CRTC

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
@@ -28,10 +28,13 @@ use types::*;
 
 mod dump;
 mod matches;
+mod prompt_membership;
 mod remove;
 mod repair;
 mod store;
 mod sync_impl;
+
+pub(crate) use prompt_membership::{PromptMembershipIndex, PromptWorkerLookup, lookup_live_hashes};
 
 #[cfg(test)]
 mod tests;

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/prompt_membership.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/prompt_membership.rs
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dynamo_tokens::SequenceHash;
+use parking_lot::RwLock;
+use rustc_hash::FxHashMap;
+#[cfg(test)]
+use rustc_hash::FxHashSet;
+
+use super::*;
+
+struct PromptHashSequence<'a>(&'a [SequenceHash]);
+
+impl HashSequence for PromptHashSequence<'_> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn at(&self, index: usize) -> LocalBlockHash {
+        LocalBlockHash(self.0[index])
+    }
+}
+
+/// Opaque per-worker reverse lookup for prompt membership.
+#[derive(Default)]
+pub(crate) struct PromptWorkerLookup {
+    inner: WorkerLookup,
+}
+
+/// Prompt-membership projection backed by [`ConcurrentRadixTreeCompressed`].
+///
+/// Prompt membership uses a single `SequenceHash` identity. The adapter maps it
+/// to both CRTC hash dimensions: `LocalBlockHash` for traversal and
+/// `ExternalSequenceBlockHash` for parent/removal lookup.
+pub(crate) struct PromptMembershipIndex {
+    index: ConcurrentRadixTreeCompressed,
+    next_event_id: AtomicU64,
+}
+
+impl Default for PromptMembershipIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PromptMembershipIndex {
+    pub(crate) fn new() -> Self {
+        Self {
+            index: ConcurrentRadixTreeCompressed::new(),
+            next_event_id: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn store_chain(
+        &self,
+        worker: WorkerWithDpRank,
+        lookup: &Arc<RwLock<PromptWorkerLookup>>,
+        parent: Option<SequenceHash>,
+        hashes: &[SequenceHash],
+    ) {
+        if hashes.is_empty() {
+            return;
+        }
+
+        let blocks = hashes
+            .iter()
+            .map(|&hash| KvCacheStoredBlockData {
+                tokens_hash: LocalBlockHash(hash),
+                block_hash: ExternalSequenceBlockHash(hash),
+                mm_extra_info: None,
+            })
+            .collect();
+
+        let event = self.router_event(
+            worker,
+            KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: parent.map(ExternalSequenceBlockHash),
+                start_position: None,
+                blocks,
+            }),
+        );
+        self.apply_event_with_worker_lookup(worker, lookup, event);
+    }
+
+    pub(crate) fn remove_chain(
+        &self,
+        worker: WorkerWithDpRank,
+        lookup: &Arc<RwLock<PromptWorkerLookup>>,
+        hashes: &[SequenceHash],
+    ) {
+        if hashes.is_empty() {
+            return;
+        }
+
+        let event = self.router_event(
+            worker,
+            KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: hashes
+                    .iter()
+                    .map(|&hash| ExternalSequenceBlockHash(hash))
+                    .collect(),
+            }),
+        );
+        self.apply_event_with_worker_lookup(worker, lookup, event);
+    }
+
+    pub(crate) fn remove_worker(
+        &self,
+        worker: WorkerWithDpRank,
+        lookup: &Arc<RwLock<PromptWorkerLookup>>,
+    ) {
+        let mut prompt_lookup = lookup.write();
+        let mut direct_lookup = self.take_worker_lookup(worker, &mut prompt_lookup);
+
+        self.repair_worker_lookup(&mut direct_lookup, worker);
+        self.index
+            .remove_worker_dp_rank(&mut direct_lookup, worker.worker_id, worker.dp_rank);
+
+        prompt_lookup.inner = direct_lookup.remove(&worker).unwrap_or_default();
+    }
+
+    pub(crate) fn compute_overlap_depths(
+        &self,
+        query: Option<&[SequenceHash]>,
+    ) -> FxHashMap<WorkerWithDpRank, usize> {
+        let Some(query) = query else {
+            return FxHashMap::default();
+        };
+        if query.is_empty() {
+            return FxHashMap::default();
+        }
+
+        let next_child = self.index.root.child_snapshot(LocalBlockHash(query[0]));
+        let details =
+            self.index
+                .find_details_from_seq(next_child, PromptHashSequence(query), false);
+        details
+            .overlap_scores
+            .scores
+            .into_iter()
+            .map(|(worker, depth)| (worker, depth as usize))
+            .collect()
+    }
+
+    pub(crate) fn maybe_cleanup(&self) {
+        if !self.index.try_schedule_cleanup() {
+            return;
+        }
+        self.index.run_cleanup_task();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn worker_hashes(&self) -> FxHashMap<WorkerWithDpRank, FxHashSet<SequenceHash>> {
+        let mut worker_hashes = FxHashMap::default();
+        for event in self.index.dump_tree_as_events() {
+            let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
+            if let KvCacheEventData::Stored(store) = event.event.data {
+                worker_hashes
+                    .entry(worker)
+                    .or_insert_with(FxHashSet::default)
+                    .extend(store.blocks.into_iter().map(|block| block.block_hash.0));
+            }
+        }
+        worker_hashes
+    }
+
+    #[cfg(any(test, feature = "bench"))]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.index.dump_tree_as_events().is_empty()
+    }
+
+    fn router_event(&self, worker: WorkerWithDpRank, data: KvCacheEventData) -> RouterEvent {
+        RouterEvent::new(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id: self.next_event_id.fetch_add(1, Ordering::Relaxed),
+                data,
+                dp_rank: worker.dp_rank,
+            },
+        )
+    }
+
+    fn apply_event_with_worker_lookup(
+        &self,
+        worker: WorkerWithDpRank,
+        lookup: &Arc<RwLock<PromptWorkerLookup>>,
+        event: RouterEvent,
+    ) {
+        let mut prompt_lookup = lookup.write();
+        let mut direct_lookup = self.take_worker_lookup(worker, &mut prompt_lookup);
+        let result = self.index.apply_event(&mut direct_lookup, event, None);
+        if let Err(error) = result {
+            tracing::warn!(?worker, ?error, "failed to apply prompt membership event");
+        }
+        prompt_lookup.inner = direct_lookup.remove(&worker).unwrap_or_default();
+    }
+
+    fn take_worker_lookup(
+        &self,
+        worker: WorkerWithDpRank,
+        prompt_lookup: &mut PromptWorkerLookup,
+    ) -> FxHashMap<WorkerWithDpRank, WorkerLookup> {
+        let mut direct_lookup = FxHashMap::default();
+        direct_lookup.insert(worker, std::mem::take(&mut prompt_lookup.inner));
+        direct_lookup
+    }
+
+    fn repair_worker_lookup(
+        &self,
+        direct_lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
+        worker: WorkerWithDpRank,
+    ) {
+        let hashes: Vec<_> = direct_lookup
+            .get(&worker)
+            .map(|worker_lookup| worker_lookup.keys().copied().collect())
+            .unwrap_or_default();
+
+        for hash in hashes {
+            let _ = self.index.resolve_lookup(
+                direct_lookup,
+                worker,
+                hash,
+                LookupRepairDirection::TowardTail,
+            );
+        }
+    }
+}
+
+#[cfg(any(test, feature = "bench"))]
+pub(crate) fn lookup_live_hashes(lookup: &Arc<RwLock<PromptWorkerLookup>>) -> Vec<SequenceHash> {
+    let lookup = lookup.read();
+    lookup
+        .inner
+        .iter()
+        .filter_map(|(&hash, node)| node.dump_snapshot().has_any_workers.then_some(hash.0))
+        .collect()
+}

--- a/lib/kv-router/src/sequences/prompt_membership_trie.rs
+++ b/lib/kv-router/src/sequences/prompt_membership_trie.rs
@@ -1,342 +1,33 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::VecDeque;
 use std::sync::Arc;
 
 use dynamo_tokens::SequenceHash;
 use parking_lot::RwLock;
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
-use crate::cleanup::{self, CleanableNode, CleanupGuard, CleanupState};
+#[cfg(any(test, feature = "bench"))]
+pub(super) use crate::indexer::concurrent_radix_tree_compressed::lookup_live_hashes;
+use crate::indexer::concurrent_radix_tree_compressed::{PromptMembershipIndex, PromptWorkerLookup};
 use crate::protocols::WorkerWithDpRank;
 
-type SharedNode = Arc<RwLock<PromptTrieNode>>;
-pub(super) type WorkerLookup = FxHashMap<SequenceHash, SharedNode>;
+pub(super) type WorkerLookup = PromptWorkerLookup;
 
-#[derive(Debug)]
-pub(super) struct PromptTrieNode {
-    edge: Vec<SequenceHash>,
-    edge_index: FxHashMap<SequenceHash, usize>,
-    worker_cutoffs: FxHashMap<WorkerWithDpRank, usize>,
-    full_edge_workers: FxHashSet<WorkerWithDpRank>,
-    children: FxHashMap<SequenceHash, SharedNode>,
-}
-
-impl PromptTrieNode {
-    fn new() -> Self {
-        Self {
-            edge: Vec::new(),
-            edge_index: FxHashMap::default(),
-            worker_cutoffs: FxHashMap::default(),
-            full_edge_workers: FxHashSet::default(),
-            children: FxHashMap::default(),
-        }
-    }
-
-    fn edge_index_for(edge: &[SequenceHash]) -> FxHashMap<SequenceHash, usize> {
-        let mut edge_index = FxHashMap::with_capacity_and_hasher(edge.len(), FxBuildHasher);
-        for (i, &hash) in edge.iter().enumerate() {
-            edge_index.insert(hash, i);
-        }
-        edge_index
-    }
-
-    fn full_edge_workers_for(worker: WorkerWithDpRank) -> FxHashSet<WorkerWithDpRank> {
-        let mut full_edge_workers = FxHashSet::with_capacity_and_hasher(1, FxBuildHasher);
-        full_edge_workers.insert(worker);
-        full_edge_workers
-    }
-
-    fn current_cutoff(&self, worker: WorkerWithDpRank) -> usize {
-        if self.full_edge_workers.contains(&worker) {
-            self.edge.len()
-        } else {
-            self.worker_cutoffs.get(&worker).copied().unwrap_or(0)
-        }
-    }
-
-    fn covers_pos(&self, worker: WorkerWithDpRank, pos: usize) -> bool {
-        self.full_edge_workers.contains(&worker)
-            || matches!(self.worker_cutoffs.get(&worker), Some(&cutoff) if pos < cutoff)
-    }
-
-    fn clear_children_if_unreachable(&mut self) {
-        if self.full_edge_workers.is_empty() {
-            self.children.clear();
-        }
-    }
-
-    fn uncovered_suffix_hashes(&self, cutoff: usize) -> Vec<SequenceHash> {
-        debug_assert!(cutoff <= self.edge.len());
-        self.edge[cutoff..].to_vec()
-    }
-
-    fn lookup_hashes_for_worker_repair(
-        &self,
-        worker: WorkerWithDpRank,
-        hash: SequenceHash,
-        direction: LookupRepairDirection,
-    ) -> Vec<SequenceHash> {
-        let Some(&pos) = self.edge_index.get(&hash) else {
-            return Vec::new();
-        };
-
-        let cutoff = self.current_cutoff(worker).min(self.edge.len());
-        let range = match direction {
-            LookupRepairDirection::TowardTail => {
-                if pos < cutoff {
-                    pos..cutoff
-                } else {
-                    0..0
-                }
-            }
-            LookupRepairDirection::TowardHead => 0..pos.min(cutoff),
-        };
-
-        self.edge[range].to_vec()
-    }
-
-    fn drop_worker(&mut self, worker: WorkerWithDpRank) {
-        self.full_edge_workers.remove(&worker);
-        self.worker_cutoffs.remove(&worker);
-        self.clear_children_if_unreachable();
-    }
-
-    fn promote_to_full(&mut self, worker: WorkerWithDpRank) {
-        if !self.full_edge_workers.contains(&worker) {
-            self.worker_cutoffs.remove(&worker);
-            self.full_edge_workers.insert(worker);
-        }
-    }
-
-    fn remove_worker_at_pos(
-        &mut self,
-        worker: WorkerWithDpRank,
-        pos: usize,
-        removed_hash: SequenceHash,
-    ) -> RemoveOutcome {
-        let current_cutoff = self.current_cutoff(worker);
-        if pos >= current_cutoff {
-            return RemoveOutcome {
-                stale_hashes: vec![removed_hash],
-            };
-        }
-
-        let new_cutoff = pos;
-        let stale_hashes = self.uncovered_suffix_hashes(new_cutoff);
-
-        if new_cutoff == 0 {
-            self.drop_worker(worker);
-        } else {
-            self.full_edge_workers.remove(&worker);
-            self.worker_cutoffs.insert(worker, new_cutoff);
-            self.clear_children_if_unreachable();
-        }
-
-        RemoveOutcome { stale_hashes }
-    }
-
-    #[cfg(any(test, feature = "bench"))]
-    fn live_children(&self) -> Vec<SharedNode> {
-        self.children
-            .values()
-            .filter(|child| {
-                let guard = child.read();
-                guard.has_any_workers() || !guard.children.is_empty()
-            })
-            .cloned()
-            .collect()
-    }
-}
-
-impl CleanableNode for PromptTrieNode {
-    type ChildKey = SequenceHash;
-
-    fn has_any_workers(&self) -> bool {
-        !self.full_edge_workers.is_empty() || !self.worker_cutoffs.is_empty()
-    }
-
-    fn children(&self) -> &FxHashMap<SequenceHash, SharedNode> {
-        &self.children
-    }
-
-    fn remove_child(&mut self, key: &SequenceHash) {
-        self.children.remove(key);
-    }
-}
-
-struct RemoveOutcome {
-    stale_hashes: Vec<SequenceHash>,
-}
-
-#[derive(Clone, Copy)]
-enum LookupRepairDirection {
-    TowardTail,
-    TowardHead,
-}
-
+#[derive(Default)]
 pub(super) struct PromptMembershipTrie {
-    root: SharedNode,
-    cleanup: CleanupState,
-}
-
-impl Default for PromptMembershipTrie {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Drop for PromptMembershipTrie {
-    fn drop(&mut self) {
-        let mut stack: Vec<SharedNode> = Vec::new();
-        {
-            let mut root = self.root.write();
-            stack.extend(root.children.drain().map(|(_, child)| child));
-        }
-
-        while let Some(node) = stack.pop() {
-            if let Ok(rwlock) = Arc::try_unwrap(node) {
-                let mut inner = rwlock.into_inner();
-                stack.extend(inner.children.drain().map(|(_, child)| child));
-            }
-        }
-    }
+    index: PromptMembershipIndex,
 }
 
 impl PromptMembershipTrie {
     pub(super) fn new() -> Self {
         Self {
-            root: Arc::new(RwLock::new(PromptTrieNode::new())),
-            cleanup: CleanupState::new(),
+            index: PromptMembershipIndex::new(),
         }
     }
 
-    /// Run the stale-child sweep if the throttle interval has elapsed.
-    ///
-    /// Safe to call from any write path; the sweep is a no-op until
-    /// [`CLEANUP_INTERVAL_MS`](crate::cleanup::CLEANUP_INTERVAL_MS) has passed
-    /// since the last completion, and only one sweep runs at a time.
     pub(super) fn maybe_cleanup(&self) {
-        if !self.cleanup.try_schedule() {
-            return;
-        }
-        let mut guard = CleanupGuard::new(&self.cleanup);
-        cleanup::sweep_stale_children(&self.root);
-        guard.mark_completed();
-    }
-
-    fn children_snapshot(node: &SharedNode) -> Vec<SharedNode> {
-        let guard = node.read();
-        guard.children.values().cloned().collect()
-    }
-
-    fn find_in_subtree(start: &SharedNode, hash: SequenceHash) -> Option<SharedNode> {
-        let mut queue = VecDeque::from(Self::children_snapshot(start));
-        while let Some(node) = queue.pop_front() {
-            let guard = node.read();
-            if guard.edge_index.contains_key(&hash) {
-                drop(guard);
-                return Some(node);
-            }
-            queue.extend(guard.children.values().cloned());
-        }
-
-        None
-    }
-
-    fn repair_lookup_for_resolved_node(
-        worker_lookup: &mut WorkerLookup,
-        worker: WorkerWithDpRank,
-        hash: SequenceHash,
-        resolved: &SharedNode,
-        direction: LookupRepairDirection,
-    ) {
-        let repair_hashes = {
-            let guard = resolved.read();
-            guard.lookup_hashes_for_worker_repair(worker, hash, direction)
-        };
-        for repair_hash in repair_hashes {
-            worker_lookup.insert(repair_hash, resolved.clone());
-        }
-    }
-
-    fn repair_stale_lookup_from_node(
-        worker_lookup: &mut WorkerLookup,
-        worker: WorkerWithDpRank,
-        node: &SharedNode,
-        hash: SequenceHash,
-        direction: LookupRepairDirection,
-    ) -> Option<SharedNode> {
-        let resolved = Self::find_in_subtree(node, hash)?;
-        Self::repair_lookup_for_resolved_node(worker_lookup, worker, hash, &resolved, direction);
-        Some(resolved)
-    }
-
-    fn resolve_lookup(
-        worker_lookup: &mut WorkerLookup,
-        worker: WorkerWithDpRank,
-        hash: SequenceHash,
-        direction: LookupRepairDirection,
-    ) -> Option<SharedNode> {
-        let node = worker_lookup.get(&hash)?.clone();
-        let found = {
-            let guard = node.read();
-            guard.edge_index.contains_key(&hash)
-        };
-        if found {
-            return Some(node);
-        }
-
-        Self::repair_stale_lookup_from_node(worker_lookup, worker, &node, hash, direction)
-    }
-
-    fn split_node(node: &mut PromptTrieNode, pos: usize) -> SharedNode {
-        debug_assert!(pos > 0 && pos < node.edge.len());
-
-        let suffix_edge = node.edge.split_off(pos);
-        let suffix_first_hash = suffix_edge[0];
-
-        let suffix_edge_index = PromptTrieNode::edge_index_for(&suffix_edge);
-        for &hash in &suffix_edge {
-            node.edge_index.remove(&hash);
-        }
-
-        let mut suffix_full =
-            FxHashSet::with_capacity_and_hasher(node.full_edge_workers.len(), FxBuildHasher);
-        let mut suffix_cutoffs =
-            FxHashMap::with_capacity_and_hasher(node.worker_cutoffs.len(), FxBuildHasher);
-        let mut to_promote = Vec::with_capacity(node.worker_cutoffs.len());
-
-        for &worker in &node.full_edge_workers {
-            suffix_full.insert(worker);
-        }
-
-        for (&worker, &cutoff) in &node.worker_cutoffs {
-            if cutoff >= pos {
-                to_promote.push(worker);
-                let suffix_cutoff = cutoff - pos;
-                if suffix_cutoff > 0 {
-                    suffix_cutoffs.insert(worker, suffix_cutoff);
-                }
-            }
-        }
-
-        for worker in to_promote {
-            node.worker_cutoffs.remove(&worker);
-            node.full_edge_workers.insert(worker);
-        }
-
-        let suffix_children = std::mem::take(&mut node.children);
-        let suffix = Arc::new(RwLock::new(PromptTrieNode {
-            edge: suffix_edge,
-            edge_index: suffix_edge_index,
-            worker_cutoffs: suffix_cutoffs,
-            full_edge_workers: suffix_full,
-            children: suffix_children,
-        }));
-        node.children.insert(suffix_first_hash, suffix.clone());
-        suffix
+        self.index.maybe_cleanup();
     }
 
     pub(super) fn store_chain(
@@ -346,189 +37,7 @@ impl PromptMembershipTrie {
         parent: Option<SequenceHash>,
         hashes: &[SequenceHash],
     ) {
-        if hashes.is_empty() {
-            return;
-        }
-
-        let mut worker_lookup = lookup.write();
-        let parent = match parent {
-            Some(parent_hash) => loop {
-                let Some(node) = Self::resolve_lookup(
-                    &mut worker_lookup,
-                    worker,
-                    parent_hash,
-                    LookupRepairDirection::TowardTail,
-                ) else {
-                    tracing::warn!(?worker, ?parent_hash, "prompt parent hash not found");
-                    return;
-                };
-
-                {
-                    let guard = node.read();
-                    let Some(&pos) = guard.edge_index.get(&parent_hash) else {
-                        continue;
-                    };
-                    if !guard.covers_pos(worker, pos) {
-                        worker_lookup.remove(&parent_hash);
-                        tracing::warn!(
-                            ?worker,
-                            ?parent_hash,
-                            pos,
-                            "worker no longer covers prompt parent"
-                        );
-                        return;
-                    }
-                }
-
-                let split_suffix = {
-                    let mut guard = node.write();
-                    if !guard.edge_index.contains_key(&parent_hash) {
-                        continue;
-                    }
-                    if !guard.edge.is_empty() && *guard.edge.last().unwrap() != parent_hash {
-                        let split_pos = guard
-                            .edge
-                            .iter()
-                            .position(|hash| *hash == parent_hash)
-                            .expect("parent hash presence was checked above");
-                        Some(Self::split_node(&mut guard, split_pos + 1))
-                    } else {
-                        None
-                    }
-                };
-
-                if split_suffix.is_some() {
-                    continue;
-                }
-
-                break node;
-            },
-            None => self.root.clone(),
-        };
-
-        self.insert_hashes_from(worker, &mut worker_lookup, &parent, hashes);
-    }
-
-    fn insert_hashes_from(
-        &self,
-        worker: WorkerWithDpRank,
-        worker_lookup: &mut WorkerLookup,
-        parent: &SharedNode,
-        hashes: &[SequenceHash],
-    ) {
-        let mut current_parent = parent.clone();
-        let mut remaining = hashes;
-        let mut last_hash = None;
-
-        while !remaining.is_empty() {
-            let first_hash = remaining[0];
-
-            let child = {
-                let mut parent_guard = current_parent.write();
-                if let Some(last_hash) = last_hash
-                    && !parent_guard.edge_index.contains_key(&last_hash)
-                {
-                    drop(parent_guard);
-                    if let Some(resolved) = Self::resolve_lookup(
-                        worker_lookup,
-                        worker,
-                        last_hash,
-                        LookupRepairDirection::TowardTail,
-                    ) {
-                        current_parent = resolved;
-                    }
-                    continue;
-                }
-
-                match parent_guard.children.get(&first_hash).cloned() {
-                    Some(existing) => existing,
-                    None => {
-                        let edge = remaining.to_vec();
-                        let edge_index = PromptTrieNode::edge_index_for(&edge);
-                        let full_edge_workers = PromptTrieNode::full_edge_workers_for(worker);
-
-                        let new_node = Arc::new(RwLock::new(PromptTrieNode {
-                            edge,
-                            edge_index,
-                            worker_cutoffs: FxHashMap::default(),
-                            full_edge_workers,
-                            children: FxHashMap::default(),
-                        }));
-                        parent_guard.children.insert(first_hash, new_node.clone());
-                        drop(parent_guard);
-
-                        for &hash in remaining {
-                            worker_lookup.insert(hash, new_node.clone());
-                        }
-                        return;
-                    }
-                }
-            };
-
-            {
-                let mut child_guard = child.write();
-                let edge_len = child_guard.edge.len();
-
-                let mut match_len = 0;
-                for (&edge_hash, &query_hash) in child_guard.edge.iter().zip(remaining.iter()) {
-                    if edge_hash != query_hash {
-                        break;
-                    }
-                    match_len += 1;
-                }
-
-                debug_assert!(match_len >= 1);
-
-                if match_len < edge_len {
-                    let _suffix = Self::split_node(&mut child_guard, match_len);
-                    child_guard.promote_to_full(worker);
-
-                    let tail = &remaining[match_len..];
-                    if !tail.is_empty() {
-                        let edge = tail.to_vec();
-                        let edge_index = PromptTrieNode::edge_index_for(&edge);
-                        let full_edge_workers = PromptTrieNode::full_edge_workers_for(worker);
-                        let tail_first_hash = tail[0];
-
-                        let new_node = Arc::new(RwLock::new(PromptTrieNode {
-                            edge,
-                            edge_index,
-                            worker_cutoffs: FxHashMap::default(),
-                            full_edge_workers,
-                            children: FxHashMap::default(),
-                        }));
-                        child_guard
-                            .children
-                            .insert(tail_first_hash, new_node.clone());
-                        drop(child_guard);
-
-                        for &hash in &remaining[..match_len] {
-                            worker_lookup.insert(hash, child.clone());
-                        }
-                        for &hash in tail {
-                            worker_lookup.insert(hash, new_node.clone());
-                        }
-                    } else {
-                        drop(child_guard);
-                        for &hash in &remaining[..match_len] {
-                            worker_lookup.insert(hash, child.clone());
-                        }
-                    }
-                    return;
-                }
-
-                child_guard.promote_to_full(worker);
-                drop(child_guard);
-
-                for &hash in &remaining[..edge_len] {
-                    worker_lookup.insert(hash, child.clone());
-                }
-
-                last_hash = Some(remaining[edge_len - 1]);
-                remaining = &remaining[edge_len..];
-                current_parent = child;
-            }
-        }
+        self.index.store_chain(worker, lookup, parent, hashes);
     }
 
     pub(super) fn remove_chain(
@@ -537,57 +46,7 @@ impl PromptMembershipTrie {
         lookup: &Arc<RwLock<WorkerLookup>>,
         hashes: &[SequenceHash],
     ) {
-        let mut worker_lookup = lookup.write();
-        if worker_lookup.is_empty() {
-            return;
-        }
-
-        'outer: for &hash in hashes {
-            let mut current_node = match Self::resolve_lookup(
-                &mut worker_lookup,
-                worker,
-                hash,
-                LookupRepairDirection::TowardHead,
-            ) {
-                Some(node) => node,
-                None => continue,
-            };
-
-            loop {
-                let update = {
-                    let mut guard = current_node.write();
-                    guard
-                        .edge_index
-                        .get(&hash)
-                        .copied()
-                        .map(|pos| guard.remove_worker_at_pos(worker, pos, hash))
-                };
-
-                match update {
-                    Some(outcome) => {
-                        for stale_hash in outcome.stale_hashes {
-                            worker_lookup.remove(&stale_hash);
-                        }
-                        continue 'outer;
-                    }
-                    None => match Self::repair_stale_lookup_from_node(
-                        &mut worker_lookup,
-                        worker,
-                        &current_node,
-                        hash,
-                        LookupRepairDirection::TowardHead,
-                    ) {
-                        Some(resolved) => {
-                            current_node = resolved;
-                        }
-                        None => {
-                            worker_lookup.remove(&hash);
-                            continue 'outer;
-                        }
-                    },
-                }
-            }
-        }
+        self.index.remove_chain(worker, lookup, hashes);
     }
 
     pub(super) fn remove_worker(
@@ -595,195 +54,27 @@ impl PromptMembershipTrie {
         worker: WorkerWithDpRank,
         lookup: &Arc<RwLock<WorkerLookup>>,
     ) {
-        let mut worker_lookup = lookup.write();
-        if worker_lookup.is_empty() {
-            return;
-        }
-
-        let hashes: Vec<_> = worker_lookup.keys().copied().collect();
-        let mut nodes = Vec::new();
-        let mut seen = FxHashSet::<usize>::with_capacity_and_hasher(hashes.len(), FxBuildHasher);
-        for hash in hashes {
-            let Some(node) = Self::resolve_lookup(
-                &mut worker_lookup,
-                worker,
-                hash,
-                LookupRepairDirection::TowardTail,
-            ) else {
-                worker_lookup.remove(&hash);
-                continue;
-            };
-            let ptr = Arc::as_ptr(&node) as usize;
-            if seen.insert(ptr) {
-                nodes.push(node);
-            }
-        }
-        worker_lookup.clear();
-        drop(worker_lookup);
-
-        for node in nodes {
-            let mut guard = node.write();
-            guard.drop_worker(worker);
-        }
+        self.index.remove_worker(worker, lookup);
     }
 
     pub(super) fn compute_overlap_depths(
         &self,
         query: Option<&[SequenceHash]>,
     ) -> FxHashMap<WorkerWithDpRank, usize> {
-        let Some(query) = query else {
-            return FxHashMap::default();
-        };
-        if query.is_empty() {
-            return FxHashMap::default();
-        }
-
-        let mut matched_depth = FxHashMap::default();
-        let mut active = FxHashSet::default();
-        let mut active_count = 0usize;
-        let mut query_pos = 0usize;
-        let mut depth = 0usize;
-        let mut first_node = true;
-
-        let mut next_child = {
-            let root = self.root.read();
-            root.children.get(&query[0]).cloned()
-        };
-
-        loop {
-            if query_pos >= query.len() {
-                break;
-            }
-
-            let Some(child) = next_child.take() else {
-                break;
-            };
-
-            let edge_len;
-            let edge_match_len;
-            {
-                let guard = child.read();
-                edge_len = guard.edge.len();
-                let walk_len = edge_len.min(query.len() - query_pos);
-
-                let mut match_len = 1usize;
-                for i in 1..walk_len {
-                    if guard.edge[i] != query[query_pos + i] {
-                        break;
-                    }
-                    match_len += 1;
-                }
-                edge_match_len = match_len;
-
-                let prev_depth = depth;
-                if first_node {
-                    active = guard.full_edge_workers.clone();
-                    active_count = active.len();
-                    for (&worker, &cutoff) in &guard.worker_cutoffs {
-                        let contribution = cutoff.min(edge_match_len);
-                        if contribution > 0 {
-                            matched_depth.insert(worker, contribution);
-                        }
-                    }
-                    first_node = false;
-                } else if !guard.worker_cutoffs.is_empty() {
-                    active.retain(|worker| {
-                        if guard.full_edge_workers.contains(worker) {
-                            true
-                        } else if let Some(&cutoff) = guard.worker_cutoffs.get(worker) {
-                            matched_depth.insert(*worker, prev_depth + cutoff.min(edge_match_len));
-                            false
-                        } else {
-                            matched_depth.insert(*worker, prev_depth);
-                            false
-                        }
-                    });
-                    active_count = active.len();
-                } else {
-                    let full_count = guard.full_edge_workers.len();
-                    if full_count != active_count {
-                        active.retain(|worker| {
-                            if guard.full_edge_workers.contains(worker) {
-                                true
-                            } else {
-                                matched_depth.insert(*worker, prev_depth);
-                                false
-                            }
-                        });
-                        active_count = active.len();
-                    }
-                }
-
-                next_child = if edge_match_len == edge_len
-                    && active_count > 0
-                    && query_pos + edge_match_len < query.len()
-                {
-                    guard
-                        .children
-                        .get(&query[query_pos + edge_match_len])
-                        .cloned()
-                } else {
-                    None
-                };
-            }
-
-            if active_count == 0 {
-                break;
-            }
-
-            depth += edge_match_len;
-            if edge_match_len < edge_len {
-                break;
-            }
-            query_pos += edge_match_len;
-        }
-
-        for worker in active {
-            matched_depth.insert(worker, depth);
-        }
-
-        matched_depth
+        self.index.compute_overlap_depths(query)
     }
 
     #[cfg(test)]
-    pub(super) fn worker_hashes(&self) -> FxHashMap<WorkerWithDpRank, FxHashSet<SequenceHash>> {
-        let mut worker_hashes = FxHashMap::default();
-        let mut stack = vec![self.root.clone()];
-
-        while let Some(node) = stack.pop() {
-            let guard = node.read();
-            for &worker in &guard.full_edge_workers {
-                worker_hashes
-                    .entry(worker)
-                    .or_insert_with(FxHashSet::default)
-                    .extend(guard.edge.iter().copied());
-            }
-            for (&worker, &cutoff) in &guard.worker_cutoffs {
-                worker_hashes
-                    .entry(worker)
-                    .or_insert_with(FxHashSet::default)
-                    .extend(guard.edge[..cutoff].iter().copied());
-            }
-            stack.extend(guard.children.values().cloned());
-        }
-
-        worker_hashes
+    pub(super) fn worker_hashes(
+        &self,
+    ) -> rustc_hash::FxHashMap<WorkerWithDpRank, rustc_hash::FxHashSet<SequenceHash>> {
+        self.index.worker_hashes()
     }
 
     #[cfg(any(test, feature = "bench"))]
     pub(super) fn is_empty(&self) -> bool {
-        let root = self.root.read();
-        root.live_children().is_empty()
+        self.index.is_empty()
     }
-}
-
-#[cfg(any(test, feature = "bench"))]
-pub(super) fn lookup_live_hashes(lookup: &Arc<RwLock<WorkerLookup>>) -> Vec<SequenceHash> {
-    let worker_lookup = lookup.read();
-    worker_lookup
-        .iter()
-        .filter_map(|(&hash, node)| node.read().has_any_workers().then_some(hash))
-        .collect()
 }
 
 #[cfg(test)]
@@ -796,18 +87,6 @@ mod tests {
 
     fn lookup() -> Arc<RwLock<WorkerLookup>> {
         Arc::new(RwLock::new(WorkerLookup::default()))
-    }
-
-    fn lookup_node(lookup: &Arc<RwLock<WorkerLookup>>, hash: SequenceHash) -> SharedNode {
-        lookup
-            .read()
-            .get(&hash)
-            .cloned()
-            .expect("hash should exist in worker lookup")
-    }
-
-    fn node_contains_hash(node: &SharedNode, hash: SequenceHash) -> bool {
-        node.read().edge_index.contains_key(&hash)
     }
 
     #[test]
@@ -937,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_lookup_repair_batches_toward_tail() {
+    fn stale_lookup_repair_removes_worker_from_split_suffix() {
         let trie = PromptMembershipTrie::new();
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
@@ -946,67 +225,11 @@ mod tests {
 
         trie.store_chain(worker_a, &lookup_a, None, &[1, 2, 3, 4]);
         trie.store_chain(worker_b, &lookup_b, None, &[1, 2, 5]);
+        trie.remove_worker(worker_a, &lookup_a);
 
-        let stale_node = lookup_node(&lookup_a, 3);
-        assert!(!node_contains_hash(&stale_node, 3));
-        assert!(!node_contains_hash(&stale_node, 4));
-
-        let mut worker_lookup = lookup_a.write();
-        let resolved = PromptMembershipTrie::resolve_lookup(
-            &mut worker_lookup,
-            worker_a,
-            3,
-            LookupRepairDirection::TowardTail,
-        )
-        .expect("stale suffix should resolve");
-
-        assert!(Arc::ptr_eq(
-            worker_lookup.get(&3).expect("hash 3 should be repaired"),
-            &resolved,
-        ));
-        assert!(Arc::ptr_eq(
-            worker_lookup
-                .get(&4)
-                .expect("hash 4 should be batch repaired"),
-            &resolved,
-        ));
-    }
-
-    #[test]
-    fn stale_lookup_repair_batches_toward_head() {
-        let trie = PromptMembershipTrie::new();
-        let worker_a = worker(1, 0);
-        let worker_b = worker(2, 0);
-        let lookup_a = lookup();
-        let lookup_b = lookup();
-
-        trie.store_chain(worker_a, &lookup_a, None, &[1, 2, 3, 4]);
-        trie.store_chain(worker_b, &lookup_b, None, &[1, 2, 5]);
-
-        let stale_node = lookup_node(&lookup_a, 4);
-        assert!(!node_contains_hash(&stale_node, 3));
-        assert!(!node_contains_hash(&stale_node, 4));
-
-        let mut worker_lookup = lookup_a.write();
-        let resolved = PromptMembershipTrie::resolve_lookup(
-            &mut worker_lookup,
-            worker_a,
-            4,
-            LookupRepairDirection::TowardHead,
-        )
-        .expect("stale suffix should resolve");
-
-        assert!(Arc::ptr_eq(
-            worker_lookup
-                .get(&3)
-                .expect("hash 3 should be batch repaired"),
-            &resolved,
-        ));
-        assert!(!Arc::ptr_eq(
-            worker_lookup
-                .get(&4)
-                .expect("current remove hash is not pre-repaired"),
-            &resolved,
-        ));
+        assert_eq!(
+            trie.compute_overlap_depths(Some(&[1, 2, 3, 4])),
+            FxHashMap::from_iter([(worker_b, 2)]),
+        );
     }
 }


### PR DESCRIPTION
## Summary

Replaces the custom `PromptMembershipTrie` backing structure with a thin crate-internal adapter over `ConcurrentRadixTreeCompressed`.

- Adds `PromptMembershipIndex` under the CRTC module.
- Keeps the existing `PromptMembershipTrie` surface as a compatibility wrapper for `PromptRegistry`.
- Preserves synchronous prompt-membership updates from the `ActiveSequences` mutation path.
- Keeps output-block accounting in `BlockTracker`; the prompt-membership index only tracks prompt blocks.
- Maps prompt `SequenceHash` values to both `LocalBlockHash` and `ExternalSequenceBlockHash` inside the adapter.

## Current Status

This is intentionally a draft. Behavior parity tests pass, but the first benchmark comparison does not show the expected speedup. In the current thin-adapter form, the CRTC-backed path is slower than the specialized prompt trie in `active_sequences_bench`.

Measured locally against baseline commit `81d0555ee23519cea80a42b4fe824e30368b7300`:

- Warm sweep, `-d 20`: both versions kept up, but p99 latency was about 2x worse with the CRTC adapter.
- Forced 1ms replay, `-d 100`: baseline was about 1.05M ops/s; CRTC adapter was about 0.93M ops/s.
- The likely issue is adapter overhead and CRTC's general KV-indexer concurrency machinery on a prompt-membership workload that was already served by a specialized compressed trie.

## Validation

- `cargo fmt --all --check`
- `cargo test -p dynamo-kv-router --lib sequences::`
- `cargo test -p dynamo-kv-router --lib concurrent_radix_tree_compressed`
- `cargo test -p dynamo-kv-router --lib`

## Benchmark Commands

```bash
cargo bench -p dynamo-bench --bench active_sequences_bench -- \
  /home/jothomson/Desktop/dynamo/.worktrees/crtc-prompt-membership/lib/bench/testdata/mooncake_trace_1000.jsonl \
  --sweep \
  --sweep-min-ms 1000 \
  --sweep-max-ms 10000 \
  --sweep-steps 6 \
  --num-unique-inference-workers 10 \
  --inference-worker-duplication-factor 20 \
  --num-gpu-blocks 16384 \
  --block-size 128
```

```bash
cargo bench -p dynamo-bench --bench active_sequences_bench -- \
  /home/jothomson/Desktop/dynamo/.worktrees/crtc-prompt-membership/lib/bench/testdata/mooncake_trace_1000.jsonl \
  --benchmark-duration-ms 1 \
  --num-unique-inference-workers 10 \
  --inference-worker-duplication-factor 100 \
  --num-gpu-blocks 16384 \
  --block-size 128
```
