### PR TITLE
feat(vllm): support NeMo-RL NCCL weight updates

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -121,6 +121,14 @@ logger = logging.getLogger(__name__)
 
 _GENERATE_REASONING_SUPPORT_CACHE_ATTR = "_dynamo_generate_reasoning_support"
 _DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
+_DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
+    {
+        "allow_unpaused",
+        "engine_rpc",
+        "reset_prefix_cache",
+        "weight_version",
+    }
+)
 
 
 class _DeferredAbort:
@@ -1669,13 +1677,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             rpc_kwargs = {
                 k: v
                 for k, v in body.items()
-                if k
-                not in (
-                    "allow_unpaused",
-                    "engine_rpc",
-                    "reset_prefix_cache",
-                    "weight_version",
-                )
+                if k not in _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS
             }
             try:
                 await self.engine_client.collective_rpc(rpc, kwargs=rpc_kwargs)

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1634,8 +1634,20 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 "status": "error",
                 "message": "request body must be a JSON object",
             }
+        allow_unpaused = body.get("allow_unpaused", False)
+        reset_prefix_cache = body.get("reset_prefix_cache", True)
+        if not isinstance(allow_unpaused, bool):
+            return {
+                "status": "error",
+                "message": "'allow_unpaused' must be a boolean",
+            }
+        if not isinstance(reset_prefix_cache, bool):
+            return {
+                "status": "error",
+                "message": "'reset_prefix_cache' must be a boolean",
+            }
         async with self._pause_lock:
-            if not getattr(self, "_paused", False):
+            if not getattr(self, "_paused", False) and not allow_unpaused:
                 return {
                     "status": "error",
                     "message": (
@@ -1649,13 +1661,20 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             rpc_kwargs = {
                 k: v
                 for k, v in body.items()
-                if k not in ("engine_rpc", "weight_version")
+                if k
+                not in (
+                    "allow_unpaused",
+                    "engine_rpc",
+                    "reset_prefix_cache",
+                    "weight_version",
+                )
             }
             try:
                 await self.engine_client.collective_rpc(rpc, kwargs=rpc_kwargs)
-                # Weights changed: stale prefix/KV cache must be invalidated
-                # before resume so it is not reused under the new weights.
-                await self.engine_client.reset_prefix_cache()
+                if reset_prefix_cache:
+                    # Weights changed: stale prefix/KV cache must be invalidated
+                    # before resume so it is not reused under the new weights.
+                    await self.engine_client.reset_prefix_cache()
                 self._weight_version = version
                 logger.info(
                     f"[RL] Weights received via distributed "

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1646,6 +1646,14 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 "status": "error",
                 "message": "'reset_prefix_cache' must be a boolean",
             }
+        if allow_unpaused and reset_prefix_cache:
+            return {
+                "status": "error",
+                "message": (
+                    "Unpaused weight updates cannot reset the prefix cache. "
+                    "Set 'reset_prefix_cache' to false or pause generation first."
+                ),
+            }
         async with self._pause_lock:
             if not self._paused and not allow_unpaused:
                 return {

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1647,7 +1647,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 "message": "'reset_prefix_cache' must be a boolean",
             }
         async with self._pause_lock:
-            if not getattr(self, "_paused", False) and not allow_unpaused:
+            if not self._paused and not allow_unpaused:
                 return {
                     "status": "error",
                     "message": (

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -1459,6 +1459,55 @@ class TestRLAdminRouteHardening:
                 assert "JSON object" in resp["message"]
 
     @pytest.mark.asyncio
+    async def test_distributed_update_can_match_async_rl_semantics(self):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler._paused = False
+        handler.engine_client = MagicMock()
+        handler.engine_client.collective_rpc = AsyncMock()
+        handler.engine_client.reset_prefix_cache = AsyncMock()
+
+        resp = await handler.update_weights_from_distributed(
+            {
+                "allow_unpaused": True,
+                "reset_prefix_cache": False,
+                "engine_rpc": "update_weights",
+                "weight_version": 7,
+                "update_info": {"names": ["weight"]},
+            }
+        )
+
+        assert resp == {"status": "ok", "version": 7}
+        handler.engine_client.collective_rpc.assert_awaited_once_with(
+            "update_weights",
+            kwargs={"update_info": {"names": ["weight"]}},
+        )
+        handler.engine_client.reset_prefix_cache.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_distributed_update_preserves_safe_defaults(self):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler.engine_client = MagicMock()
+        handler.engine_client.collective_rpc = AsyncMock()
+        handler.engine_client.reset_prefix_cache = AsyncMock()
+
+        handler._paused = False
+        resp = await handler.update_weights_from_distributed({})
+        assert resp["status"] == "error"
+        handler.engine_client.collective_rpc.assert_not_awaited()
+
+        handler._paused = True
+        resp = await handler.update_weights_from_distributed(
+            {"engine_rpc": "finish_weight_update"}
+        )
+        assert resp["status"] == "ok"
+        handler.engine_client.collective_rpc.assert_awaited_once_with(
+            "finish_weight_update", kwargs={}
+        )
+        handler.engine_client.reset_prefix_cache.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
     async def test_abort_request_surfaces_deferred_abort_failure(self):
         handler = _make_handler()
         handler.engine_client = MagicMock()

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -1485,6 +1485,24 @@ class TestRLAdminRouteHardening:
         handler.engine_client.reset_prefix_cache.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_distributed_update_rejects_unpaused_cache_reset(self):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler._paused = False
+        handler.engine_client = MagicMock()
+        handler.engine_client.collective_rpc = AsyncMock()
+        handler.engine_client.reset_prefix_cache = AsyncMock()
+
+        resp = await handler.update_weights_from_distributed(
+            {"allow_unpaused": True, "engine_rpc": "update_weights"}
+        )
+
+        assert resp["status"] == "error"
+        assert "cannot reset the prefix cache" in resp["message"]
+        handler.engine_client.collective_rpc.assert_not_awaited()
+        handler.engine_client.reset_prefix_cache.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_distributed_update_preserves_safe_defaults(self):
         handler = _make_handler()
         handler._pause_lock = asyncio.Lock()


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weight updates can now be applied without pausing the worker when explicitly allowed.
  * Cache reset behavior is now configurable, letting updates optionally preserve existing prefix/KV cache state.

* **Bug Fixes**
  * Added stricter validation for new update options to prevent invalid requests.
  * Improved update handling so only the intended control fields are passed through during distributed updates.

* **Tests**
  * Added coverage for unpaused weight updates and default-safe error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->