### PR TITLE
fix(llm): preserve fragmented agent tool calls

### DIFF
--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -40,7 +40,6 @@ pub struct AnthropicStreamConverter {
     cached_token_count: Option<u32>,
     // Tool call tracking
     tool_call_states: Vec<ToolCallState>,
-    tool_calls_sent: HashSet<String>,
     // Block index counter
     next_block_index: u32,
     // Stop reason
@@ -50,12 +49,9 @@ pub struct AnthropicStreamConverter {
 struct ToolCallState {
     id: String,
     name: String,
-    accumulated_args: String,
+    argument_fragments: Vec<String>,
     block_index: u32,
     started: bool,
-    /// Set when `content_block_stop` has already been emitted inline
-    /// (complete tool call detected mid-stream). Prevents duplicate stop in `emit_end_events()`.
-    stopped: bool,
 }
 
 impl AnthropicStreamConverter {
@@ -74,7 +70,6 @@ impl AnthropicStreamConverter {
             output_token_count: 0,
             cached_token_count: None,
             tool_call_states: Vec::new(),
-            tool_calls_sent: HashSet::new(),
             next_block_index: 0,
             stop_reason: None,
         }
@@ -301,10 +296,9 @@ impl AnthropicStreamConverter {
                         self.tool_call_states.push(ToolCallState {
                             id: String::new(),
                             name: String::new(),
-                            accumulated_args: String::new(),
+                            argument_fragments: Vec::new(),
                             block_index,
                             started: false,
-                            stopped: false,
                         });
                     }
 
@@ -317,60 +311,9 @@ impl AnthropicStreamConverter {
                             self.tool_call_states[tc_index].name = name.clone();
                         }
                         if let Some(args) = &func.arguments {
-                            // Emit content_block_start on first delta for this tool call
-                            if !self.tool_call_states[tc_index].started {
-                                let tc_id = self.tool_call_states[tc_index].id.clone();
-
-                                // Dedup guard: skip if we've already emitted this tool call ID
-                                if !tc_id.is_empty() && self.tool_calls_sent.contains(&tc_id) {
-                                    continue;
-                                }
-
-                                self.tool_call_states[tc_index].started = true;
-                                let block_index = self.tool_call_states[tc_index].block_index;
-                                let tc_name = self.tool_call_states[tc_index].name.clone();
-
-                                if !tc_id.is_empty() {
-                                    self.tool_calls_sent.insert(tc_id.clone());
-                                }
-
-                                let block_start = AnthropicStreamEvent::ContentBlockStart {
-                                    index: block_index,
-                                    content_block: AnthropicResponseContentBlock::ToolUse {
-                                        id: tc_id,
-                                        name: tc_name,
-                                        input: serde_json::json!({}),
-                                    },
-                                };
-                                events.push(make_sse_event("content_block_start", &block_start));
-                            }
-
-                            self.tool_call_states[tc_index]
-                                .accumulated_args
-                                .push_str(args);
-
-                            let block_index = self.tool_call_states[tc_index].block_index;
-                            let block_delta = AnthropicStreamEvent::ContentBlockDelta {
-                                index: block_index,
-                                delta: AnthropicDelta::InputJsonDelta {
-                                    partial_json: args.clone(),
-                                },
-                            };
-                            events.push(make_sse_event("content_block_delta", &block_delta));
-
-                            // Emit content_block_stop immediately if the tool call arrived
-                            // complete in a single chunk (id + name + args all present).
-                            // Dynamo backends emit complete tool calls, so this fires on the
-                            // same chunk — no need to wait for finish_reason.
-                            if tc.id.is_some()
-                                && func.name.is_some()
-                                && !self.tool_call_states[tc_index].stopped
-                            {
-                                self.tool_call_states[tc_index].stopped = true;
-                                let block_stop =
-                                    AnthropicStreamEvent::ContentBlockStop { index: block_index };
-                                events.push(make_sse_event("content_block_stop", &block_stop));
-                            }
+                            let state = &mut self.tool_call_states[tc_index];
+                            state.started = true;
+                            state.argument_fragments.push(args.clone());
                         }
                     }
                 }
@@ -411,9 +354,32 @@ impl AnthropicStreamConverter {
             events.push(make_sse_event("content_block_stop", &block_stop));
         }
 
-        // Close tool call blocks (skip any already stopped inline)
+        // Chat-completions tool calls may be fragmented and interleaved. Anthropic
+        // requires each content block to complete before the next block starts, so
+        // buffer tool fragments and emit complete block lifecycles in index order.
+        let mut sent_tool_call_ids = HashSet::new();
         for tc in &self.tool_call_states {
-            if tc.started && !tc.stopped {
+            if tc.started && (tc.id.is_empty() || sent_tool_call_ids.insert(tc.id.clone())) {
+                let block_start = AnthropicStreamEvent::ContentBlockStart {
+                    index: tc.block_index,
+                    content_block: AnthropicResponseContentBlock::ToolUse {
+                        id: tc.id.clone(),
+                        name: tc.name.clone(),
+                        input: serde_json::json!({}),
+                    },
+                };
+                events.push(make_sse_event("content_block_start", &block_start));
+
+                for args in &tc.argument_fragments {
+                    let block_delta = AnthropicStreamEvent::ContentBlockDelta {
+                        index: tc.block_index,
+                        delta: AnthropicDelta::InputJsonDelta {
+                            partial_json: args.clone(),
+                        },
+                    };
+                    events.push(make_sse_event("content_block_delta", &block_delta));
+                }
+
                 let block_stop = AnthropicStreamEvent::ContentBlockStop {
                     index: tc.block_index,
                 };
@@ -629,10 +595,9 @@ impl AnthropicStreamConverter {
                         self.tool_call_states.push(ToolCallState {
                             id: String::new(),
                             name: String::new(),
-                            accumulated_args: String::new(),
+                            argument_fragments: Vec::new(),
                             block_index,
                             started: false,
-                            stopped: false,
                         });
                     }
                     if let Some(id) = &tc.id {
@@ -643,52 +608,9 @@ impl AnthropicStreamConverter {
                             self.tool_call_states[tc_index].name = name.clone();
                         }
                         if let Some(args) = &func.arguments {
-                            if !self.tool_call_states[tc_index].started {
-                                let tc_id = self.tool_call_states[tc_index].id.clone();
-                                if !tc_id.is_empty() && self.tool_calls_sent.contains(&tc_id) {
-                                    continue;
-                                }
-                                self.tool_call_states[tc_index].started = true;
-                                let block_index = self.tool_call_states[tc_index].block_index;
-                                let tc_name = self.tool_call_states[tc_index].name.clone();
-                                if !tc_id.is_empty() {
-                                    self.tool_calls_sent.insert(tc_id.clone());
-                                }
-                                let ev = AnthropicStreamEvent::ContentBlockStart {
-                                    index: block_index,
-                                    content_block: AnthropicResponseContentBlock::ToolUse {
-                                        id: tc_id,
-                                        name: tc_name,
-                                        input: serde_json::json!({}),
-                                    },
-                                };
-                                events.push(make_tagged_event("content_block_start", &ev));
-                            }
-                            self.tool_call_states[tc_index]
-                                .accumulated_args
-                                .push_str(args);
-                            let block_index = self.tool_call_states[tc_index].block_index;
-                            let ev = AnthropicStreamEvent::ContentBlockDelta {
-                                index: block_index,
-                                delta: AnthropicDelta::InputJsonDelta {
-                                    partial_json: args.clone(),
-                                },
-                            };
-                            events.push(make_tagged_event("content_block_delta", &ev));
-
-                            // Emit content_block_stop immediately if the tool call arrived
-                            // complete in a single chunk (id + name + args all present).
-                            // Dynamo backends emit complete tool calls, so this fires on the
-                            // same chunk — no need to wait for finish_reason.
-                            if tc.id.is_some()
-                                && func.name.is_some()
-                                && !self.tool_call_states[tc_index].stopped
-                            {
-                                self.tool_call_states[tc_index].stopped = true;
-                                let ev =
-                                    AnthropicStreamEvent::ContentBlockStop { index: block_index };
-                                events.push(make_tagged_event("content_block_stop", &ev));
-                            }
+                            let state = &mut self.tool_call_states[tc_index];
+                            state.started = true;
+                            state.argument_fragments.push(args.clone());
                         }
                     }
                 }
@@ -725,9 +647,30 @@ impl AnthropicStreamConverter {
             events.push(make_tagged_event("content_block_stop", &ev));
         }
 
-        // Skip already-stopped tool call blocks
+        // Emit buffered tool blocks sequentially at stream end.
+        let mut sent_tool_call_ids = HashSet::new();
         for tc in &self.tool_call_states {
-            if tc.started && !tc.stopped {
+            if tc.started && (tc.id.is_empty() || sent_tool_call_ids.insert(tc.id.clone())) {
+                let ev = AnthropicStreamEvent::ContentBlockStart {
+                    index: tc.block_index,
+                    content_block: AnthropicResponseContentBlock::ToolUse {
+                        id: tc.id.clone(),
+                        name: tc.name.clone(),
+                        input: serde_json::json!({}),
+                    },
+                };
+                events.push(make_tagged_event("content_block_start", &ev));
+
+                for args in &tc.argument_fragments {
+                    let ev = AnthropicStreamEvent::ContentBlockDelta {
+                        index: tc.block_index,
+                        delta: AnthropicDelta::InputJsonDelta {
+                            partial_json: args.clone(),
+                        },
+                    };
+                    events.push(make_tagged_event("content_block_delta", &ev));
+                }
+
                 let ev = AnthropicStreamEvent::ContentBlockStop {
                     index: tc.block_index,
                 };
@@ -844,7 +787,7 @@ mod tests {
     #[test]
     fn test_append_events_reuse_caller_storage() {
         let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
-        let mut events = Vec::with_capacity(4);
+        let mut events = Vec::with_capacity(8);
 
         conv.append_start_events(&mut events);
         assert_eq!(events.len(), 1);
@@ -867,13 +810,13 @@ mod tests {
             ),
             &mut events,
         );
-        assert_eq!(events.len(), 4);
+        assert_eq!(events.len(), 1);
         assert_eq!(events.capacity(), capacity);
         assert!(events.iter().all(Result::is_ok));
 
         events.clear();
         conv.append_end_events(&mut events);
-        assert_eq!(events.len(), 2);
+        assert_eq!(events.len(), 5);
         assert_eq!(events.capacity(), capacity);
         assert!(events.iter().all(Result::is_ok));
 
@@ -911,21 +854,28 @@ mod tests {
 
         assert_eq!(
             event_types(&tool_events),
-            vec![
-                "content_block_stop",
-                "content_block_start",
-                "content_block_delta",
-                "content_block_stop",
-            ],
-            "text block must be closed before tool block starts; complete tool call stopped inline"
+            vec!["content_block_stop"],
+            "text block must close before buffered tool output"
         );
 
-        // Verify indices: stop=0 (text), start=1 (tool)
+        // Verify index 0 closes before buffered tool index 1 is emitted.
         match &tool_events[0].data {
             AnthropicStreamEvent::ContentBlockStop { index } => assert_eq!(*index, 0),
             other => panic!("expected ContentBlockStop, got {other:?}"),
         }
-        match &tool_events[1].data {
+
+        let end_events = conv.emit_end_events_tagged();
+        assert_eq!(
+            event_types(&end_events),
+            vec![
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            ]
+        );
+        match &end_events[0].data {
             AnthropicStreamEvent::ContentBlockStart {
                 index,
                 content_block,
@@ -940,14 +890,6 @@ mod tests {
             }
             other => panic!("expected ContentBlockStart, got {other:?}"),
         }
-
-        // End events should NOT duplicate either stop (both already emitted inline)
-        let end_events = conv.emit_end_events_tagged();
-        assert_eq!(
-            event_types(&end_events),
-            vec!["message_delta", "message_stop"],
-            "no block stops in end events (both text and tool already closed inline)"
-        );
     }
 
     /// Tool-only response (no preceding text): no spurious stop events.
@@ -961,21 +903,48 @@ mod tests {
             Some("Read"),
             Some("{\"path\":\"/tmp/test.txt\"}"),
         ));
-        assert_eq!(
-            event_types(&tool_events),
-            vec![
-                "content_block_start",
-                "content_block_delta",
-                "content_block_stop"
-            ],
-            "complete tool call emits stop inline"
-        );
+        assert!(tool_events.is_empty());
 
         let end_events = conv.emit_end_events_tagged();
         assert_eq!(
             event_types(&end_events),
-            vec!["message_delta", "message_stop"],
-            "no block stop in end events (already stopped inline)"
+            vec![
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_empty_initial_tool_arguments_do_not_stop_block_early() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+
+        let first =
+            conv.process_chunk_tagged(&tool_call_chunk(0, Some("call-1"), Some("Read"), Some("")));
+        assert!(first.is_empty());
+
+        let middle =
+            conv.process_chunk_tagged(&tool_call_chunk(0, None, None, Some("{\"path\":\"/tmp")));
+        assert!(middle.is_empty());
+
+        let last = conv.process_chunk_tagged(&tool_call_chunk(0, None, None, Some("\"}")));
+        assert!(last.is_empty());
+
+        let end = conv.emit_end_events_tagged();
+        assert_eq!(
+            event_types(&end),
+            vec![
+                "content_block_start",
+                "content_block_delta",
+                "content_block_delta",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            ]
         );
     }
 
@@ -1068,30 +1037,31 @@ mod tests {
             AnthropicStreamEvent::ContentBlockStart { index: 1, .. }
         ));
 
-        // 3. Tool call → text block closes, tool block opens at index 2.
-        //    Because the tool call arrives complete (id + name + args in one
-        //    chunk), inline dispatch also emits content_block_stop immediately.
+        // 3. Tool call → text block closes; tool output is buffered.
         let ev = conv.process_chunk_tagged(&tool_call_chunk(
             0,
             Some("call-1"),
             Some("Read"),
             Some("{\"path\":\"/tmp/test.txt\"}"),
         ));
-        assert_eq!(
-            event_types(&ev),
-            vec![
-                "content_block_stop",
-                "content_block_start",
-                "content_block_delta",
-                "content_block_stop"
-            ]
-        );
+        assert_eq!(event_types(&ev), vec!["content_block_stop"]);
         assert!(matches!(
             &ev[0].data,
             AnthropicStreamEvent::ContentBlockStop { index: 1 }
         ));
+        let end = conv.emit_end_events_tagged();
+        assert_eq!(
+            event_types(&end),
+            vec![
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            ]
+        );
         assert!(matches!(
-            &ev[1].data,
+            &end[0].data,
             AnthropicStreamEvent::ContentBlockStart { index: 2, .. }
         ));
     }
@@ -1114,9 +1084,9 @@ mod tests {
         );
     }
 
-    /// Multiple tool calls: each gets inline content_block_stop.
+    /// Multiple tool calls close in index order when the stream ends.
     #[test]
-    fn test_multiple_tool_calls_each_stopped_inline() {
+    fn test_multiple_tool_calls_each_stopped_at_stream_end() {
         let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
 
         let events1 = conv.process_chunk_tagged(&tool_call_chunk(
@@ -1125,15 +1095,7 @@ mod tests {
             Some("Read"),
             Some("{\"path\":\"/tmp/a.txt\"}"),
         ));
-        assert_eq!(
-            event_types(&events1),
-            vec![
-                "content_block_start",
-                "content_block_delta",
-                "content_block_stop"
-            ],
-            "first tool call closed inline"
-        );
+        assert!(events1.is_empty());
 
         let events2 = conv.process_chunk_tagged(&tool_call_chunk(
             1,
@@ -1141,22 +1103,51 @@ mod tests {
             Some("Write"),
             Some("{\"path\":\"/tmp/b.txt\"}"),
         ));
-        assert_eq!(
-            event_types(&events2),
-            vec![
-                "content_block_start",
-                "content_block_delta",
-                "content_block_stop"
-            ],
-            "second tool call closed inline"
-        );
+        assert!(events2.is_empty());
 
-        // End events: no block stops (both already closed)
         let end_events = conv.emit_end_events_tagged();
         assert_eq!(
             event_types(&end_events),
-            vec!["message_delta", "message_stop"],
-            "no block stops in end events"
+            vec![
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_duplicate_tool_call_id_is_emitted_once() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+
+        conv.process_chunk_tagged(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("Read"),
+            Some("{\"path\":\"/tmp/a.txt\"}"),
+        ));
+        conv.process_chunk_tagged(&tool_call_chunk(
+            1,
+            Some("call-1"),
+            Some("Read"),
+            Some("{\"path\":\"/tmp/a.txt\"}"),
+        ));
+
+        let end_events = conv.emit_end_events_tagged();
+        assert_eq!(
+            event_types(&end_events),
+            vec![
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop"
+            ]
         );
     }
 

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -368,6 +368,7 @@ mod tests {
                 usage: None,
             },
             nvext: None,
+            llm_metrics: None,
         };
         Annotated {
             data: Some(response),

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -64,9 +64,6 @@ struct FunctionCallState {
     accumulated_args: String,
     output_index: u32,
     started: bool,
-    /// Set when done/item_done events have already been emitted inline
-    /// (complete tool call detected mid-stream). Prevents duplicate in `emit_end_events()`.
-    done: bool,
 }
 
 impl ResponseStreamConverter {
@@ -313,7 +310,6 @@ impl ResponseStreamConverter {
                             accumulated_args: String::new(),
                             output_index,
                             started: false,
-                            done: false,
                         });
                     }
 
@@ -355,10 +351,6 @@ impl ResponseStreamConverter {
                                 .accumulated_args
                                 .push_str(args);
                             let output_index = self.function_call_items[tc_index].output_index;
-                            let is_complete = tc.id.is_some()
-                                && func.name.is_some()
-                                && !self.function_call_items[tc_index].done;
-
                             // Clone item_id once; reused by both args_delta and (if complete) done events.
                             let item_id = self.function_call_items[tc_index].item_id.clone();
                             let seq = self.next_seq();
@@ -373,49 +365,8 @@ impl ResponseStreamConverter {
                                 );
                             events.push(self.make_sse_event(&args_delta));
 
-                            // Emit done + output_item.done immediately if the tool call
-                            // arrived complete in a single chunk (id + name + args all present).
-                            // Dynamo backends emit complete tool calls, so this fires on the
-                            // same chunk — no need to wait for finish_reason.
-                            if is_complete {
-                                self.function_call_items[tc_index].done = true;
-                                // Reuse item_id from above; capture remaining values before self.next_seq()
-                                let fc_item_id = item_id;
-                                let fc_call_id = self.function_call_items[tc_index].call_id.clone();
-                                let fc_name = self.function_call_items[tc_index].name.clone();
-                                let fc_args =
-                                    self.function_call_items[tc_index].accumulated_args.clone();
-                                let fc_output_index =
-                                    self.function_call_items[tc_index].output_index;
-
-                                let args_done =
-                                    ResponseStreamEvent::ResponseFunctionCallArgumentsDone(
-                                        ResponseFunctionCallArgumentsDoneEvent {
-                                            sequence_number: self.next_seq(),
-                                            item_id: fc_item_id.clone(),
-                                            output_index: fc_output_index,
-                                            arguments: fc_args.clone(),
-                                            name: Some(fc_name.clone()),
-                                        },
-                                    );
-                                events.push(self.make_sse_event(&args_done));
-
-                                let item_done = ResponseStreamEvent::ResponseOutputItemDone(
-                                    ResponseOutputItemDoneEvent {
-                                        sequence_number: self.next_seq(),
-                                        output_index: fc_output_index,
-                                        item: OutputItem::FunctionCall(FunctionToolCall {
-                                            id: Some(fc_item_id),
-                                            call_id: fc_call_id,
-                                            namespace: None,
-                                            name: fc_name,
-                                            arguments: fc_args,
-                                            status: Some(OutputStatus::Completed),
-                                        }),
-                                    },
-                                );
-                                events.push(self.make_sse_event(&item_done));
-                            }
+                            // id + name may arrive before the final arguments fragment.
+                            // Close function-call items only when the response stream ends.
                         }
                     }
                 }
@@ -477,11 +428,11 @@ impl ResponseStreamConverter {
             events.push(self.make_sse_event(&item_done));
         }
 
-        // Close any function call items not already done inline
+        // Close function call items after every arguments fragment has arrived.
         let fc_data: Vec<_> = self
             .function_call_items
             .iter()
-            .filter(|fc| fc.started && !fc.done)
+            .filter(|fc| fc.started)
             .map(|fc| {
                 (
                     fc.item_id.clone(),
@@ -1002,9 +953,9 @@ mod tests {
         serde_json::from_str(&converter.serialize_event_data(event).unwrap()).unwrap()
     }
 
-    /// Complete tool call emits function_call_arguments.done + output_item.done inline.
+    /// Complete tool calls remain open until the response stream ends.
     #[test]
-    fn test_complete_tool_call_emits_done_inline() {
+    fn test_complete_tool_call_closes_at_stream_end() {
         let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
         let _ = conv.emit_start_events(); // consume start events
 
@@ -1024,35 +975,65 @@ mod tests {
             types.contains(&"response.function_call_arguments.delta".to_string()),
             "should emit args delta: {types:?}"
         );
-        assert!(
-            types.contains(&"response.function_call_arguments.done".to_string()),
-            "should emit args done inline: {types:?}"
-        );
-        assert!(
-            types.contains(&"response.output_item.done".to_string()),
-            "should emit output_item.done inline: {types:?}"
-        );
+        assert!(!types.contains(&"response.function_call_arguments.done".to_string()));
+        assert!(!types.contains(&"response.output_item.done".to_string()));
 
-        // End events should NOT duplicate the done events
+        // End events close the call after every argument fragment has arrived.
         let end_types = event_types(&conv.emit_end_events());
         assert!(
-            !end_types.contains(&"response.function_call_arguments.done".to_string()),
-            "done should not be duplicated in end events: {end_types:?}"
+            end_types.contains(&"response.function_call_arguments.done".to_string()),
+            "args done should be emitted at stream end: {end_types:?}"
         );
         assert!(
-            !end_types.contains(&"response.output_item.done".to_string())
-                || end_types
-                    .iter()
-                    .filter(|t| *t == "response.output_item.done")
-                    .count()
-                    == 0,
-            "output_item.done for the tool should not appear in end events"
+            end_types.contains(&"response.output_item.done".to_string()),
+            "output item done should be emitted at stream end: {end_types:?}"
         );
     }
 
-    /// Multiple tool calls each get their own inline done events.
     #[test]
-    fn test_multiple_tool_calls_each_emit_done_inline() {
+    fn test_empty_initial_arguments_do_not_finish_function_call_early() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+        let _ = conv.emit_start_events();
+
+        let first = event_types(&conv.process_chunk(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("read_file"),
+            Some(""),
+        )));
+        assert_eq!(
+            first,
+            vec![
+                "response.output_item.added".to_string(),
+                "response.function_call_arguments.delta".to_string(),
+            ]
+        );
+
+        let middle = event_types(&conv.process_chunk(&tool_call_chunk(
+            0,
+            None,
+            None,
+            Some("{\"path\":\"/tmp"),
+        )));
+        assert_eq!(
+            middle,
+            vec!["response.function_call_arguments.delta".to_string()]
+        );
+
+        let last = event_types(&conv.process_chunk(&tool_call_chunk(0, None, None, Some("\"}"))));
+        assert_eq!(
+            last,
+            vec!["response.function_call_arguments.delta".to_string()]
+        );
+
+        let end = event_types(&conv.emit_end_events());
+        assert!(end.contains(&"response.function_call_arguments.done".to_string()));
+        assert!(end.contains(&"response.output_item.done".to_string()));
+    }
+
+    /// Multiple tool calls each get their own done events at stream end.
+    #[test]
+    fn test_multiple_tool_calls_each_close_at_stream_end() {
         let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
         let _ = conv.emit_start_events();
 
@@ -1063,10 +1044,7 @@ mod tests {
             Some("{\"city\":\"SF\"}"),
         ));
         let types1 = event_types(&events1);
-        assert!(
-            types1.contains(&"response.function_call_arguments.done".to_string()),
-            "first tool call done inline: {types1:?}"
-        );
+        assert!(!types1.contains(&"response.function_call_arguments.done".to_string()));
 
         let events2 = conv.process_chunk(&tool_call_chunk(
             1,
@@ -1075,20 +1053,16 @@ mod tests {
             Some("{\"tz\":\"PST\"}"),
         ));
         let types2 = event_types(&events2);
-        assert!(
-            types2.contains(&"response.function_call_arguments.done".to_string()),
-            "second tool call done inline: {types2:?}"
-        );
+        assert!(!types2.contains(&"response.function_call_arguments.done".to_string()));
 
-        // End events should have no function call done events
         let end_types = event_types(&conv.emit_end_events());
         let fc_done_count = end_types
             .iter()
             .filter(|t| *t == "response.function_call_arguments.done")
             .count();
         assert_eq!(
-            fc_done_count, 0,
-            "no function_call_arguments.done in end events: {end_types:?}"
+            fc_done_count, 2,
+            "each call closes exactly once at stream end: {end_types:?}"
         );
     }
 
@@ -1137,14 +1111,12 @@ mod tests {
             Some("{\"q\":\"rust\"}"),
         ));
         let tool_types = event_types(&tool_events);
-        assert!(
-            tool_types.contains(&"response.function_call_arguments.done".to_string()),
-            "tool call done inline after text: {tool_types:?}"
-        );
-        assert!(
-            tool_types.contains(&"response.output_item.done".to_string()),
-            "output_item.done inline after text: {tool_types:?}"
-        );
+        assert!(!tool_types.contains(&"response.function_call_arguments.done".to_string()));
+        assert!(!tool_types.contains(&"response.output_item.done".to_string()));
+
+        let end_types = event_types(&conv.emit_end_events());
+        assert!(end_types.contains(&"response.function_call_arguments.done".to_string()));
+        assert!(end_types.contains(&"response.output_item.done".to_string()));
     }
 
     /// Verify that `with_context` populates `previous_response_id`
@@ -1220,8 +1192,6 @@ mod tests {
             vec![
                 "response.output_item.added".to_string(),
                 "response.function_call_arguments.delta".to_string(),
-                "response.function_call_arguments.done".to_string(),
-                "response.output_item.done".to_string(),
             ]
         );
     }

--- a/lib/llm/tests/anthropic_http_replay.rs
+++ b/lib/llm/tests/anthropic_http_replay.rs
@@ -1,0 +1,407 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Full-HTTP integration coverage for the Anthropic Messages compatibility surface.
+
+use std::collections::BTreeMap;
+
+use dynamo_protocols::types::{
+    ChatCompletionRequestAssistantMessageContent, ChatCompletionRequestMessage,
+    ChatCompletionRequestToolMessageContent, ChatCompletionRequestUserMessageContent,
+};
+use dynamo_runtime::config::environment_names::llm::{
+    DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
+};
+use serde_json::{Value, json};
+use serial_test::serial;
+
+#[path = "common/http_harness.rs"]
+mod http_harness;
+#[path = "common/ports.rs"]
+mod ports;
+#[path = "common/scripted_chat_engine.rs"]
+mod scripted_chat_engine;
+
+use http_harness::{HarnessService, MODEL, canonicalize, load_agent_fixture, parse_json_sse};
+use scripted_chat_engine::Script;
+
+const ENV: [(&str, Option<&str>); 2] = [
+    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+];
+
+fn user_text(
+    request: &dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionRequest,
+) -> &str {
+    match &request.inner.messages[..] {
+        [ChatCompletionRequestMessage::User(user)] => match &user.content {
+            ChatCompletionRequestUserMessageContent::Text(text) => text,
+            other => panic!("expected text user content, got {other:?}"),
+        },
+        other => panic!("expected one translated user message, got {other:#?}"),
+    }
+}
+
+async fn post_messages(svc: &HarnessService, body: &Value) -> reqwest::Response {
+    svc.client
+        .post(format!("{}/v1/messages", svc.base_url))
+        .json(body)
+        .send()
+        .await
+        .expect("POST /v1/messages failed")
+}
+
+fn tool(name: &str) -> Value {
+    json!({
+        "name": name,
+        "description": "test tool",
+        "input_schema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"]
+        }
+    })
+}
+
+#[tokio::test]
+#[serial]
+async fn unary_text_baseline() {
+    temp_env::async_with_vars(ENV, async {
+        let svc = HarnessService::start([load_agent_fixture("text.sse").await.unwrap()]).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 64,
+                "stream": false,
+                "messages": [{"role": "user", "content": "ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: Value = response.json().await.unwrap();
+        insta::assert_json_snapshot!("anthropic_unary_text", canonicalize(body));
+
+        let requests = svc.engine.take_requests().await;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(user_text(&requests[0]), "ping");
+        assert_eq!(requests[0].inner.max_completion_tokens, Some(64));
+        assert_eq!(requests[0].inner.stream, Some(true));
+        assert_eq!(svc.engine.remaining_scripts().await, 0);
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn streaming_text_baseline() {
+    temp_env::async_with_vars(ENV, async {
+        let svc = HarnessService::start([load_agent_fixture("text.sse").await.unwrap()]).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 64,
+                "stream": true,
+                "messages": [{"role": "user", "content": "ping"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let raw = response.text().await.unwrap();
+        assert_eq!(raw.matches("data: [DONE]").count(), 1);
+        let events = parse_json_sse(&raw).await.unwrap();
+        insta::assert_json_snapshot!(
+            "anthropic_streaming_text",
+            canonicalize(serde_json::to_value(events).unwrap())
+        );
+
+        assert_eq!(svc.engine.remaining_scripts().await, 0);
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn fragmented_tool_arguments_close_after_all_deltas() {
+    temp_env::async_with_vars(ENV, async {
+        let svc =
+            HarnessService::start([load_agent_fixture("fragmented-tool.sse").await.unwrap()]).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "tools": [tool("list_directory")],
+                "messages": [{"role": "user", "content": "List /tmp"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let events = parse_json_sse(&response.text().await.unwrap())
+            .await
+            .unwrap();
+
+        let start = events
+            .iter()
+            .find(|event| event.event == "content_block_start")
+            .expect("missing tool block start");
+        assert_eq!(start.data["content_block"]["id"], "call_list_directory");
+        assert_eq!(start.data["content_block"]["name"], "list_directory");
+
+        let deltas: Vec<_> = events
+            .iter()
+            .enumerate()
+            .filter(|(_, event)| {
+                event.event == "content_block_delta"
+                    && event.data["delta"]["type"] == "input_json_delta"
+            })
+            .map(|(index, event)| (index, event.data["delta"]["partial_json"].as_str().unwrap()))
+            .collect();
+        assert_eq!(
+            deltas.iter().map(|(_, part)| *part).collect::<String>(),
+            r#"{"path":"/tmp"}"#
+        );
+        let stop_positions: Vec<_> = events
+            .iter()
+            .enumerate()
+            .filter(|(_, event)| event.event == "content_block_stop")
+            .map(|(index, _)| index)
+            .collect();
+        assert_eq!(stop_positions.len(), 1);
+        assert!(stop_positions[0] > deltas.last().unwrap().0);
+        assert_eq!(
+            events
+                .iter()
+                .find(|event| event.event == "message_delta")
+                .unwrap()
+                .data["delta"]["stop_reason"],
+            "tool_use"
+        );
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn parallel_tools_preserve_identity_and_arguments() {
+    temp_env::async_with_vars(ENV, async {
+        let svc =
+            HarnessService::start([load_agent_fixture("parallel-tools.sse").await.unwrap()]).await;
+        let response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": true,
+                "tools": [tool("read_file")],
+                "messages": [{"role": "user", "content": "Read /a and /b"}]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let events = parse_json_sse(&response.text().await.unwrap())
+            .await
+            .unwrap();
+
+        let starts: Vec<_> = events
+            .iter()
+            .filter(|event| event.event == "content_block_start")
+            .map(|event| {
+                (
+                    event.data["index"].as_u64().unwrap(),
+                    event.data["content_block"]["id"]
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
+                    event.data["content_block"]["name"]
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            starts,
+            vec![
+                (0, "call_read_a".into(), "read_file".into()),
+                (1, "call_read_b".into(), "read_file".into())
+            ]
+        );
+
+        let mut arguments = BTreeMap::<u64, String>::new();
+        for event in &events {
+            if event.event == "content_block_delta"
+                && event.data["delta"]["type"] == "input_json_delta"
+            {
+                arguments
+                    .entry(event.data["index"].as_u64().unwrap())
+                    .or_default()
+                    .push_str(event.data["delta"]["partial_json"].as_str().unwrap());
+            }
+        }
+        assert_eq!(arguments.get(&0).unwrap(), r#"{"path":"/a"}"#);
+        assert_eq!(arguments.get(&1).unwrap(), r#"{"path":"/b"}"#);
+
+        let mut open_block = None;
+        for event in &events {
+            match event.event.as_str() {
+                "content_block_start" if event.data["content_block"]["type"] == "tool_use" => {
+                    assert!(open_block.is_none(), "tool blocks must not overlap");
+                    open_block = event.data["index"].as_u64();
+                }
+                "content_block_delta" if event.data["delta"]["type"] == "input_json_delta" => {
+                    assert_eq!(event.data["index"].as_u64(), open_block);
+                }
+                "content_block_stop" => {
+                    assert_eq!(event.data["index"].as_u64(), open_block);
+                    open_block = None;
+                }
+                _ => {}
+            }
+        }
+        assert!(open_block.is_none());
+
+        let stops: Vec<_> = events
+            .iter()
+            .filter(|event| event.event == "content_block_stop")
+            .map(|event| event.data["index"].as_u64().unwrap())
+            .collect();
+        assert_eq!(stops, vec![0, 1]);
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn tool_result_round_trip_reaches_the_chat_engine() {
+    temp_env::async_with_vars(ENV, async {
+        let first_script = load_agent_fixture("thinking-tool.sse").await.unwrap();
+        let second_script = load_agent_fixture("text.sse").await.unwrap();
+        let svc = HarnessService::start([first_script, second_script]).await;
+
+        let first_response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 128,
+                "stream": false,
+                "thinking": {"type": "enabled", "budget_tokens": 1024},
+                "tools": [tool("list_directory")],
+                "messages": [{"role": "user", "content": "List /tmp"}]
+            }),
+        )
+        .await;
+        assert_eq!(first_response.status(), reqwest::StatusCode::OK);
+        let first_body: Value = first_response.json().await.unwrap();
+        let prior_content = first_body["content"].clone();
+        assert!(prior_content.as_array().is_some_and(|blocks| {
+            blocks.iter().any(|block| block["type"] == "thinking")
+                && blocks.iter().any(|block| block["type"] == "tool_use")
+        }));
+
+        let second_response = post_messages(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "max_tokens": 64,
+                "stream": false,
+                "tools": [tool("list_directory")],
+                "messages": [
+                    {"role": "user", "content": "List /tmp"},
+                    {"role": "assistant", "content": prior_content},
+                    {"role": "user", "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": "call_list_directory",
+                        "content": "a.txt"
+                    }]}
+                ]
+            }),
+        )
+        .await;
+        assert_eq!(second_response.status(), reqwest::StatusCode::OK);
+        let second_body: Value = second_response.json().await.unwrap();
+        assert_eq!(second_body["content"][0]["text"], "Pong.");
+
+        let requests = svc.engine.take_requests().await;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(svc.engine.remaining_scripts().await, 0);
+        match &requests[1].inner.messages[..] {
+            [
+                ChatCompletionRequestMessage::User(user),
+                ChatCompletionRequestMessage::Assistant(assistant),
+                ChatCompletionRequestMessage::Tool(tool_result),
+            ] => {
+                assert!(matches!(
+                    &user.content,
+                    ChatCompletionRequestUserMessageContent::Text(text) if text == "List /tmp"
+                ));
+                assert!(matches!(
+                    assistant.content.as_ref(),
+                    Some(ChatCompletionRequestAssistantMessageContent::Text(text))
+                        if text == "I will list it."
+                ));
+                assert_eq!(
+                    assistant
+                        .reasoning_content
+                        .as_ref()
+                        .expect("thinking must reach the chat request")
+                        .to_flat_string(),
+                    "I should inspect the directory."
+                );
+                let calls = assistant.tool_calls.as_deref().expect("tool calls missing");
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].id, "call_list_directory");
+                assert_eq!(calls[0].function.name, "list_directory");
+                assert_eq!(calls[0].function.arguments, r#"{"path":"/tmp"}"#);
+                assert_eq!(tool_result.tool_call_id, "call_list_directory");
+                assert!(matches!(
+                    &tool_result.content,
+                    ChatCompletionRequestToolMessageContent::Text(text) if text == "a.txt"
+                ));
+            }
+            other => panic!("unexpected translated round-trip messages: {other:#?}"),
+        }
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn count_tokens_returns_exact_estimate_without_calling_engine() {
+    temp_env::async_with_vars(ENV, async {
+        let svc = HarnessService::start(Vec::<Script>::new()).await;
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages/count_tokens", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "system": "You are helpful.",
+                "messages": [{
+                    "role": "user",
+                    "content": "Hello, world! This is a test message."
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(
+            response.json::<Value>().await.unwrap(),
+            json!({"input_tokens": 19})
+        );
+        assert!(svc.engine.take_requests().await.is_empty());
+
+        svc.shutdown().await;
+    })
+    .await;
+}

--- a/lib/llm/tests/common/http_harness.rs
+++ b/lib/llm/tests/common/http_harness.rs
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared HTTP service and SSE helpers for agent-facing protocol tests.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use dynamo_llm::http::service::service_v2::HttpService;
+use dynamo_llm::model_card::ModelDeploymentCard;
+use dynamo_llm::protocols::codec::create_message_stream;
+use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+use dynamo_runtime::CancellationToken;
+use futures::StreamExt;
+use serde::Serialize;
+use serde_json::Value;
+
+use super::ports::bind_random_port;
+use super::scripted_chat_engine::{Script, ScriptedChatEngine};
+
+pub const MODEL: &str = "harness-model";
+
+pub async fn load_agent_fixture(name: &str) -> Result<Script> {
+    load_sse_fixture(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/replays/agent-harness")
+            .join(name),
+    )
+    .await
+}
+
+pub struct HarnessService {
+    pub base_url: String,
+    pub client: reqwest::Client,
+    pub engine: Arc<ScriptedChatEngine>,
+    cancel: CancellationToken,
+    join: Option<tokio::task::JoinHandle<Result<()>>>,
+}
+
+impl HarnessService {
+    pub async fn start(scripts: impl IntoIterator<Item = Script>) -> Self {
+        let engine = Arc::new(ScriptedChatEngine::new(scripts));
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("failed to build harness HTTP client");
+        let (listener, port) = bind_random_port().await;
+        let service = HttpService::builder()
+            .port(port)
+            .host("127.0.0.1")
+            .enable_chat_endpoints(true)
+            .enable_cmpl_endpoints(false)
+            .enable_responses_endpoints(true)
+            .enable_anthropic_endpoints(true)
+            .build()
+            .expect("failed to build harness HTTP service");
+
+        let card = ModelDeploymentCard::with_name_only(MODEL);
+        service
+            .model_manager()
+            .add_chat_completions_model(MODEL, card.mdcsum(), engine.clone())
+            .expect("failed to register scripted harness model");
+
+        let cancel = CancellationToken::new();
+        let join = service.spawn_with_listener(cancel.clone(), listener).await;
+        let base_url = format!("http://127.0.0.1:{port}");
+        wait_for_health(&client, &base_url).await;
+
+        Self {
+            base_url,
+            client,
+            engine,
+            cancel,
+            join: Some(join),
+        }
+    }
+
+    pub async fn shutdown(mut self) {
+        self.cancel.cancel();
+        let join = self.join.take().expect("harness join handle is missing");
+        tokio::time::timeout(Duration::from_secs(2), join)
+            .await
+            .expect("harness HTTP service did not stop within two seconds")
+            .expect("harness HTTP service task panicked")
+            .expect("harness HTTP service returned an error");
+    }
+}
+
+impl Drop for HarnessService {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(join) = self.join.take() {
+            join.abort();
+        }
+    }
+}
+
+async fn wait_for_health(client: &reqwest::Client, base_url: &str) {
+    let url = format!("{base_url}/health");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if client
+                .get(&url)
+                .send()
+                .await
+                .is_ok_and(|response| response.status().is_success())
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("harness HTTP service did not become healthy");
+}
+
+pub async fn load_sse_fixture(path: impl AsRef<Path>) -> Result<Script> {
+    let path = path.as_ref();
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read replay fixture {}", path.display()))?;
+    validate_terminal_data(&text, &format!("fixture {}", path.display()))?;
+    let mut messages = create_message_stream(&text);
+    let mut chunks = Vec::new();
+
+    while let Some(message) = messages.next().await {
+        let message = message.with_context(|| {
+            format!("failed to decode SSE framing in fixture {}", path.display())
+        })?;
+        match message.data.as_deref() {
+            Some(_) => chunks.push(message.decode_data::<NvCreateChatCompletionStreamResponse>()?),
+            None => {
+                return Err(anyhow!(
+                    "fixture {} contains an SSE event without data",
+                    path.display()
+                ));
+            }
+        }
+    }
+
+    if chunks.is_empty() {
+        return Err(anyhow!(
+            "fixture {} contains no response chunks",
+            path.display()
+        ));
+    }
+    Ok(chunks)
+}
+
+fn validate_terminal_data(text: &str, description: &str) -> Result<()> {
+    let mut seen_done = false;
+
+    for data in text.lines().filter_map(|line| line.strip_prefix("data:")) {
+        let data = data.trim();
+        if seen_done {
+            return Err(anyhow!("{description} contains SSE data after [DONE]"));
+        }
+        if data == "[DONE]" {
+            seen_done = true;
+        }
+    }
+
+    if !seen_done {
+        return Err(anyhow!("{description} does not end with [DONE]"));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonSseEvent {
+    pub event: String,
+    pub data: Value,
+}
+
+pub async fn parse_json_sse(body: &str) -> Result<Vec<JsonSseEvent>> {
+    validate_terminal_data(body, "response SSE stream")?;
+    let mut messages = create_message_stream(body);
+    let mut events = Vec::new();
+
+    while let Some(message) = messages.next().await {
+        let message = message.context("failed to decode response SSE framing")?;
+        let data = message
+            .data
+            .ok_or_else(|| anyhow!("response SSE event is missing data"))?;
+        let data = if data == "[DONE]" {
+            Value::String(data)
+        } else {
+            serde_json::from_str(&data).context("response SSE data is not valid JSON")?
+        };
+        events.push(JsonSseEvent {
+            event: message.event.unwrap_or_default(),
+            data,
+        });
+    }
+    Ok(events)
+}
+
+/// Canonicalize volatile values while preserving equality and distinctness of IDs.
+pub fn canonicalize(mut value: Value) -> Value {
+    let mut ids = HashMap::new();
+    let mut next_id = 1;
+    canonicalize_in_place(&mut value, &mut ids, &mut next_id);
+    value
+}
+
+fn canonicalize_in_place(
+    value: &mut Value,
+    ids: &mut HashMap<String, String>,
+    next_id: &mut usize,
+) {
+    match value {
+        Value::Object(map) => {
+            for (key, value) in map {
+                match key.as_str() {
+                    "id" if value.as_str().is_some_and(is_service_generated_object_id) => {
+                        canonicalize_id(value, ids, next_id);
+                    }
+                    "item_id" | "message_id" | "request_id" | "response_id" => {
+                        canonicalize_id(value, ids, next_id);
+                    }
+                    "created" | "created_at" | "completed_at" | "start_time" | "end_time"
+                        if value.is_number() =>
+                    {
+                        *value = Value::from(1_000_000_000u64);
+                    }
+                    _ => canonicalize_in_place(value, ids, next_id),
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                canonicalize_in_place(value, ids, next_id);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_service_generated_object_id(id: &str) -> bool {
+    ["msg_", "resp_", "fc_", "req_"]
+        .iter()
+        .any(|prefix| id.starts_with(prefix))
+}
+
+fn canonicalize_id(value: &mut Value, ids: &mut HashMap<String, String>, next_id: &mut usize) {
+    if let Some(id) = value.as_str() {
+        let canonical = ids.entry(id.to_string()).or_insert_with(|| {
+            let canonical = format!("[ID-{}]", *next_id);
+            *next_id += 1;
+            canonical
+        });
+        *value = Value::String(canonical.clone());
+    }
+}

--- a/lib/llm/tests/common/scripted_chat_engine.rs
+++ b/lib/llm/tests/common/scripted_chat_engine.rs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A deterministic chat-completions engine for HTTP protocol integration tests.
+
+use std::collections::VecDeque;
+
+use anyhow::{Error, Result, anyhow};
+use dynamo_llm::protocols::{
+    Annotated,
+    openai::chat_completions::{
+        NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
+    },
+};
+use dynamo_runtime::pipeline::{
+    AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn, async_trait,
+};
+use futures::stream;
+use tokio::sync::Mutex;
+
+pub type Script = Vec<NvCreateChatCompletionStreamResponse>;
+
+/// Captures translated chat requests and returns one scripted response per request.
+pub struct ScriptedChatEngine {
+    scripts: Mutex<VecDeque<Script>>,
+    requests: Mutex<Vec<NvCreateChatCompletionRequest>>,
+}
+
+impl ScriptedChatEngine {
+    pub fn new(scripts: impl IntoIterator<Item = Script>) -> Self {
+        Self {
+            scripts: Mutex::new(scripts.into_iter().collect()),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Remove and return all requests observed so far, in arrival order.
+    pub async fn take_requests(&self) -> Vec<NvCreateChatCompletionRequest> {
+        std::mem::take(&mut *self.requests.lock().await)
+    }
+
+    pub async fn remaining_scripts(&self) -> usize {
+        self.scripts.lock().await.len()
+    }
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateChatCompletionRequest>,
+        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
+        Error,
+    > for ScriptedChatEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateChatCompletionRequest>,
+    ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
+        let (request, context) = request.transfer(());
+        let ctx = context.context();
+
+        self.requests.lock().await.push(request);
+        let script = self
+            .scripts
+            .lock()
+            .await
+            .pop_front()
+            .ok_or_else(|| anyhow!("ScriptedChatEngine received an unexpected request"))?;
+
+        let output = stream::iter(script.into_iter().map(Annotated::from_data));
+        Ok(ResponseStream::new(Box::pin(output), ctx))
+    }
+}

--- a/lib/llm/tests/data/replays/agent-harness/README.md
+++ b/lib/llm/tests/data/replays/agent-harness/README.md
@@ -1,0 +1,15 @@
+# Agent API replay fixtures
+
+These fixtures are minimized, hand-authored chat-completions SSE traces. They
+preserve the response shapes used while investigating DYN-2764 and the earlier
+PR #8284; they are not unmodified captures from a hosted model backend.
+
+The fragmented-tool sequence is a minimized reconstruction of the ordering
+recorded in PR #8284: its first tool delta carried the call ID, function name,
+and empty arguments, while later deltas supplied the JSON arguments. That
+snapshot did not record a backend name or version, so these fixtures make no
+backend-specific compatibility claim.
+
+Each fixture terminates with exactly one `[DONE]` event. The scenarios cover a
+plain text response, a tool call whose initially empty arguments arrive in
+later fragments, parallel tool calls, and a reasoning-plus-tool-call response.

--- a/lib/llm/tests/data/replays/agent-harness/fragmented-tool.sse
+++ b/lib/llm/tests/data/replays/agent-harness/fragmented-tool.sse
@@ -1,0 +1,13 @@
+data: {"id":"chatcmpl-harness-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}
+
+data: {"id":"chatcmpl-harness-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_list_directory","type":"function","function":{"name":"list_directory","arguments":""}}]}}]}
+
+data: {"id":"chatcmpl-harness-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\""}}]}}]}
+
+data: {"id":"chatcmpl-harness-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\"/tmp\"}"}}]}}]}
+
+data: {"id":"chatcmpl-harness-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: {"id":"chatcmpl-harness-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[],"usage":{"prompt_tokens":30,"completion_tokens":14,"total_tokens":44}}
+
+data: [DONE]

--- a/lib/llm/tests/data/replays/agent-harness/parallel-tools.sse
+++ b/lib/llm/tests/data/replays/agent-harness/parallel-tools.sse
@@ -1,0 +1,11 @@
+data: {"id":"chatcmpl-harness-parallel","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}
+
+data: {"id":"chatcmpl-harness-parallel","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_read_a","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"/a\"}"}}]}}]}
+
+data: {"id":"chatcmpl-harness-parallel","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_read_b","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"/b\"}"}}]}}]}
+
+data: {"id":"chatcmpl-harness-parallel","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: {"id":"chatcmpl-harness-parallel","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[],"usage":{"prompt_tokens":40,"completion_tokens":22,"total_tokens":62}}
+
+data: [DONE]

--- a/lib/llm/tests/data/replays/agent-harness/text.sse
+++ b/lib/llm/tests/data/replays/agent-harness/text.sse
@@ -1,0 +1,9 @@
+data: {"id":"chatcmpl-harness-text","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}
+
+data: {"id":"chatcmpl-harness-text","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"content":"Pong."}}]}
+
+data: {"id":"chatcmpl-harness-text","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: {"id":"chatcmpl-harness-text","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}
+
+data: [DONE]

--- a/lib/llm/tests/data/replays/agent-harness/thinking-tool.sse
+++ b/lib/llm/tests/data/replays/agent-harness/thinking-tool.sse
@@ -1,0 +1,11 @@
+data: {"id":"chatcmpl-harness-thinking-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"I should inspect the directory."}}]}
+
+data: {"id":"chatcmpl-harness-thinking-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"content":"I will list it."}}]}
+
+data: {"id":"chatcmpl-harness-thinking-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_list_directory","type":"function","function":{"name":"list_directory","arguments":"{\"path\":\"/tmp\"}"}}]}}]}
+
+data: {"id":"chatcmpl-harness-thinking-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: {"id":"chatcmpl-harness-thinking-tool","object":"chat.completion.chunk","created":1000000000,"model":"harness-model","choices":[],"usage":{"prompt_tokens":30,"completion_tokens":18,"total_tokens":48}}
+
+data: [DONE]

--- a/lib/llm/tests/responses_http_replay.rs
+++ b/lib/llm/tests/responses_http_replay.rs
@@ -1,0 +1,389 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Full-HTTP integration coverage for the OpenAI Responses compatibility surface.
+
+use std::collections::BTreeMap;
+
+use dynamo_protocols::types::{
+    ChatCompletionRequestMessage, ChatCompletionRequestToolMessageContent,
+    ChatCompletionRequestUserMessageContent,
+};
+use dynamo_runtime::config::environment_names::llm::DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS;
+use serde_json::{Value, json};
+use serial_test::serial;
+
+#[path = "common/http_harness.rs"]
+mod http_harness;
+#[path = "common/ports.rs"]
+mod ports;
+#[path = "common/scripted_chat_engine.rs"]
+mod scripted_chat_engine;
+
+use http_harness::{HarnessService, MODEL, canonicalize, load_agent_fixture, parse_json_sse};
+
+const ENV: [(&str, Option<&str>); 1] = [(DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0"))];
+
+async fn post_responses(svc: &HarnessService, body: &Value) -> reqwest::Response {
+    svc.client
+        .post(format!("{}/v1/responses", svc.base_url))
+        .json(body)
+        .send()
+        .await
+        .expect("POST /v1/responses failed")
+}
+
+fn tool(name: &str) -> Value {
+    json!({
+        "type": "function",
+        "name": name,
+        "description": "test tool",
+        "parameters": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"]
+        }
+    })
+}
+
+fn event_position(events: &[http_harness::JsonSseEvent], event_type: &str) -> usize {
+    events
+        .iter()
+        .position(|event| event.event == event_type)
+        .unwrap_or_else(|| panic!("missing {event_type} event"))
+}
+
+#[tokio::test]
+#[serial]
+async fn unary_text_baseline() {
+    temp_env::async_with_vars(ENV, async {
+        let svc = HarnessService::start([load_agent_fixture("text.sse").await.unwrap()]).await;
+        let response = post_responses(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "input": "ping",
+                "stream": false,
+                "max_output_tokens": 64
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: Value = response.json().await.unwrap();
+        insta::assert_json_snapshot!("responses_unary_text", canonicalize(body));
+
+        let requests = svc.engine.take_requests().await;
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].inner.max_completion_tokens, Some(64));
+        assert_eq!(requests[0].inner.stream, Some(true));
+        match &requests[0].inner.messages[..] {
+            [ChatCompletionRequestMessage::User(user)] => assert!(matches!(
+                &user.content,
+                ChatCompletionRequestUserMessageContent::Text(text) if text == "ping"
+            )),
+            other => panic!("unexpected translated request: {other:#?}"),
+        }
+        assert_eq!(svc.engine.remaining_scripts().await, 0);
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn streaming_text_baseline() {
+    temp_env::async_with_vars(ENV, async {
+        let svc = HarnessService::start([load_agent_fixture("text.sse").await.unwrap()]).await;
+        let response = post_responses(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "input": "ping",
+                "stream": true,
+                "max_output_tokens": 64
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let raw = response.text().await.unwrap();
+        assert_eq!(raw.matches("data: [DONE]").count(), 1);
+        let events = parse_json_sse(&raw).await.unwrap();
+        insta::assert_json_snapshot!(
+            "responses_streaming_text",
+            canonicalize(serde_json::to_value(events).unwrap())
+        );
+
+        assert_eq!(svc.engine.remaining_scripts().await, 0);
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn empty_first_arguments_do_not_finish_function_call_early() {
+    temp_env::async_with_vars(ENV, async {
+        let svc =
+            HarnessService::start([load_agent_fixture("fragmented-tool.sse").await.unwrap()]).await;
+        let response = post_responses(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "input": "List /tmp",
+                "stream": true,
+                "max_output_tokens": 128,
+                "tools": [tool("list_directory")]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let events = parse_json_sse(&response.text().await.unwrap())
+            .await
+            .unwrap();
+
+        let added = events
+            .iter()
+            .find(|event| event.event == "response.output_item.added")
+            .expect("missing function-call item");
+        assert_eq!(added.data["item"]["call_id"], "call_list_directory");
+        assert_eq!(added.data["item"]["name"], "list_directory");
+
+        let deltas: Vec<_> = events
+            .iter()
+            .enumerate()
+            .filter(|(_, event)| event.event == "response.function_call_arguments.delta")
+            .map(|(index, event)| (index, event.data["delta"].as_str().unwrap()))
+            .collect();
+        assert_eq!(
+            deltas.iter().map(|(_, part)| *part).collect::<String>(),
+            r#"{"path":"/tmp"}"#
+        );
+        let args_done_position = event_position(&events, "response.function_call_arguments.done");
+        let item_done_position = event_position(&events, "response.output_item.done");
+        assert!(args_done_position > deltas.last().unwrap().0);
+        assert!(item_done_position > args_done_position);
+
+        let args_done = &events[args_done_position].data;
+        assert_eq!(args_done["arguments"], r#"{"path":"/tmp"}"#);
+        assert_eq!(args_done["name"], "list_directory");
+        let item_done = &events[item_done_position].data["item"];
+        assert_eq!(item_done["call_id"], "call_list_directory");
+        assert_eq!(item_done["arguments"], r#"{"path":"/tmp"}"#);
+        assert_eq!(item_done["id"], added.data["item"]["id"]);
+
+        let completed = events
+            .iter()
+            .find(|event| event.event == "response.completed")
+            .unwrap();
+        let output = completed.data["response"]["output"].as_array().unwrap();
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0]["id"], added.data["item"]["id"]);
+        assert_eq!(output[0]["arguments"], r#"{"path":"/tmp"}"#);
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn parallel_function_calls_preserve_identity_and_arguments() {
+    temp_env::async_with_vars(ENV, async {
+        let svc =
+            HarnessService::start([load_agent_fixture("parallel-tools.sse").await.unwrap()]).await;
+        let response = post_responses(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "input": "Read /a and /b",
+                "stream": true,
+                "max_output_tokens": 128,
+                "parallel_tool_calls": true,
+                "tools": [tool("read_file")]
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let events = parse_json_sse(&response.text().await.unwrap())
+            .await
+            .unwrap();
+
+        let mut calls = BTreeMap::<u64, (String, String, String, String)>::new();
+        let mut last_delta_positions = BTreeMap::<u64, usize>::new();
+        let mut completion_counts = BTreeMap::<u64, (usize, usize)>::new();
+        for (position, event) in events.iter().enumerate() {
+            match event.event.as_str() {
+                "response.output_item.added" => {
+                    let index = event.data["output_index"].as_u64().unwrap();
+                    let item = &event.data["item"];
+                    calls.insert(
+                        index,
+                        (
+                            item["id"].as_str().unwrap().to_string(),
+                            item["call_id"].as_str().unwrap().to_string(),
+                            item["name"].as_str().unwrap().to_string(),
+                            String::new(),
+                        ),
+                    );
+                    completion_counts.insert(index, (0, 0));
+                }
+                "response.function_call_arguments.delta" => {
+                    let index = event.data["output_index"].as_u64().unwrap();
+                    calls
+                        .get_mut(&index)
+                        .unwrap()
+                        .3
+                        .push_str(event.data["delta"].as_str().expect("arguments delta"));
+                    assert_eq!(event.data["item_id"], calls.get(&index).unwrap().0.as_str());
+                    last_delta_positions.insert(index, position);
+                }
+                "response.function_call_arguments.done" => {
+                    let index = event.data["output_index"].as_u64().unwrap();
+                    assert_eq!(event.data["item_id"], calls.get(&index).unwrap().0.as_str());
+                    assert!(position > last_delta_positions[&index]);
+                    completion_counts.get_mut(&index).unwrap().0 += 1;
+                }
+                "response.output_item.done" => {
+                    let index = event.data["output_index"].as_u64().unwrap();
+                    assert_eq!(
+                        event.data["item"]["id"],
+                        calls.get(&index).unwrap().0.as_str()
+                    );
+                    assert!(position > last_delta_positions[&index]);
+                    completion_counts.get_mut(&index).unwrap().1 += 1;
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(
+            calls,
+            BTreeMap::from([
+                (
+                    0,
+                    (
+                        calls[&0].0.clone(),
+                        "call_read_a".into(),
+                        "read_file".into(),
+                        r#"{"path":"/a"}"#.into()
+                    )
+                ),
+                (
+                    1,
+                    (
+                        calls[&1].0.clone(),
+                        "call_read_b".into(),
+                        "read_file".into(),
+                        r#"{"path":"/b"}"#.into()
+                    )
+                )
+            ])
+        );
+        assert_eq!(
+            completion_counts,
+            BTreeMap::from([(0, (1, 1)), (1, (1, 1))])
+        );
+
+        let completed = events
+            .iter()
+            .find(|event| event.event == "response.completed")
+            .expect("missing response.completed");
+        let output = completed.data["response"]["output"].as_array().unwrap();
+        assert_eq!(output.len(), 2);
+        for (index, item) in output.iter().enumerate() {
+            let call = &calls[&(index as u64)];
+            assert_eq!(item["id"], call.0);
+            assert_eq!(item["call_id"], call.1);
+            assert_eq!(item["name"], call.2);
+            assert_eq!(item["arguments"], call.3);
+        }
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn function_call_output_round_trip_reaches_the_chat_engine() {
+    temp_env::async_with_vars(ENV, async {
+        let first_script = load_agent_fixture("fragmented-tool.sse").await.unwrap();
+        let second_script = load_agent_fixture("text.sse").await.unwrap();
+        let svc = HarnessService::start([first_script, second_script]).await;
+
+        let first_response = post_responses(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "input": "List /tmp",
+                "stream": false,
+                "max_output_tokens": 128,
+                "tools": [tool("list_directory")]
+            }),
+        )
+        .await;
+        assert_eq!(first_response.status(), reqwest::StatusCode::OK);
+        let first_body: Value = first_response.json().await.unwrap();
+        let function_call = first_body["output"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|item| item["type"] == "function_call")
+            .expect("first response did not contain a function call")
+            .clone();
+
+        let second_response = post_responses(
+            &svc,
+            &json!({
+                "model": MODEL,
+                "stream": false,
+                "max_output_tokens": 64,
+                "tools": [tool("list_directory")],
+                "input": [
+                    {"role": "user", "content": "List /tmp"},
+                    function_call,
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_list_directory",
+                        "output": "[\"a.txt\"]"
+                    }
+                ]
+            }),
+        )
+        .await;
+        assert_eq!(second_response.status(), reqwest::StatusCode::OK);
+        let second_body: Value = second_response.json().await.unwrap();
+        assert_eq!(second_body["output"][0]["content"][0]["text"], "Pong.");
+
+        let requests = svc.engine.take_requests().await;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(svc.engine.remaining_scripts().await, 0);
+        match &requests[1].inner.messages[..] {
+            [
+                ChatCompletionRequestMessage::User(user),
+                ChatCompletionRequestMessage::Assistant(assistant),
+                ChatCompletionRequestMessage::Tool(tool_result),
+            ] => {
+                assert!(matches!(
+                    &user.content,
+                    ChatCompletionRequestUserMessageContent::Text(text) if text == "List /tmp"
+                ));
+                assert!(assistant.content.is_none());
+                let calls = assistant.tool_calls.as_deref().expect("tool calls missing");
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].id, "call_list_directory");
+                assert_eq!(calls[0].function.name, "list_directory");
+                assert_eq!(calls[0].function.arguments, r#"{"path":"/tmp"}"#);
+                assert_eq!(tool_result.tool_call_id, "call_list_directory");
+                assert!(matches!(
+                    &tool_result.content,
+                    ChatCompletionRequestToolMessageContent::Text(text)
+                        if text == r#"["a.txt"]"#
+                ));
+            }
+            other => panic!("unexpected translated round-trip messages: {other:#?}"),
+        }
+
+        svc.shutdown().await;
+    })
+    .await;
+}

--- a/lib/llm/tests/snapshots/anthropic_http_replay__anthropic_streaming_text.snap
+++ b/lib/llm/tests/snapshots/anthropic_http_replay__anthropic_streaming_text.snap
@@ -1,0 +1,73 @@
+---
+source: lib/llm/tests/anthropic_http_replay.rs
+expression: "canonicalize(serde_json::to_value(events).unwrap())"
+---
+[
+  {
+    "event": "message_start",
+    "data": {
+      "type": "message_start",
+      "message": {
+        "id": "[ID-1]",
+        "type": "message",
+        "role": "assistant",
+        "content": [],
+        "model": "harness-model",
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 2,
+          "output_tokens": 0
+        }
+      }
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "type": "content_block_start",
+      "index": 0,
+      "content_block": {
+        "type": "text",
+        "text": ""
+      }
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "type": "content_block_delta",
+      "index": 0,
+      "delta": {
+        "type": "text_delta",
+        "text": "Pong."
+      }
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "type": "content_block_stop",
+      "index": 0
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "type": "message_delta",
+      "delta": {
+        "stop_reason": "end_turn"
+      },
+      "usage": {
+        "input_tokens": 2,
+        "output_tokens": 2
+      }
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/lib/llm/tests/snapshots/anthropic_http_replay__anthropic_unary_text.snap
+++ b/lib/llm/tests/snapshots/anthropic_http_replay__anthropic_unary_text.snap
@@ -1,0 +1,22 @@
+---
+source: lib/llm/tests/anthropic_http_replay.rs
+expression: canonicalize(body)
+---
+{
+  "id": "[ID-1]",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "Pong."
+    }
+  ],
+  "model": "harness-model",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 5,
+    "output_tokens": 2
+  }
+}

--- a/lib/llm/tests/snapshots/responses_http_replay__responses_streaming_text.snap
+++ b/lib/llm/tests/snapshots/responses_http_replay__responses_streaming_text.snap
@@ -1,0 +1,268 @@
+---
+source: lib/llm/tests/responses_http_replay.rs
+expression: "canonicalize(serde_json::to_value(events).unwrap())"
+---
+[
+  {
+    "event": "response.created",
+    "data": {
+      "type": "response.created",
+      "sequence_number": 0,
+      "response": {
+        "background": false,
+        "billing": null,
+        "conversation": null,
+        "created_at": 1000000000,
+        "completed_at": null,
+        "error": null,
+        "id": "[ID-1]",
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": 64,
+        "max_tool_calls": null,
+        "metadata": {},
+        "model": "harness-model",
+        "object": "response",
+        "output": [],
+        "parallel_tool_calls": true,
+        "previous_response_id": null,
+        "prompt": null,
+        "prompt_cache_key": null,
+        "prompt_cache_retention": null,
+        "reasoning": null,
+        "safety_identifier": null,
+        "service_tier": "auto",
+        "status": "in_progress",
+        "temperature": 1.0,
+        "text": {
+          "format": {
+            "type": "text"
+          }
+        },
+        "tool_choice": "auto",
+        "tools": [],
+        "top_logprobs": 0,
+        "top_p": 1.0,
+        "truncation": "disabled",
+        "usage": null,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "store": false
+      }
+    }
+  },
+  {
+    "event": "response.in_progress",
+    "data": {
+      "type": "response.in_progress",
+      "sequence_number": 1,
+      "response": {
+        "background": false,
+        "billing": null,
+        "conversation": null,
+        "created_at": 1000000000,
+        "completed_at": null,
+        "error": null,
+        "id": "[ID-1]",
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": 64,
+        "max_tool_calls": null,
+        "metadata": {},
+        "model": "harness-model",
+        "object": "response",
+        "output": [],
+        "parallel_tool_calls": true,
+        "previous_response_id": null,
+        "prompt": null,
+        "prompt_cache_key": null,
+        "prompt_cache_retention": null,
+        "reasoning": null,
+        "safety_identifier": null,
+        "service_tier": "auto",
+        "status": "in_progress",
+        "temperature": 1.0,
+        "text": {
+          "format": {
+            "type": "text"
+          }
+        },
+        "tool_choice": "auto",
+        "tools": [],
+        "top_logprobs": 0,
+        "top_p": 1.0,
+        "truncation": "disabled",
+        "usage": null,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "store": false
+      }
+    }
+  },
+  {
+    "event": "response.output_item.added",
+    "data": {
+      "type": "response.output_item.added",
+      "sequence_number": 2,
+      "output_index": 0,
+      "item": {
+        "type": "message",
+        "content": [],
+        "id": "[ID-2]",
+        "role": "assistant",
+        "status": "in_progress"
+      }
+    }
+  },
+  {
+    "event": "response.content_part.added",
+    "data": {
+      "type": "response.content_part.added",
+      "sequence_number": 3,
+      "item_id": "[ID-2]",
+      "output_index": 0,
+      "content_index": 0,
+      "part": {
+        "type": "output_text",
+        "annotations": [],
+        "logprobs": [],
+        "text": ""
+      }
+    }
+  },
+  {
+    "event": "response.output_text.delta",
+    "data": {
+      "type": "response.output_text.delta",
+      "sequence_number": 4,
+      "item_id": "[ID-2]",
+      "output_index": 0,
+      "content_index": 0,
+      "delta": "Pong.",
+      "logprobs": []
+    }
+  },
+  {
+    "event": "response.output_text.done",
+    "data": {
+      "type": "response.output_text.done",
+      "sequence_number": 5,
+      "item_id": "[ID-2]",
+      "output_index": 0,
+      "content_index": 0,
+      "text": "Pong.",
+      "logprobs": []
+    }
+  },
+  {
+    "event": "response.content_part.done",
+    "data": {
+      "type": "response.content_part.done",
+      "sequence_number": 6,
+      "item_id": "[ID-2]",
+      "output_index": 0,
+      "content_index": 0,
+      "part": {
+        "type": "output_text",
+        "annotations": [],
+        "logprobs": [],
+        "text": "Pong."
+      }
+    }
+  },
+  {
+    "event": "response.output_item.done",
+    "data": {
+      "type": "response.output_item.done",
+      "sequence_number": 7,
+      "output_index": 0,
+      "item": {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": [],
+            "text": "Pong."
+          }
+        ],
+        "id": "[ID-2]",
+        "role": "assistant",
+        "status": "completed"
+      }
+    }
+  },
+  {
+    "event": "response.completed",
+    "data": {
+      "type": "response.completed",
+      "sequence_number": 8,
+      "response": {
+        "background": false,
+        "billing": null,
+        "conversation": null,
+        "created_at": 1000000000,
+        "completed_at": 1000000000,
+        "error": null,
+        "id": "[ID-1]",
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": 64,
+        "max_tool_calls": null,
+        "metadata": {},
+        "model": "harness-model",
+        "object": "response",
+        "output": [
+          {
+            "type": "message",
+            "content": [
+              {
+                "type": "output_text",
+                "annotations": [],
+                "logprobs": [],
+                "text": "Pong."
+              }
+            ],
+            "id": "[ID-2]",
+            "role": "assistant",
+            "status": "completed"
+          }
+        ],
+        "parallel_tool_calls": true,
+        "previous_response_id": null,
+        "prompt": null,
+        "prompt_cache_key": null,
+        "prompt_cache_retention": null,
+        "reasoning": null,
+        "safety_identifier": null,
+        "service_tier": "auto",
+        "status": "completed",
+        "temperature": 1.0,
+        "text": {
+          "format": {
+            "type": "text"
+          }
+        },
+        "tool_choice": "auto",
+        "tools": [],
+        "top_logprobs": 0,
+        "top_p": 1.0,
+        "truncation": "disabled",
+        "usage": {
+          "input_tokens": 5,
+          "input_tokens_details": {
+            "cached_tokens": 0
+          },
+          "output_tokens": 2,
+          "output_tokens_details": {
+            "reasoning_tokens": 0
+          },
+          "total_tokens": 7
+        },
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "store": false
+      }
+    }
+  }
+]

--- a/lib/llm/tests/snapshots/responses_http_replay__responses_unary_text.snap
+++ b/lib/llm/tests/snapshots/responses_http_replay__responses_unary_text.snap
@@ -1,0 +1,70 @@
+---
+source: lib/llm/tests/responses_http_replay.rs
+expression: canonicalize(body)
+---
+{
+  "background": false,
+  "created_at": 1000000000,
+  "completed_at": 1000000000,
+  "id": "[ID-1]",
+  "max_output_tokens": 64,
+  "metadata": {},
+  "model": "harness-model",
+  "object": "response",
+  "output": [
+    {
+      "type": "message",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "Pong."
+        }
+      ],
+      "id": "[ID-2]",
+      "role": "assistant",
+      "status": "completed"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "service_tier": "auto",
+  "status": "completed",
+  "temperature": 1.0,
+  "text": {
+    "format": {
+      "type": "text"
+    }
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1.0,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 5,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 2,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 7
+  },
+  "billing": null,
+  "conversation": null,
+  "error": null,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_tool_calls": null,
+  "previous_response_id": null,
+  "prompt": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": null,
+  "reasoning": null,
+  "safety_identifier": null,
+  "presence_penalty": 0.0,
+  "frequency_penalty": 0.0,
+  "store": false
+}


### PR DESCRIPTION
## Summary

- Add a deterministic, request-capturing chat engine and real HTTP replay coverage for the Anthropic Messages and OpenAI Responses APIs.
- Cover unary and streaming text, fragmented and parallel tool calls, two-request tool-result exchanges, and Anthropic token counting with eleven endpoint tests and four stable snapshots.
- Delay Responses function-call completion until the backend stream ends, and buffer Anthropic tool fragments so parallel calls are emitted as sequential, non-overlapping content blocks.
- Document the minimized fixture provenance and repair the current-main `llm_metrics` test initializer needed by the full library suite.

This replaces the stale approach in #8284 and implements DYN-2764 without a model, GPU, Docker, or a new dependency.

## Validation

Validation commands run on a Linux build host with CUDA toolchain:

- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-llm --tests -- -D warnings`
- `cargo test -p dynamo-llm --lib stream_converter::tests` — 20 passed
- `INSTA_UPDATE=no cargo test -p dynamo-llm --test anthropic_http_replay --test responses_http_replay` — 11 passed
- `cargo test -p dynamo-llm -- --test-threads=1` — all 1,375 active library tests passed, followed by the integration binaries until ten existing `preprocessor` cases received HTTP 401 while downloading gated `meta-llama/Llama-3.1-70B-Instruct` assets

Two independent AI reviews examined protocol correctness and harness/test design. Their block-ordering, terminal-SSE, completion-assertion, fixture-provenance, ID-canonicalization, and duplicate-call findings were addressed; both reviewers re-checked the revised diff and reported no remaining actionable findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end HTTP coverage for AI chat and responses streaming, including text, tool calls, parallel tools, and tool-result round trips.
  * Added replay fixtures for common streamed scenarios, including fragmented tool arguments and reasoning + tool-use flows.

* **Bug Fixes**
  * Improved tool-call streaming so fragmented arguments are finalized consistently at stream end.
  * Fixed completion event timing so tool-call “done” events are emitted after the full stream, matching expected output order.

* **Tests**
  * Expanded integration tests and shared harness utilities for more reliable, deterministic protocol validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
