### PR TITLE
fix(observability): idempotent logging init + disagg span-link test deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,6 +2861,7 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
+ "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ tracing-subscriber = { version = "0.3", features = [
     "local-time",
     "json",
 ] }
+tracing-log = { version = "0.2" }
 tracing-opentelemetry = { version = "0.32.0" }
 opentelemetry = { version = "0.31.0", features = ["trace", "logs"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["trace", "logs", "rt-tokio"] }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1847,6 +1847,7 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
+ "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
+ "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -58,6 +58,7 @@ tower-http = { workspace = true }
 tracing = { workspace = true }
 mio = { workspace = true }
 tracing-subscriber = { workspace = true }
+tracing-log = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -847,6 +847,7 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
+ "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -1248,7 +1248,10 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::registry()
         .with(l)
         .with(tokio_console_layer.with_filter(tokio_console_target))
-        .init();
+        .try_init()
+        .unwrap_or_else(|e| {
+            eprintln!("dynamo logging: subscriber already initialized, skipping install: {e}")
+        });
     Ok(())
 }
 
@@ -1373,7 +1376,12 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
                     .with(otel_logs_layer)
                     .with(DistributedTraceIdLayer.with_filter(trace_filter_layer))
                     .with($fmt_layer)
-                    .init();
+                    .try_init()
+                    .unwrap_or_else(|e| {
+                        eprintln!(
+                            "dynamo logging: subscriber already initialized, skipping install: {e}"
+                        )
+                    });
             };
         }
 
@@ -1402,7 +1410,12 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
             .with_writer(std::io::stderr)
             .with_filter(fmt_filter_layer);
 
-        tracing_subscriber::registry().with(l).init();
+        tracing_subscriber::registry()
+            .with(l)
+            .try_init()
+            .unwrap_or_else(|e| {
+                eprintln!("dynamo logging: subscriber already initialized, skipping install: {e}")
+            });
     }
 
     Ok(())
