### PR TITLE
fix(parsers): add llm_metrics to tool_parser_v2 test helper

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -368,6 +368,7 @@ mod tests {
                 usage: None,
             },
             nvext: None,
+            llm_metrics: None,
         };
         Annotated {
             data: Some(response),


### PR DESCRIPTION
#### Overview:

This PR fixes main, broken by a semantic conflict between [#10512](https://github.com/ai-dynamo/dynamo/pull/10512) and [#10853](https://github.com/ai-dynamo/dynamo/pull/10853): the `tool_parser_v2.rs` test helper constructs `NvCreateChatCompletionStreamResponse` without the `llm_metrics` field that #10512 made mandatory.

#### Details:

- Adds `llm_metrics: None` to the test helper's struct literal, matching every other construction site.
- Both PRs were green alone; #10853's branch predated #10512's new field, so neither PR's CI caught it. Surfaces only as `cargo clippy`/`cargo test` (`E0063: missing field llm_metrics`), test-only code.

#### Verification:

On tip-of-tree `origin/main`: `cargo clippy -p dynamo-llm --lib --tests` clean; `cargo test -p dynamo-llm` tool_parser_v2 module 3 passed.

#### Where should the reviewer start?

`lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs`

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an internal test fixture to match the latest response format. No user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->