### PR TITLE
refactor(mocker): centralize offload lifecycle ownership [DYN-3300]

### DIFF
--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -67,9 +67,8 @@ pub enum BatchSwapInOutcome {
     NoHits,
     /// Swap-in reservation accepted. Caller parks the request with this
     /// handle and polls `SwapInHandle::is_complete()` on subsequent
-    /// scheduler passes. Matched lower-tier blocks are held by the
-    /// engine/handle for the duration of the transfer, while
-    /// `destination_slots` pins the G1 write targets.
+    /// scheduler passes. The coordinator retains matched lower-tier blocks,
+    /// G1 destination slots, and any pinned cached prefix for the transfer.
     Scheduled { handle: SwapInHandle },
     /// G2 had a match, but reserving destination G1 slots first had to
     /// trigger a G1→G2 eviction. Caller should retry after offload advances.
@@ -3613,7 +3612,23 @@ mod tests {
             assert_eq!(
                 mgr.refresh_offload_dependency(queued_dependency),
                 Some(queued_dependency),
-                "the queued request must stay protected while its exact predecessor is active"
+                "the queued request must stay protected while its exact lease is active"
+            );
+            mgr.tick_offload_engine(
+                first_dependency
+                    .deadline_ms
+                    .expect("first offload dependency deadline"),
+            );
+            assert_eq!(
+                mgr.refresh_offload_dependency(first_dependency),
+                None,
+                "a completed lease must not retarget to an unrelated live offload"
+            );
+            assert_eq!(
+                mgr.refresh_offload_dependency(queued_dependency)
+                    .map(|dependency| dependency.offload_id),
+                Some(queued_dependency.offload_id),
+                "the queued lease must remain independently live"
             );
             assert_eq!(mgr.num_active_block_refs(), 0);
         }

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -54,7 +54,7 @@ use crate::common::sequence::ActiveSequence;
 #[cfg(feature = "kvbm-offload")]
 use crate::kvbm_offload::{
     G1EvictionOutcome, G2BlockEventMetadata, G2OffloadBlock, G2RouterEvent, MockOffloadEngine,
-    SwapInHandle, TransferId,
+    OffloadId, SwapInHandle,
 };
 
 /// Outcome of [`KvManager::try_batch_swap_in`]. The caller uses this to
@@ -70,10 +70,7 @@ pub enum BatchSwapInOutcome {
     /// scheduler passes. Matched lower-tier blocks are held by the
     /// engine/handle for the duration of the transfer, while
     /// `destination_slots` pins the G1 write targets.
-    Scheduled {
-        handle: SwapInHandle,
-        destination_slots: Vec<MutableBlock<G1>>,
-    },
+    Scheduled { handle: SwapInHandle },
     /// G2 had a match, but reserving destination G1 slots first had to
     /// trigger a G1→G2 eviction. Caller should retry after offload advances.
     BlockedOnG1Offload(OffloadDependency),
@@ -116,7 +113,7 @@ pub(crate) enum G1Acquire<T> {
     Ready(T),
     CapacityExhausted,
     BlockedOnOffload {
-        transfer_id: Option<TransferId>,
+        offload_id: OffloadId,
         deadline_ms: Option<f64>,
     },
     RetryNow {
@@ -126,7 +123,7 @@ pub(crate) enum G1Acquire<T> {
 }
 
 #[cfg(not(feature = "kvbm-offload"))]
-type TransferId = u64;
+type OffloadId = u64;
 
 #[cfg(not(feature = "kvbm-offload"))]
 enum G1EvictionOutcome {}
@@ -134,7 +131,7 @@ enum G1EvictionOutcome {}
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[doc(hidden)]
 pub struct OffloadDependency {
-    pub(crate) transfer_id: Option<TransferId>,
+    pub(crate) offload_id: OffloadId,
     pub(crate) deadline_ms: Option<f64>,
 }
 
@@ -378,24 +375,28 @@ impl KvManager {
 
     /// Advance the offload engine's PS models and fire any
     /// completion sinks for drained transfers. Scheduler calls this at
-    /// the top of every pass so swap-in flags flip before the
+    /// the top of every pass so swap-in statuses publish before the
     /// promote-completed loop runs, and offload awaiters fire before
     /// the next enqueue measures the active-set size. No-op when no
     /// engine is attached.
     #[cfg(feature = "kvbm-offload")]
     pub fn tick_offload_engine(&mut self, now_ms: f64) {
-        let (g2_events, released_g1_slots) = if let Some(engine_arc) = self.offload_engine.as_ref()
-        {
-            let engine = engine_arc.lock().expect("offload engine mutex poisoned");
-            let released_g1_slots = engine.tick(now_ms);
-            (engine.drain_g2_router_events(), released_g1_slots)
-        } else {
-            (Vec::new(), 0)
+        let Some(engine_arc) = self.offload_engine.clone() else {
+            return;
         };
+        let prepared = {
+            let engine = engine_arc.lock().expect("offload engine mutex poisoned");
+            engine.prepare_tick_for_kv_manager(now_ms)
+        };
+        self.publish_g2_router_events(prepared.router_events);
+        let released_g1_slots = engine_arc
+            .lock()
+            .expect("offload engine mutex poisoned")
+            .acknowledge_tick_for_kv_manager(prepared.acknowledgement)
+            .expect("freshly prepared offload advance must acknowledge");
         if released_g1_slots > 0 {
             self.bump_capacity_generation(released_g1_slots);
         }
-        self.publish_g2_router_events(g2_events);
     }
 
     /// Earliest pending completion time across offload + onboard links,
@@ -415,23 +416,12 @@ impl KvManager {
     ) -> Option<OffloadDependency> {
         let engine_arc = self.offload_engine.as_ref()?;
         let engine = engine_arc.lock().expect("offload engine mutex poisoned");
-        if let Some(transfer_id) = dependency.transfer_id
-            && engine.is_g1_offload_active(transfer_id)
-            && let Some(deadline_ms) = engine.deadline_for_g1_offload(transfer_id)
-        {
-            return Some(OffloadDependency {
-                transfer_id: Some(transfer_id),
-                deadline_ms: Some(deadline_ms),
-            });
-        }
-        if !engine.has_nonterminal_g1_pipeline() {
-            return None;
-        }
-        let current = engine.current_g1_offload_dependency();
-        Some(OffloadDependency {
-            transfer_id: current.map(|(transfer_id, _deadline_ms)| transfer_id),
-            deadline_ms: current.map(|(_transfer_id, deadline_ms)| deadline_ms),
-        })
+        engine
+            .g1_offload_dependency(dependency.offload_id)
+            .map(|(offload_id, deadline_ms)| OffloadDependency {
+                offload_id,
+                deadline_ms,
+            })
     }
 
     #[cfg(not(feature = "kvbm-offload"))]
@@ -624,6 +614,7 @@ impl KvManager {
     pub fn try_batch_swap_in(
         &mut self,
         remaining_plhs: &[PositionalLineageHash],
+        prefix_pins: Vec<ImmutableBlock<G1>>,
         now_ms: Option<f64>,
     ) -> BatchSwapInOutcome {
         let Some(engine_arc) = self.offload_engine.clone() else {
@@ -650,12 +641,41 @@ impl KvManager {
         };
         let handle = {
             let mut engine = engine_arc.lock().expect("offload engine mutex poisoned");
-            engine.start_onboard_prefix(prepared, now_ms)
+            engine.start_onboard_prefix(prepared, destination_slots, prefix_pins, now_ms)
         };
-        BatchSwapInOutcome::Scheduled {
-            handle,
-            destination_slots,
-        }
+        BatchSwapInOutcome::Scheduled { handle }
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    pub(crate) fn cancel_swap_in(&mut self, id: OffloadId) -> bool {
+        self.offload_engine.as_ref().is_some_and(|engine| {
+            engine
+                .lock()
+                .expect("offload engine mutex poisoned")
+                .cancel_swap_in(id)
+        })
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    pub(crate) fn register_completed_swap_in(
+        &mut self,
+        id: OffloadId,
+        entries: Vec<SwapInRegistrationBlock>,
+        parent_hash: Option<SequenceHash>,
+    ) -> SwapInRegistrationOutcome {
+        let (destination_slots, prefix_pins) = self
+            .offload_engine
+            .as_ref()
+            .and_then(|engine| {
+                engine
+                    .lock()
+                    .expect("offload engine mutex poisoned")
+                    .take_completed_swap_in(id)
+            })
+            .expect("completed swap-in lease must retain its G1 resources");
+        let outcome = self.register_swapped_in_blocks(entries, parent_hash, destination_slots);
+        drop(prefix_pins);
+        outcome
     }
 
     /// Hold the G1 prefix that admission used when deciding to swap in only a
@@ -854,11 +874,11 @@ impl KvManager {
                 }
                 G1Acquire::CapacityExhausted => return G1Acquire::CapacityExhausted,
                 G1Acquire::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 } => {
                     return G1Acquire::BlockedOnOffload {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     };
                 }
@@ -902,10 +922,10 @@ impl KvManager {
             }
             G1Acquire::CapacityExhausted => G1Acquire::CapacityExhausted,
             G1Acquire::BlockedOnOffload {
-                transfer_id,
+                offload_id,
                 deadline_ms,
             } => G1Acquire::BlockedOnOffload {
-                transfer_id,
+                offload_id,
                 deadline_ms,
             },
             G1Acquire::RetryNow {
@@ -949,10 +969,10 @@ impl KvManager {
                 .expect("G1 offload-enabled eviction must return a dependency outcome");
             match outcome {
                 G1EvictionOutcome::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 } => G1Acquire::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 },
                 G1EvictionOutcome::RetryNow { released_slots } => {
@@ -1079,11 +1099,11 @@ impl KvManager {
                 }
                 G1Acquire::CapacityExhausted => return G1Acquire::CapacityExhausted,
                 G1Acquire::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 } => {
                     return G1Acquire::BlockedOnOffload {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     };
                 }
@@ -1300,11 +1320,11 @@ impl KvManager {
                 G1Acquire::Ready(slots) => return SwapInSlotReservation::Reserved(slots),
                 G1Acquire::CapacityExhausted => return SwapInSlotReservation::NoCapacity,
                 G1Acquire::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 } => {
                     return SwapInSlotReservation::BlockedOnG1Offload(OffloadDependency {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     });
                 }
@@ -1366,11 +1386,11 @@ impl KvManager {
                 }
                 G1Acquire::CapacityExhausted => return G1Acquire::CapacityExhausted,
                 G1Acquire::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 } => {
                     return G1Acquire::BlockedOnOffload {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     };
                 }
@@ -1508,11 +1528,11 @@ impl KvManager {
                 G1Acquire::Ready(reservation) => reservation,
                 G1Acquire::CapacityExhausted => return G1Acquire::CapacityExhausted,
                 G1Acquire::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 } => {
                     return G1Acquire::BlockedOnOffload {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     };
                 }
@@ -3566,31 +3586,29 @@ mod tests {
             let first_dependency =
                 match use_full_with_hash(&mut mgr, 3, plh(3), 303, vec![9, 10, 11, 12]) {
                     G1Acquire::BlockedOnOffload {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     } => OffloadDependency {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     },
                     _ => panic!("first eviction must start an offload dependency"),
                 };
-            let first_id = first_dependency
-                .transfer_id
-                .expect("active predecessor must have a TransferId");
+            let first_id = first_dependency.offload_id;
             assert!(first_dependency.deadline_ms.is_some());
 
             let queued_dependency =
                 match use_full_with_hash(&mut mgr, 4, plh(4), 404, vec![13, 14, 15, 16]) {
                     G1Acquire::BlockedOnOffload {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     } => OffloadDependency {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     },
                     _ => panic!("second eviction must queue behind the active offload"),
                 };
-            assert_eq!(queued_dependency.transfer_id, Some(first_id));
+            assert_ne!(queued_dependency.offload_id, first_id);
             assert_eq!(queued_dependency.deadline_ms, first_dependency.deadline_ms);
             assert_eq!(
                 mgr.refresh_offload_dependency(queued_dependency),
@@ -3822,7 +3840,7 @@ mod tests {
         fn try_batch_swap_in_returns_no_hits_without_engine() {
             let mut mgr = make_mgr(8, 4);
             let plhs = [plh(1), plh(2), plh(3)];
-            let outcome = mgr.try_batch_swap_in(&plhs, None);
+            let outcome = mgr.try_batch_swap_in(&plhs, Vec::new(), None);
             assert!(matches!(outcome, BatchSwapInOutcome::NoHits));
         }
     }

--- a/lib/mocker/src/kvbm_offload/bandwidth_sharing_model.rs
+++ b/lib/mocker/src/kvbm_offload/bandwidth_sharing_model.rs
@@ -397,7 +397,7 @@ mod tests {
         // Two models sharing a single `Arc<AtomicU64>` counter must
         // never hand out the same TransferId. This is the invariant
         // `TransferState` relies on when keying `awaiters` and
-        // `swap_in_flags` by TransferId — a collision would cause
+        // swap-in completion publishers by TransferId — a collision would cause
         // completion signals to cross-fire into the wrong transfer.
         let counter = Arc::new(AtomicU64::new(0));
         let mut a = BandwidthSharingModel::new(1.0, counter.clone());

--- a/lib/mocker/src/kvbm_offload/coordinator.rs
+++ b/lib/mocker/src/kvbm_offload/coordinator.rs
@@ -1,0 +1,933 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Mocker-owned offload lease state and settlement checkpoints.
+
+use std::sync::{Arc, Mutex};
+
+use kvbm_engine::leader::FindMatchesResult;
+use kvbm_engine::offload::{
+    PipelineLane, SettlementTarget, SettlementToken, TransferHandle, TransferProgressCursor,
+    TransferStatus,
+};
+use kvbm_engine::{BlockId, G2, SequenceHash};
+use kvbm_logical::blocks::{ImmutableBlock, MutableBlock};
+use rustc_hash::{FxHashMap, FxHashSet};
+use slotmap::{SlotMap, new_key_type};
+use tokio::sync::watch;
+
+use crate::common::protocols::G1;
+
+use super::capacity_reservation::CapacityReservationGuard;
+
+new_key_type! {
+    /// Generational identity for one coordinator-owned lifecycle.
+    pub(crate) struct OffloadId;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LeaseState {
+    Evaluating,
+    Active,
+    CancelRequested,
+    Prepared,
+    Finished,
+    Cancelled,
+    Failed,
+}
+
+impl LeaseState {
+    fn is_terminal(self) -> bool {
+        matches!(self, Self::Finished | Self::Cancelled | Self::Failed)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SwapInTerminal {
+    Pending,
+    Completed,
+    Cancelled,
+    Failed(Arc<str>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SwapInStatus {
+    pub(crate) terminal: SwapInTerminal,
+    pub(crate) block_count: usize,
+}
+
+impl SwapInStatus {
+    pub(crate) fn pending(block_count: usize) -> Self {
+        Self {
+            terminal: SwapInTerminal::Pending,
+            block_count,
+        }
+    }
+
+    pub(crate) fn completed(block_count: usize) -> Self {
+        Self {
+            terminal: SwapInTerminal::Completed,
+            block_count,
+        }
+    }
+}
+
+/// Public compatibility handle. Resource ownership stays in the coordinator.
+pub struct SwapInHandle {
+    pub(crate) id: OffloadId,
+    status: watch::Receiver<SwapInStatus>,
+}
+
+impl SwapInHandle {
+    pub fn is_complete(&self) -> bool {
+        !matches!(self.status.borrow().terminal, SwapInTerminal::Pending)
+    }
+
+    pub fn block_count(&self) -> usize {
+        self.status.borrow().block_count
+    }
+
+    pub(crate) fn id(&self) -> OffloadId {
+        self.id
+    }
+
+    pub(crate) fn terminal(&self) -> SwapInTerminal {
+        self.status.borrow().terminal.clone()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct LeaseError {
+    pub(crate) id: OffloadId,
+    pub(crate) message: Arc<str>,
+}
+
+struct LaneCheckpoint {
+    token: SettlementToken,
+    observed_batches: u64,
+}
+
+pub(crate) struct SharedSettlement {
+    pub(crate) token: SettlementToken,
+    pub(crate) target: SettlementTarget,
+}
+
+#[derive(Default)]
+pub(crate) struct PreparedProgress {
+    pub(crate) chains: Vec<PreparedChain>,
+    pub(crate) failures: Vec<LeaseError>,
+}
+
+pub(crate) struct PreparedChain {
+    pub(crate) parent: OffloadId,
+    pub(crate) lane: PipelineLane,
+    pub(crate) hashes: Vec<SequenceHash>,
+}
+
+#[derive(Default)]
+pub(crate) struct AcknowledgedProgress {
+    pub(crate) released_g1_slots: usize,
+    pub(crate) released_g2_reservations: usize,
+    pub(crate) released_g3_reservations: usize,
+    pub(crate) abandoned_visibility: Vec<SequenceHash>,
+}
+
+pub(crate) struct G1ToG2Lease {
+    handle: TransferHandle,
+    cursor: TransferProgressCursor,
+    observed_completed: usize,
+    source_slots: FxHashMap<BlockId, MutableBlock<G1>>,
+    lower_chain: FxHashMap<BlockId, SequenceHash>,
+    pending_visibility: FxHashMap<BlockId, SequenceHash>,
+    passed: FxHashSet<BlockId>,
+    prepared_source_slots: Vec<MutableBlock<G1>>,
+    prepared_g2_reservations: usize,
+    prepared_chain: Vec<SequenceHash>,
+    prepared_abandoned_visibility: Vec<SequenceHash>,
+    chain_to_g3: bool,
+    chain_to_g4: bool,
+    registered_g3_chain: usize,
+    registered_g4_chain: usize,
+    unreleased_g2_reservations: usize,
+}
+
+impl G1ToG2Lease {
+    pub(crate) fn new(
+        handle: TransferHandle,
+        source_slots: Vec<MutableBlock<G1>>,
+        lower_chain: FxHashMap<BlockId, SequenceHash>,
+        pending_visibility: FxHashMap<BlockId, SequenceHash>,
+        chain_to_g3: bool,
+        chain_to_g4: bool,
+    ) -> Self {
+        Self {
+            cursor: handle.new_progress_cursor(),
+            handle,
+            observed_completed: 0,
+            source_slots: source_slots
+                .into_iter()
+                .map(|slot| (slot.block_id(), slot))
+                .collect(),
+            lower_chain,
+            pending_visibility,
+            passed: FxHashSet::default(),
+            prepared_source_slots: Vec::new(),
+            prepared_g2_reservations: 0,
+            prepared_chain: Vec::new(),
+            prepared_abandoned_visibility: Vec::new(),
+            chain_to_g3,
+            chain_to_g4,
+            registered_g3_chain: 0,
+            registered_g4_chain: 0,
+            unreleased_g2_reservations: 0,
+        }
+    }
+
+    fn prepare(&mut self, allow_completed: bool) -> Result<bool, Arc<str>> {
+        let counts = self.handle.progress_counts();
+        if counts.completed > self.observed_completed && !allow_completed {
+            return Ok(false);
+        }
+        let delta = self.handle.consume_progress(&mut self.cursor);
+        self.observed_completed = counts.completed;
+        self.unreleased_g2_reservations = self
+            .unreleased_g2_reservations
+            .checked_add(delta.passed_blocks.len())
+            .ok_or_else(|| Arc::from("G1→G2 reservation count overflow"))?;
+        self.passed.extend(delta.passed_blocks);
+
+        for block_id in delta.completed_blocks {
+            if let Some(slot) = self.source_slots.remove(&block_id) {
+                self.prepared_source_slots.push(slot);
+            }
+            self.prepare_g2_reservation_release()?;
+            if let Some(hash) = self.lower_chain.remove(&block_id) {
+                self.prepared_chain.push(hash);
+            }
+            self.pending_visibility.remove(&block_id);
+        }
+        for block_id in delta.failed_blocks {
+            if let Some(slot) = self.source_slots.remove(&block_id) {
+                self.prepared_source_slots.push(slot);
+            }
+            self.prepare_g2_reservation_release()?;
+            self.lower_chain.remove(&block_id);
+            if let Some(hash) = self.pending_visibility.remove(&block_id) {
+                self.prepared_abandoned_visibility.push(hash);
+            }
+        }
+
+        if !matches!(self.handle.status(), TransferStatus::Evaluating) {
+            self.lower_chain
+                .retain(|block_id, _| self.passed.contains(block_id));
+        }
+        if self.handle.status().is_terminal() {
+            self.prepared_source_slots
+                .extend(self.source_slots.drain().map(|(_, slot)| slot));
+            self.lower_chain.clear();
+            self.passed.clear();
+            self.prepared_abandoned_visibility
+                .extend(self.pending_visibility.drain().map(|(_, hash)| hash));
+            self.prepared_g2_reservations = self
+                .prepared_g2_reservations
+                .checked_add(std::mem::take(&mut self.unreleased_g2_reservations))
+                .ok_or_else(|| Arc::from("G1→G2 prepared reservation overflow"))?;
+        }
+        Ok(!self.prepared_source_slots.is_empty()
+            || self.prepared_g2_reservations > 0
+            || !self.prepared_chain.is_empty()
+            || !self.prepared_abandoned_visibility.is_empty()
+            || self.handle.status().is_terminal())
+    }
+
+    fn prepare_g2_reservation_release(&mut self) -> Result<(), Arc<str>> {
+        self.unreleased_g2_reservations = self
+            .unreleased_g2_reservations
+            .checked_sub(1)
+            .ok_or_else(|| Arc::from("G1→G2 reservation released more than once"))?;
+        self.prepared_g2_reservations = self
+            .prepared_g2_reservations
+            .checked_add(1)
+            .ok_or_else(|| Arc::from("G1→G2 prepared reservation overflow"))?;
+        Ok(())
+    }
+
+    fn prepared_chains(&self, parent: OffloadId) -> Vec<PreparedChain> {
+        let mut actions = Vec::with_capacity(2);
+        if self.chain_to_g3 && self.registered_g3_chain < self.prepared_chain.len() {
+            actions.push(PreparedChain {
+                parent,
+                lane: PipelineLane::G2ToG3,
+                hashes: self.prepared_chain[self.registered_g3_chain..].to_vec(),
+            });
+        }
+        if self.chain_to_g4 && self.registered_g4_chain < self.prepared_chain.len() {
+            actions.push(PreparedChain {
+                parent,
+                lane: PipelineLane::G2ToG4,
+                hashes: self.prepared_chain[self.registered_g4_chain..].to_vec(),
+            });
+        }
+        actions
+    }
+
+    fn mark_prepared_chain_registered(&mut self, lane: PipelineLane, count: usize) {
+        let registered = match lane {
+            PipelineLane::G2ToG3 => &mut self.registered_g3_chain,
+            PipelineLane::G2ToG4 => &mut self.registered_g4_chain,
+            PipelineLane::G1ToG2 => panic!("G1→G2 is not a lower-tier child lane"),
+        };
+        *registered = registered
+            .checked_add(count)
+            .expect("registered lower-tier chain count overflow");
+        assert!(
+            *registered <= self.prepared_chain.len(),
+            "registered more lower-tier chain actions than were prepared"
+        );
+    }
+
+    fn acknowledge(&mut self) -> AcknowledgedProgress {
+        assert!(
+            !self.chain_to_g3 || self.registered_g3_chain == self.prepared_chain.len(),
+            "G1→G2 parent acknowledged before every G2→G3 child was registered"
+        );
+        assert!(
+            !self.chain_to_g4 || self.registered_g4_chain == self.prepared_chain.len(),
+            "G1→G2 parent acknowledged before every G2→G4 child was registered"
+        );
+        let released_g1_slots = self.prepared_source_slots.len();
+        self.prepared_source_slots.clear();
+        self.prepared_chain.clear();
+        self.registered_g3_chain = 0;
+        self.registered_g4_chain = 0;
+        AcknowledgedProgress {
+            released_g1_slots,
+            released_g2_reservations: std::mem::take(&mut self.prepared_g2_reservations),
+            abandoned_visibility: std::mem::take(&mut self.prepared_abandoned_visibility),
+            ..Default::default()
+        }
+    }
+
+    fn can_finish(&self) -> bool {
+        self.handle.status().is_terminal()
+            && self.source_slots.is_empty()
+            && self.lower_chain.is_empty()
+            && self.pending_visibility.is_empty()
+            && self.prepared_source_slots.is_empty()
+            && self.prepared_chain.is_empty()
+            && self.prepared_abandoned_visibility.is_empty()
+            && self.prepared_g2_reservations == 0
+            && self.unreleased_g2_reservations == 0
+    }
+}
+
+pub(crate) struct G2ToG3Lease {
+    handle: TransferHandle,
+    cursor: TransferProgressCursor,
+    observed_completed: usize,
+    unreleased_reservations: usize,
+    prepared_reservations: usize,
+}
+
+impl G2ToG3Lease {
+    pub(crate) fn new(handle: TransferHandle) -> Self {
+        Self {
+            cursor: handle.new_progress_cursor(),
+            handle,
+            observed_completed: 0,
+            unreleased_reservations: 0,
+            prepared_reservations: 0,
+        }
+    }
+
+    fn prepare(&mut self, allow_completed: bool) -> Result<bool, Arc<str>> {
+        let counts = self.handle.progress_counts();
+        if counts.completed > self.observed_completed && !allow_completed {
+            return Ok(false);
+        }
+        let delta = self.handle.consume_progress(&mut self.cursor);
+        self.observed_completed = counts.completed;
+        self.unreleased_reservations = self
+            .unreleased_reservations
+            .checked_add(delta.passed_blocks.len())
+            .ok_or_else(|| Arc::from("G2→G3 reservation count overflow"))?;
+        let settled = delta.completed_blocks.len() + delta.failed_blocks.len();
+        self.unreleased_reservations = self
+            .unreleased_reservations
+            .checked_sub(settled)
+            .ok_or_else(|| Arc::from("G2→G3 reservation released more than once"))?;
+        self.prepared_reservations = self
+            .prepared_reservations
+            .checked_add(settled)
+            .ok_or_else(|| Arc::from("G2→G3 prepared reservation overflow"))?;
+        if self.handle.status().is_terminal() {
+            self.prepared_reservations = self
+                .prepared_reservations
+                .checked_add(std::mem::take(&mut self.unreleased_reservations))
+                .ok_or_else(|| Arc::from("G2→G3 prepared reservation overflow"))?;
+        }
+        Ok(self.prepared_reservations > 0 || self.handle.status().is_terminal())
+    }
+
+    fn acknowledge(&mut self) -> AcknowledgedProgress {
+        AcknowledgedProgress {
+            released_g3_reservations: std::mem::take(&mut self.prepared_reservations),
+            ..Default::default()
+        }
+    }
+
+    fn can_finish(&self) -> bool {
+        self.handle.status().is_terminal()
+            && self.unreleased_reservations == 0
+            && self.prepared_reservations == 0
+    }
+}
+
+pub(crate) struct G2ToG4Lease {
+    handle: TransferHandle,
+    cursor: TransferProgressCursor,
+    observed_completed: usize,
+}
+
+impl G2ToG4Lease {
+    pub(crate) fn new(handle: TransferHandle) -> Self {
+        Self {
+            cursor: handle.new_progress_cursor(),
+            handle,
+            observed_completed: 0,
+        }
+    }
+
+    fn prepare(&mut self, allow_completed: bool) -> bool {
+        let counts = self.handle.progress_counts();
+        if counts.completed > self.observed_completed && !allow_completed {
+            return false;
+        }
+        self.handle.consume_progress(&mut self.cursor);
+        self.observed_completed = counts.completed;
+        self.handle.status().is_terminal()
+    }
+}
+
+pub(crate) struct SwapInResources {
+    pub(crate) status_tx: watch::Sender<SwapInStatus>,
+    pub(crate) g2_blocks: Option<Vec<ImmutableBlock<G2>>>,
+    pub(crate) destination_slots: Option<Vec<MutableBlock<G1>>>,
+    pub(crate) prefix_pins: Option<Vec<ImmutableBlock<G1>>>,
+}
+
+pub(crate) struct DirectSwapInLease {
+    resources: SwapInResources,
+}
+
+impl DirectSwapInLease {
+    pub(crate) fn new(resources: SwapInResources) -> Self {
+        Self { resources }
+    }
+}
+
+pub(crate) struct StagedSwapInLease {
+    pub(crate) result: FindMatchesResult,
+    pub(crate) reservation_blocks: usize,
+    pub(crate) g2_capacity_reservation: Option<CapacityReservationGuard>,
+    pub(crate) resources: SwapInResources,
+    pub(crate) g2_to_g1_started: bool,
+}
+
+enum SwapInLease {
+    Direct(DirectSwapInLease),
+    Staged(StagedSwapInLease),
+}
+
+impl SwapInLease {
+    fn resources(&self) -> &SwapInResources {
+        match self {
+            Self::Direct(lease) => &lease.resources,
+            Self::Staged(lease) => &lease.resources,
+        }
+    }
+
+    fn resources_mut(&mut self) -> &mut SwapInResources {
+        match self {
+            Self::Direct(lease) => &mut lease.resources,
+            Self::Staged(lease) => &mut lease.resources,
+        }
+    }
+
+    fn into_resources(self) -> SwapInResources {
+        match self {
+            Self::Direct(lease) => lease.resources,
+            Self::Staged(lease) => lease.resources,
+        }
+    }
+
+    pub(crate) fn is_terminal(&self) -> bool {
+        !matches!(
+            self.resources().status_tx.borrow().terminal,
+            SwapInTerminal::Pending
+        )
+    }
+}
+
+enum LeaseKind {
+    G1ToG2(G1ToG2Lease),
+    G2ToG3(G2ToG3Lease),
+    G2ToG4(G2ToG4Lease),
+    SwapIn(SwapInLease),
+}
+
+struct PendingOffloadLease {
+    state: LeaseState,
+    kind: LeaseKind,
+}
+
+struct CoordinatorState {
+    leases: SlotMap<OffloadId, PendingOffloadLease>,
+    g3_checkpoint: Option<LaneCheckpoint>,
+    g4_checkpoint: Option<LaneCheckpoint>,
+}
+
+pub(crate) struct OffloadCoordinator {
+    state: Mutex<CoordinatorState>,
+}
+
+impl OffloadCoordinator {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(CoordinatorState {
+                leases: SlotMap::with_key(),
+                g3_checkpoint: None,
+                g4_checkpoint: None,
+            }),
+        }
+    }
+
+    pub(crate) fn insert_g1_to_g2(&self, lease: G1ToG2Lease) -> OffloadId {
+        self.insert(LeaseKind::G1ToG2(lease), LeaseState::Evaluating)
+    }
+
+    pub(crate) fn begin_shared_lane(&self, lane: PipelineLane, token: SettlementToken) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        let checkpoint = match lane {
+            PipelineLane::G2ToG3 => &mut state.g3_checkpoint,
+            PipelineLane::G2ToG4 => &mut state.g4_checkpoint,
+            PipelineLane::G1ToG2 => panic!("G1→G2 uses a per-round checkpoint"),
+        };
+        checkpoint.get_or_insert(LaneCheckpoint {
+            token,
+            observed_batches: 0,
+        });
+    }
+
+    pub(crate) fn insert_g2_to_g3(&self, lease: G2ToG3Lease) -> OffloadId {
+        self.insert(LeaseKind::G2ToG3(lease), LeaseState::Evaluating)
+    }
+
+    pub(crate) fn insert_g2_to_g4(&self, lease: G2ToG4Lease) -> OffloadId {
+        self.insert(LeaseKind::G2ToG4(lease), LeaseState::Evaluating)
+    }
+
+    pub(crate) fn insert_direct_swap_in(&self, lease: DirectSwapInLease) -> SwapInHandle {
+        self.insert_swap_in(SwapInLease::Direct(lease))
+    }
+
+    pub(crate) fn insert_staged_swap_in(&self, lease: StagedSwapInLease) -> SwapInHandle {
+        self.insert_swap_in(SwapInLease::Staged(lease))
+    }
+
+    fn insert_swap_in(&self, lease: SwapInLease) -> SwapInHandle {
+        let status = lease.resources().status_tx.subscribe();
+        let id = self.insert(LeaseKind::SwapIn(lease), LeaseState::Active);
+        SwapInHandle { id, status }
+    }
+
+    fn insert(&self, kind: LeaseKind, state: LeaseState) -> OffloadId {
+        self.state
+            .lock()
+            .expect("offload coordinator mutex poisoned")
+            .leases
+            .insert(PendingOffloadLease { state, kind })
+    }
+
+    pub(crate) fn shared_settlement(
+        &self,
+        lane: PipelineLane,
+        newly_observed_batches: usize,
+    ) -> Option<SharedSettlement> {
+        if newly_observed_batches == 0 {
+            return None;
+        }
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        let checkpoint = match lane {
+            PipelineLane::G2ToG3 => state.g3_checkpoint.as_mut(),
+            PipelineLane::G2ToG4 => state.g4_checkpoint.as_mut(),
+            PipelineLane::G1ToG2 => None,
+        }
+        .expect("shared completion observed without a pre-drain checkpoint");
+        checkpoint.observed_batches = checkpoint
+            .observed_batches
+            .checked_add(
+                u64::try_from(newly_observed_batches).expect("shared completion count exceeds u64"),
+            )
+            .expect("shared settlement target overflow");
+        let mut target = SettlementTarget::new();
+        target
+            .add_completed_batches(lane, checkpoint.observed_batches)
+            .expect("shared settlement target overflow");
+        Some(SharedSettlement {
+            token: checkpoint.token.clone(),
+            target,
+        })
+    }
+
+    pub(crate) fn prepare_progress(
+        &self,
+        settled_g1: bool,
+        settled_g3: bool,
+        settled_g4: bool,
+    ) -> PreparedProgress {
+        let mut output = PreparedProgress::default();
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        for (id, pending) in state.leases.iter_mut() {
+            let prepared = match &mut pending.kind {
+                LeaseKind::G1ToG2(lease) => match lease.prepare(settled_g1) {
+                    Ok(prepared) => {
+                        output.chains.extend(lease.prepared_chains(id));
+                        prepared
+                    }
+                    Err(message) => {
+                        pending.state = LeaseState::Failed;
+                        output.failures.push(LeaseError { id, message });
+                        false
+                    }
+                },
+                LeaseKind::G2ToG3(lease) => match lease.prepare(settled_g3) {
+                    Ok(prepared) => prepared,
+                    Err(message) => {
+                        pending.state = LeaseState::Failed;
+                        output.failures.push(LeaseError { id, message });
+                        false
+                    }
+                },
+                LeaseKind::G2ToG4(lease) => lease.prepare(settled_g4),
+                LeaseKind::SwapIn(_) => false,
+            };
+            if prepared && !pending.state.is_terminal() {
+                pending.state = LeaseState::Prepared;
+            }
+        }
+        output
+    }
+
+    pub(crate) fn acknowledge_prepared(&self) -> AcknowledgedProgress {
+        let mut output = AcknowledgedProgress::default();
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        for pending in state.leases.values_mut() {
+            if pending.state != LeaseState::Prepared {
+                continue;
+            }
+            let progress = match &mut pending.kind {
+                LeaseKind::G1ToG2(lease) => lease.acknowledge(),
+                LeaseKind::G2ToG3(lease) => lease.acknowledge(),
+                LeaseKind::G2ToG4(_) | LeaseKind::SwapIn(_) => AcknowledgedProgress::default(),
+            };
+            output.released_g1_slots += progress.released_g1_slots;
+            output.released_g2_reservations += progress.released_g2_reservations;
+            output.released_g3_reservations += progress.released_g3_reservations;
+            output
+                .abandoned_visibility
+                .extend(progress.abandoned_visibility);
+            pending.state = LeaseState::Active;
+        }
+
+        for pending in state.leases.values_mut() {
+            pending.state = match &pending.kind {
+                LeaseKind::G1ToG2(lease) if lease.can_finish() => {
+                    terminal_lease_state(lease.handle.status())
+                }
+                LeaseKind::G2ToG3(lease) if lease.can_finish() => {
+                    terminal_lease_state(lease.handle.status())
+                }
+                LeaseKind::G2ToG4(lease) if lease.handle.status().is_terminal() => {
+                    terminal_lease_state(lease.handle.status())
+                }
+                _ => pending.state,
+            };
+        }
+
+        state
+            .leases
+            .retain(|_, pending| !pending.state.is_terminal());
+        Self::retire_empty_checkpoints(&mut state);
+        output
+    }
+
+    pub(crate) fn mark_chain_registered(&self, id: OffloadId, lane: PipelineLane, count: usize) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        let pending = state
+            .leases
+            .get_mut(id)
+            .expect("prepared parent lease disappeared before child registration");
+        let LeaseKind::G1ToG2(lease) = &mut pending.kind else {
+            panic!("lower-tier chain parent is not a G1→G2 lease");
+        };
+        lease.mark_prepared_chain_registered(lane, count);
+    }
+
+    fn retire_empty_checkpoints(state: &mut CoordinatorState) {
+        let has_g3 = state
+            .leases
+            .values()
+            .any(|lease| matches!(lease.kind, LeaseKind::G2ToG3(_)));
+        let has_g4 = state
+            .leases
+            .values()
+            .any(|lease| matches!(lease.kind, LeaseKind::G2ToG4(_)));
+        if !has_g3 {
+            state.g3_checkpoint = None;
+        }
+        if !has_g4 {
+            state.g4_checkpoint = None;
+        }
+    }
+
+    pub(crate) fn first_live_g1(&self) -> Option<OffloadId> {
+        self.state
+            .lock()
+            .expect("offload coordinator mutex poisoned")
+            .leases
+            .iter()
+            .find_map(|(id, lease)| matches!(lease.kind, LeaseKind::G1ToG2(_)).then_some(id))
+    }
+
+    pub(crate) fn has_live_g1(&self, id: OffloadId) -> bool {
+        self.state
+            .lock()
+            .expect("offload coordinator mutex poisoned")
+            .leases
+            .get(id)
+            .is_some_and(|lease| matches!(lease.kind, LeaseKind::G1ToG2(_)))
+    }
+
+    pub(crate) fn cancel_swap_in(&self, id: OffloadId) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        let Some(pending) = state.leases.get_mut(id) else {
+            return false;
+        };
+        if !matches!(pending.kind, LeaseKind::SwapIn(_)) {
+            return false;
+        }
+        pending.state = LeaseState::CancelRequested;
+        true
+    }
+
+    pub(crate) fn with_staged_swap_in_mut<R>(
+        &self,
+        id: OffloadId,
+        f: impl FnOnce(&mut StagedSwapInLease, LeaseState) -> R,
+    ) -> Option<R> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        let pending = state.leases.get_mut(id)?;
+        let lease_state = pending.state;
+        let LeaseKind::SwapIn(SwapInLease::Staged(lease)) = &mut pending.kind else {
+            return None;
+        };
+        Some(f(lease, lease_state))
+    }
+
+    pub(crate) fn staged_swap_in_ids(&self) -> Vec<OffloadId> {
+        self.state
+            .lock()
+            .expect("offload coordinator mutex poisoned")
+            .leases
+            .iter()
+            .filter_map(|(id, lease)| {
+                matches!(lease.kind, LeaseKind::SwapIn(SwapInLease::Staged(_))).then_some(id)
+            })
+            .collect()
+    }
+
+    pub(crate) fn take_completed_swap_in(
+        &self,
+        id: OffloadId,
+    ) -> Option<(Vec<MutableBlock<G1>>, Vec<ImmutableBlock<G1>>)> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        let pending = state.leases.get(id)?;
+        let LeaseKind::SwapIn(lease) = &pending.kind else {
+            return None;
+        };
+        if !matches!(
+            lease.resources().status_tx.borrow().terminal,
+            SwapInTerminal::Completed
+        ) {
+            return None;
+        }
+        let pending = state.leases.remove(id)?;
+        let LeaseKind::SwapIn(lease) = pending.kind else {
+            unreachable!("validated swap-in lease changed kind")
+        };
+        let mut resources = lease.into_resources();
+        Some((
+            resources.destination_slots.take().unwrap_or_default(),
+            resources.prefix_pins.take().unwrap_or_default(),
+        ))
+    }
+
+    pub(crate) fn fail_swap_in(&self, id: OffloadId, context: Arc<str>) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        let Some(pending) = state.leases.get_mut(id) else {
+            return false;
+        };
+        let LeaseKind::SwapIn(lease) = &mut pending.kind else {
+            return false;
+        };
+        pending.state = LeaseState::Failed;
+        if let SwapInLease::Staged(staged) = lease {
+            drop(staged.g2_capacity_reservation.take());
+            staged.g2_to_g1_started = true;
+        }
+        let resources = lease.resources_mut();
+        let block_count = resources.status_tx.borrow().block_count;
+        resources.status_tx.send_replace(SwapInStatus {
+            terminal: SwapInTerminal::Failed(context),
+            block_count,
+        });
+        true
+    }
+
+    pub(crate) fn reap_terminal_swap_ins(&self) -> usize {
+        let mut state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        let ids: Vec<_> = state
+            .leases
+            .iter()
+            .filter_map(|(id, pending)| {
+                if !matches!(
+                    pending.state,
+                    LeaseState::CancelRequested | LeaseState::Failed
+                ) {
+                    return None;
+                }
+                let LeaseKind::SwapIn(lease) = &pending.kind else {
+                    return None;
+                };
+                lease.is_terminal().then_some(id)
+            })
+            .collect();
+        let mut released = 0usize;
+        for id in ids {
+            if let Some(PendingOffloadLease {
+                kind: LeaseKind::SwapIn(mut lease),
+                ..
+            }) = state.leases.remove(id)
+            {
+                let resources = lease.resources_mut();
+                if pending_terminal_is_cancel_requested(resources) {
+                    let block_count = resources.status_tx.borrow().block_count;
+                    resources.status_tx.send_replace(SwapInStatus {
+                        terminal: SwapInTerminal::Cancelled,
+                        block_count,
+                    });
+                }
+                released += resources
+                    .destination_slots
+                    .take()
+                    .map_or(0, |slots| slots.len());
+                released += resources.prefix_pins.take().map_or(0, |pins| pins.len());
+            }
+        }
+        released
+    }
+
+    pub(crate) fn live_lease_count(&self) -> usize {
+        self.state
+            .lock()
+            .expect("offload coordinator mutex poisoned")
+            .leases
+            .len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn lane_lease_count(&self, lane: PipelineLane) -> usize {
+        self.state
+            .lock()
+            .expect("offload coordinator mutex poisoned")
+            .leases
+            .values()
+            .filter(|pending| {
+                matches!(
+                    (&pending.kind, lane),
+                    (LeaseKind::G1ToG2(_), PipelineLane::G1ToG2)
+                        | (LeaseKind::G2ToG3(_), PipelineLane::G2ToG3)
+                        | (LeaseKind::G2ToG4(_), PipelineLane::G2ToG4)
+                )
+            })
+            .count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_g1_ownership(&self) -> (Vec<BlockId>, Vec<BlockId>) {
+        let state = self
+            .state
+            .lock()
+            .expect("offload coordinator mutex poisoned");
+        let mut source_slots = Vec::new();
+        let mut passed = Vec::new();
+        for pending in state.leases.values() {
+            if let LeaseKind::G1ToG2(lease) = &pending.kind {
+                source_slots.extend(lease.source_slots.keys().copied());
+                passed.extend(lease.handle.passed_blocks());
+            }
+        }
+        source_slots.sort_unstable();
+        passed.sort_unstable();
+        (source_slots, passed)
+    }
+}
+
+fn pending_terminal_is_cancel_requested(resources: &SwapInResources) -> bool {
+    matches!(
+        resources.status_tx.borrow().terminal,
+        SwapInTerminal::Completed | SwapInTerminal::Cancelled
+    )
+}
+
+fn terminal_lease_state(status: TransferStatus) -> LeaseState {
+    match status {
+        TransferStatus::Complete => LeaseState::Finished,
+        TransferStatus::Cancelled => LeaseState::Cancelled,
+        TransferStatus::Failed => LeaseState::Failed,
+        TransferStatus::Evaluating | TransferStatus::Queued | TransferStatus::Transferring => {
+            LeaseState::Active
+        }
+    }
+}

--- a/lib/mocker/src/kvbm_offload/coordinator.rs
+++ b/lib/mocker/src/kvbm_offload/coordinator.rs
@@ -706,15 +706,6 @@ impl OffloadCoordinator {
         }
     }
 
-    pub(crate) fn first_live_g1(&self) -> Option<OffloadId> {
-        self.state
-            .lock()
-            .expect("offload coordinator mutex poisoned")
-            .leases
-            .iter()
-            .find_map(|(id, lease)| matches!(lease.kind, LeaseKind::G1ToG2(_)).then_some(id))
-    }
-
     pub(crate) fn has_live_g1(&self, id: OffloadId) -> bool {
         self.state
             .lock()

--- a/lib/mocker/src/kvbm_offload/engine.rs
+++ b/lib/mocker/src/kvbm_offload/engine.rs
@@ -1170,22 +1170,15 @@ impl MockOffloadEngine {
     }
 
     pub(crate) fn g1_offload_dependency(&self, id: OffloadId) -> Option<(OffloadId, Option<f64>)> {
-        if self.coordinator.has_live_g1(id) {
-            return Some((
-                id,
-                self.worker
-                    .earliest_local_offload_finish_with_id()
-                    .map(|(_, d)| d),
-            ));
+        if !self.coordinator.has_live_g1(id) {
+            return None;
         }
-        self.coordinator.first_live_g1().map(|current| {
-            (
-                current,
-                self.worker
-                    .earliest_local_offload_finish_with_id()
-                    .map(|(_, d)| d),
-            )
-        })
+        Some((
+            id,
+            self.worker
+                .earliest_local_offload_finish_with_id()
+                .map(|(_, d)| d),
+        ))
     }
 
     #[cfg(test)]

--- a/lib/mocker/src/kvbm_offload/engine.rs
+++ b/lib/mocker/src/kvbm_offload/engine.rs
@@ -16,7 +16,6 @@
 use std::future::Future;
 use std::net::TcpListener;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -33,7 +32,7 @@ use kvbm_engine::object::ObjectBlockOps;
 use kvbm_engine::offload::{
     ExternalBlock, ObjectPipelineBuilder, ObjectPresenceFilter, OffloadEngine, PendingTracker,
     PipelineBuilder, PipelineLane, PresenceFilter, S3PresenceChecker, SettlementTarget,
-    SettlementToken, SourceBlocks, TransferHandle, TransferProgressCursor, TransferStatus,
+    SettlementToken, SourceBlocks, TransferHandle, TransferStatus,
 };
 use kvbm_engine::worker::Worker;
 use kvbm_engine::{BlockId, G1 as EngineG1, G2, G3, SequenceHash};
@@ -42,15 +41,19 @@ use kvbm_logical::events::{EventsManager, KvCacheEvent as LogicalKvCacheEvent};
 use kvbm_logical::manager::{BlockManager, FrequencyTrackingCapacity};
 use kvbm_logical::pools::BlockDuplicationPolicy;
 use kvbm_logical::registry::BlockRegistry;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
+use tokio::sync::watch;
 
 use crate::common::protocols::G1 as MockerG1;
 
-use super::bandwidth_sharing_model::TransferId;
 use super::capacity_reservation::{
     CapacityReservationGuard, CapacityReservationPolicy, CapacityReservations,
 };
 use super::config::KvbmOffloadConfig;
+use super::coordinator::{
+    DirectSwapInLease, G1ToG2Lease, G2ToG3Lease, G2ToG4Lease, LeaseState, OffloadCoordinator,
+    OffloadId, StagedSwapInLease, SwapInHandle, SwapInResources, SwapInStatus, SwapInTerminal,
+};
 use super::shared_g3::SharedG3Pool;
 use super::shared_g4::SharedG4Store;
 use super::worker::MockWorker;
@@ -64,37 +67,6 @@ enum ReservationBlocker {
     LocalOffload,
     SharedG3Offload,
     SharedG4Offload,
-}
-
-/// Handle returned by [`MockOffloadEngine::start_onboard_prefix`]. Scheduler
-/// parks one per deferred request and polls
-/// [`is_complete`](Self::is_complete) each pass; the bit is flipped by
-/// [`MockOffloadEngine::tick`] when the underlying transfer drains from
-/// the onboard model.
-///
-/// The handle holds strong [`ImmutableBlock<G2>`] references for the
-/// duration of the swap-in. kvbm-logical's inactive pool refuses to
-/// reclaim a G2 block while any strong ref is live — so a concurrent
-/// offload cannot race in and reassign the slots we're about to
-/// onboard. Dropping the handle (after the scheduler promotes or
-/// abandons the swap-in) releases the blocks back.
-pub struct SwapInHandle {
-    complete: Arc<AtomicBool>,
-    /// Number of G2 blocks this swap-in delivers.
-    block_count: Arc<AtomicUsize>,
-    /// Strong refs pinning the G2 blocks for the transfer's lifetime.
-    /// Not accessed directly — presence alone upholds the RAII contract.
-    _g2_blocks: Option<Vec<ImmutableBlock<G2>>>,
-}
-
-impl SwapInHandle {
-    pub fn is_complete(&self) -> bool {
-        self.complete.load(std::sync::atomic::Ordering::Acquire)
-    }
-
-    pub fn block_count(&self) -> usize {
-        self.block_count.load(Ordering::Acquire)
-    }
 }
 
 /// Lower-tier lookup prepared while the caller reserves destination G1 slots.
@@ -168,22 +140,6 @@ impl LowerTierLookupPlan {
     }
 }
 
-struct PendingStagedSwapIn {
-    result: FindMatchesResult,
-    reservation_blocks: usize,
-    complete: Arc<AtomicBool>,
-    block_count: Arc<AtomicUsize>,
-    g2_capacity_reservation: Option<CapacityReservationGuard>,
-    g2_blocks: Option<Vec<ImmutableBlock<G2>>>,
-    g2_to_g1_started: bool,
-}
-
-impl PendingStagedSwapIn {
-    fn is_done(&self) -> bool {
-        self.g2_to_g1_started && self.complete.load(Ordering::Acquire)
-    }
-}
-
 /// Router-facing metadata for a block that may become resident in G2.
 ///
 /// kvbm-engine indexes G2 by [`SequenceHash`] (a positional lineage hash),
@@ -210,113 +166,39 @@ pub(crate) enum G2RouterEvent {
     Removed { seq_hash: RouterSequenceHash },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct AdvanceAcknowledgement(u64);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AdvanceAcknowledgementError {
+    NoPreparedAdvance,
+    Stale {
+        expected: AdvanceAcknowledgement,
+        actual: AdvanceAcknowledgement,
+    },
+}
+
+#[derive(Clone)]
+pub(crate) struct PreparedAdvance {
+    pub(crate) router_events: Vec<G2RouterEvent>,
+    pub(crate) acknowledgement: AdvanceAcknowledgement,
+}
+
+#[derive(Default)]
+struct AdvanceState {
+    next_id: u64,
+    pending: Option<PreparedAdvance>,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum G1EvictionOutcome {
     BlockedOnOffload {
-        transfer_id: Option<TransferId>,
+        offload_id: OffloadId,
         deadline_ms: Option<f64>,
     },
     RetryNow {
         released_slots: usize,
     },
-}
-
-struct PendingG1ToG2 {
-    handle: TransferHandle,
-    progress_cursor: TransferProgressCursor,
-    g2_to_lower_chain_blocks: FxHashMap<BlockId, SequenceHash>,
-    passed_chain_blocks: FxHashSet<BlockId>,
-    ready_lower_chain_blocks: Vec<SequenceHash>,
-    /// Reset G1 slots held until the simulated source copy completes.
-    ///
-    /// These tokens do not preserve old bytes — `MockWorker` never reads
-    /// source contents — but they do preserve G1 capacity accounting. A real
-    /// DMA source slot cannot be reassigned while the copy is in flight.
-    source_slots: FxHashMap<BlockId, MutableBlock<MockerG1>>,
-}
-
-impl PendingG1ToG2 {
-    fn source_slots_releasable(&self) -> bool {
-        if self.source_slots.is_empty()
-            && self.g2_to_lower_chain_blocks.is_empty()
-            && self.ready_lower_chain_blocks.is_empty()
-        {
-            return true;
-        }
-        if !self.g2_to_lower_chain_blocks.is_empty() || !self.ready_lower_chain_blocks.is_empty() {
-            return false;
-        }
-        if self.handle.is_complete() {
-            return true;
-        }
-        let progress = self.handle.progress_counts();
-        if progress.passed == 0 {
-            return !matches!(self.handle.status(), TransferStatus::Evaluating);
-        }
-        progress.settled() >= progress.passed
-    }
-
-    fn consume_progress(&mut self) -> usize {
-        let track_lower_chain = !self.g2_to_lower_chain_blocks.is_empty();
-        let delta = self.handle.consume_progress(&mut self.progress_cursor);
-        let mut released = 0usize;
-        if track_lower_chain {
-            self.passed_chain_blocks.extend(delta.passed_blocks);
-        }
-
-        for block_id in delta.completed_blocks {
-            if self.source_slots.remove(&block_id).is_some() {
-                released += 1;
-            }
-            if let Some(seq_hash) = self.g2_to_lower_chain_blocks.remove(&block_id) {
-                self.ready_lower_chain_blocks.push(seq_hash);
-            }
-        }
-        for block_id in delta.failed_blocks {
-            if self.source_slots.remove(&block_id).is_some() {
-                released += 1;
-            }
-            self.g2_to_lower_chain_blocks.remove(&block_id);
-        }
-
-        if track_lower_chain && !matches!(self.handle.status(), TransferStatus::Evaluating) {
-            self.g2_to_lower_chain_blocks
-                .retain(|block_id, _seq_hash| self.passed_chain_blocks.contains(block_id));
-        }
-        released
-    }
-
-    fn take_ready_chain_blocks(&mut self) -> Vec<SequenceHash> {
-        std::mem::take(&mut self.ready_lower_chain_blocks)
-    }
-}
-
-struct PendingG2ToG3 {
-    handle: TransferHandle,
-    released_failed_reservations: usize,
-}
-
-impl PendingG2ToG3 {
-    fn take_unreleased_failed_reservations(&mut self) -> usize {
-        let failed = self.handle.progress_counts().failed;
-        let unreleased = failed.saturating_sub(self.released_failed_reservations);
-        self.released_failed_reservations = failed;
-        unreleased
-    }
-
-    fn is_complete(&self) -> bool {
-        self.handle.is_complete()
-    }
-}
-
-struct PendingG2ToG4 {
-    handle: TransferHandle,
-}
-
-impl PendingG2ToG4 {
-    fn is_complete(&self) -> bool {
-        self.handle.is_complete()
-    }
 }
 
 /// In-process offload engine driving a G1→G2 pipeline over [`MockWorker`].
@@ -344,12 +226,11 @@ pub struct MockOffloadEngine {
     shared_g3: Option<Arc<SharedG3Pool>>,
     g3_manager: Option<Arc<BlockManager<G3>>>,
     shared_g4: Option<Arc<SharedG4Store>>,
-    pending_g1_to_g2: Mutex<Vec<PendingG1ToG2>>,
-    pending_g2_to_g3: Mutex<Vec<PendingG2ToG3>>,
-    pending_g2_to_g4: Mutex<Vec<PendingG2ToG4>>,
-    pending_staged_swap_ins: Mutex<Vec<PendingStagedSwapIn>>,
+    coordinator: OffloadCoordinator,
     g2_event_stream: Mutex<Pin<Box<dyn Stream<Item = LogicalKvCacheEvent> + Send>>>,
     g2_event_metadata: Mutex<FxHashMap<SequenceHash, G2BlockEventMetadata>>,
+    pending_router_events: Mutex<Vec<G2RouterEvent>>,
+    advance_state: Mutex<AdvanceState>,
 
     /// Runtime the engine owns for kvbm-engine background pipeline /
     /// session-receiver tasks. Keeping this runtime on the engine lets both
@@ -493,12 +374,11 @@ impl MockOffloadEngine {
             shared_g3,
             g3_manager,
             shared_g4,
-            pending_g1_to_g2: Mutex::new(Vec::new()),
-            pending_g2_to_g3: Mutex::new(Vec::new()),
-            pending_g2_to_g4: Mutex::new(Vec::new()),
-            pending_staged_swap_ins: Mutex::new(Vec::new()),
+            coordinator: OffloadCoordinator::new(),
             g2_event_stream: Mutex::new(g2_event_stream),
             g2_event_metadata: Mutex::new(FxHashMap::default()),
+            pending_router_events: Mutex::new(Vec::new()),
+            advance_state: Mutex::new(AdvanceState::default()),
             _runtime: None,
         })
     }
@@ -541,7 +421,7 @@ impl MockOffloadEngine {
 
     /// Drain kvbm-logical G2 lifecycle notifications and translate them into
     /// router-tier events. The caller owns event IDs and publishing.
-    pub(crate) fn drain_g2_router_events(&self) -> Vec<G2RouterEvent> {
+    fn collect_g2_router_events(&self) -> Vec<G2RouterEvent> {
         let lifecycle_events = self.drain_g2_lifecycle_events();
         if lifecycle_events.is_empty() {
             return Vec::new();
@@ -571,6 +451,15 @@ impl MockOffloadEngine {
         router_events
     }
 
+    pub(crate) fn drain_g2_router_events(&self) -> Vec<G2RouterEvent> {
+        std::mem::take(
+            &mut *self
+                .pending_router_events
+                .lock()
+                .expect("pending router events mutex poisoned"),
+        )
+    }
+
     async fn with_barrier_timeout<F>(wait: F) -> bool
     where
         F: Future<Output = bool>,
@@ -578,6 +467,15 @@ impl MockOffloadEngine {
         tokio::time::timeout(PIPELINE_BARRIER_TIMEOUT, wait)
             .await
             .unwrap_or_default()
+    }
+
+    async fn with_barrier_timeout_value<F, T>(wait: F) -> Option<T>
+    where
+        F: Future<Output = T>,
+    {
+        tokio::time::timeout(PIPELINE_BARRIER_TIMEOUT, wait)
+            .await
+            .ok()
     }
 
     fn wait_on_attached_runtime<F>(&self, wait: F) -> bool
@@ -602,6 +500,26 @@ impl MockOffloadEngine {
             // explicit tick.
             Some(tokio::runtime::RuntimeFlavor::CurrentThread) => false,
             None => runtime.block_on(Self::with_barrier_timeout(wait)),
+            _ => unreachable!("Tokio runtime flavor is non-exhaustive"),
+        }
+    }
+
+    fn wait_on_attached_runtime_value<F, T>(&self, wait: F) -> Option<T>
+    where
+        F: Future<Output = T>,
+    {
+        let current = tokio::runtime::Handle::try_current().ok();
+        let runtime = self
+            ._runtime
+            .as_ref()
+            .map(tokio::runtime::Runtime::handle)
+            .or(current.as_ref())?;
+        match current.as_ref().map(tokio::runtime::Handle::runtime_flavor) {
+            Some(tokio::runtime::RuntimeFlavor::MultiThread) => tokio::task::block_in_place(|| {
+                runtime.block_on(Self::with_barrier_timeout_value(wait))
+            }),
+            Some(tokio::runtime::RuntimeFlavor::CurrentThread) => None,
+            None => runtime.block_on(Self::with_barrier_timeout_value(wait)),
             _ => unreachable!("Tokio runtime flavor is non-exhaustive"),
         }
     }
@@ -741,11 +659,6 @@ impl MockOffloadEngine {
         (published, Self::tier_registrations(&manager))
     }
 
-    fn wait_for_find_result_completion(&self, result: &FindMatchesResult) -> bool {
-        let wait = result.wait_for_completion();
-        self.wait_on_attached_runtime(async move { wait.await.is_ok() })
-    }
-
     fn completed_match_count(result: &FindMatchesResult) -> Option<usize> {
         match result.as_async()?.status() {
             OnboardingStatus::Complete { matched_blocks } => Some(matched_blocks),
@@ -820,40 +733,6 @@ impl MockOffloadEngine {
         }
     }
 
-    fn cleanup_g2_to_g3_pending_handles(&self) {
-        let Some(shared_g3) = self.shared_g3.as_ref() else {
-            return;
-        };
-
-        // Successful G2->G3 completions release their shared reservation when
-        // SharedG3Pool drains the global DES queue, regardless of which worker
-        // advanced time. This owner-local pass prunes terminal handles and only
-        // releases reservations for failed blocks that never produced a shared
-        // completion.
-        let mut pending = self
-            .pending_g2_to_g3
-            .lock()
-            .expect("pending G2→G3 handles mutex poisoned");
-        let mut failed_reservations = 0usize;
-        for pending in pending.iter_mut() {
-            failed_reservations += pending.take_unreleased_failed_reservations();
-        }
-        pending.retain(|pending| !pending.is_complete());
-        drop(pending);
-
-        if failed_reservations > 0 {
-            shared_g3.release_capacity_reservations(failed_reservations);
-        }
-    }
-
-    fn cleanup_g2_to_g4_pending_handles(&self) {
-        let mut pending = self
-            .pending_g2_to_g4
-            .lock()
-            .expect("pending G2→G4 handles mutex poisoned");
-        pending.retain(|pending| !pending.is_complete());
-    }
-
     fn pump_pending_staged_swap_ins(&self, now_ms: f64) {
         // Waiting for a session while foreground transfers are active can stall
         // the virtual-time loop: the session may itself be waiting for a
@@ -861,77 +740,105 @@ impl MockOffloadEngine {
         // bounded wait lets same-timestamp staging publish G2 blocks before
         // the scheduler immediately retries admission.
         let should_wait_for_sessions = self.worker.earliest_foreground_finish().is_none();
-        let pending = {
-            let mut pending = self
-                .pending_staged_swap_ins
-                .lock()
-                .expect("pending staged swap-ins mutex poisoned");
-            pending.drain(..).collect::<Vec<_>>()
-        };
-        let mut keep = Vec::with_capacity(pending.len());
+        for id in self.coordinator.staged_swap_in_ids() {
+            #[cfg(test)]
+            if let Some(context) = self.worker.take_injected_staging_failure() {
+                self.coordinator.fail_swap_in(id, context);
+                continue;
+            }
+            let wait = self
+                .coordinator
+                .with_staged_swap_in_mut(id, |lease, _| {
+                    (!lease.g2_to_g1_started).then(|| lease.result.wait_for_completion())
+                })
+                .flatten();
+            let session_result =
+                should_wait_for_sessions
+                    .then(|| wait)
+                    .flatten()
+                    .and_then(|wait| {
+                        self.wait_on_attached_runtime_value(async move {
+                            wait.await
+                                .map_err(|error| Arc::<str>::from(error.to_string()))
+                        })
+                    });
+            if let Some(Err(context)) = session_result {
+                self.coordinator.fail_swap_in(id, context);
+                continue;
+            }
+            let session_finished = matches!(session_result, Some(Ok(())));
 
-        for mut staged in pending {
-            if !staged.g2_to_g1_started {
-                let session_finished = should_wait_for_sessions
-                    && self.wait_for_find_result_completion(&staged.result);
-                let maybe_g2_blocks = staged.result.take_g2_blocks();
-                if let Some(g2_blocks) = maybe_g2_blocks {
-                    drop(staged.g2_capacity_reservation.take());
-                    let block_count = g2_blocks.len();
-                    staged.block_count.store(block_count, Ordering::Release);
-                    tracing::trace!(
-                        now_ms,
-                        block_count,
-                        "kvbm-offload: lower-tier staging produced G2 blocks"
-                    );
-                    if block_count == 0 {
-                        staged.complete.store(true, Ordering::Release);
+            let onboard = self
+                .coordinator
+                .with_staged_swap_in_mut(id, |staged, lease_state| {
+                    if staged.g2_to_g1_started {
+                        return None;
+                    }
+                    let maybe_g2_blocks = staged.result.take_g2_blocks();
+                    if let Some(g2_blocks) = maybe_g2_blocks {
+                        drop(staged.g2_capacity_reservation.take());
+                        let block_count = g2_blocks.len();
+                        tracing::trace!(
+                            now_ms,
+                            block_count,
+                            "kvbm-offload: lower-tier staging produced G2 blocks"
+                        );
+                        staged.resources.g2_blocks = Some(g2_blocks);
                         staged.g2_to_g1_started = true;
-                    } else {
+                        if lease_state == LeaseState::CancelRequested {
+                            staged.resources.status_tx.send_replace(SwapInStatus {
+                                terminal: SwapInTerminal::Cancelled,
+                                block_count: 0,
+                            });
+                            return None;
+                        }
+                        if block_count == 0 {
+                            staged
+                                .resources
+                                .status_tx
+                                .send_replace(SwapInStatus::completed(0));
+                            return None;
+                        }
                         tracing::trace!(
                             now_ms,
                             block_count,
                             "kvbm-offload: starting staged G2→G1 swap-in"
                         );
-                        self.worker
-                            .reserve_swap_in(now_ms, block_count, staged.complete.clone());
-                        staged.g2_blocks = Some(g2_blocks);
-                        staged.g2_to_g1_started = true;
+                        staged
+                            .resources
+                            .status_tx
+                            .send_replace(SwapInStatus::pending(block_count));
+                        return Some((block_count, staged.resources.status_tx.clone()));
                     }
-                } else if session_finished {
-                    let matched_blocks = Self::completed_match_count(&staged.result);
-                    tracing::debug!(
-                        now_ms,
-                        reservation_blocks = staged.reservation_blocks,
-                        matched_blocks,
-                        status = ?staged.result.as_async().map(|session| session.status()),
-                        "kvbm-offload: lower-tier staging session completed without available G2 blocks"
-                    );
-                    if matched_blocks.unwrap_or_default() > 0 {
+                    if session_finished {
+                        let matched_blocks = Self::completed_match_count(&staged.result);
                         tracing::debug!(
                             now_ms,
                             reservation_blocks = staged.reservation_blocks,
                             matched_blocks,
-                            "kvbm-offload: lower-tier staging completed with matches but no G2 blocks; treating as 0-block swap-in"
+                            status = ?staged.result.as_async().map(|session| session.status()),
+                            "kvbm-offload: lower-tier staging session completed without available G2 blocks"
+                        );
+                        drop(staged.g2_capacity_reservation.take());
+                        staged.g2_to_g1_started = true;
+                        staged.resources.status_tx.send_replace(
+                            if lease_state == LeaseState::CancelRequested {
+                                SwapInStatus {
+                                    terminal: SwapInTerminal::Cancelled,
+                                    block_count: 0,
+                                }
+                            } else {
+                                SwapInStatus::completed(0)
+                            },
                         );
                     }
-                    drop(staged.g2_capacity_reservation.take());
-                    staged.block_count.store(0, Ordering::Release);
-                    staged.complete.store(true, Ordering::Release);
-                    staged.g2_to_g1_started = true;
-                }
-            }
-
-            if !staged.is_done() {
-                keep.push(staged);
+                    None
+                })
+                .flatten();
+            if let Some((block_count, status_tx)) = onboard {
+                self.worker.reserve_swap_in(now_ms, block_count, status_tx);
             }
         }
-
-        let mut pending = self
-            .pending_staged_swap_ins
-            .lock()
-            .expect("pending staged swap-ins mutex poisoned");
-        pending.extend(keep);
     }
 
     /// Number of G1→G2 transfer batches that an idle pipeline can reserve
@@ -958,62 +865,6 @@ impl MockOffloadEngine {
             .min(max_concurrent_transfer_batches)
     }
 
-    /// Drop pending entries whose source slots are safe to release; the
-    /// `Vec<MutableBlock<MockerG1>>` Drop returns the G1 slots to the pool.
-    fn prune_releasable_g1_to_g2_sources(&self) -> usize {
-        let mut pending = self
-            .pending_g1_to_g2
-            .lock()
-            .expect("pending G1→G2 handles mutex poisoned");
-        let mut released = 0usize;
-        pending.retain(|pending| {
-            let releasable = pending.source_slots_releasable();
-            if releasable {
-                released += pending.source_slots.len();
-            }
-            !releasable
-        });
-        released
-    }
-
-    fn release_completed_g1_to_g2_sources(&self) -> usize {
-        let mut released = 0usize;
-        let mut pending = self
-            .pending_g1_to_g2
-            .lock()
-            .expect("pending G1→G2 handles mutex poisoned");
-        for pending in pending.iter_mut() {
-            released += pending.consume_progress();
-        }
-        released
-    }
-
-    fn collect_g2_to_lower_chain_blocks(&self) -> (Vec<SequenceHash>, usize) {
-        let mut chain_blocks = Vec::new();
-        let mut released_source_slots = 0usize;
-        let mut pending = self
-            .pending_g1_to_g2
-            .lock()
-            .expect("pending G1→G2 handles mutex poisoned");
-        for pending in pending.iter_mut() {
-            released_source_slots += pending.consume_progress();
-            chain_blocks.extend(pending.take_ready_chain_blocks());
-        }
-        (chain_blocks, released_source_slots)
-    }
-
-    fn enqueue_lower_tier_background(&self, hashes: Vec<SequenceHash>) {
-        if hashes.is_empty() {
-            return;
-        }
-        if self.g3_manager.is_some() {
-            self.enqueue_g2_to_g3_background(hashes.clone());
-        }
-        if self.shared_g4.is_some() {
-            self.enqueue_g2_to_g4_background(hashes);
-        }
-    }
-
     fn external_g2_source_for_hashes(&self, hashes: Vec<SequenceHash>) -> Option<SourceBlocks<G2>> {
         let mut matches = self.g2_manager.scan_matches(&hashes, false);
         let blocks: Vec<_> = hashes
@@ -1026,73 +877,62 @@ impl MockOffloadEngine {
         Some(SourceBlocks::Strong(blocks))
     }
 
-    fn enqueue_g2_to_g3_background(&self, hashes: Vec<SequenceHash>) {
+    fn enqueue_g2_to_g3_background(&self, hashes: Vec<SequenceHash>) -> Result<()> {
         if hashes.is_empty() || self.g3_manager.is_none() {
-            return;
+            return Ok(());
         }
 
         let Some(source) = self.external_g2_source_for_hashes(hashes) else {
-            return;
+            anyhow::bail!("G2→G3 chain source disappeared before child registration");
         };
-        self.enqueue_g2_to_g3_background_source(source);
+        self.enqueue_g2_to_g3_background_source(source)
     }
 
-    fn enqueue_g2_to_g3_background_source(&self, source: SourceBlocks<G2>) {
+    fn enqueue_g2_to_g3_background_source(&self, source: SourceBlocks<G2>) -> Result<()> {
         let reservation_count_before = self.worker.reservation_count();
-        let Ok(handle) = self.engine.enqueue_g2_to_g3(source) else {
-            return;
-        };
+        self.coordinator
+            .begin_shared_lane(PipelineLane::G2ToG3, self.engine.settlement_token());
+        let handle = self.engine.enqueue_g2_to_g3(source)?;
+        self.coordinator
+            .insert_g2_to_g3(G2ToG3Lease::new(handle.clone()));
         self.wait_for_policy_evaluation(&handle);
         if !handle.is_complete() {
-            let mut pending = self
-                .pending_g2_to_g3
-                .lock()
-                .expect("pending G2→G3 handles mutex poisoned");
-            pending.push(PendingG2ToG3 {
-                handle: handle.clone(),
-                released_failed_reservations: 0,
-            });
-            drop(pending);
             self.wait_for_reservations_or_completion(
                 &handle,
                 reservation_count_before + 1,
                 ReservationBlocker::SharedG3Offload,
             );
         }
+        Ok(())
     }
 
-    fn enqueue_g2_to_g4_background(&self, hashes: Vec<SequenceHash>) {
+    fn enqueue_g2_to_g4_background(&self, hashes: Vec<SequenceHash>) -> Result<()> {
         if hashes.is_empty() || self.shared_g4.is_none() {
-            return;
+            return Ok(());
         }
 
         let Some(source) = self.external_g2_source_for_hashes(hashes) else {
-            return;
+            anyhow::bail!("G2→G4 chain source disappeared before child registration");
         };
-        self.enqueue_g2_to_g4_background_source(source);
+        self.enqueue_g2_to_g4_background_source(source)
     }
 
-    fn enqueue_g2_to_g4_background_source(&self, source: SourceBlocks<G2>) {
+    fn enqueue_g2_to_g4_background_source(&self, source: SourceBlocks<G2>) -> Result<()> {
         let reservation_count_before = self.worker.reservation_count();
-        let Ok(handle) = self.engine.enqueue_g2_to_g4(source) else {
-            return;
-        };
+        self.coordinator
+            .begin_shared_lane(PipelineLane::G2ToG4, self.engine.settlement_token());
+        let handle = self.engine.enqueue_g2_to_g4(source)?;
+        self.coordinator
+            .insert_g2_to_g4(G2ToG4Lease::new(handle.clone()));
         self.wait_for_policy_evaluation(&handle);
         if !handle.is_complete() {
-            let mut pending = self
-                .pending_g2_to_g4
-                .lock()
-                .expect("pending G2→G4 handles mutex poisoned");
-            pending.push(PendingG2ToG4 {
-                handle: handle.clone(),
-            });
-            drop(pending);
             self.wait_for_reservations_or_completion(
                 &handle,
                 reservation_count_before + 1,
                 ReservationBlocker::SharedG4Offload,
             );
         }
+        Ok(())
     }
 
     /// Advance PS state to `now_ms` and fire awaiters for any transfers
@@ -1114,39 +954,45 @@ impl MockOffloadEngine {
     /// G3/G4 are modeled by process-local shared resources hanging off the
     /// worker, so lower-tier transfers contend globally while G1↔G2 remains
     /// worker-local.
-    pub fn tick(&self, now_ms: f64) -> usize {
+    fn prepare_tick(&self, now_ms: f64) -> PreparedAdvance {
+        if let Some(pending) = self
+            .advance_state
+            .lock()
+            .expect("offload advance mutex poisoned")
+            .pending
+            .clone()
+        {
+            return pending;
+        }
         self.worker.set_now_ms(now_ms);
         let g2_registrations_before = Self::tier_registrations(&self.g2_manager);
-        let settlement_token = self.engine.settlement_token();
+        let local_token = self.engine.settlement_token();
         let drained = self.worker.drain_completions_summary(now_ms);
         let offload_drained = drained.local.offload_transfers;
         let offload_drained_blocks = drained.local.offload_blocks;
         let shared_g3 = drained.shared_g3.counts;
         let shared_g4 = drained.shared_g4.counts;
-        let mut settlement_target = SettlementTarget::new();
-        settlement_target
-            .add_completed_batches(
-                PipelineLane::G1ToG2,
-                u64::try_from(offload_drained).expect("G1→G2 completion count exceeds u64"),
-            )
-            .expect("G1→G2 settlement target overflow");
-        settlement_target
-            .add_completed_batches(
-                PipelineLane::G2ToG3,
-                u64::try_from(shared_g3.offload_transfers)
-                    .expect("G2→G3 completion count exceeds u64"),
-            )
-            .expect("G2→G3 settlement target overflow");
-        settlement_target
-            .add_completed_batches(
-                PipelineLane::G2ToG4,
-                u64::try_from(shared_g4.offload_transfers)
-                    .expect("G2→G4 completion count exceeds u64"),
-            )
-            .expect("G2→G4 settlement target overflow");
-        if offload_drained > 0 || shared_g3.offload_transfers > 0 || shared_g4.offload_transfers > 0
+        if offload_drained > 0 {
+            let mut target = SettlementTarget::new();
+            target
+                .add_completed_batches(
+                    PipelineLane::G1ToG2,
+                    u64::try_from(offload_drained).expect("G1→G2 completion count exceeds u64"),
+                )
+                .expect("G1→G2 settlement target overflow");
+            self.settle_or_panic(local_token, target);
+        }
+        if let Some(settlement) = self
+            .coordinator
+            .shared_settlement(PipelineLane::G2ToG3, shared_g3.offload_transfers)
         {
-            self.settle_or_panic(settlement_token, settlement_target);
+            self.settle_or_panic(settlement.token, settlement.target);
+        }
+        if let Some(settlement) = self
+            .coordinator
+            .shared_settlement(PipelineLane::G2ToG4, shared_g4.offload_transfers)
+        {
+            self.settle_or_panic(settlement.token, settlement.target);
         }
 
         let current_shared_g3_onboard_blocks = shared_g3
@@ -1171,20 +1017,6 @@ impl MockOffloadEngine {
             );
         }
 
-        let mut released_g1_source_slots = 0usize;
-        if offload_drained_blocks > 0 {
-            self.g2_destination_reservations
-                .release(offload_drained_blocks);
-            let released_source_slots = self.release_completed_g1_to_g2_sources();
-            released_g1_source_slots += released_source_slots;
-            tracing::debug!(
-                now_ms,
-                offload_drained_blocks,
-                released_source_slots,
-                "kvbm-offload: released G1 source slots for drained G1→G2 transfers"
-            );
-        }
-
         if g2_publish_blocks > 0 {
             let (published, registrations_after) = self.wait_for_tier_publish_blocks(
                 self.g2_manager.clone(),
@@ -1206,33 +1038,124 @@ impl MockOffloadEngine {
                 );
             }
         }
-        let track_lower_chain = self.g3_manager.is_some() || self.shared_g4.is_some();
-        let (g2_to_lower_chain_blocks, released_after_settlement) =
-            if offload_drained_blocks > 0 || track_lower_chain {
-                self.collect_g2_to_lower_chain_blocks()
-            } else {
-                (Vec::new(), 0)
-            };
-        released_g1_source_slots += released_after_settlement;
-        released_g1_source_slots += self.prune_releasable_g1_to_g2_sources();
-
-        if !g2_to_lower_chain_blocks.is_empty()
-            && (self.g3_manager.is_some() || self.shared_g4.is_some())
-        {
+        let prepared = self.coordinator.prepare_progress(
+            offload_drained > 0,
+            shared_g3.offload_transfers > 0,
+            shared_g4.offload_transfers > 0,
+        );
+        if let Some(failure) = prepared.failures.first() {
+            panic!(
+                "offload lease {:?} failed while preparing finalization: {}",
+                failure.id, failure.message
+            );
+        }
+        for chain in &prepared.chains {
             tracing::trace!(
                 now_ms,
-                blocks = g2_to_lower_chain_blocks.len(),
-                g3_enabled = self.g3_manager.is_some(),
-                g4_enabled = self.shared_g4.is_some(),
+                parent = ?chain.parent,
+                lane = ?chain.lane,
+                blocks = chain.hashes.len(),
                 "kvbm-offload: enqueue lower-tier background copies"
             );
-            self.enqueue_lower_tier_background(g2_to_lower_chain_blocks);
+            match chain.lane {
+                PipelineLane::G2ToG3 => self.enqueue_g2_to_g3_background(chain.hashes.clone()),
+                PipelineLane::G2ToG4 => self.enqueue_g2_to_g4_background(chain.hashes.clone()),
+                PipelineLane::G1ToG2 => unreachable!("G1→G2 cannot be a lower-tier child"),
+            }
+            .expect("prepared lower-tier chain must register every child lease");
+            self.coordinator
+                .mark_chain_registered(chain.parent, chain.lane, chain.hashes.len());
         }
 
-        self.cleanup_g2_to_g3_pending_handles();
-        self.cleanup_g2_to_g4_pending_handles();
         self.pump_pending_staged_swap_ins(now_ms);
-        released_g1_source_slots
+        let router_events = self.collect_g2_router_events();
+        let mut state = self
+            .advance_state
+            .lock()
+            .expect("offload advance mutex poisoned");
+        let acknowledgement = AdvanceAcknowledgement(state.next_id);
+        state.next_id = state
+            .next_id
+            .checked_add(1)
+            .expect("offload advance acknowledgement overflow");
+        let prepared = PreparedAdvance {
+            router_events,
+            acknowledgement,
+        };
+        state.pending = Some(prepared.clone());
+        prepared
+    }
+
+    fn acknowledge_tick(
+        &self,
+        acknowledgement: AdvanceAcknowledgement,
+    ) -> std::result::Result<usize, AdvanceAcknowledgementError> {
+        {
+            let state = self
+                .advance_state
+                .lock()
+                .expect("offload advance mutex poisoned");
+            let Some(pending) = state.pending.as_ref() else {
+                return Err(AdvanceAcknowledgementError::NoPreparedAdvance);
+            };
+            if pending.acknowledgement != acknowledgement {
+                return Err(AdvanceAcknowledgementError::Stale {
+                    expected: pending.acknowledgement,
+                    actual: acknowledgement,
+                });
+            }
+        }
+        let acknowledged = self.coordinator.acknowledge_prepared();
+        if !acknowledged.abandoned_visibility.is_empty() {
+            let mut metadata = self
+                .g2_event_metadata
+                .lock()
+                .expect("G2 event metadata mutex poisoned");
+            for hash in &acknowledged.abandoned_visibility {
+                metadata.remove(hash);
+            }
+        }
+        self.g2_destination_reservations
+            .release(acknowledged.released_g2_reservations);
+        if acknowledged.released_g3_reservations > 0 {
+            self.shared_g3
+                .as_ref()
+                .expect("G2→G3 lease requires shared G3")
+                .release_capacity_reservations(acknowledged.released_g3_reservations);
+        }
+        let released = acknowledged
+            .released_g1_slots
+            .saturating_add(self.coordinator.reap_terminal_swap_ins());
+        let removed = self
+            .advance_state
+            .lock()
+            .expect("offload advance mutex poisoned")
+            .pending
+            .take()
+            .expect("prepared offload advance disappeared during acknowledgement");
+        assert_eq!(removed.acknowledgement, acknowledgement);
+        Ok(released)
+    }
+
+    pub(crate) fn prepare_tick_for_kv_manager(&self, now_ms: f64) -> PreparedAdvance {
+        self.prepare_tick(now_ms)
+    }
+
+    pub(crate) fn acknowledge_tick_for_kv_manager(
+        &self,
+        acknowledgement: AdvanceAcknowledgement,
+    ) -> std::result::Result<usize, AdvanceAcknowledgementError> {
+        self.acknowledge_tick(acknowledgement)
+    }
+
+    pub fn tick(&self, now_ms: f64) -> usize {
+        let prepared = self.prepare_tick(now_ms);
+        self.pending_router_events
+            .lock()
+            .expect("pending router events mutex poisoned")
+            .extend(prepared.router_events);
+        self.acknowledge_tick(prepared.acknowledgement)
+            .expect("freshly prepared offload advance must acknowledge")
     }
 
     /// Earliest transfer completion that can change offload-visible state.
@@ -1246,43 +1169,28 @@ impl MockOffloadEngine {
         self.worker.earliest_finish()
     }
 
-    pub(crate) fn deadline_for_g1_offload(&self, transfer_id: TransferId) -> Option<f64> {
-        self.worker.local_offload_deadline_for(transfer_id)
-    }
-
-    pub(crate) fn is_g1_offload_active(&self, transfer_id: TransferId) -> bool {
-        self.worker.is_local_offload_active(transfer_id)
-    }
-
-    pub(crate) fn current_g1_offload_dependency(&self) -> Option<(TransferId, f64)> {
-        self.worker.earliest_local_offload_finish_with_id()
-    }
-
-    pub(crate) fn has_nonterminal_g1_pipeline(&self) -> bool {
-        let pending = self
-            .pending_g1_to_g2
-            .lock()
-            .expect("pending G1→G2 handles mutex poisoned");
-        pending.iter().any(|pending| !pending.handle.is_complete())
+    pub(crate) fn g1_offload_dependency(&self, id: OffloadId) -> Option<(OffloadId, Option<f64>)> {
+        if self.coordinator.has_live_g1(id) {
+            return Some((
+                id,
+                self.worker
+                    .earliest_local_offload_finish_with_id()
+                    .map(|(_, d)| d),
+            ));
+        }
+        self.coordinator.first_live_g1().map(|current| {
+            (
+                current,
+                self.worker
+                    .earliest_local_offload_finish_with_id()
+                    .map(|(_, d)| d),
+            )
+        })
     }
 
     #[cfg(test)]
     pub(crate) fn pending_g1_transfer_ownership(&self) -> (Vec<BlockId>, Vec<BlockId>) {
-        let pending = self
-            .pending_g1_to_g2
-            .lock()
-            .expect("pending G1→G2 handles mutex poisoned");
-        let mut source_slot_ids: Vec<_> = pending
-            .iter()
-            .flat_map(|transfer| transfer.source_slots.keys().copied())
-            .collect();
-        let mut offload_block_ids: Vec<_> = pending
-            .iter()
-            .flat_map(|transfer| transfer.handle.passed_blocks())
-            .collect();
-        source_slot_ids.sort_unstable();
-        offload_block_ids.sort_unstable();
-        (source_slot_ids, offload_block_ids)
+        self.coordinator.pending_g1_ownership()
     }
 
     /// Enqueue a burst of G1→G2 evictions with router metadata that will be
@@ -1327,6 +1235,7 @@ impl MockOffloadEngine {
             "kvbm-offload: G1→G2 enqueue evictions"
         );
         let reservation_count_before = self.worker.reservation_count();
+        let settlement_token = self.engine.settlement_token();
         let source: SourceBlocks<EngineG1> = SourceBlocks::External(
             evicted
                 .iter()
@@ -1337,36 +1246,31 @@ impl MockOffloadEngine {
             .engine
             .enqueue_g1_to_g2(source)
             .expect("G1→G2 pipeline must be configured at engine construction");
-        {
-            let mut pending = self
-                .pending_g1_to_g2
-                .lock()
-                .expect("pending G1→G2 handles mutex poisoned");
-            let g2_to_lower_chain_blocks = if self.g3_manager.is_some() || self.shared_g4.is_some()
-            {
-                evicted.iter().copied().collect()
-            } else {
-                FxHashMap::default()
-            };
-            pending.push(PendingG1ToG2 {
-                handle: handle.clone(),
-                progress_cursor: handle.new_progress_cursor(),
-                g2_to_lower_chain_blocks,
-                passed_chain_blocks: FxHashSet::default(),
-                ready_lower_chain_blocks: Vec::new(),
-                source_slots: source_slots
-                    .into_iter()
-                    .map(|slot| (slot.block_id(), slot))
-                    .collect(),
-            });
-        }
+        let visibility: FxHashMap<_, _> = evicted.iter().copied().collect();
+        let lower_chain = if self.g3_manager.is_some() || self.shared_g4.is_some() {
+            visibility.clone()
+        } else {
+            FxHashMap::default()
+        };
+        let offload_id = self.coordinator.insert_g1_to_g2(G1ToG2Lease::new(
+            handle.clone(),
+            source_slots,
+            lower_chain,
+            visibility,
+            self.g3_manager.is_some(),
+            self.shared_g4.is_some(),
+        ));
 
         // Sync pump so policy and the first wave of batch reservations both
         // run on the current virtual `now_ms`, not a later scheduler tick.
         self.wait_for_policy_evaluation(&handle);
-        let target_reservation_count = reservation_count_before
-            + self.initial_runnable_transfer_batches(handle.progress_counts().passed) as u64;
-        if target_reservation_count > reservation_count_before {
+        let expected_reservations = self
+            .initial_runnable_transfer_batches(handle.progress_counts().passed)
+            .max(1);
+        if !handle.is_complete() {
+            let target_reservation_count = reservation_count_before
+                .checked_add(expected_reservations as u64)
+                .expect("mock transfer reservation count overflow");
             self.wait_for_reservations_or_completion(
                 &handle,
                 target_reservation_count,
@@ -1374,17 +1278,39 @@ impl MockOffloadEngine {
             );
         }
         if handle.is_complete() {
-            let (g2_to_lower_chain_blocks, released_after_settlement) =
-                self.collect_g2_to_lower_chain_blocks();
-            self.enqueue_lower_tier_background(g2_to_lower_chain_blocks);
-            let released_slots =
-                released_after_settlement.saturating_add(self.prune_releasable_g1_to_g2_sources());
+            let released_slots = self.tick(self.worker.now_ms());
             return Some(G1EvictionOutcome::RetryNow { released_slots });
         }
 
         let dependency = self.worker.earliest_local_offload_finish_with_id();
+        let can_block_for_settlement = match tokio::runtime::Handle::try_current()
+            .ok()
+            .as_ref()
+            .map(tokio::runtime::Handle::runtime_flavor)
+        {
+            Some(tokio::runtime::RuntimeFlavor::MultiThread) => true,
+            Some(tokio::runtime::RuntimeFlavor::CurrentThread) => false,
+            None => self._runtime.is_some(),
+            _ => unreachable!("Tokio runtime flavor is non-exhaustive"),
+        };
+        if dependency.is_none() && can_block_for_settlement {
+            let expected_batches = self
+                .initial_runnable_transfer_batches(handle.progress_counts().passed)
+                .max(1);
+            let mut target = SettlementTarget::new();
+            target
+                .add_completed_batches(
+                    PipelineLane::G1ToG2,
+                    u64::try_from(expected_batches).expect("G1→G2 batch count exceeds u64"),
+                )
+                .expect("G1→G2 settlement target overflow");
+            self.settle_or_panic(settlement_token, target);
+            let released_slots = self.tick(self.worker.now_ms());
+            return Some(G1EvictionOutcome::RetryNow { released_slots });
+        }
+
         Some(G1EvictionOutcome::BlockedOnOffload {
-            transfer_id: dependency.map(|(transfer_id, _deadline_ms)| transfer_id),
+            offload_id,
             deadline_ms: dependency.map(|(_transfer_id, deadline_ms)| deadline_ms),
         })
     }
@@ -1476,6 +1402,8 @@ impl MockOffloadEngine {
     pub(crate) fn start_onboard_prefix(
         &mut self,
         prepared: PreparedSwapIn,
+        destination_slots: Vec<MutableBlock<MockerG1>>,
+        prefix_pins: Vec<ImmutableBlock<MockerG1>>,
         now_ms: Option<f64>,
     ) -> SwapInHandle {
         let now_ms = now_ms.unwrap_or_else(|| self.worker.now_ms());
@@ -1492,15 +1420,16 @@ impl MockOffloadEngine {
                     block_count,
                     "kvbm-offload: G2→G1 swap-in HIT"
                 );
-                let complete = Arc::new(AtomicBool::new(false));
-                let block_count_cell = Arc::new(AtomicUsize::new(block_count));
+                let (status_tx, _) = watch::channel(SwapInStatus::pending(block_count));
                 self.worker
-                    .reserve_swap_in(now_ms, block_count, complete.clone());
-                SwapInHandle {
-                    complete,
-                    block_count: block_count_cell,
-                    _g2_blocks: Some(g2_blocks),
-                }
+                    .reserve_swap_in(now_ms, block_count, status_tx.clone());
+                self.coordinator
+                    .insert_direct_swap_in(DirectSwapInLease::new(SwapInResources {
+                        status_tx,
+                        g2_blocks: Some(g2_blocks),
+                        destination_slots: Some(destination_slots),
+                        prefix_pins: Some(prefix_pins),
+                    }))
             }
             PreparedSwapIn::Staging {
                 requested_blocks,
@@ -1514,8 +1443,7 @@ impl MockOffloadEngine {
                     reservation_blocks,
                     "kvbm-offload: lower-tier staging swap-in HIT"
                 );
-                let complete = Arc::new(AtomicBool::new(false));
-                let block_count = Arc::new(AtomicUsize::new(0));
+                let (status_tx, _) = watch::channel(SwapInStatus::pending(0));
                 let reservation_count_before = self.worker.reservation_count();
                 let result = self
                     .leader
@@ -1539,28 +1467,33 @@ impl MockOffloadEngine {
                         "kvbm-offload: lower-tier staging session has not reserved transfer yet"
                     );
                 }
-                let mut pending = self
-                    .pending_staged_swap_ins
-                    .lock()
-                    .expect("pending staged swap-ins mutex poisoned");
-                pending.push(PendingStagedSwapIn {
+                let handle = self.coordinator.insert_staged_swap_in(StagedSwapInLease {
                     result,
                     reservation_blocks,
-                    complete: complete.clone(),
-                    block_count: block_count.clone(),
                     g2_capacity_reservation,
-                    g2_blocks: None,
+                    resources: SwapInResources {
+                        status_tx,
+                        g2_blocks: None,
+                        destination_slots: Some(destination_slots),
+                        prefix_pins: Some(prefix_pins),
+                    },
                     g2_to_g1_started: false,
                 });
-                drop(pending);
                 self.pump_pending_staged_swap_ins(now_ms);
-                SwapInHandle {
-                    complete,
-                    block_count,
-                    _g2_blocks: None,
-                }
+                handle
             }
         }
+    }
+
+    pub(crate) fn cancel_swap_in(&self, id: OffloadId) -> bool {
+        self.coordinator.cancel_swap_in(id)
+    }
+
+    pub(crate) fn take_completed_swap_in(
+        &self,
+        id: OffloadId,
+    ) -> Option<(Vec<MutableBlock<MockerG1>>, Vec<ImmutableBlock<MockerG1>>)> {
+        self.coordinator.take_completed_swap_in(id)
     }
 
     /// Test-only accessor: integration tests outside this module
@@ -1585,6 +1518,20 @@ impl MockOffloadEngine {
 
 impl Drop for MockOffloadEngine {
     fn drop(&mut self) {
+        let live_leases = self.coordinator.live_lease_count();
+        let prepared_advance = self
+            .advance_state
+            .get_mut()
+            .expect("offload advance mutex poisoned")
+            .pending
+            .is_some();
+        if live_leases > 0 || prepared_advance {
+            tracing::warn!(
+                live_leases,
+                prepared_advance,
+                "offload coordinator dropped with live or prepared leases"
+            );
+        }
         let Some(rt) = self._runtime.take() else {
             return;
         };
@@ -1642,6 +1589,7 @@ mod tests {
     use super::*;
     use crate::kvbm_offload::shared_g3::{shared_g3_test_guard, shared_g3_test_guard_blocking};
     use crate::kvbm_offload::shared_g4::{shared_g4_test_guard, shared_g4_test_guard_blocking};
+    use crate::kvbm_offload::worker::WorkerFault;
 
     fn g3_config() -> KvbmOffloadConfig {
         KvbmOffloadConfig {
@@ -1684,6 +1632,21 @@ mod tests {
             .stage(plh, manager.block_size())
             .expect("stage test block");
         drop(manager.register_block(complete));
+    }
+
+    fn allocate_g1_slots(count: usize) -> (BlockManager<MockerG1>, Vec<MutableBlock<MockerG1>>) {
+        let registry = build_registry(Arc::new(EventsManager::builder().build()));
+        let manager = BlockManager::<MockerG1>::builder()
+            .block_count(count)
+            .block_size(4)
+            .registry(registry)
+            .build()
+            .expect("source manager build");
+        let (slots, evicted) = manager
+            .allocate_blocks_with_evictions(count)
+            .expect("allocate G1 slots");
+        assert!(evicted.is_empty());
+        (manager, slots)
     }
 
     #[tokio::test]
@@ -1743,13 +1706,11 @@ mod tests {
             Some(G1EvictionOutcome::BlockedOnOffload { .. })
         ));
 
-        {
-            let pending = engine.pending_g1_to_g2.lock().unwrap();
-            assert_eq!(pending.len(), 1);
-            assert!(pending[0].g2_to_lower_chain_blocks.is_empty());
-            assert!(pending[0].passed_chain_blocks.is_empty());
-            assert!(pending[0].ready_lower_chain_blocks.is_empty());
-        }
+        assert_eq!(engine.coordinator.lane_lease_count(PipelineLane::G1ToG2), 1);
+        assert_eq!(
+            engine.pending_g1_transfer_ownership().0.len(),
+            SOURCE_BLOCKS
+        );
 
         let deadline = engine
             .earliest_pending_deadline()
@@ -1759,16 +1720,10 @@ mod tests {
         assert!(first_wave_blocks < SOURCE_BLOCKS);
         assert_eq!(source_manager.available_blocks(), first_wave_blocks);
 
-        let pending = engine.pending_g1_to_g2.lock().unwrap();
-        assert_eq!(pending.len(), 1);
         assert_eq!(
-            pending[0].source_slots.len(),
+            engine.pending_g1_transfer_ownership().0.len(),
             SOURCE_BLOCKS - first_wave_blocks
         );
-        assert!(pending[0].g2_to_lower_chain_blocks.is_empty());
-        assert!(pending[0].passed_chain_blocks.is_empty());
-        assert!(pending[0].ready_lower_chain_blocks.is_empty());
-        drop(pending);
 
         let final_deadline = engine
             .earliest_pending_deadline()
@@ -1785,7 +1740,129 @@ mod tests {
         }
         assert_eq!(released_blocks, SOURCE_BLOCKS);
         assert_eq!(source_manager.available_blocks(), SOURCE_BLOCKS);
-        assert!(engine.pending_g1_to_g2.lock().unwrap().is_empty());
+        assert_eq!(engine.coordinator.lane_lease_count(PipelineLane::G1ToG2), 0);
+    }
+
+    #[test]
+    fn prepared_advance_registers_children_before_parent_capacity_release() {
+        use dynamo_tokens::PositionalLineageHash;
+
+        let _guard = shared_g3_test_guard_blocking();
+        let rt = single_thread_runtime();
+        let mut engine = rt
+            .block_on(MockOffloadEngine::new(g3_config()))
+            .expect("engine build");
+        engine.attach_runtime(rt);
+        engine.tick(0.0);
+
+        let (source_manager, source_slots) = allocate_g1_slots(1);
+        let plh = PositionalLineageHash::new(8_001, None, 0);
+        let source_id = source_slots[0].block_id();
+        engine.enqueue_g1_evictions_holding_sources(&[(source_id, plh)], source_slots, Some(0.0));
+        let deadline = engine
+            .earliest_pending_deadline()
+            .expect("G1→G2 completion deadline");
+
+        let prepared = engine.prepare_tick_for_kv_manager(deadline);
+        assert_eq!(
+            source_manager.available_blocks(),
+            0,
+            "prepared parent resources must remain retained"
+        );
+        assert_eq!(
+            engine.coordinator.lane_lease_count(PipelineLane::G2ToG3),
+            1,
+            "child lease must be coordinator-visible before acknowledgement"
+        );
+
+        let retried = engine.prepare_tick_for_kv_manager(deadline);
+        assert_eq!(retried.acknowledgement, prepared.acknowledgement);
+        assert_eq!(
+            engine.coordinator.lane_lease_count(PipelineLane::G2ToG3),
+            1,
+            "retrying an unacknowledged advance must not duplicate child leases"
+        );
+        assert_eq!(
+            engine
+                .acknowledge_tick_for_kv_manager(prepared.acknowledgement)
+                .expect("prepared advance acknowledgement"),
+            1
+        );
+        assert_eq!(source_manager.available_blocks(), 1);
+
+        let child_deadline = engine
+            .earliest_pending_deadline()
+            .expect("G2→G3 child deadline");
+        engine.tick(child_deadline);
+    }
+
+    #[test]
+    fn injected_executor_terminal_paths_release_source_ownership() {
+        use dynamo_tokens::PositionalLineageHash;
+
+        for (index, fault) in [
+            WorkerFault::ExecutorError,
+            WorkerFault::ExecutorPanic,
+            WorkerFault::ChannelClosure,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let rt = single_thread_runtime();
+            let mut engine = rt
+                .block_on(MockOffloadEngine::new(KvbmOffloadConfig::default()))
+                .expect("engine build");
+            engine.attach_runtime(rt);
+            engine.tick(0.0);
+            let (source_manager, source_slots) = allocate_g1_slots(1);
+            let source_id = source_slots[0].block_id();
+            let plh = PositionalLineageHash::new(8_100 + index as u64, None, 0);
+            engine.worker.inject_fault(fault);
+
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                engine.enqueue_g1_evictions_holding_sources(
+                    &[(source_id, plh)],
+                    source_slots,
+                    Some(0.0),
+                )
+            }));
+            if matches!(fault, WorkerFault::ExecutorPanic) {
+                assert!(
+                    outcome.is_err(),
+                    "executor task panic must surface as a fatal structured settlement failure"
+                );
+                drop(engine);
+                assert_eq!(source_manager.available_blocks(), 1);
+                continue;
+            }
+            let outcome = outcome.expect("non-panic executor fault must not unwind");
+            assert!(
+                matches!(outcome, Some(G1EvictionOutcome::RetryNow { .. })),
+                "terminal executor fault {fault:?} must complete lease cleanup; got {outcome:?}"
+            );
+            assert_eq!(source_manager.available_blocks(), 1);
+            assert_eq!(engine.coordinator.lane_lease_count(PipelineLane::G1ToG2), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn advance_acknowledgements_reject_foreign_and_stale_tokens() {
+        let engine = MockOffloadEngine::new(KvbmOffloadConfig::default())
+            .await
+            .expect("engine build");
+        let prepared = engine.prepare_tick_for_kv_manager(0.0);
+        let foreign = AdvanceAcknowledgement(prepared.acknowledgement.0 + 1);
+        assert!(matches!(
+            engine.acknowledge_tick_for_kv_manager(foreign),
+            Err(AdvanceAcknowledgementError::Stale { .. })
+        ));
+        engine
+            .acknowledge_tick_for_kv_manager(prepared.acknowledgement)
+            .expect("matching acknowledgement");
+        assert_eq!(
+            engine.acknowledge_tick_for_kv_manager(prepared.acknowledgement),
+            Err(AdvanceAcknowledgementError::NoPreparedAdvance)
+        );
     }
 
     #[tokio::test]
@@ -1936,9 +2013,11 @@ mod tests {
             .capacity_reservations();
 
         // A starts a G2->G3 copy and reserves one shared G3 capacity slot.
-        engine_a.enqueue_g2_to_g3_background(vec![plh_a]);
+        engine_a
+            .enqueue_g2_to_g3_background(vec![plh_a])
+            .expect("engine A G2→G3 enqueue");
         assert_eq!(
-            engine_a.pending_g2_to_g3.lock().unwrap().len(),
+            engine_a.coordinator.lane_lease_count(PipelineLane::G2ToG3),
             1,
             "engine A should have one owner-local G2->G3 handle"
         );
@@ -1955,25 +2034,35 @@ mod tests {
             .expect("engine A should own the shared G3 transfer");
         engine_b.tick(g3_deadline);
         assert_eq!(
-            engine_a.pending_g2_to_g3.lock().unwrap().len(),
+            engine_a.coordinator.lane_lease_count(PipelineLane::G2ToG3),
             1,
             "worker B must not perform engine A's owner-local cleanup"
         );
         assert_eq!(
             shared_reservations.reserved_blocks(),
-            0,
-            "B's shared drain should release A's completed G2->G3 reservation"
+            1,
+            "non-owner drain must retain A's reservation until A settles"
         );
 
-        // At the same timestamp, B should see the released reservation and
-        // admit its own G2->G3 copy without waiting for A to tick.
-        let pending_before = engine_b.pending_g2_to_g3.lock().unwrap().len();
-        engine_b.enqueue_g2_to_g3_background(vec![plh_b]);
-        let pending_after = engine_b.pending_g2_to_g3.lock().unwrap().len();
         assert_eq!(
-            pending_after,
-            pending_before + 1,
-            "same-time G2->G3 admission should see capacity released by the shared drain"
+            engine_a.earliest_pending_deadline(),
+            Some(g3_deadline),
+            "deferred owner completion must expose an immediate wake"
+        );
+        engine_a.tick(g3_deadline);
+        assert_eq!(
+            shared_reservations.reserved_blocks(),
+            0,
+            "owner settlement should release the shared reservation"
+        );
+
+        engine_b
+            .enqueue_g2_to_g3_background(vec![plh_b])
+            .expect("same-time admission after owner settlement");
+        assert_eq!(
+            engine_b.coordinator.lane_lease_count(PipelineLane::G2ToG3),
+            1,
+            "B should register a child lease at the same timestamp"
         );
         assert_eq!(
             shared_reservations.reserved_blocks(),
@@ -1997,6 +2086,68 @@ mod tests {
         assert!(
             presence[0].1,
             "engine B's same-time G2->G3 transfer should publish to shared G3"
+        );
+    }
+
+    #[test]
+    fn shared_g3_deferred_waves_settle_against_one_pre_drain_checkpoint() {
+        use dynamo_tokens::PositionalLineageHash;
+
+        let _guard = shared_g3_test_guard_blocking();
+        let rt_a = single_thread_runtime();
+        let rt_b = single_thread_runtime();
+        let config = KvbmOffloadConfig {
+            num_g3_blocks: Some(4),
+            offload_batch_size: 1,
+            ..g3_config()
+        };
+        let mut engine_a = rt_a
+            .block_on(MockOffloadEngine::new(config.clone()))
+            .expect("engine A build");
+        let mut engine_b = rt_b
+            .block_on(MockOffloadEngine::new(config))
+            .expect("engine B build");
+        engine_a.attach_runtime(rt_a);
+        engine_b.attach_runtime(rt_b);
+        engine_a.tick(0.0);
+        engine_b.tick(0.0);
+
+        let first = PositionalLineageHash::new(5_200, None, 0);
+        let second = PositionalLineageHash::new(5_201, None, 0);
+        register_test_block(engine_a.g2_manager(), first);
+        register_test_block(engine_a.g2_manager(), second);
+        engine_a
+            .enqueue_g2_to_g3_background(vec![first])
+            .expect("first G2→G3 enqueue");
+        engine_a
+            .enqueue_g2_to_g3_background(vec![second])
+            .expect("queued second G2→G3 enqueue");
+        assert_eq!(
+            engine_a.coordinator.lane_lease_count(PipelineLane::G2ToG3),
+            2
+        );
+
+        let first_deadline = engine_a
+            .earliest_pending_deadline()
+            .expect("first shared completion");
+        engine_b.tick(first_deadline);
+        engine_a.tick(first_deadline);
+        assert_eq!(
+            engine_a.coordinator.lane_lease_count(PipelineLane::G2ToG3),
+            1,
+            "first settlement must retain the checkpoint for the queued lease"
+        );
+
+        let second_deadline = engine_a
+            .earliest_pending_deadline()
+            .expect("permit handoff must start the second shared transfer");
+        assert!(second_deadline >= first_deadline);
+        engine_b.tick(second_deadline);
+        engine_a.tick(second_deadline);
+        assert_eq!(
+            engine_a.coordinator.lane_lease_count(PipelineLane::G2ToG3),
+            0,
+            "second deferred wave must settle cumulatively from the original token"
         );
     }
 
@@ -2068,6 +2219,63 @@ mod tests {
             "G2→G4 should store the block in shared object storage"
         );
         assert_eq!(shared_g4.object_count(), 1);
+    }
+
+    #[test]
+    fn shared_g4_cross_owner_deferred_waves_settle_cumulatively() {
+        use dynamo_tokens::PositionalLineageHash;
+
+        let _guard = shared_g4_test_guard_blocking();
+        let rt_a = single_thread_runtime();
+        let rt_b = single_thread_runtime();
+        let config = KvbmOffloadConfig {
+            offload_batch_size: 1,
+            ..g4_config()
+        };
+        let mut engine_a = rt_a
+            .block_on(MockOffloadEngine::new(config.clone()))
+            .expect("engine A build");
+        let mut engine_b = rt_b
+            .block_on(MockOffloadEngine::new(config))
+            .expect("engine B build");
+        engine_a.attach_runtime(rt_a);
+        engine_b.attach_runtime(rt_b);
+        engine_a.tick(0.0);
+        engine_b.tick(0.0);
+
+        let first = PositionalLineageHash::new(6_700, None, 0);
+        let second = PositionalLineageHash::new(6_701, None, 0);
+        register_test_block(engine_a.g2_manager(), first);
+        register_test_block(engine_a.g2_manager(), second);
+        engine_a
+            .enqueue_g2_to_g4_background(vec![first])
+            .expect("first G2→G4 enqueue");
+        engine_a
+            .enqueue_g2_to_g4_background(vec![second])
+            .expect("queued second G2→G4 enqueue");
+
+        let first_deadline = engine_a
+            .earliest_pending_deadline()
+            .expect("first shared object completion");
+        engine_b.tick(first_deadline);
+        engine_a.tick(first_deadline);
+        assert_eq!(
+            engine_a.coordinator.lane_lease_count(PipelineLane::G2ToG4),
+            1
+        );
+
+        let second_deadline = engine_a
+            .earliest_pending_deadline()
+            .expect("object permit handoff must start the second transfer");
+        engine_b.tick(second_deadline);
+        engine_a.tick(second_deadline);
+        assert_eq!(
+            engine_a.coordinator.lane_lease_count(PipelineLane::G2ToG4),
+            0
+        );
+        let store = engine_a.shared_g4().expect("G4 enabled");
+        assert!(store.has_object(&first).is_some());
+        assert!(store.has_object(&second).is_some());
     }
 
     #[test]
@@ -2288,7 +2496,7 @@ mod tests {
         let prepared = engine
             .prepare_onboard_prefix(&[plh])
             .expect("G2 prefix match must produce a prepared swap-in");
-        let handle = engine.start_onboard_prefix(prepared, Some(0.0));
+        let handle = engine.start_onboard_prefix(prepared, Vec::new(), Vec::new(), Some(0.0));
         assert_eq!(handle.block_count(), 1);
         assert!(!handle.is_complete());
 
@@ -2308,8 +2516,152 @@ mod tests {
         engine.tick(1.0);
         assert!(
             handle.is_complete(),
-            "swap-in bit must flip once tick advances past finish"
+            "swap-in status must complete once tick advances past finish"
         );
+        engine
+            .take_completed_swap_in(handle.id())
+            .expect("completed direct swap-in resources");
+    }
+
+    #[tokio::test]
+    async fn direct_swap_in_cancellation_releases_only_after_modeled_completion() {
+        use dynamo_tokens::PositionalLineageHash;
+
+        let config = KvbmOffloadConfig {
+            block_size_bytes: Some(1_000_000),
+            bandwidth_g2_to_g1_gbps: 1.0,
+            ..Default::default()
+        };
+        let mut engine = MockOffloadEngine::new(config).await.expect("engine build");
+        engine.tick(0.0);
+        let plh = PositionalLineageHash::new(9_001, None, 0);
+        register_test_block(engine.g2_manager(), plh);
+        let (g1_manager, destination_slots) = allocate_g1_slots(1);
+        let prepared = engine
+            .prepare_onboard_prefix(&[plh])
+            .expect("G2 prefix match");
+        let handle =
+            engine.start_onboard_prefix(prepared, destination_slots, Vec::new(), Some(0.0));
+        assert!(engine.cancel_swap_in(handle.id()));
+
+        engine.tick(0.5);
+        assert_eq!(handle.terminal(), SwapInTerminal::Pending);
+        assert_eq!(g1_manager.available_blocks(), 0);
+
+        engine.tick(1.0);
+        assert_eq!(handle.terminal(), SwapInTerminal::Cancelled);
+        assert_eq!(g1_manager.available_blocks(), 1);
+        assert!(engine.take_completed_swap_in(handle.id()).is_none());
+    }
+
+    #[test]
+    fn staged_swap_in_cancellation_drains_active_phase_without_successor() {
+        use dynamo_tokens::PositionalLineageHash;
+
+        let _guard = shared_g3_test_guard_blocking();
+        let rt = single_thread_runtime();
+        let mut engine = rt
+            .block_on(MockOffloadEngine::new(g3_config()))
+            .expect("engine build");
+        engine.attach_runtime(rt);
+        engine.tick(0.0);
+
+        let plh = PositionalLineageHash::new(9_002, None, 0);
+        register_test_block(engine.g3_manager().expect("G3 enabled"), plh);
+        let (g1_manager, destination_slots) = allocate_g1_slots(1);
+        let prepared = engine
+            .prepare_onboard_prefix(&[plh])
+            .expect("G3 prefix match");
+        let handle =
+            engine.start_onboard_prefix(prepared, destination_slots, Vec::new(), Some(0.0));
+        assert!(engine.cancel_swap_in(handle.id()));
+        assert_eq!(g1_manager.available_blocks(), 0);
+
+        let staging_deadline = engine
+            .earliest_pending_deadline()
+            .expect("active G3→G2 phase");
+        engine.tick(staging_deadline);
+        assert_eq!(handle.terminal(), SwapInTerminal::Cancelled);
+        assert_eq!(g1_manager.available_blocks(), 1);
+        assert_eq!(
+            engine.earliest_pending_deadline(),
+            None,
+            "cancellation must not start a G2→G1 successor"
+        );
+    }
+
+    #[test]
+    fn staged_swap_in_cancellation_during_successor_retains_destination() {
+        use dynamo_tokens::PositionalLineageHash;
+
+        let _guard = shared_g3_test_guard_blocking();
+        let rt = single_thread_runtime();
+        let mut engine = rt
+            .block_on(MockOffloadEngine::new(g3_config()))
+            .expect("engine build");
+        engine.attach_runtime(rt);
+        engine.tick(0.0);
+
+        let plh = PositionalLineageHash::new(9_003, None, 0);
+        register_test_block(engine.g3_manager().expect("G3 enabled"), plh);
+        let (g1_manager, destination_slots) = allocate_g1_slots(1);
+        let prepared = engine
+            .prepare_onboard_prefix(&[plh])
+            .expect("G3 prefix match");
+        let handle =
+            engine.start_onboard_prefix(prepared, destination_slots, Vec::new(), Some(0.0));
+        let staging_deadline = engine
+            .earliest_pending_deadline()
+            .expect("G3→G2 staging deadline");
+        engine.tick(staging_deadline);
+        let onboard_deadline = engine
+            .earliest_pending_deadline()
+            .expect("G2→G1 successor deadline");
+        assert!(engine.cancel_swap_in(handle.id()));
+
+        engine.tick((staging_deadline + onboard_deadline) / 2.0);
+        assert_eq!(handle.terminal(), SwapInTerminal::Pending);
+        assert_eq!(g1_manager.available_blocks(), 0);
+
+        engine.tick(onboard_deadline);
+        assert_eq!(handle.terminal(), SwapInTerminal::Cancelled);
+        assert_eq!(g1_manager.available_blocks(), 1);
+    }
+
+    #[test]
+    fn staged_channel_closure_publishes_failure_before_releasing_resources() {
+        use dynamo_tokens::PositionalLineageHash;
+
+        let _guard = shared_g3_test_guard_blocking();
+        let rt = single_thread_runtime();
+        let mut engine = rt
+            .block_on(MockOffloadEngine::new(g3_config()))
+            .expect("engine build");
+        engine.attach_runtime(rt);
+        engine.tick(0.0);
+
+        let plh = PositionalLineageHash::new(9_004, None, 0);
+        register_test_block(engine.g3_manager().expect("G3 enabled"), plh);
+        let (g1_manager, destination_slots) = allocate_g1_slots(1);
+        engine.worker.inject_fault(WorkerFault::ChannelClosure);
+        let prepared = engine
+            .prepare_onboard_prefix(&[plh])
+            .expect("G3 prefix match");
+        let handle =
+            engine.start_onboard_prefix(prepared, destination_slots, Vec::new(), Some(0.0));
+
+        assert!(
+            matches!(handle.terminal(), SwapInTerminal::Failed(_)),
+            "staging channel closure must publish failure; got {:?}",
+            handle.terminal()
+        );
+        assert_eq!(
+            g1_manager.available_blocks(),
+            0,
+            "failure publication must precede terminal resource cleanup"
+        );
+        engine.tick(0.0);
+        assert_eq!(g1_manager.available_blocks(), 1);
     }
 
     #[test]
@@ -2340,7 +2692,7 @@ mod tests {
             .prepare_onboard_prefix(&[plh])
             .expect("G3 prefix match must produce a staged swap-in");
         assert_eq!(prepared.reservation_block_count(), 1);
-        let handle = engine.start_onboard_prefix(prepared, Some(0.0));
+        let handle = engine.start_onboard_prefix(prepared, Vec::new(), Vec::new(), Some(0.0));
         assert!(!handle.is_complete());
 
         let first_deadline = engine
@@ -2367,6 +2719,9 @@ mod tests {
 
         engine.tick(second_deadline);
         assert!(handle.is_complete());
+        engine
+            .take_completed_swap_in(handle.id())
+            .expect("completed staged G3 swap-in resources");
     }
 
     #[test]
@@ -2391,7 +2746,7 @@ mod tests {
             .prepare_onboard_prefix(&[plh])
             .expect("G4 prefix match must produce a staged swap-in");
         assert_eq!(prepared.reservation_block_count(), 1);
-        let handle = engine.start_onboard_prefix(prepared, Some(0.0));
+        let handle = engine.start_onboard_prefix(prepared, Vec::new(), Vec::new(), Some(0.0));
         assert!(!handle.is_complete());
 
         let first_deadline = engine
@@ -2418,5 +2773,8 @@ mod tests {
 
         engine.tick(second_deadline);
         assert!(handle.is_complete());
+        engine
+            .take_completed_swap_in(handle.id())
+            .expect("completed staged G4 swap-in resources");
     }
 }

--- a/lib/mocker/src/kvbm_offload/mod.rs
+++ b/lib/mocker/src/kvbm_offload/mod.rs
@@ -13,6 +13,7 @@
 pub mod bandwidth_sharing_model;
 pub(crate) mod capacity_reservation;
 pub mod config;
+pub(crate) mod coordinator;
 pub mod engine;
 pub(crate) mod shared_g3;
 pub(crate) mod shared_g4;
@@ -20,6 +21,8 @@ pub mod worker;
 
 pub use bandwidth_sharing_model::{BandwidthSharingModel, TransferId};
 pub use config::KvbmOffloadConfig;
+pub(crate) use coordinator::OffloadId;
+pub use coordinator::SwapInHandle;
+pub use engine::MockOffloadEngine;
 pub(crate) use engine::{G1EvictionOutcome, G2BlockEventMetadata, G2OffloadBlock, G2RouterEvent};
-pub use engine::{MockOffloadEngine, SwapInHandle};
 pub use worker::{MockWorker, TransferDirection};

--- a/lib/mocker/src/kvbm_offload/shared_g3.rs
+++ b/lib/mocker/src/kvbm_offload/shared_g3.rs
@@ -15,7 +15,7 @@ use kvbm_logical::registry::BlockRegistry;
 
 use super::capacity_reservation::CapacityReservations;
 use super::config::KvbmOffloadConfig;
-use super::worker::{DrainResult, SharedDrainCounts, TransferState};
+use super::worker::{DeferredOwnerDrain, DrainResult, SharedDrainCounts, TransferState};
 
 /// Shared process-local G3 resource. All mock workers in the process share
 /// this block manager and this G2↔G3 PS model.
@@ -25,7 +25,7 @@ pub(crate) struct SharedG3Pool {
     state: Arc<Mutex<TransferState>>,
     pending_tracker: Arc<PendingTracker>,
     capacity_reservations: Arc<CapacityReservations>,
-    pending_owner_drains: Mutex<HashMap<u64, SharedDrainCounts>>,
+    pending_owner_drains: Mutex<HashMap<u64, DeferredOwnerDrain>>,
 }
 
 static SHARED_G3_POOL: OnceLock<Mutex<Option<Weak<SharedG3Pool>>>> = OnceLock::new();
@@ -113,7 +113,7 @@ impl SharedG3Pool {
         let drained = state.drain_completions(now_ms, "shared-g3");
         drop(state);
 
-        self.record_drained(drained, registrations_before, Some(owner_id))
+        self.record_drained(drained, registrations_before, Some(owner_id), now_ms)
     }
 
     pub(crate) fn drain_completions_to_pending(&self, now_ms: f64) {
@@ -122,7 +122,7 @@ impl SharedG3Pool {
         let drained = state.drain_completions(now_ms, "shared-g3");
         drop(state);
 
-        self.record_drained(drained, registrations_before, None);
+        self.record_drained(drained, registrations_before, None, now_ms);
     }
 
     fn record_drained(
@@ -130,13 +130,8 @@ impl SharedG3Pool {
         drained: DrainResult,
         registrations_before: u64,
         owner_id: Option<u64>,
+        now_ms: f64,
     ) -> SharedDrainCounts {
-        // G2->G3 completions release shared G3 capacity when the global
-        // queue is drained, regardless of which engine owns the completion.
-        if drained.total.offload_blocks > 0 {
-            self.release_capacity_reservations(drained.total.offload_blocks);
-        }
-
         let mut owner_result = SharedDrainCounts::default();
         let mut pending = self
             .pending_owner_drains
@@ -145,7 +140,7 @@ impl SharedG3Pool {
         if let Some(owner_id) = owner_id
             && let Some(record) = pending.remove(&owner_id)
         {
-            owner_result.add_deferred_record(record);
+            owner_result.add_deferred_record(record.counts);
         }
         for (owner, counts) in drained.by_owner {
             let record = SharedDrainCounts {
@@ -157,7 +152,16 @@ impl SharedG3Pool {
             if Some(owner) == owner_id {
                 owner_result.add_record(record);
             } else {
-                pending.entry(owner).or_default().add_record(record);
+                pending
+                    .entry(owner)
+                    .and_modify(|pending| {
+                        pending.counts.add_record(record);
+                        pending.deadline_ms = pending.deadline_ms.min(now_ms);
+                    })
+                    .or_insert(DeferredOwnerDrain {
+                        counts: record,
+                        deadline_ms: now_ms,
+                    });
             }
         }
         owner_result
@@ -166,6 +170,14 @@ impl SharedG3Pool {
     pub(crate) fn earliest_finish(&self) -> Option<f64> {
         let state = self.state.lock().expect("shared G3 state poisoned");
         state.earliest_finish()
+    }
+
+    pub(crate) fn pending_owner_deadline(&self, owner_id: u64) -> Option<f64> {
+        self.pending_owner_drains
+            .lock()
+            .expect("shared G3 owner drain map poisoned")
+            .get(&owner_id)
+            .map(|pending| pending.deadline_ms)
     }
 
     pub(crate) fn earliest_offload_finish(&self) -> Option<f64> {

--- a/lib/mocker/src/kvbm_offload/shared_g4.rs
+++ b/lib/mocker/src/kvbm_offload/shared_g4.rs
@@ -13,7 +13,8 @@ use kvbm_engine::offload::PendingTracker;
 use super::bandwidth_sharing_model::TransferId;
 use super::config::KvbmOffloadConfig;
 use super::worker::{
-    CompletedTransfer, DrainResult, SharedDrainCounts, TransferDirection, TransferState,
+    CompletedTransfer, DeferredOwnerDrain, DrainResult, SharedDrainCounts, TransferDirection,
+    TransferState,
 };
 
 /// Object metadata tracked by the mock G4 tier.
@@ -36,7 +37,7 @@ pub(crate) struct SharedG4Store {
     pending_puts: Mutex<HashMap<TransferId, PendingG4Put>>,
     state: Arc<Mutex<TransferState>>,
     pending_tracker: Arc<PendingTracker>,
-    pending_owner_drains: Mutex<HashMap<u64, SharedDrainCounts>>,
+    pending_owner_drains: Mutex<HashMap<u64, DeferredOwnerDrain>>,
 }
 
 static SHARED_G4_STORE: OnceLock<Mutex<Option<Weak<SharedG4Store>>>> = OnceLock::new();
@@ -130,7 +131,7 @@ impl SharedG4Store {
         let drained = state.drain_completions(now_ms, "shared-g4");
         drop(state);
 
-        self.record_drained(drained, Some(owner_id))
+        self.record_drained(drained, Some(owner_id), now_ms)
     }
 
     pub(crate) fn drain_completions_to_pending(&self, now_ms: f64) {
@@ -138,10 +139,15 @@ impl SharedG4Store {
         let drained = state.drain_completions(now_ms, "shared-g4");
         drop(state);
 
-        self.record_drained(drained, None);
+        self.record_drained(drained, None, now_ms);
     }
 
-    fn record_drained(&self, drained: DrainResult, owner_id: Option<u64>) -> SharedDrainCounts {
+    fn record_drained(
+        &self,
+        drained: DrainResult,
+        owner_id: Option<u64>,
+        now_ms: f64,
+    ) -> SharedDrainCounts {
         self.publish_completed_puts(&drained.completed);
 
         let mut owner_result = SharedDrainCounts::default();
@@ -152,7 +158,7 @@ impl SharedG4Store {
         if let Some(owner_id) = owner_id
             && let Some(record) = pending.remove(&owner_id)
         {
-            owner_result.add_deferred_record(record);
+            owner_result.add_deferred_record(record.counts);
         }
         for (owner, counts) in drained.by_owner {
             let record = SharedDrainCounts {
@@ -163,7 +169,16 @@ impl SharedG4Store {
             if Some(owner) == owner_id {
                 owner_result.add_record(record);
             } else {
-                pending.entry(owner).or_default().add_record(record);
+                pending
+                    .entry(owner)
+                    .and_modify(|pending| {
+                        pending.counts.add_record(record);
+                        pending.deadline_ms = pending.deadline_ms.min(now_ms);
+                    })
+                    .or_insert(DeferredOwnerDrain {
+                        counts: record,
+                        deadline_ms: now_ms,
+                    });
             }
         }
         owner_result
@@ -205,6 +220,14 @@ impl SharedG4Store {
     pub(crate) fn earliest_finish(&self) -> Option<f64> {
         let state = self.state.lock().expect("shared G4 state poisoned");
         state.earliest_finish()
+    }
+
+    pub(crate) fn pending_owner_deadline(&self, owner_id: u64) -> Option<f64> {
+        self.pending_owner_drains
+            .lock()
+            .expect("shared G4 owner drain map poisoned")
+            .get(&owner_id)
+            .map(|pending| pending.deadline_ms)
     }
 
     pub(crate) fn earliest_offload_finish(&self) -> Option<f64> {

--- a/lib/mocker/src/kvbm_offload/worker.rs
+++ b/lib/mocker/src/kvbm_offload/worker.rs
@@ -16,6 +16,8 @@
 //! Remote NIXL and cross-instance methods return `bail!` / all-Err futures.
 
 use std::collections::HashMap;
+#[cfg(test)]
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -35,6 +37,7 @@ use tokio::sync::watch;
 use velo::{Event, EventManager};
 
 use super::bandwidth_sharing_model::{BandwidthSharingModel, TransferId};
+use super::coordinator::SwapInStatus;
 use super::shared_g3::SharedG3Pool;
 use super::shared_g4::SharedG4Store;
 
@@ -112,12 +115,19 @@ pub(crate) struct TransferState {
     /// issued. When the model drains an id on `advance_to`, we
     /// `remove` the `Event` from this map and `trigger()` it.
     awaiters: HashMap<TransferId, PipelineAwaiter>,
-    /// Completion flags for swap-in reservations. Polled synchronously
-    /// by the scheduler via `SwapInHandle::is_complete()` — kept
+    /// Terminal status publishers for swap-in reservations — kept
     /// separate from `awaiters` because swap-in does not feed a velo
     /// notification back into a kvbm-engine pipeline; the scheduler
     /// owns lifecycle directly.
-    swap_in_flags: HashMap<TransferId, Arc<std::sync::atomic::AtomicBool>>,
+    swap_in_status: HashMap<TransferId, watch::Sender<SwapInStatus>>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum WorkerFault {
+    ExecutorError,
+    ExecutorPanic,
+    ChannelClosure,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -170,6 +180,12 @@ pub(crate) struct SharedDrainCounts {
     pub(crate) offload_registration_baseline: Option<u64>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DeferredOwnerDrain {
+    pub(crate) counts: SharedDrainCounts,
+    pub(crate) deadline_ms: f64,
+}
+
 impl SharedDrainCounts {
     pub(crate) fn add_record(&mut self, record: SharedDrainCounts) {
         self.counts.add_counts(record.counts);
@@ -208,7 +224,7 @@ pub(crate) struct CompletedTransfer {
 impl TransferState {
     pub(crate) fn new(offload_gbps: f64, onboard_gbps: f64) -> Self {
         // One shared `TransferId` counter across both models so ids
-        // are globally unique. `awaiters` and `swap_in_flags` below are
+        // are globally unique. `awaiters` and `swap_in_status` below are
         // single maps keyed by TransferId; per-model counters would
         // hand out overlapping ids and cause completion signals to
         // cross-fire between unrelated transfers.
@@ -217,7 +233,7 @@ impl TransferState {
             offload_bw: BandwidthSharingModel::new(offload_gbps, id_counter.clone()),
             onboard_bw: BandwidthSharingModel::new(onboard_gbps, id_counter),
             awaiters: HashMap::new(),
-            swap_in_flags: HashMap::new(),
+            swap_in_status: HashMap::new(),
         }
     }
 
@@ -235,14 +251,6 @@ impl TransferState {
 
     pub(crate) fn earliest_offload_finish_with_id(&self) -> Option<(TransferId, f64)> {
         self.offload_bw.earliest_finish_with_id()
-    }
-
-    pub(crate) fn offload_deadline_for(&self, transfer_id: TransferId) -> Option<f64> {
-        self.offload_bw.deadline_for(transfer_id)
-    }
-
-    pub(crate) fn is_offload_active(&self, transfer_id: TransferId) -> bool {
-        self.offload_bw.is_active(transfer_id)
     }
 
     pub(crate) fn earliest_onboard_finish(&self) -> Option<f64> {
@@ -312,8 +320,9 @@ impl TransferState {
                 let _ = awaiter.event.trigger();
                 awaiter_fired += 1;
             }
-            if let Some(flag) = self.swap_in_flags.remove(&id) {
-                flag.store(true, Ordering::Release);
+            if let Some(status) = self.swap_in_status.remove(&id) {
+                let block_count = status.borrow().block_count;
+                status.send_replace(SwapInStatus::completed(block_count));
                 swap_in_flipped += 1;
             }
         }
@@ -376,6 +385,10 @@ pub struct MockWorker {
     g2_handle: Option<LayoutHandle>,
     shared_g3: Option<Arc<SharedG3Pool>>,
     shared_g4: Option<Arc<SharedG4Store>>,
+    #[cfg(test)]
+    fault_script: Mutex<VecDeque<WorkerFault>>,
+    #[cfg(test)]
+    injected_staging_failure: Mutex<Option<Arc<str>>>,
 }
 
 impl MockWorker {
@@ -406,7 +419,35 @@ impl MockWorker {
             g2_handle,
             shared_g3,
             shared_g4,
+            #[cfg(test)]
+            fault_script: Mutex::new(VecDeque::new()),
+            #[cfg(test)]
+            injected_staging_failure: Mutex::new(None),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_fault(&self, fault: WorkerFault) {
+        self.fault_script
+            .lock()
+            .expect("worker fault script mutex poisoned")
+            .push_back(fault);
+    }
+
+    #[cfg(test)]
+    fn take_fault(&self) -> Option<WorkerFault> {
+        self.fault_script
+            .lock()
+            .expect("worker fault script mutex poisoned")
+            .pop_front()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_injected_staging_failure(&self) -> Option<Arc<str>> {
+        self.injected_staging_failure
+            .lock()
+            .expect("injected staging failure mutex poisoned")
+            .take()
     }
 
     /// Update the worker's notion of current simulation time. Engine calls
@@ -431,8 +472,8 @@ impl MockWorker {
 
     /// Advance both models to `now_ms` under PS and notify any
     /// completion sinks registered for drained `TransferId`s: `velo::Event`
-    /// awaiters (for kvbm-engine pipeline transfers) and `AtomicBool`
-    /// flags (for swap-in reservations polled by the scheduler). Called
+    /// awaiters (for kvbm-engine pipeline transfers) and watch statuses
+    /// (for swap-in reservations polled by the scheduler). Called
     /// from `MockOffloadEngine::tick` and implicitly before every new
     /// reservation — both uses need the model's active set to
     /// reflect completed transfers at the queried time.
@@ -461,14 +502,14 @@ impl MockWorker {
         }
     }
 
-    /// Reserve an onboard (G2→G1) transfer whose completion is observed
-    /// via `complete` — `MockOffloadEngine::tick` (or any drain path)
-    /// flips this bool when the PS model drains the reservation.
-    pub fn reserve_swap_in(
+    /// Reserve an onboard (G2→G1) transfer whose completion is published
+    /// through `status` when `MockOffloadEngine::tick` (or any drain path)
+    /// drains the reservation from the PS model.
+    pub(crate) fn reserve_swap_in(
         &self,
         now_ms: f64,
         num_blocks: usize,
-        complete: Arc<std::sync::atomic::AtomicBool>,
+        status: watch::Sender<SwapInStatus>,
     ) -> TransferId {
         let bytes = num_blocks.saturating_mul(self.block_bytes);
         let mut state = self.state.lock().expect("TransferState mutex poisoned");
@@ -485,7 +526,7 @@ impl MockWorker {
             next_deadline_ms = ?next_deadline_ms,
             "kvbm-offload: reserve mock swap-in transfer"
         );
-        state.swap_in_flags.insert(id, complete);
+        state.swap_in_status.insert(id, status);
         id
     }
 
@@ -495,26 +536,26 @@ impl MockWorker {
         let state = self.state.lock().expect("TransferState mutex poisoned");
         let local = state.earliest_finish();
         drop(state);
+        let pending_g3_deadline = self
+            .shared_g3
+            .as_ref()
+            .and_then(|g3| g3.pending_owner_deadline(self.owner_id));
+        let pending_g4_deadline = self
+            .shared_g4
+            .as_ref()
+            .and_then(|g4| g4.pending_owner_deadline(self.owner_id));
         local
             .into_iter()
             .chain(self.shared_g3.as_ref().and_then(|g3| g3.earliest_finish()))
             .chain(self.shared_g4.as_ref().and_then(|g4| g4.earliest_finish()))
+            .chain(pending_g3_deadline)
+            .chain(pending_g4_deadline)
             .reduce(f64::min)
     }
 
     pub(crate) fn earliest_local_offload_finish_with_id(&self) -> Option<(TransferId, f64)> {
         let state = self.state.lock().expect("TransferState mutex poisoned");
         state.earliest_offload_finish_with_id()
-    }
-
-    pub(crate) fn local_offload_deadline_for(&self, transfer_id: TransferId) -> Option<f64> {
-        let state = self.state.lock().expect("TransferState mutex poisoned");
-        state.offload_deadline_for(transfer_id)
-    }
-
-    pub(crate) fn is_local_offload_active(&self, transfer_id: TransferId) -> bool {
-        let state = self.state.lock().expect("TransferState mutex poisoned");
-        state.is_offload_active(transfer_id)
     }
 
     pub(crate) fn local_offload_active_count(&self) -> usize {
@@ -656,6 +697,28 @@ impl WorkerTransfers for MockWorker {
         _options: TransferOptions,
     ) -> Result<TransferCompleteNotification> {
         let direction = TransferDirection::try_from((src, dst))?;
+        #[cfg(test)]
+        match self.take_fault() {
+            Some(WorkerFault::ExecutorError) => {
+                bail!("injected mock transfer executor error")
+            }
+            Some(WorkerFault::ExecutorPanic) => {
+                panic!("injected mock transfer executor panic")
+            }
+            Some(WorkerFault::ChannelClosure) => {
+                if direction == TransferDirection::G3ToG2 {
+                    self.injected_staging_failure
+                        .lock()
+                        .expect("injected staging failure mutex poisoned")
+                        .replace(Arc::from("injected lower-tier staging channel closure"));
+                }
+                let event = self.event_manager.new_event()?;
+                let awaiter = event.awaiter()?;
+                let _ = event.poison("injected mock transfer notification failure");
+                return Ok(TransferCompleteNotification::from_awaiter(awaiter));
+            }
+            None => {}
+        }
         let now_ms = self.now_ms();
         self.reserve_transfer(direction, now_ms, src_block_ids.len())
     }
@@ -894,6 +957,7 @@ impl ObjectBlockOps for MockWorker {
 #[cfg(test)]
 mod tests {
     use super::super::config::KvbmOffloadConfig;
+    use super::super::coordinator::SwapInTerminal;
     use super::super::shared_g3::shared_g3_test_guard;
     use super::super::shared_g4::{SharedG4Store, shared_g4_test_guard};
     use super::*;
@@ -1283,7 +1347,7 @@ mod tests {
     #[tokio::test]
     async fn mock_worker_offload_and_swap_in_share_id_keyspace() {
         // Invariant: pipeline transfers (`awaiters`) and G2→G1 swap-ins
-        // (`swap_in_flags`) live in two HashMaps but share one TransferId
+        // (`swap_in_status`) live in two HashMaps but share one TransferId
         // keyspace, because `TransferState::drain_completions` looks up every
         // drained id in both maps. `TransferState::new` enforces this by handing the
         // same Arc<AtomicU64> counter to `offload_bw` and `onboard_bw`.
@@ -1291,15 +1355,15 @@ mod tests {
         // If a future refactor gives each BandwidthSharingModel its own
         // counter, both would start at 0 and the first offload + first
         // swap-in would alias on id=0 — causing a completing offload to
-        // falsely flip the swap-in flag (and vice versa). This test pins
+        // falsely complete the swap-in status (and vice versa). This test pins
         // that invariant: ids drawn across the two models must be disjoint.
-        use std::sync::atomic::AtomicBool;
         let worker = make_worker();
         worker.set_now_ms(0.0);
 
         // Reserve one swap-in (onboard model) and one offload (offload model)
         // at the same virtual time, so both counters are at their initial value.
-        let swap_id = worker.reserve_swap_in(0.0, 1, Arc::new(AtomicBool::new(false)));
+        let (status, _) = watch::channel(SwapInStatus::pending(1));
+        let swap_id = worker.reserve_swap_in(0.0, 1, status);
         let ids: Arc<[BlockId]> = Arc::from(vec![0usize]);
         let _offload = worker
             .execute_local_transfer(
@@ -1324,25 +1388,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mock_worker_swap_in_flag_flips_on_drain() {
+    async fn mock_worker_swap_in_status_completes_on_drain() {
         // Reserve a G2→G1 swap-in for 1 block (1 MB at 1 GB/s → 1 ms).
-        // Before drain the flag must be false; after advancing past the
-        // finish time the same drain must flip it to true.
-        use std::sync::atomic::{AtomicBool, Ordering};
+        // Before drain the status must be pending; after advancing past the
+        // finish time the same drain must publish completion.
         let worker = make_worker();
         worker.set_now_ms(0.0);
-        let complete = Arc::new(AtomicBool::new(false));
-        let _id = worker.reserve_swap_in(0.0, 1, complete.clone());
-        assert!(!complete.load(Ordering::Acquire));
+        let (status, status_rx) = watch::channel(SwapInStatus::pending(1));
+        let _id = worker.reserve_swap_in(0.0, 1, status);
+        assert_eq!(status_rx.borrow().terminal, SwapInTerminal::Pending);
         worker.drain_completions(0.5);
         assert!(
-            !complete.load(Ordering::Acquire),
+            matches!(status_rx.borrow().terminal, SwapInTerminal::Pending),
             "swap-in must not complete before its finish time"
         );
         worker.drain_completions(1.0);
         assert!(
-            complete.load(Ordering::Acquire),
-            "swap-in flag must flip after drain past finish time"
+            matches!(status_rx.borrow().terminal, SwapInTerminal::Completed),
+            "swap-in status must complete after drain past finish time"
         );
     }
 

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1123,9 +1123,9 @@ impl VllmCore {
     /// `[skip_blocks .. skip_blocks + count]` of the request's block
     /// sequence — we skip the G1-cached prefix the request already had
     /// and register only the uncached-remainder blocks that the engine
-    /// actually onboarded from G2. `aws` drops at the end →
-    /// `SwapInHandle` drops → pinned G2 blocks release to kvbm-engine's
-    /// inactive pool.
+    /// actually onboarded from G2. `register_completed_swap_in` consumes
+    /// the coordinator lease, registers its retained G1 destinations, and
+    /// releases the remaining swap-in resources.
     #[cfg(feature = "kvbm-offload")]
     fn complete_swap_in(&mut self, aws: AwaitingSwapIn) {
         let count = aws.handle.block_count();

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -6,15 +6,11 @@ use std::time::Duration;
 
 use dynamo_kv_router::protocols::WorkerId;
 use dynamo_tokens::blocks::UniqueBlock;
-#[cfg(feature = "kvbm-offload")]
-use kvbm_logical::{ImmutableBlock, MutableBlock};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::common::handoff::HandoffId;
-#[cfg(feature = "kvbm-offload")]
-use crate::common::protocols::G1;
 use crate::common::protocols::{
     DirectRequest, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal, PreemptionMode,
     PrefillCost, WorkerType,
@@ -26,6 +22,8 @@ use crate::kv_manager::KvManager;
 #[cfg(feature = "kvbm-offload")]
 use crate::kv_manager::kvbm_backend::SwapInRegistrationBlock;
 use crate::kv_manager::kvbm_backend::{G1Acquire, OffloadDependency, VllmDestinationReservation};
+#[cfg(feature = "kvbm-offload")]
+use crate::kvbm_offload::coordinator::SwapInTerminal;
 use crate::replay::TraceCollector;
 use crate::scheduler::vllm::policy::{self, AdmissionDecision};
 use crate::scheduler::{
@@ -363,14 +361,12 @@ impl SchedulerState {
 /// cached in G1 at park time; the swap-in covers the next
 /// `handle.block_count()` blocks starting at that offset. We need this
 /// to register the right slice of the request's PLHs into G1 inactive
-/// after the transfer completes. `_prefix_pins` keeps that cached prefix
-/// resident until the suffix can publish Device-tier Stored events against it.
+/// after the transfer completes. The coordinator keeps that cached prefix
+/// resident until the suffix publishes Device-tier Stored events.
 #[cfg(feature = "kvbm-offload")]
 pub(crate) struct AwaitingSwapIn {
     pub(crate) uuid: Uuid,
     pub(crate) handle: crate::kvbm_offload::SwapInHandle,
-    pub(crate) destination_slots: Vec<MutableBlock<G1>>,
-    pub(crate) _prefix_pins: Vec<ImmutableBlock<G1>>,
     pub(crate) skip_blocks: usize,
 }
 
@@ -730,11 +726,11 @@ impl VllmCore {
         let kv = match reservation {
             G1Acquire::Ready(kv) => kv,
             G1Acquire::BlockedOnOffload {
-                transfer_id,
+                offload_id,
                 deadline_ms,
             } => {
                 request.offload_dependency = Some(OffloadDependency {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 });
                 self.pending_destinations.mark_front_attempted(generation);
@@ -1054,10 +1050,13 @@ impl VllmCore {
         let mut pending = Vec::with_capacity(awaiting.len());
 
         for aws in awaiting {
-            if aws.handle.is_complete() {
-                completed.push(aws);
-            } else {
-                pending.push(aws);
+            match aws.handle.terminal() {
+                SwapInTerminal::Pending => pending.push(aws),
+                SwapInTerminal::Completed => completed.push(aws),
+                SwapInTerminal::Cancelled => {}
+                SwapInTerminal::Failed(context) => {
+                    panic!("mocker swap-in failed for request {}: {context}", aws.uuid)
+                }
             }
         }
 
@@ -1174,7 +1173,7 @@ impl VllmCore {
         let entries_len = entries.len();
         let outcome =
             self.kv_manager
-                .register_swapped_in_blocks(entries, parent_hash, aws.destination_slots);
+                .register_completed_swap_in(aws.handle.id(), entries, parent_hash);
         debug_assert_eq!(
             outcome.consumed_entries, entries_len,
             "reserved destination slots should cover every swapped-in block"
@@ -1248,58 +1247,54 @@ impl VllmCore {
                 return SwapInAdmissionAttempt::NoHit;
             }
         };
-        let (handle, destination_slots) = match self
-            .kv_manager
-            .try_batch_swap_in(remaining_plhs, Some(now_ms))
-        {
-            BatchSwapInOutcome::Scheduled {
-                handle,
-                destination_slots,
-            } => {
-                tracing::debug!(
-                    %uuid,
-                    now_ms,
-                    skip_blocks,
-                    remaining_blocks = remaining_plhs.len(),
-                    "kvbm-offload: swap-in admission parked"
-                );
-                (handle, destination_slots)
-            }
-            BatchSwapInOutcome::BlockedOnG1Offload(dependency) => {
-                tracing::debug!(
-                    %uuid,
-                    now_ms,
-                    transfer_id = ?dependency.transfer_id,
-                    deadline_ms = ?dependency.deadline_ms,
-                    skip_blocks,
-                    remaining_blocks = remaining_plhs.len(),
-                    "kvbm-offload: swap-in blocked on G1 offload"
-                );
-                let request = self
-                    .state
-                    .requests
-                    .get_mut(&uuid)
-                    .expect("swap-in dependency request must remain active");
-                request.offload_dependency = Some(dependency);
-                return SwapInAdmissionAttempt::BlockedOnG1Offload;
-            }
-            BatchSwapInOutcome::NoHits => {
-                tracing::trace!(
-                    %uuid,
-                    now_ms,
-                    skip_blocks,
-                    remaining_blocks = remaining_plhs.len(),
-                    "kvbm-offload: swap-in lower-tier miss"
-                );
-                return SwapInAdmissionAttempt::NoHit;
-            }
-        };
+        let handle =
+            match self
+                .kv_manager
+                .try_batch_swap_in(remaining_plhs, prefix_pins, Some(now_ms))
+            {
+                BatchSwapInOutcome::Scheduled { handle } => {
+                    tracing::debug!(
+                        %uuid,
+                        now_ms,
+                        skip_blocks,
+                        remaining_blocks = remaining_plhs.len(),
+                        "kvbm-offload: swap-in admission parked"
+                    );
+                    handle
+                }
+                BatchSwapInOutcome::BlockedOnG1Offload(dependency) => {
+                    tracing::debug!(
+                        %uuid,
+                        now_ms,
+                        offload_id = ?dependency.offload_id,
+                        deadline_ms = ?dependency.deadline_ms,
+                        skip_blocks,
+                        remaining_blocks = remaining_plhs.len(),
+                        "kvbm-offload: swap-in blocked on G1 offload"
+                    );
+                    let request = self
+                        .state
+                        .requests
+                        .get_mut(&uuid)
+                        .expect("swap-in dependency request must remain active");
+                    request.offload_dependency = Some(dependency);
+                    return SwapInAdmissionAttempt::BlockedOnG1Offload;
+                }
+                BatchSwapInOutcome::NoHits => {
+                    tracing::trace!(
+                        %uuid,
+                        now_ms,
+                        skip_blocks,
+                        remaining_blocks = remaining_plhs.len(),
+                        "kvbm-offload: swap-in lower-tier miss"
+                    );
+                    return SwapInAdmissionAttempt::NoHit;
+                }
+            };
         self.state.remove_from_waiting(uuid);
         self.requests_awaiting_swap_in.push(AwaitingSwapIn {
             uuid,
             handle,
-            destination_slots,
-            _prefix_pins: prefix_pins,
             skip_blocks,
         });
         SwapInAdmissionAttempt::Parked
@@ -1532,8 +1527,19 @@ impl VllmCore {
     pub(super) fn drop_request(&mut self, uuid: Uuid) {
         let active_blocks_before = self.kv_manager.num_active_blocks();
         #[cfg(feature = "kvbm-offload")]
-        self.requests_awaiting_swap_in
-            .retain(|request| request.uuid != uuid);
+        {
+            let awaiting = std::mem::take(&mut self.requests_awaiting_swap_in);
+            for request in awaiting {
+                if request.uuid == uuid {
+                    assert!(
+                        self.kv_manager.cancel_swap_in(request.handle.id()),
+                        "parked swap-in must retain a coordinator lease"
+                    );
+                } else {
+                    self.requests_awaiting_swap_in.push(request);
+                }
+            }
+        }
 
         let Some(request) = self.state.requests.get(&uuid) else {
             if self.kv_manager.num_active_blocks() < active_blocks_before {
@@ -1779,14 +1785,14 @@ impl VllmCore {
                     break;
                 }
                 G1Acquire::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 } => {
                     let request = self.state.requests.get_mut(&uuid).unwrap_or_else(|| {
                         panic!("schedule_request: {uuid} removed while attaching dependency")
                     });
                     request.offload_dependency = Some(OffloadDependency {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     });
                     actual_computed_after = effective_computed_before;
@@ -1961,7 +1967,7 @@ impl VllmCore {
                         break;
                     }
                     G1Acquire::BlockedOnOffload {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     } => {
                         sequence.pop();
@@ -1971,7 +1977,7 @@ impl VllmCore {
                             .get_mut(&uuid)
                             .expect("decode dependency request must remain active");
                         request.offload_dependency = Some(OffloadDependency {
-                            transfer_id,
+                            offload_id,
                             deadline_ms,
                         });
                         break;
@@ -2081,11 +2087,11 @@ impl VllmCore {
             match self.kv_manager.reserve_decode_blocks(required_blocks) {
                 G1Acquire::Ready(reservation) => break reservation,
                 G1Acquire::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 } => {
                     let dependency = Some(OffloadDependency {
-                        transfer_id,
+                        offload_id,
                         deadline_ms,
                     });
                     for uuid in &ready {
@@ -2324,12 +2330,12 @@ fn process_signals(kv_manager: &mut KvManager, signals: &[MoveBlock]) -> G1Acqui
         match kv_manager.process(signal) {
             G1Acquire::Ready(_) => continue,
             G1Acquire::BlockedOnOffload {
-                transfer_id,
+                offload_id,
                 deadline_ms,
             } => {
                 validate_decode_allocation_failure(signal);
                 return G1Acquire::BlockedOnOffload {
-                    transfer_id,
+                    offload_id,
                     deadline_ms,
                 };
             }

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -2596,7 +2596,7 @@ mod offload {
         let dependency = blocked_state
             .offload_dependency
             .expect("decode growth must retain its exact offload dependency");
-        assert!(dependency.transfer_id.is_some());
+        let _ = dependency.offload_id;
         let deadline = dependency
             .deadline_ms
             .expect("active offload dependency must expose a virtual deadline");
@@ -2661,7 +2661,7 @@ mod offload {
         let dependency = core.state.requests[&blocked]
             .offload_dependency
             .expect("speculative reservation must retain its exact dependency");
-        assert!(dependency.transfer_id.is_some());
+        let _ = dependency.offload_id;
         let deadline = dependency
             .deadline_ms
             .expect("active offload dependency must expose a virtual deadline");
@@ -3148,7 +3148,6 @@ mod offload {
 
         assert_eq!(pass.admissions.len(), 0);
         assert_eq!(core.requests_awaiting_swap_in.len(), 1);
-        assert_eq!(core.requests_awaiting_swap_in[0]._prefix_pins.len(), 2);
         assert_eq!(
             core.kv_manager.num_active_blocks(),
             3,
@@ -3222,7 +3221,6 @@ mod offload {
         let mut collector = crate::replay::TraceCollector::default();
         core.execute_pass(&mut collector, 0.0);
         assert_eq!(core.requests_awaiting_swap_in.len(), 1);
-        assert_eq!(core.requests_awaiting_swap_in[0]._prefix_pins.len(), 2);
         assert_eq!(core.kv_manager.num_active_blocks(), 3);
         assert!(
             core.apply_command(SchedulerCommand::Submit(DirectRequest {
@@ -3264,14 +3262,10 @@ mod offload {
         assert_eq!(canceled.result, SchedulerCommandResult::Applied);
         assert!(core.requests_awaiting_swap_in.is_empty());
         assert!(!core.state.requests.contains_key(&uuid));
-        assert!(canceled.lifecycle_events.iter().any(|event| matches!(
-            event,
-            SchedulerLifecycleEvent::DestinationReserved {
-                handoff_id,
-                request_id,
-                ..
-            } if *handoff_id == follower_handoff && *request_id == follower_uuid
-        )));
+        assert!(
+            canceled.lifecycle_events.is_empty(),
+            "cancelled swap-in must retain prefix pins and its destination until transfer termination"
+        );
 
         assert_eq!(
             core.apply_command(SchedulerCommand::CancelDestination {
@@ -3280,7 +3274,13 @@ mod offload {
             .unwrap(),
             SchedulerCommandResult::Applied
         );
-        assert_eq!(core.kv_manager.num_active_blocks(), 0);
+        assert_eq!(
+            core.kv_manager.num_active_blocks(),
+            3,
+            "cancelled swap-in prefix pins and destination must remain reserved"
+        );
+        core.tick_offload_only(0.5);
+        assert_eq!(core.kv_manager.num_active_blocks(), 3);
 
         assert_eq!(
             core.receive(DirectRequest {
@@ -3292,6 +3292,7 @@ mod offload {
             uuid
         );
         core.tick_offload_only(10.0);
+        assert_eq!(core.kv_manager.num_active_blocks(), 0);
         assert!(core.requests_awaiting_swap_in.is_empty());
         assert!(core.state.requests.contains_key(&uuid));
         let replacement = core.execute_pass(&mut collector, 10.0);


### PR DESCRIPTION
## Overview:

Centralize mocker-owned offload and swap-in resources in a crate-private generational lease coordinator. The refactor retains shared-lane settlement checkpoints across cross-owner drains and releases parent resources only after child registration and router visibility are acknowledged.

This is a mocker-only follow-up stacked on #11019. It does not change KVBM core APIs or live KVBM users. Explicit graceful shutdown remains out of scope; `Drop` performs no asynchronous cleanup and only emits a passive warning for live or prepared leases.

## Details:

- Add an `OffloadCoordinator` with opaque `OffloadId` values for G1→G2, G2→G3, G2→G4, direct swap-in, and staged swap-in leases.
- Retain the original pre-enqueue G3/G4 settlement checkpoint across cross-owner drains and accumulate deferred completion deltas against it.
- Make finalization two phase: settle and prepare progress, register child leases and drain lifecycle events, publish router visibility, then acknowledge before releasing source slots or tier reservations.
- Replace swap-in completion flags with structured watch status while the coordinator owns destination slots, prefix/source pins, staging reservations, handles, cancellation state, and terminal failures.
- Keep cancellation precise while mocker is active: direct transfers drain naturally, cancelled staged transfers do not start a new G2→G1 successor, and resources remain retained until the active modeled phase terminates.

Behavioral corrections:

- Shared G3 capacity becomes reusable only after the owning engine settles and acknowledges the corresponding lane.
- Parent offloads retain releasable resources until child leases are registered and router visibility is published.
- A deferred shared-lane drain exposes an immediate same-timestamp owner deadline instead of waiting for unrelated later work.
- Request cancellation retains pins and capacity until the active modeled transfer reaches terminal state.

## Where should the reviewer start?

1. `lib/mocker/src/kvbm_offload/coordinator.rs` for lease ownership, retained checkpoints, prepare/acknowledge finalization, and swap-in terminal state.
2. `lib/mocker/src/kvbm_offload/engine.rs` for settlement sequencing, child registration, router-event preparation, and acknowledgement-time resource release.
3. `lib/mocker/src/kv_manager/kvbm_backend.rs` and `lib/mocker/src/scheduler/vllm/core.rs` for the publish-before-ack boundary and opaque swap-in/offload ticket integration.
4. `lib/mocker/src/kvbm_offload/shared_g3.rs`, `shared_g4.rs`, and `worker.rs` for cross-owner deferred drains and immediate owner deadlines.

## Related Issues

- Relates to #11018.
- Stacked on and depends on #11019.
- Linear: [DYN-3300](https://linear.app/nvidia/issue/DYN-3300/centralize-mocker-offload-lifecycle-ownership).

## Validation

Correctness and flake coverage:

- complete `cargo test --locked -p dynamo-mocker`
- complete `cargo test --locked -p dynamo-mocker --features kvbm-offload`
- focused unchanged-core `kvbm-engine` settlement contract tests
- full mocker KVBM feature suite: 20/20 clean repetitions
- `idle_destination_reservation_wakes_at_offload_deadline`: 200/200 repetitions
- `live_destination_eviction_uses_command_application_time`: 200/200 repetitions
- `cargo clippy --no-deps --all-targets -- -D warnings`
- `cargo fmt --check`

Deterministic coverage includes cross-owner G3/G4 drains, cumulative deferred waves against one checkpoint, G2-only and lower-tier chains, concurrency one and greater than one, simultaneous completions, no successor, child registration before parent release, stale/foreign acknowledgement rejection, direct and staged cancellation, executor error/panic/channel closure, and exactly-once slot/reservation release.

Semantic parity:

- Control and G2-only traces matched exactly apart from the intended source-slot release fix inherited from #11019.
- Lower-tier traces preserved outputs, completion order, transfer counts, router decisions, and final absence of stranded work.
- The remaining lower-tier delta was the accepted two-phase lifetime change: 12 final HostPinned removals were retained past the comparison boundary, and removal timestamps moved until child registration and router publication were acknowledged.
- No unexplained semantic difference remained.

Paired before/after replay benchmarks showed no material regression:

- control workload throughput median: **+0.293%**
- offload-heavy workload throughput median: **+0.446%**

White-box tracing was applied only in the Computelab scratch checkout, preserved with its logs as an artifact, and removed before performance collection. It verified retained checkpoint capture, drained transfer counts versus settlement deltas, queued/starting/in-flight/settling transitions, permit handoff, successor invocation, router publication before acknowledgement, source-slot release, and zero final live leases or stranded modeled work.
