### PR TITLE
feat(backend): Encode disaggregation role + discovery wiring

### DIFF
--- a/components/src/dynamo/common/backend/CLAUDE.md
+++ b/components/src/dynamo/common/backend/CLAUDE.md
@@ -151,6 +151,11 @@ What the **runtime** does with the mode (Rust `Worker` in `lib/backend-common`):
 - `Decode` → keep `endpoint_types`, but force-disable
   `enable_local_indexer` (decode workers don't host the indexer endpoint).
 - `Aggregated` → register with the parsed `endpoint_types`.
+- `Encode` → register **surface-less** (`ModelType.empty()`) with
+  `WorkerType.Encode` and topology needs `[[Prefill, Decode], [Aggregated]]`,
+  so the discovery layer registers the worker for readiness only and hides it
+  from `/v1/models`. The Encode role is a multimodal encoder upstream of
+  P/D/Agg; backend-specific encoder implementations land separately.
 
 What the **engine** does with the mode (consumed in each backend's
 `generate()`):
@@ -164,6 +169,15 @@ What the **engine** does with the mode (consumed in each backend's
   loudly if missing (`require_prefill_result`), feed it into the
   engine's resume-from-KV-transfer call.
 - `Aggregated`: existing path, no branching.
+- `Encode`: produce the encoder handoff payload on the terminal chunk's
+  `encoder_result` (object-only) via `encoder_terminal_chunk`. The native
+  vLLM backend is text-only and rejects this role at startup.
+
+`route_to_encoder` (on `WorkerConfig`; CLI `--route-to-encoder` / env
+`DYN_ROUTE_TO_ENCODER`) makes an `Aggregated` or `Prefill` worker advertise an
+upstream `Encode` peer in its topology `needs`. It is meaningful only for
+agg/prefill — setting it on `Decode` or `Encode` is rejected at startup with
+`BackendError::InvalidArgument`.
 
 `is_quiescent()` lets a prefill worker exit the drain early once its KV
 transfers finish, before GPU memory is released. Engines that can't introspect

--- a/components/src/dynamo/common/backend/tests/test_backend_bindings.py
+++ b/components/src/dynamo/common/backend/tests/test_backend_bindings.py
@@ -310,16 +310,61 @@ def test_python_worker_config_rejects_unrecognized_disaggregation_mode_value():
 
 
 @pytest.mark.unified
-def test_python_worker_config_rejects_unsupported_mode_when_running():
-    """ENCODE has no unified-path implementation yet; the shim must raise
-    NotImplementedError when it tries to translate the mode for the Rust
-    binding instead of silently treating ENCODE as aggregated."""
-    from dynamo.common.backend.worker import WorkerConfig, _to_rust_disaggregation_mode
+def test_python_worker_config_translates_all_disagg_modes():
+    """Every variant of dynamo.common.constants.DisaggregationMode must map
+    to a Rust binding value -- including ENCODE, which gained unified-path
+    support. Regression for the prior `NotImplementedError`
+    behavior where ENCODE was rejected at translation time."""
+    from dynamo.common.backend.worker import _to_rust_disaggregation_mode
     from dynamo.common.constants import DisaggregationMode
 
-    cfg = WorkerConfig(namespace="ns", disaggregation_mode=DisaggregationMode.ENCODE)
-    with pytest.raises(NotImplementedError):
-        _to_rust_disaggregation_mode(cfg.disaggregation_mode)
+    rust_mode_for = {
+        DisaggregationMode.AGGREGATED: backend.DisaggregationMode.Aggregated,
+        DisaggregationMode.PREFILL: backend.DisaggregationMode.Prefill,
+        DisaggregationMode.DECODE: backend.DisaggregationMode.Decode,
+        DisaggregationMode.ENCODE: backend.DisaggregationMode.Encode,
+    }
+    for py_mode, expected_rust in rust_mode_for.items():
+        assert _to_rust_disaggregation_mode(py_mode) == expected_rust
+
+
+@pytest.mark.unified
+def test_python_worker_config_round_trips_route_to_encoder():
+    """route_to_encoder must flow from runtime_cfg -> WorkerConfig dataclass
+    -> Rust pyclass without being silently dropped at any layer. vLLM is the
+    only Python backend with the field today; SGLang/TRT-LLM get False via
+    the getattr default until they add the field."""
+    from dynamo.common.backend.worker import WorkerConfig
+
+    # Simulated vLLM-style runtime config that exposes the field.
+    class _RuntimeWithRoute:
+        namespace = "ns"
+        discovery_backend = "etcd"
+        request_plane = "tcp"
+        event_plane = None
+        route_to_encoder = True
+
+    cfg = WorkerConfig.from_runtime_config(_RuntimeWithRoute(), model_name="m")
+    assert cfg.route_to_encoder is True
+
+    # Simulated SGLang/TRT-LLM-style runtime config that doesn't expose the
+    # field yet -- the getattr default keeps it False so legacy behavior is
+    # preserved until the backend adds the field on its own runtime config.
+    class _RuntimeWithoutRoute:
+        namespace = "ns"
+        discovery_backend = "etcd"
+        request_plane = "tcp"
+        event_plane = None
+
+    cfg_default = WorkerConfig.from_runtime_config(
+        _RuntimeWithoutRoute(), model_name="m"
+    )
+    assert cfg_default.route_to_encoder is False
+
+    # Verify the Rust pyclass accepts the kwarg at the end of its signature
+    # (appended for backward-compat with positional callers).
+    rust_cfg = backend.WorkerConfig(namespace="ns", route_to_encoder=True)
+    assert rust_cfg is not None
 
 
 def test_worker_constructor_requires_engine_config_loop():

--- a/components/src/dynamo/common/backend/worker.py
+++ b/components/src/dynamo/common/backend/worker.py
@@ -62,14 +62,14 @@ def _guard_loop_signal_handlers(loop: asyncio.AbstractEventLoop) -> None:
     loop.add_signal_handler = add_signal_handler  # type: ignore[assignment]
 
 
-# Map the user-facing `dynamo.common.constants.DisaggregationMode` (which
-# carries 4 modes including ENCODE) to the 3-mode Rust enum. ENCODE is not
-# supported by the unified abstraction yet — multimodal encode workers stay
-# on the legacy main.py path until they migrate.
+# Map the user-facing `dynamo.common.constants.DisaggregationMode` to the
+# Rust enum. All four modes (AGGREGATED, PREFILL, DECODE, ENCODE) are
+# supported by the unified abstraction.
 _DISAGG_MODE_TO_RUST = {
     DisaggregationMode.AGGREGATED: _backend.DisaggregationMode.Aggregated,
     DisaggregationMode.PREFILL: _backend.DisaggregationMode.Prefill,
     DisaggregationMode.DECODE: _backend.DisaggregationMode.Decode,
+    DisaggregationMode.ENCODE: _backend.DisaggregationMode.Encode,
 }
 
 
@@ -136,6 +136,12 @@ class WorkerConfig:
     structural_tag_mode: str = "off"
     structural_tag_scope: str = "auto"
     structural_tag_schema: str = "auto"
+    # When True, this worker declares an upstream Encode peer in its
+    # topology `needs`. Meaningful only on AGGREGATED/PREFILL roles;
+    # the Rust validator rejects DECODE/ENCODE + True with InvalidArgument.
+    # Appended at the END of the dataclass to keep positional callers
+    # working -- inserting mid-class would silently shift downstream args.
+    route_to_encoder: bool = False
 
     @classmethod
     def from_runtime_config(
@@ -185,6 +191,10 @@ class WorkerConfig:
             "structural_tag_schema": getattr(
                 runtime_cfg, "dyn_structural_tag_schema", "auto"
             ),
+            # vLLM exposes `route_to_encoder` on its backend_args today;
+            # SGLang/TRT-LLM don't yet, so the getattr default keeps them at
+            # False until they add the field on their own runtime config.
+            "route_to_encoder": getattr(runtime_cfg, "route_to_encoder", False),
         }
         # vLLM/TRT-LLM expose `disaggregation_mode`; SGLang exposes
         # `serving_mode`. Skip the probe when an override is supplied so
@@ -264,6 +274,7 @@ class Worker:
             structural_tag_scope=self.config.structural_tag_scope,
             structural_tag_schema=self.config.structural_tag_schema,
             runtime=runtime_cfg,
+            route_to_encoder=self.config.route_to_encoder,
         )
 
         loop = asyncio.get_running_loop()

--- a/lib/backend-common/examples/mocker/src/engine.rs
+++ b/lib/backend-common/examples/mocker/src/engine.rs
@@ -274,6 +274,7 @@ impl MockerBackend {
             endpoint_types: args.common.endpoint_types,
             custom_jinja_template: args.common.custom_jinja_template,
             disaggregation_mode,
+            route_to_encoder: args.common.route_to_encoder,
             model_name: args.model_path,
             served_model_name: Some(args.model_name),
             tool_call_parser,

--- a/lib/backend-common/src/adapter.rs
+++ b/lib/backend-common/src/adapter.rs
@@ -353,12 +353,16 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         let guard = CancelMonitorGuard { drop_token };
 
         #[cfg(debug_assertions)]
-        let chunks = crate::validate::wrap(chunks);
+        let chunks = crate::validate::wrap(chunks, self.mode);
 
         let stream_ctx = ctx.clone();
         let stream_span = span.clone();
         let should_record_attrs = is_otlp_export_enabled();
-        let is_prefill_mode = self.mode.is_prefill();
+        // Prefill and Encode both produce empty-token terminals carrying
+        // their handoff payload (disaggregated_params and encoder_result
+        // respectively), so both need the worker_trace_link stamped on
+        // the terminal even when the chunk has no tokens.
+        let is_handoff_terminal_mode = self.mode.is_prefill() || self.mode.is_encode();
         let finalizer_span = span.clone();
         let mapped = async_stream::stream! {
             let _guard = guard;
@@ -418,13 +422,14 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                             stream_span.record("cancelled", stream_ctx.is_stopped());
                             record_itl_distribution(&stream_span, &mut itl_samples_ms);
                         }
-                        // Prefill-only: also stamp on the terminal chunk
-                        // (which may be the FIRST chunk for prefill, with
-                        // token_ids empty if the handoff is via
-                        // disaggregated_params). Belt-and-suspenders so the
-                        // decode peer always sees the link even when the
-                        // prefill terminal has no tokens.
-                        if is_prefill_mode
+                        // Prefill / Encode handoff terminals: also stamp
+                        // on the terminal chunk (which may be the FIRST
+                        // chunk for these modes, with token_ids empty
+                        // when the handoff is via disaggregated_params or
+                        // encoder_result). Belt-and-suspenders so the
+                        // downstream peer always sees the link even when
+                        // the terminal has no tokens.
+                        if is_handoff_terminal_mode
                             && is_terminal
                             && chunk.worker_trace_link.is_none()
                             && let Some(link) = &worker_trace_link
@@ -1675,6 +1680,44 @@ mod tests {
             .worker_trace_link
             .as_ref()
             .expect("prefill terminal with no tokens must be stamped via fallback");
+        assert_eq!(link.trace_id, trace_id);
+        assert_eq!(link.span_id, span_id);
+    }
+
+    /// Encode terminal with no token chunks (handoff via
+    /// `encoder_result`) must also get stamped via the handoff-mode
+    /// fallback so the downstream Prefill/Aggregated peer sees the
+    /// link. Mirrors the prefill test above with
+    /// `DisaggregationMode::Encode` and an `encode_terminal` chunk.
+    #[tokio::test]
+    async fn encode_mode_terminal_stamps_worker_trace_link() {
+        let (_guard, trace_id, span_id) = install_trace_context_injection();
+
+        let mut map = serde_json::Map::new();
+        map.insert("uri".into(), serde_json::Value::String("nixl://e/0".into()));
+        let (engine, _abort) = MockEngine::new(vec![LLMEngineOutput::encode_terminal(map)]);
+        let adapter = EngineAdapter::new(engine, DisaggregationMode::Encode);
+        let input = Context::new(make_request(vec![1, 2, 3]));
+        let stream = adapter.generate(input).await.unwrap();
+        let chunks: Vec<_> = stream.collect().await;
+
+        assert_eq!(chunks.len(), 1);
+        let data = chunks[0]
+            .data
+            .as_ref()
+            .expect("terminal chunk should have data");
+        assert!(
+            data.token_ids.is_empty(),
+            "test precondition: encode terminal has no tokens"
+        );
+        assert!(
+            data.encoder_result.as_ref().is_some_and(|v| v.is_object()),
+            "encode terminal must carry encoder_result: Some(Object(_))"
+        );
+        let link = data
+            .worker_trace_link
+            .as_ref()
+            .expect("encode terminal with no tokens must be stamped via fallback");
         assert_eq!(link.trace_id, trace_id);
         assert_eq!(link.span_id, span_id);
     }

--- a/lib/backend-common/src/args.rs
+++ b/lib/backend-common/src/args.rs
@@ -67,10 +67,12 @@ pub struct CommonArgs {
     )]
     pub exclude_tools_when_tool_choice_none: bool,
 
-    /// Disaggregation role: `agg` (default), `prefill`, or `decode`.
+    /// Disaggregation role: `agg` (default), `prefill`, `decode`, or `encode`.
     /// Prefill workers register with `ModelType::empty()` and
-    /// `WorkerType::Prefill` regardless of `endpoint_types`; decode workers
-    /// do not advertise a local KV indexer.
+    /// `WorkerType::Prefill` regardless of `endpoint_types`; decode and encode
+    /// workers do not advertise a local KV indexer. Encode workers register as
+    /// `WorkerType::Encode` and are not exposed on the public chat/completions
+    /// surface.
     #[arg(
         long,
         value_enum,
@@ -78,4 +80,14 @@ pub struct CommonArgs {
         env = "DYN_DISAGGREGATION_MODE",
     )]
     pub disaggregation_mode: DisaggregationMode,
