### PR TITLE
refactor(replay): unify offline replay on one event-driven path + fix FPM leak

### DIFF
--- a/components/src/dynamo/planner/offline/replay_adapter.py
+++ b/components/src/dynamo/planner/offline/replay_adapter.py
@@ -1,15 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Adapter that drives the planner core via the PlannerReplayBridge.
+"""Adapter that drives the planner core from the unified replay loop.
 
-The bridge (Rust, PyO3) runs the offline simulation step-by-step.
-This adapter sits between the bridge and the planner tick engine:
+The Rust offline simulation (``PlannerReplayBridge.run``) owns the drive
+loop and calls back into this adapter once per ``PlannerTick`` event, so
+the adapter is a callback hook rather than an external stepper:
 
-    Bridge.advance_to(tick_ms) -> raw metrics dict
-    Adapter._build_tick_input() -> TickInput
-    EngineProtocol.tick() -> PlannerEffects
-    Adapter -> Bridge.apply_scaling(prefill, decode)
+    Bridge.run(adapter)                        # Rust owns the loop
+      adapter.initial_tick_ms()      -> first tick time
+      per PlannerTick:
+        adapter.on_tick(metrics)     -> _build_tick_input() -> TickInput
+                                        EngineProtocol.tick() -> PlannerEffects
+                                        -> {target_prefill, target_decode, next_tick_ms}
+        # Rust applies the scaling decision and re-arms the next tick itself
+      adapter.finalize(trace_report) -> ReplayPlannerReport
 
 The tick engine is the builtin orchestrator path:
 ``OrchestratorEngineAdapter`` wrapping ``LocalPlannerOrchestrator`` +
@@ -17,9 +22,9 @@ the builtin local-planner plugins. It preserves the planner's
 ``PlannerEffects.scale_to`` replay contract while using plugin-aware
 observability (Prometheus metrics, audit events, diagnostics).
 
-Replay keeps its sync ``run()`` API; async orchestrator calls
-(``bootstrap_from_fpms`` / ``tick``) run inside a single replay-scoped
-event loop so callers don't need to change.
+The simulation steps itself — replay no longer drives the bridge
+externally. Async orchestrator calls (``bootstrap_from_fpms`` / ``tick``)
+run inside a single replay-scoped event loop so callers don't change.
 
 Supports both aggregated and disaggregated topologies. No I/O, no
 runtime dependencies. Fully deterministic with offline replay.
@@ -123,6 +128,41 @@ def _update_fpm_cache(
         del cache[worst_key]
 
 
+def _merge_traffic(
+    acc: Optional[dict[str, Any]], window: dict[str, Any]
+) -> dict[str, Any]:
+    """Num_req-weighted merge of two TrafficStats dicts into one window.
+
+    Exact for ``duration_s``/``num_req`` and the sum-based averages (isl/osl/
+    kv_hit_rate, since a num_req-weighted mean of per-window means re-sums to the
+    overall mean). ``ttft``/``itl``/``accept_length`` are num_req-weighted
+    approximations (their true per-sample counts are not carried across windows);
+    they feed diagnostics, not the simulation trajectory, so the trace_report is
+    unaffected."""
+    if acc is None:
+        return dict(window)
+    na = float(acc.get("num_req", 0.0))
+    nw = float(window.get("num_req", 0.0))
+    n = na + nw
+    merged: dict[str, Any] = {
+        "duration_s": acc.get("duration_s", 0.0) + window.get("duration_s", 0.0),
+        "num_req": n,
+    }
+    for key in ("avg_isl", "avg_osl", "avg_ttft_ms", "avg_itl_ms", "avg_kv_hit_rate"):
+        merged[key] = (
+            (acc.get(key, 0.0) * na + window.get(key, 0.0) * nw) / n if n > 0 else 0.0
+        )
+    a_acc = acc.get("avg_accept_length")
+    a_win = window.get("avg_accept_length")
+    if a_acc is None:
+        merged["avg_accept_length"] = a_win
+    elif a_win is None:
+        merged["avg_accept_length"] = a_acc
+    else:
+        merged["avg_accept_length"] = (a_acc * na + a_win * nw) / n if n > 0 else None
+    return merged
+
+
 class ReplayPlannerAdapter:
     """Drives the plugin planner using the PlannerReplayBridge.
 
@@ -224,66 +264,82 @@ class ReplayPlannerAdapter:
             agg_fpms=agg_fpms,
         )
 
-    def run(self) -> ReplayPlannerReport:
-        """Run the full replay with planner-in-the-loop."""
+    # ------------------------------------------------------------------
+    # Inverted drive: the Rust ``PlannerReplayBridge.run(self)`` owns the loop and
+    # calls ``initial_tick_ms`` once then ``on_tick`` per ``PlannerTick`` event. The
+    # entrypoint wraps the returned trace_report via ``finalize``. (Replaces the old
+    # Python while-loop that drove ``bridge.advance_to`` + ``bridge.apply_scaling``.)
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Bootstrap the orchestrator and compute the first tick. Idempotent."""
+        self._bootstrap_orchestrator_if_needed()
+        self._pending_tick: ScheduledTick = self._engine.initial_tick(0.0)
+        self._scaling_events: list[ScalingEvent] = []
+        self._diagnostics_log: list[TickDiagnostics] = []
+        self._total_ticks = 0
+
+    def initial_tick_ms(self) -> float:
+        """First tick time in milliseconds (called by the Rust PlannerHook)."""
+        if not self._orchestrator_bootstrapped or not hasattr(self, "_pending_tick"):
+            self.start()
+        return self._pending_tick.at_s * 1000.0
+
+    def on_tick(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Drive one planner tick from the bridge's metrics dict. Returns the scaling
+        decision (absolute targets, ``None`` = unchanged) + the next tick time in ms
+        (``None`` = stop) for the Rust loop to apply and re-arm."""
+        tick = self._pending_tick
+        tick_input = self._build_tick_input(tick, result)
+        effects: PlannerEffects = self._run_sync(self._engine.tick(tick, tick_input))
+        emit_diagnostics = self._should_emit_tick_diagnostics(tick, effects)
+        if emit_diagnostics:
+            self._diagnostics_log.append(effects.diagnostics)
+        self._total_ticks += 1
+        self._record_diagnostics(tick_input, effects, result, emit_diagnostics)
+
+        # Clear scaling targets once active counts match.
+        active_p = result["active_prefill_count"]
+        active_d = result["active_decode_count"]
+        if (
+            self._scaling_target_prefill is not None
+            and active_p == self._scaling_target_prefill
+        ):
+            self._scaling_target_prefill = None
+        if (
+            self._scaling_target_decode is not None
+            and active_d == self._scaling_target_decode
+        ):
+            self._scaling_target_decode = None
+
+        target_prefill: Optional[int] = None
+        target_decode: Optional[int] = None
+        if effects.scale_to is not None:
+            target_prefill, target_decode = self._compute_scale_decision(
+                effects, result, tick_input.now_s
+            )
+
+        next_tick_ms: Optional[float] = None
+        if effects.next_tick is not None:
+            self._pending_tick = effects.next_tick
+            next_tick_ms = effects.next_tick.at_s * 1000.0
+
+        return {
+            "target_prefill": target_prefill,
+            "target_decode": target_decode,
+            "next_tick_ms": next_tick_ms,
+        }
+
+    def finalize(self, trace_report: dict[str, Any]) -> ReplayPlannerReport:
+        """Assemble the enriched report from accumulated planner state. Called by the
+        entrypoint after the Rust ``run()`` returns the trace_report dict."""
         try:
-            self._bootstrap_orchestrator_if_needed()
-            next_tick = self._engine.initial_tick(0.0)
-            scaling_events: list[ScalingEvent] = []
-            diagnostics_log: list[TickDiagnostics] = []
-            total_ticks = 0
-
-            while True:
-                tick_ms = next_tick.at_s * 1000.0
-                result = self._bridge.advance_to(tick_ms)
-
-                if result["is_done"]:
-                    break
-
-                tick_input = self._build_tick_input(next_tick, result)
-                effects: PlannerEffects = self._run_sync(
-                    self._engine.tick(next_tick, tick_input)
-                )
-                emit_diagnostics = self._should_emit_tick_diagnostics(
-                    next_tick, effects
-                )
-                if emit_diagnostics:
-                    diagnostics_log.append(effects.diagnostics)
-                total_ticks += 1
-
-                # Update GPU-hours and record diagnostics snapshot
-                self._record_diagnostics(tick_input, effects, result, emit_diagnostics)
-
-                # Clear scaling targets once active counts match
-                active_p = result["active_prefill_count"]
-                active_d = result["active_decode_count"]
-                if (
-                    self._scaling_target_prefill is not None
-                    and active_p == self._scaling_target_prefill
-                ):
-                    self._scaling_target_prefill = None
-                if (
-                    self._scaling_target_decode is not None
-                    and active_d == self._scaling_target_decode
-                ):
-                    self._scaling_target_decode = None
-
-                if effects.scale_to is not None:
-                    self._apply_scaling(
-                        effects, result, tick_input.now_s, scaling_events
-                    )
-
-                if effects.next_tick is None:
-                    break
-                next_tick = effects.next_tick
-
-            trace_report = self._bridge.finalize()
             html_report_path = self._recorder.finalize()
             return ReplayPlannerReport(
                 trace_report=trace_report,
-                scaling_events=scaling_events,
-                diagnostics_log=diagnostics_log,
-                total_ticks=total_ticks,
+                scaling_events=self._scaling_events,
+                diagnostics_log=self._diagnostics_log,
+                total_ticks=self._total_ticks,
                 html_report_path=html_report_path,
             )
         finally:
@@ -335,14 +391,15 @@ class ReplayPlannerAdapter:
             or bool(diag.short_circuit_reason)
         )
 
-    def _apply_scaling(
+    def _compute_scale_decision(
         self,
         effects: PlannerEffects,
         result: dict[str, Any],
         now_s: float,
-        scaling_events: list[ScalingEvent],
-    ) -> None:
-        """Apply scaling decisions and record events."""
+    ) -> tuple[Optional[int], Optional[int]]:
+        """Compute the (prefill, decode) absolute scale targets and record the scaling
+        event. Returns ``(None, None)`` for a no-op. The Rust loop applies the targets,
+        so this no longer calls ``bridge.apply_scaling``."""
         scale = effects.scale_to
         assert scale is not None
         current_p = result["active_prefill_count"]
@@ -351,9 +408,7 @@ class ReplayPlannerAdapter:
         target_d = scale.num_decode if scale.num_decode is not None else current_d
 
         if target_p == current_p and target_d == current_d:
-            return
-
-        self._bridge.apply_scaling(target_p, target_d)
+            return (None, None)
 
         if self._is_disagg:
             if scale.num_prefill is not None and target_p != current_p:
@@ -366,7 +421,7 @@ class ReplayPlannerAdapter:
                     direction,
                 )
                 self._scaling_target_prefill = target_p
