### PR TITLE
feat(backend): add sample multimodal smoke coverage

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -142,6 +142,10 @@ def main():
 ```
 
 See `sample_engine.py` for a complete, runnable reference implementation.
+The sample engine includes synthetic multimodal handling for aggregated and
+Encode/Prefill/Decode deployments. CPU-only worker-handoff smokes live in
+`examples/backends/sample/launch/multimodal_agg.sh` and
+`examples/backends/sample/launch/multimodal_disagg.sh`.
 
 ## Request / Response Types
 
@@ -522,7 +526,7 @@ Request handling:
 | Feature | Description |
 |---------|-------------|
 | Text-in-text-out mode | OpenAI-compatible chat/completion with engine-side tokenization. Unified hardcodes `ModelInput.Tokens`. |
-| Multimodal | Images / video / embeddings, NIXL embedding transfer, encode workers. `worker.py:_to_rust_disaggregation_mode` rejects the `ENCODE` role. |
+| Multimodal | The shared request and `encoder_result` contract, Encode role, and discovery wiring are available. Frontend Encode-to-Prefill/Aggregated request routing and backend-specific encoder implementations remain separate work. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path. |
 | LoRA adapters (SGLang / TRT-LLM) | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization locks, per-request adapter threading. **vLLM is supported on the unified path** — see [What works today](#what-works-today); SGLang and TRT-LLM advertise no LoRA updates yet. |
 | Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload. |

--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -1,9 +1,10 @@
 # Dynamo Python Backend
 
-**Supported today:** aggregated and disaggregated (prefill/decode)
-inference, metrics + Prometheus bridging, KV event publishing,
-KV-aware (DP-rank) routing, health-check canaries, OpenTelemetry
-tracing, and request-side guided decoding / structural tag.
+**Supported today:** aggregated and disaggregated (prefill/decode/encode)
+inference, the shared multimodal request and encoder-handoff contract,
+metrics + Prometheus bridging, KV event publishing, KV-aware (DP-rank)
+routing, health-check canaries, OpenTelemetry tracing, and request-side
+guided decoding / structural tag.
 
 > **Work in progress.** Multimodal, diffusion (image/video/DLLM),
 > LoRA (SGLang / TRT-LLM — vLLM is supported),
@@ -143,9 +144,11 @@ def main():
 
 See `sample_engine.py` for a complete, runnable reference implementation.
 The sample engine includes synthetic multimodal handling for aggregated and
-Encode/Prefill/Decode deployments. CPU-only worker-handoff smokes live in
+Encode/Prefill/Decode deployments. CPU-only direct worker-handoff smokes live in
 `examples/backends/sample/launch/multimodal_agg.sh` and
-`examples/backends/sample/launch/multimodal_disagg.sh`.
+`examples/backends/sample/launch/multimodal_disagg.sh`. These smokes exercise
+distinct worker processes and TCP request transport; they intentionally bypass
+the frontend and do not claim frontend routing coverage.
 
 ## Request / Response Types
 

--- a/components/src/dynamo/common/backend/sample_engine.py
+++ b/components/src/dynamo/common/backend/sample_engine.py
@@ -350,6 +350,11 @@ class SampleLLMEngine(LLMEngine):
         multimodal_kwargs = extract_multimodal_kwargs(request)
         sample_multimodal_result: Optional[dict[str, Any]] = None
         if multimodal_kwargs is not None:
+            if self.disaggregation_mode == DisaggregationMode.DECODE:
+                raise ValueError(
+                    "decode worker should not receive raw multimodal payloads; "
+                    "encoder inputs are consumed by the upstream prefill worker"
+                )
             if self.route_to_encoder:
                 sample_multimodal_result = self._validate_encoder_result(request)
             else:

--- a/components/src/dynamo/common/backend/sample_engine.py
+++ b/components/src/dynamo/common/backend/sample_engine.py
@@ -28,6 +28,11 @@ from .engine import (
 )
 from .health_check import build_health_check_payload, is_probe
 from .logprobs import parse_logprob_options
+from .multimodal import (
+    encoder_terminal_chunk,
+    extract_multimodal_kwargs,
+    require_encoder_result,
+)
 from .publisher import ComponentSnapshot, KvEventSource, PushSource
 from .worker import WorkerConfig
 
@@ -86,14 +91,15 @@ class SampleLLMEngine(LLMEngine):
     for engine leads implementing real backends.
 
     Disaggregation:
-        ``--disaggregation-mode {agg,prefill,decode}`` selects the role.
+        ``--disaggregation-mode {agg,prefill,decode,encode}`` selects the role.
         AGGREGATED is the default and produces ``max_tokens`` rotating
         tokens. PREFILL caps generation at one token and stamps a
         synthetic ``disaggregated_params`` payload on the terminal so
         the frontend's PrefillRouter has something to forward. DECODE
         requires the request to carry ``prefill_result`` (otherwise the
         frontend forgot to route through the prefill peer); on success
-        it generates normally.
+        it generates normally. ENCODE emits one terminal chunk containing
+        an object-shaped synthetic ``encoder_result`` and no generated tokens.
     """
 
     def __init__(
@@ -102,11 +108,13 @@ class SampleLLMEngine(LLMEngine):
         max_tokens: int = 16,
         delay: float = 0.01,
         disaggregation_mode: DisaggregationMode = DisaggregationMode.AGGREGATED,
+        route_to_encoder: bool = False,
     ):
         self.model_name = model_name
         self.max_tokens = max_tokens
         self.delay = delay
         self.disaggregation_mode = disaggregation_mode
+        self.route_to_encoder = route_to_encoder
         self._kv_used_blocks = 0
         self._publish_queue: queue.SimpleQueue[tuple[str, dict]] = queue.SimpleQueue()
         self._publish_stop = threading.Event()
@@ -135,11 +143,14 @@ class SampleLLMEngine(LLMEngine):
         parser.add_argument("--event-plane", default=None)
         parser.add_argument(
             "--disaggregation-mode",
-            choices=[
-                m.value for m in DisaggregationMode if m != DisaggregationMode.ENCODE
-            ],
+            choices=[m.value for m in DisaggregationMode],
             default=DisaggregationMode.AGGREGATED.value,
-            help="Disaggregation role: 'agg' (default), 'prefill', or 'decode'.",
+            help="Disaggregation role: 'agg' (default), 'prefill', 'decode', or 'encode'.",
+        )
+        parser.add_argument(
+            "--route-to-encoder",
+            action="store_true",
+            help="Require an upstream Encode worker (valid for agg/prefill).",
         )
         args = parser.parse_args(argv)
 
@@ -149,6 +160,7 @@ class SampleLLMEngine(LLMEngine):
             max_tokens=args.max_tokens,
             delay=args.delay,
             disaggregation_mode=mode,
+            route_to_encoder=args.route_to_encoder,
         )
         worker_config = WorkerConfig(
             namespace=args.namespace,
@@ -161,6 +173,7 @@ class SampleLLMEngine(LLMEngine):
             request_plane=args.request_plane,
             event_plane=args.event_plane,
             disaggregation_mode=mode,
+            route_to_encoder=args.route_to_encoder,
         )
         return engine, worker_config
 
@@ -179,9 +192,13 @@ class SampleLLMEngine(LLMEngine):
         )
 
     async def kv_event_sources(self) -> list[KvEventSource]:
+        if self.disaggregation_mode == DisaggregationMode.ENCODE:
+            return []
         return [PushSource(on_ready=self._start_publisher_thread, dp_rank=0)]
 
     def component_metrics_dp_ranks(self) -> list[int]:
+        if self.disaggregation_mode == DisaggregationMode.ENCODE:
+            return []
         return [0]
 
     def attach_snapshot_publisher(self, publisher) -> None:
@@ -258,9 +275,40 @@ class SampleLLMEngine(LLMEngine):
         self._publish_queue.put(("removed", {"block_hashes": hashes}))
         self._kv_used_blocks = max(0, self._kv_used_blocks - len(hashes))
 
+    async def _encode_multimodal(self, request: GenerateRequest) -> dict[str, Any]:
+        """Return a deterministic-shape synthetic encoder handoff payload."""
+        await asyncio.sleep(self.delay)
+        multimodal_kwargs = extract_multimodal_kwargs(request) or {}
+        return {
+            "handle": f"sample-encoder:{uuid.uuid4().hex}",
+            "multimodal_kwargs": multimodal_kwargs,
+        }
+
+    def _validate_encoder_result(self, request: GenerateRequest) -> dict[str, Any]:
+        encoder_result = require_encoder_result(request, self.disaggregation_mode)
+        handle = encoder_result.get("handle")
+        if not isinstance(handle, str) or not handle.startswith("sample-encoder:"):
+            raise ValueError(
+                "encoder_result.handle must be a string starting with 'sample-encoder:'"
+            )
+        return encoder_result
+
     async def generate(
         self, request: GenerateRequest, context: Context
     ) -> AsyncGenerator[GenerateChunk, None]:
+        if self.disaggregation_mode == DisaggregationMode.ENCODE:
+            prompt_len = len(request.get("token_ids", []))
+            encoder_result = await self._encode_multimodal(request)
+            yield encoder_terminal_chunk(
+                encoder_result,
+                completion_usage={
+                    "prompt_tokens": prompt_len,
+                    "completion_tokens": 0,
+                    "total_tokens": prompt_len,
+                },
+            )
+            return
+
         # Canary probes bypass cross-worker coordination — run as aggregated.
         if self.disaggregation_mode == DisaggregationMode.DECODE and not is_probe(
             request
@@ -268,6 +316,16 @@ class SampleLLMEngine(LLMEngine):
             require_prefill_result(request, self.disaggregation_mode)
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             enforce_prefill_max_tokens(request)
+
+        multimodal_kwargs = extract_multimodal_kwargs(request)
+        sample_multimodal_result: Optional[dict[str, Any]] = None
+        if multimodal_kwargs is not None:
+            if self.route_to_encoder:
+                sample_multimodal_result = self._validate_encoder_result(request)
+            else:
+                # Aggregated workers process multimodal inputs locally when
+                # encoder routing is disabled.
+                sample_multimodal_result = await self._encode_multimodal(request)
 
         token_ids = request.get("token_ids", [])
         prompt_len = len(token_ids)
@@ -284,6 +342,13 @@ class SampleLLMEngine(LLMEngine):
                 async for chunk in self._generate_tokens(
                     prompt_len, max_new, context, logprobs_k
                 ):
+                    if (
+                        chunk.get("finish_reason")
+                        and sample_multimodal_result is not None
+                    ):
+                        chunk["engine_data"] = {
+                            "sample_multimodal": sample_multimodal_result
+                        }
                     yield chunk
         finally:
             self._release_synthetic_blocks(block_hashes)

--- a/components/src/dynamo/common/backend/sample_engine.py
+++ b/components/src/dynamo/common/backend/sample_engine.py
@@ -152,6 +152,11 @@ class SampleLLMEngine(LLMEngine):
             action="store_true",
             help="Require an upstream Encode worker (valid for agg/prefill).",
         )
+        parser.add_argument(
+            "--disable-kv-routing",
+            action="store_true",
+            help="Disable KV event and load publishers (useful for isolated smokes).",
+        )
         args = parser.parse_args(argv)
 
         mode = DisaggregationMode(args.disaggregation_mode)
@@ -174,6 +179,7 @@ class SampleLLMEngine(LLMEngine):
             event_plane=args.event_plane,
             disaggregation_mode=mode,
             route_to_encoder=args.route_to_encoder,
+            enable_kv_routing=not args.disable_kv_routing,
         )
         return engine, worker_config
 
@@ -298,7 +304,31 @@ class SampleLLMEngine(LLMEngine):
     ) -> AsyncGenerator[GenerateChunk, None]:
         if self.disaggregation_mode == DisaggregationMode.ENCODE:
             prompt_len = len(request.get("token_ids", []))
+            if context.is_stopped():
+                yield {
+                    "token_ids": [],
+                    "index": 0,
+                    "finish_reason": "cancelled",
+                    "completion_usage": {
+                        "prompt_tokens": prompt_len,
+                        "completion_tokens": 0,
+                        "total_tokens": prompt_len,
+                    },
+                }
+                return
             encoder_result = await self._encode_multimodal(request)
+            if context.is_stopped():
+                yield {
+                    "token_ids": [],
+                    "index": 0,
+                    "finish_reason": "cancelled",
+                    "completion_usage": {
+                        "prompt_tokens": prompt_len,
+                        "completion_tokens": 0,
+                        "total_tokens": prompt_len,
+                    },
+                }
+                return
             yield encoder_terminal_chunk(
                 encoder_result,
                 completion_usage={

--- a/components/src/dynamo/common/backend/tests/test_sample_engine.py
+++ b/components/src/dynamo/common/backend/tests/test_sample_engine.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -112,6 +112,147 @@ async def test_from_args_propagates_mode_to_worker_config():
     )
     assert engine.disaggregation_mode is DisaggregationMode.PREFILL
     assert worker_config.disaggregation_mode is DisaggregationMode.PREFILL
+
+
+async def test_aggregated_mode_processes_multimodal_kwargs_locally(monkeypatch):
+    engine = SampleLLMEngine(max_tokens=1, delay=0.0)
+    encode = AsyncMock(wraps=engine._encode_multimodal)
+    monkeypatch.setattr(engine, "_encode_multimodal", encode)
+    request = {
+        "token_ids": [1, 2],
+        "multi_modal_data": {"image": [{"url": "data:image/png;base64,AA=="}]},
+        "mm_processor_kwargs": {"min_pixels": 64},
+    }
+
+    chunks = await _collect(engine, request)
+
+    assert chunks[-1]["finish_reason"] == "length"
+    assert chunks[-1]["engine_data"]["sample_multimodal"]["multimodal_kwargs"] == {
+        "multi_modal_data": request["multi_modal_data"],
+        "mm_processor_kwargs": request["mm_processor_kwargs"],
+    }
+    encode.assert_awaited_once_with(request)
+
+
+async def test_encode_mode_emits_single_terminal_with_encoder_result():
+    engine = SampleLLMEngine(
+        delay=0.0,
+        disaggregation_mode=DisaggregationMode.ENCODE,
+    )
+    request = {
+        "token_ids": [1, 2, 3],
+        "multi_modal_data": {"image": [{"url": "data:image/png;base64,AA=="}]},
+    }
+
+    chunks = await _collect(engine, request)
+
+    assert len(chunks) == 1
+    terminal = chunks[0]
+    assert terminal["token_ids"] == []
+    assert terminal["finish_reason"] == "stop"
+    assert terminal["completion_usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 0,
+        "total_tokens": 3,
+    }
+    encoder_result = terminal["encoder_result"]
+    assert encoder_result["handle"].startswith("sample-encoder:")
+    assert (
+        encoder_result["multimodal_kwargs"]["multi_modal_data"]
+        == request["multi_modal_data"]
+    )
+
+
+async def test_encoder_routed_worker_requires_encoder_result():
+    engine = SampleLLMEngine(
+        max_tokens=1,
+        delay=0.0,
+        route_to_encoder=True,
+    )
+    request = {
+        "token_ids": [1],
+        "multi_modal_data": {"image": [{"url": "data:image/png;base64,AA=="}]},
+    }
+
+    with pytest.raises(ValueError, match="no encoder_result"):
+        await _collect(engine, request)
+
+
+async def test_encoder_routed_worker_rejects_malformed_encoder_result():
+    engine = SampleLLMEngine(
+        max_tokens=1,
+        delay=0.0,
+        route_to_encoder=True,
+    )
+    request = {
+        "token_ids": [1],
+        "multi_modal_data": {"image": [{"url": "data:image/png;base64,AA=="}]},
+        "encoder_result": {"handle": "not-a-sample-handle"},
+    }
+
+    with pytest.raises(ValueError, match=r"encoder_result\.handle"):
+        await _collect(engine, request)
+
+
+async def test_multimodal_epd_handoff_contract():
+    """Exercise Encode -> Prefill -> Decode using separate role instances."""
+    encode = SampleLLMEngine(
+        delay=0.0,
+        disaggregation_mode=DisaggregationMode.ENCODE,
+    )
+    prefill = SampleLLMEngine(
+        delay=0.0,
+        disaggregation_mode=DisaggregationMode.PREFILL,
+        route_to_encoder=True,
+    )
+    decode = SampleLLMEngine(
+        max_tokens=2,
+        delay=0.0,
+        disaggregation_mode=DisaggregationMode.DECODE,
+    )
+    multimodal_request = {
+        "token_ids": [1, 2, 3],
+        "multi_modal_data": {"image": [{"url": "data:image/png;base64,AA=="}]},
+    }
+
+    [encode_terminal] = await _collect(encode, multimodal_request)
+    [prefill_terminal] = await _collect(
+        prefill,
+        {
+            **multimodal_request,
+            "encoder_result": encode_terminal["encoder_result"],
+            "stop_conditions": {"max_tokens": 8},
+        },
+    )
+    decode_chunks = await _collect(
+        decode,
+        {
+            "token_ids": multimodal_request["token_ids"],
+            "prefill_result": {
+                "disaggregated_params": prefill_terminal["disaggregated_params"]
+            },
+        },
+    )
+
+    assert prefill_terminal["finish_reason"] == "length"
+    assert len(decode_chunks) == 2
+    assert decode_chunks[-1]["finish_reason"] == "length"
+
+
+async def test_from_args_propagates_encode_routing():
+    engine, worker_config = await SampleLLMEngine.from_args(
+        ["--disaggregation-mode", "prefill", "--route-to-encoder"]
+    )
+
+    assert engine.route_to_encoder is True
+    assert worker_config.route_to_encoder is True
+
+
+async def test_encode_mode_opts_out_of_kv_publishers():
+    engine = SampleLLMEngine(disaggregation_mode=DisaggregationMode.ENCODE)
+
+    assert await engine.kv_event_sources() == []
+    assert engine.component_metrics_dp_ranks() == []
 
 
 async def test_source_descriptors_have_expected_shape():

--- a/components/src/dynamo/common/backend/tests/test_sample_engine.py
+++ b/components/src/dynamo/common/backend/tests/test_sample_engine.py
@@ -106,6 +106,22 @@ async def test_decode_mode_runs_to_completion_when_prefill_result_provided():
     assert "disaggregated_params" not in terminal
 
 
+async def test_decode_mode_rejects_raw_multimodal_payload():
+    engine = SampleLLMEngine(
+        max_tokens=1,
+        delay=0.0,
+        disaggregation_mode=DisaggregationMode.DECODE,
+    )
+    request = {
+        "token_ids": [1, 2, 3],
+        "multi_modal_data": {"image": [{"url": "data:image/png;base64,AA=="}]},
+        "prefill_result": {"disaggregated_params": {"sample_handle": "from-test"}},
+    }
+
+    with pytest.raises(ValueError, match="decode worker should not receive raw"):
+        await _collect(engine, request)
+
+
 async def test_from_args_propagates_mode_to_worker_config():
     engine, worker_config = await SampleLLMEngine.from_args(
         ["--disaggregation-mode", "prefill"]

--- a/components/src/dynamo/common/backend/tests/test_sample_engine.py
+++ b/components/src/dynamo/common/backend/tests/test_sample_engine.py
@@ -163,6 +163,36 @@ async def test_encode_mode_emits_single_terminal_with_encoder_result():
     )
 
 
+@pytest.mark.parametrize("stop_checks", [[True], [False, True]])
+async def test_encode_mode_observes_cancellation(stop_checks):
+    engine = SampleLLMEngine(
+        delay=0.0,
+        disaggregation_mode=DisaggregationMode.ENCODE,
+    )
+    context = _ctx()
+    context.is_stopped.side_effect = stop_checks
+
+    chunks = [
+        chunk
+        async for chunk in engine.generate(
+            {"token_ids": [1, 2, 3], "multi_modal_data": {"image": []}}, context
+        )
+    ]
+
+    assert chunks == [
+        {
+            "token_ids": [],
+            "index": 0,
+            "finish_reason": "cancelled",
+            "completion_usage": {
+                "prompt_tokens": 3,
+                "completion_tokens": 0,
+                "total_tokens": 3,
+            },
+        }
+    ]
+
+
 async def test_encoder_routed_worker_requires_encoder_result():
     engine = SampleLLMEngine(
         max_tokens=1,
@@ -235,6 +265,10 @@ async def test_multimodal_epd_handoff_contract():
     )
 
     assert prefill_terminal["finish_reason"] == "length"
+    assert (
+        prefill_terminal["engine_data"]["sample_multimodal"]
+        == encode_terminal["encoder_result"]
+    )
     assert len(decode_chunks) == 2
     assert decode_chunks[-1]["finish_reason"] == "length"
 
@@ -246,6 +280,12 @@ async def test_from_args_propagates_encode_routing():
 
     assert engine.route_to_encoder is True
     assert worker_config.route_to_encoder is True
+
+
+async def test_from_args_can_disable_kv_routing():
+    _, worker_config = await SampleLLMEngine.from_args(["--disable-kv-routing"])
+
+    assert worker_config.enable_kv_routing is False
 
 
 async def test_encode_mode_opts_out_of_kv_publishers():

--- a/examples/backends/sample/launch/multimodal_agg.sh
+++ b/examples/backends/sample/launch/multimodal_agg.sh
@@ -8,13 +8,13 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+REPO_ROOT="$(readlink -f "$SCRIPT_DIR/../../../..")"
 source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
-MODEL_NAME="${MODEL_NAME:-sample-model}"
+MODEL_NAME="${MODEL_NAME:-$REPO_ROOT/lib/llm/tests/data/sample-models/TinyLlama_v1.1}"
 NAMESPACE="${NAMESPACE:-dynamo}"
 COMPONENT="${COMPONENT:-sample-multimodal-agg}"
-HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 
 EXTRA_ARGS=()
 while [[ $# -gt 0 ]]; do
@@ -38,16 +38,14 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-print_launch_banner --no-curl "Sample Aggregated Multimodal Smoke (CPU-only)" "$MODEL_NAME" "$HTTP_PORT" \
-    "Validation:  direct worker endpoint handoff"
-
-python3 -m dynamo.frontend &
+echo "Running direct aggregated-worker multimodal handoff smoke with $MODEL_NAME"
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
 python3 -m dynamo.common.backend.sample_main \
   --model-name "$MODEL_NAME" \
   --namespace "$NAMESPACE" \
   --component "$COMPONENT" \
+  --disable-kv-routing \
   "${EXTRA_ARGS[@]}" &
 
 python3 "$SCRIPT_DIR/multimodal_smoke_client.py" \

--- a/examples/backends/sample/launch/multimodal_agg.sh
+++ b/examples/backends/sample/launch/multimodal_agg.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# CPU-only aggregated multimodal smoke for the sample backend.
+
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+MODEL_NAME="${MODEL_NAME:-sample-model}"
+NAMESPACE="${NAMESPACE:-dynamo}"
+COMPONENT="${COMPONENT:-sample-multimodal-agg}"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model-name)
+            MODEL_NAME="$2"
+            shift 2
+            ;;
+        --namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--model-name NAME] [--namespace NAMESPACE] [WORKER OPTIONS]"
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+print_launch_banner --no-curl "Sample Aggregated Multimodal Smoke (CPU-only)" "$MODEL_NAME" "$HTTP_PORT" \
+    "Validation:  direct worker endpoint handoff"
+
+python3 -m dynamo.frontend &
+
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+python3 -m dynamo.common.backend.sample_main \
+  --model-name "$MODEL_NAME" \
+  --namespace "$NAMESPACE" \
+  --component "$COMPONENT" \
+  "${EXTRA_ARGS[@]}" &
+
+python3 "$SCRIPT_DIR/multimodal_smoke_client.py" \
+  --mode aggregated \
+  --model-name "$MODEL_NAME" \
+  --namespace "$NAMESPACE" \
+  --aggregated-component "$COMPONENT" &
+
+wait_any_exit

--- a/examples/backends/sample/launch/multimodal_agg.sh
+++ b/examples/backends/sample/launch/multimodal_agg.sh
@@ -38,6 +38,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# This direct worker smoke intentionally has no frontend. print_launch_banner
+# always advertises a frontend URL, so use a scoped message instead.
 echo "Running direct aggregated-worker multimodal handoff smoke with $MODEL_NAME"
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \

--- a/examples/backends/sample/launch/multimodal_disagg.sh
+++ b/examples/backends/sample/launch/multimodal_disagg.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# CPU-only Encode/Prefill/Decode multimodal handoff smoke for the sample backend.
+
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+MODEL_NAME="${MODEL_NAME:-sample-model}"
+NAMESPACE="${NAMESPACE:-dynamo}"
+ENCODE_COMPONENT="${ENCODE_COMPONENT:-sample-multimodal-encode}"
+PREFILL_COMPONENT="${PREFILL_COMPONENT:-sample-multimodal-prefill}"
+DECODE_COMPONENT="${DECODE_COMPONENT:-sample-multimodal-decode}"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model-name)
+            MODEL_NAME="$2"
+            shift 2
+            ;;
+        --namespace)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--model-name NAME] [--namespace NAMESPACE] [WORKER OPTIONS]"
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+print_launch_banner --no-curl "Sample Encode/Prefill/Decode Multimodal Smoke (CPU-only)" "$MODEL_NAME" "$HTTP_PORT" \
+    "Validation:  direct Encode -> Prefill -> Decode worker handoff"
+
+python3 -m dynamo.frontend &
+
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
+python3 -m dynamo.common.backend.sample_main \
+  --model-name "$MODEL_NAME" \
+  --namespace "$NAMESPACE" \
+  --component "$ENCODE_COMPONENT" \
+  --disaggregation-mode encode \
+  "${EXTRA_ARGS[@]}" &
+
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
+python3 -m dynamo.common.backend.sample_main \
+  --model-name "$MODEL_NAME" \
+  --namespace "$NAMESPACE" \
+  --component "$PREFILL_COMPONENT" \
+  --disaggregation-mode prefill \
+  --route-to-encoder \
+  "${EXTRA_ARGS[@]}" &
+
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT3:-8083} \
+python3 -m dynamo.common.backend.sample_main \
+  --model-name "$MODEL_NAME" \
+  --namespace "$NAMESPACE" \
+  --component "$DECODE_COMPONENT" \
+  --disaggregation-mode decode \
+  "${EXTRA_ARGS[@]}" &
+
+python3 "$SCRIPT_DIR/multimodal_smoke_client.py" \
+  --mode epd \
+  --model-name "$MODEL_NAME" \
+  --namespace "$NAMESPACE" \
+  --encode-component "$ENCODE_COMPONENT" \
+  --prefill-component "$PREFILL_COMPONENT" \
+  --decode-component "$DECODE_COMPONENT" &
+
+wait_any_exit

--- a/examples/backends/sample/launch/multimodal_disagg.sh
+++ b/examples/backends/sample/launch/multimodal_disagg.sh
@@ -8,15 +8,15 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+REPO_ROOT="$(readlink -f "$SCRIPT_DIR/../../../..")"
 source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
-MODEL_NAME="${MODEL_NAME:-sample-model}"
+MODEL_NAME="${MODEL_NAME:-$REPO_ROOT/lib/llm/tests/data/sample-models/TinyLlama_v1.1}"
 NAMESPACE="${NAMESPACE:-dynamo}"
 ENCODE_COMPONENT="${ENCODE_COMPONENT:-sample-multimodal-encode}"
 PREFILL_COMPONENT="${PREFILL_COMPONENT:-sample-multimodal-prefill}"
 DECODE_COMPONENT="${DECODE_COMPONENT:-sample-multimodal-decode}"
-HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 
 EXTRA_ARGS=()
 while [[ $# -gt 0 ]]; do
@@ -40,10 +40,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-print_launch_banner --no-curl "Sample Encode/Prefill/Decode Multimodal Smoke (CPU-only)" "$MODEL_NAME" "$HTTP_PORT" \
-    "Validation:  direct Encode -> Prefill -> Decode worker handoff"
-
-python3 -m dynamo.frontend &
+echo "Running direct Encode -> Prefill -> Decode multimodal handoff smoke with $MODEL_NAME"
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 python3 -m dynamo.common.backend.sample_main \
@@ -51,6 +48,7 @@ python3 -m dynamo.common.backend.sample_main \
   --namespace "$NAMESPACE" \
   --component "$ENCODE_COMPONENT" \
   --disaggregation-mode encode \
+  --disable-kv-routing \
   "${EXTRA_ARGS[@]}" &
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
@@ -60,6 +58,7 @@ python3 -m dynamo.common.backend.sample_main \
   --component "$PREFILL_COMPONENT" \
   --disaggregation-mode prefill \
   --route-to-encoder \
+  --disable-kv-routing \
   "${EXTRA_ARGS[@]}" &
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT3:-8083} \
@@ -68,6 +67,7 @@ python3 -m dynamo.common.backend.sample_main \
   --namespace "$NAMESPACE" \
   --component "$DECODE_COMPONENT" \
   --disaggregation-mode decode \
+  --disable-kv-routing \
   "${EXTRA_ARGS[@]}" &
 
 python3 "$SCRIPT_DIR/multimodal_smoke_client.py" \

--- a/examples/backends/sample/launch/multimodal_disagg.sh
+++ b/examples/backends/sample/launch/multimodal_disagg.sh
@@ -40,6 +40,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# This direct worker smoke intentionally has no frontend. print_launch_banner
+# always advertises a frontend URL, so use a scoped message instead.
 echo "Running direct Encode -> Prefill -> Decode multimodal handoff smoke with $MODEL_NAME"
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \

--- a/examples/backends/sample/launch/multimodal_smoke_client.py
+++ b/examples/backends/sample/launch/multimodal_smoke_client.py
@@ -64,6 +64,11 @@ def multimodal_request(model_name: str) -> dict[str, Any]:
     }
 
 
+def _require_equal(actual: Any, expected: Any, field: str) -> None:
+    if actual != expected:
+        raise RuntimeError(f"{field} mismatch: expected {expected!r}, got {actual!r}")
+
+
 async def run_aggregated(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
     client = await connect(
         runtime,
@@ -74,8 +79,16 @@ async def run_aggregated(runtime: DistributedRuntime, args: argparse.Namespace) 
     chunks = await collect(client, request, args.timeout)
     terminal = chunks[-1]
     observed = terminal["engine_data"]["sample_multimodal"]["multimodal_kwargs"]
-    assert observed["multi_modal_data"] == request["multi_modal_data"]
-    assert observed["mm_processor_kwargs"] == request["mm_processor_kwargs"]
+    _require_equal(
+        observed["multi_modal_data"],
+        request["multi_modal_data"],
+        "aggregated multi_modal_data",
+    )
+    _require_equal(
+        observed["mm_processor_kwargs"],
+        request["mm_processor_kwargs"],
+        "aggregated mm_processor_kwargs",
+    )
 
 
 async def run_epd(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
@@ -99,22 +112,27 @@ async def run_epd(runtime: DistributedRuntime, args: argparse.Namespace) -> None
     request = multimodal_request(args.model_name)
 
     [encode_terminal] = await collect(encode, request, args.timeout)
-    assert encode_terminal["token_ids"] == []
-    assert encode_terminal["finish_reason"] == "stop"
+    _require_equal(encode_terminal["token_ids"], [], "encode token_ids")
+    _require_equal(encode_terminal["finish_reason"], "stop", "encode finish_reason")
 
     [prefill_terminal] = await collect(
         prefill,
         {**request, "encoder_result": encode_terminal["encoder_result"]},
         args.timeout,
     )
-    assert (
-        prefill_terminal["engine_data"]["sample_multimodal"]
-        == encode_terminal["encoder_result"]
+    _require_equal(
+        prefill_terminal["engine_data"]["sample_multimodal"],
+        encode_terminal["encoder_result"],
+        "prefill encoder_result handoff",
     )
-    assert encode_terminal["encoder_result"]["multimodal_kwargs"] == {
-        "multi_modal_data": request["multi_modal_data"],
-        "mm_processor_kwargs": request["mm_processor_kwargs"],
-    }
+    _require_equal(
+        encode_terminal["encoder_result"]["multimodal_kwargs"],
+        {
+            "multi_modal_data": request["multi_modal_data"],
+            "mm_processor_kwargs": request["mm_processor_kwargs"],
+        },
+        "encode multimodal_kwargs",
+    )
 
     decode_request = {
         "model": args.model_name,
@@ -127,7 +145,7 @@ async def run_epd(runtime: DistributedRuntime, args: argparse.Namespace) -> None
         },
     }
     decode_chunks = await collect(decode, decode_request, args.timeout)
-    assert decode_chunks[-1]["finish_reason"] == "length"
+    _require_equal(decode_chunks[-1]["finish_reason"], "length", "decode finish_reason")
 
 
 async def main() -> None:

--- a/examples/backends/sample/launch/multimodal_smoke_client.py
+++ b/examples/backends/sample/launch/multimodal_smoke_client.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct CPU smoke client for the sample multimodal worker roles."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from typing import Any
+
+from dynamo.runtime import DistributedRuntime
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("aggregated", "epd"), required=True)
+    parser.add_argument("--namespace", default="dynamo")
+    parser.add_argument("--model-name", default="sample-model")
+    parser.add_argument("--aggregated-component", default="sample-multimodal-agg")
+    parser.add_argument("--encode-component", default="sample-multimodal-encode")
+    parser.add_argument("--prefill-component", default="sample-multimodal-prefill")
+    parser.add_argument("--decode-component", default="sample-multimodal-decode")
+    parser.add_argument("--timeout", type=float, default=60.0)
+    return parser.parse_args()
+
+
+async def connect(runtime: DistributedRuntime, endpoint_name: str, timeout: float):
+    endpoint = runtime.endpoint(endpoint_name)
+    client = await endpoint.client()
+    await asyncio.wait_for(client.wait_for_instances(), timeout=timeout)
+    return client
+
+
+async def collect(
+    client, request: dict[str, Any], timeout: float
+) -> list[dict[str, Any]]:
+    chunks: list[dict[str, Any]] = []
+    async with asyncio.timeout(timeout):
+        stream = await client.generate(request)
+        async for response in stream:
+            if response.is_error():
+                comments = response.comments() or []
+                raise RuntimeError("worker returned an error: " + "; ".join(comments))
+            data = response.data()
+            if isinstance(data, str):
+                data = json.loads(data)
+            if data is not None:
+                chunks.append(data)
+    return chunks
+
+
+def multimodal_request(model_name: str) -> dict[str, Any]:
+    return {
+        "model": model_name,
+        "token_ids": [1, 2, 3],
+        "sampling_options": {},
+        "stop_conditions": {"max_tokens": 2},
+        "output_options": {},
+        "multi_modal_data": {"image_url": [{"Url": "data:image/png;base64,AA=="}]},
+        "mm_processor_kwargs": {"min_pixels": 64},
+    }
+
+
+async def run_aggregated(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
+    client = await connect(
+        runtime,
+        f"{args.namespace}.{args.aggregated_component}.generate",
+        args.timeout,
+    )
+    request = multimodal_request(args.model_name)
+    chunks = await collect(client, request, args.timeout)
+    terminal = chunks[-1]
+    observed = terminal["engine_data"]["sample_multimodal"]["multimodal_kwargs"]
+    assert observed["multi_modal_data"] == request["multi_modal_data"]
+    assert observed["mm_processor_kwargs"] == request["mm_processor_kwargs"]
+
+
+async def run_epd(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
+    encode, prefill, decode = await asyncio.gather(
+        connect(
+            runtime,
+            f"{args.namespace}.{args.encode_component}.generate",
+            args.timeout,
+        ),
+        connect(
+            runtime,
+            f"{args.namespace}.{args.prefill_component}.generate",
+            args.timeout,
+        ),
+        connect(
+            runtime,
+            f"{args.namespace}.{args.decode_component}.generate",
+            args.timeout,
+        ),
+    )
+    request = multimodal_request(args.model_name)
+
+    [encode_terminal] = await collect(encode, request, args.timeout)
+    assert encode_terminal["token_ids"] == []
+    assert encode_terminal["finish_reason"] == "stop"
+
+    [prefill_terminal] = await collect(
+        prefill,
+        {**request, "encoder_result": encode_terminal["encoder_result"]},
+        args.timeout,
+    )
+    assert (
+        prefill_terminal["engine_data"]["sample_multimodal"]["handle"]
+        == encode_terminal["encoder_result"]["handle"]
+    )
+
+    decode_request = {
+        "model": args.model_name,
+        "token_ids": request["token_ids"],
+        "sampling_options": {},
+        "stop_conditions": {"max_tokens": 2},
+        "output_options": {},
+        "prefill_result": {
+            "disaggregated_params": prefill_terminal["disaggregated_params"]
+        },
+    }
+    decode_chunks = await collect(decode, decode_request, args.timeout)
+    assert decode_chunks[-1]["finish_reason"] == "length"
+
+
+async def main() -> None:
+    args = parse_args()
+    runtime = DistributedRuntime(asyncio.get_running_loop(), "etcd", "tcp")
+    try:
+        if args.mode == "aggregated":
+            await run_aggregated(runtime, args)
+        else:
+            await run_epd(runtime, args)
+    finally:
+        runtime.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/backends/sample/launch/multimodal_smoke_client.py
+++ b/examples/backends/sample/launch/multimodal_smoke_client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 from typing import Any
 
 from dynamo.runtime import DistributedRuntime
@@ -107,9 +108,13 @@ async def run_epd(runtime: DistributedRuntime, args: argparse.Namespace) -> None
         args.timeout,
     )
     assert (
-        prefill_terminal["engine_data"]["sample_multimodal"]["handle"]
-        == encode_terminal["encoder_result"]["handle"]
+        prefill_terminal["engine_data"]["sample_multimodal"]
+        == encode_terminal["encoder_result"]
     )
+    assert encode_terminal["encoder_result"]["multimodal_kwargs"] == {
+        "multi_modal_data": request["multi_modal_data"],
+        "mm_processor_kwargs": request["mm_processor_kwargs"],
+    }
 
     decode_request = {
         "model": args.model_name,
@@ -127,12 +132,18 @@ async def run_epd(runtime: DistributedRuntime, args: argparse.Namespace) -> None
 
 async def main() -> None:
     args = parse_args()
+    # Launch scripts assign DYN_SYSTEM_PORT to workers. The direct client is a
+    # separate runtime and must allocate its own system-server port.
+    os.environ.pop("DYN_SYSTEM_PORT", None)
     runtime = DistributedRuntime(asyncio.get_running_loop(), "etcd", "tcp")
     try:
-        if args.mode == "aggregated":
-            await run_aggregated(runtime, args)
-        else:
-            await run_epd(runtime, args)
+        # Bound the whole smoke, rather than granting each sequential EPD stage
+        # a fresh timeout that can exceed the outer test harness deadline.
+        async with asyncio.timeout(args.timeout):
+            if args.mode == "aggregated":
+                await run_aggregated(runtime, args)
+            else:
+                await run_epd(runtime, args)
     finally:
         runtime.shutdown()
 

--- a/lib/backend-common/CLAUDE.md
+++ b/lib/backend-common/CLAUDE.md
@@ -512,9 +512,10 @@ pristine engine for the "cleanup before start" check.
 
 Encode-role engines call `run_encode_conformance`. It sends a multimodal
 request and checks the narrower handoff response contract: one terminal `Stop`
-chunk, no generated tokens, consistent usage, and an object-shaped
-`encoder_result`. Encode engines must also satisfy the common KV source,
-metrics, concurrency, cancellation, and cleanup lifecycle guarantees.
+chunk, no generated tokens, and an object-shaped `encoder_result`. Terminal
+usage remains optional; when provided, it must report zero completion tokens
+consistently. Encode engines must also satisfy the common KV source, metrics,
+concurrency, cancellation, and cleanup lifecycle guarantees.
 
 The kit asserts:
 

--- a/lib/backend-common/CLAUDE.md
+++ b/lib/backend-common/CLAUDE.md
@@ -510,9 +510,11 @@ async fn my_engine_satisfies_contract() {
 constructs one engine for the main lifecycle test and a second
 pristine engine for the "cleanup before start" check.
 
-Encode-role engines call `run_encode_conformance`. It checks the narrower
-handoff stream contract: one terminal `Stop` chunk, no generated tokens, and
-an object-shaped `encoder_result`, plus the same cleanup lifecycle guarantees.
+Encode-role engines call `run_encode_conformance`. It sends a multimodal
+request and checks the narrower handoff response contract: one terminal `Stop`
+chunk, no generated tokens, consistent usage, and an object-shaped
+`encoder_result`. Encode engines must also satisfy the common KV source,
+metrics, concurrency, cancellation, and cleanup lifecycle guarantees.
 
 The kit asserts:
 
@@ -554,7 +556,7 @@ Also available: `testing::mock_context()` and
 | `adapter.rs` | `EngineAdapter` — bridges `LLMEngine` to `AsyncEngine` (token telemetry, disagg first-token, debug validator). `RawEngineAdapter` — bridges `RawEngine` to `AsyncEngine` (JSON passthrough, cancellation monitor; no token telemetry/disagg). `JsonProbeAdapter` — JSON health-check wrapper for the LLM path (the raw path is already JSON-shaped). |
 | `run.rs` | `pub fn run(engine, config)` (LLM) and `pub fn run_raw(engine, config)` (raw media) — entry points used by per-backend `main.rs`. Non-generic. |
 | `args.rs` | `CommonArgs` — shared CLI flags (`--namespace`, `--component`, `--disaggregation-mode`, etc.) that every engine's `Args` flattens in. |
-| `disagg.rs` | `DisaggregationMode` enum (`Aggregated` / `Prefill` / `Decode`) with `clap::ValueEnum` derive. |
+| `disagg.rs` | `DisaggregationMode` enum (`Aggregated` / `Prefill` / `Decode` / `Encode`) with `clap::ValueEnum` derive. |
 | `error.rs` | Re-exports `DynamoError`, `ErrorType`, `BackendError` from `dynamo-runtime`. No custom error types. |
 | `validate.rs` | Debug-build stream validator. Compiled out in release. |
 | `testing.rs` | Conformance test kit. Gated behind the `testing` feature. |

--- a/lib/backend-common/CLAUDE.md
+++ b/lib/backend-common/CLAUDE.md
@@ -510,6 +510,10 @@ async fn my_engine_satisfies_contract() {
 constructs one engine for the main lifecycle test and a second
 pristine engine for the "cleanup before start" check.
 
+Encode-role engines call `run_encode_conformance`. It checks the narrower
+handoff stream contract: one terminal `Stop` chunk, no generated tokens, and
+an object-shaped `encoder_result`, plus the same cleanup lifecycle guarantees.
+
 The kit asserts:
 
 - `start()` returns a non-empty `EngineConfig.model`.

--- a/lib/backend-common/README.md
+++ b/lib/backend-common/README.md
@@ -291,10 +291,10 @@ async fn my_encoder_passes_conformance() {
 ```
 
 `run_encode_conformance` sends a multimodal request and requires one terminal
