### PR TITLE
ci: only run external-contributor check on fork PRs

### DIFF
--- a/.github/workflows/approved-external-contributor.yml
+++ b/.github/workflows/approved-external-contributor.yml
@@ -17,20 +17,12 @@ permissions:
 
 jobs:
   ok-to-test:
+    if: github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     environment: external_collaborator
     steps:
-      - name: Check if PR is from a fork
-        id: fork_check
-        run: |
-          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
-            echo "is_fork=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_fork=false" >> "$GITHUB_OUTPUT"
-          fi
       - name: Validate approved contributor
         id: author_check
-        if: steps.fork_check.outputs.is_fork == 'true'
         env:
           APPROVED_EXTERNAL_CONTRIBUTORS: ${{ secrets.APPROVED_EXTERNAL_CONTRIBUTORS }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -50,7 +42,7 @@ jobs:
           fi
       - name: Verify commit signatures
         id: signature_check
-        if: steps.fork_check.outputs.is_fork == 'true' && steps.author_check.outputs.is_approved == 'true'
+        if: steps.author_check.outputs.is_approved == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO_OWNER: ${{ github.repository_owner }}
@@ -96,7 +88,7 @@ jobs:
             echo "unsigned_commits=$unsigned_commits" >> "$GITHUB_OUTPUT"
           fi
       - name: Clean up previous unsigned-commits comments
-        if: steps.fork_check.outputs.is_fork == 'true' && steps.author_check.outputs.is_approved == 'true'
+        if: steps.author_check.outputs.is_approved == 'true'
         env:
           GH_TOKEN: ${{ secrets.AUTO_VERIFIER_CI_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
@@ -112,7 +104,7 @@ jobs:
               gh api --method DELETE "repos/$REPO_OWNER/$REPO_NAME/issues/comments/$comment_id"
             done
       - name: Comment unsigned commits
-        if: steps.fork_check.outputs.is_fork == 'true' && steps.author_check.outputs.is_approved == 'true' && steps.signature_check.outputs.all_signed == 'false'
+        if: steps.author_check.outputs.is_approved == 'true' && steps.signature_check.outputs.all_signed == 'false'
         env:
           GH_TOKEN: ${{ secrets.AUTO_VERIFIER_CI_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
@@ -136,7 +128,7 @@ jobs:
             --repo "$REPO_OWNER/$REPO_NAME" \
             --body "$body"
       - name: Comment /ok to test
-        if: steps.fork_check.outputs.is_fork == 'true' && steps.author_check.outputs.is_approved == 'true' && steps.signature_check.outputs.all_signed == 'true'
+        if: steps.author_check.outputs.is_approved == 'true' && steps.signature_check.outputs.all_signed == 'true'
         env:
           GH_TOKEN: ${{ secrets.AUTO_VERIFIER_CI_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
The ok-to-test job declares an environment, which makes GitHub create a deployment record on every PR and surfaces a "temporarily deployed to external_collaborator" entry in the PR timeline. The job's steps were already no-ops for non-fork PRs, so gate the whole job on github.event.pull_request.head.repo.fork and drop the now-redundant per-step fork checks. Internal PRs no longer trigger the job or the deployment message; fork PRs are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automated PR handling so approved external contributors receive the same follow-up checks and comments even when their changes are not from a fork.
  * Improved consistency of commit-signature verification and test-approval messaging for eligible pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->