### PR TITLE
fix(event-plane): give each ZMQ EventChannel a unique discovery key

### DIFF
--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -44,14 +44,26 @@ impl KVStoreDiscovery {
         format!("{}/{}/{}/{:x}", namespace, component, endpoint, instance_id)
     }
 
-    /// Build the key path for an event channel relative to bucket, not absolute)
+    /// Build the key path for an event channel (relative to bucket, not absolute).
+    ///
+    /// When `discriminator` is `Some`, it is appended as a fifth segment so that
+    /// multiple publishers in the same process (sharing one `instance_id`) for the
+    /// same `(namespace, component, topic)` get distinct keys instead of
+    /// overwriting one another. Matches [`EventChannelInstanceId::to_path`].
     fn event_channel_key(
         namespace: &str,
         component: &str,
         topic: &str,
         instance_id: u64,
+        discriminator: Option<u64>,
     ) -> String {
-        format!("{}/{}/{}/{:x}", namespace, component, topic, instance_id)
+        match discriminator {
+            Some(discriminator) => format!(
+                "{}/{}/{}/{:x}/{:x}",
+                namespace, component, topic, instance_id, discriminator
+            ),
+            None => format!("{}/{}/{}/{:x}", namespace, component, topic, instance_id),
+        }
     }
 
     /// Extract prefix for querying based on discovery query
