### PR TITLE
perf(runtime): remove TCP response registry mutex

### DIFF
--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -6,7 +6,10 @@ use std::{
     collections::{HashMap, HashSet},
     net::{IpAddr, SocketAddr, TcpListener},
     os::fd::{AsFd, FromRawFd},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 use tokio::time::Instant;
@@ -103,6 +106,7 @@ pub struct TcpStreamServer {
 struct RequestedSendConnection {
     context: Arc<dyn AsyncEngineContext>,
     connection: oneshot::Sender<Result<StreamSender, String>>,
+    instance_gate: Option<Arc<InstanceGate>>,
     /// Capacity of the per-stream mpsc buffer between the socket task and the
     /// engine producer; carried from the registration [`StreamOptions`].
     send_buffer_count: usize,
@@ -111,9 +115,26 @@ struct RequestedSendConnection {
 struct RequestedRecvConnection {
     context: Arc<dyn AsyncEngineContext>,
     connection: oneshot::Sender<Result<StreamReceiver, String>>,
+    instance_gate: Option<Arc<InstanceGate>>,
     /// Capacity of the per-stream mpsc buffer between the socket task and the
     /// engine consumer; carried from the registration [`StreamOptions`].
     send_buffer_count: usize,
+}
+
+impl RequestedSendConnection {
+    fn is_cancelled(&self) -> bool {
+        self.instance_gate
+            .as_ref()
+            .is_some_and(|gate| gate.is_cancelled())
+    }
+}
+
+impl RequestedRecvConnection {
+    fn is_cancelled(&self) -> bool {
+        self.instance_gate
+            .as_ref()
+            .is_some_and(|gate| gate.is_cancelled())
+    }
 }
 
 /// Build the per-stream data-plane mpsc channel that bridges the socket task
@@ -146,29 +167,49 @@ fn data_plane_channel<T>(send_buffer_count: usize) -> (mpsc::Sender<T>, mpsc::Re
 // }
 
 #[derive(Default)]
+struct InstanceGate {
+    cancelled: AtomicBool,
+}
+
+impl InstanceGate {
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+}
+
+#[derive(Default)]
+struct InstanceState {
+    gate: Arc<InstanceGate>,
+    subjects: HashSet<(StreamType, String)>,
+    removed_at: Option<Instant>,
+}
+
+#[derive(Default)]
 struct StreamRegistries {
     tx_subjects: DashMap<String, RequestedSendConnection>,
     rx_subjects: DashMap<String, RequestedRecvConnection>,
     /// subject UUID -> EndpointInstanceId. Full 4-field key isolates services
     /// that share an endpoint name across namespaces/components.
     subject_instance: DashMap<String, EndpointInstanceId>,
-    /// EndpointInstanceId -> tagged subject UUIDs, for batch cancellation on
-    /// removal. The `StreamType` tag tells `cancel_instance_streams` which
-    /// of `rx_subjects` / `tx_subjects` holds the registration so both halves
-    /// of a bidirectional session get dropped together.
-    instance_subjects: DashMap<EndpointInstanceId, HashSet<(StreamType, String)>>,
-    /// Tombstones (instance -> insertion time) close the
-    /// `cancel_instance_streams` vs `associate_instance` race; entries expire
-    /// after [`TOMBSTONE_TTL`].
-    removed_instances: DashMap<EndpointInstanceId, Instant>,
+    /// Per-instance cancellation generation, tagged pending subjects, and
+    /// optional tombstone timestamp. A cancelled generation is never reset;
+    /// clear/re-add installs a fresh gate so stale registrations stay cancelled.
+    instance_states: DashMap<EndpointInstanceId, InstanceState>,
 }
 
 impl StreamRegistries {
     /// Drop tombstones older than [`TOMBSTONE_TTL`]. Called lazily on every
     /// `associate_instance` / `cancel_instance_streams` to bound the set size.
     fn prune_tombstones(&self, now: Instant) {
-        self.removed_instances
-            .retain(|_, ts| now.saturating_duration_since(*ts) < TOMBSTONE_TTL);
+        self.instance_states.retain(|_, state| {
+            state
+                .removed_at
+                .is_none_or(|ts| now.saturating_duration_since(ts) < TOMBSTONE_TTL)
+        });
     }
 
     fn insert_request_stream(&self, subject: String, connection: RequestedSendConnection) {
@@ -191,13 +232,53 @@ impl StreamRegistries {
         conn
     }
 
-    fn associate_subject(&self, kind: StreamType, subject: &str, id: &EndpointInstanceId) {
-        self.subject_instance
-            .insert(subject.to_string(), id.clone());
-        self.instance_subjects
+    fn instance_gate(&self, id: &EndpointInstanceId) -> Arc<InstanceGate> {
+        self.instance_states
             .entry(id.clone())
             .or_default()
-            .insert((kind, subject.to_string()));
+            .gate
+            .clone()
+    }
+
+    fn associate_subject(
+        &self,
+        kind: StreamType,
+        subject: &str,
+        id: &EndpointInstanceId,
+        gate: &Arc<InstanceGate>,
+    ) -> bool {
+        let found = match kind {
+            StreamType::Request => self.tx_subjects.get_mut(subject).map(|mut connection| {
+                connection.instance_gate = Some(gate.clone());
+            }),
+            StreamType::Response => self.rx_subjects.get_mut(subject).map(|mut connection| {
+                connection.instance_gate = Some(gate.clone());
+            }),
+        }
+        .is_some();
+
+        if !found {
+            return false;
+        }
+
+        self.subject_instance
+            .insert(subject.to_string(), id.clone());
+
+        let tracked = if let Some(mut state) = self.instance_states.get_mut(id) {
+            if Arc::ptr_eq(&state.gate, gate) {
+                state.subjects.insert((kind, subject.to_string()));
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        if !tracked {
+            self.subject_instance.remove(subject);
+        }
+        tracked
     }
 
     fn remove_subject_tracking(&self, kind: StreamType, subject: &str) {
@@ -205,11 +286,9 @@ impl StreamRegistries {
             return;
         };
 
-        if let Some(mut subjects) = self.instance_subjects.get_mut(&id) {
-            subjects.remove(&(kind, subject.to_string()));
+        if let Some(mut state) = self.instance_states.get_mut(&id) {
+            state.subjects.remove(&(kind, subject.to_string()));
         }
-        self.instance_subjects
-            .remove_if(&id, |_, subjects| subjects.is_empty());
     }
 
     fn cancel_registered_subject(&self, kind: StreamType, subject: &str) {
@@ -317,16 +396,17 @@ impl TcpStreamServer {
     ) -> bool {
         let now = Instant::now();
         self.registries.prune_tombstones(now);
+        let gate = self.registries.instance_gate(id);
 
-        self.registries
-            .associate_subject(StreamType::Response, recv_subject, id);
-        if let Some(s) = send_subject {
+        let recv_associated =
             self.registries
-                .associate_subject(StreamType::Request, s, id);
-        }
+                .associate_subject(StreamType::Response, recv_subject, id, &gate);
+        let send_associated = send_subject.is_none_or(|subject| {
+            self.registries
+                .associate_subject(StreamType::Request, subject, id, &gate)
+        });
 
-        if self.registries.removed_instances.contains_key(id) {
-            // Instance was already removed -- cancel immediately.
+        if !recv_associated || !send_associated || gate.is_cancelled() {
             tracing::warn!(
                 recv_subject,
                 send_subject,
@@ -334,7 +414,10 @@ impl TcpStreamServer {
                 component = %id.component,
                 endpoint = %id.endpoint,
                 instance_id = id.instance_id,
-                "Cancelling subject immediately: instance already removed (tombstoned)"
+                recv_associated,
+                send_associated,
+                cancelled = gate.is_cancelled(),
+                "Cancelling subject immediately: registration missing or instance removed"
             );
             self.registries
                 .cancel_registered_subject(StreamType::Response, recv_subject);
@@ -357,7 +440,7 @@ impl TcpStreamServer {
     /// Cancel one pending request-stream registration. Parallel to
     /// [`Self::cancel_recv_stream`]: drops the `tx_subjects` entry and, if
     /// the subject was associated with an instance, clears its
-    /// `(StreamType::Request, _)` tag from `instance_subjects` so the per-
+    /// `(StreamType::Request, _)` tag from `instance_states` so the per-
     /// instance bookkeeping stays consistent.
     pub async fn cancel_send_stream(&self, subject: &str) {
         self.registries
@@ -371,10 +454,15 @@ impl TcpStreamServer {
     pub async fn cancel_instance_streams(&self, id: &EndpointInstanceId) -> usize {
         let now = Instant::now();
         self.registries.prune_tombstones(now);
-        self.registries.removed_instances.insert(id.clone(), now);
-        let subjects = match self.registries.instance_subjects.remove(id) {
-            Some((_, subjects)) => subjects,
-            None => return 0,
+        let subjects = {
+            let mut state = self
+                .registries
+                .instance_states
+                .entry(id.clone())
+                .or_default();
+            state.gate.cancel();
+            state.removed_at = Some(now);
+            std::mem::take(&mut state.subjects)
         };
         let count = subjects.len();
         for (kind, subject) in &subjects {
@@ -387,7 +475,11 @@ impl TcpStreamServer {
     /// Drop the tombstone for an instance that has reappeared in discovery,
     /// so future subjects for that identity are tracked normally.
     pub async fn clear_instance_tombstone(&self, id: &EndpointInstanceId) {
-        self.registries.removed_instances.remove(id);
+        if let Some(mut state) = self.registries.instance_states.get_mut(id)
+            && state.removed_at.is_some()
+        {
+            *state = InstanceState::default();
+        }
     }
 
     async fn start(
@@ -440,6 +532,7 @@ impl ResponseService for TcpStreamServer {
             let connection_info = RequestedSendConnection {
                 context: options.context.clone(),
                 connection: pending_sender_tx,
+                instance_gate: None,
                 send_buffer_count: options.send_buffer_count,
             };
 
@@ -459,11 +552,7 @@ impl ResponseService for TcpStreamServer {
                 pending_sender_rx,
             )
             .with_cleanup(move || {
-                // Drop is sync; fire-and-forget any bookkeeping cleanup.
-                tokio::spawn(async move {
-                    cleanup_registries
-                        .cancel_registered_subject(StreamType::Request, &cleanup_subject);
-                });
+                cleanup_registries.cancel_registered_subject(StreamType::Request, &cleanup_subject);
             });
 
             Some(registered_stream)
@@ -478,6 +567,7 @@ impl ResponseService for TcpStreamServer {
             let connection_info = RequestedRecvConnection {
                 context: options.context.clone(),
                 connection: pending_recver_tx,
+                instance_gate: None,
                 send_buffer_count: options.send_buffer_count,
             };
 
@@ -497,11 +587,8 @@ impl ResponseService for TcpStreamServer {
                 pending_recver_rx,
             )
             .with_cleanup(move || {
-                // Drop is sync; fire-and-forget any bookkeeping cleanup.
-                tokio::spawn(async move {
-                    cleanup_registries
-                        .cancel_registered_subject(StreamType::Response, &cleanup_subject);
-                });
+                cleanup_registries
+                    .cancel_registered_subject(StreamType::Response, &cleanup_subject);
             });
 
             Some(registered_stream)
@@ -667,9 +754,17 @@ async fn tcp_listener(
                 subject
             ))?;
 
+        if request_stream.is_cancelled() {
+            return Err(error!(
+                "Subject cancelled before request-stream call-home completed: {}",
+                subject
+            ));
+        }
+
         let RequestedSendConnection {
             context,
             connection,
+            instance_gate: _,
             send_buffer_count,
         } = request_stream;
 
@@ -772,10 +867,18 @@ async fn tcp_listener(
             .remove_response_stream(&subject)
             .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
 
+        if response_stream.is_cancelled() {
+            return Err(error!(
+                "Subject cancelled before response-stream call-home completed: {}",
+                subject
+            ));
+        }
+
         // unwrap response_stream
         let RequestedRecvConnection {
             context,
             connection,
+            instance_gate: _,
             send_buffer_count,
         } = response_stream;
 
@@ -1502,13 +1605,38 @@ mod tests {
         // Drop the RegisteredStream -- RAII cleanup should fire
         drop(recv_stream);
 
-        // Give the spawned cleanup task a moment to run
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        // Verify it's been removed from rx_subjects
+        // Cleanup is synchronous now that it only touches DashMap registries.
         assert!(
             !server.registries.rx_subjects.contains_key(&subject),
             "RAII cleanup should have removed the rx_subjects entry"
+        );
+    }
+
+    #[test]
+    fn test_registered_stream_drop_without_tokio_runtime() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let (server, recv_stream, subject) = runtime.block_on(async {
+            let server = test_server().await;
+            let context = Context::new(());
+            let options = StreamOptions::builder()
+                .context(context.context())
+                .enable_request_stream(false)
+                .enable_response_stream(true)
+                .build()
+                .unwrap();
+            let pending = server.register(options).await;
+            let recv_stream = pending.recv_stream.unwrap();
+            let tcp_info: TcpStreamConnectionInfo =
+                recv_stream.connection_info.clone().try_into().unwrap();
+            (server, recv_stream, tcp_info.subject)
+        });
+
+        drop(runtime);
+        drop(recv_stream);
+
+        assert!(
+            !server.registries.rx_subjects.contains_key(&subject),
+            "cleanup should run synchronously without an active Tokio runtime"
         );
     }
 
@@ -1575,6 +1703,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_response_call_home_observes_cancelled_gate() {
+        let server = test_server().await;
+        let context = Context::new(());
+        let options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(false)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+        let pending = server.register(options).await;
+        let (connection_info, provider) = pending.recv_stream.unwrap().into_parts();
+        let tcp_info: TcpStreamConnectionInfo = connection_info.try_into().unwrap();
+        let id = make_eid("ns", "comp", "generate", 43);
+        assert!(
+            server
+                .associate_instance(&tcp_info.subject, None, &id)
+                .await
+        );
+
+        // Model cancellation's linearization point while deliberately leaving
+        // the subject in rx_subjects so call-home wins the DashMap removal race.
+        server
+            .registries
+            .instance_states
+            .get(&id)
+            .unwrap()
+            .gate
+            .cancel();
+
+        let stream = TcpStream::connect(&tcp_info.address).await.unwrap();
+        let (_read_half, write_half) = tokio::io::split(stream);
+        let mut writer = FramedWrite::new(write_half, TwoPartCodec::default());
+        writer
+            .send(TwoPartMessage::from_header(
+                serde_json::to_vec(&CallHomeHandshake {
+                    subject: tcp_info.subject,
+                    stream_type: StreamType::Response,
+                })
+                .unwrap()
+                .into(),
+            ))
+            .await
+            .unwrap();
+
+        let outcome = tokio::time::timeout(Duration::from_secs(1), provider)
+            .await
+            .expect("cancelled response provider should resolve promptly");
+        assert!(
+            outcome.is_err(),
+            "cancelled response call-home must drop the provider sender"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_request_call_home_observes_cancelled_gate() {
+        let server = test_server().await;
+        let context = Context::new(());
+        let options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(true)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+        let pending = server.register(options).await;
+        let (send_info, send_provider) = pending.send_stream.unwrap().into_parts();
+        let (recv_info, recv_provider) = pending.recv_stream.unwrap().into_parts();
+        let send_tcp_info: TcpStreamConnectionInfo = send_info.try_into().unwrap();
+        let recv_tcp_info: TcpStreamConnectionInfo = recv_info.try_into().unwrap();
+        let id = make_eid("ns", "comp", "generate", 44);
+        assert!(
+            server
+                .associate_instance(&recv_tcp_info.subject, Some(&send_tcp_info.subject), &id,)
+                .await
+        );
+
+        server
+            .registries
+            .instance_states
+            .get(&id)
+            .unwrap()
+            .gate
+            .cancel();
+
+        let stream = TcpStream::connect(&send_tcp_info.address).await.unwrap();
+        let (_read_half, write_half) = tokio::io::split(stream);
+        let mut writer = FramedWrite::new(write_half, TwoPartCodec::default());
+        writer
+            .send(TwoPartMessage::from_header(
+                serde_json::to_vec(&CallHomeHandshake {
+                    subject: send_tcp_info.subject,
+                    stream_type: StreamType::Request,
+                })
+                .unwrap()
+                .into(),
+            ))
+            .await
+            .unwrap();
+
+        let outcome = tokio::time::timeout(Duration::from_secs(1), send_provider)
+            .await
+            .expect("cancelled request provider should resolve promptly");
+        assert!(
+            outcome.is_err(),
+            "cancelled request call-home must drop the provider sender"
+        );
+
+        server.cancel_recv_stream(&recv_tcp_info.subject).await;
+        assert!(recv_provider.await.is_err());
+    }
+
+    #[tokio::test]
     async fn test_clear_tombstone_allows_new_associations() {
         let server = test_server().await;
 
@@ -1593,6 +1832,44 @@ mod tests {
             cancelled, 1,
             "After clearing tombstone, subjects should be tracked normally"
         );
+    }
+
+    #[tokio::test]
+    async fn test_clear_tombstone_installs_new_gate_generation() {
+        let server = test_server().await;
+        let id = make_eid("ns", "comp", "generate", 45);
+
+        let (old_subject, old_provider) = register_and_get_subject(&server).await;
+        assert!(server.associate_instance(&old_subject, None, &id).await);
+        let old_gate = server
+            .registries
+            .instance_states
+            .get(&id)
+            .unwrap()
+            .gate
+            .clone();
+
+        assert_eq!(server.cancel_instance_streams(&id).await, 1);
+        assert!(old_gate.is_cancelled());
+        assert!(old_provider.await.is_err());
+
+        server.clear_instance_tombstone(&id).await;
+        let (new_subject, new_provider) = register_and_get_subject(&server).await;
+        assert!(server.associate_instance(&new_subject, None, &id).await);
+        let new_gate = server
+            .registries
+            .instance_states
+            .get(&id)
+            .unwrap()
+            .gate
+            .clone();
+
+        assert!(!Arc::ptr_eq(&old_gate, &new_gate));
+        assert!(old_gate.is_cancelled());
+        assert!(!new_gate.is_cancelled());
+
+        assert_eq!(server.cancel_instance_streams(&id).await, 1);
+        assert!(new_provider.await.is_err());
     }
 
     #[tokio::test]
@@ -1685,14 +1962,20 @@ mod tests {
     async fn test_tombstone_expires_after_ttl() {
         // After TOMBSTONE_TTL elapses, a previously-tombstoned identity must
         // accept new associations again, AND the entry must be physically
-        // pruned from `removed_instances` so the set remains bounded.
+        // replaced in `instance_states` so the set remains bounded.
         let server = test_server().await;
 
         let id = make_eid("ns", "comp", "generate", 42);
 
         // Tombstone the identity.
         server.cancel_instance_streams(&id).await;
-        assert!(server.registries.removed_instances.contains_key(&id));
+        assert!(
+            server
+                .registries
+                .instance_states
+                .get(&id)
+                .is_some_and(|state| state.removed_at.is_some())
+        );
 
         // Advance past the TTL.
         tokio::time::advance(TOMBSTONE_TTL + Duration::from_secs(1)).await;
@@ -1708,7 +1991,11 @@ mod tests {
         // The expired tombstone must have been pruned (lazy pruning fires on
         // every associate_instance/cancel_instance_streams call).
         assert!(
-            !server.registries.removed_instances.contains_key(&id),
+            server
+                .registries
+                .instance_states
+                .get(&id)
+                .is_some_and(|state| state.removed_at.is_none()),
             "expired tombstone should be pruned, not retained"
         );
     }
@@ -1747,14 +2034,18 @@ mod tests {
         server.cancel_instance_streams(&id_new).await;
 
         assert!(
-            !server.registries.removed_instances.contains_key(&id_old),
+            !server.registries.instance_states.contains_key(&id_old),
             "old tombstone should be pruned by the next cancel_instance_streams call"
         );
         assert!(
-            server.registries.removed_instances.contains_key(&id_new),
+            server
+                .registries
+                .instance_states
+                .get(&id_new)
+                .is_some_and(|state| state.removed_at.is_some()),
             "fresh tombstone should be retained"
         );
-        assert_eq!(server.registries.removed_instances.len(), 1);
+        assert_eq!(server.registries.instance_states.len(), 1);
     }
 
     #[tokio::test]
@@ -1772,7 +2063,11 @@ mod tests {
         server.clear_instance_tombstone(&id_b).await;
 
         assert!(
-            server.registries.removed_instances.contains_key(&id_a),
+            server
+                .registries
+                .instance_states
+                .get(&id_a)
+                .is_some_and(|state| state.removed_at.is_some()),
             "clearing a different identity must not remove id_a's tombstone"
         );
     }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -121,20 +121,10 @@ struct RequestedRecvConnection {
     send_buffer_count: usize,
 }
 
-impl RequestedSendConnection {
-    fn is_cancelled(&self) -> bool {
-        self.instance_gate
-            .as_ref()
-            .is_some_and(|gate| gate.is_cancelled())
-    }
-}
-
-impl RequestedRecvConnection {
-    fn is_cancelled(&self) -> bool {
-        self.instance_gate
-            .as_ref()
-            .is_some_and(|gate| gate.is_cancelled())
-    }
+fn is_instance_cancelled(instance_gate: &Option<Arc<InstanceGate>>) -> bool {
+    instance_gate
+        .as_deref()
+        .is_some_and(InstanceGate::is_cancelled)
 }
 
 /// Build the per-stream data-plane mpsc channel that bridges the socket task
@@ -202,8 +192,8 @@ struct StreamRegistries {
 }
 
 impl StreamRegistries {
-    /// Drop tombstones older than [`TOMBSTONE_TTL`]. Called lazily on every
-    /// `associate_instance` / `cancel_instance_streams` to bound the set size.
+    /// Drop tombstones older than [`TOMBSTONE_TTL`]. Called from instance
+    /// cancellation, which is off the per-request association hot path.
     fn prune_tombstones(&self, now: Instant) {
         self.instance_states.retain(|_, state| {
             state
@@ -232,12 +222,18 @@ impl StreamRegistries {
         conn
     }
 
-    fn instance_gate(&self, id: &EndpointInstanceId) -> Arc<InstanceGate> {
-        self.instance_states
-            .entry(id.clone())
-            .or_default()
-            .gate
-            .clone()
+    /// Return the active cancellation generation for `id`. An expired
+    /// tombstone is refreshed in-place so association only touches this
+    /// instance's shard instead of scanning all instance states.
+    fn instance_gate(&self, id: &EndpointInstanceId, now: Instant) -> Arc<InstanceGate> {
+        let mut state = self.instance_states.entry(id.clone()).or_default();
+        if state
+            .removed_at
+            .is_some_and(|ts| now.saturating_duration_since(ts) >= TOMBSTONE_TTL)
+        {
+            *state = InstanceState::default();
+        }
+        state.gate.clone()
     }
 
     fn associate_subject(
@@ -286,12 +282,21 @@ impl StreamRegistries {
             return;
         };
 
-        if let Some(mut state) = self.instance_states.get_mut(&id) {
+        let active_state_is_empty = if let Some(mut state) = self.instance_states.get_mut(&id) {
             state.subjects.remove(&(kind, subject.to_string()));
+            state.subjects.is_empty() && state.removed_at.is_none()
+        } else {
+            false
+        };
+
+        if active_state_is_empty {
+            self.instance_states.remove_if(&id, |_, state| {
+                state.subjects.is_empty() && state.removed_at.is_none()
+            });
         }
     }
 
-    fn cancel_registered_subject(&self, kind: StreamType, subject: &str) {
+    fn remove_registered_subject(&self, kind: StreamType, subject: &str) {
         match kind {
             StreamType::Request => {
                 self.tx_subjects.remove(subject);
@@ -300,7 +305,17 @@ impl StreamRegistries {
                 self.rx_subjects.remove(subject);
             }
         }
+    }
+
+    fn cancel_registered_subject(&self, kind: StreamType, subject: &str) {
+        self.remove_registered_subject(kind.clone(), subject);
         self.remove_subject_tracking(kind, subject);
+    }
+
+    /// Cancel a subject already removed from its instance's subject set.
+    fn cancel_drained_subject(&self, kind: StreamType, subject: &str) {
+        self.remove_registered_subject(kind, subject);
+        self.subject_instance.remove(subject);
     }
 }
 
@@ -395,8 +410,7 @@ impl TcpStreamServer {
         id: &EndpointInstanceId,
     ) -> bool {
         let now = Instant::now();
-        self.registries.prune_tombstones(now);
-        let gate = self.registries.instance_gate(id);
+        let gate = self.registries.instance_gate(id, now);
 
         let recv_associated =
             self.registries
@@ -467,7 +481,7 @@ impl TcpStreamServer {
         let count = subjects.len();
         for (kind, subject) in &subjects {
             self.registries
-                .cancel_registered_subject(kind.clone(), subject);
+                .cancel_drained_subject(kind.clone(), subject);
         }
         count
     }
@@ -754,7 +768,7 @@ async fn tcp_listener(
                 subject
             ))?;
 
-        if request_stream.is_cancelled() {
+        if is_instance_cancelled(&request_stream.instance_gate) {
             return Err(error!(
                 "Subject cancelled before request-stream call-home completed: {}",
                 subject
@@ -867,7 +881,7 @@ async fn tcp_listener(
             .remove_response_stream(&subject)
             .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
 
-        if response_stream.is_cancelled() {
+        if is_instance_cancelled(&response_stream.instance_gate) {
             return Err(error!(
                 "Subject cancelled before response-stream call-home completed: {}",
                 subject
@@ -1570,7 +1584,12 @@ mod tests {
         // Cancel the individual subject
         server.cancel_recv_stream(&subject).await;
 
-        // Instance should have no remaining subjects
+        assert!(
+            !server.registries.instance_states.contains_key(&id),
+            "empty active instance state should be reclaimed"
+        );
+
+        // Cancelling the instance now should create an empty tombstone.
         let cancelled = server.cancel_instance_streams(&id).await;
         assert_eq!(
             cancelled, 0,
@@ -1988,8 +2007,8 @@ mod tests {
             "tombstone older than TTL should not block association"
         );
 
-        // The expired tombstone must have been pruned (lazy pruning fires on
-        // every associate_instance/cancel_instance_streams call).
+        // The expired tombstone for this identity must have been replaced by
+        // a fresh active generation without scanning unrelated identities.
         assert!(
             server
                 .registries
@@ -1997,6 +2016,37 @@ mod tests {
                 .get(&id)
                 .is_some_and(|state| state.removed_at.is_none()),
             "expired tombstone should be pruned, not retained"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_associate_refreshes_only_target_tombstone() {
+        let server = test_server().await;
+        let target_id = make_eid("ns", "comp", "generate", 42);
+        let sibling_id = make_eid("ns", "comp", "generate", 43);
+
+        server.cancel_instance_streams(&target_id).await;
+        server.cancel_instance_streams(&sibling_id).await;
+        tokio::time::advance(TOMBSTONE_TTL + Duration::from_secs(1)).await;
+
+        let (subject, _provider) = register_and_get_subject(&server).await;
+        assert!(server.associate_instance(&subject, None, &target_id).await);
+
+        assert!(
+            server
+                .registries
+                .instance_states
+                .get(&target_id)
+                .is_some_and(|state| state.removed_at.is_none()),
+            "the associated instance should receive a fresh active generation"
+        );
+        assert!(
+            server
+                .registries
+                .instance_states
+                .get(&sibling_id)
+                .is_some_and(|state| state.removed_at.is_some()),
+            "association should not scan and prune unrelated tombstones"
         );
     }
 

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -9,7 +9,6 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::sync::Mutex;
 use tokio::time::Instant;
 
 /// Tombstone lifetime. Bridges the `register()` → `associate_instance()`
@@ -19,6 +18,7 @@ use tokio::time::Instant;
 const TOMBSTONE_TTL: Duration = Duration::from_secs(5);
 
 use bytes::Bytes;
+use dashmap::DashMap;
 use derive_builder::Builder;
 use futures::{SinkExt, StreamExt};
 use local_ip_address::{Error, list_afinet_netifas, local_ip, local_ipv6};
@@ -90,12 +90,12 @@ impl ServerOptions {
 pub struct TcpStreamServer {
     local_ip: String,
     local_port: u16,
-    state: Arc<Mutex<State>>,
+    registries: Arc<StreamRegistries>,
+    _handle: tokio::task::JoinHandle<Result<()>>,
 }
 
 // pub struct TcpStreamReceiver {
 //     address: TcpStreamConnectionInfo,
-//     state: Arc<Mutex<State>>,
 //     rx: mpsc::Receiver<ResponseType>,
 // }
 
@@ -146,28 +146,83 @@ fn data_plane_channel<T>(send_buffer_count: usize) -> (mpsc::Sender<T>, mpsc::Re
 // }
 
 #[derive(Default)]
-struct State {
-    tx_subjects: HashMap<String, RequestedSendConnection>,
-    rx_subjects: HashMap<String, RequestedRecvConnection>,
+struct StreamRegistries {
+    tx_subjects: DashMap<String, RequestedSendConnection>,
+    rx_subjects: DashMap<String, RequestedRecvConnection>,
     /// subject UUID -> EndpointInstanceId. Full 4-field key isolates services
     /// that share an endpoint name across namespaces/components.
-    subject_instance: HashMap<String, EndpointInstanceId>,
+    subject_instance: DashMap<String, EndpointInstanceId>,
     /// EndpointInstanceId -> tagged subject UUIDs, for batch cancellation on
     /// removal. The `StreamType` tag tells `cancel_instance_streams` which
     /// of `rx_subjects` / `tx_subjects` holds the registration so both halves
     /// of a bidirectional session get dropped together.
-    instance_subjects: HashMap<EndpointInstanceId, HashSet<(StreamType, String)>>,
+    instance_subjects: DashMap<EndpointInstanceId, HashSet<(StreamType, String)>>,
     /// Tombstones (instance -> insertion time) close the
     /// `cancel_instance_streams` vs `associate_instance` race; entries expire
     /// after [`TOMBSTONE_TTL`].
-    removed_instances: HashMap<EndpointInstanceId, Instant>,
-    handle: Option<tokio::task::JoinHandle<Result<()>>>,
+    removed_instances: DashMap<EndpointInstanceId, Instant>,
 }
 
-/// Drop tombstones older than [`TOMBSTONE_TTL`]. Called lazily on every
-/// `associate_instance` / `cancel_instance_streams` to bound the set size.
-fn prune_tombstones(tombstones: &mut HashMap<EndpointInstanceId, Instant>, now: Instant) {
-    tombstones.retain(|_, ts| now.saturating_duration_since(*ts) < TOMBSTONE_TTL);
+impl StreamRegistries {
+    /// Drop tombstones older than [`TOMBSTONE_TTL`]. Called lazily on every
+    /// `associate_instance` / `cancel_instance_streams` to bound the set size.
+    fn prune_tombstones(&self, now: Instant) {
+        self.removed_instances
+            .retain(|_, ts| now.saturating_duration_since(*ts) < TOMBSTONE_TTL);
+    }
+
+    fn insert_request_stream(&self, subject: String, connection: RequestedSendConnection) {
+        self.tx_subjects.insert(subject, connection);
+    }
+
+    fn insert_response_stream(&self, subject: String, connection: RequestedRecvConnection) {
+        self.rx_subjects.insert(subject, connection);
+    }
+
+    fn remove_request_stream(&self, subject: &str) -> Option<RequestedSendConnection> {
+        let conn = self.tx_subjects.remove(subject).map(|(_, conn)| conn);
+        self.remove_subject_tracking(StreamType::Request, subject);
+        conn
+    }
+
+    fn remove_response_stream(&self, subject: &str) -> Option<RequestedRecvConnection> {
+        let conn = self.rx_subjects.remove(subject).map(|(_, conn)| conn);
+        self.remove_subject_tracking(StreamType::Response, subject);
+        conn
+    }
+
+    fn associate_subject(&self, kind: StreamType, subject: &str, id: &EndpointInstanceId) {
+        self.subject_instance
+            .insert(subject.to_string(), id.clone());
+        self.instance_subjects
+            .entry(id.clone())
+            .or_default()
+            .insert((kind, subject.to_string()));
+    }
+
+    fn remove_subject_tracking(&self, kind: StreamType, subject: &str) {
+        let Some((_, id)) = self.subject_instance.remove(subject) else {
+            return;
+        };
+
+        if let Some(mut subjects) = self.instance_subjects.get_mut(&id) {
+            subjects.remove(&(kind, subject.to_string()));
+        }
+        self.instance_subjects
+            .remove_if(&id, |_, subjects| subjects.is_empty());
+    }
+
+    fn cancel_registered_subject(&self, kind: StreamType, subject: &str) {
+        match kind {
+            StreamType::Request => {
+                self.tx_subjects.remove(subject);
+            }
+            StreamType::Response => {
+                self.rx_subjects.remove(subject);
+            }
+        }
+        self.remove_subject_tracking(kind, subject);
+    }
 }
 
 impl TcpStreamServer {
@@ -224,9 +279,9 @@ impl TcpStreamServer {
             }
         };
 
-        let state = Arc::new(Mutex::new(State::default()));
+        let registries = Arc::new(StreamRegistries::default());
 
-        let local_port = Self::start(local_ip.clone(), options.port, state.clone())
+        let (local_port, handle) = Self::start(local_ip.clone(), options.port, registries.clone())
             .await
             .map_err(|e| {
                 PipelineError::Generic(format!("Failed to start TcpStreamServer: {}", e))
@@ -237,7 +292,8 @@ impl TcpStreamServer {
         Ok(Arc::new(Self {
             local_ip,
             local_port,
-            state,
+            registries,
+            _handle: handle,
         }))
     }
 
@@ -259,10 +315,17 @@ impl TcpStreamServer {
         send_subject: Option<&str>,
         id: &EndpointInstanceId,
     ) -> bool {
-        let mut state = self.state.lock().await;
         let now = Instant::now();
-        prune_tombstones(&mut state.removed_instances, now);
-        if state.removed_instances.contains_key(id) {
+        self.registries.prune_tombstones(now);
+
+        self.registries
+            .associate_subject(StreamType::Response, recv_subject, id);
+        if let Some(s) = send_subject {
+            self.registries
+                .associate_subject(StreamType::Request, s, id);
+        }
+
+        if self.registries.removed_instances.contains_key(id) {
             // Instance was already removed -- cancel immediately.
             tracing::warn!(
                 recv_subject,
@@ -273,22 +336,13 @@ impl TcpStreamServer {
                 instance_id = id.instance_id,
                 "Cancelling subject immediately: instance already removed (tombstoned)"
             );
-            state.rx_subjects.remove(recv_subject);
+            self.registries
+                .cancel_registered_subject(StreamType::Response, recv_subject);
             if let Some(s) = send_subject {
-                state.tx_subjects.remove(s);
+                self.registries
+                    .cancel_registered_subject(StreamType::Request, s);
             }
             return false;
-        }
-        state
-            .subject_instance
-            .insert(recv_subject.to_string(), id.clone());
-        if let Some(s) = send_subject {
-            state.subject_instance.insert(s.to_string(), id.clone());
-        }
-        let entry = state.instance_subjects.entry(id.clone()).or_default();
-        entry.insert((StreamType::Response, recv_subject.to_string()));
-        if let Some(s) = send_subject {
-            entry.insert((StreamType::Request, s.to_string()));
         }
         true
     }
@@ -296,16 +350,8 @@ impl TcpStreamServer {
     /// Cancel one pending response-stream registration. Drops the
     /// `oneshot::Sender` so the waiting receiver resolves with `RecvError`.
     pub async fn cancel_recv_stream(&self, subject: &str) {
-        let mut state = self.state.lock().await;
-        state.rx_subjects.remove(subject);
-        if let Some(key) = state.subject_instance.remove(subject)
-            && let Some(subjects) = state.instance_subjects.get_mut(&key)
-        {
-            subjects.remove(&(StreamType::Response, subject.to_string()));
-            if subjects.is_empty() {
-                state.instance_subjects.remove(&key);
-            }
-        }
+        self.registries
+            .cancel_registered_subject(StreamType::Response, subject);
     }
 
     /// Cancel one pending request-stream registration. Parallel to
@@ -314,16 +360,8 @@ impl TcpStreamServer {
     /// `(StreamType::Request, _)` tag from `instance_subjects` so the per-
     /// instance bookkeeping stays consistent.
     pub async fn cancel_send_stream(&self, subject: &str) {
-        let mut state = self.state.lock().await;
-        state.tx_subjects.remove(subject);
-        if let Some(key) = state.subject_instance.remove(subject)
-            && let Some(subjects) = state.instance_subjects.get_mut(&key)
-        {
-            subjects.remove(&(StreamType::Request, subject.to_string()));
-            if subjects.is_empty() {
-                state.instance_subjects.remove(&key);
-            }
-        }
+        self.registries
+            .cancel_registered_subject(StreamType::Request, subject);
     }
 
     /// Cancel all pending streams for an instance — both response-side and
@@ -331,25 +369,17 @@ impl TcpStreamServer {
     /// `associate_instance` — and tombstone the id so any racing associate
     /// for the same id cancels too. Returns the number of streams cancelled.
     pub async fn cancel_instance_streams(&self, id: &EndpointInstanceId) -> usize {
-        let mut state = self.state.lock().await;
         let now = Instant::now();
-        prune_tombstones(&mut state.removed_instances, now);
-        state.removed_instances.insert(id.clone(), now);
-        let subjects = match state.instance_subjects.remove(id) {
-            Some(subjects) => subjects,
+        self.registries.prune_tombstones(now);
+        self.registries.removed_instances.insert(id.clone(), now);
+        let subjects = match self.registries.instance_subjects.remove(id) {
+            Some((_, subjects)) => subjects,
             None => return 0,
         };
         let count = subjects.len();
         for (kind, subject) in &subjects {
-            match kind {
-                StreamType::Response => {
-                    state.rx_subjects.remove(subject);
-                }
-                StreamType::Request => {
-                    state.tx_subjects.remove(subject);
-                }
-            }
-            state.subject_instance.remove(subject);
+            self.registries
+                .cancel_registered_subject(kind.clone(), subject);
         }
         count
     }
@@ -357,24 +387,19 @@ impl TcpStreamServer {
     /// Drop the tombstone for an instance that has reappeared in discovery,
     /// so future subjects for that identity are tracked normally.
     pub async fn clear_instance_tombstone(&self, id: &EndpointInstanceId) {
-        let mut state = self.state.lock().await;
-        state.removed_instances.remove(id);
+        self.registries.removed_instances.remove(id);
     }
 
-    #[allow(clippy::await_holding_lock)]
-    async fn start(local_ip: String, local_port: u16, state: Arc<Mutex<State>>) -> Result<u16> {
+    async fn start(
+        local_ip: String,
+        local_port: u16,
+        registries: Arc<StreamRegistries>,
+    ) -> Result<(u16, tokio::task::JoinHandle<Result<()>>)> {
         let addr = format!("{}:{}", local_ip, local_port);
-        let state_clone = state.clone();
-        let mut guard = state.lock().await;
-        if guard.handle.is_some() {
-            panic!("TcpStreamServer already started");
-        }
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<Result<u16>>();
-        let handle = tokio::spawn(tcp_listener(addr, state_clone, ready_tx));
-        guard.handle = Some(handle);
-        drop(guard);
+        let handle = tokio::spawn(tcp_listener(addr, registries, ready_tx));
         let local_port = ready_rx.await??;
-        Ok(local_port)
+        Ok((local_port, handle))
     }
 }
 
@@ -418,13 +443,11 @@ impl ResponseService for TcpStreamServer {
                 send_buffer_count: options.send_buffer_count,
             };
 
-            let mut state = self.state.lock().await;
-            state
-                .tx_subjects
-                .insert(sender_subject.clone(), connection_info);
+            self.registries
+                .insert_request_stream(sender_subject.clone(), connection_info);
 
             let cleanup_subject = sender_subject.clone();
-            let cleanup_state = self.state.clone();
+            let cleanup_registries = self.registries.clone();
             let registered_stream = RegisteredStream::new(
                 TcpStreamConnectionInfo {
                     address: address.clone(),
@@ -436,18 +459,10 @@ impl ResponseService for TcpStreamServer {
                 pending_sender_rx,
             )
             .with_cleanup(move || {
-                // Drop is sync; fire-and-forget the lock acquisition.
+                // Drop is sync; fire-and-forget any bookkeeping cleanup.
                 tokio::spawn(async move {
-                    let mut state = cleanup_state.lock().await;
-                    state.tx_subjects.remove(&cleanup_subject);
-                    if let Some(key) = state.subject_instance.remove(&cleanup_subject)
-                        && let Some(subjects) = state.instance_subjects.get_mut(&key)
-                    {
-                        subjects.remove(&(StreamType::Request, cleanup_subject.clone()));
-                        if subjects.is_empty() {
-                            state.instance_subjects.remove(&key);
-                        }
-                    }
+                    cleanup_registries
+                        .cancel_registered_subject(StreamType::Request, &cleanup_subject);
                 });
             });
 
@@ -466,13 +481,11 @@ impl ResponseService for TcpStreamServer {
                 send_buffer_count: options.send_buffer_count,
             };
 
-            let mut state = self.state.lock().await;
-            state
-                .rx_subjects
-                .insert(receiver_subject.clone(), connection_info);
+            self.registries
+                .insert_response_stream(receiver_subject.clone(), connection_info);
 
             let cleanup_subject = receiver_subject.clone();
-            let cleanup_state = self.state.clone();
+            let cleanup_registries = self.registries.clone();
             let registered_stream = RegisteredStream::new(
                 TcpStreamConnectionInfo {
                     address: address.clone(),
@@ -484,18 +497,10 @@ impl ResponseService for TcpStreamServer {
                 pending_recver_rx,
             )
             .with_cleanup(move || {
-                // Drop is sync; fire-and-forget the lock acquisition.
+                // Drop is sync; fire-and-forget any bookkeeping cleanup.
                 tokio::spawn(async move {
-                    let mut state = cleanup_state.lock().await;
-                    state.rx_subjects.remove(&cleanup_subject);
-                    if let Some(key) = state.subject_instance.remove(&cleanup_subject)
-                        && let Some(subjects) = state.instance_subjects.get_mut(&key)
-                    {
-                        subjects.remove(&(StreamType::Response, cleanup_subject.clone()));
-                        if subjects.is_empty() {
-                            state.instance_subjects.remove(&key);
-                        }
-                    }
+                    cleanup_registries
+                        .cancel_registered_subject(StreamType::Response, &cleanup_subject);
                 });
             });
 
@@ -519,7 +524,7 @@ impl ResponseService for TcpStreamServer {
 // to the sender
 async fn tcp_listener(
     addr: String,
-    state: Arc<Mutex<State>>,
+    registries: Arc<StreamRegistries>,
     read_tx: tokio::sync::oneshot::Sender<Result<u16>>,
 ) -> Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr)
@@ -575,13 +580,13 @@ async fn tcp_listener(
             }
         }
 
-        tokio::spawn(handle_connection(stream, state.clone()));
+        tokio::spawn(handle_connection(stream, registries.clone()));
     }
 
     // #[instrument(level = "trace"), skip(state)]
     // todo - clone before spawn and trace process_stream
-    async fn handle_connection(stream: tokio::net::TcpStream, state: Arc<Mutex<State>>) {
-        let result = process_stream(stream, state).await;
+    async fn handle_connection(stream: tokio::net::TcpStream, registries: Arc<StreamRegistries>) {
+        let result = process_stream(stream, registries).await;
         match result {
             Ok(_) => tracing::trace!("successfully processed tcp connection"),
             Err(e) => {
@@ -594,7 +599,10 @@ async fn tcp_listener(
 
     /// This method is responsible for the internal tcp stream handshake
     /// The handshake will specialize the stream as a request/sender or response/receiver stream
-    async fn process_stream(stream: tokio::net::TcpStream, state: Arc<Mutex<State>>) -> Result<()> {
+    async fn process_stream(
+        stream: tokio::net::TcpStream,
+        registries: Arc<StreamRegistries>,
+    ) -> Result<()> {
         // split the socket in to a reader and writer
         let (read_half, write_half) = tokio::io::split(stream);
 
@@ -625,10 +633,11 @@ async fn tcp_listener(
         // branch here to handle sender stream or receiver stream
         match handshake.stream_type {
             StreamType::Request => {
-                process_request_stream(handshake.subject, state, framed_reader, framed_writer).await
+                process_request_stream(handshake.subject, registries, framed_reader, framed_writer)
+                    .await
             }
             StreamType::Response => {
-                process_response_stream(handshake.subject, state, framed_reader, framed_writer)
+                process_response_stream(handshake.subject, registries, framed_reader, framed_writer)
                     .await
             }
         }
@@ -646,29 +655,17 @@ async fn tcp_listener(
     /// read half, on fatal error, downstream should drop the request stream.
     async fn process_request_stream(
         subject: String,
-        state: Arc<Mutex<State>>,
+        registries: Arc<StreamRegistries>,
         reader: FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
         writer: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>,
     ) -> Result<()> {
         // Request stream is unidirectional; we don't read from the downstream.
         drop(reader);
 
-        let request_stream = {
-            let mut guard = state.lock().await;
-            let conn = guard.tx_subjects.remove(&subject).ok_or(error!(
+        let request_stream = registries.remove_request_stream(&subject).ok_or(error!(
                 "Subject not found: {}; downstream subscriber specified a subject unknown to the upstream publisher",
                 subject
             ))?;
-            if let Some(key) = guard.subject_instance.remove(&subject)
-                && let Some(subjects) = guard.instance_subjects.get_mut(&key)
-            {
-                subjects.remove(&(StreamType::Request, subject.clone()));
-                if subjects.is_empty() {
-                    guard.instance_subjects.remove(&key);
-                }
-            }
-            conn
-        };
 
         let RequestedSendConnection {
             context,
@@ -767,26 +764,13 @@ async fn tcp_listener(
 
     async fn process_response_stream(
         subject: String,
-        state: Arc<Mutex<State>>,
+        registries: Arc<StreamRegistries>,
         mut reader: FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
         writer: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>,
     ) -> Result<()> {
-        let response_stream = {
-            let mut guard = state.lock().await;
-            let conn = guard
-                .rx_subjects
-                .remove(&subject)
-                .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
-            if let Some(key) = guard.subject_instance.remove(&subject)
-                && let Some(subjects) = guard.instance_subjects.get_mut(&key)
-            {
-                subjects.remove(&(StreamType::Response, subject.clone()));
-                if subjects.is_empty() {
-                    guard.instance_subjects.remove(&key);
-                }
-            }
-            conn
-        };
+        let response_stream = registries
+            .remove_response_stream(&subject)
+            .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
 
         // unwrap response_stream
         let RequestedRecvConnection {
@@ -1036,6 +1020,7 @@ mod tests {
     use crate::engine::AsyncEngineContextProvider;
     use crate::pipeline::Context;
     use crate::pipeline::network::DEFAULT_SEND_BUFFER_COUNT;
+    use crate::pipeline::network::tcp::client::TcpClient;
     use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf};
     use tokio::net::TcpStream;
 
@@ -1138,16 +1123,90 @@ mod tests {
 
         let _pending = server.register(options).await;
 
-        let state = server.state.lock().await;
-        assert_eq!(state.tx_subjects.len(), 1, "one request stream registered");
-        assert_eq!(state.rx_subjects.len(), 1, "one response stream registered");
+        assert_eq!(
+            server.registries.tx_subjects.len(),
+            1,
+            "one request stream registered"
+        );
+        assert_eq!(
+            server.registries.rx_subjects.len(),
+            1,
+            "one response stream registered"
+        );
         assert!(
-            state.tx_subjects.values().all(|c| c.send_buffer_count == 7),
+            server
+                .registries
+                .tx_subjects
+                .iter()
+                .all(|c| c.value().send_buffer_count == 7),
             "send_buffer_count must reach RequestedSendConnection"
         );
         assert!(
-            state.rx_subjects.values().all(|c| c.send_buffer_count == 7),
+            server
+                .registries
+                .rx_subjects
+                .iter()
+                .all(|c| c.value().send_buffer_count == 7),
             "send_buffer_count must reach RequestedRecvConnection"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_tcp_stream_server_concurrent_response_registration() {
+        const STREAMS: usize = 128;
+
+        let result = time::timeout(std::time::Duration::from_secs(20), async {
+            let options = ServerOptions::builder().port(0).build().unwrap();
+            let server = TcpStreamServer::new(options).await.unwrap();
+
+            let mut pending_streams = Vec::with_capacity(STREAMS);
+            let mut client_tasks = Vec::with_capacity(STREAMS);
+
+            for idx in 0..STREAMS {
+                let context = Context::new(());
+                let stream_options = StreamOptions::builder()
+                    .context(context.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap();
+
+                let pending_connection = server.register(stream_options).await;
+                let registered_stream = pending_connection.recv_stream.unwrap();
+                let (connection_info, stream_provider) = registered_stream.into_parts();
+                let client_context =
+                    Context::with_id_and_metadata((), context.id().to_string(), Default::default());
+                let payload = Bytes::from(format!("payload-{idx}"));
+
+                pending_streams.push((idx, payload.clone(), stream_provider));
+                client_tasks.push(tokio::spawn(async move {
+                    let mut sender = TcpClient::create_response_stream(
+                        client_context.context(),
+                        connection_info,
+                        None,
+                    )
+                    .await
+                    .unwrap();
+                    sender.send_prologue(None).await.unwrap();
+                    sender.send(payload).await.unwrap();
+                }));
+            }
+
+            for task in client_tasks {
+                task.await.unwrap();
+            }
+
+            for (idx, expected, stream_provider) in pending_streams {
+                let mut stream = stream_provider.await.unwrap().unwrap();
+                let actual = stream.rx.recv().await.unwrap();
+                assert_eq!(actual, expected, "payload mismatch for stream {idx}");
+            }
+        })
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "concurrent response stream registration timed out"
         );
     }
 
@@ -1438,10 +1497,7 @@ mod tests {
         let subject = tcp_info.subject.clone();
 
         // Verify it's in rx_subjects
-        {
-            let state = server.state.lock().await;
-            assert!(state.rx_subjects.contains_key(&subject));
-        }
+        assert!(server.registries.rx_subjects.contains_key(&subject));
 
         // Drop the RegisteredStream -- RAII cleanup should fire
         drop(recv_stream);
@@ -1450,13 +1506,10 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Verify it's been removed from rx_subjects
-        {
-            let state = server.state.lock().await;
-            assert!(
-                !state.rx_subjects.contains_key(&subject),
-                "RAII cleanup should have removed the rx_subjects entry"
-            );
-        }
+        assert!(
+            !server.registries.rx_subjects.contains_key(&subject),
+            "RAII cleanup should have removed the rx_subjects entry"
+        );
     }
 
     #[tokio::test]
@@ -1485,13 +1538,10 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // The entry should still be in rx_subjects (cleanup was disarmed)
-        {
-            let state = server.state.lock().await;
-            assert!(
-                state.rx_subjects.contains_key(&subject),
-                "into_parts() should disarm the RAII cleanup"
-            );
-        }
+        assert!(
+            server.registries.rx_subjects.contains_key(&subject),
+            "into_parts() should disarm the RAII cleanup"
+        );
     }
 
     #[tokio::test]
@@ -1642,10 +1692,7 @@ mod tests {
 
         // Tombstone the identity.
         server.cancel_instance_streams(&id).await;
-        {
-            let state = server.state.lock().await;
-            assert!(state.removed_instances.contains_key(&id));
-        }
+        assert!(server.registries.removed_instances.contains_key(&id));
 
         // Advance past the TTL.
         tokio::time::advance(TOMBSTONE_TTL + Duration::from_secs(1)).await;
@@ -1660,13 +1707,10 @@ mod tests {
 
         // The expired tombstone must have been pruned (lazy pruning fires on
         // every associate_instance/cancel_instance_streams call).
-        {
-            let state = server.state.lock().await;
-            assert!(
-                !state.removed_instances.contains_key(&id),
-                "expired tombstone should be pruned, not retained"
-            );
-        }
+        assert!(
+            !server.registries.removed_instances.contains_key(&id),
+            "expired tombstone should be pruned, not retained"
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -1702,16 +1746,15 @@ mod tests {
         tokio::time::advance(TOMBSTONE_TTL + Duration::from_secs(1)).await;
         server.cancel_instance_streams(&id_new).await;
 
-        let state = server.state.lock().await;
         assert!(
-            !state.removed_instances.contains_key(&id_old),
+            !server.registries.removed_instances.contains_key(&id_old),
             "old tombstone should be pruned by the next cancel_instance_streams call"
         );
         assert!(
-            state.removed_instances.contains_key(&id_new),
+            server.registries.removed_instances.contains_key(&id_new),
             "fresh tombstone should be retained"
         );
-        assert_eq!(state.removed_instances.len(), 1);
+        assert_eq!(server.registries.removed_instances.len(), 1);
     }
 
     #[tokio::test]
@@ -1728,9 +1771,8 @@ mod tests {
         server.cancel_instance_streams(&id_a).await;
         server.clear_instance_tombstone(&id_b).await;
 
-        let state = server.state.lock().await;
         assert!(
-            state.removed_instances.contains_key(&id_a),
+            server.registries.removed_instances.contains_key(&id_a),
             "clearing a different identity must not remove id_a's tombstone"
         );
     }


### PR DESCRIPTION
## Summary

- Replace the hot `TcpStreamServer` response/request stream registry mutex with sharded `DashMap` registries.
- Move the listener task handle out of the registry state.
- Preserve endpoint-instance tombstone/cancellation behavior with concurrent registry bookkeeping.
- Add a concurrent response registration/call-home regression test.

## Why

I've been looking into benchmarks of how the Dynamo frontend scales with higher concurrencies, especially in scenarios where the frontend is not cpu-bound.

## Benchmark Evidence

Focused 8 worker, concurrency 1024, ISL 256, OSL 32, 50k prompts, frontend CPU request/limit 32, KV routing enabled:

| case | output tok/s | req/s | frontend CPU avg/max | worker CPU avg/max |
| --- | ---: | ---: | ---: | ---: |
| before | 21458.1 | 670.6 | 19.3% / 37.1% of 32 cores | 3.10 / 7.20 cores per worker |
| after | 22893.9 | 715.4 | 20.8% / 23.7% of 32 cores | 4.04 / 5.42 cores per worker |

Observed throughput improvement: **+6.7% output tok/s**.

CPU was not saturated in either run. Frontend average CPU stayed around 20% of its 32-core limit, and workers stayed well below their CPU allocation.

Registry timing also collapsed in the diagnostic run:

| metric | before N=8 avg/p99 | after N=8 avg/p99 |
| --- | ---: | ---: |
| request-plane `pre_send` | 14.07 / 49.10 ms | 0.05 / 0.40 ms |
| `response_stream_register` | 14.032 / 49.095 ms | 0.011 / 0.050 ms |
| frontend registry access | 14.019 / 49.092 ms | 0.001 / 0.010 ms |
| TCP call-home lookup access | 13.719 / 48.874 ms | 0.003 / 0.010 ms |

## Validation

- `cargo fmt`
- `cargo test -p dynamo-runtime tcp_stream_server -- --nocapture`
- `cargo test -p dynamo-runtime pipeline::network::tcp::server::tests -- --nocapture`
- `cargo check -p dynamo-runtime`
