### PR TITLE
fix(multimodal): make nixl imports lazy

### DIFF
--- a/components/src/dynamo/common/multimodal/embedding_transfer.py
+++ b/components/src/dynamo/common/multimodal/embedding_transfer.py
@@ -15,15 +15,37 @@ from typing import Any, Awaitable, List, Optional
 
 import msgspec
 import torch
-from nixl._api import nixl_agent, nixl_agent_config
 from pydantic import BaseModel
 from safetensors import torch as safetensors_torch
 
-import dynamo.nixl_connect as nixl_connect
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.runtime import run_async
 
 logger = logging.getLogger(__name__)
+
+
+def _load_nixl_api():
+    try:
+        from nixl._api import nixl_agent, nixl_agent_config
+    except ImportError as exc:
+        raise RuntimeError(
+            "NIXL is required for NIXL embedding transfer; install nixl "
+            "to use NIXL write-based multimodal embedding transfer."
+        ) from exc
+
+    return nixl_agent, nixl_agent_config
+
+
+def _load_nixl_connect():
+    try:
+        import dynamo.nixl_connect as nixl_connect
+    except ImportError as exc:
+        raise RuntimeError(
+            "NIXL is required for NIXL embedding transfer; install "
+            "dynamo.nixl_connect to use NIXL read-based transfers."
+        ) from exc
+
+    return nixl_connect
 
 
 def torch_dtype_from_string(dtype_str: str) -> torch.dtype:
@@ -379,6 +401,7 @@ class NixlWriteEmbeddingSender(AbstractEmbeddingSender):
 
     def __init__(self):
         # NIXL agent setup
