### PR TITLE
fix(vllm): clamp kv_used_blocks >=0 in metrics publisher

### DIFF
--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -61,7 +61,9 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
         if scheduler_stats is None:
             return
 
-        active_decode_blocks = int(self.num_gpu_block * scheduler_stats.kv_cache_usage)
+        # Clamp >=0: an offloading KV connector can drive kv_cache_usage negative,
+        # and publish() rejects negative kv_used_blocks (unsigned) -> engine crash.
+        active_decode_blocks = max(0, int(self.num_gpu_block * scheduler_stats.kv_cache_usage))
         self.inner.publish(self.dp_rank, kv_used_blocks=active_decode_blocks)
 
         dp_rank_str = str(self.dp_rank)


### PR DESCRIPTION
## Problem

When a KV **offloading** connector is active (e.g. `SimpleCPUOffloadConnector`, `OffloadingConnector`), vLLM's `scheduler_stats.kv_cache_usage` can go **negative** — offloaded blocks are counted as available, so free blocks exceed the physical GPU total and the usage fraction drops below zero.

In `components/src/dynamo/vllm/publisher.py`:

```python
active_decode_blocks = int(self.num_gpu_block * scheduler_stats.kv_cache_usage)
self.inner.publish(self.dp_rank, kv_used_blocks=active_decode_blocks)
```

a negative `kv_cache_usage` yields a negative `active_decode_blocks`, and the Rust `KvMetricsPublisher.publish()` binding rejects a negative `kv_used_blocks` (it's unsigned), raising:

```
OverflowError: can't convert negative int to unsigned
```

This propagates out of the AsyncLLM `output_handler`, trips `EngineDeadError`, and crash-loops the worker. Reproduced on DeepSeek-V4-Flash (vLLM 0.23.0) with `SimpleCPUOffloadConnector` under real traffic — the worker boots and serves, then dies the moment the connector drives usage negative.

## Fix

Clamp `kv_used_blocks` to `>= 0`. A negative used-block count is never meaningful for the router, and the metric is purely informational.

```python
active_decode_blocks = max(0, int(self.num_gpu_block * scheduler_stats.kv_cache_usage))
```

One line, no behavior change for the non-offloading path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash when publishing block counts by ensuring the active decode block value is never negative.
  * Improved stability in cases where cache usage data may be invalid or below zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->