### PR TITLE
fix(frontend): correct Anthropic /v1/messages input_tokens accounting

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -266,6 +266,16 @@ async fn anthropic_messages(
     let (orig_request, context) = request.into_parts();
     let model_for_resp = orig_request.model.clone();
 
+    // Anthropic exposes input usage in `message_start`, before the backend's
+    // authoritative count is available. Seed the stream with the same
+    // best-effort estimate as `/count_tokens`; the converter replaces it when
+    // the backend reports final usage.
+    let estimated_input_tokens = if streaming {
+        estimate_input_tokens(&orig_request)
+    } else {
+        0
+    };
+
     // Check if the Anthropic request explicitly disabled thinking.
     let thinking_explicitly_disabled = orig_request
         .thinking
@@ -408,8 +418,10 @@ async fn anthropic_messages(
         stream_handle.arm();
 
         let mut converter = match anthropic_ctx {
-            Some(ctx) => AnthropicStreamConverter::with_context(model_for_resp, ctx),
-            None => AnthropicStreamConverter::new(model_for_resp),
+            Some(ctx) => {
+                AnthropicStreamConverter::with_context(model_for_resp, estimated_input_tokens, ctx)
+            }
+            None => AnthropicStreamConverter::new(model_for_resp, estimated_input_tokens),
         };
 
         let mut http_queue_guard = Some(http_queue_guard);
@@ -759,6 +771,20 @@ fn strip_billing_preamble(system: &mut Option<SystemContent>) {
             content.text = trimmed[newline_pos + 1..].to_string();
         }
     }
+}
+
+/// Estimate input usage for a streaming `message_start` event.
+///
+/// The backend's rendered prompt and cache-hit split are not available when
+/// the event is emitted. Final `message_delta` usage replaces this estimate.
+fn estimate_input_tokens(req: &AnthropicCreateMessageRequest) -> u32 {
+    AnthropicCountTokensRequest {
+        model: req.model.clone(),
+        messages: req.messages.clone(),
+        system: req.system.clone(),
+        tools: req.tools.clone(),
+    }
+    .estimate_tokens()
 }
 
 fn gate_anthropic_nvext(request: &mut AnthropicCreateMessageRequest, nvext_enabled: bool) {

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -272,14 +272,6 @@ async fn anthropic_messages(
         .as_ref()
         .is_some_and(|t| t.thinking_type == "disabled");
 
-    // Estimate input tokens before consuming the request via try_into().
-    // Only used in the streaming path to populate message_start.
-    let estimated_input_tokens = if streaming {
-        estimate_input_tokens(&orig_request)
-    } else {
-        0
-    };
-
     // Convert Anthropic request -> UnifiedRequest -> Chat Completion request
     let unified_request: UnifiedRequest = orig_request.try_into().map_err(|e: anyhow::Error| {
         tracing::error!(
@@ -416,10 +408,8 @@ async fn anthropic_messages(
         stream_handle.arm();
 
         let mut converter = match anthropic_ctx {
-            Some(ctx) => {
-                AnthropicStreamConverter::with_context(model_for_resp, estimated_input_tokens, ctx)
-            }
-            None => AnthropicStreamConverter::new(model_for_resp, estimated_input_tokens),
+            Some(ctx) => AnthropicStreamConverter::with_context(model_for_resp, ctx),
+            None => AnthropicStreamConverter::new(model_for_resp),
         };
 
         let mut http_queue_guard = Some(http_queue_guard);
@@ -769,23 +759,6 @@ fn strip_billing_preamble(system: &mut Option<SystemContent>) {
             content.text = trimmed[newline_pos + 1..].to_string();
         }
     }
-}
-
-/// Estimate input token count for an Anthropic request.
-///
-/// Uses the same heuristic as `AnthropicCountTokensRequest::estimate_tokens()`
-/// (sum character lengths / 3). This populates `input_tokens` in the streaming
-/// `message_start` event, since the engine only reports prompt token counts on
-/// the final chunk.
-fn estimate_input_tokens(req: &AnthropicCreateMessageRequest) -> u32 {
-    // Build a temporary count-tokens request to reuse the existing estimator.
-    let count_req = AnthropicCountTokensRequest {
-        model: req.model.clone(),
-        messages: req.messages.clone(),
-        system: req.system.clone(),
-        tools: req.tools.clone(),
-    };
-    count_req.estimate_tokens()
 }
 
 fn gate_anthropic_nvext(request: &mut AnthropicCreateMessageRequest, nvext_enabled: bool) {

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -10,12 +10,15 @@
 use std::collections::HashSet;
 
 use axum::response::sse::Event;
-use dynamo_protocols::types::{ChatCompletionMessageContent, ChatCompletionMessageToolCallChunk};
+use dynamo_protocols::types::{
+    ChatCompletionMessageContent, ChatCompletionMessageToolCallChunk, CompletionUsage,
+};
 use uuid::Uuid;
 
 use super::types::{
     AnthropicDelta, AnthropicErrorBody, AnthropicMessageDeltaBody, AnthropicMessageResponse,
     AnthropicResponseContentBlock, AnthropicStopReason, AnthropicStreamEvent, AnthropicUsage,
+    completion_usage_to_anthropic,
 };
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
 use crate::protocols::unified::AnthropicContext;
@@ -34,10 +37,9 @@ pub struct AnthropicStreamConverter {
     text_block_started: bool,
     text_block_closed: bool,
     text_block_index: u32,
-    // Token usage (from engine)
-    input_token_count: u32,
-    output_token_count: u32,
-    cached_token_count: Option<u32>,
+    // Starts with a frontend estimate and is replaced atomically when the
+    // engine reports authoritative usage.
+    usage: AnthropicUsage,
     // Tool call tracking
     tool_call_states: Vec<ToolCallState>,
     tool_blocks_flushed: bool,
@@ -63,7 +65,7 @@ impl ToolCallState {
 }
 
 impl AnthropicStreamConverter {
-    pub fn new(model: String) -> Self {
+    pub fn new(model: String, estimated_input_tokens: u32) -> Self {
         Self {
             model,
             message_id: format!("msg_{}", Uuid::new_v4().simple()),
@@ -74,14 +76,10 @@ impl AnthropicStreamConverter {
             text_block_started: false,
             text_block_closed: false,
             text_block_index: 0,
-            // 0 until the engine reports the real prompt_tokens on the final
-            // chunk. The frontend can't produce an authoritative count here:
-            // the cache-hit split is unknown pre-generation and the frontend
-            // tokenizer may diverge from the worker's. message_delta carries
-            // the real value (see append_chunk_events).
-            input_token_count: 0,
-            output_token_count: 0,
-            cached_token_count: None,
+            usage: AnthropicUsage {
+                input_tokens: estimated_input_tokens,
+                ..Default::default()
+            },
             tool_call_states: Vec::new(),
             tool_blocks_flushed: false,
             next_block_index: 0,
@@ -92,8 +90,12 @@ impl AnthropicStreamConverter {
     /// Create a converter seeded with the original Anthropic request context.
     /// This allows the response stream to carry forward metadata that was lost
     /// during the Anthropic-to-OpenAI request conversion.
-    pub fn with_context(model: String, context: AnthropicContext) -> Self {
-        let mut converter = Self::new(model);
+    pub fn with_context(
+        model: String,
+        estimated_input_tokens: u32,
+        context: AnthropicContext,
+    ) -> Self {
+        let mut converter = Self::new(model, estimated_input_tokens);
         converter.api_context = Some(context);
         converter
     }
@@ -194,6 +196,10 @@ impl AnthropicStreamConverter {
         }
     }
 
+    fn record_usage(&mut self, usage: &CompletionUsage) {
+        self.usage = completion_usage_to_anthropic(usage);
+    }
+
     /// Emit the initial `message_start` event.
     pub fn emit_start_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::with_capacity(1);
@@ -213,12 +219,7 @@ impl AnthropicStreamConverter {
             model: self.model.clone(),
             stop_reason: None,
             stop_sequence: None,
-            usage: AnthropicUsage {
-                input_tokens: self.input_token_count,
-                output_tokens: 0,
-                cache_creation_input_tokens: None,
-                cache_read_input_tokens: None,
-            },
+            usage: self.usage.clone(),
         };
 
         let event = AnthropicStreamEvent::MessageStart { message };
@@ -241,25 +242,11 @@ impl AnthropicStreamConverter {
         chunk: &NvCreateChatCompletionStreamResponse,
         events: &mut Vec<Result<Event, anyhow::Error>>,
     ) {
-        // Capture token usage from the engine when available (typically on the
-        // final chunk). Per the Anthropic streaming spec, `message_delta.usage`
-        // is cumulative, so we report the engine's real `prompt_tokens` here.
-        // OpenAI's `prompt_tokens` is the TOTAL prompt and already includes the
-        // cached tokens, whereas Anthropic's `input_tokens` counts only the
-        // *uncached* input (cache_read is reported separately and must not
-        // overlap) — so subtract the cached count. The engine is the only
-        // authoritative source for this number: the frontend tokenizer can
-        // diverge from the worker's (multimodal expansion, sglang chat-processor
-        // mode, special-token handling), so we never synthesize it upstream.
+        // Replace the initial estimate when the engine reports authoritative
+        // usage (typically on the final chunk). This also applies Anthropic's
+        // non-overlapping cached-token accounting.
         if let Some(usage) = &chunk.inner.usage {
-            self.output_token_count = usage.completion_tokens;
-            self.cached_token_count = usage
-                .prompt_tokens_details
-                .as_ref()
-                .and_then(|d| d.cached_tokens);
-            self.input_token_count = usage
-                .prompt_tokens
-                .saturating_sub(self.cached_token_count.unwrap_or(0));
+            self.record_usage(usage);
         }
 
         let mut should_flush_tool_blocks = false;
@@ -466,12 +453,7 @@ impl AnthropicStreamConverter {
                 stop_reason: self.stop_reason.clone(),
                 stop_sequence: None,
             },
-            usage: AnthropicUsage {
-                input_tokens: self.input_token_count,
-                output_tokens: self.output_token_count,
-                cache_creation_input_tokens: None,
-                cache_read_input_tokens: self.cached_token_count,
-            },
+            usage: self.usage.clone(),
         };
         events.push(make_sse_event("message_delta", &message_delta));
 
@@ -532,14 +514,7 @@ impl AnthropicStreamConverter {
         let mut events = Vec::new();
 
         if let Some(usage) = &chunk.inner.usage {
-            self.output_token_count = usage.completion_tokens;
-            self.cached_token_count = usage
-                .prompt_tokens_details
-                .as_ref()
-                .and_then(|d| d.cached_tokens);
-            self.input_token_count = usage
-                .prompt_tokens
-                .saturating_sub(self.cached_token_count.unwrap_or(0));
+            self.record_usage(usage);
         }
 
         let mut should_flush_tool_blocks = false;
@@ -634,7 +609,7 @@ impl AnthropicStreamConverter {
                     events.push(make_tagged_event("content_block_start", &ev));
                 }
 
-                self.output_token_count += 1;
+                self.usage.output_tokens += 1;
                 let ev = AnthropicStreamEvent::ContentBlockDelta {
                     index: self.text_block_index,
                     delta: AnthropicDelta::TextDelta {
@@ -724,12 +699,7 @@ impl AnthropicStreamConverter {
                 stop_reason: self.stop_reason.clone(),
                 stop_sequence: None,
             },
-            usage: AnthropicUsage {
-                input_tokens: self.input_token_count,
-                output_tokens: self.output_token_count,
-                cache_creation_input_tokens: None,
-                cache_read_input_tokens: self.cached_token_count,
-            },
+            usage: self.usage.clone(),
         };
         events.push(make_tagged_event("message_delta", &ev));
 
@@ -911,24 +881,29 @@ mod tests {
                 }),
             },
             nvext: None,
+            llm_metrics: None,
         }
     }
 
-    /// Streaming usage: `message_start` reports input_tokens=0 (engine count not
-    /// known yet), and the final `message_delta` reports the engine's real
-    /// `prompt_tokens` minus the cached tokens (Anthropic `input_tokens` counts
-    /// only the uncached input; cache_read is separate and must not overlap).
+    /// Streaming usage starts with the frontend estimate, then reconciles to
+    /// the engine's total prompt tokens minus its cached-token count.
     #[test]
-    fn test_streaming_input_tokens_zero_at_start_real_at_delta() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into());
+    fn test_streaming_input_tokens_reconciled_from_engine_usage() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 19);
 
-        // message_start: nothing from the engine yet -> 0.
-        assert_eq!(conv.input_token_count, 0);
+        // `message_start` is emitted before backend usage is available.
+        assert_eq!(conv.usage.input_tokens, 19);
 
-        conv.process_chunk_tagged(&text_chunk("Hi!"));
-        // Final chunk carries usage: prompt=12, cached=11 -> input=1.
-        let end = conv.process_chunk_tagged(&usage_chunk(12, Some(11), 5));
-        assert!(end.is_empty(), "usage-only chunk emits no content events");
+        // Exercise the production chunk path rather than its tagged test mirror.
+        let mut events = Vec::new();
+        conv.append_chunk_events(&usage_chunk(12, Some(11), 5), &mut events);
+        assert!(
+            events.is_empty(),
+            "usage-only chunk emits no content events"
+        );
+        assert_eq!(conv.usage.input_tokens, 1);
+        assert_eq!(conv.usage.cache_read_input_tokens, Some(11));
+        assert_eq!(conv.usage.output_tokens, 5);
 
         let delta = conv.emit_end_events_tagged();
         let message_delta = delta
@@ -953,7 +928,7 @@ mod tests {
     /// events and fail to execute tool calls ("Error editing file").
     #[test]
     fn test_text_block_stops_before_tool_block_starts() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into());
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
 
         // Stream some text
         let text_events = conv.process_chunk_tagged(&text_chunk("I'll edit the file."));
@@ -1175,7 +1150,7 @@ mod tests {
     /// Text-only response: stop emitted in end events (no early close).
     #[test]
     fn test_text_only_response_stop_in_end_events() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into());
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
 
         conv.process_chunk_tagged(&text_chunk("Hello world"));
 
@@ -1225,7 +1200,7 @@ mod tests {
     /// block is properly closed before the next one starts.
     #[test]
     fn test_thinking_text_then_tool_call() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into());
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
 
         // 1. Reasoning tokens → thinking block starts
         let ev = conv.process_chunk_tagged(&reasoning_chunk("Let me think..."));
@@ -1293,7 +1268,7 @@ mod tests {
     /// Thinking-only response (no text/tool follows): thinking block closed in end events.
     #[test]
     fn test_thinking_only_closed_in_end_events() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into());
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
         conv.process_chunk_tagged(&reasoning_chunk("Deep thought..."));
 
         let ev = conv.emit_end_events_tagged();
@@ -1405,7 +1380,7 @@ mod tests {
             service_tier: Some("priority".to_string()),
             ..Default::default()
         };
-        let mut conv = AnthropicStreamConverter::with_context("test-model".into(), ctx);
+        let mut conv = AnthropicStreamConverter::with_context("test-model".into(), 0, ctx);
         assert!(conv.api_context.is_some());
         assert_eq!(
             conv.api_context.as_ref().unwrap().service_tier.as_deref(),

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -63,7 +63,7 @@ impl ToolCallState {
 }
 
 impl AnthropicStreamConverter {
-    pub fn new(model: String, estimated_input_tokens: u32) -> Self {
+    pub fn new(model: String) -> Self {
         Self {
             model,
             message_id: format!("msg_{}", Uuid::new_v4().simple()),
@@ -74,7 +74,12 @@ impl AnthropicStreamConverter {
             text_block_started: false,
             text_block_closed: false,
             text_block_index: 0,
-            input_token_count: estimated_input_tokens,
+            // 0 until the engine reports the real prompt_tokens on the final
+            // chunk. The frontend can't produce an authoritative count here:
+            // the cache-hit split is unknown pre-generation and the frontend
+            // tokenizer may diverge from the worker's. message_delta carries
+            // the real value (see append_chunk_events).
+            input_token_count: 0,
             output_token_count: 0,
             cached_token_count: None,
             tool_call_states: Vec::new(),
@@ -87,12 +92,8 @@ impl AnthropicStreamConverter {
     /// Create a converter seeded with the original Anthropic request context.
     /// This allows the response stream to carry forward metadata that was lost
     /// during the Anthropic-to-OpenAI request conversion.
-    pub fn with_context(
-        model: String,
-        estimated_input_tokens: u32,
-        context: AnthropicContext,
-    ) -> Self {
-        let mut converter = Self::new(model, estimated_input_tokens);
+    pub fn with_context(model: String, context: AnthropicContext) -> Self {
+        let mut converter = Self::new(model);
         converter.api_context = Some(context);
         converter
     }
@@ -240,16 +241,25 @@ impl AnthropicStreamConverter {
         chunk: &NvCreateChatCompletionStreamResponse,
         events: &mut Vec<Result<Event, anyhow::Error>>,
     ) {
-        // Capture token usage from engine when available (typically on the final chunk).
-        // Only update output_token_count — input_token_count is set once from the
-        // estimate in new() and must stay consistent between message_start and
-        // message_delta to avoid Claude Code's token display jumping.
+        // Capture token usage from the engine when available (typically on the
+        // final chunk). Per the Anthropic streaming spec, `message_delta.usage`
+        // is cumulative, so we report the engine's real `prompt_tokens` here.
+        // OpenAI's `prompt_tokens` is the TOTAL prompt and already includes the
+        // cached tokens, whereas Anthropic's `input_tokens` counts only the
+        // *uncached* input (cache_read is reported separately and must not
+        // overlap) — so subtract the cached count. The engine is the only
+        // authoritative source for this number: the frontend tokenizer can
+        // diverge from the worker's (multimodal expansion, sglang chat-processor
+        // mode, special-token handling), so we never synthesize it upstream.
         if let Some(usage) = &chunk.inner.usage {
             self.output_token_count = usage.completion_tokens;
             self.cached_token_count = usage
                 .prompt_tokens_details
                 .as_ref()
                 .and_then(|d| d.cached_tokens);
+            self.input_token_count = usage
+                .prompt_tokens
+                .saturating_sub(self.cached_token_count.unwrap_or(0));
         }
 
         let mut should_flush_tool_blocks = false;
@@ -527,6 +537,9 @@ impl AnthropicStreamConverter {
                 .prompt_tokens_details
                 .as_ref()
                 .and_then(|d| d.cached_tokens);
+            self.input_token_count = usage
+                .prompt_tokens
+                .saturating_sub(self.cached_token_count.unwrap_or(0));
         }
 
         let mut should_flush_tool_blocks = false;
@@ -868,6 +881,70 @@ mod tests {
         assert!(events.iter().all(Result::is_ok));
     }
 
+    /// A chunk carrying engine usage (typically the final chunk).
+    fn usage_chunk(
+        prompt_tokens: u32,
+        cached_tokens: Option<u32>,
+        completion_tokens: u32,
+    ) -> NvCreateChatCompletionStreamResponse {
+        #[allow(deprecated)]
+        NvCreateChatCompletionStreamResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "chat-1".into(),
+                choices: vec![],
+                created: 0,
+                model: "test".into(),
+                service_tier: None,
+                system_fingerprint: None,
+                object: "chat.completion.chunk".into(),
+                usage: Some(dynamo_protocols::types::CompletionUsage {
+                    prompt_tokens,
+                    completion_tokens,
+                    total_tokens: prompt_tokens + completion_tokens,
+                    prompt_tokens_details: cached_tokens.map(|c| {
+                        dynamo_protocols::types::PromptTokensDetails {
+                            audio_tokens: None,
+                            cached_tokens: Some(c),
+                        }
+                    }),
+                    completion_tokens_details: None,
+                }),
+            },
+            nvext: None,
+        }
+    }
+
+    /// Streaming usage: `message_start` reports input_tokens=0 (engine count not
+    /// known yet), and the final `message_delta` reports the engine's real
+    /// `prompt_tokens` minus the cached tokens (Anthropic `input_tokens` counts
+    /// only the uncached input; cache_read is separate and must not overlap).
+    #[test]
+    fn test_streaming_input_tokens_zero_at_start_real_at_delta() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into());
+
+        // message_start: nothing from the engine yet -> 0.
+        assert_eq!(conv.input_token_count, 0);
+
+        conv.process_chunk_tagged(&text_chunk("Hi!"));
+        // Final chunk carries usage: prompt=12, cached=11 -> input=1.
+        let end = conv.process_chunk_tagged(&usage_chunk(12, Some(11), 5));
+        assert!(end.is_empty(), "usage-only chunk emits no content events");
+
+        let delta = conv.emit_end_events_tagged();
+        let message_delta = delta
+            .iter()
+            .find(|e| e.event_type == "message_delta")
+            .expect("message_delta present");
+        match &message_delta.data {
+            AnthropicStreamEvent::MessageDelta { usage, .. } => {
+                assert_eq!(usage.input_tokens, 1);
+                assert_eq!(usage.cache_read_input_tokens, Some(11));
+                assert_eq!(usage.output_tokens, 5);
+            }
+            other => panic!("expected MessageDelta, got {other:?}"),
+        }
+    }
+
     /// Regression test: text block must be closed (content_block_stop)
     /// before the tool_use block starts (content_block_start).
     ///
@@ -876,7 +953,7 @@ mod tests {
     /// events and fail to execute tool calls ("Error editing file").
     #[test]
     fn test_text_block_stops_before_tool_block_starts() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        let mut conv = AnthropicStreamConverter::new("test-model".into());
 
         // Stream some text
         let text_events = conv.process_chunk_tagged(&text_chunk("I'll edit the file."));
@@ -1098,7 +1175,7 @@ mod tests {
     /// Text-only response: stop emitted in end events (no early close).
     #[test]
     fn test_text_only_response_stop_in_end_events() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        let mut conv = AnthropicStreamConverter::new("test-model".into());
 
         conv.process_chunk_tagged(&text_chunk("Hello world"));
 
@@ -1148,7 +1225,7 @@ mod tests {
     /// block is properly closed before the next one starts.
     #[test]
     fn test_thinking_text_then_tool_call() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        let mut conv = AnthropicStreamConverter::new("test-model".into());
 
         // 1. Reasoning tokens → thinking block starts
         let ev = conv.process_chunk_tagged(&reasoning_chunk("Let me think..."));
@@ -1216,7 +1293,7 @@ mod tests {
     /// Thinking-only response (no text/tool follows): thinking block closed in end events.
     #[test]
     fn test_thinking_only_closed_in_end_events() {
-        let mut conv = AnthropicStreamConverter::new("test-model".into(), 0);
+        let mut conv = AnthropicStreamConverter::new("test-model".into());
         conv.process_chunk_tagged(&reasoning_chunk("Deep thought..."));
 
         let ev = conv.emit_end_events_tagged();
@@ -1328,7 +1405,7 @@ mod tests {
             service_tier: Some("priority".to_string()),
             ..Default::default()
         };
-        let mut conv = AnthropicStreamConverter::with_context("test-model".into(), 0, ctx);
+        let mut conv = AnthropicStreamConverter::with_context("test-model".into(), ctx);
         assert!(conv.api_context.is_some());
         assert_eq!(
             conv.api_context.as_ref().unwrap().service_tier.as_deref(),

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -545,8 +545,17 @@ pub fn chat_completion_to_anthropic_response(
                 .prompt_tokens_details
                 .and_then(|d| d.cached_tokens)
                 .filter(|&n| n > 0);
+            // OpenAI's `prompt_tokens` is the TOTAL prompt size and already
+            // includes the cached (and cache-creation) tokens. Anthropic's
+            // `input_tokens` semantics are the opposite: it counts only the
+            // *uncached* input, with cache_read/cache_creation reported
+            // separately and non-overlapping. Subtract so the same token isn't
+            // double-counted across input_tokens + cache_read_input_tokens.
+            let input_tokens = u
+                .prompt_tokens
+                .saturating_sub(cache_read_input_tokens.unwrap_or(0));
             AnthropicUsage {
-                input_tokens: u.prompt_tokens,
+                input_tokens,
                 output_tokens: u.completion_tokens,
                 cache_creation_input_tokens: None, // Not available from OpenAI format
                 cache_read_input_tokens,
@@ -964,6 +973,56 @@ mod tests {
             }
             _ => panic!("expected text block"),
         }
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn test_anthropic_response_input_tokens_excludes_cached() {
+        // OpenAI prompt_tokens is the total (12) and already includes the
+        // cached tokens (11). Anthropic input_tokens must report only the
+        // uncached portion (12 - 11 = 1), with cache_read reported separately.
+        let chat_resp = NvCreateChatCompletionResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionResponse {
+                id: "chatcmpl-cache".into(),
+                choices: vec![dynamo_protocols::types::ChatChoice {
+                    index: 0,
+                    message: dynamo_protocols::types::ChatCompletionResponseMessage {
+                        content: Some(dynamo_protocols::types::ChatCompletionMessageContent::Text(
+                            "Hi!".to_string(),
+                        )),
+                        refusal: None,
+                        tool_calls: None,
+                        role: dynamo_protocols::types::Role::Assistant,
+                        function_call: None,
+                        audio: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: Some(dynamo_protocols::types::FinishReason::Stop),
+                    logprobs: None,
+                }],
+                created: 1726000000,
+                model: "test-model".into(),
+                service_tier: None,
+                system_fingerprint: None,
+                object: "chat.completion".to_string(),
+                usage: Some(dynamo_protocols::types::CompletionUsage {
+                    prompt_tokens: 12,
+                    completion_tokens: 5,
+                    total_tokens: 17,
+                    prompt_tokens_details: Some(dynamo_protocols::types::PromptTokensDetails {
+                        audio_tokens: None,
+                        cached_tokens: Some(11),
+                    }),
+                    completion_tokens_details: None,
+                }),
+            },
+            nvext: None,
+        };
+
+        let response = chat_completion_to_anthropic_response(chat_resp, "test-model", None);
+        assert_eq!(response.usage.input_tokens, 1);
+        assert_eq!(response.usage.cache_read_input_tokens, Some(11));
+        assert_eq!(response.usage.output_tokens, 5);
     }
 
     #[allow(deprecated)]

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -19,8 +19,8 @@ use dynamo_protocols::types::{
     ChatCompletionRequestSystemMessageContent, ChatCompletionRequestToolMessage,
     ChatCompletionRequestToolMessageContent, ChatCompletionRequestUserMessage,
     ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
-    ChatCompletionTool, ChatCompletionToolChoiceOption, ChatCompletionToolType, FunctionName,
-    FunctionObject, FunctionType, ImageUrl, ReasoningContent,
+    ChatCompletionTool, ChatCompletionToolChoiceOption, ChatCompletionToolType, CompletionUsage,
+    FunctionName, FunctionObject, FunctionType, ImageUrl, ReasoningContent,
 };
 use uuid::Uuid;
 
@@ -458,6 +458,34 @@ fn convert_anthropic_tool_choice(tc: &AnthropicToolChoice) -> ChatCompletionTool
         }
     }
 }
+
+/// Convert Dynamo's OpenAI-compatible usage into Anthropic's non-overlapping
+/// input-token accounting.
+///
+/// Dynamo backends report `prompt_tokens` as the complete prompt and
+/// `cached_tokens` as a subset of it. Anthropic reports the cached subset
+/// separately, so `input_tokens` must exclude it.
+pub(super) fn completion_usage_to_anthropic(usage: &CompletionUsage) -> AnthropicUsage {
+    let cache_read_input_tokens = usage
+        .prompt_tokens_details
+        .as_ref()
+        .and_then(|details| details.cached_tokens)
+        // A backend must not be able to produce an Anthropic usage breakdown
+        // whose cached subset exceeds the complete prompt.
+        .map(|tokens| tokens.min(usage.prompt_tokens))
+        .filter(|&tokens| tokens > 0);
+
+    AnthropicUsage {
+        input_tokens: usage
+            .prompt_tokens
+            .saturating_sub(cache_read_input_tokens.unwrap_or(0)),
+        output_tokens: usage.completion_tokens,
+        // OpenAI-compatible backends do not distinguish cache writes.
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens,
+    }
+}
+
 /// Convert a completed chat completion response into an Anthropic Messages response.
 pub fn chat_completion_to_anthropic_response(
     chat_resp: NvCreateChatCompletionResponse,
@@ -536,31 +564,12 @@ pub fn chat_completion_to_anthropic_response(
         });
     }
 
-    // Map usage
+    // Map usage through the same protocol conversion used by the streaming path.
     let usage = chat_resp
         .inner
         .usage
-        .map(|u| {
-            let cache_read_input_tokens = u
-                .prompt_tokens_details
-                .and_then(|d| d.cached_tokens)
-                .filter(|&n| n > 0);
-            // OpenAI's `prompt_tokens` is the TOTAL prompt size and already
-            // includes the cached (and cache-creation) tokens. Anthropic's
-            // `input_tokens` semantics are the opposite: it counts only the
-            // *uncached* input, with cache_read/cache_creation reported
-            // separately and non-overlapping. Subtract so the same token isn't
-            // double-counted across input_tokens + cache_read_input_tokens.
-            let input_tokens = u
-                .prompt_tokens
-                .saturating_sub(cache_read_input_tokens.unwrap_or(0));
-            AnthropicUsage {
-                input_tokens,
-                output_tokens: u.completion_tokens,
-                cache_creation_input_tokens: None, // Not available from OpenAI format
-                cache_read_input_tokens,
-            }
-        })
+        .as_ref()
+        .map(completion_usage_to_anthropic)
         .unwrap_or_default();
 
     AnthropicMessageResponse {
@@ -1023,6 +1032,25 @@ mod tests {
         assert_eq!(response.usage.input_tokens, 1);
         assert_eq!(response.usage.cache_read_input_tokens, Some(11));
         assert_eq!(response.usage.output_tokens, 5);
+    }
+
+    #[test]
+    fn test_anthropic_usage_clamps_cached_tokens_to_prompt_tokens() {
+        let usage = CompletionUsage {
+            prompt_tokens: 12,
+            completion_tokens: 5,
+            total_tokens: 17,
+            prompt_tokens_details: Some(dynamo_protocols::types::PromptTokensDetails {
+                audio_tokens: None,
+                cached_tokens: Some(20),
+            }),
+            completion_tokens_details: None,
+        };
+
+        let usage = completion_usage_to_anthropic(&usage);
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.cache_read_input_tokens, Some(12));
+        assert_eq!(usage.output_tokens, 5);
     }
 
     #[allow(deprecated)]

--- a/lib/llm/tests/snapshots/anthropic_http_replay__anthropic_streaming_text.snap
+++ b/lib/llm/tests/snapshots/anthropic_http_replay__anthropic_streaming_text.snap
@@ -59,7 +59,7 @@ expression: "canonicalize(serde_json::to_value(events).unwrap())"
         "stop_reason": "end_turn"
       },
       "usage": {
-        "input_tokens": 2,
+        "input_tokens": 5,
         "output_tokens": 2
       }
     }


### PR DESCRIPTION
## Summary

This PR corrects the input-token counts returned by Dynamo's Anthropic Messages API. Streaming responses continue to give clients an early estimate in `message_start`, then replace that estimate with the backend's final count in `message_delta`. Non-streaming responses use the same final accounting.

Dynamo's OpenAI-compatible backends report `prompt_tokens` as the complete prompt, including any cached tokens. Anthropic reports uncached `input_tokens` and cached input in separate, non-overlapping fields. Dynamo previously copied the complete prompt count into `input_tokens` while also reporting `cache_read_input_tokens`, so cached tokens appeared twice. For example, a backend result with 12 prompt tokens and 11 cached tokens produced `input_tokens: 12` and `cache_read_input_tokens: 11`; the correct Anthropic result is `input_tokens: 1` and `cache_read_input_tokens: 11`.

The streaming path cannot use the backend count in `message_start` because the backend reports usage only after generation. Dynamo therefore keeps its frontend estimate for the start event. When the backend usage chunk arrives, the final `message_delta` replaces the estimate with the backend's prompt and cache counts. This preserves useful early information without retaining an estimate after the exact count is available.

The HTTP replay test demonstrates that transition directly. Its `message_start` contains the frontend estimate of two input tokens, while its final `message_delta` contains the fixture's backend count of five input tokens.

## Implementation

`completion_usage_to_anthropic` provides one conversion for streaming and non-streaming responses. It subtracts cached input from the complete prompt count, clamps an invalid cached count to the complete prompt count, and uses saturating subtraction.

`AnthropicStreamConverter` starts with the frontend estimate and replaces the complete usage object when the backend reports final usage. The service computes the initial estimate before consuming the Anthropic request.

The tests cover uncached input, cached input, an invalid cached count larger than the prompt count, streaming reconciliation, and the full HTTP event sequence.

## Review guide

- Start with `lib/llm/src/protocols/anthropic/types.rs`, which contains the shared OpenAI-to-Anthropic usage conversion.
- Continue with `lib/llm/src/protocols/anthropic/stream_converter.rs`, which reconciles the initial estimate with final backend usage.
- `lib/llm/src/http/service/anthropic.rs` computes the initial streaming estimate.
- `lib/llm/tests/snapshots/anthropic_http_replay__anthropic_streaming_text.snap` records the estimate-to-final transition exercised by the HTTP replay fixture.

## Validation

GitHub Actions completed on the current head `dd198892` with 21 checks passed, four jobs skipped by workflow conditions, and no pending or failing checks. The repository-root Rust test suite passed with the corrected HTTP replay snapshot.

`git diff --check upstream/main...HEAD` completed without errors. No local build was run.

## Related work

This PR is not linked to a Dynamo issue. The relevant upstream SGLang changes are:

- https://github.com/sgl-project/sglang/pull/19792
- https://github.com/sgl-project/sglang/pull/25876
