### PR TITLE
fix(toolcalling): synthesize tool_calls finish_reason when stream lacks one

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use dynamo_runtime::protocols::annotated::AnnotationsProvider;
+use dynamo_runtime::protocols::annotated::{Annotated, AnnotationsProvider};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
@@ -30,8 +30,9 @@ pub use delta::DeltaGenerator;
 
 use dynamo_parsers::tool_calling::{ToolCallResponse, ToolCallResponseChunk};
 use dynamo_protocols::types::{
-    ChatCompletionMessageToolCall, ChatCompletionMessageToolCallChunk, FunctionCall,
-    FunctionCallStream, FunctionType,
+    ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionMessageToolCall,
+    ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta, FinishReason,
+    FunctionCall, FunctionCallStream, FunctionType,
 };
 
 /// Map a parser-native [`ToolCallResponse`] onto the protocol/wire
@@ -237,6 +238,45 @@ pub struct NvCreateChatCompletionStreamResponse {
     /// client-facing OpenAI-compatible streams.
     #[serde(skip)]
     pub llm_metrics: Option<crate::protocols::common::metrics::LLMMetricAnnotation>,
+}
+
+/// Build one synthetic stream choice from an existing response template.
+///
+/// Both streaming tool-call paths use this constructor when an engine omits a
+/// terminal choice. Accounting data belongs only on the usage chunk and must
+/// not be copied onto the synthetic choice.
+pub(super) fn stream_choice_chunk_from_template(
+    template: &NvCreateChatCompletionStreamResponse,
+    index: u32,
+    content: Option<ChatCompletionMessageContent>,
+    tool_calls: Option<Vec<ChatCompletionMessageToolCallChunk>>,
+    finish_reason: Option<FinishReason>,
+) -> Annotated<NvCreateChatCompletionStreamResponse> {
+    let mut response = template.clone();
+    response.inner.usage = None;
+    response.llm_metrics = None;
+    #[allow(deprecated)]
+    let choice = ChatChoiceStream {
+        index,
+        delta: ChatCompletionStreamResponseDelta {
+            role: None,
+            content,
+            tool_calls,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason,
+        logprobs: None,
+    };
+    response.inner.choices = vec![choice];
+    Annotated {
+        data: Some(response),
+        id: None,
+        event: None,
+        comment: None,
+        error: None,
+    }
 }
 
 /// Implements `NvExtProvider` for `NvCreateChatCompletionRequest`,

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1571,11 +1571,11 @@ impl JailedStream {
                     .unwrap_or(true);
                 if is_empty_choices && !synthesized {
                     if let Some(template) = &template {
-                        for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| *has) {
+                        for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| **has) {
                             if terminated.contains(index) {
                                 continue;
                             }
-                            yield synthesize_tool_calls_chunk(template, *index);
+                            yield Self::synthesize_tool_calls_chunk(template, *index);
                         }
                     }
                     synthesized = true;
@@ -1593,14 +1593,12 @@ impl JailedStream {
             // complete; without this they hang until their client-side timeout
             // (DGH-967). Choices that never emitted tool calls are left alone — there
             // is no signal to invent a finish_reason from for text-only output.
-            if !synthesized {
-                if let Some(template) = template {
-                    for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| *has) {
-                        if terminated.contains(index) {
-                            continue;
-                        }
-                        yield synthesize_tool_calls_chunk(template, *index);
+            if !synthesized && let Some(template) = template {
+                for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| **has) {
+                    if terminated.contains(index) {
+                        continue;
                     }
+                    yield Self::synthesize_tool_calls_chunk(&template, *index);
                 }
             }
         }
@@ -2231,9 +2229,9 @@ mod tests {
     async fn jail_synthesizes_tool_calls_finish_reason_when_stream_lacks_one() {
         let jail = JailedStream::builder().tool_call_parser("hermes").build();
 
-        let chunks = vec![text_chunk("```
-{"name": "get_weather", "arguments": {"location": "SF"}}
-```")];
+        let chunks = vec![text_chunk(
+            "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>",
+        )];
 
         let input_stream = Box::pin(stream::iter(chunks));
         let output_stream = jail.apply_with_finish_reason(input_stream);
@@ -2286,9 +2284,12 @@ mod tests {
     async fn jail_synthesizes_tool_calls_before_usage_only_chunk() {
         let jail = JailedStream::builder().tool_call_parser("hermes").build();
 
-        let chunks = vec![text_chunk("```
-{"name": "get_weather", "arguments": {"location": "SF"}}
-```"), usage_only_chunk()];
+        let chunks = vec![
+            text_chunk(
+                "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>",
+            ),
+            usage_only_chunk(),
+        ];
 
         let input_stream = Box::pin(stream::iter(chunks));
         let output_stream = jail.apply_with_finish_reason(input_stream);

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1572,16 +1572,17 @@ impl JailedStream {
                     .data
                     .as_ref()
                     .is_some_and(|d| d.inner.choices.is_empty());
-                if is_empty_choices && !synthesized {
-                    if let Some(template) = &template {
-                        for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| **has) {
-                            if terminated.contains(index) {
-                                continue;
-                            }
-                            yield Self::synthesize_tool_calls_chunk(template, *index);
+                if is_empty_choices
+                    && !synthesized
+                    && let Some(template) = &template
+                {
+                    for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| **has) {
+                        if terminated.contains(index) {
+                            continue;
                         }
-                        synthesized = true;
+                        yield Self::synthesize_tool_calls_chunk(template, *index);
                     }
+                    synthesized = true;
                 }
 
                 yield response;

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1533,7 +1533,7 @@ impl JailedStream {
             // reason. Choices that never emitted tool calls are left alone — there is no
             // signal to invent a finish_reason from for text-only output.
             if let Some(template) = template {
-                for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, &has)| has) {
+                for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| *has) {
                     if terminated.contains(index) {
                         continue;
                     }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1451,6 +1451,41 @@ impl JailedStream {
         false
     }
 
+    /// Build a synthetic terminal chunk carrying `finish_reason: ToolCalls` for a
+    /// choice that emitted tool calls but never received a finish_reason from the
+    /// engine. Used by `fix_finish_reason` to satisfy the OpenAI stream ordering
+    /// requirement (the terminal chunk must carry a non-null `finish_reason`)
+    /// when the stream ends without one — DGH-967. The delta is empty; only the
+    /// `finish_reason` carries information.
+    fn synthesize_tool_calls_chunk(
+        template: &NvCreateChatCompletionStreamResponse,
+        index: u32,
+    ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let mut response = template.clone();
+        #[allow(deprecated)]
+        let choice = dynamo_protocols::types::ChatChoiceStream {
+            index,
+            delta: dynamo_protocols::types::ChatCompletionStreamResponseDelta {
+                role: None,
+                content: None,
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: Some(FinishReason::ToolCalls),
+            logprobs: None,
+        };
+        response.inner.choices = vec![choice];
+        Annotated {
+            data: Some(response),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
     /// Post-processor that sets finish_reason to ToolCalls when tool calls were emitted
     /// This should be called after apply() to fix the finish_reason for tool call chunks
     fn fix_finish_reason<S>(
@@ -1467,14 +1502,17 @@ impl JailedStream {
             tokio::pin!(input_stream);
             let mut has_tool_calls_per_choice: HashMap<u32, bool> = HashMap::new();
             // Choices that already received a finish_reason during the stream — used by
-            // the end-of-stream backstop below to avoid synthesizing a duplicate.
+            // the backstop below to avoid synthesizing a duplicate.
             let mut terminated: std::collections::HashSet<u32> = std::collections::HashSet::new();
             // Last response, kept (with choices cleared) as a template for a synthesized
-            // trailing finish_reason chunk when the stream ended without one.
+            // finish_reason chunk when the stream ended without one.
             let mut template: Option<NvCreateChatCompletionStreamResponse> = None;
+            // Whether we have already emitted the synthesized terminal chunks (either
+            // before the usage-only chunk or at stream end), so we don't emit twice.
+            let mut synthesized = false;
 
             while let Some(mut response) = input_stream.next().await {
-                // Track if any choice emitted tool calls
+                // Track if any choice emitted tool calls, and which already terminated.
                 if let Some(ref data) = response.data {
                     for choice in &data.inner.choices {
                         if choice.delta.tool_calls.is_some() {
@@ -1521,45 +1559,48 @@ impl JailedStream {
                     }
                 }
 
+                // OpenAI stream ordering: the terminal finish_reason chunk must precede
+                // the usage-only chunk. When a chunk with no choices arrives (the
+                // frontend's compliance usage chunk, or any other empty-choices chunk)
+                // and tool-call choices are still missing a finish_reason, synthesize
+                // their terminal `ToolCalls` chunks *before* yielding this one.
+                let is_empty_choices = response
+                    .data
+                    .as_ref()
+                    .map(|d| d.inner.choices.is_empty())
+                    .unwrap_or(true);
+                if is_empty_choices && !synthesized {
+                    if let Some(template) = &template {
+                        for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| *has) {
+                            if terminated.contains(index) {
+                                continue;
+                            }
+                            yield synthesize_tool_calls_chunk(template, *index);
+                        }
+                    }
+                    synthesized = true;
+                }
+
                 yield response;
             }
 
-            // Backstop: the stream ended without a finish_reason for some choice that
-            // emitted tool calls (e.g. speculative decoding folded EOS into content, or
-            // the engine dropped the terminal signal). Strict OpenAI clients wait for a
-            // non-null finish_reason before considering a tool call complete; without a
-            // synthesized `ToolCalls` here they hang until their client-side timeout
-            // (DGH-967). Emit one trailing chunk per such choice carrying the missing
-            // reason. Choices that never emitted tool calls are left alone — there is no
-            // signal to invent a finish_reason from for text-only output.
-            if let Some(template) = template {
-                for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| *has) {
-                    if terminated.contains(index) {
-                        continue;
+            // Backstop: the stream ended without a finish_reason AND without an
+            // empty-choices/usage chunk to anchor the synthesized terminal chunks
+            // before (e.g. the engine dropped the terminal signal and the frontend
+            // never emitted a usage chunk). Emit one trailing `ToolCalls` chunk per
+            // tool-call choice that never received a finish_reason. Strict OpenAI
+            // clients wait for a non-null finish_reason before considering a tool call
+            // complete; without this they hang until their client-side timeout
+            // (DGH-967). Choices that never emitted tool calls are left alone — there
+            // is no signal to invent a finish_reason from for text-only output.
+            if !synthesized {
+                if let Some(template) = template {
+                    for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| *has) {
+                        if terminated.contains(index) {
+                            continue;
+                        }
+                        yield synthesize_tool_calls_chunk(template, *index);
                     }
-                    let mut response = template.clone();
-                    #[allow(deprecated)]
-                    let choice = dynamo_protocols::types::ChatChoiceStream {
-                        index: *index,
-                        delta: dynamo_protocols::types::ChatCompletionStreamResponseDelta {
-                            role: None,
-                            content: None,
-                            tool_calls: None,
-                            function_call: None,
-                            refusal: None,
-                            reasoning_content: None,
-                        },
-                        finish_reason: Some(FinishReason::ToolCalls),
-                        logprobs: None,
-                    };
-                    response.inner.choices = vec![choice];
-                    yield Annotated {
-                        data: Some(response),
-                        id: None,
-                        event: None,
-                        comment: None,
-                        error: None,
-                    };
                 }
             }
         }
@@ -1816,6 +1857,38 @@ mod tests {
                     model: "test-model".to_string(),
                     choices: vec![choice],
                     usage: None,
+                    service_tier: None,
+                    system_fingerprint: None,
+                },
+                nvext: None,
+                llm_metrics: None,
+            }),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// A usage-only chunk (empty `choices`, a usage object) — the frontend's
+    /// OpenAI-compliance terminal chunk. Used to test that the synthesized
+    /// `ToolCalls` finish_reason chunk is emitted *before* this one.
+    fn usage_only_chunk() -> Annotated<NvCreateChatCompletionStreamResponse> {
+        Annotated {
+            data: Some(NvCreateChatCompletionStreamResponse {
+                inner: CreateChatCompletionStreamResponse {
+                    id: "id-42".to_string(),
+                    object: "chat.completion.chunk".to_string(),
+                    created: 0,
+                    model: "test-model".to_string(),
+                    choices: vec![],
+                    usage: Some(dynamo_protocols::types::CompletionUsage {
+                        prompt_tokens: 10,
+                        completion_tokens: 5,
+                        total_tokens: 15,
+                        prompt_tokens_details: None,
+                        completion_tokens_details: None,
+                    }),
                     service_tier: None,
                     system_fingerprint: None,
                 },
@@ -2201,6 +2274,57 @@ mod tests {
             final_finish_reason(&responses),
             None,
             "text-only stream with no upstream finish_reason must not get a synthetic one"
+        );
+    }
+
+    // DGH-967 ordering: the ticket's repro is a tool call followed by a
+    // usage-only chunk, with NO finish_reason chunk from the engine. The
+    // synthesized `ToolCalls` terminal chunk must be emitted *before* the
+    // usage-only chunk (OpenAI stream ordering — the terminal finish_reason
+    // precedes usage). This mirrors the production repro in the ticket.
+    #[tokio::test]
+    async fn jail_synthesizes_tool_calls_before_usage_only_chunk() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk("```
+{"name": "get_weather", "arguments": {"location": "SF"}}
+```"), usage_only_chunk()];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert!(
+            !tool_calls.is_empty(),
+            "expected the hermes tool call: {tool_calls:?}"
+        );
+        assert_eq!(tool_calls[0].0, "get_weather");
+        assert_eq!(
+            final_finish_reason(&responses),
+            Some(FinishReason::ToolCalls),
+            "a synthesized ToolCalls terminal chunk must be present"
+        );
+
+        // The ToolCalls terminal chunk must precede the usage-only chunk.
+        let finish_pos = responses.iter().position(|r| {
+            r.data.as_ref().is_some_and(|d| {
+                d.inner
+                    .choices
+                    .iter()
+                    .any(|c| c.finish_reason == Some(FinishReason::ToolCalls))
+            })
+        });
+        let usage_pos = responses.iter().position(|r| {
+            r.data
+                .as_ref()
+                .is_some_and(|d| d.inner.usage.is_some() && d.inner.choices.is_empty())
+        });
+        let finish_pos = finish_pos.expect("no ToolCalls chunk emitted");
+        let usage_pos = usage_pos.expect("no usage-only chunk in output");
+        assert!(
+            finish_pos < usage_pos,
+            "ToolCalls chunk at {finish_pos} must precede the usage chunk at {usage_pos}"
         );
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1455,13 +1455,17 @@ impl JailedStream {
     /// choice that emitted tool calls but never received a finish_reason from the
     /// engine. Used by `fix_finish_reason` to satisfy the OpenAI stream ordering
     /// requirement (the terminal chunk must carry a non-null `finish_reason`)
-    /// when the stream ends without one — DGH-967. The delta is empty; only the
+    /// when the stream ends without one. The delta is empty; only the
     /// `finish_reason` carries information.
     fn synthesize_tool_calls_chunk(
         template: &NvCreateChatCompletionStreamResponse,
         index: u32,
     ) -> Annotated<NvCreateChatCompletionStreamResponse> {
         let mut response = template.clone();
+        // A terminal finish chunk must not repeat accounting data copied from a
+        // usage-only template.
+        response.inner.usage = None;
+        response.llm_metrics = None;
         #[allow(deprecated)]
         let choice = dynamo_protocols::types::ChatChoiceStream {
             index,
@@ -1590,8 +1594,8 @@ impl JailedStream {
             // never emitted a usage chunk). Emit one trailing `ToolCalls` chunk per
             // tool-call choice that never received a finish_reason. Strict OpenAI
             // clients wait for a non-null finish_reason before considering a tool call
-            // complete; without this they hang until their client-side timeout
-            // (DGH-967). Choices that never emitted tool calls are left alone — there
+            // complete; without this they hang until their client-side timeout.
+            // Choices that never emitted tool calls are left alone — there
             // is no signal to invent a finish_reason from for text-only output.
             if !synthesized && let Some(template) = template {
                 for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| **has) {
@@ -1891,7 +1895,21 @@ mod tests {
                     system_fingerprint: None,
                 },
                 nvext: None,
-                llm_metrics: None,
+                llm_metrics: Some(crate::protocols::common::metrics::LLMMetricAnnotation {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    chunk_tokens: 0,
+                    cached_tokens: None,
+                    prefill_worker_id: None,
+                    prefill_dp_rank: None,
+                    prefill_worker_type: None,
+                    decode_worker_id: None,
+                    decode_dp_rank: None,
+                    decode_worker_type: None,
+                    tokenize_latency: None,
+                    detokenize_total_latency: None,
+                    detokenize_count: None,
+                }),
             }),
             id: None,
             event: None,
@@ -2206,7 +2224,7 @@ mod tests {
     }
 
     /// The last `finish_reason` a client sees across the stream. `None` if the
-    /// stream never carried one (the DGH-967 hang condition).
+    /// stream never carried one (the missing-finish-reason hang condition).
     fn final_finish_reason(
         responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
     ) -> Option<FinishReason> {
@@ -2218,12 +2236,12 @@ mod tests {
             .next_back()
     }
 
-    // DGH-967: when the engine emits a complete tool call but the stream ends
-    // WITHOUT any finish_reason chunk (speculative decoding folded EOS into
-    // content, or the terminal signal was dropped), a strict OpenAI client
-    // waits for a non-null finish_reason and hangs until its timeout. The jail
-    // path's finalize() emits the tool call with the (absent) upstream
-    // finish_reason; fix_finish_reason's end-of-stream backstop must synthesize
+    // Missing-finish-reason regression: when the engine emits a complete tool call
+    // but the stream ends without any finish_reason chunk (speculative decoding
+    // folded EOS into content, or the terminal signal was dropped), a strict
+    // OpenAI client waits for a non-null finish_reason and hangs until its timeout.
+    // The jail path's finalize() emits the tool call with the absent upstream
+    // finish_reason; fix_finish_reason's end-of-stream path must synthesize
     // `ToolCalls` so the client gets a terminal signal.
     #[tokio::test]
     async fn jail_synthesizes_tool_calls_finish_reason_when_stream_lacks_one() {
@@ -2250,8 +2268,8 @@ mod tests {
         );
     }
 
-    // DGH-967 corollary: a text-only stream that ends without a finish_reason
-    // must NOT get a synthesized one — there is no signal to invent a
+    // Text-only corollary: a text-only stream that ends without a finish_reason
+    // must not get a synthesized one. There is no signal to invent a
     // finish_reason from when no tool call was emitted.
     #[tokio::test]
     async fn jail_does_not_synthesize_finish_reason_for_text_only_stream() {
@@ -2275,11 +2293,11 @@ mod tests {
         );
     }
 
-    // DGH-967 ordering: the ticket's repro is a tool call followed by a
-    // usage-only chunk, with NO finish_reason chunk from the engine. The
+    // Usage-ordering regression: a tool call is followed by a usage-only chunk,
+    // with no finish_reason chunk from the engine. The
     // synthesized `ToolCalls` terminal chunk must be emitted *before* the
     // usage-only chunk (OpenAI stream ordering — the terminal finish_reason
-    // precedes usage). This mirrors the production repro in the ticket.
+    // precedes usage). This mirrors the production stream ordering.
     #[tokio::test]
     async fn jail_synthesizes_tool_calls_before_usage_only_chunk() {
         let jail = JailedStream::builder().tool_call_parser("hermes").build();
@@ -2326,6 +2344,18 @@ mod tests {
         assert!(
             finish_pos < usage_pos,
             "ToolCalls chunk at {finish_pos} must precede the usage chunk at {usage_pos}"
+        );
+        let finish_data = responses[finish_pos]
+            .data
+            .as_ref()
+            .expect("ToolCalls chunk has no response data");
+        assert!(
+            finish_data.inner.usage.is_none(),
+            "synthesized ToolCalls chunk must not repeat usage data"
+        );
+        assert!(
+            finish_data.llm_metrics.is_none(),
+            "synthesized ToolCalls chunk must not repeat LLM metrics"
         );
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1461,9 +1461,17 @@ impl JailedStream {
     where
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
     {
+        let _ = named_tool_active;
+        let _ = &jail_mode;
         stream! {
             tokio::pin!(input_stream);
             let mut has_tool_calls_per_choice: HashMap<u32, bool> = HashMap::new();
+            // Choices that already received a finish_reason during the stream — used by
+            // the end-of-stream backstop below to avoid synthesizing a duplicate.
+            let mut terminated: std::collections::HashSet<u32> = std::collections::HashSet::new();
+            // Last response, kept (with choices cleared) as a template for a synthesized
+            // trailing finish_reason chunk when the stream ended without one.
+            let mut template: Option<NvCreateChatCompletionStreamResponse> = None;
 
             while let Some(mut response) = input_stream.next().await {
                 // Track if any choice emitted tool calls
@@ -1472,6 +1480,14 @@ impl JailedStream {
                         if choice.delta.tool_calls.is_some() {
                             has_tool_calls_per_choice.insert(choice.index, true);
                         }
+                        if choice.finish_reason.is_some() {
+                            terminated.insert(choice.index);
+                        }
+                    }
+                    {
+                        let mut t = data.clone();
+                        t.inner.choices.clear();
+                        template = Some(t);
                     }
                 }
 
@@ -1487,7 +1503,6 @@ impl JailedStream {
                                 // choice, finish_reason MUST be "tool_calls" — regardless of
                                 // whether tool_choice was "auto", "required", or a named
                                 // function.
-                                let _ = named_tool_active;
                                 match &jail_mode {
                                     JailMode::MarkerBased => {
                                         if has_tool_calls {
@@ -1507,6 +1522,45 @@ impl JailedStream {
                 }
 
                 yield response;
+            }
+
+            // Backstop: the stream ended without a finish_reason for some choice that
+            // emitted tool calls (e.g. speculative decoding folded EOS into content, or
+            // the engine dropped the terminal signal). Strict OpenAI clients wait for a
+            // non-null finish_reason before considering a tool call complete; without a
+            // synthesized `ToolCalls` here they hang until their client-side timeout
+            // (DGH-967). Emit one trailing chunk per such choice carrying the missing
+            // reason. Choices that never emitted tool calls are left alone — there is no
+            // signal to invent a finish_reason from for text-only output.
+            if let Some(template) = template {
+                for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, &has)| has) {
+                    if terminated.contains(index) {
+                        continue;
+                    }
+                    let mut response = template.clone();
+                    #[allow(deprecated)]
+                    let choice = dynamo_protocols::types::ChatChoiceStream {
+                        index: *index,
+                        delta: dynamo_protocols::types::ChatCompletionStreamResponseDelta {
+                            role: None,
+                            content: None,
+                            tool_calls: None,
+                            function_call: None,
+                            refusal: None,
+                            reasoning_content: None,
+                        },
+                        finish_reason: Some(FinishReason::ToolCalls),
+                        logprobs: None,
+                    };
+                    response.inner.choices = vec![choice];
+                    yield Annotated {
+                        data: Some(response),
+                        id: None,
+                        event: None,
+                        comment: None,
+                        error: None,
+                    };
+                }
             }
         }
     }
@@ -2077,6 +2131,76 @@ mod tests {
             all_text.contains("Done!"),
             "Trailing text 'Done!' should appear in output. Got text: {:?}",
             all_text
+        );
+    }
+
+    /// The last `finish_reason` a client sees across the stream. `None` if the
+    /// stream never carried one (the DGH-967 hang condition).
+    fn final_finish_reason(
+        responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Option<FinishReason> {
+        responses
+            .iter()
+            .filter_map(|r| r.data.as_ref())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter_map(|c| c.finish_reason)
+            .next_back()
+    }
+
+    // DGH-967: when the engine emits a complete tool call but the stream ends
+    // WITHOUT any finish_reason chunk (speculative decoding folded EOS into
+    // content, or the terminal signal was dropped), a strict OpenAI client
+    // waits for a non-null finish_reason and hangs until its timeout. The jail
+    // path's finalize() emits the tool call with the (absent) upstream
+    // finish_reason; fix_finish_reason's end-of-stream backstop must synthesize
+    // `ToolCalls` so the client gets a terminal signal.
+    #[tokio::test]
+    async fn jail_synthesizes_tool_calls_finish_reason_when_stream_lacks_one() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk("```
+{"name": "get_weather", "arguments": {"location": "SF"}}
+```")];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert!(
+            !tool_calls.is_empty(),
+            "expected the hermes tool call to be parsed: {tool_calls:?}"
+        );
+        assert_eq!(tool_calls[0].0, "get_weather");
+        assert_eq!(
+            final_finish_reason(&responses),
+            Some(FinishReason::ToolCalls),
+            "backstop must synthesize ToolCalls when the stream ended without a finish_reason"
+        );
+    }
+
+    // DGH-967 corollary: a text-only stream that ends without a finish_reason
+    // must NOT get a synthesized one — there is no signal to invent a
+    // finish_reason from when no tool call was emitted.
+    #[tokio::test]
+    async fn jail_does_not_synthesize_finish_reason_for_text_only_stream() {
+        let jail = JailedStream::builder().tool_call_parser("hermes").build();
+
+        let chunks = vec![text_chunk("hello world"), text_chunk("")];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert!(
+            tool_calls.is_empty(),
+            "no tool calls expected: {tool_calls:?}"
+        );
+        assert_eq!(
+            final_finish_reason(&responses),
+            None,
+            "text-only stream with no upstream finish_reason must not get a synthetic one"
         );
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -17,12 +17,12 @@ use dynamo_parsers::tool_calling::{
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::{Stream, StreamExt};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use crate::utils::{MarkerMatcher, MatchResult};
 
-use super::NvCreateChatCompletionStreamResponse;
+use super::{NvCreateChatCompletionStreamResponse, stream_choice_chunk_from_template};
 
 fn is_harmony_parser(parser: Option<&str>) -> bool {
     parser == Some("harmony")
@@ -1451,45 +1451,6 @@ impl JailedStream {
         false
     }
 
-    /// Build a synthetic terminal chunk carrying `finish_reason: ToolCalls` for a
-    /// choice that emitted tool calls but never received a finish_reason from the
-    /// engine. Used by `fix_finish_reason` to satisfy the OpenAI stream ordering
-    /// requirement (the terminal chunk must carry a non-null `finish_reason`)
-    /// when the stream ends without one. The delta is empty; only the
-    /// `finish_reason` carries information.
-    fn synthesize_tool_calls_chunk(
-        template: &NvCreateChatCompletionStreamResponse,
-        index: u32,
-    ) -> Annotated<NvCreateChatCompletionStreamResponse> {
-        let mut response = template.clone();
-        // A terminal finish chunk must not repeat accounting data copied from a
-        // usage-only template.
-        response.inner.usage = None;
-        response.llm_metrics = None;
-        #[allow(deprecated)]
-        let choice = dynamo_protocols::types::ChatChoiceStream {
-            index,
-            delta: dynamo_protocols::types::ChatCompletionStreamResponseDelta {
-                role: None,
-                content: None,
-                tool_calls: None,
-                function_call: None,
-                refusal: None,
-                reasoning_content: None,
-            },
-            finish_reason: Some(FinishReason::ToolCalls),
-            logprobs: None,
-        };
-        response.inner.choices = vec![choice];
-        Annotated {
-            data: Some(response),
-            id: None,
-            event: None,
-            comment: None,
-            error: None,
-        }
-    }
-
     /// Post-processor that sets finish_reason to ToolCalls when tool calls were emitted
     /// This should be called after apply() to fix the finish_reason for tool call chunks
     fn fix_finish_reason<S>(
@@ -1507,13 +1468,14 @@ impl JailedStream {
             let mut has_tool_calls_per_choice: HashMap<u32, bool> = HashMap::new();
             // Choices that already received a finish_reason during the stream — used by
             // the backstop below to avoid synthesizing a duplicate.
-            let mut terminated: std::collections::HashSet<u32> = std::collections::HashSet::new();
+            let mut terminated: HashSet<u32> = HashSet::new();
             // Last response, kept (with choices cleared) as a template for a synthesized
             // finish_reason chunk when the stream ended without one.
             let mut template: Option<NvCreateChatCompletionStreamResponse> = None;
-            // Whether we have already emitted the synthesized terminal chunks (either
-            // before the usage-only chunk or at stream end), so we don't emit twice.
-            let mut synthesized = false;
+            // Choices for which this post-processor has already emitted a synthetic
+            // terminal chunk. Tracking this per choice allows a later tool-call choice
+            // to terminate even if an earlier empty-choices chunk emitted nothing.
+            let mut synthesized: HashSet<u32> = HashSet::new();
 
             while let Some(mut response) = input_stream.next().await {
                 // Track if any choice emitted tool calls, and which already terminated.
@@ -1572,17 +1534,25 @@ impl JailedStream {
                     .data
                     .as_ref()
                     .is_some_and(|d| d.inner.choices.is_empty());
-                if is_empty_choices
-                    && !synthesized
-                    && let Some(template) = &template
-                {
-                    for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| **has) {
-                        if terminated.contains(index) {
-                            continue;
-                        }
-                        yield Self::synthesize_tool_calls_chunk(template, *index);
+                if is_empty_choices && let Some(template) = &template {
+                    let mut indices: Vec<_> = has_tool_calls_per_choice
+                        .iter()
+                        .filter_map(|(index, has)| {
+                            (*has && !terminated.contains(index) && !synthesized.contains(index))
+                                .then_some(*index)
+                        })
+                        .collect();
+                    indices.sort_unstable();
+                    for index in indices {
+                        yield stream_choice_chunk_from_template(
+                            template,
+                            index,
+                            None,
+                            None,
+                            Some(FinishReason::ToolCalls),
+                        );
+                        synthesized.insert(index);
                     }
-                    synthesized = true;
                 }
 
                 yield response;
@@ -1597,12 +1567,24 @@ impl JailedStream {
             // complete; without this they hang until their client-side timeout.
             // Choices that never emitted tool calls are left alone — there
             // is no signal to invent a finish_reason from for text-only output.
-            if !synthesized && let Some(template) = template {
-                for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| **has) {
-                    if terminated.contains(index) {
-                        continue;
-                    }
-                    yield Self::synthesize_tool_calls_chunk(&template, *index);
+            if let Some(template) = template {
+                let mut indices: Vec<_> = has_tool_calls_per_choice
+                    .iter()
+                    .filter_map(|(index, has)| {
+                        (*has && !terminated.contains(index) && !synthesized.contains(index))
+                            .then_some(*index)
+                    })
+                    .collect();
+                indices.sort_unstable();
+                for index in indices {
+                    yield stream_choice_chunk_from_template(
+                        &template,
+                        index,
+                        None,
+                        None,
+                        Some(FinishReason::ToolCalls),
+                    );
+                    synthesized.insert(index);
                 }
             }
         }
@@ -1916,6 +1898,40 @@ mod tests {
             comment: None,
             error: None,
         }
+    }
+
+    /// Build one data chunk whose choices have already emitted tool-call deltas.
+    fn tool_call_choices_chunk(indices: &[u32]) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let mut chunk = text_chunk("");
+        let data = chunk.data.as_mut().expect("tool-call response data");
+        #[allow(deprecated)]
+        {
+            data.inner.choices = indices
+                .iter()
+                .map(|index| ChatChoiceStream {
+                    index: *index,
+                    delta: ChatCompletionStreamResponseDelta {
+                        role: Some(Role::Assistant),
+                        content: None,
+                        tool_calls: Some(vec![ChatCompletionMessageToolCallChunk {
+                            index: 0,
+                            id: Some(format!("call-{index}")),
+                            r#type: Some(FunctionType::Function),
+                            function: Some(FunctionCallStream {
+                                name: Some(format!("tool_{index}")),
+                                arguments: Some("{}".to_string()),
+                            }),
+                        }]),
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: None,
+                    logprobs: None,
+                })
+                .collect();
+        }
+        chunk
     }
 
     fn heartbeat() -> Annotated<NvCreateChatCompletionStreamResponse> {
@@ -2374,6 +2390,67 @@ mod tests {
         assert!(
             finish_data.llm_metrics.is_none(),
             "synthesized ToolCalls chunk must not repeat LLM metrics"
+        );
+    }
+
+    // An empty-choices chunk can precede tool deltas (for example, a metadata
+    // response). It must not disable later synthesis. When several choices then
+    // emit tool calls, their terminal chunks must be ordered by choice index.
+    #[tokio::test]
+    async fn jail_synthesizes_late_tool_choices_in_index_order() {
+        let chunks = vec![
+            usage_only_chunk(),
+            tool_call_choices_chunk(&[2, 0, 1]),
+            usage_only_chunk(),
+        ];
+
+        let responses: Vec<_> =
+            JailedStream::fix_finish_reason(stream::iter(chunks), JailMode::MarkerBased, false)
+                .collect()
+                .await;
+
+        let usage_positions: Vec<_> = responses
+            .iter()
+            .enumerate()
+            .filter_map(|(position, response)| {
+                response
+                    .data
+                    .as_ref()
+                    .is_some_and(|data| data.inner.choices.is_empty() && data.inner.usage.is_some())
+                    .then_some(position)
+            })
+            .collect();
+        assert_eq!(
+            usage_positions.len(),
+            2,
+            "both empty-choices chunks must pass through"
+        );
+
+        let terminals: Vec<_> = responses
+            .iter()
+            .enumerate()
+            .flat_map(|(position, response)| {
+                response.data.iter().flat_map(move |data| {
+                    data.inner.choices.iter().filter_map(move |choice| {
+                        (choice.finish_reason == Some(FinishReason::ToolCalls))
+                            .then_some((position, choice.index))
+                    })
+                })
+            })
+            .collect();
+        assert_eq!(
+            terminals
+                .iter()
+                .map(|(_, index)| *index)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "synthetic terminal chunks must be deterministic"
+        );
+        assert!(
+            terminals.iter().all(|(position, _)| {
+                usage_positions[0] < *position && *position < usage_positions[1]
+            }),
+            "terminal chunks must follow the early empty response and precede the final usage response"
         );
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1571,8 +1571,7 @@ impl JailedStream {
                 let is_empty_choices = response
                     .data
                     .as_ref()
-                    .map(|d| d.inner.choices.is_empty())
-                    .unwrap_or(true);
+                    .is_some_and(|d| d.inner.choices.is_empty());
                 if is_empty_choices && !synthesized {
                     if let Some(template) = &template {
                         for (index, _) in has_tool_calls_per_choice.iter().filter(|(_, has)| **has) {
@@ -1581,8 +1580,8 @@ impl JailedStream {
                             }
                             yield Self::synthesize_tool_calls_chunk(template, *index);
                         }
+                        synthesized = true;
                     }
-                    synthesized = true;
                 }
 
                 yield response;
@@ -1914,6 +1913,16 @@ mod tests {
             id: None,
             event: None,
             comment: None,
+            error: None,
+        }
+    }
+
+    fn heartbeat() -> Annotated<NvCreateChatCompletionStreamResponse> {
+        Annotated {
+            data: None,
+            id: None,
+            event: None,
+            comment: Some(vec!["heartbeat".to_string()]),
             error: None,
         }
     }
@@ -2303,6 +2312,7 @@ mod tests {
         let jail = JailedStream::builder().tool_call_parser("hermes").build();
 
         let chunks = vec![
+            heartbeat(),
             text_chunk(
                 "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"SF\"}}\n</tool_call>",
             ),
@@ -2313,6 +2323,13 @@ mod tests {
         let output_stream = jail.apply_with_finish_reason(input_stream);
 
         let responses: Vec<_> = output_stream.collect().await;
+        assert_eq!(
+            responses
+                .first()
+                .and_then(|response| response.comment.clone()),
+            Some(vec!["heartbeat".to_string()]),
+            "leading non-data annotations must pass through unchanged"
+        );
         let tool_calls = collect_tool_calls(&responses);
         assert!(
             !tool_calls.is_empty(),

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -33,7 +33,7 @@ use dynamo_parsers::tool_calling::{
 };
 use dynamo_parsers_v2::{Tool as ToolV2, ToolCallDelta, ToolParser, create_tool_parser_for_family};
 
-use super::NvCreateChatCompletionStreamResponse;
+use super::{NvCreateChatCompletionStreamResponse, stream_choice_chunk_from_template};
 
 /// Tool-call families with a `dynamo-parsers-v2` parser wired into both the batch and
 /// the streaming path. Must stay a subset of the families
@@ -184,8 +184,12 @@ fn finish_unterminated_choices(
         let state = states
             .get_mut(&index)
             .expect("choice index came from parser state map");
-        let Ok(result) = state.parser.finish() else {
-            continue;
+        let result = match state.parser.finish() {
+            Ok(result) => result,
+            Err(error) => {
+                tracing::warn!(error = %error, choice_index = index, "v2 stream finish failed");
+                dynamo_parsers_v2::ToolParseResult::default()
+            }
         };
         let tool_calls = state.emit_chunks(result.calls);
         if tool_calls.is_some() {
@@ -199,38 +203,18 @@ fn finish_unterminated_choices(
         } else {
             None
         };
-        if result.normal_text.is_empty() && tool_calls.is_none() && finish_reason.is_none() {
+        let content = (!result.normal_text.is_empty())
+            .then_some(ChatCompletionMessageContent::Text(result.normal_text));
+        if content.is_none() && tool_calls.is_none() && finish_reason.is_none() {
             continue;
         }
-
-        let mut response = template.clone();
-        // A synthesized terminal chunk must not repeat accounting data copied
-        // from a usage-only template.
-        response.inner.usage = None;
-        response.llm_metrics = None;
-        #[allow(deprecated)]
-        let choice = dynamo_protocols::types::ChatChoiceStream {
+        responses.push(stream_choice_chunk_from_template(
+            template,
             index,
-            delta: dynamo_protocols::types::ChatCompletionStreamResponseDelta {
-                role: None,
-                content: (!result.normal_text.is_empty())
-                    .then_some(ChatCompletionMessageContent::Text(result.normal_text)),
-                tool_calls,
-                function_call: None,
-                refusal: None,
-                reasoning_content: None,
-            },
+            content,
+            tool_calls,
             finish_reason,
-            logprobs: None,
-        };
-        response.inner.choices = vec![choice];
-        responses.push(Annotated {
-            data: Some(response),
-            id: None,
-            event: None,
-            comment: None,
-            error: None,
-        });
+        ));
     }
     responses
 }
@@ -397,6 +381,22 @@ mod tests {
         ChatChoiceStream, ChatCompletionStreamResponseDelta, CompletionUsage, FinishReason, Role,
     };
     use futures::stream;
+
+    struct FinishErrorParser;
+
+    impl ToolParser for FinishErrorParser {
+        fn create(_tools: &[ToolV2]) -> anyhow::Result<Box<dyn ToolParser>> {
+            Ok(Box::new(Self))
+        }
+
+        fn push(&mut self, _chunk: &str) -> anyhow::Result<dynamo_parsers_v2::ToolParseResult> {
+            Ok(dynamo_parsers_v2::ToolParseResult::default())
+        }
+
+        fn finish(&mut self) -> anyhow::Result<dynamo_parsers_v2::ToolParseResult> {
+            anyhow::bail!("intentional finish failure")
+        }
+    }
 
     const QWEN3_GET_WEATHER: &str = "<tool_call>\n<function=get_weather>\n<parameter=location>\nParis\n</parameter>\n</function>\n</tool_call>";
 
@@ -721,6 +721,44 @@ mod tests {
             final_finish_reason(&out),
             None,
             "text-only stream with no upstream finish_reason must not get a synthetic one"
+        );
+    }
+
+    #[test]
+    fn finish_error_still_terminates_a_choice_that_emitted_tools() {
+        let mut states = HashMap::from([(
+            3,
+            ChoiceState {
+                parser: Box::new(FinishErrorParser),
+                opened: HashSet::new(),
+            },
+        )]);
+        let mut finished = HashSet::new();
+        let mut tool_emitted = HashSet::from([3]);
+        let template = usage_chunk().data.expect("usage response data");
+
+        let responses =
+            finish_unterminated_choices(&mut states, &mut finished, &mut tool_emitted, &template);
+
+        assert_eq!(
+            responses.len(),
+            1,
+            "the choice still needs a terminal chunk"
+        );
+        let response = responses[0].data.as_ref().expect("terminal response data");
+        assert!(
+            response.inner.usage.is_none(),
+            "terminal chunk must not repeat usage"
+        );
+        assert!(
+            response.llm_metrics.is_none(),
+            "terminal chunk must not repeat LLM metrics"
+        );
+        assert_eq!(response.inner.choices.len(), 1);
+        assert_eq!(response.inner.choices[0].index, 3);
+        assert_eq!(
+            response.inner.choices[0].finish_reason,
+            Some(FinishReason::ToolCalls)
         );
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -286,7 +286,9 @@ where
         }
 
         // Backstop: the stream ended without a finish_reason for some choice. Flush
-        // each unfinished parser; emit a trailing chunk only when it yields output.
+        // each unfinished parser; emit a trailing chunk when the flush yields output
+        // or when the choice already emitted tool calls and still needs a terminal
+        // `ToolCalls` reason.
         if let Some(template) = template {
             for (index, state) in states.iter_mut() {
                 if finished.contains(index) {
@@ -296,8 +298,8 @@ where
                     continue;
                 };
                 let tool_calls = state.emit_chunks(result.calls);
-                if result.normal_text.is_empty() && tool_calls.is_none() {
-                    continue;
+                if tool_calls.is_some() {
+                    tool_emitted.insert(*index);
                 }
                 // A choice that produced tool calls during the stream must terminate
                 // with `ToolCalls` even when the backend never sent a finish_reason
@@ -312,6 +314,12 @@ where
                 } else {
                     None
                 };
+                if result.normal_text.is_empty()
+                    && tool_calls.is_none()
+                    && finish_reason.is_none()
+                {
+                    continue;
+                }
                 let mut response = template.clone();
                 #[allow(deprecated)]
                 let choice = dynamo_protocols::types::ChatChoiceStream {

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -307,7 +307,7 @@ where
                 // engine dropped the terminal signal). Strict OpenAI clients wait for
                 // a non-null finish_reason before considering a tool call complete;
                 // emitting `None` here left them hanging until their client-side
-                // timeout (DGH-967). Text-only output without an upstream finish
+                // timeout. Text-only output without an upstream finish
                 // reason stays `None` — we have no signal to invent one from.
                 let finish_reason = if tool_emitted.contains(index) {
                     Some(FinishReason::ToolCalls)
@@ -557,12 +557,12 @@ mod tests {
         );
     }
 
-    // DGH-967: the stream emits a complete tool call but ends WITHOUT any
-    // finish_reason chunk (e.g. speculative decoding folded EOS into content, or
-    // the engine dropped the terminal signal). A strict OpenAI client waits for a
-    // non-null finish_reason before considering the tool call complete; the
-    // end-of-stream backstop must synthesize `ToolCalls` so the client doesn't
-    // hang until its timeout.
+    // Missing-finish-reason regression: the stream emits a complete tool call but
+    // ends without any finish_reason chunk (e.g. speculative decoding folded EOS
+    // into content, or the engine dropped the terminal signal). A strict OpenAI
+    // client waits for a non-null finish_reason before considering the tool call
+    // complete; the end-of-stream backstop must synthesize `ToolCalls` so the
+    // client doesn't hang until its timeout.
     #[tokio::test]
     async fn qwen3_bypass_synthesizes_tool_calls_when_stream_lacks_finish_reason() {
         // Same call as the incremental test, but the final chunk carries NO
@@ -591,10 +591,10 @@ mod tests {
         );
     }
 
-    // DGH-967 corollary: when the stream ends without a finish_reason AND no tool
-    // call was emitted (text-only output), the backstop must NOT invent a
-    // finish_reason — there is no signal to synthesize one from. A trailing
-    // content chunk may be emitted, but its finish_reason stays None.
+    // Text-only corollary: when the stream ends without a finish_reason and no
+    // tool call was emitted, the backstop must not invent a finish_reason. There
+    // is no signal to synthesize one from. A trailing content chunk may be
+    // emitted, but its finish_reason stays None.
     #[tokio::test]
     async fn qwen3_bypass_does_not_synthesize_finish_reason_for_text_only_stream() {
         let chunks = vec![chunk("hello world", false), chunk("", false)];

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -163,6 +163,78 @@ impl ChoiceState {
     }
 }
 
+/// Finish every choice that has not received an upstream finish reason. This is
+/// called before a usage-only chunk when one exists, with EOF as a fallback.
+fn finish_unterminated_choices(
+    states: &mut HashMap<u32, ChoiceState>,
+    finished: &mut HashSet<u32>,
+    tool_emitted: &mut HashSet<u32>,
+    template: &NvCreateChatCompletionStreamResponse,
+) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
+    let mut indices: Vec<_> = states
+        .keys()
+        .copied()
+        .filter(|index| !finished.contains(index))
+        .collect();
+    indices.sort_unstable();
+
+    let mut responses = Vec::new();
+    for index in indices {
+        finished.insert(index);
+        let state = states
+            .get_mut(&index)
+            .expect("choice index came from parser state map");
+        let Ok(result) = state.parser.finish() else {
+            continue;
+        };
+        let tool_calls = state.emit_chunks(result.calls);
+        if tool_calls.is_some() {
+            tool_emitted.insert(index);
+        }
+        // A choice that produced tool calls during the stream must terminate
+        // with `ToolCalls` even when the backend never sent a finish_reason.
+        // Text-only output without an upstream finish reason stays `None`.
+        let finish_reason = if tool_emitted.contains(&index) {
+            Some(FinishReason::ToolCalls)
+        } else {
+            None
+        };
+        if result.normal_text.is_empty() && tool_calls.is_none() && finish_reason.is_none() {
+            continue;
+        }
+
+        let mut response = template.clone();
+        // A synthesized terminal chunk must not repeat accounting data copied
+        // from a usage-only template.
+        response.inner.usage = None;
+        response.llm_metrics = None;
+        #[allow(deprecated)]
+        let choice = dynamo_protocols::types::ChatChoiceStream {
+            index,
+            delta: dynamo_protocols::types::ChatCompletionStreamResponseDelta {
+                role: None,
+                content: (!result.normal_text.is_empty())
+                    .then_some(ChatCompletionMessageContent::Text(result.normal_text)),
+                tool_calls,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason,
+            logprobs: None,
+        };
+        response.inner.choices = vec![choice];
+        responses.push(Annotated {
+            data: Some(response),
+            id: None,
+            event: None,
+            comment: None,
+            error: None,
+        });
+    }
+    responses
+}
+
 /// Streaming path: replace the jail with the `family` v2 parser. Each upstream text
 /// delta is pushed into the parser; the parser's `normal_text` becomes the emitted
 /// content and its tool-call deltas become OpenAI tool-call chunks. The jail is never
@@ -213,6 +285,7 @@ where
                 t.inner.choices.clear();
                 template = Some(t);
             }
+            let is_empty_choices = chat_response.inner.choices.is_empty();
 
             for choice in chat_response.inner.choices.iter_mut() {
                 let state = states.entry(choice.index).or_insert_with(|| {
@@ -282,6 +355,21 @@ where
                 }
             }
 
+            // OpenAI stream ordering requires a terminal finish_reason before the
+            // usage-only chunk. Finish every unterminated choice before yielding an
+            // empty-choices response; EOF below remains the fallback when no such
+            // response arrives.
+            if is_empty_choices && let Some(template) = &template {
+                for terminal in finish_unterminated_choices(
+                    &mut states,
+                    &mut finished,
+                    &mut tool_emitted,
+                    template,
+                ) {
+                    yield terminal;
+                }
+            }
+
             yield response;
         }
 
@@ -289,65 +377,14 @@ where
         // each unfinished parser; emit a trailing chunk when the flush yields output
         // or when the choice already emitted tool calls and still needs a terminal
         // `ToolCalls` reason.
-        if let Some(template) = template {
-            for (index, state) in states.iter_mut() {
-                if finished.contains(index) {
-                    continue;
-                }
-                let Ok(result) = state.parser.finish() else {
-                    continue;
-                };
-                let tool_calls = state.emit_chunks(result.calls);
-                if tool_calls.is_some() {
-                    tool_emitted.insert(*index);
-                }
-                // A choice that produced tool calls during the stream must terminate
-                // with `ToolCalls` even when the backend never sent a finish_reason
-                // chunk (e.g. speculative decoding folded EOS into content, or the
-                // engine dropped the terminal signal). Strict OpenAI clients wait for
-                // a non-null finish_reason before considering a tool call complete;
-                // emitting `None` here left them hanging until their client-side
-                // timeout. Text-only output without an upstream finish
-                // reason stays `None` — we have no signal to invent one from.
-                let finish_reason = if tool_emitted.contains(index) {
-                    Some(FinishReason::ToolCalls)
-                } else {
-                    None
-                };
-                if result.normal_text.is_empty()
-                    && tool_calls.is_none()
-                    && finish_reason.is_none()
-                {
-                    continue;
-                }
-                let mut response = template.clone();
-                // A synthesized terminal chunk must not repeat accounting data
-                // copied from a usage-only template.
-                response.inner.usage = None;
-                response.llm_metrics = None;
-                #[allow(deprecated)]
-                let choice = dynamo_protocols::types::ChatChoiceStream {
-                    index: *index,
-                    delta: dynamo_protocols::types::ChatCompletionStreamResponseDelta {
-                        role: None,
-                        content: (!result.normal_text.is_empty())
-                            .then_some(ChatCompletionMessageContent::Text(result.normal_text)),
-                        tool_calls,
-                        function_call: None,
-                        refusal: None,
-                        reasoning_content: None,
-                    },
-                    finish_reason,
-                    logprobs: None,
-                };
-                response.inner.choices = vec![choice];
-                yield Annotated {
-                    data: Some(response),
-                    id: None,
-                    event: None,
-                    comment: None,
-                    error: None,
-                };
+        if let Some(template) = &template {
+            for terminal in finish_unterminated_choices(
+                &mut states,
+                &mut finished,
+                &mut tool_emitted,
+                template,
+            ) {
+                yield terminal;
             }
         }
     }
@@ -622,9 +659,39 @@ mod tests {
             Some(FinishReason::ToolCalls),
             "backstop must synthesize ToolCalls when the stream ended without a finish_reason"
         );
-        let terminal = out
-            .last()
-            .and_then(|response| response.data.as_ref())
+        let finish_positions: Vec<_> = out
+            .iter()
+            .enumerate()
+            .filter_map(|(position, response)| {
+                response.data.as_ref().and_then(|data| {
+                    data.inner
+                        .choices
+                        .iter()
+                        .any(|choice| choice.finish_reason == Some(FinishReason::ToolCalls))
+                        .then_some(position)
+                })
+            })
+            .collect();
+        assert_eq!(
+            finish_positions.len(),
+            1,
+            "expected exactly one synthesized finish chunk"
+        );
+        let usage_position =
+            out.iter()
+                .position(|response| {
+                    response.data.as_ref().is_some_and(|data| {
+                        data.inner.choices.is_empty() && data.inner.usage.is_some()
+                    })
+                })
+                .expect("usage-only response");
+        assert!(
+            finish_positions[0] < usage_position,
+            "synthesized finish chunk must precede usage"
+        );
+        let terminal = out[finish_positions[0]]
+            .data
+            .as_ref()
             .expect("synthesized terminal response");
         assert!(
             terminal.inner.usage.is_none(),

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -299,6 +299,19 @@ where
                 if result.normal_text.is_empty() && tool_calls.is_none() {
                     continue;
                 }
+                // A choice that produced tool calls during the stream must terminate
+                // with `ToolCalls` even when the backend never sent a finish_reason
+                // chunk (e.g. speculative decoding folded EOS into content, or the
+                // engine dropped the terminal signal). Strict OpenAI clients wait for
+                // a non-null finish_reason before considering a tool call complete;
+                // emitting `None` here left them hanging until their client-side
+                // timeout (DGH-967). Text-only output without an upstream finish
+                // reason stays `None` — we have no signal to invent one from.
+                let finish_reason = if tool_emitted.contains(index) {
+                    Some(FinishReason::ToolCalls)
+                } else {
+                    None
+                };
                 let mut response = template.clone();
                 #[allow(deprecated)]
                 let choice = dynamo_protocols::types::ChatChoiceStream {
@@ -312,7 +325,7 @@ where
                         refusal: None,
                         reasoning_content: None,
                     },
-                    finish_reason: None,
+                    finish_reason,
                     logprobs: None,
                 };
                 response.inner.choices = vec![choice];
@@ -533,6 +546,61 @@ mod tests {
             final_finish_reason(&out),
             Some(FinishReason::ToolCalls),
             "finish_reason must flip Stop->ToolCalls when tool calls are emitted"
+        );
+    }
+
+    // DGH-967: the stream emits a complete tool call but ends WITHOUT any
+    // finish_reason chunk (e.g. speculative decoding folded EOS into content, or
+    // the engine dropped the terminal signal). A strict OpenAI client waits for a
+    // non-null finish_reason before considering the tool call complete; the
+    // end-of-stream backstop must synthesize `ToolCalls` so the client doesn't
+    // hang until its timeout.
+    #[tokio::test]
+    async fn qwen3_bypass_synthesizes_tool_calls_when_stream_lacks_finish_reason() {
+        // Same call as the incremental test, but the final chunk carries NO
+        // finish_reason — the stream simply ends after the tool markup.
+        let mut chunks: Vec<_> = QWEN3_GET_WEATHER
+            .as_bytes()
+            .chunks(8)
+            .map(|b| chunk(std::str::from_utf8(b).unwrap(), false))
+            .collect();
+        // Trailing empty chunk with finish=false — no finish_reason at all.
+        chunks.push(chunk("", false));
+
+        let out: Vec<_> = apply_stream(stream::iter(chunks), None, "qwen3_coder".to_string())
+            .collect::<Vec<_>>()
+            .await;
+
+        let (calls, _content) = reassemble(&out);
+        assert_eq!(calls.len(), 1, "expected exactly one tool call: {calls:?}");
+        assert_eq!(calls[0].0, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+        assert_eq!(args["location"], "Paris");
+        assert_eq!(
+            final_finish_reason(&out),
+            Some(FinishReason::ToolCalls),
+            "backstop must synthesize ToolCalls when the stream ended without a finish_reason"
+        );
+    }
+
+    // DGH-967 corollary: when the stream ends without a finish_reason AND no tool
+    // call was emitted (text-only output), the backstop must NOT invent a
+    // finish_reason — there is no signal to synthesize one from. A trailing
+    // content chunk may be emitted, but its finish_reason stays None.
+    #[tokio::test]
+    async fn qwen3_bypass_does_not_synthesize_finish_reason_for_text_only_stream() {
+        let chunks = vec![chunk("hello world", false), chunk("", false)];
+
+        let out: Vec<_> = apply_stream(stream::iter(chunks), None, "qwen3_coder".to_string())
+            .collect::<Vec<_>>()
+            .await;
+
+        let (calls, _content) = reassemble(&out);
+        assert!(calls.is_empty(), "no tool calls expected: {calls:?}");
+        assert_eq!(
+            final_finish_reason(&out),
+            None,
+            "text-only stream with no upstream finish_reason must not get a synthetic one"
         );
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -321,6 +321,10 @@ where
                     continue;
                 }
                 let mut response = template.clone();
+                // A synthesized terminal chunk must not repeat accounting data
+                // copied from a usage-only template.
+                response.inner.usage = None;
+                response.llm_metrics = None;
                 #[allow(deprecated)]
                 let choice = dynamo_protocols::types::ChatChoiceStream {
                     index: *index,
@@ -353,7 +357,7 @@ where
 mod tests {
     use super::*;
     use dynamo_protocols::types::{
-        ChatChoiceStream, ChatCompletionStreamResponseDelta, FinishReason, Role,
+        ChatChoiceStream, ChatCompletionStreamResponseDelta, CompletionUsage, FinishReason, Role,
     };
     use futures::stream;
 
@@ -398,6 +402,35 @@ mod tests {
             comment: None,
             error: None,
         }
+    }
+
+    fn usage_chunk() -> Annotated<NvCreateChatCompletionStreamResponse> {
+        let mut chunk = chunk("", false);
+        let data = chunk.data.as_mut().expect("usage chunk response data");
+        data.inner.choices.clear();
+        data.inner.usage = Some(CompletionUsage {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: 15,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+        data.llm_metrics = Some(crate::protocols::common::metrics::LLMMetricAnnotation {
+            input_tokens: 10,
+            output_tokens: 5,
+            chunk_tokens: 0,
+            cached_tokens: None,
+            prefill_worker_id: None,
+            prefill_dp_rank: None,
+            prefill_worker_type: None,
+            decode_worker_id: None,
+            decode_dp_rank: None,
+            decode_worker_type: None,
+            tokenize_latency: None,
+            detokenize_total_latency: None,
+            detokenize_count: None,
+        });
+        chunk
     }
 
     /// Reassemble the streamed tool-call deltas into (name, arguments) per index and
@@ -572,8 +605,8 @@ mod tests {
             .chunks(8)
             .map(|b| chunk(std::str::from_utf8(b).unwrap(), false))
             .collect();
-        // Trailing empty chunk with finish=false — no finish_reason at all.
-        chunks.push(chunk("", false));
+        // A usage-only chunk arrives without any terminating choice.
+        chunks.push(usage_chunk());
 
         let out: Vec<_> = apply_stream(stream::iter(chunks), None, "qwen3_coder".to_string())
             .collect::<Vec<_>>()
@@ -588,6 +621,18 @@ mod tests {
             final_finish_reason(&out),
             Some(FinishReason::ToolCalls),
             "backstop must synthesize ToolCalls when the stream ended without a finish_reason"
+        );
+        let terminal = out
+            .last()
+            .and_then(|response| response.data.as_ref())
+            .expect("synthesized terminal response");
+        assert!(
+            terminal.inner.usage.is_none(),
+            "synthesized terminal chunk must not repeat usage"
+        );
+        assert!(
+            terminal.llm_metrics.is_none(),
+            "synthesized terminal chunk must not repeat LLM metrics"
         );
     }
 

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -1107,6 +1107,29 @@ mod tests {
     }
 
     #[test]
+    fn test_function_call_finish_reason_closes_tool_call() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+        let _ = conv.emit_start_events();
+
+        let _ = conv.process_chunk(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("get_weather"),
+            Some("{\"city\":\"SF\"}"),
+        ));
+
+        let finish_types =
+            event_types(&conv.process_chunk(&finish_chunk(FinishReason::FunctionCall)));
+        assert_eq!(
+            finish_types,
+            vec![
+                "response.function_call_arguments.done".to_string(),
+                "response.output_item.done".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn test_identity_only_tool_call_is_emitted_and_finished() {
         let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
         let _ = conv.emit_start_events();

--- a/lib/llm/tests/common/http_harness.rs
+++ b/lib/llm/tests/common/http_harness.rs
@@ -139,6 +139,7 @@ pub async fn load_sse_fixture(path: impl AsRef<Path>) -> Result<Script> {
             format!("failed to decode SSE framing in fixture {}", path.display())
         })?;
         match message.data.as_deref() {
+            Some("[DONE]") => break,
             Some(_) => chunks.push(message.decode_data::<NvCreateChatCompletionStreamResponse>()?),
             None => {
                 return Err(anyhow!(

--- a/lib/llm/tests/responses_http_replay.rs
+++ b/lib/llm/tests/responses_http_replay.rs
@@ -415,6 +415,10 @@ async fn function_call_output_round_trip_reaches_the_chat_engine() {
             .find(|item| item["type"] == "function_call")
             .expect("first response did not contain a function call")
             .clone();
+        let call_id = function_call["call_id"]
+            .as_str()
+            .expect("function call missing call_id")
+            .to_string();
 
         let second_response = post_responses(
             &svc,
@@ -428,7 +432,7 @@ async fn function_call_output_round_trip_reaches_the_chat_engine() {
                     function_call,
                     {
                         "type": "function_call_output",
-                        "call_id": "call_list_directory",
+                        "call_id": call_id,
                         "output": "[\"a.txt\"]"
                     }
                 ]

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -322,7 +322,7 @@ mod tests {
         }
 
         /// Assert that a stream with tool calls but no upstream finish chunk ends
-        /// with the synthesized `ToolCalls` terminal chunk required by DGH-967.
+        /// with the synthesized `ToolCalls` terminal chunk required by strict clients.
         pub fn assert_synthesized_tool_calls_finish(
             results: &[Annotated<NvCreateChatCompletionStreamResponse>],
             expected_prefix_chunks: usize,

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -321,6 +321,40 @@ mod tests {
             }
         }
 
+        /// Assert that a stream with tool calls but no upstream finish chunk ends
+        /// with the synthesized `ToolCalls` terminal chunk required by DGH-967.
+        pub fn assert_synthesized_tool_calls_finish(
+            results: &[Annotated<NvCreateChatCompletionStreamResponse>],
+            expected_prefix_chunks: usize,
+            index: u32,
+        ) {
+            assert_eq!(
+                results.len(),
+                expected_prefix_chunks + 1,
+                "expected {expected_prefix_chunks} content/tool-call chunks followed by one synthesized terminal chunk"
+            );
+
+            let choice = results
+                .last()
+                .and_then(|result| result.data.as_ref())
+                .and_then(|data| data.inner.choices.first())
+                .expect("expected a synthesized terminal choice");
+            assert_eq!(choice.index, index, "terminal choice index mismatch");
+            assert_eq!(
+                choice.finish_reason,
+                Some(FinishReason::ToolCalls),
+                "missing synthesized ToolCalls finish reason"
+            );
+            assert!(
+                choice.delta.content.is_none(),
+                "synthesized terminal chunk must not contain content"
+            );
+            assert!(
+                choice.delta.tool_calls.is_none(),
+                "synthesized terminal chunk must not repeat tool calls"
+            );
+        }
+
         /// Helper to assert no content or tool calls (for accumulated chunks)
         #[allow(dead_code)]
         pub fn assert_empty_emission(result: &Annotated<NvCreateChatCompletionStreamResponse>) {
@@ -549,7 +583,7 @@ mod tests {
     async fn test_jailed_stream_early_exit() {
         // Tests detection of complete tool call with unjail in same chunk as the end marker
         // Input: "<TOOLCALL>" + "[{\"name\": \"test\", " + "\"arguments\": {}}]" + "</TOOLCALL>More text"
-        // Expected output: 2 chunks [ToolCall(), Content()]
+        // Expected output: 3 chunks [ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
             create_mock_response_chunk("[{\"name\": \"test\", ".to_string(), 0),
@@ -565,14 +599,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 2 chunks: tool call + trailing content
-        assert_eq!(
-            results.len(),
-            2,
-            "Should have tool call and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 2, 0);
 
-        // Verify exact output structure: [ToolCall(), Content()]
+        // Verify the non-terminal prefix: [ToolCall(), Content()]
         test_utils::assert_tool_call(&results[0], "test", serde_json::json!({}));
         test_utils::assert_content(&results[1], "More text");
 
@@ -640,7 +669,7 @@ mod tests {
     async fn test_jailed_stream_hermes_parser() {
         // Tests Hermes format tool call parsing with <tool_call> markers
         // Input: "I'll help you with that. " + "<tool_call>{\"name\": \"search_web\", \"arguments\": {\"query\": \"weather today\"}}</tool_call>" + " Let me search for that."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("I'll help you with that. ".to_string(), 0),
             create_mock_response_chunk("<tool_call>".to_string(), 0),
@@ -660,14 +689,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "I'll help you with that. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -688,7 +712,7 @@ mod tests {
     async fn test_jailed_stream_mistral_parser() {
         // Tests Mistral format tool call parsing with [{ pattern
         // Input: "Sure, I can help. " + "[{\"name\": \"calculate\", \"arguments\": {\"expression\": \"2+2\"}}]" + " The calculation is done."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Sure, I can help. ".to_string(), 0),
             create_mock_response_chunk("[{".to_string(), 0),
@@ -705,14 +729,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "Sure, I can help. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -730,7 +749,7 @@ mod tests {
     async fn test_jailed_stream_mistral_parser_with_tool_calls_marker() {
         // Tests Mistral format tool call parsing with explicit [TOOL_CALLS] marker
         // Input: "Let me check that for you. " + "[TOOL_CALLS][{\"name\": \"get_time\", \"arguments\": {\"timezone\": \"UTC\"}}]" + " Here's the time."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Let me check that for you. ".to_string(), 0),
             create_mock_response_chunk("[TOOL_CALLS]".to_string(), 0),
@@ -746,14 +765,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "Let me check that for you. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -824,7 +838,7 @@ mod tests {
     async fn test_jailed_stream_phi4_parser() {
         // Tests Phi4 format tool call parsing with functools[ pattern
         // Input: "I'll analyze this data. " + "functools[{\"name\": \"analyze_data\", \"arguments\": {\"dataset\": \"sales_data\"}}]" + " Analysis complete."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("I'll analyze this data. ".to_string(), 0),
             create_mock_response_chunk("functools[".to_string(), 0),
@@ -844,14 +858,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "I'll analyze this data. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -869,7 +878,7 @@ mod tests {
     async fn test_jailed_stream_llama3_json_parser() {
         // Tests Llama3 JSON format tool call parsing with <|python_tag|> pattern
         // Input: "Let me run some code. " + "<|python_tag|>{\"name\": \"execute_code\", \"arguments\": {\"code\": \"print('Hello')\"}}" + " Done executing."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Let me run some code. ".to_string(), 0),
             create_mock_response_chunk("<|python_tag|>".to_string(), 0),
@@ -890,14 +899,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + content
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "Let me run some code. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -1003,7 +1007,8 @@ mod tests {
         // end-token to actually arrive, so this only fires at stream end.
         //
         // Input: "Starting function call. " + "<TOOLCALL>[{\"name\": \"incomplete_func\", \"arguments\": {" (no end marker)
-        // Expected output: 2 chunks [Content(), ToolCall(incomplete_func, {})]
+        // Expected output: 3 chunks
+        // [Content(), ToolCall(incomplete_func, {}), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Starting function call. ".to_string(), 0),
             create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
@@ -1021,11 +1026,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(
-            results.len(),
-            2,
-            "Should emit prefix content + recovered tool call"
-        );
+        assert_synthesized_tool_calls_finish(&results, 2, 0);
 
         test_utils::assert_content(&results[0], "Starting function call. ");
         test_utils::assert_tool_call(&results[1], "incomplete_func", serde_json::json!({}));
@@ -1073,6 +1074,7 @@ mod tests {
         // [2] Content(" Now let me get the time. ")
         // [3] ToolCall("get_time", {"timezone": "EST"})
         // [4] Content(" Both tasks completed!")
+        // [5] Finish(ToolCalls)
         let chunks = vec![
             create_mock_response_chunk("I'll help with multiple tasks. ".to_string(), 0),
             // First tool call
@@ -1102,12 +1104,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // === Verify chunk count ===
-        assert_eq!(
-            results.len(),
-            5,
-            "Should emit exactly 5 chunks as documented above"
-        );
+        assert_synthesized_tool_calls_finish(&results, 5, 0);
 
         // === Verify individual chunks ===
         assert_content(&results[0], "I'll help with multiple tasks. ");
@@ -1130,7 +1127,7 @@ mod tests {
     async fn test_jailed_stream_tool_call_across_many_chunks() {
         // Tests extreme fragmentation: tool call split across 65 individual character chunks
         // Input: "I'll process your request. " + "<TOOLCALL>[{"name": "process_data", "arguments": {}}]</TOOLCALL>" + " Processing complete!"
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("I'll process your request. ".to_string(), 0),
             create_mock_response_chunk("<".to_string(), 0),
@@ -1211,14 +1208,10 @@ mod tests {
 
         // Should consolidate extreme fragmentation into 3 clean chunks
         // Input: "I'll process your request. " + 54-char tool call + " Processing complete!"
-        // Expected output: [Content(), ToolCall(), Content()]
-        assert_eq!(
-            results.len(),
-            3,
-            "Should consolidate fragments into 3 chunks"
-        );
+        // Expected output: [Content(), ToolCall(), Content(), Finish(ToolCalls)]
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure
+        // Verify the non-terminal prefix.
         test_utils::assert_content(&results[0], "I'll process your request. ");
         test_utils::assert_tool_call(&results[1], "process_data", serde_json::json!({}));
         test_utils::assert_content(&results[2], " Processing complete!");
@@ -1353,8 +1346,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should get 2 chunks: first chunk passes through, stream end releases accumulated
-        assert_eq!(results.len(), 2, "Should have exactly 2 chunks");
+        // The first chunk passes through, stream end releases the accumulated tool
+        // call, and the finish-reason postprocessor adds its terminal chunk.
+        assert_synthesized_tool_calls_finish(&results, 2, 0);
 
         // The second chunk is the accumulated content released when stream ended
         let accumulated_chunk = &results[1];
@@ -1481,6 +1475,7 @@ mod tests {
         // [0] Content("I'll help you. ")
         // [1] ToolCall("search", {})
         // [2] Content("trailing text that should not be lost")
+        // [3] Finish(ToolCalls)
         let chunks = vec![
             create_mock_response_chunk("I'll help you. ".to_string(), 0),
             create_mock_response_chunk("<tool_call>".to_string(), 0),
@@ -1498,12 +1493,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // === Verify chunk count ===
-        assert_eq!(
-            results.len(),
-            3,
-            "Should emit exactly 3 chunks as documented above"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
         // === Verify individual chunks ===
         assert_content(&results[0], "I'll help you. ");
@@ -1523,7 +1513,7 @@ mod tests {
     async fn test_jailed_stream_early_exit_with_trailing() {
         // Tests early exit when complete tool call is detected in chunk that also contains trailing content
         // Input: "Starting task: " + "<tool_call>{\"name\": \"complete_task\", \"arguments\": {}}" + "</tool_call> Task completed successfully."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("Starting task: ".to_string(), 0),
             create_mock_response_chunk(
@@ -1540,14 +1530,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have exactly 3 chunks: content + tool call + trailing
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()]
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()]
         test_utils::assert_content(&results[0], "Starting task: ");
         test_utils::assert_tool_call(&results[1], "complete_task", serde_json::json!({}));
         test_utils::assert_content(&results[2], " Task completed successfully.");
@@ -1896,6 +1881,7 @@ mod tests {
         // Expected output:
         // [0] Content("text")  // "<TO" held as partial
         // [1] ToolCall("test", {})
+        // [2] Finish(ToolCalls)
         let chunks = vec![
             create_mock_response_chunk("text<TO".to_string(), 0),
             create_mock_response_chunk(
@@ -1913,12 +1899,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // === Verify chunk count ===
-        assert_eq!(
-            results.len(),
-            2,
-            "Should emit exactly 2 chunks: [0] 'text' content, [1] tool call"
-        );
+        assert_synthesized_tool_calls_finish(&results, 2, 0);
 
         // === Verify individual chunks ===
         assert_content(&results[0], "text");
@@ -2220,7 +2201,7 @@ mod tests {
         // "I'll call a function. "
         // + "<tool_call><function=get_weather><parameter=location>San Francisco</parameter><parameter=unit>celsius</parameter></function></tool_call>"
         // + " Done."
-        // Expected output: 3 chunks [Content(), ToolCall(), Content()]
+        // Expected output: 4 chunks [Content(), ToolCall(), Content(), Finish(ToolCalls)]
         let chunks = vec![
             create_mock_response_chunk("I'll call a function. ".to_string(), 0),
             create_mock_response_chunk("<tool_call>".to_string(), 0),
@@ -2243,13 +2224,9 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
-        // Verify exact output structure: [Content(), ToolCall(), Content()].
+        // Verify the non-terminal prefix: [Content(), ToolCall(), Content()].
         test_utils::assert_content(&results[0], "I'll call a function. ");
         test_utils::assert_tool_call(
             &results[1],
@@ -2298,7 +2275,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(results.len(), 3, "Should have 3 chunks");
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
         test_utils::assert_content(&results[0], "Let me search for that. ");
         test_utils::assert_tool_call(
@@ -2338,11 +2315,7 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        assert_eq!(
-            results.len(),
-            3,
-            "Should have content, tool call, and trailing content"
-        );
+        assert_synthesized_tool_calls_finish(&results, 3, 0);
 
         test_utils::assert_content(&results[0], "Before tool call. ");
         test_utils::assert_tool_call(


### PR DESCRIPTION
## Overview:

A streamed OpenAI chat completion can contain a complete tool call and then end without any `finish_reason` chunk. Strict clients wait for a non-null finish reason before treating the call as complete, which produced the 30-second timeout reported in DGH-967. This PR makes both chat-completions tool-call paths emit `finish_reason: "tool_calls"` when tool calls were emitted but the upstream stream omitted its terminal reason. Text-only streams do not receive an invented finish reason.

This PR follows merged PR #10988. Its diff now contains only the DGH-967 chat-completions follow-up.

## Details:

1. `JailedStream::fix_finish_reason` now emits a synthetic `ToolCalls` chunk before an empty-choices usage chunk. An end-of-stream path covers streams without a usage chunk. Synthetic terminal chunks do not copy usage or internal LLM metrics from their template.
2. `tool_parser_v2::apply_stream` now emits a finish-only terminal chunk before a usage-only response for every unterminated choice that previously emitted tool calls. End of stream remains the fallback when no usage response arrives, and synthetic chunks clear copied usage and metrics.
3. Regression coverage exercises missing finish reasons, text-only streams, usage-chunk ordering, both `ToolCalls` and legacy `FunctionCall` finish reasons, and the affected HTTP replay paths.

## Where should the reviewer start?

Start with `JailedStream::fix_finish_reason` in `lib/llm/src/protocols/openai/chat_completions/jail.rs`, then compare the v2 terminal-finalization path in `lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs`. The focused regressions are adjacent to those implementations and in `lib/llm/tests/test_jail.rs`.

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue:**

- [x] Confirmed — no related issue
- Internal tracker: [DGH-967](https://linear.app/nvidia/issue/DGH-967)
- Follow-on to #10988

## Validation

The required GitHub checks on the latest commit are the authoritative validation record. The affected coverage is GPU-free and runs within the existing `dynamo-llm` Rust test jobs.
