### PR TITLE
fix(dgdr): create final DGDs as v1beta1

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -34,6 +34,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	runtimejson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/record"
@@ -2082,30 +2084,19 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 		}
 	}
 
-	// The DGDR status/annotation store a manifest that is parsed later as
-	// unstructured YAML, so keep apiVersion/kind there without setting TypeMeta
-	// on the typed object submitted through the Kubernetes client.
-	dgdManifest, err := betaDGDManifestObject(dgd)
+	// Store manifest bytes with apiVersion/kind in status/annotation without
+	// setting TypeMeta on the typed object submitted through the Kubernetes client.
+	dgdJSON, dgdYAML, err := r.encodeBetaDGDManifest(dgd)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to build generated DGD manifest: %w", err)
-	}
-
-	// Store the generated DGD in ProfilingResults.SelectedConfig
-	dgdJSON, err := json.Marshal(dgdManifest)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to marshal generated DGD to JSON: %w", err)
+		return nil, "", fmt.Errorf("failed to encode generated DGD manifest: %w", err)
 	}
 	profilingResults.SelectedConfig = &runtime.RawExtension{Raw: dgdJSON}
 
 	// Serialize the DGD spec to an annotation so createDGD can retrieve it
-	dgdBytes, err := sigsyaml.Marshal(dgdManifest)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to marshal generated DGD: %w", err)
-	}
 	if dgdr.Annotations == nil {
 		dgdr.Annotations = make(map[string]string)
 	}
-	dgdr.Annotations["nvidia.com/generated-dgd-spec"] = string(dgdBytes)
+	dgdr.Annotations["nvidia.com/generated-dgd-spec"] = string(dgdYAML)
 
 	if err := r.Update(ctx, dgdr); err != nil {
 		return nil, "", fmt.Errorf("failed to update DGDR with generated DGD annotation: %w", err)
@@ -2113,17 +2104,36 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	return profilingResults, dgd.Name, nil
 }
 