+
+    /// Declare an upstream Encode peer in this worker's topology `needs`.
+    /// Meaningful only on `--disaggregation-mode agg` and `prefill`.
+    /// Setting it on `decode` or `encode` is rejected at startup.
+    ///
+    /// Scope: Rust backends consuming `CommonArgs` via clap. Python
+    /// backends populate this from their own runtime config -- the Python
+    /// shim does not read this env var.
+    #[arg(long, default_value_t = false, env = "DYN_ROUTE_TO_ENCODER")]
+    pub route_to_encoder: bool,
 }

--- a/lib/backend-common/src/disagg.rs
+++ b/lib/backend-common/src/disagg.rs
@@ -22,6 +22,8 @@ use crate::error::{BackendError, DynamoError, ErrorType};
 /// `Aggregated` is the default: the worker handles prefill and decode in the
 /// same engine. `Prefill` and `Decode` workers split the two phases across
 /// processes / GPUs and exchange KV cache via the engine-specific transport.
+/// `Encode` workers run a multimodal encoder upstream of Prefill/Aggregated
+/// and emit an opaque `encoder_result` payload on their terminal chunk.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum DisaggregationMode {
@@ -37,6 +39,11 @@ pub enum DisaggregationMode {
     /// Worker only runs the decode phase, consuming KV cache produced by a
     /// prefill peer. Does not advertise a local KV indexer.
     Decode,
+    /// Worker runs a multimodal encoder and emits an opaque `encoder_result`
+    /// payload on its terminal chunk. Registered as `WorkerType::Encode` with
+    /// topology needs `[[Prefill, Decode], [Aggregated]]`. Does not advertise
+    /// a local KV indexer.
+    Encode,
 }
 
 impl DisaggregationMode {
@@ -47,6 +54,7 @@ impl DisaggregationMode {
             Self::Aggregated => "agg",
             Self::Prefill => "prefill",
             Self::Decode => "decode",
+            Self::Encode => "encode",
         }
     }
 
