### PR TITLE
perf(kvbm): consume offload progress incrementally

### DIFF
--- a/lib/kvbm-engine/src/offload/handle.rs
+++ b/lib/kvbm-engine/src/offload/handle.rs
@@ -10,6 +10,7 @@
 //! - Cancellation with confirmation
 
 use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use tokio::sync::watch;
@@ -104,6 +105,89 @@ pub struct TransferResult {
     pub error: Option<String>,
 }
 
+/// Monotonic block counts for a transfer.
+///
+/// Counts are published through a watch channel, while the corresponding block
+/// IDs remain in shared progress storage. This keeps progress notifications
+/// constant-size regardless of the number of blocks in the transfer.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TransferProgressCounts {
+    /// Blocks accepted by policy evaluation.
+    pub passed: usize,
+    /// Blocks transferred successfully.
+    pub completed: usize,
+    /// Blocks whose transfer failed.
+    pub failed: usize,
+}
+
+impl TransferProgressCounts {
+    /// Number of blocks that have reached either success or failure.
+    pub fn settled(self) -> usize {
+        self.completed.saturating_add(self.failed)
+    }
+}
+
+/// Per-consumer cursor for incrementally reading transfer progress.
+///
+/// A cursor belongs to one transfer. Create it with
+/// [`TransferHandle::new_progress_cursor`] and retain it at the consumer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransferProgressCursor {
+    transfer_id: TransferId,
+    passed: usize,
+    completed: usize,
+    failed: usize,
+}
+
+/// Blocks appended since a [`TransferProgressCursor`] was last consumed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TransferProgressDelta {
+    /// Blocks newly accepted by policy evaluation.
+    pub passed_blocks: Vec<BlockId>,
+    /// Blocks newly transferred successfully.
+    pub completed_blocks: Vec<BlockId>,
+    /// Blocks whose transfer newly failed.
+    pub failed_blocks: Vec<BlockId>,
+}
+
+impl TransferProgressDelta {
+    /// Whether the cursor observed no new progress.
+    pub fn is_empty(&self) -> bool {
+        self.passed_blocks.is_empty()
+            && self.completed_blocks.is_empty()
+            && self.failed_blocks.is_empty()
+    }
+}
+
+#[derive(Debug)]
+struct TransferProgress {
+    input_blocks: Vec<BlockId>,
+    policy_evaluated: bool,
+    passed_blocks: Vec<BlockId>,
+    completed_blocks: Vec<BlockId>,
+    failed_blocks: Vec<BlockId>,
+}
+
+impl TransferProgress {
+    fn new(input_blocks: Vec<BlockId>) -> Self {
+        Self {
+            input_blocks,
+            policy_evaluated: false,
+            passed_blocks: Vec::new(),
+            completed_blocks: Vec::new(),
+            failed_blocks: Vec::new(),
+        }
+    }
+
+    fn counts(&self) -> TransferProgressCounts {
+        TransferProgressCounts {
+            passed: self.passed_blocks.len(),
+            completed: self.completed_blocks.len(),
+            failed: self.failed_blocks.len(),
+        }
+    }
+}
+
 /// Handle for tracking and controlling an offload transfer.
 ///
 /// Obtained from `OffloadEngine::enqueue()`. Use this to:
