### PR TITLE
docs(dgdr): clarify rapid fallback gates

### DIFF
--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -88,8 +88,8 @@ searchStrategy: rapid
 
 - Supports all backends: vLLM, SGLang, TensorRT-LLM
 - Falls back to a naive config (memory-fit TP calculation) only after DGDR
-  accepts the GPU SKU and AIC has base system metadata for it; unknown or
-  metadata-missing SKUs fail before fallback.
+  accepts the GPU SKU. Fallback sizing depends on AIC system metadata and does
+  not add support for additional GPU SKUs.
 - No GPU resources consumed during profiling
 
 ### Thorough

--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -92,15 +92,10 @@ searchStrategy: rapid
 ```
 
 - Supports all backends: vLLM, SGLang, TensorRT-LLM
-- DGDR must accept `hardware.gpuSku`, and AIC must have base system metadata
-  for that GPU SKU before fallback can run.
-- If those gates pass but the exact model/GPU/backend combination is not
-  supported by AIC, the profiler falls back to a naive config (memory-fit TP
-  calculation).
-- If hardware discovery produces an unknown GPU product name, set
-  `hardware.gpuSku`, `hardware.vramMb`, `hardware.numGpusPerNode`, and
-  `hardware.totalGpus` manually. Unknown GPU SKUs, and GPU SKUs without AIC
-  base system metadata, fail before naive fallback can produce a valid config.
+- Requires a DGDR-recognized GPU SKU and AIC base system metadata before
+  fallback can run.
+- Falls back to a naive config (memory-fit TP calculation) when the GPU SKU is
+  known but the exact model/GPU/backend combination is not supported by AIC.
 - No GPU resources consumed during profiling
 
 ### Thorough
@@ -434,8 +429,8 @@ hardware:
 > If you don't specify hardware constraints, the controller auto-detects GPU
 > hardware from cluster resources. If discovery cannot map the GPU to a
 > recognized DGDR SKU, provide all hardware fields manually. Unknown GPU SKUs
-> fail validation before rapid naive fallback can run. A recognized GPU SKU also
-> needs AIC base system metadata before fallback can generate a correct config.
+> fail validation before rapid naive fallback can run. AIC also needs base
+> system metadata for the GPU SKU before fallback can generate a correct config.
 
 ### Search Strategy (Optional)
 

--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -55,7 +55,11 @@ flowchart TD
 
 ### Stage-by-stage walkthrough
 
-1. **Validation**: The DGDR spec is validated — required fields checked (`image`, `hardware.gpuSku`, `hardware.numGpusPerNode`), SLA targets verified, and gate checks applied (see [Gate Checks](#gate-checks-and-constraints)).
+1. **Validation**: The DGDR spec is validated — required fields checked (`image`,
+   `hardware.gpuSku`, `hardware.numGpusPerNode`), SLA targets verified, and gate
+   checks applied (see [Gate Checks](#gate-checks-and-constraints)). This happens
+   before rapid fallback logic, so unknown GPU SKUs fail validation instead of
+   falling back.
 
 2. **Search Strategy**: The profiler branches based on `searchStrategy`:
    - **Rapid**: Uses AIC simulation to estimate performance across parallelization configs. No GPUs needed, completes in ~30 seconds.
@@ -78,14 +82,25 @@ flowchart TD
 
 ### Rapid
 
-Uses AIC's performance simulation to estimate optimal configurations without deploying real engines. Completes in ~30 seconds.
+Uses AIC's performance simulation to estimate optimal configurations without
+deploying real engines. Completes in ~30 seconds. Check the
+[AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
+for the latest model, GPU, backend, and backend-version support.
 
 ```yaml
 searchStrategy: rapid
 ```
 
 - Supports all backends: vLLM, SGLang, TensorRT-LLM
-- If the model/hardware/backend combination is not supported by AIC, falls back to a naive config (memory-fit TP calculation)
+- DGDR must accept `hardware.gpuSku`, and AIC must have base system metadata
+  for that GPU SKU before fallback can run.
+- If those gates pass but the exact model/GPU/backend combination is not
+  supported by AIC, the profiler falls back to a naive config (memory-fit TP
+  calculation).
+- If hardware discovery produces an unknown GPU product name, set
+  `hardware.gpuSku`, `hardware.vramMb`, `hardware.numGpusPerNode`, and
+  `hardware.totalGpus` manually. Unknown GPU SKUs, and GPU SKUs without AIC
+  base system metadata, fail before naive fallback can produce a valid config.
 - No GPU resources consumed during profiling
 
 ### Thorough
@@ -415,8 +430,12 @@ hardware:
 - **numGpusPerNode**: Determine the upper bound of GPUs per node for dense models and configure Grove for multi-node MoE engines
 - **gpuSku**: GPU SKU identifier, auto-detected by the controller
 
-> [!TIP]
-> If you don't specify hardware constraints, the controller auto-detects based on your model size and available cluster resources.
+> [!IMPORTANT]
+> If you don't specify hardware constraints, the controller auto-detects GPU
+> hardware from cluster resources. If discovery cannot map the GPU to a
+> recognized DGDR SKU, provide all hardware fields manually. Unknown GPU SKUs
+> fail validation before rapid naive fallback can run. A recognized GPU SKU also
+> needs AIC base system metadata before fallback can generate a correct config.
 
 ### Search Strategy (Optional)
 

--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -55,11 +55,7 @@ flowchart TD
 
 ### Stage-by-stage walkthrough
 
-1. **Validation**: The DGDR spec is validated — required fields checked (`image`,
-   `hardware.gpuSku`, `hardware.numGpusPerNode`), SLA targets verified, and gate
-   checks applied (see [Gate Checks](#gate-checks-and-constraints)). This happens
-   before rapid fallback logic, so unknown GPU SKUs fail validation instead of
-   falling back.
+1. **Validation**: The DGDR spec is validated — required fields checked (`image`, `hardware.gpuSku`, `hardware.numGpusPerNode`), SLA targets verified, and gate checks applied (see [Gate Checks](#gate-checks-and-constraints)).
 
 2. **Search Strategy**: The profiler branches based on `searchStrategy`:
    - **Rapid**: Uses AIC simulation to estimate performance across parallelization configs. No GPUs needed, completes in ~30 seconds.
@@ -83,19 +79,17 @@ flowchart TD
 ### Rapid
 
 Uses AIC's performance simulation to estimate optimal configurations without
-deploying real engines. Completes in ~30 seconds. Check the
-[AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
-for the latest model, GPU, backend, and backend-version support.
+deploying real engines. Completes in ~30 seconds; see the
+[AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/).
 
 ```yaml
 searchStrategy: rapid
 ```
 
 - Supports all backends: vLLM, SGLang, TensorRT-LLM
-- Requires a DGDR-recognized GPU SKU and AIC base system metadata before
-  fallback can run.
-- Falls back to a naive config (memory-fit TP calculation) when the GPU SKU is
-  known but the exact model/GPU/backend combination is not supported by AIC.
+- Falls back to a naive config (memory-fit TP calculation) only after DGDR
+  accepts the GPU SKU and AIC has base system metadata for it; unknown or
+  metadata-missing SKUs fail before fallback.
 - No GPU resources consumed during profiling
 
 ### Thorough
@@ -425,12 +419,8 @@ hardware:
 - **numGpusPerNode**: Determine the upper bound of GPUs per node for dense models and configure Grove for multi-node MoE engines
 - **gpuSku**: GPU SKU identifier, auto-detected by the controller
 
-> [!IMPORTANT]
-> If you don't specify hardware constraints, the controller auto-detects GPU
-> hardware from cluster resources. If discovery cannot map the GPU to a
-> recognized DGDR SKU, provide all hardware fields manually. Unknown GPU SKUs
-> fail validation before rapid naive fallback can run. AIC also needs base
-> system metadata for the GPU SKU before fallback can generate a correct config.
+> [!TIP]
+> If you don't specify hardware constraints, the controller auto-detects based on your model size and available cluster resources.
 
 ### Search Strategy (Optional)
 

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -195,36 +195,27 @@ benchmarks with AIPerf. Takes 2–4 hours.
 - **Requires GPU resources** — the profiler deploys real inference engines on
   your cluster during profiling.
 
-## DGDR Detail: AIC Support Gates
+## DGDR Detail: AIC Support
 
 The rapid strategy relies on AIC system metadata and performance models. Check
 the [AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
 for the latest model, GPU, backend, and backend-version support.
 
-### Gate 1: DGDR GPU SKU
+Rapid fallback has three gates:
 
-DGDR accepts only known GPU SKU identifiers. When specifying GPU SKUs manually,
-use lowercase underscore format (e.g., `h100_sxm`, not `H100-SXM5-80GB`). See
-the [DGDR Reference — SKU Format](dgdr.md#sku-format) for the full list.
-
-If hardware discovery cannot map a GPU product name to a recognized DGDR SKU,
-set `hardware.gpuSku`, `hardware.vramMb`, `hardware.numGpusPerNode`, and
-`hardware.totalGpus` manually. If the GPU SKU is not listed in the
-[DGDR Reference](dgdr.md#sku-format), profiling fails before fallback generation
-runs.
-
-### Gate 2: AIC Base System Metadata
-
-AIC must have base system metadata for the GPU SKU before rapid fallback can
-generate a valid deployment. This metadata provides the GPU memory, GPUs per
-node, and hardware facts used by naive memory-fit generation. Without it,
-fallback cannot produce a correct config for that GPU.
-
-### Gate 3: AIC Combination Support
-
-After DGDR accepts the GPU SKU and AIC has base system metadata, AIC checks
-whether the exact model/GPU/backend combination has rapid-mode performance
-support. If it does not, rapid can fall back to naive memory-fit generation.
+- **DGDR GPU SKU:** DGDR must accept `hardware.gpuSku`. If discovery cannot map
+  your GPU product name to a recognized SKU, set `hardware.gpuSku`,
+  `hardware.vramMb`, `hardware.numGpusPerNode`, and `hardware.totalGpus`
+  manually. Use lowercase underscore format (e.g., `h100_sxm`, not
+  `H100-SXM5-80GB`). See the
+  [DGDR Reference — SKU Format](dgdr.md#sku-format) for the full list.
+- **AIC base system metadata:** AIC must know the GPU SKU's memory, GPUs per
+  node, and hardware facts. Naive fallback does not add support for a GPU SKU
+  missing from AIC system metadata.
+- **AIC combination support:** If DGDR accepts the GPU SKU and AIC has base
+  system metadata, but AIC lacks rapid performance support for the exact
+  model/GPU/backend combination, rapid can fall back to naive memory-fit
+  generation.
 
 ### GPU SKUs
 

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -156,19 +156,13 @@ GPU resources consumed during profiling.
 **Use rapid when:**
 - Getting started or iterating quickly
 - Running in CI/CD pipelines
-- Your GPU SKU is in the
-  [AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
+- Your GPU SKU is in the [AIC support matrix](#aic-support-matrix)
 
 **Limitations:**
-- Rapid has two hardware gates before fallback can run:
-  - DGDR must accept `hardware.gpuSku`, and the hardware fields must be
-    auto-detected or set manually.
-  - AIC must have base system metadata for that GPU SKU, so the generator can
-    use the correct GPU count and VRAM.
-- If those gates pass but AIC does not support the exact model/GPU/backend
-  combination, the profiler falls back to a naive memory-fit config (basic TP
-  calculation). This fallback does not add support for a GPU SKU that is
-  missing from AIC's system metadata.
+- Fallback to a naive memory-fit config only applies after DGDR accepts
+  `hardware.gpuSku` and AIC has base system metadata for that GPU SKU. Unknown
+  or metadata-missing GPU SKUs fail before fallback; unsupported
+  model/GPU/backend combinations can fall back but may be suboptimal.
 - Simulated results may differ from real-hardware performance for unusual
   configurations.
 
@@ -184,8 +178,7 @@ benchmarks with AIPerf. Takes 2–4 hours.
 
 **Use thorough when:**
 - Tuning for production and you need the most optimal configuration
-- Your hardware uses a recognized DGDR GPU SKU but rapid AIC data is not
-  available
+- Your DGDR-recognized hardware does not have rapid AIC data
 - You want measured rather than simulated performance data
 
 **Constraints:**
@@ -199,27 +192,9 @@ benchmarks with AIPerf. Takes 2–4 hours.
 
 The rapid strategy relies on AIC system metadata and performance models. Check
 the [AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
-for the latest model, GPU, backend, and backend-version support.
-
-Rapid checks support in this order:
-
-- **DGDR GPU SKU:** DGDR must accept `hardware.gpuSku`. If discovery cannot map
-  your GPU product name to a recognized SKU, set `hardware.gpuSku`,
-  `hardware.vramMb`, `hardware.numGpusPerNode`, and `hardware.totalGpus`
-  manually. Use lowercase underscore format (e.g., `h100_sxm`, not
-  `H100-SXM5-80GB`). See the
-  [DGDR Reference — SKU Format](dgdr.md#sku-format) for the full list.
-- **AIC base system metadata:** AIC must know the GPU SKU's memory, GPUs per
-  node, and hardware facts. Naive fallback does not add support for a GPU SKU
-  missing from AIC system metadata.
-- **AIC combination support:** If DGDR accepts the GPU SKU and AIC has base
-  system metadata, but AIC lacks rapid performance support for the exact
-  model/GPU/backend combination, rapid can fall back to naive memory-fit
-  generation.
+for the latest support. AIC currently supports:
 
 ### GPU SKUs
-
-AIC currently supports:
 
 | Supported (rapid) | Not Yet Supported (use thorough) |
 |---|---|
@@ -238,6 +213,10 @@ AIC currently supports:
 > Some rapid-mode SKUs use AIC estimate-only data until measured profiles are
 > available. Use `searchStrategy: thorough` when you need hardware-measured
 > profiling for an estimate-only or unsupported SKU.
+
+When specifying GPU SKUs manually, use lowercase underscore format (e.g.,
+`h100_sxm`, not `H100-SXM5-80GB`). See the
+[DGDR Reference — SKU Format](dgdr.md#sku-format) for the full list.
 
 ### Backends
 

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -193,7 +193,9 @@ benchmarks with AIPerf. Takes 2–4 hours.
 
 The rapid strategy relies on AIC system metadata and performance models. Check
 the [AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
-for the latest support.
+for the latest support. Measured profiling still needs AIC system and generator
+support to enumerate and render candidates; rapid also needs performance support
+for the exact model/GPU/backend combination.
 
 ### GPU SKUs
 
@@ -213,7 +215,7 @@ for the latest support.
 > [!NOTE]
 > Some rapid-mode SKUs use AIC estimate-only data until measured profiles are
 > available. Use `searchStrategy: thorough` for measured profiling only when
-> DGDR accepts the SKU and AIC can enumerate it.
+> DGDR accepts the SKU and AIC has system and generator support for it.
 
 When specifying GPU SKUs manually, use lowercase underscore format (e.g.,
 `h100_sxm`, not `H100-SXM5-80GB`). See the

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -178,13 +178,14 @@ benchmarks with AIPerf. Takes 2–4 hours.
 
 **Use thorough when:**
 - Tuning for production and you need the most optimal configuration
-- Your DGDR-recognized hardware does not have rapid AIC data
 - You want measured rather than simulated performance data
 
 **Constraints:**
 - **Disaggregated mode only** — thorough does not run aggregated configurations.
 - **`backend: auto` is not supported** — you must specify `vllm`, `sglang`, or
   `trtllm`. The DGDR will be rejected if you use `auto` with `thorough`.
+- **Still requires AIC generator support** — thorough measures candidates on
+  real GPUs, but uses AIC to enumerate candidates and generate the final DGD.
 - **Requires GPU resources** — the profiler deploys real inference engines on
   your cluster during profiling.
 
@@ -192,11 +193,11 @@ benchmarks with AIPerf. Takes 2–4 hours.
 
 The rapid strategy relies on AIC system metadata and performance models. Check
 the [AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
-for the latest support. AIC currently supports:
+for the latest support.
 
 ### GPU SKUs
 
-| Supported (rapid) | Not Yet Supported (use thorough) |
+| Supported (rapid) | No rapid performance data |
 |---|---|
 | H100 SXM | V100 (SXM/PCIe) |
 | H100 PCIe | T4 |
@@ -211,8 +212,8 @@ for the latest support. AIC currently supports:
 
 > [!NOTE]
 > Some rapid-mode SKUs use AIC estimate-only data until measured profiles are
-> available. Use `searchStrategy: thorough` when you need hardware-measured
-> profiling for an estimate-only or unsupported SKU.
+> available. Use `searchStrategy: thorough` for measured profiling only when
+> DGDR accepts the SKU and AIC can enumerate it.
 
 When specifying GPU SKUs manually, use lowercase underscore format (e.g.,
 `h100_sxm`, not `H100-SXM5-80GB`). See the

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -197,7 +197,7 @@ for the latest support.
 
 ### GPU SKUs
 
-| Supported (rapid) | No rapid performance data |
+| Supported (rapid) | Not supported by rapid |
 |---|---|
 | H100 SXM | V100 (SXM/PCIe) |
 | H100 PCIe | T4 |

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -160,9 +160,9 @@ GPU resources consumed during profiling.
 
 **Limitations:**
 - Fallback to a naive memory-fit config only applies after DGDR accepts
-  `hardware.gpuSku` and AIC has base system metadata for that GPU SKU. Unknown
-  or metadata-missing GPU SKUs fail before fallback; unsupported
-  model/GPU/backend combinations can fall back but may be suboptimal.
+  `hardware.gpuSku`. Fallback sizing depends on AIC system metadata and does
+  not add support for additional GPU SKUs; unsupported model/GPU/backend
+  combinations can fall back but may be suboptimal.
 - Simulated results may differ from real-hardware performance for unusual
   configurations.
 

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -156,12 +156,19 @@ GPU resources consumed during profiling.
 **Use rapid when:**
 - Getting started or iterating quickly
 - Running in CI/CD pipelines
-- Your GPU SKU is in the [AIC support matrix](#aic-support-matrix)
+- Your GPU SKU is in the
+  [AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
 
 **Limitations:**
-- If AIC does not support your model/hardware/backend combination, the profiler
-  falls back to a naive memory-fit config (basic TP calculation) which may not
-  be optimal.
+- Rapid has two hardware gates before fallback can run:
+  - DGDR must accept `hardware.gpuSku`, and the hardware fields must be
+    auto-detected or set manually.
+  - AIC must have base system metadata for that GPU SKU, so the generator can
+    use the correct GPU count and VRAM.
+- If those gates pass but AIC does not support the exact model/GPU/backend
+  combination, the profiler falls back to a naive memory-fit config (basic TP
+  calculation). This fallback does not add support for a GPU SKU that is
+  missing from AIC's system metadata.
 - Simulated results may differ from real-hardware performance for unusual
   configurations.
 
@@ -177,7 +184,8 @@ benchmarks with AIPerf. Takes 2–4 hours.
 
 **Use thorough when:**
 - Tuning for production and you need the most optimal configuration
-- Your hardware is not supported by AIC (e.g., PCIe GPUs)
+- Your hardware uses a recognized DGDR GPU SKU but rapid AIC data is not
+  available
 - You want measured rather than simulated performance data
 
 **Constraints:**
@@ -187,11 +195,40 @@ benchmarks with AIPerf. Takes 2–4 hours.
 - **Requires GPU resources** — the profiler deploys real inference engines on
   your cluster during profiling.
 
-## DGDR Detail: AIC Support Matrix
+## DGDR Detail: AIC Support Gates
 
-The rapid strategy relies on AIC performance models. AIC currently supports:
+The rapid strategy relies on AIC system metadata and performance models. Check
+the [AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
+for the latest model, GPU, backend, and backend-version support.
+
+### Gate 1: DGDR GPU SKU
+
+DGDR accepts only known GPU SKU identifiers. When specifying GPU SKUs manually,
+use lowercase underscore format (e.g., `h100_sxm`, not `H100-SXM5-80GB`). See
+the [DGDR Reference — SKU Format](dgdr.md#sku-format) for the full list.
+
+If hardware discovery cannot map a GPU product name to a recognized DGDR SKU,
+set `hardware.gpuSku`, `hardware.vramMb`, `hardware.numGpusPerNode`, and
+`hardware.totalGpus` manually. If the GPU SKU is not listed in the
+[DGDR Reference](dgdr.md#sku-format), profiling fails before fallback generation
+runs.
+
+### Gate 2: AIC Base System Metadata
+
+AIC must have base system metadata for the GPU SKU before rapid fallback can
+generate a valid deployment. This metadata provides the GPU memory, GPUs per
+node, and hardware facts used by naive memory-fit generation. Without it,
+fallback cannot produce a correct config for that GPU.
+
+### Gate 3: AIC Combination Support
+
+After DGDR accepts the GPU SKU and AIC has base system metadata, AIC checks
+whether the exact model/GPU/backend combination has rapid-mode performance
+support. If it does not, rapid can fall back to naive memory-fit generation.
 
 ### GPU SKUs
+
+AIC currently supports:
 
 | Supported (rapid) | Not Yet Supported (use thorough) |
 |---|---|
@@ -210,10 +247,6 @@ The rapid strategy relies on AIC performance models. AIC currently supports:
 > Some rapid-mode SKUs use AIC estimate-only data until measured profiles are
 > available. Use `searchStrategy: thorough` when you need hardware-measured
 > profiling for an estimate-only or unsupported SKU.
-
-When specifying GPU SKUs manually, use lowercase underscore format (e.g.,
-`h100_sxm`, not `H100-SXM5-80GB`). See the
-[DGDR Reference — SKU Format](dgdr.md#sku-format) for the full list.
 
 ### Backends
 

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -195,13 +195,13 @@ benchmarks with AIPerf. Takes 2–4 hours.
 - **Requires GPU resources** — the profiler deploys real inference engines on
   your cluster during profiling.
 
-## DGDR Detail: AIC Support
+## DGDR Detail: AIC Support Matrix
 
 The rapid strategy relies on AIC system metadata and performance models. Check
 the [AIC support matrix](https://ai-dynamo.github.io/aiconfigurator/support-matrix/)
 for the latest model, GPU, backend, and backend-version support.
 
-Rapid fallback has three gates:
+Rapid checks support in this order:
 
 - **DGDR GPU SKU:** DGDR must accept `hardware.gpuSku`. If discovery cannot map
   your GPU product name to a recognized SKU, set `hardware.gpuSku`,


### PR DESCRIPTION
Summary
- Clarify that rapid naive fallback only runs after DGDR accepts the GPU SKU and AIC has base system metadata.
- Link the AIC support matrix and document the gates for DGDR GPU SKU acceptance, AIC system/generator support, and rapid performance data.
- Update profiler guide wording so unknown GPU product names and GPUs without AIC system metadata are not described as fallback-capable.

Validation
- git diff --check
- pre-commit hooks from git commit: codespell, case conflict check, merge conflict check, script/shebang checks, line ending/trailing whitespace checks, pytest marker report

Related Issues
- Refs https://github.com/ai-dynamo/dynamo/issues/10072
- Related AIC work for actual A40 enablement: https://github.com/ai-dynamo/aiconfigurator/issues/1259

Note
- The AIC issue is not a prerequisite for merging this docs-only PR. It is a prerequisite for end-to-end A40 enablement.