@@ -2116,12 +2129,9 @@ pub mod tests {
 
     #[test]
     fn inject_trace_headers_preserves_current_span_flags() {
-        // Use the core `set_default` (not `SubscriberInitExt::set_default`, which
-        // also installs the global `log` LogTracer and would poison a later
-        // `logging::init()` with SetLoggerError).
-        let _guard = tracing::subscriber::set_default(
-            tracing_subscriber::registry().with(DistributedTraceIdLayer),
-        );
+        let _guard = tracing_subscriber::registry()
+            .with(DistributedTraceIdLayer)
+            .set_default();
         let span = tracing::info_span!(
             "root",
             trace_id = "11111111111111111111111111111111",
@@ -2141,12 +2151,9 @@ pub mod tests {
 
     #[test]
     fn request_span_preserves_inbound_trace_flags() {
-        // Use the core `set_default` (not `SubscriberInitExt::set_default`, which
-        // also installs the global `log` LogTracer and would poison a later
-        // `logging::init()` with SetLoggerError).
-        let _guard = tracing::subscriber::set_default(
-            tracing_subscriber::registry().with(DistributedTraceIdLayer),
-        );
+        let _guard = tracing_subscriber::registry()
+            .with(DistributedTraceIdLayer)
+            .set_default();
         let req = Request::builder()
             .header(
                 "traceparent",
@@ -2179,14 +2186,10 @@ pub mod tests {
             .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOff)
             .build();
         let tracer = provider.tracer("test");
-        // Core `set_default` (not `SubscriberInitExt::set_default`) to avoid
-        // installing the global `log` LogTracer, which would poison a later
-        // `logging::init()` with SetLoggerError.
-        let _guard = tracing::subscriber::set_default(
-            tracing_subscriber::registry()
-                .with(tracing_opentelemetry::layer().with_tracer(tracer))
-                .with(DistributedTraceIdLayer),
-        );
+        let _guard = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .with(DistributedTraceIdLayer)
+            .set_default();
         let span = tracing::info_span!("root");
         let _enter = span.enter();
         let mut headers = std::collections::HashMap::new();
@@ -2208,14 +2211,10 @@ pub mod tests {
             .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn)
             .build();
         let tracer = provider.tracer("test");
-        // Core `set_default` (not `SubscriberInitExt::set_default`) to avoid
-        // installing the global `log` LogTracer, which would poison a later
-        // `logging::init()` with SetLoggerError.
-        let _guard = tracing::subscriber::set_default(
-            tracing_subscriber::registry()
-                .with(tracing_opentelemetry::layer().with_tracer(tracer))
-                .with(DistributedTraceIdLayer),
-        );
+        let _guard = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .with(DistributedTraceIdLayer)
+            .set_default();
         let span = tracing::info_span!("root");
         let _enter = span.enter();
         let mut headers = std::collections::HashMap::new();

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -90,7 +90,6 @@ use tracing_subscriber::layer::SubscriberExt;
 use std::time::Duration;
 use tracing::{info, instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::config::environment_names::logging as env_logging;
 
@@ -293,6 +292,45 @@ fn span_events_for_logging() -> FmtSpan {
     } else {
         FmtSpan::NONE
     }
+}
+
+/// Install `subscriber` as the process-global default, returning whether the
+/// install happened.
+///
+/// Mirrors `SubscriberInitExt::try_init` but distinguishes its two failure
+/// modes, which have opposite outcomes:
+///
+/// - the global dispatcher is already set (e.g. a host application in an
+///   embedded context) → the subscriber was NOT installed → returns `false`
+///   so callers can skip dependent side effects;
+/// - the dispatcher install succeeded but a `log`-crate logger already exists
+///   (e.g. a scoped `set_default` elsewhere installed `LogTracer`, the
+///   original double-init trigger) → the subscriber IS live, only the
+///   `log` bridge couldn't be re-registered → warns and returns `true`.
+///
+/// `try_init` collapses both into `Err`. Failures are reported via
+/// `tracing::warn!` rather than stderr: on every failure path a live
+/// dispatcher exists (ours or a pre-existing one) to route the event, and
+/// stderr would bypass JSONL formatting.
+fn install_global_subscriber(subscriber: impl Into<tracing::Dispatch>) -> bool {
+    if let Err(e) = tracing::dispatcher::set_global_default(subscriber.into()) {
+        tracing::warn!(
+            "dynamo logging: global tracing subscriber already set, skipping install: {e}"
+        );
+        return false;
+    }
+    // The dispatcher is ours from here. Bridge `log` records into `tracing`
+    // as `try_init` would, propagating the max-level hint so disabled `log`
+    // records are skipped cheaply.
+    if let Err(e) = tracing_log::LogTracer::builder()
+        .with_max_level(tracing_log::AsLog::as_log(
+            &tracing::level_filters::LevelFilter::current(),
+        ))
+        .init()
+    {
+        tracing::warn!("dynamo logging: `log` logger already registered, leaving it in place: {e}");
+    }
+    true
 }
 
 fn log_otel_init_status(service_name: &str, endpoint_opt: Option<(OtlpProtocol, String)>) {
@@ -1232,10 +1270,25 @@ pub fn init() {
 
 #[cfg(feature = "tokio-console")]
 fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
-    let tokio_console_layer = console_subscriber::ConsoleLayer::builder()
+    // Build the console layer and server separately (rather than
+    // `Builder::spawn()`, which starts the server immediately) so the server
+    // only starts if our subscriber actually installs. Otherwise a lost init
+    // race would leave a console server thread listening with no layer
+    // feeding it.
+    let (console_layer, console_server) = console_subscriber::ConsoleLayer::builder()
         .with_default_env()
         .server_addr(([0, 0, 0, 0], console_subscriber::Server::DEFAULT_PORT))
-        .spawn();
+        .build();
+    // Replicates the filter `Builder::spawn()` applies to the layer: only
+    // tokio/runtime instrumentation reaches the console layer.
+    fn console_filter(meta: &tracing::Metadata<'_>) -> bool {
+        if meta.is_event() {
+            return meta.target().starts_with("runtime") || meta.target().starts_with("tokio");
+        }
+        meta.name().starts_with("runtime.") || meta.target().starts_with("tokio")
+    }
+    let tokio_console_layer =
+        console_layer.with_filter(tracing_subscriber::filter::FilterFn::new(console_filter));
     let tokio_console_target = tracing_subscriber::filter::Targets::new()
         .with_default(LevelFilter::ERROR)
         .with_target("runtime", LevelFilter::TRACE)
@@ -1245,13 +1298,31 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
         .event_format(fmt::format().compact().with_timer(TimeFormatter::new()))
         .with_writer(std::io::stderr)
         .with_filter(filters(load_config()));
-    tracing_subscriber::registry()
-        .with(l)
-        .with(tokio_console_layer.with_filter(tokio_console_target))
-        .try_init()
-        .unwrap_or_else(|e| {
-            eprintln!("dynamo logging: subscriber already initialized, skipping install: {e}")
-        });
+    let installed = install_global_subscriber(
+        tracing_subscriber::registry()
+            .with(l)
+            .with(tokio_console_layer.with_filter(tokio_console_target)),
+    );
+    if installed {
+        // What `Builder::spawn()` does, deferred until the subscriber is
+        // ours: serve on a dedicated single-threaded runtime, with tracing
+        // disabled on that thread so the server does not instrument itself.
+        std::thread::Builder::new()
+            .name("console_subscriber".into())
+            .spawn(move || {
+                let _subscriber_guard =
+                    tracing::subscriber::set_default(tracing::subscriber::NoSubscriber::default());
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_io()
+                    .enable_time()
+                    .build()
+                    .expect("console subscriber runtime initialization failed");
+                runtime
+                    .block_on(console_server.serve())
+                    .expect("console subscriber server failed");
+            })
+            .expect("console subscriber could not spawn thread");
+    }
     Ok(())
 }
 
@@ -1352,14 +1423,6 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
             (provider, None, None)
         };
 
-        // Register the provider globally so direct OTel API users
-        // (`opentelemetry::global::tracer(...)`) hit the same exporter as
-        // the tracing-opentelemetry bridge below. Without this, ad-hoc
-        // OTel spans created via `global::tracer()` go to the default
-        // no-op provider and are silently dropped.
-        // Cheap — `SdkTracerProvider` is Arc-shared internally.
-        opentelemetry::global::set_tracer_provider(tracer_provider.clone());
-
         let tracer = tracer_provider.tracer(service_name.to_string());
         let otel_logs_layer = logger_provider_opt
             .as_ref()
@@ -1367,42 +1430,51 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 
         macro_rules! init_otel_subscriber {
             ($fmt_layer:expr) => {
-                tracing_subscriber::registry()
-                    .with(
-                        tracing_opentelemetry::layer()
-                            .with_tracer(tracer)
-                            .with_filter(otel_filter_layer),
-                    )
-                    .with(otel_logs_layer)
-                    .with(DistributedTraceIdLayer.with_filter(trace_filter_layer))
-                    .with($fmt_layer)
-                    .try_init()
-                    .unwrap_or_else(|e| {
-                        eprintln!(
-                            "dynamo logging: subscriber already initialized, skipping install: {e}"
+                install_global_subscriber(
+                    tracing_subscriber::registry()
+                        .with(
+                            tracing_opentelemetry::layer()
+                                .with_tracer(tracer)
+                                .with_filter(otel_filter_layer),
                         )
-                    });
+                        .with(otel_logs_layer)
+                        .with(DistributedTraceIdLayer.with_filter(trace_filter_layer))
+                        .with($fmt_layer),
+                )
             };
         }
 
-        if jsonl_enabled {
+        let installed = if jsonl_enabled {
             let l = fmt::layer()
                 .with_ansi(false)
                 .with_span_events(span_events_for_logging())
                 .event_format(CustomJsonFormatter::new())
                 .with_writer(std::io::stderr)
                 .with_filter(fmt_filter_layer);
-            init_otel_subscriber!(l);
+            init_otel_subscriber!(l)
         } else {
             let l = fmt::layer()
                 .with_ansi(!disable_ansi_logging())
                 .event_format(fmt::format().compact().with_timer(TimeFormatter::new()))
                 .with_writer(std::io::stderr)
                 .with_filter(fmt_filter_layer);
-            init_otel_subscriber!(l);
-        }
+            init_otel_subscriber!(l)
+        };
 
-        log_otel_init_status(&service_name, endpoint_opt);
+        // Register the provider globally so direct OTel API users
+        // (`opentelemetry::global::tracer(...)`) hit the same exporter as
+        // the tracing-opentelemetry bridge above. Without this, ad-hoc
+        // OTel spans created via `global::tracer()` go to the default
+        // no-op provider and are silently dropped.
+        // Cheap — `SdkTracerProvider` is Arc-shared internally.
+        // Gated on the install: if we lost the init race, swapping the
+        // global provider would orphan its batch-exporter threads and
+        // clobber a host application's provider; left unregistered, the
+        // provider shuts its exporters down on drop.
+        if installed {
+            opentelemetry::global::set_tracer_provider(tracer_provider.clone());
+            log_otel_init_status(&service_name, endpoint_opt);
+        }
     } else {
         let l = fmt::layer()
             .with_ansi(!disable_ansi_logging())
@@ -1410,12 +1482,7 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
             .with_writer(std::io::stderr)
             .with_filter(fmt_filter_layer);
 
-        tracing_subscriber::registry()
-            .with(l)
-            .try_init()
-            .unwrap_or_else(|e| {
-                eprintln!("dynamo logging: subscriber already initialized, skipping install: {e}")
-            });
+        install_global_subscriber(tracing_subscriber::registry().with(l));
     }
 
     Ok(())
@@ -2129,9 +2196,12 @@ pub mod tests {
 
     #[test]
     fn inject_trace_headers_preserves_current_span_flags() {
-        let _guard = tracing_subscriber::registry()
-            .with(DistributedTraceIdLayer)
-            .set_default();
+        // The free function scopes only the dispatcher; the trait method
+        // `SubscriberInitExt::set_default` would also permanently install the
+        // global `LogTracer`, leaking state into later tests.
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::registry().with(DistributedTraceIdLayer),
+        );
         let span = tracing::info_span!(
             "root",
             trace_id = "11111111111111111111111111111111",
@@ -2151,9 +2221,12 @@ pub mod tests {
 
     #[test]
     fn request_span_preserves_inbound_trace_flags() {
-        let _guard = tracing_subscriber::registry()
-            .with(DistributedTraceIdLayer)
-            .set_default();
+        // The free function scopes only the dispatcher; the trait method
+        // `SubscriberInitExt::set_default` would also permanently install the
+        // global `LogTracer`, leaking state into later tests.
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::registry().with(DistributedTraceIdLayer),
+        );
         let req = Request::builder()
             .header(
                 "traceparent",
@@ -2186,10 +2259,11 @@ pub mod tests {
             .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOff)
             .build();
         let tracer = provider.tracer("test");
-        let _guard = tracing_subscriber::registry()
-            .with(tracing_opentelemetry::layer().with_tracer(tracer))
-            .with(DistributedTraceIdLayer)
-            .set_default();
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::registry()
+                .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                .with(DistributedTraceIdLayer),
+        );
         let span = tracing::info_span!("root");
         let _enter = span.enter();
         let mut headers = std::collections::HashMap::new();
@@ -2211,10 +2285,11 @@ pub mod tests {
             .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn)
             .build();
         let tracer = provider.tracer("test");
-        let _guard = tracing_subscriber::registry()
-            .with(tracing_opentelemetry::layer().with_tracer(tracer))
-            .with(DistributedTraceIdLayer)
-            .set_default();
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::registry()
+                .with(tracing_opentelemetry::layer().with_tracer(tracer))
+                .with(DistributedTraceIdLayer),
+        );
         let span = tracing::info_span!("root");
         let _enter = span.enter();
         let mut headers = std::collections::HashMap::new();

--- a/lib/runtime/tests/logging_double_init_dispatcher.rs
+++ b/lib/runtime/tests/logging_double_init_dispatcher.rs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Double-init behavior when a global tracing dispatcher is already set.
+//!
+//! Embedded scenario: a host application (e.g. a Python process with its own
+//! telemetry) installed a global tracing subscriber before dynamo's
+//! `logging::init()` ran. Dynamo's subscriber cannot install, so `init()`
+//! must not perform the global OTel side effects either: swapping the global
+//! tracer provider would orphan its batch-exporter threads and clobber the
+//! host's provider. The provider it built must be left unregistered (and
+//! thereby shut down on drop).
+//!
+//! Must stay in its own integration-test binary: it manipulates
+//! process-global logger/dispatcher/provider state.
+
+use opentelemetry::trace::{Span, Tracer};
+
+#[test]
+fn init_with_preexisting_dispatcher_skips_otel_side_effects() {
+    // Simulate the host application owning tracing for this process.
+    tracing::dispatcher::set_global_default(tracing::Dispatch::new(tracing_subscriber::registry()))
+        .expect("first dispatcher install must succeed");
+
+    // JSONL mode exercises the OTel branch with a local-only provider
+    // (no OTLP exporter, no network).
+    // SAFETY: single-threaded at this point; this binary owns the process.
+    unsafe { std::env::set_var("DYN_LOGGING_JSONL", "1") };
+
+    // Old `.init()` behavior would panic here; must warn and continue.
+    dynamo_runtime::logging::init();
+
+    // The subscriber install was skipped, so the global OTel provider must
+    // still be the default noop provider: spans from the global tracer have
+    // invalid (all-zero) contexts. A valid context means `init()` swapped in
+    // its provider despite losing the init race — the leak/hijack bug.
+    let mut span = opentelemetry::global::tracer("probe").start("probe-span");
+    assert!(
+        !span.span_context().is_valid(),
+        "global tracer provider was swapped despite the subscriber install \
+         being skipped (orphans exporter threads, hijacks the host's provider)"
+    );
+    span.end();
+}

--- a/lib/runtime/tests/logging_double_init_log_logger.rs
+++ b/lib/runtime/tests/logging_double_init_log_logger.rs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Double-init behavior when a `log`-crate logger is already installed.
+//!
+//! This is the scenario that originally broke CI: a scoped
+//! `SubscriberInitExt::set_default()` elsewhere in the process permanently
+//! installs the global `LogTracer`, then `logging::init()` runs. The global
+//! tracing dispatcher slot is still free, so dynamo's subscriber (including
+//! the OTel layer) installs successfully — only the `log` bridge cannot be
+//! re-registered. `init()` must treat this as a successful install: no panic,
+//! and the global OTel tracer provider must be swapped in so direct
+//! `opentelemetry::global::tracer()` users get real (non-noop) spans.
+//!
+//! Must stay in its own integration-test binary: it manipulates
+//! process-global logger/dispatcher/provider state.
+
+use opentelemetry::trace::{Span, Tracer};
+
+#[test]
+fn init_with_preexisting_log_logger_still_installs_otel() {
+    // Simulate the poisoned state: a global `log` logger already registered.
+    tracing_log::LogTracer::init().expect("first LogTracer install must succeed");
+
+    // JSONL mode exercises the OTel branch with a local-only provider
+    // (no OTLP exporter, no network).
+    // SAFETY: single-threaded at this point; this binary owns the process.
+    unsafe { std::env::set_var("DYN_LOGGING_JSONL", "1") };
+
+    // Old `.init()` behavior would panic here; the subscriber itself must
+    // install fine since the dispatcher slot is free.
+    dynamo_runtime::logging::init();
+
+    // The install succeeded, so the global OTel provider must have been
+    // swapped in: spans from the global tracer carry real (valid) contexts.
+    // A noop provider would yield an all-zero, invalid span context.
+    let mut span = opentelemetry::global::tracer("probe").start("probe-span");
+    assert!(
+        span.span_context().is_valid(),
+        "global tracer provider was not registered even though the \
+         subscriber installed (log-bridge failure must not gate OTel side effects)"
+    );
+    span.end();
+}

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -362,6 +362,7 @@ class SampleUnifiedWorkerProcess(ManagedProcess):
         worker_id: str = "sample-worker",
         extra_args: list | None = None,
         extra_env: dict | None = None,
+        wait_for_frontend_model: bool = True,
     ):
         self.worker_id = worker_id
         self.frontend_port = frontend_port
@@ -395,13 +396,25 @@ class SampleUnifiedWorkerProcess(ManagedProcess):
         except FileNotFoundError:
             pass
 
+        # In disaggregated mode a single worker (prefill OR decode alone) never
+        # makes the model appear on /v1/models — the frontend only publishes it
+        # once the full prefill+decode set registers (decode-completeness gate).
+        # So callers starting workers one at a time must gate each worker on its
+        # own system /health and defer the model-served check to
+        # wait_for_http_completions_ready after the whole set is up.
+        health_check_urls = [
+            (f"http://localhost:{system_port}/health", self.is_ready),
+        ]
+        if wait_for_frontend_model:
+            health_check_urls.insert(
+                0,
+                (f"http://localhost:{frontend_port}/v1/models", self._check_models_api),
+            )
+
         super().__init__(
             command=command,
             env=env,
-            health_check_urls=[
-                (f"http://localhost:{frontend_port}/v1/models", self._check_models_api),
-                (f"http://localhost:{system_port}/health", self.is_ready),
-            ],
+            health_check_urls=health_check_urls,
             timeout=120,
             display_output=True,
             terminate_all_matching_process_names=False,

--- a/tests/frontend/test_unified_worker_otlp_export.py
+++ b/tests/frontend/test_unified_worker_otlp_export.py
@@ -417,6 +417,11 @@ def test_disagg_decode_span_links_to_prefill_span(
             disaggregation_mode="prefill",
             extra_env=otel_env,
             worker_id="sample-prefill",
+            # Disagg: the model isn't published to /v1/models until BOTH prefill
+            # and decode register, and decode starts only after this worker is
+            # ready. Gate on its own /health and let wait_for_http_completions_ready
+            # (after both are up) confirm the model is served — else deadlock.
+            wait_for_frontend_model=False,
         ):
             with SampleUnifiedWorkerProcess(
                 request,
@@ -427,6 +432,7 @@ def test_disagg_decode_span_links_to_prefill_span(
                 disaggregation_mode="decode",
                 extra_env=otel_env,
                 worker_id="sample-decode",
+                wait_for_frontend_model=False,
             ):
                 wait_for_http_completions_ready(
                     frontend_port=frontend_port, model=TEST_MODEL


### PR DESCRIPTION
## Summary

Two independent issues found while investigating CI/test failures after #10980 (squash-merged). Both are pre-existing on `main`; neither is exercised by the gating CI today.

### 1. `dynamo-runtime` logging-init test isolation (fixes `rust-tests`)
`setup_logging()` used `SubscriberInitExt::init()`, which **panics** if a global subscriber or a `log` logger (`LogTracer`) is already installed — and that panic **poisons the `INIT` `Once`**, cascading panics into every later `logging::init()`. The trace-flag tests added in #10980 call `SubscriberInitExt::set_default()`, which installs the global `log` logger as a side effect, so a subsequent `logging::init()` panicked and took down 6 unrelated tests (`shared_tcp_endpoint`, `storage::kv`).

**Fix:** use `try_init()` at the three subscriber-install sites and warn (instead of panic) on the already-initialized path. Production startup calls `init()` first, so the happy path is unchanged; this only makes a double-init graceful and idempotent.

### 2. Disagg span-link e2e test startup deadlock
`test_disagg_decode_span_links_to_prefill_span` started the prefill worker and blocked in `__enter__` waiting for `/v1/models`, but in disaggregated serving the frontend only publishes the model once **both** prefill and decode register — and decode was only started *inside* prefill's `with` block. Deadlock → 120s timeout.

**Fix:** `SampleUnifiedWorkerProcess(wait_for_frontend_model=False)` so disagg workers gate on their own system `/health`; `wait_for_http_completions_ready` (after both are up) confirms the model is served.

## Validation
- `cargo test -p dynamo-runtime --lib` → **424 passed; 0 failed** (excluding `transport_resolution_falls_back_when_selected_instance_disappears`, a pre-existing local-only flake that passes in CI).
- `cargo fmt` + `cargo clippy -p dynamo-runtime --lib -D warnings` clean.
- Disagg test ran green end-to-end in a local container (both workers start, chat request served, decode→prefill span-link assertions pass).

## Note (follow-up, not in this PR)
`tests/frontend/test_unified_worker_otlp_export.py` is `post_merge` + `gpu_0` + no backend marker, so **no CI job selects it** (post-merge non-backend job is still `pre_merge`-only per a TODO in `post-merge-ci.yml`). Worth widening coverage so these tests actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging startup so the app no longer fails if tracing is already configured; it now skips re-installing logging and continues normally.
  * Made worker startup readiness more flexible, reducing hangs in distributed startup scenarios by allowing model checks to be deferred until all components are available.

* **Tests**
  * Updated test setup to match the new startup behavior and avoid readiness deadlocks during distributed tracing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->