### PR TITLE
fix(router): skip aborted None output chunks

### DIFF
--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -119,6 +119,14 @@ class StandaloneRouterHandler:
         async for worker_output in await self.kv_router.generate_from_request(
             preprocessed_request  # type: ignore[arg-type]
         ):
+            # The kv_router stream can yield None when an in-flight request is
+            # aborted mid-generation, for example when a weight refit pauses and
+            # aborts worker generation. Skip that terminal chunk so the stream
+            # closes cleanly instead of turning worker_output.get(...) below
+            # into a BackendUnknown 500.
+            if worker_output is None:
+                continue
+
             # Wrap worker output into LLMEngineOutput format
             # Worker should return dict with at minimum kv_transfer_params in extra_args
             llm_engine_output = {


### PR DESCRIPTION
## Summary
- Skip `None` chunks yielded by the KV router stream after an in-flight generation is aborted.
- Prevent `worker_output.get(...)` from raising and surfacing as a hard `BackendUnknown` 500.

## Why
`kv_router.generate_from_request(...)` can yield `None` when worker generation is aborted mid-stream, for example during a pause/abort flow around weight refit. The standalone router should treat that as a terminal/no-op chunk rather than converting it into an unrelated backend error.

## Validation
- `git diff --check -- components/src/dynamo/router/__main__.py`
- In-memory Python syntax compile for `components/src/dynamo/router/__main__.py`