@@ -114,10 +198,8 @@ pub struct TransferResult {
 pub struct TransferHandle {
     id: TransferId,
     status_rx: watch::Receiver<TransferStatus>,
-    passed_blocks_rx: watch::Receiver<Vec<BlockId>>,
-    completed_rx: watch::Receiver<Vec<BlockId>>,
-    failed_rx: watch::Receiver<Vec<BlockId>>,
-    remaining_rx: watch::Receiver<Vec<BlockId>>,
+    progress: Arc<RwLock<TransferProgress>>,
+    progress_rx: watch::Receiver<TransferProgressCounts>,
     cancel_token: CancellationToken,
     result_rx: watch::Receiver<Option<TransferResult>>,
 }
@@ -135,22 +217,94 @@ impl TransferHandle {
 
     /// Get blocks that passed all filter policies.
     pub fn passed_blocks(&self) -> Vec<BlockId> {
-        self.passed_blocks_rx.borrow().clone()
+        self.progress
+            .read()
+            .expect("transfer progress lock poisoned")
+            .passed_blocks
+            .clone()
     }
 
     /// Get blocks that have been successfully transferred.
     pub fn completed_blocks(&self) -> Vec<BlockId> {
-        self.completed_rx.borrow().clone()
+        self.progress
+            .read()
+            .expect("transfer progress lock poisoned")
+            .completed_blocks
+            .clone()
     }
 
     /// Get blocks that failed transfer.
     pub fn failed_blocks(&self) -> Vec<BlockId> {
-        self.failed_rx.borrow().clone()
+        self.progress
+            .read()
+            .expect("transfer progress lock poisoned")
+            .failed_blocks
+            .clone()
     }
 
     /// Get blocks remaining to be transferred.
     pub fn remaining_blocks(&self) -> Vec<BlockId> {
-        self.remaining_rx.borrow().clone()
+        let progress = self
+            .progress
+            .read()
+            .expect("transfer progress lock poisoned");
+        if !progress.policy_evaluated {
+            return progress.input_blocks.clone();
+        }
+
+        let settled: HashSet<_> = progress
+            .completed_blocks
+            .iter()
+            .chain(&progress.failed_blocks)
+            .copied()
+            .collect();
+        progress
+            .passed_blocks
+            .iter()
+            .filter(|id| !settled.contains(id))
+            .copied()
+            .collect()
+    }
+
+    /// Return constant-size progress counts without cloning block vectors.
+    pub fn progress_counts(&self) -> TransferProgressCounts {
+        *self.progress_rx.borrow()
+    }
+
+    /// Create a cursor that consumes this transfer's progress from the start.
+    pub fn new_progress_cursor(&self) -> TransferProgressCursor {
+        TransferProgressCursor {
+            transfer_id: self.id,
+            passed: 0,
+            completed: 0,
+            failed: 0,
+        }
+    }
+
+    /// Read each newly passed, completed, or failed block exactly once for this
+    /// cursor, then advance the cursor to the current progress boundary.
+    pub fn consume_progress(&self, cursor: &mut TransferProgressCursor) -> TransferProgressDelta {
+        assert_eq!(
+            cursor.transfer_id, self.id,
+            "transfer progress cursor used with a different handle"
+        );
+        let progress = self
+            .progress
+            .read()
+            .expect("transfer progress lock poisoned");
+        assert!(cursor.passed <= progress.passed_blocks.len());
+        assert!(cursor.completed <= progress.completed_blocks.len());
+        assert!(cursor.failed <= progress.failed_blocks.len());
+
+        let delta = TransferProgressDelta {
+            passed_blocks: progress.passed_blocks[cursor.passed..].to_vec(),
+            completed_blocks: progress.completed_blocks[cursor.completed..].to_vec(),
+            failed_blocks: progress.failed_blocks[cursor.failed..].to_vec(),
+        };
+        cursor.passed = progress.passed_blocks.len();
+        cursor.completed = progress.completed_blocks.len();
+        cursor.failed = progress.failed_blocks.len();
+        delta
     }
 
     /// Check if the transfer is complete (success, cancelled, or failed).
@@ -204,25 +358,21 @@ impl TransferHandle {
         self.status_rx.clone()
     }
 
-    /// Subscribe to completed-block progress.
-    pub fn subscribe_completed(&self) -> watch::Receiver<Vec<BlockId>> {
-        self.completed_rx.clone()
-    }
-
-    /// Subscribe to failed-block progress.
-    pub fn subscribe_failed(&self) -> watch::Receiver<Vec<BlockId>> {
-        self.failed_rx.clone()
+    /// Subscribe to constant-size block progress counts.
+    pub fn subscribe_progress(&self) -> watch::Receiver<TransferProgressCounts> {
+        self.progress_rx.clone()
     }
 }
 
 impl std::fmt::Debug for TransferHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let progress = self.progress_counts();
         f.debug_struct("TransferHandle")
             .field("id", &self.id)
             .field("status", &self.status())
-            .field("passed_count", &self.passed_blocks().len())
-            .field("completed_count", &self.completed_blocks().len())
-            .field("failed_count", &self.failed_blocks().len())
+            .field("passed_count", &progress.passed)
+            .field("completed_count", &progress.completed)
+            .field("failed_count", &progress.failed)
             .field("remaining_count", &self.remaining_blocks().len())
             .finish()
     }
@@ -234,16 +384,11 @@ pub(crate) struct TransferState {
     pub(crate) id: TransferId,
     /// Current phase
     pub(crate) status: TransferStatus,
-    /// Original input block IDs
-    pub(crate) input_blocks: Vec<BlockId>,
-    /// Blocks that passed policy filters
-    pub(crate) passed_blocks: Vec<BlockId>,
+    /// Shared cumulative block progress. Consumers use monotonic cursors so
+    /// scheduler ticks copy only newly settled IDs.
+    progress: Arc<RwLock<TransferProgress>>,
     /// Blocks currently in-flight (being transferred)
     pub(crate) in_flight: HashSet<BlockId>,
-    /// Successfully transferred blocks
-    pub(crate) completed: Vec<BlockId>,
-    /// Blocks that failed transfer
-    pub(crate) failed: Vec<BlockId>,
     /// Blocks that failed filters
     pub(crate) filtered_out: Vec<BlockId>,
     /// Error message if failed
@@ -268,30 +413,22 @@ impl TransferState {
     /// Create transfer state and associated handle.
     pub(crate) fn new(id: TransferId, input_blocks: Vec<BlockId>) -> (Self, TransferHandle) {
         let (status_tx, status_rx) = watch::channel(TransferStatus::Evaluating);
-        let (passed_tx, passed_rx) = watch::channel(Vec::new());
-        let (completed_tx, completed_rx) = watch::channel(Vec::new());
-        let (failed_tx, failed_rx) = watch::channel(Vec::new());
-        let (remaining_tx, remaining_rx) = watch::channel(input_blocks.clone());
+        let progress = Arc::new(RwLock::new(TransferProgress::new(input_blocks)));
+        let (progress_tx, progress_rx) = watch::channel(TransferProgressCounts::default());
         let (result_tx, result_rx) = watch::channel(None);
         let (cancel_token, cancel_updater) = CancellationToken::new();
 
         let notifiers = TransferNotifiers {
             status_tx,
-            passed_tx,
-            completed_tx,
-            failed_tx,
-            remaining_tx,
+            progress_tx,
             result_tx,
         };
 
         let state = TransferState {
             id,
             status: TransferStatus::Evaluating,
-            input_blocks: input_blocks.clone(),
-            passed_blocks: Vec::new(),
+            progress: progress.clone(),
             in_flight: HashSet::new(),
-            completed: Vec::new(),
-            failed: Vec::new(),
             filtered_out: Vec::new(),
             error: None,
             notifiers,
@@ -304,10 +441,8 @@ impl TransferState {
         let handle = TransferHandle {
             id,
             status_rx,
-            passed_blocks_rx: passed_rx,
-            completed_rx,
-            failed_rx,
-            remaining_rx,
+            progress,
+            progress_rx,
             cancel_token,
             result_rx,
         };
@@ -328,15 +463,21 @@ impl TransferState {
 
     /// Add blocks that passed filters.
     pub(crate) fn add_passed(&mut self, block_ids: impl IntoIterator<Item = BlockId>) {
-        self.passed_blocks.extend(block_ids);
-        let _ = self.notifiers.passed_tx.send(self.passed_blocks.clone());
-        self.update_remaining();
+        let counts = {
+            let mut progress = self
+                .progress
+                .write()
+                .expect("transfer progress lock poisoned");
+            progress.policy_evaluated = true;
+            progress.passed_blocks.extend(block_ids);
+            progress.counts()
+        };
+        let _ = self.notifiers.progress_tx.send(counts);
     }
 
     /// Add blocks that were filtered out.
     pub(crate) fn add_filtered(&mut self, block_ids: impl IntoIterator<Item = BlockId>) {
         self.filtered_out.extend(block_ids);
-        self.update_remaining();
     }
 
     /// Mark blocks as in-flight (being transferred).
@@ -346,33 +487,36 @@ impl TransferState {
 
     /// Mark blocks as completed (transferred successfully).
     pub(crate) fn mark_completed(&mut self, block_ids: impl IntoIterator<Item = BlockId>) {
-        for id in block_ids {
-            self.in_flight.remove(&id);
-            self.completed.push(id);
+        let completed: Vec<_> = block_ids.into_iter().collect();
+        for id in &completed {
+            self.in_flight.remove(id);
         }
-        let _ = self.notifiers.completed_tx.send(self.completed.clone());
-        self.update_remaining();
+        let counts = {
+            let mut progress = self
+                .progress
+                .write()
+                .expect("transfer progress lock poisoned");
+            progress.completed_blocks.extend(completed);
+            progress.counts()
+        };
+        let _ = self.notifiers.progress_tx.send(counts);
     }
 
     /// Mark blocks as failed (transfer unsuccessful).
     pub(crate) fn mark_failed(&mut self, block_ids: impl IntoIterator<Item = BlockId>) {
-        for id in block_ids {
-            self.in_flight.remove(&id);
-            self.failed.push(id);
+        let failed: Vec<_> = block_ids.into_iter().collect();
+        for id in &failed {
+            self.in_flight.remove(id);
         }
-        let _ = self.notifiers.failed_tx.send(self.failed.clone());
-        self.update_remaining();
-    }
-
-    /// Update remaining blocks notification.
-    fn update_remaining(&self) {
-        let remaining: Vec<BlockId> = self
-            .passed_blocks
-            .iter()
-            .filter(|id| !self.completed.contains(id) && !self.failed.contains(id))
-            .copied()
-            .collect();
-        let _ = self.notifiers.remaining_tx.send(remaining);
+        let counts = {
+            let mut progress = self
+                .progress
+                .write()
+                .expect("transfer progress lock poisoned");
+            progress.failed_blocks.extend(failed);
+            progress.counts()
+        };
+        let _ = self.notifiers.progress_tx.send(counts);
     }
 
     /// Set error and mark as failed.
@@ -397,16 +541,27 @@ impl TransferState {
 
     /// Finalize and send result.
     fn finalize(&mut self) {
+        let progress = self
+            .progress
+            .read()
+            .expect("transfer progress lock poisoned");
         let result = TransferResult {
             id: self.id,
             status: self.status,
-            passed_blocks: self.passed_blocks.clone(),
-            completed_blocks: self.completed.clone(),
-            failed_blocks: self.failed.clone(),
+            passed_blocks: progress.passed_blocks.clone(),
+            completed_blocks: progress.completed_blocks.clone(),
+            failed_blocks: progress.failed_blocks.clone(),
             filtered_blocks: self.filtered_out.clone(),
             error: self.error.clone(),
         };
         let _ = self.notifiers.result_tx.send(Some(result));
+    }
+
+    pub(crate) fn progress_counts(&self) -> TransferProgressCounts {
+        self.progress
+            .read()
+            .expect("transfer progress lock poisoned")
+            .counts()
     }
 
     /// Get current in-flight count (for draining).
@@ -429,10 +584,7 @@ impl TransferState {
 #[allow(dead_code)]
 pub(crate) struct TransferNotifiers {
     pub(crate) status_tx: watch::Sender<TransferStatus>,
-    pub(crate) passed_tx: watch::Sender<Vec<BlockId>>,
-    pub(crate) completed_tx: watch::Sender<Vec<BlockId>>,
-    pub(crate) failed_tx: watch::Sender<Vec<BlockId>>,
-    pub(crate) remaining_tx: watch::Sender<Vec<BlockId>>,
+    pub(crate) progress_tx: watch::Sender<TransferProgressCounts>,
     pub(crate) result_tx: watch::Sender<Option<TransferResult>>,
 }
 
@@ -465,9 +617,7 @@ mod tests {
 
         assert_eq!(state.id, id);
         assert_eq!(state.status, TransferStatus::Evaluating);
-        assert_eq!(state.input_blocks, blocks);
-        assert!(state.passed_blocks.is_empty());
-        assert!(state.completed.is_empty());
+        assert_eq!(state.progress_counts(), TransferProgressCounts::default());
 
         assert_eq!(handle.id(), id);
         assert_eq!(handle.status(), TransferStatus::Evaluating);
@@ -564,7 +714,7 @@ mod tests {
     fn test_partial_failure_result() {
         let id = TransferId::new();
         let blocks = vec![1, 2, 3, 4, 5];
-        let (mut state, _handle) = TransferState::new(id, blocks);
+        let (mut state, handle) = TransferState::new(id, blocks);
 
         state.add_passed(vec![1, 2, 3]);
         state.add_filtered(vec![4, 5]);
@@ -574,22 +724,53 @@ mod tests {
         state.mark_completed(vec![1, 3]);
         state.mark_failed(vec![2]);
 
-        assert_eq!(state.completed, vec![1, 3]);
-        assert_eq!(state.failed, vec![2]);
+        assert_eq!(handle.completed_blocks(), vec![1, 3]);
+        assert_eq!(handle.failed_blocks(), vec![2]);
         assert_eq!(state.in_flight_count(), 0);
 
         // Simulate the pipeline's terminal state logic
-        let total = state.passed_blocks.len() + state.filtered_out.len();
-        let done = state.completed.len() + state.failed.len() + state.filtered_out.len();
+        let progress = state.progress_counts();
+        let total = progress.passed + state.filtered_out.len();
+        let done = progress.settled() + state.filtered_out.len();
         assert_eq!(done, total);
 
         // With failures, should set_error not set_complete
-        let failed_count = state.failed.len();
+        let failed_count = progress.failed;
         assert!(failed_count > 0);
         state.set_error(format!(
             "{failed_count} blocks failed to transfer to object storage",
         ));
         assert_eq!(state.status, TransferStatus::Failed);
+    }
+
+    #[test]
+    fn test_progress_cursor_consumes_each_block_once() {
+        let id = TransferId::new();
+        let (mut state, handle) = TransferState::new(id, vec![1, 2, 3]);
+        let mut cursor = handle.new_progress_cursor();
+
+        state.add_passed([1, 2, 3]);
+        state.mark_completed([1]);
+        let first = handle.consume_progress(&mut cursor);
+        assert_eq!(first.passed_blocks, vec![1, 2, 3]);
+        assert_eq!(first.completed_blocks, vec![1]);
+        assert!(first.failed_blocks.is_empty());
+
+        state.mark_completed([2]);
+        state.mark_failed([3]);
+        let second = handle.consume_progress(&mut cursor);
+        assert!(second.passed_blocks.is_empty());
+        assert_eq!(second.completed_blocks, vec![2]);
+        assert_eq!(second.failed_blocks, vec![3]);
+        assert!(handle.consume_progress(&mut cursor).is_empty());
+        assert_eq!(
+            handle.progress_counts(),
+            TransferProgressCounts {
+                passed: 3,
+                completed: 2,
+                failed: 1,
+            }
+        );
     }
 
     #[tokio::test]

--- a/lib/kvbm-engine/src/offload/mod.rs
+++ b/lib/kvbm-engine/src/offload/mod.rs
@@ -108,7 +108,10 @@ mod cancel_tests;
 // Re-export public API
 pub use cancel::{CancelConfirmation, CancelState, CancellationToken};
 pub use engine::{OffloadEngine, OffloadEngineBuilder};
-pub use handle::{TransferHandle, TransferId, TransferResult, TransferStatus};
+pub use handle::{
+    TransferHandle, TransferId, TransferProgressCounts, TransferProgressCursor,
+    TransferProgressDelta, TransferResult, TransferStatus,
+};
 pub use pending::{PendingGuard, PendingTracker};
 pub use pipeline::{
     ObjectPipeline, ObjectPipelineBuilder, ObjectPipelineConfig, Pipeline, PipelineBuilder,

--- a/lib/kvbm-engine/src/offload/pipeline.rs
+++ b/lib/kvbm-engine/src/offload/pipeline.rs
@@ -1457,16 +1457,17 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
             let end_xfer = Instant::now();
 
             // Register each transferred block in the destination tier
-            let registered_blocks: Vec<ImmutableBlock<Dst>> = dst_blocks
+            let completed_blocks = dst_blocks
                 .into_iter()
                 .zip(sequence_hashes.iter())
                 .map(|(dst_block, seq_hash)| {
-                    let complete = dst_block
+                    dst_block
                         .stage(*seq_hash, shared.dst_manager.block_size())
-                        .expect("block size mismatch");
-                    shared.dst_manager.register_block(complete)
+                        .expect("block size mismatch")
                 })
                 .collect();
+            let registered_blocks: Vec<ImmutableBlock<Dst>> =
+                shared.dst_manager.register_blocks(completed_blocks);
 
             let registration_timepoint = Instant::now();
 
@@ -1560,15 +1561,16 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
             let mut state_guard = state.lock().unwrap();
             state_guard.mark_completed(block_ids);
 
-            let total = state_guard.passed_blocks.len() + state_guard.filtered_out.len();
-            let done = state_guard.completed.len() + state_guard.filtered_out.len();
+            let progress = state_guard.progress_counts();
+            let total = progress.passed + state_guard.filtered_out.len();
+            let done = progress.completed + state_guard.filtered_out.len();
             tracing::debug!(
                 %transfer_id,
                 total,
                 done,
-                passed = state_guard.passed_blocks.len(),
+                passed = progress.passed,
                 filtered = state_guard.filtered_out.len(),
-                completed = state_guard.completed.len(),
+                completed = progress.completed,
                 "Transfer batch progress"
             );
             if done >= total && total > 0 {
@@ -1929,22 +1931,21 @@ impl<Src: BlockMetadata> ObjectTransferExecutor<Src> {
                 }
             }
 
-            let total = state_guard.passed_blocks.len() + state_guard.filtered_out.len();
-            let done = state_guard.completed.len()
-                + state_guard.failed.len()
-                + state_guard.filtered_out.len();
+            let progress = state_guard.progress_counts();
+            let total = progress.passed + state_guard.filtered_out.len();
+            let done = progress.settled() + state_guard.filtered_out.len();
             tracing::debug!(
                 %transfer_id,
                 total,
                 done,
-                passed = state_guard.passed_blocks.len(),
+                passed = progress.passed,
                 filtered = state_guard.filtered_out.len(),
-                completed = state_guard.completed.len(),
-                failed = state_guard.failed.len(),
+                completed = progress.completed,
+                failed = progress.failed,
                 "Object transfer batch progress"
             );
             if done >= total && total > 0 {
-                let failed_count = state_guard.failed.len();
+                let failed_count = progress.failed;
                 if failed_count == 0 {
                     state_guard.set_complete();
                 } else {
@@ -2094,8 +2095,8 @@ mod tests {
 
         // Verify: block 20 (hash_fail) should be in failed, not completed
         let state_guard = state_arc.lock().unwrap();
-        assert_eq!(state_guard.completed, vec![10, 30]);
-        assert_eq!(state_guard.failed, vec![20]);
+        assert_eq!(handle.completed_blocks(), vec![10, 30]);
+        assert_eq!(handle.failed_blocks(), vec![20]);
         assert_eq!(state_guard.in_flight.len(), 0);
         assert_eq!(state_guard.status, TransferStatus::Failed);
         assert!(state_guard.error.is_some());
@@ -2162,8 +2163,8 @@ mod tests {
             .expect("execute_transfer should succeed");
 
         let state_guard = state_arc.lock().unwrap();
-        assert_eq!(state_guard.completed, vec![10, 20]);
-        assert!(state_guard.failed.is_empty());
+        assert_eq!(handle.completed_blocks(), vec![10, 20]);
+        assert!(handle.failed_blocks().is_empty());
         assert_eq!(state_guard.status, TransferStatus::Complete);
 
         drop(state_guard);
@@ -2253,8 +2254,8 @@ mod tests {
 
         // Transfer A: block 100 succeeded, block 200 failed
         let sa = state_a_arc.lock().unwrap();
-        assert_eq!(sa.completed, vec![100]);
-        assert_eq!(sa.failed, vec![200]);
+        assert_eq!(handle_a.completed_blocks(), vec![100]);
+        assert_eq!(handle_a.failed_blocks(), vec![200]);
         assert_eq!(sa.status, TransferStatus::Failed);
         assert!(sa.error.is_some());
         drop(sa);
@@ -2264,8 +2265,8 @@ mod tests {
 
         // Transfer B: both succeeded
         let sb = state_b_arc.lock().unwrap();
-        assert_eq!(sb.completed, vec![300, 400]);
-        assert!(sb.failed.is_empty());
+        assert_eq!(handle_b.completed_blocks(), vec![300, 400]);
+        assert!(handle_b.failed_blocks().is_empty());
         assert_eq!(sb.status, TransferStatus::Complete);
         drop(sb);
 

--- a/lib/kvbm-logical/src/manager/mod.rs
+++ b/lib/kvbm-logical/src/manager/mod.rs
@@ -91,9 +91,26 @@ impl<T: BlockMetadata + Sync> BlockManager<T> {
 
     /// Register a batch of completed blocks.
     pub fn register_blocks(&self, blocks: Vec<CompleteBlock<T>>) -> Vec<ImmutableBlock<T>> {
-        blocks
+        if blocks.is_empty() {
+            return Vec::new();
+        }
+
+        let handles = self
+            .block_registry
+            .register_sequence_hashes(blocks.iter().map(CompleteBlock::sequence_hash));
+        let batch_size = blocks.len();
+        let registered = self.store.register_completed_blocks(
+            blocks.into_iter().zip(handles).collect(),
+            self.duplication_policy,
+        );
+        // The offline settlement bridge observes this counter as a
+        // publication watermark, so publish only after every store transition
+        // and presence marker in the batch is complete.
+        self.metrics
+            .inc_registrations_by(u64::try_from(batch_size).unwrap_or(u64::MAX));
+        registered
             .into_iter()
-            .map(|block| self.register_block(block))
+            .map(ImmutableBlock::from_inner)
             .collect()
     }
 

--- a/lib/kvbm-logical/src/metrics/pool_metrics.rs
+++ b/lib/kvbm-logical/src/metrics/pool_metrics.rs
@@ -96,7 +96,13 @@ impl BlockPoolMetrics {
 
     #[inline(always)]
     pub fn inc_registrations(&self) {
-        self.registrations.fetch_add(1, Ordering::Relaxed);
+        self.inc_registrations_by(1);
+    }
+
+    /// Increment registrations after a completed batch becomes visible.
+    #[inline(always)]
+    pub fn inc_registrations_by(&self, n: u64) {
+        self.registrations.fetch_add(n, Ordering::Relaxed);
     }
 
     #[inline(always)]

--- a/lib/kvbm-logical/src/pools/store.rs
+++ b/lib/kvbm-logical/src/pools/store.rs
@@ -626,29 +626,78 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         handle: BlockRegistrationHandle,
         policy: BlockDuplicationPolicy,
     ) -> Arc<ImmutableBlockInner<T>> {
-        let block_id = block.block_id();
-        let seq_hash = block.sequence_hash();
-        debug_assert_eq!(seq_hash, handle.seq_hash());
-
         // Disarm the guard up front so the slot stays in `Staged` state
         // when we transition; we re-arm only on the Reject path.
         let mut block = block;
         block.disarm();
 
         let mut inner = self.inner.lock();
-        let existing = self.acquire_for_hash_locked(&mut inner, seq_hash, false);
+        let (result, presence_added) =
+            self.register_completed_block_locked(&mut inner, &mut block, &handle, policy);
 
-        // Whether we added a new presence-bearing slot (Primary or
-        // Duplicate). Reject does not, since the slot returns to Reset.
-        let mut presence_added = false;
+        drop(inner);
 
-        let result = if let Some(existing_primary) = existing {
+        // mark_present takes the attachments lock; lock-order
+        // (attachments → store) is satisfied because the store lock has
+        // already been released. Skip on Reject — no new presence-bearing
+        // slot was created.
+        if presence_added {
+            handle.mark_present::<T>();
+        }
+
+        // Block guard drops here: armed=false on Allow/fresh paths
+        // (slot already transitioned), armed=true on Reject (releases
+        // Staged → Reset).
+        drop(block);
+        result
+    }
+
+    /// Register a batch while acquiring the store mutex only once.
+    pub(crate) fn register_completed_blocks(
+        self: &Arc<Self>,
+        blocks: Vec<(CompleteBlock<T>, BlockRegistrationHandle)>,
+        policy: BlockDuplicationPolicy,
+    ) -> Vec<Arc<ImmutableBlockInner<T>>> {
+        let mut registrations = Vec::with_capacity(blocks.len());
+        let mut inner = self.inner.lock();
+        for (mut block, handle) in blocks {
+            block.disarm();
+            let (result, presence_added) =
+                self.register_completed_block_locked(&mut inner, &mut block, &handle, policy);
+            registrations.push((block, handle, presence_added, result));
+        }
+        drop(inner);
+
+        let mut results = Vec::with_capacity(registrations.len());
+        for (block, handle, presence_added, result) in registrations {
+            if presence_added {
+                handle.mark_present::<T>();
+            }
+            drop(block);
+            results.push(result);
+        }
+        results
+    }
+
+    fn register_completed_block_locked(
+        self: &Arc<Self>,
+        inner: &mut BlockStoreInner<T>,
+        block: &mut CompleteBlock<T>,
+        handle: &BlockRegistrationHandle,
+        policy: BlockDuplicationPolicy,
+    ) -> (Arc<ImmutableBlockInner<T>>, bool) {
+        let block_id = block.block_id();
+        let seq_hash = block.sequence_hash();
+        debug_assert_eq!(seq_hash, handle.seq_hash());
+        let existing = self.acquire_for_hash_locked(inner, seq_hash, false);
+
+        if let Some(existing_primary) = existing {
             assert_ne!(
                 existing_primary.block_id(),
                 block_id,
                 "register_completed_block: collision with same block_id {block_id}"
             );
-            match policy {
+            return match policy {
                 BlockDuplicationPolicy::Allow => {
                     debug_assert!(matches!(
                         inner.slots[block_id].state,
@@ -667,50 +716,29 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
                         inner: Arc::downgrade(&inner_arc),
                     };
                     self.metrics.inc_duplicate_blocks();
-                    presence_added = true;
-                    inner_arc
+                    (inner_arc, true)
                 }
                 BlockDuplicationPolicy::Reject => {
                     self.metrics.inc_registration_dedup();
-                    // Re-arm so the block guard's drop releases the slot
-                    // (Staged → Reset) when it falls out of scope below.
                     block.rearm();
-                    existing_primary
+                    (existing_primary, false)
                 }
-            }
-        } else {
-            // Fresh primary.
-            debug_assert!(matches!(
-                inner.slots[block_id].state,
-                SlotState::Staged { .. }
-            ));
-            let inner_arc =
-                ImmutableBlockInner::new_primary(self.clone(), block_id, seq_hash, handle.clone());
-            inner.slots[block_id].state = SlotState::Primary {
-                seq_hash,
-                handle: handle.clone(),
-                inner: Arc::downgrade(&inner_arc),
             };
-            inner.active_by_hash.insert(seq_hash, block_id);
-            presence_added = true;
-            inner_arc
-        };
-
-        drop(inner);
-
-        // mark_present takes the attachments lock; lock-order
-        // (attachments → store) is satisfied because the store lock has
-        // already been released. Skip on Reject — no new presence-bearing
-        // slot was created.
-        if presence_added {
-            handle.mark_present::<T>();
         }
 
-        // Block guard drops here: armed=false on Allow/fresh paths
-        // (slot already transitioned), armed=true on Reject (releases
-        // Staged → Reset).
-        drop(block);
-        result
+        debug_assert!(matches!(
+            inner.slots[block_id].state,
+            SlotState::Staged { .. }
+        ));
+        let inner_arc =
+            ImmutableBlockInner::new_primary(self.clone(), block_id, seq_hash, handle.clone());
+        inner.slots[block_id].state = SlotState::Primary {
+            seq_hash,
+            handle: handle.clone(),
+            inner: Arc::downgrade(&inner_arc),
+        };
+        inner.active_by_hash.insert(seq_hash, block_id);
+        (inner_arc, true)
     }
 
     /// Internal helper: under the store lock, transition a Primary slot to

--- a/lib/kvbm-logical/src/registry/mod.rs
+++ b/lib/kvbm-logical/src/registry/mod.rs
@@ -43,6 +43,7 @@ use crate::{events::EventsManager, tinylfu::FrequencyTracker};
 
 use crate::blocks::SequenceHash;
 
+use std::collections::BTreeMap;
 use std::sync::{Arc, Weak};
 
 use handle::BlockRegistrationHandleInner;
@@ -248,6 +249,61 @@ impl BlockRegistry {
         self.touch(seq_hash);
 
         handle
+    }
+
+    /// Register a batch of sequence hashes in input order.
+    pub fn register_sequence_hashes(
+        &self,
+        seq_hashes: impl IntoIterator<Item = SequenceHash>,
+    ) -> Vec<BlockRegistrationHandle> {
+        let seq_hashes: Vec<_> = seq_hashes.into_iter().collect();
+        if seq_hashes.is_empty() {
+            return Vec::new();
+        }
+
+        let mut by_position = BTreeMap::<u64, Vec<(usize, SequenceHash)>>::new();
+        for (index, seq_hash) in seq_hashes.iter().copied().enumerate() {
+            by_position
+                .entry(seq_hash.position())
+                .or_default()
+                .push((index, seq_hash));
+        }
+
+        let mut registered = vec![None; seq_hashes.len()];
+        let mut newly_created = vec![false; seq_hashes.len()];
+        for hashes in by_position.into_values() {
+            let map = self.prt.prefix(&hashes[0].1);
+            for (index, seq_hash) in hashes {
+                let mut weak = map.entry(seq_hash).or_default();
+                let (inner, is_new) = match weak.upgrade() {
+                    Some(inner) => (inner, false),
+                    None => {
+                        let inner = self.create_registration(seq_hash);
+                        *weak = Arc::downgrade(&inner);
+                        (inner, true)
+                    }
+                };
+                registered[index] = Some(BlockRegistrationHandle::from_inner(inner));
+                newly_created[index] = is_new;
+            }
+        }
+
+        registered
+            .into_iter()
+            .zip(newly_created)
+            .map(|(handle, is_new)| {
+                let handle = handle.expect("every batched sequence hash must be registered");
+                if is_new {
+                    if let Some(event_manager) = &self.event_manager
+                        && let Err(e) = event_manager.on_block_registered(&handle)
+                    {
+                        tracing::warn!("Failed to register block with event manager: {}", e);
+                    }
+                    self.touch(handle.seq_hash());
+                }
+                handle
+            })
+            .collect()
     }
 
     /// Internal method for transferring block registration without triggering frequency tracking.

--- a/lib/kvbm-logical/src/registry/tests.rs
+++ b/lib/kvbm-logical/src/registry/tests.rs
@@ -47,6 +47,27 @@ fn register_one<T: crate::blocks::BlockMetadata + Sync>(
 }
 
 #[test]
+fn test_batch_registration_preserves_order_and_reuses_duplicate_handle() {
+    let registry = BlockRegistry::new();
+    let first = create_test_token_block(&[1, 2, 3, 4]).kvbm_sequence_hash();
+    let second = create_test_token_block(&[5, 6, 7, 8]).kvbm_sequence_hash();
+    let handles = registry.register_sequence_hashes([first, second, first]);
+
+    assert_eq!(
+        handles
+            .iter()
+            .map(BlockRegistrationHandle::seq_hash)
+            .collect::<Vec<_>>(),
+        vec![first, second, first]
+    );
+    handles[0].attach_unique(17_u64).unwrap();
+    assert_eq!(
+        handles[2].get::<u64>().with_unique(|value| *value),
+        Some(17)
+    );
+}
+
+#[test]
 fn test_type_tracking_enforcement() {
     let registry = BlockRegistry::new();
     let seq_hash = create_test_token_block(&[1, 2, 3, 4]).kvbm_sequence_hash();

--- a/lib/mocker/src/kvbm_offload/engine.rs
+++ b/lib/mocker/src/kvbm_offload/engine.rs
@@ -34,7 +34,7 @@ use kvbm_engine::object::ObjectBlockOps;
 use kvbm_engine::offload::{
     ExternalBlock, ObjectPipelineBuilder, ObjectPresenceFilter, OffloadEngine, PendingTracker,
     PipelineBuilder, PresenceFilter, S3PresenceChecker, SourceBlocks, TransferHandle,
-    TransferStatus,
+    TransferProgressCursor, TransferStatus,
 };
 use kvbm_engine::worker::Worker;
 use kvbm_engine::{BlockId, G1 as EngineG1, G2, G3, SequenceHash};
@@ -231,7 +231,10 @@ pub(crate) enum G1EvictionOutcome {
 
 struct PendingG1ToG2 {
     handle: TransferHandle,
+    progress_cursor: TransferProgressCursor,
     g2_to_lower_chain_blocks: FxHashMap<BlockId, SequenceHash>,
+    passed_chain_blocks: FxHashSet<BlockId>,
+    ready_lower_chain_blocks: Vec<SequenceHash>,
     /// Reset G1 slots held until the simulated source copy completes.
     ///
     /// These tokens do not preserve old bytes — `MockWorker` never reads
@@ -242,75 +245,68 @@ struct PendingG1ToG2 {
 
 impl PendingG1ToG2 {
     fn source_slots_releasable(&self) -> bool {
-        if self.source_slots.is_empty() && self.g2_to_lower_chain_blocks.is_empty() {
+        if self.source_slots.is_empty()
+            && self.g2_to_lower_chain_blocks.is_empty()
+            && self.ready_lower_chain_blocks.is_empty()
+        {
             return true;
         }
-        if !self.g2_to_lower_chain_blocks.is_empty() {
+        if !self.g2_to_lower_chain_blocks.is_empty() || !self.ready_lower_chain_blocks.is_empty() {
             return false;
         }
         if self.handle.is_complete() {
             return true;
         }
-        let passed = self.handle.passed_blocks().len();
-        if passed == 0 {
+        let progress = self.handle.progress_counts();
+        if progress.passed == 0 {
             return !matches!(self.handle.status(), TransferStatus::Evaluating);
         }
-        self.handle.completed_blocks().len() + self.handle.failed_blocks().len() >= passed
+        progress.settled() >= progress.passed
     }
 
-    fn release_completed_source_slots(&mut self) -> usize {
+    fn consume_progress(&mut self) -> usize {
+        let delta = self.handle.consume_progress(&mut self.progress_cursor);
         let mut released = 0usize;
-        for block_id in self
-            .handle
-            .completed_blocks()
-            .into_iter()
-            .chain(self.handle.failed_blocks())
-        {
+        self.passed_chain_blocks.extend(delta.passed_blocks);
+
+        for block_id in delta.completed_blocks {
             if self.source_slots.remove(&block_id).is_some() {
                 released += 1;
             }
-        }
-        released
-    }
-
-    fn collect_completed_chain_blocks(&mut self) -> Vec<SequenceHash> {
-        if self.g2_to_lower_chain_blocks.is_empty() {
-            return Vec::new();
-        }
-
-        let mut chain_blocks = Vec::new();
-        for block_id in self.handle.completed_blocks() {
             if let Some(seq_hash) = self.g2_to_lower_chain_blocks.remove(&block_id) {
-                chain_blocks.push(seq_hash);
+                self.ready_lower_chain_blocks.push(seq_hash);
             }
         }
-
-        for block_id in self.handle.failed_blocks() {
+        for block_id in delta.failed_blocks {
+            if self.source_slots.remove(&block_id).is_some() {
+                released += 1;
+            }
             self.g2_to_lower_chain_blocks.remove(&block_id);
         }
 
         if !matches!(self.handle.status(), TransferStatus::Evaluating) {
-            let passed: FxHashSet<BlockId> = self.handle.passed_blocks().into_iter().collect();
             self.g2_to_lower_chain_blocks
-                .retain(|block_id, _seq_hash| passed.contains(block_id));
+                .retain(|block_id, _seq_hash| self.passed_chain_blocks.contains(block_id));
         }
+        released
+    }
 
-        chain_blocks
+    fn take_ready_chain_blocks(&mut self) -> Vec<SequenceHash> {
+        std::mem::take(&mut self.ready_lower_chain_blocks)
     }
 }
 
 struct PendingG2ToG3 {
     handle: TransferHandle,
-    released_failed_reservations: usize,
+    progress_cursor: TransferProgressCursor,
 }
 
 impl PendingG2ToG3 {
     fn take_unreleased_failed_reservations(&mut self) -> usize {
-        let failed = self.handle.failed_blocks().len();
-        let unreleased = failed.saturating_sub(self.released_failed_reservations);
-        self.released_failed_reservations =
-            self.released_failed_reservations.saturating_add(unreleased);
-        unreleased
+        self.handle
+            .consume_progress(&mut self.progress_cursor)
+            .failed_blocks
+            .len()
     }
 
     fn is_complete(&self) -> bool {
@@ -741,7 +737,7 @@ impl MockOffloadEngine {
     fn settled_blocks(&self, lane: TransferLane) -> usize {
         self.pending_handles(lane)
             .iter()
-            .map(|handle| handle.completed_blocks().len() + handle.failed_blocks().len())
+            .map(|handle| handle.progress_counts().settled())
             .sum()
     }
 
@@ -752,19 +748,15 @@ impl MockOffloadEngine {
     ) -> bool {
         let handles = self.pending_handles(lane);
         self.wait_on_attached_runtime(async move {
-            let mut completed: Vec<_> = handles
+            let mut progress: Vec<_> = handles
                 .iter()
-                .map(TransferHandle::subscribe_completed)
-                .collect();
-            let mut failed: Vec<_> = handles
-                .iter()
-                .map(TransferHandle::subscribe_failed)
+                .map(TransferHandle::subscribe_progress)
                 .collect();
 
             loop {
                 let settled_blocks: usize = handles
                     .iter()
-                    .map(|handle| handle.completed_blocks().len() + handle.failed_blocks().len())
+                    .map(|handle| handle.progress_counts().settled())
                     .sum();
                 if settled_blocks >= expected_settled_blocks {
                     return true;
@@ -774,10 +766,7 @@ impl MockOffloadEngine {
                 }
 
                 let mut changes = FuturesUnordered::new();
-                for rx in completed.iter_mut() {
-                    changes.push(rx.changed());
-                }
-                for rx in failed.iter_mut() {
+                for rx in progress.iter_mut() {
                     changes.push(rx.changed());
                 }
 
@@ -1043,22 +1032,26 @@ impl MockOffloadEngine {
             .lock()
             .expect("pending G1→G2 handles mutex poisoned");
         for pending in pending.iter_mut() {
-            released += pending.release_completed_source_slots();
+            released += pending.consume_progress();
         }
-        pending.retain(|pending| !pending.source_slots_releasable());
         released
     }
 
-    fn collect_g2_to_lower_chain_blocks(&self) -> Vec<SequenceHash> {
+    fn collect_g2_to_lower_chain_blocks(&self) -> (Vec<SequenceHash>, usize) {
+        if self.g3_manager.is_none() && self.shared_g4.is_none() {
+            return (Vec::new(), 0);
+        }
         let mut chain_blocks = Vec::new();
+        let mut released_source_slots = 0usize;
         let mut pending = self
             .pending_g1_to_g2
             .lock()
             .expect("pending G1→G2 handles mutex poisoned");
         for pending in pending.iter_mut() {
-            chain_blocks.extend(pending.collect_completed_chain_blocks());
+            released_source_slots += pending.consume_progress();
+            chain_blocks.extend(pending.take_ready_chain_blocks());
         }
-        chain_blocks
+        (chain_blocks, released_source_slots)
     }
 
     fn enqueue_lower_tier_background(&self, hashes: Vec<SequenceHash>) {
@@ -1109,7 +1102,7 @@ impl MockOffloadEngine {
                 .expect("pending G2→G3 handles mutex poisoned");
             pending.push(PendingG2ToG3 {
                 handle: handle.clone(),
-                released_failed_reservations: 0,
+                progress_cursor: handle.new_progress_cursor(),
             });
             drop(pending);
             self.wait_for_reservations_or_completion(
@@ -1258,7 +1251,9 @@ impl MockOffloadEngine {
                 );
             }
         }
-        let g2_to_lower_chain_blocks = self.collect_g2_to_lower_chain_blocks();
+        let (g2_to_lower_chain_blocks, released_after_settlement) =
+            self.collect_g2_to_lower_chain_blocks();
+        released_g1_source_slots += released_after_settlement;
         released_g1_source_slots += self.prune_releasable_g1_to_g2_sources();
 
         if !g2_to_lower_chain_blocks.is_empty()
@@ -1434,9 +1429,18 @@ impl MockOffloadEngine {
                 .pending_g1_to_g2
                 .lock()
                 .expect("pending G1→G2 handles mutex poisoned");
+            let g2_to_lower_chain_blocks = if self.g3_manager.is_some() || self.shared_g4.is_some()
+            {
+                evicted.iter().copied().collect()
+            } else {
+                FxHashMap::default()
+            };
             pending.push(PendingG1ToG2 {
                 handle: handle.clone(),
-                g2_to_lower_chain_blocks: evicted.iter().copied().collect(),
+                progress_cursor: handle.new_progress_cursor(),
+                g2_to_lower_chain_blocks,
+                passed_chain_blocks: FxHashSet::default(),
+                ready_lower_chain_blocks: Vec::new(),
                 source_slots: source_slots
                     .into_iter()
                     .map(|slot| (slot.block_id(), slot))
@@ -1448,7 +1452,7 @@ impl MockOffloadEngine {
         // run on the current virtual `now_ms`, not a later scheduler tick.
         self.wait_for_policy_evaluation(&handle);
         let target_reservation_count = reservation_count_before
-            + self.initial_runnable_transfer_batches(handle.passed_blocks().len()) as u64;
+            + self.initial_runnable_transfer_batches(handle.progress_counts().passed) as u64;
         if target_reservation_count > reservation_count_before {
             self.wait_for_reservations_or_completion(
                 &handle,
@@ -1457,9 +1461,11 @@ impl MockOffloadEngine {
             );
         }
         if handle.is_complete() {
-            let g2_to_lower_chain_blocks = self.collect_g2_to_lower_chain_blocks();
+            let (g2_to_lower_chain_blocks, released_after_settlement) =
+                self.collect_g2_to_lower_chain_blocks();
             self.enqueue_lower_tier_background(g2_to_lower_chain_blocks);
-            let released_slots = self.prune_releasable_g1_to_g2_sources();
+            let released_slots =
+                released_after_settlement.saturating_add(self.prune_releasable_g1_to_g2_sources());
             return Some(G1EvictionOutcome::RetryNow { released_slots });
         }
 
@@ -1778,6 +1784,23 @@ mod tests {
         assert!(!engine.engine.has_g2_to_g3());
         assert!(!engine.engine.has_g2_to_g4());
         assert_eq!(engine.earliest_pending_deadline(), None);
+    }
+
+    #[test]
+    fn g2_only_eviction_does_not_track_lower_tier_chain_blocks() {
+        let rt = single_thread_runtime();
+        let mut engine = rt
+            .block_on(MockOffloadEngine::new(KvbmOffloadConfig::default()))
+            .expect("engine build");
+        engine.attach_runtime(rt);
+
+        let plh = SequenceHash::new(42, None, 0);
+        engine.enqueue_g1_evictions_holding_sources(&[(0, plh)], Vec::new(), Some(0.0));
+
+        let pending = engine.pending_g1_to_g2.lock().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert!(pending[0].g2_to_lower_chain_blocks.is_empty());
+        assert!(pending[0].ready_lower_chain_blocks.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Overview

Reduce the per-block CPU cost of G2 KVBM offline replay by making transfer
progress incremental, eliminating G3/G4 bookkeeping in G2-only engines, and
batching destination registration.

This is stacked on #11019 because the exact issue workload depends on its
transactional G1 allocation/lifecycle fixes. The benchmark harness remains in
#11010 and is not duplicated here.

## Details

- Publish constant-size transfer progress counts and add a per-consumer cursor
  that returns only newly passed, completed, and failed block IDs.
- Consume each settled block once in the mock offload engine instead of cloning
  and rescanning cumulative vectors on scheduler ticks.
- Compute legacy `remaining_blocks()` snapshots lazily, removing the quadratic
  `update_remaining`/`slice_contains` path.
- Skip `g2_to_lower_chain_blocks` construction and lower-tier collection
  entirely when neither G3 nor G4 is configured.
- Batch registry handle creation and complete destination-store transitions
  under one store-mutex acquisition, then publish presence and the registration
  watermark after releasing the mutex.
- Preserve pending G1-to-G2 progress until the settlement/chain-consumption pass
  has observed it, preventing premature pruning from creating barrier timeouts.

Exact 1,000-request replay results, one successful run per block size:

| Block size | Baseline wall | Final wall | Change | Processed-token throughput |
|---:|---:|---:|---:|---:|
| 512 | 903.162 ms | 868.932 ms | -3.79% | +3.94% |
| 128 | 1,575.912 ms | 1,561.640 ms | -0.91% | +0.91% |
| 16 | 9,167.367 ms | 7,584.064 ms | -17.27% | +20.88% |

The 499 Hz DWARF profiles completed 1,000 requests with zero lost samples.
At block size 16, profile wall time fell 18.26% and weighted on-CPU events fell
29.15%. Lower-tier collection, cumulative completed-chain scans,
`TransferState::update_remaining`, and `slice_contains` all fell to zero in the
final profile. Offload-tick weighted work fell to 0.52x and tier-publish-barrier
work to 0.57x.

One preceding block-128 attempt hit the known host-scheduling-sensitive replay
dead-end and produced no report; the immediate retry completed in 1.56 seconds.
That invalid performance sample is tracked separately by #11015/#11018. #11019
explicitly does not implement the causal-settlement contract proposed there.

## Where should the reviewer start?

1. `lib/kvbm-engine/src/offload/handle.rs` for the progress storage/cursor API.
2. `lib/mocker/src/kvbm_offload/engine.rs` for delta consumption, G2-only
   gating, and pending-transfer lifecycle ordering.
3. `lib/kvbm-logical/src/manager/mod.rs` and
   `lib/kvbm-logical/src/pools/store.rs` for batched registration and lock
   ordering.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p kvbm-engine -p kvbm-logical --lib -- -D warnings`
- `cargo test -p kvbm-engine --lib` (117 passed)
- `cargo test -p kvbm-logical --lib` (493 passed)
- `cargo test -p dynamo-mocker --features kvbm-offload kvbm_offload::engine::tests --lib` (20 passed)
- Profiling build of `offline_replay_bench` with `mocker-kvbm-offload`
- Exact 512/128/16 replay run and on-CPU profile for each block size

## Related Issues

- Closes #11013
- Relates to #11015
- Relates to #11018

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incremental transfer progress tracking, making progress updates lighter and easier to consume.
  * Improved batch registration so multiple blocks can be registered more efficiently while preserving order.
* **Bug Fixes**
  * Fixed progress reporting to better reflect settled, completed, and failed transfers.
  * Improved block registration handling to avoid duplicate work and ensure consistent state updates.
  * Updated transfer flow handling to better release resources as progress advances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->