-`FinishReason::Stop` chunk, empty `token_ids`, consistent zero-completion-token
-usage, and an object-shaped `encoder_result`. It also applies the same KV
-source, metrics, concurrency, cancellation, and cleanup checks as token-engine
-conformance.
+`FinishReason::Stop` chunk, empty `token_ids`, and an object-shaped
+`encoder_result`. When terminal usage is provided, it must consistently report
+zero completion tokens. The suite also applies the same KV source, metrics,
+concurrency, cancellation, and cleanup checks as token-engine conformance.
 
 The kit asserts:
 

--- a/lib/backend-common/README.md
+++ b/lib/backend-common/README.md
@@ -290,8 +290,11 @@ async fn my_encoder_passes_conformance() {
 }
 ```
 
-`run_encode_conformance` requires one terminal `FinishReason::Stop` chunk,
-empty `token_ids`, and an object-shaped `encoder_result`.
+`run_encode_conformance` sends a multimodal request and requires one terminal
+`FinishReason::Stop` chunk, empty `token_ids`, consistent zero-completion-token
+usage, and an object-shaped `encoder_result`. It also applies the same KV
+source, metrics, concurrency, cancellation, and cleanup checks as token-engine
+conformance.
 
 The kit asserts:
 

--- a/lib/backend-common/README.md
+++ b/lib/backend-common/README.md
@@ -279,6 +279,20 @@ async fn my_engine_passes_conformance() {
 }
 ```
 
