### PR TITLE
fix(llm): propagate chat completion token details

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -269,6 +269,11 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
             if let Some(prompt_details) = completion_usage.prompt_tokens_details.as_ref() {
                 self.usage.prompt_tokens_details = Some(prompt_details.clone());
             }
+
+            // Propagate completion token details if provided, including reasoning tokens.
+            if let Some(completion_details) = completion_usage.completion_tokens_details.as_ref() {
+                self.usage.completion_tokens_details = Some(completion_details.clone());
+            }
         }
 
         let logprobs = self.create_logprobs(

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -386,7 +386,8 @@ mod tests {
     use crate::protocols::openai::DeltaGeneratorExt;
     use dynamo_protocols::types::{
         ChatCompletionRequestMessage, ChatCompletionRequestUserMessage,
-        ChatCompletionRequestUserMessageContent, CreateChatCompletionRequest,
+        ChatCompletionRequestUserMessageContent, CompletionTokensDetails, CompletionUsage,
+        CreateChatCompletionRequest,
     };
 
     fn create_test_request() -> NvCreateChatCompletionRequest {
@@ -480,6 +481,35 @@ mod tests {
             encoder_result: None,
             routing_data: None,
         }
+    }
+
+    #[test]
+    fn test_completion_token_details_are_propagated_from_backend_usage() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-token-details".to_string());
+
+        let mut backend_output = final_backend_output();
+        backend_output.completion_usage = Some(CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 1,
+            total_tokens: 6,
+            prompt_tokens_details: None,
+            completion_tokens_details: Some(CompletionTokensDetails {
+                reasoning_tokens: Some(3),
+                ..Default::default()
+            }),
+        });
+
+        generator
+            .choice_from_postprocessor(backend_output)
+            .expect("choice generation");
+
+        let usage = generator.get_usage();
+        let completion_details = usage
+            .completion_tokens_details
+            .expect("completion token details should be propagated");
+
+        assert_eq!(completion_details.reasoning_tokens, Some(3));
     }
 
     fn create_test_request_with_extra_fields(fields: Vec<String>) -> NvCreateChatCompletionRequest {


### PR DESCRIPTION
## Overview:

Relates to #2941.

Chat Completions responses were not surfacing `completion_tokens_details`, which can carry `reasoning_tokens`, from backend usage metadata into the final response `usage` field.

This PR propagates `completion_tokens_details` in the Chat Completions delta generator, following the existing pattern already used for `prompt_tokens_details`.

## Details:

* Updated `lib/llm/src/protocols/openai/chat_completions/delta.rs`
* Propagated `completion_usage.completion_tokens_details` into `self.usage.completion_tokens_details`
* Added a targeted unit test for completion token details propagation

## Where should the reviewer start?

Please start with:

`lib/llm/src/protocols/openai/chat_completions/delta.rs`

The production change is small and mirrors the existing `prompt_tokens_details` propagation pattern.

## Related Issues

**🔗 This PR is linked to an issue:**

* Closes #2941

## Testing:

Passed locally:

```bash
cargo fmt
git diff --check
```

Added unit test:

```text
test_completion_token_details_are_propagated_from_backend_usage
```

Attempted locally:

```bash
cargo check -p dynamo-llm
cargo test -p dynamo-llm test_completion_token_details_are_propagated_from_backend_usage --lib
```

Both commands progressed into the `dynamo-llm` crate but could not complete on macOS because of Linux-specific APIs related to NUMA, `fallocate`, `DiskStorage`, and `O_DIRECT`. This appears to be a local platform limitation rather than an issue caused by this change.

## Acceptance Criteria

* [x] Tests added for changed behavior
* [x] Relevant Rust tests passed on Linux CI
* [x] Rust clippy passed on Linux CI
* [x] Follows existing code style and mirrors the existing `prompt_tokens_details` propagation pattern
* [x] No unrelated files changed
* [x] No breaking changes introduced
* [x] Documentation update not applicable because this is a small backend usage-field fix