### PR TITLE
fix: account for bad secret formatting. Fixes [DGH-1029]

### DIFF
--- a/deploy/operator/internal/secrets/docker.go
+++ b/deploy/operator/internal/secrets/docker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type DockerSecretIndexer struct {
@@ -50,6 +51,7 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 		}
 		return 0
 	})
+	logger := log.FromContext(ctx)
 	tmpSecrets := make(map[string]map[string][]string)
 	for _, secret := range secrets.Items {
 		if secret.Type == corev1.SecretTypeDockerConfigJson {
@@ -58,7 +60,11 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 				Auths map[string]any `json:"auths"`
 			}{}
 			if err := json.Unmarshal(secret.Data[corev1.DockerConfigJsonKey], dockerConfig); err != nil {
-				return fmt.Errorf("unable to unmarshal docker config json for secret %s: %w", secret.Name, err)
+				// A single malformed secret must not block indexing of every
+				// other docker secret, so skip it instead of failing the refresh.
+				logger.Error(err, "skipping docker secret with invalid docker config json",
+					"secret", secret.Name, "namespace", secret.Namespace)
+				continue
 			}
 			namespace := secret.Namespace
 			if _, ok := tmpSecrets[namespace]; !ok {
@@ -68,7 +74,11 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 				// retrieve the registry host
 				registry, err := common.GetHost(auth)
 				if err != nil {
-					return fmt.Errorf("unable to get host for registry %s for secret %s: %w", auth, secret.Name, err)
+					// Skip the malformed registry key but keep indexing the
+					// remaining valid auths in this and other secrets.
+					logger.Error(err, "skipping malformed registry auth key in docker secret",
+						"secret", secret.Name, "namespace", secret.Namespace, "authKey", auth)
+					continue
 				}
 				tmpSecrets[namespace][registry] = append(tmpSecrets[namespace][registry], secret.Name)
 			}

--- a/deploy/operator/internal/secrets/docker_test.go
+++ b/deploy/operator/internal/secrets/docker_test.go
@@ -146,6 +146,64 @@ func TestDockerSecretIndexer_DeterministicSecrets(t *testing.T) {
 	}
 }
 
+func TestDockerSecretIndexer_RefreshIndexSkipsMalformedSecrets(t *testing.T) {
+	mockSecrets := []corev1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bad-auth-key",
+				Namespace: "default",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				// The auth key is a stray command instead of a registry host,
+				// which fails URL host parsing. The valid key must still index.
+				".dockerconfigjson": []byte(`{"auths":{"pip install torch --index-url https:":{}, "good-registry.io/team":{}}}`),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bad-json",
+				Namespace: "default",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`not-json`),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "valid-secret",
+				Namespace: "default",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`{"auths":{"good-registry.io/other":{}}}`),
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&mockSecrets[0], &mockSecrets[1], &mockSecrets[2]).
+		Build()
+
+	i := NewDockerSecretIndexer(fakeClient, "")
+	// A malformed secret must not fail the whole refresh.
+	if err := i.RefreshIndex(t.Context()); err != nil {
+		t.Fatalf("DockerSecretIndexer.RefreshIndex() error = %v, want nil", err)
+	}
+
+	// The valid auth key in the otherwise-malformed secret is still indexed,
+	// alongside the fully valid secret.
+	secrets, err := i.GetSecrets("default", "good-registry.io")
+	if err != nil {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() error = %v", err)
+	}
+	if got, want := secrets, []string{"bad-auth-key", "valid-secret"}; !slices.Equal(got, want) {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() = %v, want %v", got, want)
+	}
+}
+
 func TestDockerSecretIndexer_RefreshIndexRespectsNamespaceScope(t *testing.T) {
 	mockSecrets := []corev1.Secret{
 		{


### PR DESCRIPTION
## Overview:

fix: account for bad secret formatting. skip the malformed one and let others go.
fixes [DGH-1029]
• [#10790](https://github.com/ai-dynamo/dynamo/issues/10790) / [DGH-1029](https://linear.app/nvidia/issue/DGH-1029/bug-pods-repeatedly-restart-due-to-malformed-dockerconfigjson-secrets) -- [BUG]: pods repeatedly restart due to malformed dockerconfigjson Secrets in the environment


<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue
