### PR TITLE
[codex] Stage decode cost for pending prefills

### DIFF
--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -141,6 +141,8 @@ class frontend_service:
     # Active decode blocks (KV cache blocks) per worker
     # Gauge metric tracking current KV cache block utilization for each worker
     WORKER_ACTIVE_DECODE_BLOCKS = "worker_active_decode_blocks"
+    # Selector-only staged decode-cost blocks per worker
+    WORKER_SELECTOR_DECODE_BLOCKS = "worker_selector_decode_blocks"
     # Active prefill tokens per worker
     # Gauge metric tracking current queued prefill tokens for each worker
     WORKER_ACTIVE_PREFILL_TOKENS = "worker_active_prefill_tokens"

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -648,9 +648,12 @@ impl<
     /// Run the full scheduling pipeline for a single request:
     /// compute projected load -> select worker -> book tracked state -> respond.
     fn admit_one(&self, mut request: SchedulingRequest, decay_now: Instant) {
-        request.worker_loads = self
-            .slots
-            .project_worker_loads(request.token_seq.as_deref(), decay_now);
+        request.worker_loads = self.slots.project_worker_loads_with_staged_decode_cost(
+            request.token_seq.as_deref(),
+            request.track_prefill_tokens,
+            &request.overlap.effective_cached_tokens,
+            decay_now,
+        );
 
         let selection = {
             let workers = self.workers_with_configs.borrow();
@@ -923,7 +926,7 @@ mod tests {
             self.response_rx.lock().unwrap().take();
         }
 
-        fn observe_load(&self, _: &WorkerWithDpRank, _: &str, _: usize, _: usize) {}
+        fn observe_load(&self, _: &WorkerWithDpRank, _: &str, _: usize, _: usize, _: usize) {}
     }
 
     #[derive(Default)]

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -1257,6 +1257,7 @@ mod tests {
                 active_prefill_tokens: 16,
                 active_decode_blocks: 2,
                 additional_active_blocks: 3,
+                staged_decode_blocks: None,
             },
         );
         let selector = DefaultWorkerSelector::new(Some(KvRouterConfig::default()), "test");

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -27,7 +27,7 @@ use super::prefill_tracker::PrefillTimeLoad;
 use super::prompt_membership_trie::lookup_live_hashes;
 use super::prompt_registry::{PromptRegistry, WorkerLoadSnapshot};
 use super::request_maps::RequestIndex;
-use super::single::{ActiveSequences, PromptMembershipDelta, RequestId};
+use super::single::{ActiveSequences, PromptMembershipDelta, PromptMembershipUpdates, RequestId};
 use super::topology::{WorkerDpRange, WorkerTable, WorkerTopologyChange, WorkerTopologyError};
 use super::{PotentialLoadMaps, PrefillTokenDeltas, WorkerLoadProjection};
 use crate::protocols::{
@@ -72,6 +72,7 @@ pub trait SequencePublisher: Send + Sync {
         worker: &WorkerWithDpRank,
         worker_type: &str,
         blocks: usize,
+        selector_decode_blocks: usize,
         tokens: usize,
     );
 
@@ -232,6 +233,12 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             "expected all workers to have zero active blocks, got {active_blocks:?}",
         );
 
+        let selector_decode_blocks = self.selector_decode_blocks();
+        assert!(
+            selector_decode_blocks.values().all(|&count| count == 0),
+            "expected all workers to have zero staged selector blocks, got {selector_decode_blocks:?}",
+        );
+
         let active_tokens = self.active_tokens(decay_now);
         assert!(
             active_tokens.values().all(|&count| count == 0),
@@ -265,8 +272,13 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 .slots
                 .iter()
                 .filter_map(|slot| {
-                    let live_hashes = lookup_live_hashes(&slot.trie_lookup);
-                    (!live_hashes.is_empty()).then_some((slot.worker, live_hashes))
+                    let active = lookup_live_hashes(&slot.trie_lookup);
+                    let selector = lookup_live_hashes(&slot.selector_trie_lookup);
+                    (!active.is_empty() || !selector.is_empty()).then_some((
+                        slot.worker,
+                        active,
+                        selector,
+                    ))
                 })
                 .collect()
         };
@@ -294,10 +306,16 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         decay_now: Instant,
     ) -> ActiveLoad {
         let active_blocks = load.active_blocks;
+        let selector_decode_blocks = load.selector_decode_blocks;
         let active_tokens = load.active_tokens(decay_now);
 
-        self.publisher
-            .observe_load(&worker, self.worker_type, active_blocks, active_tokens);
+        self.publisher.observe_load(
+            &worker,
+            self.worker_type,
+            active_blocks,
+            selector_decode_blocks,
+            active_tokens,
+        );
 
         ActiveLoad {
             worker_id: worker.worker_id,
@@ -521,13 +539,15 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         request_id: &RequestId,
         decay_now: Instant,
     ) -> Result<(), SequenceError> {
-        self.mutate_request_worker_load_state(
+        self.mutate_request_worker_prompt_state(
             request_id,
             decay_now,
             ActiveSequenceEventData::MarkPrefillCompleted,
-            |seqs, rid, decay_now| {
-                seqs.mark_prefill_completed(rid, decay_now);
+            |seqs, rid, decay_now| PromptMembershipUpdates {
+                active: PromptMembershipDelta::default(),
+                selector: seqs.mark_prefill_completed(rid, decay_now),
             },
+            false,
         )
     }
 
@@ -655,6 +675,23 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         result
     }
 
+    pub fn project_worker_loads_with_staged_decode_cost(
+        &self,
+        token_sequence: Option<&[SequenceHash]>,
+        track_prefill_tokens: bool,
+        cached_tokens: &HashMap<WorkerWithDpRank, usize>,
+        decay_now: Instant,
+    ) -> FxHashMap<WorkerWithDpRank, WorkerLoadProjection> {
+        self.prompt_registry
+            .project_worker_loads_with_staged_decode_cost(
+                token_sequence,
+                track_prefill_tokens,
+                cached_tokens,
+                self.block_size,
+                decay_now,
+            )
+    }
+
     /// Query all workers for their current number of active blocks.
     pub fn active_blocks(&self) -> HashMap<WorkerWithDpRank, usize> {
         self.prompt_registry.active_blocks()
@@ -714,6 +751,10 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         self.prompt_registry.active_request_counts()
     }
 
+    pub fn selector_decode_blocks(&self) -> HashMap<WorkerWithDpRank, usize> {
+        self.prompt_registry.selector_decode_blocks()
+    }
+
     /// Force expire stale requests across all workers (one-shot).
     ///
     /// This is necessary because worker expiration otherwise only runs as a side-effect
@@ -730,10 +771,12 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             let outcome = seq.force_expiry();
             if !outcome.expired_request_ids.is_empty() {
                 let load = seq.worker_load_snapshot();
-                self.prompt_registry.apply_membership_delta_and_load(
+                self.prompt_registry.apply_membership_deltas_and_load(
                     slot.worker,
                     &slot.trie_lookup,
+                    &slot.selector_trie_lookup,
                     outcome.membership_delta,
+                    outcome.selector_membership_delta,
                     load,
                 );
                 removed_request_count += outcome.expired_request_ids.len();
@@ -853,10 +896,12 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 decay_now,
             );
             let load = seq.worker_load_snapshot();
-            self.prompt_registry.apply_membership_delta_and_load(
+            self.prompt_registry.apply_membership_deltas_and_load(
                 worker,
                 &slot.trie_lookup,
+                &slot.selector_trie_lookup,
                 outcome.membership_delta,
+                outcome.selector_membership_delta,
                 load,
             );
             break (outcome.expired_request_ids, load);
@@ -903,7 +948,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         worker: WorkerWithDpRank,
         request_id: &RequestId,
         decay_now: Instant,
-        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant) -> PromptMembershipDelta,
+        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant) -> PromptMembershipUpdates,
         remove_mapping: bool,
     ) -> Result<(), SequenceError> {
         let load = {
@@ -914,12 +959,14 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             };
             let slot = &table.slots[idx];
             let mut seq = slot.sequences.write();
-            let delta = mutate_fn(&mut seq, request_id, decay_now);
+            let updates = mutate_fn(&mut seq, request_id, decay_now);
             let load = seq.worker_load_snapshot();
-            self.prompt_registry.apply_membership_delta_and_load(
+            self.prompt_registry.apply_membership_deltas_and_load(
                 worker,
                 &slot.trie_lookup,
-                delta,
+                &slot.selector_trie_lookup,
+                updates.active,
+                updates.selector,
                 load,
             );
             load
@@ -934,37 +981,12 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         Ok(())
     }
 
-    fn mutate_request_worker_load_state_local(
-        &self,
-        worker: WorkerWithDpRank,
-        request_id: &RequestId,
-        decay_now: Instant,
-        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant),
-    ) -> Result<(), SequenceError> {
-        let load = {
-            let table = self.workers.read();
-            let Some(&idx) = table.index.get(&worker) else {
-                drop(table);
-                return Err(self.stale_request_not_found(request_id, worker, "load_only_mutate"));
-            };
-            let mut seq = table.slots[idx].sequences.write();
-            mutate_fn(&mut seq, request_id, decay_now);
-            let load = seq.worker_load_snapshot();
-            self.prompt_registry.replace_worker_load_state(worker, load);
-            load
-        };
-
-        self.publish_worker_load_snapshot(worker, load, decay_now);
-
-        Ok(())
-    }
-
     fn mutate_request_worker_prompt_state(
         &self,
         request_id: &RequestId,
         decay_now: Instant,
         event_data: ActiveSequenceEventData,
-        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant) -> PromptMembershipDelta,
+        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant) -> PromptMembershipUpdates,
         remove_mapping: bool,
     ) -> Result<(), SequenceError> {
         let worker = self.request_index.worker_for(request_id).ok_or_else(|| {
@@ -981,31 +1003,6 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             mutate_fn,
             remove_mapping,
         )?;
-        self.spawn_publish_event(ActiveSequenceEvent {
-            request_id: request_id.clone(),
-            worker,
-            data: event_data,
-            router_id: self.router_id,
-            lora_name,
-        });
-        Ok(())
-    }
-
-    fn mutate_request_worker_load_state(
-        &self,
-        request_id: &RequestId,
-        decay_now: Instant,
-        event_data: ActiveSequenceEventData,
-        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant),
-    ) -> Result<(), SequenceError> {
-        let worker = self.request_index.worker_for(request_id).ok_or_else(|| {
-            SequenceError::RequestNotFound {
-                request_id: request_id.clone(),
-            }
-        })?;
-
-        let lora_name = self.request_index.lora_for(request_id);
-        self.mutate_request_worker_load_state_local(worker, request_id, decay_now, mutate_fn)?;
         self.spawn_publish_event(ActiveSequenceEvent {
             request_id: request_id.clone(),
             worker,
@@ -1261,6 +1258,7 @@ mod tests {
             worker: &WorkerWithDpRank,
             _worker_type: &str,
             blocks: usize,
+            _selector_decode_blocks: usize,
             tokens: usize,
         ) {
             self.state
@@ -1602,6 +1600,7 @@ mod tests {
                 active_prefill_tokens: 0,
                 active_decode_blocks: 2,
                 additional_active_blocks: 1,
+                staged_decode_blocks: None,
             })
         );
         assert_eq!(
@@ -1610,6 +1609,7 @@ mod tests {
                 active_prefill_tokens: 12,
                 active_decode_blocks: 3,
                 additional_active_blocks: 2,
+                staged_decode_blocks: None,
             })
         );
     }
