### PR TITLE
fix(kv-router): share event-plane publishers across dp ranks

### DIFF
--- a/lib/backend-common/src/publisher.rs
+++ b/lib/backend-common/src/publisher.rs
@@ -7,20 +7,22 @@
 //!
 //! - [`KvEventPublisher`] (per dp_rank) — wired from the engine's
 //!   [`KvEventSource`] declarations. Engine pushes stored/removed events
-//!   to the publisher; framework relays to NATS.
+//!   to the publisher; framework relays to the configured event plane.
 //! - [`SnapshotPublisher`] — single per-worker handle for per-rank
 //!   `ComponentSnapshot` writes. Engine pushes; publisher atomically
 //!   updates the Rust `ComponentGauges` (for /metrics) AND the
-//!   per-rank `WorkerMetricsPublisher` (for KV router NATS signal)
+//!   per-rank `WorkerMetricsPublisher` (for KV router load signal)
 //!   inline.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use dynamo_llm::kv_router::publisher::{
-    KvEventPublisher, KvEventSourceConfig, WorkerMetricsPublisher,
+use dynamo_llm::kv_router::{
+    KV_EVENT_SUBJECT, KV_METRICS_SUBJECT,
+    publisher::{KvEventPublisher, KvEventSourceConfig, WorkerMetricsPublisher},
 };
 use dynamo_runtime::component::Component;
+use dynamo_runtime::transports::event_plane::EventPublisher;
 
 use crate::engine::KvEventSource;
 use crate::error::{BackendError, DynamoError, ErrorType};
@@ -36,21 +38,28 @@ pub(crate) struct PublisherHandles {
     /// Stashed so the engine's `Arc<SnapshotPublisher>` reference stays
     /// valid for the worker's lifetime. Engines drop their copy when
     /// they shut down; we keep ours so the `WorkerMetricsPublisher`s
-    /// inside don't drop their NATS endpoints prematurely.
+    /// inside don't drop their event-plane endpoints prematurely.
     #[allow(dead_code)]
     snapshot_publisher: Option<Arc<SnapshotPublisher>>,
 }
 
