### PR TITLE
feat(vllm): add upstream SMG sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-vllm-smg-sidecar"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "clap 4.6.1",
+ "dynamo-backend-common",
+ "dynamo-llm",
+ "dynamo-runtime",
+ "futures",
+ "prost 0.13.5",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tracing",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "lib/bench",
     "lib/backend-common",
     "lib/backend-common/examples/mocker",
+    "lib/vllm-smg-sidecar",
     "lib/bindings/c",
     "lib/bindings/python/codegen",
 ]

--- a/examples/backends/vllm/deploy/sidecar_smg_agg.yaml
+++ b/examples/backends/vllm/deploy/sidecar_smg_agg.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated serving via the upstream vLLM SMG sidecar.
+#
+# Each worker pod runs TWO containers sharing the pod network (localhost):
+#   - vllm-engine  : upstream `vllm serve --grpc` exposing SMG's vLLM service
+#                    (GPU)
+#   - mainContainer: the Dynamo vLLM SMG sidecar worker, an SMG client (CPU)
+#
+# The vLLM image must include the optional gRPC dependencies, either through
+# `vllm[grpc]` or `smg-grpc-servicer[vllm]>=0.5.2`.
+#
+# v1 scope is aggregated text/token generation. Disaggregated serving,
+# multimodal URL passthrough, KV-aware routing, and logprobs are intentionally
+# not enabled on this SMG path.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-smg-sidecar-agg
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    VllmSmgSidecarWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        # Engine container: holds the GPU and runs upstream vLLM's SMG server.
+        containers:
+          - name: vllm-engine
+            image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+            command:
+              - vllm
+              - serve
+              - Qwen/Qwen3-0.6B
+              - --grpc
+              - --host
+              - 127.0.0.1
+              - --port
+              - "50051"
+              - --enforce-eager
+            resources:
+              limits:
+                nvidia.com/gpu: "1"
+        # Sidecar container (Dynamo worker): CPU-only SMG client.
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - dynamo-vllm-smg-sidecar
+          args:
+            - --smg-endpoint
+            - 127.0.0.1:50051

--- a/examples/backends/vllm/launch/sidecar_smg_agg.sh
+++ b/examples/backends/vllm/launch/sidecar_smg_agg.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated serving via the upstream vLLM SMG sidecar (1 GPU).
+#
+# This launches three processes:
+#   1. Dynamo frontend (HTTP ingress)
+#   2. Upstream `vllm serve --grpc` exposing SMG's vLLM gRPC service
+#   3. The Dynamo vLLM SMG sidecar worker, which talks to (2)
+#
+# The vLLM environment must include the optional gRPC dependencies:
+#   pip install 'vllm[grpc]'
+# or equivalently:
+#   pip install 'smg-grpc-servicer[vllm]>=0.5.2'
+#
+# v1 scope is aggregated text/token generation. Disaggregated serving,
+# multimodal URL passthrough, KV-aware routing, and logprobs are intentionally
+# not enabled on this SMG path.
+
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+
+# Default model
+MODEL="Qwen/Qwen3-0.6B"
+
+# Parse command line arguments
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo "Options:"
+            echo "  --model <name>       Specify model (default: $MODEL)"
+            echo "  -h, --help           Show this help message"
+            echo ""
+            echo "Additional options are passed through to vllm serve --grpc."
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# ---- Tunable (override via env vars) ----
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_CONCURRENT_SEQS="${MAX_CONCURRENT_SEQS:-2}"
+SMG_HOST="${SMG_HOST:-127.0.0.1}"
+SMG_PORT="${SMG_PORT:-50051}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+print_launch_banner "Launching SMG Sidecar Aggregated Serving (1 GPU)" "$MODEL" "$HTTP_PORT"
+
+# 1. Dynamo frontend (HTTP ingress)
+"$PYTHON_BIN" -m dynamo.frontend &
+
+# 2. Upstream vLLM engine with SMG gRPC enabled. The vLLM OpenAI HTTP server is
+# not started in this mode; --port is the gRPC listener port when --grpc is set.
+vllm serve "$MODEL" \
+    --grpc \
+    --host "$SMG_HOST" \
+    --port "$SMG_PORT" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --enforce-eager \
+    --max-num-seqs "$MAX_CONCURRENT_SEQS" \
+    "${EXTRA_ARGS[@]}" &
+
+# 3. Dynamo SMG sidecar worker (no vllm import; SMG client only).
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+    dynamo-vllm-smg-sidecar \
+    --smg-endpoint "${SMG_HOST}:${SMG_PORT}" &
+
+# Exit on first process failure; kill 0 in the EXIT trap tears down the rest
+wait_any_exit

--- a/lib/vllm-smg-sidecar/Cargo.toml
+++ b/lib/vllm-smg-sidecar/Cargo.toml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-vllm-smg-sidecar"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Dynamo vLLM SMG sidecar backend — drives an out-of-process upstream vLLM --grpc engine through the backend-common LLMEngine trait."
+
+[[bin]]
+name = "dynamo-vllm-smg-sidecar"
+path = "src/main.rs"
+
+[dependencies]
+dynamo-backend-common = { workspace = true }
+
+anyhow = { workspace = true }
+async-stream = { workspace = true }
+async-trait = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }
+futures = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+
+# Match the existing vLLM OpenEngine sidecar's tonic/prost pins.
+prost = { version = "0.13.5" }
+tonic = { version = "0.13.1" }
+
+[build-dependencies]
+tonic-build = { version = "0.13.1" }
+
+[dev-dependencies]
+dynamo-backend-common = { workspace = true, features = ["testing"] }
+dynamo-llm = { workspace = true }
+dynamo-runtime = { workspace = true }
+tokio-stream = { workspace = true, features = ["net"] }

--- a/lib/vllm-smg-sidecar/build.rs
+++ b/lib/vllm-smg-sidecar/build.rs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compiles the vendored SMG vLLM proto into client + server stubs.
+//!
+//! The sources are copied from `smg-grpc-proto==0.4.11`, which is what upstream
+//! vLLM's `vllm[grpc]` path consumes through `smg-grpc-servicer`.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile_protos(
+            &["proto/common.proto", "proto/vllm_engine.proto"],
+            &["proto"],
+        )?;
+    println!("cargo:rerun-if-changed=proto/common.proto");
+    println!("cargo:rerun-if-changed=proto/vllm_engine.proto");
+    Ok(())
+}

--- a/lib/vllm-smg-sidecar/proto/common.proto
+++ b/lib/vllm-smg-sidecar/proto/common.proto
@@ -1,0 +1,94 @@
+syntax = "proto3";
+package smg.grpc.common;
+
+// =====================
+// Tokenizer
+// =====================
+
+message GetTokenizerRequest {}
+
+message GetTokenizerChunk {
+  bytes data = 1;       // Raw zip bytes (concatenate all chunks)
+  string sha256 = 2;    // SHA-256 fingerprint; set on final chunk only, empty on previous
+}
+
+// =====================
+// KV Cache Events
+// =====================
+
+message SubscribeKvEventsRequest {
+  // Resume from this sequence number (0 = start from current state).
+  uint64 start_sequence_number = 1;
+}
+
+message KvEventBatch {
+  uint64 sequence_number = 1;
+  double timestamp = 2;
+  repeated KvCacheEvent events = 3;
+  optional int32 dp_rank = 4;
+}
+
+message KvCacheEvent {
+  uint64 event_id = 1;
+  oneof data {
+    KvBlocksStored stored = 2;
+    KvBlocksRemoved removed = 3;
+    KvCacheCleared cleared = 4;
+  }
+}
+
+message KvBlocksStored {
+  repeated KvBlock blocks = 1;
+  optional int64 parent_block_hash = 2;
+}
+
+message KvBlock {
+  int64 block_hash = 1;
+  repeated uint32 token_ids = 2;
+  int32 block_size = 3;
+  optional int64 lora_id = 4;
+  optional int32 cache_level = 5;
+}
+
+message KvBlocksRemoved {
+  repeated int64 block_hashes = 1;
+  optional int32 cache_level = 2;
+}
+
+message KvCacheCleared {}
+
+// =====================
+// Admin Operations
+// =====================
+
+message FlushCacheRequest {
+  // Seconds to wait for the scheduler to go idle before flushing.
+  // 0 = flush immediately (fails if requests are in flight).
+  float timeout_s = 1;
+}
+
+message FlushCacheResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+message StartProfileRequest {
+  // Directory where profiler traces are written (backend default if unset).
+  optional string output_dir = 1;
+  // Forward step at which profiling starts (immediately if unset).
+  optional int32 start_step = 2;
+  // Number of forward steps to profile (until StopProfile if unset).
+  optional int32 num_steps = 3;
+  // Profiler activities, e.g. "CPU", "GPU", "MEM". Backend default if empty.
+  repeated string activities = 4;
+  optional bool with_stack = 5;
+  optional bool record_shapes = 6;
+  bool profile_by_stage = 7;
+}
+
+message StopProfileRequest {}
+
+message ProfileResponse {
+  bool success = 1;
+  string message = 2;
+}

