### PR TITLE
test(kv-router): remove low-signal tests [DYN-3585]

### DIFF
--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -1561,25 +1561,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cleanup_updates_router_state() {
-        let index = make_indexer(2, 4);
-        index
-            .apply_event(store_event_with_dp_rank(0, 0, &[1, 2, 3]))
-            .await;
-        index
-            .apply_event(store_event_with_dp_rank(0, 1, &[1, 2, 4]))
-            .await;
-
-        index.remove_worker_dp_rank(0, 0).await;
-        let after_dp_remove = index.find_matches(local_hashes(&[1, 2, 3])).await.unwrap();
-        assert_eq!(score(&after_dp_remove, WorkerWithDpRank::new(0, 0)), None);
-
-        index.apply_event(clear_event(0)).await;
-        let after_clear = index.find_matches(local_hashes(&[1, 2])).await.unwrap();
-        assert!(after_clear.scores.is_empty());
-    }
-
-    #[tokio::test]
     async fn worker_wide_cleanup_scans_block_and_anchor_worker_keys() {
         let index = make_indexer(2, 3);
         let dp0 = WorkerWithDpRank::new(7, 0);

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -873,23 +873,6 @@ mod tests {
     }
 
     #[test]
-    fn root_query_uses_none_parent_transition() {
-        let mut index = TestLowerTierIndex::new();
-        index
-            .apply_event(store_event(7, 0, 0, None, &[11, 12, 13], &[101, 102, 103]))
-            .unwrap();
-
-        let mut continuations = FxHashMap::default();
-        continuations.insert(
-            WorkerWithDpRank::new(7, 0),
-            LowerTierContinuation::from_root(0),
-        );
-
-        let hits = index.query_contiguous_hits(&local_hashes(&[11, 12, 13]), &continuations);
-        assert_eq!(hits.get(&WorkerWithDpRank::new(7, 0)), Some(&3));
-    }
-
-    #[test]
     fn root_workers_only_include_matching_root_edges() {
         let mut index = TestLowerTierIndex::new();
         index
@@ -902,25 +885,6 @@ mod tests {
         let workers = index.root_workers(LocalBlockHash(11));
         assert_eq!(workers.len(), 1);
         assert!(workers.contains(&WorkerWithDpRank::new(7, 0)));
-    }
-
-    #[tokio::test]
-    async fn thread_pool_backend_applies_lower_tier_events() {
-        let index = ThreadPoolIndexer::new(LowerTierIndexer::new(), 2, 1);
-        let worker = WorkerWithDpRank::new(7, 0);
-
-        index
-            .apply_event(store_event(7, 0, 0, None, &[11, 12], &[101, 102]))
-            .await;
-        let _ = index.dump_events().await.unwrap();
-
-        let mut continuations = FxHashMap::default();
-        continuations.insert(worker, LowerTierContinuation::from_root(0));
-
-        let hits = index
-            .backend()
-            .query_contiguous_hits(&local_hashes(&[11, 12]), &continuations);
-        assert_eq!(hits.get(&worker), Some(&2));
     }
 
     #[tokio::test]
@@ -1809,22 +1773,6 @@ mod tests {
         assert_eq!(details.hits.get(&WorkerWithDpRank::new(103, 0)), Some(&0),);
     }
 
-    /// Empty continuations map — should return empty results without panicking.
-    #[test]
-    fn empty_continuations_returns_empty_results() {
-        let mut index = TestLowerTierIndex::new();
-        index
-            .apply_event(store_event(110, 0, 0, None, &[1, 2], &[101, 102]))
-            .unwrap();
-
-        let continuations: FxHashMap<WorkerWithDpRank, LowerTierContinuation> =
-            FxHashMap::default();
-
-        let details = index.query_match_details(&local_hashes(&[1, 2]), &continuations);
-        assert!(details.hits.is_empty());
-        assert!(details.next_continuations.is_empty());
-    }
-
     /// Empty sequence — every worker should get 0 hits.
     #[test]
     fn empty_sequence_returns_zero_hits() {
@@ -1852,36 +1800,6 @@ mod tests {
             fresh.apply_event(event).unwrap();
         }
         fresh
-    }
-
-    #[test]
-    fn dump_empty_indexer_returns_no_events() {
-        let index = TestLowerTierIndex::new();
-        assert!(index.dump_events().is_empty());
-    }
-
-    #[test]
-    fn dump_round_trip_single_chain() {
-        let mut index = TestLowerTierIndex::new();
-        index
-            .apply_event(store_event(7, 0, 0, None, &[11, 12, 13], &[101, 102, 103]))
-            .unwrap();
-
-        let events = index.dump_events();
-        assert_eq!(events.len(), 3);
-
-        let restored = replay_dump(events);
-
-        let mut continuations = FxHashMap::default();
-        continuations.insert(
-            WorkerWithDpRank::new(7, 0),
-            LowerTierContinuation::from_root(0),
-        );
-
-        let original = index.query_contiguous_hits(&local_hashes(&[11, 12, 13]), &continuations);
-        let replayed = restored.query_contiguous_hits(&local_hashes(&[11, 12, 13]), &continuations);
-        assert_eq!(original, replayed);
-        assert_eq!(replayed.get(&WorkerWithDpRank::new(7, 0)), Some(&3));
     }
 
     #[test]

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -761,26 +761,6 @@ mod tests {
         assert_eq!(expired_after, vec![42]);
     }
 
-    /// Test that BlockEntry ordering prioritizes sequence position.
-    #[test]
-    fn test_block_entry_ordering() {
-        let worker = WorkerWithDpRank::from_worker_id(0);
-
-        let entry1 = BlockEntry {
-            key: ExternalSequenceBlockHash(100),
-            worker,
-            seq_position: 0,
-        };
-        let entry2 = BlockEntry {
-            key: ExternalSequenceBlockHash(50),
-            worker,
-            seq_position: 1,
-        };
-
-        // entry1 < entry2 because seq_position 0 < 1
-        assert!(entry1 < entry2);
-    }
-
     #[test]
     fn test_worker_expiry_heap_rebuilds_under_churn() {
         let manager = WorkerPruneManager::new(PruneConfig {

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -739,31 +739,6 @@ mod interface_tests {
 
     #[tokio::test]
     #[apply(indexer_template)]
-    async fn test_large_stores(variant: &str) {
-        let index = make_indexer(variant);
-
-        // Test sequences of increasing sizes
-        for i in 0..10u64 {
-            let len = 1 << i; // 1, 2, 4, 8, ..., 512
-            let worker_id = i;
-            let sequence: Vec<u64> = (1..=len).map(|x| x + (i * 10000)).collect();
-            index
-                .apply_event(make_store_event(worker_id, &sequence))
-                .await;
-        }
-
-        flush_and_settle(index.as_ref()).await;
-
-        let worker = WorkerWithDpRank::new(9, 0);
-        let last_seq: Vec<LocalBlockHash> = (1..=512u64)
-            .map(|x| LocalBlockHash(x + (9 * 10000)))
-            .collect();
-        let scores = index.find_matches(last_seq).await.unwrap();
-        assert_eq!(scores.scores.get(&worker), Some(&512));
-    }
-
-    #[tokio::test]
-    #[apply(indexer_template)]
     async fn test_dump_and_restore(variant: &str) {
         let index = make_indexer(variant);
 
@@ -1571,90 +1546,6 @@ mod long_sequence_tests {
 
     #[tokio::test]
     #[apply(indexer_template)]
-    async fn test_long_sequence_single_store(variant: &str) {
-        let index = make_indexer(variant);
-
-        // Store a long sequence (128 blocks) in a single event
-        let seq_len = 128;
-        let sequence: Vec<u64> = (1..=seq_len).collect();
-        index.apply_event(make_store_event(0, &sequence)).await;
-
-        flush_and_settle(index.as_ref()).await;
-
-        // Query full sequence - should match all blocks
-        let full_query: Vec<LocalBlockHash> = sequence.iter().map(|&i| LocalBlockHash(i)).collect();
-        let scores = index.find_matches(full_query).await.unwrap();
-        assert_eq!(scores.scores.len(), 1);
-        assert_eq!(
-            *scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(),
-            seq_len as u32
-        );
-
-        // Query prefix (first 64 blocks)
-        let prefix_query: Vec<LocalBlockHash> = (1..=64).map(LocalBlockHash).collect();
-        let scores = index.find_matches(prefix_query).await.unwrap();
-        assert_eq!(
-            *scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(),
-            64
-        );
-
-        // Query with divergence at position 50
-        let mut divergent_query: Vec<LocalBlockHash> = (1..=100).map(LocalBlockHash).collect();
-        divergent_query[49] = LocalBlockHash(99999); // Position 49 (0-indexed) diverges
-        let scores = index.find_matches(divergent_query).await.unwrap();
-        assert_eq!(
-            *scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(),
-            49
-        );
-    }
-
-    #[tokio::test]
-    #[apply(indexer_template)]
-    async fn test_long_sequence_multiple_continuations(variant: &str) {
-        let index = make_indexer(variant);
-
-        // Build a long sequence through multiple continuations
-        // First store: blocks 1-50
-        let first_chunk: Vec<u64> = (1..=50).collect();
-        index.apply_event(make_store_event(0, &first_chunk)).await;
-
-        // Second store: blocks 51-100 (continuation of first)
-        let second_chunk: Vec<u64> = (51..=100).collect();
-        index
-            .apply_event(make_store_event_with_parent(0, &first_chunk, &second_chunk))
-            .await;
-
-        // Third store: blocks 101-150 (continuation of second)
-        let prefix_1_2: Vec<u64> = (1..=100).collect();
-        let third_chunk: Vec<u64> = (101..=150).collect();
-        index
-            .apply_event(make_store_event_with_parent(0, &prefix_1_2, &third_chunk))
-            .await;
-
-        flush_and_settle(index.as_ref()).await;
-
-        // Query full sequence - should match all 150 blocks
-        let full_query: Vec<LocalBlockHash> = (1..=150).map(LocalBlockHash).collect();
-        let scores = index.find_matches(full_query).await.unwrap();
-        assert_eq!(scores.scores.len(), 1);
-        assert_eq!(
-            *scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(),
-            150
-        );
-
-        // Query crossing continuation boundaries
-        let cross_boundary_query: Vec<LocalBlockHash> = (45..=105).map(LocalBlockHash).collect();
-        let scores = index.find_matches(cross_boundary_query).await.unwrap();
-        // Query starts at block 45, but stored sequence starts at 1, so this won't match
-        // because the sequence hash at position 0 of our query (block 45) won't match
-        // the stored sequence hash at position 0 (block 1)
-        assert!(
-            scores.scores.is_empty() || !scores.scores.contains_key(&WorkerWithDpRank::new(0, 0))
-        );
-    }
-
-    #[tokio::test]
-    #[apply(indexer_template)]
     async fn test_long_sequence_branching_continuations(variant: &str) {
         let index = make_indexer(variant);
 
@@ -1741,51 +1632,6 @@ mod long_sequence_tests {
         assert_eq!(
             *scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(),
             79
-        );
-    }
-
-    #[tokio::test]
-    #[apply(indexer_template)]
-    async fn test_long_sequence_interleaved_workers(variant: &str) {
-        let index = make_indexer(variant);
-
-        // Multiple workers storing overlapping long sequences concurrently
-        // Worker 0: blocks 1-100
-        // Worker 1: blocks 1-75
-        // Worker 2: blocks 1-50
-        // Worker 3: blocks 1-25
-
-        let seq_100: Vec<u64> = (1..=100).collect();
-        let seq_75: Vec<u64> = (1..=75).collect();
-        let seq_50: Vec<u64> = (1..=50).collect();
-        let seq_25: Vec<u64> = (1..=25).collect();
-
-        index.apply_event(make_store_event(0, &seq_100)).await;
-        index.apply_event(make_store_event(1, &seq_75)).await;
-        index.apply_event(make_store_event(2, &seq_50)).await;
-        index.apply_event(make_store_event(3, &seq_25)).await;
-
-        flush_and_settle(index.as_ref()).await;
-
-        // Query for 60 blocks - workers 0,1 match 60, worker 2 matches 50, worker 3 matches 25
-        let query_60: Vec<LocalBlockHash> = (1..=60).map(LocalBlockHash).collect();
-        let scores = index.find_matches(query_60).await.unwrap();
-        assert_eq!(scores.scores.len(), 4);
-        assert_eq!(
-            *scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(),
-            60
-        );
-        assert_eq!(
-            *scores.scores.get(&WorkerWithDpRank::new(1, 0)).unwrap(),
-            60
-        );
-        assert_eq!(
-            *scores.scores.get(&WorkerWithDpRank::new(2, 0)).unwrap(),
-            50
-        );
-        assert_eq!(
-            *scores.scores.get(&WorkerWithDpRank::new(3, 0)).unwrap(),
-            25
         );
     }
 

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -1215,12 +1215,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_overlap_scores_default() {
-        let overlap_scores: OverlapScores = Default::default();
-        assert!(overlap_scores.scores.is_empty());
-    }
-
     #[rstest]
     #[case(11)]
     #[case(32)]
@@ -1460,59 +1454,6 @@ mod tests {
 
         let deserialized: ExternalSequenceBlockHash = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, hash);
-    }
-
-    #[test]
-    fn test_kv_cache_events_serialization() {
-        let event_data = KvCacheEventData::Stored(KvCacheStoreData {
-            parent_hash: Some(ExternalSequenceBlockHash(1)),
-            start_position: None,
-            blocks: vec![KvCacheStoredBlockData {
-                block_hash: ExternalSequenceBlockHash(2),
-                tokens_hash: LocalBlockHash(3),
-                mm_extra_info: None,
-            }],
-        });
-
-        let event = KvCacheEvent {
-            event_id: 1,
-            data: event_data,
-            dp_rank: 0,
-        };
-
-        let events = KvCacheEvents {
-            events: vec![event],
-            shutdown: false,
-        };
-
-        let serialized = serde_json::to_string(&events).unwrap();
-        let deserialized: KvCacheEvents = serde_json::from_str(&serialized).unwrap();
-
-        assert_eq!(deserialized.events.len(), 1);
-        assert_eq!(deserialized.events[0].event_id, 1);
-        if let KvCacheEventData::Stored(store_data) = &deserialized.events[0].data {
-            assert_eq!(store_data.parent_hash.unwrap().0, 1);
-            assert_eq!(store_data.blocks.len(), 1);
-            assert_eq!(store_data.blocks[0].block_hash.0, 2);
-            assert_eq!(store_data.blocks[0].tokens_hash.0, 3);
-        } else {
-            panic!("Expected KvCacheEventData::Stored variant");
-        }
-        assert!(!deserialized.shutdown);
-    }
-
-    #[test]
-    fn test_kv_cache_remove_data_serialization() {
-        let remove_data = KvCacheRemoveData {
-            block_hashes: vec![ExternalSequenceBlockHash(4), ExternalSequenceBlockHash(5)],
-        };
-
-        let serialized = serde_json::to_string(&remove_data).unwrap();
-        let deserialized: KvCacheRemoveData = serde_json::from_str(&serialized).unwrap();
-
-        assert_eq!(deserialized.block_hashes.len(), 2);
-        assert_eq!(deserialized.block_hashes[0].0, 4);
-        assert_eq!(deserialized.block_hashes[1].0, 5);
     }
 
     #[test]

--- a/lib/kv-router/src/recovery/cursor.rs
+++ b/lib/kv-router/src/recovery/cursor.rs
@@ -160,13 +160,4 @@ mod tests {
             }
         );
     }
-
-    #[test]
-    fn apply_barrier_and_advance_restore_live_cursor() {
-        assert_eq!(
-            CursorState::Initial.apply_barrier(20),
-            CursorState::Live(20)
-        );
-        assert_eq!(CursorState::Initial.advance_to(7), CursorState::Live(7));
-    }
 }

--- a/lib/kv-router/src/scheduling/policy.rs
+++ b/lib/kv-router/src/scheduling/policy.rs
@@ -250,30 +250,6 @@ mod tests {
     // ---- FCFS policy tests ----
 
     #[test]
-    fn fcfs_earlier_arrival_scheduled_first() {
-        let policy = FcfsPolicy;
-        let req = request_with(512, 0.0, OverlapScores::default());
-        let early = enqueue_key(&policy, Duration::from_secs(1), &req);
-        let late = enqueue_key(&policy, Duration::from_secs(10), &req);
-        assert!(early > late, "earlier arrival should have higher key");
-    }
-
-    #[test]
-    fn fcfs_priority_jump_promotes() {
-        let policy = FcfsPolicy;
-        // Both arrive at the same wall-clock offset (10s), but one has priority.
-        let normal = request_with(512, 0.0, OverlapScores::default());
-        let boosted = request_with(512, 100.0, OverlapScores::default());
-        let t = Duration::from_secs(10);
-        let key_normal = enqueue_key(&policy, t, &normal);
-        let key_boosted = enqueue_key(&policy, t, &boosted);
-        assert!(
-            key_boosted > key_normal,
-            "priority_jump should produce a higher key"
-        );
-    }
-
-    #[test]
     fn fcfs_priority_jump_beats_earlier_arrival() {
         let policy = FcfsPolicy;
         // Request A arrived at t=0 with no priority.
@@ -284,15 +260,6 @@ mod tests {
         let key_a = enqueue_key(&policy, Duration::from_secs(0), &a);
         let key_b = enqueue_key(&policy, Duration::from_secs(5), &b);
         assert!(key_b > key_a);
-    }
-
-    #[test]
-    fn lcfs_later_arrival_scheduled_first() {
-        let policy = LcfsPolicy;
-        let req = request_with(512, 0.0, OverlapScores::default());
-        let early = enqueue_key(&policy, Duration::from_secs(1), &req);
-        let late = enqueue_key(&policy, Duration::from_secs(10), &req);
-        assert!(late > early, "later arrival should have higher key");
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -2050,23 +2050,6 @@ policy_classes:
         assert_eq!(queue.pending_count(), 0);
     }
 
-    #[tokio::test]
-    async fn test_no_workers_returns_error() {
-        let (queue, _slots) = make_queue(0, 16, 512, None);
-
-        let (req, rx) = make_request("lonely-req", 512);
-        queue.enqueue(req).await;
-
-        let resp = rx.await.expect("oneshot dropped");
-        assert!(
-            matches!(
-                resp,
-                Err(crate::scheduling::types::KvSchedulerError::NoEndpoints)
-            ),
-            "expected NoEndpoints, got {resp:?}"
-        );
-    }
-
     #[tokio::test(flavor = "multi_thread")]
     async fn test_overloaded_provider_filters_at_admission() {
         let overloaded_worker_provider: OverloadedWorkerProvider =

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -103,23 +103,4 @@ mod tests {
         assert!(tracker.fractional_blocks.is_empty());
         assert_eq!(tracker.active_blocks(), 0);
     }
-
-    #[test]
-    fn shared_block_counts_once_until_last_reference_drops() {
-        let mut tracker = BlockTracker::default();
-        let first = tracker.touch_block(&7);
-        let second = tracker.touch_block(&7);
-        let third = tracker.touch_block(&7);
-
-        assert_eq!(tracker.active_blocks(), 1);
-
-        drop(first.rc);
-        drop(second.rc);
-        assert!(!tracker.try_remove_block(&7));
-        assert_eq!(tracker.active_blocks(), 1);
-
-        drop(third.rc);
-        assert!(tracker.try_remove_block(&7));
-        assert_eq!(tracker.active_blocks(), 0);
-    }
 }

--- a/lib/kv-router/src/services/indexer/listener.rs
+++ b/lib/kv-router/src/services/indexer/listener.rs
@@ -536,26 +536,3 @@ async fn connect_replay_socket(
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::{WATERMARK_UNSET, cursor_from_watermark};
-    use crate::recovery::CursorObservation;
-
-    #[test]
-    fn initial_gap_replays_from_zero_and_replayed_seq_becomes_stale() {
-        let replay_start = match cursor_from_watermark(WATERMARK_UNSET).observe(5) {
-            CursorObservation::Initial { got } if got > 0 => Some(0),
-            CursorObservation::Gap { expected, .. } => Some(expected),
-            _ => None,
-        };
-        assert_eq!(replay_start, Some(0));
-        assert!(matches!(
-            cursor_from_watermark(5).observe(5),
-            CursorObservation::Stale {
-                got: 5,
-                last_applied: Some(5),
-            }
-        ));
-    }
-}

--- a/lib/kv-router/src/services/indexer/server.rs
+++ b/lib/kv-router/src/services/indexer/server.rs
@@ -17,8 +17,6 @@ use tokio_util::sync::CancellationToken;
 #[cfg(feature = "metrics")]
 use crate::indexer::KvIndexerMetrics;
 use crate::indexer::TieredMatchDetails;
-#[cfg(test)]
-use crate::protocols::StorageTier;
 use crate::protocols::{BlockHashOptions, LocalBlockHash, WorkerId, compute_block_hash_for_seq};
 use crate::services::overlap::{MooncakeOverlapSummary, build_mooncake_overlap_summaries};
 
@@ -605,117 +603,9 @@ fn build_router(state: Arc<AppState>, test_endpoints: bool) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::indexer::KvIndexerInterface;
-    use crate::services::indexer::backend::create_indexer;
-    use crate::services::indexer::backend::test_util::store_event;
     use axum::body::Body;
     use axum::http::{Request, StatusCode, header};
     use tower::ServiceExt;
-
-    /// Drive a tiered query through `build_score_response` after feeding
-    /// mixed-tier events. The response must carry both shapes:
-    /// - flat `scores`/`tree_sizes` (legacy; used by existing callers), and
-    /// - `instances` map keyed by stringified `worker_id` with per-tier
-    ///   counts plus `longest_matched`, matching Mooncake RFC #1403.
-    #[tokio::test]
-    async fn build_score_response_contains_per_instance_tier_breakdown() {
-        let block_size: u32 = 4;
-        let indexer = create_indexer(block_size, 1);
-
-        // Worker 7 owns 2 device blocks and a 3rd anchored on host-pinned.
-        // Worker 8 owns the same 2 device blocks with no lower tier.
-        for &worker_id in &[7u64, 8] {
-            indexer
-                .apply_event_routed(store_event(
-                    worker_id,
-                    0,
-                    1,
-                    &[],
-                    &[11, 12],
-                    StorageTier::Device,
-                ))
-                .await;
-        }
-        indexer
-            .apply_event_routed(store_event(
-                7,
-                0,
-                2,
-                &[11, 12],
-                &[13],
-                StorageTier::HostPinned,
-            ))
-            .await;
-
-        // Flush primary + lower tiers.
-        if let Indexer::Single {
-            primary,
-            lower_tier,
-        } = &indexer
-        {
-            let _ = primary.flush().await;
-            for inner in lower_tier.all() {
-                let _ = inner.dump_events().await.unwrap();
-            }
-        }
-
-        let sequence = vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)];
-        let tiered = indexer.find_tiered_matches(sequence).await.unwrap();
-        let response = build_score_response(&tiered, block_size);
-
-        // Flat shape (legacy callers) carries device-tier overlap scaled by block_size.
-        assert_eq!(
-            response
-                .scores
-                .get("7")
-                .and_then(|by_dp| by_dp.get("0").copied()),
-            Some(2 * block_size),
-            "legacy `scores` must still reflect device-tier hits"
-        );
-
-        // Per-instance breakdown (Mooncake RFC #1403 alignment).
-        // Tier counts are CUMULATIVE through each tier's walk: cpu includes
-        // device's reach plus the host-pinned extension; disk includes
-        // everything below it. Without a disk extension, disk == cpu.
-        let inst_7 = response
-            .instances
-            .get("7")
-            .expect("instance 7 must appear with tier breakdown");
-        assert_eq!(inst_7.gpu, 2 * block_size, "instance 7 device count");
-        assert_eq!(
-            inst_7.cpu,
-            3 * block_size,
-            "instance 7 host-pinned cumulative count = device + host extension"
-        );
-        assert_eq!(
-            inst_7.disk,
-            3 * block_size,
-            "instance 7 disk cumulative falls back to cpu when no disk extension exists"
-        );
-        assert_eq!(
-            inst_7.dp.get("0").copied(),
-            Some(2 * block_size),
-            "instance 7 dp_rank=0 device count"
-        );
-        assert_eq!(
-            inst_7.longest_matched,
-            3 * block_size,
-            "longest_matched should be the max across device/host/disk"
-        );
-
-        let inst_8 = response
-            .instances
-            .get("8")
-            .expect("instance 8 must appear with tier breakdown");
-        assert_eq!(inst_8.gpu, 2 * block_size);
-        assert_eq!(
-            inst_8.cpu,
-            2 * block_size,
-            "instance 8 cpu falls back to device when no host extension exists"
-        );
-        assert_eq!(inst_8.disk, 2 * block_size);
-        assert_eq!(inst_8.longest_matched, 2 * block_size);
-    }
 
     fn oversized_query_body() -> String {
         let mut body = String::from(r#"{"token_ids":["#);

--- a/lib/kv-router/src/services/shared_cache/server.rs
+++ b/lib/kv-router/src/services/shared_cache/server.rs
@@ -186,20 +186,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_store_and_check() {
-        let store = SharedCacheStore::new();
-        store.store(&[100, 200, 300]);
-
-        // Query: [100, 999, 200, 300, 888]
-        // Hits at positions 0, 2, 3 => ranges [0..1, 2..4]
-        let hits = store.check_blocks(&[100, 999, 200, 300, 888]);
-        assert_eq!(hits.total_hits, 3);
-        assert_eq!(hits.ranges, vec![0..1, 2..4]);
-        store.store(&[100, 400]);
-        assert_eq!(store.len(), 4);
-    }
-
-    #[test]
     fn test_remove_blocks() {
         let store = SharedCacheStore::new();
         store.store(&[10, 20, 30]);

--- a/lib/kv-router/src/zmq_wire/tests.rs
+++ b/lib/kv-router/src/zmq_wire/tests.rs
@@ -384,23 +384,6 @@ fn test_normalizer_ignores_map_serialized_non_main_attention_kind() {
 }
 
 #[test]
-fn test_normalizer_learns_main_attention_metadata_for_remove() {
-    let store: RawKvEvent = from_slice(&sequence_with_cache_spec_kind(
-        TestEventKind::BlockStored,
-        Some(3),
-        "full_attention",
-    ))
-    .expect("valid store event");
-    let remove: RawKvEvent =
-        from_slice(&block_removed_sequence(Some(3), None)).expect("valid remove event");
-    let mut normalizer = ZmqEventNormalizer::new(2);
-    let worker = WorkerWithDpRank::new(7, 0);
-
-    assert!(normalizer.preprocess(store, worker).is_some());
-    assert!(normalizer.preprocess(remove, worker).is_some());
-}
-
-#[test]
 fn test_normalizer_metadata_is_dp_rank_scoped() {
     let store: RawKvEvent = from_slice(&sequence_with_cache_spec_kind(
         TestEventKind::BlockStored,

--- a/lib/kv-router/tests/standalone_indexer_http.rs
+++ b/lib/kv-router/tests/standalone_indexer_http.rs
@@ -294,25 +294,6 @@ async fn query_returns_404_for_unknown_model() {
     task.await.expect("server task join");
 }
 
-/// Smoke test that the axum router is wired correctly end-to-end and
-/// reports `/health` 200. Catches misuse of feature flags / route gates.
-#[tokio::test]
-async fn health_returns_ok() {
-    let registry = Arc::new(WorkerRegistry::new(1));
-    let state = make_app_state(registry);
-    let (base_url, cancel, task) = spawn_indexer_http(state).await;
-
-    let resp = reqwest::Client::new()
-        .get(format!("{base_url}/health"))
-        .send()
-        .await
-        .expect("GET /health");
-    assert_eq!(resp.status(), reqwest::StatusCode::OK);
-
-    cancel.cancel();
-    task.await.expect("server task join");
-}
-
 #[cfg(feature = "metrics")]
 #[tokio::test]
 async fn duplicate_store_warning_is_exported() {


### PR DESCRIPTION
## Summary

- remove 25 low-signal tests across kv-router indexer, scheduling, sequence, service, protocol, recovery, and wire modules
- eliminate duplicated coverage, tautological Serde/default/helper checks, and vacuous no-op cases while retaining tests for concurrency, recovery, ownership, cleanup, and wire contracts
- make no production-code changes

## Validation

- `cargo test -p dynamo-kv-router --no-default-features` — 585 passed
- `cargo test -p dynamo-kv-router --no-default-features --features standalone-indexer,standalone-slot-tracker,standalone-selection` — 656 unit and 3 integration tests passed
- `git diff --check`
- commit hooks passed except `pytest-marker-report`, which was skipped because the local project extension is stale and lacks `DisaggregationMode.Encode` across 24 unrelated Python test modules
- an additional metrics-enabled run passed 667/668 tests; the pre-existing `services::indexer::metrics::tests::register_and_encode` assertion also fails in isolation because uninstantiated metric-vector labels are absent from the encoded output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated and streamlined test coverage around routing, cleanup, replay, scheduling, recovery, and service behavior.
  * Added several new regression-style tests to better verify state consistency and event replay outcomes.
  * Removed a number of older tests that were redundant or no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->