### PR TITLE
test(llm): eliminate ZMQ listener port race

### DIFF
--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -936,8 +936,7 @@ mod tests_startup_helpers {
     }
 
     //--------------------------------------------------------------------
-    // Test start_zmq_listener without a real socket
-    //   (feed it frames through a ZMQ PAIR tcp socket)
+    // Test start_zmq_listener with a real ZMQ publisher
     //--------------------------------------------------------------------
     #[tokio::test]
     async fn test_start_zmq_listener_pushes_to_channel() {
@@ -956,16 +955,8 @@ mod tests_startup_helpers {
         // Prepare channel that listener should fill
         let (tx, mut rx) = mpsc::unbounded_channel::<PlacementEvent>();
 
-        // ZMQ TCP endpoint using localhost with an ephemeral port
-        let reserved_listener = reserve_open_port();
-        let endpoint = format!(
-            "tcp://127.0.0.1:{}",
-            reserved_listener
-                .local_addr()
-                .expect("failed to read reserved listener address")
-                .port()
-        );
-        drop(reserved_listener);
+        // Keep the unique IPC directory alive until the sockets shut down.
+        let (_ipc_dir, endpoint) = unique_ipc_endpoint();
         let topic = "".to_string(); // subscribe to all
 
         // Publisher side - set up first
@@ -1072,15 +1063,8 @@ mod tests_startup_helpers {
     #[tokio::test]
     async fn test_start_zmq_listener_connects_before_publisher_bind() {
         let (tx, mut rx) = mpsc::unbounded_channel::<PlacementEvent>();
-        let reserved_listener = reserve_open_port();
-        let endpoint = format!(
-            "tcp://127.0.0.1:{}",
-            reserved_listener
-                .local_addr()
-                .expect("failed to read reserved listener address")
-                .port()
-        );
-        drop(reserved_listener);
+        // Keep the unique IPC directory alive until the sockets shut down.
+        let (_ipc_dir, endpoint) = unique_ipc_endpoint();
         let topic = String::new();
         let token = dynamo_runtime::CancellationToken::new();
         let next_event_id = Arc::new(AtomicU64::new(0));
@@ -1143,8 +1127,10 @@ mod tests_startup_helpers {
         let _ = listener_handle.await;
     }
 
-    fn reserve_open_port() -> std::net::TcpListener {
-        std::net::TcpListener::bind("127.0.0.1:0").expect("failed to bind probe listener")
+    fn unique_ipc_endpoint() -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().expect("failed to create temporary ZMQ directory");
+        let endpoint = format!("ipc://{}", dir.path().join("events.sock").display());
+        (dir, endpoint)
     }
 
     //--------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- replace the two ZMQ listener tests' TCP probe-and-rebind endpoints with unique IPC endpoints
- retain each temporary IPC directory until the listener and publisher sockets have shut down
- remove the bind-release-rebind window without changing production behavior or public APIs

## Root cause

`test_start_zmq_listener_connects_before_publisher_bind` selected a TCP port by binding `127.0.0.1:0`, dropped the probe listener, waited 150 ms, and then tried to bind the ZMQ publisher to the same port. Another process could claim the port during that window, producing `Zmq error: Address already in use`.

- Original failure: https://github.com/ai-dynamo/dynamo/actions/runs/28309424249/job/83872408993
- Successful rerun on the same commit: https://github.com/ai-dynamo/dynamo/actions/runs/28309424249/job/83928970712

## Validation

- `cargo fmt --all -- --check`
- focused ZMQ listener tests with `block-manager,testing-nixl,integration`: 2 passed
- connect-before-bind stress test: 50/50 iterations passed
- `cargo clippy -p dynamo-llm --locked --features=block-manager,testing-nixl,integration --no-deps --all-targets -- -D warnings`
- `cargo test -p dynamo-llm --locked --all-targets --features=block-manager,integration -- --nocapture`: passed, including 1,396 library tests

The host does not provide `libavutil.pc` or `libnixl_capi.so`, so local execution of the full `media-ffmpeg,testing-nixl` feature combination was not available. The focused tests compiled with `testing-nixl`; GitHub CI will exercise the complete container-provided feature set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved listener test reliability by using a unique local endpoint for each run.
  * Reduced flaky behavior when starting and connecting sockets by keeping the temporary endpoint available until shutdown.
  * Updated test wording for clearer, more accurate descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->