+Encode-role engines use the narrower handoff contract:
+
+```rust
+#[tokio::test]
+async fn my_encoder_passes_conformance() {
+    dynamo_backend_common::testing::run_encode_conformance(MyEncoder::new_for_test)
+        .await
+        .expect("encode conformance");
+}
+```
+
+`run_encode_conformance` requires one terminal `FinishReason::Stop` chunk,
+empty `token_ids`, and an object-shaped `encoder_result`.
+
 The kit asserts:
 
 | Check | Failure mode |

--- a/lib/backend-common/src/testing.rs
+++ b/lib/backend-common/src/testing.rs
@@ -27,7 +27,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use dynamo_llm::protocols::common::preprocessor::PreprocessedRequest;
+use dynamo_llm::protocols::common::preprocessor::{MultimodalData, PreprocessedRequest};
 use dynamo_llm::protocols::common::{FinishReason, OutputOptions, SamplingOptions, StopConditions};
 use dynamo_runtime::engine::AsyncEngineContext;
 use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
@@ -59,6 +59,7 @@ pub fn cancelling_context(after: Duration) -> Arc<dyn AsyncEngineContext> {
 
 /// Which conformance check failed, and why.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ConformanceFailure {
     StartFailed(String),
     EmptyModelInConfig,
@@ -100,6 +101,13 @@ pub enum ConformanceFailure {
     /// Encode workers produce a handoff payload, not generated tokens.
     EncodeTokensNotEmpty {
         count: usize,
+    },
+    /// Encode terminal usage must describe a zero-token handoff response.
+    EncodeUsageMismatch {
+        expected_prompt: u32,
+        prompt: u32,
+        completion: u32,
+        total: u32,
     },
     /// The encoder handoff contract is object-shaped at every boundary.
     EncoderResultExpectedObject,
@@ -173,6 +181,17 @@ impl std::fmt::Display for ConformanceFailure {
                 f,
                 "encode terminal chunk must have empty token_ids; got {count} tokens"
             ),
+            EncodeUsageMismatch {
+                expected_prompt,
+                prompt,
+                completion,
+                total,
+            } => write!(
+                f,
+                "encode terminal usage must report prompt={expected_prompt}, completion=0, \
+                 total={expected_prompt}; got prompt={prompt}, completion={completion}, \
+                 total={total}"
+            ),
             EncoderResultExpectedObject => write!(
                 f,
                 "encode terminal chunk must carry an object-shaped encoder_result"
@@ -219,10 +238,16 @@ where
     // 5. Interleaved generate() calls both complete — catches shared-state bugs.
     //    Uses tokio::join! under the test runtime (single-threaded by default),
     //    so this is interleaving rather than true parallelism.
-    check_concurrent_generates(&engine, &config.model).await?;
+    check_concurrent_generates(&engine, &config.model, LlmConformanceMode::Token).await?;
 
     // 6. Cancellation is observed within a bounded deadline.
-    check_cancellation(&engine, &config.model, DEFAULT_CANCEL_DEADLINE).await?;
+    check_cancellation(
+        &engine,
+        &config.model,
+        LlmConformanceMode::Token,
+        DEFAULT_CANCEL_DEADLINE,
+    )
+    .await?;
 
     // 7. cleanup() succeeds and is idempotent.
     engine
@@ -248,9 +273,9 @@ where
 
 /// Run the Encode-role conformance suite against an [`LLMEngine`].
 ///
-/// Encode engines have a deliberately smaller streaming contract than token
-/// generators: one terminal `Stop` chunk, no generated tokens, and an
-/// object-shaped `encoder_result` handoff payload.
+/// Encode engines have a narrower response shape than token generators, but
+/// share the same routing, metrics, concurrency, cancellation, and cleanup
+/// lifecycle contracts.
 pub async fn run_encode_conformance<E, F>(mut factory: F) -> Result<(), ConformanceFailure>
 where
     E: LLMEngine,
@@ -265,7 +290,17 @@ where
         return Err(EmptyModelInConfig);
     }
 
+    check_kv_event_sources(&engine).await?;
+    check_setup_metrics(&engine).await?;
     check_encode_generate(&engine, &config.model).await?;
+    check_concurrent_generates(&engine, &config.model, LlmConformanceMode::Encode).await?;
+    check_cancellation(
+        &engine,
+        &config.model,
+        LlmConformanceMode::Encode,
+        DEFAULT_CANCEL_DEADLINE,
+    )
+    .await?;
 
     engine
         .cleanup()
@@ -289,11 +324,20 @@ async fn check_encode_generate<E: LLMEngine>(
     engine: &E,
     model: &str,
 ) -> Result<(), ConformanceFailure> {
+    let request = encode_request(model);
+    let expected_prompt = request.token_ids.len() as u32;
     let stream = engine
-        .generate(request(model), GenerateContext::new(mock_context(), None))
+        .generate(request, GenerateContext::new(mock_context(), None))
         .await
         .map_err(|e| GenerateFailed(e.to_string()))?;
     let items: Vec<_> = stream.collect().await;
+    validate_encode_items(items, expected_prompt)
+}
+
+fn validate_encode_items(
+    items: Vec<Result<crate::engine::LLMEngineOutput, crate::error::DynamoError>>,
+    expected_prompt: u32,
+) -> Result<(), ConformanceFailure> {
     if items.len() != 1 {
         return Err(EncodeChunkCount { count: items.len() });
     }
@@ -314,7 +358,25 @@ async fn check_encode_generate<E: LLMEngine>(
     if !chunk.encoder_result.as_ref().is_some_and(|v| v.is_object()) {
         return Err(EncoderResultExpectedObject);
     }
+    if let Some(usage) = chunk.completion_usage.as_ref()
+        && (usage.prompt_tokens != expected_prompt
+            || usage.completion_tokens != 0
+            || usage.total_tokens != expected_prompt)
+    {
+        return Err(EncodeUsageMismatch {
+            expected_prompt,
+            prompt: usage.prompt_tokens,
+            completion: usage.completion_tokens,
+            total: usage.total_tokens,
+        });
+    }
     Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum LlmConformanceMode {
+    Token,
+    Encode,
 }
 
 fn request(model: &str) -> PreprocessedRequest {
@@ -335,6 +397,28 @@ fn request_with_max_tokens(model: &str, max_tokens: Option<u32>) -> Preprocessed
         .output_options(OutputOptions::default())
         .build()
         .expect("build request")
+}
+
+fn encode_request(model: &str) -> PreprocessedRequest {
+    let multi_modal_data = std::collections::HashMap::from([(
+        "image".to_string(),
+        vec![MultimodalData::RawUrl(
+            "data:image/png;base64,AA==".to_string(),
+        )],
+    )]);
+    PreprocessedRequest::builder()
+        .model(model.to_string())
+        .token_ids(vec![1, 2, 3])
+        .multi_modal_data(Some(multi_modal_data))
+        .mm_processor_kwargs(Some(serde_json::json!({ "min_pixels": 64 })))
+        .stop_conditions(StopConditions {
+            max_tokens: Some(8),
+            ..Default::default()
+        })
+        .sampling_options(SamplingOptions::default())
+        .output_options(OutputOptions::default())
+        .build()
+        .expect("build encode request")
 }
 
 async fn check_single_generate<E: LLMEngine>(
@@ -391,6 +475,7 @@ async fn check_single_generate<E: LLMEngine>(
 async fn check_concurrent_generates<E: LLMEngine>(
     engine: &E,
     model: &str,
+    mode: LlmConformanceMode,
 ) -> Result<(), ConformanceFailure> {
     // 8 in-flight streams — enough to catch state-tramping under interleaved
     // polls. Under a single-threaded test runtime this is interleaving rather
@@ -398,15 +483,27 @@ async fn check_concurrent_generates<E: LLMEngine>(
     const CONCURRENT: usize = 8;
     let futs = (0..CONCURRENT).map(|_| async {
         let ctx = mock_context();
+        let request = match mode {
+            LlmConformanceMode::Token => request(model),
+            LlmConformanceMode::Encode => encode_request(model),
+        };
+        let expected_prompt = request.token_ids.len() as u32;
         let stream = engine
-            .generate(request(model), GenerateContext::new(ctx, None))
+            .generate(request, GenerateContext::new(ctx, None))
             .await
             .map_err(|e| ConcurrentGenerateFailed(e.to_string()))?;
-        let n = stream.count().await;
-        if n == 0 {
-            Err(ConcurrentGenerateFailed("stream was empty".to_string()))
-        } else {
-            Ok(())
+        match mode {
+            LlmConformanceMode::Token => {
+                let n = stream.count().await;
+                if n == 0 {
+                    Err(ConcurrentGenerateFailed("stream was empty".to_string()))
+                } else {
+                    Ok(())
+                }
+            }
+            LlmConformanceMode::Encode => {
+                validate_encode_items(stream.collect().await, expected_prompt)
+            }
         }
     });
     for result in futures::future::join_all(futs).await {
@@ -467,6 +564,7 @@ async fn check_setup_metrics<E: LLMEngine>(engine: &E) -> Result<(), Conformance
 async fn check_cancellation<E: LLMEngine>(
     engine: &E,
     model: &str,
+    mode: LlmConformanceMode,
     deadline: Duration,
 ) -> Result<(), ConformanceFailure> {
     // Request enough tokens that an engine which ignores cancellation
@@ -474,11 +572,12 @@ async fn check_cancellation<E: LLMEngine>(
     const LONG_MAX_TOKENS: u32 = 10_000;
 
     let ctx = mock_context();
+    let request = match mode {
+        LlmConformanceMode::Token => request_with_max_tokens(model, Some(LONG_MAX_TOKENS)),
+        LlmConformanceMode::Encode => encode_request(model),
+    };
     let stream = engine
-        .generate(
-            request_with_max_tokens(model, Some(LONG_MAX_TOKENS)),
-            GenerateContext::new(ctx.clone(), None),
-        )
+        .generate(request, GenerateContext::new(ctx.clone(), None))
         .await
         .map_err(|e| GenerateFailed(e.to_string()))?;
 
@@ -656,7 +755,9 @@ async fn check_cancellation_raw<E: RawEngine>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::{EngineConfig, LLMEngineOutput, PreprocessedRequest};
+    use crate::engine::{
+        EngineConfig, LLMEngineOutput, LLMEngineOutputExt, PreprocessedRequest, usage,
+    };
     use crate::error::DynamoError;
     use async_trait::async_trait;
     use futures::stream::BoxStream;
@@ -718,8 +819,34 @@ mod tests {
         assert!(check_setup_metrics(&engine).await.is_ok());
     }
 
+    #[derive(Clone, Copy)]
+    enum EncodeMockResponse {
+        Valid,
+        MissingEncoderResult,
+        WrongCount,
+        WrongFinish,
+        Tokens,
+        BadUsage,
+        Empty,
+    }
+
     struct EncodeConformanceMock {
-        omit_encoder_result: bool,
+        response: EncodeMockResponse,
+        honor_cancel: bool,
+    }
+
+    fn encode_mock(response: EncodeMockResponse) -> EncodeConformanceMock {
+        EncodeConformanceMock {
+            response,
+            honor_cancel: true,
+        }
+    }
+
+    fn valid_encode_chunk() -> LLMEngineOutput {
+        LLMEngineOutput::encode_terminal(serde_json::Map::from_iter([(
+            "handle".to_string(),
+            serde_json::json!("sample-encoder:test"),
+        )]))
     }
 
     #[async_trait]
@@ -733,18 +860,53 @@ mod tests {
 
         async fn generate(
             &self,
-            _request: PreprocessedRequest,
-            _ctx: GenerateContext,
+            request: PreprocessedRequest,
+            ctx: GenerateContext,
         ) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
-            let chunk = if self.omit_encoder_result {
-                LLMEngineOutput::stop()
-            } else {
-                LLMEngineOutput::encode_terminal(serde_json::Map::from_iter([(
-                    "handle".to_string(),
-                    serde_json::json!("sample-encoder:test"),
-                )]))
+            assert!(
+                request
+                    .multi_modal_data
+                    .as_ref()
+                    .is_some_and(|data| !data.is_empty()),
+                "encode conformance request must contain multi_modal_data"
+            );
+            assert_eq!(
+                request.mm_processor_kwargs,
+                Some(serde_json::json!({ "min_pixels": 64 })),
+                "encode conformance request must contain mm_processor_kwargs"
+            );
+            let chunks = match self.response {
+                EncodeMockResponse::Valid => vec![Ok(valid_encode_chunk())],
+                EncodeMockResponse::MissingEncoderResult => vec![Ok(LLMEngineOutput::stop())],
+                EncodeMockResponse::WrongCount => {
+                    vec![Ok(valid_encode_chunk()), Ok(valid_encode_chunk())]
+                }
+                EncodeMockResponse::WrongFinish => {
+                    let mut chunk = valid_encode_chunk();
+                    chunk.finish_reason = Some(FinishReason::Length);
+                    vec![Ok(chunk)]
+                }
+                EncodeMockResponse::Tokens => {
+                    let mut chunk = valid_encode_chunk();
+                    chunk.token_ids = vec![1];
+                    vec![Ok(chunk)]
+                }
+                EncodeMockResponse::BadUsage => {
+                    vec![Ok(valid_encode_chunk().with_usage(usage(3, 1)))]
+                }
+                EncodeMockResponse::Empty => vec![],
             };
-            Ok(Box::pin(futures::stream::iter([Ok(chunk)])))
+            let honor_cancel = self.honor_cancel;
+            let ctx = ctx.inner_arc();
+            Ok(Box::pin(async_stream::stream! {
+                if honor_cancel && ctx.is_stopped() {
+                    yield Ok(LLMEngineOutput::cancelled());
+                    return;
+                }
+                for chunk in chunks {
+                    yield chunk;
+                }
+            }))
         }
 
         async fn cleanup(&self) -> Result<(), DynamoError> {
@@ -754,23 +916,71 @@ mod tests {
 
     #[tokio::test]
     async fn encode_mock_satisfies_conformance() {
-        run_encode_conformance(|| EncodeConformanceMock {
-            omit_encoder_result: false,
-        })
-        .await
-        .expect("encode conformance");
+        run_encode_conformance(|| encode_mock(EncodeMockResponse::Valid))
+            .await
+            .expect("encode conformance");
     }
 
     #[tokio::test]
     async fn encode_conformance_rejects_missing_encoder_result() {
-        let result = run_encode_conformance(|| EncodeConformanceMock {
-            omit_encoder_result: true,
-        })
-        .await;
+        let result =
+            run_encode_conformance(|| encode_mock(EncodeMockResponse::MissingEncoderResult)).await;
         assert!(
             matches!(result, Err(EncoderResultExpectedObject)),
             "expected EncoderResultExpectedObject, got {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn encode_conformance_rejects_wrong_chunk_count() {
+        let engine = encode_mock(EncodeMockResponse::WrongCount);
+        let result = check_encode_generate(&engine, "encode-mock").await;
+        assert!(matches!(result, Err(EncodeChunkCount { count: 2 })));
+    }
+
+    #[tokio::test]
+    async fn encode_conformance_rejects_wrong_finish_reason() {
+        let engine = encode_mock(EncodeMockResponse::WrongFinish);
+        let result = check_encode_generate(&engine, "encode-mock").await;
+        assert!(matches!(result, Err(EncodeTerminalExpected)));
+    }
+
+    #[tokio::test]
+    async fn encode_conformance_rejects_generated_tokens() {
+        let engine = encode_mock(EncodeMockResponse::Tokens);
+        let result = check_encode_generate(&engine, "encode-mock").await;
+        assert!(matches!(result, Err(EncodeTokensNotEmpty { count: 1 })));
+    }
+
+    #[tokio::test]
+    async fn encode_conformance_rejects_inconsistent_usage() {
+        let engine = encode_mock(EncodeMockResponse::BadUsage);
+        let result = check_encode_generate(&engine, "encode-mock").await;
+        assert!(matches!(result, Err(EncodeUsageMismatch { .. })));
+    }
+
+    #[tokio::test]
+    async fn encode_conformance_rejects_ignored_cancellation() {
+        let engine = EncodeConformanceMock {
+            response: EncodeMockResponse::Valid,
+            honor_cancel: false,
+        };
+        let result = check_cancellation(
+            &engine,
+            "encode-mock",
+            LlmConformanceMode::Encode,
+            Duration::from_millis(150),
+        )
+        .await;
+        assert!(matches!(result, Err(CancellationIgnored)));
+    }
+
+    #[tokio::test]
+    async fn encode_conformance_validates_concurrent_streams() {
+        let engine = encode_mock(EncodeMockResponse::Empty);
+        let result =
+            check_concurrent_generates(&engine, "encode-mock", LlmConformanceMode::Encode).await;
+        assert!(matches!(result, Err(EncodeChunkCount { count: 0 })));
     }
 
     /// Minimal `RawEngine` for exercising the raw conformance kit itself.

--- a/lib/backend-common/src/testing.rs
+++ b/lib/backend-common/src/testing.rs
@@ -4,8 +4,8 @@
 //! Conformance test kit for [`LLMEngine`] and [`RawEngine`] implementations.
 //!
 //! Engines wire themselves into the test suite with one call —
-//! [`run_conformance`] for token engines, [`run_raw_conformance`] for raw
-//! media engines:
+//! [`run_conformance`] for token engines, [`run_encode_conformance`] for
+//! Encode-role engines, and [`run_raw_conformance`] for raw media engines:
 //!
 //! ```ignore
 //! #[tokio::test]
@@ -91,6 +91,18 @@ pub enum ConformanceFailure {
         chunked: usize,
         reported: u32,
     },
+    /// Encode conformance requires exactly one terminal handoff chunk.
+    EncodeChunkCount {
+        count: usize,
+    },
+    /// Encode terminals use the standard `Stop` finish reason.
+    EncodeTerminalExpected,
+    /// Encode workers produce a handoff payload, not generated tokens.
+    EncodeTokensNotEmpty {
+        count: usize,
+    },
+    /// The encoder handoff contract is object-shaped at every boundary.
+    EncoderResultExpectedObject,
 }
 
 impl std::fmt::Display for ConformanceFailure {
@@ -147,6 +159,23 @@ impl std::fmt::Display for ConformanceFailure {
                 "engine emitted {chunked} tokens across the stream but reported \
                  completion_usage.completion_tokens = {reported} on the terminal \
                  (engine bookkeeping diverges from streamed output)"
+            ),
+            EncodeChunkCount { count } => write!(
+                f,
+                "encode generate() must yield exactly one terminal chunk; got {count}"
+            ),
+            EncodeTerminalExpected => write!(
+                f,
+                "encode generate() must yield a terminal chunk with \
+                 finish_reason = FinishReason::Stop"
+            ),
+            EncodeTokensNotEmpty { count } => write!(
+                f,
+                "encode terminal chunk must have empty token_ids; got {count} tokens"
+            ),
+            EncoderResultExpectedObject => write!(
+                f,
+                "encode terminal chunk must carry an object-shaped encoder_result"
             ),
         }
     }
@@ -214,6 +243,77 @@ where
         .await
         .map_err(|e| CleanupWithoutStartFailed(e.to_string()))?;
 
+    Ok(())
+}
+
+/// Run the Encode-role conformance suite against an [`LLMEngine`].
+///
+/// Encode engines have a deliberately smaller streaming contract than token
+/// generators: one terminal `Stop` chunk, no generated tokens, and an
+/// object-shaped `encoder_result` handoff payload.
+pub async fn run_encode_conformance<E, F>(mut factory: F) -> Result<(), ConformanceFailure>
+where
+    E: LLMEngine,
+    F: FnMut() -> E,
+{
+    let engine = factory();
+    let config = engine
+        .start(0)
+        .await
+        .map_err(|e| StartFailed(e.to_string()))?;
+    if config.model.is_empty() {
+        return Err(EmptyModelInConfig);
+    }
+
+    check_encode_generate(&engine, &config.model).await?;
+
+    engine
+        .cleanup()
+        .await
+        .map_err(|e| CleanupFailed(e.to_string()))?;
+    engine
+        .cleanup()
+        .await
+        .map_err(|e| SecondCleanupFailed(e.to_string()))?;
+
+    let fresh = factory();
+    fresh
+        .cleanup()
+        .await
+        .map_err(|e| CleanupWithoutStartFailed(e.to_string()))?;
+
+    Ok(())
+}
+
+async fn check_encode_generate<E: LLMEngine>(
+    engine: &E,
+    model: &str,
+) -> Result<(), ConformanceFailure> {
+    let stream = engine
+        .generate(request(model), GenerateContext::new(mock_context(), None))
+        .await
+        .map_err(|e| GenerateFailed(e.to_string()))?;
+    let items: Vec<_> = stream.collect().await;
+    if items.len() != 1 {
+        return Err(EncodeChunkCount { count: items.len() });
+    }
+    let chunk = items
+        .into_iter()
+        .next()
+        .expect("length checked")
+        .map_err(|e| StreamYieldedError(e.to_string()))?;
+
+    if !matches!(chunk.finish_reason, Some(FinishReason::Stop)) {
+        return Err(EncodeTerminalExpected);
+    }
+    if !chunk.token_ids.is_empty() {
+        return Err(EncodeTokensNotEmpty {
+            count: chunk.token_ids.len(),
+        });
+    }
+    if !chunk.encoder_result.as_ref().is_some_and(|v| v.is_object()) {
+        return Err(EncoderResultExpectedObject);
+    }
     Ok(())
 }
 
@@ -556,7 +656,7 @@ async fn check_cancellation_raw<E: RawEngine>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::{EngineConfig, PreprocessedRequest};
+    use crate::engine::{EngineConfig, LLMEngineOutput, PreprocessedRequest};
     use crate::error::DynamoError;
     use async_trait::async_trait;
     use futures::stream::BoxStream;
@@ -616,6 +716,61 @@ mod tests {
             dp_ranks: vec![0, 1, 2],
         };
         assert!(check_setup_metrics(&engine).await.is_ok());
+    }
+
+    struct EncodeConformanceMock {
+        omit_encoder_result: bool,
+    }
+
+    #[async_trait]
+    impl LLMEngine for EncodeConformanceMock {
+        async fn start(&self, _worker_id: u64) -> Result<EngineConfig, DynamoError> {
+            Ok(EngineConfig {
+                model: "encode-mock".to_string(),
+                ..EngineConfig::default()
+            })
+        }
+
+        async fn generate(
+            &self,
+            _request: PreprocessedRequest,
+            _ctx: GenerateContext,
+        ) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
+            let chunk = if self.omit_encoder_result {
+                LLMEngineOutput::stop()
+            } else {
+                LLMEngineOutput::encode_terminal(serde_json::Map::from_iter([(
+                    "handle".to_string(),
+                    serde_json::json!("sample-encoder:test"),
+                )]))
+            };
+            Ok(Box::pin(futures::stream::iter([Ok(chunk)])))
+        }
+
+        async fn cleanup(&self) -> Result<(), DynamoError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn encode_mock_satisfies_conformance() {
+        run_encode_conformance(|| EncodeConformanceMock {
+            omit_encoder_result: false,
+        })
+        .await
+        .expect("encode conformance");
+    }
+
+    #[tokio::test]
+    async fn encode_conformance_rejects_missing_encoder_result() {
+        let result = run_encode_conformance(|| EncodeConformanceMock {
+            omit_encoder_result: true,
+        })
+        .await;
+        assert!(
+            matches!(result, Err(EncoderResultExpectedObject)),
+            "expected EncoderResultExpectedObject, got {result:?}"
+        );
     }
 
     /// Minimal `RawEngine` for exercising the raw conformance kit itself.

--- a/lib/backend-common/src/testing.rs
+++ b/lib/backend-common/src/testing.rs
@@ -915,7 +915,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn encode_mock_satisfies_conformance() {
+    async fn encode_mock_without_usage_satisfies_conformance() {
         run_encode_conformance(|| encode_mock(EncodeMockResponse::Valid))
             .await
             .expect("encode conformance");

--- a/tests/runtime/test_sample_multimodal_smoke.py
+++ b/tests/runtime/test_sample_multimodal_smoke.py
@@ -32,17 +32,16 @@ LAUNCH_DIR = REPO_ROOT / "examples" / "backends" / "sample" / "launch"
 )
 def test_sample_multimodal_smoke(script_name, request, runtime_services_dynamic_ports):
     del runtime_services_dynamic_ports
-    ports = allocate_ports(4, 18000)
+    ports = allocate_ports(3, 18000)
     request.addfinalizer(lambda: deallocate_ports(ports))
 
     env = os.environ.copy()
     env.update(
         {
-            "DYN_HTTP_PORT": str(ports[0]),
-            "DYN_SYSTEM_PORT": str(ports[1]),
-            "DYN_SYSTEM_PORT1": str(ports[1]),
-            "DYN_SYSTEM_PORT2": str(ports[2]),
-            "DYN_SYSTEM_PORT3": str(ports[3]),
+            "DYN_SYSTEM_PORT": str(ports[0]),
+            "DYN_SYSTEM_PORT1": str(ports[0]),
+            "DYN_SYSTEM_PORT2": str(ports[1]),
+            "DYN_SYSTEM_PORT3": str(ports[2]),
             "NAMESPACE": f"sample-mm-{uuid.uuid4().hex}",
         }
     )
@@ -59,7 +58,11 @@ def test_sample_multimodal_smoke(script_name, request, runtime_services_dynamic_
         output, _ = process.communicate(timeout=90)
     except subprocess.TimeoutExpired:
         os.killpg(process.pid, signal.SIGTERM)
-        output, _ = process.communicate(timeout=10)
+        try:
+            output, _ = process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            output, _ = process.communicate(timeout=5)
         pytest.fail(f"{script_name} timed out\n{output}")
 
     assert process.returncode == 0, f"{script_name} failed\n{output}"

--- a/tests/runtime/test_sample_multimodal_smoke.py
+++ b/tests/runtime/test_sample_multimodal_smoke.py
@@ -20,6 +20,7 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
     pytest.mark.unified,
+    pytest.mark.timeout(270),
 ]
 
 REPO_ROOT = Path(__file__).parents[2]

--- a/tests/runtime/test_sample_multimodal_smoke.py
+++ b/tests/runtime/test_sample_multimodal_smoke.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only process smokes for sample multimodal worker handoffs."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tests.utils.port_utils import allocate_ports, deallocate_ports
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unified,
+]
+
+REPO_ROOT = Path(__file__).parents[2]
+LAUNCH_DIR = REPO_ROOT / "examples" / "backends" / "sample" / "launch"
+
+
+@pytest.mark.parametrize(
+    "script_name",
+    ["multimodal_agg.sh", "multimodal_disagg.sh"],
+)
+def test_sample_multimodal_smoke(script_name, request, runtime_services_dynamic_ports):
+    del runtime_services_dynamic_ports
+    ports = allocate_ports(4, 18000)
+    request.addfinalizer(lambda: deallocate_ports(ports))
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "DYN_HTTP_PORT": str(ports[0]),
+            "DYN_SYSTEM_PORT": str(ports[1]),
+            "DYN_SYSTEM_PORT1": str(ports[1]),
+            "DYN_SYSTEM_PORT2": str(ports[2]),
+            "DYN_SYSTEM_PORT3": str(ports[3]),
+            "NAMESPACE": f"sample-mm-{uuid.uuid4().hex}",
+        }
+    )
+    process = subprocess.Popen(
+        ["bash", str(LAUNCH_DIR / script_name)],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        output, _ = process.communicate(timeout=90)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGTERM)
+        output, _ = process.communicate(timeout=10)
+        pytest.fail(f"{script_name} timed out\n{output}")
+
+    assert process.returncode == 0, f"{script_name} failed\n{output}"


### PR DESCRIPTION
## Summary

- Extend `SampleLLMEngine` with synthetic multimodal handling for aggregated and Encode roles, including object-shaped `encoder_result` handoff validation for routed Prefill workers.
- Add an Encode-role Rust conformance helper covering multimodal request shape, lifecycle, concurrency, cancellation, terminal response shape, usage consistency, and cleanup.
- Add CPU-only aggregated and Encode/Prefill/Decode direct worker-process smokes over the TCP request plane with isolated ports and a checked-in offline tokenizer fixture.
- Supersede #10905 on current `main`, building on the encoder contract and discovery work from #10969 and #10970.

## Validation

- `pre-commit run --files <changed files>`
- `ruff check components/src/dynamo/common/backend/sample_engine.py components/src/dynamo/common/backend/tests/test_sample_engine.py examples/backends/sample/launch/multimodal_smoke_client.py tests/runtime/test_sample_multimodal_smoke.py`
- `python3 -m compileall -q <changed Python files>`
- `shellcheck -e SC1091 examples/backends/sample/launch/multimodal_agg.sh examples/backends/sample/launch/multimodal_disagg.sh`
- `bash -n examples/backends/sample/launch/multimodal_agg.sh examples/backends/sample/launch/multimodal_disagg.sh`
- `cargo fmt --all -- --check`
- `cargo test -p dynamo-backend-common --lib` — 132 passed
- `python3 -m pytest -q components/src/dynamo/common/backend/tests/test_sample_engine.py` against freshly built bindings — 23 passed
- `python3 -m pytest -q -s tests/runtime/test_sample_multimodal_smoke.py` against freshly built bindings and rebased request-plane code — 2 passed

## Related Issues

- Addresses DIS-2111
- Supersedes #10905


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multimodal inference across both aggregated and encode/prefill/decode flows.
  * Added new CPU-only smoke test launchers and an end-to-end smoke client for multimodal handoffs.

* **Bug Fixes**
  * Improved handling of multimodal request data and encoder handoff responses.
  * Added validation for expected stop/cancel behavior and response formatting in encode flows.

* **Tests**
  * Expanded backend conformance coverage for encode-role engines.
  * Added end-to-end smoke tests for aggregated and disaggregated multimodal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->