--- a/lib/vllm-smg-sidecar/proto/vllm_engine.proto
+++ b/lib/vllm-smg-sidecar/proto/vllm_engine.proto
@@ -1,0 +1,385 @@
+syntax = "proto3";
+
+package vllm.grpc.engine;
+
+import "common.proto";
+
+// Service definition for vLLM engine communication
+// This protocol is designed for efficient binary communication between
+// the Rust router and vLLM Python engine (AsyncLLM).
+service VllmEngine {
+  // Submit a generation request (supports streaming)
+  rpc Generate(GenerateRequest) returns (stream GenerateResponse);
+
+  // Submit an embedding request
+  rpc Embed(EmbedRequest) returns (EmbedResponse);
+
+  // Health check
+  rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // Abort a running request
+  rpc Abort(AbortRequest) returns (AbortResponse);
+
+  // Get model information
+  rpc GetModelInfo(GetModelInfoRequest) returns (GetModelInfoResponse);
+
+  // Get server information
+  rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+
+  // Get scheduler load metrics
+  rpc GetLoads(GetLoadsRequest) returns (GetLoadsResponse);
+
+  // Get tokenizer artifacts for remote construction
+  rpc GetTokenizer(smg.grpc.common.GetTokenizerRequest) returns (stream smg.grpc.common.GetTokenizerChunk);
+
+  // Subscribe to KV cache events (server-streaming)
+  rpc SubscribeKvEvents(smg.grpc.common.SubscribeKvEventsRequest)
+      returns (stream smg.grpc.common.KvEventBatch);
+}
+
+// =====================
+// Common Types
+// =====================
+
+// Sampling parameters for text generation
+message SamplingParams {
+  optional float temperature = 1;
+  float top_p = 2;
+  uint32 top_k = 3;
+  float min_p = 4;
+  float frequency_penalty = 5;
+  float presence_penalty = 6;
+  float repetition_penalty = 7;
+
+  optional uint32 max_tokens = 8;
+  uint32 min_tokens = 9;
+
+  repeated string stop = 10;
+  repeated uint32 stop_token_ids = 11;
+
+  bool skip_special_tokens = 12;
+  bool spaces_between_special_tokens = 13;
+  bool ignore_eos = 14;
+
+  uint32 n = 15;  // Number of parallel samples
+
+  // Logprobs configuration
+  optional int32 logprobs = 22;  // Number of log probabilities per output token (-1 for all)
+  optional int32 prompt_logprobs = 23;  // Number of log probabilities per prompt token (-1 for all)
+
+  // Additional vLLM fields
+  optional int32 seed = 24;  // Random seed for reproducibility
+  bool include_stop_str_in_output = 25;  // Whether to include stop strings in output
+  map<int32, float> logit_bias = 26;  // Token ID to bias mapping (-100 to 100)
+  optional int32 truncate_prompt_tokens = 27;  // Prompt truncation (-1 for model max)
+
+  // Structured outputs (one of) - matches vLLM's StructuredOutputsParams
+  oneof constraint {
+    string json_schema = 16;  // JSON schema for structured output
+    string regex = 17;  // Regex pattern
+    string grammar = 18;  // Grammar/EBNF for structured output
+    string structural_tag = 19;  // Structural tag (e.g., Harmony models)
+    bool json_object = 20;  // Force JSON object output
+    ChoiceConstraint choice = 21;  // List of allowed choices
+  }
+}
+
+// Choice constraint for structured outputs
+message ChoiceConstraint {
+  repeated string choices = 1;
+}
+
+// Pre-tokenized input from Rust router
+message TokenizedInput {
+  string original_text = 1;  // For reference/debugging
+  repeated uint32 input_ids = 2;  // Actual token IDs to process
+}
+
+// A typed tensor: raw little-endian bytes + shape + dtype.
+message TensorData {
+  bytes data = 1;              // Raw little-endian bytes (f32/i64/u32)
+  repeated uint32 shape = 2;   // Dimension sizes
+  string dtype = 3;            // "float32", "int64", "uint32"
+}
+
+message PlaceholderRange {
+  uint32 offset = 1;
+  uint32 length = 2;
+}
+
+// Multimodal inputs for vision/audio models
+message MultimodalInputs {
+  // Reserved: field 1 was image_data (raw bytes), removed in favor of
+  // preprocessed pixel_values.
+  reserved 1;
+
+  // Preprocessed pixel values tensor
+  TensorData pixel_values = 2;
+
+  // Model-specific tensors (image_grid_thw, aspect_ratios, etc.)
+  map<string, TensorData> model_specific_tensors = 3;
+
+  // Image token ID used for placeholder expansion
+  optional uint32 im_token_id = 4;
+
+  // Placeholder offsets: where each image's tokens are in input_ids
+  repeated PlaceholderRange mm_placeholders = 5;
+
+  // Per-image blake3 hex hashes for encoder output caching
+  repeated string mm_hashes = 6;
+
+  // Tensor keys whose first dimension is per-image (batched).
+  // Keys not listed here are shared across all images.
+  repeated string batched_keys = 7;
+
+  // Tensor keys that need flat slicing: maps tensor name -> sizes tensor name.
+  // e.g. {"pixel_values": "patches_per_image"} means pixel_values should be
+  // split per-item using sizes from the patches_per_image tensor.
+  map<string, string> flat_keys = 8;
+
+  // Tensor keys that should remain on CPU (not transferred to GPU).
+  // Maps to vLLM's MultiModalFieldConfig keep_on_cpu flag.
+  repeated string keep_on_cpu_keys = 9;
+}
+
+// =====================
+// Generate Request
+// =====================
+
+message GenerateRequest {
+  string request_id = 1;
+
+  // Prompt input
+  oneof input {
+    TokenizedInput tokenized = 2;
+    string text = 3;
+  }
+
+  // Generation parameters (includes logprobs config)
+  SamplingParams sampling_params = 4;
+
+  // Streaming
+  bool stream = 5;
+
+  // KV transfer parameters for PD disaggregation (Mooncake)
+  // Decode worker uses this to fetch KV cache from prefill worker
+  // Deprecated: use kv_transfer_params_json instead
+  KvTransferParams kv_transfer_params = 6;
+
+  // Optional multimodal data (images for vision models)
+  MultimodalInputs mm_inputs = 7;
+
+  // Connector KV-transfer params as a JSON object, passed verbatim to the
+  // engine (e.g. NIXL's do_remote_prefill/remote_block_ids/remote_host/...).
+  // Preferred over the legacy typed kv_transfer_params field.
+  optional string kv_transfer_params_json = 8;
+
+  // DP rank to pin this request to; unset lets the engine balance internally
+  optional int32 data_parallel_rank = 9;
+}
+
+// KV cache transfer parameters for Mooncake PD disaggregation
+// Deprecated: use kv_transfer_params_json on GenerateRequest/GenerateComplete
+message KvTransferParams {
+  string remote_host = 1;  // Prefill worker's side-channel host
+  uint32 remote_port = 2;  // Prefill worker's side-channel port
+}
+
+// =====================
+// Logprobs Types
+// =====================
+
+// Output logprobs - matches SGLang structure for code reuse
+message OutputLogProbs {
+  repeated float token_logprobs = 1;   // Logprob for each output token
+  repeated uint32 token_ids = 2;       // Token ID for each position
+  repeated TopLogProbs top_logprobs = 3; // Top-k alternatives per position
+}
+
+// Input (prompt) logprobs - first token has no logprob (None)
+message InputLogProbs {
+  repeated InputTokenLogProb token_logprobs = 1;  // Logprob per prompt token
+  repeated uint32 token_ids = 2;                  // Prompt token IDs
+  repeated TopLogProbs top_logprobs = 3;          // Top-k alternatives per position
+}
+
+// Wrapper for optional logprob (first prompt token has no logprob)
+message InputTokenLogProb {
+  optional float value = 1;
+}
+
+message TopLogProbs {
+  repeated float values = 1;           // Logprob values for top-k tokens
+  repeated uint32 token_ids = 2;       // Token IDs for top-k tokens
+}
+
+// =====================
+// Generate Response
+// =====================
+
+message GenerateResponse {
+  oneof response {
+    GenerateStreamChunk chunk = 1;     // For streaming
+    GenerateComplete complete = 2;     // For final/non-streaming
+  }
+}
+
+message GenerateStreamChunk {
+  repeated uint32 token_ids = 1;       // Incremental tokens
+  uint32 prompt_tokens = 2;
+  uint32 completion_tokens = 3;
+  uint32 cached_tokens = 4;
+
+  // Logprobs support
+  OutputLogProbs output_logprobs = 5;
+  InputLogProbs input_logprobs = 6;  // Only in first chunk
+
+  // Index for n>1 support (0-indexed, identifies which of n outputs this belongs to)
+  uint32 index = 7;
+}
+
+message GenerateComplete {
+  repeated uint32 output_ids = 1;      // All output tokens
+  string finish_reason = 2;            // "stop", "length", "abort"
+  uint32 prompt_tokens = 3;
+  uint32 completion_tokens = 4;
+  uint32 cached_tokens = 5;
+
+  // Logprobs support
+  OutputLogProbs output_logprobs = 6;
+  InputLogProbs input_logprobs = 7;
+
+  // Index for n>1 support (0-indexed, identifies which of n outputs this belongs to)
+  uint32 index = 8;
+
+  // KV transfer parameters returned by prefill worker (Mooncake PD)
+  // Contains prefill's side-channel address for decode to fetch KV cache
+  // Deprecated: use kv_transfer_params_json instead
+  KvTransferParams kv_transfer_params = 9;
+
+  // Matched stop information (for stop sequences)
+  oneof matched_stop {
+    uint32 matched_token_id = 10;
+    string matched_stop_str = 11;
+  }
+
+  // Connector KV-transfer params returned by the engine, as a JSON object
+  // (e.g. NIXL's handoff for the decode worker). Forwarded verbatim by the router.
+  optional string kv_transfer_params_json = 12;
+}
+
+// =====================
+// Embedding Request
+// =====================
+
+message EmbedRequest {
+  string request_id = 1;
+  TokenizedInput tokenized = 2;
+}
+
+message EmbedResponse {
+  repeated float embedding = 1;
+  uint32 prompt_tokens = 2;
+  uint32 embedding_dim = 3;
+}
+
+// =====================
+// Management Operations
+// =====================
+
+message HealthCheckRequest {}
+
+message HealthCheckResponse {
+  bool healthy = 1;
+  string message = 2;
+}
+
+message AbortRequest {
+  repeated string request_ids = 1;
+}
+
+message AbortResponse {
+}
+
+// =====================
+// Model and Server Info
+// =====================
+
+message GetModelInfoRequest {}
+
+message GetModelInfoResponse {
+  string model_path = 1;
+  bool is_generation = 2;
+  uint32 max_context_length = 3;
+  uint32 vocab_size = 4;
+  bool supports_vision = 5;
+  string served_model_name = 6;
+  string tokenizer_path = 7;
+  string model_type = 8;
+  repeated string architectures = 9;
+  repeated int32 eos_token_ids = 10;
+  int32 pad_token_id = 11;
+  int32 bos_token_id = 12;
+  int32 max_req_input_len = 13;
+  string default_sampling_params_json = 14;
+}
+
+message GetServerInfoRequest {}
+
+message GetServerInfoResponse {
+  uint32 active_requests = 1;
+  bool is_paused = 2;
+  double last_receive_timestamp = 3;
+  double uptime_seconds = 4;
+  string server_type = 5;  // "vllm-grpc"
+
+  // KV transfer config (for PD disaggregation)
+  string kv_connector = 6;  // "MooncakeConnector", "NixlConnector", "" if not configured
+  string kv_role = 7;       // "kv_producer", "kv_consumer", "kv_both", "" if not configured
+  string kv_engine_id = 8;  // kv_transfer_config.engine_id, "" if not configured
+
+  int32 data_parallel_size = 9;  // parallel_config.data_parallel_size (1 when DP is off)
+}
+
+// =====================
+// Load Metrics
+// =====================
+
+message GetLoadsRequest {
+  // Optional: filter to a specific DP rank.
+  optional int32 dp_rank = 1;
+
+  // Sections to include (e.g. "core"). vLLM currently emits only core metrics.
+  repeated string include = 2;
+}
+
+message GetLoadsResponse {
+  // ISO 8601 timestamp.
+  string timestamp = 1;
+
+  // vLLM version.
+  string version = 2;
+
+  // Number of DP ranks reported.
+  int32 dp_rank_count = 3;
+
+  // Per-DP-rank load metrics.
+  repeated SchedulerLoad loads = 4;
+}
+
+// Per-DP-rank scheduler load snapshot. vLLM populates the fields it can read
+// cheaply from the engine's scheduler stats; unset fields are 0.
+message SchedulerLoad {
+  int32 dp_rank = 1;
+  int32 num_running_reqs = 2;
+  int32 num_waiting_reqs = 3;
+  int32 num_total_reqs = 4;
+  int32 num_used_tokens = 5;
+  int32 max_total_num_tokens = 6;
+  // KV-cache utilization in [0,1) (vLLM SchedulerStats.kv_cache_usage).
+  double token_usage = 7;
+  double gen_throughput = 8;
+  double cache_hit_rate = 9;
+  double utilization = 10;
+  int32 max_running_requests = 11;
+}

