### PR TITLE
docs(agents): add missing AGENTS symlinks

### DIFF
--- a/components/src/dynamo/common/backend/AGENTS.md
+++ b/components/src/dynamo/common/backend/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/components/src/dynamo/router/AGENTS.md
+++ b/components/src/dynamo/router/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/backend-common/AGENTS.md
+++ b/lib/backend-common/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kv-router/AGENTS.md
+++ b/lib/kv-router/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/AGENTS.md
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kv-router/src/scheduling/AGENTS.md
+++ b/lib/kv-router/src/scheduling/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kv-router/src/sequences/AGENTS.md
+++ b/lib/kv-router/src/sequences/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kv-router/src/services/AGENTS.md
+++ b/lib/kv-router/src/services/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kv-router/src/services/indexer/AGENTS.md
+++ b/lib/kv-router/src/services/indexer/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kv-router/src/services/slot_tracker/AGENTS.md
+++ b/lib/kv-router/src/services/slot_tracker/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kvbm-engine/AGENTS.md
+++ b/lib/kvbm-engine/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kvbm-kernels/AGENTS.md
+++ b/lib/kvbm-kernels/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/kvbm-logical/AGENTS.md
+++ b/lib/kvbm-logical/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/llm/src/local_model/AGENTS.md
+++ b/lib/llm/src/local_model/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/llm/src/request_trace/AGENTS.md
+++ b/lib/llm/src/request_trace/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/mocker/src/scheduler/vllm/AGENTS.md
+++ b/lib/mocker/src/scheduler/vllm/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/tests/router/AGENTS.md
+++ b/tests/router/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` symlinks alongside existing `CLAUDE.md` files in packages that were missing agent instructions aliases.
- Keep the symlinks consistent with existing directories that already use `AGENTS.md -> CLAUDE.md`.

## Validation
- `find . -name CLAUDE.md -exec sh -c 'for f do d=${f%/*}; test "$d" = "$f" && d=.; test -e "$d/AGENTS.md" || echo "$d"; done' sh {} +`
- `uv tool run pre-commit run --all-files --show-diff-on-failure`
- `git commit -s -m "docs(agents): add missing AGENTS symlinks"` pre-commit and commit-msg hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several guidance files to point to a shared reference file.
  * Standardized agent instruction locations across backend, router, KV, LLM, mocker, and test areas.
  * No functional, API, or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->