-// betaDGDManifestObject returns the serialized-manifest form of a beta DGD.
-// Typed client objects should let the scheme provide GVK, but stored manifests
-// need explicit apiVersion/kind so extractResourcesFromYAML can identify them.
-func betaDGDManifestObject(dgd *nvidiacomv1beta1.DynamoGraphDeployment) (map[string]interface{}, error) {
-	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(dgd)
+// encodeBetaDGDManifest returns JSON/YAML manifest bytes for a beta DGD.
+// The Kubernetes versioning encoder temporarily supplies apiVersion/kind from
+// the scheme during serialization and restores the typed object's TypeMeta after.
+func (r *DynamoGraphDeploymentRequestReconciler) encodeBetaDGDManifest(dgd *nvidiacomv1beta1.DynamoGraphDeployment) ([]byte, []byte, error) {
+	scheme := r.Scheme()
+	codecs := serializer.NewCodecFactory(scheme)
+
+	jsonSerializer := runtimejson.NewSerializerWithOptions(
+		runtimejson.DefaultMetaFactory,
+		scheme,
+		scheme,
+		runtimejson.SerializerOptions{},
+	)
+	jsonBytes, err := runtime.Encode(codecs.EncoderForVersion(jsonSerializer, nvidiacomv1beta1.GroupVersion), dgd)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	obj["apiVersion"] = nvidiacomv1beta1.GroupVersion.String()
-	obj["kind"] = consts.ResourceTypeDynamoGraphDeployment
-	return obj, nil
+
+	yamlSerializer := runtimejson.NewSerializerWithOptions(
+		runtimejson.DefaultMetaFactory,
+		scheme,
+		scheme,
+		runtimejson.SerializerOptions{Yaml: true},
+	)
+	yamlBytes, err := runtime.Encode(codecs.EncoderForVersion(yamlSerializer, nvidiacomv1beta1.GroupVersion), dgd)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return jsonBytes, yamlBytes, nil
 }
 
 // extractParetoFromWebUIData parses webui_data.json and returns all Pareto-optimal

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -795,7 +795,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingPhase(ctx contex
 		return r.createDGD(ctx, dgdr)
 	}
 
-	dgd := &dgdv1alpha1.DynamoGraphDeployment{}
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
 	err := r.Get(ctx, types.NamespacedName{
 		Name:      dgdr.Status.DGDName,
 		Namespace: dgdr.Namespace,
@@ -822,7 +822,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingPhase(ctx contex
 	var condStatus metav1.ConditionStatus
 	var condReason, condMessage string
 
-	if dgd.Status.State == dgdv1alpha1.DGDStateSuccessful {
+	if dgd.Status.State == nvidiacomv1beta1.DGDStateSuccessful {
 		logger.Info("DGD is Ready, transitioning to Deployed phase")
 		dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
 		setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseDeployed)
@@ -862,7 +862,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployedPhase(ctx context
 	logger.Info("DGDR is deployed", "name", dgdr.Name)
 
 	// Check if DGD still exists and monitor its status
-	dgd := &dgdv1alpha1.DynamoGraphDeployment{}
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
 	err := r.Get(ctx, types.NamespacedName{
 		Name:      dgdr.Status.DGDName,
 		Namespace: dgdr.Namespace,
@@ -882,7 +882,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployedPhase(ctx context
 	}
 
 	// Check if DGD degraded from Ready
-	if dgd.Status.State != dgdv1alpha1.DGDStateSuccessful {
+	if dgd.Status.State != nvidiacomv1beta1.DGDStateSuccessful {
 		logger.Info("DGD degraded, transitioning back to Deploying",
 			"dgdState", dgd.Status.State)
 
@@ -946,8 +946,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 		return ctrl.Result{}, fmt.Errorf("generated DGD spec not found in annotation nvidia.com/generated-dgd-spec")
 	}
 
-	generatedDGD := &dgdv1alpha1.DynamoGraphDeployment{}
-	if err := yaml.Unmarshal([]byte(dgdSpecYAML), generatedDGD); err != nil {
+	generatedDGD, err := r.extractDGDFromYAML([]byte(dgdSpecYAML))
+	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to unmarshal generated deployment from annotation: %w", err)
 	}
 
@@ -976,7 +976,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	}
 
 	// Create DGD from generated deployment
-	dgd := &dgdv1alpha1.DynamoGraphDeployment{
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: nvidiacomv1beta1.GroupVersion.String(),
+			Kind:       consts.ResourceTypeDynamoGraphDeployment,
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        dgdName,
 			Namespace:   dgdNamespace,
@@ -995,7 +999,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	if err := r.Create(ctx, dgd); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			logger.Info("DGD already exists, updating status")
-			existingDGD := &dgdv1alpha1.DynamoGraphDeployment{}
+			existingDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
 			if getErr := r.Get(ctx, types.NamespacedName{Name: dgdName, Namespace: dgdNamespace}, existingDGD); getErr != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to get existing DGD %s: %w", dgdName, getErr)
 			}
@@ -1053,7 +1057,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 }
 
 // adoptAdditionalResources makes profiling-generated ConfigMaps follow the DGD lifecycle.
-func (r *DynamoGraphDeploymentRequestReconciler) adoptAdditionalResources(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, dgd *dgdv1alpha1.DynamoGraphDeployment) error {
+func (r *DynamoGraphDeploymentRequestReconciler) adoptAdditionalResources(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, dgd *nvidiacomv1beta1.DynamoGraphDeployment) error {
 	logger := log.FromContext(ctx)
 
 	configMaps := &corev1.ConfigMapList{}
@@ -1113,10 +1117,10 @@ func removeDGDROwnerReferences(ownerReferences []metav1.OwnerReference, dgdr *nv
 	return filtered, removed
 }
 
-func isControlledByDGD(ownerReferences []metav1.OwnerReference, dgd *dgdv1alpha1.DynamoGraphDeployment) bool {
+func isControlledByDGD(ownerReferences []metav1.OwnerReference, dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
 	controller := metav1.GetControllerOf(&metav1.ObjectMeta{OwnerReferences: ownerReferences})
 	return controller != nil &&
-		controller.Kind == "DynamoGraphDeployment" &&
+		controller.Kind == consts.ResourceTypeDynamoGraphDeployment &&
 		controller.Name == dgd.Name &&
 		controller.UID == dgd.UID
 }
@@ -2212,10 +2216,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) storeAdditionalResources(ctx co
 
 // extractResourcesFromYAML parses multi-document YAML from profiling output,
 // extracting the DynamoGraphDeployment and any ConfigMaps that should be deployed with it.
-func (r *DynamoGraphDeploymentRequestReconciler) extractResourcesFromYAML(yamlContent []byte) (*dgdv1alpha1.DynamoGraphDeployment, []*unstructured.Unstructured, error) {
+func (r *DynamoGraphDeploymentRequestReconciler) extractResourcesFromYAML(yamlContent []byte) (*nvidiacomv1beta1.DynamoGraphDeployment, []*unstructured.Unstructured, error) {
 	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlContent), 4096)
 
-	var dgd *dgdv1alpha1.DynamoGraphDeployment
+	var dgd *nvidiacomv1beta1.DynamoGraphDeployment
 	var additionalResources []*unstructured.Unstructured
 
 	for {
@@ -2233,11 +2237,12 @@ func (r *DynamoGraphDeploymentRequestReconciler) extractResourcesFromYAML(yamlCo
 			continue
 		}
 
-		if obj.GetKind() == "DynamoGraphDeployment" {
-			dgd = &dgdv1alpha1.DynamoGraphDeployment{}
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, dgd); err != nil {
+		if obj.GetKind() == consts.ResourceTypeDynamoGraphDeployment {
+			converted, err := dgdFromUnstructured(obj)
+			if err != nil {
 				return nil, nil, fmt.Errorf("failed to convert to DynamoGraphDeployment: %w", err)
 			}
+			dgd = converted
 		} else {
 			// Store ConfigMaps or other resources for deployment
 			additionalResources = append(additionalResources, obj)
@@ -2251,19 +2256,54 @@ func (r *DynamoGraphDeploymentRequestReconciler) extractResourcesFromYAML(yamlCo
 	return dgd, additionalResources, nil
 }
 
+func dgdFromUnstructured(obj *unstructured.Unstructured) (*nvidiacomv1beta1.DynamoGraphDeployment, error) {
+	if obj.GetKind() != consts.ResourceTypeDynamoGraphDeployment {
+		return nil, fmt.Errorf("expected kind %s, got %q", consts.ResourceTypeDynamoGraphDeployment, obj.GetKind())
+	}
+
+	switch obj.GetAPIVersion() {
+	case dgdv1alpha1.GroupVersion.String():
+		alphaDGD := &dgdv1alpha1.DynamoGraphDeployment{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, alphaDGD); err != nil {
+			return nil, err
+		}
+		betaDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
+		if err := alphaDGD.ConvertTo(betaDGD); err != nil {
+			return nil, err
+		}
+		betaDGD.TypeMeta = metav1.TypeMeta{
+			APIVersion: nvidiacomv1beta1.GroupVersion.String(),
+			Kind:       consts.ResourceTypeDynamoGraphDeployment,
+		}
+		return betaDGD, nil
+	case nvidiacomv1beta1.GroupVersion.String():
+		betaDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, betaDGD); err != nil {
+			return nil, err
+		}
+		betaDGD.TypeMeta = metav1.TypeMeta{
+			APIVersion: nvidiacomv1beta1.GroupVersion.String(),
+			Kind:       consts.ResourceTypeDynamoGraphDeployment,
+		}
+		return betaDGD, nil
+	default:
+		return nil, fmt.Errorf("unsupported DynamoGraphDeployment apiVersion %q", obj.GetAPIVersion())
+	}
+}
+
 // extractDGDFromYAML is a convenience wrapper that extracts only the DGD (used by tests)
-func (r *DynamoGraphDeploymentRequestReconciler) extractDGDFromYAML(yamlContent []byte) (*dgdv1alpha1.DynamoGraphDeployment, error) {
+func (r *DynamoGraphDeploymentRequestReconciler) extractDGDFromYAML(yamlContent []byte) (*nvidiacomv1beta1.DynamoGraphDeployment, error) {
 	dgd, _, err := r.extractResourcesFromYAML(yamlContent)
 	return dgd, err
 }
 
-// updateDeploymentInfo populates status.deploymentInfo from DGD service replica counts.
-func updateDeploymentInfo(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, dgd *dgdv1alpha1.DynamoGraphDeployment) bool {
+// updateDeploymentInfo populates status.deploymentInfo from DGD component replica counts.
+func updateDeploymentInfo(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
 	var totalReplicas, totalAvailable int32
-	for _, svc := range dgd.Status.Services {
-		totalReplicas += svc.Replicas
-		if svc.AvailableReplicas != nil {
-			totalAvailable += *svc.AvailableReplicas
+	for _, component := range dgd.Status.Components {
+		totalReplicas += component.Replicas
+		if component.AvailableReplicas != nil {
+			totalAvailable += *component.AvailableReplicas
 		}
 	}
 
@@ -2386,10 +2426,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) SetupWithManager(mgr ctrl.Manag
 		})). // Watch Jobs created by this controller (via ownerReference)
 		// Watch DGDs created by this controller (via label)
 		Watches(
-			&dgdv1alpha1.DynamoGraphDeployment{},
+			&nvidiacomv1beta1.DynamoGraphDeployment{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
 				// Find DGDR by label instead of owner reference
-				dgd := obj.(*dgdv1alpha1.DynamoGraphDeployment)
+				dgd := obj.(*nvidiacomv1beta1.DynamoGraphDeployment)
 				dgdrName, hasName := dgd.Labels[nvidiacomv1beta1.LabelDGDRName]
 				dgdrNamespace, hasNamespace := dgd.Labels[nvidiacomv1beta1.LabelDGDRNamespace]
 				if !hasName || !hasNamespace {

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -977,10 +977,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 
 	// Create DGD from generated deployment
 	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: nvidiacomv1beta1.GroupVersion.String(),
-			Kind:       consts.ResourceTypeDynamoGraphDeployment,
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        dgdName,
 			Namespace:   dgdNamespace,
@@ -2086,15 +2082,23 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 		}
 	}
 
+	// The DGDR status/annotation store a manifest that is parsed later as
+	// unstructured YAML, so keep apiVersion/kind there without setting TypeMeta
+	// on the typed object submitted through the Kubernetes client.
+	dgdManifest, err := betaDGDManifestObject(dgd)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to build generated DGD manifest: %w", err)
+	}
+
 	// Store the generated DGD in ProfilingResults.SelectedConfig
-	dgdJSON, err := json.Marshal(dgd)
+	dgdJSON, err := json.Marshal(dgdManifest)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to marshal generated DGD to JSON: %w", err)
 	}
 	profilingResults.SelectedConfig = &runtime.RawExtension{Raw: dgdJSON}
 
 	// Serialize the DGD spec to an annotation so createDGD can retrieve it
-	dgdBytes, err := sigsyaml.Marshal(dgd)
+	dgdBytes, err := sigsyaml.Marshal(dgdManifest)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to marshal generated DGD: %w", err)
 	}
@@ -2107,6 +2111,19 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 		return nil, "", fmt.Errorf("failed to update DGDR with generated DGD annotation: %w", err)
 	}
 	return profilingResults, dgd.Name, nil
+}
+
+// betaDGDManifestObject returns the serialized-manifest form of a beta DGD.
+// Typed client objects should let the scheme provide GVK, but stored manifests
+// need explicit apiVersion/kind so extractResourcesFromYAML can identify them.
+func betaDGDManifestObject(dgd *nvidiacomv1beta1.DynamoGraphDeployment) (map[string]interface{}, error) {
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(dgd)
+	if err != nil {
+		return nil, err
+	}
+	obj["apiVersion"] = nvidiacomv1beta1.GroupVersion.String()
+	obj["kind"] = consts.ResourceTypeDynamoGraphDeployment
+	return obj, nil
 }
 
 // extractParetoFromWebUIData parses webui_data.json and returns all Pareto-optimal
@@ -2271,19 +2288,11 @@ func dgdFromUnstructured(obj *unstructured.Unstructured) (*nvidiacomv1beta1.Dyna
 		if err := alphaDGD.ConvertTo(betaDGD); err != nil {
 			return nil, err
 		}
-		betaDGD.TypeMeta = metav1.TypeMeta{
-			APIVersion: nvidiacomv1beta1.GroupVersion.String(),
-			Kind:       consts.ResourceTypeDynamoGraphDeployment,
-		}
 		return betaDGD, nil
 	case nvidiacomv1beta1.GroupVersion.String():
 		betaDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, betaDGD); err != nil {
 			return nil, err
-		}
-		betaDGD.TypeMeta = metav1.TypeMeta{
-			APIVersion: nvidiacomv1beta1.GroupVersion.String(),
-			Kind:       consts.ResourceTypeDynamoGraphDeployment,
 		}
 		return betaDGD, nil
 	default:

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	dgdv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
@@ -561,7 +560,12 @@ spec:
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
 
 			// Check that DGD spec was generated (stored in annotation)
-			Expect(updated.Annotations["nvidia.com/generated-dgd-spec"]).NotTo(BeEmpty())
+			generatedSpec := updated.Annotations["nvidia.com/generated-dgd-spec"]
+			Expect(generatedSpec).NotTo(BeEmpty())
+			Expect(generatedSpec).Should(ContainSubstring("apiVersion: nvidia.com/v1beta1"))
+			Expect(updated.Status.ProfilingResults).ShouldNot(BeNil())
+			Expect(updated.Status.ProfilingResults.SelectedConfig).ShouldNot(BeNil())
+			Expect(string(updated.Status.ProfilingResults.SelectedConfig.Raw)).Should(ContainSubstring("nvidia.com/v1beta1"))
 
 			// autoApply defaults to true in v1beta1, so after profiling the DGDR transitions to Deploying
 			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseDeploying))
@@ -685,9 +689,11 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify DGD was created with the DGDR-scoped name (not the profiler's "vllm-agg")
-			dgd := &dgdv1alpha1.DynamoGraphDeployment{}
+			// Verify beta DGD was created with the DGDR-scoped name (not the profiler's "vllm-agg")
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: expectedDGDName, Namespace: namespace}, dgd)).Should(Succeed())
+			Expect(dgd.Spec.Components).Should(HaveLen(1))
+			Expect(dgd.Spec.Components[0].ComponentName).Should(Equal("Frontend"))
 
 			// Get final DGDR status
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
@@ -826,7 +832,7 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			dgd := &dgdv1alpha1.DynamoGraphDeployment{}
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: expectedDGDName, Namespace: namespace}, dgd)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
 
@@ -871,12 +877,12 @@ spec:
 			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
 
-			dgd := &dgdv1alpha1.DynamoGraphDeployment{
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dgdName,
 					Namespace: namespace,
 				},
-				Spec: dgdv1alpha1.DynamoGraphDeploymentSpec{},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{},
 			}
 			Expect(k8sClient.Create(ctx, dgd)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
@@ -927,12 +933,12 @@ spec:
 			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
 
-			dgd := &dgdv1alpha1.DynamoGraphDeployment{
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dgdName,
 					Namespace: namespace,
 				},
-				Spec: dgdv1alpha1.DynamoGraphDeploymentSpec{},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{},
 			}
 			Expect(k8sClient.Create(ctx, dgd)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
@@ -1720,10 +1726,33 @@ spec:
 			dgd, additionalResources, err := reconciler.extractResourcesFromYAML([]byte(multiDocYAML))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dgd).NotTo(BeNil())
+			Expect(dgd.APIVersion).Should(Equal(nvidiacomv1beta1.GroupVersion.String()))
 			Expect(dgd.Name).Should(Equal("test-dgd"))
 			Expect(additionalResources).To(HaveLen(1))
 			Expect(additionalResources[0].GetKind()).Should(Equal("ConfigMap"))
 			Expect(additionalResources[0].GetName()).Should(Equal("model-config"))
+		})
+
+		It("Should extract native beta DGD output", func() {
+			betaDGDYAML := `apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: test-beta-dgd
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1`
+
+			dgd, err := reconciler.extractDGDFromYAML([]byte(betaDGDYAML))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dgd).NotTo(BeNil())
+			Expect(dgd.APIVersion).Should(Equal(nvidiacomv1beta1.GroupVersion.String()))
+			Expect(dgd.Name).Should(Equal("test-beta-dgd"))
+			Expect(dgd.Spec.Components).Should(HaveLen(1))
+			Expect(dgd.Spec.Components[0].ComponentName).Should(Equal("Frontend"))
+			Expect(dgd.Spec.Components[0].ComponentType).Should(Equal(nvidiacomv1beta1.ComponentTypeFrontend))
 		})
 
 		It("Should handle multiple additional resources", func() {
@@ -2117,7 +2146,7 @@ spec:
 			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
 
 			// Create the DGD in Ready state
-			dgd := &dgdv1alpha1.DynamoGraphDeployment{
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd-deployed",
 					Namespace: namespace,
@@ -2126,13 +2155,13 @@ spec:
 						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
 					},
 				},
-				Spec: dgdv1alpha1.DynamoGraphDeploymentSpec{},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{},
 			}
 			Expect(k8sClient.Create(ctx, dgd)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
 
 			// Set DGD to Successful state
-			dgd.Status.State = dgdv1alpha1.DGDStateSuccessful
+			dgd.Status.State = nvidiacomv1beta1.DGDStateSuccessful
 			Expect(k8sClient.Status().Update(ctx, dgd)).Should(Succeed())
 
 			// Reconcile — should transition DGDR to Deployed
@@ -2379,6 +2408,7 @@ spec:
 			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
 			Expect(updated.Annotations["nvidia.com/generated-dgd-spec"]).Should(ContainSubstring(expectedDGDName))
+			Expect(updated.Annotations["nvidia.com/generated-dgd-spec"]).Should(ContainSubstring("apiVersion: nvidia.com/v1beta1"))
 		})
 
 		It("Should populate profilingJobName in status", func() {
@@ -3482,7 +3512,7 @@ var _ = Describe("DGDR Image Pull Error Detection", func() {
 			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
 
 			// DGD exists but is still in a non-successful state.
-			dgd := &dgdv1alpha1.DynamoGraphDeployment{
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dgdName,
 					Namespace: namespace,
@@ -3491,11 +3521,11 @@ var _ = Describe("DGDR Image Pull Error Detection", func() {
 						nvidiacomv1beta1.LabelDGDRNamespace: namespace,
 					},
 				},
-				Spec: dgdv1alpha1.DynamoGraphDeploymentSpec{},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{},
 			}
 			Expect(k8sClient.Create(ctx, dgd)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
-			dgd.Status.State = dgdv1alpha1.DGDStatePending
+			dgd.Status.State = nvidiacomv1beta1.DGDStatePending
 			Expect(k8sClient.Status().Update(ctx, dgd)).Should(Succeed())
 
 			// Worker pod belonging to the DGD is stuck on ErrImagePull.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -1599,7 +1599,7 @@ var _ = Describe("DGDR Error Handling", func() {
 	})
 
 	Context("When parsing multi-document YAML", func() {
-		It("Should add apiVersion and kind when serializing beta DGD manifests", func() {
+		It("Should include apiVersion and kind when serializing beta DGD manifests", func() {
 			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-dgd",
@@ -1614,10 +1614,14 @@ var _ = Describe("DGDR Error Handling", func() {
 			Expect(rawTypedObject).NotTo(HaveKey("apiVersion"))
 			Expect(rawTypedObject).NotTo(HaveKey("kind"))
 
-			manifest, err := betaDGDManifestObject(dgd)
+			manifestJSON, manifestYAML, err := reconciler.encodeBetaDGDManifest(dgd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(manifest).To(HaveKeyWithValue("apiVersion", nvidiacomv1beta1.GroupVersion.String()))
-			Expect(manifest).To(HaveKeyWithValue("kind", consts.ResourceTypeDynamoGraphDeployment))
+			Expect(string(manifestJSON)).Should(ContainSubstring(`"apiVersion":"nvidia.com/v1beta1"`))
+			Expect(string(manifestJSON)).Should(ContainSubstring(`"kind":"DynamoGraphDeployment"`))
+			Expect(string(manifestYAML)).Should(ContainSubstring("apiVersion: nvidia.com/v1beta1"))
+			Expect(string(manifestYAML)).Should(ContainSubstring("kind: DynamoGraphDeployment"))
+			Expect(dgd.APIVersion).Should(BeEmpty())
+			Expect(dgd.Kind).Should(BeEmpty())
 		})
 
 		It("Should extract DGD from ConfigMap + DGD YAML", func() {

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -563,9 +564,11 @@ spec:
 			generatedSpec := updated.Annotations["nvidia.com/generated-dgd-spec"]
 			Expect(generatedSpec).NotTo(BeEmpty())
 			Expect(generatedSpec).Should(ContainSubstring("apiVersion: nvidia.com/v1beta1"))
+			Expect(generatedSpec).Should(ContainSubstring("kind: DynamoGraphDeployment"))
 			Expect(updated.Status.ProfilingResults).ShouldNot(BeNil())
 			Expect(updated.Status.ProfilingResults.SelectedConfig).ShouldNot(BeNil())
 			Expect(string(updated.Status.ProfilingResults.SelectedConfig.Raw)).Should(ContainSubstring("nvidia.com/v1beta1"))
+			Expect(string(updated.Status.ProfilingResults.SelectedConfig.Raw)).Should(ContainSubstring(`"kind":"DynamoGraphDeployment"`))
 
 			// autoApply defaults to true in v1beta1, so after profiling the DGDR transitions to Deploying
 			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseDeploying))
@@ -1596,6 +1599,27 @@ var _ = Describe("DGDR Error Handling", func() {
 	})
 
 	Context("When parsing multi-document YAML", func() {
+		It("Should add apiVersion and kind when serializing beta DGD manifests", func() {
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-dgd",
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+					BackendFramework: "vllm",
+				},
+			}
+
+			rawTypedObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(dgd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rawTypedObject).NotTo(HaveKey("apiVersion"))
+			Expect(rawTypedObject).NotTo(HaveKey("kind"))
+
+			manifest, err := betaDGDManifestObject(dgd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(manifest).To(HaveKeyWithValue("apiVersion", nvidiacomv1beta1.GroupVersion.String()))
+			Expect(manifest).To(HaveKeyWithValue("kind", consts.ResourceTypeDynamoGraphDeployment))
+		})
+
 		It("Should extract DGD from ConfigMap + DGD YAML", func() {
 			// Multi-document YAML with ConfigMap first, then DGD
 			multiDocYAML := `---
@@ -1619,7 +1643,6 @@ spec:
 			dgd, err := reconciler.extractDGDFromYAML([]byte(multiDocYAML))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dgd).NotTo(BeNil())
-			Expect(dgd.Kind).Should(Equal("DynamoGraphDeployment"))
 			Expect(dgd.Name).Should(Equal("test-dgd"))
 			Expect(dgd.Spec.BackendFramework).Should(Equal("vllm"))
 		})
@@ -1638,7 +1661,6 @@ spec:
 			dgd, err := reconciler.extractDGDFromYAML([]byte(singleDocYAML))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dgd).NotTo(BeNil())
-			Expect(dgd.Kind).Should(Equal("DynamoGraphDeployment"))
 			Expect(dgd.Name).Should(Equal("test-dgd-single"))
 		})
 
@@ -1665,7 +1687,6 @@ data:
 			dgd, err := reconciler.extractDGDFromYAML([]byte(multiDocYAML))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dgd).NotTo(BeNil())
-			Expect(dgd.Kind).Should(Equal("DynamoGraphDeployment"))
 			Expect(dgd.Name).Should(Equal("test-dgd-first"))
 		})
 
@@ -1726,7 +1747,6 @@ spec:
 			dgd, additionalResources, err := reconciler.extractResourcesFromYAML([]byte(multiDocYAML))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dgd).NotTo(BeNil())
-			Expect(dgd.APIVersion).Should(Equal(nvidiacomv1beta1.GroupVersion.String()))
 			Expect(dgd.Name).Should(Equal("test-dgd"))
 			Expect(additionalResources).To(HaveLen(1))
 			Expect(additionalResources[0].GetKind()).Should(Equal("ConfigMap"))
@@ -1748,7 +1768,6 @@ spec:
 			dgd, err := reconciler.extractDGDFromYAML([]byte(betaDGDYAML))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dgd).NotTo(BeNil())
-			Expect(dgd.APIVersion).Should(Equal(nvidiacomv1beta1.GroupVersion.String()))
 			Expect(dgd.Name).Should(Equal("test-beta-dgd"))
 			Expect(dgd.Spec.Components).Should(HaveLen(1))
 			Expect(dgd.Spec.Components[0].ComponentName).Should(Equal("Frontend"))

--- a/deploy/operator/internal/controller/suite_test.go
+++ b/deploy/operator/internal/controller/suite_test.go
@@ -52,6 +52,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -136,7 +137,21 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
+		WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
+			Host:    testEnv.WebhookInstallOptions.LocalServingHost,
+			Port:    testEnv.WebhookInstallOptions.LocalServingPort,
+			CertDir: testEnv.WebhookInstallOptions.LocalServingCertDir,
+		}),
 	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ctrl.NewWebhookManagedBy(k8sManager, &v1beta1.DynamoGraphDeploymentRequest{}).Complete()
+	Expect(err).NotTo(HaveOccurred())
+	err = ctrl.NewWebhookManagedBy(k8sManager, &v1beta1.DynamoGraphDeployment{}).Complete()
+	Expect(err).NotTo(HaveOccurred())
+	err = ctrl.NewWebhookManagedBy(k8sManager, &v1beta1.DynamoComponentDeployment{}).Complete()
+	Expect(err).NotTo(HaveOccurred())
+	err = ctrl.NewWebhookManagedBy(k8sManager, &v1beta1.DynamoGraphDeploymentScalingAdapter{}).Complete()
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
## Summary

This updates the DGDR reconciler so the final generated/created DynamoGraphDeployment is handled as `nvidia.com/v1beta1`.

Changes:
- Normalize profiler-produced DGD YAML to `v1beta1` when reading profiling output.
- Continue accepting legacy `v1alpha1` profiler output by converting the complete DGD object in Go.
- Accept native `v1beta1` profiler output.
- Create, read, watch, and adopt final DGDs as `v1beta1`.
- Populate DGDR deployment info from beta `status.components`.
- Update controller tests to assert generated specs and created DGDs are beta.
- Start conversion webhooks in the controller envtest suite so beta DGD create paths exercise the real conversion boundary.

This does not change `spec.overrides.dgd` merge behavior or profiler candidate/temporary DGD behavior; those remain follow-up work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the newer `v1beta1` DynamoGraphDeployment format throughout deployment reconciliation and profiling output handling.
  * YAML-based deployment data can now be read from both older and newer versions, improving compatibility.

* **Bug Fixes**
  * Improved readiness and status tracking for deployed resources.
  * Updated resource ownership checks and adoption behavior to work reliably with the new deployment format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #10584 