### PR TITLE
fix(epp): route completion prompts in Rust EPP

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -20,7 +20,11 @@ use dynamo_llm::kv_router::prefill_router::PrefillQueryOutcome;
 use dynamo_llm::kv_router::{KvRouter, PrefillRouter};
 use dynamo_llm::model_card::ModelDeploymentCard;
 use dynamo_llm::preprocessor::OpenAIPreprocessor;
-use dynamo_llm::protocols::common::extensions::{HEADER_TENANT_ID, request_cache_salt};
+use dynamo_llm::protocols::common::extensions::{
+    HEADER_TENANT_ID, NvExt, request_cache_salt, routing_constraints_to_kv,
+};
+use dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest;
+use dynamo_llm::types::openai::completions::NvCreateCompletionRequest;
 use dynamo_runtime::discovery::{DiscoveryInstance, DiscoveryQuery, hash_pod_name};
 use dynamo_runtime::pipeline::RouterMode;
 use dynamo_runtime::{DistributedRuntime, Runtime};
@@ -209,18 +213,42 @@ impl Router {
 
     /// Tokenize a JSON request body and extract router queue priorities.
     ///
-    /// Returns `(token_ids, cache_namespace, priority_jump, strict_priority)`.
+    /// Returns `(token_ids, cache_namespace, priority_jump, strict_priority, routing_constraints)`.
     /// Priorities default to zero when absent. Mirrors the standalone Dynamo
     /// preprocessor lift in `lib/llm/src/preprocessor.rs`.
-    pub fn tokenize(&self, request_json: &str) -> Result<(Vec<u32>, Option<String>, f64, u32)> {
+    pub fn tokenize(
+        &self,
+        request_json: &str,
+    ) -> Result<(Vec<u32>, Option<String>, f64, u32, RoutingConstraints)> {
         // TODO(epp-request-routing): Reuse shared preprocessing so expected output
         // length, LoRA, pins, sessions, topology constraints, additional protocols,
         // and multimodal routing hashes are preserved.
-        let request: dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest =
-            serde_json::from_str(request_json)?;
+        let mut request_json: serde_json::Value = serde_json::from_str(request_json)?;
 
-        let priority_jump = extract_priority_jump(&request);
-        let strict_priority = extract_strict_priority(&request);
+        if request_json.get("prompt").is_some() {
+            normalize_completion_prompt_for_routing(&mut request_json);
+            let request: NvCreateCompletionRequest = serde_json::from_value(request_json)?;
+            let nvext = request.nvext.as_ref();
+            let priority_jump = extract_priority_jump(nvext);
+            let strict_priority = extract_strict_priority(nvext);
+            let routing_constraints = extract_routing_constraints(nvext);
+            let cache_namespace = request_cache_salt(&request).map(str::to_owned);
+            let (token_ids, _) = self.preprocessor.gather_tokens(&request, None, None)?;
+
+            return Ok((
+                token_ids,
+                cache_namespace,
+                priority_jump,
+                strict_priority,
+                routing_constraints,
+            ));
+        }
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(request_json)?;
+        let nvext = request.nvext.as_ref();
+        let priority_jump = extract_priority_jump(nvext);
+        let strict_priority = extract_strict_priority(nvext);
+        let routing_constraints = extract_routing_constraints(nvext);
         let cache_namespace = request_cache_salt(&request).map(str::to_owned);
 
         let formatted_prompt = self
@@ -234,6 +262,7 @@ impl Router {
             cache_namespace,
             priority_jump,
             strict_priority,
+            routing_constraints,
         ))
     }
 
@@ -315,6 +344,7 @@ impl Router {
         priority_jump: f64,
         strict_priority: u32,
         allowed_worker_ids: Option<HashSet<u64>>,
+        routing_constraints: RoutingConstraints,
     ) -> Result<(u64, Option<u32>)> {
         if let Some(ref ids) = allowed_worker_ids {
             self.prefill_router.register_workers(ids);
@@ -332,7 +362,7 @@ impl Router {
                 priority_jump,
                 strict_priority,
                 allowed_worker_ids,
-                RoutingConstraints::default(),
+                routing_constraints,
             )
             .await
             .map_err(|e| anyhow::anyhow!("Prefill query failed: {:?}", e))?;
@@ -362,6 +392,7 @@ impl Router {
         priority_jump: f64,
         strict_priority: u32,
         allowed_worker_ids: Option<HashSet<u64>>,
+        routing_constraints: RoutingConstraints,
     ) -> Result<(WorkerWithDpRank, u32)> {
         if let Some(ref ids) = allowed_worker_ids {
             self.decode_router.register_workers(ids);
@@ -382,7 +413,7 @@ impl Router {
                 strict_priority,
                 None,
                 allowed_worker_ids,
-                RoutingConstraints::default(),
+                routing_constraints,
             )
             .await
             .map_err(|e| anyhow::anyhow!("Decode query failed: {:?}", e))
@@ -480,7 +511,32 @@ impl Router {
     }
 }
 
-/// Extract the router queue `priority_jump` from a chat completion request's
+/// Collapse completion batch prompts into the single prompt shape the router
+/// can score today. Full batch-aware routing needs an explicit policy.
+fn normalize_completion_prompt_for_routing(request_json: &mut serde_json::Value) {
+    let Some(prompt) = request_json.get_mut("prompt") else {
+        return;
+    };
+    let Some(items) = prompt.as_array() else {
+        return;
+    };
+    if items.len() <= 1 {
+        return;
+    }
+
+    if items.iter().all(|item| item.is_string()) {
+        let joined = items
+            .iter()
+            .filter_map(|item| item.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        *prompt = serde_json::Value::String(joined);
+    } else if items.iter().all(|item| item.is_array()) {
+        *prompt = items[0].clone();
+    }
+}
+
+/// Extract the router queue `priority_jump` from an OpenAI request's
 /// `nvext.agent_hints.priority`.
 ///
 /// Negative priorities are clamped to `0.0` so a low-priority hint never
@@ -488,12 +544,8 @@ impl Router {
 /// in `lib/llm/src/preprocessor.rs`). Falls back to the deprecated
 /// `latency_sensitivity` alias for callers still on the old field name.
 /// Returns `0.0` when `nvext` is absent.
-fn extract_priority_jump(
-    request: &dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest,
-) -> f64 {
-    request
-        .nvext
-        .as_ref()
+fn extract_priority_jump(nvext: Option<&NvExt>) -> f64 {
+    nvext
         .and_then(|n| n.agent_hints.as_ref())
         .and_then(|h| {
             h.priority
@@ -503,15 +555,18 @@ fn extract_priority_jump(
         .unwrap_or(0.0)
 }
 
-fn extract_strict_priority(
-    request: &dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest,
-) -> u32 {
-    request
-        .nvext
-        .as_ref()
+fn extract_strict_priority(nvext: Option<&NvExt>) -> u32 {
+    nvext
         .and_then(|n| n.agent_hints.as_ref())
         .and_then(|h| h.strict_priority)
         .unwrap_or(0)
+}
+
+fn extract_routing_constraints(nvext: Option<&NvExt>) -> RoutingConstraints {
+    nvext
+        .and_then(|n| n.routing_constraints.clone())
+        .map(routing_constraints_to_kv)
+        .unwrap_or_default()
 }
 
 struct DiscoveredModelBootstrap {
@@ -931,7 +986,7 @@ impl EndpointPicker for Router {
         let body_str = std::str::from_utf8(&req.body)
             .map_err(|e| PickError::TokenizationFailed(format!("Invalid UTF-8: {e}")))?;
 
-        let (tokens, body_cache_namespace, priority_jump, strict_priority) = self
+        let (tokens, body_cache_namespace, priority_jump, strict_priority, routing_constraints) = self
             .tokenize(body_str)
             .map_err(|e| PickError::TokenizationFailed(e.to_string()))?;
         let cache_namespace =
@@ -948,6 +1003,7 @@ impl EndpointPicker for Router {
                 priority_jump,
                 strict_priority,
                 allowed_worker_ids.clone(),
+                routing_constraints.clone(),
             )
             .await;
 
@@ -974,6 +1030,7 @@ impl EndpointPicker for Router {
                 priority_jump,
                 strict_priority,
                 allowed_worker_ids,
+                routing_constraints,
             )
             .await
             .map_err(|e| PickError::RoutingFailed(e.to_string()))?;
@@ -1144,7 +1201,7 @@ mod tests {
     /// regresses, the GAIE ext-proc path is back to ignoring priority.
     #[test]
     fn priority_jump_lifted_from_agent_hints_priority() {
-        let with_priority: dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest =
+        let with_priority: NvCreateChatCompletionRequest =
             serde_json::from_str(
                 r#"{
                     "model": "test",
@@ -1153,9 +1210,9 @@ mod tests {
                 }"#,
             )
             .unwrap();
-        assert_eq!(extract_priority_jump(&with_priority), 5.0);
+        assert_eq!(extract_priority_jump(with_priority.nvext.as_ref()), 5.0);
 
-        let without_nvext: dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest =
+        let without_nvext: NvCreateChatCompletionRequest =
             serde_json::from_str(
                 r#"{
                     "model": "test",
@@ -1163,12 +1220,12 @@ mod tests {
                 }"#,
             )
             .unwrap();
-        assert_eq!(extract_priority_jump(&without_nvext), 0.0);
+        assert_eq!(extract_priority_jump(without_nvext.nvext.as_ref()), 0.0);
     }
 
     #[test]
     fn strict_priority_lifted_from_agent_hints() {
-        let with_priority: dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest =
+        let with_priority: NvCreateChatCompletionRequest =
             serde_json::from_str(
                 r#"{
                     "model": "test",
@@ -1177,9 +1234,9 @@ mod tests {
                 }"#,
             )
             .unwrap();
-        assert_eq!(extract_strict_priority(&with_priority), 9);
+        assert_eq!(extract_strict_priority(with_priority.nvext.as_ref()), 9);
 
-        let without_nvext: dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest =
+        let without_nvext: NvCreateChatCompletionRequest =
             serde_json::from_str(
                 r#"{
                     "model": "test",
@@ -1187,6 +1244,78 @@ mod tests {
                 }"#,
             )
             .unwrap();
-        assert_eq!(extract_strict_priority(&without_nvext), 0);
+        assert_eq!(extract_strict_priority(without_nvext.nvext.as_ref()), 0);
+    }
+
+    #[test]
+    fn completion_agent_hints_are_lifted() {
+        let request: NvCreateCompletionRequest = serde_json::from_str(
+            r#"{
+                "model": "test",
+                "prompt": [101, 102, 103],
+                "nvext": {"agent_hints": {"priority": 5, "strict_priority": 9}}
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(extract_priority_jump(request.nvext.as_ref()), 5.0);
+        assert_eq!(extract_strict_priority(request.nvext.as_ref()), 9);
+    }
+
+    #[test]
+    fn completion_string_array_prompt_collapses_to_single_prompt() {
+        let mut request = serde_json::json!({
+            "model": "test",
+            "prompt": ["hello", "world"]
+        });
+
+        normalize_completion_prompt_for_routing(&mut request);
+
+        assert_eq!(request["prompt"], "hello world");
+    }
+
+    #[test]
+    fn completion_token_array_prompt_stays_token_array() {
+        let mut request = serde_json::json!({
+            "model": "test",
+            "prompt": [101, 102, 103]
+        });
+
+        normalize_completion_prompt_for_routing(&mut request);
+
+        assert_eq!(request["prompt"], serde_json::json!([101, 102, 103]));
+    }
+
+    #[test]
+    fn completion_token_batch_prompt_uses_first_prompt() {
+        let mut request = serde_json::json!({
+            "model": "test",
+            "prompt": [[101, 102], [201, 202]]
+        });
+
+        normalize_completion_prompt_for_routing(&mut request);
+
+        assert_eq!(request["prompt"], serde_json::json!([101, 102]));
+    }
+
+    #[test]
+    fn completion_routing_constraints_are_lifted() {
+        let request: NvCreateCompletionRequest = serde_json::from_str(
+            r#"{
+                "model": "test",
+                "prompt": [101, 102, 103],
+                "nvext": {
+                    "routing_constraints": {
+                        "required_taints": ["gpu=A100"],
+                        "preferred_taints": {"zone=west": 0.75}
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let constraints = extract_routing_constraints(request.nvext.as_ref());
+        assert!(constraints.required_taints.contains("gpu=A100"));
+        assert_eq!(constraints.preferred_taints.get("zone=west"), Some(&0.75));
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -215,7 +215,7 @@ impl Router {
     ///
     /// Priorities default to zero when absent. Mirrors the standalone Dynamo
     /// preprocessor lift in `lib/llm/src/preprocessor.rs`.
-    fn tokenize(&self, request_json: &str) -> Result<TokenizeResult> {
+    async fn tokenize(&self, request_json: &str) -> Result<TokenizeResult> {
         // TODO(epp-request-routing): Reuse shared preprocessing so expected output
         // length, LoRA, pins, sessions, topology constraints, additional protocols,
         // and multimodal routing hashes are preserved.
@@ -234,7 +234,10 @@ impl Router {
             let routing_constraints = extract_routing_constraints(nvext);
             let cache_namespace = request_cache_salt(&request).map(str::to_owned);
 
-            let (token_ids, _) = self.preprocessor.gather_tokens(&request, None, None)?;
+            let (token_ids, _) = self
+                .preprocessor
+                .gather_tokens(&request, None, None)
+                .await?;
 
             return Ok(TokenizeResult {
                 token_ids,
@@ -1086,6 +1089,7 @@ impl EndpointPicker for Router {
             token_data_policy,
         } = self
             .tokenize(body_str)
+            .await
             .map_err(|e| PickError::TokenizationFailed(e.to_string()))?;
         let cache_namespace =
             cache_namespace_with_header_override(&req.headers, body_cache_namespace);

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -222,6 +222,10 @@ impl Router {
         let mut request_json: serde_json::Value = serde_json::from_str(request_json)?;
 
         if request_json.get("prompt").is_some() || request_json.get("prompt_embeds").is_some() {
+            if let Some(result) = tokenize_completion_prompt_embeds(&request_json)? {
+                return Ok(result);
+            }
+
             let token_data_policy = prepare_completion_prompt_for_routing(&mut request_json);
             let request: NvCreateCompletionRequest = serde_json::from_value(request_json)?;
             let nvext = request.nvext.as_ref();
@@ -229,17 +233,6 @@ impl Router {
             let strict_priority = extract_strict_priority(nvext);
             let routing_constraints = extract_routing_constraints(nvext);
             let cache_namespace = request_cache_salt(&request).map(str::to_owned);
-
-            if request.inner.prompt_embeds.is_some() {
-                return Ok(TokenizeResult {
-                    token_ids: Vec::new(),
-                    cache_namespace,
-                    priority_jump,
-                    strict_priority,
-                    routing_constraints,
-                    token_data_policy: TokenDataPolicy::Strip,
-                });
-            }
 
             let (token_ids, _) = self.preprocessor.gather_tokens(&request, None, None)?;
 
@@ -530,6 +523,18 @@ struct TokenizeResult {
     token_data_policy: TokenDataPolicy,
 }
 
+#[derive(serde::Deserialize)]
+struct CompletionPromptEmbedsRoutingFields {
+    #[serde(rename = "model")]
+    _model: String,
+    #[serde(rename = "prompt_embeds")]
+    _prompt_embeds: String,
+    #[serde(default)]
+    cache_salt: Option<String>,
+    #[serde(default)]
+    nvext: Option<NvExt>,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TokenDataPolicy {
     Inject,
@@ -544,6 +549,38 @@ impl TokenDataPolicy {
     fn strips(self) -> bool {
         matches!(self, Self::Strip)
     }
+}
+
+fn tokenize_completion_prompt_embeds(
+    request_json: &serde_json::Value,
+) -> Result<Option<TokenizeResult>> {
+    let Some(prompt_embeds) = request_json.get("prompt_embeds") else {
+        return Ok(None);
+    };
+    if prompt_embeds.is_null() {
+        return Ok(None);
+    }
+
+    let fields: CompletionPromptEmbedsRoutingFields =
+        serde_json::from_value(request_json.clone())?;
+    let nvext = fields.nvext.as_ref();
+    let priority_jump = extract_priority_jump(nvext);
+    let strict_priority = extract_strict_priority(nvext);
+    let routing_constraints = extract_routing_constraints(nvext);
+    let cache_namespace = nvext
+        .and_then(|nvext| nvext.cache_salt.as_deref())
+        .filter(|salt| !salt.is_empty())
+        .or_else(|| fields.cache_salt.as_deref().filter(|salt| !salt.is_empty()))
+        .map(str::to_owned);
+
+    Ok(Some(TokenizeResult {
+        token_ids: Vec::new(),
+        cache_namespace,
+        priority_jump,
+        strict_priority,
+        routing_constraints,
+        token_data_policy: TokenDataPolicy::Strip,
+    }))
 }
 
 /// Pick a single completion prompt shape the router can score today.
@@ -1412,6 +1449,47 @@ mod tests {
 
         assert_eq!(token_data_policy, TokenDataPolicy::Strip);
         assert_eq!(request["prompt"], "placeholder");
+    }
+
+    #[test]
+    fn completion_prompt_embeds_without_prompt_routes_without_tokens() {
+        let request = serde_json::json!({
+            "model": "test",
+            "prompt_embeds": "encoded",
+            "nvext": {
+                "agent_hints": {"priority": 5, "strict_priority": 9},
+                "routing_constraints": {"required_taints": ["gpu=A100"]}
+            }
+        });
+
+        let result = tokenize_completion_prompt_embeds(&request)
+            .expect("prompt embeds should parse")
+            .expect("prompt embeds should short-circuit");
+
+        assert!(result.token_ids.is_empty());
+        assert_eq!(result.priority_jump, 5.0);
+        assert_eq!(result.strict_priority, 9);
+        assert!(
+            result
+                .routing_constraints
+                .required_taints
+                .contains("gpu=A100")
+        );
+        assert_eq!(result.token_data_policy, TokenDataPolicy::Strip);
+    }
+
+    #[test]
+    fn completion_prompt_embeds_helper_ignores_absent_embeds() {
+        let request = serde_json::json!({
+            "model": "test",
+            "prompt": "hello"
+        });
+
+        assert!(
+            tokenize_completion_prompt_embeds(&request)
+                .expect("request should parse")
+                .is_none()
+        );
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -582,11 +582,7 @@ fn prepare_completion_prompt_for_routing(request_json: &mut serde_json::Value) -
 fn extract_priority_jump(nvext: Option<&NvExt>) -> f64 {
     nvext
         .and_then(|n| n.agent_hints.as_ref())
-        .and_then(|h| {
-            h.priority
-                .map(|p| p as f64)
-                .or(h.latency_sensitivity)
-        })
+        .and_then(|h| h.priority.map(|p| p as f64).or(h.latency_sensitivity))
         .map(|p| p.max(0.0))
         .unwrap_or(0.0)
 }
@@ -1245,9 +1241,8 @@ mod tests {
     /// regresses, the GAIE ext-proc path is back to ignoring priority.
     #[test]
     fn priority_jump_lifted_from_agent_hints_priority() {
-        let with_priority: NvCreateChatCompletionRequest =
-            serde_json::from_str(
-                r#"{
+        let with_priority: NvCreateChatCompletionRequest = serde_json::from_str(
+            r#"{
                     "model": "test",
                     "messages": [{"role": "user", "content": "hi"}],
                     "nvext": {"agent_hints": {"priority": 5}}
@@ -1256,52 +1251,48 @@ mod tests {
         .unwrap();
         assert_eq!(extract_priority_jump(with_priority.nvext.as_ref()), 5.0);
 
-        let with_negative_alias: NvCreateChatCompletionRequest =
-            serde_json::from_str(
-                r#"{
+        let with_negative_alias: NvCreateChatCompletionRequest = serde_json::from_str(
+            r#"{
                     "model": "test",
                     "messages": [{"role": "user", "content": "hi"}],
                     "nvext": {"agent_hints": {"latency_sensitivity": -3.5}}
                 }"#,
-            )
-            .unwrap();
+        )
+        .unwrap();
         assert_eq!(
             extract_priority_jump(with_negative_alias.nvext.as_ref()),
             0.0
         );
 
-        let without_nvext: NvCreateChatCompletionRequest =
-            serde_json::from_str(
-                r#"{
+        let without_nvext: NvCreateChatCompletionRequest = serde_json::from_str(
+            r#"{
                     "model": "test",
                     "messages": [{"role": "user", "content": "hi"}]
                 }"#,
-            )
-            .unwrap();
+        )
+        .unwrap();
         assert_eq!(extract_priority_jump(without_nvext.nvext.as_ref()), 0.0);
     }
 
     #[test]
     fn strict_priority_lifted_from_agent_hints() {
-        let with_priority: NvCreateChatCompletionRequest =
-            serde_json::from_str(
-                r#"{
+        let with_priority: NvCreateChatCompletionRequest = serde_json::from_str(
+            r#"{
                     "model": "test",
                     "messages": [{"role": "user", "content": "hi"}],
                     "nvext": {"agent_hints": {"strict_priority": 9}}
                 }"#,
-            )
-            .unwrap();
+        )
+        .unwrap();
         assert_eq!(extract_strict_priority(with_priority.nvext.as_ref()), 9);
 
-        let without_nvext: NvCreateChatCompletionRequest =
-            serde_json::from_str(
-                r#"{
+        let without_nvext: NvCreateChatCompletionRequest = serde_json::from_str(
+            r#"{
                     "model": "test",
                     "messages": [{"role": "user", "content": "hi"}]
                 }"#,
-            )
-            .unwrap();
+        )
+        .unwrap();
         assert_eq!(extract_strict_priority(without_nvext.nvext.as_ref()), 0);
     }
 

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -222,7 +222,7 @@ impl Router {
         let mut request_json: serde_json::Value = serde_json::from_str(request_json)?;
 
         if request_json.get("prompt").is_some() || request_json.get("prompt_embeds").is_some() {
-            let inject_token_data = prepare_completion_prompt_for_routing(&mut request_json);
+            let token_data_policy = prepare_completion_prompt_for_routing(&mut request_json);
             let request: NvCreateCompletionRequest = serde_json::from_value(request_json)?;
             let nvext = request.nvext.as_ref();
             let priority_jump = extract_priority_jump(nvext);
@@ -237,7 +237,7 @@ impl Router {
                     priority_jump,
                     strict_priority,
                     routing_constraints,
-                    inject_token_data: false,
+                    token_data_policy: TokenDataPolicy::Strip,
                 });
             }
 
@@ -249,7 +249,7 @@ impl Router {
                 priority_jump,
                 strict_priority,
                 routing_constraints,
-                inject_token_data,
+                token_data_policy,
             });
         }
 
@@ -272,7 +272,7 @@ impl Router {
             priority_jump,
             strict_priority,
             routing_constraints,
-            inject_token_data: true,
+            token_data_policy: TokenDataPolicy::Inject,
         })
     }
 
@@ -527,48 +527,71 @@ struct TokenizeResult {
     priority_jump: f64,
     strict_priority: u32,
     routing_constraints: RoutingConstraints,
-    inject_token_data: bool,
+    token_data_policy: TokenDataPolicy,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TokenDataPolicy {
+    Inject,
+    Strip,
+}
+
+impl TokenDataPolicy {
+    fn injects(self) -> bool {
+        matches!(self, Self::Inject)
+    }
+
+    fn strips(self) -> bool {
+        matches!(self, Self::Strip)
+    }
 }
 
 /// Pick a single completion prompt shape the router can score today.
 ///
-/// Returns whether the resulting tokens may be injected into the original
-/// forwarded request as `nvext.token_data`. Batch and prompt-embeds completions
-/// must not receive synthetic token data because the backend preprocesses them
-/// per subrequest or from embeddings.
-fn prepare_completion_prompt_for_routing(request_json: &mut serde_json::Value) -> bool {
+/// Returns how the forwarded request's `nvext.token_data` should be handled.
+/// Only scalar text completion prompts consume injected token data correctly.
+/// Other completion shapes either already carry tokens, are batch-shaped, or
+/// use embeddings, so stale flat token data must be stripped.
+fn prepare_completion_prompt_for_routing(request_json: &mut serde_json::Value) -> TokenDataPolicy {
     if request_json.get("prompt_embeds").is_some() {
-        return false;
+        return TokenDataPolicy::Strip;
     }
 
     let Some(prompt) = request_json.get_mut("prompt") else {
-        return true;
+        return TokenDataPolicy::Strip;
     };
+    if prompt.is_string() {
+        return TokenDataPolicy::Inject;
+    }
     let Some(items) = prompt.as_array() else {
-        return true;
+        return TokenDataPolicy::Strip;
     };
-    if items.len() <= 1 {
-        return true;
+    if items.is_empty() {
+        return TokenDataPolicy::Strip;
     }
 
     if items.iter().all(|item| item.is_string()) {
-        let first = items
-            .first()
-            .and_then(|item| item.as_str())
-            .map(str::to_string);
-        if let Some(first) = first {
-            *prompt = serde_json::Value::String(first);
+        if items.len() > 1 {
+            let first = items
+                .first()
+                .and_then(|item| item.as_str())
+                .map(str::to_string);
+            if let Some(first) = first {
+                *prompt = serde_json::Value::String(first);
+            }
         }
-        return false;
+        return TokenDataPolicy::Strip;
     } else if items.iter().all(|item| item.is_array()) {
-        let first = items.first().cloned();
-        if let Some(first) = first {
-            *prompt = first;
+        if items.len() > 1 {
+            let first = items.first().cloned();
+            if let Some(first) = first {
+                *prompt = first;
+            }
         }
-        return false;
+        return TokenDataPolicy::Strip;
     }
 
-    true
+    TokenDataPolicy::Strip
 }
 
 /// Extract the router queue `priority_jump` from an OpenAI request's
@@ -1024,7 +1047,7 @@ impl EndpointPicker for Router {
             priority_jump,
             strict_priority,
             routing_constraints,
-            inject_token_data,
+            token_data_policy,
         } = self
             .tokenize(body_str)
             .map_err(|e| PickError::TokenizationFailed(e.to_string()))?;
@@ -1160,7 +1183,7 @@ impl EndpointPicker for Router {
             is_disaggregated,
             endpoint = %endpoint,
             token_count = tokens.len(),
-            inject_token_data,
+            ?token_data_policy,
             priority_jump,
             model = %req.model,
             header_count = headers.len(),
@@ -1174,7 +1197,8 @@ impl EndpointPicker for Router {
             endpoint,
             fallbacks: vec![],
             headers,
-            token_ids: inject_token_data.then_some(tokens),
+            strip_token_data: token_data_policy.strips(),
+            token_ids: token_data_policy.injects().then_some(tokens),
         })
     }
 
@@ -1318,9 +1342,9 @@ mod tests {
             "prompt": ["hello", "world"]
         });
 
-        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
+        let token_data_policy = prepare_completion_prompt_for_routing(&mut request);
 
-        assert!(!inject_token_data);
+        assert_eq!(token_data_policy, TokenDataPolicy::Strip);
         assert_eq!(request["prompt"], "hello");
     }
 
@@ -1331,35 +1355,35 @@ mod tests {
             "prompt": "hello"
         });
 
-        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
+        let token_data_policy = prepare_completion_prompt_for_routing(&mut request);
 
-        assert!(inject_token_data);
+        assert_eq!(token_data_policy, TokenDataPolicy::Inject);
         assert_eq!(request["prompt"], "hello");
     }
 
     #[test]
-    fn completion_single_string_array_prompt_keeps_token_injection() {
+    fn completion_single_string_array_prompt_strips_token_data() {
         let mut request = serde_json::json!({
             "model": "test",
             "prompt": ["hello"]
         });
 
-        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
+        let token_data_policy = prepare_completion_prompt_for_routing(&mut request);
 
-        assert!(inject_token_data);
+        assert_eq!(token_data_policy, TokenDataPolicy::Strip);
         assert_eq!(request["prompt"], serde_json::json!(["hello"]));
     }
 
     #[test]
-    fn completion_token_array_prompt_stays_token_array() {
+    fn completion_token_array_prompt_strips_token_data() {
         let mut request = serde_json::json!({
             "model": "test",
             "prompt": [101, 102, 103]
         });
 
-        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
+        let token_data_policy = prepare_completion_prompt_for_routing(&mut request);
 
-        assert!(inject_token_data);
+        assert_eq!(token_data_policy, TokenDataPolicy::Strip);
         assert_eq!(request["prompt"], serde_json::json!([101, 102, 103]));
     }
 
@@ -1370,9 +1394,9 @@ mod tests {
             "prompt": [[101, 102], [201, 202]]
         });
 
-        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
+        let token_data_policy = prepare_completion_prompt_for_routing(&mut request);
 
-        assert!(!inject_token_data);
+        assert_eq!(token_data_policy, TokenDataPolicy::Strip);
         assert_eq!(request["prompt"], serde_json::json!([101, 102]));
     }
 
@@ -1384,9 +1408,9 @@ mod tests {
             "prompt_embeds": "encoded"
         });
 
-        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
+        let token_data_policy = prepare_completion_prompt_for_routing(&mut request);
 
-        assert!(!inject_token_data);
+        assert_eq!(token_data_policy, TokenDataPolicy::Strip);
         assert_eq!(request["prompt"], "placeholder");
     }
 

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -213,35 +213,44 @@ impl Router {
 
     /// Tokenize a JSON request body and extract router queue priorities.
     ///
-    /// Returns `(token_ids, cache_namespace, priority_jump, strict_priority, routing_constraints)`.
     /// Priorities default to zero when absent. Mirrors the standalone Dynamo
     /// preprocessor lift in `lib/llm/src/preprocessor.rs`.
-    pub fn tokenize(
-        &self,
-        request_json: &str,
-    ) -> Result<(Vec<u32>, Option<String>, f64, u32, RoutingConstraints)> {
+    fn tokenize(&self, request_json: &str) -> Result<TokenizeResult> {
         // TODO(epp-request-routing): Reuse shared preprocessing so expected output
         // length, LoRA, pins, sessions, topology constraints, additional protocols,
         // and multimodal routing hashes are preserved.
         let mut request_json: serde_json::Value = serde_json::from_str(request_json)?;
 
-        if request_json.get("prompt").is_some() {
-            normalize_completion_prompt_for_routing(&mut request_json);
+        if request_json.get("prompt").is_some() || request_json.get("prompt_embeds").is_some() {
+            let inject_token_data = prepare_completion_prompt_for_routing(&mut request_json);
             let request: NvCreateCompletionRequest = serde_json::from_value(request_json)?;
             let nvext = request.nvext.as_ref();
             let priority_jump = extract_priority_jump(nvext);
             let strict_priority = extract_strict_priority(nvext);
             let routing_constraints = extract_routing_constraints(nvext);
             let cache_namespace = request_cache_salt(&request).map(str::to_owned);
+
+            if request.inner.prompt_embeds.is_some() {
+                return Ok(TokenizeResult {
+                    token_ids: Vec::new(),
+                    cache_namespace,
+                    priority_jump,
+                    strict_priority,
+                    routing_constraints,
+                    inject_token_data: false,
+                });
+            }
+
             let (token_ids, _) = self.preprocessor.gather_tokens(&request, None, None)?;
 
-            return Ok((
+            return Ok(TokenizeResult {
                 token_ids,
                 cache_namespace,
                 priority_jump,
                 strict_priority,
                 routing_constraints,
-            ));
+                inject_token_data,
+            });
         }
 
         let request: NvCreateChatCompletionRequest = serde_json::from_value(request_json)?;
@@ -257,13 +266,14 @@ impl Router {
             .unwrap_or_default();
 
         let encoding = self.preprocessor.tokenize(&formatted_prompt)?;
-        Ok((
-            encoding.token_ids().to_vec(),
+        Ok(TokenizeResult {
+            token_ids: encoding.token_ids().to_vec(),
             cache_namespace,
             priority_jump,
             strict_priority,
             routing_constraints,
-        ))
+            inject_token_data: true,
+        })
     }
 
     /// Resolve a worker_id to a pod endpoint address (ip:port).
@@ -511,29 +521,54 @@ impl Router {
     }
 }
 
-/// Collapse completion batch prompts into the single prompt shape the router
-/// can score today. Full batch-aware routing needs an explicit policy.
-fn normalize_completion_prompt_for_routing(request_json: &mut serde_json::Value) {
+struct TokenizeResult {
+    token_ids: Vec<u32>,
+    cache_namespace: Option<String>,
+    priority_jump: f64,
+    strict_priority: u32,
+    routing_constraints: RoutingConstraints,
+    inject_token_data: bool,
+}
+
+/// Pick a single completion prompt shape the router can score today.
+///
+/// Returns whether the resulting tokens may be injected into the original
+/// forwarded request as `nvext.token_data`. Batch and prompt-embeds completions
+/// must not receive synthetic token data because the backend preprocesses them
+/// per subrequest or from embeddings.
+fn prepare_completion_prompt_for_routing(request_json: &mut serde_json::Value) -> bool {
+    if request_json.get("prompt_embeds").is_some() {
+        return false;
+    }
+
     let Some(prompt) = request_json.get_mut("prompt") else {
-        return;
+        return true;
     };
     let Some(items) = prompt.as_array() else {
-        return;
+        return true;
     };
     if items.len() <= 1 {
-        return;
+        return true;
     }
 
     if items.iter().all(|item| item.is_string()) {
-        let joined = items
-            .iter()
-            .filter_map(|item| item.as_str())
-            .collect::<Vec<_>>()
-            .join(" ");
-        *prompt = serde_json::Value::String(joined);
+        let first = items
+            .first()
+            .and_then(|item| item.as_str())
+            .map(str::to_string);
+        if let Some(first) = first {
+            *prompt = serde_json::Value::String(first);
+        }
+        return false;
     } else if items.iter().all(|item| item.is_array()) {
-        *prompt = items[0].clone();
+        let first = items.first().cloned();
+        if let Some(first) = first {
+            *prompt = first;
+        }
+        return false;
     }
+
+    true
 }
 
 /// Extract the router queue `priority_jump` from an OpenAI request's
@@ -986,7 +1021,14 @@ impl EndpointPicker for Router {
         let body_str = std::str::from_utf8(&req.body)
             .map_err(|e| PickError::TokenizationFailed(format!("Invalid UTF-8: {e}")))?;
 
-        let (tokens, body_cache_namespace, priority_jump, strict_priority, routing_constraints) = self
+        let TokenizeResult {
+            token_ids: tokens,
+            cache_namespace: body_cache_namespace,
+            priority_jump,
+            strict_priority,
+            routing_constraints,
+            inject_token_data,
+        } = self
             .tokenize(body_str)
             .map_err(|e| PickError::TokenizationFailed(e.to_string()))?;
         let cache_namespace =
@@ -1121,6 +1163,7 @@ impl EndpointPicker for Router {
             is_disaggregated,
             endpoint = %endpoint,
             token_count = tokens.len(),
+            inject_token_data,
             priority_jump,
             model = %req.model,
             header_count = headers.len(),
@@ -1134,7 +1177,7 @@ impl EndpointPicker for Router {
             endpoint,
             fallbacks: vec![],
             headers,
-            token_ids: Some(tokens),
+            token_ids: inject_token_data.then_some(tokens),
         })
     }
 
@@ -1263,15 +1306,16 @@ mod tests {
     }
 
     #[test]
-    fn completion_string_array_prompt_collapses_to_single_prompt() {
+    fn completion_string_array_prompt_routes_first_prompt_without_token_injection() {
         let mut request = serde_json::json!({
             "model": "test",
             "prompt": ["hello", "world"]
         });
 
-        normalize_completion_prompt_for_routing(&mut request);
+        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
 
-        assert_eq!(request["prompt"], "hello world");
+        assert!(!inject_token_data);
+        assert_eq!(request["prompt"], "hello");
     }
 
     #[test]
@@ -1281,21 +1325,37 @@ mod tests {
             "prompt": [101, 102, 103]
         });
 
-        normalize_completion_prompt_for_routing(&mut request);
+        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
 
+        assert!(inject_token_data);
         assert_eq!(request["prompt"], serde_json::json!([101, 102, 103]));
     }
 
     #[test]
-    fn completion_token_batch_prompt_uses_first_prompt() {
+    fn completion_token_batch_prompt_routes_first_prompt_without_token_injection() {
         let mut request = serde_json::json!({
             "model": "test",
             "prompt": [[101, 102], [201, 202]]
         });
 
-        normalize_completion_prompt_for_routing(&mut request);
+        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
 
+        assert!(!inject_token_data);
         assert_eq!(request["prompt"], serde_json::json!([101, 102]));
+    }
+
+    #[test]
+    fn completion_prompt_embeds_disables_token_injection() {
+        let mut request = serde_json::json!({
+            "model": "test",
+            "prompt": "placeholder",
+            "prompt_embeds": "encoded"
+        });
+
+        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
+
+        assert!(!inject_token_data);
+        assert_eq!(request["prompt"], "placeholder");
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -584,9 +584,10 @@ fn extract_priority_jump(nvext: Option<&NvExt>) -> f64 {
         .and_then(|n| n.agent_hints.as_ref())
         .and_then(|h| {
             h.priority
-                .map(|p| p.max(0) as f64)
+                .map(|p| p as f64)
                 .or(h.latency_sensitivity)
         })
+        .map(|p| p.max(0.0))
         .unwrap_or(0.0)
 }
 
@@ -1251,9 +1252,23 @@ mod tests {
                     "messages": [{"role": "user", "content": "hi"}],
                     "nvext": {"agent_hints": {"priority": 5}}
                 }"#,
+        )
+        .unwrap();
+        assert_eq!(extract_priority_jump(with_priority.nvext.as_ref()), 5.0);
+
+        let with_negative_alias: NvCreateChatCompletionRequest =
+            serde_json::from_str(
+                r#"{
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "nvext": {"agent_hints": {"latency_sensitivity": -3.5}}
+                }"#,
             )
             .unwrap();
-        assert_eq!(extract_priority_jump(with_priority.nvext.as_ref()), 5.0);
+        assert_eq!(
+            extract_priority_jump(with_negative_alias.nvext.as_ref()),
+            0.0
+        );
 
         let without_nvext: NvCreateChatCompletionRequest =
             serde_json::from_str(
@@ -1316,6 +1331,32 @@ mod tests {
 
         assert!(!inject_token_data);
         assert_eq!(request["prompt"], "hello");
+    }
+
+    #[test]
+    fn completion_text_prompt_keeps_token_injection() {
+        let mut request = serde_json::json!({
+            "model": "test",
+            "prompt": "hello"
+        });
+
+        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
+
+        assert!(inject_token_data);
+        assert_eq!(request["prompt"], "hello");
+    }
+
+    #[test]
+    fn completion_single_string_array_prompt_keeps_token_injection() {
+        let mut request = serde_json::json!({
+            "model": "test",
+            "prompt": ["hello"]
+        });
+
+        let inject_token_data = prepare_completion_prompt_for_routing(&mut request);
+
+        assert!(inject_token_data);
+        assert_eq!(request["prompt"], serde_json::json!(["hello"]));
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -1456,9 +1456,11 @@ mod tests {
             "model": "test",
             "prompt_embeds": "encoded",
             "nvext": {
+                "cache_salt": "tenant-nvext",
                 "agent_hints": {"priority": 5, "strict_priority": 9},
                 "routing_constraints": {"required_taints": ["gpu=A100"]}
-            }
+            },
+            "cache_salt": "tenant-legacy"
         });
 
         let result = tokenize_completion_prompt_embeds(&request)
@@ -1468,6 +1470,7 @@ mod tests {
         assert!(result.token_ids.is_empty());
         assert_eq!(result.priority_jump, 5.0);
         assert_eq!(result.strict_priority, 9);
+        assert_eq!(result.cache_namespace.as_deref(), Some("tenant-nvext"));
         assert!(
             result
                 .routing_constraints

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -390,16 +390,20 @@ impl Router {
     ///
     /// Queue priorities are forwarded to the decode scheduler. `priority_jump`
     /// adjusts the policy score, while `strict_priority` selects the primary tier.
-    pub async fn route_decode(
+    async fn route_decode(
         &self,
-        tokens: &[u32],
-        is_disaggregated: bool,
-        cache_namespace: Option<String>,
-        priority_jump: f64,
-        strict_priority: u32,
-        allowed_worker_ids: Option<HashSet<u64>>,
-        routing_constraints: RoutingConstraints,
+        request: DecodeRouteRequest<'_>,
     ) -> Result<(WorkerWithDpRank, u32)> {
+        let DecodeRouteRequest {
+            tokens,
+            is_disaggregated,
+            cache_namespace,
+            priority_jump,
+            strict_priority,
+            allowed_worker_ids,
+            routing_constraints,
+        } = request;
+
         if let Some(ref ids) = allowed_worker_ids {
             self.decode_router.register_workers(ids);
         }
@@ -524,6 +528,16 @@ struct TokenizeResult {
     strict_priority: u32,
     routing_constraints: RoutingConstraints,
     token_data_policy: TokenDataPolicy,
+}
+
+struct DecodeRouteRequest<'a> {
+    tokens: &'a [u32],
+    is_disaggregated: bool,
+    cache_namespace: Option<String>,
+    priority_jump: f64,
+    strict_priority: u32,
+    allowed_worker_ids: Option<HashSet<u64>>,
+    routing_constraints: RoutingConstraints,
 }
 
 #[derive(serde::Deserialize)]
@@ -1125,15 +1139,15 @@ impl EndpointPicker for Router {
         // booking ID independent of x-request-id, handle cancellation races, roll
         // back endpoint-resolution failures, and never forward to an unbooked fallback.
         let (decode_worker, _overlap) = self
-            .route_decode(
-                &tokens,
+            .route_decode(DecodeRouteRequest {
+                tokens: &tokens,
                 is_disaggregated,
-                cache_namespace.clone(),
+                cache_namespace: cache_namespace.clone(),
                 priority_jump,
                 strict_priority,
                 allowed_worker_ids,
                 routing_constraints,
-            )
+            })
             .await
             .map_err(|e| PickError::RoutingFailed(e.to_string()))?;
 

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -561,8 +561,7 @@ fn tokenize_completion_prompt_embeds(
         return Ok(None);
     }
 
-    let fields: CompletionPromptEmbedsRoutingFields =
-        serde_json::from_value(request_json.clone())?;
+    let fields: CompletionPromptEmbedsRoutingFields = serde_json::from_value(request_json.clone())?;
     let nvext = fields.nvext.as_ref();
     let priority_jump = extract_priority_jump(nvext);
     let strict_priority = extract_strict_priority(nvext);

--- a/deploy/inference-gateway/ext-proc/src/picker.rs
+++ b/deploy/inference-gateway/ext-proc/src/picker.rs
@@ -60,9 +60,11 @@ pub struct PickResult {
     /// Extra headers to inject into the forwarded request.
     /// Used by Dynamo for routing metadata (worker IDs, DP ranks, routing mode).
     pub headers: Vec<(String, String)>,
-    /// Pre-computed token IDs from the picker's tokenization.
+    /// Optional pre-computed token IDs safe to forward to the backend.
     /// Injected into the request body as `nvext.token_data` so the backend
-    /// skips redundant tokenization. Mirrors Go EPP's `setTokenizedPrompt`.
+    /// skips redundant tokenization. Pickers must leave this unset when their
+    /// routing tokens do not exactly match the original request's execution
+    /// prompt, such as batch completions collapsed for routing.
     pub token_ids: Option<Vec<u32>>,
 }
 

--- a/deploy/inference-gateway/ext-proc/src/picker.rs
+++ b/deploy/inference-gateway/ext-proc/src/picker.rs
@@ -66,6 +66,10 @@ pub struct PickResult {
     /// routing tokens do not exactly match the original request's execution
     /// prompt, such as batch completions collapsed for routing.
     pub token_ids: Option<Vec<u32>>,
+    /// Remove caller-provided `nvext.token_data` from the forwarded body.
+    /// Used when flat token data would be unsafe or ignored for the request
+    /// shape, such as batch completions, token prompts, or prompt embeddings.
+    pub strip_token_data: bool,
 }
 
 /// EndpointPicker is the central abstraction for endpoint selection.

--- a/deploy/inference-gateway/ext-proc/src/server.rs
+++ b/deploy/inference-gateway/ext-proc/src/server.rs
@@ -308,8 +308,9 @@ impl<P: EndpointPicker> ExtProcServer<P> {
             &result.headers,
         ));
 
-        // Inject nvext.token_data into the request body JSON so the backend
-        // skips redundant tokenization. Mirrors Go EPP's setTokenizedPrompt.
+        // Mutate nvext.token_data only when the picker says the request shape
+        // is safe for backend token reuse. Some completion shapes must strip
+        // caller-provided flat token_data to avoid corrupting batch execution.
         let forwarded_body = if let Some(ref token_ids) = result.token_ids {
             match inject_token_data(raw_body, token_ids) {
                 Ok(modified) => {
@@ -323,6 +324,22 @@ impl<P: EndpointPicker> ExtProcServer<P> {
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "Failed to inject token_data, forwarding original body");
+                    raw_body.to_vec()
+                }
+            }
+        } else if result.strip_token_data {
+            match strip_token_data(raw_body) {
+                Ok(Some(modified)) => {
+                    tracing::debug!(
+                        body_size_before = raw_body.len(),
+                        body_size_after = modified.len(),
+                        "Stripped nvext.token_data from request body"
+                    );
+                    modified
+                }
+                Ok(None) => raw_body.to_vec(),
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to strip token_data, forwarding original body");
                     raw_body.to_vec()
                 }
             }
@@ -657,6 +674,29 @@ fn inject_token_data(body: &[u8], token_ids: &[u32]) -> anyhow::Result<Vec<u8>> 
     Ok(serde_json::to_vec(&parsed)?)
 }
 
+/// Remove existing `nvext.token_data` from a JSON request body.
+fn strip_token_data(body: &[u8]) -> anyhow::Result<Option<Vec<u8>>> {
+    let mut parsed: serde_json::Value = serde_json::from_slice(body)?;
+
+    let obj = parsed
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("body is not a JSON object"))?;
+
+    let Some(nvext) = obj.get_mut("nvext") else {
+        return Ok(None);
+    };
+
+    let nvext_obj = nvext
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("nvext is not a JSON object"))?;
+
+    if nvext_obj.remove("token_data").is_none() {
+        return Ok(None);
+    }
+
+    Ok(Some(serde_json::to_vec(&parsed)?))
+}
+
 /// Extract the "model" field from a JSON request body.
 /// Mirrors Go LW-EPP `extractModelFromBody`.
 fn extract_model_from_body(body: &[u8]) -> String {
@@ -753,6 +793,38 @@ mod tests {
         HttpBody, HttpHeaders, ProcessingRequest,
         external_processor_client::ExternalProcessorClient, processing_request::Request as ProcReq,
     };
+
+    #[test]
+    fn strip_token_data_removes_existing_nvext_token_data() {
+        let body = br#"{
+            "model": "test",
+            "prompt": ["a", "b"],
+            "nvext": {
+                "token_data": [1, 2, 3],
+                "agent_hints": {"priority": 5}
+            }
+        }"#;
+
+        let stripped = strip_token_data(body)
+            .expect("strip should parse")
+            .expect("token_data should be removed");
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&stripped).expect("stripped body should parse");
+
+        assert!(parsed["nvext"].get("token_data").is_none());
+        assert_eq!(parsed["nvext"]["agent_hints"]["priority"], 5);
+    }
+
+    #[test]
+    fn strip_token_data_is_noop_when_absent() {
+        let body = br#"{"model":"test","prompt":"hello","nvext":{"agent_hints":{"priority":5}}}"#;
+
+        assert!(
+            strip_token_data(body)
+                .expect("strip should parse")
+                .is_none()
+        );
+    }
 
     struct Tracker {
         add: AtomicU32,

--- a/deploy/inference-gateway/ext-proc/tests/ext_proc_test.rs
+++ b/deploy/inference-gateway/ext-proc/tests/ext_proc_test.rs
@@ -76,6 +76,7 @@ async fn test_pick_result_translates_to_ext_proc_mutations() {
             ("x-dynamo-prefill-dp-rank".to_string(), "0".to_string()),
         ],
         token_ids: Some(vec![1, 2, 3, 4, 5]),
+        strip_token_data: false,
     };
 
     let picker = Arc::new(MockPicker {


### PR DESCRIPTION
## Overview

Rust ext-proc EPP handled every request body as chat completions. This PR teaches it to route `/v1/completions` bodies through the completion request type so text prompts, token-ID prompts, and nvext routing hints keep their intended semantics.

## Summary

- Parse completion request JSON as `NvCreateCompletionRequest` instead of forcing chat completion parsing.
- Preserve completion token-ID prompts and raw text prompt tokenization for routing.
- Avoid injecting synthetic `nvext.token_data` for batch completion prompts and prompt-embedding completions.
- Forward `nvext` priority, strict priority, and routing constraints for chat and completion requests.

## Details

- Batch completion prompts are reduced to a representative first prompt for router scoring only until batch-aware routing has an explicit policy.
- Prompt-embedding completions route with empty token IDs, matching the backend preprocessing path where embeddings are authoritative.
- Deprecated `latency_sensitivity` priority hints are clamped the same way as `priority`.

## Where should the reviewer start?

Start with `deploy/inference-gateway/ext-proc/src/epp.rs`, especially `Router::tokenize`, `prepare_completion_prompt_for_routing`, and the `PickResult` construction in `pick()`.

## Validation

- `git diff --check`
- Pre-commit hooks passed during commits.
- Not run locally: Rust `cargo`/`rustfmt`; this environment has no Rust toolchain installed.

## Related Issues

Fixes #11041.
Related to #10872.