--- a/lib/vllm-smg-sidecar/src/args.rs
+++ b/lib/vllm-smg-sidecar/src/args.rs
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Command-line arguments for the vLLM SMG sidecar.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Parsed sidecar arguments.
+#[derive(clap::Parser, Debug, Clone)]
+#[command(
+    name = "dynamo-vllm-smg-sidecar",
+    about = "Dynamo vLLM SMG sidecar — drives upstream vLLM `serve --grpc` in aggregated text mode."
+)]
+pub struct Args {
+    /// `host:port` (or full URL) of the upstream vLLM SMG gRPC server.
+    ///
+    /// A bare `host:port` is normalised to `http://host:port`.
+    #[arg(long, env = "SMG_ENDPOINT")]
+    pub smg_endpoint: String,
+
+    /// Number of independent gRPC connections to open to the engine.
+    #[arg(long, env = "SMG_CONNECTIONS", default_value_t = 8)]
+    pub smg_connections: usize,
+
+    /// Dynamo namespace for discovery routing.
+    #[arg(long, env = "DYN_NAMESPACE", default_value = "dynamo")]
+    pub namespace: String,
+
+    /// Endpoint name exposed by this worker.
+    #[arg(long, env = "DYN_ENDPOINT", default_value = "generate")]
+    pub endpoint: String,
+
+    /// Comma-separated endpoint types (e.g. `chat,completions`).
+    #[arg(long, env = "DYN_ENDPOINT_TYPES", default_value = "chat,completions")]
+    pub endpoint_types: String,
+
+    /// Optional path to a custom Jinja chat template.
+    #[arg(long, env = "DYN_CUSTOM_JINJA_TEMPLATE")]
+    pub custom_jinja_template: Option<PathBuf>,
+
+    /// Per-attempt connect timeout, in seconds, when dialling the engine.
+    #[arg(long, default_value_t = 30)]
+    pub connect_timeout_secs: u64,
+
+    /// How often (seconds) to poll health while waiting for readiness.
+    #[arg(long, default_value_t = 2)]
+    pub health_poll_interval_secs: u64,
+
+    /// Upper bound (seconds) on bootstrap connectivity and readiness.
+    #[arg(long, default_value_t = 300)]
+    pub health_deadline_secs: u64,
+}
+
+impl Args {
+    /// Transport tunables distilled into [`Duration`]s.
+    pub fn transport(&self) -> TransportConfig {
+        TransportConfig {
+            connect_timeout: Duration::from_secs(self.connect_timeout_secs),
+            poll_interval: Duration::from_secs(self.health_poll_interval_secs.max(1)),
+            deadline: Duration::from_secs(self.health_deadline_secs),
+            connections: self.smg_connections.max(1),
+        }
+    }
+}
+
+/// Connection + readiness tunables shared by bootstrap and `start`.
+#[derive(Debug, Clone)]
+pub struct TransportConfig {
+    pub connect_timeout: Duration,
+    pub poll_interval: Duration,
+    pub deadline: Duration,
+    pub connections: usize,
+}
+
+impl Default for TransportConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout: Duration::from_secs(30),
+            poll_interval: Duration::from_secs(2),
+            deadline: Duration::from_secs(300),
+            connections: 1,
+        }
+    }
+}
+
+/// Normalise an endpoint into a URI tonic accepts.
+pub fn normalize_endpoint(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("http://{trimmed}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_host_port_gets_http_scheme() {
+        assert_eq!(
+            normalize_endpoint("127.0.0.1:50051"),
+            "http://127.0.0.1:50051"
+        );
+    }
+
+    #[test]
+    fn explicit_scheme_is_preserved() {
+        assert_eq!(normalize_endpoint("https://host:443"), "https://host:443");
+        assert_eq!(normalize_endpoint("http://host:1"), "http://host:1");
+    }
+
+    #[test]
+    fn whitespace_is_trimmed() {
+        assert_eq!(normalize_endpoint("  host:9  "), "http://host:9");
+    }
+}

--- a/lib/vllm-smg-sidecar/src/client.rs
+++ b/lib/vllm-smg-sidecar/src/client.rs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Thin SMG vLLM gRPC client: connect-with-backoff, discovery, and error
+//! mapping into [`DynamoError`].
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use dynamo_backend_common::{BackendError, DynamoError, ErrorType};
+use tokio::time::Instant;
+use tonic::transport::{Channel, Endpoint};
+
+use crate::args::TransportConfig;
+use crate::proto::engine as pb;
+use crate::proto::engine::vllm_engine_client::VllmEngineClient;
+
+/// Connected SMG vLLM client over a tonic [`Channel`].
+pub type Client = VllmEngineClient<Channel>;
+
+/// Engine discovery snapshot: model metadata plus server / KV role metadata.
+#[derive(Clone, Debug)]
+pub struct Discovery {
+    pub model: pb::GetModelInfoResponse,
+    pub server: pb::GetServerInfoResponse,
+}
+
+/// Dial the engine, retrying with backoff until reachable or the deadline
+/// elapses.
+pub async fn connect(uri: &str, cfg: &TransportConfig) -> Result<Client, DynamoError> {
+    let deadline = Instant::now() + cfg.deadline;
+    let mut last_err;
+    loop {
+        match try_connect_once(uri, cfg).await {
+            Ok(client) => return Ok(client),
+            Err(e) => {
+                last_err = e;
+                if Instant::now() >= deadline {
+                    return Err(cannot_connect(format!(
+                        "could not reach SMG vLLM engine at {uri} within {:?}: {last_err}",
+                        cfg.deadline
+                    )));
+                }
+                tokio::time::sleep(cfg.poll_interval).await;
+            }
+        }
+    }
+}
+
+async fn try_connect_once(uri: &str, cfg: &TransportConfig) -> Result<Client, String> {
+    let endpoint = Endpoint::from_shared(uri.to_string())
+        .map_err(|e| format!("invalid endpoint `{uri}`: {e}"))?
+        .connect_timeout(cfg.connect_timeout);
+    let channel = endpoint.connect().await.map_err(|e| e.to_string())?;
+    Ok(VllmEngineClient::new(channel))
+}
+
+/// A fixed-size pool of independent SMG gRPC connections.
+pub struct Pool {
+    clients: Vec<Client>,
+    next: AtomicUsize,
+}
+
+impl Pool {
+    /// Dial `size` (clamped to >=1) independent connections to `uri`.
+    pub async fn connect(
+        uri: &str,
+        cfg: &TransportConfig,
+        size: usize,
+    ) -> Result<Self, DynamoError> {
+        let size = size.max(1);
+        let mut clients = Vec::with_capacity(size);
+        for _ in 0..size {
+            clients.push(connect(uri, cfg).await?);
+        }
+        Ok(Self {
+            clients,
+            next: AtomicUsize::new(0),
+        })
+    }
+
+    /// Number of connections in the pool (always >= 1).
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.clients.len()
+    }
+
+    /// Round-robin a client for a streaming `Generate` call.
+    pub fn stream_client(&self) -> Client {
+        let i = self.next.fetch_add(1, Ordering::Relaxed) % self.clients.len();
+        self.clients[i].clone()
+    }
+
+    /// A stable client for low-frequency control RPCs.
+    pub fn control_client(&self) -> Client {
+        self.clients[0].clone()
+    }
+}
+
+/// Fetch model + server metadata in one shot.
+pub async fn discover(client: &mut Client) -> Result<Discovery, DynamoError> {
+    let model = client
+        .get_model_info(pb::GetModelInfoRequest {})
+        .await
+        .map_err(|s| status_to_dynamo("GetModelInfo", s))?
+        .into_inner();
+    let server = client
+        .get_server_info(pb::GetServerInfoRequest {})
+        .await
+        .map_err(|s| status_to_dynamo("GetServerInfo", s))?
+        .into_inner();
+    Ok(Discovery { model, server })
+}
+
+// ============================================================================
+// Error mapping
+// ============================================================================
+
+fn backend(kind: BackendError, msg: impl Into<String>) -> DynamoError {
+    DynamoError::builder()
+        .error_type(ErrorType::Backend(kind))
+        .message(msg)
+        .build()
+}
+
+/// Client-supplied bad input.
+pub fn invalid_arg(msg: impl Into<String>) -> DynamoError {
+    backend(BackendError::InvalidArgument, msg)
+}
+
+/// The engine is gone / never came up / used before start.
+pub fn engine_shutdown(msg: impl Into<String>) -> DynamoError {
+    backend(BackendError::EngineShutdown, msg)
+}
+
+/// Could not establish the transport to the engine.
+pub fn cannot_connect(msg: impl Into<String>) -> DynamoError {
+    backend(BackendError::CannotConnect, msg)
+}
+
+/// Map a tonic transport-level [`Status`](tonic::Status) to a typed error.
+pub fn status_to_dynamo(rpc: &str, status: tonic::Status) -> DynamoError {
+    let kind = match status.code() {
+        tonic::Code::InvalidArgument | tonic::Code::NotFound | tonic::Code::OutOfRange => {
+            BackendError::InvalidArgument
+        }
+        tonic::Code::Unavailable => BackendError::CannotConnect,
+        tonic::Code::Cancelled => BackendError::Cancelled,
+        tonic::Code::DeadlineExceeded => BackendError::ConnectionTimeout,
+        _ => BackendError::Unknown,
+    };
+    backend(
+        kind,
+        format!("{rpc}: {} ({:?})", status.message(), status.code()),
+    )
+}

