### PR TITLE
fix: add missing llm_metrics field to tool_parser_v2 test helper

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -368,6 +368,7 @@ mod tests {
                 usage: None,
             },
             nvext: None,
+            llm_metrics: None,
         };
         Annotated {
             data: Some(response),


### PR DESCRIPTION
The chunk() test helper in tool_parser_v2.rs constructs NvCreateChatCompletionStreamResponse without the llm_metrics field that was added to the struct, breaking the post-merge rust-gpu job with E0063 - https://github.com/ai-dynamo/dynamo/actions/runs/28245372779/job/83683622594

This is a merge-skew failure: the field was introduced by #10512 and the test helper by #10853, each green against its own base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated streaming chat completion test data to include the latest response field, keeping coverage aligned with current output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->