### PR TITLE
fix(mocker): disable offline wall-clock expiry

### DIFF
--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -111,6 +111,12 @@ pub enum ReplicaWorkerPolicy {
     RequireRegistered,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct SequenceTrackerOptions {
+    replica_worker_policy: ReplicaWorkerPolicy,
+    expiry_enabled: bool,
+}
+
 /// Errors that can occur during sequence management operations.
 #[derive(Debug, thiserror::Error)]
 pub enum SequenceError {
@@ -188,6 +194,29 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         )
     }
 
+    /// Create a tracker that relies exclusively on explicit request lifecycle events.
+    pub fn new_without_expiry(
+        publisher: P,
+        block_size: usize,
+        dp_range: HashMap<u64, (u32, u32)>,
+        replica_sync: bool,
+        router_id: u64,
+        worker_type: &'static str,
+    ) -> Self {
+        Self::new_with_options(
+            publisher,
+            block_size,
+            dp_range,
+            replica_sync,
+            router_id,
+            worker_type,
+            SequenceTrackerOptions {
+                replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
+                expiry_enabled: false,
+            },
+        )
+    }
+
     /// Create a tracker with an explicit worker-admission policy for replica events.
     pub fn new_with_replica_worker_policy(
         publisher: P,
@@ -198,9 +227,36 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         worker_type: &'static str,
         replica_worker_policy: ReplicaWorkerPolicy,
     ) -> Self {
+        Self::new_with_options(
+            publisher,
+            block_size,
+            dp_range,
+            replica_sync,
+            router_id,
+            worker_type,
+            SequenceTrackerOptions {
+                replica_worker_policy,
+                expiry_enabled: true,
+            },
+        )
+    }
+
+    fn new_with_options(
+        publisher: P,
+        block_size: usize,
+        dp_range: HashMap<u64, (u32, u32)>,
+        replica_sync: bool,
+        router_id: u64,
+        worker_type: &'static str,
+        options: SequenceTrackerOptions,
+    ) -> Self {
         assert!(block_size > 0, "block_size must be greater than 0");
         let (remote_state_updates, _) = watch::channel(());
-        let workers = WorkerTable::new(block_size, &dp_range);
+        let workers = if options.expiry_enabled {
+            WorkerTable::new(block_size, &dp_range)
+        } else {
+            WorkerTable::new_without_expiry(block_size, &dp_range)
+        };
         let initial_workers: Vec<_> = workers.workers().collect();
         let prompt_registry = PromptRegistry::new(initial_workers.iter().copied());
         let publisher = Arc::new(publisher);
@@ -219,7 +275,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             #[cfg(test)]
             remote_state_update_count: AtomicUsize::new(0),
             replica_sync,
-            replica_worker_policy,
+            replica_worker_policy: options.replica_worker_policy,
             worker_type,
         }
     }