+        nixl_agent, nixl_agent_config = _load_nixl_api()
         self.sender_id = f"sender_{str(uuid.uuid4())}"
         self.nixl_agent = nixl_agent(
             self.sender_id, nixl_agent_config(num_threads=8, capture_telemetry=True)
@@ -406,7 +429,9 @@ class NixlWriteEmbeddingSender(AbstractEmbeddingSender):
         self.transfer_timeout = 60  # seconds, can be tuned based on expected transfer time and network condition
 
     def __del__(self):
-        self._state_update_task.cancel()
+        state_update_task = getattr(self, "_state_update_task", None)
+        if state_update_task is not None:
+            state_update_task.cancel()
 
     async def _state_update(self):
         """Long-running async task that processes transfer requests."""
@@ -626,6 +651,7 @@ class NixlWriteEmbeddingReceiver(AbstractEmbeddingReceiver):
         self.transfer_tensor = self.ring_buffer.buffer_tensor
 
         # NIXL agent setup
+        nixl_agent, nixl_agent_config = _load_nixl_api()
         self.receiver_id = f"receiver_{str(uuid.uuid4())}"
         self.nixl_agent = nixl_agent(
             self.receiver_id, nixl_agent_config(num_threads=8, capture_telemetry=True)
@@ -774,7 +800,8 @@ class NixlReadEmbeddingSender(AbstractEmbeddingSender):
     """
 
     def __init__(self):
-        self.connector = nixl_connect.Connector()
+        self._nixl_connect = _load_nixl_connect()
+        self.connector = self._nixl_connect.Connector()
 
     @_nvtx.annotate("mm:nixl:send_embeddings", color="magenta")
     async def send_embeddings(
@@ -796,7 +823,7 @@ class NixlReadEmbeddingSender(AbstractEmbeddingSender):
         else:
             transfer_buf = embeddings.clone().detach()
         with _nvtx.annotate("mm:nixl:create_descriptor", color="pink"):
-            descriptor = nixl_connect.Descriptor(transfer_buf)
+            descriptor = self._nixl_connect.Descriptor(transfer_buf)
         with _nvtx.annotate("mm:nixl:create_readable", color="pink"):
             try:
                 readable_op = await self.connector.create_readable(descriptor)
@@ -810,7 +837,7 @@ class NixlReadEmbeddingSender(AbstractEmbeddingSender):
                         exc,
                     )
                     transfer_buf = transfer_buf.cpu()
-                    descriptor = nixl_connect.Descriptor(transfer_buf)
+                    descriptor = self._nixl_connect.Descriptor(transfer_buf)
                     readable_op = await self.connector.create_readable(descriptor)
                 else:
                     raise
@@ -836,19 +863,20 @@ class NixlReadEmbeddingReceiver(AbstractEmbeddingReceiver):
         max_items: int = 1024,
     ) -> None:
         super().__init__()
-        self.connector = nixl_connect.Connector()
+        self._nixl_connect = _load_nixl_connect()
+        self.connector = self._nixl_connect.Connector()
         self.tensor_id_counter = 0
         self.aggregated_op_create_time = 0
         self.aggregated_op_wait_time = 0
-        self.warmedup_descriptors: Queue[nixl_connect.Descriptor] = Queue()
-        self.inuse_descriptors: dict[int, tuple[nixl_connect.Descriptor, bool]] = {}
+        self.warmedup_descriptors: Queue[Any] = Queue()
+        self.inuse_descriptors: dict[int, tuple[Any, bool]] = {}
         connection = run_async(self.connector._create_connection)
         # Create descriptor for our allocated tensor
         for _ in range(max_items):
             encodings_tensor = torch.zeros(
                 max_item_mm_token * embedding_hidden_size, dtype=torch.int8
             )
-            descriptor = nixl_connect.Descriptor(encodings_tensor)
+            descriptor = self._nixl_connect.Descriptor(encodings_tensor)
             descriptor.register_with_connector(connection)
             self.warmedup_descriptors.put(descriptor)
 
@@ -869,7 +897,7 @@ class NixlReadEmbeddingReceiver(AbstractEmbeddingReceiver):
         # Extract dynamic shape, metadata, and auxiliary data
         embeddings_shape = request.embeddings_shape
         embeddings_dtype = torch_dtype_from_string(request.embedding_dtype_str)
-        readable_metadata = nixl_connect.RdmaMetadata.model_validate(
+        readable_metadata = self._nixl_connect.RdmaMetadata.model_validate(
             request.serialized_request
         )
 
@@ -879,7 +907,7 @@ class NixlReadEmbeddingReceiver(AbstractEmbeddingReceiver):
                 "No warmed up descriptors available, creating a temporary one for transfer."
             )
             encodings_tensor = torch.zeros(*embeddings_shape, dtype=embeddings_dtype)
-            descriptor = nixl_connect.Descriptor(encodings_tensor)
+            descriptor = self._nixl_connect.Descriptor(encodings_tensor)
             dynamic_descriptor = True
         else:
             descriptor = self.warmedup_descriptors.get()


### PR DESCRIPTION
## Summary
- Backport PR #10737 to `release/1.2.1`.
- Defer `nixl._api` and `dynamo.nixl_connect` imports in `embedding_transfer.py` until NIXL embedding-transfer classes are constructed.
- Guard `NixlWriteEmbeddingSender.__del__` so a failed NIXL constructor does not raise an ignored cleanup exception.

## Original PR
- Main PR: #10737
- Patch commit: 8b93c2fd68d99403a96548616e7855c7b5fb4160

## Validation
- `uv build --wheel`
- `cd lib/bindings/python && uv build --wheel`
- Installed the local root/runtime wheels into a clean venv where `importlib.util.find_spec("nixl") is None`.
- Verified installed `embedding_transfer.py` loads without importing `nixl` or `dynamo.nixl_connect`.
- Verified `LocalEmbeddingSender()` constructs without NIXL.
- Verified `NixlWriteEmbeddingSender()` raises the expected explicit `RuntimeError` when NIXL is absent.
- Verified no unraisable `__del__` exception after the failed NIXL constructor.