@@ -1809,7 +1809,65 @@ mod tests {
         assert!(sequences.request_index.is_empty());
         assert!(sequences.prompt_registry.is_block_index_empty());
         assert_eq!(sequences.active_blocks().get(&worker).copied(), Some(0));
+        assert_eq!(
+            sequences.selector_decode_blocks().get(&worker).copied(),
+            Some(0)
+        );
         assert_eq!(active_request_count(&sequences, worker), 0);
+    }
+
+    #[tokio::test]
+    async fn replica_sync_promotes_staged_decode_blocks_without_wire_changes() {
+        let sequences = ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            true,
+            0,
+            "test",
+        );
+        let worker = WorkerWithDpRank::new(1, 0);
+        let subscriber = VecSubscriber {
+            events: VecDeque::from(vec![
+                Ok(ActiveSequenceEvent {
+                    request_id: "req-1".to_string(),
+                    worker,
+                    data: ActiveSequenceEventData::AddRequest {
+                        token_sequence: Some(vec![1, 2, 3]),
+                        track_prefill_tokens: true,
+                        expected_output_tokens: None,
+                        prefill_load_hint: tracking_hint(8),
+                    },
+                    router_id: 99,
+                    lora_name: None,
+                }),
+                Ok(ActiveSequenceEvent {
+                    request_id: "req-1".to_string(),
+                    worker,
+                    data: ActiveSequenceEventData::MarkPrefillCompleted,
+                    router_id: 99,
+                    lora_name: None,
+                }),
+            ]),
+        };
+
+        sequences
+            .run_replica_sync(subscriber, CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert_eq!(sequences.active_blocks().get(&worker).copied(), Some(3));
+        assert_eq!(
+            sequences.selector_decode_blocks().get(&worker).copied(),
+            Some(3)
+        );
+        assert_eq!(
+            sequences
+                .active_tokens(Instant::now())
+                .get(&worker)
+                .copied(),
+            Some(0)
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -35,11 +35,16 @@ pub struct WorkerLoadProjection {
     /// These blocks may still exist in an inactive cache; this field describes
     /// additional active block footprint, not cache misses.
     pub additional_active_blocks: usize,
+    /// Selector-only staged decode cost for aggregated dual-signal routing.
+    ///
+    /// `None` preserves the legacy full active-block projection exactly.
+    pub staged_decode_blocks: Option<usize>,
 }
 
 impl WorkerLoadProjection {
     pub fn potential_decode_blocks(self) -> usize {
-        self.active_decode_blocks + self.additional_active_blocks
+        self.staged_decode_blocks
+            .unwrap_or(self.active_decode_blocks + self.additional_active_blocks)
     }
 }
 
@@ -58,6 +63,7 @@ pub type PotentialLoadMaps = (
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(super) struct WorkerLoadSnapshot {
     pub(super) active_blocks: usize,
+    pub(super) selector_decode_blocks: usize,
     pub(super) active_requests: usize,
     pub(super) prefill: PrefillLoadSnapshot,
 }
@@ -175,6 +181,7 @@ pub(super) struct PromptRegistry {
     // after the write finishes, but reads can still observe a mixed membership/load state that
     // never existed atomically and make a suboptimal routing choice.
     membership: PromptMembershipTrie,
+    selector_membership: PromptMembershipTrie,
     loads: RwLock<WorkerLoadTable>,
     #[cfg(test)]
     cleanup_attempts: AtomicUsize,
@@ -184,6 +191,7 @@ impl Default for PromptRegistry {
     fn default() -> Self {
         Self {
             membership: PromptMembershipTrie::new(),
+            selector_membership: PromptMembershipTrie::new(),
             loads: RwLock::new(WorkerLoadTable::default()),
             #[cfg(test)]
             cleanup_attempts: AtomicUsize::new(0),
@@ -210,6 +218,7 @@ impl PromptRegistry {
         self.upsert_worker_load(worker, load);
     }
 
+    #[cfg(test)]
     pub(super) fn apply_membership_delta_and_load(
         &self,
         worker: WorkerWithDpRank,
@@ -221,6 +230,27 @@ impl PromptRegistry {
         self.maybe_cleanup();
     }
 
+    pub(super) fn apply_membership_deltas_and_load(
+        &self,
+        worker: WorkerWithDpRank,
+        lookup: &Arc<parking_lot::RwLock<WorkerLookup>>,
+        selector_lookup: &Arc<parking_lot::RwLock<WorkerLookup>>,
+        delta: PromptMembershipDelta,
+        selector_delta: PromptMembershipDelta,
+        load: WorkerLoadSnapshot,
+    ) {
+        self.apply_membership_deltas_and_load_without_cleanup(
+            worker,
+            lookup,
+            selector_lookup,
+            delta,
+            selector_delta,
+            load,
+        );
+        self.maybe_cleanup();
+    }
+
+    #[cfg(test)]
     pub(super) fn apply_membership_delta_and_load_without_cleanup(
         &self,
         worker: WorkerWithDpRank,
@@ -238,6 +268,37 @@ impl PromptRegistry {
         self.upsert_worker_load(worker, load);
     }
 
+    pub(super) fn apply_membership_deltas_and_load_without_cleanup(
+        &self,
+        worker: WorkerWithDpRank,
+        lookup: &Arc<parking_lot::RwLock<WorkerLookup>>,
+        selector_lookup: &Arc<parking_lot::RwLock<WorkerLookup>>,
+        delta: PromptMembershipDelta,
+        selector_delta: PromptMembershipDelta,
+        load: WorkerLoadSnapshot,
+    ) {
+        for remove in delta.removes {
+            self.membership.remove_chain(worker, lookup, &remove.hashes);
+        }
+        for store in delta.stores {
+            self.membership
+                .store_chain(worker, lookup, store.parent, &store.hashes);
+        }
+        for remove in selector_delta.removes {
+            self.selector_membership
+                .remove_chain(worker, selector_lookup, &remove.hashes);
+        }
+        for store in selector_delta.stores {
+            self.selector_membership.store_chain(
+                worker,
+                selector_lookup,
+                store.parent,
+                &store.hashes,
+            );
+        }
+        self.upsert_worker_load(worker, load);
+    }
+
     fn upsert_worker_load(&self, worker: WorkerWithDpRank, load: WorkerLoadSnapshot) {
         if self.loads.read().update(worker, load) {
             return;
@@ -249,6 +310,7 @@ impl PromptRegistry {
         #[cfg(test)]
         self.cleanup_attempts.fetch_add(1, Ordering::Relaxed);
         self.membership.maybe_cleanup();
+        self.selector_membership.maybe_cleanup();
     }
 
     #[cfg(test)]
@@ -260,6 +322,8 @@ impl PromptRegistry {
         for removed in change.removed {
             self.membership
                 .remove_worker(removed.worker, &removed.trie_lookup);
+            self.selector_membership
+                .remove_worker(removed.worker, &removed.selector_trie_lookup);
             self.loads.write().remove(removed.worker);
         }
 
@@ -267,6 +331,7 @@ impl PromptRegistry {
             self.loads.write().ensure_worker(worker);
         }
         self.membership.maybe_cleanup();
+        self.selector_membership.maybe_cleanup();
     }
 
     fn project_loads_from_membership<const INCLUDE_ACTIVE_REQUESTS: bool>(
@@ -332,6 +397,59 @@ impl PromptRegistry {
                     active_prefill_tokens: load.active_tokens(decay_now),
                     active_decode_blocks: load.active_blocks,
                     additional_active_blocks: query_len.saturating_sub(overlap_depth),
+                    staged_decode_blocks: None,
+                },
+            );
+        }
+
+        projections
+    }
+
+    pub(super) fn project_worker_loads_with_staged_decode_cost(
+        &self,
+        token_sequence: Option<&[SequenceHash]>,
+        track_prefill_tokens: bool,
+        cached_tokens: &HashMap<WorkerWithDpRank, usize>,
+        block_size: usize,
+        decay_now: Instant,
+    ) -> FxHashMap<WorkerWithDpRank, WorkerLoadProjection> {
+        let query_len = token_sequence.map_or(0, |query| query.len());
+        let stage_decode_cost = track_prefill_tokens && query_len > 0;
+        if !stage_decode_cost {
+            return self.project_worker_loads(token_sequence, decay_now);
+        }
+
+        let matched_depth = self.membership.compute_overlap_depths(token_sequence);
+        let selector_matched_depth = self
+            .selector_membership
+            .compute_overlap_depths(token_sequence);
+        let loads = self.loads.read();
+        let mut projections = FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher);
+
+        for (worker, load) in loads.iter() {
+            let overlap_depth = matched_depth.get(&worker).copied().unwrap_or(0);
+            let cached_prefix_blocks = cached_tokens
+                .get(&worker)
+                .copied()
+                .unwrap_or(0)
+                .checked_div(block_size)
+                .unwrap_or(0)
+                .min(query_len);
+            let selector_overlap_depth = selector_matched_depth
+                .get(&worker)
+                .copied()
+                .unwrap_or(0)
+                .min(cached_prefix_blocks);
+            projections.insert(
+                worker,
+                WorkerLoadProjection {
+                    active_prefill_tokens: load.active_tokens(decay_now),
+                    active_decode_blocks: load.active_blocks,
+                    additional_active_blocks: query_len.saturating_sub(overlap_depth),
+                    staged_decode_blocks: Some(
+                        load.selector_decode_blocks
+                            + cached_prefix_blocks.saturating_sub(selector_overlap_depth),
+                    ),
                 },
             );
         }
@@ -352,6 +470,14 @@ impl PromptRegistry {
             .read()
             .iter()
             .map(|(worker, load)| (worker, load.active_requests))
+            .collect()
+    }
+
+    pub(super) fn selector_decode_blocks(&self) -> HashMap<WorkerWithDpRank, usize> {
+        self.loads
+            .read()
+            .iter()
+            .map(|(worker, load)| (worker, load.selector_decode_blocks))
             .collect()
     }
 
@@ -405,7 +531,7 @@ impl PromptRegistry {
 
     #[cfg(any(test, feature = "bench"))]
     pub(super) fn is_block_index_empty(&self) -> bool {
-        self.membership.is_empty()
+        self.membership.is_empty() && self.selector_membership.is_empty()
     }
 }
 
@@ -442,6 +568,7 @@ mod tests {
     fn worker_load_snapshot(active_blocks: usize) -> WorkerLoadSnapshot {
         WorkerLoadSnapshot {
             active_blocks,
+            selector_decode_blocks: active_blocks,
             active_requests: 0,
             prefill: PrefillLoadSnapshot::default(),
         }
@@ -456,6 +583,7 @@ mod tests {
     ) -> WorkerLoadSnapshot {
         WorkerLoadSnapshot {
             active_blocks,
+            selector_decode_blocks: active_blocks,
             active_requests: 0,
             prefill: PrefillLoadSnapshot {
                 prefill_full_tokens_sum,
@@ -622,6 +750,66 @@ mod tests {
     }
 
     #[test]
+    fn staged_projection_counts_only_cached_prefix_and_preserves_legacy_boundaries() {
+        let worker = worker(1, 0);
+        let registry = PromptRegistry::new([worker]);
+        let active_lookup = lookup();
+        let selector_lookup = lookup();
+        let now = Instant::now();
+        let load = WorkerLoadSnapshot {
+            active_blocks: 4,
+            selector_decode_blocks: 2,
+            active_requests: 1,
+            prefill: PrefillLoadSnapshot::default(),
+        };
+        registry.apply_membership_deltas_and_load(
+            worker,
+            &active_lookup,
+            &selector_lookup,
+            store(None, &[1, 2, 3, 4]),
+            store(None, &[1, 2]),
+            load,
+        );
+
+        for (cached_tokens, expected_decode_blocks) in [(0, 2), (12, 3), (16, 4)] {
+            let projection = registry.project_worker_loads_with_staged_decode_cost(
+                Some(&[1, 2, 3, 4]),
+                true,
+                &HashMap::from([(worker, cached_tokens)]),
+                4,
+                now,
+            )[&worker];
+            assert_eq!(
+                projection.staged_decode_blocks,
+                Some(expected_decode_blocks)
+            );
+            assert_eq!(projection.potential_decode_blocks(), expected_decode_blocks);
+            assert_eq!(projection.active_decode_blocks, 4);
+            assert_eq!(projection.additional_active_blocks, 0);
+        }
+
+        let decode_only = registry.project_worker_loads_with_staged_decode_cost(
+            Some(&[1, 2, 3, 4]),
+            false,
+            &HashMap::from([(worker, 16)]),
+            4,
+            now,
+        )[&worker];
+        assert_eq!(decode_only.staged_decode_blocks, None);
+        assert_eq!(decode_only.potential_decode_blocks(), 4);
+
+        let no_active_block_tracking = registry.project_worker_loads_with_staged_decode_cost(
+            None,
+            true,
+            &HashMap::from([(worker, 16)]),
+            4,
+            now,
+        )[&worker];
+        assert_eq!(no_active_block_tracking.staged_decode_blocks, None);
+        assert_eq!(no_active_block_tracking.potential_decode_blocks(), 4);
+    }
+
+    #[test]
     fn removing_worker_clears_prompt_membership_and_load_state() {
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
@@ -650,6 +838,7 @@ mod tests {
             removed: vec![RemovedWorkerState {
                 worker: worker_a,
                 trie_lookup: Arc::clone(&lookup_a),
+                selector_trie_lookup: lookup(),
             }],
         });
         expected_loads.remove(&worker_a);

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -13,6 +13,7 @@ use super::multi_worker::{
     ActiveSequencesMultiWorker, ReplicaWorkerPolicy, SequencePublisher, SequenceSubscriber,
 };
 use super::prompt_registry::WorkerLoadSnapshot;
+use super::single::PromptMembershipDelta;
 use crate::protocols::{ActiveSequenceEvent, ActiveSequenceEventData, WorkerWithDpRank};
 
 const MAX_REPLICA_BATCH_EVENTS: usize = 256;
@@ -196,10 +197,12 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                     );
                     let load = seq.worker_load_snapshot();
                     self.prompt_registry
-                        .apply_membership_delta_and_load_without_cleanup(
+                        .apply_membership_deltas_and_load_without_cleanup(
                             event_worker,
                             &slot.trie_lookup,
+                            &slot.selector_trie_lookup,
                             outcome.membership_delta,
+                            outcome.selector_membership_delta,
                             load,
                         );
                     (outcome.expired_request_ids, load)
@@ -221,13 +224,15 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 let load = {
                     let slot = &table.slots[idx];
                     let mut seq = slot.sequences.write();
-                    let delta = seq.free(&request_id, decay_now);
+                    let updates = seq.free(&request_id, decay_now);
                     let load = seq.worker_load_snapshot();
                     self.prompt_registry
-                        .apply_membership_delta_and_load_without_cleanup(
+                        .apply_membership_deltas_and_load_without_cleanup(
                             worker,
                             &slot.trie_lookup,
-                            delta,
+                            &slot.selector_trie_lookup,
+                            updates.active,
+                            updates.selector,
                             load,
                         );
                     load
@@ -246,10 +251,19 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                     return;
                 };
                 let load = {
-                    let mut seq = table.slots[idx].sequences.write();
-                    seq.mark_prefill_completed(&request_id, decay_now);
+                    let slot = &table.slots[idx];
+                    let mut seq = slot.sequences.write();
+                    let selector_delta = seq.mark_prefill_completed(&request_id, decay_now);
                     let load = seq.worker_load_snapshot();
-                    self.prompt_registry.replace_worker_load_state(worker, load);
+                    self.prompt_registry
+                        .apply_membership_deltas_and_load_without_cleanup(
+                            worker,
+                            &slot.trie_lookup,
+                            &slot.selector_trie_lookup,
+                            PromptMembershipDelta::default(),
+                            selector_delta,
+                            load,
+                        );
                     load
                 };
                 drop(table);

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -46,7 +46,10 @@ pub type RequestId = String;
 #[derive(Debug)]
 pub(super) struct RequestState {
     prompt_blocks: Vec<(SequenceHash, Arc<()>)>,
+    selector_prompt_blocks: Vec<(SequenceHash, Arc<()>)>,
     output_blocks: Vec<(SequenceHash, Arc<()>)>,
+    selector_output_blocks: Vec<(SequenceHash, Arc<()>)>,
+    staged_selector_tracking: bool,
     started_at: Instant,
     expected_output_tokens: Option<u32>,
 }
@@ -55,6 +58,12 @@ impl RequestState {
     fn all_blocks(&self) -> impl Iterator<Item = &(SequenceHash, Arc<()>)> {
         self.prompt_blocks.iter().chain(self.output_blocks.iter())
     }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(super) struct PromptMembershipUpdates {
+    pub active: PromptMembershipDelta,
+    pub selector: PromptMembershipDelta,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -98,6 +107,7 @@ impl PromptMembershipDelta {
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(super) struct SequenceMutationOutcome {
     pub membership_delta: PromptMembershipDelta,
+    pub selector_membership_delta: PromptMembershipDelta,
     pub expired_request_ids: HashSet<RequestId>,
 }
 
@@ -107,6 +117,8 @@ pub struct ActiveSequences {
     requests: HashMap<RequestId, RequestState>,
     prefill: PrefillLoadTracker,
     blocks: BlockTracker,
+    selector_blocks: BlockTracker,
+    block_size: usize,
     last_expiry_check_time: Instant,
 }
 
@@ -119,6 +131,8 @@ impl ActiveSequences {
             requests: HashMap::new(),
             prefill: PrefillLoadTracker::default(),
             blocks: BlockTracker::default(),
+            selector_blocks: BlockTracker::default(),
+            block_size,
             last_expiry_check_time: Instant::now(),
         }
     }
@@ -139,6 +153,24 @@ impl ActiveSequences {
                 .all(|hash| self.blocks.unique_blocks.contains_key(hash)),
             "fractional_blocks cannot reference non-active blocks",
         );
+        assert!(
+            self.selector_blocks
+                .fractional_blocks
+                .keys()
+                .all(|hash| self.selector_blocks.unique_blocks.contains_key(hash)),
+            "selector fractional_blocks cannot reference non-active blocks",
+        );
+        for request in self.requests.values() {
+            if request.staged_selector_tracking {
+                assert!(
+                    request.selector_prompt_blocks.len() <= request.prompt_blocks.len(),
+                    "staged selector prompt cannot be longer than the full prompt",
+                );
+            } else {
+                assert!(request.selector_prompt_blocks.is_empty());
+                assert!(request.selector_output_blocks.is_empty());
+            }
+        }
     }
 
     #[inline]
@@ -149,6 +181,10 @@ impl ActiveSequences {
 
     pub(super) fn active_blocks(&self) -> usize {
         self.blocks.active_blocks()
+    }
+
+    pub(super) fn selector_decode_blocks(&self) -> usize {
+        self.selector_blocks.active_blocks()
     }
 
     #[cfg(test)]
@@ -175,41 +211,38 @@ impl ActiveSequences {
         let mut outcome = self.force_expiry();
         let started_at = Instant::now();
 
-        let prompt_blocks = match token_sequence {
-            Some(sequence) => {
-                let mut first_new_prompt_idx = None;
-                let prompt_blocks: Vec<_> = sequence
-                    .into_iter()
-                    .enumerate()
-                    .map(|(idx, block)| {
-                        let acquire = self.blocks.touch_block(&block);
-                        if acquire.became_present_on_worker && first_new_prompt_idx.is_none() {
-                            first_new_prompt_idx = Some(idx);
-                        }
-                        (block, acquire.rc)
-                    })
-                    .collect();
+        let sequence = token_sequence.unwrap_or_default();
+        let (prompt_blocks, membership_delta) =
+            Self::touch_prompt_chain(&mut self.blocks, &sequence, None);
+        outcome.membership_delta.extend(membership_delta);
 
-                if let Some(first_new_prompt_idx) = first_new_prompt_idx {
-                    debug_assert!(
-                        prompt_blocks[first_new_prompt_idx..]
-                            .iter()
-                            .all(|(hash, _)| self.blocks.unique_blocks.contains_key(hash))
-                    );
-                    let parent = first_new_prompt_idx
-                        .checked_sub(1)
-                        .map(|idx| prompt_blocks[idx].0);
-                    let hashes = prompt_blocks[first_new_prompt_idx..]
-                        .iter()
-                        .map(|(hash, _)| *hash)
-                        .collect();
-                    outcome.membership_delta.push_store(parent, hashes);
-                }
-
-                prompt_blocks
-            }
-            None => Vec::new(),
+        // Aggregated routing tracks both prompt-side prefill load and active blocks. While
+        // prefill is in progress, only its already-cached prefix belongs in the selector's
+        // decode term; the uncached suffix is represented by the prefill term and is promoted
+        // when prefill completes. Other configurations bypass this tracker and retain the
+        // legacy full active-block projection.
+        let staged_selector_tracking = track_prefill_tokens && !sequence.is_empty();
+        let effective_prefill_tokens = prefill_load_hint
+            .map(|hint| hint.initial_effective_prefill_tokens)
+            .unwrap_or(0);
+        let selector_prompt_len = if staged_selector_tracking {
+            // `sequence` contains only complete prompt blocks. Effective prefill tokens are
+            // the uncached complete blocks plus any partial final block, so integer division
+            // recovers the uncached complete-block count without adding replica wire fields.
+            sequence
+                .len()
+                .saturating_sub(effective_prefill_tokens / self.block_size)
+        } else {
+            0
         };
+        let (selector_prompt_blocks, selector_membership_delta) = Self::touch_prompt_chain(
+            &mut self.selector_blocks,
+            &sequence[..selector_prompt_len],
+            None,
+        );
+        outcome
+            .selector_membership_delta
+            .extend(selector_membership_delta);
 
         let prefill = if track_prefill_tokens {
             prefill_load_hint.and_then(|hint| {
@@ -226,7 +259,10 @@ impl ActiveSequences {
             request_id.clone(),
             RequestState {
                 prompt_blocks,
+                selector_prompt_blocks,
                 output_blocks: Vec::new(),
+                selector_output_blocks: Vec::new(),
+                staged_selector_tracking,
                 started_at,
                 expected_output_tokens,
             },
@@ -241,46 +277,74 @@ impl ActiveSequences {
     }
 
     /// Mark prefill as completed for a request, removing it from prompt-load tracking.
-    pub(super) fn mark_prefill_completed(&mut self, request_id: &RequestId, decay_now: Instant) {
-        let _ = self.prefill.remove(request_id, decay_now);
-        self.validate_state();
-    }
-
-    /// Free all blocks associated with a request.
-    ///
-    /// This implicitly calls [`Self::mark_prefill_completed`] first, so callers do not need
-    /// to invoke both when the request is finishing.
-    pub(super) fn free(
+    pub(super) fn mark_prefill_completed(
         &mut self,
         request_id: &RequestId,
         decay_now: Instant,
     ) -> PromptMembershipDelta {
         let _ = self.prefill.remove(request_id, decay_now);
+        let Some(request_state) = self.requests.get_mut(request_id) else {
+            self.validate_state();
+            return PromptMembershipDelta::default();
+        };
+        if !request_state.staged_selector_tracking {
+            self.validate_state();
+            return PromptMembershipDelta::default();
+        }
+
+        let promoted_from = request_state.selector_prompt_blocks.len();
+        let parent = promoted_from
+            .checked_sub(1)
+            .map(|idx| request_state.prompt_blocks[idx].0);
+        let promoted_hashes: Vec<_> = request_state.prompt_blocks[promoted_from..]
+            .iter()
+            .map(|(hash, _)| *hash)
+            .collect();
+        let (promoted_blocks, selector_delta) =
+            Self::touch_prompt_chain(&mut self.selector_blocks, &promoted_hashes, parent);
+        request_state.selector_prompt_blocks.extend(promoted_blocks);
+        self.validate_state();
+        selector_delta
+    }
+
+    /// Free all blocks associated with a request.
+    ///
+    /// This removes any remaining prefill load without promoting its uncached suffix, since all
+    /// selector and active-block references are removed as part of the same operation.
+    pub(super) fn free(
+        &mut self,
+        request_id: &RequestId,
+        decay_now: Instant,
+    ) -> PromptMembershipUpdates {
+        let _ = self.prefill.remove(request_id, decay_now);
 
         let Some(request_state) = self.requests.remove(request_id) else {
             tracing::warn!("Trying to free non-existent request {request_id}");
-            return PromptMembershipDelta::default();
+            return PromptMembershipUpdates::default();
         };
 
         let _ = request_state.expected_output_tokens;
-        let mut membership_delta = PromptMembershipDelta::default();
-        let mut prompt_remove = Vec::new();
-
-        for (block_hash, rc) in request_state.prompt_blocks {
-            drop(rc);
-            if self.blocks.try_remove_block(&block_hash) || !prompt_remove.is_empty() {
-                prompt_remove.push(block_hash);
-            }
-        }
-        membership_delta.push_remove(prompt_remove);
+        let active_delta =
+            Self::release_prompt_chain(&mut self.blocks, request_state.prompt_blocks);
+        let selector_delta = Self::release_prompt_chain(
+            &mut self.selector_blocks,
+            request_state.selector_prompt_blocks,
+        );
 
         for (block_hash, rc) in request_state.output_blocks {
             drop(rc);
             self.blocks.try_remove_block(&block_hash);
         }
+        for (block_hash, rc) in request_state.selector_output_blocks {
+            drop(rc);
+            self.selector_blocks.try_remove_block(&block_hash);
+        }
 
         self.validate_state();
-        membership_delta
+        PromptMembershipUpdates {
+            active: active_delta,
+            selector: selector_delta,
+        }
     }
 
     /// Add an output block with a random hash and optional fractional decay weight.
@@ -300,11 +364,17 @@ impl ActiveSequences {
         // generic block bookkeeping and usually adds little real reuse signal.
         let random_hash: SequenceHash = Uuid::new_v4().as_u64_pair().0;
         let acquire = self.blocks.touch_block(&random_hash);
-        self.requests
+        let request_state = self
+            .requests
             .get_mut(request_id)
-            .expect("request existence was checked above")
-            .output_blocks
-            .push((random_hash, acquire.rc));
+            .expect("request existence was checked above");
+        request_state.output_blocks.push((random_hash, acquire.rc));
+        if request_state.staged_selector_tracking {
+            let selector_acquire = self.selector_blocks.touch_block(&random_hash);
+            request_state
+                .selector_output_blocks
+                .push((random_hash, selector_acquire.rc));
+        }
 
         if let Some(frac) = decay_fraction {
             self.set_single_ref_blocks_as_fractional(request_id, frac);
@@ -339,7 +409,9 @@ impl ActiveSequences {
 
         for request_id in &outcome.expired_request_ids {
             tracing::warn!("Expiring stale request: {}", request_id);
-            outcome.membership_delta.extend(self.free(request_id, now));
+            let updates = self.free(request_id, now);
+            outcome.membership_delta.extend(updates.active);
+            outcome.selector_membership_delta.extend(updates.selector);
         }
 
         self.validate_state();
@@ -361,14 +433,82 @@ impl ActiveSequences {
                 self.blocks.fractional_blocks.insert(*hash, fraction);
             }
         }
+        for (hash, rc) in request_state
+            .selector_prompt_blocks
+            .iter()
+            .chain(request_state.selector_output_blocks.iter())
+        {
+            if Arc::strong_count(rc) == 1 {
+                self.selector_blocks
+                    .fractional_blocks
+                    .insert(*hash, fraction);
+            }
+        }
     }
 
     pub(super) fn worker_load_snapshot(&self) -> WorkerLoadSnapshot {
         WorkerLoadSnapshot {
             active_blocks: self.active_blocks(),
+            selector_decode_blocks: self.selector_decode_blocks(),
             active_requests: self.requests.len(),
             prefill: self.prefill.snapshot(),
         }
+    }
+
+    fn touch_prompt_chain(
+        tracker: &mut BlockTracker,
+        hashes: &[SequenceHash],
+        parent: Option<SequenceHash>,
+    ) -> (Vec<(SequenceHash, Arc<()>)>, PromptMembershipDelta) {
+        let mut first_new_idx = None;
+        let blocks: Vec<_> = hashes
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(idx, hash)| {
+                let acquire = tracker.touch_block(&hash);
+                if acquire.became_present_on_worker && first_new_idx.is_none() {
+                    first_new_idx = Some(idx);
+                }
+                (hash, acquire.rc)
+            })
+            .collect();
+
+        let mut delta = PromptMembershipDelta::default();
+        if let Some(first_new_idx) = first_new_idx {
+            let store_parent = first_new_idx
+                .checked_sub(1)
+                .map(|idx| blocks[idx].0)
+                .or(parent);
+            delta.push_store(
+                store_parent,
+                blocks[first_new_idx..]
+                    .iter()
+                    .map(|(hash, _)| *hash)
+                    .collect(),
+            );
+        }
+        (blocks, delta)
+    }
+
+    fn release_prompt_chain(
+        tracker: &mut BlockTracker,
+        blocks: Vec<(SequenceHash, Arc<()>)>,
+    ) -> PromptMembershipDelta {
+        let hashes: Vec<_> = blocks.iter().map(|(hash, _)| *hash).collect();
+        let mut first_absent_idx = None;
+        for (idx, (hash, rc)) in blocks.into_iter().enumerate() {
+            drop(rc);
+            if tracker.try_remove_block(&hash) && first_absent_idx.is_none() {
+                first_absent_idx = Some(idx);
+            }
+        }
+
+        let mut delta = PromptMembershipDelta::default();
+        if let Some(first_absent_idx) = first_absent_idx {
+            delta.push_remove(hashes[first_absent_idx..].to_vec());
+        }
+        delta
     }
 
     #[cfg(test)]
@@ -449,13 +589,13 @@ mod tests {
         );
 
         let first_free = seq_manager.free(&"r1".to_string(), decay_now);
-        assert!(first_free.removes.is_empty());
-        assert!(first_free.stores.is_empty());
+        assert!(first_free.active.removes.is_empty());
+        assert!(first_free.active.stores.is_empty());
 
         let second_free = seq_manager.free(&"r2".to_string(), decay_now);
-        assert!(second_free.stores.is_empty());
+        assert!(second_free.active.stores.is_empty());
         assert_eq!(
-            second_free.removes,
+            second_free.active.removes,
             vec![PromptMembershipRemove {
                 hashes: vec![1, 2, 3],
             }]
@@ -504,7 +644,7 @@ mod tests {
 
         let free_delta = seq_manager.free(&"r1".to_string(), decay_now);
         assert_eq!(
-            free_delta.removes,
+            free_delta.active.removes,
             vec![PromptMembershipRemove {
                 hashes: vec![1, 2, 3],
             }]
@@ -561,6 +701,134 @@ mod tests {
         seq_manager.free(&"request_1".to_string(), decay_now);
         assert_eq!(seq_manager.active_blocks(), 0);
         assert_eq!(seq_manager.active_tokens(decay_now), 0);
+    }
+
+    #[test]
+    fn staged_decode_cost_uses_cached_complete_prefix_for_partial_prompt_blocks() {
+        let decay_now = Instant::now();
+
+        for (request_id, effective_prefill_tokens, expected_selector_blocks) in
+            [("zero", 18, 0), ("partial", 10, 2), ("full", 2, 4)]
+        {
+            let mut sequences = ActiveSequences::new(4);
+            sequences.add_request_with_prefill_tracking(
+                request_id.to_string(),
+                Some(vec![1, 2, 3, 4]),
+                None,
+                true,
+                tracking_hint(effective_prefill_tokens),
+                decay_now,
+            );
+
+            assert_eq!(sequences.active_blocks(), 4);
+            assert_eq!(sequences.selector_decode_blocks(), expected_selector_blocks);
+        }
+    }
+
+    #[test]
+    fn staged_decode_cost_promotes_uncached_suffix_and_frees_both_trackers() {
+        let mut sequences = ActiveSequences::new(4);
+        let decay_now = Instant::now();
+        let added = sequences.add_request_with_prefill_tracking(
+            "r1".to_string(),
+            Some(vec![1, 2, 3, 4]),
+            None,
+            true,
+            tracking_hint(8),
+            decay_now,
+        );
+
+        assert_eq!(sequences.active_blocks(), 4);
+        assert_eq!(sequences.selector_decode_blocks(), 2);
+        assert_eq!(
+            added.selector_membership_delta.stores,
+            vec![PromptMembershipStore {
+                parent: None,
+                hashes: vec![1, 2],
+            }]
+        );
+
+        let promoted = sequences.mark_prefill_completed(&"r1".to_string(), decay_now);
+        assert_eq!(sequences.selector_decode_blocks(), 4);
+        assert_eq!(
+            promoted.stores,
+            vec![PromptMembershipStore {
+                parent: Some(2),
+                hashes: vec![3, 4],
+            }]
+        );
+        assert!(
+            sequences
+                .mark_prefill_completed(&"r1".to_string(), decay_now)
+                .stores
+                .is_empty()
+        );
+
+        let removed = sequences.free(&"r1".to_string(), decay_now);
+        assert_eq!(sequences.active_blocks(), 0);
+        assert_eq!(sequences.selector_decode_blocks(), 0);
+        assert_eq!(
+            removed.selector.removes,
+            vec![PromptMembershipRemove {
+                hashes: vec![1, 2, 3, 4],
+            }]
+        );
+    }
+
+    #[test]
+    fn staged_decode_cost_deduplicates_shared_prefix_and_tracks_fractional_output() {
+        let mut sequences = ActiveSequences::new(4);
+        let decay_now = Instant::now();
+
+        for request_id in ["r1", "r2"] {
+            sequences.add_request_with_prefill_tracking(
+                request_id.to_string(),
+                Some(vec![1, 2, 3]),
+                None,
+                true,
+                tracking_hint(4),
+                decay_now,
+            );
+        }
+        assert_eq!(sequences.selector_decode_blocks(), 2);
+
+        sequences.mark_prefill_completed(&"r1".to_string(), decay_now);
+        assert_eq!(sequences.selector_decode_blocks(), 3);
+        assert!(
+            sequences
+                .add_output_block(&"r1".to_string(), Some(0.5))
+                .is_some()
+        );
+        assert_eq!(sequences.selector_decode_blocks(), 3);
+
+        sequences.free(&"r1".to_string(), decay_now);
+        assert_eq!(sequences.selector_decode_blocks(), 2);
+        sequences.free(&"r2".to_string(), decay_now);
+        assert_eq!(sequences.selector_decode_blocks(), 0);
+    }
+
+    #[test]
+    fn staged_decode_cost_is_bypassed_without_prefill_tracking() {
+        let mut sequences = ActiveSequences::new(4);
+        let decay_now = Instant::now();
+        sequences.add_request_with_prefill_tracking(
+            "r1".to_string(),
+            Some(vec![1, 2, 3]),
+            None,
+            false,
+            None,
+            decay_now,
+        );
+
+        assert_eq!(sequences.active_blocks(), 3);
+        assert_eq!(sequences.selector_decode_blocks(), 0);
+        assert!(
+            sequences
+                .mark_prefill_completed(&"r1".to_string(), decay_now)
+                .stores
+                .is_empty()
+        );
+        assert_eq!(sequences.selector_decode_blocks(), 0);
     }
 
     #[test]
@@ -729,7 +997,7 @@ mod tests {
             Some(vec![1, 2]),
             None,
             true,
-            tracking_hint(8),
+            tracking_hint(0),
             Instant::now(),
         );
         seq_manager.add_request_with_prefill_tracking(
@@ -737,10 +1005,11 @@ mod tests {
             Some(vec![3, 4]),
             None,
             true,
-            tracking_hint(8),
+            tracking_hint(4),
             Instant::now(),
         );
         assert_eq!(seq_manager.active_blocks(), 4);
+        assert_eq!(seq_manager.selector_decode_blocks(), 3);
 
         tokio::time::advance(Duration::from_secs(20)).await;
         let expired = seq_manager.force_expiry();
@@ -766,6 +1035,7 @@ mod tests {
             HashSet::from(["r1".to_string(), "r2".to_string()])
         );
         assert_eq!(seq_manager.active_blocks(), 0);
+        assert_eq!(seq_manager.selector_decode_blocks(), 0);
         assert_eq!(seq_manager.active_tokens(Instant::now()), 0);
         seq_manager.assert_consistent();
 

--- a/lib/kv-router/src/sequences/topology.rs
+++ b/lib/kv-router/src/sequences/topology.rs
@@ -67,6 +67,7 @@ pub enum WorkerTopologyError {
 pub(super) struct RemovedWorkerState {
     pub(super) worker: WorkerWithDpRank,
     pub(super) trie_lookup: Arc<RwLock<WorkerLookup>>,
+    pub(super) selector_trie_lookup: Arc<RwLock<WorkerLookup>>,
 }
 
 impl std::fmt::Debug for RemovedWorkerState {
@@ -87,6 +88,7 @@ pub(super) struct WorkerSlot {
     pub(super) worker: WorkerWithDpRank,
     pub(super) sequences: RwLock<ActiveSequences>,
     pub(super) trie_lookup: Arc<RwLock<WorkerLookup>>,
+    pub(super) selector_trie_lookup: Arc<RwLock<WorkerLookup>>,
 }
 
 impl WorkerSlot {
@@ -95,6 +97,7 @@ impl WorkerSlot {
             worker,
             sequences: RwLock::new(ActiveSequences::new(block_size)),
             trie_lookup: Arc::new(RwLock::new(WorkerLookup::default())),
+            selector_trie_lookup: Arc::new(RwLock::new(WorkerLookup::default())),
         }
     }
 }
@@ -269,6 +272,7 @@ impl WorkerTable {
             .map(|slot| RemovedWorkerState {
                 worker: slot.worker,
                 trie_lookup: slot.trie_lookup,
+                selector_trie_lookup: slot.selector_trie_lookup,
             })
             .collect();
 
@@ -309,6 +313,7 @@ impl From<WorkerSlot> for RemovedWorkerState {
         Self {
             worker: slot.worker,
             trie_lookup: slot.trie_lookup,
+            selector_trie_lookup: slot.selector_trie_lookup,
         }
     }
 }

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -135,6 +135,7 @@ impl SequencePublisher for ScopedSequencePublisher {
         _worker: &WorkerWithDpRank,
         _worker_type: &str,
         _blocks: usize,
+        _selector_decode_blocks: usize,
         _tokens: usize,
     ) {
     }

--- a/lib/kv-router/src/test_utils.rs
+++ b/lib/kv-router/src/test_utils.rs
@@ -379,7 +379,7 @@ impl SequencePublisher for NoopSequencePublisher {
 
     fn publish_load(&self, _load: ActiveLoad) {}
 
-    fn observe_load(&self, _: &WorkerWithDpRank, _: &str, _: usize, _: usize) {}
+    fn observe_load(&self, _: &WorkerWithDpRank, _: &str, _: usize, _: usize, _: usize) {}
 }
 
 /// Minimal [`WorkerConfigLike`] for scheduler/queue tests and benchmarks.

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -40,6 +40,7 @@ fn cleanup_worker_metrics(worker_id: u64, dp_ranks: &[u32], worker_type: &str) {
         let dp_rank_str = dp_rank.to_string();
         let labels = &[worker_id_str.as_str(), dp_rank_str.as_str(), worker_type];
         let _ = m.active_decode_blocks.remove_label_values(labels);
+        let _ = m.selector_decode_blocks.remove_label_values(labels);
         let _ = m.active_prefill_tokens.remove_label_values(labels);
         let _ = WORKER_LAST_TIME_TO_FIRST_TOKEN_GAUGE.remove_label_values(labels);
         let _ = WORKER_LAST_INPUT_SEQUENCE_TOKENS_GAUGE.remove_label_values(labels);

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -5,7 +5,8 @@
 //!
 //! This module centralizes all router-side Prometheus metric definitions:
 //!
-//! - [`WorkerLoadMetrics`]: Per-worker active decode blocks and prefill tokens gauges.
+//! - [`WorkerLoadMetrics`]: Per-worker active decode blocks, staged selector decode blocks,
+//!   and prefill token gauges.
 //!   Registered on the frontend's own `prometheus::Registry` (default port 8000).
 //!   Populated by `KvWorkerMonitor` in the frontend when receiving ActiveLoad events.
 //!   - Frontend (aggregated and disaggregated): available on default port 8000
@@ -247,6 +248,7 @@ impl RouterWorkerStatusMetrics {
 /// and cleaned up by `KvWorkerMonitor` when workers disappear.
 pub struct WorkerLoadMetrics {
     pub active_decode_blocks: IntGaugeVec,
+    pub selector_decode_blocks: IntGaugeVec,
     pub active_prefill_tokens: IntGaugeVec,
 }
 
@@ -257,6 +259,7 @@ impl WorkerLoadMetrics {
         dp_rank: u32,
         worker_type: &str,
         active_blocks: usize,
+        selector_decode_blocks: usize,
         active_tokens: usize,
     ) {
         let worker_id_str = worker_id.to_string();
@@ -265,6 +268,9 @@ impl WorkerLoadMetrics {
         self.active_decode_blocks
             .with_label_values(labels)
             .set(active_blocks as i64);
+        self.selector_decode_blocks
+            .with_label_values(labels)
+            .set(selector_decode_blocks as i64);
         self.active_prefill_tokens
             .with_label_values(labels)
             .set(active_tokens as i64);
@@ -284,6 +290,18 @@ pub static WORKER_LOAD_METRICS: LazyLock<WorkerLoadMetrics> = LazyLock::new(|| W
         &[labels::WORKER_ID, labels::DP_RANK, labels::WORKER_TYPE],
     )
     .expect("Failed to create worker_active_decode_blocks gauge"),
+    selector_decode_blocks: IntGaugeVec::new(
+        Opts::new(
+            format!(
+                "{}_{}",
+                name_prefix::FRONTEND,
+                frontend_service::WORKER_SELECTOR_DECODE_BLOCKS
+            ),
+            "Selector-only staged decode-cost KV blocks per worker",
+        ),
+        &[labels::WORKER_ID, labels::DP_RANK, labels::WORKER_TYPE],
+    )
+    .expect("Failed to create worker_selector_decode_blocks gauge"),
     active_prefill_tokens: IntGaugeVec::new(
         Opts::new(
             format!(
@@ -305,6 +323,7 @@ pub fn register_worker_load_metrics(
 ) -> Result<(), prometheus::Error> {
     let m = &*WORKER_LOAD_METRICS;
     registry.register(Box::new(m.active_decode_blocks.clone()))?;
+    registry.register(Box::new(m.selector_decode_blocks.clone()))?;
     registry.register(Box::new(m.active_prefill_tokens.clone()))?;
     Ok(())
 }
@@ -793,6 +812,18 @@ mod tests {
                 &[labels::WORKER_ID, labels::DP_RANK, labels::WORKER_TYPE],
             )
             .unwrap(),
+            selector_decode_blocks: IntGaugeVec::new(
+                Opts::new(
+                    format!(
+                        "{}_{}",
+                        name_prefix::FRONTEND,
+                        frontend_service::WORKER_SELECTOR_DECODE_BLOCKS
+                    ),
+                    "Selector-only staged decode-cost KV blocks per worker",
+                ),
+                &[labels::WORKER_ID, labels::DP_RANK, labels::WORKER_TYPE],
+            )
+            .unwrap(),
             active_prefill_tokens: IntGaugeVec::new(
                 Opts::new(
                     format!(
@@ -810,10 +841,13 @@ mod tests {
             .register(Box::new(metrics.active_decode_blocks.clone()))
             .unwrap();
         registry
+            .register(Box::new(metrics.selector_decode_blocks.clone()))
+            .unwrap();
+        registry
             .register(Box::new(metrics.active_prefill_tokens.clone()))
             .unwrap();
 
-        metrics.observe(123, 0, "decode", 42, 100);
+        metrics.observe(123, 0, "decode", 42, 17, 100);
 
         let output = gather_pef(&registry);
         let expected = "\
@@ -823,6 +857,9 @@ dynamo_frontend_worker_active_decode_blocks{dp_rank=\"0\",worker_id=\"123\",work
 # HELP dynamo_frontend_worker_active_prefill_tokens Active prefill tokens queued per worker
 # TYPE dynamo_frontend_worker_active_prefill_tokens gauge
 dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",worker_type=\"decode\"} 100
+# HELP dynamo_frontend_worker_selector_decode_blocks Selector-only staged decode-cost KV blocks per worker
+# TYPE dynamo_frontend_worker_selector_decode_blocks gauge
+dynamo_frontend_worker_selector_decode_blocks{dp_rank=\"0\",worker_id=\"123\",worker_type=\"decode\"} 17
 ";
         assert_eq!(
             output, expected,

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -73,6 +73,7 @@ impl SequencePublisher for RuntimeSequencePublisher {
         worker: &WorkerWithDpRank,
         worker_type: &str,
         blocks: usize,
+        selector_decode_blocks: usize,
         tokens: usize,
     ) {
         WORKER_LOAD_METRICS.observe(
@@ -80,6 +81,7 @@ impl SequencePublisher for RuntimeSequencePublisher {
             worker.dp_rank,
             worker_type,
             blocks,
+            selector_decode_blocks,
             tokens,
         );
     }

--- a/lib/mocker/src/replay/online/entrypoints.rs
+++ b/lib/mocker/src/replay/online/entrypoints.rs
@@ -204,6 +204,28 @@ pub(super) fn simulate_trace_requests_with_stats(
 }
 
 #[cfg(test)]
+pub(super) fn simulate_trace_requests_with_config_and_stats(
+    args: MockEngineArgs,
+    router_config: KvRouterConfig,
+    requests: Vec<DirectRequest>,
+    num_workers: usize,
+    arrival_speedup_ratio: f64,
+    router_mode: ReplayRouterMode,
+) -> Result<(TraceSimulationReport, LiveRuntimeStats)> {
+    let args = args.normalized()?;
+    let pending = normalize_trace_requests(requests, arrival_speedup_ratio)?;
+    run_live_runtime(
+        args,
+        Some(router_config),
+        None,
+        pending,
+        num_workers,
+        LiveReplayMode::Trace,
+        router_mode,
+    )
+}
+
+#[cfg(test)]
 pub(super) fn simulate_concurrency_requests_with_stats(
     args: MockEngineArgs,
     requests: Vec<DirectRequest>,

--- a/lib/mocker/src/replay/online/tests.rs
+++ b/lib/mocker/src/replay/online/tests.rs
@@ -21,8 +21,8 @@ use crate::replay::ReplayRouterMode;
 use super::ReplayRouter;
 use super::entrypoints::{
     simulate_concurrency_requests_with_stats, simulate_concurrency_workload_with_stats,
-    simulate_trace_requests, simulate_trace_requests_with_stats,
-    simulate_trace_workload_with_stats,
+    simulate_trace_requests, simulate_trace_requests_with_config_and_stats,
+    simulate_trace_requests_with_stats, simulate_trace_workload_with_stats,
 };
 use super::state::{SharedLiveRuntimeStats, WorkloadDispatchState, record_arrival};
 use super::task::{RequestTaskContext, run_request_task, wait_for_workload_progress};
@@ -505,9 +505,21 @@ fn test_online_trace_replay_kv_router_prefers_cached_worker() {
     let args = replay_args();
     let requests = vec![request(1, 88, Some(0.0)), request(2, 88, Some(500.0))];
 
-    let (_, stats) =
-        simulate_trace_requests_with_stats(args, requests, 2, 1.0, ReplayRouterMode::KvRouter)
-            .unwrap();
+    // Under staged decode accounting and equal prefill/decode weights, a fully cached request
+    // ties a cold request: its prompt blocks move from the prefill term to the decode term.
+    // Increase the prefill scale so this fixture continues to exercise explicit cache affinity.
+    let (_, stats) = simulate_trace_requests_with_config_and_stats(
+        args,
+        KvRouterConfig {
+            prefill_load_scale: 2.0,
+            ..Default::default()
+        },
+        requests,
+        2,
+        1.0,
+        ReplayRouterMode::KvRouter,
+    )
+    .unwrap();
 
     assert_eq!(stats.dispatch_history.len(), 2);
     assert_eq!(stats.dispatch_history[0], stats.dispatch_history[1]);

--- a/lib/mocker/src/replay/router_shared.rs
+++ b/lib/mocker/src/replay/router_shared.rs
@@ -28,7 +28,7 @@ impl SequencePublisher for ReplayNoopPublisher {
 
     fn publish_load(&self, _load: ActiveLoad) {}
 
-    fn observe_load(&self, _: &WorkerWithDpRank, _: &str, _: usize, _: usize) {}
+    fn observe_load(&self, _: &WorkerWithDpRank, _: &str, _: usize, _: usize, _: usize) {}
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -272,6 +272,9 @@ pub mod frontend_service {
     /// Gauge metric tracking current KV cache block utilization for each worker
     pub const WORKER_ACTIVE_DECODE_BLOCKS: &str = "worker_active_decode_blocks";
 
+    /// Selector-only staged decode-cost blocks per worker
+    pub const WORKER_SELECTOR_DECODE_BLOCKS: &str = "worker_selector_decode_blocks";
+
     /// Active prefill tokens per worker
     /// Gauge metric tracking current queued prefill tokens for each worker
     pub const WORKER_ACTIVE_PREFILL_TOKENS: &str = "worker_active_prefill_tokens";


### PR DESCRIPTION
## Summary

Prototype a staged decode-cost model for aggregated KV routing so uncached prompt blocks are not represented in both the prefill and decode terms while prefill is pending.

```text
prefill_cost = active prefill tokens + incoming uncached tokens

decode_cost = unique blocks from decode-active requests
            + cached-prefix blocks from prefill-active requests
            + incoming cached-prefix blocks
```

The existing configured prefill weighting, overlap credit, and selector formula remain in place; this changes only the decode-block projection supplied to that formula.

## Implementation

- Add a selector-only block tracker and prompt-membership trie with unique-block semantics.
- At admission, book the full prompt in the existing active-block state but only the cached complete-block prefix in staged selector state.
- Promote the uncached suffix when prefill completes, and release both trackers on free or expiry.
- Include generated output blocks and fractional decay in staged state.
- Gate staging on both prefill-token tracking and at least one complete prompt hash. Missing either signal uses the exact legacy projection.
- Preserve existing full active blocks, capacity/admission state, queue behavior, published `ActiveLoad`, and replica event wire format.
- Export `dynamo_frontend_worker_selector_decode_blocks` separately from the existing full active-block gauge.

Disaggregated routing is intentionally unchanged. The prefill path has no active-block hashes, and the decode override still disables prefill tracking and overlap credit, so both bypass staged state and retain full active-block decode cost. The bootstrap and synchronous paths continue through the same common decode override.

At equal prefill/decode weights, a fully cached request and a cold request now tie when otherwise unloaded: the prompt blocks move from the prefill term to the decode term. The online replay cache-affinity fixture therefore sets `prefill_load_scale=2` explicitly. The separate deterministic offline replay simulator retains its existing legacy projection in this prototype.

## Validation

- `cargo test -p dynamo-kv-router`: 627 passed
- `cargo test -p dynamo-mocker --lib`: 468 passed, 1 pre-existing ignored
- `cargo test -p dynamo-llm kv_router::prefill_router::tests`: 12 passed
- `cargo test -p dynamo-llm test_worker_load_metrics_pef`: passed
- `cargo check -p dynamo-llm -p dynamo-mocker`: passed
- `cargo clippy -p dynamo-kv-router -p dynamo-llm -p dynamo-mocker --lib -- -D warnings`: passed
- `cargo fmt --all -- --check` and `git diff --check`: passed

Lifecycle coverage includes zero/partial/full overlap, partial final prompt blocks, promotion, shared-prefix deduplication, output-block fractional decay, free, expiry, topology cleanup, replica synchronization, and both configuration fallbacks.

## Prototype benchmark

An earlier Dynamo 1.1.1 implementation of the same policy was tested with AIPerf 0.8.0 on the canonical unique-prefix ISL256/OSL32 workload at N=8, concurrency 1024, 50,000 requests:

| route / policy | output tok/s | TTFT p50/p99 ms | ITL p50/p99 ms | mean GPU |
|---|---:|---:|---:|---:|
| clean custom KV | 19,940.9 | 213.4 / 3334.5 | 42.9 / 102.6 | 49.8% |
| explicit least-loaded | 29,932.8 | 292.9 / 3378.9 | 21.4 / 88.9 | 78.0% |
| prior zero-hit active-block fix | 29,893.5 | 292.3 / 3361.0 | 21.7 / 89.3 | 77.4% |
| staged decode cost | 28,334.9 | 301.4 / 5410.8 | 22.6 / 43.1 | 74.0% |

The staged run completed exactly 50,000 requests with zero failures or 503s and server-reported mean ISL/OSL 264.00016/32. It was +42.09% over clean KV, but -5.34% versus least-loaded and -5.21% versus the simpler zero-hit fix. The staged prefill and decode signals were almost perfectly anticorrelated (`r=-0.999`), suggesting phase segregation despite a tightly balanced combined score.

This is therefore a draft policy prototype, not a claim that it should replace the simpler fix without further evaluation on current main and workloads with meaningful prefix reuse.