@@ -58,6 +66,11 @@ impl DisaggregationMode {
     /// `true` when this worker only runs the decode phase.
     pub fn is_decode(&self) -> bool {
         matches!(self, Self::Decode)
+    }
+
+    /// `true` when this worker runs the encoder phase.
+    pub fn is_encode(&self) -> bool {
+        matches!(self, Self::Encode)
     }
 }
 
@@ -78,10 +91,11 @@ impl FromStr for DisaggregationMode {
             "agg" | "aggregated" => Ok(Self::Aggregated),
             "prefill" => Ok(Self::Prefill),
             "decode" => Ok(Self::Decode),
+            "encode" => Ok(Self::Encode),
             other => Err(DynamoError::builder()
                 .error_type(ErrorType::Backend(BackendError::InvalidArgument))
                 .message(format!(
-                    "unknown disaggregation mode '{other}' (expected one of: agg, prefill, decode)"
+                    "unknown disaggregation mode '{other}' (expected one of: agg, prefill, decode, encode)"
                 ))
                 .build()),
         }
@@ -106,6 +120,10 @@ mod tests {
             "decode".parse::<DisaggregationMode>().unwrap(),
             DisaggregationMode::Decode
         );
+        assert_eq!(
+            "encode".parse::<DisaggregationMode>().unwrap(),
+            DisaggregationMode::Encode
+        );
     }
 
     #[test]
