### PR TITLE
docs(inference-gateway): recover EPP developer build docs

### DIFF
--- a/deploy/inference-gateway/epp/DEVEL.md
+++ b/deploy/inference-gateway/epp/DEVEL.md
@@ -1,0 +1,166 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Dynamo EPP Development
+
+This directory contains the standard Dynamo Endpoint Picker Plugin (EPP) for Gateway API Inference
+Extension (GAIE). The implementation builds a Rust Dynamo routing library and links it into the Go
+EPP binary through CGO.
+
+Use this file for developer build, test, and image workflows. User-facing GAIE setup belongs in the
+published Kubernetes Gateway API documentation.
+
+## Prerequisites
+
+- Docker with BuildKit/buildx for image builds.
+- Go and a C toolchain for host-native Go builds.
+- Rust and Cargo for host-native Dynamo library builds.
+- `kind` only when using `make image-kind` or `make all-kind`.
+
+Image builds are self-contained and do not require a host-built Dynamo library. Host-native binary
+builds do require the local Dynamo static library artifacts.
+
+## Image Builds
+
+From this directory:
+
+```bash
+cd deploy/inference-gateway/epp
+```
+
+Build and load a local image:
+
+```bash
+make image-load
+```
+
+Build with a temporary local buildx builder and load the image:
+
+```bash
+make all
+```
+
+Build and push an image:
+
+```bash
+export DOCKER_SERVER=ghcr.io/nvidia/dynamo
+export IMAGE_TAG=ghcr.io/nvidia/dynamo/dynamo-epp:<tag>
+make image-push
+```
+
+Build and push through the aggregate target:
+
+```bash
+make all-push
+```
+
+Build, load, and import into a kind cluster:
+
+```bash
+export KIND_CLUSTER=kind
+make image-kind
+```
+
+Build and import through the aggregate target:
+
+```bash
+make all-kind
+```
+
+Build and push a multi-architecture image:
+
+```bash
+export DOCKER_SERVER=ghcr.io/nvidia/dynamo
+export IMAGE_TAG=ghcr.io/nvidia/dynamo/dynamo-epp:<tag>
+make image-multiarch-push
+```
+
+Useful image variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DOCKER_SERVER` | `dynamo` | Registry or registry namespace used to form `IMAGE_REPO`. |
+| `IMAGE_TAG` | `$(DOCKER_SERVER)/dynamo-epp:$(git describe ...)` | Full image reference to build. |
+| `DYNAMO_DIR` | Repository root auto-detected from this directory | Named Docker build context for the Dynamo workspace. |
+| `PLATFORMS` | Host architecture | Platform for local image builds. |
+| `MULTIARCH_PLATFORMS` | `linux/amd64,linux/arm64` | Platforms for multi-architecture builds. |
+| `DOCKER_PROXY` | unset | Optional image prefix or mirror for base images. |
+| `EXTRA_BUILD_ARGS` | unset | Extra arguments passed to `docker buildx build`. |
+| `KIND_CLUSTER` | `kind` | kind cluster name for `make image-kind`. |
+
+Run `make info` to print the resolved build values.
+
+Common image targets:
+
+| Target | Purpose |
+|---|---|
+| `make image-build` | Build the image with the default buildx builder. |
+| `make image-load` | Build the image and load it into the local Docker daemon. |
+| `make image-push` | Build the image and push it to `IMAGE_TAG`. |
+| `make image-kind` | Build, load, and import the image into `KIND_CLUSTER`. |
+| `make image-multiarch-push` | Build and push a multi-architecture image. |
+| `make image-local-build` | Build with a temporary local buildx builder. |
+| `make image-local-load` | Build with a temporary local buildx builder and load locally. |
+| `make image-local-push` | Build with a temporary local buildx builder and push. |
+| `make all` | Alias for `make image-local-load`. |
+| `make all-push` | Alias for `make image-push`. |
+| `make all-kind` | Alias for `make image-kind`. |
+
+## Host-Native Build
+
+Host-native `go build` needs the Dynamo C API static library and header copied into this project.
+Build those artifacts first:
+
+```bash
+make dynamo-lib
+```
+
+Then build the EPP binary:
+
+```bash
+make build
+```
+
+The combined target builds the library and binary:
+
+```bash
+make build-with-lib
+```
+
+The binary is written to:
+
+```text
+deploy/inference-gateway/epp/bin/epp
+```
+
+`make dynamo-lib` builds `libdynamo_llm` from the repository root and copies:
+
+- `libdynamo_llm_capi.a` to `pkg/plugins/dynamo_kv_scorer/lib/`
+- `llm_engine.h` to `pkg/plugins/dynamo_kv_scorer/include/`
+
+## Development Checks
+
+Run the Go checks from this directory:
+
+```bash
+make fmt
+make vet
+make tidy
+make test
+```
+
+`make test` runs with `CGO_ENABLED=1`, so it needs the same local C library artifacts as
+host-native builds.
+
+## Cleaning
+
+Remove local Go build artifacts:
+
+```bash
+make clean
+```
+
+This removes `bin/` and runs `go clean`. It does not clean the repository-level Cargo target
+directory used by `make dynamo-lib`.

--- a/deploy/inference-gateway/ext-proc/DEVEL.md
+++ b/deploy/inference-gateway/ext-proc/DEVEL.md
@@ -1,0 +1,145 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Rust EPP Development
+
+This directory contains the native Rust Envoy `ext_proc` Endpoint Picker Plugin (EPP) for Gateway
+API Inference Extension (GAIE). It builds a single Rust binary, `dynamo-ext-proc`, and does not use
+the Go EPP or CGO bridge.
+
+Use this file for developer build, test, and image workflows. User-facing GAIE setup belongs in the
+published Kubernetes Gateway API documentation.
+
+## Prerequisites
+
+- Rust and Cargo for host-native builds and tests.
+- Docker with BuildKit/buildx for image builds.
+- `kind` only when using `make image-kind`.
+
+The Makefile runs Cargo commands from the repository root so the crate participates in the full
+Dynamo workspace.
+
+## Host-Native Build
+
+From this directory:
+
+```bash
+cd deploy/inference-gateway/ext-proc
+```
+
+Build the release binary:
+
+```bash
+make build
+```
+
+Build a debug binary:
+
+```bash
+make build-debug
+```
+
+The release binary is written to:
+
+```text
+target/release/dynamo-ext-proc
+```
+
+## Development Checks
+
+Run the Rust checks from this directory:
+
+```bash
+make fmt
+make check
+make clippy
+make test
+```
+
+These targets map to Cargo commands for the `dynamo-ext-proc` package.
+
+## Image Builds
+
+Build and load a local image:
+
+```bash
+make image-load
+```
+
+Build and push an image:
+
+```bash
+export DOCKER_SERVER=ghcr.io/nvidia/dynamo
+export IMAGE_TAG=ghcr.io/nvidia/dynamo/dynamo-rust-epp:<tag>
+make image-push
+```
+
+Build, load, and import into a kind cluster:
+
+```bash
+export KIND_CLUSTER=kind
+make image-kind
+```
+
+Build and push a multi-architecture image:
+
+```bash
+export DOCKER_SERVER=ghcr.io/nvidia/dynamo
+export IMAGE_TAG=ghcr.io/nvidia/dynamo/dynamo-rust-epp:<tag>
+make image-multiarch-push
+```
+
+Useful image variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DOCKER_SERVER` | `dynamo` | Registry or registry namespace used to form `IMAGE_REPO`. |
+| `IMAGE_TAG` | `$(DOCKER_SERVER)/dynamo-rust-epp:$(git describe ...)` | Full image reference to build. |
+| `DYNAMO_DIR` | Repository root auto-detected from this directory | Named Docker build context for the Dynamo workspace. |
+| `PLATFORMS` | Host architecture | Platform for local image builds. |
+| `MULTIARCH_PLATFORMS` | `linux/amd64,linux/arm64` | Platforms for multi-architecture builds. |
+| `DOCKER_PROXY` | unset | Optional image prefix or mirror for base images. |
+| `EXTRA_BUILD_ARGS` | unset | Extra arguments passed to `docker buildx build`. |
+| `KIND_CLUSTER` | `kind` | kind cluster name for `make image-kind`. |
+
+Run `make info` to print the resolved build values.
+
+Common image targets:
+
+| Target | Purpose |
+|---|---|
+| `make image-build` | Build the image with the default buildx builder. |
+| `make image-load` | Build the image and load it into the local Docker daemon. |
+| `make image-push` | Build the image and push it to `IMAGE_TAG`. |
+| `make image-kind` | Build, load, and import the image into `KIND_CLUSTER`. |
+| `make image-multiarch-push` | Build and push a multi-architecture image. |
+| `make image-local-build` | Build with a temporary local buildx builder. |
+| `make image-local-load` | Build with a temporary local buildx builder and load locally. |
+| `make image-local-push` | Build with a temporary local buildx builder and push. |
+
+## Runtime Notes for Developers
+
+The Rust EPP serves Envoy `ext_proc` gRPC on port `9002` and plaintext gRPC health on port `9003`.
+It serves TLS on the `ext_proc` port by default. Set `DYN_SECURE_SERVING=false` only for local
+debugging with a plaintext h2c gateway.
+
+The common local environment variables are:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DYN_NAMESPACE_PREFIX` | unset | Preferred Dynamo discovery namespace prefix. |
+| `DYN_NAMESPACE` | unset | Exact Dynamo discovery namespace fallback. If unset, the binary uses `vllm-agg`. |
+| `DYN_COMPONENT_NAME` | `backend` | Dynamo component that exposes the `generate` endpoint. |
+| `DYN_ENFORCE_DISAGG` | `false` | Fail when prefill routing is unavailable instead of falling back to aggregated routing. |
+| `DYN_KUBE_DISCOVERY_MODE` | `pod` | Kubernetes discovery identity mode. The Rust EPP currently rejects `container`. |
+| `RUST_LOG` | `info` | Tracing log filter. |
+
+## Cleaning
+
+Clean the Rust package build artifacts:
+
+```bash
+make clean
+```


### PR DESCRIPTION
## Summary
- Add Go EPP developer build, test, image, and cleanup notes under deploy/inference-gateway/epp/DEVEL.md.
- Add Rust ext_proc EPP developer build, test, image, runtime, and cleanup notes under deploy/inference-gateway/ext-proc/DEVEL.md.
- Keep build-your-own-image details out of the user-facing GAIE guide and close the documentation gap in the component directories.

## Validation
- Pre-commit hooks from signed commit.
- rg style check for trailing whitespace, TODO/FIXME, docs.nvidia.com self-links, and banned filler terms.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added developer guides for two inference gateway components.
  * Documented setup prerequisites, local build and test steps, image build/load/push workflows, and cleanup commands.
  * Included guidance for host-native development, multi-arch builds, and runtime notes such as ports and TLS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->