@@ -223,9 +235,16 @@ impl Discovery for KVStoreDiscovery {
                 component,
                 topic,
                 instance_id,
+                discriminator,
                 ..
             } => {
-                let key = Self::event_channel_key(namespace, component, topic, *instance_id);
+                let key = Self::event_channel_key(
+                    namespace,
+                    component,
+                    topic,
+                    *instance_id,
+                    *discriminator,
+                );
                 // TODO: bis - remove this info log
                 tracing::info!(
                     "KVStoreDiscovery::register: EventChannel bucket={}, key={}",
@@ -341,9 +360,16 @@ impl Discovery for KVStoreDiscovery {
                 component,
                 topic,
                 instance_id,
+                discriminator,
                 ..
             } => {
-                let key = Self::event_channel_key(namespace, component, topic, *instance_id);
+                let key = Self::event_channel_key(
+                    namespace,
+                    component,
+                    topic,
+                    *instance_id,
+                    *discriminator,
+                );
                 tracing::debug!(
                     "KVStoreDiscovery::unregister: Unregistering event channel instance_id={}, namespace={}, component={}, topic={}, key={}",
                     instance_id,
@@ -489,7 +515,8 @@ impl Discovery for KVStoreDiscovery {
                         // - Endpoints: "namespace/component/endpoint/{instance_id:x}"
                         // - Models: "namespace/component/endpoint/{instance_id:x}"
                         // - LoRA models: "namespace/component/endpoint/{instance_id:x}/{lora_slug}"
-                        // - EventChannels: "namespace/component/{instance_id:x}"
+                        // - EventChannels: "namespace/component/topic/{instance_id:x}"
+                        // - EventChannels (ZMQ direct): "namespace/component/topic/{instance_id:x}/{discriminator:x}"
                         //
                         // Use strip_bucket_prefix for consistency with matches_prefix().
                         let relative_key = Self::strip_bucket_prefix(key_str, bucket_name);
@@ -513,11 +540,29 @@ impl Discovery for KVStoreDiscovery {
                         let namespace = key_parts[0].to_string();
                         let component = key_parts[1].to_string();
 
-                        // Handle EventChannel (4 parts: namespace/component/topic/instance_id) vs Endpoints/Models
+                        // Handle EventChannel (4 or 5 parts) vs Endpoints/Models
                         let id = if bucket_name == EVENT_CHANNELS_BUCKET {
-                            // EventChannel keys: namespace/component/topic/{instance_id:x}
+                            // EventChannel keys:
+                            //   namespace/component/topic/{instance_id:x}
+                            //   namespace/component/topic/{instance_id:x}/{discriminator:x}
                             let topic = key_parts[2].to_string();
                             let instance_id_hex = key_parts[3];
+                            // Optional 5th part is the per-publisher discriminator (ZMQ direct).
+                            let discriminator = match key_parts.get(4) {
+                                Some(d) => match u64::from_str_radix(d, 16) {
+                                    Ok(discriminator) => Some(discriminator),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            key = %key_str,
+                                            error = %e,
+                                            discriminator_hex = %d,
+                                            "Failed to parse event channel discriminator hex"
+                                        );
+                                        continue;
+                                    }
+                                },
+                                None => None,
+                            };
                             match u64::from_str_radix(instance_id_hex, 16) {
                                 Ok(instance_id) => {
                                     DiscoveryInstanceId::EventChannel(EventChannelInstanceId {
@@ -525,6 +570,7 @@ impl Discovery for KVStoreDiscovery {
                                         component,
                                         topic,
                                         instance_id,
+                                        discriminator,
                                     })
                                 }
                                 Err(e) => {
@@ -626,6 +672,62 @@ mod tests {
             }
             _ => panic!("Expected Endpoint instance"),
         }
+    }
+
+    /// A single `KVStoreDiscovery` (one process => one `instance_id`) registering
+    /// several ZMQ-direct EventChannels for the same (namespace, component, topic)
+    /// must produce one discoverable key per publisher rather than overwriting on
+    /// the shared `instance_id`. This is the worker-side of the ZMQ KV-events bug:
+    /// a dp_size=N mocker creates N publishers in one process.
+    #[tokio::test]
+    async fn test_kv_store_event_channels_multiple_publishers_same_process() {
+        use crate::discovery::{EventChannelQuery, EventTransport};
+
+        let store = kv::Manager::memory();
+        let cancel_token = CancellationToken::new();
+        let client = KVStoreDiscovery::new(store, cancel_token);
+
+        // All four share the client's (process) instance_id; only the
+        // discriminator (bound port) differs, mirroring one publisher per dp_rank.
+        let ports = [40001u16, 40002, 40003, 40004];
+        let mut registered = Vec::new();
+        for port in ports {
+            let spec = DiscoverySpec::EventChannel {
+                namespace: "ns".to_string(),
+                component: "mocker".to_string(),
+                topic: "kv-events".to_string(),
+                transport: EventTransport::zmq(format!("tcp://10.0.0.1:{port}")),
+                discriminator: Some(u64::from(port)),
+            };
+            registered.push(client.register(spec).await.unwrap());
+        }
+
+        // The router's component+topic query must discover every publisher.
+        let listed = client
+            .list(DiscoveryQuery::EventChannels(EventChannelQuery::topic(
+                "ns",
+                "mocker",
+                "kv-events",
+            )))
+            .await
+            .unwrap();
+        assert_eq!(
+            listed.len(),
+            4,
+            "all per-publisher EventChannels must be discoverable"
+        );
+
+        // Unregistering one publisher removes exactly its own key.
+        client.unregister(registered.remove(1)).await.unwrap();
+        let listed = client
+            .list(DiscoveryQuery::EventChannels(EventChannelQuery::topic(
+                "ns",
+                "mocker",
+                "kv-events",
+            )))
+            .await
+            .unwrap();
+        assert_eq!(listed.len(), 3);
     }
 
     #[tokio::test]

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -46,21 +46,20 @@ impl KVStoreDiscovery {
 
     /// Build the key path for an event channel (relative to bucket, not absolute).
     ///
-    /// When `discriminator` is `Some`, it is appended as a fifth segment so that
-    /// multiple publishers in the same process (sharing one `instance_id`) for the
-    /// same `(namespace, component, topic)` get distinct keys instead of
-    /// overwriting one another. Matches [`EventChannelInstanceId::to_path`].
+    /// When `endpoint_port` is `Some` (ZMQ direct), it is appended as a fifth segment so
+    /// publishers sharing one process `instance_id` get distinct keys. Matches
+    /// [`EventChannelInstanceId::to_path`].
     fn event_channel_key(
         namespace: &str,
         component: &str,
         topic: &str,
         instance_id: u64,
-        discriminator: Option<u64>,
+        endpoint_port: Option<u64>,
     ) -> String {
-        match discriminator {
-            Some(discriminator) => format!(
+        match endpoint_port {
+            Some(endpoint_port) => format!(
                 "{}/{}/{}/{:x}/{:x}",
-                namespace, component, topic, instance_id, discriminator
+                namespace, component, topic, instance_id, endpoint_port
             ),
             None => format!("{}/{}/{}/{:x}", namespace, component, topic, instance_id),
         }
@@ -235,7 +234,7 @@ impl Discovery for KVStoreDiscovery {
                 component,
                 topic,
                 instance_id,
-                discriminator,
+                endpoint_port,
                 ..
             } => {
                 let key = Self::event_channel_key(
@@ -243,7 +242,7 @@ impl Discovery for KVStoreDiscovery {
                     component,
                     topic,
                     *instance_id,
-                    *discriminator,
+                    *endpoint_port,
                 );
                 // TODO: bis - remove this info log
                 tracing::info!(
@@ -360,7 +359,7 @@ impl Discovery for KVStoreDiscovery {
                 component,
                 topic,
                 instance_id,
-                discriminator,
+                endpoint_port,
                 ..
             } => {
                 let key = Self::event_channel_key(
@@ -368,7 +367,7 @@ impl Discovery for KVStoreDiscovery {
                     component,
                     topic,
                     *instance_id,
-                    *discriminator,
+                    *endpoint_port,
                 );
                 tracing::debug!(
                     "KVStoreDiscovery::unregister: Unregistering event channel instance_id={}, namespace={}, component={}, topic={}, key={}",
@@ -516,7 +515,7 @@ impl Discovery for KVStoreDiscovery {
                         // - Models: "namespace/component/endpoint/{instance_id:x}"
                         // - LoRA models: "namespace/component/endpoint/{instance_id:x}/{lora_slug}"
                         // - EventChannels: "namespace/component/topic/{instance_id:x}"
-                        // - EventChannels (ZMQ direct): "namespace/component/topic/{instance_id:x}/{discriminator:x}"
+                        // - EventChannels (ZMQ direct): "namespace/component/topic/{instance_id:x}/{endpoint_port:x}"
                         //
                         // Use strip_bucket_prefix for consistency with matches_prefix().
                         let relative_key = Self::strip_bucket_prefix(key_str, bucket_name);
@@ -544,19 +543,19 @@ impl Discovery for KVStoreDiscovery {
                         let id = if bucket_name == EVENT_CHANNELS_BUCKET {
                             // EventChannel keys:
                             //   namespace/component/topic/{instance_id:x}
-                            //   namespace/component/topic/{instance_id:x}/{discriminator:x}
+                            //   namespace/component/topic/{instance_id:x}/{endpoint_port:x}
                             let topic = key_parts[2].to_string();
                             let instance_id_hex = key_parts[3];
-                            // Optional 5th part is the per-publisher discriminator (ZMQ direct).
-                            let discriminator = match key_parts.get(4) {
+                            // Optional 5th part is the per-publisher endpoint_port (ZMQ direct).
+                            let endpoint_port = match key_parts.get(4) {
                                 Some(d) => match u64::from_str_radix(d, 16) {
-                                    Ok(discriminator) => Some(discriminator),
+                                    Ok(endpoint_port) => Some(endpoint_port),
                                     Err(e) => {
                                         tracing::warn!(
                                             key = %key_str,
                                             error = %e,
-                                            discriminator_hex = %d,
-                                            "Failed to parse event channel discriminator hex"
+                                            endpoint_port_hex = %d,
+                                            "Failed to parse event channel endpoint_port hex"
                                         );
                                         continue;
                                     }
@@ -570,7 +569,7 @@ impl Discovery for KVStoreDiscovery {
                                         component,
                                         topic,
                                         instance_id,
-                                        discriminator,
+                                        endpoint_port,
                                     })
                                 }
                                 Err(e) => {
@@ -688,7 +687,8 @@ mod tests {
         let client = KVStoreDiscovery::new(store, cancel_token);
 
         // All four share the client's (process) instance_id; only the
-        // discriminator (bound port) differs, mirroring one publisher per dp_rank.
+        // endpoint_port (bound port, derived from the transport) differs,
+        // mirroring one publisher per dp_rank.
         let ports = [40001u16, 40002, 40003, 40004];
         let mut registered = Vec::new();
         for port in ports {
@@ -697,7 +697,6 @@ mod tests {
                 component: "mocker".to_string(),
                 topic: "kv-events".to_string(),
                 transport: EventTransport::zmq(format!("tcp://10.0.0.1:{port}")),
-                discriminator: Some(u64::from(port)),
             };
             registered.push(client.register(spec).await.unwrap());
         }

--- a/lib/runtime/src/discovery/metadata.rs
+++ b/lib/runtime/src/discovery/metadata.rs
@@ -503,6 +503,7 @@ mod tests {
                 topic: "test-topic".to_string(),
                 instance_id: i,
                 transport: EventTransport::zmq(format!("tcp://localhost:{}", 5000 + i)),
+                discriminator: None,
             };
             metadata.register_event_channel(instance).unwrap();
         }
@@ -536,9 +537,117 @@ mod tests {
             topic: "test-topic".to_string(),
             instance_id: 0,
             transport: EventTransport::zmq("tcp://localhost:5000"),
+            discriminator: None,
         };
         metadata.unregister_event_channel(&instance).unwrap();
         assert_eq!(metadata.get_all_event_channels().len(), 2);
+    }
+
+    /// Reproduces the multi-publisher-per-process collision: several ZMQ-direct
+    /// publishers for the same (namespace, component, topic) share one
+    /// process-level `instance_id`. Without the per-publisher discriminator they
+    /// collapse onto a single `event_channels` key and overwrite each other
+    /// (only the last survives). With the discriminator (the bound port) each
+    /// gets a distinct key, and the component-scoped query still returns them
+    /// all — exactly what the router needs to connect to every dp_rank.
+    #[tokio::test]
+    async fn test_event_channel_per_publisher_discriminator() {
+        use crate::discovery::EventTransport;
+
+        let instance_id = 0xABCDu64; // single shared process instance_id
+
+        // Without a discriminator: 4 publishers, one shared key -> collapse to 1.
+        let mut collapsed = DiscoveryMetadata::new();
+        for port in [5001u16, 5002, 5003, 5004] {
+            collapsed
+                .register_event_channel(DiscoveryInstance::EventChannel {
+                    namespace: "test".to_string(),
+                    component: "mocker".to_string(),
+                    topic: "kv-events".to_string(),
+                    instance_id,
+                    transport: EventTransport::zmq(format!("tcp://10.0.0.1:{port}")),
+                    discriminator: None,
+                })
+                .unwrap();
+        }
+        assert_eq!(
+            collapsed.get_all_event_channels().len(),
+            1,
+            "shared instance_id with no discriminator must collide to a single key"
+        );
+
+        // With a per-publisher discriminator (the bound port): 4 distinct keys.
+        let mut distinct = DiscoveryMetadata::new();
+        for port in [5001u16, 5002, 5003, 5004] {
+            distinct
+                .register_event_channel(DiscoveryInstance::EventChannel {
+                    namespace: "test".to_string(),
+                    component: "mocker".to_string(),
+                    topic: "kv-events".to_string(),
+                    instance_id,
+                    transport: EventTransport::zmq(format!("tcp://10.0.0.1:{port}")),
+                    discriminator: Some(u64::from(port)),
+                })
+                .unwrap();
+        }
+        assert_eq!(
+            distinct.get_all_event_channels().len(),
+            4,
+            "distinct discriminators must produce one key per publisher"
+        );
+
+        // The router's component-scoped query must still match all of them.
+        let filtered = distinct.filter(&DiscoveryQuery::EventChannels(EventChannelQuery::topic(
+            "test",
+            "mocker",
+            "kv-events",
+        )));
+        assert_eq!(filtered.len(), 4);
+
+        // Unregister targets exactly one publisher's key (its own discriminator).
+        distinct
+            .unregister_event_channel(&DiscoveryInstance::EventChannel {
+                namespace: "test".to_string(),
+                component: "mocker".to_string(),
+                topic: "kv-events".to_string(),
+                instance_id,
+                transport: EventTransport::zmq("tcp://10.0.0.1:5002"),
+                discriminator: Some(5002),
+            })
+            .unwrap();
+        assert_eq!(distinct.get_all_event_channels().len(), 3);
+    }
+
+    /// EventChannelInstanceId::to_path / from_path round-trips for both the
+    /// no-discriminator (NATS/broker) and with-discriminator (ZMQ direct) forms,
+    /// and the two forms never produce the same path for a shared instance_id.
+    #[test]
+    fn test_event_channel_instance_id_path_roundtrip() {
+        use crate::discovery::EventChannelInstanceId;
+
+        let no_disc = EventChannelInstanceId {
+            namespace: "ns".to_string(),
+            component: "comp".to_string(),
+            topic: "kv-events".to_string(),
+            instance_id: 0x1234,
+            discriminator: None,
+        };
+        let path = no_disc.to_path();
+        assert_eq!(path, "ns/comp/kv-events/1234");
+        assert_eq!(EventChannelInstanceId::from_path(&path).unwrap(), no_disc);
+
+        let with_disc = EventChannelInstanceId {
+            namespace: "ns".to_string(),
+            component: "comp".to_string(),
+            topic: "kv-events".to_string(),
+            instance_id: 0x1234,
+            discriminator: Some(0x162a),
+        };
+        let path = with_disc.to_path();
+        assert_eq!(path, "ns/comp/kv-events/1234/162a");
+        assert_eq!(EventChannelInstanceId::from_path(&path).unwrap(), with_disc);
+
+        assert_ne!(no_disc.to_path(), with_disc.to_path());
     }
 
     #[tokio::test]
@@ -574,6 +683,7 @@ mod tests {
             topic: "test-topic".to_string(),
             instance_id: 3,
             transport: EventTransport::zmq("tcp://localhost:5000"),
+            discriminator: None,
         };
         metadata.register_event_channel(event_channel).unwrap();
 

--- a/lib/runtime/src/discovery/metadata.rs
+++ b/lib/runtime/src/discovery/metadata.rs
@@ -503,7 +503,7 @@ mod tests {
                 topic: "test-topic".to_string(),
                 instance_id: i,
                 transport: EventTransport::zmq(format!("tcp://localhost:{}", 5000 + i)),
-                discriminator: None,
+                endpoint_port: None,
             };
             metadata.register_event_channel(instance).unwrap();
         }
@@ -537,26 +537,22 @@ mod tests {
             topic: "test-topic".to_string(),
             instance_id: 0,
             transport: EventTransport::zmq("tcp://localhost:5000"),
-            discriminator: None,
+            endpoint_port: None,
         };
         metadata.unregister_event_channel(&instance).unwrap();
         assert_eq!(metadata.get_all_event_channels().len(), 2);
     }
 
-    /// Reproduces the multi-publisher-per-process collision: several ZMQ-direct
-    /// publishers for the same (namespace, component, topic) share one
-    /// process-level `instance_id`. Without the per-publisher discriminator they
-    /// collapse onto a single `event_channels` key and overwrite each other
-    /// (only the last survives). With the discriminator (the bound port) each
-    /// gets a distinct key, and the component-scoped query still returns them
-    /// all — exactly what the router needs to connect to every dp_rank.
+    /// Multiple ZMQ-direct publishers sharing one process `instance_id` collapse to a
+    /// single key without a per-publisher `endpoint_port`; with it they get distinct keys
+    /// and the component-scoped query still returns them all.
     #[tokio::test]
-    async fn test_event_channel_per_publisher_discriminator() {
+    async fn test_event_channel_per_publisher_endpoint_port() {
         use crate::discovery::EventTransport;
 
         let instance_id = 0xABCDu64; // single shared process instance_id
 
-        // Without a discriminator: 4 publishers, one shared key -> collapse to 1.
+        // Without an endpoint_port: 4 publishers, one shared key -> collapse to 1.
         let mut collapsed = DiscoveryMetadata::new();
         for port in [5001u16, 5002, 5003, 5004] {
             collapsed
@@ -566,17 +562,17 @@ mod tests {
                     topic: "kv-events".to_string(),
                     instance_id,
                     transport: EventTransport::zmq(format!("tcp://10.0.0.1:{port}")),
-                    discriminator: None,
+                    endpoint_port: None,
                 })
                 .unwrap();
         }
         assert_eq!(
             collapsed.get_all_event_channels().len(),
             1,
-            "shared instance_id with no discriminator must collide to a single key"
+            "shared instance_id with no endpoint_port must collide to a single key"
         );
 
-        // With a per-publisher discriminator (the bound port): 4 distinct keys.
+        // With a per-publisher endpoint_port (the bound port): 4 distinct keys.
         let mut distinct = DiscoveryMetadata::new();
         for port in [5001u16, 5002, 5003, 5004] {
             distinct
@@ -586,14 +582,14 @@ mod tests {
                     topic: "kv-events".to_string(),
                     instance_id,
                     transport: EventTransport::zmq(format!("tcp://10.0.0.1:{port}")),
-                    discriminator: Some(u64::from(port)),
+                    endpoint_port: Some(u64::from(port)),
                 })
                 .unwrap();
         }
         assert_eq!(
             distinct.get_all_event_channels().len(),
             4,
-            "distinct discriminators must produce one key per publisher"
+            "distinct endpoint_ports must produce one key per publisher"
         );
 
         // The router's component-scoped query must still match all of them.
@@ -604,7 +600,7 @@ mod tests {
         )));
         assert_eq!(filtered.len(), 4);
 
-        // Unregister targets exactly one publisher's key (its own discriminator).
+        // Unregister targets exactly one publisher's key (its own endpoint_port).
         distinct
             .unregister_event_channel(&DiscoveryInstance::EventChannel {
                 namespace: "test".to_string(),
@@ -612,42 +608,42 @@ mod tests {
                 topic: "kv-events".to_string(),
                 instance_id,
                 transport: EventTransport::zmq("tcp://10.0.0.1:5002"),
-                discriminator: Some(5002),
+                endpoint_port: Some(5002),
             })
             .unwrap();
         assert_eq!(distinct.get_all_event_channels().len(), 3);
     }
 
     /// EventChannelInstanceId::to_path / from_path round-trips for both the
-    /// no-discriminator (NATS/broker) and with-discriminator (ZMQ direct) forms,
+    /// no-endpoint_port (NATS/broker) and with-endpoint_port (ZMQ direct) forms,
     /// and the two forms never produce the same path for a shared instance_id.
     #[test]
     fn test_event_channel_instance_id_path_roundtrip() {
         use crate::discovery::EventChannelInstanceId;
 
-        let no_disc = EventChannelInstanceId {
+        let no_port = EventChannelInstanceId {
             namespace: "ns".to_string(),
             component: "comp".to_string(),
             topic: "kv-events".to_string(),
             instance_id: 0x1234,
-            discriminator: None,
+            endpoint_port: None,
         };
-        let path = no_disc.to_path();
+        let path = no_port.to_path();
         assert_eq!(path, "ns/comp/kv-events/1234");
-        assert_eq!(EventChannelInstanceId::from_path(&path).unwrap(), no_disc);
+        assert_eq!(EventChannelInstanceId::from_path(&path).unwrap(), no_port);
 
-        let with_disc = EventChannelInstanceId {
+        let with_port = EventChannelInstanceId {
             namespace: "ns".to_string(),
             component: "comp".to_string(),
             topic: "kv-events".to_string(),
             instance_id: 0x1234,
-            discriminator: Some(0x162a),
+            endpoint_port: Some(0x162a),
         };
-        let path = with_disc.to_path();
+        let path = with_port.to_path();
         assert_eq!(path, "ns/comp/kv-events/1234/162a");
-        assert_eq!(EventChannelInstanceId::from_path(&path).unwrap(), with_disc);
+        assert_eq!(EventChannelInstanceId::from_path(&path).unwrap(), with_port);
 
-        assert_ne!(no_disc.to_path(), with_disc.to_path());
+        assert_ne!(no_port.to_path(), with_port.to_path());
     }
 
     #[tokio::test]
@@ -683,7 +679,7 @@ mod tests {
             topic: "test-topic".to_string(),
             instance_id: 3,
             transport: EventTransport::zmq("tcp://localhost:5000"),
-            discriminator: None,
+            endpoint_port: None,
         };
         metadata.register_event_channel(event_channel).unwrap();
 

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -335,6 +335,16 @@ pub enum DiscoverySpec {
         topic: String,
         /// Event transport type (NATS subject prefix or ZMQ endpoint)
         transport: EventTransport,
+        /// Optional per-publisher discriminator that disambiguates multiple
+        /// publishers created in the same process (which share one process-level
+        /// `instance_id`). Without it, multiple ZMQ-direct publishers in one
+        /// worker (e.g. one per dp_rank) collapse onto the same discovery key
+        /// `{namespace}/{component}/{topic}/{instance_id}` and overwrite each
+        /// other, so the router discovers only one endpoint per worker. ZMQ
+        /// direct mode sets this to the bound port (unique per publisher within
+        /// the process); NATS and ZMQ broker mode leave it `None`, preserving
+        /// their original single-key behaviour.
+        discriminator: Option<u64>,
     },
 }
 
@@ -411,12 +421,14 @@ impl DiscoverySpec {
                 component,
                 topic,
                 transport,
+                discriminator,
             } => DiscoveryInstance::EventChannel {
                 namespace,
                 component,
                 topic,
                 instance_id,
                 transport,
+                discriminator,
             },
         }
     }
@@ -450,6 +462,11 @@ pub enum DiscoveryInstance {
         instance_id: u64,
         /// Event transport type (NATS subject prefix or ZMQ endpoint)
         transport: EventTransport,
+        /// Optional per-publisher discriminator (see [`DiscoverySpec::EventChannel`]).
+        /// Older registrations and other transports omit it, hence `Option` + serde
+        /// default so existing serialized instances continue to deserialize.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        discriminator: Option<u64>,
     },
 }
 
@@ -509,12 +526,14 @@ impl DiscoveryInstance {
                 component,
                 topic,
                 instance_id,
+                discriminator,
                 ..
             } => DiscoveryInstanceId::EventChannel(EventChannelInstanceId {
                 namespace: namespace.clone(),
                 component: component.clone(),
                 topic: topic.clone(),
                 instance_id: *instance_id,
+                discriminator: *discriminator,
             }),
         }
     }
@@ -570,6 +589,12 @@ pub struct ModelCardInstanceId {
 }
 
 /// Unique identifier for an event channel instance
+///
+/// The process-level `instance_id` alone is not unique when a single process
+/// creates multiple publishers for the same `(namespace, component, topic)` —
+/// e.g. one ZMQ-direct `KvEventPublisher` per dp_rank. The optional
+/// `discriminator` (the bound ZMQ port for direct mode) restores uniqueness so
+/// every publisher gets its own discovery key and is independently discoverable.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EventChannelInstanceId {
     pub namespace: String,
@@ -577,32 +602,57 @@ pub struct EventChannelInstanceId {
     /// Topic name for this channel (e.g., "kv-events", "kv-metrics")
     pub topic: String,
     pub instance_id: u64,
+    /// Optional per-publisher discriminator (see [`DiscoverySpec::EventChannel`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<u64>,
 }
 
 impl EventChannelInstanceId {
-    /// Converts to a path string: `{namespace}/{component}/{topic}/{instance_id:x}`
+    /// Converts to a path string.
+    ///
+    /// - Without a discriminator: `{namespace}/{component}/{topic}/{instance_id:x}`
+    ///   (NATS / ZMQ broker — unchanged from the original format).
+    /// - With a discriminator: `{namespace}/{component}/{topic}/{instance_id:x}/{discriminator:x}`
+    ///   (ZMQ direct — one key per publisher in the process).
     pub fn to_path(&self) -> String {
-        format!(
-            "{}/{}/{}/{:x}",
-            self.namespace, self.component, self.topic, self.instance_id
-        )
+        match self.discriminator {
+            Some(discriminator) => format!(
+                "{}/{}/{}/{:x}/{:x}",
+                self.namespace, self.component, self.topic, self.instance_id, discriminator
+            ),
+            None => format!(
+                "{}/{}/{}/{:x}",
+                self.namespace, self.component, self.topic, self.instance_id
+            ),
+        }
     }
 
-    /// Parses from a path string: `{namespace}/{component}/{topic}/{instance_id:x}`
+    /// Parses from a path string produced by [`Self::to_path`].
+    ///
+    /// Accepts both the 4-part (no discriminator) and 5-part (with discriminator)
+    /// forms.
     pub fn from_path(path: &str) -> Result<Self> {
         let parts: Vec<&str> = path.split('/').collect();
-        if parts.len() != 4 {
+        if parts.len() != 4 && parts.len() != 5 {
             anyhow::bail!(
-                "Invalid EventChannelInstanceId path: expected 4 parts, got {}",
+                "Invalid EventChannelInstanceId path: expected 4 or 5 parts, got {}",
                 parts.len()
             );
         }
+        let discriminator = match parts.get(4) {
+            Some(d) => Some(
+                u64::from_str_radix(d, 16)
+                    .map_err(|e| anyhow::anyhow!("Invalid discriminator hex: {}", e))?,
+            ),
+            None => None,
+        };
         Ok(Self {
             namespace: parts[0].to_string(),
             component: parts[1].to_string(),
             topic: parts[2].to_string(),
             instance_id: u64::from_str_radix(parts[3], 16)
                 .map_err(|e| anyhow::anyhow!("Invalid instance_id hex: {}", e))?,
+            discriminator,
         })
     }
 }

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -335,17 +335,19 @@ pub enum DiscoverySpec {
         topic: String,
         /// Event transport type (NATS subject prefix or ZMQ endpoint)
         transport: EventTransport,
-        /// Optional per-publisher discriminator that disambiguates multiple
-        /// publishers created in the same process (which share one process-level
-        /// `instance_id`). Without it, multiple ZMQ-direct publishers in one
-        /// worker (e.g. one per dp_rank) collapse onto the same discovery key
-        /// `{namespace}/{component}/{topic}/{instance_id}` and overwrite each
-        /// other, so the router discovers only one endpoint per worker. ZMQ
-        /// direct mode sets this to the bound port (unique per publisher within
-        /// the process); NATS and ZMQ broker mode leave it `None`, preserving
-        /// their original single-key behaviour.
-        discriminator: Option<u64>,
     },
+}
+
+/// ZMQ-direct publishers each bind a unique PUB port; that port disambiguates
+/// multiple publishers that share one process-level `instance_id`. NATS and
+/// ZMQ-broker share a channel, so they need no per-publisher key segment.
+fn event_channel_endpoint_port(transport: &EventTransport) -> Option<u64> {
+    match transport {
+        EventTransport::Zmq { endpoint } => {
+            endpoint.rsplit(':').next().and_then(|p| p.parse().ok())
+        }
+        _ => None,
+    }
 }
 
 impl DiscoverySpec {
@@ -421,15 +423,17 @@ impl DiscoverySpec {
                 component,
                 topic,
                 transport,
-                discriminator,
-            } => DiscoveryInstance::EventChannel {
-                namespace,
-                component,
-                topic,
-                instance_id,
-                transport,
-                discriminator,
-            },
+            } => {
+                let endpoint_port = event_channel_endpoint_port(&transport);
+                DiscoveryInstance::EventChannel {
+                    namespace,
+                    component,
+                    topic,
+                    instance_id,
+                    transport,
+                    endpoint_port,
+                }
+            }
         }
     }
 }
@@ -462,11 +466,9 @@ pub enum DiscoveryInstance {
         instance_id: u64,
         /// Event transport type (NATS subject prefix or ZMQ endpoint)
         transport: EventTransport,
-        /// Optional per-publisher discriminator (see [`DiscoverySpec::EventChannel`]).
-        /// Older registrations and other transports omit it, hence `Option` + serde
-        /// default so existing serialized instances continue to deserialize.
+        /// ZMQ-direct bound port; disambiguates publishers sharing one process instance_id. None for NATS/broker.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        discriminator: Option<u64>,
+        endpoint_port: Option<u64>,
     },
 }
 
@@ -526,14 +528,14 @@ impl DiscoveryInstance {
                 component,
                 topic,
                 instance_id,
-                discriminator,
+                endpoint_port,
                 ..
             } => DiscoveryInstanceId::EventChannel(EventChannelInstanceId {
                 namespace: namespace.clone(),
                 component: component.clone(),
                 topic: topic.clone(),
                 instance_id: *instance_id,
-                discriminator: *discriminator,
+                endpoint_port: *endpoint_port,
             }),
         }
     }
@@ -588,13 +590,10 @@ pub struct ModelCardInstanceId {
     pub model_suffix: Option<String>,
 }
 
-/// Unique identifier for an event channel instance
+/// Unique identifier for an event channel instance.
 ///
-/// The process-level `instance_id` alone is not unique when a single process
-/// creates multiple publishers for the same `(namespace, component, topic)` —
-/// e.g. one ZMQ-direct `KvEventPublisher` per dp_rank. The optional
-/// `discriminator` (the bound ZMQ port for direct mode) restores uniqueness so
-/// every publisher gets its own discovery key and is independently discoverable.
+/// The optional `endpoint_port` (ZMQ-direct bound port) disambiguates multiple
+/// publishers that share one process-level `instance_id`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EventChannelInstanceId {
     pub namespace: String,
@@ -602,23 +601,18 @@ pub struct EventChannelInstanceId {
     /// Topic name for this channel (e.g., "kv-events", "kv-metrics")
     pub topic: String,
     pub instance_id: u64,
-    /// Optional per-publisher discriminator (see [`DiscoverySpec::EventChannel`]).
+    /// ZMQ-direct bound port; disambiguates publishers sharing one process instance_id. None for NATS/broker.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub discriminator: Option<u64>,
+    pub endpoint_port: Option<u64>,
 }
 
 impl EventChannelInstanceId {
-    /// Converts to a path string.
-    ///
-    /// - Without a discriminator: `{namespace}/{component}/{topic}/{instance_id:x}`
-    ///   (NATS / ZMQ broker — unchanged from the original format).
-    /// - With a discriminator: `{namespace}/{component}/{topic}/{instance_id:x}/{discriminator:x}`
-    ///   (ZMQ direct — one key per publisher in the process).
+    /// Converts to a path string; appends `/{endpoint_port:x}` when present (ZMQ direct).
     pub fn to_path(&self) -> String {
-        match self.discriminator {
-            Some(discriminator) => format!(
+        match self.endpoint_port {
+            Some(endpoint_port) => format!(
                 "{}/{}/{}/{:x}/{:x}",
-                self.namespace, self.component, self.topic, self.instance_id, discriminator
+                self.namespace, self.component, self.topic, self.instance_id, endpoint_port
             ),
             None => format!(
                 "{}/{}/{}/{:x}",
@@ -627,10 +621,7 @@ impl EventChannelInstanceId {
         }
     }
 
-    /// Parses from a path string produced by [`Self::to_path`].
-    ///
-    /// Accepts both the 4-part (no discriminator) and 5-part (with discriminator)
-    /// forms.
+    /// Parses from a path string produced by [`Self::to_path`] (4- or 5-part form).
     pub fn from_path(path: &str) -> Result<Self> {
         let parts: Vec<&str> = path.split('/').collect();
         if parts.len() != 4 && parts.len() != 5 {
@@ -639,10 +630,10 @@ impl EventChannelInstanceId {
                 parts.len()
             );
         }
-        let discriminator = match parts.get(4) {
+        let endpoint_port = match parts.get(4) {
             Some(d) => Some(
                 u64::from_str_radix(d, 16)
-                    .map_err(|e| anyhow::anyhow!("Invalid discriminator hex: {}", e))?,
+                    .map_err(|e| anyhow::anyhow!("Invalid endpoint_port hex: {}", e))?,
             ),
             None => None,
         };
@@ -652,7 +643,7 @@ impl EventChannelInstanceId {
             topic: parts[2].to_string(),
             instance_id: u64::from_str_radix(parts[3], 16)
                 .map_err(|e| anyhow::anyhow!("Invalid instance_id hex: {}", e))?,
-            discriminator,
+            endpoint_port,
         })
     }
 }

--- a/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
+++ b/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
@@ -103,7 +103,14 @@ impl DynamicSubscriber {
                 match event_result {
                     Ok(DiscoveryEvent::Added(instance)) => {
                         tracing::info!(instance = ?instance, "Discovery Added event received");
-                        let instance_id = instance.instance_id().to_string();
+                        // Track by the full instance ID path, not the bare u64
+                        // instance_id: a single worker process can register
+                        // multiple EventChannels for the same (namespace,
+                        // component, topic) — one ZMQ-direct publisher per
+                        // dp_rank — that all share the process-level instance_id.
+                        // Keying on instance_id alone would collapse them and
+                        // connect to only one endpoint per worker.
+                        let instance_id = Self::tracking_key(&instance.id());
 
                         // Extract ZMQ endpoint from the instance
                         if let Some(endpoint) = Self::extract_zmq_endpoint(&instance) {
@@ -158,7 +165,7 @@ impl DynamicSubscriber {
                         }
                     }
                     Ok(DiscoveryEvent::Removed(instance_id)) => {
-                        let id_str = instance_id.instance_id().to_string();
+                        let id_str = Self::tracking_key(&instance_id);
                         tracing::info!(
                             instance_id = %id_str,
                             "ZMQ publisher removed from discovery, cancelling endpoint stream"
@@ -198,6 +205,20 @@ impl DynamicSubscriber {
         };
 
         Ok(Box::pin(stream))
+    }
+
+    /// Build the per-publisher tracking key used for `active_endpoints`.
+    ///
+    /// Uses the full discovery path (which, for EventChannels, includes the
+    /// optional per-publisher discriminator) so that multiple publishers from
+    /// the same process — sharing one `instance_id` — are tracked and torn down
+    /// independently. The same key is derived from both `Added` and `Removed`
+    /// events, so cancellation-on-removal still targets the correct stream.
+    fn tracking_key(id: &DiscoveryInstanceId) -> String {
+        match id {
+            DiscoveryInstanceId::EventChannel(ecid) => ecid.to_path(),
+            other => other.instance_id().to_string(),
+        }
     }
 
     /// Extract ZMQ endpoint from a discovery instance.

--- a/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
+++ b/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
@@ -210,7 +210,7 @@ impl DynamicSubscriber {
     /// Build the per-publisher tracking key used for `active_endpoints`.
     ///
     /// Uses the full discovery path (which, for EventChannels, includes the
-    /// optional per-publisher discriminator) so that multiple publishers from
+    /// optional per-publisher endpoint_port) so that multiple publishers from
     /// the same process — sharing one `instance_id` — are tracked and torn down
     /// independently. The same key is derived from both `Added` and `Removed`
     /// events, so cancellation-on-removal still targets the correct stream.

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -353,7 +353,7 @@ impl EventPublisher {
         // Use Msgpack codec for all transports
         enum TransportSetup {
             Nats(Arc<dyn EventTransportTx>, Arc<Codec>),
-            ZmqDirect(Arc<dyn EventTransportTx>, Arc<Codec>, String, u16), // public endpoint + bound port
+            ZmqDirect(Arc<dyn EventTransportTx>, Arc<Codec>, String), // public endpoint
             ZmqBroker(Arc<dyn EventTransportTx>, Arc<Codec>),
         }
 
@@ -417,7 +417,6 @@ impl EventPublisher {
                         Arc::new(pub_transport) as Arc<dyn EventTransportTx>,
                         codec,
                         public_endpoint,
-                        actual_port,
                     )
                 }
             }
@@ -432,9 +431,6 @@ impl EventPublisher {
                     component: scope.component().unwrap_or("").to_string(),
                     topic: topic.clone(),
                     transport: transport_config,
-                    // NATS publishers all share one subject, so the process-level
-                    // instance_id is a sufficient (and intentionally shared) key.
-                    discriminator: None,
                 };
 
                 let registered_instance = drt.discovery().register(spec).await?;
@@ -446,21 +442,13 @@ impl EventPublisher {
                 );
                 (tx, codec, Some(registered_instance))
             }
-            TransportSetup::ZmqDirect(tx, codec, public_endpoint, bound_port) => {
+            TransportSetup::ZmqDirect(tx, codec, public_endpoint) => {
                 let transport_config = EventTransport::zmq(public_endpoint);
                 let spec = DiscoverySpec::EventChannel {
                     namespace: scope.namespace().to_string(),
                     component: scope.component().unwrap_or("").to_string(),
                     topic: topic.clone(),
                     transport: transport_config,
-                    // Each direct-mode publisher binds its own PUB socket on a
-                    // distinct OS-assigned port. Multiple publishers in one
-                    // process (e.g. one per dp_rank) share the process-level
-                    // instance_id, so without this discriminator they collapse
-                    // onto a single discovery key and overwrite each other. The
-                    // bound port is unique per publisher within the process and
-                    // path-safe (numeric), giving each its own discoverable key.
-                    discriminator: Some(u64::from(bound_port)),
                 };
 
                 let registered_instance = drt.discovery().register(spec).await?;

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -353,7 +353,7 @@ impl EventPublisher {
         // Use Msgpack codec for all transports
         enum TransportSetup {
             Nats(Arc<dyn EventTransportTx>, Arc<Codec>),
-            ZmqDirect(Arc<dyn EventTransportTx>, Arc<Codec>, String), // includes public endpoint
+            ZmqDirect(Arc<dyn EventTransportTx>, Arc<Codec>, String, u16), // public endpoint + bound port
             ZmqBroker(Arc<dyn EventTransportTx>, Arc<Codec>),
         }
 
@@ -417,6 +417,7 @@ impl EventPublisher {
                         Arc::new(pub_transport) as Arc<dyn EventTransportTx>,
                         codec,
                         public_endpoint,
+                        actual_port,
                     )
                 }
             }
@@ -431,6 +432,9 @@ impl EventPublisher {
                     component: scope.component().unwrap_or("").to_string(),
                     topic: topic.clone(),
                     transport: transport_config,
+                    // NATS publishers all share one subject, so the process-level
+                    // instance_id is a sufficient (and intentionally shared) key.
+                    discriminator: None,
                 };
 
                 let registered_instance = drt.discovery().register(spec).await?;
@@ -442,13 +446,21 @@ impl EventPublisher {
                 );
                 (tx, codec, Some(registered_instance))
             }
-            TransportSetup::ZmqDirect(tx, codec, public_endpoint) => {
+            TransportSetup::ZmqDirect(tx, codec, public_endpoint, bound_port) => {
                 let transport_config = EventTransport::zmq(public_endpoint);
                 let spec = DiscoverySpec::EventChannel {
                     namespace: scope.namespace().to_string(),
                     component: scope.component().unwrap_or("").to_string(),
                     topic: topic.clone(),
                     transport: transport_config,
+                    // Each direct-mode publisher binds its own PUB socket on a
+                    // distinct OS-assigned port. Multiple publishers in one
+                    // process (e.g. one per dp_rank) share the process-level
+                    // instance_id, so without this discriminator they collapse
+                    // onto a single discovery key and overwrite each other. The
+                    // bound port is unique per publisher within the process and
+                    // path-safe (numeric), giving each its own discoverable key.
+                    discriminator: Some(u64::from(bound_port)),
                 };
 
                 let registered_instance = drt.discovery().register(spec).await?;


### PR DESCRIPTION
## Problem

On the ZMQ event plane, a worker **process** can register **multiple** `KvEventPublisher`s — one per dp_rank / KV-event source (`backend-common::setup_kv_publishers` returns a `Vec`; the mocker and the sglang/trtllm/vllm backends each construct one per dp_rank). Each binds its own PUB socket, but they all registered their `EventChannel` under the **same** discovery key:

```
{namespace}/{component}/{topic}/{instance_id}
```

`instance_id` is **process-level**, so the registrations overwrote each other in both the in-memory `event_channels` map and the KV store — only **one** ZMQ endpoint survived per worker. The router's `DynamicSubscriber` then discovered/connected to only that one and **missed the other dp_ranks' KV events**, so KV routing silently degraded (the router sees 0 cached blocks for the lost ranks). NATS is unaffected because all publishers share a single subject.

A second collision: `DynamicSubscriber` keyed its `active_endpoints` map by the bare process `instance_id`, so even with unique discovery keys it would treat all-but-one endpoint as "already connected".

## Fix

- Disambiguate per-process publishers with the ZMQ-direct **bound PUB port** (`endpoint_port`). It is **derived internally** in `DiscoverySpec::with_instance_id` from the transport's endpoint — it is deliberately **not** a field on the public `DiscoverySpec::EventChannel` variant, so existing downstream callers that construct event-channel specs stay source-compatible. The discovery key becomes `.../{instance_id:x}/{endpoint_port:x}` for ZMQ-direct, else the original 4-part form.
- **NATS and ZMQ-broker derive `None`** → keys/paths byte-identical to before; `#[serde(default, skip_serializing_if = "Option::is_none")]` keeps wire/serde compatibility. **No NATS behavior change.**
- The router's component/topic query (prefix `.../{topic}`) still matches all N (5-part keys `starts_with` the prefix).
- `DynamicSubscriber` now keys `active_endpoints` by the full instance path (both Added and Removed), so it connects to / cancels each publisher individually.
- Uses the numeric port (not the raw `tcp://ip:port` endpoint) so keys stay `/`-delimited and IPv6-safe.

## Tests

- `discovery::metadata::tests::test_event_channel_per_publisher_endpoint_port` — same `instance_id` + 4 ports: no port collapses to 1 key (reproduces the bug), distinct ports → 4 distinct keys, the topic query returns all 4, and a targeted unregister removes exactly 1.
- `discovery::kv_store::tests::test_kv_store_event_channels_multiple_publishers_same_process` — end-to-end through the real `KVStoreDiscovery`: register 4 → `list` returns 4 → unregister 1 → 3.
- `discovery::metadata::tests::test_event_channel_instance_id_path_roundtrip` — `to_path`/`from_path` round-trip for both the 4-part and 5-part forms.
- `cargo build` / `cargo clippy -p dynamo-runtime --all-targets` clean; `discovery` (30) + `event_plane` (15) tests pass.

## Why this first

This is a prerequisite for switching the default event plane to ZMQ (#10902): without it, defaulting to ZMQ would silently drop KV events for any multi-publisher-per-process worker (e.g. single-process dp>1).

## Known / out of scope

In multi-broker HA mode, `DeduplicatingStream` deduplicates on `(publisher_id, sequence)`, and all publishers in a process share one process-level `publisher_id`. That is a pre-existing collision in a different code path (it does not affect ZMQ-direct, which this PR fixes); left as a follow-up.