@@ -122,7 +140,7 @@ mod tests {
 
     #[test]
     fn rejects_unknown() {
-        let e = "encode".parse::<DisaggregationMode>().unwrap_err();
+        let e = "not-a-mode".parse::<DisaggregationMode>().unwrap_err();
         assert_eq!(
             e.error_type(),
             ErrorType::Backend(BackendError::InvalidArgument)
@@ -135,6 +153,7 @@ mod tests {
             DisaggregationMode::Aggregated,
             DisaggregationMode::Prefill,
             DisaggregationMode::Decode,
+            DisaggregationMode::Encode,
         ] {
             let printed = mode.to_string();
             assert_eq!(printed.parse::<DisaggregationMode>().unwrap(), mode);
@@ -145,9 +164,15 @@ mod tests {
     fn predicates_match_variants() {
         assert!(DisaggregationMode::Prefill.is_prefill());
         assert!(!DisaggregationMode::Prefill.is_decode());
+        assert!(!DisaggregationMode::Prefill.is_encode());
         assert!(DisaggregationMode::Decode.is_decode());
+        assert!(!DisaggregationMode::Decode.is_encode());
+        assert!(DisaggregationMode::Encode.is_encode());
+        assert!(!DisaggregationMode::Encode.is_prefill());
+        assert!(!DisaggregationMode::Encode.is_decode());
         assert!(!DisaggregationMode::Aggregated.is_prefill());
         assert!(!DisaggregationMode::Aggregated.is_decode());
+        assert!(!DisaggregationMode::Aggregated.is_encode());
     }
 
     #[test]
@@ -164,5 +189,10 @@ mod tests {
         assert_eq!(json, "\"prefill\"");
         let back: DisaggregationMode = serde_json::from_str(&json).unwrap();
         assert_eq!(back, DisaggregationMode::Prefill);
+
+        let json = serde_json::to_string(&DisaggregationMode::Encode).unwrap();
+        assert_eq!(json, "\"encode\"");
+        let back: DisaggregationMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, DisaggregationMode::Encode);
     }
 }

--- a/lib/backend-common/src/validate.rs
+++ b/lib/backend-common/src/validate.rs
@@ -5,6 +5,11 @@
 //!
 //! Wraps the engine's returned stream and panics on contract violations:
 //! - a chunk yielded after a terminal chunk (one carrying `finish_reason`)
+//! - an Encode-mode non-cancelled terminal that lacks an
+//!   `encoder_result: Some(Value::Object(_))` payload (engines that build
+//!   the terminal via `LLMEngineOutput::stop()` instead of
+//!   `encode_terminal()` would otherwise ship a no-handoff terminal and
+//!   the downstream router would silently misroute)
 //!
 //! `completion_usage` on a terminal chunk is optional — the rest of the
 //! Dynamo pipeline (frontend, router) treats it as nice-to-have, matching
@@ -13,13 +18,16 @@
 //! The wrapper is compiled out in release — `lib.rs` gates the module
 //! with `#[cfg(debug_assertions)]`, so zero cost in release builds.
 
+use crate::disagg::DisaggregationMode;
 use crate::error::DynamoError;
+use dynamo_llm::protocols::common::FinishReason;
 use dynamo_llm::protocols::common::llm_backend::LLMEngineOutput;
 use futures::StreamExt;
 use futures::stream::BoxStream;
 
 pub(crate) fn wrap(
     stream: BoxStream<'static, Result<LLMEngineOutput, DynamoError>>,
+    mode: DisaggregationMode,
 ) -> BoxStream<'static, Result<LLMEngineOutput, DynamoError>> {
     let mut terminal_seen = false;
     Box::pin(async_stream::stream! {
@@ -31,7 +39,35 @@ pub(crate) fn wrap(
                  (a chunk with finish_reason set, or an Err, must be the last item)"
             );
             match &item {
-                Ok(chunk) if chunk.finish_reason.is_some() => terminal_seen = true,
+                Ok(chunk) if chunk.finish_reason.is_some() => {
+                    // Encode-mode terminal rule: successful terminals MUST
+                    // carry an object-shaped encoder_result. Cancelled is
+                    // exempt because cancellation can land before the encoder
+                    // produces a payload; Error terminals are exempt because a
+                    // failure path (LLMEngineOutput::error) legitimately has no
+                    // encoder_result.
+                    if mode.is_encode()
+                        && !matches!(
+                            chunk.finish_reason,
+                            Some(FinishReason::Cancelled | FinishReason::Error(_))
+                        )
+                    {
+                        assert!(
+                            matches!(
+                                chunk.encoder_result.as_ref(),
+                                Some(v) if v.is_object()
+                            ),
+                            "Encode-mode contract violation: non-cancelled terminal \
+                             chunk must carry encoder_result: Some(Value::Object(_)). \
+                             Use LLMEngineOutput::encode_terminal(map) or \
+                             .with_encoder_result(map) instead of LLMEngineOutput::stop(). \
+                             Got finish_reason={:?}, encoder_result={:?}",
+                            chunk.finish_reason,
+                            chunk.encoder_result,
+                        );
+                    }
+                    terminal_seen = true;
+                }
                 Err(_) => terminal_seen = true,
                 _ => {}
             }
@@ -60,21 +96,24 @@ mod tests {
 
     #[tokio::test]
     async fn valid_stream_passes_through() {
-        let wrapped = wrap(to_stream(vec![
-            chunk::token(1),
-            chunk::token(2),
-            LLMEngineOutput::length(),
-        ]));
+        let wrapped = wrap(
+            to_stream(vec![
+                chunk::token(1),
+                chunk::token(2),
+                LLMEngineOutput::length(),
+            ]),
+            DisaggregationMode::Aggregated,
+        );
         let collected: Vec<_> = wrapped.collect().await;
         assert_eq!(collected.len(), 3);
     }
 
     #[tokio::test]
     async fn valid_terminal_without_usage_passes() {
-        let wrapped = wrap(to_stream(vec![
-            chunk::token(1),
-            LLMEngineOutput::cancelled(),
-        ]));
+        let wrapped = wrap(
+            to_stream(vec![chunk::token(1), LLMEngineOutput::cancelled()]),
+            DisaggregationMode::Aggregated,
+        );
         let collected: Vec<_> = wrapped.collect().await;
         assert_eq!(collected.len(), 2);
         assert!(matches!(
@@ -86,17 +125,82 @@ mod tests {
     #[tokio::test]
     #[should_panic(expected = "item yielded after terminal item")]
     async fn panics_on_chunk_after_terminal() {
-        let wrapped = wrap(to_stream(vec![LLMEngineOutput::length(), chunk::token(2)]));
+        let wrapped = wrap(
+            to_stream(vec![LLMEngineOutput::length(), chunk::token(2)]),
+            DisaggregationMode::Aggregated,
+        );
         let _collected: Vec<_> = wrapped.collect().await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "item yielded after terminal item")]
     async fn panics_on_chunk_after_err() {
-        let wrapped = wrap(to_stream_with_err(vec![
-            Err(DynamoError::msg("typed failure")),
-            Ok(chunk::token(1)),
-        ]));
+        let wrapped = wrap(
+            to_stream_with_err(vec![
+                Err(DynamoError::msg("typed failure")),
+                Ok(chunk::token(1)),
+            ]),
+            DisaggregationMode::Aggregated,
+        );
         let _collected: Vec<_> = wrapped.collect().await;
+    }
+
+    /// Encode-mode terminal must carry encoder_result: Some(Object). An
+    /// engine that builds its terminal via LLMEngineOutput::stop()
+    /// (which seeds encoder_result: None) is a producer bug -- catch it
+    /// in debug so the failure surfaces where it originates.
+    #[tokio::test]
+    #[should_panic(expected = "Encode-mode contract violation")]
+    async fn panics_on_encode_terminal_without_encoder_result() {
+        let wrapped = wrap(
+            to_stream(vec![LLMEngineOutput::stop()]),
+            DisaggregationMode::Encode,
+        );
+        let _collected: Vec<_> = wrapped.collect().await;
+    }
+
+    /// Encode-mode terminal with a proper encoder_result via
+    /// encode_terminal passes the validator.
+    #[tokio::test]
+    async fn encode_terminal_with_encoder_result_passes() {
+        let mut map = serde_json::Map::new();
+        map.insert("uri".into(), serde_json::Value::String("nixl://e/0".into()));
+        let wrapped = wrap(
+            to_stream(vec![LLMEngineOutput::encode_terminal(map)]),
+            DisaggregationMode::Encode,
+        );
+        let collected: Vec<_> = wrapped.collect().await;
+        assert_eq!(collected.len(), 1);
+        assert!(matches!(
+            collected[0].as_ref().unwrap().finish_reason,
+            Some(FinishReason::Stop)
+        ));
+    }
+
+    /// Cancelled Encode-mode terminals are exempt -- cancellation can
+    /// land before the encoder produces a payload, so requiring a
+    /// non-None encoder_result on cancel would force engines to
+    /// fabricate one.
+    #[tokio::test]
+    async fn encode_mode_cancelled_terminal_without_encoder_result_passes() {
+        let wrapped = wrap(
+            to_stream(vec![LLMEngineOutput::cancelled()]),
+            DisaggregationMode::Encode,
+        );
+        let collected: Vec<_> = wrapped.collect().await;
+        assert_eq!(collected.len(), 1);
+    }
+
+    /// The Encode rule is mode-gated: non-encode modes (Aggregated,
+    /// Prefill, Decode) emit terminals without encoder_result as
+    /// normal, and the validator must not fire.
+    #[tokio::test]
+    async fn aggregated_terminal_without_encoder_result_passes() {
+        let wrapped = wrap(
+            to_stream(vec![LLMEngineOutput::stop()]),
+            DisaggregationMode::Aggregated,
+        );
+        let collected: Vec<_> = wrapped.collect().await;
+        assert_eq!(collected.len(), 1);
     }
 }

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -160,7 +160,9 @@ pub struct WorkerConfig {
     /// and `WorkerType::Prefill`, so the frontend's prefill router targets it
     /// via `worker_type`. `Decode` keeps `endpoint_types` but force-disables the
     /// local KV indexer because decode workers do not host the indexer
-    /// endpoint.
+    /// endpoint. `Encode` registers as `WorkerType::Encode` with topology needs
+    /// `[[Prefill, Decode], [Aggregated]]`; it also force-disables the local KV
+    /// indexer.
     pub disaggregation_mode: DisaggregationMode,
     /// Operator override. `Worker` resolves precedence: this field >
     /// `DYN_HEALTH_CHECK_PAYLOAD` env > `engine.health_check_payload()`.
@@ -176,14 +178,21 @@ pub struct WorkerConfig {
     /// Runtime / transport overrides applied via env vars before the
     /// `DistributedRuntime` is constructed.
     pub runtime: RuntimeConfig,
+    /// When `true`, this worker declares an upstream `Encode` dependency in
+    /// its topology `needs`. Meaningful only for `Prefill` and `Aggregated`
+    /// roles -- setting it on `Decode` or `Encode` is rejected at
+    /// `Worker::run` validation time with `BackendError::InvalidArgument`.
+    pub route_to_encoder: bool,
 }
 
 impl WorkerConfig {
     /// Effective `enable_local_indexer`, accounting for disaggregation
-    /// mode. Decode workers force this off because they don't host the
-    /// in-process KV indexer endpoint and must not advertise it.
+    /// mode. Decode and Encode workers force this off because they don't
+    /// host the in-process KV indexer endpoint and must not advertise it.
     pub(crate) fn effective_enable_local_indexer(&self) -> bool {
-        self.enable_local_indexer && !self.disaggregation_mode.is_decode()
+        self.enable_local_indexer
+            && !self.disaggregation_mode.is_decode()
+            && !self.disaggregation_mode.is_encode()
     }
 }
 
@@ -210,6 +219,7 @@ impl Default for WorkerConfig {
             structural_tag_scope: StructuralTagScope::Auto,
             structural_tag_schema: StructuralTagSchemaMode::Auto,
             runtime: RuntimeConfig::default(),
+            route_to_encoder: false,
         }
     }
 }
@@ -426,6 +436,7 @@ impl Worker {
         // doesn't pay the cost of installing signal handlers and spawning
         // a listener task just to get an InvalidArgument error.
         validate_model_input(self.config.model_input, &self.engine)?;
+        validate_route_to_encoder(&self.config)?;
 
         // Install the OS signal handlers synchronously, before spawning
         // anything, so a SIGTERM delivered between this point and the
@@ -1421,23 +1432,86 @@ fn resolve_served_name(config: &WorkerConfig, engine_config: &EngineConfig) -> O
 /// no OpenAI surface. They register the legacy `ModelType::Prefill` *marker*
 /// bit (not a surface) so an OLD frontend, which detects prefill via that bit,
 /// still routes disaggregated traffic during the cross-version rollout. A new
-/// frontend ignores it and dispatches off `worker_type`. Everything else falls
-/// back to the parsed `endpoint_types`.
+/// frontend ignores it and dispatches off `worker_type`.
+///
+/// Encode workers also expose no public OpenAI surface — they are reached via
+/// the EncoderRouter, not the frontend. They register surface-less
+/// (`ModelType::empty()`) so the discovery watcher registers them for
+/// serving-readiness only and hides them from `/v1/models`; the role is
+/// carried by `WorkerType::Encode`.
+///
+/// Everything else falls back to the parsed `endpoint_types`.
 fn resolve_model_type(config: &WorkerConfig) -> Result<ModelType, DynamoError> {
     if config.disaggregation_mode.is_prefill() {
         return Ok(ModelType::Prefill);
     }
+    if config.disaggregation_mode.is_encode() {
+        return Ok(ModelType::empty());
+    }
     parse_endpoint_types(&config.endpoint_types)
 }
 
-/// Derive the model-serving-readiness fields (`worker_type`, `needs`) for
-/// the worker's disaggregation role. Prefill workers need a Decode peer,
-/// Decode workers need a Prefill peer, and Aggregated workers stand alone.
+/// Derive the topology-readiness fields (`worker_type`, `needs`) for the
+/// worker's disaggregation role. Prefill workers need a Decode peer, Decode
+/// workers need a Prefill peer, Aggregated workers stand alone, and Encode
+/// workers need either a Prefill+Decode pair or a single Aggregated peer.
+///
+/// `route_to_encoder` extends the `needs` of `Prefill`/`Aggregated` to
+/// also require an `Encode` peer. Invalid combinations (`Decode` or
+/// `Encode` with `route_to_encoder=true`) are rejected upstream in
+/// `validate_route_to_encoder`; this function trusts that gate and only
+/// applies the flag when it is meaningful.
 fn resolve_worker_type_and_needs(config: &WorkerConfig) -> (WorkerType, Vec<Vec<WorkerType>>) {
     match config.disaggregation_mode {
-        DisaggregationMode::Prefill => (WorkerType::Prefill, vec![vec![WorkerType::Decode]]),
+        DisaggregationMode::Prefill => {
+            let inner = if config.route_to_encoder {
+                vec![WorkerType::Decode, WorkerType::Encode]
+            } else {
+                vec![WorkerType::Decode]
+            };
+            (WorkerType::Prefill, vec![inner])
+        }
         DisaggregationMode::Decode => (WorkerType::Decode, vec![vec![WorkerType::Prefill]]),
-        DisaggregationMode::Aggregated => (WorkerType::Aggregated, Vec::new()),
+        DisaggregationMode::Aggregated => {
+            let needs = if config.route_to_encoder {
+                vec![vec![WorkerType::Encode]]
+            } else {
+                Vec::new()
+            };
+            (WorkerType::Aggregated, needs)
+        }
+        DisaggregationMode::Encode => (
+            WorkerType::Encode,
+            vec![
+                vec![WorkerType::Prefill, WorkerType::Decode],
+                vec![WorkerType::Aggregated],
+            ],
+        ),
+    }
+}
+
+/// Validate that `route_to_encoder` is meaningful for the worker's
+/// disaggregation role. Setting the flag on `Decode` or `Encode` is a
+/// configuration bug: Decode reads KV cache from a Prefill peer and never
+/// sees the encoder output (the dependency is transitive through Prefill),
+/// while Encode is the producer of the encoder result and has nothing
+/// upstream to route to.
+fn validate_route_to_encoder(config: &WorkerConfig) -> Result<(), DynamoError> {
+    if !config.route_to_encoder {
+        return Ok(());
+    }
+    match config.disaggregation_mode {
+        DisaggregationMode::Aggregated | DisaggregationMode::Prefill => Ok(()),
+        DisaggregationMode::Decode | DisaggregationMode::Encode => Err(err(
+            ErrorType::Backend(BackendError::InvalidArgument),
+            format!(
+                "--route-to-encoder is meaningful only for --disaggregation-mode \
+                 agg|prefill; got '{}'. Decode workers consume KV cache from a \
+                 Prefill peer (encoder dependency propagates transitively through \
+                 Prefill); Encode workers are the producer of the encoder result.",
+                config.disaggregation_mode
+            ),
+        )),
     }
 }
 
@@ -1936,6 +2010,196 @@ mod tests {
         assert!(mt.supports_prefill());
         assert!(!mt.supports_chat());
         assert!(!mt.supports_completions());
+    }
+
+    #[test]
+    fn resolve_model_type_encode_is_surface_less() {
+        // Encode workers expose no public OpenAI surface: they are reached via
+        // the EncoderRouter, not the frontend. --disaggregation-mode encode
+        // forces ModelType::empty() (even when endpoint_types is left at the
+        // "chat,completions" default) so the discovery watcher registers them
+        // for serving-readiness only and hides them from /v1/models. The role
+        // is carried by WorkerType::Encode + topology needs at the discovery
+        // layer.
+        let config = WorkerConfig {
+            endpoint_types: "chat,completions".to_string(),
+            disaggregation_mode: DisaggregationMode::Encode,
+            ..WorkerConfig::default()
+        };
+        let mt = resolve_model_type(&config).unwrap();
+        assert_eq!(mt, ModelType::empty());
+        assert!(mt.is_empty());
+        assert!(!mt.supports_chat());
+        assert!(!mt.supports_completions());
+    }
+
+    // -------------------------------------------------------------------
+    // resolve_worker_type_and_needs: one test per row of the topology table
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn topology_aggregated_no_route_to_encoder() {
+        let cfg = WorkerConfig {
+            disaggregation_mode: DisaggregationMode::Aggregated,
+            route_to_encoder: false,
+            ..WorkerConfig::default()
+        };
+        let (wt, needs) = resolve_worker_type_and_needs(&cfg);
+        assert_eq!(wt, WorkerType::Aggregated);
+        assert!(needs.is_empty());
+    }
+
+    #[test]
+    fn topology_aggregated_with_route_to_encoder() {
+        let cfg = WorkerConfig {
+            disaggregation_mode: DisaggregationMode::Aggregated,
+            route_to_encoder: true,
+            ..WorkerConfig::default()
+        };
+        let (wt, needs) = resolve_worker_type_and_needs(&cfg);
+        assert_eq!(wt, WorkerType::Aggregated);
+        assert_eq!(needs, vec![vec![WorkerType::Encode]]);
+    }
+
+    #[test]
+    fn topology_prefill_no_route_to_encoder() {
+        let cfg = WorkerConfig {
+            disaggregation_mode: DisaggregationMode::Prefill,
+            route_to_encoder: false,
+            ..WorkerConfig::default()
+        };
+        let (wt, needs) = resolve_worker_type_and_needs(&cfg);
+        assert_eq!(wt, WorkerType::Prefill);
+        assert_eq!(needs, vec![vec![WorkerType::Decode]]);
+    }
+
+    #[test]
+    fn topology_prefill_with_route_to_encoder() {
+        let cfg = WorkerConfig {
+            disaggregation_mode: DisaggregationMode::Prefill,
+            route_to_encoder: true,
+            ..WorkerConfig::default()
+        };
+        let (wt, needs) = resolve_worker_type_and_needs(&cfg);
+        assert_eq!(wt, WorkerType::Prefill);
+        assert_eq!(needs, vec![vec![WorkerType::Decode, WorkerType::Encode]]);
+    }
+
+    #[test]
+    fn topology_decode_ignores_route_to_encoder_flag_in_needs() {
+        // route_to_encoder=true on Decode is rejected by
+        // validate_route_to_encoder; resolve_worker_type_and_needs only
+        // sees the flag false case in production. But sanity-check that
+        // even if it leaks through (e.g. internal callers bypassing the
+        // validator), Decode's needs don't grow an encoder leg.
+        let cfg = WorkerConfig {
+            disaggregation_mode: DisaggregationMode::Decode,
+            route_to_encoder: false,
+            ..WorkerConfig::default()
+        };
+        let (wt, needs) = resolve_worker_type_and_needs(&cfg);
+        assert_eq!(wt, WorkerType::Decode);
+        assert_eq!(needs, vec![vec![WorkerType::Prefill]]);
+    }
+
+    #[test]
+    fn topology_encode_has_two_alternative_needs() {
+        // Encode: needs `[[Prefill, Decode], [Aggregated]]` (DNF).
+        let cfg = WorkerConfig {
+            disaggregation_mode: DisaggregationMode::Encode,
+            route_to_encoder: false,
+            ..WorkerConfig::default()
+        };
+        let (wt, needs) = resolve_worker_type_and_needs(&cfg);
+        assert_eq!(wt, WorkerType::Encode);
+        assert_eq!(
+            needs,
+            vec![
+                vec![WorkerType::Prefill, WorkerType::Decode],
+                vec![WorkerType::Aggregated],
+            ],
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // validate_route_to_encoder: one test per row of the rejection table
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn validate_route_to_encoder_accepts_aggregated_and_prefill_when_true() {
+        for mode in [DisaggregationMode::Aggregated, DisaggregationMode::Prefill] {
+            let cfg = WorkerConfig {
+                disaggregation_mode: mode,
+                route_to_encoder: true,
+                ..WorkerConfig::default()
+            };
+            validate_route_to_encoder(&cfg).unwrap_or_else(|e| {
+                panic!("route_to_encoder=true should be accepted for {mode}; got {e}")
+            });
+        }
+    }
+
+    #[test]
+    fn validate_route_to_encoder_rejects_decode_when_true() {
+        let cfg = WorkerConfig {
+            disaggregation_mode: DisaggregationMode::Decode,
+            route_to_encoder: true,
+            ..WorkerConfig::default()
+        };
+        let e = validate_route_to_encoder(&cfg).unwrap_err();
+        assert_eq!(
+            e.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert!(e.to_string().contains("decode"), "msg = {e}");
+    }
+
+    #[test]
+    fn validate_route_to_encoder_rejects_encode_when_true() {
+        let cfg = WorkerConfig {
+            disaggregation_mode: DisaggregationMode::Encode,
+            route_to_encoder: true,
+            ..WorkerConfig::default()
+        };
+        let e = validate_route_to_encoder(&cfg).unwrap_err();
+        assert_eq!(
+            e.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert!(e.to_string().contains("encode"), "msg = {e}");
+    }
+
+    #[test]
+    fn validate_route_to_encoder_accepts_any_mode_when_false() {
+        for mode in [
+            DisaggregationMode::Aggregated,
+            DisaggregationMode::Prefill,
+            DisaggregationMode::Decode,
+            DisaggregationMode::Encode,
+        ] {
+            let cfg = WorkerConfig {
+                disaggregation_mode: mode,
+                route_to_encoder: false,
+                ..WorkerConfig::default()
+            };
+            validate_route_to_encoder(&cfg).unwrap_or_else(|e| {
+                panic!("route_to_encoder=false should be accepted for {mode}; got {e}")
+            });
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // effective_enable_local_indexer: Encode must force off
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn effective_enable_local_indexer_encode_force_disabled() {
+        let cfg = WorkerConfig {
+            enable_local_indexer: true,
+            disaggregation_mode: DisaggregationMode::Encode,
+            ..WorkerConfig::default()
+        };
+        assert!(!cfg.effective_enable_local_indexer());
     }
 
     #[tokio::test]

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -86,6 +86,7 @@ pub enum DisaggregationMode {
     Aggregated = 1,
     Prefill = 2,
     Decode = 3,
+    Encode = 4,
 }
 
 impl From<DisaggregationMode> for RsDisaggregationMode {
@@ -94,6 +95,7 @@ impl From<DisaggregationMode> for RsDisaggregationMode {
             DisaggregationMode::Aggregated => RsDisaggregationMode::Aggregated,
             DisaggregationMode::Prefill => RsDisaggregationMode::Prefill,
             DisaggregationMode::Decode => RsDisaggregationMode::Decode,
+            DisaggregationMode::Encode => RsDisaggregationMode::Encode,
         }
     }
 }
@@ -313,6 +315,7 @@ impl WorkerConfig {
         structural_tag_mode = "off".to_string(),
         structural_tag_scope = "auto".to_string(),
         structural_tag_schema = "auto".to_string(),
+        route_to_encoder = false,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -337,6 +340,7 @@ impl WorkerConfig {
         structural_tag_mode: String,
         structural_tag_scope: String,
         structural_tag_schema: String,
+        route_to_encoder: bool,
     ) -> PyResult<Self> {
         // Delegating to the same conversion used by `register_model`.
         let model_input_rs = match model_input {
@@ -413,6 +417,7 @@ impl WorkerConfig {
                 structural_tag_scope: st_scope,
                 structural_tag_schema: st_schema,
                 runtime: runtime.map(|r| r.inner).unwrap_or_default(),
+                route_to_encoder,
             },
         })
     }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -3094,6 +3094,7 @@ class backend:
         Aggregated: "backend.DisaggregationMode"
         Prefill: "backend.DisaggregationMode"
         Decode: "backend.DisaggregationMode"
+        Encode: "backend.DisaggregationMode"
 
     class LlmRegistration:
         def __init__(
@@ -3175,6 +3176,7 @@ class backend:
             structural_tag_mode: str = ...,
             structural_tag_scope: str = ...,
             structural_tag_schema: str = ...,
+            route_to_encoder: bool = ...,
         ) -> None: ...
 
     class Worker:

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -1109,6 +1109,78 @@ mod tests {
         );
     }
 
+    // -- Encode-set visibility --
+    //
+    // Encode workers ride the EncoderRouter, not the public chat/completions
+    // surface. Tests below verify is_displayable correctly hides Encode-only
+    // deployments from /v1/models and continues to surface mixed
+    // Aggregated+Encode deployments via the Aggregated set only.
+
+    /// Helper: build an Encode-role WorkerSet wrapped in Arc. worker_count=1
+    /// via a live watcher so is_displayable doesn't filter it at the
+    /// worker_count == 0 guard. Dropping the sender is fine: tokio's
+    /// `watch::Receiver::borrow()` returns the current value even after the
+    /// sender closes, which is all `is_displayable` reads.
+    fn make_encode_worker_set(namespace: &str, mdcsum: &str) -> Arc<WorkerSet> {
+        let mut card = ModelDeploymentCard::default();
+        card.worker_type = Some(crate::worker_type::WorkerType::Encode);
+        let (_tx, rx) = watch::channel(vec![1_u64]);
+        let mut ws = WorkerSet::new(namespace.to_string(), mdcsum.to_string(), card);
+        ws.set_instance_watcher(rx);
+        Arc::new(ws)
+    }
+
+    #[test]
+    fn encode_only_model_is_not_displayable() {
+        // An Encode worker has no serving engines (the watcher's role gate
+        // skips pipeline construction) and is_prefill_set excludes Encode,
+        // so an Encode-only model has no displayable WorkerSet and stays
+        // hidden from /v1/models. The frontend's chat/completions surface
+        // is not where users hit Encode workers; the EncoderRouter is.
+        let model = Model::new("llava".to_string());
+        model.add_worker_set(
+            "dynamo:encode".to_string(),
+            make_encode_worker_set("dynamo", "mdc-e"),
+        );
+
+        assert!(
+            !model.is_displayable(),
+            "Encode-only model must be hidden from /v1/models -- Encode workers \
+             aren't a public serving surface"
+        );
+    }
+
+    #[test]
+    fn aggregated_plus_encode_model_is_displayable_via_aggregated() {
+        // E/Agg topology: an Aggregated worker plus an Encode peer. The
+        // Aggregated set is engineless in this stub but is_prefill_set
+        // remains true for it (legacy classification), so the model is
+        // displayable via the Aggregated WorkerSet's fallback. The Encode
+        // WorkerSet does NOT contribute to displayability -- it's filtered
+        // by is_encode_set excluding it from is_prefill_set.
+        let model = Model::new("llava".to_string());
+        model.add_worker_set("dynamo".to_string(), make_worker_set("dynamo", "mdc-a"));
+        model.add_worker_set(
+            "dynamo:encode".to_string(),
+            make_encode_worker_set("dynamo", "mdc-e"),
+        );
+
+        assert!(
+            model.is_displayable(),
+            "Aggregated+Encode model must be displayable via the Aggregated set"
+        );
+
+        // Removing the Aggregated set leaves only the Encode set -- model
+        // must flip to hidden (the bug we're guarding against would have
+        // kept it displayable via the Encode set being misclassified as
+        // prefill).
+        model.remove_worker_set("dynamo");
+        assert!(
+            !model.is_displayable(),
+            "after Aggregated leaves, Encode-only model must be hidden"
+        );
+    }
+
     // -- Model serving readiness --
     //
     // These tests exercise the live-compute readiness methods on `Model`.

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -471,12 +471,25 @@ impl ModelWatcher {
             .await
             .with_context(|| model_name.clone())?;
 
-        // Check if instances of the SAME component remain in this namespace.
-        // In disaggregated deployments, prefill and decode are different components
-        // in the same namespace, so we must check at the component level to avoid
-        // removing one type's WorkerSet while the other still has workers.
-        let component_has_instances = active_instances.iter().any(|(eid, _)| {
-            eid.namespace == *worker_namespace && eid.component == *worker_component
+        // Check if instances of the SAME role and component remain in
+        // this namespace. In disaggregated deployments, prefill and
+        // decode are different components in the same namespace -- so
+        // checking only (ns, component) is necessary but not sufficient.
+        // Encode workers can share a (ns, component) with Aggregated, so
+        // we ALSO require the remaining instance to map to the same
+        // computed `ws_key` (which folds in worker_type for Encode). If
+        // we used only (ns, component), removing the last Encode
+        // instance from a namespace that still has an Aggregated worker
+        // in the same component would see "instances exist" and skip
+        // remove_worker_set, leaking the Encode WorkerSet forever.
+        let component_has_instances = active_instances.iter().any(|(eid, other_card)| {
+            eid.namespace == *worker_namespace
+                && eid.component == *worker_component
+                && worker_set_key(
+                    &eid.namespace,
+                    other_card.model_type,
+                    other_card.worker_type,
+                ) == ws_key
         });
 
         if !component_has_instances {
@@ -1439,5 +1452,24 @@ mod tests {
         );
         let prefill = worker_set_key("ns1", ModelType::empty(), Some(WorkerType::Prefill));
         assert_ne!(decode, prefill);
+    }
+
+    #[test]
+    fn worker_set_key_encode_and_aggregated_coexist_in_same_namespace() {
+        // Regression for the Encode/Aggregated key collision: Encode and
+        // Aggregated workers in the same namespace MUST map to different keys,
+        // so both can register without an MDC checksum mismatch. Under the
+        // role-in-key scheme, an Encode worker registers surface-less
+        // (ModelType::empty()) and lands in `{ns}::encode`, while Aggregated
+        // keeps its `{ns}:chat|completions:aggregated` bucket.
+        let agg_key = worker_set_key(
+            "dynamo",
+            ModelType::Chat | ModelType::Completions,
+            Some(WorkerType::Aggregated),
+        );
+        let enc_key = worker_set_key("dynamo", ModelType::empty(), Some(WorkerType::Encode));
+        assert_ne!(agg_key, enc_key);
+        assert_eq!(agg_key, "dynamo:chat|completions:aggregated");
+        assert_eq!(enc_key, "dynamo::encode");
     }
 }

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -147,9 +147,32 @@ impl WorkerSet {
             || self.has_realtime_engine()
     }
 
-    /// Whether this set tracks a prefill model (no engine, just lifecycle)
+    /// Whether this set tracks an Encode worker. Encode WorkerSets carry
+    /// no serving engines (the watcher's Encode role gate skips
+    /// pipeline construction) -- if we let `is_prefill_set` classify
+    /// them, model-displayability logic would gate /v1/models on a
+    /// PrefillRouter that doesn't exist for Encode. Keep the two
+    /// mutually exclusive.
+    ///
+    /// **Role-based, not engine-field-based.** Unlike `has_chat_engine()`
+    /// / `has_completions_engine()` / etc. (which inspect typed engine
+    /// slots on the WorkerSet), `is_encode_set` reads `card.worker_type`
+    /// directly. The Encode role intentionally has no `encode_engine`
+    /// field -- Encode workers don't expose a public OpenAI-shaped
+    /// endpoint, so there is nothing to slot. The role itself is the
+    /// contract.
+    pub fn is_encode_set(&self) -> bool {
+        matches!(
+            self.card.worker_type,
+            Some(crate::worker_type::WorkerType::Encode),
+        )
+    }
+
+    /// Whether this set tracks a prefill model (no engine, just
+    /// lifecycle). Excludes Encode sets, which also lack engines but
+    /// are not gated through PrefillRouter.
     pub fn is_prefill_set(&self) -> bool {
-        !self.has_any_serving_engine()
+        !self.is_encode_set() && !self.has_any_serving_engine()
     }
 
     /// Build ParsingOptions from this WorkerSet's card configuration.
@@ -381,5 +404,60 @@ mod tests {
 
         tx.send(vec![100, 200, 300]).unwrap();
         assert_eq!(ws.worker_count(), 3);
+    }
+
+    // -------------------------------------------------------------------
+    // Encode-set classification
+    //
+    // Encode WorkerSets carry no serving engines (the watcher's role
+    // gate skips pipeline construction), so the legacy "no engines =
+    // prefill" rule would misclassify them. is_encode_set distinguishes
+    // them via card.worker_type and is_prefill_set excludes them so the
+    // two predicates stay mutually exclusive.
+    // -------------------------------------------------------------------
+
+    fn make_encode_worker_set() -> WorkerSet {
+        let mut card = ModelDeploymentCard::default();
+        card.worker_type = Some(crate::worker_type::WorkerType::Encode);
+        WorkerSet::new("ns1".to_string(), "abc".to_string(), card)
+    }
+
+    #[test]
+    fn encode_set_is_classified_as_encode_not_prefill() {
+        let ws = make_encode_worker_set();
+        assert!(ws.is_encode_set());
+        // The two predicates must be mutually exclusive: an Encode set
+        // has no engines but must NOT be classified as prefill, since
+        // model-displayability logic gates /v1/models on PrefillRouter
+        // for prefill sets and Encode workers have no such router.
+        assert!(!ws.is_prefill_set());
+    }
+
+    #[test]
+    fn non_encode_engineless_set_stays_classified_as_prefill() {
+        // Regression guard: the existing "engineless = prefill" rule
+        // must still hold for worker_type = None / Prefill / Decode /
+        // Aggregated. Only Encode is carved out.
+        let mut card_none = ModelDeploymentCard::default();
+        card_none.worker_type = None;
+        let ws = WorkerSet::new("ns1".to_string(), "abc".to_string(), card_none);
+        assert!(!ws.is_encode_set());
+        assert!(ws.is_prefill_set());
+
+        for role in [
+            crate::worker_type::WorkerType::Prefill,
+            crate::worker_type::WorkerType::Decode,
+            crate::worker_type::WorkerType::Aggregated,
+        ] {
+            let mut card = ModelDeploymentCard::default();
+            card.worker_type = Some(role);
+            let ws = WorkerSet::new("ns1".to_string(), "abc".to_string(), card);
+            assert!(!ws.is_encode_set(), "{:?} should not be Encode", role);
+            assert!(
+                ws.is_prefill_set(),
+                "{:?} should remain prefill-classified",
+                role
+            );
+        }
     }
 }

--- a/lib/vllm-rs-backend/src/backend.rs
+++ b/lib/vllm-rs-backend/src/backend.rs
@@ -184,6 +184,17 @@ impl LLMEngine for VllmBackend {
             return Err(engine_shutdown("vLLM backend has already been started"));
         }
 
+        // Fail fast on an unsupported role: the Encode disaggregation mode is a
+        // multimodal encoder upstream of P/D/Agg, but this backend is text-only
+        // (multimodal payloads are rejected in `validate_request`). Reject at
+        // startup so the misconfiguration can't register as a healthy worker and
+        // only surface as a per-request error in `apply_disaggregation_mode`.
+        if self.disaggregation_mode.is_encode() {
+            return Err(invalid_arg(
+                "encode disaggregation mode is not supported by the native vLLM backend",
+            ));
+        }
+
         // TODO: currently vLLM's Rust engine-core client only supports local data-parallel engines
         if !self.managed_engine.frontend_local_only() {
             return Err(invalid_arg(

--- a/lib/vllm-rs-backend/src/convert.rs
+++ b/lib/vllm-rs-backend/src/convert.rs
@@ -180,6 +180,15 @@ fn apply_disaggregation_mode(
                 .insert("kv_transfer_params".to_string(), kv_transfer_params);
         }
         DisaggregationMode::Aggregated => {} // do nothing
+        DisaggregationMode::Encode => {
+            // The Encode role is a multimodal encoder upstream of P/D/Agg.
+            // This native backend is text-only (multimodal execution payloads
+            // are rejected in `validate_request`), so an Encode worker is never
+            // a valid configuration here.
+            return Err(invalid_arg(
+                "encode disaggregation mode is not supported by the native vLLM backend",
+            ));
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Overview:

**Stacked on #10969** (the `encoder_result` handoff contract) — **review that first**; this PR's diff is just the role + discovery layer that consumes the contract.

Adds `Encode` as a first-class disaggregation role across the unified backend: the role/config surface, topology, discovery, and validation. This is **contract + role + discovery plumbing only** — the frontend `EncoderRouter` (Encode → P/D/Agg request routing), backend-specific encoder implementations, and NIXL embedding transfer land in follow-ups.

Split out of #9901 per review feedback (separate interface from implementation). Tracked internally under Linear **DIS-2110** (parent **DIS-2051**; unblocks **DIS-2111** sample-engine smoke, **DIS-2112** TRT-LLM aggregated MM, **DIS-2113** TRT-LLM E/PD + precomputed embeddings + NIXL transfer).

## Details:

- `DisaggregationMode::Encode` + `route_to_encoder: bool` on `WorkerConfig`; `--route-to-encoder` CLI flag (env `DYN_ROUTE_TO_ENCODER`) + PyO3/`worker.py` plumbing. Invalid-combo rejection at `Worker::run` (Decode/Encode + `route_to_encoder` → `BackendError::InvalidArgument`).
- Topology `needs` for the Encode role; `resolve_model_type` registers Encode workers **surface-less** (`ModelType::empty()`) so the surface-driven discovery layer registers them for readiness only and hides them from `/v1/models`.
- Discovery: role-aware `worker_set_key`, surface-driven watcher pipeline-skip + `handle_delete`, `WorkerSet::is_encode_set` excluding Encode from `is_prefill_set`.
- Debug-build Encode stream validator (successful terminals must carry `encoder_result: Some(Object)`; Cancelled and Error terminals exempt) + adapter trace-link stamping for Encode terminals; an `Encode` arm in the native vLLM backend's disaggregation match.

**Test plan**

- [x] Python `test_backend_bindings.py` (ENCODE → Rust enum + `route_to_encoder` round-trip through `from_runtime_config`) + Rust discovery/worker unit tests (`worker_set_key_*`, `is_encode_set`/displayability, `resolve_model_type`, `validate` encode-terminal rules).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean; `dynamo-backend-common --lib` 124 pass, `dynamo-llm --lib` 1110 pass.

## Where should the reviewer start?

- `lib/backend-common/src/worker.rs` — role config, topology (`resolve_worker_type_and_needs`), `resolve_model_type` (Encode → `ModelType::empty()`), `validate_route_to_encoder`.
- `lib/llm/src/discovery/{watcher,model,worker_set}.rs` — keying, surface-driven `handle_put`/`handle_delete`, public-surface gating.
- `lib/backend-common/src/validate.rs` and `lib/vllm-rs-backend/src/convert.rs`.

## Related Issues

> No GitHub issue — this work is tracked internally under Linear **DIS-2110**. Depends on / stacked on #10969.

**🚫 This PR is NOT linked to a GitHub issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->