@@ -1810,6 +1866,56 @@ mod tests {
         assert!(sequences.prompt_registry.is_block_index_empty());
         assert_eq!(sequences.active_blocks().get(&worker).copied(), Some(0));
         assert_eq!(active_request_count(&sequences, worker), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disabled_expiry_requires_explicit_cleanup_for_all_workers() {
+        let sequences = ActiveSequencesMultiWorker::new_without_expiry(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            false,
+            0,
+            "test",
+        );
+        let initial_worker = WorkerWithDpRank::new(1, 0);
+        let dynamic_worker = WorkerWithDpRank::new(2, 0);
+        sequences
+            .register_worker(WorkerDpRange::new(2, 0, 1))
+            .unwrap();
+
+        for (request_id, token_sequence, worker) in [
+            ("initial", vec![1, 2], initial_worker),
+            ("dynamic", vec![3], dynamic_worker),
+        ] {
+            sequences
+                .add_request(
+                    SequenceRequest {
+                        request_id: request_id.to_string(),
+                        token_sequence: Some(token_sequence),
+                        track_prefill_tokens: true,
+                        expected_output_tokens: None,
+                        prefill_load_hint: tracking_hint(4),
+                        worker,
+                        lora_name: None,
+                    },
+                    Instant::now(),
+                )
+                .unwrap();
+        }
+
+        tokio::time::advance(Duration::from_secs(331)).await;
+        sequences.force_expire_requests_across_all_workers();
+
+        assert_eq!(active_request_count(&sequences, initial_worker), 1);
+        assert_eq!(active_request_count(&sequences, dynamic_worker), 1);
+        assert_eq!(sequences.active_blocks().get(&initial_worker), Some(&2));
+        assert_eq!(sequences.active_blocks().get(&dynamic_worker), Some(&1));
+
+        let now = Instant::now();
+        sequences.free(&"initial".to_string(), now).unwrap();
+        sequences.free(&"dynamic".to_string(), now).unwrap();
+        sequences.assert_completely_drained(now);
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -108,11 +108,20 @@ pub struct ActiveSequences {
     prefill: PrefillLoadTracker,
     blocks: BlockTracker,
     last_expiry_check_time: Instant,
+    expiry_duration: Option<Duration>,
 }
 
 impl ActiveSequences {
     /// Create a new SharedSequenceManager instance
     pub(super) fn new(block_size: usize) -> Self {
+        Self::new_with_expiry(block_size, Some(EXPIRY_DURATION))
+    }
+
+    pub(super) fn new_without_expiry(block_size: usize) -> Self {
+        Self::new_with_expiry(block_size, None)
+    }
+
+    fn new_with_expiry(block_size: usize, expiry_duration: Option<Duration>) -> Self {
         assert!(block_size > 0, "block_size must be greater than 0");
 
         Self {
@@ -120,6 +129,7 @@ impl ActiveSequences {
             prefill: PrefillLoadTracker::default(),
             blocks: BlockTracker::default(),
             last_expiry_check_time: Instant::now(),
+            expiry_duration,
         }
     }
 
@@ -317,6 +327,9 @@ impl ActiveSequences {
     /// Force expiry of stale requests if the timer has elapsed.
     /// Returns block membership transitions plus the set of expired request IDs that were removed.
     pub(super) fn force_expiry(&mut self) -> SequenceMutationOutcome {
+        let Some(expiry_duration) = self.expiry_duration else {
+            return SequenceMutationOutcome::default();
+        };
         let now = Instant::now();
 
         if now < self.last_expiry_check_time + CHECK_EXPIRY_FREQUENCY {
@@ -324,7 +337,7 @@ impl ActiveSequences {
         }
 
         self.last_expiry_check_time = now;
-        let expired_requests_time = now - EXPIRY_DURATION;
+        let expired_requests_time = now - expiry_duration;
         let expired_request_ids: HashSet<RequestId> = self
             .requests
             .iter()

--- a/lib/kv-router/src/sequences/topology.rs
+++ b/lib/kv-router/src/sequences/topology.rs
@@ -90,10 +90,15 @@ pub(super) struct WorkerSlot {
 }
 
 impl WorkerSlot {
-    fn new(worker: WorkerWithDpRank, block_size: usize) -> Self {
+    fn new(worker: WorkerWithDpRank, block_size: usize, expiry_enabled: bool) -> Self {
+        let sequences = if expiry_enabled {
+            ActiveSequences::new(block_size)
+        } else {
+            ActiveSequences::new_without_expiry(block_size)
+        };
         Self {
             worker,
-            sequences: RwLock::new(ActiveSequences::new(block_size)),
+            sequences: RwLock::new(sequences),
             trie_lookup: Arc::new(RwLock::new(WorkerLookup::default())),
         }
     }
@@ -103,10 +108,26 @@ pub(super) struct WorkerTable {
     pub(super) slots: Vec<WorkerSlot>,
     pub(super) index: FxHashMap<WorkerWithDpRank, usize>,
     worker_ranges: HashMap<WorkerId, WorkerDpRange>,
+    expiry_enabled: bool,
 }
 
 impl WorkerTable {
     pub(super) fn new(block_size: usize, dp_range: &HashMap<u64, (u32, u32)>) -> Self {
+        Self::new_with_expiry(block_size, dp_range, true)
+    }
+
+    pub(super) fn new_without_expiry(
+        block_size: usize,
+        dp_range: &HashMap<u64, (u32, u32)>,
+    ) -> Self {
+        Self::new_with_expiry(block_size, dp_range, false)
+    }
+
+    fn new_with_expiry(
+        block_size: usize,
+        dp_range: &HashMap<u64, (u32, u32)>,
+        expiry_enabled: bool,
+    ) -> Self {
         let worker_ranges: HashMap<WorkerId, WorkerDpRange> = dp_range
             .iter()
             .map(|(&worker_id, &(dp_start, dp_size))| {
@@ -121,13 +142,14 @@ impl WorkerTable {
         let mut index = FxHashMap::default();
         for worker in workers_from_ranges(worker_ranges.values().copied()) {
             let idx = slots.len();
-            slots.push(WorkerSlot::new(worker, block_size));
+            slots.push(WorkerSlot::new(worker, block_size, expiry_enabled));
             index.insert(worker, idx);
         }
         Self {
             slots,
             index,
             worker_ranges,
+            expiry_enabled,
         }
     }
 
@@ -229,7 +251,7 @@ impl WorkerTable {
         for worker in target_workers {
             let slot = old.remove(&worker).unwrap_or_else(|| {
                 added.push(worker);
-                WorkerSlot::new(worker, block_size)
+                WorkerSlot::new(worker, block_size, self.expiry_enabled)
             });
             self.slots.push(slot);
         }
@@ -259,7 +281,7 @@ impl WorkerTable {
             let idx = self.slots.len();
             let slot = old
                 .remove(&worker)
-                .unwrap_or_else(|| WorkerSlot::new(worker, block_size));
+                .unwrap_or_else(|| WorkerSlot::new(worker, block_size, self.expiry_enabled));
             self.slots.push(slot);
             self.index.insert(worker, idx);
         }
@@ -295,7 +317,8 @@ impl WorkerTable {
         }
 
         let idx = self.slots.len();
-        self.slots.push(WorkerSlot::new(worker, block_size));
+        self.slots
+            .push(WorkerSlot::new(worker, block_size, self.expiry_enabled));
         self.index.insert(worker, idx);
         WorkerTopologyChange {
             added: vec![worker],

--- a/lib/mocker/src/replay/router_shared.rs
+++ b/lib/mocker/src/replay/router_shared.rs
@@ -87,7 +87,12 @@ pub(super) fn replay_slots(
         .copied()
         .map(|worker_id| (worker_id, (0, 1)))
         .collect();
-    Arc::new(ActiveSequencesMultiWorker::new(
+    // NOTE: Offline replay must retire requests through explicit lifecycle events. Wall-clock
+    // expiry is a live-router cleanup heuristic and must not observe simulator CPU time: a
+    // healthy replay may spend minutes of wall time advancing seconds of virtual time. Keep
+    // expiry disabled here until replay has a liveness-aware definition of a stale request; do
+    // not mask replay dead ends by expiring requests that are still live in virtual time.
+    Arc::new(ActiveSequencesMultiWorker::new_without_expiry(
         ReplayNoopPublisher,
         args.block_size,
         dp_range,


### PR DESCRIPTION
## Summary

- disable wall-clock request expiry for offline replay while preserving the live router five-minute TTL
- require offline requests to leave through explicit completion or cancellation lifecycle events
- propagate the policy to initial and dynamically registered workers

## Validation

- `cargo test -p dynamo-kv-router sequences::multi_worker::tests`
- `cargo clippy -p dynamo-kv-router --tests -- -D warnings`
- `cargo clippy -p dynamo-mocker --no-default-features --tests -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to run request tracking without automatic expiry.
  * Offline replay now uses explicit request cleanup instead of wall-clock timeout handling.

* **Bug Fixes**
  * Improved cleanup behavior for multi-worker and single-worker tracking so stale requests are handled correctly when expiry is turned off.
  * Worker slot creation and reconciliation now consistently follow the configured expiry setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->