### PR TITLE
fix(operator): default DGD admission on updates

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -252,6 +252,7 @@ webhooks:
     - v1alpha1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - dynamographdeployments
   sideEffects: None

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -353,9 +353,10 @@ webhooks:
     - ""
     apiVersions:
     - v1
+    # Pod checkpoint restore injects pod spec fields before creation. It is
+    # intentionally CREATE-only because pod UPDATE cannot apply that mutation.
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
   sideEffects: None

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -287,6 +287,7 @@ webhooks:
     - v1beta1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - dynamocomponentdeployments
   sideEffects: None
@@ -320,6 +321,7 @@ webhooks:
     - v1beta1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - dynamographdeploymentrequests
   sideEffects: None
@@ -353,6 +355,7 @@ webhooks:
     - v1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - pods
   sideEffects: None

--- a/deploy/operator/internal/webhook/defaulting/dynamocomponentdeployment_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamocomponentdeployment_handler.go
@@ -45,6 +45,8 @@ func NewDCDDefaulter() *DCDDefaulter {
 
 // Default implements admission.CustomDefaulter.
 // On CREATE, standalone v1beta1 DCDs default spec.name from metadata.name.
+// UPDATE requests are admitted unchanged because renaming an existing component
+// from metadata would rewrite user intent.
 func (d *DCDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	logger := log.FromContext(ctx).WithName(dcdDefaultingWebhookName)
 

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler.go
@@ -64,8 +64,9 @@ func NewDGDRDefaulter(operatorVersion string) *DGDRDefaulter {
 }
 
 // Default implements admission.CustomDefaulter.
-// Only called on CREATE (the webhook is not registered for UPDATE).
 // If spec.image is not set, derives a default image from the backend and operator version.
+// UPDATE requests are admitted unchanged so an omitted image is not rewritten after
+// creation.
 func (d *DGDRDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	logger := log.FromContext(ctx).WithName(dgdrDefaultingWebhookName)
 

--- a/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go
+++ b/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler.go
@@ -52,6 +52,9 @@ func (h *PodCheckpointRestoreMutator) RegisterWithManager(mgr manager.Manager) e
 
 func (h *PodCheckpointRestoreMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	logger := log.FromContext(ctx).WithName(podCheckpointRestoreWebhookName)
+
+	// Restore injection changes pod spec fields that are only meaningful before
+	// the pod is created; UPDATE requests are admitted unchanged.
 	if req.Operation != admissionv1.Create {
 		return admission.Allowed("not a pod create")
 	}

--- a/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler_test.go
+++ b/deploy/operator/internal/webhook/mutation/pod_checkpoint_restore_handler_test.go
@@ -115,6 +115,19 @@ func TestPodCheckpointRestoreMutatorHandle(t *testing.T) {
 		assert.Empty(t, resp.Patches)
 	})
 
+	t.Run("update leaves pod unchanged", func(t *testing.T) {
+		pod := checkpointCandidatePod("worker-checkpoint")
+		req := admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			Namespace: "default",
+			Object:    runtime.RawExtension{Raw: mustMarshalPod(t, pod)},
+		}}
+
+		resp := mutator.Handle(context.Background(), req)
+		require.True(t, resp.Allowed)
+		assert.Empty(t, resp.Patches)
+	})
+
 	t.Run("arbitrary annotated pod without operator stamp is ignored", func(t *testing.T) {
 		pod := checkpointCandidatePod("worker-checkpoint")
 		delete(pod.Labels, consts.KubeLabelDynamoComponent)


### PR DESCRIPTION
## Summary

- Enable DGD, DCD, and DGDR mutating webhook rules for UPDATE operations.
- Allows Grove-backed DGD updates that omit component minAvailable to be defaulted before immutable-field validation.
- Keep pod checkpoint restore mutation explicitly CREATE-only in webhook registration because it injects pod spec fields before creation and cannot apply on pod UPDATE.
- Make create-only mutation behavior explicit in handler code for DCD name defaulting, DGDR image defaulting, and pod checkpoint restore injection.

## Validation

- helm lint deploy/helm/charts/platform/components/operator --set discoveryBackend=kubernetes
- helm template dynamo deploy/helm/charts/platform/components/operator --namespace dynamo --show-only templates/webhook-configuration.yaml --set discoveryBackend=kubernetes
- go test ./internal/webhook/defaulting ./internal/webhook/mutation -count=1