-// Sync — `KvEventPublisher::new_with_local_indexer` doesn't await. The
-// snapshot router-publisher construction below is async because
-// `create_endpoint` does.
-fn setup_kv_publishers(
+async fn setup_kv_publishers(
     component: &Component,
     sources: Vec<KvEventSource>,
     kv_cache_block_size: u32,
     enable_local_indexer: bool,
 ) -> Result<Vec<Arc<KvEventPublisher>>, DynamoError> {
     let mut publishers = Vec::with_capacity(sources.len());
+    let shared_event_publisher = if enable_local_indexer {
+        Some(Arc::new(
+            EventPublisher::for_component(component, KV_EVENT_SUBJECT)
+                .await
+                .map_err(|e| publisher_err(format!("shared kv event publisher setup: {e}")))?,
+        ))
+    } else {
+        None
+    };
+
     for source in sources {
         let dp_rank = source.dp_rank();
         let (source_config, on_ready) = match source {
@@ -66,14 +75,26 @@ fn setup_kv_publishers(
             ),
             KvEventSource::Push { on_ready, .. } => (None, Some(on_ready)),
         };
-        let publisher = KvEventPublisher::new_with_local_indexer(
-            component.clone(),
-            kv_cache_block_size,
-            source_config,
-            enable_local_indexer,
-            dp_rank,
-            None,
-        )
+        let publisher = if let Some(event_publisher) = shared_event_publisher.clone() {
+            KvEventPublisher::new_with_shared_event_publisher(
+                component.clone(),
+                kv_cache_block_size,
+                source_config,
+                enable_local_indexer,
+                dp_rank,
+                None,
+                event_publisher,
+            )
+        } else {
+            KvEventPublisher::new_with_local_indexer(
+                component.clone(),
+                kv_cache_block_size,
+                source_config,
+                enable_local_indexer,
+                dp_rank,
+                None,
+            )
+        }
         .map_err(|e| publisher_err(format!("kv publisher setup (dp_rank={dp_rank}): {e}")))?;
         let publisher = Arc::new(publisher);
         if let Some(on_ready) = on_ready {
@@ -91,20 +112,26 @@ fn setup_kv_publishers(
 }
 
 /// Build one `WorkerMetricsPublisher` per declared dp_rank. Each owns a
-/// NATS endpoint advertising the rank's `kv_used_blocks` signal to the
-/// KV router. Constructed eagerly so the `SnapshotPublisher` can route
-/// per-rank writes inline.
+/// watch channel advertising the rank's `kv_used_blocks` signal to the
+/// KV router. The underlying event-plane publisher is shared per worker
+/// because discovery identifies event channels by worker instance/topic.
 async fn build_router_publishers(
     component: &Component,
     dp_ranks: &[u32],
 ) -> Result<HashMap<u32, Arc<WorkerMetricsPublisher>>, DynamoError> {
     let mut out = HashMap::with_capacity(dp_ranks.len());
+    let event_publisher = Arc::new(
+        EventPublisher::for_namespace(component.namespace(), KV_METRICS_SUBJECT)
+            .await
+            .map_err(|e| publisher_err(format!("shared metrics publisher setup: {e}")))?,
+    );
+
     for &dp_rank in dp_ranks {
         let publisher = WorkerMetricsPublisher::new().map_err(|e| {
             publisher_err(format!("metrics publisher new (dp_rank={dp_rank}): {e}"))
         })?;
         publisher
-            .create_endpoint(component.clone())
+            .create_endpoint_with_event_publisher(component.clone(), event_publisher.clone())
             .await
             .map_err(|e| {
                 publisher_err(format!(
@@ -117,7 +144,7 @@ async fn build_router_publishers(
 }
 
 fn publisher_err(message: String) -> DynamoError {
-    // Publisher construction errors are almost always NATS-reach related.
+    // Publisher construction errors are almost always transport/discovery reach related.
     DynamoError::builder()
         .error_type(ErrorType::Backend(BackendError::CannotConnect))
         .message(message)
@@ -137,7 +164,7 @@ pub(crate) async fn setup_publishers(
     // router can't translate token IDs into cache blocks. Snapshot publisher
     // is independent — load reporting works regardless of cache structure.
     let kv_publishers = if let Some(block_size) = kv_cache_block_size {
-        setup_kv_publishers(component, kv_sources, block_size, enable_local_indexer)?
+        setup_kv_publishers(component, kv_sources, block_size, enable_local_indexer).await?
     } else {
         if !kv_sources.is_empty() {
             tracing::warn!(

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -4,11 +4,11 @@
 use std::{collections::HashSet, sync::Arc, time::Instant};
 
 use anyhow::Result;
+pub use dynamo_kv_router::protocols::KV_EVENT_SUBJECT;
 use dynamo_kv_router::{
     KvSchedulerError, PrefillLoadEstimator, SharedKvCache,
     config::{KvRouterConfig, RouterConfigOverride, min_initial_workers_from_env},
     indexer::{KvRouterError, RoutingDecisionHashes},
-    protocols::KV_EVENT_SUBJECT,
     protocols::{
         BlockExtraInfo, BlockHashOptions, DpRank, LocalBlockHash, PrefillLoadHint, RouterEvent,
         RouterRequest, RouterResponse, RoutingConstraints, TokensWithHashes, WorkerConfigLike,

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -17,6 +17,7 @@ use dynamo_runtime::config::environment_names::nats as env_nats;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_runtime::{
     component::Component,
+    transports::event_plane::EventPublisher,
     transports::nats::{NatsQueue, Slug},
 };
 
@@ -194,6 +195,50 @@ impl KvEventPublisher {
         dp_rank: DpRank,
         batching_timeout_ms: Option<u64>,
     ) -> Result<Self> {
+        Self::new_internal(
+            component,
+            worker_id,
+            kv_block_size,
+            source_config,
+            enable_local_indexer,
+            dp_rank,
+            batching_timeout_ms,
+            None,
+        )
+    }
+
+    pub fn new_with_shared_event_publisher(
+        component: Component,
+        kv_block_size: u32,
+        source_config: Option<KvEventSourceConfig>,
+        enable_local_indexer: bool,
+        dp_rank: DpRank,
+        batching_timeout_ms: Option<u64>,
+        event_publisher: Arc<EventPublisher>,
+    ) -> Result<Self> {
+        Self::new_internal(
+            component,
+            None,
+            kv_block_size,
+            source_config,
+            enable_local_indexer,
+            dp_rank,
+            batching_timeout_ms,
+            Some(event_publisher),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_internal(
+        component: Component,
+        worker_id: Option<WorkerId>,
+        kv_block_size: u32,
+        source_config: Option<KvEventSourceConfig>,
+        enable_local_indexer: bool,
+        dp_rank: DpRank,
+        batching_timeout_ms: Option<u64>,
+        event_publisher: Option<Arc<EventPublisher>>,
+    ) -> Result<Self> {
         let cancellation_token = CancellationToken::new();
         let batching_timeout_ms = batching_timeout_ms
             .filter(|&ms| {
@@ -274,19 +319,20 @@ impl KvEventPublisher {
             tracing::info!("Using event plane for KV event publishing (local_indexer mode)");
             let component_clone = component.clone();
             component.drt().runtime().secondary().spawn(async move {
-                let event_publisher =
-                    match dynamo_runtime::transports::event_plane::EventPublisher::for_component(
-                        &component_clone,
-                        KV_EVENT_SUBJECT,
-                    )
-                    .await
-                    {
-                        Ok(publisher) => publisher,
-                        Err(e) => {
-                            tracing::error!("Failed to create event publisher: {}", e);
-                            return;
+                let event_publisher = match event_publisher {
+                    Some(publisher) => publisher,
+                    None => {
+                        match EventPublisher::for_component(&component_clone, KV_EVENT_SUBJECT)
+                            .await
+                        {
+                            Ok(publisher) => Arc::new(publisher),
+                            Err(e) => {
+                                tracing::error!("Failed to create event publisher: {}", e);
+                                return;
+                            }
                         }
-                    };
+                    }
+                };
 
                 start_event_processor(
                     EventPlanePublisher(event_publisher),

--- a/lib/llm/src/kv_router/publisher/sinks.rs
+++ b/lib/llm/src/kv_router/publisher/sinks.rs
@@ -14,7 +14,7 @@ use dynamo_runtime::transports::nats::NatsQueue;
 
 use crate::kv_router::KV_EVENT_SUBJECT;
 
-pub(super) struct EventPlanePublisher(pub(super) EventPublisher);
+pub(super) struct EventPlanePublisher(pub(super) Arc<EventPublisher>);
 
 impl RouterEventSink for EventPlanePublisher {
     fn publish_event(&self, event: &RouterEvent) -> impl Future<Output = Result<()>> + Send {

--- a/lib/llm/src/kv_router/publisher/worker_metrics.rs
+++ b/lib/llm/src/kv_router/publisher/worker_metrics.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use std::sync::Arc;
 
+use anyhow::Result;
 use dynamo_kv_router::protocols::{ActiveLoad, DpRank};
 use dynamo_runtime::component::{Component, Namespace};
 use dynamo_runtime::traits::DistributedRuntimeProvider;
@@ -56,11 +57,29 @@ impl WorkerMetricsPublisher {
 
     pub async fn create_endpoint(&self, component: Component) -> Result<()> {
         let worker_id = component.drt().connection_id();
-        self.start_nats_metrics_publishing(component.namespace().clone(), worker_id);
+        self.start_event_metrics_publishing_with_namespace(
+            component.namespace().clone(),
+            worker_id,
+        );
         Ok(())
     }
 
+    pub async fn create_endpoint_with_event_publisher(
+        &self,
+        component: Component,
+        event_publisher: Arc<EventPublisher>,
+    ) -> Result<()> {
+        let worker_id = component.drt().connection_id();
+        self.start_event_metrics_publishing(worker_id, event_publisher);
+        Ok(())
+    }
+
+    #[cfg(all(test, feature = "integration"))]
     pub(super) fn start_nats_metrics_publishing(&self, namespace: Namespace, worker_id: u64) {
+        self.start_event_metrics_publishing_with_namespace(namespace, worker_id);
+    }
+
+    fn start_event_metrics_publishing_with_namespace(&self, namespace: Namespace, worker_id: u64) {
         let nats_rx = self.rx.clone();
 
         tokio::spawn(async move {
@@ -73,51 +92,66 @@ impl WorkerMetricsPublisher {
                     }
                 };
 
-            let mut rx = nats_rx;
-            let mut last_metrics: Option<WorkerMetrics> = None;
-            let mut pending_publish: Option<WorkerMetrics> = None;
-            let publish_timer = tokio::time::sleep(tokio::time::Duration::ZERO);
-            tokio::pin!(publish_timer);
+            run_metrics_publishing_loop(worker_id, nats_rx, Arc::new(event_publisher)).await;
+        });
+    }
 
-            loop {
-                tokio::select! {
-                    result = rx.changed() => {
-                        if result.is_err() {
-                            tracing::debug!(
-                                "Metrics publisher sender dropped, stopping NATS background task"
-                            );
-                            break;
-                        }
+    fn start_event_metrics_publishing(&self, worker_id: u64, event_publisher: Arc<EventPublisher>) {
+        let rx = self.rx.clone();
 
-                        let metrics = rx.borrow_and_update().clone();
-                        if last_metrics.as_ref() == Some(&metrics) {
-                            continue;
-                        }
+        tokio::spawn(async move {
+            run_metrics_publishing_loop(worker_id, rx, event_publisher).await;
+        });
+    }
+}
 
-                        pending_publish = Some(metrics.clone());
-                        last_metrics = Some(metrics);
-                        publish_timer.as_mut().reset(
-                            tokio::time::Instant::now()
-                                + tokio::time::Duration::from_millis(1)
-                        );
-                    }
-                    _ = &mut publish_timer, if pending_publish.is_some() => {
-                        if let Some(metrics) = pending_publish.take() {
-                            let active_load = ActiveLoad {
-                                worker_id,
-                                dp_rank: metrics.dp_rank,
-                                active_decode_blocks: metrics.active_decode_blocks,
-                                active_prefill_tokens: None,
-                                kv_used_blocks: metrics.kv_used_blocks,
-                            };
+async fn run_metrics_publishing_loop(
+    worker_id: u64,
+    mut rx: tokio::sync::watch::Receiver<WorkerMetrics>,
+    event_publisher: Arc<EventPublisher>,
+) {
+    let mut last_metrics: Option<WorkerMetrics> = None;
+    let mut pending_publish: Option<WorkerMetrics> = None;
+    let publish_timer = tokio::time::sleep(tokio::time::Duration::ZERO);
+    tokio::pin!(publish_timer);
 
-                            if let Err(e) = event_publisher.publish(&active_load).await {
-                                tracing::warn!("Failed to publish metrics: {}", e);
-                            }
-                        }
+    loop {
+        tokio::select! {
+            result = rx.changed() => {
+                if result.is_err() {
+                    tracing::debug!(
+                        "Metrics publisher sender dropped, stopping event-plane background task"
+                    );
+                    break;
+                }
+
+                let metrics = rx.borrow_and_update().clone();
+                if last_metrics.as_ref() == Some(&metrics) {
+                    continue;
+                }
+
+                pending_publish = Some(metrics.clone());
+                last_metrics = Some(metrics);
+                publish_timer.as_mut().reset(
+                    tokio::time::Instant::now()
+                        + tokio::time::Duration::from_millis(1)
+                );
+            }
+            _ = &mut publish_timer, if pending_publish.is_some() => {
+                if let Some(metrics) = pending_publish.take() {
+                    let active_load = ActiveLoad {
+                        worker_id,
+                        dp_rank: metrics.dp_rank,
+                        active_decode_blocks: metrics.active_decode_blocks,
+                        active_prefill_tokens: None,
+                        kv_used_blocks: metrics.kv_used_blocks,
+                    };
+
+                    if let Err(e) = event_publisher.publish(&active_load).await {
+                        tracing::warn!("Failed to publish metrics: {}", e);
                     }
                 }
             }
-        });
+        }
     }
 }

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -14,7 +14,10 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::backend::ExecutionContext;
-use crate::kv_router::publisher::{KvEventPublisher, KvEventSourceConfig, WorkerMetricsPublisher};
+use crate::kv_router::{
+    KV_EVENT_SUBJECT,
+    publisher::{KvEventPublisher, KvEventSourceConfig, WorkerMetricsPublisher},
+};
 use crate::protocols::TokenIdType;
 use crate::protocols::common::llm_backend::{LLMEngineOutput, PreprocessedRequest};
 use anyhow::Result;
@@ -35,6 +38,7 @@ use dynamo_mocker::services::zmq_events::ZmqKvEventSink;
 use dynamo_runtime::DistributedRuntime;
 use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::protocols::annotated::Annotated;
+use dynamo_runtime::transports::event_plane::EventPublisher;
 use dynamo_runtime::{
     component::Component,
     engine::AsyncEngineContextProvider,
@@ -384,6 +388,46 @@ impl MockEngine {
         let mut senders = Vec::with_capacity(args.dp_size as usize);
         let mut command_senders = Vec::with_capacity(args.dp_size as usize);
         let mut handoff_session_permits = Vec::with_capacity(args.dp_size as usize);
+        let shared_event_publisher = match component {
+            Some(comp) if args.enable_local_indexer => {
+                match EventPublisher::for_component(comp, KV_EVENT_SUBJECT).await {
+                    Ok(publisher) => Some(Arc::new(publisher)),
+                    Err(e) => {
+                        tracing::error!("Failed to create shared KV event publisher: {e}");
+                        None
+                    }
+                }
+            }
+            _ => None,
+        };
+        let build_kv_event_publisher = |comp: &Component,
+                                        source_config: Option<KvEventSourceConfig>,
+                                        dp_rank: u32|
+         -> Result<KvEventPublisher> {
+            if args.enable_local_indexer {
+                let event_publisher = shared_event_publisher
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("shared KV event publisher unavailable"))?;
+                KvEventPublisher::new_with_shared_event_publisher(
+                    comp.clone(),
+                    args.block_size as u32,
+                    source_config,
+                    args.enable_local_indexer,
+                    dp_rank,
+                    None,
+                    event_publisher,
+                )
+            } else {
+                KvEventPublisher::new_with_local_indexer(
+                    comp.clone(),
+                    args.block_size as u32,
+                    source_config,
+                    args.enable_local_indexer,
+                    dp_rank,
+                    None,
+                )
+            }
+        };
 
         for (dp_rank, fpm_publisher) in (0..args.dp_size).zip(fpm_sinks) {
             let (output_tx, mut output_rx) = mpsc::unbounded_channel::<Vec<OutputSignal>>();
@@ -409,14 +453,7 @@ impl MockEngine {
                                 topic: String::new(),
                                 image_token_id: None,
                             });
-                            match KvEventPublisher::new_with_local_indexer(
-                                comp.clone(),
-                                args.block_size as u32,
-                                source_config,
-                                args.enable_local_indexer,
-                                dp_rank,
-                                None,
-                            ) {
+                            match build_kv_event_publisher(comp, source_config, dp_rank) {
                                 Ok(publisher) => (
                                     KvEventPublishers::new(
                                         None,
@@ -440,31 +477,22 @@ impl MockEngine {
                         }
                     }
                 }
-                Some(comp) => {
-                    match KvEventPublisher::new_with_local_indexer(
-                        comp.clone(),
-                        args.block_size as u32,
-                        None,
-                        args.enable_local_indexer,
-                        dp_rank,
-                        None,
-                    ) {
-                        Ok(publisher) => (
-                            KvEventPublishers::new(
-                                Some(Arc::new(KvEventSinkAdapter(publisher))
-                                    as Arc<dyn KvCacheEventSink>),
-                                None,
-                            ),
+                Some(comp) => match build_kv_event_publisher(comp, None, dp_rank) {
+                    Ok(publisher) => (
+                        KvEventPublishers::new(
+                            Some(Arc::new(KvEventSinkAdapter(publisher))
+                                as Arc<dyn KvCacheEventSink>),
                             None,
                         ),
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to create KV event publisher for dp_rank {dp_rank}: {e}"
-                            );
-                            (KvEventPublishers::default(), None)
-                        }
+                        None,
+                    ),
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to create KV event publisher for dp_rank {dp_rank}: {e}"
+                        );
+                        (KvEventPublishers::default(), None)
                     }
-                }
+                },
                 None => (KvEventPublishers::default(), None),
             };
 
@@ -510,7 +538,7 @@ impl MockEngine {
 
             self.scheduler_tasks.spawn(async move {
                 // Keep the relay publisher alive for the lifetime of this task.
-                // Dropping it would cancel its background ZMQ→NATS relay tasks.
+                // Dropping it would cancel its background ZMQ/event-plane relay tasks.
                 let _relay_publisher = relay_publisher;
 
                 loop {


### PR DESCRIPTION
## Summary

- Share event-plane KV event publishers across dp ranks within a worker so ZMQ direct discovery does not collide on component/topic/instance_id.
- Share worker metrics event-plane publishers for the same reason, while keeping per-dp local indexer/query endpoints separate.
- Update mocker scheduler setup to reuse the shared KV event publisher when local indexer publishing is enabled.

## Validation

- cargo fmt
- git diff --check
- cargo check -p dynamo-llm
- cargo check -p dynamo-backend-common
- DYN_EVENT_PLANE=zmq /home/zhongdaor/dynamo/bin/python -m pytest -q tests/router/test_router_e2e_with_mockers.py::test_router_decisions[nats_core-tcp] -s

## Related Issues

- [x] Confirmed no related issue