--- a/lib/vllm-smg-sidecar/src/engine.rs
+++ b/lib/vllm-smg-sidecar/src/engine.rs
@@ -1,0 +1,668 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `VllmSmgSidecarEngine` — an [`LLMEngine`] that drives upstream vLLM
+//! `serve --grpc` over SMG's `vllm.grpc.engine.VllmEngine` service.
+//!
+//! This is intentionally smaller than the OpenEngine sidecar. SMG's upstream
+//! vLLM servicer provides generation, health, abort, and coarse model/server
+//! metadata, but not enough stable surface for Dynamo-equivalent disaggregated
+//! serving, KV-event routing, or URL-passthrough multimodal inputs. The first
+//! implementation is therefore aggregated text/token generation only.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dynamo_backend_common::{
+    AsyncEngineContext, DisaggregationMode, DynamoError, EngineConfig, GenerateContext,
+    HEALTH_CHECK_KEY, LLMEngine, LLMEngineOutput, LLMEngineOutputExt, PreprocessedRequest,
+    WorkerConfig, usage,
+};
+use futures::stream::BoxStream;
+use tokio::sync::{OnceCell, watch};
+use tokio::time::{Instant, MissedTickBehavior};
+use tokio_util::sync::CancellationToken;
+
+use crate::args::{Args, TransportConfig, normalize_endpoint};
+use crate::client::{self, Client, Discovery, Pool};
+use crate::proto::engine as pb;
+
+/// A Dynamo backend that proxies inference to an upstream vLLM SMG server.
+pub struct VllmSmgSidecarEngine {
+    /// Normalised gRPC endpoint (e.g. `http://127.0.0.1:50051`).
+    endpoint: String,
+    /// Connect / readiness tunables.
+    transport: TransportConfig,
+    /// Connection pool, set once in `start()`.
+    pool: OnceCell<Pool>,
+    /// Cancels in-flight `generate()` streams on `cleanup()`.
+    cancel: CancellationToken,
+    /// Set when the out-of-process SMG server can no longer serve.
+    fatal: watch::Sender<Option<String>>,
+}
+
+impl VllmSmgSidecarEngine {
+    /// Direct constructor. The public entry point is [`from_args`](Self::from_args);
+    /// this exists for programmatic / test construction.
+    pub(crate) fn new(endpoint: impl Into<String>, transport: TransportConfig) -> Self {
+        let (fatal, _) = watch::channel(None);
+        Self {
+            endpoint: endpoint.into(),
+            transport,
+            pool: OnceCell::new(),
+            cancel: CancellationToken::new(),
+            fatal,
+        }
+    }
+
+    /// Parse CLI args, bootstrap-discover the engine metadata, and build the
+    /// pair `run()` consumes.
+    pub fn from_args(argv: Option<Vec<String>>) -> Result<(Self, WorkerConfig), DynamoError> {
+        let args = match argv {
+            Some(a) => <Args as clap::Parser>::try_parse_from(a),
+            None => <Args as clap::Parser>::try_parse(),
+        }
+        .map_err(|e| client::invalid_arg(e.to_string()))?;
+
+        let endpoint = normalize_endpoint(&args.smg_endpoint);
+        let transport = args.transport();
+
+        let discovery = bootstrap_discover(&endpoint, &transport)?;
+        validate_discovery(&discovery)?;
+
+        let served_model_name = (!discovery.model.served_model_name.is_empty())
+            .then(|| discovery.model.served_model_name.clone());
+
+        tracing::info!(
+            %endpoint,
+            model = %discovery.model.model_path,
+            served_model_name = ?served_model_name,
+            kv_role = %discovery.server.kv_role,
+            "vllm SMG sidecar bootstrapped engine discovery"
+        );
+
+        let config = WorkerConfig {
+            namespace: args.namespace,
+            component: "backend".to_string(),
+            endpoint: args.endpoint,
+            endpoint_types: args.endpoint_types,
+            custom_jinja_template: args.custom_jinja_template,
+            disaggregation_mode: DisaggregationMode::Aggregated,
+            model_name: discovery.model.model_path.clone(),
+            served_model_name,
+            ..Default::default()
+        };
+
+        let engine = Self::new(endpoint, transport);
+        Ok((engine, config))
+    }
+
+    /// Poll SMG `HealthCheck` until the engine reports healthy or the deadline
+    /// elapses. Transient RPC errors are retried because the vLLM process may
+    /// still be loading the model.
+    async fn await_ready(&self, client: &mut Client) -> Result<(), DynamoError> {
+        let deadline = Instant::now() + self.transport.deadline;
+        loop {
+            let outcome = client.health_check(pb::HealthCheckRequest {}).await;
+            let retry_msg = match outcome {
+                Ok(resp) => {
+                    let resp = resp.into_inner();
+                    if resp.healthy {
+                        return Ok(());
+                    }
+                    if resp.message.is_empty() {
+                        "engine health check returned unhealthy".to_string()
+                    } else {
+                        format!("engine unhealthy: {}", resp.message)
+                    }
+                }
+                Err(status) => format!("HealthCheck RPC failed: {}", status.message()),
+            };
+
+            if Instant::now() >= deadline {
+                return Err(client::engine_shutdown(format!(
+                    "SMG vLLM engine did not become healthy within {:?}: {retry_msg}",
+                    self.transport.deadline
+                )));
+            }
+            tokio::time::sleep(self.transport.poll_interval).await;
+        }
+    }
+}
+
+#[async_trait]
+impl LLMEngine for VllmSmgSidecarEngine {
+    async fn start(&self, _worker_id: u64) -> Result<EngineConfig, DynamoError> {
+        if self.pool.initialized() {
+            return Err(client::engine_shutdown("vllm SMG sidecar already started"));
+        }
+
+        let pool =
+            Pool::connect(&self.endpoint, &self.transport, self.transport.connections).await?;
+        let mut control = pool.control_client();
+        self.await_ready(&mut control).await?;
+        let discovery = client::discover(&mut control).await?;
+        validate_discovery(&discovery)?;
+
+        let pool_size = pool.len();
+        self.pool
+            .set(pool)
+            .map_err(|_| client::engine_shutdown("vllm SMG sidecar already started"))?;
+
+        let config = build_engine_config(&discovery);
+        tracing::info!(
+            model = %config.model,
+            context_length = ?config.context_length,
+            data_parallel_size = ?config.data_parallel_size,
+            connections = pool_size,
+            "vllm SMG sidecar started"
+        );
+        Ok(config)
+    }
+
+    async fn generate(
+        &self,
+        request: PreprocessedRequest,
+        ctx: GenerateContext,
+    ) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
+        validate_supported_request(&request)?;
+
+        let mut client = self
+            .pool
+            .get()
+            .map(Pool::stream_client)
+            .ok_or_else(|| client::engine_shutdown("generate called before start"))?;
+
+        let prompt_len = request.token_ids.len() as u32;
+        let grpc_req = build_generate_request(&request, ctx.id())?;
+        let cancel = self.cancel.clone();
+        let fatal = self.fatal.clone();
+        let current_failure = {
+            let fatal_rx = self.fatal.subscribe();
+            fatal_rx.borrow().as_ref().cloned()
+        };
+
+        Ok(Box::pin(async_stream::stream! {
+            if let Some(reason) = current_failure {
+                yield Err(client::engine_shutdown(reason));
+                return;
+            }
+
+            if ctx.is_stopped() || cancel.is_cancelled() {
+                yield Ok(LLMEngineOutput::cancelled().with_usage(usage(prompt_len, 0)));
+                return;
+            }
+
+            let open = tokio::select! {
+                biased;
+                _ = ctx.stopped() => None,
+                _ = cancel.cancelled() => None,
+                res = client.generate(grpc_req) => Some(res),
+            };
+            let Some(open) = open else {
+                yield Ok(LLMEngineOutput::cancelled().with_usage(usage(prompt_len, 0)));
+                return;
+            };
+            let mut stream = match open {
+                Ok(resp) => resp.into_inner(),
+                Err(status) => {
+                    if is_fatal_generate_status(status.code()) {
+                        let err = fatal_generate_error(status);
+                        signal_engine_failure(&fatal, err.message().to_string());
+                        yield Err(err);
+                    } else {
+                        yield Err(client::status_to_dynamo("Generate", status));
+                    }
+                    return;
+                }
+            };
+
+            let mut generated: u32 = 0;
+            let mut prompt_tokens = prompt_len;
+
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = ctx.stopped() => {
+                        yield Ok(LLMEngineOutput::cancelled()
+                            .with_usage(usage(prompt_tokens, generated)));
+                        break;
+                    }
+                    _ = cancel.cancelled() => {
+                        yield Ok(LLMEngineOutput::cancelled()
+                            .with_usage(usage(prompt_tokens, generated)));
+                        break;
+                    }
+                    msg = stream.message() => {
+                        match msg {
+                            Ok(Some(resp)) => {
+                                match resp.response {
+                                    Some(pb::generate_response::Response::Chunk(chunk)) => {
+                                        if chunk.prompt_tokens != 0 {
+                                            prompt_tokens = chunk.prompt_tokens;
+                                        }
+                                        if chunk.token_ids.is_empty() {
+                                            continue;
+                                        }
+                                        generated = generated.saturating_add(chunk.token_ids.len() as u32);
+                                        let mut out = LLMEngineOutput {
+                                            token_ids: chunk.token_ids,
+                                            ..Default::default()
+                                        };
+                                        out.index = Some(chunk.index);
+                                        yield Ok(out);
+                                    }
+                                    Some(pb::generate_response::Response::Complete(done)) => {
+                                        if done.prompt_tokens != 0 {
+                                            prompt_tokens = done.prompt_tokens;
+                                        }
+                                        let mut out = finish_output(
+                                            &done.finish_reason,
+                                            prompt_tokens,
+                                            generated,
+                                        );
+                                        out.index = Some(done.index);
+                                        yield Ok(out);
+                                        break;
+                                    }
+                                    None => continue,
+                                }
+                            }
+                            Ok(None) => {
+                                let err = client::engine_shutdown(
+                                    "SMG vLLM engine closed the Generate stream before a complete event",
+                                );
+                                signal_engine_failure(&fatal, err.message().to_string());
+                                yield Err(err);
+                                break;
+                            }
+                            Err(status) => {
+                                if is_fatal_generate_status(status.code()) {
+                                    let err = fatal_generate_error(status);
+                                    signal_engine_failure(&fatal, err.message().to_string());
+                                    yield Err(err);
+                                } else {
+                                    yield Err(client::status_to_dynamo("Generate", status));
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+    }
+
+    async fn abort(&self, ctx: Arc<dyn AsyncEngineContext>) {
+        let Some(mut client) = self.pool.get().map(Pool::control_client) else {
+            return;
+        };
+        let req = pb::AbortRequest {
+            request_ids: vec![ctx.id().to_string()],
+        };
+        if let Err(status) = client.abort(req).await {
+            tracing::debug!(
+                error = %status.message(),
+                request_id = ctx.id(),
+                "vllm SMG sidecar: abort RPC failed (ignored)"
+            );
+        }
+    }
+
+    async fn watch(&self) -> Result<(), DynamoError> {
+        let Some(pool) = self.pool.get() else {
+            return std::future::pending::<Result<(), DynamoError>>().await;
+        };
+
+        let mut fatal_rx = self.fatal.subscribe();
+        let mut client = pool.control_client();
+        let mut interval = tokio::time::interval(self.transport.poll_interval);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            if let Some(reason) = fatal_rx.borrow().as_ref().cloned() {
+                return Err(client::engine_shutdown(reason));
+            }
+
+            tokio::select! {
+                changed = fatal_rx.changed() => {
+                    if changed.is_err() {
+                        return Err(client::engine_shutdown(
+                            "vllm SMG sidecar fatal watcher closed",
+                        ));
+                    }
+                }
+                _ = interval.tick() => {
+                    match tokio::time::timeout(
+                        self.transport.connect_timeout,
+                        client.health_check(pb::HealthCheckRequest {}),
+                    )
+                    .await
+                    {
+                        Ok(Ok(resp)) => {
+                            let resp = resp.into_inner();
+                            if !resp.healthy {
+                                let message = if resp.message.is_empty() {
+                                    "SMG HealthCheck returned unhealthy".to_string()
+                                } else {
+                                    format!("SMG HealthCheck returned unhealthy: {}", resp.message)
+                                };
+                                return Err(client::engine_shutdown(message));
+                            }
+                        }
+                        Ok(Err(status)) => {
+                            return Err(client::engine_shutdown(format!(
+                                "SMG HealthCheck RPC failed after startup: {} ({:?})",
+                                status.message(),
+                                status.code(),
+                            )));
+                        }
+                        Err(_) => {
+                            return Err(client::engine_shutdown(format!(
+                                "SMG HealthCheck RPC timed out after {:?}",
+                                self.transport.connect_timeout,
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn cleanup(&self) -> Result<(), DynamoError> {
+        self.cancel.cancel();
+        tracing::info!("vllm SMG sidecar: cleanup invoked");
+        Ok(())
+    }
+
+    async fn health_check_payload(&self) -> Result<Option<serde_json::Value>, DynamoError> {
+        let mut payload = serde_json::json!({
+            "token_ids": [1],
+            "stop_conditions": {"max_tokens": 1, "ignore_eos": true},
+            "sampling_options": {"temperature": 0.0},
+        });
+        payload[HEALTH_CHECK_KEY] = serde_json::Value::Bool(true);
+        Ok(Some(payload))
+    }
+}
+
+// ============================================================================
+// Discovery / config helpers
+// ============================================================================
+
+fn bootstrap_discover(
+    endpoint: &str,
+    transport: &TransportConfig,
+) -> Result<Discovery, DynamoError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| client::engine_shutdown(format!("bootstrap runtime: {e}")))?;
+    rt.block_on(async {
+        let mut client = client::connect(endpoint, transport).await?;
+        client::discover(&mut client).await
+    })
+}
+
+fn validate_discovery(discovery: &Discovery) -> Result<(), DynamoError> {
+    if discovery.model.model_path.is_empty() {
+        return Err(client::invalid_arg(
+            "SMG GetModelInfo returned an empty model_path",
+        ));
+    }
+    if !discovery.model.is_generation {
+        return Err(client::invalid_arg(format!(
+            "SMG vLLM sidecar supports generation models only; model `{}` reports is_generation=false",
+            discovery.model.model_path
+        )));
+    }
+
+    match discovery.server.kv_role.as_str() {
+        "" | "kv_both" => Ok(()),
+        "kv_producer" | "kv_consumer" => Err(client::invalid_arg(format!(
+            "SMG vLLM sidecar v1 supports aggregated serving only; engine reported kv_role={}",
+            discovery.server.kv_role
+        ))),
+        other => Err(client::invalid_arg(format!(
+            "SMG vLLM sidecar v1 does not understand kv_role={other:?}"
+        ))),
+    }
+}
+
+fn build_engine_config(discovery: &Discovery) -> EngineConfig {
+    let model = &discovery.model;
+    let served_model_name =
+        (!model.served_model_name.is_empty()).then(|| model.served_model_name.clone());
+    let context_length = if model.max_context_length != 0 {
+        Some(model.max_context_length)
+    } else if model.max_req_input_len > 0 {
+        Some(model.max_req_input_len as u32)
+    } else {
+        None
+    };
+
+    EngineConfig {
+        model: model.model_path.clone(),
+        served_model_name,
+        context_length,
+        data_parallel_size: (discovery.server.data_parallel_size > 0)
+            .then_some(discovery.server.data_parallel_size as u32),
+        // SMG vLLM does not expose stable KV block capacity / block size in
+        // the upstream servicer, so leave KV-aware scheduling hints unset.
+        kv_cache_block_size: None,
+        total_kv_blocks: None,
+        max_num_seqs: None,
+        max_num_batched_tokens: None,
+        data_parallel_start_rank: None,
+        bootstrap_host: None,
+        bootstrap_port: None,
+        runtime_data: Default::default(),
+    }
+}
+
+fn signal_engine_failure(fatal: &watch::Sender<Option<String>>, reason: impl Into<String>) {
+    let _ = fatal.send(Some(reason.into()));
+}
+
+fn is_fatal_generate_status(code: tonic::Code) -> bool {
+    matches!(
+        code,
+        tonic::Code::Unknown
+            | tonic::Code::Unavailable
+            | tonic::Code::Internal
+            | tonic::Code::DeadlineExceeded
+            | tonic::Code::DataLoss
+            | tonic::Code::Aborted
+    )
+}
+
+fn fatal_generate_error(status: tonic::Status) -> DynamoError {
+    client::engine_shutdown(format!(
+        "SMG Generate RPC failed: {} ({:?})",
+        status.message(),
+        status.code(),
+    ))
+}
+
+// ============================================================================
+// Request building + response mapping
+// ============================================================================
+
+pub(crate) fn validate_supported_request(request: &PreprocessedRequest) -> Result<(), DynamoError> {
+    if request.prompt_embeds.is_some() {
+        return Err(unsupported("prompt embeddings"));
+    }
+    if request.multi_modal_data.is_some() || request.mm_processor_kwargs.is_some() {
+        return Err(unsupported("multimodal execution"));
+    }
+    if request.prefill_result.is_some() || request.bootstrap_info.is_some() {
+        return Err(unsupported("disaggregated prefill/decode handoff"));
+    }
+    if request.output_options.logprobs.is_some() || request.output_options.prompt_logprobs.is_some()
+    {
+        return Err(unsupported("logprobs"));
+    }
+    if request.stop_conditions.max_thinking_tokens.is_some() {
+        return Err(unsupported("thinking-token budget"));
+    }
+
+    let sampling = &request.sampling_options;
+    if sampling.n.unwrap_or(1) > 1 {
+        return Err(unsupported("multi-output sampling (n > 1)"));
+    }
+    if sampling.best_of.unwrap_or(1) > 1 {
+        return Err(unsupported("best_of > 1"));
+    }
+    if sampling.use_beam_search.unwrap_or(false) {
+        return Err(unsupported("beam search"));
+    }
+    if sampling.length_penalty.is_some() {
+        return Err(unsupported("length_penalty"));
+    }
+    if let Some(guided) = sampling.guided_decoding.as_ref() {
+        if guided.backend.is_some() {
+            return Err(unsupported("guided decoding backend override"));
+        }
+        if guided.whitespace_pattern.is_some() {
+            return Err(unsupported("guided decoding whitespace_pattern"));
+        }
+    }
+    if let Some(routing) = request.routing.as_ref() {
+        if routing.dp_rank.is_some() || routing.prefill_dp_rank.is_some() {
+            return Err(unsupported("KV-aware DP-rank routing"));
+        }
+    }
+
+    Ok(())
+}
+
+fn unsupported(feature: &str) -> DynamoError {
+    client::invalid_arg(format!(
+        "SMG vLLM sidecar v1 supports aggregated text/token generation only; unsupported feature: {feature}"
+    ))
+}
+
+pub(crate) fn build_generate_request(
+    request: &PreprocessedRequest,
+    request_id: &str,
+) -> Result<pb::GenerateRequest, DynamoError> {
+    validate_supported_request(request)?;
+
+    Ok(pb::GenerateRequest {
+        request_id: request_id.to_string(),
+        input: Some(pb::generate_request::Input::Tokenized(pb::TokenizedInput {
+            original_text: String::new(),
+            input_ids: request.token_ids.clone(),
+        })),
+        sampling_params: Some(build_sampling_params(request)?),
+        stream: true,
+        kv_transfer_params: None,
+        mm_inputs: None,
+        kv_transfer_params_json: None,
+        data_parallel_rank: None,
+    })
+}
+
+fn build_sampling_params(request: &PreprocessedRequest) -> Result<pb::SamplingParams, DynamoError> {
+    let sampling = &request.sampling_options;
+    let stop = &request.stop_conditions;
+
+    let seed = match sampling.seed {
+        Some(seed) => Some(i32::try_from(seed).map_err(|_| {
+            client::invalid_arg(format!(
+                "SMG seed is int32 but request seed {seed} is outside int32 range"
+            ))
+        })?),
+        None => None,
+    };
+
+    let mut stop_token_ids = Vec::new();
+    if let Some(ids) = &stop.stop_token_ids {
+        stop_token_ids.extend(ids.iter().copied());
+    }
+    if let Some(ids) = &stop.stop_token_ids_hidden {
+        stop_token_ids.extend(ids.iter().copied());
+    }
+
+    Ok(pb::SamplingParams {
+        temperature: sampling.temperature,
+        top_p: sampling.top_p.unwrap_or(0.0),
+        top_k: sampling.top_k.filter(|v| *v > 0).unwrap_or(0) as u32,
+        min_p: sampling.min_p.unwrap_or(0.0),
+        frequency_penalty: sampling.frequency_penalty.unwrap_or(0.0),
+        presence_penalty: sampling.presence_penalty.unwrap_or(0.0),
+        repetition_penalty: sampling.repetition_penalty.unwrap_or(0.0),
+        max_tokens: stop.max_tokens,
+        min_tokens: stop.min_tokens.unwrap_or(0),
+        stop: stop.stop.clone().unwrap_or_default(),
+        stop_token_ids,
+        skip_special_tokens: request.output_options.skip_special_tokens.unwrap_or(true),
+        spaces_between_special_tokens: true,
+        ignore_eos: stop.ignore_eos.unwrap_or(false),
+        n: sampling.n.map(u32::from).unwrap_or(1),
+        logprobs: None,
+        prompt_logprobs: None,
+        seed,
+        include_stop_str_in_output: sampling.include_stop_str_in_output.unwrap_or(false),
+        logit_bias: Default::default(),
+        truncate_prompt_tokens: None,
+        constraint: build_guided_constraint(sampling)?,
+    })
+}
+
+fn build_guided_constraint(
+    sampling: &dynamo_backend_common::SamplingOptions,
+) -> Result<Option<pb::sampling_params::Constraint>, DynamoError> {
+    let Some(guided) = sampling.guided_decoding.as_ref() else {
+        return Ok(None);
+    };
+
+    if let Some(json) = guided.json.as_ref() {
+        let schema = match json {
+            serde_json::Value::String(s) => s.clone(),
+            value => serde_json::to_string(value).map_err(|e| {
+                client::invalid_arg(format!("failed to serialize guided JSON schema: {e}"))
+            })?,
+        };
+        return Ok(Some(pb::sampling_params::Constraint::JsonSchema(schema)));
+    }
+    if let Some(regex) = guided.regex.as_ref() {
+        return Ok(Some(pb::sampling_params::Constraint::Regex(regex.clone())));
+    }
+    if let Some(choice) = guided.choice.as_ref()
+        && !choice.is_empty()
+    {
+        return Ok(Some(pb::sampling_params::Constraint::Choice(
+            pb::ChoiceConstraint {
+                choices: choice.clone(),
+            },
+        )));
+    }
+    if let Some(grammar) = guided.grammar.as_ref() {
+        return Ok(Some(pb::sampling_params::Constraint::Grammar(
+            grammar.clone(),
+        )));
+    }
+    if let Some(tag) = guided.structural_tag.as_ref() {
+        let tag = match tag {
+            serde_json::Value::String(s) => s.clone(),
+            value => serde_json::to_string(value).map_err(|e| {
+                client::invalid_arg(format!("failed to serialize structural_tag: {e}"))
+            })?,
+        };
+        return Ok(Some(pb::sampling_params::Constraint::StructuralTag(tag)));
+    }
+
+    Ok(None)
+}
+
+fn finish_output(reason: &str, prompt_tokens: u32, generated: u32) -> LLMEngineOutput {
+    let normalized = reason.to_ascii_lowercase();
+    match normalized.as_str() {
+        "length" => LLMEngineOutput::length(),
+        "abort" | "aborted" | "cancelled" | "canceled" => LLMEngineOutput::cancelled(),
+        "error" => LLMEngineOutput::error("engine reported error finish reason".to_string()),
+        _ => LLMEngineOutput::stop(),
+    }
+    .with_usage(usage(prompt_tokens, generated))
+}

--- a/lib/vllm-smg-sidecar/src/lib.rs
+++ b/lib/vllm-smg-sidecar/src/lib.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dynamo vLLM SMG sidecar backend.
+//!
+//! This crate implements [`dynamo_backend_common::LLMEngine`] by proxying
+//! inference to an out-of-process upstream vLLM `--grpc` engine over SMG's
+//! `vllm.grpc.engine.VllmEngine` contract. It is intentionally separate from
+//! the OpenEngine sidecar so users can run against upstream vLLM without any
+//! vLLM fork changes.
+
+pub mod args;
+pub mod client;
+pub mod engine;
+pub mod proto;
+
+pub use engine::VllmSmgSidecarEngine;
+
+#[cfg(test)]
+mod tests;

--- a/lib/vllm-smg-sidecar/src/main.rs
+++ b/lib/vllm-smg-sidecar/src/main.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Entry point for the `dynamo-vllm-smg-sidecar` binary.
+
+use std::sync::Arc;
+
+fn main() -> anyhow::Result<()> {
+    let (engine, config) = dynamo_vllm_smg_sidecar::VllmSmgSidecarEngine::from_args(None)?;
+    dynamo_backend_common::run(Arc::new(engine), config)
+}

--- a/lib/vllm-smg-sidecar/src/proto.rs
+++ b/lib/vllm-smg-sidecar/src/proto.rs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generated protobuf / gRPC types for SMG's vLLM engine service.
+//!
+//! Codegen is driven by `build.rs` from the vendored SMG proto sources.
+
+#![allow(clippy::all)]
+#![allow(missing_docs)]
+
+pub mod smg {
+    pub mod grpc {
+        pub mod common {
+            tonic::include_proto!("smg.grpc.common");
+        }
+    }
+}
+
+pub mod vllm {
+    pub mod grpc {
+        pub mod engine {
+            tonic::include_proto!("vllm.grpc.engine");
+        }
+    }
+}
+
+pub use smg::grpc::common;
+pub use vllm::grpc::engine;

--- a/lib/vllm-smg-sidecar/src/tests.rs
+++ b/lib/vllm-smg-sidecar/src/tests.rs
@@ -1,0 +1,640 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit + conformance tests for [`VllmSmgSidecarEngine`].
+//!
+//! Everything runs against an in-process fake SMG vLLM server bound to an
+//! ephemeral loopback port on its own runtime thread.
+
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use dynamo_backend_common::{
+    BackendError, DisaggregationMode, ErrorType, FinishReason, GenerateContext, LLMEngine,
+    LLMEngineOutput, MultimodalDataMap, OutputOptions, PrefillResult, PreprocessedRequest,
+    RoutingHints, SamplingOptions, StopConditions,
+};
+use dynamo_runtime::engine::AsyncEngineContext;
+use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
+use futures::{Stream, StreamExt};
+use tonic::{Request, Response, Status};
+
+use crate::args::TransportConfig;
+use crate::engine::{VllmSmgSidecarEngine, build_generate_request, validate_supported_request};
+use crate::proto::common as common_pb;
+use crate::proto::engine as pb;
+use crate::proto::engine::vllm_engine_server::{VllmEngine, VllmEngineServer};
+
+type RespStream<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send>>;
+
+// ============================================================================
+// Fake SMG vLLM server
+// ============================================================================
+
+#[derive(Clone)]
+struct FakeConfig {
+    tokens: u32,
+    model_path: String,
+    served_model_name: String,
+    is_generation: bool,
+    healthy: bool,
+    kv_role: String,
+    data_parallel_size: i32,
+}
+
+impl Default for FakeConfig {
+    fn default() -> Self {
+        Self {
+            tokens: 4,
+            model_path: "fake-model".to_string(),
+            served_model_name: "fake-served".to_string(),
+            is_generation: true,
+            healthy: true,
+            kv_role: String::new(),
+            data_parallel_size: 1,
+        }
+    }
+}
+
+struct FakeSmgVllm {
+    cfg: FakeConfig,
+    abort_count: Arc<AtomicUsize>,
+    abort_ids: Arc<Mutex<Vec<String>>>,
+    last_generate: Arc<Mutex<Option<pb::GenerateRequest>>>,
+}
+
+#[tonic::async_trait]
+impl VllmEngine for FakeSmgVllm {
+    type GenerateStream = RespStream<pb::GenerateResponse>;
+    type GetTokenizerStream = RespStream<common_pb::GetTokenizerChunk>;
+    type SubscribeKvEventsStream = RespStream<common_pb::KvEventBatch>;
+
+    async fn generate(
+        &self,
+        request: Request<pb::GenerateRequest>,
+    ) -> Result<Response<Self::GenerateStream>, Status> {
+        let req = request.into_inner();
+        *self.last_generate.lock().unwrap() = Some(req.clone());
+        let request_tokens = match req.input.as_ref() {
+            Some(pb::generate_request::Input::Tokenized(t)) => t.input_ids.len() as u32,
+            Some(pb::generate_request::Input::Text(t)) => t.len() as u32,
+            None => 0,
+        };
+        let tokens = self.cfg.tokens;
+
+        let stream = async_stream::stream! {
+            for i in 0..tokens {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                yield Ok(pb::GenerateResponse {
+                    response: Some(pb::generate_response::Response::Chunk(
+                        pb::GenerateStreamChunk {
+                            token_ids: vec![1000 + i],
+                            prompt_tokens: request_tokens,
+                            completion_tokens: 1,
+                            cached_tokens: 0,
+                            output_logprobs: None,
+                            input_logprobs: None,
+                            index: 0,
+                        },
+                    )),
+                });
+            }
+            yield Ok(pb::GenerateResponse {
+                response: Some(pb::generate_response::Response::Complete(
+                    pb::GenerateComplete {
+                        output_ids: Vec::new(),
+                        finish_reason: "stop".to_string(),
+                        prompt_tokens: request_tokens,
+                        completion_tokens: tokens,
+                        cached_tokens: 0,
+                        output_logprobs: None,
+                        input_logprobs: None,
+                        index: 0,
+                        kv_transfer_params: None,
+                        matched_stop: None,
+                        kv_transfer_params_json: None,
+                    },
+                )),
+            });
+        };
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    async fn embed(
+        &self,
+        _request: Request<pb::EmbedRequest>,
+    ) -> Result<Response<pb::EmbedResponse>, Status> {
+        Err(Status::unimplemented("fake embed is not implemented"))
+    }
+
+    async fn health_check(
+        &self,
+        _request: Request<pb::HealthCheckRequest>,
+    ) -> Result<Response<pb::HealthCheckResponse>, Status> {
+        Ok(Response::new(pb::HealthCheckResponse {
+            healthy: self.cfg.healthy,
+            message: if self.cfg.healthy {
+                "ok".to_string()
+            } else {
+                "not healthy".to_string()
+            },
+        }))
+    }
+
+    async fn abort(
+        &self,
+        request: Request<pb::AbortRequest>,
+    ) -> Result<Response<pb::AbortResponse>, Status> {
+        self.abort_count.fetch_add(1, Ordering::SeqCst);
+        self.abort_ids
+            .lock()
+            .unwrap()
+            .extend(request.into_inner().request_ids);
+        Ok(Response::new(pb::AbortResponse {}))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<pb::GetModelInfoRequest>,
+    ) -> Result<Response<pb::GetModelInfoResponse>, Status> {
+        Ok(Response::new(pb::GetModelInfoResponse {
+            model_path: self.cfg.model_path.clone(),
+            is_generation: self.cfg.is_generation,
+            max_context_length: 4096,
+            vocab_size: 32000,
+            supports_vision: false,
+            served_model_name: self.cfg.served_model_name.clone(),
+            tokenizer_path: String::new(),
+            model_type: "fake".to_string(),
+            architectures: vec!["FakeForCausalLM".to_string()],
+            eos_token_ids: vec![2],
+            pad_token_id: 0,
+            bos_token_id: 1,
+            max_req_input_len: 4096,
+            default_sampling_params_json: String::new(),
+        }))
+    }
+
+    async fn get_server_info(
+        &self,
+        _request: Request<pb::GetServerInfoRequest>,
+    ) -> Result<Response<pb::GetServerInfoResponse>, Status> {
+        Ok(Response::new(pb::GetServerInfoResponse {
+            active_requests: 0,
+            is_paused: false,
+            last_receive_timestamp: 0.0,
+            uptime_seconds: 1.0,
+            server_type: "vllm-grpc".to_string(),
+            kv_connector: String::new(),
+            kv_role: self.cfg.kv_role.clone(),
+            kv_engine_id: String::new(),
+            data_parallel_size: self.cfg.data_parallel_size,
+        }))
+    }
+
+    async fn get_loads(
+        &self,
+        _request: Request<pb::GetLoadsRequest>,
+    ) -> Result<Response<pb::GetLoadsResponse>, Status> {
+        Err(Status::unimplemented("fake loads are not implemented"))
+    }
+
+    async fn get_tokenizer(
+        &self,
+        _request: Request<common_pb::GetTokenizerRequest>,
+    ) -> Result<Response<Self::GetTokenizerStream>, Status> {
+        Err(Status::unimplemented("fake tokenizer is not implemented"))
+    }
+
+    async fn subscribe_kv_events(
+        &self,
+        _request: Request<common_pb::SubscribeKvEventsRequest>,
+    ) -> Result<Response<Self::SubscribeKvEventsStream>, Status> {
+        Err(Status::unimplemented("fake KV events are not implemented"))
+    }
+}
+
+struct FakeHandle {
+    endpoint: String,
+    abort_count: Arc<AtomicUsize>,
+    abort_ids: Arc<Mutex<Vec<String>>>,
+    last_generate: Arc<Mutex<Option<pb::GenerateRequest>>>,
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl FakeHandle {
+    fn shutdown(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+impl Drop for FakeHandle {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn spawn_fake_engine(cfg: FakeConfig) -> FakeHandle {
+    let abort_count = Arc::new(AtomicUsize::new(0));
+    let abort_ids = Arc::new(Mutex::new(Vec::new()));
+    let last_generate = Arc::new(Mutex::new(None));
+    let (tx, rx) = std::sync::mpsc::channel();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
+    let svc_abort_count = abort_count.clone();
+    let svc_abort_ids = abort_ids.clone();
+    let svc_generate = last_generate.clone();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("fake engine runtime");
+        rt.block_on(async move {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind fake engine");
+            let addr = listener.local_addr().expect("local_addr");
+            tx.send(addr).expect("send addr");
+
+            let svc = FakeSmgVllm {
+                cfg,
+                abort_count: svc_abort_count,
+                abort_ids: svc_abort_ids,
+                last_generate: svc_generate,
+            };
+            tonic::transport::Server::builder()
+                .add_service(VllmEngineServer::new(svc))
+                .serve_with_incoming_shutdown(
+                    tokio_stream::wrappers::TcpListenerStream::new(listener),
+                    async move {
+                        let _ = shutdown_rx.await;
+                    },
+                )
+                .await
+                .expect("serve fake engine");
+        });
+    });
+
+    let addr = rx.recv().expect("fake engine never bound");
+    FakeHandle {
+        endpoint: format!("http://{addr}"),
+        abort_count,
+        abort_ids,
+        last_generate,
+        shutdown_tx: Some(shutdown_tx),
+    }
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+fn test_transport() -> TransportConfig {
+    TransportConfig {
+        connect_timeout: Duration::from_secs(5),
+        poll_interval: Duration::from_millis(50),
+        deadline: Duration::from_secs(10),
+        connections: 2,
+    }
+}
+
+fn engine_for(handle: &FakeHandle) -> VllmSmgSidecarEngine {
+    VllmSmgSidecarEngine::new(handle.endpoint.clone(), test_transport())
+}
+
+fn fresh_ctx() -> Arc<dyn AsyncEngineContext> {
+    Context::new(()).context()
+}
+
+fn gen_ctx(ctx: Arc<dyn AsyncEngineContext>) -> GenerateContext {
+    GenerateContext::new(ctx, None)
+}
+
+fn request(max_tokens: Option<u32>) -> PreprocessedRequest {
+    PreprocessedRequest::builder()
+        .model("fake-model".to_string())
+        .token_ids(vec![1, 2, 3])
+        .stop_conditions(StopConditions {
+            max_tokens,
+            ..Default::default()
+        })
+        .sampling_options(SamplingOptions::default())
+        .output_options(OutputOptions::default())
+        .build()
+        .expect("build request")
+}
+
+async fn collect_ok(
+    stream: futures::stream::BoxStream<
+        'static,
+        Result<LLMEngineOutput, dynamo_backend_common::DynamoError>,
+    >,
+) -> Vec<LLMEngineOutput> {
+    stream
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .map(|item| item.expect("engine yielded Err in test"))
+        .collect()
+}
+
+fn assert_invalid_arg(err: dynamo_backend_common::DynamoError) {
+    assert_eq!(
+        err.error_type(),
+        ErrorType::Backend(BackendError::InvalidArgument)
+    );
+}
+
+// ============================================================================
+// Conformance + lifecycle
+// ============================================================================
+
+#[tokio::test]
+async fn smg_sidecar_passes_conformance() {
+    let handle = spawn_fake_engine(FakeConfig::default());
+    dynamo_backend_common::testing::run_conformance(|| engine_for(&handle))
+        .await
+        .expect("SMG sidecar must satisfy conformance");
+}
+
+#[tokio::test]
+async fn from_args_builds_aggregated_worker_config() {
+    let handle = spawn_fake_engine(FakeConfig::default());
+    let endpoint = handle.endpoint.clone();
+    let cfg = std::thread::spawn(move || {
+        let (_engine, cfg) = VllmSmgSidecarEngine::from_args(Some(vec![
+            "dynamo-vllm-smg-sidecar".to_string(),
+            "--smg-endpoint".to_string(),
+            endpoint,
+            "--endpoint-types".to_string(),
+            "chat".to_string(),
+        ]))
+        .expect("from_args");
+        cfg
+    })
+    .join()
+    .expect("from_args thread");
+
+    assert_eq!(cfg.component, "backend");
+    assert_eq!(cfg.disaggregation_mode, DisaggregationMode::Aggregated);
+    assert_eq!(cfg.model_name, "fake-model");
+    assert_eq!(cfg.served_model_name.as_deref(), Some("fake-served"));
+    assert_eq!(cfg.endpoint_types, "chat");
+}
+
+#[tokio::test]
+async fn start_advertises_smg_metadata() {
+    let handle = spawn_fake_engine(FakeConfig {
+        data_parallel_size: 3,
+        ..FakeConfig::default()
+    });
+    let engine = engine_for(&handle);
+
+    let cfg = engine.start(0).await.expect("start");
+    assert_eq!(cfg.model, "fake-model");
+    assert_eq!(cfg.served_model_name.as_deref(), Some("fake-served"));
+    assert_eq!(cfg.context_length, Some(4096));
+    assert_eq!(cfg.data_parallel_size, Some(3));
+    assert!(cfg.kv_cache_block_size.is_none());
+    assert!(cfg.total_kv_blocks.is_none());
+    assert!(cfg.bootstrap_host.is_none());
+
+    engine.cleanup().await.unwrap();
+}
+
+#[tokio::test]
+async fn start_rejects_disaggregated_kv_role() {
+    let handle = spawn_fake_engine(FakeConfig {
+        kv_role: "kv_producer".to_string(),
+        ..FakeConfig::default()
+    });
+    let engine = engine_for(&handle);
+
+    let err = engine
+        .start(0)
+        .await
+        .expect_err("disaggregated role must fail");
+    assert_invalid_arg(err);
+}
+
+#[tokio::test]
+async fn watch_reports_engine_shutdown_when_health_endpoint_disappears() {
+    let mut handle = spawn_fake_engine(FakeConfig::default());
+    let engine = engine_for(&handle);
+    engine.start(0).await.expect("start");
+
+    handle.shutdown();
+
+    let err = tokio::time::timeout(Duration::from_secs(3), engine.watch())
+        .await
+        .expect("watch should notice fake engine shutdown")
+        .expect_err("engine shutdown should fail watch");
+    assert_eq!(
+        err.error_type(),
+        ErrorType::Backend(BackendError::EngineShutdown)
+    );
+
+    engine.cleanup().await.unwrap();
+}
+
+// ============================================================================
+// Generate happy path + cancellation
+// ============================================================================
+
+#[tokio::test]
+async fn generate_maps_request_and_streams_tokens_then_stop_terminal() {
+    let handle = spawn_fake_engine(FakeConfig {
+        tokens: 4,
+        ..FakeConfig::default()
+    });
+    let engine = engine_for(&handle);
+    engine.start(0).await.unwrap();
+
+    let mut req = request(Some(64));
+    req.stop_conditions.min_tokens = Some(2);
+    req.stop_conditions.stop = Some(vec!["done".to_string()]);
+    req.stop_conditions.stop_token_ids = Some(vec![7]);
+    req.stop_conditions.ignore_eos = Some(true);
+    req.sampling_options.temperature = Some(0.7);
+    req.sampling_options.top_p = Some(0.9);
+    req.sampling_options.top_k = Some(50);
+    req.sampling_options.min_p = Some(0.01);
+    req.sampling_options.frequency_penalty = Some(0.2);
+    req.sampling_options.presence_penalty = Some(0.3);
+    req.sampling_options.repetition_penalty = Some(1.05);
+    req.sampling_options.seed = Some(123);
+    req.sampling_options.include_stop_str_in_output = Some(true);
+    req.output_options.skip_special_tokens = Some(false);
+
+    let stream = engine
+        .generate(req, gen_ctx(fresh_ctx()))
+        .await
+        .expect("stream");
+    let chunks = collect_ok(stream).await;
+
+    let token_chunks = &chunks[..chunks.len() - 1];
+    let total: usize = token_chunks.iter().map(|c| c.token_ids.len()).sum();
+    assert_eq!(total, 4);
+    assert!(token_chunks.iter().all(|c| c.finish_reason.is_none()));
+
+    let terminal = chunks.last().unwrap();
+    assert!(matches!(terminal.finish_reason, Some(FinishReason::Stop)));
+    let usage = terminal.completion_usage.as_ref().unwrap();
+    assert_eq!(usage.prompt_tokens, 3);
+    assert_eq!(usage.completion_tokens, 4);
+    assert_eq!(usage.total_tokens, 7);
+
+    let sent = handle
+        .last_generate
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("captured generate request");
+    assert!(sent.stream);
+    match sent.input.unwrap() {
+        pb::generate_request::Input::Tokenized(t) => assert_eq!(t.input_ids, vec![1, 2, 3]),
+        pb::generate_request::Input::Text(_) => panic!("expected tokenized input"),
+    }
+    let sampling = sent.sampling_params.expect("sampling params");
+    assert_eq!(sampling.temperature, Some(0.7));
+    assert_eq!(sampling.top_p, 0.9);
+    assert_eq!(sampling.top_k, 50);
+    assert_eq!(sampling.min_p, 0.01);
+    assert_eq!(sampling.frequency_penalty, 0.2);
+    assert_eq!(sampling.presence_penalty, 0.3);
+    assert_eq!(sampling.repetition_penalty, 1.05);
+    assert_eq!(sampling.max_tokens, Some(64));
+    assert_eq!(sampling.min_tokens, 2);
+    assert_eq!(sampling.stop, vec!["done".to_string()]);
+    assert_eq!(sampling.stop_token_ids, vec![7]);
+    assert!(sampling.ignore_eos);
+    assert_eq!(sampling.seed, Some(123));
+    assert!(sampling.include_stop_str_in_output);
+    assert!(!sampling.skip_special_tokens);
+
+    engine.cleanup().await.unwrap();
+}
+
+#[tokio::test]
+async fn build_generate_request_maps_guided_decoding_regex() {
+    let mut req = request(Some(5));
+    req.sampling_options.guided_decoding =
+        Some(dynamo_llm::protocols::common::GuidedDecodingOptions::new(
+            None,
+            Some("[a-z]+".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        ));
+
+    let sent = build_generate_request(&req, "req-1").expect("build");
+    let sampling = sent.sampling_params.expect("sampling");
+    assert_eq!(
+        sampling.constraint,
+        Some(pb::sampling_params::Constraint::Regex("[a-z]+".to_string()))
+    );
+}
+
+#[tokio::test]
+async fn generate_observes_midstream_cancellation() {
+    let handle = spawn_fake_engine(FakeConfig {
+        tokens: 50,
+        ..FakeConfig::default()
+    });
+    let engine = engine_for(&handle);
+    engine.start(0).await.unwrap();
+
+    let ctx = fresh_ctx();
+    let mut stream = engine
+        .generate(request(Some(10_000)), gen_ctx(ctx.clone()))
+        .await
+        .expect("stream");
+
+    let first = stream.next().await.expect("first item").expect("ok");
+    assert!(
+        first.finish_reason.is_none(),
+        "first item should be a token"
+    );
+
+    ctx.stop_generating();
+
+    let rest: Vec<_> = stream.collect().await;
+    let last = rest
+        .last()
+        .expect("terminal after cancel")
+        .as_ref()
+        .unwrap();
+    assert!(
+        matches!(last.finish_reason, Some(FinishReason::Cancelled)),
+        "expected Cancelled terminal, got {:?}",
+        last.finish_reason
+    );
+
+    engine.cleanup().await.unwrap();
+}
+
+#[tokio::test]
+async fn abort_sends_request_id_to_smg() {
+    let handle = spawn_fake_engine(FakeConfig::default());
+    let engine = engine_for(&handle);
+    engine.start(0).await.unwrap();
+
+    let ctx = fresh_ctx();
+    let request_id = ctx.id().to_string();
+    engine.abort(ctx).await;
+
+    assert_eq!(handle.abort_count.load(Ordering::SeqCst), 1);
+    assert_eq!(*handle.abort_ids.lock().unwrap(), vec![request_id]);
+    engine.cleanup().await.unwrap();
+}
+
+// ============================================================================
+// Unsupported feature gates
+// ============================================================================
+
+#[test]
+fn unsupported_features_fail_explicitly() {
+    let mut req = request(Some(4));
+    req.prompt_embeds = Some("abc".to_string());
+    assert_invalid_arg(validate_supported_request(&req).unwrap_err());
+
+    let mut req = request(Some(4));
+    req.multi_modal_data = Some(MultimodalDataMap::default());
+    assert_invalid_arg(validate_supported_request(&req).unwrap_err());
+
+    let mut req = request(Some(4));
+    req.prefill_result = Some(PrefillResult {
+        disaggregated_params: serde_json::json!({"remote_host": "127.0.0.1"}),
+        prompt_tokens_details: None,
+    });
+    assert_invalid_arg(validate_supported_request(&req).unwrap_err());
+
+    let mut req = request(Some(4));
+    req.output_options.logprobs = Some(1);
+    assert_invalid_arg(validate_supported_request(&req).unwrap_err());
+
+    let mut req = request(Some(4));
+    req.sampling_options.n = Some(2);
+    assert_invalid_arg(validate_supported_request(&req).unwrap_err());
+
+    let mut req = request(Some(4));
+    req.sampling_options.best_of = Some(2);
+    assert_invalid_arg(validate_supported_request(&req).unwrap_err());
+
+    let mut req = request(Some(4));
+    req.sampling_options.use_beam_search = Some(true);
+    assert_invalid_arg(validate_supported_request(&req).unwrap_err());
+
+    let mut req = request(Some(4));
+    req.routing = Some(RoutingHints {
+        dp_rank: Some(0),
+        ..Default::default()
+    });
+    assert_invalid_arg(validate_supported_request(&req).unwrap_err());
+}


### PR DESCRIPTION
## Summary

Adds a standalone Rust `dynamo-vllm-smg-sidecar` binary that connects Dynamo to upstream vLLM's existing SMG gRPC service.

This PR:
- Adds the new `lib/vllm-smg-sidecar` workspace crate.
- Vendors the upstream SMG proto files from `smg-grpc-proto==0.4.11`.
- Implements aggregated text/token generation over SMG `Generate`, plus `Abort`, `HealthCheck`, `GetModelInfo`, and `GetServerInfo`.
- Adds local launch and DGD deploy examples for `vllm serve --grpc`.

## Running vLLM With `vllm serve`

This sidecar lets Dynamo run against an ordinary upstream vLLM server started with the vLLM CLI:

```bash
vllm serve Qwen/Qwen3-0.6B --grpc --host 127.0.0.1 --port 50051
dynamo-vllm-smg-sidecar --smg-endpoint 127.0.0.1:50051
```

The vLLM environment needs gRPC support installed, for example `vllm[grpc]` / `smg-grpc-servicer[vllm]>=0.5.2`.

## Scope

This v1 sidecar supports aggregated serving only.

Unsupported features fail explicitly or remain no-op in v1:
- disaggregated serving
- multimodal execution
- prompt embeddings
- logprobs
- multi-output `n > 1`
- `best_of` / beam search
- KV-aware routing and load metrics

## H100 Perf Validation

Ran a locked H100 mini-sweep on dlcluster with `Qwen/Qwen3-0.6B`.

| Point | SMG tok/s | Legacy tok/s | vs Legacy | Unified tok/s | vs Unified |
|---|---:|---:|---:|---:|---:|
| short c4 | 244.72 | 247.73 | -1.22% | 249.69 | -1.99% |
| short c16 | 503.42 | 482.61 | +4.31% | 490.69 | +2.59% |
| short c64 | 499.76 | 489.73 | +2.05% | 492.57 | +1.46% |
| long c16 | 510.18 | 501.96 | +1.64% | 501.06 | +1.82% |
| long c64 | 502.58 | 503.30 | -0.14% | 496.35 | +1.26% |
| long c256 | 508.60 | 497.61 | +2.21% | 496.99 | +2.34% |

Average output throughput across the six workload points:
- SMG sidecar: 461.54 tok/s
- legacy Python backend: 453.82 tok/s
- Python unified backend: 454.56 tok/s

## Validation

- `git diff --cached --check`
- H100 mini-sweep on dlcluster:
  - 18/18 backend/workload rows completed with `status=ok`
  - 0 request failures
