### PR TITLE
feat(observability): engine.generate span for legacy TRT-LLM worker

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1092,6 +1092,17 @@ class HandlerBase(BaseGenerativeHandler):
             prefill_result.get("prompt_tokens_details") if prefill_result else None
         )
 
+        # Open the worker-level `engine.generate` span so downstream TRT-LLM
+        # spans nest under it, then build the (now bridged) trace headers.
+        # The legacy worker path doesn't run through the Rust EngineAdapter
+        # that opens this span for the unified backend, so we open it
+        # explicitly on the context. Held until the request completes.
+        context.start_engine_span(
+            {
+                "disagg_role": str(self.disaggregation_mode),
+                "request_id": request_id,
+            }
+        )
         # Build trace headers for distributed tracing
         trace_headers = context.trace_headers()
 

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -467,9 +467,10 @@ impl Context {
             // contiguous in the distributed trace. No-op when the inbound
             // context is absent or malformed — the span is then a root.
             if let Some(tc) = self.trace_context.as_ref()
-                && let (Ok(trace_id), Ok(span_id)) =
-                    (TraceId::from_hex(&tc.trace_id), SpanId::from_hex(&tc.span_id))
-            {
+                && let (Ok(trace_id), Ok(span_id)) = (
+                    TraceId::from_hex(&tc.trace_id),
+                    SpanId::from_hex(&tc.span_id),
+                )            {
                 let parent = OtelContext::new().with_remote_span_context(SpanContext::new(
                     trace_id,
                     span_id,

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -14,8 +14,11 @@ use dynamo_runtime::logging::DistributedTraceContext;
 pub use dynamo_runtime::pipeline::AsyncEngineContext;
 use dynamo_runtime::pipeline::context::Controller;
 use opentelemetry::global::BoxedSpan;
-use opentelemetry::trace::{Span as OtelSpan, Status, TraceContextExt, Tracer};
-use opentelemetry::{KeyValue, global};
+use opentelemetry::trace::{
+    Span as OtelSpan, SpanContext, SpanId, Status, TraceContextExt, TraceFlags, TraceId,
+    TraceState, Tracer,
+};
+use opentelemetry::{Context as OtelContext, KeyValue, global};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString};
 use std::collections::{BTreeMap, HashMap};
@@ -429,6 +432,76 @@ impl Context {
             }
         }
         Some(headers)
+    }
+
+    /// Open the worker-level `engine.generate` span for backends that do
+    /// NOT run through the Rust `EngineAdapter` (the legacy per-backend
+    /// workers, e.g. TRT-LLM's `HandlerBase`). The unified backend
+    /// receives this span from the adapter via `with_span`; legacy
+    /// handlers call this once, before invoking the engine, so that:
+    ///
+    ///   * `trace_headers()` returns the *bridged* traceparent — downstream
+    ///     engine internals (TRT-LLM forward, etc.) nest UNDER
+    ///     `engine.generate` instead of directly under the inbound frontend
+    ///     span, matching the unified backend's trace tree, and
+    ///   * `current_span()` / `start_span()` become functional for the
+    ///     legacy handler.
+    ///
+    /// The span is parented to the inbound `DistributedTraceContext` (the
+    /// frontend's span) when present — the same source `fallback_traceparent`
+    /// uses — so the worker layer slots contiguously into the distributed
+    /// trace. It is stored on the `Context` and ends when the `Context` is
+    /// dropped at request completion.
+    ///
+    /// Idempotent: if a span is already attached (a second call, or the
+    /// unified path) it is reused and no new span is opened. Returns a
+    /// no-op `SpanProxy` when the OTel bridge layer isn't installed (the
+    /// span carries no valid OTel context).
+    ///
+    /// `attrs` are applied to the span (e.g. `{"disagg_role": "prefill"}`).
+    #[pyo3(signature = (attrs=None))]
+    fn start_engine_span(&mut self, attrs: Option<&Bound<'_, PyDict>>) -> PyResult<SpanProxy> {
+        if self.span.is_none() {
+            let span = tracing::info_span!(target: "request_span", "engine.generate");
+            // Parent to the inbound frontend span so the worker layer is
+            // contiguous in the distributed trace. No-op when the inbound
+            // context is absent or malformed — the span is then a root.
+            if let Some(tc) = self.trace_context.as_ref()
+                && let (Ok(trace_id), Ok(span_id)) =
+                    (TraceId::from_hex(&tc.trace_id), SpanId::from_hex(&tc.span_id))
+            {
+                let parent = OtelContext::new().with_remote_span_context(SpanContext::new(
+                    trace_id,
+                    span_id,
+                    TraceFlags::SAMPLED,
+                    true, // is_remote
+                    TraceState::default(),
+                ));
+                // Errors only when the bridge layer isn't installed; the
+                // `is_valid()` check below handles (and warns about) that.
+                let _ = span.set_parent(parent);
+            }
+            self.span = Some(span);
+        }
+
+        let span = self
+            .span
+            .as_ref()
+            .expect("span attached above or already present");
+        if !span.context().span().span_context().is_valid() {
+            warn_bridge_missing_once("start_engine_span");
+            return Ok(SpanProxy {
+                inner: SpanProxyInner::NoOp,
+            });
+        }
+        if let Some(d) = attrs {
+            for (k, v) in d.iter() {
+                span.set_attribute(k.extract::<String>()?, py_to_otel_value(&v)?);
+            }
+        }
+        Ok(SpanProxy {
+            inner: SpanProxyInner::Tracing(span.clone()),
+        })
     }
 }
 

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -470,7 +470,8 @@ impl Context {
                 && let (Ok(trace_id), Ok(span_id)) = (
                     TraceId::from_hex(&tc.trace_id),
                     SpanId::from_hex(&tc.span_id),
-                )            {
+                )
+            {
                 let parent = OtelContext::new().with_remote_span_context(SpanContext::new(
                     trace_id,
                     span_id,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -590,6 +590,28 @@ class Context:
         """
         ...
 
+    def start_engine_span(
+        self, attrs: Optional[dict[str, Any]] = None
+    ) -> "SpanProxy":
+        """
+        Open the worker-level ``engine.generate`` span for backends that do
+        NOT run through the Rust ``EngineAdapter`` (the legacy per-backend
+        workers). Call once, before invoking the engine, so that
+        ``trace_headers()`` returns the *bridged* traceparent (downstream
+        engine spans nest under ``engine.generate``) and
+        ``current_span()`` / ``start_span()`` become functional.
+
+        The span is parented to the inbound trace context when present and
+        ends when the ``Context`` is dropped at request completion.
+        Idempotent: reuses an already-attached span. Returns a no-op proxy
+        when the OTel bridge isn't installed. ``attrs`` are applied to the
+        span (e.g. ``{"disagg_role": "prefill"}``).
+
+        The unified backend gets this span from the framework and does NOT
+        call this.
+        """
+        ...
+
     def current_span(self) -> "SpanProxy":
         """
         Handle on the framework's ``engine.generate`` span. Use it to


### PR DESCRIPTION
The OTel tracing work (#9543) opens the worker-level `engine.generate` span in the Rust `EngineAdapter`, which only the unified backend flows through. Legacy per-backend workers (TRT-LLM's `HandlerBase`) register a plain endpoint and never hit the adapter, so their `Context.span` is `None`: `trace_headers()` falls back to the inbound frontend context and `current_span()` / `start_span()` are no-ops. TRT-LLM internals then nest directly under the frontend span with no worker layer.

Add `Context.start_engine_span(attrs)` to the shared PyO3 binding so a legacy handler can open and attach the `engine.generate` span itself, parented to the inbound `DistributedTraceContext`. Once attached, `trace_headers()` returns the bridged traceparent (downstream engine spans nest under `engine.generate`) and the child-span helpers work — matching the unified backend's trace tree. Idempotent and a no-op when the OTel bridge layer isn't installed.

Wire it into TRT-LLM's `HandlerBase._generate_locally_impl` before the `trace_headers()` call. No dependency on `dynamo.common.backend`.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue
