### PR TITLE
docs(agents): add trace replay walkthrough

### DIFF
--- a/docs/agents/agent-replay.md
+++ b/docs/agents/agent-replay.md
@@ -11,11 +11,11 @@ Agent trace replay records the workload that an agent sends to Dynamo and turns 
 
 A Dynamo request trace preserves the parts of an agent run that affect serving:
 
-- when each model request arrived;
-- its input and output token lengths;
-- which prompt blocks were shared with earlier requests;
-- which requests belonged to the same agent session; and
-- parent-child relationships between agent sessions.
+- when each model request arrived
+- its input and output token lengths
+- which prompt blocks were shared with earlier requests
+- which requests belonged to the same agent session
+- parent-child relationships between agent sessions
 
 Prompts, responses, and tool arguments are not stored. Enable [audit payloads](agent-tracing.md#audit-payloads) alongside tracing if you need them. Optional tool spans record where time was spent, but replay uses the captured request schedule rather than calling those tools again.
 
@@ -23,10 +23,10 @@ Prompts, responses, and tool arguments are not stored. Enable [audit payloads](a
 
 Use trace replay to:
 
-- reproduce realistic multi-turn and multi-agent load without rerunning the agent, tools, or external APIs;
-- compare routing, cache, worker, or model-server changes against the same workload;
-- investigate latency or cache regressions with a repeatable request schedule; and
-- screen deployment choices offline before spending GPU time on live validation.
+- reproduce realistic multi-turn and multi-agent load without rerunning the agent, tools, or external APIs
+- compare routing, cache, worker, or model-server changes against the same workload
+- investigate latency or cache regressions with a repeatable request schedule
+- screen deployment choices offline before spending GPU time on live validation
 
 ## Choose Live Replay or Offline Simulation
 
@@ -35,7 +35,7 @@ One capture supports both paths:
 | Path | What runs | Use it for |
 |---|---|---|
 | **Live replay with AIPerf** | Synthetic requests against a real Dynamo endpoint, model, and GPUs | Final latency, throughput, cache, and regression measurements |
-| **Offline simulation with DynoSim** | The request graph against Dynamo's simulated scheduler, router, and KV cache | Fast topology, routing, capacity, and what-if exploration |
+| **Offline simulation with DynoSim** | The request graph against Dynamo's simulated scheduler, router, and KV cache | Compare worker counts, serving topologies, routing policies, and KV-cache capacity |
 
 Live replay measures the real serving stack. Offline simulation predicts how a configuration behaves and should be followed by live validation for final numbers. See the official [AIPerf trace replay](https://github.com/ai-dynamo/aiperf/blob/main/docs/benchmark-modes/trace-replay.md) and [fixed schedule](https://github.com/ai-dynamo/aiperf/blob/main/docs/tutorials/fixed-schedule.md) guides for live benchmarking. See [DynoSim](../dynosim/README.md) and [DynoSim Runs](../dynosim/runs.md) for offline simulation.
 
@@ -65,27 +65,27 @@ Run the agent workload normally against this frontend. Use the real tools if you
 
 Each agent chain should send `X-Dynamo-Session-ID`. A child agent should also send `X-Dynamo-Parent-Session-ID`. These headers describe the request graph; they do not enable session affinity or change routing.
 
-The sink writes rotating `request-trace.NNNNNN.jsonl.gz` files. Stop the frontend, or otherwise allow the sink to flush, before using the files. See [Agent Tracing](agent-tracing.md) for configuration, the record schema, Perfetto conversion, and optional tool-event ingestion.
+Dynamo writes rotating `request-trace.NNNNNN.jsonl.gz` files. Stop the frontend, or otherwise allow tracing to flush, before using the files. See [Agent Tracing](agent-tracing.md) for configuration, the record schema, Perfetto conversion, and optional tool-event ingestion.
 
 ## Step 2: Check the Capture
 
 Before replaying, confirm that the trace contains the workload you intended:
 
-- `request_end` count matches the number of completed model requests;
-- session and per-session turn counts look reasonable;
-- every request has input length, output length, and sequence hashes; and
-- the final trace file was flushed cleanly.
+- `request_end` count matches the number of completed model requests
+- session and per-session turn counts look reasonable
+- every request has input length, output length, and sequence hashes
+- the final trace file was flushed cleanly
 
-These checks catch a wrong frontend, missing session headers, and an incomplete shutdown before those errors become misleading replay results.
+These are manual sanity checks. The replay tools validate required fields and consistent block sizes, but they cannot know the request or session counts you intended to capture. Checking both catches a wrong frontend, missing session headers, and an incomplete shutdown before those errors become misleading replay results.
 
 ## Step 3: Prepare the Request Graph
 
 Both replay paths build a graph from the same trace fields:
 
-- `session_id` orders requests into one linear agent chain.
-- `parent_session_id` adds a child branch to its direct parent session.
-- `request_received_ms` determines the recorded arrival schedule.
-- `replay.input_length`, `output_tokens`, and `input_sequence_hashes` reproduce the request shape and complete-block prompt-prefix relationships.
+- `session_id` orders requests into one linear agent chain
+- `parent_session_id` adds a child branch to its direct parent session
+- `request_received_ms` determines the recorded arrival schedule
+- `replay.input_length`, `output_tokens`, and `input_sequence_hashes` reproduce the request shape and complete-block prompt-prefix relationships
 
 DynoSim reads the original request trace directly. Live AIPerf replay requires one conversion step.
 
@@ -130,6 +130,8 @@ aiperf profile \
 
 Do not add a concurrency or request-rate cap when reproducing the capture. The recorded timestamps and graph already supply concurrency. A turn starts no earlier than both its target timestamp and its predecessor's completion, so a slower target accumulates schedule drift instead of overlapping dependent turns.
 
+Fixed-schedule behavior is required to preserve recorded arrival times, although AIPerf enables it automatically for trace datasets. It is explicit above for clarity. `--fixed-schedule-auto-offset` shifts the schedule to start at zero without changing relative timing.
+
 `ignore_eos:true` asks the backend to generate the captured output length rather than stop early on newly sampled content. The split override prevents AIPerf from reconstructing a second conversation graph on top of the one Dynamo already built. `--use-dynamo-session-control` sends the session and parent-session headers so the replayed trace preserves agent session identity.
 
 ### Offline simulation with DynoSim
@@ -151,14 +153,20 @@ DynoSim derives and validates the block size across all shards. When every reque
 
 For a successful live replay, check that:
 
-- captured, converted, dispatched, and completed request counts match;
-- session counts and per-session turn counts match;
-- AIPerf reports no request errors;
-- replayed output lengths match the capture; and
-- arrival-time, request-duration, and cache-reuse deltas are reported.
+- captured, converted, dispatched, and completed request counts match
+- session counts and per-session turn counts match
+- AIPerf reports no request errors
+- replayed output lengths match the capture
+- arrival-time, request-duration, and cache-reuse deltas are reported
 
 Keep the model, tokenizer, block size, worker topology, and initial cache state the same when measuring replay fidelity. For a DynoSim run, first verify request and token totals, then compare configurations using the generated report rather than treating simulation output as hardware measurements.
 
 ## Fidelity Boundaries
 
-Replay is intentionally content-free. Synthetic prompts preserve block-sharing topology, not the original text. Wire input length can differ slightly because the target tokenizer and chat template reconstruct the request. Service time can also differ even against the same model. Tool rows are not dispatched by AIPerf. Their elapsed time remains represented by the gap between model requests, and DynoSim can retain it as tool-wait time. If a changed model response would make the agent choose another tool or branch, that requires another live agent run rather than static trace replay.
+Replay is intentionally content-free:
+
+- Synthetic prompts preserve block-sharing topology, not the original text
+- Wire input length can differ slightly because the target tokenizer and chat template reconstruct the request
+- Service time can differ even against the same model
+- AIPerf does not dispatch tool rows; their elapsed time remains in the gap between model requests, and DynoSim retains it as tool-wait time
+- If a changed model response would select another tool or branch, capture another live agent run instead of using static replay

--- a/docs/agents/agent-replay.md
+++ b/docs/agents/agent-replay.md
@@ -1,69 +1,164 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: Agent Simulation
-subtitle: Replay agent request traces against mock Dynamo workers
+title: Agent Trace Replay
+subtitle: Capture an agent workload once, then replay it on real or simulated infrastructure
 ---
 
-Use agent simulation to replay collected agent trajectories against mock Dynamo
-workers. Start with [Agent Tracing](agent-tracing.md) to collect request rows,
-then pass those rows directly to `python -m dynamo.replay`.
+Agent trace replay records the workload that an agent sends to Dynamo and turns it into a reusable benchmark. Capture one real run, then use the same request graph to validate a live endpoint or explore configurations offline. It replays the serving workload rather than the agent itself, so the model does not repeat its decisions and tools are not executed again.
 
-## Collect a Trace
+## What This Captures
 
-Enable request tracing while running the agent workload:
+A Dynamo request trace preserves the parts of an agent run that affect serving:
+
+- when each model request arrived;
+- its input and output token lengths;
+- which prompt blocks were shared with earlier requests;
+- which requests belonged to the same agent session; and
+- parent-child relationships between agent sessions.
+
+Prompts, responses, and tool arguments are not stored. Enable [audit payloads](agent-tracing.md#audit-payloads) alongside tracing if you need them. Optional tool spans record where time was spent, but replay uses the captured request schedule rather than calling those tools again.
+
+## Why Replay an Agent Trace
+
+Use trace replay to:
+
+- reproduce realistic multi-turn and multi-agent load without rerunning the agent, tools, or external APIs;
+- compare routing, cache, worker, or model-server changes against the same workload;
+- investigate latency or cache regressions with a repeatable request schedule; and
+- screen deployment choices offline before spending GPU time on live validation.
+
+## Choose Live Replay or Offline Simulation
+
+One capture supports both paths:
+
+| Path | What runs | Use it for |
+|---|---|---|
+| **Live replay with AIPerf** | Synthetic requests against a real Dynamo endpoint, model, and GPUs | Final latency, throughput, cache, and regression measurements |
+| **Offline simulation with DynoSim** | The request graph against Dynamo's simulated scheduler, router, and KV cache | Fast topology, routing, capacity, and what-if exploration |
+
+Live replay measures the real serving stack. Offline simulation predicts how a configuration behaves and should be followed by live validation for final numbers. See the official [AIPerf trace replay](https://github.com/ai-dynamo/aiperf/blob/main/docs/benchmark-modes/trace-replay.md) and [fixed schedule](https://github.com/ai-dynamo/aiperf/blob/main/docs/tutorials/fixed-schedule.md) guides for live benchmarking. See [DynoSim](../dynosim/README.md) and [DynoSim Runs](../dynosim/runs.md) for offline simulation.
+
+The complete flow is:
+
+```mermaid
+flowchart LR
+    A["Agent harness"] --> F["Dynamo frontend"]
+    F --> C["request trace"]
+    C --> D["DynoSim"]
+    C --> W["Live replay trace"] --> P["AIPerf"] --> E["Dynamo endpoint"]
+```
+
+## Step 1: Capture a Real Agent Run
+
+Enable request tracing on the frontend that receives the agent traffic:
 
 ```bash
 export DYN_REQUEST_TRACE=1
-export DYN_REQUEST_TRACE_SINKS=jsonl_gz
-export DYN_REQUEST_TRACE_OUTPUT_PATH=/tmp/dynamo-trace
+export DYN_REQUEST_TRACE_OUTPUT_PATH=/tmp/agent-run/request-trace
+
+# Optional: bind the ingress used by a harness that publishes explicit tool spans.
+export DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT=tcp://127.0.0.1:20390
 ```
 
-For tool timing fidelity, publish explicit tool events over the optional ZMQ
-ingress described in [Agent Tracing](agent-tracing.md#tool-call-observability).
-Without tool events, Dynamo can still infer tool-wait time from the gap between
-adjacent LLM requests in the same session.
+Run the agent workload normally against this frontend. Use the real tools if you want the captured schedule to include their actual latency. For example, a coding agent can solve SWE-bench tasks in its normal sandbox while every model request is recorded at the Dynamo frontend.
 
-## Replay Offline
+Each agent chain should send `X-Dynamo-Session-ID`. A child agent should also send `X-Dynamo-Parent-Session-ID`. These headers describe the request graph; they do not enable session affinity or change routing.
 
-**Experimental.** Replay uses Dynamo `request_end` rows for request timing,
-token lengths, worker placement, and replay hashes. It also uses terminal
-harness tool rows (`tool_end` / `tool_error`) to preserve tool-wait time between
-dependent LLM requests.
+The sink writes rotating `request-trace.NNNNNN.jsonl.gz` files. Stop the frontend, or otherwise allow the sink to flush, before using the files. See [Agent Tracing](agent-tracing.md) for configuration, the record schema, Perfetto conversion, and optional tool-event ingestion.
 
-Replay ignores non-replay request fields such as `finish_reason_metadata`; use
-the Perfetto view in [Agent Tracing](agent-tracing.md#view-traces-in-perfetto)
-when you want to inspect final finish reasons, backend stop signals, or complete
-tool-call metadata inside the trace.
+## Step 2: Check the Capture
+
+Before replaying, confirm that the trace contains the workload you intended:
+
+- `request_end` count matches the number of completed model requests;
+- session and per-session turn counts look reasonable;
+- every request has input length, output length, and sequence hashes; and
+- the final trace file was flushed cleanly.
+
+These checks catch a wrong frontend, missing session headers, and an incomplete shutdown before those errors become misleading replay results.
+
+## Step 3: Prepare the Request Graph
+
+Both replay paths build a graph from the same trace fields:
+
+- `session_id` orders requests into one linear agent chain.
+- `parent_session_id` adds a child branch to its direct parent session.
+- `request_received_ms` determines the recorded arrival schedule.
+- `replay.input_length`, `output_tokens`, and `input_sequence_hashes` reproduce the request shape and complete-block prompt-prefix relationships.
+
+DynoSim reads the original request trace directly. Live AIPerf replay requires one conversion step.
+
+### Convert for live replay
+
+This path currently requires [a branch of AIPerf](https://github.com/ajcasagrande/aiperf/pull/3). AIPerf's converter reads uncompressed JSONL:
 
 ```bash
-python -m dynamo.replay "${DYN_REQUEST_TRACE_OUTPUT_PATH}".*.jsonl.gz \
+gzip -cd /tmp/agent-run/request-trace.*.jsonl.gz > /tmp/agent-run/request-trace.jsonl
+
+aiperf synthesize dynamo-trace /tmp/agent-run/request-trace.jsonl \
+  --output /tmp/agent-run/aiperf-trace
+```
+
+The output contains one replay graph per root session. Requests in a session remain ordered, while independent roots and child branches can overlap. Dynamo sequence hashes become global synthetic block IDs, preserving complete-block prefix sharing across sessions without exposing the original tokens. Each file also declares the capture block size, which AIPerf uses automatically.
+
+The current live graph supports one direct child-session level. The converter rejects deeper trees instead of silently flattening them.
+
+## Step 4: Run the Replay
+
+### Live replay with AIPerf
+
+Replay against a Dynamo endpoint serving the target model:
+
+```bash
+AIPERF_DATASET_WEKA_SPLIT_FLATTENED_AGENTS=false \
+AIPERF_DYNAMO_SESSION_TRANSPORT=headers \
+aiperf profile \
+  --url http://localhost:8000 \
+  --model my-model \
+  --tokenizer /path/to/my-model \
+  --endpoint-type chat \
+  --input-file /tmp/agent-run/aiperf-trace \
+  --custom-dataset-type weka_trace \
+  --fixed-schedule \
+  --fixed-schedule-auto-offset \
+  --use-dynamo-session-control \
+  --use-server-token-count \
+  --extra-inputs ignore_eos:true \
+  --output-artifact-dir /tmp/agent-run/aiperf
+```
+
+Do not add a concurrency or request-rate cap when reproducing the capture. The recorded timestamps and graph already supply concurrency. A turn starts no earlier than both its target timestamp and its predecessor's completion, so a slower target accumulates schedule drift instead of overlapping dependent turns.
+
+`ignore_eos:true` asks the backend to generate the captured output length rather than stop early on newly sampled content. The split override prevents AIPerf from reconstructing a second conversation graph on top of the one Dynamo already built. `--use-dynamo-session-control` sends the session and parent-session headers so the replayed trace preserves agent session identity.
+
+### Offline simulation with DynoSim
+
+Pass the captured shards directly to simulated workers:
+
+```bash
+python -m dynamo.replay /tmp/agent-run/request-trace.*.jsonl.gz \
   --trace-format dynamo \
   --replay-mode offline \
   --router-mode kv_router \
   --num-workers 4 \
-  --report-json /tmp/dynamo-request-trace.replay-report.json
+  --report-json /tmp/agent-run/dynosim-report.json
 ```
 
-Replay derives the trace block size from all input shards. If every request has
-`agent_context`, replay applies the same DAG and tool-wait lowering used by the
-agentic Mooncake converter.
+DynoSim derives and validates the block size across all shards. When every request carries session identity, it also reconstructs the agent DAG and tool-wait timing. `kv_router` requires at least two simulated workers. Change worker count, routing, or engine settings to compare configurations without running the model.
 
-`kv_router` needs at least two mock workers. For a single-worker smoke test, use
-`--router-mode round_robin --num-workers 1`.
+## Step 5: Validate Fidelity
 
-## Agentic Replay Semantics
+For a successful live replay, check that:
 
-Agentic Mooncake rows preserve:
+- captured, converted, dispatched, and completed request counts match;
+- session counts and per-session turn counts match;
+- AIPerf reports no request errors;
+- replayed output lengths match the capture; and
+- arrival-time, request-duration, and cache-reuse deltas are reported.
 
-- `request_id`: the LLM request row identity.
-- Mooncake `session_id`: derived from the Dynamo `session_id`.
-- `wait_for`: request IDs that must complete before this row becomes eligible.
-- `branches`: child request IDs spawned from this row.
-- `prefix_reset`: first request in a session.
-- `delay`: non-tool delay after dependencies finish.
-- `tool_wait_ms`: tool time after dependencies finish, parallel-aware as the union of overlapping spans rather than their sum.
-- `tool_events`: per-tool spans attributed to this LLM request, each carrying `tool_call_id`, `tool_class`, `status`, `started_at_unix_ms`, `ended_at_unix_ms`, `duration_ms`, and optional `output_bytes`, `output_tokens`, or `error_type`.
-- `hash_ids`, `input_length`, and `output_length`: prompt-prefix and length data for mocker replay.
+Keep the model, tokenizer, block size, worker topology, and initial cache state the same when measuring replay fidelity. For a DynoSim run, first verify request and token totals, then compare configurations using the generated report rather than treating simulation output as hardware measurements.
 
-Rows with no `wait_for` use their `timestamp` as the replay start time. Rows with dependencies wait for all listed requests to complete, then wait `delay + tool_wait_ms` before dispatch. For more flags and engine settings, see [DynoSim Runs](../dynosim/runs.md).
+## Fidelity Boundaries
+
+Replay is intentionally content-free. Synthetic prompts preserve block-sharing topology, not the original text. Wire input length can differ slightly because the target tokenizer and chat template reconstruct the request. Service time can also differ even against the same model. Tool rows are not dispatched by AIPerf. Their elapsed time remains represented by the gap between model requests, and DynoSim can retain it as tool-wait time. If a changed model response would make the agent choose another tool or branch, that requires another live agent run rather than static trace replay.


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Turns the agent replay page into a capture-to-replay walkthrough for live AIPerf runs and offline DynoSim simulation. It makes the fidelity boundary explicit: replay preserves the request graph, timing, lengths, and hash topology, not prompts, responses, or tool side effects.

CLOSES: DYN-3248

### How This Was Implemented
- Documented trace capture with session headers, optional tool-event ingress, and sink flushing.
- Explained how session chains, parent relationships, timestamps, and global hash IDs become the replay graph.
- Added the current AIPerf conversion and fixed-schedule replay path using Dynamo header transport and trace-derived concurrency.
- Added concrete alignment checks, cache-state caveats, and direct offline replay with `--trace-format dynamo`.

<details>
<summary>Walkthrough</summary>

```mermaid
flowchart LR
    A[Agent] --> F[Dynamo frontend] --> T[Request trace]
    T --> R[Live replay trace] --> P[AIPerf] --> E[Live endpoint]
    T --> D[DynoSim]
```

</details>

### Validation
- `git diff --check`
- `pre-commit run -c /ephemeral/dynamo/.pre-commit-config.yaml codespell --files docs/agents/agent-replay.md`
- `pre-commit run -c /ephemeral/dynamo/.pre-commit-config.yaml mixed-line-ending --files docs/agents/agent-replay.md`
- `pre-commit run -c /ephemeral/dynamo/.pre-commit-config.yaml trailing-whitespace --files docs/agents/agent-replay.md`
- Live Pi/Harbor capture, AIPerf replay, and DynoSim replay against MiniMax M2.7 TP4.

### Benchmark Results
- Capture: 10/10 SWE-bench tasks passed with 0 errors; 10 sessions, 321 LLM requests, and 325 terminal tool spans in 26m37s.
- Live replay: 321/321 requests mapped with 0 errors and 321/321 exact output lengths; arrival drift p95 132 ms and duration drift p95 252 ms. Synthetic reconstruction increased total input tokens by 1.15%.
- Engine cache reuse was 96.79% during capture and 95.41% during replay (-1.38 percentage points). Offline DynoSim completed 321/321 with exact token totals and 95.45% prefix reuse.
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked the agent replay guide to describe a trace-based workflow for capturing real agent runs and replaying them in either live benchmarking or offline simulation.
  * Added clearer setup steps, validation checks, and conversion instructions for replay traces.
  * Clarified replay limitations and when a fresh agent run is needed for changes in tools or branching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->