### PR TITLE
perf(mocker): reduce scheduler and FPM publish overhead

### DIFF
--- a/lib/llm/src/fpm_publisher.rs
+++ b/lib/llm/src/fpm_publisher.rs
@@ -156,9 +156,9 @@ struct QueuedRequestMetricsSer {
 
 /// Top-level serialization struct matching Python `ForwardPassMetrics`.
 #[derive(Serialize)]
-struct ForwardPassMetricsSer {
+struct ForwardPassMetricsSer<'a> {
     version: i32,
-    worker_id: String,
+    worker_id: &'a str,
     dp_rank: i64,
     counter_id: i64,
     wall_time: f64,
@@ -166,15 +166,17 @@ struct ForwardPassMetricsSer {
     queued_requests: QueuedRequestMetricsSer,
 }
 
-fn serialize_fpm(
+fn serialize_fpm_into(
+    buffer: &mut Vec<u8>,
     snapshot: &ForwardPassSnapshot,
     worker_id: &str,
     dp_rank: u32,
     counter_id: i64,
-) -> Result<Vec<u8>> {
+) -> Result<()> {
+    buffer.clear();
     let metrics = ForwardPassMetricsSer {
         version: FPM_VERSION,
-        worker_id: worker_id.to_owned(),
+        worker_id,
         dp_rank: dp_rank as i64,
         counter_id,
         wall_time: snapshot.wall_time_secs,
@@ -196,7 +198,27 @@ fn serialize_fpm(
             var_decode_kv_tokens: snapshot.var_queued_decode_kv_tokens,
         },
     };
-    rmp_serde::to_vec_named(&metrics).map_err(|e| anyhow::anyhow!("FPM serialization failed: {e}"))
+    metrics
+        .serialize(&mut rmp_serde::Serializer::new(buffer).with_struct_map())
+        .map_err(|e| anyhow::anyhow!("FPM serialization failed: {e}"))
+}
+
+#[cfg(test)]
+fn serialize_fpm(
+    snapshot: &ForwardPassSnapshot,
+    worker_id: &str,
+    dp_rank: u32,
+    counter_id: i64,
+) -> Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    serialize_fpm_into(&mut buffer, snapshot, worker_id, dp_rank, counter_id)?;
+    Ok(buffer)
+}
+
+struct PendingFpm {
+    snapshot: ForwardPassSnapshot,
+    dp_rank: u32,
+    counter_id: i64,
 }
 
 /// Live FPM sink that forwards snapshots to the `FpmDirectPublisher`'s
@@ -242,22 +264,40 @@ impl FpmDirectPublisher {
 
         let publisher = EventPublisher::for_component(&component, FPM_TOPIC).await?;
 
-        // Shared channel: per-dp_rank serialization tasks send bytes here,
-        // a single publisher task writes them to the event plane.
-        let (pub_tx, mut pub_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        // Shared channel: per-dp_rank tasks send snapshots here. A single publisher task
+        // serializes them into a reusable buffer and preserves event-plane publish ordering.
+        let (pub_tx, mut pub_rx) = mpsc::unbounded_channel::<PendingFpm>();
 
         // Publisher task
         let cancel_pub = cancel.clone();
+        let publisher_worker_id = worker_id.clone();
         rt.spawn(async move {
+            let mut payload = Vec::new();
             loop {
                 tokio::select! {
                     biased;
                     _ = cancel_pub.cancelled() => break,
                     result = pub_rx.recv() => {
                         match result {
-                            Some(payload) => {
-                                if let Err(e) = publisher.publish_bytes(payload).await {
-                                    tracing::warn!("FPM direct publisher: event plane publish failed: {e}");
+                            Some(pending) => {
+                                match serialize_fpm_into(
+                                    &mut payload,
+                                    &pending.snapshot,
+                                    &publisher_worker_id,
+                                    pending.dp_rank,
+                                    pending.counter_id,
+                                ) {
+                                    Ok(()) => {
+                                        if let Err(e) = publisher.publish_bytes_ref(&payload).await {
+                                            tracing::warn!("FPM direct publisher: event plane publish failed: {e}");
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "FPM serialization failed for dp_rank {}: {e}",
+                                            pending.dp_rank
+                                        );
+                                    }
                                 }
                             }
                             None => break,
@@ -280,7 +320,6 @@ impl FpmDirectPublisher {
             fpm_publishers.push(FpmPublisher::new(Some(sink)));
 
             let pub_tx = pub_tx.clone();
-            let worker_id = worker_id.clone();
             let cancel_ser = cancel.clone();
 
             rt.spawn(async move {
@@ -316,16 +355,11 @@ impl FpmDirectPublisher {
                     };
 
                     counter += 1;
-                    match serialize_fpm(&snapshot, &worker_id, dp_rank, counter) {
-                        Ok(bytes) => {
-                            let _ = pub_tx.send(bytes);
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "FPM serialization failed for dp_rank {dp_rank}: {e}"
-                            );
-                        }
-                    }
+                    let _ = pub_tx.send(PendingFpm {
+                        snapshot,
+                        dp_rank,
+                        counter_id: counter,
+                    });
                 }
             });
         }
@@ -433,6 +467,40 @@ mod tests {
         assert_eq!(decoded.queued_requests.num_prefill_requests, 1);
         assert_eq!(decoded.queued_requests.sum_prefill_tokens, 128);
         assert_eq!(decoded.queued_requests.num_decode_requests, 0);
+    }
+
+    #[test]
+    fn test_serialize_fpm_into_reuses_buffer() {
+        let mut buffer = Vec::with_capacity(1024);
+        let allocation = buffer.as_ptr();
+        let capacity = buffer.capacity();
+
+        serialize_fpm_into(
+            &mut buffer,
+            &ForwardPassSnapshot::default(),
+            "worker-abc",
+            0,
+            1,
+        )
+        .unwrap();
+        serialize_fpm_into(
+            &mut buffer,
+            &ForwardPassSnapshot::default(),
+            "worker-abc",
+            0,
+            2,
+        )
+        .unwrap();
+
+        assert_eq!(buffer.as_ptr(), allocation);
+        assert_eq!(buffer.capacity(), capacity);
+
+        #[derive(Deserialize)]
+        struct Counter {
+            counter_id: i64,
+        }
+        let decoded: Counter = rmp_serde::from_slice(&buffer).unwrap();
+        assert_eq!(decoded.counter_id, 2);
     }
 
     /// Verify that worker_id and dp_rank can be extracted from the serialized

--- a/lib/mocker/src/common/utils.rs
+++ b/lib/mocker/src/common/utils.rs
@@ -85,8 +85,10 @@ pub async fn sleep_precise(duration: Duration) {
 /// computation time should be subtracted from the sleep.
 pub async fn sleep_until_precise(deadline: Instant) {
     // Scheduler work may consume the modeled delay, especially at high speedup ratios. Avoid
-    // allocating and registering a timerfd when there is no remaining time to sleep.
+    // allocating and registering a timerfd when there is no remaining time to sleep. Preserve
+    // the scheduler loop's cooperative yield so other tasks on the runtime can make progress.
     if deadline <= Instant::now() {
+        tokio::task::yield_now().await;
         return;
     }
 
@@ -107,6 +109,24 @@ pub async fn sleep_until_precise(deadline: Instant) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_expired_precise_sleep_yields_to_runtime() {
+        let task_ran = Arc::new(AtomicBool::new(false));
+        let task_ran_clone = task_ran.clone();
+        let task = tokio::spawn(async move {
+            task_ran_clone.store(true, Ordering::SeqCst);
+        });
+
+        sleep_until_precise(Instant::now()).await;
+
+        assert!(task_ran.load(Ordering::SeqCst));
+        task.await.unwrap();
+    }
 
     #[test]
     fn test_prefill_handoff_delay_only_applies_to_completed_prefill() {

--- a/lib/mocker/src/common/utils.rs
+++ b/lib/mocker/src/common/utils.rs
@@ -109,23 +109,17 @@ pub async fn sleep_until_precise(deadline: Instant) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    };
+    use std::task::Poll;
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_expired_precise_sleep_yields_to_runtime() {
-        let task_ran = Arc::new(AtomicBool::new(false));
-        let task_ran_clone = task_ran.clone();
-        let task = tokio::spawn(async move {
-            task_ran_clone.store(true, Ordering::SeqCst);
-        });
+        let sleep = sleep_until_precise(Instant::now());
+        tokio::pin!(sleep);
 
-        sleep_until_precise(Instant::now()).await;
+        let first_poll = futures::poll!(sleep.as_mut());
 
-        assert!(task_ran.load(Ordering::SeqCst));
-        task.await.unwrap();
+        assert!(matches!(first_poll, Poll::Pending));
+        sleep.await;
     }
 
     #[test]

--- a/lib/mocker/src/common/utils.rs
+++ b/lib/mocker/src/common/utils.rs
@@ -84,6 +84,12 @@ pub async fn sleep_precise(duration: Duration) {
 /// deadline's reference point, making it suitable for simulation loops where
 /// computation time should be subtracted from the sleep.
 pub async fn sleep_until_precise(deadline: Instant) {
+    // Scheduler work may consume the modeled delay, especially at high speedup ratios. Avoid
+    // allocating and registering a timerfd when there is no remaining time to sleep.
+    if deadline <= Instant::now() {
+        return;
+    }
+
     #[cfg(target_os = "linux")]
     {
         if let Ok(delay) = tokio_timerfd::Delay::new(deadline) {

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -476,6 +476,15 @@ impl DistributedRuntime {
         subject: String,
         payload: bytes::Bytes,
     ) -> anyhow::Result<()> {
+        self.kv_router_nats_publish_subject(subject.into(), payload)
+            .await
+    }
+
+    pub(crate) async fn kv_router_nats_publish_subject(
+        &self,
+        subject: async_nats::Subject,
+        payload: bytes::Bytes,
+    ) -> anyhow::Result<()> {
         let Some(nats_client) = self.nats_client.as_ref() else {
             // NATS not available - this is expected in approximate mode (--no-kv-events)
             tracing::trace!("Skipping NATS publish (NATS not configured): {subject}");

--- a/lib/runtime/src/transports/event_plane/codec.rs
+++ b/lib/runtime/src/transports/event_plane/codec.rs
@@ -31,6 +31,22 @@ impl Codec {
         }
     }
 
+    /// Encode an event envelope while borrowing its immutable topic and payload.
+    pub fn encode_envelope_parts(
+        &self,
+        publisher_id: u64,
+        sequence: u64,
+        published_at: u64,
+        topic: &str,
+        payload: &[u8],
+    ) -> Result<Bytes> {
+        match self {
+            Codec::Msgpack(c) => {
+                c.encode_envelope_parts(publisher_id, sequence, published_at, topic, payload)
+            }
+        }
+    }
+
     /// Decode wire bytes to an EventEnvelope
     pub fn decode_envelope(&self, bytes: &Bytes) -> Result<EventEnvelope> {
         match self {
@@ -63,9 +79,44 @@ impl Codec {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MsgpackCodec;
 
+#[derive(Serialize)]
+struct BorrowedEventEnvelope<'a> {
+    publisher_id: u64,
+    sequence: u64,
+    published_at: u64,
+    topic: &'a str,
+    #[serde(serialize_with = "serialize_bytes")]
+    payload: &'a [u8],
+}
+
+fn serialize_bytes<S>(bytes: &&[u8], serializer: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_bytes(bytes)
+}
+
 impl MsgpackCodec {
     pub fn encode_envelope(&self, envelope: &EventEnvelope) -> Result<Bytes> {
         Ok(Bytes::from(rmp_serde::to_vec_named(envelope)?))
+    }
+
+    pub fn encode_envelope_parts(
+        &self,
+        publisher_id: u64,
+        sequence: u64,
+        published_at: u64,
+        topic: &str,
+        payload: &[u8],
+    ) -> Result<Bytes> {
+        let envelope = BorrowedEventEnvelope {
+            publisher_id,
+            sequence,
+            published_at,
+            topic,
+            payload,
+        };
+        Ok(Bytes::from(rmp_serde::to_vec_named(&envelope)?))
     }
 
     pub fn decode_envelope(&self, bytes: &Bytes) -> Result<EventEnvelope> {
@@ -115,6 +166,34 @@ mod tests {
         assert_eq!(decoded.published_at, envelope.published_at);
         assert_eq!(decoded.topic, envelope.topic);
         assert_eq!(decoded.payload, envelope.payload);
+    }
+
+    #[test]
+    fn test_msgpack_codec_borrowed_envelope_roundtrip() {
+        let codec = MsgpackCodec;
+        let payload = b"borrowed payload";
+
+        let borrowed = codec
+            .encode_envelope_parts(12345, 42, 1700000000000, "test-topic", payload)
+            .unwrap();
+        let owned = codec
+            .encode_envelope(&EventEnvelope {
+                publisher_id: 12345,
+                sequence: 42,
+                published_at: 1700000000000,
+                topic: "test-topic".to_string(),
+                payload: Bytes::from_static(payload),
+            })
+            .unwrap();
+        assert_eq!(borrowed, owned);
+
+        let decoded: EventEnvelope = rmp_serde::from_slice(&borrowed).unwrap();
+
+        assert_eq!(decoded.publisher_id, 12345);
+        assert_eq!(decoded.sequence, 42);
+        assert_eq!(decoded.published_at, 1700000000000);
+        assert_eq!(decoded.topic, "test-topic");
+        assert_eq!(decoded.payload.as_ref(), payload);
     }
 
     #[test]

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -278,8 +278,8 @@ impl Stream for DeduplicatingStream {
 /// Event publisher for a specific topic.
 pub struct EventPublisher {
     transport_kind: EventTransportKind,
-    scope: EventScope,
     topic: String,
+    subject: String,
     publisher_id: u64,
     sequence: AtomicU64,
     tx: Arc<dyn EventTransportTx>,
@@ -349,6 +349,7 @@ impl EventPublisher {
         let publisher_id = drt.discovery().instance_id();
         let discovery = Some(drt.discovery());
         let runtime_handle = drt.runtime().secondary();
+        let subject = format!("{}.{}", scope.subject_prefix(), topic);
 
         // Use Msgpack codec for all transports
         enum TransportSetup {
@@ -359,7 +360,10 @@ impl EventPublisher {
 
         let transport_setup = match transport_kind {
             EventTransportKind::Nats => {
-                let transport = Arc::new(nats_transport::NatsTransport::new(drt.clone()));
+                let transport = Arc::new(nats_transport::NatsTransport::new_publisher(
+                    drt.clone(),
+                    subject.clone(),
+                ));
                 let codec = Arc::new(Codec::Msgpack(MsgpackCodec));
                 TransportSetup::Nats(transport as Arc<dyn EventTransportTx>, codec)
             }
@@ -472,8 +476,8 @@ impl EventPublisher {
 
         Ok(Self {
             transport_kind,
-            scope,
             topic,
+            subject,
             publisher_id,
             sequence: AtomicU64::new(0),
             tx,
@@ -487,23 +491,25 @@ impl EventPublisher {
     /// Publish a serializable event.
     pub async fn publish<T: Serialize + Send + Sync>(&self, event: &T) -> Result<()> {
         let payload = self.codec.encode_payload(event)?;
-        self.publish_bytes(payload.to_vec()).await
+        self.publish_bytes_ref(payload.as_ref()).await
     }
 
     /// Publish raw bytes.
     pub async fn publish_bytes(&self, bytes: Vec<u8>) -> Result<()> {
-        let envelope = EventEnvelope {
-            publisher_id: self.publisher_id,
-            sequence: self.sequence.fetch_add(1, Ordering::SeqCst),
-            published_at: current_timestamp_ms(),
-            topic: self.topic.clone(),
-            payload: Bytes::from(bytes),
-        };
+        self.publish_bytes_ref(&bytes).await
+    }
 
-        let envelope_bytes = self.codec.encode_envelope(&envelope)?;
-        let subject = format!("{}.{}", self.scope.subject_prefix(), self.topic);
+    /// Publish raw bytes without taking ownership of the payload buffer.
+    pub async fn publish_bytes_ref(&self, bytes: &[u8]) -> Result<()> {
+        let envelope_bytes = self.codec.encode_envelope_parts(
+            self.publisher_id,
+            self.sequence.fetch_add(1, Ordering::SeqCst),
+            current_timestamp_ms(),
+            &self.topic,
+            bytes,
+        )?;
 
-        self.tx.publish(&subject, envelope_bytes).await
+        self.tx.publish(&self.subject, envelope_bytes).await
     }
 
     /// Get the publisher ID.

--- a/lib/runtime/src/transports/event_plane/nats_transport.rs
+++ b/lib/runtime/src/transports/event_plane/nats_transport.rs
@@ -14,19 +14,34 @@ use crate::discovery::EventTransportKind;
 
 pub struct NatsTransport {
     drt: DistributedRuntime,
+    publish_subject: Option<async_nats::Subject>,
 }
 
 impl NatsTransport {
     pub fn new(drt: DistributedRuntime) -> Self {
-        Self { drt }
+        Self {
+            drt,
+            publish_subject: None,
+        }
+    }
+
+    pub fn new_publisher(drt: DistributedRuntime, subject: String) -> Self {
+        Self {
+            drt,
+            publish_subject: Some(subject.into()),
+        }
     }
 }
 
 #[async_trait]
 impl EventTransportTx for NatsTransport {
     async fn publish(&self, subject: &str, envelope_bytes: Bytes) -> Result<()> {
+        let subject = self
+            .publish_subject
+            .clone()
+            .unwrap_or_else(|| subject.into());
         self.drt
-            .kv_router_nats_publish(subject.to_string(), envelope_bytes)
+            .kv_router_nats_publish_subject(subject, envelope_bytes)
             .await
     }
 


### PR DESCRIPTION
## Summary

- skip `tokio_timerfd::Delay` construction when scheduler work has already consumed a mocker's modeled deadline; future deadlines retain the precise timerfd path
- reuse the single FPM publisher task's MessagePack buffer, borrow the worker ID during serialization, and encode event envelopes from borrowed payload/topic data
- cache the formatted event-plane subject and parsed NATS subject instead of rebuilding and validating them for every FPM event

The FPM path still publishes every snapshot in channel order and preserves the existing per-rank counters and idle-heartbeat behavior. The owned event publication and public string-based NATS entry points remain available, and a regression test verifies that the borrowed envelope is byte-for-byte identical to the existing owned encoding.

## Benchmark

The comparison used an optimized build with debug symbols on the same host throughout:

- one mocker process/worker pinned to CPUs `0-1`
- one KV-routing frontend plus aiperf sharing CPUs `2-23`
- `Qwen/Qwen3-0.6B`, 64-token blocks, `--speedup-ratio 1000000`
- aiperf c256 with exact ISL/OSL `1024/1024`, zero variance, `ignore_eos`, fixed seed, 10-second warmup, and a 45-second measured interval
- fresh frontend/mocker processes per run; all reported runs had zero errors and cancellations

| build | clean throughput | incremental benefit | cumulative benefit |
|---|---:|---:|---:|
| original `main` | 207.95 req/s | baseline | baseline |
| expired-deadline fast path | 258.47 req/s | **+24.30%** | **+24.30%** |
| FPM buffer + subject reuse | 273.65 req/s | **+5.87%** | **+31.59%** |

The FPM change also reduced mean latency by `5.62%` and p99 latency by `5.44%` relative to the timer-only build. A separate `perf stat` run measured `7.09%` higher throughput and `5.85%` fewer task-clock CPU seconds/request.

User+kernel profiles at 99 Hz contained about 11K samples with no lost samples and less than 1% unknown leaves. The timer change reduced the precise-sleep stack from `12.15%` to `0.18%`. The FPM change then reduced FPM publisher inclusive cycles from `14.50%` to `9.78%`, serialization from `3.64%` to `0.71%`, subject conversion from `0.65%` to `0.04%`, and NATS subject validation from `0.84%` to `0.17%`.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p dynamo-runtime -p dynamo-llm --lib -- -D warnings`
- `cargo test -p dynamo-llm --lib` (1,389 passed, 5 ignored)
- `cargo test -p dynamo-mocker` (468 passed, 1 ignored)
- `cargo test -p dynamo-runtime transports::event_plane::codec::tests -- --nocapture` (3 passed)
- focused FPM serialization/heartbeat tests (6 passed)
- two clean 45-second aiperf repeats, one 60-second user+kernel profile, and one separate counter run for each optimization stage
