### PR TITLE
perf(kv-router): reduce active sequence load tracking locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "dynamo-runtime",
  "dynamo-tokens",
  "flume 0.12.0",
+ "indexmap 2.14.0",
  "ordered-float 4.6.0",
  "parking_lot",
  "prometheus",
@@ -2505,6 +2506,7 @@ dependencies = [
  "rstest 0.18.2",
  "rstest_reuse",
  "rustc-hash 2.1.2",
+ "seqlock",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -8215,6 +8217,15 @@ name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
+name = "seqlock"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c67b6f14ecc5b86c66fa63d76b5092352678545a8a3cdae80aef5128371910"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ reqwest = { version = "0.12.24", default-features = false, features = [
 ] }
 rmp-serde = { version = "1" }
 serde_bytes = { version = "0.11" }
+seqlock = { version = "0.2.0" }
 # "rc" is for async-openai. Allows serializing Rc and Arc. Generally avoid doing that.
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1" }

--- a/lib/bench/kv_router/active_sequences_shared.rs
+++ b/lib/bench/kv_router/active_sequences_shared.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::hint::black_box;
 use std::sync::Arc;
 
 use dynamo_kv_router::protocols::{PrefillLoadHint, WorkerWithDpRank};
@@ -301,7 +302,7 @@ async fn apply_entry(
             isl,
             output_length,
         } => {
-            let _ = multi.project_worker_loads(Some(&block_hashes), decay_now);
+            black_box(multi.project_worker_loads(Some(&block_hashes), decay_now));
             let _ = multi.add_request(
                 SequenceRequest {
                     request_id,

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1546,12 +1546,14 @@ dependencies = [
  "dynamo-runtime",
  "dynamo-tokens",
  "flume",
+ "indexmap 2.14.0",
  "ordered-float 4.6.0",
  "parking_lot",
  "prometheus",
  "rand 0.9.4",
  "rmp-serde",
  "rustc-hash 2.1.2",
+ "seqlock",
  "serde",
  "serde_yaml",
  "thiserror 2.0.18",
@@ -5992,6 +5994,15 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seqlock"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c67b6f14ecc5b86c66fa63d76b5092352678545a8a3cdae80aef5128371910"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "serde"

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2145,6 +2145,7 @@ dependencies = [
  "dynamo-runtime",
  "dynamo-tokens",
  "flume",
+ "indexmap 2.14.0",
  "ordered-float 4.6.0",
  "parking_lot",
  "prometheus",
@@ -2152,6 +2153,7 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "rustc-hash 2.1.2",
+ "seqlock",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7213,6 +7215,15 @@ name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
+name = "seqlock"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c67b6f14ecc5b86c66fa63d76b5092352678545a8a3cdae80aef5128371910"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "serde"

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -32,10 +32,12 @@ dynamo-tokens = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
+indexmap = { workspace = true }
 ordered-float = { workspace = true }
 derive_builder = { workspace = true }
 prometheus = { workspace = true, optional = true }
 rand = { workspace = true }
+seqlock = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 serde_yaml = "0.9.34"

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -780,10 +780,18 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
     }
 
     pub(super) fn ensure_worker_registered(&self, worker: WorkerWithDpRank) {
-        if self.workers.read().index.contains_key(&worker) {
-            return;
+        {
+            let table = self.workers.read();
+            if table.index.contains_key(&worker) {
+                return;
+            }
         }
 
+        self.ensure_worker_registered_after_miss(worker);
+    }
+
+    fn ensure_worker_registered_after_miss(&self, worker: WorkerWithDpRank) {
+        // Called only after any read guard has been dropped.
         let mut table = self.workers.write();
         if table.index.contains_key(&worker) {
             return;
@@ -812,16 +820,19 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             lora_name,
         } = req;
 
-        if lazily_register_worker {
-            self.ensure_worker_registered(worker);
-        }
+        let mut attempted_lazy_registration = false;
 
-        let (expired_request_ids, load) = {
+        let (expired_request_ids, load) = loop {
             let table = self.workers.read();
-            let &idx = table
-                .index
-                .get(&worker)
-                .ok_or(SequenceError::WorkerNotFound { worker })?;
+            let Some(&idx) = table.index.get(&worker) else {
+                drop(table);
+                if !lazily_register_worker || attempted_lazy_registration {
+                    return Err(SequenceError::WorkerNotFound { worker });
+                }
+                attempted_lazy_registration = true;
+                self.ensure_worker_registered_after_miss(worker);
+                continue;
+            };
             if let Err(existing_worker) =
                 self.request_index
                     .try_insert_request(request_id.clone(), worker, lora_name)
@@ -848,7 +859,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 outcome.membership_delta,
                 load,
             );
-            (outcome.expired_request_ids, load)
+            break (outcome.expired_request_ids, load);
         };
 
         self.request_index

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -78,19 +78,21 @@ impl WorkerLoadSnapshot {
 #[derive(Debug)]
 struct WorkerLoadSlot {
     // SeqLock gives the hot projection path a lock-free read of the latest
-    // whole-worker snapshot. Readers sample a sequence counter, copy the
-    // `Copy` payload, then retry if a writer changed the sequence while the
-    // copy was in flight. Writers still serialize with each other, but they do
-    // not wait for readers.
+    // whole-worker snapshot. Writers mark the sequence odd, replace the
+    // snapshot, then mark the sequence even. Readers only return after seeing
+    // the same even sequence before and after copying the `Copy` payload, so a
+    // copy that overlaps a write is retried instead of exposing a mixed
+    // snapshot. Writers still serialize with each other, but they do not wait
+    // for readers.
     //
     // The upstream crate implements the copy with `read_volatile`, which is
     // technically UB under Rust/LLVM if a writer mutates the same memory at the
     // same time: volatile is not atomic and does not by itself legalize a data
     // race. See https://github.com/Amanieu/seqlock/issues/2#issuecomment-473606523.
     //
-    // This use is intentionally narrow. `WorkerLoadSnapshot` is a small `Copy`
-    // value with no references or ownership, any torn read is discarded when
-    // the sequence changes, and the value is only advisory routing load state.
+    // `WorkerLoadSnapshot` is a small `Copy` value with no references or drop
+    // state. The sequence check is what makes the read logically race-free for
+    // this slot: a reader either observes a stable whole snapshot or retries.
     // In practice this is the same seqlock/READ_ONCE pattern the crate is
     // designed for, while avoiding the per-worker RwLock read on every request.
     load: SeqLock<WorkerLoadSnapshot>,

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -77,6 +77,22 @@ impl WorkerLoadSnapshot {
 
 #[derive(Debug)]
 struct WorkerLoadSlot {
+    // SeqLock gives the hot projection path a lock-free read of the latest
+    // whole-worker snapshot. Readers sample a sequence counter, copy the
+    // `Copy` payload, then retry if a writer changed the sequence while the
+    // copy was in flight. Writers still serialize with each other, but they do
+    // not wait for readers.
+    //
+    // The upstream crate implements the copy with `read_volatile`, which is
+    // technically UB under Rust/LLVM if a writer mutates the same memory at the
+    // same time: volatile is not atomic and does not by itself legalize a data
+    // race. See https://github.com/Amanieu/seqlock/issues/2#issuecomment-473606523.
+    //
+    // This use is intentionally narrow. `WorkerLoadSnapshot` is a small `Copy`
+    // value with no references or ownership, any torn read is discarded when
+    // the sequence changes, and the value is only advisory routing load state.
+    // In practice this is the same seqlock/READ_ONCE pattern the crate is
+    // designed for, while avoiding the per-worker RwLock read on every request.
     load: SeqLock<WorkerLoadSnapshot>,
 }
 

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_tokens::SequenceHash;
+use indexmap::IndexMap;
 use parking_lot::RwLock;
 #[cfg(test)]
 use rustc_hash::FxHashSet;
 use rustc_hash::{FxBuildHasher, FxHashMap};
+use seqlock::SeqLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 #[cfg(test)]
@@ -75,82 +77,75 @@ impl WorkerLoadSnapshot {
 
 #[derive(Debug)]
 struct WorkerLoadSlot {
-    worker: WorkerWithDpRank,
-    load: RwLock<WorkerLoadSnapshot>,
+    load: SeqLock<WorkerLoadSnapshot>,
 }
 
 impl WorkerLoadSlot {
-    fn new(worker: WorkerWithDpRank, load: WorkerLoadSnapshot) -> Self {
+    fn new(load: WorkerLoadSnapshot) -> Self {
         Self {
-            worker,
-            load: RwLock::new(load),
+            load: SeqLock::new(load),
         }
     }
 
     fn snapshot(&self) -> WorkerLoadSnapshot {
-        *self.load.read()
+        self.load.read()
     }
 
     fn replace(&self, load: WorkerLoadSnapshot) {
-        *self.load.write() = load;
+        *self.load.lock_write() = load;
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct WorkerLoadTable {
-    // Admission projects every registered worker's load. Keep that hot scan as a dense Vec walk;
-    // the hash index is only for point updates/removes when worker state changes.
-    slots: Vec<WorkerLoadSlot>,
-    index: FxHashMap<WorkerWithDpRank, usize>,
+    // IndexMap gives us the dense full-worker scan plus point lookup shape that was previously
+    // hand-rolled as Vec<WorkerLoadSlot> + FxHashMap<WorkerWithDpRank, usize>.
+    entries: IndexMap<WorkerWithDpRank, WorkerLoadSlot, FxBuildHasher>,
+}
+
+impl Default for WorkerLoadTable {
+    fn default() -> Self {
+        Self {
+            entries: IndexMap::with_hasher(FxBuildHasher),
+        }
+    }
 }
 
 impl WorkerLoadTable {
     fn len(&self) -> usize {
-        self.slots.len()
+        self.entries.len()
     }
 
-    fn iter(&self) -> impl Iterator<Item = &WorkerLoadSlot> + '_ {
-        self.slots.iter()
+    fn iter(&self) -> impl Iterator<Item = (WorkerWithDpRank, WorkerLoadSnapshot)> + '_ {
+        self.entries
+            .iter()
+            .map(|(&worker, slot)| (worker, slot.snapshot()))
     }
 
     fn ensure_worker(&mut self, worker: WorkerWithDpRank) {
-        if self.index.contains_key(&worker) {
-            return;
-        }
-        self.insert(worker, WorkerLoadSnapshot::default());
+        self.entries
+            .entry(worker)
+            .or_insert_with(|| WorkerLoadSlot::new(WorkerLoadSnapshot::default()));
     }
 
     fn update(&self, worker: WorkerWithDpRank, load: WorkerLoadSnapshot) -> bool {
-        let Some(&idx) = self.index.get(&worker) else {
+        let Some(slot) = self.entries.get(&worker) else {
             return false;
         };
-        self.slots[idx].replace(load);
+        slot.replace(load);
         true
     }
 
     fn upsert(&mut self, worker: WorkerWithDpRank, load: WorkerLoadSnapshot) {
-        if let Some(&idx) = self.index.get(&worker) {
-            self.slots[idx].replace(load);
+        if let Some(slot) = self.entries.get(&worker) {
+            slot.replace(load);
         } else {
-            self.insert(worker, load);
+            self.entries.insert(worker, WorkerLoadSlot::new(load));
         }
     }
 
     fn remove(&mut self, worker: WorkerWithDpRank) {
-        let Some(idx) = self.index.remove(&worker) else {
-            return;
-        };
-
-        self.slots.swap_remove(idx);
-        if idx < self.slots.len() {
-            self.index.insert(self.slots[idx].worker, idx);
-        }
-    }
-
-    fn insert(&mut self, worker: WorkerWithDpRank, load: WorkerLoadSnapshot) {
-        let idx = self.slots.len();
-        self.slots.push(WorkerLoadSlot::new(worker, load));
-        self.index.insert(worker, idx);
+        self.entries.swap_remove(&worker);
     }
 }
 
@@ -269,9 +264,7 @@ impl PromptRegistry {
         let mut active_requests = INCLUDE_ACTIVE_REQUESTS
             .then(|| FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher));
 
-        for entry in loads.iter() {
-            let worker = entry.worker;
-            let load = entry.snapshot();
+        for (worker, load) in loads.iter() {
             let overlap_depth = matched_depth.get(&worker).copied().unwrap_or(0);
             let new_blocks = query_len.saturating_sub(overlap_depth);
             let active_tokens = load.active_tokens(decay_now);
@@ -313,9 +306,7 @@ impl PromptRegistry {
         let loads = self.loads.read();
         let mut projections = FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher);
 
-        for entry in loads.iter() {
-            let worker = entry.worker;
-            let load = entry.snapshot();
+        for (worker, load) in loads.iter() {
             let overlap_depth = matched_depth.get(&worker).copied().unwrap_or(0);
             projections.insert(
                 worker,
@@ -334,7 +325,7 @@ impl PromptRegistry {
         self.loads
             .read()
             .iter()
-            .map(|entry| (entry.worker, entry.snapshot().active_blocks))
+            .map(|(worker, load)| (worker, load.active_blocks))
             .collect()
     }
 
@@ -342,7 +333,7 @@ impl PromptRegistry {
         self.loads
             .read()
             .iter()
-            .map(|entry| (entry.worker, entry.snapshot().active_requests))
+            .map(|(worker, load)| (worker, load.active_requests))
             .collect()
     }
 
@@ -350,7 +341,7 @@ impl PromptRegistry {
         self.loads
             .read()
             .iter()
-            .map(|entry| (entry.worker, entry.snapshot().active_tokens(decay_now)))
+            .map(|(worker, load)| (worker, load.active_tokens(decay_now)))
             .collect()
     }
 
@@ -361,10 +352,7 @@ impl PromptRegistry {
         self.loads
             .read()
             .iter()
-            .map(|entry| {
-                let load = entry.snapshot();
-                (entry.worker, load.modeled_remaining_prefill_time_ms(now))
-            })
+            .map(|(worker, load)| (worker, load.modeled_remaining_prefill_time_ms(now)))
             .collect()
     }
 
@@ -376,7 +364,7 @@ impl PromptRegistry {
         self.loads
             .read()
             .iter()
-            .any(|entry| predicate(entry.worker, entry.snapshot().active_tokens(decay_now)))
+            .any(|(worker, load)| predicate(worker, load.active_tokens(decay_now)))
     }
 
     #[cfg(test)]
@@ -385,12 +373,7 @@ impl PromptRegistry {
         expected_loads: &FxHashMap<WorkerWithDpRank, WorkerLoadSnapshot>,
         expected_blocks: &FxHashMap<WorkerWithDpRank, FxHashSet<SequenceHash>>,
     ) {
-        let actual_loads: FxHashMap<_, _> = self
-            .loads
-            .read()
-            .iter()
-            .map(|entry| (entry.worker, entry.snapshot()))
-            .collect();
+        let actual_loads: FxHashMap<_, _> = self.loads.read().iter().collect();
         let actual_blocks = self.membership.worker_hashes();
         assert_eq!(
             actual_loads, *expected_loads,


### PR DESCRIPTION
## Summary

This PR reduces hot-path locking in active sequence tracking:

- updates `active_sequences_bench` to black-box the production projection result so the measured path is not optimized away
- replaces each worker load entry's `RwLock<WorkerLoadSnapshot>` with `SeqLock<WorkerLoadSnapshot>` so projection reads copy the snapshot without taking a per-worker read lock
- switches the worker load table to `IndexMap` to keep dense scan behavior plus direct worker lookup without the hand-rolled `Vec + FxHashMap` pair
- folds lazy worker registration into the existing add-request worker-table lookup so the common pre-registered path no longer takes an extra `workers.read()` lock

## Motivation

Profiling the Mooncake active sequence replay showed `PromptRegistry::project_worker_loads` and worker-load projection spending substantial CPU in read-lock acquisition. After removing the per-worker load lock, the next visible lock bucket was the redundant lazy-registration check before add-request slot lookup.

## Validation

- `cargo fmt --all --check`
- `cargo test --locked -p dynamo-kv-router --lib sequences::`
- `cargo test --locked -p dynamo-kv-router --lib`
- `cargo test --locked -p dynamo-bench --test active_sequences_trace`

## Benchmark / Profile Notes

Mooncake-1000 replay, same config for both runs:

```text
--num-unique-inference-workers 10
--inference-worker-duplication-factor 20
--trace-duplication-factor 50
--benchmark-duration-ms 20
--num-gpu-blocks 16384
--block-size 128
```

| Build | Throughput | p99 latency | Notes |
| --- | ---: | ---: | --- |
| `5402e337fa` corrected benchmark only | 2.58M ops/s | 63.355us | Production projection path is preserved with `black_box`, but worker load entries still use per-worker `RwLock`s. |
| `50604e8165` PR tip | 3.74M ops/s | 73.446us | Uses seqlock-backed worker load slots and avoids the redundant lazy-registration read lock on the common add path. |

This is about a 1.45x throughput improvement on this short replay. Both runs emitted the benchmarker `could not keep up` warning, so p99 is noisy; the throughput and on-CPU profile shift are the useful signals.

Latest profile notes from the PR-tip run:

- worker-table `lock_shared_slow` samples inside `apply_entry` dropped from 2226 to 695 after the lazy-registration change
- remaining lock samples are mostly real add/free/prefill slot lookups, registry load-table reads, and bench-only `num_workers` instrumentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved worker load tracking and request routing internals, helping the system make more consistent routing decisions under load.

* **Bug Fixes**
  * Reduced the chance of stale or missing worker state during request handling.
  * Tightened retry behavior when a worker is not immediately available, improving reliability for late-registered workers.

* **Performance**
  * Updated benchmark handling to avoid unnecessary compiler optimizations, giving more trustworthy performance measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->