-                scaling_events.append(
+                self._scaling_events.append(
                     ScalingEvent(
                         at_s=now_s,
                         component="prefill",
@@ -385,7 +440,7 @@ class ReplayPlannerAdapter:
                     direction,
                 )
                 self._scaling_target_decode = target_d
-                scaling_events.append(
+                self._scaling_events.append(
                     ScalingEvent(
                         at_s=now_s,
                         component="decode",
@@ -404,7 +459,7 @@ class ReplayPlannerAdapter:
                 direction,
             )
             self._scaling_target_decode = target_d
-            scaling_events.append(
+            self._scaling_events.append(
                 ScalingEvent(
                     at_s=now_s,
                     component="agg",
@@ -413,6 +468,7 @@ class ReplayPlannerAdapter:
                     reason=direction,
                 )
             )
+        return (target_p, target_d)
 
     def _feed_extra_fpm_to_regression(
         self,
@@ -577,9 +633,19 @@ class ReplayPlannerAdapter:
                 decode=decode_dict,
             )
 
+        # The Rust bridge drains the per-tick traffic window into ``result["traffic"]``;
+        # accumulate it so a need_traffic_metrics tick sees the full window since the
+        # last consumed one (the planner consumes traffic only on throughput ticks).
+        tick_traffic = result.get("traffic")
+        if tick_traffic is not None:
+            self._pending_traffic = _merge_traffic(
+                getattr(self, "_pending_traffic", None), tick_traffic
+            )
+
         traffic = None
         if tick.need_traffic_metrics:
-            t = self._bridge.drain_traffic()
+            t = getattr(self, "_pending_traffic", None) or {}
+            self._pending_traffic = None
             duration_s = t.get("duration_s", 0.0)
             if duration_s > 0:
                 num_req = float(t.get("num_req", 0))

--- a/components/src/dynamo/planner/offline/replay_adapter.py
+++ b/components/src/dynamo/planner/offline/replay_adapter.py
@@ -225,13 +225,16 @@ class ReplayPlannerAdapter:
         # Replay's ``run()`` is synchronous; we own a scoped event loop to
         # drive the async engine calls without forcing callers to use
         # ``asyncio.run``.
-        self._loop = asyncio.new_event_loop()
+        self._loop: Optional[asyncio.AbstractEventLoop] = asyncio.new_event_loop()
 
         # Last-seen FPM caches (separate for prefill/decode)
         self._prefill_fpm_cache: dict[tuple[str, int], ForwardPassMetrics] = {}
         self._decode_fpm_cache: dict[tuple[str, int], ForwardPassMetrics] = {}
         self._pending_prefill_fpm_snaps: list[dict[str, Any]] = []
         self._pending_decode_fpm_snaps: list[dict[str, Any]] = []
+        # Partial traffic window accumulated across ticks until a throughput tick
+        # consumes it (``None`` = nothing pending).
+        self._pending_traffic: Optional[dict[str, Any]] = None
 
         # Scaling targets -- used as `expected` in WorkerCounts
         self._scaling_target_prefill: Optional[int] = None

--- a/components/src/dynamo/planner/offline/replay_adapter.py
+++ b/components/src/dynamo/planner/offline/replay_adapter.py
@@ -131,35 +131,66 @@ def _update_fpm_cache(
 def _merge_traffic(
     acc: Optional[dict[str, Any]], window: dict[str, Any]
 ) -> dict[str, Any]:
-    """Num_req-weighted merge of two TrafficStats dicts into one window.
+    """Merge two TrafficStats dicts into one window.
 
-    Exact for ``duration_s``/``num_req`` and the sum-based averages (isl/osl/
-    kv_hit_rate, since a num_req-weighted mean of per-window means re-sums to the
-    overall mean). ``ttft``/``itl``/``accept_length`` are num_req-weighted
-    approximations (their true per-sample counts are not carried across windows);
-    they feed diagnostics, not the simulation trajectory, so the trace_report is
-    unaffected."""
+    Exact for every field the planner's scaling consumes:
+      - ``duration_s``/``num_req``: summed.
+      - ``avg_isl``/``avg_osl``: num_req-weighted — their denominator *is*
+        ``num_req``, so a num_req-weighted mean of per-window means re-sums to
+        the exact overall mean.
+      - ``avg_kv_hit_rate``: weighted by ``hit_rate_count`` (its true
+        denominator: router admissions with ``isl_blocks > 0``), so the merge
+        reconstructs the exact sample mean rather than approximating it.
+      - ``avg_accept_length``: weighted by ``accept_length_forward_count``
+        (decode request-forwards, its true denominator), exact across windows.
+
+    ``avg_ttft_ms``/``avg_itl_ms`` are num_req-weighted approximations (their
+    per-sample counts are not carried across windows); they feed diagnostics
+    only, never the scaling trajectory."""
     if acc is None:
         return dict(window)
     na = float(acc.get("num_req", 0.0))
     nw = float(window.get("num_req", 0.0))
     n = na + nw
+
+    def _weighted(key: str, wa: float, ww: float) -> float:
+        w = wa + ww
+        if w <= 0:
+            return 0.0
+        return (acc.get(key, 0.0) * wa + window.get(key, 0.0) * ww) / w
+
+    hit_a = float(acc.get("hit_rate_count", 0.0))
+    hit_w = float(window.get("hit_rate_count", 0.0))
+    fwd_a = float(acc.get("accept_length_forward_count", 0.0))
+    fwd_w = float(window.get("accept_length_forward_count", 0.0))
+
     merged: dict[str, Any] = {
         "duration_s": acc.get("duration_s", 0.0) + window.get("duration_s", 0.0),
         "num_req": n,
+        # Carry the native denominators so chained multi-window merges stay exact.
+        "hit_rate_count": hit_a + hit_w,
+        "accept_length_forward_count": fwd_a + fwd_w,
+        # num_req-weighted: exact for isl/osl, diagnostics-only for ttft/itl.
+        "avg_isl": _weighted("avg_isl", na, nw),
+        "avg_osl": _weighted("avg_osl", na, nw),
+        "avg_ttft_ms": _weighted("avg_ttft_ms", na, nw),
+        "avg_itl_ms": _weighted("avg_itl_ms", na, nw),
+        # Count-weighted by the true denominator -> exact across windows.
+        "avg_kv_hit_rate": _weighted("avg_kv_hit_rate", hit_a, hit_w),
     }
-    for key in ("avg_isl", "avg_osl", "avg_ttft_ms", "avg_itl_ms", "avg_kv_hit_rate"):
-        merged[key] = (
-            (acc.get(key, 0.0) * na + window.get(key, 0.0) * nw) / n if n > 0 else 0.0
-        )
     a_acc = acc.get("avg_accept_length")
     a_win = window.get("avg_accept_length")
-    if a_acc is None:
+    if a_acc is None and a_win is None:
+        merged["avg_accept_length"] = None
+    elif a_acc is None:
         merged["avg_accept_length"] = a_win
     elif a_win is None:
         merged["avg_accept_length"] = a_acc
     else:
-        merged["avg_accept_length"] = (a_acc * na + a_win * nw) / n if n > 0 else None
+        fwd = fwd_a + fwd_w
+        merged["avg_accept_length"] = (
+            (a_acc * fwd_a + a_win * fwd_w) / fwd if fwd > 0 else None
+        )
     return merged
 
 
@@ -343,9 +374,20 @@ class ReplayPlannerAdapter:
                 html_report_path=html_report_path,
             )
         finally:
-            if self._loop is not None:
-                self._run_sync(self._engine.shutdown())
-                self._loop.close()
+            self.close()
+
+    def close(self) -> None:
+        """Shut down the engine and the replay-scoped event loop. Idempotent so it
+        runs cleanly from both ``finalize`` (success) and the entrypoint's error
+        path (when ``bridge.run`` raises before ``finalize`` is reached)."""
+        loop = self._loop
+        if loop is None:
+            return
+        self._loop = None
+        try:
+            loop.run_until_complete(self._engine.shutdown())
+        finally:
+            loop.close()
 
     def _record_diagnostics(
         self,
@@ -401,7 +443,10 @@ class ReplayPlannerAdapter:
         event. Returns ``(None, None)`` for a no-op. The Rust loop applies the targets,
         so this no longer calls ``bridge.apply_scaling``."""
         scale = effects.scale_to
-        assert scale is not None
+        if scale is None:
+            raise ValueError(
+                "_compute_scale_decision requires effects.scale_to to be set"
+            )
         current_p = result["active_prefill_count"]
         current_d = result["active_decode_count"]
         target_p = scale.num_prefill if scale.num_prefill is not None else current_p

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -16,11 +16,9 @@ asserts it does not raise.
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
-from dynamo.mocker import MockEngineArgs, PlannerReplayBridge
+from dynamo.mocker import MockEngineArgs
 from dynamo.planner.config.planner_config import PlannerConfig
 from dynamo.planner.core.types import (
     EngineCapabilities,
@@ -132,9 +130,16 @@ def test_get_regression_uses_orchestrator_scaling_state_without_aic_install():
     )
 
 
-class _TrafficBridge:
-    def drain_traffic(self):
-        return {
+def test_build_tick_input_maps_replay_accept_length():
+    # The Rust simulation drains the per-tick traffic window into
+    # ``result["traffic"]``; a need_traffic_metrics tick maps it onto
+    # ``TickInput.traffic`` (accept_length, isl/osl, kv-hit, latency).
+    adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
+
+    tick = ScheduledTick(at_s=60.0, need_traffic_metrics=True)
+    result = {
+        "now_ms": 1_000.0,
+        "traffic": {
             "duration_s": 60.0,
             "num_req": 4,
             "avg_isl": 512.0,
@@ -143,15 +148,9 @@ class _TrafficBridge:
             "avg_accept_length": 2.5,
             "avg_ttft_ms": 10.0,
             "avg_itl_ms": 5.0,
-        }
-
-
-def test_build_tick_input_maps_replay_accept_length():
-    adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
-    adapter._bridge = _TrafficBridge()
-
-    tick = ScheduledTick(at_s=60.0, need_traffic_metrics=True)
-    ti = adapter._build_tick_input(tick, {"now_ms": 1_000.0})
+        },
+    }
+    ti = adapter._build_tick_input(tick, result)
 
     assert ti.now_s == 60.0
     assert ti.traffic is not None
@@ -164,7 +163,6 @@ def test_build_tick_input_buffers_fpm_until_fpm_tick():
     adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
     adapter._config = cfg
     adapter._is_disagg = False
-    adapter._bridge = _TrafficBridge()
     adapter._prefill_fpm_cache = {}
     adapter._decode_fpm_cache = {}
     adapter._pending_prefill_fpm_snaps = []
@@ -208,77 +206,6 @@ def test_build_tick_input_buffers_fpm_until_fpm_tick():
 
     assert second.fpm_observations is not None
     assert ("1", 0) in second.fpm_observations.decode
-
-
-def test_planner_bridge_drains_mtp_accept_length(tmp_path):
-    trace_path = tmp_path / "mtp_trace.jsonl"
-    records = [
-        {
-            "timestamp": 0.0,
-            "session_id": f"req-{i}",
-            "input_length": 128,
-            "output_length": 12,
-            "hash_ids": [100 + i * 2, 101 + i * 2],
-        }
-        for i in range(2)
-    ]
-    trace_path.write_text(
-        "\n".join(json.dumps(record) for record in records) + "\n",
-        encoding="utf-8",
-    )
-    agg_args = MockEngineArgs(
-        block_size=64,
-        num_gpu_blocks=512,
-        max_num_batched_tokens=2048,
-        max_num_seqs=16,
-        speedup_ratio=1000.0,
-        aic_nextn=2,
-        aic_nextn_accept_rates="1,1",
-    )
-
-    bridge = PlannerReplayBridge(
-        trace_file=trace_path,
-        extra_engine_args=agg_args,
-        num_workers=1,
-        trace_block_size=64,
-    )
-    bridge.advance_to(1000.0)
-
-    traffic = bridge.drain_traffic()
-    assert traffic["avg_osl"] == 12.0
-    assert traffic["avg_accept_length"] == pytest.approx(3.0)
-
-    prefill_args = MockEngineArgs(
-        block_size=64,
-        num_gpu_blocks=512,
-        max_num_batched_tokens=2048,
-        max_num_seqs=16,
-        speedup_ratio=1000.0,
-        worker_type="prefill",
-    )
-    decode_args = MockEngineArgs(
-        block_size=64,
-        num_gpu_blocks=512,
-        max_num_batched_tokens=2048,
-        max_num_seqs=16,
-        speedup_ratio=1000.0,
-        worker_type="decode",
-        aic_nextn=2,
-        aic_nextn_accept_rates="1,1",
-    )
-    bridge = PlannerReplayBridge.create_disagg(
-        trace_file=trace_path,
-        prefill_engine_args=prefill_args,
-        decode_engine_args=decode_args,
-        num_prefill_workers=1,
-        num_decode_workers=1,
-        trace_block_size=64,
-    )
-    bridge.advance_to(1000.0)
-
-    traffic = bridge.drain_traffic()
-    assert traffic["avg_osl"] == 12.0
-    assert traffic["avg_accept_length"] == pytest.approx(3.0)
 
 
 def test_replay_engine_caps_exposes_aic_nextn():

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -28,6 +28,7 @@ from dynamo.planner.core.types import (
 from dynamo.planner.offline.replay_adapter import (
     ReplayPlannerAdapter,
     _build_fpm_from_dict,
+    _merge_traffic,
 )
 from dynamo.planner.plugins.orchestrator.engine_adapter import OrchestratorEngineAdapter
 from dynamo.replay.main import _engine_caps
@@ -212,3 +213,42 @@ def test_replay_engine_caps_exposes_aic_nextn():
     caps = _engine_caps(MockEngineArgs(aic_nextn=2))
 
     assert caps.speculative_nextn == 2
+
+
+def test_merge_traffic_weights_ratio_fields_by_native_counts():
+    # kv_hit_rate and accept_length must merge by their true denominators
+    # (hit_rate_count / accept_length_forward_count), not num_req, so a window
+    # whose ratio-sample count is disproportionate to its request count still
+    # contributes its exact share. Here num_req-weighting would give the wrong
+    # answer (0.9 and 1.2); count-weighting reconstructs the exact mean.
+    a = {
+        "num_req": 1,
+        "duration_s": 1.0,
+        "avg_isl": 100.0,
+        "avg_osl": 50.0,
+        "avg_kv_hit_rate": 0.0,
+        "hit_rate_count": 90,
+        "avg_accept_length": 3.0,
+        "accept_length_forward_count": 90,
+    }
+    b = {
+        "num_req": 9,
+        "duration_s": 1.0,
+        "avg_isl": 100.0,
+        "avg_osl": 50.0,
+        "avg_kv_hit_rate": 1.0,
+        "hit_rate_count": 10,
+        "avg_accept_length": 1.0,
+        "accept_length_forward_count": 10,
+    }
+    merged = _merge_traffic(a, b)
+    assert merged["avg_kv_hit_rate"] == pytest.approx(
+        (0.0 * 90 + 1.0 * 10) / 100
+    )  # 0.1
+    assert merged["avg_accept_length"] == pytest.approx(
+        (3.0 * 90 + 1.0 * 10) / 100
+    )  # 2.8
+    assert merged["num_req"] == 10
+    assert merged["hit_rate_count"] == 100
+    assert merged["accept_length_forward_count"] == 100
+    assert merged["avg_isl"] == pytest.approx(100.0)

--- a/components/src/dynamo/replay/api.py
+++ b/components/src/dynamo/replay/api.py
@@ -46,6 +46,21 @@ def run_trace_replay(
     benchmark_granularity=8,
 ):
     if planner_config is not None:
+        # Planner replay is offline-only and Mooncake-only; reject controls the
+        # planner path ignores so callers fail fast instead of silently getting an
+        # offline planner run (matches the CLI's guardrails).
+        if replay_mode != "offline":
+            raise ValueError(
+                "planner_config replay only supports replay_mode='offline'"
+            )
+        if trace_format != "mooncake":
+            raise ValueError(
+                "planner_config replay only supports trace_format='mooncake'"
+            )
+        if report_jsonl_path is not None:
+            raise ValueError("report_jsonl_path is not supported with planner_config")
+        if max_sim_time_ms is not None:
+            raise ValueError("max_sim_time_ms is not supported with planner_config")
         # Planner-in-the-loop: the Rust bridge owns the sim loop and calls back into
         # the Python planner adapter once per PlannerTick (main._run_planner_replay),
         # returning a ReplayPlannerReport (its .trace_report matches the static dict).
@@ -63,6 +78,7 @@ def run_trace_replay(
             router_mode=router_mode,
             arrival_speedup_ratio=arrival_speedup_ratio,
             trace_block_size=trace_block_size,
+            model_name=model_name,
             planner_config_arg=_planner_config_arg(planner_config),
             benchmark_granularity=benchmark_granularity,
             sla_ttft_ms=sla_ttft_ms,
@@ -129,6 +145,10 @@ def run_synthetic_trace_replay(
     benchmark_granularity=8,
 ):
     if planner_config is not None:
+        if replay_mode != "offline":
+            raise ValueError(
+                "planner_config replay only supports replay_mode='offline'"
+            )
         from dynamo.replay.main import SyntheticWorkload, _run_planner_replay
 
         return _run_planner_replay(
@@ -143,6 +163,7 @@ def run_synthetic_trace_replay(
             router_mode=router_mode,
             arrival_speedup_ratio=arrival_speedup_ratio,
             trace_block_size=512,
+            model_name=model_name,
             planner_config_arg=_planner_config_arg(planner_config),
             benchmark_granularity=benchmark_granularity,
             sla_ttft_ms=sla_ttft_ms,

--- a/components/src/dynamo/replay/api.py
+++ b/components/src/dynamo/replay/api.py
@@ -1,10 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+
 from dynamo._core import (
     run_mocker_synthetic_trace_replay as _run_mocker_synthetic_trace_replay,
 )
 from dynamo._core import run_mocker_trace_replay as _run_mocker_trace_replay
+
+
+def _planner_config_arg(planner_config):
+    """Normalize a planner config to the JSON-string form ``_run_planner_replay``
+    expects: a dict is json-encoded; a str (path or inline JSON) passes through."""
+    if isinstance(planner_config, dict):
+        return json.dumps(planner_config)
+    return planner_config
 
 
 def run_trace_replay(
@@ -32,7 +42,34 @@ def run_trace_replay(
     sla_ttft_ms=None,
     sla_itl_ms=None,
     sla_e2e_ms=None,
+    planner_config=None,
+    benchmark_granularity=8,
 ):
+    if planner_config is not None:
+        # Planner-in-the-loop: the Rust bridge owns the sim loop and calls back into
+        # the Python planner adapter once per PlannerTick (main._run_planner_replay),
+        # returning a ReplayPlannerReport (its .trace_report matches the static dict).
+        from dynamo.replay.main import _run_planner_replay
+
+        return _run_planner_replay(
+            trace_file=trace_file,
+            extra_engine_args=extra_engine_args,
+            prefill_engine_args=prefill_engine_args,
+            decode_engine_args=decode_engine_args,
+            router_config=router_config,
+            num_workers=num_workers,
+            num_prefill_workers=num_prefill_workers,
+            num_decode_workers=num_decode_workers,
+            router_mode=router_mode,
+            arrival_speedup_ratio=arrival_speedup_ratio,
+            trace_block_size=trace_block_size,
+            planner_config_arg=_planner_config_arg(planner_config),
+            benchmark_granularity=benchmark_granularity,
+            sla_ttft_ms=sla_ttft_ms,
+            sla_itl_ms=sla_itl_ms,
+            sla_e2e_ms=sla_e2e_ms,
+            replay_concurrency=replay_concurrency,
+        )
     return _run_mocker_trace_replay(
         trace_file,
         extra_engine_args=extra_engine_args,
@@ -85,7 +122,44 @@ def run_synthetic_trace_replay(
     num_prefix_groups=0,
     inter_turn_delay_ms=0.0,
     model_name=None,
+    sla_ttft_ms=None,
+    sla_itl_ms=None,
+    sla_e2e_ms=None,
+    planner_config=None,
+    benchmark_granularity=8,
 ):
+    if planner_config is not None:
+        from dynamo.replay.main import SyntheticWorkload, _run_planner_replay
+
+        return _run_planner_replay(
+            trace_file=None,
+            extra_engine_args=extra_engine_args,
+            prefill_engine_args=prefill_engine_args,
+            decode_engine_args=decode_engine_args,
+            router_config=router_config,
+            num_workers=num_workers,
+            num_prefill_workers=num_prefill_workers,
+            num_decode_workers=num_decode_workers,
+            router_mode=router_mode,
+            arrival_speedup_ratio=arrival_speedup_ratio,
+            trace_block_size=512,
+            planner_config_arg=_planner_config_arg(planner_config),
+            benchmark_granularity=benchmark_granularity,
+            sla_ttft_ms=sla_ttft_ms,
+            sla_itl_ms=sla_itl_ms,
+            sla_e2e_ms=sla_e2e_ms,
+            replay_concurrency=replay_concurrency,
+            synthetic=SyntheticWorkload(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                request_count=request_count,
+                arrival_interval_ms=arrival_interval_ms,
+                turns_per_session=turns_per_session,
+                shared_prefix_ratio=shared_prefix_ratio,
+                num_prefix_groups=num_prefix_groups,
+                inter_turn_delay_ms=inter_turn_delay_ms,
+            ),
+        )
     return _run_mocker_synthetic_trace_replay(
         input_tokens,
         output_tokens,
@@ -108,4 +182,8 @@ def run_synthetic_trace_replay(
         num_prefix_groups=num_prefix_groups,
         inter_turn_delay_ms=inter_turn_delay_ms,
         model_name=model_name,
+        # Goodput SLA for synthetic-static (offline): emits goodput_* in the report.
+        sla_ttft_ms=sla_ttft_ms,
+        sla_itl_ms=sla_itl_ms,
+        sla_e2e_ms=sla_e2e_ms,
     )

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -630,7 +630,14 @@ def _run_planner_replay(
     # Unified drive: the Rust bridge owns the loop and calls back into the adapter
     # (initial_tick_ms / on_tick) once per PlannerTick; `finalize` wraps the returned
     # trace_report with the adapter's accumulated scaling events / diagnostics.
-    trace_report = bridge.run(adapter)
+    try:
+        trace_report = bridge.run(adapter)
+    except BaseException:
+        # `finalize` (which closes the engine + replay-scoped event loop) is only
+        # reached on success; ensure cleanup also runs when the Rust loop or a
+        # planner callback raises. `close()` is idempotent.
+        adapter.close()
+        raise
     return adapter.finalize(trace_report)
 
 

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -626,7 +626,12 @@ def _run_planner_replay(
     # gpu_hours (and prefill/decode_gpus_per_worker) are computed in the mocker
     # from its own worker parallelism (aic_tp x aic_attention_dp) and ride the
     # report dict — no per-engine GPU count from the planner config is needed.
-    return adapter.run()
+    #
+    # Unified drive: the Rust bridge owns the loop and calls back into the adapter
+    # (initial_tick_ms / on_tick) once per PlannerTick; `finalize` wraps the returned
+    # trace_report with the adapter's accumulated scaling events / diagnostics.
+    trace_report = bridge.run(adapter)
+    return adapter.finalize(trace_report)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/lib/bench/offline_replay_bench.rs
+++ b/lib/bench/offline_replay_bench.rs
@@ -16,7 +16,9 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use dynamo_mocker::common::protocols::{EngineType, MockEngineArgs, SglangArgs};
 use dynamo_mocker::loadgen::Trace;
-use dynamo_mocker::replay::{ReplayRouterMode, simulate_trace_workload_with_router_mode};
+use dynamo_mocker::replay::{
+    ReplayRouterMode, SlaThresholds, simulate_trace_workload_with_router_mode,
+};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 enum RouterModeArg {
@@ -163,6 +165,8 @@ fn main() -> Result<()> {
             trace.clone(),
             args.num_workers,
             args.router_mode.into(),
+            // Bench measures replay overhead, not goodput — default (unset) SLA.
+            SlaThresholds::default(),
         )?);
     }
     let report = last_report.expect("iterations must be at least 1");

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1983,10 +1983,22 @@ impl PlannerReplayBridge {
             .take()
             .ok_or_else(|| PyException::new_err("bridge has been finalized"))?;
         let hook: Box<dyn PlannerHook> = Box::new(PyPlannerHook { callback: planner });
-        let report = handle.run(hook).map_err(to_pyerr)?;
+        let report = handle.run(hook).map_err(planner_run_err_to_pyerr)?;
         pythonize(py, &report)
             .map_err(to_pyerr)
             .map(|obj| obj.unbind())
+    }
+}
+
+/// Convert a planner-run error back into a `PyErr`, preserving the original
+/// Python exception (its type and traceback) when the failure originated in a
+/// planner callback (`initial_tick_ms` / `on_tick` stash the `PyErr` via
+/// `anyhow::Error::new`). Non-Python errors (e.g. a simulation dead-end) fall
+/// back to the generic conversion.
+fn planner_run_err_to_pyerr(err: anyhow::Error) -> PyErr {
+    match err.downcast::<PyErr>() {
+        Ok(py_err) => py_err,
+        Err(other) => to_pyerr(other),
     }
 }
 
@@ -2005,7 +2017,9 @@ impl PlannerHook for PyPlannerHook {
                 .call_method0("initial_tick_ms")?
                 .extract::<f64>()
         })
-        .map_err(|err: PyErr| anyhow::anyhow!(err.to_string()))
+        // Preserve the original `PyErr` (type + traceback) through the anyhow
+        // boundary so `PlannerReplayBridge::run` can re-raise it unchanged.
+        .map_err(anyhow::Error::new)
     }
 
     fn on_tick(&mut self, metrics: PlannerTickMetrics) -> anyhow::Result<PlannerTickDecision> {
@@ -2058,6 +2072,8 @@ impl PlannerHook for PyPlannerHook {
                 next_tick_ms: decision.get_item("next_tick_ms")?.extract()?,
             })
         })
-        .map_err(|err: PyErr| anyhow::anyhow!(err.to_string()))
+        // Preserve the original `PyErr` (type + traceback) through the anyhow
+        // boundary so `PlannerReplayBridge::run` can re-raise it unchanged.
+        .map_err(anyhow::Error::new)
     }
 }

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -13,7 +13,7 @@ use dynamo_mocker::common::protocols::{
 use dynamo_mocker::loadgen::{
     ArrivalSpec, DelaySpec, LengthSpec, SyntheticTraceSpec, Trace as RsTrace,
 };
-use dynamo_mocker::replay::ReplayArgsMode;
+use dynamo_mocker::replay::{PlannerHook, PlannerTickDecision, PlannerTickMetrics, ReplayArgsMode};
 use pyo3::{
     exceptions::{PyException, PyValueError},
     prelude::*,
@@ -984,7 +984,7 @@ fn write_per_request_jsonl(
 }
 
 #[pyfunction]
-#[pyo3(signature = (input_tokens, output_tokens, request_count, extra_engine_args=None, prefill_engine_args=None, decode_engine_args=None, router_config=None, aic_perf_config=None, num_workers=1, num_prefill_workers=1, num_decode_workers=1, replay_concurrency=None, replay_mode="offline", router_mode="round_robin", arrival_speedup_ratio=1.0, arrival_interval_ms=1.0, turns_per_session=1, shared_prefix_ratio=0.0, num_prefix_groups=0, inter_turn_delay_ms=0.0, model_name=None))]
+#[pyo3(signature = (input_tokens, output_tokens, request_count, extra_engine_args=None, prefill_engine_args=None, decode_engine_args=None, router_config=None, aic_perf_config=None, num_workers=1, num_prefill_workers=1, num_decode_workers=1, replay_concurrency=None, replay_mode="offline", router_mode="round_robin", arrival_speedup_ratio=1.0, arrival_interval_ms=1.0, turns_per_session=1, shared_prefix_ratio=0.0, num_prefix_groups=0, inter_turn_delay_ms=0.0, model_name=None, sla_ttft_ms=None, sla_itl_ms=None, sla_e2e_ms=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn run_mocker_synthetic_trace_replay(
     py: Python<'_>,
@@ -1009,7 +1009,18 @@ pub fn run_mocker_synthetic_trace_replay(
     num_prefix_groups: usize,
     inter_turn_delay_ms: f64,
     model_name: Option<String>,
+    sla_ttft_ms: Option<f64>,
+    sla_itl_ms: Option<f64>,
+    sla_e2e_ms: Option<f64>,
 ) -> PyResult<PyObject> {
+    validate_sla_threshold("sla_ttft_ms", sla_ttft_ms)?;
+    validate_sla_threshold("sla_itl_ms", sla_itl_ms)?;
+    validate_sla_threshold("sla_e2e_ms", sla_e2e_ms)?;
+    let sla = dynamo_mocker::replay::SlaThresholds {
+        ttft_ms: sla_ttft_ms,
+        itl_ms: sla_itl_ms,
+        e2e_ms: sla_e2e_ms,
+    };
     let args_selection = load_replay_args_selection(
         py,
         extra_engine_args,
@@ -1067,6 +1078,7 @@ pub fn run_mocker_synthetic_trace_replay(
                             max_in_flight,
                             num_workers,
                             router_mode,
+                            sla,
                         )
                     }
                     ("offline", None) => {
@@ -1077,6 +1089,7 @@ pub fn run_mocker_synthetic_trace_replay(
                             trace,
                             num_workers,
                             router_mode,
+                            sla,
                         )
                     }
                     ("online", Some(max_in_flight)) => {
@@ -1114,6 +1127,7 @@ pub fn run_mocker_synthetic_trace_replay(
                             trace,
                             max_in_flight,
                             router_mode,
+                            sla,
                         ),
                         ("offline", None) => dynamo_mocker::replay::simulate_trace_workload_disagg_with_router_mode(
                             *config,
@@ -1121,6 +1135,7 @@ pub fn run_mocker_synthetic_trace_replay(
                             prefill_load_estimator.clone(),
                             trace,
                             router_mode,
+                            sla,
                         ),
                         ("online", _) => anyhow::bail!(
                             "disagg replay only supports replay_mode='offline'"
@@ -1154,6 +1169,7 @@ pub fn run_mocker_synthetic_trace_replay(
                         max_in_flight,
                         num_workers,
                         router_mode,
+                        sla,
                     )
                 }
                 ("offline", None) => dynamo_mocker::replay::simulate_trace_requests_with_router_mode(
@@ -1164,6 +1180,7 @@ pub fn run_mocker_synthetic_trace_replay(
                     num_workers,
                     arrival_speedup_ratio,
                     router_mode,
+                    sla,
                 ),
                 ("online", Some(max_in_flight)) => {
                     dynamo_mocker::replay::simulate_concurrency_live_requests_with_router_mode(
@@ -1202,6 +1219,7 @@ pub fn run_mocker_synthetic_trace_replay(
                         requests,
                         max_in_flight,
                         router_mode,
+                        sla,
                     )
                 }
                 ("offline", None) => {
@@ -1212,6 +1230,7 @@ pub fn run_mocker_synthetic_trace_replay(
                         requests,
                         arrival_speedup_ratio,
                         router_mode,
+                        sla,
                     )
                 }
                 ("online", _) => anyhow::bail!("disagg replay only supports replay_mode='offline'"),
@@ -1947,106 +1966,89 @@ impl PlannerReplayBridge {
         })
     }
 
-    /// Advance the simulation to `until_ms` simulated time.
-    ///
-    /// Returns a dict with separate prefill/decode worker counts and FPM snapshots.
-    /// Traffic metrics are NOT included — call `drain_traffic()` explicitly on
-    /// throughput-scaling ticks only.
-    fn advance_to(&mut self, py: Python<'_>, until_ms: f64) -> PyResult<PyObject> {
-        let handle = self
-            .handle
-            .as_mut()
-            .ok_or_else(|| PyException::new_err("bridge has been finalized"))?;
-
-        let tick_data = handle.advance_to(until_ms).map_err(to_pyerr)?;
-
-        let result = json!({
-            "now_ms": tick_data.now_ms,
-            "is_done": tick_data.is_done,
-            "prefill_fpm_snapshots": fpm_snapshots_to_json(tick_data.prefill_fpm_snapshots),
-            "decode_fpm_snapshots": fpm_snapshots_to_json(tick_data.decode_fpm_snapshots),
-            "active_prefill_count": tick_data.active_prefill_count,
-            "active_decode_count": tick_data.active_decode_count,
-            "total_prefill_count": tick_data.total_prefill_count,
-            "total_decode_count": tick_data.total_decode_count,
-        });
-
-        pythonize(py, &result)
-            .map_err(to_pyerr)
-            .map(|obj| obj.unbind())
-    }
-
-    /// Drain accumulated traffic metrics since the last drain.
-    ///
-    /// Returns a dict with:
-    ///   - `duration_s`      (f64): window length in seconds
-    ///   - `num_req`         (usize): completed requests in the window
-    ///   - `avg_isl`         (f64): mean input sequence length (tokens)
-    ///   - `avg_osl`         (f64): mean output sequence length (tokens)
-    ///   - `avg_ttft_ms`     (f64): mean time-to-first-token in milliseconds,
-    ///                              averaged only over requests that reported
-    ///                              a TTFT sample (0.0 when no samples)
-    ///   - `avg_itl_ms`      (f64): mean inter-token latency in milliseconds,
-    ///                              averaged only over requests that generated
-    ///                              at least one token gap (0.0 when no samples)
-    ///   - `avg_accept_length` (f64 | None): mean visible tokens per decode
-    ///                              request-forward, including the base token
-    ///                              (`None` when no decode forwards were observed)
-    ///   - `avg_kv_hit_rate` (f64): arithmetic mean of per-request
-    ///                              ``overlap_blocks / isl_blocks`` ratios
-    ///                              across router admissions in the window
-    ///                              (one sample per request, not weighted
-    ///                              by ISL), matching the real router's
-    ///                              `dynamo_component_router_kv_hit_rate`
-    ///                              histogram semantics
-    ///
-    /// Call this only on throughput-scaling ticks so the observation window
-    /// covers the full `throughput_adjustment_interval`.
-    fn drain_traffic(&mut self, py: Python<'_>) -> PyResult<PyObject> {
-        let handle = self
-            .handle
-            .as_mut()
-            .ok_or_else(|| PyException::new_err("bridge has been finalized"))?;
-
-        let stats = handle.drain_traffic();
-
-        let result = json!({
-            "duration_s": stats.duration_s,
-            "num_req": stats.num_req,
-            "avg_isl": stats.avg_isl,
-            "avg_osl": stats.avg_osl,
-            "avg_ttft_ms": stats.avg_ttft_ms,
-            "avg_itl_ms": stats.avg_itl_ms,
-            "avg_accept_length": stats.avg_accept_length,
-            "avg_kv_hit_rate": stats.avg_kv_hit_rate,
-        });
-
-        pythonize(py, &result)
-            .map_err(to_pyerr)
-            .map(|obj| obj.unbind())
-    }
-
-    /// Apply a scaling decision with separate prefill and decode targets.
-    /// For agg mode, `target_prefill` is ignored (pass 0).
-    fn apply_scaling(&mut self, target_prefill: usize, target_decode: usize) -> PyResult<()> {
-        let handle = self
-            .handle
-            .as_mut()
-            .ok_or_else(|| PyException::new_err("bridge has been finalized"))?;
-        handle
-            .apply_scaling(target_prefill, target_decode)
-            .map_err(to_pyerr)
-    }
-
-    /// Finalize the replay and return the trace simulation report.
-    fn finalize(&mut self, py: Python<'_>) -> PyResult<PyObject> {
+    /// Run the whole replay to completion with the Python planner driving the tick
+    /// cadence (the unified replacement for the advance_to/apply_scaling stepping
+    /// loop). `planner` must expose `initial_tick_ms() -> float` and
+    /// `on_tick(metrics: dict) -> dict` with keys `target_prefill`/`target_decode`
+    /// (int | None) and `next_tick_ms` (float | None). The simulation owns the drive
+    /// loop and calls back into `planner` once per `PlannerTick`; the GIL is held
+    /// throughout, so each callback is a cheap re-entry. Returns the trace report.
+    fn run(&mut self, py: Python<'_>, planner: Py<PyAny>) -> PyResult<PyObject> {
         let handle = self
             .handle
             .take()
-            .ok_or_else(|| PyException::new_err("bridge has already been finalized"))?;
-        let report = handle.finalize();
+            .ok_or_else(|| PyException::new_err("bridge has been finalized"))?;
+        let hook: Box<dyn PlannerHook> = Box::new(PyPlannerHook { callback: planner });
+        let report = handle.run(hook).map_err(to_pyerr)?;
         pythonize(py, &report)
             .map_err(to_pyerr)
             .map(|obj| obj.unbind())
+    }
+}
+
+/// Adapts a Python planner object to the Rust [`PlannerHook`] trait. Invoked once
+/// per `PlannerTick` from inside the simulation's `run()` loop; the bridge holds the
+/// GIL while running so the per-tick `Python::with_gil` is a cheap re-entry.
+struct PyPlannerHook {
+    callback: Py<PyAny>,
+}
+
+impl PlannerHook for PyPlannerHook {
+    fn initial_tick_ms(&mut self) -> anyhow::Result<f64> {
+        Python::with_gil(|py| {
+            self.callback
+                .bind(py)
+                .call_method0("initial_tick_ms")?
+                .extract::<f64>()
+        })
+        .map_err(|err: PyErr| anyhow::anyhow!(err.to_string()))
+    }
+
+    fn on_tick(&mut self, metrics: PlannerTickMetrics) -> anyhow::Result<PlannerTickDecision> {
+        let PlannerTickMetrics {
+            now_ms,
+            prefill_fpm,
+            decode_fpm,
+            traffic,
+            active_prefill,
+            active_decode,
+            total_prefill,
+            total_decode,
+        } = metrics;
+        Python::with_gil(|py| -> PyResult<PlannerTickDecision> {
+            // The metrics dict mirrors the old `advance_to` + `drain_traffic` dicts so
+            // the Python adapter's `_build_tick_input` consumes it unchanged.
+            let metrics_json = json!({
+                "now_ms": now_ms,
+                "prefill_fpm_snapshots": fpm_snapshots_to_json(prefill_fpm),
+                "decode_fpm_snapshots": fpm_snapshots_to_json(decode_fpm),
+                "active_prefill_count": active_prefill,
+                "active_decode_count": active_decode,
+                "total_prefill_count": total_prefill,
+                "total_decode_count": total_decode,
+                "traffic": {
+                    "duration_s": traffic.duration_s,
+                    "num_req": traffic.num_req,
+                    "avg_isl": traffic.avg_isl,
+                    "avg_osl": traffic.avg_osl,
+                    "avg_ttft_ms": traffic.avg_ttft_ms,
+                    "avg_itl_ms": traffic.avg_itl_ms,
+                    "avg_accept_length": traffic.avg_accept_length,
+                    "avg_kv_hit_rate": traffic.avg_kv_hit_rate,
+                },
+            });
+            let metrics_obj = pythonize(py, &metrics_json).map_err(to_pyerr)?;
+            let decision = self
+                .callback
+                .bind(py)
+                .call_method1("on_tick", (metrics_obj,))?;
+            // The planner returns a dict with all three keys (values may be None).
+            Ok(PlannerTickDecision {
+                target_prefill: decision.get_item("target_prefill")?.extract()?,
+                target_decode: decision.get_item("target_decode")?.extract()?,
+                next_tick_ms: decision.get_item("next_tick_ms")?.extract()?,
+            })
+        })
+        .map_err(|err: PyErr| anyhow::anyhow!(err.to_string()))
     }
 }

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1021,6 +1021,16 @@ pub fn run_mocker_synthetic_trace_replay(
         itl_ms: sla_itl_ms,
         e2e_ms: sla_e2e_ms,
     };
+    // The online branches below don't thread `sla`, so reject SLA with a
+    // non-offline replay_mode rather than silently dropping goodput
+    // (mirrors run_mocker_trace_replay).
+    if replay_mode != "offline"
+        && (sla_ttft_ms.is_some() || sla_itl_ms.is_some() || sla_e2e_ms.is_some())
+    {
+        return Err(PyValueError::new_err(
+            "sla_ttft_ms, sla_itl_ms, and sla_e2e_ms only support replay_mode='offline'",
+        ));
+    }
     let args_selection = load_replay_args_selection(
         py,
         extra_engine_args,
@@ -1665,12 +1675,6 @@ fn fpm_snapshots_to_json(
         .collect()
 }
 
-/// Step-based bridge for driving an offline replay with a Python planner.
-///
-/// Supports both aggregated and disaggregated topologies. The Python adapter
-/// calls `advance_to()` to run the simulation forward, collects FPM/traffic
-/// metrics, feeds them to the planner state machine, then calls
-/// `apply_scaling()` to resize worker pools.
 /// Reject a goodput SLA threshold that is not a finite, non-negative value;
 /// `None` (unset) is allowed and means "do not gate on this dimension".
 fn validate_sla_threshold(name: &str, value: Option<f64>) -> PyResult<()> {
@@ -2035,6 +2039,11 @@ impl PlannerHook for PyPlannerHook {
                     "avg_itl_ms": traffic.avg_itl_ms,
                     "avg_accept_length": traffic.avg_accept_length,
                     "avg_kv_hit_rate": traffic.avg_kv_hit_rate,
+                    // Denominators behind the two ratio averages, so the Python
+                    // adapter can merge partial windows with exact count weights
+                    // instead of approximating with num_req.
+                    "hit_rate_count": traffic.hit_rate_count,
+                    "accept_length_forward_count": traffic.accept_length_forward_count,
                 },
             });
             let metrics_obj = pythonize(py, &metrics_json).map_err(to_pyerr)?;

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2404,12 +2404,23 @@ def run_mocker_synthetic_trace_replay(
     num_prefix_groups: int = 0,
     inter_turn_delay_ms: float = 0.0,
     model_name: Optional[str] = None,
+    sla_ttft_ms: Optional[float] = None,
+    sla_itl_ms: Optional[float] = None,
+    sla_e2e_ms: Optional[float] = None,
 ) -> Dict[str, Any]:
-    """Replay a synthetic mocker workload without requiring a trace file."""
+    """Replay a synthetic mocker workload without requiring a trace file.
+
+    ``sla_ttft_ms`` / ``sla_itl_ms`` / ``sla_e2e_ms`` are the goodput SLA bounds
+    (offline replay only); when any is set the report carries ``goodput_*`` keys
+    classifying SLA-satisfying requests.
+    """
     ...
 
 class PlannerReplayBridge:
-    """Step-based bridge for driving an offline replay with a Python planner."""
+    """Drives an offline replay to completion with a Python planner. The Rust
+    simulation owns the drive loop and calls back into ``planner`` once per
+    ``PlannerTick`` via ``run(planner)`` (``planner`` exposes
+    ``initial_tick_ms() -> float`` and ``on_tick(metrics: dict) -> dict``)."""
 
     def __init__(
         self,
@@ -2491,9 +2502,7 @@ class PlannerReplayBridge:
         sla_e2e_ms: Optional[float] = None,
     ) -> "PlannerReplayBridge": ...
 
-    def advance_to(self, until_ms: float) -> Dict[str, Any]: ...
-    def apply_scaling(self, target_prefill: int, target_decode: int) -> None: ...
-    def finalize(self) -> Dict[str, Any]: ...
+    def run(self, planner: Any) -> Dict[str, Any]: ...
 
 class Layer:
     """

--- a/lib/bindings/python/tests/replay/test_replay_planner_load_modes.py
+++ b/lib/bindings/python/tests/replay/test_replay_planner_load_modes.py
@@ -72,4 +72,4 @@ def test_trace_closed_loop(tmp_path):
         replay_concurrency=2,
         replay_mode="offline",
     )
-    assert report["completed_requests"] > 0
+    assert report["completed_requests"] == 2

--- a/lib/bindings/python/tests/replay/test_replay_planner_load_modes.py
+++ b/lib/bindings/python/tests/replay/test_replay_planner_load_modes.py
@@ -1,16 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Planner-bridge load modes: synthetic workloads and closed-loop concurrency.
+"""Replay load modes: synthetic workloads and closed-loop concurrency.
 
-Drives ``PlannerReplayBridge`` directly (advance_to -> finalize, no Python planner
-adapter) to cover the constructors added so the planner path matches the non-planner
-path: a concurrency cap on a trace, and synthetic open/closed-loop workloads.
+Exercises the single offline-replay entrypoints (``run_synthetic_trace_replay`` /
+``run_trace_replay`` with no ``planner_config``) across the load modes that the
+planner path previously needed bespoke bridge constructors for: synthetic
+open-loop (arrival-timestamp) and closed-loop (concurrency-capped) workloads,
+synthetic prefix-cache sharing, and a concurrency cap on a Mooncake trace file.
+With the unified event-driven path these all run through the same multi-worker
+runtime, so a bare run drives every request to completion.
 """
 
 import pytest
 
-from dynamo.mocker import MockEngineArgs, PlannerReplayBridge
+from dynamo.mocker import MockEngineArgs
+from dynamo.replay import run_synthetic_trace_replay, run_trace_replay
 
 from .replay_utils import _vllm_args, _write_trace_and_args
 
@@ -23,56 +28,48 @@ pytestmark = [
 ]
 
 
-def _drive_to_completion(bridge: PlannerReplayBridge) -> dict:
-    """One large advance drains every event (arrival + concurrency alike)."""
-    tick = bridge.advance_to(1.0e15)
-    assert tick["is_done"], "replay should finish within the advance window"
-    return bridge.finalize()
-
-
 @pytest.mark.parametrize("replay_concurrency", [None, 2])
-def test_planner_bridge_from_synthetic_agg(replay_concurrency):
-    # Synthetic workload through the planner bridge: arrival (None) and closed-loop
-    # (Some) both run every request to completion. Previously the planner bridge
-    # only accepted a Mooncake trace file.
-    bridge = PlannerReplayBridge.from_synthetic(
-        input_tokens=64,
-        output_tokens=16,
-        request_count=8,
+def test_synthetic_agg_load_modes(replay_concurrency):
+    # Synthetic workload through the unified offline path: arrival (None) and
+    # closed-loop (Some) both run every request to completion across two workers.
+    report = run_synthetic_trace_replay(
+        64,
+        16,
+        8,
         extra_engine_args=MockEngineArgs(block_size=64, speedup_ratio=1000.0),
         num_workers=2,
         replay_concurrency=replay_concurrency,
+        replay_mode="offline",
         arrival_interval_ms=1.0,
     )
-    report = _drive_to_completion(bridge)
     assert report["completed_requests"] == 8
 
 
-def test_planner_bridge_from_synthetic_shared_prefix():
-    # Prefix-cache sharing knobs apply to synthetic planner workloads too.
-    bridge = PlannerReplayBridge.from_synthetic(
-        input_tokens=128,
-        output_tokens=8,
-        request_count=8,
+def test_synthetic_shared_prefix_closed_loop():
+    # Prefix-cache sharing knobs apply to synthetic closed-loop workloads too.
+    report = run_synthetic_trace_replay(
+        128,
+        8,
+        8,
         extra_engine_args=MockEngineArgs(block_size=64, speedup_ratio=1000.0),
         num_workers=2,
         replay_concurrency=4,
+        replay_mode="offline",
         shared_prefix_ratio=0.5,
         num_prefix_groups=2,
     )
-    report = _drive_to_completion(bridge)
     assert report["completed_requests"] == 8
 
 
-def test_planner_bridge_trace_closed_loop(tmp_path):
-    # A concurrency cap on a Mooncake trace file (closed-loop) through the planner
-    # bridge — previously only arrival-timestamp replay was reachable here.
+def test_trace_closed_loop(tmp_path):
+    # A concurrency cap on a Mooncake trace file (closed-loop), driven to
+    # completion through the unified multi-worker offline path.
     trace_path = _write_trace_and_args(tmp_path)
-    bridge = PlannerReplayBridge(
-        trace_file=str(trace_path),
+    report = run_trace_replay(
+        str(trace_path),
         extra_engine_args=_vllm_args(),
         num_workers=2,
         replay_concurrency=2,
+        replay_mode="offline",
     )
-    report = _drive_to_completion(bridge)
     assert report["completed_requests"] > 0

--- a/lib/bindings/python/tests/replay/test_replay_planner_load_modes.py
+++ b/lib/bindings/python/tests/replay/test_replay_planner_load_modes.py
@@ -14,7 +14,7 @@ runtime, so a bare run drives every request to completion.
 
 import pytest
 
-from dynamo.mocker import MockEngineArgs
+from dynamo.mocker import MockEngineArgs, PlannerReplayBridge
 from dynamo.replay import run_synthetic_trace_replay, run_trace_replay
 
 from .replay_utils import _vllm_args, _write_trace_and_args
@@ -73,3 +73,28 @@ def test_trace_closed_loop(tmp_path):
         replay_mode="offline",
     )
     assert report["completed_requests"] == 2
+
+
+def test_planner_callback_error_preserves_python_exception_type():
+    # A raising planner callback must propagate its original Python exception
+    # type (here ValueError) out of bridge.run() — not a generic Exception — so
+    # callback failures stay diagnosable (type + traceback preserved across the
+    # Rust seam).
+    class _RaisingPlanner:
+        def initial_tick_ms(self):
+            return 1.0  # finite -> seeds a PlannerTick that will fire
+
+        def on_tick(self, metrics):
+            raise ValueError("boom from on_tick")
+
+    bridge = PlannerReplayBridge.from_synthetic(
+        input_tokens=64,
+        output_tokens=16,
+        request_count=8,
+        extra_engine_args=MockEngineArgs(block_size=64, speedup_ratio=1000.0),
+        num_workers=1,
+        replay_concurrency=2,
+        arrival_interval_ms=1.0,
+    )
+    with pytest.raises(ValueError, match="boom from on_tick"):
+        bridge.run(_RaisingPlanner())

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -465,6 +465,7 @@ pub fn simulate_trace_requests(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn simulate_trace_requests_with_router_mode(
     args: MockEngineArgs,
     router_config: Option<KvRouterConfig>,
@@ -892,6 +893,7 @@ pub fn simulate_concurrency_requests(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn simulate_concurrency_requests_with_router_mode(
     args: MockEngineArgs,
     router_config: Option<KvRouterConfig>,
@@ -1067,6 +1069,7 @@ pub fn simulate_concurrency_workload(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn simulate_concurrency_workload_with_router_mode(
     args: MockEngineArgs,
     router_config: Option<KvRouterConfig>,

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -461,6 +461,7 @@ pub fn simulate_trace_requests(
         num_workers,
         arrival_speedup_ratio,
         ReplayRouterMode::RoundRobin,
+        SlaThresholds::default(),
     )
 }
 
@@ -472,6 +473,7 @@ pub fn simulate_trace_requests_with_router_mode(
     num_workers: usize,
     arrival_speedup_ratio: f64,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let args = args.normalized()?;
     validate_offline_replay_args(&args, num_workers, router_mode)?;
@@ -489,7 +491,7 @@ pub fn simulate_trace_requests_with_router_mode(
         router_mode,
         false,
         None,
-        SlaThresholds::default(),
+        sla,
     )?;
     Ok(report)
 }
@@ -501,6 +503,7 @@ pub fn simulate_trace_requests_disagg_with_router_mode(
     requests: Vec<DirectRequest>,
     arrival_speedup_ratio: f64,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let config = config.normalized()?;
     validate_offline_disagg_replay_args(&config, router_mode)?;
@@ -517,7 +520,7 @@ pub fn simulate_trace_requests_disagg_with_router_mode(
         router_mode,
         false,
         None,
-        SlaThresholds::default(),
+        sla,
     )?;
     Ok(report)
 }
@@ -885,6 +888,7 @@ pub fn simulate_concurrency_requests(
         max_in_flight,
         num_workers,
         ReplayRouterMode::RoundRobin,
+        SlaThresholds::default(),
     )
 }
 
@@ -896,6 +900,7 @@ pub fn simulate_concurrency_requests_with_router_mode(
     max_in_flight: usize,
     num_workers: usize,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let args = args.normalized()?;
     validate_offline_concurrency_args(&args, num_workers, max_in_flight, router_mode)?;
@@ -913,7 +918,7 @@ pub fn simulate_concurrency_requests_with_router_mode(
         router_mode,
         false,
         None,
-        SlaThresholds::default(),
+        sla,
     )
 }
 
@@ -924,6 +929,7 @@ pub fn simulate_concurrency_requests_disagg_with_router_mode(
     requests: Vec<DirectRequest>,
     max_in_flight: usize,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let config = config.normalized()?;
     validate_offline_disagg_concurrency_args(&config, max_in_flight, router_mode)?;
@@ -940,7 +946,7 @@ pub fn simulate_concurrency_requests_disagg_with_router_mode(
         router_mode,
         false,
         None,
-        SlaThresholds::default(),
+        sla,
     )
 }
 
@@ -956,6 +962,7 @@ pub fn simulate_trace_workload(
         trace,
         num_workers,
         ReplayRouterMode::RoundRobin,
+        SlaThresholds::default(),
     )
 }
 
@@ -966,6 +973,7 @@ pub fn simulate_trace_workload_with_router_mode(
     trace: Trace,
     num_workers: usize,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let args = args.normalized()?;
     validate_offline_replay_args(&args, num_workers, router_mode)?;
@@ -978,7 +986,7 @@ pub fn simulate_trace_workload_with_router_mode(
         router_mode,
         false,
         None,
-        SlaThresholds::default(),
+        sla,
     )?;
     Ok(report)
 }
@@ -989,6 +997,7 @@ pub fn simulate_trace_workload_disagg_with_router_mode(
     prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
     trace: Trace,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let config = config.normalized()?;
     validate_offline_disagg_replay_args(&config, router_mode)?;
@@ -1000,7 +1009,7 @@ pub fn simulate_trace_workload_disagg_with_router_mode(
         router_mode,
         false,
         None,
-        SlaThresholds::default(),
+        sla,
     )?;
     Ok(report)
 }
@@ -1054,6 +1063,7 @@ pub fn simulate_concurrency_workload(
         max_in_flight,
         num_workers,
         ReplayRouterMode::RoundRobin,
+        SlaThresholds::default(),
     )
 }
 
@@ -1065,6 +1075,7 @@ pub fn simulate_concurrency_workload_with_router_mode(
     max_in_flight: usize,
     num_workers: usize,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let args = args.normalized()?;
     validate_offline_concurrency_args(&args, num_workers, max_in_flight, router_mode)?;
@@ -1078,7 +1089,7 @@ pub fn simulate_concurrency_workload_with_router_mode(
         router_mode,
         false,
         None,
-        SlaThresholds::default(),
+        sla,
     )
 }
 
@@ -1089,6 +1100,7 @@ pub fn simulate_concurrency_workload_disagg_with_router_mode(
     trace: Trace,
     max_in_flight: usize,
     router_mode: ReplayRouterMode,
+    sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let config = config.normalized()?;
     validate_offline_disagg_concurrency_args(&config, max_in_flight, router_mode)?;
@@ -1101,7 +1113,7 @@ pub fn simulate_concurrency_workload_disagg_with_router_mode(
         router_mode,
         false,
         None,
-        SlaThresholds::default(),
+        sla,
     )
 }
 
@@ -1184,6 +1196,7 @@ mod tests {
             1,
             1.0,
             ReplayRouterMode::RoundRobin,
+            SlaThresholds::default(),
         )
         .unwrap_err();
 

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -86,7 +86,10 @@ pub use entrypoints::{
     simulate_trace_workload, simulate_trace_workload_disagg_with_router_mode,
     simulate_trace_workload_with_router_mode,
 };
-pub use planner_handle::{PlannerReplayHandle, PlannerTickData};
+pub use offline::planner_hook::{
+    NoopPlannerHook, PlannerHook, PlannerTickDecision, PlannerTickMetrics,
+};
+pub use planner_handle::PlannerReplayHandle;
 pub use validate::validate_replay_args_mode;
 
 pub(crate) fn normalize_trace_requests(

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -86,6 +86,7 @@ pub use entrypoints::{
     simulate_trace_workload, simulate_trace_workload_disagg_with_router_mode,
     simulate_trace_workload_with_router_mode,
 };
+pub use offline::components::TrafficStats;
 pub use offline::planner_hook::{
     NoopPlannerHook, PlannerHook, PlannerTickDecision, PlannerTickMetrics,
 };

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -4,11 +4,14 @@
 #[cfg(test)]
 use super::components::OfflineRouterSnapshot;
 pub(super) use super::components::ReplayMode;
+#[cfg(test)]
+use super::components::TrafficStats;
 use super::events::{SimulationEvent, SimulationWorkerStage};
+use super::planner_hook::{PlannerHook, PlannerTickMetrics};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
-    next_timestamp as choose_next_timestamp, pop_ready_worker_completion, pop_ready_worker_ready,
-    push_worker_completion, push_worker_ready,
+    next_timestamp as choose_next_timestamp, pop_ready_planner_tick, pop_ready_worker_completion,
+    pop_ready_worker_ready, push_planner_tick, push_worker_completion, push_worker_ready,
 };
 #[cfg(test)]
 use super::state::AggRequestPhase;
@@ -17,7 +20,7 @@ use super::state::OfflineWorkerSnapshot;
 use super::{
     components::{
         AdmissionQueue, EngineComponent, EngineEffects, EnginePassMode, OfflineReplayRouter,
-        ReadyArrival, ScheduledWorkerCompletion, TrafficAccumulator, TrafficStats, WorkerAdmission,
+        ReadyArrival, ScheduledWorkerCompletion, TrafficAccumulator, WorkerAdmission,
     },
     state::AggRequestState,
 };
@@ -35,7 +38,7 @@ use uuid::Uuid;
 
 #[cfg(test)]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub(super) struct AggRuntimeStats {
+pub(in crate::replay) struct AggRuntimeStats {
     dispatch_history: Vec<usize>,
     dispatch_order: Vec<Uuid>,
     assigned_worker_by_uuid: HashMap<Uuid, usize>,
@@ -59,7 +62,7 @@ struct AggRuntimeSnapshot {
 
 #[cfg(not(test))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub(super) struct AggRuntimeStats;
+pub(in crate::replay) struct AggRuntimeStats;
 
 pub(in crate::replay) struct AggRuntime {
     now_ms: f64,
@@ -81,6 +84,14 @@ pub(in crate::replay) struct AggRuntime {
     /// gracefully once the next scheduled timestamp exceeds this cap, leaving
     /// any in-flight requests as incomplete in the report.
     max_sim_time_ms: Option<f64>,
+    /// Planner hook. When set, `run()` seeds a recurring `PlannerTick` event and
+    /// calls back into the planner at each tick (the unified replacement for the
+    /// old Python-driven `advance_to` stepping loop).
+    planner_hook: Option<Box<dyn PlannerHook>>,
+    /// Whether to retain per-pass FPM snapshots. Only the planner consumes them, so
+    /// the plain `run()` path leaves this `false` (otherwise the buffer grows
+    /// unbounded for the whole run with no reader — the leak this gating fixes).
+    collect_fpm: bool,
     #[cfg(test)]
     worker_active_requests: Vec<Vec<Uuid>>,
     #[cfg(test)]
@@ -188,6 +199,8 @@ impl AggRuntime {
             fpm_buffer: Vec::new(),
             traffic: TrafficAccumulator::new(),
             max_sim_time_ms: None,
+            planner_hook: None,
+            collect_fpm: false,
             #[cfg(test)]
             worker_active_requests: vec![Vec::new(); num_workers],
             #[cfg(test)]
@@ -225,6 +238,14 @@ impl AggRuntime {
     /// Set the SLA thresholds used to classify goodput in the final report.
     pub(in crate::replay) fn with_sla_thresholds(mut self, sla: SlaThresholds) -> Self {
         self.collector.set_sla_thresholds(sla);
+        self
+    }
+
+    /// Attach a planner hook. Enables FPM collection and makes `run()` drive the
+    /// planner via recurring `PlannerTick` events (one `on_tick` callback per tick).
+    pub(in crate::replay) fn with_planner_hook(mut self, hook: Box<dyn PlannerHook>) -> Self {
+        self.collect_fpm = true;
+        self.planner_hook = Some(hook);
         self
     }
 
@@ -372,31 +393,37 @@ impl AggRuntime {
         Ok(uuid)
     }
 
-    /// Return true once no events, workers, router queues, or admissions remain.
+    /// Return true once no request work remains. Lingering `WorkerReady`/`PlannerTick`
+    /// events (worker startup, a re-armed planner heartbeat) carry no work and do not
+    /// keep the run alive — otherwise a recurring tick would never let `run()` exit.
     fn is_done(&self) -> bool {
-        self.events.is_empty()
+        self.only_idle_events_remain()
             && self.cluster_in_flight() == 0
             && self.admission.is_drained()
             && self.engine.is_drained()
     }
 
     /// Return true once the request workload is complete, even if `WorkerReady`
-    /// events remain in the queue. Used by `advance_to` so the planner adapter
-    /// can terminate when there is no more work — lingering startup events for
+    /// or `PlannerTick` events remain in the queue. Lingering startup events for
     /// workers that will never receive requests should not block completion.
     fn is_workload_done(&self) -> bool {
         self.cluster_in_flight() == 0
             && self.admission.is_drained()
             && self.engine.is_drained()
-            && self.only_worker_ready_events_remain()
+            && self.only_idle_events_remain()
     }
 
-    /// True if the event heap is empty or contains only `WorkerReady` events.
-    fn only_worker_ready_events_remain(&self) -> bool {
+    /// True if the event heap is empty or contains only "idle" events that carry no
+    /// pending request work: `WorkerReady` (a worker still starting up) or
+    /// `PlannerTick` (a re-armed planner heartbeat).
+    fn only_idle_events_remain(&self) -> bool {
         use super::events::SimulationEventKind;
-        self.events
-            .iter()
-            .all(|e| matches!(e.kind, SimulationEventKind::WorkerReady { .. }))
+        self.events.iter().all(|e| {
+            matches!(
+                e.kind,
+                SimulationEventKind::WorkerReady { .. } | SimulationEventKind::PlannerTick
+            )
+        })
     }
 
     /// Pick the next logical timestamp from either arrivals or scheduled worker completions.
@@ -594,7 +621,9 @@ impl AggRuntime {
     }
 
     fn handle_engine_effects(&mut self, effects: EngineEffects) -> anyhow::Result<()> {
-        self.fpm_buffer.extend(effects.fpm_snapshots);
+        if self.collect_fpm {
+            self.fpm_buffer.extend(effects.fpm_snapshots);
+        }
         self.apply_router_events(effects.pass_start_kv_events)?;
         for payload in effects.immediate_completions {
             let payload = self.engine.on_scheduled_completion(payload)?;
@@ -647,6 +676,11 @@ impl AggRuntime {
             changed |= self.apply_worker_ready_events()?;
             changed |= self.release_ready_arrivals()?;
             changed |= self.drive_ready_workers()?;
+            // Planner ticks fire LAST so the planner observes a fully settled
+            // timestamp; any scaling it applies is picked up by the next iteration.
+            if self.planner_hook.is_some() {
+                changed |= self.apply_planner_ticks()?;
+            }
 
             if !changed {
                 break;
@@ -656,42 +690,71 @@ impl AggRuntime {
         Ok(())
     }
 
-    // ------------------------------------------------------------------
-    // Planner integration: step-based execution
-    // ------------------------------------------------------------------
+    /// Seed the first `PlannerTick` from the hook's requested start time (a
+    /// non-finite time means "no tick" and is skipped).
+    fn seed_first_planner_tick(&mut self) -> anyhow::Result<()> {
+        let Some(mut hook) = self.planner_hook.take() else {
+            return Ok(());
+        };
+        let first_ms = hook.initial_tick_ms();
+        self.planner_hook = Some(hook);
+        let first_ms = first_ms?;
+        if first_ms.is_finite() {
+            let at_ms = first_ms.max(self.now_ms);
+            push_planner_tick(&mut self.events, &mut self.next_event_seq, at_ms);
+        }
+        Ok(())
+    }
 
-    /// Advance the simulation up to `until_ms` simulated time, then pause.
-    /// Returns `true` if the request workload is done — pending `WorkerReady`
-    /// events do not block completion since there is no work for those workers.
-    pub(in crate::replay) fn advance_to(&mut self, until_ms: f64) -> anyhow::Result<bool> {
-        self.drain_current_timestamp()?;
-
-        while !self.is_done() {
-            let Some(next_timestamp_ms) = self.next_timestamp() else {
-                bail!(
-                    "offline replay reached a dead end with {} in-flight requests remaining",
-                    self.cluster_in_flight()
-                );
+    /// Fire every `PlannerTick` scheduled for the current timestamp: gather the
+    /// drained metrics, call the planner, apply its scaling decision, and re-arm.
+    /// Agg routes all FPM through `decode_fpm` and ignores the prefill target.
+    fn apply_planner_ticks(&mut self) -> anyhow::Result<bool> {
+        let mut changed = false;
+        while pop_ready_planner_tick(&mut self.events, self.now_ms) {
+            if self.is_workload_done() {
+                continue;
+            }
+            let metrics = PlannerTickMetrics {
+                now_ms: self.now_ms,
+                prefill_fpm: Vec::new(),
+                decode_fpm: std::mem::take(&mut self.fpm_buffer),
+                traffic: self.traffic.drain(self.now_ms),
+                active_prefill: 0,
+                active_decode: self.active_worker_count(),
+                total_prefill: 0,
+                total_decode: self.total_worker_count(),
             };
+            let mut hook = self
+                .planner_hook
+                .take()
+                .expect("planner tick fired without a hook");
+            let decision = hook.on_tick(metrics);
+            self.planner_hook = Some(hook);
+            let decision = decision?;
 
-            if next_timestamp_ms > until_ms {
-                if until_ms > self.now_ms {
-                    self.advance_now_ms(until_ms);
-                }
-                break;
+            if decision.target_decode.is_some() {
+                let target = decision
+                    .target_decode
+                    .unwrap_or_else(|| self.total_worker_count());
+                self.apply_scaling(target)?;
             }
 
-            self.advance_now_ms(next_timestamp_ms);
-            self.drain_current_timestamp()?;
+            if let Some(next_ms) = decision.next_tick_ms
+                && next_ms > self.now_ms
+                && !self.is_workload_done()
+            {
+                push_planner_tick(&mut self.events, &mut self.next_event_seq, next_ms);
+            }
+            changed = true;
         }
-
-        Ok(self.is_workload_done())
+        Ok(changed)
     }
 
-    /// Current simulated time in milliseconds.
-    pub(in crate::replay) fn now_ms(&self) -> f64 {
-        self.now_ms
-    }
+    // ------------------------------------------------------------------
+    // Planner integration: scaling + worker-count accessors used by the
+    // in-loop `PlannerTick` handler (apply_planner_ticks).
+    // ------------------------------------------------------------------
 
     /// Advance the sim clock to `new_now_ms`, integrating provisioned
     /// worker-seconds over the interval just elapsed. `worker_count()` counts
@@ -716,16 +779,6 @@ impl AggRuntime {
     /// Total worker count including pending-removal.
     pub(in crate::replay) fn total_worker_count(&self) -> usize {
         self.engine.worker_count()
-    }
-
-    /// Drain accumulated FPM snapshots since the last drain.
-    pub(in crate::replay) fn drain_fpm(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
-        std::mem::take(&mut self.fpm_buffer)
-    }
-
-    /// Drain accumulated traffic stats since the last drain.
-    pub(in crate::replay) fn drain_traffic(&mut self) -> TrafficStats {
-        self.traffic.drain(self.now_ms)
     }
 
     /// Apply a scaling decision: set the target number of workers.
@@ -779,31 +832,75 @@ impl AggRuntime {
         Ok(())
     }
 
-    /// Finalize the replay: finish progress bar, return collector and stats.
-    pub(in crate::replay::offline) fn finalize(self) -> (TraceCollector, AggRuntimeStats) {
-        self.progress.finish();
-        (self.collector, self.stats)
+    // ------------------------------------------------------------------
+    // Test-only stepping helpers. White-box unit tests advance the sim to a
+    // chosen simulated time, inspect mid-flight state, apply a manual scaling
+    // decision, and resume — a granularity `run()` (which goes straight to
+    // completion) cannot offer. Not part of the production drive path.
+    // ------------------------------------------------------------------
+
+    /// Advance the simulation up to `until_ms` simulated time, then pause.
+    /// Returns `true` if the request workload is done — pending `WorkerReady`
+    /// events do not block completion since there is no work for those workers.
+    #[cfg(test)]
+    fn advance_to(&mut self, until_ms: f64) -> anyhow::Result<bool> {
+        self.drain_current_timestamp()?;
+
+        while !self.is_done() {
+            let Some(next_timestamp_ms) = self.next_timestamp() else {
+                bail!(
+                    "offline replay reached a dead end with {} in-flight requests remaining",
+                    self.cluster_in_flight()
+                );
+            };
+
+            if next_timestamp_ms > until_ms {
+                if until_ms > self.now_ms {
+                    self.advance_now_ms(until_ms);
+                }
+                break;
+            }
+
+            self.advance_now_ms(next_timestamp_ms);
+            self.drain_current_timestamp()?;
+        }
+
+        Ok(self.is_workload_done())
+    }
+
+    /// Current simulated time in milliseconds.
+    #[cfg(test)]
+    fn now_ms(&self) -> f64 {
+        self.now_ms
+    }
+
+    /// Drain accumulated traffic stats since the last drain.
+    #[cfg(test)]
+    fn drain_traffic(&mut self) -> TrafficStats {
+        self.traffic.drain(self.now_ms)
     }
 
     /// Finalize the replay and return the simulation report directly.
-    pub(in crate::replay) fn finalize_report(self) -> crate::replay::TraceSimulationReport {
-        let (collector, _stats) = self.finalize();
-        collector.finish()
+    #[cfg(test)]
+    fn finalize_report(self) -> crate::replay::TraceSimulationReport {
+        self.progress.finish();
+        self.collector.finish()
     }
 
     /// Run the aggregated offline replay until all arrivals and worker work are exhausted.
     /// If `max_sim_time_ms` is set, exits gracefully when the next scheduled
     /// timestamp would exceed that cap; in-flight requests at that point are
     /// reported as incomplete.
-    pub(in crate::replay::offline) fn run(
-        mut self,
-    ) -> anyhow::Result<(TraceCollector, AggRuntimeStats)> {
+    pub(in crate::replay) fn run(mut self) -> anyhow::Result<(TraceCollector, AggRuntimeStats)> {
         if let Some(cap_ms) = self.max_sim_time_ms
             && (!cap_ms.is_finite() || cap_ms < 0.0)
         {
             bail!("max_sim_time_ms must be a finite, non-negative value; got {cap_ms}");
         }
         self.drain_current_timestamp()?;
+        // With a planner attached, seed the recurring heartbeat; ticks then fire as
+        // events inside drain_current_timestamp (see apply_planner_ticks).
+        self.seed_first_planner_tick()?;
 
         while !self.is_done() {
             let Some(next_timestamp_ms) = self.next_timestamp() else {
@@ -2548,6 +2645,61 @@ mod tests {
         assert_eq!(rt.now_ms(), 500.0);
         let stats = rt.drain_traffic();
         assert!((stats.duration_s - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_drain_traffic_reports_mtp_accept_length() {
+        // MTP (nextn=2, accept_rates="1,1") makes every decode forward emit
+        // 3 visible tokens (1 base + 2 accepted speculative), so draining
+        // traffic after the workload completes must surface
+        // avg_accept_length == 3.0 alongside the requested output length
+        // (osl == 12). This is the end-to-end accept-length path the planner
+        // observes per tick via the drained traffic stats. (Ported from the
+        // Python `test_planner_bridge_drains_mtp_accept_length` that drove the
+        // now-removed bridge stepping API directly.)
+        let args = MockEngineArgs::builder()
+            .block_size(64)
+            .num_gpu_blocks(512)
+            .max_num_batched_tokens(Some(2048))
+            .max_num_seqs(Some(16))
+            .enable_prefix_caching(false)
+            .speedup_ratio(1000.0)
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("1,1".to_string()))
+            .build()
+            .unwrap();
+        let requests = (0..2)
+            .map(|i| DirectRequest {
+                tokens: vec![1; 128],
+                max_output_tokens: 12,
+                uuid: Some(Uuid::from_u128(i + 1)),
+                dp_rank: 0,
+                arrival_timestamp_ms: Some(0.0),
+                ..Default::default()
+            })
+            .collect::<VecDeque<_>>();
+        let mut rt = AggRuntime::new(
+            &args,
+            None,
+            None,
+            requests,
+            1,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        let done = rt.advance_to(1000.0).unwrap();
+        assert!(done, "workload should complete within the advance window");
+
+        let stats = rt.drain_traffic();
+        assert_eq!(stats.num_req, 2);
+        assert_eq!(stats.avg_osl, 12.0);
+        assert!(
+            (stats.avg_accept_length.unwrap() - 3.0).abs() < 1e-6,
+            "expected MTP accept_length 3.0, got {:?}",
+            stats.avg_accept_length
+        );
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -702,6 +702,9 @@ impl AggRuntime {
         if first_ms.is_finite() {
             let at_ms = first_ms.max(self.now_ms);
             push_planner_tick(&mut self.events, &mut self.next_event_seq, at_ms);
+        } else {
+            // No tick will ever fire to drain the FPM buffer; stop collecting it.
+            self.collect_fpm = false;
         }
         Ok(())
     }
@@ -740,11 +743,18 @@ impl AggRuntime {
                 self.apply_scaling(target)?;
             }
 
-            if let Some(next_ms) = decision.next_tick_ms
-                && next_ms > self.now_ms
+            // Re-arm only into the strict, finite future and only while work
+            // remains; otherwise no later tick will drain the FPM buffer, so stop
+            // collecting it (prevents unbounded growth once the cadence stops).
+            let next_tick = decision
+                .next_tick_ms
+                .filter(|next_ms| next_ms.is_finite() && *next_ms > self.now_ms);
+            if let Some(next_ms) = next_tick
                 && !self.is_workload_done()
             {
                 push_planner_tick(&mut self.events, &mut self.next_event_seq, next_ms);
+            } else {
+                self.collect_fpm = false;
             }
             changed = true;
         }

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -105,6 +105,14 @@ pub struct TrafficStats {
     /// returns the arithmetic mean of those samples, independent of
     /// per-request ISL size.
     pub avg_kv_hit_rate: f64,
+    /// Number of samples behind `avg_kv_hit_rate` (its denominator: router
+    /// admissions with `isl_blocks > 0`). Carried so a consumer that merges
+    /// several drained windows can reconstruct the exact sample-weighted mean
+    /// rather than approximating it with `num_req`.
+    pub hit_rate_count: usize,
+    /// Number of decode request-forwards behind `avg_accept_length` (its
+    /// denominator). Same purpose as `hit_rate_count` for cross-window merges.
+    pub accept_length_forward_count: usize,
 }
 
 /// Accumulates traffic statistics between planner ticks for deriving
@@ -254,6 +262,10 @@ impl TrafficAccumulator {
         } else {
             None
         };
+        // Capture the sample counts before the reset so a consumer that merges
+        // several drained windows can reconstruct exact count-weighted means.
+        let hit_rate_count = self.hit_rate_count;
+        let accept_length_forward_count = self.accept_length_forward_count;
         self.window_start_ms = now_ms;
         self.num_req = 0;
         self.total_isl = 0;
@@ -275,6 +287,8 @@ impl TrafficAccumulator {
             avg_itl_ms,
             avg_accept_length,
             avg_kv_hit_rate,
+            hit_rate_count,
+            accept_length_forward_count,
         }
     }
 }

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -953,6 +953,9 @@ impl DisaggRuntime {
         if first_ms.is_finite() {
             let at_ms = first_ms.max(self.now_ms);
             push_planner_tick(&mut self.events, &mut self.next_event_seq, at_ms);
+        } else {
+            // No tick will ever fire to drain the FPM buffers; stop collecting them.
+            self.collect_fpm = false;
         }
         Ok(())
     }
@@ -999,14 +1002,20 @@ impl DisaggRuntime {
                 self.apply_scaling(target_prefill, target_decode)?;
             }
 
-            // Re-arm only into the strict future and only while work remains; the
-            // `at_ms == now_ms` pop guard plus this check prevent a same-pass re-fire
-            // or an infinite spin from a degenerate `next_tick_ms <= now_ms`.
-            if let Some(next_ms) = decision.next_tick_ms
-                && next_ms > self.now_ms
+            // Re-arm only into the strict, finite future and only while work
+            // remains; the `at_ms == now_ms` pop guard plus this check prevent a
+            // same-pass re-fire or an infinite spin from a degenerate
+            // `next_tick_ms <= now_ms`. When no future tick will fire, stop FPM
+            // collection so neither buffer grows unbounded after the cadence ends.
+            let next_tick = decision
+                .next_tick_ms
+                .filter(|next_ms| next_ms.is_finite() && *next_ms > self.now_ms);
+            if let Some(next_ms) = next_tick
                 && !self.is_workload_done()
             {
                 push_planner_tick(&mut self.events, &mut self.next_event_seq, next_ms);
+            } else {
+                self.collect_fpm = false;
             }
             changed = true;
         }

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -9,15 +9,19 @@ use dynamo_kv_router::protocols::RouterEvent;
 use uuid::Uuid;
 
 pub(super) use super::components::ReplayMode;
+#[cfg(test)]
+use super::components::TrafficStats;
 use super::components::{
     AdmissionQueue, EngineComponent, EngineEffects, EnginePassMode, OfflineReplayRouter,
-    ReadyArrival, ScheduledWorkerCompletion, TrafficAccumulator, TrafficStats, WorkerAdmission,
+    ReadyArrival, ScheduledWorkerCompletion, TrafficAccumulator, WorkerAdmission,
 };
 use super::events::{SimulationEvent, SimulationWorkerStage};
+use super::planner_hook::{PlannerHook, PlannerTickMetrics};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
-    next_timestamp as choose_next_timestamp, pop_ready_decode_handoff, pop_ready_worker_completion,
-    pop_ready_worker_ready, push_decode_handoff, push_worker_completion, push_worker_ready,
+    next_timestamp as choose_next_timestamp, pop_ready_decode_handoff, pop_ready_planner_tick,
+    pop_ready_worker_completion, pop_ready_worker_ready, push_decode_handoff, push_planner_tick,
+    push_worker_completion, push_worker_ready,
 };
 #[cfg(test)]
 use super::state::DisaggRequestSnapshot;
@@ -44,7 +48,7 @@ pub(crate) enum DisaggTransition {
 
 #[cfg(test)]
 #[derive(Debug, Default, Clone, PartialEq)]
-pub(super) struct DisaggRuntimeStats {
+pub(in crate::replay) struct DisaggRuntimeStats {
     request_snapshots: HashMap<Uuid, DisaggRequestSnapshot>,
     prefill_assignments: HashMap<Uuid, usize>,
     decode_assignments: HashMap<Uuid, usize>,
@@ -59,7 +63,7 @@ pub(super) struct DisaggRuntimeStats {
 
 #[cfg(not(test))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub(super) struct DisaggRuntimeStats;
+pub(in crate::replay) struct DisaggRuntimeStats;
 
 pub(in crate::replay) struct DisaggRuntime {
     now_ms: f64,
@@ -85,6 +89,15 @@ pub(in crate::replay) struct DisaggRuntime {
     /// gracefully once the next scheduled timestamp exceeds this cap, leaving
     /// any in-flight requests as incomplete in the report.
     max_sim_time_ms: Option<f64>,
+    /// Planner hook. When set, `run()` seeds a recurring `PlannerTick` event and
+    /// calls back into the planner at each tick (this is the unified replacement
+    /// for the old Python-driven `advance_to` stepping loop).
+    planner_hook: Option<Box<dyn PlannerHook>>,
+    /// Whether to retain per-pass FPM snapshots in the buffers above. Only the
+    /// planner consumes them, so the plain `run()` path leaves this `false` —
+    /// otherwise the buffers grow unbounded (one entry per worker pass) for the
+    /// whole run with no reader (the memory leak this gating fixes).
+    collect_fpm: bool,
 }
 
 impl DisaggRuntime {
@@ -217,6 +230,8 @@ impl DisaggRuntime {
             decode_fpm_buffer: Vec::new(),
             traffic: TrafficAccumulator::new(),
             max_sim_time_ms: None,
+            planner_hook: None,
+            collect_fpm: false,
         })
     }
 
@@ -250,6 +265,14 @@ impl DisaggRuntime {
     /// Set the SLA thresholds used to classify goodput in the final report.
     pub(in crate::replay) fn with_sla_thresholds(mut self, sla: SlaThresholds) -> Self {
         self.collector.set_sla_thresholds(sla);
+        self
+    }
+
+    /// Attach a planner hook. Enables FPM collection and makes `run()` drive the
+    /// planner via recurring `PlannerTick` events (one `on_tick` callback per tick).
+    pub(in crate::replay) fn with_planner_hook(mut self, hook: Box<dyn PlannerHook>) -> Self {
+        self.collect_fpm = true;
+        self.planner_hook = Some(hook);
         self
     }
 
@@ -457,9 +480,12 @@ impl DisaggRuntime {
         Ok(uuid)
     }
 
-    /// Return true once both stages, both routers, and all admissions are fully drained.
+    /// Return true once both stages, both routers, and all admissions are fully
+    /// drained. Lingering `WorkerReady`/`PlannerTick` events (worker startup, a
+    /// re-armed planner heartbeat) do not represent request work, so they do not
+    /// keep the run alive — otherwise a recurring tick would never let `run()` exit.
     fn is_done(&self) -> bool {
-        self.events.is_empty()
+        self.only_idle_events_remain()
             && self.cluster_in_flight() == 0
             && self.admission.is_drained()
             && self.prefill_engine.is_drained()
@@ -467,21 +493,26 @@ impl DisaggRuntime {
     }
 
     /// Return true once the request workload is complete, even if `WorkerReady`
-    /// events remain in the queue.
+    /// or `PlannerTick` events remain in the queue.
     fn is_workload_done(&self) -> bool {
         self.cluster_in_flight() == 0
             && self.admission.is_drained()
             && self.prefill_engine.is_drained()
             && self.decode_engine.is_drained()
-            && self.only_worker_ready_events_remain()
+            && self.only_idle_events_remain()
     }
 
-    /// True if the event heap is empty or contains only `WorkerReady` events.
-    fn only_worker_ready_events_remain(&self) -> bool {
+    /// True if the event heap is empty or contains only "idle" events that carry no
+    /// pending request work: `WorkerReady` (a worker still starting up) or
+    /// `PlannerTick` (a re-armed planner heartbeat).
+    fn only_idle_events_remain(&self) -> bool {
         use super::events::SimulationEventKind;
-        self.events
-            .iter()
-            .all(|e| matches!(e.kind, SimulationEventKind::WorkerReady { .. }))
+        self.events.iter().all(|e| {
+            matches!(
+                e.kind,
+                SimulationEventKind::WorkerReady { .. } | SimulationEventKind::PlannerTick
+            )
+        })
     }
 
     /// Pick the next logical timestamp from arrivals, worker completions, or decode handoffs.
@@ -801,7 +832,9 @@ impl DisaggRuntime {
     }
 
     fn handle_prefill_engine_effects(&mut self, effects: EngineEffects) -> Result<()> {
-        self.prefill_fpm_buffer.extend(effects.fpm_snapshots);
+        if self.collect_fpm {
+            self.prefill_fpm_buffer.extend(effects.fpm_snapshots);
+        }
         self.record_prefill_admissions(effects.admissions);
         self.apply_prefill_router_events(effects.pass_start_kv_events)?;
         for payload in effects.immediate_completions {
@@ -827,7 +860,9 @@ impl DisaggRuntime {
     }
 
     fn handle_decode_engine_effects(&mut self, effects: EngineEffects) -> Result<()> {
-        self.decode_fpm_buffer.extend(effects.fpm_snapshots);
+        if self.collect_fpm {
+            self.decode_fpm_buffer.extend(effects.fpm_snapshots);
+        }
         for payload in effects.immediate_completions {
             let payload = self.decode_engine.on_scheduled_completion(payload)?;
             self.process_decode_pass(
@@ -892,12 +927,90 @@ impl DisaggRuntime {
             changed |= self.release_ready_arrivals()?;
             changed |= self.drive_prefill_workers()?;
             changed |= self.drive_decode_workers()?;
+            // Planner ticks fire LAST so the planner observes a fully settled
+            // timestamp (matching the old advance-then-tick ordering). Any scaling
+            // it applies is picked up by the next loop iteration.
+            if self.planner_hook.is_some() {
+                changed |= self.apply_planner_ticks()?;
+            }
 
             if !changed {
                 break;
             }
         }
         Ok(())
+    }
+
+    /// Seed the first `PlannerTick` event from the hook's requested start time.
+    /// A non-finite time means "no tick" (e.g. `NoopPlannerHook`) and is skipped.
+    fn seed_first_planner_tick(&mut self) -> Result<()> {
+        let Some(mut hook) = self.planner_hook.take() else {
+            return Ok(());
+        };
+        let first_ms = hook.initial_tick_ms();
+        self.planner_hook = Some(hook);
+        let first_ms = first_ms?;
+        if first_ms.is_finite() {
+            let at_ms = first_ms.max(self.now_ms);
+            push_planner_tick(&mut self.events, &mut self.next_event_seq, at_ms);
+        }
+        Ok(())
+    }
+
+    /// Fire every `PlannerTick` scheduled for the current timestamp: gather the
+    /// drained metrics, call the planner, apply its scaling decision, and re-arm
+    /// the next tick. Called only when a hook is attached.
+    fn apply_planner_ticks(&mut self) -> Result<bool> {
+        let mut changed = false;
+        while pop_ready_planner_tick(&mut self.events, self.now_ms) {
+            // Once the workload is finished, drop the tick without bothering the
+            // planner and without re-arming (mirrors the Python loop's pre-tick
+            // `if is_done: break`), so the heap drains and `run()` exits.
+            if self.is_workload_done() {
+                continue;
+            }
+            let metrics = PlannerTickMetrics {
+                now_ms: self.now_ms,
+                prefill_fpm: std::mem::take(&mut self.prefill_fpm_buffer),
+                decode_fpm: std::mem::take(&mut self.decode_fpm_buffer),
+                traffic: self.traffic.drain(self.now_ms),
+                active_prefill: self.active_prefill_count(),
+                active_decode: self.active_decode_count(),
+                total_prefill: self.total_prefill_count(),
+                total_decode: self.total_decode_count(),
+            };
+            // Borrow the hook out so the runtime stays mutably available for
+            // apply_scaling; restore it before propagating any error.
+            let mut hook = self
+                .planner_hook
+                .take()
+                .expect("planner tick fired without a hook");
+            let decision = hook.on_tick(metrics);
+            self.planner_hook = Some(hook);
+            let decision = decision?;
+
+            if decision.target_prefill.is_some() || decision.target_decode.is_some() {
+                let target_prefill = decision
+                    .target_prefill
+                    .unwrap_or_else(|| self.total_prefill_count());
+                let target_decode = decision
+                    .target_decode
+                    .unwrap_or_else(|| self.total_decode_count());
+                self.apply_scaling(target_prefill, target_decode)?;
+            }
+
+            // Re-arm only into the strict future and only while work remains; the
+            // `at_ms == now_ms` pop guard plus this check prevent a same-pass re-fire
+            // or an infinite spin from a degenerate `next_tick_ms <= now_ms`.
+            if let Some(next_ms) = decision.next_tick_ms
+                && next_ms > self.now_ms
+                && !self.is_workload_done()
+            {
+                push_planner_tick(&mut self.events, &mut self.next_event_seq, next_ms);
+            }
+            changed = true;
+        }
+        Ok(changed)
     }
 
     /// Finalize test-only request snapshots before returning.
@@ -913,41 +1026,9 @@ impl DisaggRuntime {
     }
 
     // ------------------------------------------------------------------
-    // Planner integration: step-based execution
+    // Planner integration: scaling + worker-count accessors used by the
+    // in-loop `PlannerTick` handler (apply_planner_ticks).
     // ------------------------------------------------------------------
-
-    /// Advance the simulation up to `until_ms` simulated time, then pause.
-    /// Returns `true` if the request workload is done — pending `WorkerReady`
-    /// events do not block completion since there is no work for those workers.
-    pub(in crate::replay) fn advance_to(&mut self, until_ms: f64) -> Result<bool> {
-        self.drain_current_timestamp()?;
-
-        while !self.is_done() {
-            let Some(next_timestamp_ms) = self.next_timestamp() else {
-                bail!(
-                    "offline disagg replay reached a dead end with {} in-flight requests remaining",
-                    self.cluster_in_flight()
-                );
-            };
-
-            if next_timestamp_ms > until_ms {
-                if until_ms > self.now_ms {
-                    self.advance_now_ms(until_ms);
-                }
-                break;
-            }
-
-            self.advance_now_ms(next_timestamp_ms);
-            self.drain_current_timestamp()?;
-        }
-
-        Ok(self.is_workload_done())
-    }
-
-    /// Current simulated time in milliseconds.
-    pub(in crate::replay) fn now_ms(&self) -> f64 {
-        self.now_ms
-    }
 
     /// Advance the sim clock to `new_now_ms`, integrating provisioned
     /// worker-seconds for both pools over the interval just elapsed.
@@ -978,21 +1059,6 @@ impl DisaggRuntime {
 
     pub(in crate::replay) fn total_decode_count(&self) -> usize {
         self.decode_engine.worker_count()
-    }
-
-    /// Drain accumulated prefill FPM snapshots since the last drain.
-    pub(in crate::replay) fn drain_prefill_fpm(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
-        std::mem::take(&mut self.prefill_fpm_buffer)
-    }
-
-    /// Drain accumulated decode FPM snapshots since the last drain.
-    pub(in crate::replay) fn drain_decode_fpm(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
-        std::mem::take(&mut self.decode_fpm_buffer)
-    }
-
-    /// Drain accumulated traffic stats since the last drain.
-    pub(in crate::replay) fn drain_traffic(&mut self) -> TrafficStats {
-        self.traffic.drain(self.now_ms)
     }
 
     /// Apply a scaling decision with separate prefill and decode targets.
@@ -1074,23 +1140,68 @@ impl DisaggRuntime {
         Ok(())
     }
 
-    /// Finalize the replay and return the simulation report directly.
-    pub(in crate::replay) fn finalize_report(self) -> crate::replay::TraceSimulationReport {
-        self.progress.finish();
-        self.collector.finish()
+    // ------------------------------------------------------------------
+    // Test-only stepping helpers. White-box unit tests advance the sim to a
+    // chosen simulated time, inspect mid-flight state, apply a manual scaling
+    // decision, and resume — a granularity `run()` (which goes straight to
+    // completion) cannot offer. Not part of the production drive path.
+    // ------------------------------------------------------------------
+
+    /// Advance the simulation up to `until_ms` simulated time, then pause.
+    /// Returns `true` if the request workload is done — pending `WorkerReady`
+    /// events do not block completion since there is no work for those workers.
+    #[cfg(test)]
+    fn advance_to(&mut self, until_ms: f64) -> Result<bool> {
+        self.drain_current_timestamp()?;
+
+        while !self.is_done() {
+            let Some(next_timestamp_ms) = self.next_timestamp() else {
+                bail!(
+                    "offline disagg replay reached a dead end with {} in-flight requests remaining",
+                    self.cluster_in_flight()
+                );
+            };
+
+            if next_timestamp_ms > until_ms {
+                if until_ms > self.now_ms {
+                    self.advance_now_ms(until_ms);
+                }
+                break;
+            }
+
+            self.advance_now_ms(next_timestamp_ms);
+            self.drain_current_timestamp()?;
+        }
+
+        Ok(self.is_workload_done())
+    }
+
+    /// Current simulated time in milliseconds.
+    #[cfg(test)]
+    fn now_ms(&self) -> f64 {
+        self.now_ms
+    }
+
+    /// Drain accumulated traffic stats since the last drain.
+    #[cfg(test)]
+    fn drain_traffic(&mut self) -> TrafficStats {
+        self.traffic.drain(self.now_ms)
     }
 
     /// Run the staged offline replay until both prefill and decode pipelines are drained.
     /// If `max_sim_time_ms` is set, exits gracefully when the next scheduled
     /// timestamp would exceed that cap; in-flight requests at that point are
     /// reported as incomplete.
-    pub(super) fn run(mut self) -> Result<(TraceCollector, DisaggRuntimeStats)> {
+    pub(in crate::replay) fn run(mut self) -> Result<(TraceCollector, DisaggRuntimeStats)> {
         if let Some(cap_ms) = self.max_sim_time_ms
             && (!cap_ms.is_finite() || cap_ms < 0.0)
         {
             bail!("max_sim_time_ms must be a finite, non-negative value; got {cap_ms}");
         }
         self.drain_current_timestamp()?;
+        // With a planner attached, seed the recurring heartbeat; ticks then fire as
+        // events inside drain_current_timestamp (see apply_planner_ticks).
+        self.seed_first_planner_tick()?;
 
         while !self.is_done() {
             let Some(next_timestamp_ms) = self.next_timestamp() else {

--- a/lib/mocker/src/replay/offline/events.rs
+++ b/lib/mocker/src/replay/offline/events.rs
@@ -37,6 +37,20 @@ pub(crate) enum SimulationEventKind {
     PlannerTick,
 }
 
+impl SimulationEventKind {
+    /// Tie-breaker among events at the *same* `at_ms`: a `PlannerTick` always
+    /// sorts after every other kind, so the planner observes a fully settled
+    /// timestamp (all worker completions / ready / handoff events at that time
+    /// drain first). `seq_no` is globally unique, so this only ever reorders a
+    /// tick relative to same-timestamp events — never two real events.
+    fn ordering_rank(&self) -> u8 {
+        match self {
+            SimulationEventKind::PlannerTick => 1,
+            _ => 0,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct SimulationEvent {
     pub(crate) at_ms: f64,
@@ -64,6 +78,7 @@ impl Ord for SimulationEvent {
             .at_ms
             .partial_cmp(&self.at_ms)
             .unwrap_or(Ordering::Equal)
+            .then_with(|| other.kind.ordering_rank().cmp(&self.kind.ordering_rank()))
             .then_with(|| other.seq_no.cmp(&self.seq_no))
     }
 }

--- a/lib/mocker/src/replay/offline/events.rs
+++ b/lib/mocker/src/replay/offline/events.rs
@@ -31,6 +31,10 @@ pub(crate) enum SimulationEventKind {
         stage: SimulationWorkerStage,
         worker_id: usize,
     },
+    /// A recurring planner heartbeat. Payload-free: the planner metrics are
+    /// gathered from live runtime state when the tick fires. Re-enqueues itself
+    /// at the time the planner hook returns (see `apply_planner_ticks`).
+    PlannerTick,
 }
 
 #[derive(Debug)]

--- a/lib/mocker/src/replay/offline/mod.rs
+++ b/lib/mocker/src/replay/offline/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod core;
 pub(crate) mod disagg;
 mod entrypoints;
 pub(crate) mod events;
+pub(crate) mod planner_hook;
 mod progress;
 pub(crate) mod runtime_utils;
 pub(crate) mod single;

--- a/lib/mocker/src/replay/offline/planner_hook.rs
+++ b/lib/mocker/src/replay/offline/planner_hook.rs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The planner-replay seam.
+//!
+//! A [`PlannerHook`] is invoked once per [`PlannerTick`](super::events::SimulationEventKind::PlannerTick)
+//! event inside the unified `run()` loop: it receives the metrics drained at the tick
+//! (per-pass FPM snapshots accumulated since the last tick, the traffic window, and worker
+//! counts) and returns a scaling decision plus the time of the next tick. This replaces the
+//! old Python-driven `advance_to`/`apply_scaling` stepping loop — the planner's decision logic
+//! still lives in Python (via a PyO3 wrapper that implements this trait), but the simulation
+//! now owns the drive loop and the tick cadence is just another event.
+//!
+//! [`NoopPlannerHook`] is the inert stand-in for tests and the no-planner path.
+
+use super::components::TrafficStats;
+use crate::common::protocols::ForwardPassSnapshot;
+
+/// Metrics handed to the planner at one tick. The runtime has already advanced the clock to
+/// `now_ms` and settled all same-timestamp work before this is built, so the planner observes a
+/// consistent post-settlement snapshot (matching the old advance-then-tick ordering).
+#[derive(Debug)]
+pub struct PlannerTickMetrics {
+    /// Simulated clock at this tick (equals the scheduled tick time).
+    pub now_ms: f64,
+    /// Every prefill FPM snapshot accumulated since the previous tick (empty in agg mode,
+    /// which routes all passes through `decode_fpm`).
+    pub prefill_fpm: Vec<(usize, ForwardPassSnapshot)>,
+    /// Every decode (agg: aggregated) FPM snapshot accumulated since the previous tick.
+    pub decode_fpm: Vec<(usize, ForwardPassSnapshot)>,
+    /// Traffic stats over `[previous tick, now]`. Drained every tick; the Python side merges
+    /// partial windows across ticks that don't consume traffic (mirrors how it already
+    /// accumulates FPM snapshots).
+    pub traffic: TrafficStats,
+    /// Active (ready, non-draining) worker counts. Agg reports decode only (`active_prefill = 0`).
+    pub active_prefill: usize,
+    pub active_decode: usize,
+    /// Total workers including pending startup + pending removal.
+    pub total_prefill: usize,
+    pub total_decode: usize,
+}
+
+/// The planner's decision for one tick. A `None` target leaves that count unchanged;
+/// `next_tick_ms = None` stops the recurring tick (the sim then runs to natural completion).
+#[derive(Debug, Default, Clone)]
+pub struct PlannerTickDecision {
+    /// Target prefill replica count (agg ignores this).
+    pub target_prefill: Option<usize>,
+    /// Target decode (agg: total) replica count.
+    pub target_decode: Option<usize>,
+    /// Absolute simulated time (ms) of the next tick. `None` => do not re-arm.
+    pub next_tick_ms: Option<f64>,
+}
+
+/// Implemented by the (Python-backed) planner. One call per `PlannerTick`; ticks are seconds
+/// apart in sim-time, so the per-call cost (a GIL acquire + a Python method) is negligible.
+///
+/// Intentionally NOT `Send`: the simulation runs single-threaded and the PyO3 implementation
+/// holds Python state, so the runtime loop holds the GIL rather than crossing threads.
+pub trait PlannerHook {
+    /// First tick time (ms) the planner wants. Seeds the first `PlannerTick`. A non-finite
+    /// value means "no tick" (the runtime skips seeding) — used by [`NoopPlannerHook`].
+    fn initial_tick_ms(&mut self) -> anyhow::Result<f64>;
+
+    /// Drive one tick: decide scaling targets and the next tick time.
+    fn on_tick(&mut self, metrics: PlannerTickMetrics) -> anyhow::Result<PlannerTickDecision>;
+}
+
+/// A planner that never scales and never re-arms — used in tests and as an inert stand-in.
+pub struct NoopPlannerHook;
+
+impl PlannerHook for NoopPlannerHook {
+    fn initial_tick_ms(&mut self) -> anyhow::Result<f64> {
+        Ok(f64::INFINITY) // non-finite => the runtime does not seed a tick
+    }
+
+    fn on_tick(&mut self, _metrics: PlannerTickMetrics) -> anyhow::Result<PlannerTickDecision> {
+        Ok(PlannerTickDecision::default())
+    }
+}

--- a/lib/mocker/src/replay/offline/runtime_utils.rs
+++ b/lib/mocker/src/replay/offline/runtime_utils.rs
@@ -124,7 +124,9 @@ pub(super) fn pop_ready_worker_completion(
             accept_length_output_tokens,
             accept_length_decode_forwards,
         ),
-        SimulationEventKind::DecodeHandoff { .. } | SimulationEventKind::WorkerReady { .. } => {
+        SimulationEventKind::DecodeHandoff { .. }
+        | SimulationEventKind::WorkerReady { .. }
+        | SimulationEventKind::PlannerTick => {
             unreachable!("peeked worker completion event must match popped event")
         }
     };
@@ -202,6 +204,38 @@ pub(super) fn pop_ready_worker_ready(
         unreachable!("peeked worker ready event must match popped event");
     };
     Some((stage, worker_id))
+}
+
+pub(super) fn push_planner_tick(
+    events: &mut BinaryHeap<SimulationEvent>,
+    next_event_seq: &mut u64,
+    at_ms: f64,
+) {
+    events.push(SimulationEvent {
+        at_ms,
+        seq_no: *next_event_seq,
+        kind: SimulationEventKind::PlannerTick,
+    });
+    *next_event_seq += 1;
+}
+
+/// Pop a `PlannerTick` scheduled for exactly `now_ms` (peek-and-pop-at-now, like the
+/// other `pop_ready_*` helpers). Payload-free, so it returns whether one fired.
+pub(super) fn pop_ready_planner_tick(
+    events: &mut BinaryHeap<SimulationEvent>,
+    now_ms: f64,
+) -> bool {
+    let Some(event) = events.peek() else {
+        return false;
+    };
+    if event.at_ms != now_ms {
+        return false;
+    }
+    if !matches!(event.kind, SimulationEventKind::PlannerTick) {
+        return false;
+    }
+    events.pop().expect("event must exist after peek");
+    true
 }
 
 #[cfg(test)]

--- a/lib/mocker/src/replay/planner_handle.rs
+++ b/lib/mocker/src/replay/planner_handle.rs
@@ -4,9 +4,10 @@
 //! Public handle for driving an offline replay with planner-in-the-loop.
 //!
 //! Supports both aggregated and disaggregated topologies via [`RuntimeKind`].
-//! The Python planner adapter calls [`PlannerReplayHandle::advance_to`] to
-//! step the simulation, collects metrics, and calls [`PlannerReplayHandle::apply_scaling`]
-//! to resize worker pools.
+//! [`PlannerReplayHandle::run`] drives the simulation to completion; the planner
+//! is invoked once per `PlannerTick` event through the [`PlannerHook`] callback,
+//! which observes per-tick metrics and returns the scale decision plus the next
+//! tick time. The simulation owns the drive loop — there is no external stepping.
 
 use std::path::Path;
 use std::time::Instant;
@@ -15,42 +16,15 @@ use anyhow::Result;
 use dynamo_kv_router::config::KvRouterConfig;
 
 use super::offline::agg::AggRuntime;
-use super::offline::components::{ReplayMode, TrafficStats};
+use super::offline::components::ReplayMode;
 use super::offline::disagg::DisaggRuntime;
+use super::offline::planner_hook::PlannerHook;
 use super::{
     OfflineDisaggReplayConfig, ReplayPrefillLoadEstimator, ReplayRouterMode, SlaThresholds,
     TraceSimulationReport,
 };
-use crate::common::protocols::{ForwardPassSnapshot, MockEngineArgs};
+use crate::common::protocols::MockEngineArgs;
 use crate::loadgen::Trace;
-
-/// Snapshot of metrics collected between planner ticks.
-///
-/// For aggregated mode, prefill fields are 0 and all data is in decode fields
-/// (matching how the planner treats agg as a single decode-stage engine).
-///
-/// Traffic metrics are NOT included here — they accumulate across ticks and
-/// must be drained explicitly via [`PlannerReplayHandle::drain_traffic`] on
-/// throughput-scaling ticks only. Draining on every tick would discard data
-/// between the more frequent load-scaling ticks.
-pub struct PlannerTickData {
-    /// Current simulated time in milliseconds.
-    pub now_ms: f64,
-    /// Whether the replay has finished (no more work).
-    pub is_done: bool,
-    /// Prefill FPM snapshots since last tick: (worker_id, snapshot).
-    pub prefill_fpm_snapshots: Vec<(usize, ForwardPassSnapshot)>,
-    /// Decode (or agg) FPM snapshots since last tick: (worker_id, snapshot).
-    pub decode_fpm_snapshots: Vec<(usize, ForwardPassSnapshot)>,
-    /// Active prefill workers (0 for agg mode).
-    pub active_prefill_count: usize,
-    /// Active decode workers (or total active for agg mode).
-    pub active_decode_count: usize,
-    /// Total prefill workers including pending removal (0 for agg mode).
-    pub total_prefill_count: usize,
-    /// Total decode workers including pending removal (or total for agg mode).
-    pub total_decode_count: usize,
-}
 
 #[allow(clippy::large_enum_variant)]
 enum RuntimeKind {
@@ -220,77 +194,19 @@ impl PlannerReplayHandle {
         )
     }
 
-    /// Advance the simulation up to `until_ms`, collect metrics, return tick data.
-    ///
-    /// Traffic metrics are NOT drained here — call [`drain_traffic`] explicitly
-    /// on throughput-scaling ticks so the accumulator covers the full interval.
-    pub fn advance_to(&mut self, until_ms: f64) -> Result<PlannerTickData> {
-        match &mut self.runtime {
-            RuntimeKind::Agg(rt) => {
-                let is_done = rt.advance_to(until_ms)?;
-                let fpm = rt.drain_fpm();
-                Ok(PlannerTickData {
-                    now_ms: rt.now_ms(),
-                    is_done,
-                    prefill_fpm_snapshots: Vec::new(),
-                    decode_fpm_snapshots: fpm,
-                    active_prefill_count: 0,
-                    active_decode_count: rt.active_worker_count(),
-                    total_prefill_count: 0,
-                    total_decode_count: rt.total_worker_count(),
-                })
-            }
-            RuntimeKind::Disagg(rt) => {
-                let is_done = rt.advance_to(until_ms)?;
-                let prefill_fpm = rt.drain_prefill_fpm();
-                let decode_fpm = rt.drain_decode_fpm();
-                Ok(PlannerTickData {
-                    now_ms: rt.now_ms(),
-                    is_done,
-                    prefill_fpm_snapshots: prefill_fpm,
-                    decode_fpm_snapshots: decode_fpm,
-                    active_prefill_count: rt.active_prefill_count(),
-                    active_decode_count: rt.active_decode_count(),
-                    total_prefill_count: rt.total_prefill_count(),
-                    total_decode_count: rt.total_decode_count(),
-                })
-            }
-        }
-    }
-
-    /// Drain accumulated traffic metrics since the last drain.
-    ///
-    /// Call this only on throughput-scaling ticks so the window covers the
-    /// full `throughput_adjustment_interval`, not just the gap between load
-    /// ticks. The returned [`TrafficStats::avg_kv_hit_rate`] is the
-    /// arithmetic mean of per-request ``overlap / isl`` ratios across
-    /// admissions in the window — matching the real router's per-request
-    /// Prometheus histogram, where each request contributes one sample
-    /// regardless of ISL size.
-    pub fn drain_traffic(&mut self) -> TrafficStats {
-        match &mut self.runtime {
-            RuntimeKind::Agg(rt) => rt.drain_traffic(),
-            RuntimeKind::Disagg(rt) => rt.drain_traffic(),
-        }
-    }
-
-    /// Apply a scaling decision with separate prefill and decode targets.
-    /// For agg mode, `target_prefill` is ignored.
-    pub fn apply_scaling(&mut self, target_prefill: usize, target_decode: usize) -> Result<()> {
-        match &mut self.runtime {
-            RuntimeKind::Agg(rt) => rt.apply_scaling(target_decode),
-            RuntimeKind::Disagg(rt) => rt.apply_scaling(target_prefill, target_decode),
-        }
-    }
-
-    /// Finalize the replay and return the report.
-    pub fn finalize(self) -> TraceSimulationReport {
-        let wall_time_ms = self.started_at.elapsed().as_secs_f64() * 1000.0;
-        let report = match self.runtime {
-            RuntimeKind::Agg(rt) => rt.finalize_report(),
-            RuntimeKind::Disagg(rt) => rt.finalize_report(),
+    /// Run the whole replay to completion with the planner driving the tick cadence
+    /// via `hook`. This is the unified entrypoint that replaces the external
+    /// `advance_to`/`apply_scaling` stepping loop: the simulation owns the drive loop
+    /// and calls back into `hook` once per `PlannerTick` event. Returns the final
+    /// report (wall-time stamped, SLA thresholds already set at construction).
+    pub fn run(self, hook: Box<dyn PlannerHook>) -> Result<TraceSimulationReport> {
+        let started_at = self.started_at;
+        let collector = match self.runtime {
+            RuntimeKind::Agg(rt) => rt.with_planner_hook(hook).run()?.0,
+            RuntimeKind::Disagg(rt) => rt.with_planner_hook(hook).run()?.0,
         };
-        report.with_wall_time_ms(wall_time_ms)
+        let wall_time_ms = started_at.elapsed().as_secs_f64() * 1000.0;
+        Ok(collector.finish().with_wall_time_ms(wall_time_ms))
     }
 }
 
@@ -299,6 +215,7 @@ mod tests {
     use super::PlannerReplayHandle;
     use crate::common::protocols::MockEngineArgs;
     use crate::loadgen::{ArrivalSpec, DelaySpec, LengthSpec, SyntheticTraceSpec, Trace};
+    use crate::replay::NoopPlannerHook;
     use crate::replay::{ReplayRouterMode, SlaThresholds};
 
     const NUM_SESSIONS: usize = 8;
@@ -338,23 +255,13 @@ mod tests {
         .unwrap()
     }
 
-    /// One large advance drains every event (arrival timestamps and concurrency
-    /// admissions alike), so the planner loop is mode-agnostic.
-    fn drive_to_completion(handle: &mut PlannerReplayHandle) {
-        let tick = handle.advance_to(1.0e15).unwrap();
-        assert!(
-            tick.is_done,
-            "replay should finish within the advance window"
-        );
-    }
-
     #[test]
     fn from_trace_closed_loop_completes_all_requests() {
         // Burst arrivals + an in-flight cap -> closed-loop: trace timestamps are
         // ignored and at most `max_in_flight` run at once, but every request still
         // completes. This is the planner + concurrency path that was previously
         // unreachable (the handle hard-coded ReplayMode::Trace).
-        let mut handle = PlannerReplayHandle::from_trace(
+        let handle = PlannerReplayHandle::from_trace(
             small_args(),
             None,
             None,
@@ -365,17 +272,14 @@ mod tests {
             SlaThresholds::default(),
         )
         .unwrap();
-        drive_to_completion(&mut handle);
-        assert_eq!(
-            handle.finalize().request_counts.completed_requests,
-            NUM_SESSIONS
-        );
+        let report = handle.run(Box::new(NoopPlannerHook)).unwrap();
+        assert_eq!(report.request_counts.completed_requests, NUM_SESSIONS);
     }
 
     #[test]
     fn from_trace_arrival_completes_all_requests() {
         // No cap -> arrival-timestamp (open-loop) replay; every request completes.
-        let mut handle = PlannerReplayHandle::from_trace(
+        let handle = PlannerReplayHandle::from_trace(
             small_args(),
             None,
             None,
@@ -386,10 +290,7 @@ mod tests {
             SlaThresholds::default(),
         )
         .unwrap();
-        drive_to_completion(&mut handle);
-        assert_eq!(
-            handle.finalize().request_counts.completed_requests,
-            NUM_SESSIONS
-        );
+        let report = handle.run(Box::new(NoopPlannerHook)).unwrap();
+        assert_eq!(report.request_counts.completed_requests, NUM_SESSIONS);
     }
 }


### PR DESCRIPTION
## Summary

The mocker offline replay had **two** drive paths: the plain `DisaggRuntime`/`AggRuntime` `run()` loop, and a separate Python-driven stepping loop (`PlannerReplayHandle::advance_to` + the `PlannerReplayBridge` advance/scale/drain pymethods). The split caused:

1. an **unbounded FPM-snapshot memory leak** on the plain path — per-pass `ForwardPassSnapshot` buffers were `extend()`-ed every worker pass but only ever drained by the planner path, so a plain `run()` grew them without bound (OOM on high-concurrency runs); and
2. **two-path complexity** — static workloads couldn't emit SLA goodput on the plain path, forcing callers onto the bridge.

This unifies everything onto **one event-driven path**: a planner tick is now a first-class `PlannerTick` event in the single `run()` loop. At each tick the simulation calls back into the planner via the new `PlannerHook` trait for the scale decision and re-enqueues the next tick, so the simulation owns the drive loop and the external stepping path is removed.

## What changed

- **Rust (`lib/mocker`)**: add `SimulationEventKind::PlannerTick` + a `PlannerHook` trait (`initial_tick_ms`/`on_tick`) + `NoopPlannerHook`. Runtimes gain `with_planner_hook` and `apply_planner_ticks` (drain FPM/traffic → `hook.on_tick` → `apply_scaling` → re-arm next tick). **FPM is collected only when a hook is attached, fixing the leak.** The external stepping API (`advance_to`/`apply_scaling`/`drain_*`/`finalize_report`) is removed from the production surface; the white-box steppers survive as `#[cfg(test)]` helpers. SLA thresholds thread through the 8 synthetic `simulate_*` entrypoints.
- **Bindings (`lib/bindings/python`)**: `PyPlannerHook` bridges the Python adapter; `PlannerReplayBridge` keeps its constructors + `run(planner)` and drops the `advance_to`/`drain_traffic`/`apply_scaling`/`finalize` pymethods. `sla_*_ms` threaded through the synthetic offline calls.
- **Python (`components/src/dynamo`)**: `run_trace_replay` / `run_synthetic_trace_replay` gain `planner_config` (+ synthetic `sla_ttft/itl/e2e_ms`) so **one entrypoint covers static and planner replay, trace and synthetic, with SLA goodput on every shape**. The replay adapter is inverted into `initial_tick_ms`/`on_tick`/`finalize` callbacks (Rust owns the loop).
- **Tests**: migrate the bridge load-mode + adapter-FPM tests onto the unified entrypoints; port the MTP accept-length coverage to a Rust integration test; drop the now-dead `_TrafficBridge` test double.

## Verification

- `cargo test -p dynamo-mocker` — **388 passing** (incl. the new MTP accept-length integration test); `cargo check` clean for mocker and bindings (`--features aic-forward-pass`); `cargo fmt` clean.
- `pre-commit run --all-files` — all hooks pass.
- Migrated Python tests verified: load-modes 3/3, adapter-FPM 5/5.
- Bare path (`planner_config=None`) returns the plain report dict (keeps existing smoke tests green); planner path returns `ReplayPlannerReport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added planner-in-the-loop replay support, enabling replay runs to adapt scaling decisions during execution.
  * Replay APIs now accept optional planner configuration and benchmark granularity settings for both trace and synthetic runs.
  * Synthetic replay now supports optional SLA thresholds for reporting and evaluation.

* **Bug Fixes**
  * Improved traffic and latency metric handling during replay, including better accumulation across ticks.
  * Updated replay behavior to produce more consistent completion results across load modes and closed-loop scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->