### PR TITLE
feat(gms): add host-tier storage contracts [GMS 06/18]

### DIFF
--- a/lib/gms_kv_ring/common/__init__.py
+++ b/lib/gms_kv_ring/common/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-process SHM primitives shared by engine + daemon."""

--- a/lib/gms_kv_ring/common/checksum.py
+++ b/lib/gms_kv_ring/common/checksum.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CRC32 over a raw memory range.
+
+The daemon computes a CRC of each host-tier slot after D2H + sync
+(offload integrity) and verifies it before H2D (restore integrity).
+This catches:
+  - DMA tearing / partial writes on the offload side
+  - Bit-flips in pinned RAM between offload and restore
+  - Stale-pointer reads (e.g., slot index races) — the CRC won't
+    match for unrelated bytes
+
+Implementation: prefer the SIMD-accelerated Rust path (gms_rust_ring,
+~25 GB/s on modern x86), fall back to stdlib zlib.crc32 (~500 MB/s).
+Both produce the same CRC32 (IEEE 802.3 polynomial).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import zlib
+
+try:
+    from gms_rust_ring import crc32_at_ptr as _rust_crc32_at_ptr
+
+    _HAS_RUST = True
+except ImportError:
+    _HAS_RUST = False
+
+
+def crc32_at_ptr(ptr: int, size: int) -> int:
+    """CRC32 (IEEE) of `size` bytes starting at raw pointer `ptr`.
+
+    Caller MUST hold a reference to the memory keeping it live for
+    the duration of this call. In daemon use, the pointer is a
+    cudaHostAlloc'd pinned buffer owned by a HostTier slot.
+
+    Returns the 32-bit CRC as a Python int."""
+    if size <= 0:
+        return 0
+    if _HAS_RUST:
+        return int(_rust_crc32_at_ptr(int(ptr), int(size)))
+    # Fallback: zero-copy view via ctypes.
+    buf = (ctypes.c_ubyte * size).from_address(int(ptr))
+    return zlib.crc32(buf) & 0xFFFFFFFF

--- a/lib/gms_kv_ring/common/counter.py
+++ b/lib/gms_kv_ring/common/counter.py
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared semaphore counter array for cuStreamWaitValue32 sync.
+
+How it works:
+
+  1. Engine creates a /dev/shm file of size N*4 bytes; mmaps it
+     MAP_SHARED; `cuMemHostRegister`s with DEVICEMAP; obtains a
+     CUdeviceptr via `cuMemHostGetDevicePointer`.
+  2. Daemon attaches the same /dev/shm file, also registers with
+     CUDA so it can use `cuStreamWriteValue32` on its CUDA stream.
+  3. Per restore, engine reserves a slot K and target value N.
+  4. Engine queues `cuStreamWaitValue32(compute_stream, counter[K],
+     N, GEQ)` BEFORE any kernel that needs the restored bytes.
+  5. Daemon does its H2D's on the daemon CUDA stream; AFTER them,
+     enqueues `cuStreamWriteValue32(daemon_stream, counter[K], N)`.
+  6. The write is stream-ordered AFTER the H2D's. When the write
+     fires, the engine's stream wait releases.
+
+Why this is better than cudaEvent IPC:
+  • No IPC event handle exchange (saves a socket round-trip).
+  • No `cudaIpcGetEventHandle` / `cudaIpcOpenEventHandle` calls.
+  • Pure GPU-side serialization once the counter array is set up.
+
+Constraints:
+  • The counter file MUST live on tmpfs (/dev/shm).
+    `cuMemHostRegister` rejects regular-fs mmaps.
+  • One counter array per engine. Engines don't share slots.
+  • Round-robin slot reuse with per-slot monotonic targets — caller
+    must wait on slot K's prior target before reusing K.
+"""
+
+from __future__ import annotations
+
+import logging
+import mmap
+import os
+import struct
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _file_size(num_counters: int) -> int:
+    raw = num_counters * 4
+    return (raw + 4095) & ~4095  # page-aligned
+
+
+class EngineCounterArray:
+    """Engine-side: owns the tmpfs file + CUDA host-registration.
+
+    Engine *waits* on counter slots via `wait_value32`. The daemon
+    *writes* slot values to signal completion.
+    """
+
+    def __init__(self, path: str, num_counters: int) -> None:
+        self.path = path
+        self.num_counters = num_counters
+        self._size = _file_size(num_counters)
+        self._fd = -1
+        self.buf: Optional[mmap.mmap] = None
+        self._host_addr: int = 0
+        self.device_ptr: int = 0
+        self._registered = False
+        self._slot_seq = 0
+        self._slot_target = [0] * num_counters
+        self._lock = threading.Lock()
+
+    @classmethod
+    def create(
+        cls,
+        path: str,
+        num_counters: int = 512,
+    ) -> "EngineCounterArray":
+        inst = cls(path, num_counters)
+        inst._open(create=True)
+        inst._register_with_cuda()
+        return inst
+
+    def _open(self, *, create: bool) -> None:
+        flags = os.O_CREAT | os.O_RDWR if create else os.O_RDWR
+        self._fd = os.open(self.path, flags, 0o600)
+        if create:
+            os.ftruncate(self._fd, self._size)
+        self.buf = mmap.mmap(
+            self._fd,
+            self._size,
+            mmap.MAP_SHARED,
+            mmap.PROT_READ | mmap.PROT_WRITE,
+        )
+        if create:
+            self.buf[:] = b"\x00" * self._size
+        import ctypes
+
+        self._host_addr = ctypes.addressof(
+            ctypes.c_char.from_buffer(self.buf),
+        )
+
+    def _register_with_cuda(self) -> None:
+        from cuda.bindings import driver as drv
+
+        flags = drv.CU_MEMHOSTREGISTER_DEVICEMAP | drv.CU_MEMHOSTREGISTER_PORTABLE
+        err = drv.cuMemHostRegister(self._host_addr, self._size, int(flags))[0]
+        if err == drv.CUresult.CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED:
+            # Same process already pinned these tmpfs pages via another
+            # mmap. That's fine — just skip re-register, get the devptr.
+            self._registered = False
+        elif err != drv.CUresult.CUDA_SUCCESS:
+            _, msg = drv.cuGetErrorString(err)
+            raise RuntimeError(
+                f"cuMemHostRegister failed: " f"{msg.decode() if msg else err}",
+            )
+        else:
+            self._registered = True
+        err, devptr = drv.cuMemHostGetDevicePointer(self._host_addr, 0)
+        if err != drv.CUresult.CUDA_SUCCESS:
+            _, msg = drv.cuGetErrorString(err)
+            raise RuntimeError(
+                f"cuMemHostGetDevicePointer failed: " f"{msg.decode() if msg else err}",
+            )
+        self.device_ptr = int(devptr)
+
+    def reserve_slot(self) -> tuple[int, int]:
+        """Reserve a (slot_idx, success_target) for one restore op.
+
+        Each reservation consumes TWO consecutive target values per
+        slot: success_target = N and failure_target = N+1. The daemon
+        writes N on success, N+1 on failure. Engine's
+        `cuStreamWaitValue32(GEQ N)` satisfies on either (so the
+        engine's compute stream doesn't hang on a daemon-side error),
+        and the engine then reads the counter host-side after sync to
+        learn the actual outcome via `restore_succeeded` on the handle.
+
+        Slots round-robin; per-slot target monotonically increases."""
+        with self._lock:
+            slot = self._slot_seq % self.num_counters
+            self._slot_seq += 1
+            return self._reserve_slot_locked(slot)
+
+    def try_reserve_completed_slot(self) -> Optional[tuple[int, int]]:
+        """Reserve a counter slot only if its prior op completed.
+
+        Returns ``None`` when every slot still has an in-flight target.
+        This prevents wrapping the fixed counter array under high
+        concurrency and reusing a slot whose previous daemon write has
+        not become visible yet.
+        """
+        with self._lock:
+            for _ in range(self.num_counters):
+                slot = self._slot_seq % self.num_counters
+                self._slot_seq += 1
+                previous_success_target = self._slot_target[slot] - 1
+                if previous_success_target > 0:
+                    if self.read_slot(slot) < previous_success_target:
+                        continue
+                return self._reserve_slot_locked(slot)
+            return None
+
+    def _reserve_slot_locked(self, slot: int) -> tuple[int, int]:
+        # Consume two values: N (success) and N+1 (failure).
+        success_target = self._slot_target[slot] + 1
+        self._slot_target[slot] += 2
+        return slot, success_target
+
+    def mark_slot_failed(self, slot: int, target: int) -> None:
+        """Host-side failure mark for a reserved slot with no daemon op.
+
+        Used when the producer reserved a slot but could not enqueue the
+        ring record. It makes the slot reusable and wakes any accidental
+        GEQ wait as a failure.
+        """
+        if not 0 <= slot < self.num_counters:
+            raise ValueError(f"slot {slot} out of range")
+        struct.pack_into("<I", self.buf, slot * 4, int(target) + 1)
+
+    def read_slot(self, slot: int) -> int:
+        """Host-side read of counter[slot]. Used post-sync by the
+        engine to learn whether a restore succeeded — daemon writes
+        target on success, target+1 on failure."""
+        if not 0 <= slot < self.num_counters:
+            raise ValueError(f"slot {slot} out of range")
+        import struct
+
+        return struct.unpack_from("<I", self.buf, slot * 4)[0]
+
+    def slot_device_ptr(self, slot: int) -> int:
+        if not 0 <= slot < self.num_counters:
+            raise ValueError(f"slot {slot} out of range")
+        return self.device_ptr + slot * 4
+
+    def wait_value32(self, stream: int, slot: int, target: int) -> None:
+        """Make `stream` wait until slot's value reaches `target` (GEQ).
+        Pure GPU sync — no host syscall."""
+        from cuda.bindings import driver as drv
+
+        addr = self.slot_device_ptr(slot)
+        err = drv.cuStreamWaitValue32(
+            stream,
+            addr,
+            int(target) & 0xFFFFFFFF,
+            int(drv.CUstreamWaitValue_flags.CU_STREAM_WAIT_VALUE_GEQ),
+        )[0]
+        if err != drv.CUresult.CUDA_SUCCESS:
+            _, msg = drv.cuGetErrorString(err)
+            raise RuntimeError(
+                f"cuStreamWaitValue32 failed: " f"{msg.decode() if msg else err}",
+            )
+
+    def close(self) -> None:
+        # Always try to unregister, even if our own register() was
+        # skipped because the pages were already pinned via a different
+        # VA in this process. If we leave a phantom pinning entry behind
+        # for the VA we're about to unmap, a later mmap of a different
+        # tmpfs file that the kernel happens to place at the same VA
+        # will see cuMemHostGetDevicePointer return a stale device
+        # pointer — and `cuStreamWaitValue32` ends up polling memory
+        # that nothing writes to. Quietly tolerate the unregister
+        # error if no pinning is recorded for this exact VA.
+        if self._host_addr:
+            try:
+                from cuda.bindings import driver as drv
+
+                drv.cuMemHostUnregister(self._host_addr)
+            except Exception:
+                pass
+            self._registered = False
+            self._host_addr = 0
+        if self.buf is not None:
+            try:
+                self.buf.close()
+            except Exception:
+                pass
+            self.buf = None
+        if self._fd >= 0:
+            try:
+                os.close(self._fd)
+            except Exception:
+                pass
+            self._fd = -1
+
+
+class DaemonCounterArray:
+    """Daemon-side: attaches the same file + uses cuStreamWriteValue32
+    to signal completion on the daemon's CUDA stream."""
+
+    def __init__(self, path: str, num_counters: int) -> None:
+        self.path = path
+        self.num_counters = num_counters
+        self._size = _file_size(num_counters)
+        self._fd = -1
+        self.buf: Optional[mmap.mmap] = None
+        self._host_addr = 0
+        self.device_ptr = 0
+        self._registered = False
+        self._in_process = False
+
+    @classmethod
+    def attach(
+        cls,
+        path: str,
+        num_counters: int = 512,
+    ) -> "DaemonCounterArray":
+        inst = cls(path, num_counters)
+        inst._open()
+        inst._register_with_cuda()
+        return inst
+
+    @classmethod
+    def attach_in_process(
+        cls,
+        host_addr: int,
+        num_counters: int = 512,
+    ) -> "DaemonCounterArray":
+        """Same-process attach: reuse the engine's already-pinned VA.
+
+        The engine's `EngineCounterArray` mmap'd the counter file and
+        called `cuMemHostRegister` with DEVICEMAP. In a same-process
+        daemon, we don't need our own mmap or register — we already
+        share the address space, and under UVA the device pointer
+        equals the host address. Just remember the host_addr and use
+        it as the device pointer.
+
+        Cross-process daemons must use `attach(path, num_counters)`
+        instead, which does its own mmap + register.
+
+        Skipping the second register also avoids the
+        CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED path entirely, which
+        is what caused phantom pinning entries to leak across tests."""
+        inst = cls("<in-process>", num_counters)
+        inst._host_addr = int(host_addr)
+        inst.device_ptr = int(host_addr)
+        inst._registered = False
+        inst._in_process = True
+        return inst
+
+    def _open(self) -> None:
+        self._fd = os.open(self.path, os.O_RDWR)
+        actual = os.fstat(self._fd).st_size
+        if actual < self.num_counters * 4:
+            os.close(self._fd)
+            raise ValueError(
+                f"counter file too small: {actual} < {self.num_counters * 4}",
+            )
+        self.buf = mmap.mmap(
+            self._fd,
+            self._size,
+            mmap.MAP_SHARED,
+            mmap.PROT_READ | mmap.PROT_WRITE,
+        )
+        import ctypes
+
+        self._host_addr = ctypes.addressof(
+            ctypes.c_char.from_buffer(self.buf),
+        )
+
+    def _register_with_cuda(self) -> None:
+        from cuda.bindings import driver as drv
+
+        flags = drv.CU_MEMHOSTREGISTER_DEVICEMAP | drv.CU_MEMHOSTREGISTER_PORTABLE
+        err = drv.cuMemHostRegister(self._host_addr, self._size, int(flags))[0]
+        if err == drv.CUresult.CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED:
+            # Same process already pinned this tmpfs region via another
+            # mmap (e.g. EngineCounterArray on the same path). Skip
+            # re-register; cuMemHostGetDevicePointer still works.
+            self._registered = False
+        elif err != drv.CUresult.CUDA_SUCCESS:
+            _, msg = drv.cuGetErrorString(err)
+            raise RuntimeError(
+                f"DaemonCounterArray cuMemHostRegister failed: "
+                f"{msg.decode() if msg else err}",
+            )
+        else:
+            self._registered = True
+        err, devptr = drv.cuMemHostGetDevicePointer(self._host_addr, 0)
+        if err != drv.CUresult.CUDA_SUCCESS:
+            _, msg = drv.cuGetErrorString(err)
+            raise RuntimeError(
+                f"DaemonCounterArray cuMemHostGetDevicePointer failed: "
+                f"{msg.decode() if msg else err}",
+            )
+        self.device_ptr = int(devptr)
+
+    def close(self) -> None:
+        if self._in_process:
+            # Engine owns the registration + mmap. Nothing to release.
+            self._host_addr = 0
+            self.device_ptr = 0
+            return
+        if self._host_addr:
+            try:
+                from cuda.bindings import driver as drv
+
+                drv.cuMemHostUnregister(self._host_addr)
+            except Exception:
+                pass
+            self._registered = False
+            self._host_addr = 0
+        if self.buf is not None:
+            try:
+                self.buf.close()
+            except Exception:
+                pass
+            self.buf = None
+        if self._fd >= 0:
+            try:
+                os.close(self._fd)
+            except Exception:
+                pass
+            self._fd = -1
+
+    def write_host(self, slot: int, value: int) -> None:
+        """Write `value` to counter[slot] directly via CPU. Caller is
+        responsible for ensuring prior GPU work (e.g. cuMemcpyBatchAsync
+        on the daemon stream) has been drained — cuStreamSynchronize
+        first if you care about ordering.
+
+        Pinned host memory mapped with DEVICEMAP is coherent: a CPU
+        store is visible to GPU reads via cuStreamWaitValue32. This
+        is the same write that cuStreamWriteValue32 would have done,
+        just from the CPU side — no devptr round-trip, no risk of
+        aliasing through a stale registration."""
+        if not 0 <= slot < self.num_counters:
+            raise ValueError(f"slot {slot} out of range")
+        import ctypes
+
+        addr = self._host_addr + slot * 4
+        if not addr:
+            raise RuntimeError("counter not attached")
+        ctypes.c_uint32.from_address(addr).value = int(value) & 0xFFFFFFFF
+
+    def write_on_stream(
+        self,
+        stream: int,
+        slot: int,
+        value: int,
+    ) -> None:
+        """Enqueue `value → counter[slot]` on the daemon stream.
+        Ordered AFTER prior async work on the same stream."""
+        if not 0 <= slot < self.num_counters:
+            raise ValueError(f"slot {slot} out of range")
+        from cuda.bindings import driver as drv
+
+        addr = self.device_ptr + slot * 4
+        err = drv.cuStreamWriteValue32(
+            stream,
+            addr,
+            int(value) & 0xFFFFFFFF,
+            0,
+        )[0]
+        if err != drv.CUresult.CUDA_SUCCESS:
+            _, msg = drv.cuGetErrorString(err)
+            raise RuntimeError(
+                f"cuStreamWriteValue32 failed: " f"{msg.decode() if msg else err}",
+            )
+
+    def read(self, slot: int) -> int:
+        if not 0 <= slot < self.num_counters:
+            raise ValueError(f"slot {slot} out of range")
+        if self._in_process:
+            import ctypes
+
+            return ctypes.c_uint32.from_address(self._host_addr + slot * 4).value
+        return struct.unpack_from("<I", self.buf, slot * 4)[0]

--- a/lib/gms_kv_ring/common/crc32_gpu.py
+++ b/lib/gms_kv_ring/common/crc32_gpu.py
@@ -1,0 +1,424 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU-side CRC32 over a device pointer (slice-by-16).
+
+Used by the GDS-direct demote path to compute the integrity stamp
+WITHOUT a D2H copy of the payload. Engine's HBM bytes go to
+storage via GPUDirect Storage; CRC is computed in situ via this
+kernel.
+
+Implementation:
+  - Parallel chunked CRC32 kernel compiled via NVRTC on first use.
+    Each thread processes a contiguous chunk using SLICE-BY-16:
+    16 bytes consumed per inner-loop iteration via 16 precomputed
+    256-entry tables (T0..T15) in __constant__ memory. The
+    last 1-15 bytes of each chunk fall through to a byte-by-byte
+    tail loop.
+  - Per-chunk CRCs land in a device buffer; we D2H the small output
+    (one u32 per thread) and combine via the Rust-side
+    `crc32_combine_chunks` helper (GF(2) matrix math, zlib-compat).
+  - Up to 256 threads × ⌈N/256⌉ bytes per thread by default. The
+    chunk_bytes is rounded up to 16 so per-thread `start = tid *
+    chunk_bytes` is 16-byte aligned (assuming the data pointer
+    itself is 16-byte aligned, which holds for torch CUDA tensors
+    and cuMemAlloc'd ranges). Aligned u32 loads compile to one
+    LDG.32 per word; without alignment the compiler emits the
+    byte-by-byte fallback that's many times slower.
+
+Tables baked into the source by `_build_slice_tables(16)`. Total
+constant memory used: 16 × 256 × 4 = 16 KB.
+
+PERF NOTE (honest):
+  Slice-by-16 gives ~2x over the original byte-by-byte kernel,
+  but on this SM86 GPU still measures slower than the D2H+CPU CRC
+  path for typical block sizes (1.8 MB: ~3 ms GPU vs ~660 µs
+  D2H+zlib). The table-lookup parallel-CRC algorithm is bottle-
+  necked by per-thread serial dependencies on the CRC state and
+  constant-memory bandwidth — adding threads helps occupancy but
+  pushes host-side combine cost up at the same rate, capping the
+  achievable speedup. To actually beat D2H+CPU, the next-level
+  optimization is PCLMUL-style polynomial folding (sm_75+ inline
+  PTX `mad.s32.lo.lo` or similar), which is a different
+  algorithm. GDS restore nevertheless uses this kernel because a
+  host round-trip defeats the GPU-direct data path.
+
+If NVRTC compilation, module load, or kernel launch fails,
+`is_available()` returns False. GPU-direct callers fail closed rather
+than copying the payload through host memory."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from importlib.util import find_spec
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ----- CRC32 lookup table (zlib polynomial, reversed) -----
+
+
+def _build_slice_tables(n_slices: int = 16) -> list[list[int]]:
+    """Build slice-by-N CRC32 tables. T[k][b] = state after
+    processing byte b followed by k zero bytes (from initial state
+    0). T[0] is the standard zlib CRC32 byte table; T[1]..T[N-1]
+    are derived by advancing T[k-1][b] through 8 zero bits.
+
+    Reversed IEEE polynomial 0xEDB88320 (zlib compatible)."""
+    poly = 0xEDB88320
+    T = [[0] * 256 for _ in range(n_slices)]
+    for b in range(256):
+        c = b
+        for _ in range(8):
+            c = (c >> 1) ^ poly if c & 1 else c >> 1
+        T[0][b] = c & 0xFFFFFFFF
+    for k in range(1, n_slices):
+        for b in range(256):
+            prev = T[k - 1][b]
+            T[k][b] = ((prev >> 8) ^ T[0][prev & 0xFF]) & 0xFFFFFFFF
+    return T
+
+
+_SLICE_TABLES = _build_slice_tables(16)
+
+
+# ----- CUDA C source (compiled by NVRTC on first use) -----
+
+
+def _kernel_source() -> str:
+    """Generate CUDA C with the 16 slice-by-N tables baked as a
+    flat __constant__ array. The kernel processes 16 bytes per
+    iteration via 16 table lookups, then falls through to byte-by-
+    byte for the 0-15 byte tail. NVRTC compiles this once per
+    process — the source is ~80 KB of hex literals but compile is
+    fast (one shot)."""
+    flat = ", ".join(f"0x{v:08x}u" for table in _SLICE_TABLES for v in table)
+    # T is laid out as T[16][256] in C — flat array of 4096 u32s,
+    # row-major so T[k][b] = T[k*256 + b].
+    return f"""
+extern "C" {{
+
+__constant__ unsigned int T[16 * 256] = {{ {flat} }};
+
+#define TBL(k, b) T[(k) * 256 + (b)]
+
+__global__ void crc32_chunks_kernel(
+    const unsigned char* __restrict__ data,
+    unsigned long long n_bytes,
+    unsigned long long chunk_bytes,
+    unsigned int* __restrict__ out_crcs)
+{{
+    unsigned long long tid =
+        (unsigned long long)blockIdx.x * (unsigned long long)blockDim.x
+        + (unsigned long long)threadIdx.x;
+    unsigned long long start = tid * chunk_bytes;
+    if (start >= n_bytes) {{
+        // Threads with no work leave out_crcs[tid] at the
+        // zero-init value. The host-side combine loop uses
+        // remaining-bytes tracking and ignores them.
+        return;
+    }}
+    unsigned long long end = start + chunk_bytes;
+    if (end > n_bytes) end = n_bytes;
+
+    unsigned int crc = 0xFFFFFFFFu;
+    unsigned long long i = start;
+
+    // Slice-by-16 main loop: consume 16 bytes per iteration.
+    // The host-side wrapper rounds chunk_bytes up to a multiple of
+    // 16 and torch / cuMemAlloc base pointers are 256-byte aligned,
+    // so `data + i` is 16-byte aligned for every iteration. Direct
+    // u32 reinterpret-cast reads compile to vectorized aligned
+    // loads (one LDG.32 per word).
+    while (i + 16 <= end) {{
+        const unsigned int* p = (const unsigned int*)(data + i);
+        unsigned int w0 = p[0];
+        unsigned int w1 = p[1];
+        unsigned int w2 = p[2];
+        unsigned int w3 = p[3];
+        unsigned int v  = crc ^ w0;
+        crc = TBL(15,  v        & 0xFFu)
+            ^ TBL(14, (v  >> 8) & 0xFFu)
+            ^ TBL(13, (v  >> 16) & 0xFFu)
+            ^ TBL(12, (v  >> 24))
+            ^ TBL(11,  w1       & 0xFFu)
+            ^ TBL(10, (w1 >> 8) & 0xFFu)
+            ^ TBL( 9, (w1 >> 16) & 0xFFu)
+            ^ TBL( 8, (w1 >> 24))
+            ^ TBL( 7,  w2       & 0xFFu)
+            ^ TBL( 6, (w2 >> 8) & 0xFFu)
+            ^ TBL( 5, (w2 >> 16) & 0xFFu)
+            ^ TBL( 4, (w2 >> 24))
+            ^ TBL( 3,  w3       & 0xFFu)
+            ^ TBL( 2, (w3 >> 8) & 0xFFu)
+            ^ TBL( 1, (w3 >> 16) & 0xFFu)
+            ^ TBL( 0, (w3 >> 24));
+        i += 16;
+    }}
+
+    // Tail: 0-15 leftover bytes byte-by-byte using T[0].
+    while (i < end) {{
+        crc = (crc >> 8) ^ TBL(0, (crc ^ (unsigned int)data[i]) & 0xFFu);
+        i += 1;
+    }}
+
+    out_crcs[tid] = crc ^ 0xFFFFFFFFu;
+}}
+
+}}  // extern "C"
+"""
+
+
+# ----- Compiled module cache (one per process) -----
+
+_lock = threading.Lock()
+_kernel: Optional[object] = None  # cuda.bindings.driver.CUfunction
+_compile_attempted = False
+_compile_error: Optional[str] = None
+
+
+_TLS = threading.local()
+
+
+def _ensure_cuda_context(device_ordinal: int = 0) -> None:
+    """Retain + push the primary CUDA context on this thread, once.
+    Mirrors the daemon's helper; we duplicate here to avoid a hot
+    import from gms_kv_ring.daemon (we live in common/)."""
+    if getattr(_TLS, "cuda_pushed", False):
+        return
+    from cuda.bindings import driver as drv
+
+    err = drv.cuInit(0)[0]
+    if err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuInit failed: {err}")
+    err, dev = drv.cuDeviceGet(device_ordinal)
+    if err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuDeviceGet failed: {err}")
+    err, ctx = drv.cuDevicePrimaryCtxRetain(dev)
+    if err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuDevicePrimaryCtxRetain failed: {err}")
+    err = drv.cuCtxPushCurrent(ctx)[0]
+    if err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuCtxPushCurrent failed: {err}")
+    _TLS.cuda_pushed = True
+
+
+def _nvrtc_arch_option(drv, nvrtc, device_ordinal: int = 0) -> bytes:
+    """Choose the newest NVRTC target supported by both compiler and GPU.
+
+    CUDA 13 no longer accepts ``compute_70``.  Conversely, an older NVRTC may
+    not know a newer GPU's native target yet.  Querying both sides lets newer
+    GPUs run compatible PTX while refusing to target an architecture newer
+    than the device.
+    """
+    err, dev = drv.cuDeviceGet(device_ordinal)
+    if err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuDeviceGet failed while selecting NVRTC arch: {err}")
+    err, major = drv.cuDeviceGetAttribute(
+        drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+        dev,
+    )
+    if err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cannot read CUDA compute-capability major: {err}")
+    err, minor = drv.cuDeviceGetAttribute(
+        drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+        dev,
+    )
+    if err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cannot read CUDA compute-capability minor: {err}")
+    device_arch = int(major) * 10 + int(minor)
+
+    target_arch = device_arch
+    get_archs = getattr(nvrtc, "nvrtcGetSupportedArchs", None)
+    if get_archs is not None:
+        arch_err, supported = get_archs()
+        if arch_err == nvrtc.nvrtcResult.NVRTC_SUCCESS and supported:
+            compatible = [int(arch) for arch in supported if int(arch) <= device_arch]
+            if not compatible:
+                raise RuntimeError(
+                    "NVRTC has no target compatible with device "
+                    f"compute_{device_arch}; supported={list(supported)}"
+                )
+            target_arch = max(compatible)
+    return f"--gpu-architecture=compute_{target_arch}".encode("ascii")
+
+
+def _compile_once() -> bool:
+    """Lazy NVRTC compile + module load. Returns True on success.
+    Subsequent calls are O(1) — the kernel handle is cached."""
+    global _kernel, _compile_attempted, _compile_error
+    with _lock:
+        if _compile_attempted:
+            return _kernel is not None
+        _compile_attempted = True
+        if find_spec("gms_rust_ring") is None:
+            _compile_error = "gms_rust_ring extension is not installed"
+            logger.warning(
+                "crc32_gpu: kernel unavailable (%s)",
+                _compile_error,
+            )
+            return False
+        try:
+            _ensure_cuda_context()
+            from cuda.bindings import driver as drv
+            from cuda.bindings import nvrtc
+
+            src = _kernel_source().encode("utf-8")
+            err, prog = nvrtc.nvrtcCreateProgram(
+                src,
+                b"crc32_chunks.cu",
+                0,
+                [],
+                [],
+            )
+            if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
+                raise RuntimeError(f"nvrtcCreateProgram failed: {err}")
+            opts = [_nvrtc_arch_option(drv, nvrtc)]
+            err = nvrtc.nvrtcCompileProgram(
+                prog,
+                len(opts),
+                opts,
+            )[0]
+            if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
+                # Read the log for the error.
+                lsz_err, log_size = nvrtc.nvrtcGetProgramLogSize(prog)
+                log = b"\x00" * log_size
+                nvrtc.nvrtcGetProgramLog(prog, log)
+                raise RuntimeError(f"nvrtcCompileProgram failed: {err} log={log!r}")
+            err, ptx_size = nvrtc.nvrtcGetPTXSize(prog)
+            if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
+                raise RuntimeError(f"nvrtcGetPTXSize failed: {err}")
+            ptx = b"\x00" * ptx_size
+            err = nvrtc.nvrtcGetPTX(prog, ptx)[0]
+            if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:
+                raise RuntimeError(f"nvrtcGetPTX failed: {err}")
+            nvrtc.nvrtcDestroyProgram(prog)
+
+            err, module = drv.cuModuleLoadData(ptx)
+            if err != drv.CUresult.CUDA_SUCCESS:
+                raise RuntimeError(f"cuModuleLoadData failed: {err}")
+            err, func = drv.cuModuleGetFunction(
+                module,
+                b"crc32_chunks_kernel",
+            )
+            if err != drv.CUresult.CUDA_SUCCESS:
+                raise RuntimeError(f"cuModuleGetFunction failed: {err}")
+            _kernel = func
+            logger.info("crc32_gpu: NVRTC kernel compiled OK")
+            return True
+        except Exception as exc:  # noqa: BLE001
+            _compile_error = str(exc)
+            logger.warning(
+                "crc32_gpu: kernel unavailable (%s)",
+                exc,
+            )
+            return False
+
+
+def is_available() -> bool:
+    """True iff the GPU CRC32 kernel can be used. Lazy-compiles on
+    first call. Subsequent calls are O(1)."""
+    return _compile_once()
+
+
+def crc32_gpu(device_ptr: int, n_bytes: int) -> int:
+    """Compute CRC32 (IEEE polynomial, zlib-compatible) over
+    `n_bytes` starting at the GPU `device_ptr`. The pointer must be
+    a valid CUdeviceptr (e.g., from `cuMemAlloc` or a torch CUDA
+    tensor's data_ptr()).
+
+    Returns the 32-bit CRC, matching `zlib.crc32(host_bytes)`.
+
+    Raises if the kernel is unavailable or the launch fails. GDS
+    callers must fail the restore rather than route payload bytes
+    through host memory."""
+    if not is_available():
+        raise RuntimeError(f"crc32_gpu kernel not available: {_compile_error}")
+    if n_bytes == 0:
+        return 0
+    from cuda.bindings import driver as drv
+    from gms_rust_ring import crc32_combine_chunks
+
+    # Choose parallelism. We want enough threads to hide latency,
+    # but not so many that the host-side combine dominates. 64
+    # threads × ~28KB chunks for a 1.8MB block, kernel ~50 µs.
+    # For very small payloads we use fewer threads.
+    # Parallelism: target enough threads to keep an SM busy. Above
+    # ~256 the host-side combine cost dominates (each combine is
+    # O(log chunk) GF(2) matrix-squarings in Rust, ~1 µs).
+    num_threads = min(
+        max(1, (n_bytes + 1023) // 1024),  # ≥1 thread per 1 KB
+        256,
+    )
+    chunk_bytes = (n_bytes + num_threads - 1) // num_threads
+    # Round chunk_bytes UP to 16 so each thread's `start = tid *
+    # chunk_bytes` is 16-byte aligned (assuming the data ptr is
+    # itself ≥16-byte aligned, which holds for torch CUDA tensors
+    # and cuMemAlloc'd ranges). Aligned loads avoid the
+    # byte-by-byte fallback the compiler emits for
+    # potentially-unaligned addresses.
+    chunk_bytes = (chunk_bytes + 15) & ~15
+    if chunk_bytes == 0:
+        chunk_bytes = 16
+
+    # Output buffer: one u32 per thread.
+    err, d_out = drv.cuMemAlloc(num_threads * 4)
+    if err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuMemAlloc({num_threads*4}) failed: {err}")
+    try:
+        # Zero the output buffer so unused thread slots stay 0
+        # (they won't write anything; combine ignores them via
+        # remaining-bytes tracking, but defensive zero anyway).
+        drv.cuMemsetD8(d_out, 0, num_threads * 4)
+
+        # Launch. CUDA kernel arg packing via ctypes.
+        import ctypes
+
+        ptr_arg = ctypes.c_void_p(int(device_ptr))
+        n_arg = ctypes.c_ulonglong(int(n_bytes))
+        chunk_arg = ctypes.c_ulonglong(int(chunk_bytes))
+        out_arg = ctypes.c_void_p(int(d_out))
+        args = (ctypes.c_void_p * 4)(
+            ctypes.addressof(ptr_arg),
+            ctypes.addressof(n_arg),
+            ctypes.addressof(chunk_arg),
+            ctypes.addressof(out_arg),
+        )
+
+        block_dim = min(num_threads, 256)
+        grid_dim = (num_threads + block_dim - 1) // block_dim
+        err = drv.cuLaunchKernel(
+            _kernel,
+            grid_dim,
+            1,
+            1,  # grid
+            block_dim,
+            1,
+            1,  # block
+            0,
+            0,  # shared mem, stream (default)
+            args,
+            0,
+        )[0]
+        if err != drv.CUresult.CUDA_SUCCESS:
+            raise RuntimeError(f"cuLaunchKernel failed: {err}")
+
+        # D2H the per-chunk CRCs. cuMemcpy synchronizes implicitly.
+        h_out = (ctypes.c_uint * num_threads)()
+        err = drv.cuMemcpyDtoH(
+            ctypes.addressof(h_out),
+            d_out,
+            num_threads * 4,
+        )[0]
+        if err != drv.CUresult.CUDA_SUCCESS:
+            raise RuntimeError(f"cuMemcpyDtoH failed: {err}")
+    finally:
+        drv.cuMemFree(d_out)
+
+    return crc32_combine_chunks(
+        list(h_out),
+        int(chunk_bytes),
+        int(n_bytes),
+    )

--- a/lib/gms_kv_ring/common/cuda_batch.py
+++ b/lib/gms_kv_ring/common/cuda_batch.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Batched H2D via cuMemcpyBatchAsync (CUDA 12.6+).
+
+The daemon does N×L cuMemcpyAsync per chunk restore. Looping them
+costs ~2 µs per call in CUDA driver overhead. Batching them via
+cuMemcpyBatchAsync drops that to one call total — measured ~4×
+speedup at N=128.
+
+Falls back gracefully on older CUDA where the API isn't available
+(caller checks `has_batch_h2d()` first).
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def has_batch_h2d() -> bool:
+    """True iff cuMemcpyBatchAsync is available in the linked CUDA."""
+    from cuda.bindings import driver as drv
+
+    return hasattr(drv, "cuMemcpyBatchAsync")
+
+
+def batch_h2d(
+    dest_vas: list[int],
+    src_host_ptrs: list[int],
+    sizes: list[int],
+    stream: int,
+) -> None:
+    """Issue N H2D copies in ONE driver call. All ops queue on `stream`.
+
+    Requires CUDA 12.6+. Caller is responsible for sync (typically via
+    cuStreamWriteValue32 enqueued after this returns).
+
+    Args lists must be same length. dest_vas are CUdeviceptr-castable
+    device addresses; src_host_ptrs are pinned-host pointers.
+    """
+    n = len(dest_vas)
+    if n == 0:
+        return
+    if len(src_host_ptrs) != n or len(sizes) != n:
+        raise ValueError(
+            f"batch_h2d length mismatch: "
+            f"dsts={n} srcs={len(src_host_ptrs)} sizes={len(sizes)}",
+        )
+
+    from cuda.bindings import driver as drv
+
+    dsts = [drv.CUdeviceptr(int(v)) for v in dest_vas]
+    srcs = [drv.CUdeviceptr(int(v)) for v in src_host_ptrs]
+    # CUmemcpyAttributes with STREAM access order — required for
+    # mixed host/device source pointers under UVA.
+    attrs = drv.CUmemcpyAttributes()
+    attrs.srcAccessOrder = drv.CUmemcpySrcAccessOrder.CU_MEMCPY_SRC_ACCESS_ORDER_STREAM
+    err = drv.cuMemcpyBatchAsync(
+        dsts,
+        srcs,
+        sizes,
+        n,
+        [attrs],
+        [0] * n,
+        1,
+        int(stream),
+    )[0]
+    if err != drv.CUresult.CUDA_SUCCESS:
+        _, msg = drv.cuGetErrorString(err)
+        raise RuntimeError(
+            f"cuMemcpyBatchAsync({n}) failed: " f"{msg.decode() if msg else err}",
+        )

--- a/lib/gms_kv_ring/common/evict_ring.py
+++ b/lib/gms_kv_ring/common/evict_ring.py
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evict ring — SPSC SHM ring for engine→daemon spill requests.
+
+Engine pushes one EvictRecord per evicted block. Daemon consumer
+drains in the background and does the actual cuMemcpyAsync D2H.
+
+Layout (one /dev/shm file, mmap'd by both processes):
+
+  ┌─ Header (64B, cache-line aligned) ──────────────────────────┐
+  │  magic        : u32  = 0x47_4D_53_45  ("GMSE")              │
+  │  version      : u32  = 1                                     │
+  │  capacity     : u32  power-of-2 record count                 │
+  │  record_size  : u32  = 512                                   │
+  │  head_seq     : u64  producer-only writes                    │
+  │  tail_seq     : u64  consumer-only writes                    │
+  │  drops        : u64  full-queue drop counter                 │
+  │  padding      : 16B                                          │
+  └──────────────────────────────────────────────────────────────┘
+  ┌─ Record (512B) ─────────────────────────────────────────────┐
+  │  seq          : u64  (non-zero ⇒ ready for consumer)         │
+  │  block_id     : u64                                          │
+  │  n_ranges     : u32                                          │
+  │  flags        : u32                                          │
+  │  ipc_event    : 64B  cudaIpcEventHandle (zeros = none)       │
+  │  ranges[24]   : each (u32 layer_idx, u32 size, u64 offset)   │
+  └──────────────────────────────────────────────────────────────┘
+
+Concurrency:
+  • Single producer (one engine eviction hook thread).
+  • Single consumer (daemon's evict ring drain thread).
+  • `head_seq` written only by producer; `tail_seq` only by consumer.
+  • Payload is written first; seq published last (release ordering).
+  • x86-TSO + GIL gives correct ordering in Python; Rust hot path
+    uses explicit AtomicU64::store(Release).
+
+Backpressure:
+  Ring full → push returns False + bumps `drops`. Caller's policy
+  decides (typically: log + skip; the engine's allocator will reuse
+  the slot anyway, just no future cache hit).
+"""
+
+from __future__ import annotations
+
+import mmap
+import os
+import struct
+from typing import Iterable, Optional
+
+# Try the native Rust hot path. Fall back to pure Python.
+try:
+    import gms_rust_ring as _RUST  # type: ignore[import-not-found]
+except Exception:
+    _RUST = None
+
+
+MAGIC = 0x4754_4D53  # bytes "GMSE" in little-endian
+VERSION = 1
+HEADER_SIZE = 64
+RECORD_SIZE = 512
+MAX_RANGES = 24
+
+_OFF_MAGIC = 0
+_OFF_VERSION = 4
+_OFF_CAPACITY = 8
+_OFF_RECORD_SIZE = 12
+_OFF_HEAD = 16
+_OFF_TAIL = 24
+_OFF_DROPS = 32
+
+_R_SEQ = 0
+_R_BLOCK_ID = 8
+_R_N_RANGES = 16
+_R_FLAGS = 20
+_R_IPC_EVENT = 24
+_R_RANGES = 88
+_RANGE_STRIDE = 16
+# Evict-ack fields (placed in the record's tail slack, after the
+# 24-range slot region which ends at _R_RANGES + 24*16 = 472):
+#   counter_slot   = u32 @ 472   — engine's counter slot for ack
+#   counter_target = u32 @ 476   — daemon writes this on success,
+#                                  target+1 on failure. 0/0 means
+#                                  the engine doesn't want an ack
+#                                  (legacy fire-and-forget path).
+#   generation     = u64 @ 480   — source block generation for host-tier
+#                                  restore validation. 0 means legacy/no check.
+_R_COUNTER_SLOT = 472
+_R_COUNTER_TARGET = 476
+_R_GENERATION = 480
+
+
+def _is_pow2(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def create_ring(path: str, capacity: int = 8192) -> "EvictRingWriter":
+    """Create a fresh ring file at `path`. Capacity must be power of 2."""
+    if not _is_pow2(capacity):
+        raise ValueError(f"capacity must be power-of-2: got {capacity}")
+    size = HEADER_SIZE + capacity * RECORD_SIZE
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        os.ftruncate(fd, size)
+        buf = mmap.mmap(fd, size, mmap.MAP_SHARED, mmap.PROT_READ | mmap.PROT_WRITE)
+        struct.pack_into(
+            "<IIIIQQQ",
+            buf,
+            0,
+            MAGIC,
+            VERSION,
+            capacity,
+            RECORD_SIZE,
+            0,
+            0,
+            0,
+        )
+    finally:
+        os.close(fd)
+    return EvictRingWriter(path, buf, capacity)
+
+
+def attach_writer(path: str) -> "EvictRingWriter":
+    return _attach(path, EvictRingWriter)
+
+
+def attach_reader(path: str) -> "EvictRingReader":
+    return _attach(path, EvictRingReader)
+
+
+def _attach(path: str, cls):
+    fd = os.open(path, os.O_RDWR)
+    try:
+        size = os.fstat(fd).st_size
+        if size < HEADER_SIZE:
+            raise ValueError(f"ring file too small: {size} < {HEADER_SIZE}")
+        buf = mmap.mmap(fd, size, mmap.MAP_SHARED, mmap.PROT_READ | mmap.PROT_WRITE)
+    finally:
+        os.close(fd)
+    magic, version, capacity, rec_size, _h, _t, _d = struct.unpack_from(
+        "<IIIIQQQ",
+        buf,
+        0,
+    )
+    error = None
+    if magic != MAGIC:
+        error = f"bad magic 0x{magic:x}: not a GMSE ring"
+    elif version != VERSION:
+        error = f"version mismatch: {version} != {VERSION}"
+    elif not _is_pow2(capacity):
+        error = f"capacity must be power-of-2: got {capacity}"
+    elif rec_size != RECORD_SIZE:
+        error = f"record_size mismatch: {rec_size} != {RECORD_SIZE}"
+    else:
+        expected_size = HEADER_SIZE + capacity * rec_size
+        if size != expected_size:
+            error = f"ring size mismatch: {size} != {expected_size}"
+    if error is not None:
+        buf.close()
+        raise ValueError(error)
+    return cls(path, buf, capacity)
+
+
+class _RingBase:
+    def __init__(self, path: str, buf: mmap.mmap, capacity: int) -> None:
+        self.path = path
+        self.buf = buf
+        self.capacity = capacity
+        self._mask = capacity - 1
+
+    def close(self) -> None:
+        if self.buf is not None:
+            try:
+                self.buf.close()
+            except Exception:
+                pass
+            self.buf = None
+
+    def stats(self) -> dict:
+        return {
+            "head": struct.unpack_from("<Q", self.buf, _OFF_HEAD)[0],
+            "tail": struct.unpack_from("<Q", self.buf, _OFF_TAIL)[0],
+            "drops": struct.unpack_from("<Q", self.buf, _OFF_DROPS)[0],
+            "capacity": self.capacity,
+        }
+
+
+class EvictRingWriter(_RingBase):
+    """Engine-side producer. Single thread only.
+
+    Use `push(block_id, ranges, ipc_event_handle)` to enqueue one
+    eviction. Returns True on success; False if the ring is full
+    (drops counter incremented).
+    """
+
+    def push(
+        self,
+        block_id: int,
+        ranges: Iterable[tuple],
+        ipc_event_handle: bytes = b"",
+        flags: int = 0,
+        counter_slot: int = 0,
+        counter_target: int = 0,
+        generation: int = 0,
+    ) -> bool:
+        """Push one evict record. Optional `counter_slot`/`counter_target`
+        request a host-side completion ack: the daemon writes
+        `counter_target` to counter[counter_slot] after the D2H is
+        synced, or `counter_target+1` on failure. Pass 0/0 to opt out
+        (legacy fire-and-forget path, unsafe if the engine plans to
+        reuse the HBM slot before the DMA completes)."""
+        ranges_list = list(ranges)
+        if len(ranges_list) > MAX_RANGES:
+            raise ValueError(
+                f"too many ranges per record: {len(ranges_list)} > {MAX_RANGES}",
+            )
+        if len(ipc_event_handle) not in (0, 64):
+            raise ValueError(
+                f"ipc_event_handle must be 0 or 64 bytes, got {len(ipc_event_handle)}",
+            )
+
+        head = struct.unpack_from("<Q", self.buf, _OFF_HEAD)[0]
+        tail = struct.unpack_from("<Q", self.buf, _OFF_TAIL)[0]
+        if head - tail >= self.capacity:
+            drops = struct.unpack_from("<Q", self.buf, _OFF_DROPS)[0]
+            struct.pack_into("<Q", self.buf, _OFF_DROPS, drops + 1)
+            return False
+
+        slot = head & self._mask
+        base = HEADER_SIZE + slot * RECORD_SIZE
+
+        # Zero the seq first — a half-written record must not be seen.
+        struct.pack_into("<Q", self.buf, base + _R_SEQ, 0)
+        struct.pack_into(
+            "<QII",
+            self.buf,
+            base + _R_BLOCK_ID,
+            int(block_id),
+            len(ranges_list),
+            int(flags) & 0xFFFFFFFF,
+        )
+        # ipc_event field — zero-fill then copy.
+        self.buf[base + _R_IPC_EVENT : base + _R_IPC_EVENT + 64] = (
+            ipc_event_handle.ljust(64, b"\x00") if ipc_event_handle else b"\x00" * 64
+        )
+        for i, (layer_idx, size, offset) in enumerate(ranges_list):
+            struct.pack_into(
+                "<IIQ",
+                self.buf,
+                base + _R_RANGES + i * _RANGE_STRIDE,
+                int(layer_idx),
+                int(size),
+                int(offset),
+            )
+        # Zero unused range slots (defensive).
+        for i in range(len(ranges_list), MAX_RANGES):
+            struct.pack_into(
+                "<IIQ",
+                self.buf,
+                base + _R_RANGES + i * _RANGE_STRIDE,
+                0,
+                0,
+                0,
+            )
+        # Evict-ack fields.
+        struct.pack_into(
+            "<II",
+            self.buf,
+            base + _R_COUNTER_SLOT,
+            int(counter_slot) & 0xFFFFFFFF,
+            int(counter_target) & 0xFFFFFFFF,
+        )
+        struct.pack_into(
+            "<Q",
+            self.buf,
+            base + _R_GENERATION,
+            int(generation) & 0xFFFFFFFFFFFFFFFF,
+        )
+
+        # Release: seq AFTER payload. x86-TSO + GIL keeps this ordered.
+        struct.pack_into("<Q", self.buf, base + _R_SEQ, head + 1)
+        struct.pack_into("<Q", self.buf, _OFF_HEAD, head + 1)
+        return True
+
+
+class EvictRingReader(_RingBase):
+    """Daemon-side consumer. Single thread only.
+
+    `try_pop()` returns the next record or None if empty.
+    """
+
+    def try_pop(self) -> Optional[dict]:
+        tail = struct.unpack_from("<Q", self.buf, _OFF_TAIL)[0]
+        head = struct.unpack_from("<Q", self.buf, _OFF_HEAD)[0]
+        if tail >= head:
+            return None
+        slot = tail & self._mask
+        base = HEADER_SIZE + slot * RECORD_SIZE
+        seq = struct.unpack_from("<Q", self.buf, base + _R_SEQ)[0]
+        if seq != tail + 1:
+            return None  # producer hasn't released yet
+
+        block_id, n_ranges, flags = struct.unpack_from(
+            "<QII",
+            self.buf,
+            base + _R_BLOCK_ID,
+        )
+        ipc_event = bytes(self.buf[base + _R_IPC_EVENT : base + _R_IPC_EVENT + 64])
+        if ipc_event == b"\x00" * 64:
+            ipc_event = b""
+        n_ranges = min(int(n_ranges), MAX_RANGES)
+        ranges = []
+        for i in range(n_ranges):
+            li, sz, off = struct.unpack_from(
+                "<IIQ",
+                self.buf,
+                base + _R_RANGES + i * _RANGE_STRIDE,
+            )
+            ranges.append((int(li), int(sz), int(off)))
+
+        counter_slot, counter_target = struct.unpack_from(
+            "<II",
+            self.buf,
+            base + _R_COUNTER_SLOT,
+        )
+        (generation,) = struct.unpack_from("<Q", self.buf, base + _R_GENERATION)
+        struct.pack_into("<Q", self.buf, _OFF_TAIL, tail + 1)
+        return {
+            "block_id": int(block_id),
+            "ranges": ranges,
+            "flags": int(flags),
+            "ipc_event": ipc_event,
+            "counter_slot": int(counter_slot),
+            "counter_target": int(counter_target),
+            "generation": int(generation),
+        }

--- a/lib/gms_kv_ring/common/metrics.py
+++ b/lib/gms_kv_ring/common/metrics.py
@@ -1,0 +1,481 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tiny metrics registry + Prometheus text exporter.
+
+Why not just use `prometheus_client`: we want zero non-stdlib
+dependencies on the daemon's hot path. The counters here are pure
+Python (atomic int via Lock, fine for the consumer-thread cadence).
+
+Usage:
+
+    from gms_kv_ring.common import metrics
+    metrics.evict_records.inc(engine_id="eng-A", n=1)
+    metrics.evict_d2h_bytes.inc(engine_id="eng-A", n=4096)
+
+    # Anywhere:
+    text = metrics.render_prometheus()
+    # or expose over HTTP:
+    server = metrics.serve_http("0.0.0.0", 9090)
+    ...
+    server.shutdown()
+"""
+
+from __future__ import annotations
+
+import http.server
+import socketserver
+import threading
+from typing import Optional
+
+
+class Counter:
+    """Monotonic counter with one optional string label dimension.
+
+    We deliberately keep this at *one* label (typically engine_id).
+    A real metrics library handles arbitrary label sets; we don't
+    need that here, and limiting it keeps the code dumb-simple."""
+
+    def __init__(
+        self, name: str, help_text: str, label_name: Optional[str] = None
+    ) -> None:
+        self.name = name
+        self.help_text = help_text
+        self.label_name = label_name
+        self._values: dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def inc(self, **labels) -> None:
+        n = int(labels.pop("n", 1))
+        key = self._key(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0) + n
+
+    def set(self, value: int, **labels) -> None:
+        key = self._key(labels)
+        with self._lock:
+            self._values[key] = int(value)
+
+    def get(self, **labels) -> int:
+        key = self._key(labels)
+        with self._lock:
+            return self._values.get(key, 0)
+
+    def _key(self, labels: dict) -> str:
+        if not self.label_name:
+            if labels:
+                raise ValueError(f"{self.name}: counter has no label, got {labels}")
+            return ""
+        if list(labels.keys()) != [self.label_name]:
+            raise ValueError(
+                f"{self.name}: expected single label {self.label_name!r}, "
+                f"got {list(labels.keys())}"
+            )
+        return str(labels[self.label_name])
+
+    def render(self) -> str:
+        out = [
+            f"# HELP {self.name} {self.help_text}",
+            f"# TYPE {self.name} counter",
+        ]
+        with self._lock:
+            items = list(self._values.items())
+        for key, val in items:
+            if self.label_name:
+                out.append(f'{self.name}{{{self.label_name}="{key}"}} {val}')
+            else:
+                out.append(f"{self.name} {val}")
+        return "\n".join(out) + "\n"
+
+
+# ----- registry -----
+
+_ALL_COUNTERS: list[Counter] = []
+
+
+def _register(c: Counter) -> Counter:
+    _ALL_COUNTERS.append(c)
+    return c
+
+
+evict_records = _register(
+    Counter(
+        "gms_kvr_evict_records_total",
+        "Evict ring records consumed by the daemon",
+        label_name="engine_id",
+    )
+)
+evict_d2h_bytes = _register(
+    Counter(
+        "gms_kvr_evict_d2h_bytes_total",
+        "Bytes copied D2H by the evict consumer",
+        label_name="engine_id",
+    )
+)
+evict_errors = _register(
+    Counter(
+        "gms_kvr_evict_errors_total",
+        "cuMemcpyAsync D2H errors during evict consumption",
+        label_name="engine_id",
+    )
+)
+restore_records = _register(
+    Counter(
+        "gms_kvr_restore_records_total",
+        "Restore ring records consumed by the daemon",
+        label_name="engine_id",
+    )
+)
+restore_failures = _register(
+    Counter(
+        "gms_kvr_restore_failures_total",
+        "Restores that signalled failure (target+1) to the engine — "
+        "missing host_tier slot, H2D error, or sync error",
+        label_name="engine_id",
+    )
+)
+restore_h2d_bytes = _register(
+    Counter(
+        "gms_kvr_restore_h2d_bytes_total",
+        "Bytes copied H2D by the restore consumer",
+        label_name="engine_id",
+    )
+)
+ring_drops = _register(
+    Counter(
+        "gms_kvr_ring_drops_total",
+        "Records dropped because the ring was full (engine producer)",
+        label_name="ring_type",
+    )
+)
+host_tier_leaked_slots = _register(
+    Counter(
+        "gms_kvr_host_tier_leaked_slots_total",
+        "Host-tier slots intentionally leaked (index dropped, buffer NOT "
+        "freed) because stream sync failed at detach — prevents "
+        "cudaFreeHost-during-DMA undefined behavior. Process restart "
+        "reclaims.",
+        label_name="engine_id",
+    )
+)
+host_tier_slots = _register(
+    Counter(
+        "gms_kvr_host_tier_slots",
+        "Current host-tier slot count (gauge — set, not incremented)",
+        label_name="engine_id",
+    )
+)
+checksum_mismatches = _register(
+    Counter(
+        "gms_kvr_checksum_mismatches_total",
+        "Host-tier slot CRC32 mismatches detected on restore — indicates "
+        "the offloaded bytes were corrupted between evict and restore "
+        "(DMA tear, bitrot, or stale slot read). Restore signals failure "
+        "to the engine on mismatch.",
+        label_name="engine_id",
+    )
+)
+storage_tier_slots = _register(
+    Counter(
+        "gms_kvr_storage_tier_slots",
+        "Current storage-tier (filesystem) slot count (gauge — set, not "
+        "incremented). One slot per demoted (engine_id, layer, offset).",
+        label_name="engine_id",
+    )
+)
+storage_tier_promote_failures = _register(
+    Counter(
+        "gms_kvr_storage_tier_promote_failures_total",
+        "Storage-tier promote failures — file missing, header malformed, "
+        "or CRC mismatch (at-rest corruption).",
+        label_name="engine_id",
+    )
+)
+storage_tier_evictions = _register(
+    Counter(
+        "gms_kvr_storage_tier_evictions_total",
+        "Storage-tier slots evicted by operator-driven cleanup — sum of "
+        "TTL prune + byte-quota enforcement + explicit release.",
+        label_name="reason",
+    )
+)
+storage_tier_bytes = _register(
+    Counter(
+        "gms_kvr_storage_tier_bytes",
+        "Total payload bytes resident in the storage tier (gauge).",
+    )
+)
+backend_call_failures = _register(
+    Counter(
+        "gms_kvr_backend_call_failures_total",
+        "Python exceptions raised by a supervised storage backend method. "
+        "Labeled by backend name; method name is in the log line.",
+        label_name="backend",
+    )
+)
+backend_restarts = _register(
+    Counter(
+        "gms_kvr_backend_restarts_total",
+        "Supervised storage backend re-instantiations after persistent "
+        "Python-level failures. Process-level (C SIGSEGV) crashes are NOT "
+        "counted here — they kill the daemon.",
+        label_name="backend",
+    )
+)
+mooncake_manifest_compactions = _register(
+    Counter(
+        "gms_kvr_mooncake_manifest_compactions_total",
+        "MooncakeBackend manifest compactions (sidecar JSONL rewrites).",
+    )
+)
+demote_hbm_overlapped = _register(
+    Counter(
+        "gms_kvr_demote_hbm_overlapped_total",
+        "demote_hbm_to_storage calls that used the overlapped fast "
+        "path (GDS write concurrent with async D2H+CPU CRC).",
+        label_name="engine_id",
+    )
+)
+demote_hbm_sync = _register(
+    Counter(
+        "gms_kvr_demote_hbm_sync_total",
+        "demote_hbm_to_storage calls that used the synchronous "
+        "fallback (CRC pre-computed before GDS write).",
+        label_name="engine_id",
+    )
+)
+promote_hbm_ok = _register(
+    Counter(
+        "gms_kvr_promote_hbm_ok_total",
+        "promote_storage_to_hbm calls that completed with verified "
+        "CRC. Engine consumes the HBM bytes.",
+        label_name="engine_id",
+    )
+)
+promote_hbm_failures = _register(
+    Counter(
+        "gms_kvr_promote_hbm_failures_total",
+        "promote_storage_to_hbm calls that failed verification "
+        "(slot missing, header mismatch, CRC mismatch). Engine falls "
+        "to cold compute.",
+        label_name="engine_id",
+    )
+)
+daemon_engine_attaches = _register(
+    Counter(
+        "gms_kvr_daemon_engine_attaches_total",
+        "Engine pool attach RPCs accepted by the daemon. A rising rate "
+        "for the same engine_id usually means process restart, failover, "
+        "or a supervisor crash loop.",
+        label_name="engine_id",
+    )
+)
+daemon_engine_detaches = _register(
+    Counter(
+        "gms_kvr_daemon_engine_detaches_total",
+        "Engine pool detach operations completed by the daemon. Pair "
+        "with attach counts to detect unbalanced lifecycle churn.",
+        label_name="engine_id",
+    )
+)
+daemon_engine_reattaches = _register(
+    Counter(
+        "gms_kvr_daemon_engine_reattaches_total",
+        "Attach RPCs that replaced an already-attached pool for the "
+        "same engine_id. This should be rare outside restart/failover "
+        "tests; sustained increases indicate duplicate owners or a "
+        "flapping engine supervisor.",
+        label_name="engine_id",
+    )
+)
+daemon_storage_releases = _register(
+    Counter(
+        "gms_kvr_daemon_storage_releases_total",
+        "Explicit release_engine_storage RPCs. Each increment means "
+        "persistent storage for the engine_id was intentionally retired.",
+        label_name="engine_id",
+    )
+)
+daemon_generation_mismatches = _register(
+    Counter(
+        "gms_kvr_daemon_generation_mismatches_total",
+        "promote_storage_to_hbm calls rejected because expected_generation "
+        "did not match the daemon's persisted block generation. These are "
+        "Race #3 stale-read preventions; the engine should recompute.",
+        label_name="engine_id",
+    )
+)
+daemon_stale_demotes = _register(
+    Counter(
+        "gms_kvr_daemon_stale_demotes_total",
+        "demote_hbm_to_storage calls rejected because the caller supplied "
+        "a generation older than the daemon's persisted block generation. "
+        "This indicates a stale writer or duplicate owner attempted to "
+        "overwrite newer durable KV bytes.",
+        label_name="engine_id",
+    )
+)
+daemon_persisted_generations = _register(
+    Counter(
+        "gms_kvr_daemon_persisted_generations",
+        "Current count of block generation records retained by the daemon "
+        "for an engine_id. This is a gauge despite the simple Counter "
+        "implementation; it is updated with set().",
+        label_name="engine_id",
+    )
+)
+
+# Connector-level metrics (V1 KVCacheConnector wiring). These
+# fire from the worker side of GMSKVCacheConnectorV1 in
+# `bind_connector_metadata` to surface restore/evict outcomes
+# the daemon-level counters don't capture (e.g., ring full).
+connector_evict_failures = _register(
+    Counter(
+        "gms_kvr_connector_evict_failures_total",
+        "V1 connector saw `evict_blocks_to_storage` raise or return "
+        "partial failure. Bytes did NOT reach durable storage; vLLM "
+        "still receives a 'finished save' ack to avoid block-pin "
+        "deadlock, so the storage tier is the source of truth for "
+        "whether the spill succeeded.",
+        label_name="engine_id",
+    )
+)
+connector_restore_failures = _register(
+    Counter(
+        "gms_kvr_connector_restore_failures_total",
+        "V1 connector restore failed verification at the daemon "
+        "(restore_succeeded() returned False after stream sync) or "
+        "the connector's sync remap raised. Engine reads stale HBM "
+        "for these blocks — output for the affected requests will be "
+        "wrong. Alert on this counter.",
+        label_name="engine_id",
+    )
+)
+connector_restore_ring_full = _register(
+    Counter(
+        "gms_kvr_connector_restore_ring_full_total",
+        "V1 connector's `record_restore_gds` returned None (ring "
+        "full). Connector fell back to synchronous restore in bind; "
+        "forward pass blocks for the cuFile read. Sustained increases "
+        "mean the restore ring capacity is undersized for cache-hit "
+        "rate × per-step pair count.",
+        label_name="engine_id",
+    )
+)
+connector_restore_conflict_sync = _register(
+    Counter(
+        "gms_kvr_connector_restore_conflict_sync_total",
+        "V1 connector routed a restore through the SYNCHRONOUS lane "
+        "because its src_block_id was also in the same step's evict "
+        "set (race-#2 conflict). Steady-state should be near zero in "
+        "well-behaved workloads; spikes indicate frequent prefix-cache "
+        "thrash where hash-indexed blocks are being immediately "
+        "re-evicted.",
+        label_name="engine_id",
+    )
+)
+connector_daemon_epoch_changes = _register(
+    Counter(
+        "gms_kvr_connector_daemon_epoch_changes_total",
+        "V1 connector observed a daemon-epoch change (daemon process "
+        "restarted) and dropped its in-memory _PrefixIndex. After this "
+        "the connector behaves like a cold cache until evictions "
+        "repopulate the index. Sustained increases mean the daemon "
+        "is crash-looping.",
+        label_name="engine_id",
+    )
+)
+connector_prefix_invalidated_on_failure = _register(
+    Counter(
+        "gms_kvr_connector_prefix_invalidated_on_failure_total",
+        "V1 connector dropped a (engine_id, block_id) entry from its "
+        "_PrefixIndex after `restore_succeeded()=False` indicated the "
+        "daemon could not deliver clean bytes for that slot. Bounds "
+        "the blast radius of an unrecoverable restore failure to ONE "
+        "request — subsequent requests can't re-claim the same broken "
+        "slot. Pair with `connector_restore_failures` (one-to-one in "
+        "the common case).",
+        label_name="engine_id",
+    )
+)
+daemon_scrub_corruptions = _register(
+    Counter(
+        "gms_kvr_daemon_scrub_corruptions_total",
+        "Daemon scrub thread detected a host_tier slot whose in-RAM "
+        "CRC didn't match the stored CRC. Slot was dropped. Each "
+        "increment is an at-rest corruption event — typically rare "
+        "on ECC RAM; a non-zero rate may indicate failing hardware.",
+        label_name="engine_id",
+    )
+)
+daemon_scrub_scanned = _register(
+    Counter(
+        "gms_kvr_daemon_scrub_scanned_total",
+        "Number of host_tier slots scrubbed (CRC re-verified) by the "
+        "daemon's background scrub thread. Useful as a denominator "
+        "for `daemon_scrub_corruptions`.",
+        label_name="engine_id",
+    )
+)
+daemon_backend_scrub_corruptions = _register(
+    Counter(
+        "gms_kvr_daemon_backend_scrub_corruptions_total",
+        "Daemon backend scrub thread detected a durable-storage slot "
+        "(NIXL file, mooncake blob, etc.) whose payload CRC didn't "
+        "match the stored CRC. Slot was dropped. Critical for the GDS "
+        "production path — GDS reads bypass host_tier verification, "
+        "so backend scrub is the only at-rest corruption detector for "
+        "those deployments.",
+        label_name="engine_id",
+    )
+)
+daemon_backend_scrub_scanned = _register(
+    Counter(
+        "gms_kvr_daemon_backend_scrub_scanned_total",
+        "Number of backend slots verified by the daemon's background "
+        "backend-scrub thread. Denominator for "
+        "`daemon_backend_scrub_corruptions`.",
+        label_name="engine_id",
+    )
+)
+
+
+def render_prometheus() -> str:
+    """Render every registered counter in Prometheus text format."""
+    return "".join(c.render() + "\n" for c in _ALL_COUNTERS)
+
+
+# ----- HTTP exporter -----
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path != "/metrics":
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = render_prometheus().encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_a) -> None:
+        return  # silence per-request stderr noise
+
+
+class _ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def serve_http(host: str = "127.0.0.1", port: int = 0) -> _ThreadedHTTPServer:
+    """Start a /metrics HTTP server in a background thread.
+
+    Returns the server object — call `.shutdown()` to stop. If port=0
+    the OS assigns one; read it from `server.server_address[1]`."""
+    server = _ThreadedHTTPServer((host, port), _Handler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server

--- a/lib/gms_kv_ring/common/pinned_scratch.py
+++ b/lib/gms_kv_ring/common/pinned_scratch.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tiny pool of pinned-host scratch buffers.
+
+Used by the overlapped HBM→storage demote path: we want a pinned
+host buffer for the async D2H + CPU CRC compute. Pinned because:
+  - Async D2H from device to PAGEABLE host falls back to a
+    synchronous path on the hot stream (silently makes the
+    overlap useless).
+  - Pinned D2H runs at PCIe bandwidth (~25 GB/s Gen4) and is
+    properly stream-ordered.
+
+The pool is process-wide and keyed by size. Each scratch buffer
+is `cudaHostAlloc`'d once and reused. We never free — the buffers
+are reclaimed at process exit. For typical KV-block sizes (tens
+of KB to a few MB) this caps RAM use at "1 buffer per distinct
+size we've seen," which is small.
+
+`acquire(size)` returns a context manager that yields the buffer
+address. The buffer is parked back on the pool on exit."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import threading
+from typing import Generator
+
+logger = logging.getLogger(__name__)
+
+
+_lock = threading.Lock()
+# size_bucket -> list of (host_ptr, allocated_size) free buffers
+_pool: dict[int, list[int]] = {}
+
+
+def _size_bucket(size: int) -> int:
+    """Round up to a power-of-two bucket to limit the number of
+    distinct sizes we cache. A 1.8 MB ask gets a 2 MB buffer."""
+    if size <= 1:
+        return 1
+    return 1 << (int(size - 1).bit_length())
+
+
+def _alloc_pinned(size: int) -> int:
+    """One-shot cudaHostAlloc of `size` bytes. Returns the host VA."""
+    from cuda.bindings import runtime as rt
+
+    err, ptr = rt.cudaHostAlloc(int(size), 0)
+    if err != rt.cudaError_t.cudaSuccess:
+        raise RuntimeError(f"cudaHostAlloc({size}) failed: {err}")
+    return int(ptr)
+
+
+@contextlib.contextmanager
+def acquire(size: int) -> Generator[int, None, None]:
+    """Yield a pinned host pointer with at least `size` bytes. The
+    pointer is returned to the pool on exit, NOT freed."""
+    bucket = _size_bucket(size)
+    with _lock:
+        free_list = _pool.setdefault(bucket, [])
+        if free_list:
+            ptr = free_list.pop()
+        else:
+            ptr = None
+    if ptr is None:
+        ptr = _alloc_pinned(bucket)
+    try:
+        yield ptr
+    finally:
+        with _lock:
+            _pool[bucket].append(ptr)

--- a/lib/gms_kv_ring/common/prefix_hashes.py
+++ b/lib/gms_kv_ring/common/prefix_hashes.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-engine prefix-block hash function.
+
+A `content_hash` in GMS uniquely identifies "the bytes that should
+be in a KV slot for a given prefix of tokens." It is the only
+identifier the daemon uses to route cross-node transfers — the
+sender's daemon and the receiver's daemon must agree on a hash for
+the same prefix regardless of which engine produced it.
+
+To make that hash stable across engines, both vLLM and SGLang
+connectors compute it via this single shared function. Changing
+it requires bumping a version byte AND ensuring both connectors
+upgrade in lockstep.
+
+Hash construction (version `GMSKVRv1`):
+
+    h_0 = sha256("GMSKVRv1\\x00" || BE_u32(len(salt)) || salt
+                 || BE_u32(block_size))
+    h_i = sha256(h_{i-1}_state || BE_u64*block_size(token_ids[i*B:(i+1)*B]))
+
+i.e., a cumulative running sha256 over (salt, block_size, prefix
+tokens) chunked into blocks. The returned list contains one digest
+per FULL block in the prefix — partial trailing blocks are not
+emitted because they cannot be cache-hit externally (vLLM and
+SGLang both match whole blocks).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+from typing import Optional
+
+
+def prefix_block_hashes(
+    token_ids: "list[int]",
+    block_size: int,
+    cache_salt: Optional[str],
+) -> "list[bytes]":
+    """Per-block cumulative prefix sha256 hashes.
+
+    Returns one hash per FULL block (partial trailing blocks
+    excluded). Each hash covers `(cache_salt, token_ids[:i*block_size])`
+    for `i in 1..n_full_blocks`.
+
+    The salt is mixed in so two requests with the same tokens but
+    different `cache_salt` won't cross-hit (matches vLLM's
+    prefix-cache isolation semantics).
+
+    Determinism: the function is pure over `(token_ids, block_size,
+    cache_salt)`. Use the exact same inputs on the receiver side to
+    look up bytes by hash."""
+    if block_size <= 0:
+        return []
+    salt = (cache_salt or "").encode("utf-8")
+    n_full = len(token_ids) // block_size
+    if n_full == 0:
+        return []
+    hashes: list[bytes] = []
+    h = hashlib.sha256()
+    h.update(b"GMSKVRv1\x00")
+    h.update(struct.pack(">I", len(salt)))
+    h.update(salt)
+    h.update(struct.pack(">I", int(block_size)))
+    for i in range(n_full):
+        chunk = token_ids[i * block_size : (i + 1) * block_size]
+        h.update(struct.pack(f">{block_size}Q", *chunk))
+        hashes.append(h.digest())
+    return hashes

--- a/lib/gms_kv_ring/common/prefix_index.py
+++ b/lib/gms_kv_ring/common/prefix_index.py
@@ -1,0 +1,436 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-engine `_PrefixIndex` + snapshot persistence.
+
+The connector-side hash → (engine_id, block_id, generation) mapping
+that powers cache-hit detection for vLLM, SGLang (indirectly via the
+radix tree), and TRT-LLM. Lives in `common/` so all three connectors
+share one implementation and snapshot format.
+
+Invariants the class enforces (referenced by the cross-engine
+parity work):
+  - I-1 (prune-on-record): older hashes pointing at a slot are
+    deleted before the new mapping is inserted.
+  - I-3 (generation tagging): every slot mapping carries a
+    monotonically increasing generation; daemon-side enforces
+    match on restore (closes Race #3).
+  - LRU bound: oldest-record-first eviction at `max_entries`.
+  - Persistence: optional snapshot/load tied to daemon_epoch.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+import struct
+import time
+import zlib
+from collections import OrderedDict
+from typing import Optional
+
+from gms_kv_ring.common.prefix_hashes import prefix_block_hashes as _prefix_block_hashes
+
+logger = logging.getLogger(__name__)
+
+
+# Snapshot file format. Layout:
+#   magic   (8 bytes)  : b"GMSPIDX\x00"
+#   version (2 bytes)  : uint16 LE
+#   pkl_len (4 bytes)  : uint32 LE (length of the pickle payload)
+#   pkl     (pkl_len)  : pickle.dumps(payload_dict, protocol=4)
+#   crc32   (4 bytes)  : zlib.crc32 over the pickle bytes
+_SNAPSHOT_MAGIC = b"GMSPIDX\x00"
+_SNAPSHOT_VERSION = 2
+_SNAPSHOT_HEADER_FMT = "<8sHI"  # 8s + uint16 + uint32 = 14 bytes
+_SNAPSHOT_HEADER_LEN = struct.calcsize(_SNAPSHOT_HEADER_FMT)
+
+
+def _serialize_snapshot(
+    max_entries: int,
+    table: "OrderedDict[bytes, tuple[str, int, int]]",
+    slot_to_hashes: "dict[tuple[str, int], set[bytes]]",
+    slot_generations: "dict[tuple[str, int], int]",
+    daemon_epoch: Optional[int] = None,
+) -> bytes:
+    payload = {
+        "max": int(max_entries),
+        "table": table,
+        "slot_to_hashes": slot_to_hashes,
+        "slot_generations": slot_generations,
+        "daemon_epoch": (None if daemon_epoch is None else int(daemon_epoch)),
+    }
+    pkl = pickle.dumps(payload, protocol=4)
+    header = struct.pack(
+        _SNAPSHOT_HEADER_FMT,
+        _SNAPSHOT_MAGIC,
+        _SNAPSHOT_VERSION,
+        len(pkl),
+    )
+    crc = struct.pack("<I", zlib.crc32(pkl) & 0xFFFFFFFF)
+    return header + pkl + crc
+
+
+def _deserialize_snapshot(blob: bytes) -> Optional[dict]:
+    """Returns the payload dict, or None if the blob is malformed or
+    of an unrecognized version. Never raises — corrupt files must
+    not break connector init."""
+    if len(blob) < _SNAPSHOT_HEADER_LEN + 4:
+        return None
+    try:
+        magic, version, pkl_len = struct.unpack(
+            _SNAPSHOT_HEADER_FMT,
+            blob[:_SNAPSHOT_HEADER_LEN],
+        )
+    except struct.error:
+        return None
+    if magic != _SNAPSHOT_MAGIC:
+        return None
+    if version != _SNAPSHOT_VERSION:
+        logger.warning(
+            "PrefixIndex snapshot version %d; this build expects "
+            "%d. Ignoring snapshot.",
+            version,
+            _SNAPSHOT_VERSION,
+        )
+        return None
+    expected_end = _SNAPSHOT_HEADER_LEN + pkl_len + 4
+    if len(blob) != expected_end:
+        return None
+    pkl = blob[_SNAPSHOT_HEADER_LEN : _SNAPSHOT_HEADER_LEN + pkl_len]
+    (stored_crc,) = struct.unpack(
+        "<I",
+        blob[_SNAPSHOT_HEADER_LEN + pkl_len : expected_end],
+    )
+    if zlib.crc32(pkl) & 0xFFFFFFFF != stored_crc:
+        return None
+    try:
+        payload = pickle.loads(pkl)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+class PrefixIndex:
+    """Scheduler-local content-hash → (engine_id, src_block_id)
+    mapping. Populated at eviction time, queried at cache-hit time.
+
+    See the module docstring for invariants.
+
+    Each connector (vLLM, SGLang, TRT-LLM) instantiates one and feeds
+    it spilled `(prompt_tokens, block_ids, block_size, cache_salt,
+    engine_id)` tuples via `record()`. Cache-hit detection at request
+    arrival walks `lookup()` for matching prefix hits."""
+
+    _DEFAULT_MAX_ENTRIES = 100_000
+    _DEFAULT_SNAPSHOT_THRESHOLD = 256
+    _DEFAULT_SNAPSHOT_INTERVAL_S = 30.0
+
+    def __init__(
+        self,
+        max_entries: Optional[int] = None,
+        snapshot_path: Optional[str] = None,
+        snapshot_interval_s: Optional[float] = None,
+        snapshot_threshold: Optional[int] = None,
+        expected_daemon_epoch: Optional[int] = None,
+    ) -> None:
+        if max_entries is None:
+            try:
+                max_entries = int(
+                    os.environ.get(
+                        "GMS_KVR_PREFIX_INDEX_MAX",
+                        self._DEFAULT_MAX_ENTRIES,
+                    ),
+                )
+            except ValueError:
+                max_entries = self._DEFAULT_MAX_ENTRIES
+        if max_entries <= 0:
+            raise ValueError("max_entries must be > 0")
+        self._max = int(max_entries)
+        self._table: "OrderedDict[bytes, tuple[str, int, int]]" = OrderedDict()
+        self._slot_to_hashes: dict[tuple[str, int], set[bytes]] = {}
+        self._slot_generations: dict[tuple[str, int], int] = {}
+
+        if snapshot_path is None:
+            snapshot_path = os.environ.get(
+                "GMS_KVR_PREFIX_INDEX_SNAPSHOT",
+                "",
+            )
+        self._snap_path: str = snapshot_path or ""
+        if snapshot_interval_s is None:
+            try:
+                snapshot_interval_s = float(
+                    os.environ.get(
+                        "GMS_KVR_PREFIX_INDEX_SNAPSHOT_INTERVAL",
+                        self._DEFAULT_SNAPSHOT_INTERVAL_S,
+                    ),
+                )
+            except ValueError:
+                snapshot_interval_s = self._DEFAULT_SNAPSHOT_INTERVAL_S
+        if snapshot_threshold is None:
+            try:
+                snapshot_threshold = int(
+                    os.environ.get(
+                        "GMS_KVR_PREFIX_INDEX_SNAPSHOT_THRESHOLD",
+                        self._DEFAULT_SNAPSHOT_THRESHOLD,
+                    ),
+                )
+            except ValueError:
+                snapshot_threshold = self._DEFAULT_SNAPSHOT_THRESHOLD
+        self._snap_interval_s: float = max(0.0, float(snapshot_interval_s))
+        self._snap_threshold: int = max(1, int(snapshot_threshold))
+        self._dirty: int = 0
+        self._last_snap_t: float = time.monotonic()
+        self._daemon_epoch: Optional[int] = (
+            None if expected_daemon_epoch is None else int(expected_daemon_epoch)
+        )
+
+        if self._snap_path:
+            self._load_snapshot()
+
+    def set_daemon_epoch(self, epoch: Optional[int]) -> None:
+        self._daemon_epoch = None if epoch is None else int(epoch)
+
+    def __len__(self) -> int:
+        return len(self._table)
+
+    def _drop_hash(self, h: bytes) -> None:
+        entry = self._table.pop(h, None)
+        if entry is None:
+            return
+        slot_key = (entry[0], entry[1])
+        slot_hashes = self._slot_to_hashes.get(slot_key)
+        if slot_hashes is not None:
+            slot_hashes.discard(h)
+            if not slot_hashes:
+                del self._slot_to_hashes[slot_key]
+
+    def _evict_lru(self) -> None:
+        try:
+            oldest_hash, oldest_entry = next(iter(self._table.items()))
+        except StopIteration:
+            return
+        del self._table[oldest_hash]
+        slot_key = (oldest_entry[0], oldest_entry[1])
+        slot_hashes = self._slot_to_hashes.get(slot_key)
+        if slot_hashes is not None:
+            slot_hashes.discard(oldest_hash)
+            if not slot_hashes:
+                del self._slot_to_hashes[slot_key]
+
+    def record(
+        self,
+        prompt_token_ids: "list[int]",
+        block_ids: "list[int]",
+        block_size: int,
+        cache_salt: Optional[str],
+        engine_id: str,
+    ) -> "list[int]":
+        """Index a finished request's prompt prefix block-by-block.
+        Returns per-block generations parallel to `block_ids`."""
+        hashes = _prefix_block_hashes(
+            prompt_token_ids,
+            block_size,
+            cache_salt,
+        )
+        n = min(len(hashes), len(block_ids))
+        assigned_generations: list[int] = []
+        for i in range(n):
+            h = hashes[i]
+            bid = int(block_ids[i])
+            slot_key = (engine_id, bid)
+            new_gen = self._slot_generations.get(slot_key, 0) + 1
+            self._slot_generations[slot_key] = new_gen
+            assigned_generations.append(new_gen)
+            stale = self._slot_to_hashes.pop(slot_key, None)
+            if stale is not None:
+                for old in stale:
+                    self._table.pop(old, None)
+            self._table.pop(h, None)
+            self._table[h] = (engine_id, bid, new_gen)
+            self._slot_to_hashes[slot_key] = {h}
+            while len(self._table) > self._max:
+                self._evict_lru()
+            self._dirty += 1
+        self._maybe_snapshot()
+        return assigned_generations
+
+    def drop_slots(
+        self,
+        engine_id: str,
+        block_ids: "list[int]",
+    ) -> int:
+        """Drop every hash currently pointing at any (engine_id,
+        block_id) in `block_ids`. Used by the post-forward failure
+        path."""
+        n_dropped = 0
+        for bid in block_ids:
+            slot_key = (str(engine_id), int(bid))
+            hashes = self._slot_to_hashes.pop(slot_key, None)
+            if not hashes:
+                continue
+            for h in hashes:
+                if self._table.pop(h, None) is not None:
+                    n_dropped += 1
+        return n_dropped
+
+    def invalidate(self) -> None:
+        """Drop every entry. Used by the daemon-epoch-change path."""
+        self._table.clear()
+        self._slot_to_hashes.clear()
+        self._slot_generations.clear()
+        self._dirty = 0
+        if self._snap_path:
+            try:
+                self.snapshot()
+            except Exception:
+                logger.warning(
+                    "PrefixIndex invalidate: snapshot rewrite failed; "
+                    "stale on-disk view will be discarded on next "
+                    "load via the epoch-mismatch guard.",
+                    exc_info=True,
+                )
+
+    def _load_snapshot(self) -> None:
+        path = self._snap_path
+        try:
+            with open(path, "rb") as f:
+                blob = f.read()
+        except FileNotFoundError:
+            return
+        except OSError as e:
+            logger.warning(
+                "PrefixIndex snapshot %s: read failed (%s); " "starting cold.",
+                path,
+                e,
+            )
+            return
+        payload = _deserialize_snapshot(blob)
+        if payload is None:
+            logger.warning(
+                "PrefixIndex snapshot %s: malformed; starting cold.",
+                path,
+            )
+            return
+        try:
+            table = payload["table"]
+            slot_to_hashes = payload["slot_to_hashes"]
+            slot_generations = payload["slot_generations"]
+        except (KeyError, TypeError):
+            logger.warning(
+                "PrefixIndex snapshot %s: schema mismatch; starting " "cold.",
+                path,
+            )
+            return
+        snap_epoch = payload.get("daemon_epoch")
+        if (
+            self._daemon_epoch is not None
+            and snap_epoch is not None
+            and int(snap_epoch) != int(self._daemon_epoch)
+        ):
+            logger.info(
+                "PrefixIndex snapshot %s: daemon_epoch %d != "
+                "current %d (daemon restarted since snapshot); "
+                "starting cold.",
+                path,
+                int(snap_epoch),
+                int(self._daemon_epoch),
+            )
+            return
+        if not isinstance(table, OrderedDict):
+            try:
+                table = OrderedDict(table)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "PrefixIndex snapshot %s: table not iterable as "
+                    "mapping; starting cold.",
+                    path,
+                )
+                return
+        self._table = table
+        self._slot_to_hashes = dict(slot_to_hashes)
+        self._slot_generations = dict(slot_generations)
+        while len(self._table) > self._max:
+            self._evict_lru()
+        logger.info(
+            "PrefixIndex loaded %d entries from snapshot %s " "(daemon_epoch=%r)",
+            len(self._table),
+            path,
+            snap_epoch,
+        )
+
+    def snapshot(self) -> None:
+        path = self._snap_path
+        if not path:
+            return
+        blob = _serialize_snapshot(
+            self._max,
+            self._table,
+            self._slot_to_hashes,
+            self._slot_generations,
+            daemon_epoch=self._daemon_epoch,
+        )
+        tmp_path = f"{path}.tmp.{os.getpid()}"
+        try:
+            parent = os.path.dirname(path)
+            if parent and not os.path.isdir(parent):
+                os.makedirs(parent, exist_ok=True)
+            fd = os.open(
+                tmp_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            try:
+                os.write(fd, blob)
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            os.rename(tmp_path, path)
+        except OSError as e:
+            logger.warning(
+                "PrefixIndex snapshot %s: write failed (%s); "
+                "in-memory index unaffected.",
+                path,
+                e,
+            )
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            return
+        self._dirty = 0
+        self._last_snap_t = time.monotonic()
+
+    def _maybe_snapshot(self) -> None:
+        if not self._snap_path:
+            return
+        if self._dirty < self._snap_threshold:
+            return
+        if time.monotonic() - self._last_snap_t < self._snap_interval_s:
+            return
+        self.snapshot()
+
+    def lookup(
+        self,
+        prompt_token_ids: "list[int]",
+        block_size: int,
+        cache_salt: Optional[str],
+        engine_id: str,
+    ) -> "list[tuple[int, int]]":
+        """Return the longest contiguous prefix's (src_block_id,
+        expected_generation) pairs for this engine."""
+        hashes = _prefix_block_hashes(
+            prompt_token_ids,
+            block_size,
+            cache_salt,
+        )
+        out: list[tuple[int, int]] = []
+        for h in hashes:
+            entry = self._table.get(h)
+            if entry is None or entry[0] != engine_id:
+                break
+            out.append((entry[1], entry[2]))
+        return out

--- a/lib/gms_kv_ring/common/restore_ring.py
+++ b/lib/gms_kv_ring/common/restore_ring.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restore ring — SPSC SHM ring for engine→daemon cache-hit restore.
+
+Chunk-grained: one record describes one prefix-chunk's restore as
+N (src_block, dest_block) pairs. The daemon expands and issues
+N×L cuMemcpyAsync H2D's, then signals a shared counter via
+cuStreamWriteValue32. Engine waits on the counter via
+cuStreamWaitValue32.
+
+Layout (one /dev/shm file, mmap'd by both):
+
+  ┌─ Header (64B) ──────────────────────────────────────────────┐
+  │  magic        : u32  = 0x47_4D_53_52  ("GMSR")              │
+  │  version      : u32  = 1                                     │
+  │  capacity     : u32  power-of-2                              │
+  │  record_size  : u32  = 512                                   │
+  │  head_seq     : u64                                          │
+  │  tail_seq     : u64                                          │
+  │  drops        : u64                                          │
+  │  padding      : 16B                                          │
+  └──────────────────────────────────────────────────────────────┘
+  ┌─ Record (512B) ─────────────────────────────────────────────┐
+  │  seq            : u64                                        │
+  │  op_kind        : u8   = 1 (RESTORE_CHUNK)                   │
+  │  flags          : u8                                         │
+  │  _pad           : u16                                        │
+  │  counter_slot   : u32                                        │
+  │  counter_target : u32                                        │
+  │  n_pairs        : u32                                        │
+  │  _pad2          : u64                                        │
+  │  src_engine_id  : char[48]  NUL-padded                       │
+  │  pairs[54]      : each (u32 src_block, u32 dest_block)       │
+  └──────────────────────────────────────────────────────────────┘
+"""
+
+from __future__ import annotations
+
+import mmap
+import os
+import struct
+from typing import Iterable, Optional
+
+try:
+    import gms_rust_ring as _RUST  # type: ignore[import-not-found]
+except Exception:
+    _RUST = None
+
+
+MAGIC = 0x5253_4D47  # "GMSR" little-endian
+VERSION = 1
+HEADER_SIZE = 64
+RECORD_SIZE = 512
+ENGINE_ID_MAX_LEN = 48
+MAX_BLOCK_PAIRS = 54
+
+OP_RESTORE_CHUNK = 1
+
+# Flags byte (8 bits) on each ring record. Currently:
+#   bit 0 — FLAG_GDS_DIRECT: bytes come from the storage tier via
+#           the backend's `promote_into_gpu` (cuFile read direct
+#           into HBM), NOT from host_tier. Daemon consumer
+#           branches in `_RestoreConsumer._process`.
+#   bit 1 — FLAG_SOURCE_STAGING: src_block in each pair is an opaque
+#           staging-restore handle registered with the daemon. Bytes
+#           come from StagingTier and are scattered into dest HBM.
+# Remaining bits reserved.
+FLAG_GDS_DIRECT = 0x01
+FLAG_SOURCE_STAGING = 0x02
+
+_OFF_MAGIC = 0
+_OFF_VERSION = 4
+_OFF_CAPACITY = 8
+_OFF_RECORD_SIZE = 12
+_OFF_HEAD = 16
+_OFF_TAIL = 24
+_OFF_DROPS = 32
+
+_R_SEQ = 0
+_R_OP = 8
+_R_FLAGS = 9
+_R_COUNTER_SLOT = 12
+_R_COUNTER_TARGET = 16
+_R_N_PAIRS = 20
+_R_ENGINE_ID = 32
+_R_PAIRS = 80
+_PAIR_STRIDE = 8
+
+
+def _is_pow2(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def create_ring(path: str, capacity: int = 4096) -> "RestoreRingWriter":
+    if not _is_pow2(capacity):
+        raise ValueError(f"capacity must be power-of-2: got {capacity}")
+    size = HEADER_SIZE + capacity * RECORD_SIZE
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        os.ftruncate(fd, size)
+        buf = mmap.mmap(fd, size, mmap.MAP_SHARED, mmap.PROT_READ | mmap.PROT_WRITE)
+        struct.pack_into(
+            "<IIIIQQQ",
+            buf,
+            0,
+            MAGIC,
+            VERSION,
+            capacity,
+            RECORD_SIZE,
+            0,
+            0,
+            0,
+        )
+    finally:
+        os.close(fd)
+    return RestoreRingWriter(path, buf, capacity)
+
+
+def attach_writer(path: str) -> "RestoreRingWriter":
+    return _attach(path, RestoreRingWriter)
+
+
+def attach_reader(path: str) -> "RestoreRingReader":
+    return _attach(path, RestoreRingReader)
+
+
+def _attach(path: str, cls):
+    fd = os.open(path, os.O_RDWR)
+    try:
+        size = os.fstat(fd).st_size
+        if size < HEADER_SIZE:
+            raise ValueError(f"ring file too small: {size} < {HEADER_SIZE}")
+        buf = mmap.mmap(fd, size, mmap.MAP_SHARED, mmap.PROT_READ | mmap.PROT_WRITE)
+    finally:
+        os.close(fd)
+    magic, version, capacity, rec_size, _h, _t, _d = struct.unpack_from(
+        "<IIIIQQQ",
+        buf,
+        0,
+    )
+    error = None
+    if magic != MAGIC:
+        error = f"bad magic 0x{magic:x}: not a GMSR ring"
+    elif version != VERSION:
+        error = f"version mismatch: {version} != {VERSION}"
+    elif not _is_pow2(capacity):
+        error = f"capacity must be power-of-2: got {capacity}"
+    elif rec_size != RECORD_SIZE:
+        error = f"record_size mismatch: {rec_size} != {RECORD_SIZE}"
+    else:
+        expected_size = HEADER_SIZE + capacity * rec_size
+        if size != expected_size:
+            error = f"ring size mismatch: {size} != {expected_size}"
+    if error is not None:
+        buf.close()
+        raise ValueError(error)
+    return cls(path, buf, capacity)
+
+
+class _RingBase:
+    def __init__(self, path: str, buf: mmap.mmap, capacity: int) -> None:
+        self.path = path
+        self.buf = buf
+        self.capacity = capacity
+        self._mask = capacity - 1
+
+    def close(self) -> None:
+        if self.buf is not None:
+            try:
+                self.buf.close()
+            except Exception:
+                pass
+            self.buf = None
+
+    def stats(self) -> dict:
+        return {
+            "head": struct.unpack_from("<Q", self.buf, _OFF_HEAD)[0],
+            "tail": struct.unpack_from("<Q", self.buf, _OFF_TAIL)[0],
+            "drops": struct.unpack_from("<Q", self.buf, _OFF_DROPS)[0],
+            "capacity": self.capacity,
+        }
+
+
+def is_rust_accelerated() -> bool:
+    """True iff the native Rust extension is loaded and will be used
+    for push/pop. False ⇒ pure-Python fallback path is active."""
+    return _RUST is not None
+
+
+class RestoreRingWriter(_RingBase):
+    """Engine-side producer. Single thread.
+
+    `push()` auto-selects: Rust extension if available (~1 µs/op),
+    pure-Python fallback otherwise (~9 µs/op). Both paths write the
+    same on-disk bytes (verified by test_rust_python_parity)."""
+
+    def push(
+        self,
+        src_engine_id: str,
+        block_pairs: Iterable[tuple],
+        counter_slot: int,
+        counter_target: int,
+        flags: int = 0,
+    ) -> bool:
+        if _RUST is not None:
+            pairs = list(block_pairs)
+            src = [int(p[0]) for p in pairs]
+            dst = [int(p[1]) for p in pairs]
+            return _RUST.push_record(
+                self.buf,
+                self.capacity,
+                src_engine_id.encode("utf-8"),
+                src,
+                dst,
+                int(counter_slot),
+                int(counter_target),
+                int(flags) & 0xFF,
+            )
+        return self._push_python(
+            src_engine_id,
+            block_pairs,
+            counter_slot,
+            counter_target,
+            flags,
+        )
+
+    def _push_python(
+        self,
+        src_engine_id: str,
+        block_pairs: Iterable[tuple],
+        counter_slot: int,
+        counter_target: int,
+        flags: int = 0,
+    ) -> bool:
+        pairs = list(block_pairs)
+        if len(pairs) > MAX_BLOCK_PAIRS:
+            raise ValueError(
+                f"too many pairs per record: {len(pairs)} > {MAX_BLOCK_PAIRS}",
+            )
+        eid_bytes = src_engine_id.encode("utf-8")
+        if len(eid_bytes) >= ENGINE_ID_MAX_LEN:
+            raise ValueError(
+                f"engine_id too long: {len(eid_bytes)} >= {ENGINE_ID_MAX_LEN}",
+            )
+
+        head = struct.unpack_from("<Q", self.buf, _OFF_HEAD)[0]
+        tail = struct.unpack_from("<Q", self.buf, _OFF_TAIL)[0]
+        if head - tail >= self.capacity:
+            drops = struct.unpack_from("<Q", self.buf, _OFF_DROPS)[0]
+            struct.pack_into("<Q", self.buf, _OFF_DROPS, drops + 1)
+            return False
+
+        slot = head & self._mask
+        base = HEADER_SIZE + slot * RECORD_SIZE
+
+        struct.pack_into("<Q", self.buf, base + _R_SEQ, 0)
+        struct.pack_into("<B", self.buf, base + _R_OP, OP_RESTORE_CHUNK)
+        struct.pack_into("<B", self.buf, base + _R_FLAGS, int(flags) & 0xFF)
+        struct.pack_into(
+            "<III",
+            self.buf,
+            base + _R_COUNTER_SLOT,
+            int(counter_slot),
+            int(counter_target),
+            len(pairs),
+        )
+        self.buf[
+            base + _R_ENGINE_ID : base + _R_ENGINE_ID + ENGINE_ID_MAX_LEN
+        ] = eid_bytes.ljust(ENGINE_ID_MAX_LEN, b"\x00")
+        for i, (src_blk, dest_blk) in enumerate(pairs):
+            struct.pack_into(
+                "<II",
+                self.buf,
+                base + _R_PAIRS + i * _PAIR_STRIDE,
+                int(src_blk),
+                int(dest_blk),
+            )
+        for i in range(len(pairs), MAX_BLOCK_PAIRS):
+            struct.pack_into(
+                "<II",
+                self.buf,
+                base + _R_PAIRS + i * _PAIR_STRIDE,
+                0,
+                0,
+            )
+
+        struct.pack_into("<Q", self.buf, base + _R_SEQ, head + 1)
+        struct.pack_into("<Q", self.buf, _OFF_HEAD, head + 1)
+        return True
+
+
+class RestoreRingReader(_RingBase):
+    def try_pop(self) -> Optional[dict]:
+        if _RUST is not None:
+            res = _RUST.try_pop_record(self.buf, self.capacity)
+            if res is None:
+                return None
+            op, flags, slot, target, eid_bytes, pairs = res
+            return {
+                "op": int(op),
+                "flags": int(flags),
+                "counter_slot": int(slot),
+                "counter_target": int(target),
+                "src_engine_id": eid_bytes.decode("utf-8", errors="replace"),
+                "block_pairs": [(int(s), int(d)) for s, d in pairs],
+            }
+        return self._try_pop_python()
+
+    def _try_pop_python(self) -> Optional[dict]:
+        tail = struct.unpack_from("<Q", self.buf, _OFF_TAIL)[0]
+        head = struct.unpack_from("<Q", self.buf, _OFF_HEAD)[0]
+        if tail >= head:
+            return None
+        slot = tail & self._mask
+        base = HEADER_SIZE + slot * RECORD_SIZE
+        seq = struct.unpack_from("<Q", self.buf, base + _R_SEQ)[0]
+        if seq != tail + 1:
+            return None
+
+        op = struct.unpack_from("<B", self.buf, base + _R_OP)[0]
+        flags = struct.unpack_from("<B", self.buf, base + _R_FLAGS)[0]
+        counter_slot, counter_target, n_pairs = struct.unpack_from(
+            "<III",
+            self.buf,
+            base + _R_COUNTER_SLOT,
+        )
+        eid_raw = bytes(
+            self.buf[base + _R_ENGINE_ID : base + _R_ENGINE_ID + ENGINE_ID_MAX_LEN]
+        )
+        nul = eid_raw.find(b"\x00")
+        if nul >= 0:
+            eid_raw = eid_raw[:nul]
+        src_engine_id = eid_raw.decode("utf-8", errors="replace")
+
+        n_pairs = min(int(n_pairs), MAX_BLOCK_PAIRS)
+        pairs = []
+        for i in range(n_pairs):
+            s, d = struct.unpack_from(
+                "<II",
+                self.buf,
+                base + _R_PAIRS + i * _PAIR_STRIDE,
+            )
+            pairs.append((int(s), int(d)))
+
+        struct.pack_into("<Q", self.buf, _OFF_TAIL, tail + 1)
+        return {
+            "op": int(op),
+            "flags": int(flags),
+            "counter_slot": int(counter_slot),
+            "counter_target": int(counter_target),
+            "src_engine_id": src_engine_id,
+            "block_pairs": pairs,
+        }

--- a/lib/gms_kv_ring/daemon/backend.py
+++ b/lib/gms_kv_ring/daemon/backend.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Storage-backend abstraction.
+
+The daemon's storage tier is a pluggable thing: today's `StorageTier`
+writes local files; tomorrow's `NixlBackend` ships bytes over a
+NIXL transport (POSIX plugin for disk, OBJ plugin for S3) and a
+`MooncakeBackend` uses the Mooncake transfer engine.
+
+All backends implement the same `StorageBackend` interface so the
+daemon shell, the engine RPCs, and the sweeper can treat them
+uniformly. The slot dataclass `StorageSlot` is the abstract record;
+backends are free to subclass it to attach backend-specific resource
+handles (e.g., a file path for the local backend, an object key for
+NIXL OBJ).
+
+Crash semantics: a backend method may raise. The daemon wraps backend
+calls in a `BackendSupervisor` (see `daemon/supervisor.py`) that
+catches Python exceptions, increments a metric, and re-creates the
+backend instance after N consecutive failures. A C-level SIGSEGV
+from a transport library will still kill the whole daemon — surviving
+that requires subprocess workers, which is a separate evolution."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class StorageSlot:
+    """Abstract record for one offloaded block. Backends MAY subclass
+    to attach resource handles (file path, NIXL region id, S3 key);
+    this base shape carries only what the cleanup primitives use."""
+
+    size: int
+    # CRC32 (IEEE) of the payload bytes. Stored at demote, verified
+    # on promote. Single source of truth across tier hops.
+    crc: int
+    # Last-write time, seconds since epoch. Set by demote() and
+    # backend reconcile(). Drives LRU + TTL eviction without
+    # per-slot stat() syscalls.
+    mtime: float = 0.0
+
+
+class StorageBackend(ABC):
+    """Pluggable backend for the storage tier.
+
+    Lifecycle:
+      - Backends are constructed at daemon startup. The constructor
+        SHOULD probe its runtime deps and raise a clear error if
+        they're missing (typically via `cls.is_available()` first).
+      - `reconcile()` is called at construction to rebuild the index
+        from durable state (disk files / remote registry / etc).
+      - The daemon calls `demote/promote/get/release_*` during
+        normal operation.
+      - Cleanup primitives (`prune_older_than`, `enforce_byte_quota`,
+        `enforce_per_engine_byte_quota`) are driven by the sweeper
+        thread and operator-driven RPCs.
+
+    Slot identity is (engine_id, layer, offset). The backend owns the
+    mapping from key → backend-specific resource."""
+
+    #: Short identifier exported via /metrics + logs. Override.
+    name: str = "abstract"
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """Return True iff this backend's runtime dependencies are
+        importable + usable in the current process. Default: True
+        (no deps). Backends that wrap external libs override this to
+        probe their imports lazily — so a daemon shipping with no
+        NIXL installed still imports cleanly."""
+        return True
+
+    # ----- core slot lifecycle -----
+
+    @abstractmethod
+    def demote(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        host_ptr: int,
+        size: int,
+        crc: int,
+    ) -> StorageSlot:
+        """Write `size` bytes from pinned-host `host_ptr` into durable
+        backend storage, stamped with the provided CRC. Returns the
+        slot record (subclass-specific resource handle attached).
+
+        Caller MUST guarantee the source bytes are stable for the
+        duration of the call (typically by having synced the engine's
+        evict stream before calling demote)."""
+
+    @abstractmethod
+    def promote(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        dest_host_ptr: int,
+        max_size: int,
+    ) -> Optional[int]:
+        """Read the backend's stored bytes into pinned-host
+        `dest_host_ptr` and verify integrity. Returns the verified
+        CRC on success. Returns None if:
+          - the slot is unknown
+          - reading the backend failed
+          - the on-backend size doesn't fit in max_size
+          - the CRC verify failed (at-rest corruption)
+        Implementations MUST be safe to call concurrently with
+        demote() of other keys."""
+
+    @abstractmethod
+    def get(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+    ) -> Optional[StorageSlot]:
+        """Index lookup. Cheap, in-memory."""
+
+    @abstractmethod
+    def release_slot(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+    ) -> bool:
+        """Drop the slot and free its backend resource. Idempotent."""
+
+    def release_if_current(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        expected: StorageSlot,
+    ) -> bool:
+        """Release only when ``expected`` is still indexed at the key.
+
+        Backends should override this with an atomic implementation. The
+        conservative default never risks deleting a replacement slot.
+        """
+        return False
+
+    @abstractmethod
+    def release_engine(self, engine_id: str) -> int:
+        """Free every slot for `engine_id`. Returns count released."""
+
+    # ----- introspection / observability -----
+
+    @abstractmethod
+    def n_slots(self) -> int:
+        ...
+
+    @abstractmethod
+    def total_bytes(self) -> int:
+        ...
+
+    @abstractmethod
+    def bytes_by_engine(self) -> dict[str, int]:
+        ...
+
+    @abstractmethod
+    def stats(self) -> dict:
+        ...
+
+    # ----- cleanup primitives (driven by sweeper + RPCs) -----
+
+    @abstractmethod
+    def prune_older_than(
+        self,
+        max_age_seconds: float,
+        now: Optional[float] = None,
+    ) -> int:
+        ...
+
+    @abstractmethod
+    def enforce_byte_quota(self, max_bytes: int) -> int:
+        ...
+
+    @abstractmethod
+    def enforce_per_engine_byte_quota(
+        self,
+        max_bytes_per_engine: int,
+    ) -> int:
+        ...
+
+    # ----- optional: key snapshot for scrub -----
+
+    def snapshot_keys(self) -> list[tuple[str, int, int]]:
+        """Return a copy of the current slot-key list. Used by the
+        daemon's background backend-scrub thread, which doesn't
+        want to hold the backend's lock across per-slot read +
+        CRC compute (slow when reading large slots from disk).
+
+        Default implementation reads `self._slots` under
+        `self._lock` if both attributes exist — true for every
+        first-party backend (Local, NIXL, Mooncake). Backends that
+        don't follow this convention return an empty list, opting
+        out of scrub support."""
+        slots = getattr(self, "_slots", None)
+        if slots is None:
+            return []
+        lock = getattr(self, "_lock", None)
+        if lock is None:
+            return list(slots.keys())
+        with lock:
+            return list(slots.keys())
+
+    # ----- optional GPU-direct data plane (GDS-style backends) -----
+
+    def supports_gpu_direct(self) -> bool:
+        """True iff the backend has `demote_from_gpu` /
+        `promote_into_gpu` data-plane methods (i.e., it can accept a
+        GPU pointer as source/dest and skip CPU staging). Default
+        False — most backends route through pinned host."""
+        return False
+
+    # ----- optional sidecar manifest (mooncake-style backends) -----
+
+    def manifest_size_bytes(self) -> int:
+        """Bytes on disk for any sidecar metadata file the backend
+        maintains (e.g., MooncakeBackend's JSONL manifest). Default 0
+        — backends that walk durable storage on reconcile (Local,
+        NIXL POSIX) don't have a sidecar."""
+        return 0
+
+    def compact_manifest(self) -> int:
+        """Rewrite the sidecar manifest to drop dead records.
+        Returns bytes freed. Default 0 (no-op) — only backends that
+        maintain an append-only manifest implement this."""
+        return 0
+
+    def _sweep_once(
+        self,
+        max_age_seconds: Optional[float] = None,
+        max_bytes: Optional[int] = None,
+        max_bytes_per_engine: Optional[int] = None,
+    ) -> tuple[int, int, int]:
+        """Run one cleanup pass.
+        Returns (ttl_evicted, per_engine_evicted, global_quota_evicted).
+
+        Order: TTL → per-engine → global. Each phase sees state from
+        the prior. Backends may override if they want a different
+        order, but the default works for any in-memory `_slots` shape."""
+        ttl_n = 0
+        per_eng_n = 0
+        global_n = 0
+        if max_age_seconds is not None:
+            ttl_n = self.prune_older_than(float(max_age_seconds))
+        if max_bytes_per_engine is not None:
+            per_eng_n = self.enforce_per_engine_byte_quota(
+                int(max_bytes_per_engine),
+            )
+        if max_bytes is not None:
+            global_n = self.enforce_byte_quota(int(max_bytes))
+        return ttl_n, per_eng_n, global_n

--- a/lib/gms_kv_ring/daemon/staging_receive_buffer.py
+++ b/lib/gms_kv_ring/daemon/staging_receive_buffer.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Receive-side buffer pool for cross-node staging transfers.
+
+One pinned host buffer per daemon, allocated at startup, registered
+once with the NIXL transport. The daemon hands out offsets into this
+buffer for each inbound transfer; the sender writes RDMA-style into
+the offset; the receiver's notif callback reads back from the offset
+and bridges into StagingTier.commit_or_reject.
+
+Why a single pool, not per-transfer alloc:
+
+  - NIXL `register_memory` triggers a metadata snapshot bump. Peers
+    don't see new registrations until they re-fetch (cross-host) or
+    re-add_remote_agent (loopback). One-time registration of a pool
+    sidesteps that entirely; senders see all offsets within the pool
+    as soon as initial metadata exchange completes.
+
+  - Fixed memory budget: capacity is bounded at daemon startup,
+    matching the StagingTier's own capacity discipline.
+
+  - Free-list-then-bump allocator is good-enough for typical KV
+    sizes; per-block allocations are tens of KiB to MiB. Fragmentation
+    is acceptable at these grain sizes.
+
+The pool is concurrency-safe (single lock). All operations are O(N)
+in the free-list size, which stays small in practice."""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class StagingReceiveBuffer:
+    """Pinned host buffer with a simple free-list + bump allocator."""
+
+    def __init__(self, capacity_bytes: int) -> None:
+        if capacity_bytes <= 0:
+            raise ValueError(
+                f"capacity_bytes must be > 0, got {capacity_bytes}",
+            )
+        self._capacity = int(capacity_bytes)
+        # Hold the ctypes array so refcount keeps the backing storage.
+        self._buf = (ctypes.c_ubyte * self._capacity)()
+        self._base_ptr = ctypes.addressof(self._buf)
+        # Bump pointer for fresh-region allocs.
+        self._used = 0
+        # Free regions returned via `free()`. Each entry is (offset, size).
+        # Coalescing happens on free() so the list stays compact.
+        self._free_list: list[tuple[int, int]] = []
+        self._lock = threading.Lock()
+
+    def base_ptr(self) -> int:
+        return self._base_ptr
+
+    def capacity(self) -> int:
+        return self._capacity
+
+    def bytes_free(self) -> int:
+        with self._lock:
+            free_in_list = sum(sz for _, sz in self._free_list)
+            return (self._capacity - self._used) + free_in_list
+
+    def alloc_many(self, sizes: "list[int]") -> "list[Optional[int]]":
+        """Vectorized alloc: takes the lock ONCE, allocates N regions
+        contiguously when possible. Designed for `fetch_remote` which
+        reserves N regions per call. Amortizes lock acquisition cost."""
+        out: list = []
+        with self._lock:
+            for size in sizes:
+                if size <= 0 or size > self._capacity:
+                    out.append(None)
+                    continue
+                placed = False
+                for i, (off, sz) in enumerate(self._free_list):
+                    if sz < size:
+                        continue
+                    if sz == size:
+                        self._free_list.pop(i)
+                    else:
+                        self._free_list[i] = (off + size, sz - size)
+                    out.append(off)
+                    placed = True
+                    break
+                if placed:
+                    continue
+                if self._used + size <= self._capacity:
+                    off = self._used
+                    self._used += size
+                    out.append(off)
+                else:
+                    out.append(None)
+        return out
+
+    def alloc(self, size: int) -> Optional[int]:
+        """Reserve `size` bytes; returns the offset, or None on
+        out-of-memory."""
+        if size <= 0:
+            raise ValueError(f"size must be > 0, got {size}")
+        if size > self._capacity:
+            return None
+        with self._lock:
+            # First-fit on the free list.
+            for i, (off, sz) in enumerate(self._free_list):
+                if sz < size:
+                    continue
+                # Use this region.
+                if sz == size:
+                    self._free_list.pop(i)
+                else:
+                    self._free_list[i] = (off + size, sz - size)
+                return off
+            # Bump.
+            if self._used + size <= self._capacity:
+                off = self._used
+                self._used += size
+                return off
+            return None
+
+    def free(self, offset: int, size: int) -> None:
+        """Return a previously-allocated region to the pool. Coalesces
+        with adjacent free regions."""
+        if size <= 0:
+            return
+        with self._lock:
+            # Insert and coalesce.
+            self._free_list.append((int(offset), int(size)))
+            self._free_list.sort()
+            coalesced: list[tuple[int, int]] = []
+            for off, sz in self._free_list:
+                if coalesced and coalesced[-1][0] + coalesced[-1][1] == off:
+                    last_off, last_sz = coalesced[-1]
+                    coalesced[-1] = (last_off, last_sz + sz)
+                else:
+                    coalesced.append((off, sz))
+            self._free_list = coalesced
+            # If the highest region is at the end, fold it back into bump.
+            if self._free_list and (
+                self._free_list[-1][0] + self._free_list[-1][1] == self._used
+            ):
+                tail_off, tail_sz = self._free_list.pop()
+                self._used = tail_off
+
+    def ptr_at(self, offset: int) -> int:
+        """Absolute pointer for `offset`. Used by NIXL `remote_ptr`."""
+        if offset < 0 or offset >= self._capacity:
+            raise ValueError(
+                f"offset {offset} out of range [0, {self._capacity})",
+            )
+        return self._base_ptr + int(offset)
+
+    def read(self, offset: int, size: int) -> bytes:
+        """Copy `size` bytes from `offset` into a fresh Python bytes
+        object. Used by the inbound notif callback to extract the
+        payload after a NIXL WRITE landed."""
+        if offset < 0 or offset + size > self._capacity:
+            raise ValueError(
+                f"read [{offset}, {offset + size}) out of range "
+                f"[0, {self._capacity})",
+            )
+        view = (ctypes.c_ubyte * size).from_address(self._base_ptr + offset)
+        return bytes(view)
+
+
+__all__ = ["StagingReceiveBuffer"]

--- a/lib/gms_kv_ring/daemon/staging_tier.py
+++ b/lib/gms_kv_ring/daemon/staging_tier.py
@@ -1,0 +1,922 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Staging tier — content-hash-keyed buffer for cross-node KV transfers.
+
+External (router-orchestrated) byte transfers land in this tier BEFORE
+being consumed by the connector through the existing restore ring. The
+engine never sees this tier directly; the connector polls it by content
+hash at `get_num_new_matched_tokens` time and emits a restore record
+with the `SOURCE_STAGING` flag.
+
+See `docs/CROSS_NODE_DESIGN.md` for the architecture and full race
+analysis. This file enforces:
+
+  I-8 — At most one inbound transfer per `(daemon, content_hash)` pair.
+        Atomic reservation in `reserve_or_wait` under a single lock.
+        Concurrent commands for the same hash coalesce as waiters on
+        the original reservation. Solves the
+        "two-peer-simultaneously-deliver" race.
+
+  I-9 — Receiver hash-verifies on commit by default. Bytes whose
+        content hash does not match the advertised hash transition the
+        slot to CORRUPT and notify waiters with failure. Trusted
+        prefix-hash paths can explicitly skip the byte-digest check and
+        use the hash as a routing key.
+
+  I-3' (staging) — Each staging slot carries a monotonic per-hash
+        generation. `begin_consume` requires the caller-supplied
+        `expected_generation` to match; mismatch → None → the connector
+        treats it the same as a missing slot and falls through to its
+        existing drop-on-failure (I-5) recompute path.
+
+  I-6' (staging) — `scrub_step` re-CRC's READY slots on a slow cadence;
+        drift drops the slot and bumps a corruption counter.
+
+State machine (one slot per content hash):
+
+    EMPTY ──reserve──> RESERVED ──commit_ok──> READY
+                          │                      │
+                          │  commit_corrupt      │  LRU evict
+                          │  or fail             │  or scrub drift
+                          ▼                      ▼
+                       CORRUPT ───────────────> EMPTY
+                          │                      ▲
+                          │   reclaim            │
+                          └──────────────────────┘
+
+Reservation TTL handles client crashes — RESERVED slots whose owner
+hasn't called commit_or_reject within `reservation_stale_s` get
+reclaimed by `evict_stale_reservations`.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import logging
+import threading
+import time
+import uuid
+import zlib
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+# ---- Pluggable allocator -----------------------------------------------------
+
+
+class StagingAllocator:
+    """Pluggable allocator for staging-slot bytes.
+
+    Production uses `_CudaPinnedAllocator` (cudaHostAlloc-backed) so
+    cuFile / NIXL can DMA directly. Tests use `_BytearrayAllocator` so
+    the state machine can be exercised without CUDA."""
+
+    def alloc(self, size: int) -> int:
+        raise NotImplementedError
+
+    def free(self, ptr: int) -> None:
+        raise NotImplementedError
+
+    def write(self, ptr: int, data: bytes) -> None:
+        raise NotImplementedError
+
+    def read(self, ptr: int, size: int) -> bytes:
+        raise NotImplementedError
+
+
+class _BytearrayAllocator(StagingAllocator):
+    """Backed by Python bytearrays. Test-only; the "pointer" returned is
+    just a stable id into a dict that maps to the underlying bytes."""
+
+    def __init__(self) -> None:
+        self._buffers: dict[int, bytearray] = {}
+        self._next_id = 1
+        self._lock = threading.Lock()
+
+    def alloc(self, size: int) -> int:
+        with self._lock:
+            ptr = self._next_id
+            self._next_id += 1
+            self._buffers[ptr] = bytearray(size)
+        return ptr
+
+    def free(self, ptr: int) -> None:
+        with self._lock:
+            self._buffers.pop(ptr, None)
+
+    def write(self, ptr: int, data: bytes) -> None:
+        with self._lock:
+            buf = self._buffers[ptr]
+            if len(data) != len(buf):
+                raise ValueError(
+                    f"write size {len(data)} != buffer size {len(buf)}",
+                )
+            buf[:] = data
+
+    def read(self, ptr: int, size: int) -> bytes:
+        with self._lock:
+            return bytes(self._buffers[ptr][:size])
+
+
+class _CudaPinnedAllocator(StagingAllocator):
+    """Pinned host allocator. Imports `cuda.bindings` lazily so the
+    module can be imported in CUDA-free environments (tests)."""
+
+    def alloc(self, size: int) -> int:
+        from cuda.bindings import runtime as rt
+
+        err, ptr = rt.cudaHostAlloc(size, 0)
+        if err != rt.cudaError_t.cudaSuccess:
+            _, msg = rt.cudaGetErrorString(err)
+            raise RuntimeError(
+                f"cudaHostAlloc({size}) failed: " f"{msg.decode() if msg else err}",
+            )
+        return int(ptr)
+
+    def free(self, ptr: int) -> None:
+        from cuda.bindings import runtime as rt
+
+        err = rt.cudaFreeHost(ptr)[0]
+        if err != rt.cudaError_t.cudaSuccess:
+            _, msg = rt.cudaGetErrorString(err)
+            logger.warning(
+                "cudaFreeHost failed: %s",
+                msg.decode() if msg else err,
+            )
+
+    def write(self, ptr: int, data: bytes) -> None:
+        import ctypes
+
+        ctypes.memmove(ptr, data, len(data))
+
+    def read(self, ptr: int, size: int) -> bytes:
+        import ctypes
+
+        buf = (ctypes.c_char * size).from_address(ptr)
+        return bytes(buf)
+
+
+# ---- Hash helpers ------------------------------------------------------------
+
+
+def _sha256_bytes(data: bytes) -> bytes:
+    """Cryptographic-strength content hash: SHA-256 → 32-byte digest.
+    Slowest but strongest. Backward-compatible default."""
+    return hashlib.sha256(data).digest()
+
+
+def _blake2b_256_bytes(data: bytes) -> bytes:
+    """Full 256-bit BLAKE2b content identity.
+
+    Content addresses remain collision resistant independently of transport
+    checksums. CRC32 remains a separate, fast corruption check.
+    """
+    return hashlib.blake2b(data, digest_size=32).digest()
+
+
+HASH_FN_BY_MODE: dict = {
+    "sha256": _sha256_bytes,
+    "blake2b_256": _blake2b_256_bytes,
+}
+
+
+def hash_fn_for_mode(mode: str):
+    """Resolve a supported synchronous hash mode to its callable."""
+    if mode not in HASH_FN_BY_MODE:
+        raise KeyError(
+            f"unknown hash mode {mode!r}; expected one of " f"{sorted(HASH_FN_BY_MODE)}"
+        )
+    return HASH_FN_BY_MODE[mode]
+
+
+# ---- Slot state --------------------------------------------------------------
+
+
+class _State(enum.Enum):
+    EMPTY = "empty"  # placeholder; not stored — absence = EMPTY
+    RESERVED = "reserved"  # transfer in flight
+    READY = "ready"  # bytes verified, available to consume
+    CORRUPT = "corrupt"  # commit verification failed; awaiting cleanup
+
+
+@dataclass
+class _Waiter:
+    """Coalesced caller blocked on the active reservation for some hash.
+    Notified atomically when the reservation resolves (READY / fail).
+    `hit` set on success, `failure` set on error; exactly one is set
+    before `event.set()`."""
+
+    event: threading.Event = field(default_factory=threading.Event)
+    hit: Optional["StagingHit"] = None
+    failure: Optional[str] = None
+
+
+@dataclass
+class _Slot:
+    state: _State
+    content_hash: bytes
+    reservation_id: Optional[str] = None
+    source_daemon: Optional[str] = None
+    reserved_at: float = 0.0
+    bytes_ptr: Optional[int] = None
+    bytes_size: int = 0
+    crc32: int = 0
+    generation: int = 0  # bumped on each successful commit
+    refcount: int = 0  # nonzero while a consume is in flight
+    waiters: list[_Waiter] = field(default_factory=list)
+    last_accessed: float = 0.0
+
+
+# ---- Result types ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Reservation:
+    """Caller owns the slot. Must call `commit_or_reject(reservation_id,
+    payload)` or `fail_reservation(reservation_id, reason)` within
+    `reservation_stale_s` to avoid the slot being reclaimed."""
+
+    reservation_id: str
+    content_hash: bytes
+
+
+@dataclass(frozen=True)
+class Waiter:
+    """Another caller is fetching this hash. Block on `waiter.event` and
+    read `waiter.hit` (success) or `waiter.failure` (error)."""
+
+    waiter: _Waiter
+    content_hash: bytes
+
+
+@dataclass(frozen=True)
+class AlreadyReady:
+    """Hash is already populated and ready to consume immediately."""
+
+    hit: "StagingHit"
+
+
+@dataclass(frozen=True)
+class Rejected:
+    """Reservation refused — typically capacity-driven backpressure."""
+
+    reason: str
+
+
+ReserveResult = Union[Reservation, Waiter, AlreadyReady, Rejected]
+
+
+@dataclass(frozen=True)
+class CommitOk:
+    hit: "StagingHit"
+
+
+@dataclass(frozen=True)
+class CommitCorrupt:
+    """Hash verify failed; slot transitioned to CORRUPT. Waiters were
+    notified with failure."""
+
+    reason: str
+
+
+@dataclass(frozen=True)
+class CommitRejected:
+    """Reservation no longer valid (stale-reclaimed, mismatched id)."""
+
+    reason: str
+
+
+CommitResult = Union[CommitOk, CommitCorrupt, CommitRejected]
+
+
+@dataclass(frozen=True)
+class StagingHit:
+    """Information about a READY staging slot."""
+
+    content_hash: bytes
+    bytes_ptr: int
+    bytes_size: int
+    crc32: int
+    generation: int
+
+
+@dataclass(frozen=True)
+class ConsumeHandle:
+    """Opaque token returned by `begin_consume`. Must be passed to
+    `end_consume` to release the slot's refcount."""
+
+    content_hash: bytes
+    generation: int
+
+
+# ---- Staging tier ------------------------------------------------------------
+
+
+class StagingTier:
+    """Content-hash-keyed buffer tier. Owned exclusively by the GMS daemon.
+    The engine has no direct binding; the connector consumes via the
+    existing restore ring with a `SOURCE_STAGING` flag."""
+
+    def __init__(
+        self,
+        *,
+        capacity_bytes: int,
+        reservation_stale_s: float = 30.0,
+        allocator: Optional[StagingAllocator] = None,
+        hash_fn: Optional[Callable[[bytes], bytes]] = None,
+        clock: Optional[Callable[[], float]] = None,
+        verify_on_receive: bool = True,
+    ) -> None:
+        if capacity_bytes <= 0:
+            raise ValueError(
+                f"capacity_bytes must be > 0, got {capacity_bytes}",
+            )
+        self._capacity = int(capacity_bytes)
+        self._reservation_stale_s = float(reservation_stale_s)
+        self._alloc = allocator if allocator is not None else _CudaPinnedAllocator()
+        self._hash_fn = hash_fn or _sha256_bytes
+        self._verify_on_receive = bool(verify_on_receive)
+        self._clock = clock or time.monotonic
+
+        # All slots, keyed by content hash. Absence = EMPTY state.
+        self._slots: dict[bytes, _Slot] = {}
+        # LRU order for READY slots only. Most-recently-accessed at end.
+        self._lru: "OrderedDict[bytes, None]" = OrderedDict()
+        # reservation_id → content_hash (for commit/fail lookup).
+        self._by_reservation: dict[str, bytes] = {}
+        # Bytes used by READY + CORRUPT slots. RESERVED slots have no
+        # allocation yet; they reserve the slot key, not memory.
+        self._bytes_used = 0
+        # Round-robin cursor for scrub.
+        self._scrub_cursor = 0
+
+        self._lock = threading.Lock()
+
+        self._stats = {
+            "reservations_created": 0,
+            "waiters_coalesced": 0,
+            "commits_ok": 0,
+            "commits_corrupt": 0,
+            "reservations_failed": 0,
+            "stale_reservations_reclaimed": 0,
+            "evictions_lru": 0,
+            "scrub_corruptions": 0,
+            "rejected_capacity": 0,
+        }
+
+    # ----- Reservation API -----
+
+    def reserve_or_wait_many(
+        self,
+        content_hashes: "list[bytes]",
+        source_daemon: str,
+    ) -> "list[ReserveResult]":
+        """Vectorized reservation: takes the lock ONCE and processes N
+        hashes inside. ~100× faster than N separate `reserve_or_wait`
+        calls for large N because we amortize lock acquisition + dict
+        bookkeeping cost. Returns one result per input hash, in order.
+
+        Used by `fetch_remote` which always reserves N hashes at once
+        — eliminates the per-block Python overhead that dominated the
+        GMS-vs-Dynamo benchmark gap."""
+        now = self._clock()
+        results: list = []
+        with self._lock:
+            for content_hash in content_hashes:
+                slot = self._slots.get(content_hash)
+                if slot is None:
+                    results.append(
+                        self._create_reservation_locked(
+                            content_hash,
+                            source_daemon,
+                            now,
+                        )
+                    )
+                    continue
+                if slot.state is _State.READY:
+                    self._lru.move_to_end(content_hash)
+                    slot.last_accessed = now
+                    results.append(AlreadyReady(hit=_hit_from_slot(slot)))
+                    continue
+                if slot.state is _State.RESERVED:
+                    if (now - slot.reserved_at) > self._reservation_stale_s:
+                        self._reclaim_stale_reservation_locked(slot, now)
+                        results.append(
+                            self._create_reservation_locked(
+                                content_hash,
+                                source_daemon,
+                                now,
+                            )
+                        )
+                        continue
+                    w = _Waiter()
+                    slot.waiters.append(w)
+                    self._stats["waiters_coalesced"] += 1
+                    results.append(Waiter(waiter=w, content_hash=content_hash))
+                    continue
+                # CORRUPT
+                self._drop_slot_locked(content_hash)
+                results.append(
+                    self._create_reservation_locked(
+                        content_hash,
+                        source_daemon,
+                        now,
+                    )
+                )
+        return results
+
+    def reserve_or_wait(
+        self,
+        content_hash: bytes,
+        source_daemon: str,
+    ) -> ReserveResult:
+        """Atomic per-hash reservation (I-8).
+
+        - EMPTY (absent) → create RESERVED, return Reservation.
+        - RESERVED (active owner) → add to waiters, return Waiter.
+        - RESERVED (stale owner) → reclaim, create new RESERVED, return Reservation.
+        - READY → return AlreadyReady.
+        - CORRUPT → reclaim, create new RESERVED, return Reservation.
+        """
+        now = self._clock()
+        with self._lock:
+            slot = self._slots.get(content_hash)
+
+            if slot is None:
+                return self._create_reservation_locked(
+                    content_hash,
+                    source_daemon,
+                    now,
+                )
+
+            if slot.state is _State.READY:
+                # Mark accessed for LRU
+                self._lru.move_to_end(content_hash)
+                slot.last_accessed = now
+                return AlreadyReady(hit=_hit_from_slot(slot))
+
+            if slot.state is _State.RESERVED:
+                if (now - slot.reserved_at) > self._reservation_stale_s:
+                    # Owner is stuck/dead; reclaim.
+                    self._reclaim_stale_reservation_locked(slot, now)
+                    return self._create_reservation_locked(
+                        content_hash,
+                        source_daemon,
+                        now,
+                    )
+                # Active owner; coalesce.
+                w = _Waiter()
+                slot.waiters.append(w)
+                self._stats["waiters_coalesced"] += 1
+                return Waiter(waiter=w, content_hash=content_hash)
+
+            # CORRUPT — reclaim and retry. (Waiters were already
+            # notified when state transitioned to CORRUPT.)
+            self._drop_slot_locked(content_hash)
+            return self._create_reservation_locked(
+                content_hash,
+                source_daemon,
+                now,
+            )
+
+    def commit_or_reject(
+        self,
+        reservation_id: str,
+        payload: bytes,
+        *,
+        verify_content_hash: bool = True,
+    ) -> CommitResult:
+        """Transition RESERVED to READY or CORRUPT.
+
+        By default this verifies that ``hash_fn(payload)`` equals the
+        reservation key (I-9). Some engine integrations use the key as a
+        deterministic prefix hash rather than a byte hash; those trusted paths
+        pass ``verify_content_hash=False`` and rely on transport integrity plus
+        the source daemon's prefix-to-address bookkeeping.
+        """
+        # Hash compute happens OUTSIDE the lock — it can be slow for
+        # large payloads (~MB) and we don't want to block reserve_or_wait
+        # callers during verify. The state-machine transition step does
+        # the final critical-section work under the lock.
+        #
+        # When `verify_on_receive=False` (mode="none"), we skip the
+        # content hash entirely and trust the wire — the receiver's
+        # check_remote_metadata + NIXL/UCX CRC layer already protect
+        # against random corruption. `computed_hash` falls back to the
+        # registered hash so the equality check at line 488 trivially
+        # passes. `computed_crc` is always computed because it's cheap
+        # (zlib.crc32 is ~5ns/byte hardware-accelerated) and used as
+        # the storage-tier integrity check on later reads.
+        # Never publish READY before verification completes: consumers
+        # must not observe bytes that may later be declared corrupt.
+        if verify_content_hash and self._verify_on_receive:
+            computed_hash = self._hash_fn(payload)
+        else:
+            computed_hash = None
+        computed_crc = zlib.crc32(payload) & 0xFFFFFFFF
+        now = self._clock()
+
+        with self._lock:
+            content_hash = self._by_reservation.get(reservation_id)
+            if content_hash is None:
+                return CommitRejected(
+                    reason="reservation_id unknown (reclaimed?)",
+                )
+            slot = self._slots.get(content_hash)
+            if slot is None or slot.reservation_id != reservation_id:
+                # Stale reservation; somebody else owns this hash now.
+                self._by_reservation.pop(reservation_id, None)
+                return CommitRejected(
+                    reason="reservation no longer matches slot",
+                )
+            if slot.state is not _State.RESERVED:
+                self._by_reservation.pop(reservation_id, None)
+                return CommitRejected(
+                    reason=f"slot state is {slot.state.value}",
+                )
+            if computed_hash is None:
+                # Trusted routing-key path; the key is not a byte digest.
+                computed_hash = content_hash
+
+            if computed_hash != content_hash:
+                # I-9 violation: bytes don't match advertised hash.
+                # Drop the slot to CORRUPT, notify waiters with failure.
+                slot.state = _State.CORRUPT
+                self._stats["commits_corrupt"] += 1
+                reason = (
+                    f"hash mismatch (expected {content_hash.hex()[:16]}…, "
+                    f"got {computed_hash.hex()[:16]}…)"
+                )
+                self._notify_waiters_locked(slot, None, reason)
+                self._by_reservation.pop(reservation_id, None)
+                # Eagerly drop CORRUPT slots so the next reserver sees EMPTY.
+                self._drop_slot_locked(content_hash)
+                logger.warning(
+                    "[StagingTier] commit rejected: %s",
+                    reason,
+                )
+                return CommitCorrupt(reason=reason)
+
+            # Make room before allocating.
+            size = len(payload)
+            if not self._make_room_locked(size, exclude_hash=content_hash):
+                # Cannot fit even after eviction; reject.
+                slot.state = _State.EMPTY  # transient; will be removed
+                self._drop_slot_locked(content_hash)
+                self._stats["rejected_capacity"] += 1
+                self._notify_waiters_locked(slot, None, "capacity")
+                self._by_reservation.pop(reservation_id, None)
+                return CommitRejected(reason="capacity exhausted")
+
+            # Allocate + copy outside the critical bytes path but still
+            # under the lock (allocator state must be consistent with
+            # _bytes_used). For pinned allocator this is a fast syscall.
+            ptr = self._alloc.alloc(size)
+            self._alloc.write(ptr, payload)
+            self._bytes_used += size
+
+            slot.state = _State.READY
+            slot.bytes_ptr = ptr
+            slot.bytes_size = size
+            slot.crc32 = computed_crc
+            slot.generation += 1
+            slot.last_accessed = now
+            self._lru[content_hash] = None
+            self._lru.move_to_end(content_hash)
+            self._stats["commits_ok"] += 1
+            hit = _hit_from_slot(slot)
+            self._notify_waiters_locked(slot, hit, None)
+            self._by_reservation.pop(reservation_id, None)
+            return CommitOk(hit=hit)
+
+    def fail_reservation(
+        self,
+        reservation_id: str,
+        reason: str,
+    ) -> None:
+        """Release a reservation without delivering bytes; notify
+        waiters of failure."""
+        with self._lock:
+            content_hash = self._by_reservation.pop(reservation_id, None)
+            if content_hash is None:
+                return
+            slot = self._slots.get(content_hash)
+            if slot is None or slot.reservation_id != reservation_id:
+                return
+            if slot.state is not _State.RESERVED:
+                return
+            self._stats["reservations_failed"] += 1
+            self._notify_waiters_locked(slot, None, reason)
+            self._drop_slot_locked(content_hash)
+
+    # ----- Lookup API -----
+
+    def scan(
+        self,
+        content_hashes: list[bytes],
+    ) -> dict[bytes, StagingHit]:
+        """Batch lookup. Returns only currently-READY slots."""
+        out: dict[bytes, StagingHit] = {}
+        now = self._clock()
+        with self._lock:
+            for h in content_hashes:
+                slot = self._slots.get(h)
+                if slot is None or slot.state is not _State.READY:
+                    continue
+                out[h] = _hit_from_slot(slot)
+                # Don't move-to-end on scan — only on actual consume.
+                # Scanning is read-only from LRU's perspective; a poll
+                # that finds nothing shouldn't keep cold slots warm.
+                slot.last_accessed = now
+        return out
+
+    def begin_consume(
+        self,
+        content_hash: bytes,
+        expected_generation: int,
+    ) -> Optional[ConsumeHandle]:
+        """Pin a READY slot for restore. Returns None if not READY or
+        generation mismatch (I-3'). Increments refcount; caller MUST
+        call end_consume to release."""
+        with self._lock:
+            slot = self._slots.get(content_hash)
+            if slot is None or slot.state is not _State.READY:
+                return None
+            if slot.generation != expected_generation:
+                return None
+            slot.refcount += 1
+            slot.last_accessed = self._clock()
+            self._lru.move_to_end(content_hash)
+            return ConsumeHandle(
+                content_hash=content_hash,
+                generation=slot.generation,
+            )
+
+    def consume_pointer(
+        self,
+        handle: ConsumeHandle,
+    ) -> Optional[tuple[int, int, int]]:
+        """Return ``(ptr, size, crc32)`` for a pinned READY slot.
+
+        The caller must have obtained ``handle`` from ``begin_consume``
+        and must call ``end_consume`` after it has copied the bytes.
+        ``None`` means the slot disappeared or its generation changed,
+        so the caller must fail the restore and let the engine
+        recompute.
+        """
+        with self._lock:
+            slot = self._slots.get(handle.content_hash)
+            if slot is None or slot.state is not _State.READY:
+                return None
+            if slot.generation != handle.generation:
+                return None
+            if slot.bytes_ptr is None or slot.bytes_size <= 0:
+                return None
+            return (int(slot.bytes_ptr), int(slot.bytes_size), int(slot.crc32))
+
+    def end_consume(self, handle: ConsumeHandle) -> None:
+        with self._lock:
+            slot = self._slots.get(handle.content_hash)
+            if slot is None:
+                return
+            if slot.refcount > 0:
+                slot.refcount -= 1
+
+            if slot.refcount == 0 and slot.state is _State.CORRUPT:
+                self._drop_slot_locked(handle.content_hash)
+
+    # ----- Background sweeps -----
+
+    def scrub_step(self) -> int:
+        """Re-CRC one READY slot while holding a consumer pin."""
+        with self._lock:
+            ready_hashes = [
+                h
+                for h, slot in self._slots.items()
+                if slot.state is _State.READY and slot.refcount == 0
+            ]
+            if not ready_hashes:
+                return 0
+            self._scrub_cursor = (self._scrub_cursor + 1) % len(ready_hashes)
+            target_hash = ready_hashes[self._scrub_cursor]
+            slot = self._slots[target_hash]
+            ptr = slot.bytes_ptr
+            size = slot.bytes_size
+            expected_crc = slot.crc32
+            slot.refcount += 1
+
+        try:
+            actual_crc = zlib.crc32(self._alloc.read(ptr, size)) & 0xFFFFFFFF
+        except Exception:
+            logger.exception("[StagingTier] scrub read failed")
+            with self._lock:
+                current = self._slots.get(target_hash)
+                if current is slot and current.refcount > 0:
+                    current.refcount -= 1
+            return 0
+
+        with self._lock:
+            current = self._slots.get(target_hash)
+            if current is not slot:
+                return 1
+            if current.refcount > 0:
+                current.refcount -= 1
+            if actual_crc == expected_crc:
+                return 1
+            logger.warning(
+                "[StagingTier] scrub drift: hash=%s expected_crc=%08x "
+                "actual_crc=%08x — dropping slot",
+                target_hash.hex()[:16],
+                expected_crc,
+                actual_crc,
+            )
+            self._stats["scrub_corruptions"] += 1
+            current.state = _State.CORRUPT
+            if current.refcount == 0:
+                self._drop_slot_locked(target_hash)
+        return 1
+
+    def evict_stale_reservations(self) -> int:
+        """Reclaim RESERVED slots whose owners have been silent past
+        `reservation_stale_s`. Returns count reclaimed."""
+        now = self._clock()
+        reclaimed = 0
+        with self._lock:
+            stale_hashes = [
+                h
+                for h, s in self._slots.items()
+                if s.state is _State.RESERVED
+                and (now - s.reserved_at) > self._reservation_stale_s
+            ]
+            for h in stale_hashes:
+                slot = self._slots[h]
+                self._reclaim_stale_reservation_locked(slot, now)
+                reclaimed += 1
+        return reclaimed
+
+    # ----- Lifecycle / inspection -----
+
+    def shutdown(self) -> None:
+        """Free all allocations and notify any waiters with failure."""
+        with self._lock:
+            for h, slot in list(self._slots.items()):
+                if slot.waiters:
+                    self._notify_waiters_locked(slot, None, "daemon shutdown")
+                if slot.bytes_ptr is not None:
+                    try:
+                        self._alloc.free(slot.bytes_ptr)
+                    except Exception:
+                        logger.exception(
+                            "[StagingTier] alloc.free during shutdown",
+                        )
+            self._slots.clear()
+            self._lru.clear()
+            self._by_reservation.clear()
+            self._bytes_used = 0
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._stats)
+
+    def n_slots(self) -> int:
+        with self._lock:
+            return len(self._slots)
+
+    def bytes_used(self) -> int:
+        with self._lock:
+            return self._bytes_used
+
+    # ----- Internal helpers (must be called with self._lock held) -----
+
+    def _create_reservation_locked(
+        self,
+        content_hash: bytes,
+        source_daemon: str,
+        now: float,
+    ) -> Reservation:
+        reservation_id = uuid.uuid4().hex
+        # Preserve generation across reservations so a freshly-reclaimed
+        # slot's new generation differs from its previous incarnation
+        # (defense in depth on top of I-3').
+        prev_gen = (
+            self._slots[content_hash].generation if content_hash in self._slots else 0
+        )
+        self._slots[content_hash] = _Slot(
+            state=_State.RESERVED,
+            content_hash=content_hash,
+            reservation_id=reservation_id,
+            source_daemon=source_daemon,
+            reserved_at=now,
+            last_accessed=now,
+            generation=prev_gen,
+        )
+        self._by_reservation[reservation_id] = content_hash
+        self._stats["reservations_created"] += 1
+        return Reservation(
+            reservation_id=reservation_id,
+            content_hash=content_hash,
+        )
+
+    def _reclaim_stale_reservation_locked(
+        self,
+        slot: _Slot,
+        now: float,
+    ) -> None:
+        logger.warning(
+            "[StagingTier] stale reservation reclaimed: hash=%s " "owner=%s age=%.1fs",
+            slot.content_hash.hex()[:16],
+            slot.source_daemon,
+            now - slot.reserved_at,
+        )
+        self._stats["stale_reservations_reclaimed"] += 1
+        self._notify_waiters_locked(slot, None, "reservation stale")
+        if slot.reservation_id is not None:
+            self._by_reservation.pop(slot.reservation_id, None)
+        self._drop_slot_locked(slot.content_hash)
+
+    def _notify_waiters_locked(
+        self,
+        slot: _Slot,
+        hit: Optional[StagingHit],
+        failure: Optional[str],
+    ) -> None:
+        for w in slot.waiters:
+            w.hit = hit
+            w.failure = failure
+            w.event.set()
+        slot.waiters = []
+
+    def _drop_slot_locked(self, content_hash: bytes) -> None:
+        slot = self._slots.pop(content_hash, None)
+        if slot is None:
+            return
+        self._lru.pop(content_hash, None)
+        if slot.reservation_id is not None:
+            self._by_reservation.pop(slot.reservation_id, None)
+        if slot.bytes_ptr is not None:
+            try:
+                self._alloc.free(slot.bytes_ptr)
+            except Exception:
+                logger.exception("[StagingTier] alloc.free during drop")
+            self._bytes_used -= slot.bytes_size
+
+    def _make_room_locked(
+        self,
+        needed: int,
+        exclude_hash: bytes,
+    ) -> bool:
+        """Try to evict LRU READY slots (with refcount==0) until
+        `_bytes_used + needed <= _capacity`. Returns True on success,
+        False if we couldn't fit even after evicting everything
+        evictable."""
+        if self._bytes_used + needed <= self._capacity:
+            return True
+        # Iterate LRU front (coldest) → back. Skip exclude_hash and
+        # any slot with refcount > 0.
+        for h in list(self._lru.keys()):
+            if self._bytes_used + needed <= self._capacity:
+                return True
+            if h == exclude_hash:
+                continue
+            slot = self._slots.get(h)
+            if slot is None or slot.state is not _State.READY:
+                continue
+            if slot.refcount > 0:
+                continue
+            self._stats["evictions_lru"] += 1
+            self._drop_slot_locked(h)
+        return self._bytes_used + needed <= self._capacity
+
+
+def _hit_from_slot(slot: _Slot) -> StagingHit:
+    assert slot.state is _State.READY
+    assert slot.bytes_ptr is not None
+    return StagingHit(
+        content_hash=slot.content_hash,
+        bytes_ptr=slot.bytes_ptr,
+        bytes_size=slot.bytes_size,
+        crc32=slot.crc32,
+        generation=slot.generation,
+    )
+
+
+__all__ = [
+    "StagingTier",
+    "StagingAllocator",
+    "StagingHit",
+    "Reservation",
+    "Waiter",
+    "AlreadyReady",
+    "Rejected",
+    "CommitOk",
+    "CommitCorrupt",
+    "CommitRejected",
+    "ConsumeHandle",
+    "ReserveResult",
+    "CommitResult",
+]

--- a/lib/gms_kv_ring/daemon/storage_tier.py
+++ b/lib/gms_kv_ring/daemon/storage_tier.py
@@ -1,0 +1,834 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Storage tier — filesystem-backed offload below host_tier.
+
+ROLE IN THE BACKEND STRATEGY: this is the **dev / test / CI**
+backend. Use it when a zero-extra-deps path is required (pure
+Python + local filesystem only) — unit tests, laptop dev, CI
+without NIXL installed. **PRODUCTION** should use `NixlBackend`
+(POSIX plugin is a strict superset functionally, plus brings
+GDS/OBJ/UCX). **Mooncake** is OPTIONAL for users already running
+a Mooncake-store fabric. New GMS features land in NIXL first;
+Local and Mooncake only get parity on explicit demand. The state
+machine + sweeper + CRC + manifest infrastructure is shared via
+`backend.StorageBackend`, so the behavioral contract is uniform
+across all three.
+
+State machine (per (engine_id, layer, offset) block):
+
+    EMPTY -> HBM_FRESH -> EVICT_PENDING_HOST -> AT_REST_HOST
+        ^                                            |
+        |                                            v
+        |                                   SPILL_PENDING_STORAGE  <-- (this module)
+        |                                            |
+        |                                            v
+        +---- RESTORE_PENDING <-- AT_REST_HOST <-- AT_REST_STORAGE
+                                  (promote)        (demote)
+
+Demote (AT_REST_HOST -> AT_REST_STORAGE):
+    1. Read host_tier slot's pinned bytes + its stored CRC.
+    2. Write a versioned file: header (magic+version+crc+size) + payload.
+    3. fsync the payload so a crash doesn't leave a torn file looking valid.
+    4. Atomic rename into place (open temp, rename) so a partial file
+       is never indexable.
+    5. Free the host_tier slot.
+
+Promote (AT_REST_STORAGE -> AT_REST_HOST):
+    1. Open the file, verify magic/version, read header.
+    2. Allocate a host_tier slot of size == header.size.
+    3. Read payload bytes into the slot.
+    4. Recompute CRC over the bytes. If it doesn't match the header's
+       stored CRC, FAIL — the bytes were corrupted at rest.
+    5. mark_ready the host_tier slot with the (now-verified) CRC.
+
+The CRC pattern matches host_tier exactly — same CRC32 (IEEE), same
+helper (`common/checksum.py`). A demoted block thus survives any
+number of tier-to-tier hops with end-to-end integrity: each
+transition re-verifies and re-stamps.
+
+This module is intentionally minimal: synchronous file I/O, no
+worker thread, no LRU. SSD bandwidth (~2-3 GB/s for NVMe) is the
+dominant cost; a worker pool can be layered above if needed."""
+
+from __future__ import annotations
+
+import logging
+import os
+import struct
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import quote
+
+from gms_kv_ring.daemon.backend import StorageBackend
+
+logger = logging.getLogger(__name__)
+
+
+_MAGIC = 0x47535453  # 'STSG' little-endian read as "GSTS"
+_VERSION = 1
+_HEADER_FMT = "<IIIIQ"  # magic, version, crc, size, _pad
+_HEADER_SIZE = struct.calcsize(_HEADER_FMT)
+
+
+@dataclass
+class _StorageSlot:
+    path: str
+    size: int
+    # CRC32 of the payload bytes, captured at demote-time and
+    # re-verified on promote. Mismatch on promote == at-rest corruption.
+    crc: int
+    # Last-write time, seconds since epoch. Set at demote (time.time())
+    # and at reconcile (os.stat). Drives LRU quota eviction and TTL
+    # prune without per-iteration stat() syscalls.
+    mtime: float = 0.0
+
+
+class StorageTier(StorageBackend):
+    """Filesystem-backed offload pool, keyed by (engine_id, layer, offset).
+
+    All files live under `base_dir` in a deterministic per-engine
+    subtree. Files are written atomically (temp + rename + fsync) so a
+    crash mid-demote never leaves a torn file the index would trust.
+
+    Implements the `StorageBackend` interface — see daemon/backend.py
+    for the contract. Other backends (NIXL, Mooncake) sit beside this
+    one as siblings."""
+
+    name = "local"
+
+    def __init__(self, base_dir: str) -> None:
+        self.base_dir = os.path.abspath(base_dir)
+        os.makedirs(self.base_dir, exist_ok=True)
+        self._slots: dict[tuple[str, int, int], _StorageSlot] = {}
+        self._lock = threading.Lock()
+        # On startup, rebuild the index from disk and clean up any
+        # torn temp files left over from a kill -9 mid-write.
+        self._reconcile_from_disk()
+
+    # ----- startup reconcile (crash-recovery) -----
+
+    def _reconcile_from_disk(self) -> None:
+        """Walk `base_dir` and rebuild `_slots` from on-disk files.
+
+        Daemon restart invariant: in-memory state is gone, but storage
+        files persist. After this runs:
+          - every valid file is indexed with its header CRC
+          - every torn .tmp-* file is unlinked (atomic rename never
+            ran => caller's write was incomplete => file is suspect)
+          - files with bad magic/version are LEFT on disk but not
+            indexed (out-of-band recovery / forensics)
+
+        CRC of the payload is verified lazily on promote — scanning
+        every byte at startup would be O(disk size). The header CRC
+        stamp gives us index-level integrity; the lazy verify gives
+        us payload-level integrity. Both must agree on promote."""
+        n_indexed = 0
+        n_torn = 0
+        n_bad = 0
+        for dirpath, _dirnames, filenames in os.walk(self.base_dir):
+            for fn in filenames:
+                full = os.path.join(dirpath, fn)
+                if fn.startswith(".tmp-"):
+                    try:
+                        os.unlink(full)
+                        n_torn += 1
+                    except OSError:
+                        pass
+                    continue
+                if not fn.endswith(".bin"):
+                    continue
+                # Derive (engine_id, layer, offset) from the path.
+                rel = os.path.relpath(full, self.base_dir)
+                parts = rel.split(os.sep)
+                if len(parts) != 3:
+                    continue
+                eid_quoted, layer_str, offset_bin = parts
+                try:
+                    layer = int(layer_str)
+                    offset = int(offset_bin[: -len(".bin")])
+                except ValueError:
+                    continue
+                from urllib.parse import unquote
+
+                engine_id = unquote(eid_quoted)
+                slot = self._read_header(full)
+                if slot is None:
+                    n_bad += 1
+                    continue
+                self._slots[(engine_id, layer, offset)] = slot
+                n_indexed += 1
+        if n_indexed or n_torn or n_bad:
+            logger.info(
+                "storage_tier reconcile: indexed=%d torn-tmp-cleaned=%d "
+                "bad-header=%d",
+                n_indexed,
+                n_torn,
+                n_bad,
+            )
+
+    def _read_header(self, path: str) -> Optional[_StorageSlot]:
+        """Open `path`, read+validate the 24-byte header. Returns a
+        slot describing the indexed entry, or None on any error.
+        Does NOT read the payload (lazy CRC verify happens on promote)."""
+        try:
+            with open(path, "rb") as f:
+                hdr = f.read(_HEADER_SIZE)
+                if len(hdr) != _HEADER_SIZE:
+                    return None
+                magic, version, file_crc, file_size, _pad = struct.unpack(
+                    _HEADER_FMT,
+                    hdr,
+                )
+                if magic != _MAGIC or version != _VERSION:
+                    return None
+                # Sanity-check the file is at least header + payload.
+                # Don't read the payload — that's promote's job.
+                f.seek(0, 2)
+                disk_size = f.tell()
+                if disk_size < _HEADER_SIZE + file_size:
+                    # Truncated file — write got killed after the
+                    # rename but before fsync completed flushing the
+                    # payload. (Unlikely with our write order, but
+                    # possible on power loss between fsync and dirent
+                    # commit.) Discard the index entry.
+                    logger.warning(
+                        "reconcile: truncated file %s " "(disk_size=%d header.size=%d)",
+                        path,
+                        disk_size,
+                        file_size,
+                    )
+                    return None
+            try:
+                mtime = os.path.getmtime(path)
+            except OSError:
+                mtime = time.time()
+            return _StorageSlot(
+                path=path,
+                size=int(file_size),
+                crc=int(file_crc) & 0xFFFFFFFF,
+                mtime=mtime,
+            )
+        except OSError as exc:
+            logger.warning("reconcile: read %s failed: %s", path, exc)
+            return None
+
+    # ----- key/path helpers -----
+
+    def _path_for(self, engine_id: str, layer: int, offset: int) -> str:
+        # engine_id may contain user-provided characters; quote for fs.
+        safe_eid = quote(str(engine_id), safe="")
+        return os.path.join(
+            self.base_dir,
+            safe_eid,
+            str(int(layer)),
+            f"{int(offset)}.bin",
+        )
+
+    # ----- demote: host_tier slot -> filesystem -----
+
+    def demote(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        host_ptr: int,
+        size: int,
+        crc: int,
+    ) -> _StorageSlot:
+        """Write `size` bytes from `host_ptr` to a file, stamped with
+        the provided CRC. Replaces any prior file at the same key.
+
+        Caller is responsible for ensuring the host_tier slot's CRC
+        matches the bytes being written — typically by passing the
+        slot's stored CRC directly. We do NOT recompute here because:
+          a) we want to detect drift across tier boundaries (i.e., if
+             this CRC doesn't match the file's bytes on promote, that
+             tells us *where* the corruption occurred), and
+          b) it's a single source of truth — the host_tier CRC.
+
+        Raises OSError on filesystem failure."""
+        import ctypes
+
+        key = (str(engine_id), int(layer), int(offset))
+        path = self._path_for(engine_id, layer, offset)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+
+        # Write to a temp file in the same dir, fsync, rename.
+        # Same-dir rename is atomic on POSIX.
+        header = struct.pack(
+            _HEADER_FMT,
+            _MAGIC,
+            _VERSION,
+            int(crc) & 0xFFFFFFFF,
+            int(size),
+            0,
+        )
+        buf = (ctypes.c_ubyte * size).from_address(int(host_ptr))
+        payload = bytes(buf)  # one copy: pinned RAM -> bytes
+
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".tmp-",
+            suffix=".bin",
+            dir=os.path.dirname(path),
+        )
+        try:
+            with os.fdopen(fd, "wb", closefd=True) as f:
+                f.write(header)
+                f.write(payload)
+                f.flush()
+                os.fsync(f.fileno())
+            os.rename(tmp_path, path)
+            tmp_path = None  # signal: rename succeeded, don't unlink
+        finally:
+            if tmp_path is not None and os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+        slot = _StorageSlot(
+            path=path,
+            size=int(size),
+            crc=int(crc) & 0xFFFFFFFF,
+            mtime=time.time(),
+        )
+        with self._lock:
+            self._slots[key] = slot
+        return slot
+
+    # ----- promote: filesystem -> host_tier slot -----
+
+    def promote(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+        dest_host_ptr: int,
+        max_size: int,
+    ) -> Optional[int]:
+        """Read the storage file into `dest_host_ptr` and verify CRC.
+
+        Returns the verified CRC on success (caller stores it on the
+        host_tier slot via mark_ready). Returns None if:
+          - no storage slot at this key
+          - file header is malformed (magic/version mismatch)
+          - file size doesn't fit in max_size
+          - CRC mismatch (at-rest corruption)
+
+        Logs the failure cause at WARNING level."""
+        import ctypes
+
+        from gms_kv_ring.common.checksum import crc32_at_ptr
+
+        key = (str(engine_id), int(layer), int(offset))
+        with self._lock:
+            slot = self._slots.get(key)
+        if slot is None:
+            logger.debug("promote: no slot at %r", key)
+            return None
+        if slot.size > int(max_size):
+            logger.warning(
+                "promote: slot.size=%d > max_size=%d for %r",
+                slot.size,
+                max_size,
+                key,
+            )
+            return None
+
+        try:
+            with open(slot.path, "rb") as f:
+                hdr_bytes = f.read(_HEADER_SIZE)
+                if len(hdr_bytes) != _HEADER_SIZE:
+                    logger.warning(
+                        "promote: short header for %r (%d bytes)",
+                        key,
+                        len(hdr_bytes),
+                    )
+                    return None
+                magic, version, file_crc, file_size, _pad = struct.unpack(
+                    _HEADER_FMT,
+                    hdr_bytes,
+                )
+                if magic != _MAGIC or version != _VERSION:
+                    logger.warning(
+                        "promote: bad magic/version for %r: %#x/%d",
+                        key,
+                        magic,
+                        version,
+                    )
+                    return None
+                if file_size != slot.size or file_crc != slot.crc:
+                    # Index and on-disk header disagree — that's a
+                    # write-side bug. Don't trust the file.
+                    logger.warning(
+                        "promote: index/header mismatch for %r: "
+                        "size %d/%d crc %#x/%#x",
+                        key,
+                        slot.size,
+                        file_size,
+                        slot.crc,
+                        file_crc,
+                    )
+                    return None
+                payload = f.read(file_size)
+                if len(payload) != file_size:
+                    logger.warning(
+                        "promote: short payload for %r (%d/%d bytes)",
+                        key,
+                        len(payload),
+                        file_size,
+                    )
+                    return None
+        except OSError as exc:
+            logger.warning("promote: open/read failed for %r: %s", key, exc)
+            return None
+
+        # Write into the destination host_tier slot.
+        dst = (ctypes.c_ubyte * file_size).from_address(int(dest_host_ptr))
+        ctypes.memmove(dst, payload, file_size)
+
+        # Re-verify CRC from the bytes we just wrote — catches both
+        # at-rest disk corruption AND any in-flight munging through
+        # the read path.
+        actual_crc = crc32_at_ptr(int(dest_host_ptr), file_size)
+        if actual_crc != slot.crc:
+            logger.warning(
+                "promote: CRC mismatch for %r: stored=%#x actual=%#x "
+                "(at-rest corruption)",
+                key,
+                slot.crc,
+                actual_crc,
+            )
+            return None
+        return slot.crc
+
+    # ----- introspection / lifecycle -----
+
+    def get(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+    ) -> Optional[_StorageSlot]:
+        with self._lock:
+            return self._slots.get(
+                (str(engine_id), int(layer), int(offset)),
+            )
+
+    def release_slot(
+        self,
+        engine_id: str,
+        layer: int,
+        offset: int,
+    ) -> bool:
+        with self._lock:
+            slot = self._slots.pop(
+                (str(engine_id), int(layer), int(offset)),
+                None,
+            )
+        if slot is None:
+            return False
+        try:
+            os.unlink(slot.path)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("release_slot: unlink failed: %s", exc)
+        return True
+
+    def release_if_current(self, engine_id, layer, offset, expected) -> bool:
+        key = (str(engine_id), int(layer), int(offset))
+        with self._lock:
+            if self._slots.get(key) is not expected:
+                return False
+            slot = self._slots.pop(key)
+        try:
+            os.unlink(slot.path)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("release_if_current: unlink failed: %s", exc)
+        return True
+
+    def release_engine(self, engine_id: str) -> int:
+        eid = str(engine_id)
+        to_release: list[_StorageSlot] = []
+        with self._lock:
+            keys = [k for k in self._slots if k[0] == eid]
+            for k in keys:
+                to_release.append(self._slots.pop(k))
+        for slot in to_release:
+            try:
+                os.unlink(slot.path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+        # Best-effort cleanup of the engine's subdirectory tree.
+        eng_dir = os.path.join(self.base_dir, quote(eid, safe=""))
+        if os.path.isdir(eng_dir):
+            for dirpath, _dirnames, filenames in os.walk(
+                eng_dir,
+                topdown=False,
+            ):
+                for fn in filenames:
+                    try:
+                        os.unlink(os.path.join(dirpath, fn))
+                    except OSError:
+                        pass
+                try:
+                    os.rmdir(dirpath)
+                except OSError:
+                    pass
+        return len(to_release)
+
+    def n_slots(self) -> int:
+        with self._lock:
+            return len(self._slots)
+
+    def total_bytes(self) -> int:
+        """Sum of payload sizes across all indexed slots. Does NOT
+        include the 24-byte header per file or the filesystem's
+        block-size overhead — those are typically a small fraction."""
+        with self._lock:
+            return sum(s.size for s in self._slots.values())
+
+    def bytes_by_engine(self) -> dict[str, int]:
+        """Bytes resident per engine_id. O(n_slots), in-memory."""
+        out: dict[str, int] = {}
+        with self._lock:
+            for (eid, _layer, _offset), s in self._slots.items():
+                out[eid] = out.get(eid, 0) + s.size
+        return out
+
+    def stats(self) -> dict:
+        """Snapshot for /metrics + operator dashboards. Cheap — all
+        in-memory, no syscalls. Includes per-engine bytes so operators
+        can size per-engine quotas."""
+        with self._lock:
+            slots_list = list(self._slots.items())
+        if not slots_list:
+            return {
+                "n_slots": 0,
+                "total_bytes": 0,
+                "oldest_mtime": 0.0,
+                "newest_mtime": 0.0,
+                "bytes_by_engine": {},
+            }
+        by_eng: dict[str, int] = {}
+        for (eid, _l, _o), s in slots_list:
+            by_eng[eid] = by_eng.get(eid, 0) + s.size
+        return {
+            "n_slots": len(slots_list),
+            "total_bytes": sum(s.size for _k, s in slots_list),
+            "oldest_mtime": min(s.mtime for _k, s in slots_list),
+            "newest_mtime": max(s.mtime for _k, s in slots_list),
+            "bytes_by_engine": by_eng,
+        }
+
+    # ----- operator-driven cleanup -----
+
+    def prune_older_than(
+        self,
+        max_age_seconds: float,
+        now: Optional[float] = None,
+    ) -> int:
+        """TTL eviction. Unlinks every slot whose mtime is older than
+        `now - max_age_seconds`. Returns the count removed.
+
+        Driven by an operator-facing RPC or a periodic policy thread.
+        Concretely useful when (a) an engine was retired and its
+        stale spills should age out, or (b) a daemon is approaching
+        a disk-pressure threshold and operators want a coarse purge."""
+        if now is None:
+            now = time.time()
+        threshold = float(now) - float(max_age_seconds)
+        to_remove: list[tuple[tuple[str, int, int], _StorageSlot]] = []
+        with self._lock:
+            for k, s in list(self._slots.items()):
+                if s.mtime < threshold:
+                    to_remove.append((k, s))
+            for k, _ in to_remove:
+                self._slots.pop(k, None)
+        for _k, slot in to_remove:
+            try:
+                os.unlink(slot.path)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.warning("prune: unlink %s failed: %s", slot.path, exc)
+        return len(to_remove)
+
+    def _sweep_once(
+        self,
+        max_age_seconds: Optional[float] = None,
+        max_bytes: Optional[int] = None,
+        max_bytes_per_engine: Optional[int] = None,
+    ) -> tuple[int, int, int]:
+        """Run one cleanup pass.
+        Returns (ttl_evicted, per_engine_evicted, global_quota_evicted).
+
+        Order matters: TTL first (clears obvious junk), then per-engine
+        (catches noisy individual engines), then global quota
+        (mops up aggregate pressure). Each phase reads the state left
+        by the prior — so a per-engine eviction may make global a
+        no-op, which is the right behavior."""
+        ttl_n = 0
+        per_eng_n = 0
+        global_n = 0
+        if max_age_seconds is not None:
+            ttl_n = self.prune_older_than(float(max_age_seconds))
+        if max_bytes_per_engine is not None:
+            per_eng_n = self.enforce_per_engine_byte_quota(
+                int(max_bytes_per_engine),
+            )
+        if max_bytes is not None:
+            global_n = self.enforce_byte_quota(int(max_bytes))
+        return ttl_n, per_eng_n, global_n
+
+    def enforce_per_engine_byte_quota(
+        self,
+        max_bytes_per_engine: int,
+    ) -> int:
+        """LRU eviction PER ENGINE: any engine over `max_bytes_per_engine`
+        loses its oldest slots until under. Returns total evictions
+        across all engines.
+
+        Why per-engine in addition to global quota: shared storage
+        without per-engine bounds means one noisy engine can fill
+        the disk and the global LRU then evicts other engines'
+        legitimate (smaller, older) data. With per-engine quotas,
+        a misbehaving tenant only evicts ITS OWN data."""
+        cap = int(max_bytes_per_engine)
+        n_evicted = 0
+        with self._lock:
+            # Group slots by engine_id.
+            by_eng: dict[str, list[tuple[tuple[str, int, int], _StorageSlot]]] = {}
+            for k, s in self._slots.items():
+                by_eng.setdefault(k[0], []).append((k, s))
+            to_remove: list[tuple[tuple[str, int, int], _StorageSlot]] = []
+            for eid, items in by_eng.items():
+                current = sum(s.size for _, s in items)
+                if current <= cap:
+                    continue
+                # Oldest-mtime-first within this engine.
+                items.sort(key=lambda kv: kv[1].mtime)
+                for k, s in items:
+                    if current <= cap:
+                        break
+                    to_remove.append((k, s))
+                    current -= s.size
+            for k, _ in to_remove:
+                self._slots.pop(k, None)
+        for _k, slot in to_remove:
+            try:
+                os.unlink(slot.path)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.warning(
+                    "enforce_per_engine_quota: unlink %s failed: %s",
+                    slot.path,
+                    exc,
+                )
+            n_evicted += 1
+        return n_evicted
+
+    def enforce_byte_quota(self, max_bytes: int) -> int:
+        """LRU eviction until total_bytes <= max_bytes. Returns the
+        count of slots evicted.
+
+        Oldest-mtime-first. Ties are broken arbitrarily (dict order).
+        This is best-effort: if a concurrent demote happens during
+        enforcement, the post-condition `total_bytes <= max_bytes`
+        may not strictly hold — caller can re-run if precise bound
+        matters. For typical operator use (background sweeper), the
+        eventual-consistency is fine."""
+        max_bytes = int(max_bytes)
+        n_evicted = 0
+        with self._lock:
+            current = sum(s.size for s in self._slots.values())
+            if current <= max_bytes:
+                return 0
+            # Sort by mtime ascending — oldest first.
+            ordered = sorted(
+                self._slots.items(),
+                key=lambda kv: kv[1].mtime,
+            )
+            to_remove: list[tuple[tuple[str, int, int], _StorageSlot]] = []
+            for k, s in ordered:
+                if current <= max_bytes:
+                    break
+                to_remove.append((k, s))
+                current -= s.size
+            for k, _ in to_remove:
+                self._slots.pop(k, None)
+        for _k, slot in to_remove:
+            try:
+                os.unlink(slot.path)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.warning("enforce_quota: unlink %s failed: %s", slot.path, exc)
+            n_evicted += 1
+        return n_evicted
+
+
+class StorageSweeper:
+    """Background thread that periodically runs cleanup against a
+    StorageTier. Configured with TTL and/or byte quota; either or
+    both may be None (disabled).
+
+    Lifecycle: tied to the Daemon's serve() — started when the daemon
+    starts listening, stopped when serve() returns. The thread is a
+    plain daemon thread (not asyncio); we don't share state with the
+    control loop beyond the StorageTier instance, which is already
+    lock-protected.
+
+    Why a thread, not an asyncio task: cleanup is synchronous
+    filesystem I/O. Doing it on the asyncio loop would block control
+    RPCs for the duration of the sweep — fine when there's nothing
+    to evict, but unbounded when the index is large or disk is slow.
+    A separate thread keeps the control plane responsive."""
+
+    def __init__(
+        self,
+        storage_tier: StorageBackend,
+        *,
+        interval_s: float,
+        max_age_s: Optional[float] = None,
+        max_bytes: Optional[int] = None,
+        max_bytes_per_engine: Optional[int] = None,
+        compact_manifest_at_bytes: Optional[int] = None,
+        on_sweep: Optional[callable] = None,
+    ) -> None:
+        """`compact_manifest_at_bytes`: if set, after each sweep the
+        sweeper checks `backend.manifest_size_bytes()` and calls
+        `compact_manifest()` when the file is over the threshold.
+        Backends without a manifest (Local, NIXL POSIX) return 0
+        from both, so the check is a free no-op for them."""
+        if interval_s <= 0:
+            raise ValueError(f"sweeper interval_s must be > 0, got {interval_s}")
+        if (
+            max_age_s is None
+            and max_bytes is None
+            and max_bytes_per_engine is None
+            and compact_manifest_at_bytes is None
+        ):
+            raise ValueError(
+                "sweeper needs at least one of max_age_s / max_bytes / "
+                "max_bytes_per_engine / compact_manifest_at_bytes",
+            )
+        self.storage_tier = storage_tier
+        self.interval_s = float(interval_s)
+        self.max_age_s = max_age_s
+        self.max_bytes = max_bytes
+        self.max_bytes_per_engine = max_bytes_per_engine
+        self.compact_manifest_at_bytes = compact_manifest_at_bytes
+        # Test hook: called after each sweep as
+        # (ttl_n, per_engine_n, global_n).
+        self._on_sweep = on_sweep
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        # Counters for introspection. Read by tests + the daemon's
+        # exported gauge. No lock needed for ints under GIL.
+        self.sweeps_run = 0
+        self.last_ttl_evicted = 0
+        self.last_per_engine_evicted = 0
+        self.last_quota_evicted = 0
+        self.compactions_run = 0
+        self.last_compaction_savings = 0
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("sweeper already started")
+        self._thread = threading.Thread(
+            target=self._run,
+            name="storage-sweeper",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Signal + join. Safe to call multiple times."""
+        self._stop.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+            if self._thread.is_alive():
+                logger.warning(
+                    "storage sweeper failed to exit within %.1fs",
+                    timeout,
+                )
+        self._thread = None
+
+    def _run(self) -> None:
+        logger.info(
+            "storage sweeper: interval=%.1fs max_age=%s max_bytes=%s "
+            "max_bytes_per_engine=%s",
+            self.interval_s,
+            self.max_age_s,
+            self.max_bytes,
+            self.max_bytes_per_engine,
+        )
+        # Wait first so we don't race the daemon's startup. Use the
+        # stop event so shutdown is immediate, not blocked on a sleep.
+        while not self._stop.wait(self.interval_s):
+            try:
+                ttl_n, per_eng_n, quota_n = self.storage_tier._sweep_once(
+                    max_age_seconds=self.max_age_s,
+                    max_bytes=self.max_bytes,
+                    max_bytes_per_engine=self.max_bytes_per_engine,
+                )
+                self.sweeps_run += 1
+                self.last_ttl_evicted = ttl_n
+                self.last_per_engine_evicted = per_eng_n
+                self.last_quota_evicted = quota_n
+                # Optional manifest compaction. Cheap when no manifest
+                # (default impl returns 0); when configured, triggers
+                # a rewrite once the file bloats past the threshold.
+                # Runs AFTER eviction so any release-driven dead
+                # records are already gone from the in-memory index
+                # — compaction will drop them from the manifest too.
+                if self.compact_manifest_at_bytes is not None:
+                    size = self.storage_tier.manifest_size_bytes()
+                    if size > self.compact_manifest_at_bytes:
+                        savings = self.storage_tier.compact_manifest()
+                        self.compactions_run += 1
+                        self.last_compaction_savings = savings
+                        logger.info(
+                            "storage sweeper: manifest compaction "
+                            "fired (size=%d > threshold=%d, "
+                            "savings=%d)",
+                            size,
+                            self.compact_manifest_at_bytes,
+                            savings,
+                        )
+                if ttl_n or per_eng_n or quota_n:
+                    logger.info(
+                        "storage sweeper: ttl=%d per_engine=%d quota=%d " "(sweep #%d)",
+                        ttl_n,
+                        per_eng_n,
+                        quota_n,
+                        self.sweeps_run,
+                    )
+                if self._on_sweep is not None:
+                    try:
+                        self._on_sweep(ttl_n, per_eng_n, quota_n)
+                    except Exception:  # noqa: BLE001
+                        logger.debug(
+                            "storage sweeper: on_sweep hook failed",
+                            exc_info=True,
+                        )
+            except Exception:  # noqa: BLE001
+                # Sweeper must never crash — a one-off failure (disk
+                # full, permission glitch) is recoverable; we'll try
+                # again next interval. Crashing leaves storage growing
+                # silently.
+                logger.warning(
+                    "storage sweeper: sweep failed, will retry",
+                    exc_info=True,
+                )

--- a/lib/gms_kv_ring/daemon/transport/__init__.py
+++ b/lib/gms_kv_ring/daemon/transport/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional cross-node transport implementations."""
+
+__all__ = [
+    "NixlTransport",
+    "PeerHandle",
+    "TransportClosed",
+    "TransportNotAvailable",
+]
+
+
+def __getattr__(name: str):
+    if name not in __all__:
+        raise AttributeError(name)
+    from importlib import import_module
+
+    module = import_module("gms_kv_ring.daemon.transport.nixl_transport")
+    return getattr(module, name)

--- a/lib/gms_kv_ring/daemon/vmm_allocator.py
+++ b/lib/gms_kv_ring/daemon/vmm_allocator.py
@@ -1,0 +1,440 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Daemon-side allocator that backs the KV cache pool via the CUDA VMM
+driver API and exports POSIX file descriptors for cross-process
+attach.
+
+This module is **isolated from the rest of the daemon** so we can
+exercise its surface area on hosts without CUDA via the no-op /
+unsupported branch, and so the runtime cost of the CUDA driver API
+is paid only when the feature is actually used (`allocate_kv_pool`
+RPC).
+
+End-to-end flow this implements the daemon side of:
+
+  1. RPC: engine asks for an HBM pool of a given size on a given
+     device.
+  2. ``VmmAllocator.allocate(...)`` here:
+       - ``cuMemCreate`` → physical allocation handle
+       - ``cuMemAddressReserve`` → daemon-side VA
+       - ``cuMemMap`` + ``cuMemSetAccess`` → daemon can read/write
+         the bytes
+       - ``cuMemExportToShareableHandle`` → POSIX FD ready to ship
+         to the engine over SCM_RIGHTS
+  3. The daemon's RPC handler ships the FD; the engine imports it
+     (P3 + P4 of the design) and maps the same physical pages into
+     its own VA.
+  4. ``VmmAllocator.release(...)`` later: unmaps the daemon-side
+     VA, releases the daemon's refcount on the handle, frees the
+     VA reservation, closes the FD. Engine-side mappings continue
+     to work (``cuMemRelease`` is refcounted).
+
+See ``docs/ALLOCATE_KV_POOL_DESIGN.md`` for the full plan.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import uuid
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class VmmUnsupportedError(RuntimeError):
+    """Raised by ``allocate`` when the host driver doesn't support VMM
+    or the cuda-python package isn't importable. Callers should turn
+    this into the ``vmm_unsupported`` RPC error code."""
+
+
+class VmmAllocateError(RuntimeError):
+    """Raised when one of the cuMem* driver calls fails. The message
+    carries the underlying CUDA error name. Callers should turn this
+    into the appropriate RPC error code (``insufficient_memory``,
+    ``fd_export_failed``, etc.) based on the failing step."""
+
+
+@dataclass
+class VmmAllocation:
+    """Bookkeeping for one VMM-backed pool. Owned by the daemon;
+    the engine receives only ``fd`` + ``size_aligned``."""
+
+    pool_id: str
+    cu_handle: int  # CUmemGenericAllocationHandle (opaque integer)
+    va: int  # daemon-side mapped virtual address
+    size_aligned: int  # bytes; multiple of granularity
+    granularity: int  # the allocator granularity used
+    fd: int  # cuMemExportToShareableHandle output
+    device_index: int  # GPU id the allocation lives on
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+class VmmAllocator:
+    """Per-GPU VMM allocator.
+
+    Construction is cheap; the actual CUDA support probe happens on
+    the first ``is_supported()`` call (or implicitly inside
+    ``allocate()``). This lazy-probe pattern lets the daemon boot
+    cleanly on hosts where cuda-python isn't installed; only the
+    ``allocate_kv_pool`` RPC is affected.
+
+    Thread-safety: ``allocate`` / ``release`` acquire an internal
+    lock around the in-memory pool-id → allocation dict. The cuMem*
+    calls themselves are not serialized — the CUDA driver is
+    thread-safe and these are non-overlapping per-allocation operations.
+    """
+
+    def __init__(self, device_index: int) -> None:
+        self.device_index = int(device_index)
+        self._allocations: dict[str, VmmAllocation] = {}
+        self._granularity: Optional[int] = None
+        self._supported: Optional[bool] = None
+        self._primary_ctx = None
+        self._cu_device = None
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def is_supported(self) -> bool:
+        """Probe whether VMM is usable on this host. Cached after the
+        first call; subsequent calls return the cached result.
+
+        Returns False (no exception) in these cases:
+          * cuda-python isn't importable
+          * the CUDA driver is too old / lacks
+            ``CU_MEM_ALLOC_GRANULARITY_MINIMUM`` for our requested
+            property
+          * any other unexpected error during the probe
+        """
+        if self._supported is not None:
+            return self._supported
+        self._supported = self._probe_support()
+        return self._supported
+
+    def allocate(self, size_bytes: int) -> VmmAllocation:
+        """Allocate an HBM region of at least ``size_bytes`` bytes,
+        export a POSIX FD for cross-process attach, and return the
+        bookkeeping record. The caller is responsible for shipping
+        the FD to the engine via SCM_RIGHTS (P3 of the design)."""
+        if size_bytes <= 0:
+            raise ValueError(
+                f"VmmAllocator.allocate: size_bytes must be > 0, got {size_bytes}"
+            )
+        if not self.is_supported():
+            raise VmmUnsupportedError(
+                "VMM not supported on this host (cuda-python missing or "
+                "driver too old)."
+            )
+        return self._allocate_supported(size_bytes)
+
+    def release(self, pool_id: str) -> bool:
+        """Drop the daemon's refcount on ``pool_id``. Returns True if
+        the allocation was found + released, False if the pool_id is
+        unknown (idempotent on duplicate release).
+
+        After ``release``, engine-side mappings of the same handle
+        continue to work — physical pages are only reclaimed when ALL
+        processes have dropped their refcount (``cuMemRelease``
+        semantics)."""
+        with self._lock:
+            alloc = self._allocations.pop(pool_id, None)
+        if alloc is None:
+            return False
+        self._release_locked(alloc)
+        return True
+
+    def known_pool_ids(self) -> "list[str]":
+        """Snapshot of currently-allocated pool_ids (for tests +
+        diagnostics)."""
+        with self._lock:
+            return list(self._allocations.keys())
+
+    def shutdown(self) -> None:
+        """Release every outstanding allocation. Called from the
+        daemon's shutdown path."""
+        with self._lock:
+            pool_ids = list(self._allocations.keys())
+        for pid in pool_ids:
+            self.release(pid)
+
+    # ------------------------------------------------------------------
+    # Internal — cuda-python interaction
+    # ------------------------------------------------------------------
+
+    def _probe_support(self) -> bool:
+        """Run a one-time check that VMM + POSIX-FD export are
+        available on this host. The result is cached in
+        ``self._supported`` and the granularity in
+        ``self._granularity`` for later allocate() calls."""
+        try:
+            from cuda import cuda  # type: ignore[import-not-found]
+        except ImportError:
+            logger.warning(
+                "[VmmAllocator] cuda-python not importable; VMM mode "
+                "disabled. Install `cuda-python` to enable the "
+                "allocate_kv_pool RPC.",
+            )
+            return False
+        try:
+            # Ensure the driver is initialized and a primary context is
+            # current on the target device. The daemon process won't
+            # have one set up unless something earlier (e.g. torch)
+            # touched CUDA — for tests + standalone deployments we
+            # need the allocator to be self-sufficient.
+            (err_init,) = cuda.cuInit(0)
+            if err_init != cuda.CUresult.CUDA_SUCCESS:
+                logger.warning(
+                    "[VmmAllocator] cuInit failed (%s); VMM mode disabled.",
+                    self._err_name(cuda, err_init),
+                )
+                return False
+            err_dev, dev = cuda.cuDeviceGet(self.device_index)
+            if err_dev != cuda.CUresult.CUDA_SUCCESS:
+                logger.warning(
+                    "[VmmAllocator] cuDeviceGet(%d) failed (%s); " "VMM mode disabled.",
+                    self.device_index,
+                    self._err_name(cuda, err_dev),
+                )
+                return False
+            err_ctx, ctx = cuda.cuDevicePrimaryCtxRetain(dev)
+            if err_ctx != cuda.CUresult.CUDA_SUCCESS:
+                logger.warning(
+                    "[VmmAllocator] cuDevicePrimaryCtxRetain failed "
+                    "(%s); VMM mode disabled.",
+                    self._err_name(cuda, err_ctx),
+                )
+                return False
+            (err_set,) = cuda.cuCtxSetCurrent(ctx)
+            if err_set != cuda.CUresult.CUDA_SUCCESS:
+                logger.warning(
+                    "[VmmAllocator] cuCtxSetCurrent failed (%s); " "VMM mode disabled.",
+                    self._err_name(cuda, err_set),
+                )
+                return False
+            # Track the retained context so shutdown() can release it.
+            self._primary_ctx = ctx
+            self._cu_device = dev
+
+            prop = self._build_alloc_prop(cuda)
+            err, gran = cuda.cuMemGetAllocationGranularity(
+                prop,
+                cuda.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_MINIMUM,
+            )
+            if err != cuda.CUresult.CUDA_SUCCESS:
+                logger.warning(
+                    "[VmmAllocator] cuMemGetAllocationGranularity failed "
+                    "(err=%s); VMM mode disabled.",
+                    err,
+                )
+                return False
+            self._granularity = int(gran)
+            if self._granularity <= 0:
+                logger.warning(
+                    "[VmmAllocator] driver returned non-positive "
+                    "granularity %d; VMM mode disabled.",
+                    self._granularity,
+                )
+                return False
+            logger.info(
+                "[VmmAllocator] VMM mode available on device %d "
+                "(granularity=%d bytes)",
+                self.device_index,
+                self._granularity,
+            )
+            return True
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[VmmAllocator] support probe raised; VMM mode disabled.",
+                exc_info=True,
+            )
+            return False
+
+    def _build_alloc_prop(self, cuda):
+        """Build a ``CUmemAllocationProp`` for a pinned device
+        allocation on ``self.device_index`` with POSIX-FD export
+        requested. Used both by the support probe and by allocate()."""
+        prop = cuda.CUmemAllocationProp()
+        prop.type = cuda.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+        prop.location = cuda.CUmemLocation()
+        prop.location.type = cuda.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+        prop.location.id = self.device_index
+        # Request POSIX FD as the shareable handle format so we can
+        # SCM_RIGHTS-pass it to the engine. Without this, exported
+        # handles would be opaque integers tied to the daemon process.
+        prop.requestedHandleTypes = (
+            cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        )
+        return prop
+
+    def _allocate_supported(self, size_bytes: int) -> VmmAllocation:
+        """Run the actual cuMem* sequence. Caller MUST have verified
+        is_supported(); this method assumes self._granularity is set."""
+        from cuda import cuda  # type: ignore[import-not-found]
+
+        assert self._granularity is not None  # invariant from is_supported
+        size_aligned = _round_up(size_bytes, self._granularity)
+        prop = self._build_alloc_prop(cuda)
+
+        # ---- cuMemCreate ----
+        err, handle = cuda.cuMemCreate(size_aligned, prop, 0)
+        if err != cuda.CUresult.CUDA_SUCCESS:
+            raise VmmAllocateError(
+                f"cuMemCreate failed: {self._err_name(cuda, err)} "
+                f"(size={size_aligned})"
+            )
+
+        # ---- cuMemAddressReserve ----
+        try:
+            err, va = cuda.cuMemAddressReserve(size_aligned, 0, 0, 0)
+            if err != cuda.CUresult.CUDA_SUCCESS:
+                raise VmmAllocateError(
+                    f"cuMemAddressReserve failed: {self._err_name(cuda, err)}"
+                )
+        except VmmAllocateError:
+            cuda.cuMemRelease(handle)
+            raise
+
+        # ---- cuMemMap ----
+        try:
+            (err,) = cuda.cuMemMap(va, size_aligned, 0, handle, 0)
+            if err != cuda.CUresult.CUDA_SUCCESS:
+                raise VmmAllocateError(f"cuMemMap failed: {self._err_name(cuda, err)}")
+        except VmmAllocateError:
+            cuda.cuMemAddressFree(va, size_aligned)
+            cuda.cuMemRelease(handle)
+            raise
+
+        # ---- cuMemSetAccess ----
+        try:
+            access = cuda.CUmemAccessDesc()
+            access.location = prop.location
+            access.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+            (err,) = cuda.cuMemSetAccess(va, size_aligned, [access], 1)
+            if err != cuda.CUresult.CUDA_SUCCESS:
+                raise VmmAllocateError(
+                    f"cuMemSetAccess failed: {self._err_name(cuda, err)}"
+                )
+        except VmmAllocateError:
+            cuda.cuMemUnmap(va, size_aligned)
+            cuda.cuMemAddressFree(va, size_aligned)
+            cuda.cuMemRelease(handle)
+            raise
+
+        # ---- cuMemExportToShareableHandle ----
+        try:
+            err, fd = cuda.cuMemExportToShareableHandle(
+                handle,
+                cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+                0,
+            )
+            if err != cuda.CUresult.CUDA_SUCCESS:
+                raise VmmAllocateError(
+                    f"cuMemExportToShareableHandle failed: "
+                    f"{self._err_name(cuda, err)}"
+                )
+        except VmmAllocateError:
+            cuda.cuMemUnmap(va, size_aligned)
+            cuda.cuMemAddressFree(va, size_aligned)
+            cuda.cuMemRelease(handle)
+            raise
+
+        pool_id = f"pool-{uuid.uuid4().hex[:12]}"
+        alloc = VmmAllocation(
+            pool_id=pool_id,
+            cu_handle=int(handle),
+            va=int(va),
+            size_aligned=int(size_aligned),
+            granularity=int(self._granularity),
+            fd=int(fd),
+            device_index=self.device_index,
+        )
+        with self._lock:
+            self._allocations[pool_id] = alloc
+        logger.info(
+            "[VmmAllocator] allocated pool %s: %d bytes (aligned), fd=%d, " "device=%d",
+            pool_id,
+            alloc.size_aligned,
+            alloc.fd,
+            alloc.device_index,
+        )
+        return alloc
+
+    def _release_locked(self, alloc: VmmAllocation) -> None:
+        """Unmap + release a single allocation. Already removed from
+        the dict; this method only touches CUDA + FD resources.
+        Best-effort: errors are logged but not raised, since release
+        is typically called from shutdown / cleanup paths."""
+        try:
+            from cuda import cuda  # type: ignore[import-not-found]
+        except ImportError:
+            # If we got here we must have allocated successfully, so
+            # cuda-python should be present. This branch is defensive
+            # for tests that mock the import.
+            return
+        try:
+            (err,) = cuda.cuMemUnmap(alloc.va, alloc.size_aligned)
+            if err != cuda.CUresult.CUDA_SUCCESS:
+                logger.warning(
+                    "[VmmAllocator] cuMemUnmap(%s) failed: %s",
+                    alloc.pool_id,
+                    self._err_name(cuda, err),
+                )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[VmmAllocator] cuMemUnmap(%s) raised",
+                alloc.pool_id,
+                exc_info=True,
+            )
+        try:
+            (err,) = cuda.cuMemRelease(alloc.cu_handle)
+            if err != cuda.CUresult.CUDA_SUCCESS:
+                logger.warning(
+                    "[VmmAllocator] cuMemRelease(%s) failed: %s",
+                    alloc.pool_id,
+                    self._err_name(cuda, err),
+                )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[VmmAllocator] cuMemRelease(%s) raised",
+                alloc.pool_id,
+                exc_info=True,
+            )
+        try:
+            (err,) = cuda.cuMemAddressFree(alloc.va, alloc.size_aligned)
+            if err != cuda.CUresult.CUDA_SUCCESS:
+                logger.warning(
+                    "[VmmAllocator] cuMemAddressFree(%s) failed: %s",
+                    alloc.pool_id,
+                    self._err_name(cuda, err),
+                )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[VmmAllocator] cuMemAddressFree(%s) raised",
+                alloc.pool_id,
+                exc_info=True,
+            )
+        try:
+            os.close(alloc.fd)
+        except OSError:
+            pass
+
+    @staticmethod
+    def _err_name(cuda, err) -> str:
+        """Stringify a CUDA error code. Falls back to the integer
+        repr if cuGetErrorName itself fails."""
+        try:
+            _, name = cuda.cuGetErrorName(err)
+            if name is not None:
+                return name.decode() if isinstance(name, bytes) else str(name)
+        except Exception:  # noqa: BLE001
+            pass
+        return str(err)

--- a/lib/gms_kv_ring/tests/conftest.py
+++ b/lib/gms_kv_ring/tests/conftest.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-test faulthandler watchdog for the suite.
+
+If any test hangs longer than HANG_S, dump tracebacks of every
+thread to stderr. Tests are individually short (<5s) so a 30s
+watchdog is comfortably above the usual legitimate run. Longer stress
+tests can use pytest-timeout markers; the watchdog follows those markers
+so it does not dump noisy stacks for healthy scale tests."""
+
+import faulthandler
+import os
+import sys
+
+HANG_S = float(os.environ.get("GMS_KV_RING_TEST_WATCHDOG_S", "30"))
+
+
+def _watchdog_seconds(item) -> float:
+    marker = item.get_closest_marker("timeout")
+    if marker and marker.args:
+        try:
+            return max(HANG_S, float(marker.args[0]))
+        except (TypeError, ValueError):
+            pass
+    return HANG_S
+
+
+def pytest_runtest_setup(item):
+    faulthandler.dump_traceback_later(
+        _watchdog_seconds(item), repeat=False, file=sys.stderr
+    )
+
+
+def pytest_runtest_teardown(item, nextitem):
+    faulthandler.cancel_dump_traceback_later()

--- a/lib/gms_kv_ring/tests/test_crc32_gpu.py
+++ b/lib/gms_kv_ring/tests/test_crc32_gpu.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GPU CRC32 kernel + Rust-side combine helper.
+
+The kernel verifies GDS-restored payloads directly in HBM, preserving
+the GPU-direct data path. The native GF(2) reduction combines parallel
+chunk CRCs without copying payload bytes to host memory.
+
+These tests are CUDA-gated. The kernel falls back gracefully when
+NVRTC compile fails — `is_available()` returns False — but in this
+host we expect a working CUDA + NVRTC, so we hard-skip on CUDA
+absence."""
+
+from __future__ import annotations
+
+import zlib
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("gms_rust_ring")
+if not torch.cuda.is_available():  # pragma: no cover
+    pytest.skip("CUDA required", allow_module_level=True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _ensure_cuda_inited():
+    torch.cuda.init()
+    _ = torch.empty(1, device="cuda")  # warm CUDA context
+
+
+def test_crc32_combine_chunks_matches_zlib_on_known_data():
+    """Pure-Rust math test: combine independently-computed chunk
+    CRCs into the CRC of the whole. Verifies the GF(2) matrix
+    machinery vs zlib for various chunk counts."""
+    from gms_rust_ring import crc32_combine_chunks
+
+    data = bytes((i * 13 & 0xFF) for i in range(12_345))
+    expected = zlib.crc32(data) & 0xFFFFFFFF
+    for chunk in (1, 7, 256, 4096, len(data), len(data) + 1):
+        crcs = []
+        for off in range(0, len(data), chunk):
+            crcs.append(zlib.crc32(data[off : off + chunk]) & 0xFFFFFFFF)
+        got = crc32_combine_chunks(crcs, chunk, len(data))
+        assert got == expected, (
+            f"combine mismatch with chunk={chunk}: "
+            f"expected {expected:#x} got {got:#x}"
+        )
+
+
+def test_crc32_gpu_is_available():
+    """On a normal CUDA host, NVRTC compile should succeed and the
+    kernel should be ready to use. If it ever does not, the failure
+    is logged and GDS restore fails closed. We assert availability
+    here as the expected production case."""
+    from gms_kv_ring.common.crc32_gpu import is_available
+
+    assert is_available(), "expected NVRTC kernel to compile on a working CUDA install"
+
+
+@pytest.mark.parametrize(
+    "size",
+    [
+        0,
+        1,
+        16,
+        256,
+        4096,
+        100_000,
+        1_800_000,
+    ],
+)
+def test_crc32_gpu_matches_zlib(size):
+    """GPU CRC over a torch CUDA tensor matches zlib.crc32 of the
+    same bytes. Spans single byte → ~2MB to exercise both small
+    (single-thread useful work) and large (multi-thread) regimes."""
+    from gms_kv_ring.common.crc32_gpu import crc32_gpu
+
+    payload = bytes((i * 17 & 0xFF) for i in range(size))
+    expected = zlib.crc32(payload) & 0xFFFFFFFF
+    if size == 0:
+        # GPU pointer doesn't matter for empty; pass 0.
+        assert crc32_gpu(0, 0) == expected
+        return
+    t = torch.frombuffer(
+        bytearray(payload),
+        dtype=torch.uint8,
+    ).cuda()
+    got = crc32_gpu(int(t.data_ptr()), size)
+    assert got == expected, f"size={size}: expected {expected:#x} got {got:#x}"
+
+
+def test_crc32_gpu_handles_unaligned_size():
+    """Sizes not divisible by chunk_bytes still produce the correct
+    CRC. The last thread handles the partial tail."""
+    from gms_kv_ring.common.crc32_gpu import crc32_gpu
+
+    # 64 threads × chunk = ceil(n / 64). With n = 100003 prime,
+    # chunk = ceil(100003/64) = 1563 bytes; last thread sees 100003
+    # - 63*1563 = 1534 bytes (a shorter tail).
+    n = 100_003
+    payload = bytes((i & 0xFF) for i in range(n))
+    expected = zlib.crc32(payload) & 0xFFFFFFFF
+    t = torch.frombuffer(bytearray(payload), dtype=torch.uint8).cuda()
+    assert crc32_gpu(int(t.data_ptr()), n) == expected
+
+
+def test_crc32_gpu_detects_device_corruption():
+    """A mutation in HBM must not verify against the stored CRC."""
+    from gms_kv_ring.common.crc32_gpu import crc32_gpu
+
+    payload = bytearray((i * 29 & 0xFF) for i in range(1_800_003))
+    expected = zlib.crc32(payload) & 0xFFFFFFFF
+    tensor = torch.frombuffer(payload, dtype=torch.uint8).cuda()
+    assert crc32_gpu(int(tensor.data_ptr()), len(payload)) == expected
+    tensor[len(payload) // 2] ^= 0x80
+    assert crc32_gpu(int(tensor.data_ptr()), len(payload)) != expected

--- a/lib/gms_kv_ring/tests/test_cuda_batch.py
+++ b/lib/gms_kv_ring/tests/test_cuda_batch.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""cuMemcpyBatchAsync correctness + speedup vs loop."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+torch = pytest.importorskip("torch")
+if not torch.cuda.is_available():  # pragma: no cover
+    pytest.skip("CUDA required", allow_module_level=True)
+
+
+def test_batch_h2d_byte_correctness():
+    """Bytes batched H2D'd must equal what a loop would produce."""
+    import ctypes
+
+    torch.cuda.init()
+    _ = torch.empty(1, device="cuda")
+    from cuda.bindings import driver as drv
+    from cuda.bindings import runtime as rt
+    from gms_kv_ring.common.cuda_batch import batch_h2d, has_batch_h2d
+
+    if not has_batch_h2d():
+        pytest.skip("cuMemcpyBatchAsync not available")
+
+    N, SZ = 16, 4096
+    # Pinned host source with a recognizable per-region pattern.
+    err, host_ptr = rt.cudaHostAlloc(N * SZ, 0)
+    assert err == rt.cudaError_t.cudaSuccess
+    try:
+        host_bytes = (ctypes.c_ubyte * (N * SZ)).from_address(int(host_ptr))
+        for i in range(N):
+            for j in range(SZ):
+                host_bytes[i * SZ + j] = (i * 7 + j * 13) & 0xFF
+
+        dev = torch.zeros(N * SZ, dtype=torch.uint8, device="cuda")
+        dest_vas = [int(dev.data_ptr()) + i * SZ for i in range(N)]
+        src_ptrs = [int(host_ptr) + i * SZ for i in range(N)]
+
+        err, stream = drv.cuStreamCreate(0)
+        assert err == drv.CUresult.CUDA_SUCCESS
+        batch_h2d(dest_vas, src_ptrs, [SZ] * N, int(stream))
+        drv.cuStreamSynchronize(int(stream))
+
+        out = dev.cpu().numpy()
+        for i in range(N):
+            for j in range(0, SZ, 257):  # sparse check
+                expected = (i * 7 + j * 13) & 0xFF
+                assert (
+                    int(out[i * SZ + j]) == expected
+                ), f"mismatch region {i} offset {j}"
+    finally:
+        rt.cudaFreeHost(host_ptr)
+
+
+def test_batch_h2d_speedup_vs_loop():
+    """Batched H2D should be meaningfully faster than N×cuMemcpyAsync."""
+    torch.cuda.init()
+    _ = torch.empty(1, device="cuda")
+    from cuda.bindings import driver as drv
+    from cuda.bindings import runtime as rt
+    from gms_kv_ring.common.cuda_batch import batch_h2d, has_batch_h2d
+
+    if not has_batch_h2d():
+        pytest.skip("cuMemcpyBatchAsync not available")
+
+    N, SZ = 128, 1024
+    err, host_ptr = rt.cudaHostAlloc(N * SZ, 0)
+    assert err == rt.cudaError_t.cudaSuccess
+    try:
+        dev = torch.zeros(N * SZ, dtype=torch.uint8, device="cuda")
+        dsts = [int(dev.data_ptr()) + i * SZ for i in range(N)]
+        srcs = [int(host_ptr) + i * SZ for i in range(N)]
+
+        err, stream = drv.cuStreamCreate(0)
+        assert err == drv.CUresult.CUDA_SUCCESS
+
+        ITERS = 50
+        # Loop baseline
+        t0 = time.perf_counter()
+        for _ in range(ITERS):
+            for i in range(N):
+                drv.cuMemcpyAsync(
+                    drv.CUdeviceptr(dsts[i]),
+                    drv.CUdeviceptr(srcs[i]),
+                    SZ,
+                    int(stream),
+                )
+        drv.cuStreamSynchronize(int(stream))
+        loop_us = (time.perf_counter() - t0) / ITERS * 1e6
+
+        t0 = time.perf_counter()
+        for _ in range(ITERS):
+            batch_h2d(dsts, srcs, [SZ] * N, int(stream))
+        drv.cuStreamSynchronize(int(stream))
+        batch_us = (time.perf_counter() - t0) / ITERS * 1e6
+
+        speedup = loop_us / max(batch_us, 1e-6)
+        print(
+            f"\n[cuda_batch bench] N={N} size={SZ}B\n"
+            f"  loop:  {loop_us:6.2f} µs/iter\n"
+            f"  batch: {batch_us:6.2f} µs/iter\n"
+            f"  speedup: {speedup:.2f}×"
+        )
+        assert speedup >= 2.0
+    finally:
+        rt.cudaFreeHost(host_ptr)

--- a/lib/gms_kv_ring/tests/test_ring_attach_validation.py
+++ b/lib/gms_kv_ring/tests/test_ring_attach_validation.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import struct
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["gms_kv_ring.common.evict_ring", "gms_kv_ring.common.restore_ring"],
+)
+def test_attach_rejects_truncated_header(tmp_path, module_name):
+    ring = importlib.import_module(module_name)
+    path = tmp_path / "truncated.ring"
+    path.write_bytes(b"short")
+
+    with pytest.raises(ValueError, match="too small"):
+        ring.attach_reader(str(path))
+
+
+@pytest.mark.parametrize(
+    ("offset", "value", "message"),
+    [
+        (4, 99, "version mismatch"),
+        (8, 3, "power-of-2"),
+        (12, 128, "record_size mismatch"),
+    ],
+)
+@pytest.mark.parametrize(
+    "module_name",
+    ["gms_kv_ring.common.evict_ring", "gms_kv_ring.common.restore_ring"],
+)
+def test_attach_rejects_invalid_header_field(
+    tmp_path,
+    module_name,
+    offset,
+    value,
+    message,
+):
+    ring = importlib.import_module(module_name)
+    path = tmp_path / "invalid.ring"
+    writer = ring.create_ring(str(path), capacity=8)
+    writer.close()
+    with path.open("r+b") as file:
+        file.seek(offset)
+        file.write(struct.pack("<I", value))
+
+    with pytest.raises(ValueError, match=message):
+        ring.attach_reader(str(path))

--- a/lib/gms_kv_ring/tests/test_ring_primitives.py
+++ b/lib/gms_kv_ring/tests/test_ring_primitives.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ring + counter primitives.
+
+Covers:
+  - Evict ring roundtrip: push N → pop N, payload preserved
+  - Evict ring capacity drops on full
+  - Restore ring roundtrip + chunk-grained shape
+  - Restore ring power-of-2 enforcement
+  - Counter array: engine ↔ daemon visibility
+  - Counter cuStreamWaitValue32 (stored-before-wait)
+  - Counter cuStreamWriteValue32 (daemon-stream-ordered)
+
+Tests run from any cwd; the gms_kv_ring package must be importable
+(set PYTHONPATH or use editable install).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+
+def test_evict_ring_roundtrip(tmp_path):
+    from gms_kv_ring.common import evict_ring as er
+
+    path = str(tmp_path / "e.ring")
+    w = er.create_ring(path, capacity=16)
+    r = er.attach_reader(path)
+
+    ranges = [(0, 1024, 0), (1, 1024, 0)]
+    assert w.push(block_id=42, ranges=ranges) is True
+    rec = r.try_pop()
+    assert rec["block_id"] == 42
+    assert rec["ranges"] == [(0, 1024, 0), (1, 1024, 0)]
+    assert rec["ipc_event"] == b""
+    assert r.try_pop() is None
+    w.close()
+    r.close()
+
+
+def test_evict_ring_drops_when_full(tmp_path):
+    from gms_kv_ring.common import evict_ring as er
+
+    path = str(tmp_path / "e.ring")
+    w = er.create_ring(path, capacity=4)
+    for i in range(4):
+        assert w.push(block_id=i, ranges=[(0, 8, 0)])
+    assert w.push(block_id=99, ranges=[(0, 8, 0)]) is False
+    assert w.stats()["drops"] == 1
+    w.close()
+
+
+def test_evict_ring_rejects_non_pow2_capacity(tmp_path):
+    from gms_kv_ring.common import evict_ring as er
+
+    with pytest.raises(ValueError):
+        er.create_ring(str(tmp_path / "e.ring"), capacity=10)
+
+
+def test_evict_ring_ipc_event_carry(tmp_path):
+    from gms_kv_ring.common import evict_ring as er
+
+    path = str(tmp_path / "e.ring")
+    w = er.create_ring(path, capacity=8)
+    r = er.attach_reader(path)
+    handle = bytes(range(64))
+    w.push(block_id=1, ranges=[(0, 16, 0)], ipc_event_handle=handle)
+    rec = r.try_pop()
+    assert rec["ipc_event"] == handle
+    w.close()
+    r.close()
+
+
+def test_restore_ring_roundtrip(tmp_path):
+    from gms_kv_ring.common import restore_ring as rr
+
+    path = str(tmp_path / "r.ring")
+    w = rr.create_ring(path, capacity=8)
+    r = rr.attach_reader(path)
+    pairs = [(0, 100), (1, 101), (2, 102)]
+    assert w.push(
+        src_engine_id="eng-abc",
+        block_pairs=pairs,
+        counter_slot=7,
+        counter_target=42,
+    )
+    rec = r.try_pop()
+    assert rec["src_engine_id"] == "eng-abc"
+    assert rec["counter_slot"] == 7
+    assert rec["counter_target"] == 42
+    assert rec["block_pairs"] == pairs
+    w.close()
+    r.close()
+
+
+def test_restore_ring_max_pairs(tmp_path):
+    from gms_kv_ring.common import restore_ring as rr
+
+    path = str(tmp_path / "r.ring")
+    w = rr.create_ring(path, capacity=8)
+    # OK at the cap.
+    pairs = [(i, i + 100) for i in range(rr.MAX_BLOCK_PAIRS)]
+    assert w.push(
+        src_engine_id="e",
+        block_pairs=pairs,
+        counter_slot=0,
+        counter_target=1,
+    )
+    # One over → ValueError.
+    with pytest.raises(ValueError):
+        w.push(
+            src_engine_id="e",
+            block_pairs=pairs + [(99, 199)],
+            counter_slot=0,
+            counter_target=2,
+        )
+    w.close()
+
+
+# ----- counter tests (need CUDA) -----
+
+torch = pytest.importorskip("torch")
+if not torch.cuda.is_available():  # pragma: no cover
+    pytest.skip("CUDA required for counter tests", allow_module_level=True)
+
+
+def _shm_path(prefix: str) -> str:
+    return f"/dev/shm/gms-kvr-test-{prefix}-{uuid.uuid4().hex}.bin"
+
+
+def test_counter_cross_process_visibility():
+    """Daemon write → engine read across two file handles."""
+    torch.cuda.init()
+    _ = torch.empty(1, device="cuda")
+    from gms_kv_ring.common.counter import DaemonCounterArray, EngineCounterArray
+
+    path = _shm_path("vis")
+    eng = EngineCounterArray.create(path, num_counters=32)
+    try:
+        dmn = DaemonCounterArray.attach(path, num_counters=32)
+        try:
+            # Reserve a slot — engine state.
+            slot, target = eng.reserve_slot()
+            assert target == 1
+            # Daemon writes via host store path.
+            import struct as _s
+
+            _s.pack_into("<I", dmn.buf, slot * 4, target)
+            assert eng.read_slot(slot) == target
+        finally:
+            dmn.close()
+    finally:
+        eng.close()
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_counter_stream_wait_then_write():
+    """cuStreamWaitValue32 releases after cuStreamWriteValue32."""
+
+    torch.cuda.init()
+    _ = torch.empty(1, device="cuda")
+    from gms_kv_ring.common.counter import DaemonCounterArray, EngineCounterArray
+
+    path = _shm_path("wait-write")
+    eng = EngineCounterArray.create(path, num_counters=16)
+    dmn = DaemonCounterArray.attach(path, num_counters=16)
+    try:
+        slot, target = eng.reserve_slot()
+
+        # Engine stream waits for `target`.
+        engine_stream = torch.cuda.Stream()
+        flag = torch.zeros((1,), dtype=torch.int32, device="cuda")
+        with torch.cuda.stream(engine_stream):
+            eng.wait_value32(int(engine_stream.cuda_stream), slot, target)
+            flag.fill_(1)
+
+        # Daemon stream writes `target` AFTER a no-op (proves ordering).
+        from cuda.bindings import driver as drv
+
+        err, daemon_stream = drv.cuStreamCreate(0)
+        assert err == drv.CUresult.CUDA_SUCCESS
+        dmn.write_on_stream(int(daemon_stream), slot, target)
+
+        # synchronize both — flag must end up 1.
+        torch.cuda.synchronize()
+        assert int(flag.item()) == 1
+    finally:
+        dmn.close()
+        eng.close()
+        if os.path.exists(path):
+            os.unlink(path)

--- a/lib/gms_kv_ring/tests/test_rust_hot_path.py
+++ b/lib/gms_kv_ring/tests/test_rust_hot_path.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rust hot path — correctness + speedup vs pure-Python fallback.
+
+Both paths write the same on-disk bytes (verified by reading via
+the Python fallback after Rust pushes, and vice versa). The Rust
+path is ~3× faster on push/pop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("gms_rust_ring")
+
+
+def test_rust_extension_loaded():
+    """Sanity: the native crate is importable and matches our layout."""
+    import gms_rust_ring as r
+
+    assert r.RECORD_SIZE == 512
+    assert r.HEADER_SIZE == 64
+    assert r.MAX_BLOCK_PAIRS == 54
+    assert r.ENGINE_ID_MAX_LEN == 48
+
+
+def test_rust_path_active_in_restore_ring():
+    """Python wrapper auto-selects Rust when available."""
+    from gms_kv_ring.common.restore_ring import is_rust_accelerated
+
+    assert is_rust_accelerated() is True
+
+
+def test_rust_python_layout_parity(tmp_path):
+    """Bytes written by Rust must be byte-identical to Python — both
+    paths share the same on-disk format. Verified by pushing via Rust
+    + popping via Python's fallback (or vice versa)."""
+    from gms_kv_ring.common import restore_ring as rr
+
+    path = str(tmp_path / "parity.ring")
+    w = rr.create_ring(path, capacity=8)
+    r = rr.attach_reader(path)
+
+    # Push via the active path (Rust if loaded).
+    pairs = [(1, 101), (2, 102), (3, 103), (4, 104)]
+    assert w.push(
+        src_engine_id="parity-test",
+        block_pairs=pairs,
+        counter_slot=5,
+        counter_target=7,
+    )
+
+    # Pop via PYTHON path explicitly (force the fallback).
+    rec = r._try_pop_python()
+    assert rec is not None, "Python pop saw nothing — layout mismatch"
+    assert rec["src_engine_id"] == "parity-test"
+    assert rec["counter_slot"] == 5
+    assert rec["counter_target"] == 7
+    assert rec["block_pairs"] == pairs
+
+    # Now push via PYTHON path (force fallback) and pop via the
+    # active path (Rust if loaded). Bytes must round-trip the
+    # other direction too.
+    w._push_python(
+        src_engine_id="parity-2",
+        block_pairs=[(9, 99)],
+        counter_slot=2,
+        counter_target=3,
+    )
+    rec = r.try_pop()
+    assert rec["src_engine_id"] == "parity-2"
+    assert rec["counter_slot"] == 2
+    assert rec["counter_target"] == 3
+    assert rec["block_pairs"] == [(9, 99)]
+
+    w.close()
+    r.close()
+
+
+def test_rust_speedup_vs_python(tmp_path):
+    """Microbench: Rust push/pop must be ≥2× faster than Python.
+    Observational — prints numbers; asserts only on direction."""
+    import time
+
+    from gms_kv_ring.common import restore_ring as rr
+    from gms_kv_ring.common.restore_ring import is_rust_accelerated
+
+    if not is_rust_accelerated():
+        pytest.skip("Rust extension not loaded; nothing to compare")
+
+    path_rs = str(tmp_path / "rs.ring")
+    path_py = str(tmp_path / "py.ring")
+    w_rs = rr.create_ring(path_rs, capacity=2048)
+    r_rs = rr.attach_reader(path_rs)
+    w_py = rr.create_ring(path_py, capacity=2048)
+    r_py = rr.attach_reader(path_py)
+
+    ITERS = 1000
+    pairs = [(i, i + 100) for i in range(8)]
+
+    # Rust path
+    t0 = time.perf_counter()
+    for _ in range(ITERS):
+        w_rs.push(
+            src_engine_id="x",
+            block_pairs=pairs,
+            counter_slot=0,
+            counter_target=1,
+        )
+        r_rs.try_pop()
+    rs_us = (time.perf_counter() - t0) / ITERS * 1e6
+
+    # Python path
+    t0 = time.perf_counter()
+    for _ in range(ITERS):
+        w_py._push_python(
+            src_engine_id="x",
+            block_pairs=pairs,
+            counter_slot=0,
+            counter_target=1,
+        )
+        r_py._try_pop_python()
+    py_us = (time.perf_counter() - t0) / ITERS * 1e6
+
+    speedup = py_us / max(rs_us, 1e-6)
+    print(
+        f"\n[rust hot-path bench] push+pop\n"
+        f"  Rust:   {rs_us:6.2f} µs/iter\n"
+        f"  Python: {py_us:6.2f} µs/iter\n"
+        f"  Speedup: {speedup:.2f}×"
+    )
+    assert speedup >= 2.0, f"Rust path should be ≥2× faster; got {speedup:.2f}×"
+
+    w_rs.close()
+    r_rs.close()
+    w_py.close()
+    r_py.close()

--- a/lib/gms_kv_ring/tests/test_staging_receive_buffer.py
+++ b/lib/gms_kv_ring/tests/test_staging_receive_buffer.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for StagingReceiveBuffer (Phase 4 helper)."""
+
+from __future__ import annotations
+
+import ctypes
+
+import pytest
+from gms_kv_ring.daemon.staging_receive_buffer import StagingReceiveBuffer
+
+
+def test_alloc_returns_valid_offset():
+    buf = StagingReceiveBuffer(capacity_bytes=4096)
+    off = buf.alloc(128)
+    assert off == 0
+    off2 = buf.alloc(256)
+    assert off2 == 128
+
+
+def test_alloc_returns_none_when_capacity_exhausted():
+    buf = StagingReceiveBuffer(capacity_bytes=1024)
+    assert buf.alloc(800) == 0
+    assert buf.alloc(300) is None  # 800+300 > 1024
+
+
+def test_alloc_size_larger_than_capacity_returns_none():
+    buf = StagingReceiveBuffer(capacity_bytes=1024)
+    assert buf.alloc(2048) is None
+
+
+def test_free_returns_region_to_pool():
+    buf = StagingReceiveBuffer(capacity_bytes=1024)
+    a = buf.alloc(256)
+    assert buf.alloc(256) == 256
+    buf.free(a, 256)
+    # Free-list now has [0, 256). Next 256-byte alloc should reuse it.
+    c = buf.alloc(256)
+    assert c == 0
+    # bytes_free should reflect what's left
+    assert buf.bytes_free() == 1024 - 512
+
+
+def test_free_coalesces_adjacent_regions():
+    buf = StagingReceiveBuffer(capacity_bytes=1024)
+    a = buf.alloc(100)
+    b = buf.alloc(100)
+    assert buf.alloc(100) == 200
+    buf.free(a, 100)
+    buf.free(b, 100)  # coalesces with `a` → one 200-byte region
+    # Now alloc(200) should fit in the coalesced region starting at 0
+    d = buf.alloc(200)
+    assert d == 0
+
+
+def test_free_at_tail_folds_back_into_bump():
+    """When the freed region is at the bump-pointer tail, the bump
+    pointer rolls back, leaving no fragment behind."""
+    buf = StagingReceiveBuffer(capacity_bytes=1024)
+    assert buf.alloc(100) == 0
+    b = buf.alloc(100)
+    buf.free(b, 100)  # tail region — should fold
+    assert buf.bytes_free() == 1024 - 100
+
+
+def test_write_then_read_round_trips():
+    buf = StagingReceiveBuffer(capacity_bytes=4096)
+    off = buf.alloc(256)
+    payload = bytes(range(256))
+    # Write directly via the absolute pointer (simulates an RDMA WRITE)
+    ctypes.memmove(buf.ptr_at(off), payload, len(payload))
+    assert buf.read(off, 256) == payload
+
+
+def test_read_out_of_range_rejected():
+    buf = StagingReceiveBuffer(capacity_bytes=1024)
+    with pytest.raises(ValueError):
+        buf.read(0, 2048)
+    with pytest.raises(ValueError):
+        buf.read(-1, 64)
+
+
+def test_ptr_at_out_of_range_rejected():
+    buf = StagingReceiveBuffer(capacity_bytes=1024)
+    with pytest.raises(ValueError):
+        buf.ptr_at(1024)
+
+
+def test_invalid_capacity_rejected():
+    with pytest.raises(ValueError):
+        StagingReceiveBuffer(capacity_bytes=0)
+    with pytest.raises(ValueError):
+        StagingReceiveBuffer(capacity_bytes=-1)
+
+
+def test_concurrent_alloc_free_thread_safe():
+    """Hammer alloc + free from many threads; no double-allocation."""
+    import threading
+
+    buf = StagingReceiveBuffer(capacity_bytes=4096)
+    n_threads = 8
+    n_iters = 50
+    seen_offsets = []
+    seen_lock = threading.Lock()
+
+    def worker() -> None:
+        for _ in range(n_iters):
+            off = buf.alloc(64)
+            if off is None:
+                continue
+            with seen_lock:
+                seen_offsets.append(off)
+            buf.free(off, 64)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # No assertion on exact values — just that we didn't crash and
+    # the pool is still functional.
+    assert buf.alloc(64) is not None
+
+
+def test_full_capacity_round_trip():
+    buf = StagingReceiveBuffer(capacity_bytes=1024)
+    off = buf.alloc(1024)
+    assert off == 0
+    assert buf.alloc(1) is None
+    buf.free(off, 1024)
+    assert buf.alloc(1024) == 0

--- a/lib/gms_kv_ring/tests/test_staging_tier.py
+++ b/lib/gms_kv_ring/tests/test_staging_tier.py
@@ -1,0 +1,633 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for StagingTier — Phase 1 of cross-node KV transfer.
+
+Validates the state machine + invariants documented in
+`docs/CROSS_NODE_DESIGN.md`:
+
+  I-8  — At most one inbound transfer per (daemon, hash) in flight.
+         Concurrent reservers for the same hash coalesce as waiters.
+  I-9  — Receiver verifies bytes' content hash on commit by default.
+         Trusted prefix-hash commits can opt out of byte verification.
+  I-3' — Each staging slot carries a per-hash generation. begin_consume
+         requires expected_generation; mismatch returns None.
+  I-6' — Periodic scrub re-CRCs READY slots and drops drift.
+
+Runs without CUDA via injected `_BytearrayAllocator`."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import zlib
+
+import pytest
+from gms_kv_ring.daemon.staging_tier import (
+    AlreadyReady,
+    CommitCorrupt,
+    CommitOk,
+    CommitRejected,
+    Reservation,
+    StagingTier,
+    Waiter,
+    _BytearrayAllocator,
+)
+
+# ----- helpers ----------------------------------------------------------------
+
+
+def _hash(data: bytes) -> bytes:
+    return hashlib.sha256(data).digest()
+
+
+def _make_tier(
+    *,
+    capacity_bytes: int = 1 << 20,
+    reservation_stale_s: float = 30.0,
+) -> StagingTier:
+    return StagingTier(
+        capacity_bytes=capacity_bytes,
+        reservation_stale_s=reservation_stale_s,
+        allocator=_BytearrayAllocator(),
+    )
+
+
+# ----- content identity -------------------------------------------------------
+
+
+def test_content_hash_modes_are_full_width_and_collision_resistant():
+    from gms_kv_ring.daemon.staging_tier import hash_fn_for_mode
+
+    data = b"content-address-contract"
+    assert hash_fn_for_mode("sha256")(data) == hashlib.sha256(data).digest()
+    assert (
+        hash_fn_for_mode("blake2b_256")(data)
+        == hashlib.blake2b(data, digest_size=32).digest()
+    )
+    assert len(hash_fn_for_mode("blake2b_256")(data)) == 32
+
+
+@pytest.mark.parametrize("weak_mode", ["crc32", "none", "blake2b_128"])
+def test_weak_content_hash_modes_are_rejected(weak_mode):
+    from gms_kv_ring.daemon.staging_tier import hash_fn_for_mode
+
+    with pytest.raises(KeyError, match="unknown hash mode"):
+        hash_fn_for_mode(weak_mode)
+
+
+def test_hash_algorithm_mismatch_fails_closed():
+    from gms_kv_ring.daemon.staging_tier import hash_fn_for_mode
+
+    data = b"rolling-upgrade-algorithm-mismatch"
+    sha_id = hash_fn_for_mode("sha256")(data)
+    tier = StagingTier(
+        capacity_bytes=4096,
+        allocator=_BytearrayAllocator(),
+        hash_fn=hash_fn_for_mode("blake2b_256"),
+    )
+    reservation = tier.reserve_or_wait(sha_id, source_daemon="sha-peer")
+    result = tier.commit_or_reject(reservation.reservation_id, data)
+    assert isinstance(result, CommitCorrupt)
+    assert tier.scan([sha_id]) == {}
+
+
+# ----- happy path -------------------------------------------------------------
+
+
+def test_reserve_then_commit_round_trip():
+    tier = _make_tier()
+    data = b"hello world" * 16
+    h = _hash(data)
+
+    res = tier.reserve_or_wait(h, source_daemon="node-A")
+    assert isinstance(res, Reservation)
+    assert res.content_hash == h
+
+    result = tier.commit_or_reject(res.reservation_id, data)
+    assert isinstance(result, CommitOk)
+    assert result.hit.content_hash == h
+    assert result.hit.bytes_size == len(data)
+    assert result.hit.crc32 == zlib.crc32(data) & 0xFFFFFFFF
+    assert result.hit.generation == 1
+
+    # scan finds it
+    found = tier.scan([h])
+    assert h in found
+    assert found[h].generation == 1
+
+
+def test_already_ready_short_circuits():
+    tier = _make_tier()
+    data = b"already there"
+    h = _hash(data)
+    res = tier.reserve_or_wait(h, source_daemon="A")
+    tier.commit_or_reject(res.reservation_id, data)
+
+    # Second reserver sees AlreadyReady
+    res2 = tier.reserve_or_wait(h, source_daemon="B")
+    assert isinstance(res2, AlreadyReady)
+    assert res2.hit.content_hash == h
+
+
+def test_consume_pointer_returns_pinned_ready_slot():
+    tier = _make_tier()
+    data = b"consume pointer" * 16
+    h = _hash(data)
+    res = tier.reserve_or_wait(h, source_daemon="node-A")
+    assert isinstance(res, Reservation)
+    committed = tier.commit_or_reject(res.reservation_id, data)
+    assert isinstance(committed, CommitOk)
+
+    handle = tier.begin_consume(h, expected_generation=1)
+    assert handle is not None
+    try:
+        ptr, size, crc = tier.consume_pointer(handle)
+        assert ptr > 0
+        assert size == len(data)
+        assert crc == zlib.crc32(data) & 0xFFFFFFFF
+        assert tier._alloc.read(ptr, size) == data
+    finally:
+        tier.end_consume(handle)
+
+
+def test_consume_pointer_rejects_stale_generation():
+    tier = _make_tier()
+    data = b"stale generation" * 8
+    h = _hash(data)
+    res = tier.reserve_or_wait(h, source_daemon="node-A")
+    assert isinstance(res, Reservation)
+    assert isinstance(tier.commit_or_reject(res.reservation_id, data), CommitOk)
+    assert tier.begin_consume(h, expected_generation=2) is None
+
+
+# ----- I-8 coalescing --------------------------------------------------------
+
+
+def test_two_concurrent_reservations_coalesce():
+    tier = _make_tier()
+    data = b"abc" * 100
+    h = _hash(data)
+
+    res = tier.reserve_or_wait(h, source_daemon="A")
+    assert isinstance(res, Reservation)
+
+    # Second caller sees the in-flight reservation and becomes a waiter
+    res2 = tier.reserve_or_wait(h, source_daemon="B")
+    assert isinstance(res2, Waiter)
+    assert res2.content_hash == h
+    assert not res2.waiter.event.is_set()
+
+    # When original reservation commits, waiter is notified
+    result = tier.commit_or_reject(res.reservation_id, data)
+    assert isinstance(result, CommitOk)
+    assert res2.waiter.event.is_set()
+    assert res2.waiter.hit is not None
+    assert res2.waiter.hit.content_hash == h
+    assert res2.waiter.failure is None
+
+    # Coalesced waiter did NOT trigger a second reservation
+    stats = tier.stats()
+    assert stats["reservations_created"] == 1
+    assert stats["waiters_coalesced"] == 1
+    assert stats["commits_ok"] == 1
+
+
+def test_many_concurrent_waiters_all_notified_on_success():
+    tier = _make_tier()
+    data = b"x" * 50
+    h = _hash(data)
+
+    res = tier.reserve_or_wait(h, source_daemon="A")
+    assert isinstance(res, Reservation)
+
+    waiters = []
+    for i in range(8):
+        r = tier.reserve_or_wait(h, source_daemon=f"peer-{i}")
+        assert isinstance(r, Waiter)
+        waiters.append(r)
+
+    tier.commit_or_reject(res.reservation_id, data)
+    for w in waiters:
+        assert w.waiter.event.is_set()
+        assert w.waiter.hit is not None
+        assert w.waiter.failure is None
+
+
+def test_waiters_notified_on_failure():
+    tier = _make_tier()
+    data = b"y" * 20
+    h = _hash(data)
+
+    res = tier.reserve_or_wait(h, source_daemon="A")
+    waiter_result = tier.reserve_or_wait(h, source_daemon="B")
+    assert isinstance(waiter_result, Waiter)
+
+    tier.fail_reservation(res.reservation_id, "transport error")
+
+    assert waiter_result.waiter.event.is_set()
+    assert waiter_result.waiter.hit is None
+    assert waiter_result.waiter.failure == "transport error"
+
+
+# ----- I-9 hash verify --------------------------------------------------------
+
+
+def test_corrupt_bytes_rejected():
+    tier = _make_tier()
+    data = b"actual content"
+    advertised_hash = _hash(b"different content")  # mismatched
+
+    res = tier.reserve_or_wait(advertised_hash, source_daemon="A")
+    assert isinstance(res, Reservation)
+    result = tier.commit_or_reject(res.reservation_id, data)
+    assert isinstance(result, CommitCorrupt)
+    assert "hash mismatch" in result.reason
+
+    # Slot is dropped after CORRUPT — next reserve sees EMPTY
+    res2 = tier.reserve_or_wait(advertised_hash, source_daemon="B")
+    assert isinstance(res2, Reservation)
+
+
+def test_trusted_commit_accepts_prefix_hash_key():
+    """Router-orchestrated engine transfers key staging by prefix hash,
+    which is not a digest of the KV bytes themselves."""
+    tier = _make_tier()
+    data = b"actual kv bytes"
+    prefix_hash = b"\x8a" * 32
+
+    res = tier.reserve_or_wait(prefix_hash, source_daemon="router")
+    assert isinstance(res, Reservation)
+    result = tier.commit_or_reject(
+        res.reservation_id,
+        data,
+        verify_content_hash=False,
+    )
+
+    assert isinstance(result, CommitOk)
+    hits = tier.scan([prefix_hash])
+    assert prefix_hash in hits
+    assert hits[prefix_hash].bytes_size == len(data)
+
+
+def test_corrupt_notifies_waiters_with_failure():
+    tier = _make_tier()
+    data = b"actual"
+    bad_hash = _hash(b"expected")
+
+    res = tier.reserve_or_wait(bad_hash, source_daemon="A")
+    waiter = tier.reserve_or_wait(bad_hash, source_daemon="B")
+    assert isinstance(waiter, Waiter)
+
+    tier.commit_or_reject(res.reservation_id, data)
+
+    assert waiter.waiter.event.is_set()
+    assert waiter.waiter.hit is None
+    assert waiter.waiter.failure is not None
+    assert "hash mismatch" in waiter.waiter.failure
+
+
+# ----- I-3' generation --------------------------------------------------------
+
+
+def test_generation_increments_across_commits():
+    tier = _make_tier()
+    data1, data2 = b"first", b"second"
+    h1 = _hash(data1)
+    h2 = _hash(data2)
+
+    r1 = tier.reserve_or_wait(h1, "A")
+    tier.commit_or_reject(r1.reservation_id, data1)
+    g1 = tier.scan([h1])[h1].generation
+    assert g1 == 1
+
+    # Different hash → its own generation starts at 1
+    r2 = tier.reserve_or_wait(h2, "A")
+    tier.commit_or_reject(r2.reservation_id, data2)
+    g2 = tier.scan([h2])[h2].generation
+    assert g2 == 1
+
+
+def test_generation_resets_after_full_reclaim():
+    """When a slot is fully reclaimed (LRU eviction, scrub corruption,
+    or explicit fail), the new slot starts fresh at generation 1. This
+    is safe because staging slots are content-addressed (same hash →
+    same bytes by collision resistance + I-9), so a "stale" generation
+    on the connector side that happens to match the new slot's
+    generation still consumes correct bytes."""
+    tier = _make_tier()
+    data = b"hello"
+    h = _hash(data)
+
+    r1 = tier.reserve_or_wait(h, "A")
+    tier.commit_or_reject(r1.reservation_id, data)
+    assert tier.scan([h])[h].generation == 1
+
+    # Fail then re-reserve → generation back to 1 (not 2)
+    r2 = tier.reserve_or_wait(_hash(b"unrelated"), "A")
+    tier.fail_reservation(r2.reservation_id, "test")
+    # h still ready; re-deposit needs eviction first
+    # Drop h by explicit shutdown path then verify generation resets
+    tier.shutdown()
+    tier2 = _make_tier()
+    r3 = tier2.reserve_or_wait(h, "A")
+    tier2.commit_or_reject(r3.reservation_id, data)
+    assert tier2.scan([h])[h].generation == 1
+
+
+def test_begin_consume_rejects_generation_mismatch():
+    tier = _make_tier()
+    data = b"data"
+    h = _hash(data)
+    r = tier.reserve_or_wait(h, "A")
+    tier.commit_or_reject(r.reservation_id, data)
+    gen = tier.scan([h])[h].generation
+
+    # Right generation → succeeds
+    handle = tier.begin_consume(h, expected_generation=gen)
+    assert handle is not None
+    tier.end_consume(handle)
+
+    # Wrong generation → rejected
+    bad_handle = tier.begin_consume(h, expected_generation=gen + 1)
+    assert bad_handle is None
+
+
+# ----- I-6' scrub -------------------------------------------------------------
+
+
+def test_scrub_detects_in_place_corruption():
+    alloc = _BytearrayAllocator()
+    tier = StagingTier(capacity_bytes=1 << 20, allocator=alloc)
+    data = b"original bytes here"
+    h = _hash(data)
+    r = tier.reserve_or_wait(h, "A")
+    tier.commit_or_reject(r.reservation_id, data)
+    hit = tier.scan([h])[h]
+
+    # Simulate bit-flip in place by writing different bytes to the same ptr
+    alloc.write(hit.bytes_ptr, b"X" * len(data))
+
+    scrubbed = tier.scrub_step()
+    assert scrubbed == 1
+    assert tier.stats()["scrub_corruptions"] == 1
+    # The slot has been dropped
+    assert tier.scan([h]) == {}
+
+
+def test_scrub_clean_pass_no_drops():
+    tier = _make_tier()
+    data = b"unchanged bytes"
+    h = _hash(data)
+    r = tier.reserve_or_wait(h, "A")
+    tier.commit_or_reject(r.reservation_id, data)
+
+    for _ in range(5):
+        tier.scrub_step()
+    assert tier.stats()["scrub_corruptions"] == 0
+    assert h in tier.scan([h])
+
+
+def test_scrub_skips_active_consumers():
+    """A slot pinned by begin_consume should not be scrubbed (refcount>0)."""
+    tier = _make_tier()
+    data = b"pinned"
+    h = _hash(data)
+    r = tier.reserve_or_wait(h, "A")
+    tier.commit_or_reject(r.reservation_id, data)
+    gen = tier.scan([h])[h].generation
+    handle = tier.begin_consume(h, expected_generation=gen)
+    assert handle is not None
+
+    # No other slots → scrub finds nothing to do
+    assert tier.scrub_step() == 0
+
+    tier.end_consume(handle)
+    # Now scrubable
+    assert tier.scrub_step() == 1
+
+
+def test_scrub_pins_slot_against_concurrent_capacity_eviction():
+    data = b"12345678"
+    other = b"abcdefgh"
+    alloc = _BytearrayAllocator()
+    tier = StagingTier(capacity_bytes=len(data), allocator=alloc)
+    content_hash = _hash(data)
+    reservation = tier.reserve_or_wait(content_hash, "A")
+    assert isinstance(reservation, Reservation)
+    result = tier.commit_or_reject(reservation.reservation_id, data)
+    assert isinstance(result, CommitOk)
+
+    original_read = alloc.read
+    attempted = []
+
+    def read_while_reserving(ptr, size):
+        # The scrubber must pin before exposing the pointer outside its lock.
+        assert tier._slots[content_hash].refcount == 1
+        other_reservation = tier.reserve_or_wait(_hash(other), "B")
+        assert isinstance(other_reservation, Reservation)
+        attempted.append(tier.commit_or_reject(other_reservation.reservation_id, other))
+        return original_read(ptr, size)
+
+    alloc.read = read_while_reserving
+
+    assert tier.scrub_step() == 1
+    assert len(attempted) == 1
+    assert isinstance(attempted[0], CommitRejected)
+    assert content_hash in tier.scan([content_hash])
+
+
+# ----- stale reservation reclaim ---------------------------------------------
+
+
+def test_stale_reservation_reclaimed_by_evict_call():
+    """Reservation older than reservation_stale_s gets reclaimed."""
+    fake_now = {"t": 1000.0}
+    tier = StagingTier(
+        capacity_bytes=1 << 20,
+        reservation_stale_s=10.0,
+        allocator=_BytearrayAllocator(),
+        clock=lambda: fake_now["t"],
+    )
+    h = _hash(b"data")
+    r = tier.reserve_or_wait(h, "A")
+    assert isinstance(r, Reservation)
+    # Not stale yet
+    assert tier.evict_stale_reservations() == 0
+
+    # Advance past staleness window
+    fake_now["t"] = 1100.0
+    assert tier.evict_stale_reservations() == 1
+    # Slot is gone; a new reservation can be created
+    r2 = tier.reserve_or_wait(h, "B")
+    assert isinstance(r2, Reservation)
+
+
+def test_stale_reservation_reclaimed_by_new_reserver():
+    fake_now = {"t": 1000.0}
+    tier = StagingTier(
+        capacity_bytes=1 << 20,
+        reservation_stale_s=5.0,
+        allocator=_BytearrayAllocator(),
+        clock=lambda: fake_now["t"],
+    )
+    h = _hash(b"data")
+    r1 = tier.reserve_or_wait(h, "stuck-owner")
+    assert isinstance(r1, Reservation)
+
+    # Owner is stuck. Time passes.
+    fake_now["t"] = 1010.0
+
+    # New reserver sees stale + takes over
+    r2 = tier.reserve_or_wait(h, "rescuer")
+    assert isinstance(r2, Reservation)
+    assert r2.reservation_id != r1.reservation_id
+    assert tier.stats()["stale_reservations_reclaimed"] == 1
+
+    # Original owner's commit attempt now fails (different reservation id holds slot)
+    result = tier.commit_or_reject(r1.reservation_id, b"data")
+    assert isinstance(result, CommitRejected)
+
+
+# ----- LRU eviction -----------------------------------------------------------
+
+
+def test_lru_evicts_cold_slot_to_fit_new():
+    tier = StagingTier(
+        capacity_bytes=100,
+        allocator=_BytearrayAllocator(),
+    )
+    # Two 40-byte slots fit (80 total). Third would push past 100.
+    d_a = b"A" * 40
+    d_b = b"B" * 40
+    d_c = b"C" * 40
+    ha, hb, hc = _hash(d_a), _hash(d_b), _hash(d_c)
+
+    for h, d in [(ha, d_a), (hb, d_b)]:
+        r = tier.reserve_or_wait(h, "src")
+        tier.commit_or_reject(r.reservation_id, d)
+
+    assert tier.bytes_used() == 80
+    assert tier.scan([ha, hb, hc]).keys() == {ha, hb}
+
+    # Touch hb so ha becomes coldest
+    tier.scan([hb])  # scan touches last_accessed but NOT lru position;
+    # to actually promote LRU we need begin_consume
+    gen_b = tier.scan([hb])[hb].generation
+    handle = tier.begin_consume(hb, expected_generation=gen_b)
+    tier.end_consume(handle)
+
+    # Deposit hc — should evict ha (coldest), not hb
+    r_c = tier.reserve_or_wait(hc, "src")
+    tier.commit_or_reject(r_c.reservation_id, d_c)
+    remaining = tier.scan([ha, hb, hc])
+    assert hc in remaining
+    assert hb in remaining
+    assert ha not in remaining
+    assert tier.stats()["evictions_lru"] >= 1
+
+
+def test_refcount_blocks_eviction_during_consume():
+    tier = StagingTier(
+        capacity_bytes=100,
+        allocator=_BytearrayAllocator(),
+    )
+    d_a = b"A" * 60
+    d_b = b"B" * 60
+    ha, hb = _hash(d_a), _hash(d_b)
+
+    r = tier.reserve_or_wait(ha, "src")
+    tier.commit_or_reject(r.reservation_id, d_a)
+    gen = tier.scan([ha])[ha].generation
+    handle = tier.begin_consume(ha, expected_generation=gen)
+
+    # Try to insert hb (60 bytes) — would need to evict ha (60 bytes)
+    # but ha is pinned. Reservation succeeds, but commit fails for capacity.
+    r_b = tier.reserve_or_wait(hb, "src")
+    assert isinstance(r_b, Reservation)
+    result = tier.commit_or_reject(r_b.reservation_id, d_b)
+    assert isinstance(result, CommitRejected)
+    assert "capacity" in result.reason
+
+    tier.end_consume(handle)
+    # Now hb can fit by evicting unpinned ha
+    r_b2 = tier.reserve_or_wait(hb, "src")
+    result2 = tier.commit_or_reject(r_b2.reservation_id, d_b)
+    assert isinstance(result2, CommitOk)
+
+
+# ----- commit lifecycle -------------------------------------------------------
+
+
+def test_commit_with_unknown_reservation_rejected():
+    tier = _make_tier()
+    result = tier.commit_or_reject("bogus-id", b"data")
+    assert isinstance(result, CommitRejected)
+
+
+def test_commit_twice_second_rejected():
+    tier = _make_tier()
+    data = b"data"
+    h = _hash(data)
+    r = tier.reserve_or_wait(h, "A")
+    first = tier.commit_or_reject(r.reservation_id, data)
+    assert isinstance(first, CommitOk)
+    second = tier.commit_or_reject(r.reservation_id, data)
+    assert isinstance(second, CommitRejected)
+
+
+def test_fail_reservation_releases_slot():
+    tier = _make_tier()
+    h = _hash(b"never arrives")
+    r = tier.reserve_or_wait(h, "A")
+    tier.fail_reservation(r.reservation_id, "transport timeout")
+    # New reservation possible
+    r2 = tier.reserve_or_wait(h, "B")
+    assert isinstance(r2, Reservation)
+
+
+# ----- shutdown ---------------------------------------------------------------
+
+
+def test_shutdown_notifies_pending_waiters():
+    tier = _make_tier()
+    h = _hash(b"never delivered")
+    assert isinstance(tier.reserve_or_wait(h, "A"), Reservation)
+    waiter = tier.reserve_or_wait(h, "B")
+    assert isinstance(waiter, Waiter)
+    tier.shutdown()
+    assert waiter.waiter.event.is_set()
+    assert waiter.waiter.failure == "daemon shutdown"
+
+
+# ----- concurrency stress -----------------------------------------------------
+
+
+def test_concurrent_reservers_serialize_through_single_transfer():
+    """Hammer reserve_or_wait from many threads with the SAME hash;
+    only one Reservation should be returned, all others should be
+    Waiter or AlreadyReady."""
+    tier = _make_tier()
+    h = _hash(b"contended")
+    n_threads = 16
+
+    barrier = threading.Barrier(n_threads + 1)
+    results: list = [None] * n_threads
+
+    def worker(i: int) -> None:
+        barrier.wait()
+        results[i] = tier.reserve_or_wait(h, source_daemon=f"src-{i}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    barrier.wait()
+    for t in threads:
+        t.join()
+
+    n_reservations = sum(isinstance(r, Reservation) for r in results)
+    n_waiters = sum(isinstance(r, Waiter) for r in results)
+    assert n_reservations == 1
+    assert n_reservations + n_waiters == n_threads
+    assert tier.stats()["reservations_created"] == 1
+    assert tier.stats()["waiters_coalesced"] == n_threads - 1

--- a/lib/gms_kv_ring/tests/test_staging_tier_stress.py
+++ b/lib/gms_kv_ring/tests/test_staging_tier_stress.py
@@ -1,0 +1,478 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stress tests for the StagingTier state machine and its invariants.
+
+Targets:
+  - I-8 (atomic per-hash reservation): under N-thread contention, exactly
+    one thread receives a Reservation per hash; all others get a Waiter
+    (or AlreadyReady once the first commits).
+  - I-9 (hash-on-receive): when a sender ships bytes that don't match
+    the advertised content hash, commit_or_reject MUST transition the
+    slot to CORRUPT, notify waiters with failure, and free the slot
+    for a fresh reservation.
+  - Reservation lifecycle: a never-completed reservation (caller dies,
+    network drops the message) must be reclaimable via fail_reservation
+    AND via the stale-timeout path. Subsequent reservations succeed
+    without slot leakage and with a fresh reservation_id.
+  - Capacity backpressure: filling the tier to capacity and committing
+    more must NOT silently overwrite; the daemon either evicts an LRU
+    READY slot or rejects with `capacity exhausted`.
+
+All tests run in-process with the test-only `_BytearrayAllocator`, so
+no CUDA / NIXL is required. They are deterministic — the contention
+tests use sufficient repetitions + thread counts to surface any
+non-atomic reservation gap, but each iteration is independently
+verifiable, not flake-prone."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from gms_kv_ring.daemon.staging_tier import (
+    AlreadyReady,
+    CommitCorrupt,
+    CommitOk,
+    CommitRejected,
+    Reservation,
+    StagingTier,
+    Waiter,
+    _BytearrayAllocator,
+)
+
+
+def _hash(b: bytes) -> bytes:
+    return hashlib.sha256(b).digest()
+
+
+def _new_tier(capacity_bytes: int = 1 << 20, stale_s: float = 30.0):
+    return StagingTier(
+        capacity_bytes=capacity_bytes,
+        reservation_stale_s=stale_s,
+        allocator=_BytearrayAllocator(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# I-8: atomic per-hash reservation under contention
+# ---------------------------------------------------------------------------
+
+
+def test_i8_atomic_reservation_under_contention():
+    """N threads race reserve_or_wait for the SAME hash. Exactly ONE
+    thread must receive a Reservation; all others must receive Waiter
+    (until the winner commits, after which late-comers see AlreadyReady).
+
+    This is the load-bearing invariant for cross-node correctness: if
+    two threads both got Reservations for the same hash, two different
+    sets of bytes could land in the slot non-deterministically."""
+    payload = b"contention-payload" * 64
+    h = _hash(payload)
+
+    for trial in range(20):
+        tier = _new_tier()
+        N = 16
+        results: list = [None] * N
+        barrier = threading.Barrier(N)
+
+        def worker(i: int) -> None:
+            barrier.wait()
+            results[i] = tier.reserve_or_wait(h, source_daemon=f"peer-{i}")
+
+        with ThreadPoolExecutor(max_workers=N) as ex:
+            list(ex.map(worker, range(N)))
+
+        reservations = [r for r in results if isinstance(r, Reservation)]
+        waiters = [r for r in results if isinstance(r, Waiter)]
+        already_ready = [r for r in results if isinstance(r, AlreadyReady)]
+
+        assert len(reservations) == 1, (
+            f"trial {trial}: expected exactly 1 Reservation, "
+            f"got {len(reservations)} (waiters={len(waiters)} "
+            f"already_ready={len(already_ready)})"
+        )
+        assert len(waiters) + len(already_ready) == N - 1
+        assert (
+            len(already_ready) == 0
+        ), "no thread saw the slot READY before the winner committed"
+
+        # All Waiters carry the same content_hash and the same _Waiter
+        # bucket? No — each Waiter has its own _Waiter event, but all
+        # point at the same content_hash.
+        for w in waiters:
+            assert w.content_hash == h
+
+
+def test_i8_winner_commit_wakes_all_waiters():
+    """Once the Reservation winner commits OK, ALL queued waiters must
+    receive the StagingHit, not just one."""
+    payload = b"wake-all-waiters" * 100
+    h = _hash(payload)
+    tier = _new_tier()
+
+    # Reserve first (becomes the slot owner).
+    res = tier.reserve_or_wait(h, source_daemon="leader")
+    assert isinstance(res, Reservation)
+
+    # Queue up 8 waiters.
+    waiters: list[Waiter] = []
+    for i in range(8):
+        w = tier.reserve_or_wait(h, source_daemon=f"follower-{i}")
+        assert isinstance(w, Waiter)
+        waiters.append(w)
+
+    # Commit the bytes.
+    out = tier.commit_or_reject(res.reservation_id, payload)
+    assert isinstance(out, CommitOk)
+
+    # All waiters' events must be set, all hits must be non-None.
+    for i, w in enumerate(waiters):
+        assert w.waiter.event.is_set(), f"waiter {i} not woken"
+        assert w.waiter.hit is not None, f"waiter {i} got no hit"
+        assert w.waiter.failure is None
+        assert w.waiter.hit.content_hash == h
+        assert w.waiter.hit.bytes_size == len(payload)
+
+
+# ---------------------------------------------------------------------------
+# I-9: hash-on-receive — corrupted bytes must NOT commit
+# ---------------------------------------------------------------------------
+
+
+def test_i9_hash_mismatch_lands_corrupt_and_notifies_waiters():
+    """When commit_or_reject is given bytes whose sha256 does NOT match
+    the advertised content_hash, the slot must transition to CORRUPT,
+    all waiters must be notified with failure (not a hit), and the
+    slot must drop so a re-reservation succeeds."""
+    advertised = _hash(b"the-truth")
+    tier = _new_tier()
+
+    res = tier.reserve_or_wait(advertised, source_daemon="liar")
+    assert isinstance(res, Reservation)
+    w = tier.reserve_or_wait(advertised, source_daemon="hopeful")
+    assert isinstance(w, Waiter)
+
+    # Sender ships different bytes (network bit-flip, malicious peer,
+    # mismatched cache_salt, etc.). Hash check MUST catch it.
+    out = tier.commit_or_reject(res.reservation_id, b"the-lie")
+    assert isinstance(out, CommitCorrupt)
+    assert "hash mismatch" in out.reason
+
+    # Waiter must have been notified with FAILURE.
+    assert w.waiter.event.is_set()
+    assert w.waiter.hit is None
+    assert w.waiter.failure is not None
+    assert "hash mismatch" in w.waiter.failure
+
+    # The corrupt slot must have been dropped — a fresh reservation
+    # for the same hash must SUCCEED with a NEW reservation_id.
+    res2 = tier.reserve_or_wait(advertised, source_daemon="retry")
+    assert isinstance(res2, Reservation)
+    assert res2.reservation_id != res.reservation_id
+
+    # Stats reflect the corruption.
+    stats = tier._stats
+    assert stats["commits_corrupt"] == 1
+    assert stats["commits_ok"] == 0
+
+
+def test_i9_corruption_under_concurrent_waiters():
+    """Heavy contention + corrupt commit: ALL waiters must see failure;
+    no waiter must spuriously see a hit."""
+    h = _hash(b"correct-payload" * 32)
+    tier = _new_tier()
+
+    res = tier.reserve_or_wait(h, source_daemon="leader")
+    assert isinstance(res, Reservation)
+
+    N = 12
+    waiters: list[Waiter] = []
+    for i in range(N):
+        w = tier.reserve_or_wait(h, source_daemon=f"f-{i}")
+        assert isinstance(w, Waiter)
+        waiters.append(w)
+
+    # Ship bytes that hash to something else.
+    out = tier.commit_or_reject(res.reservation_id, b"WRONG")
+    assert isinstance(out, CommitCorrupt)
+
+    for i, w in enumerate(waiters):
+        assert w.waiter.event.is_set(), f"waiter {i} not notified"
+        assert w.waiter.hit is None, f"waiter {i} got phantom hit"
+        assert w.waiter.failure is not None
+
+
+# ---------------------------------------------------------------------------
+# Reservation lifecycle: fail/reclaim, generation, no slot leak
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_fail_then_re_reserve_succeeds():
+    """A failed reservation must release the slot; the next reservation
+    must succeed with a fresh reservation_id."""
+    h = _hash(b"will-fail-first" * 10)
+    tier = _new_tier()
+
+    r1 = tier.reserve_or_wait(h, source_daemon="src1")
+    assert isinstance(r1, Reservation)
+
+    tier.fail_reservation(r1.reservation_id, reason="net error")
+
+    # Slot should be empty now → fresh Reservation.
+    r2 = tier.reserve_or_wait(h, source_daemon="src2")
+    assert isinstance(r2, Reservation)
+    assert r2.reservation_id != r1.reservation_id
+
+    # And this one can commit normally.
+    payload = b"will-fail-first" * 10
+    out = tier.commit_or_reject(r2.reservation_id, payload)
+    assert isinstance(out, CommitOk)
+    assert tier._stats["reservations_failed"] == 1
+    assert tier._stats["commits_ok"] == 1
+
+
+def test_lifecycle_fail_with_waiters_notifies_failure():
+    """fail_reservation must wake queued waiters with a failure
+    notification — otherwise a slow consumer would block forever."""
+    h = _hash(b"abandoned" * 50)
+    tier = _new_tier()
+
+    r1 = tier.reserve_or_wait(h, source_daemon="dropper")
+    assert isinstance(r1, Reservation)
+    w = tier.reserve_or_wait(h, source_daemon="hopeful")
+    assert isinstance(w, Waiter)
+
+    tier.fail_reservation(r1.reservation_id, reason="peer crashed")
+
+    assert w.waiter.event.is_set()
+    assert w.waiter.hit is None
+    assert w.waiter.failure is not None
+
+
+def test_lifecycle_stale_timeout_reclaims_silent_owner():
+    """If the reservation owner never commits and the stale timeout
+    expires, the next reserver claims the slot. Uses a fake clock for
+    determinism."""
+    h = _hash(b"silent-owner" * 8)
+    t = [1000.0]
+
+    def clock():
+        return t[0]
+
+    tier = StagingTier(
+        capacity_bytes=1 << 20,
+        reservation_stale_s=5.0,
+        allocator=_BytearrayAllocator(),
+        clock=clock,
+    )
+
+    r1 = tier.reserve_or_wait(h, source_daemon="silent")
+    assert isinstance(r1, Reservation)
+
+    # Advance the clock past the stale window.
+    t[0] += 10.0
+
+    r2 = tier.reserve_or_wait(h, source_daemon="impatient")
+    assert isinstance(r2, Reservation)
+    assert r2.reservation_id != r1.reservation_id
+    assert tier._stats["stale_reservations_reclaimed"] == 1
+
+    # And the original owner can no longer commit — stale reservation_id.
+    out = tier.commit_or_reject(r1.reservation_id, b"silent-owner" * 8)
+    assert isinstance(out, CommitRejected)
+
+
+def test_lifecycle_commit_after_stale_reclaim_does_not_corrupt_new_slot():
+    """Critical: if the original owner finally shows up after being
+    reclaimed, their late commit must NOT corrupt the new owner's slot
+    (e.g., write the wrong bytes into someone else's reservation)."""
+    h = _hash(b"late-arrival" * 20)
+    t = [1000.0]
+
+    def clock():
+        return t[0]
+
+    tier = StagingTier(
+        capacity_bytes=1 << 20,
+        reservation_stale_s=2.0,
+        allocator=_BytearrayAllocator(),
+        clock=clock,
+    )
+
+    r1 = tier.reserve_or_wait(h, source_daemon="laggard")
+    assert isinstance(r1, Reservation)
+    t[0] += 10.0  # stale
+
+    r2 = tier.reserve_or_wait(h, source_daemon="winner")
+    assert isinstance(r2, Reservation)
+
+    # Late commit from r1 must be rejected, not silently swap bytes
+    # in r2's slot.
+    late = tier.commit_or_reject(r1.reservation_id, b"late-arrival" * 20)
+    assert isinstance(late, CommitRejected)
+
+    # r2 can still commit normally.
+    ok = tier.commit_or_reject(r2.reservation_id, b"late-arrival" * 20)
+    assert isinstance(ok, CommitOk)
+
+
+def test_lifecycle_unknown_reservation_id_is_rejected():
+    """A commit with a bogus reservation_id must NOT succeed silently."""
+    tier = _new_tier()
+    out = tier.commit_or_reject("never-issued-id", b"anything")
+    assert isinstance(out, CommitRejected)
+
+
+# ---------------------------------------------------------------------------
+# Capacity backpressure
+# ---------------------------------------------------------------------------
+
+
+def test_capacity_lru_eviction_under_pressure():
+    """Filling the tier to capacity then committing more should evict
+    the LRU READY slot, not reject. Validates the LRU-as-backpressure
+    assumption built into commit_or_reject."""
+    PAYLOAD_SIZE = 1024
+    CAPACITY = 4 * PAYLOAD_SIZE  # exactly 4 slots fit
+    tier = _new_tier(capacity_bytes=CAPACITY)
+
+    hashes = []
+    for i in range(4):
+        p = bytes([i & 0xFF]) * PAYLOAD_SIZE
+        h = _hash(p)
+        hashes.append(h)
+        r = tier.reserve_or_wait(h, source_daemon=f"s{i}")
+        assert isinstance(r, Reservation)
+        out = tier.commit_or_reject(r.reservation_id, p)
+        assert isinstance(out, CommitOk)
+
+    # Fifth commit should evict the LRU (hashes[0]) to make room.
+    p5 = bytes([5]) * PAYLOAD_SIZE
+    h5 = _hash(p5)
+    r5 = tier.reserve_or_wait(h5, source_daemon="s5")
+    assert isinstance(r5, Reservation)
+    out5 = tier.commit_or_reject(r5.reservation_id, p5)
+    assert isinstance(out5, CommitOk), out5
+
+    # Newest is present.
+    res_h5 = tier.reserve_or_wait(h5, source_daemon="lookup")
+    assert isinstance(res_h5, AlreadyReady)
+
+    # LRU (hashes[0]) was evicted.
+    res_h0 = tier.reserve_or_wait(hashes[0], source_daemon="lookup")
+    assert isinstance(
+        res_h0, Reservation
+    ), "expected LRU eviction to make hashes[0] re-reservable"
+    assert tier._stats["evictions_lru"] >= 1
+
+
+def test_capacity_exhaustion_with_single_oversized_payload_rejects_cleanly():
+    """A single payload larger than total capacity must NOT crash —
+    commit must return CommitRejected with reason 'capacity exhausted',
+    waiters must be notified, slot must be cleared."""
+    CAPACITY = 1024
+    tier = _new_tier(capacity_bytes=CAPACITY)
+
+    oversized = bytes(2 * CAPACITY)
+    h = _hash(oversized)
+
+    r = tier.reserve_or_wait(h, source_daemon="too-big")
+    assert isinstance(r, Reservation)
+    w = tier.reserve_or_wait(h, source_daemon="watching")
+    assert isinstance(w, Waiter)
+
+    out = tier.commit_or_reject(r.reservation_id, oversized)
+    assert isinstance(out, CommitRejected)
+    assert "capacity" in out.reason.lower()
+
+    # Waiter must have been notified with failure.
+    assert w.waiter.event.is_set()
+    assert w.waiter.hit is None
+    assert w.waiter.failure is not None
+
+    # And the slot must be re-reservable (no leak).
+    r2 = tier.reserve_or_wait(h, source_daemon="retry")
+    assert isinstance(r2, Reservation)
+    assert tier._stats["rejected_capacity"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Mixed-load smoke: hundreds of distinct hashes + heavy concurrent reservations
+# ---------------------------------------------------------------------------
+
+
+def test_high_volume_distinct_hashes_no_dropped_reservations():
+    """Many distinct hashes commit concurrently. After the dust
+    settles, every hash should be either READY (within capacity) or
+    LRU-evicted (gracefully). No hash should be stuck in RESERVED,
+    no _by_reservation entry should leak."""
+    # Generous capacity so most stay READY.
+    PAYLOAD_SIZE = 256
+    N_HASHES = 200
+    tier = _new_tier(capacity_bytes=PAYLOAD_SIZE * N_HASHES)
+
+    payloads = [
+        bytes([i % 256] * PAYLOAD_SIZE) + i.to_bytes(4, "big") for i in range(N_HASHES)
+    ]
+    hashes = [_hash(p) for p in payloads]
+
+    def worker(i: int) -> None:
+        r = tier.reserve_or_wait(hashes[i], source_daemon=f"src-{i}")
+        if isinstance(r, Reservation):
+            out = tier.commit_or_reject(r.reservation_id, payloads[i])
+            assert isinstance(out, CommitOk), out
+        # else: AlreadyReady on retry — fine.
+
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        list(ex.map(worker, range(N_HASHES)))
+
+    # Bookkeeping invariants:
+    # - No reservation_ids left dangling.
+    assert tier._by_reservation == {}, f"leaked reservations: {tier._by_reservation}"
+    # - At least most hashes landed READY (no silent drops under load).
+    ready_count = sum(1 for _ in tier._slots.values())
+    assert (
+        ready_count >= N_HASHES // 2
+    ), f"too many hashes dropped: ready_count={ready_count} / {N_HASHES}"
+
+
+def test_mixed_corrupt_and_clean_under_contention():
+    """Mix of valid + invalid commits across many distinct hashes. The
+    corrupt ones must NOT poison the valid ones."""
+    tier = _new_tier(capacity_bytes=1 << 20)
+    N = 50
+
+    payloads = [f"payload-{i}".encode() * 16 for i in range(N)]
+    hashes = [_hash(p) for p in payloads]
+
+    def worker(i: int) -> None:
+        r = tier.reserve_or_wait(hashes[i], source_daemon=f"s{i}")
+        if not isinstance(r, Reservation):
+            return
+        # Every 5th sender ships corrupt bytes (deliberate hash mismatch).
+        if i % 5 == 0:
+            tier.commit_or_reject(r.reservation_id, b"GARBAGE" + bytes(i))
+        else:
+            tier.commit_or_reject(r.reservation_id, payloads[i])
+
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        list(ex.map(worker, range(N)))
+
+    # All non-corrupt hashes must be queryable as ready.
+    ready_hits = 0
+    for i in range(N):
+        if i % 5 == 0:
+            continue
+        r = tier.reserve_or_wait(hashes[i], source_daemon="lookup")
+        if isinstance(r, AlreadyReady):
+            ready_hits += 1
+    # At least 80% of clean ones land ready (some LRU churn allowed).
+    expected_min = int(0.8 * (N - N // 5))
+    assert (
+        ready_hits >= expected_min
+    ), f"too few clean commits landed: {ready_hits} < {expected_min}"
+
+    # Corrupt commits should all have been rejected.
+    assert tier._stats["commits_corrupt"] >= N // 5 - 1  # off-by-1 tolerance

--- a/lib/gms_kv_ring/tests/test_vmm_allocator_isolated.py
+++ b/lib/gms_kv_ring/tests/test_vmm_allocator_isolated.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the daemon-side VmmAllocator.
+
+The tests partition into two groups:
+
+  - **No-CUDA tests** (always run): exercise the unsupported / lazy
+    path. The allocator must:
+      * report ``is_supported() == False`` cleanly when cuda-python
+        isn't importable or the driver doesn't expose VMM
+      * raise ``VmmUnsupportedError`` from ``allocate`` in that state
+      * stay idempotent across ``release()`` of unknown ids
+
+  - **CUDA-gated tests** (env knob ``GMS_TEST_VMM_REAL=1`` AND
+    cuda-python importable AND the driver actually supports VMM):
+    exercise the full cuMem* round trip.
+
+The no-CUDA group uses ``monkeypatch`` to make the in-method import
+of cuda-python fail or to inject a fake module."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+from gms_kv_ring.daemon.vmm_allocator import (
+    VmmAllocation,
+    VmmAllocator,
+    VmmUnsupportedError,
+    _round_up,
+)
+
+# ----------------------------------------------------------------------
+# Small utility tests
+# ----------------------------------------------------------------------
+
+
+def test_round_up_zero():
+    assert _round_up(0, 4096) == 0
+
+
+def test_round_up_exact_multiple():
+    assert _round_up(8192, 4096) == 8192
+
+
+def test_round_up_below_multiple():
+    assert _round_up(1, 4096) == 4096
+
+
+def test_round_up_above_multiple():
+    assert _round_up(4097, 4096) == 8192
+
+
+# ----------------------------------------------------------------------
+# No-CUDA: unsupported path
+# ----------------------------------------------------------------------
+
+
+def test_unsupported_when_cuda_python_missing(monkeypatch):
+    """If ``from cuda import cuda`` raises ImportError, is_supported()
+    returns False (not raises) and allocate() raises
+    VmmUnsupportedError."""
+    # Make the in-method import fail by replacing the ``cuda`` module
+    # entry with an object that raises on attribute access. The simpler
+    # approach: ensure ``cuda`` is not importable by adding a finder
+    # that refuses it.
+    real_cuda = sys.modules.pop("cuda", None)
+    real_cuda_submod = sys.modules.pop("cuda.cuda", None)
+
+    class _RefuseFinder:
+        def find_module(self, name, path=None):
+            return self if name in ("cuda", "cuda.cuda") else None
+
+        def load_module(self, name):
+            raise ImportError(f"Test refuses {name}")
+
+        # PEP 451 path
+        def find_spec(self, name, path, target=None):
+            if name in ("cuda", "cuda.cuda"):
+                raise ImportError(f"Test refuses {name}")
+            return None
+
+    sys.meta_path.insert(0, _RefuseFinder())
+    try:
+        a = VmmAllocator(device_index=0)
+        assert a.is_supported() is False
+        # Cached: a second call doesn't re-probe.
+        assert a.is_supported() is False
+        with pytest.raises(VmmUnsupportedError):
+            a.allocate(4096)
+    finally:
+        sys.meta_path.pop(0)
+        if real_cuda is not None:
+            sys.modules["cuda"] = real_cuda
+        if real_cuda_submod is not None:
+            sys.modules["cuda.cuda"] = real_cuda_submod
+
+
+def test_allocate_zero_size_raises_value_error():
+    """Zero / negative size is rejected before the CUDA probe even
+    runs, so this works on any host."""
+    a = VmmAllocator(device_index=0)
+    with pytest.raises(ValueError, match="size_bytes must be > 0"):
+        a.allocate(0)
+    with pytest.raises(ValueError, match="size_bytes must be > 0"):
+        a.allocate(-1)
+
+
+def test_release_unknown_pool_id_is_idempotent():
+    """release() on an unknown pool_id returns False, doesn't raise.
+    This holds regardless of CUDA availability."""
+    a = VmmAllocator(device_index=0)
+    assert a.release("not-a-real-pool") is False
+    # Even called twice in a row — defensive against duplicate
+    # release_kv_pool RPCs from a confused client.
+    assert a.release("not-a-real-pool") is False
+
+
+def test_shutdown_with_no_allocations_is_safe():
+    """shutdown() on a freshly-constructed allocator is a no-op,
+    not an error."""
+    a = VmmAllocator(device_index=0)
+    a.shutdown()  # must not raise
+    assert a.known_pool_ids() == []
+
+
+def test_unsupported_probe_handles_driver_failure(monkeypatch):
+    """If cuda-python imports but cuMemGetAllocationGranularity returns
+    a non-SUCCESS code, is_supported() returns False (not raises) and
+    logs a warning."""
+
+    # Build a minimal fake `cuda.cuda` module that exposes just what
+    # _build_alloc_prop + _probe_support touch, and whose
+    # cuMemGetAllocationGranularity returns ERROR_NOT_SUPPORTED.
+    class _FakeCUresult:
+        CUDA_SUCCESS = 0
+        CUDA_ERROR_NOT_SUPPORTED = 801
+
+    class _FakeAllocType:
+        CU_MEM_ALLOCATION_TYPE_PINNED = 1
+
+    class _FakeLocType:
+        CU_MEM_LOCATION_TYPE_DEVICE = 1
+
+    class _FakeHandleType:
+        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = 1
+
+    class _FakeGranFlags:
+        CU_MEM_ALLOC_GRANULARITY_MINIMUM = 0
+
+    class _FakeProp:
+        def __init__(self):
+            self.type = None
+            self.location = None
+            self.requestedHandleTypes = None
+
+    class _FakeLoc:
+        def __init__(self):
+            self.type = None
+            self.id = -1
+
+    fake_cuda = type(sys)("cuda.cuda")
+    fake_cuda.CUresult = _FakeCUresult
+    fake_cuda.CUmemAllocationType = _FakeAllocType
+    fake_cuda.CUmemLocationType = _FakeLocType
+    fake_cuda.CUmemAllocationHandleType = _FakeHandleType
+    fake_cuda.CUmemAllocationGranularity_flags = _FakeGranFlags
+    fake_cuda.CUmemAllocationProp = _FakeProp
+    fake_cuda.CUmemLocation = _FakeLoc
+
+    def _gran(_prop, _flag):
+        return (
+            _FakeCUresult.CUDA_ERROR_NOT_SUPPORTED,
+            0,
+        )
+
+    def _err_name(_err):
+        return (_FakeCUresult.CUDA_SUCCESS, b"CUDA_ERROR_NOT_SUPPORTED")
+
+    fake_cuda.cuMemGetAllocationGranularity = _gran
+    fake_cuda.cuGetErrorName = _err_name
+
+    fake_outer = type(sys)("cuda")
+    fake_outer.cuda = fake_cuda
+
+    monkeypatch.setitem(sys.modules, "cuda", fake_outer)
+    monkeypatch.setitem(sys.modules, "cuda.cuda", fake_cuda)
+
+    a = VmmAllocator(device_index=0)
+    assert a.is_supported() is False
+    # Subsequent calls don't re-probe (cached).
+    assert a.is_supported() is False
+
+
+def test_unsupported_probe_handles_zero_granularity(monkeypatch):
+    """Defensive: if the driver returns SUCCESS but granularity=0,
+    treat as unsupported (avoid div-by-zero / infinite loop later)."""
+
+    class _OK:
+        CUDA_SUCCESS = 0
+
+    class _AT:
+        CU_MEM_ALLOCATION_TYPE_PINNED = 1
+
+    class _LT:
+        CU_MEM_LOCATION_TYPE_DEVICE = 1
+
+    class _HT:
+        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = 1
+
+    class _GF:
+        CU_MEM_ALLOC_GRANULARITY_MINIMUM = 0
+
+    fake_cuda = type(sys)("cuda.cuda")
+    fake_cuda.CUresult = _OK
+    fake_cuda.CUmemAllocationType = _AT
+    fake_cuda.CUmemLocationType = _LT
+    fake_cuda.CUmemAllocationHandleType = _HT
+    fake_cuda.CUmemAllocationGranularity_flags = _GF
+    fake_cuda.CUmemAllocationProp = type(
+        "P",
+        (),
+        {"__init__": lambda s: setattr(s, "_x", None)},
+    )
+    fake_cuda.CUmemLocation = type(
+        "L",
+        (),
+        {"__init__": lambda s: None},
+    )
+    fake_cuda.cuMemGetAllocationGranularity = lambda *_a: (
+        _OK.CUDA_SUCCESS,
+        0,
+    )
+    fake_outer = type(sys)("cuda")
+    fake_outer.cuda = fake_cuda
+    monkeypatch.setitem(sys.modules, "cuda", fake_outer)
+    monkeypatch.setitem(sys.modules, "cuda.cuda", fake_cuda)
+
+    a = VmmAllocator(device_index=0)
+    assert a.is_supported() is False
+
+
+# ----------------------------------------------------------------------
+# CUDA-gated round trip
+# ----------------------------------------------------------------------
+
+
+_REAL_VMM_ENABLED = bool(os.environ.get("GMS_TEST_VMM_REAL"))
+
+
+@pytest.mark.skipif(
+    not _REAL_VMM_ENABLED,
+    reason="Set GMS_TEST_VMM_REAL=1 and run on a CUDA host with cuda-python "
+    "to exercise the real cuMem* round trip.",
+)
+def test_supports_query_real():
+    """On a CUDA host, is_supported() must succeed and cache a
+    granularity > 0."""
+    a = VmmAllocator(device_index=0)
+    assert a.is_supported() is True
+    assert a._granularity is not None
+    assert a._granularity > 0
+    # Second call returns the cached result.
+    assert a.is_supported() is True
+
+
+@pytest.mark.skipif(
+    not _REAL_VMM_ENABLED,
+    reason="Set GMS_TEST_VMM_REAL=1 on a CUDA host to run.",
+)
+def test_alloc_release_round_trip_real():
+    """End-to-end: allocate a small pool, verify the bookkeeping
+    record is populated correctly, then release and confirm the FD
+    is closed + the pool_id no longer tracked."""
+    a = VmmAllocator(device_index=0)
+    assert a.is_supported() is True
+
+    # Request 4 MiB; it'll be rounded up to granularity.
+    requested = 4 * 1024 * 1024
+    alloc = a.allocate(requested)
+    try:
+        assert isinstance(alloc, VmmAllocation)
+        assert alloc.size_aligned >= requested
+        assert alloc.size_aligned % alloc.granularity == 0
+        assert alloc.fd > 0
+        assert alloc.va != 0
+        assert alloc.device_index == 0
+        assert alloc.pool_id in a.known_pool_ids()
+    finally:
+        ok = a.release(alloc.pool_id)
+        assert ok is True
+        # The pool is no longer tracked.
+        assert alloc.pool_id not in a.known_pool_ids()
+        # The exported FD is closed (further close should fail).
+        with pytest.raises(OSError):
+            os.close(alloc.fd)
+
+
+@pytest.mark.skipif(
+    not _REAL_VMM_ENABLED,
+    reason="Set GMS_TEST_VMM_REAL=1 on a CUDA host to run.",
+)
+def test_shutdown_releases_all_pending_real():
+    """shutdown() releases every outstanding allocation."""
+    a = VmmAllocator(device_index=0)
+    a1 = a.allocate(4 * 1024 * 1024)
+    a2 = a.allocate(4 * 1024 * 1024)
+    assert sorted(a.known_pool_ids()) == sorted([a1.pool_id, a2.pool_id])
+    a.shutdown()
+    assert a.known_pool_ids() == []

--- a/lib/gpu_memory_service/rust_ring/src/lib.rs
+++ b/lib/gpu_memory_service/rust_ring/src/lib.rs
@@ -1,11 +1,63 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Native shared-memory KV lease atomics for GMS persistent allocations.
+//! Native hot-path SPSC ring push/pop for GMS RestoreRing.
+//!
+//! Mirrors the on-disk layout defined in `common/restore_ring.py` exactly.
+//! Engine/daemon attach the mmap'd file via the Python wrapper, then
+//! pass the buffer pointer + capacity into these native push/pop calls
+//! to avoid the ~9 µs/op Python overhead (struct.pack_into × 7 +
+//! function-call overhead).
+//!
+//! Layout (little-endian, must match common/restore_ring.py):
+//!
+//!   Header (64B):
+//!     magic        : u32   = 0x4752_5347  ("GMSR" little-endian read)
+//!     version      : u32   = 1
+//!     capacity     : u32   record count (power of 2)
+//!     record_size  : u32   = 512
+//!     head_seq     : u64   producer-only
+//!     tail_seq     : u64   consumer-only
+//!     drops        : u64   producer-only
+//!     padding      : 16B
+//!
+//!   Record (512B):
+//!     seq            : u64    (non-zero ⇒ ready for consumer)
+//!     op_kind        : u8
+//!     flags          : u8
+//!     _pad           : u16
+//!     counter_slot   : u32
+//!     counter_target : u32
+//!     n_blocks       : u32
+//!     _pad2          : u64
+//!     src_engine_id  : char[48]   (NUL-padded)
+//!     block_pairs[54]: each (u32 src_blk, u32 dest_blk)
 
 use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
+use pyo3::types::PyBytes;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+const HEADER_SIZE: usize = 64;
+const RECORD_SIZE: usize = 512;
+const ENGINE_ID_MAX_LEN: usize = 48;
+const MAX_BLOCK_PAIRS_PER_RECORD: usize = 54;
+
+const OFF_HEAD_SEQ: usize = 16;
+const OFF_TAIL_SEQ: usize = 24;
+const OFF_DROPS: usize = 32;
+
+const R_SEQ: usize = 0;
+const R_OP: usize = 8;
+const R_FLAGS: usize = 9;
+const R_COUNTER_SLOT: usize = 12;
+const R_COUNTER_TARGET: usize = 16;
+const R_N_BLOCKS: usize = 20;
+const R_ENGINE_ID: usize = 32;
+const R_BLOCK_PAIRS: usize = 80;
+const BLOCK_PAIR_STRIDE: usize = 8;
+
+const OP_RESTORE_CHUNK: u8 = 1;
 
 const LEASE_MAGIC: u32 = 0x4c53_4d47; // "GMSL" as little-endian u32.
 const LEASE_VERSION: u32 = 1;
@@ -256,6 +308,201 @@ unsafe fn load_lease_reservation(ptr: *const u8) -> (u32, u64, u64) {
         if before == after {
             return (reserved_blocks, reserved_owner_hash, after);
         }
+    }
+}
+
+/// Push one chunk-restore record into the ring.
+///
+/// Arguments:
+///   - `buf`: mutable bytes-like object backing the mmap. Must be at
+///     least HEADER_SIZE + capacity*RECORD_SIZE bytes.
+///   - `capacity`: ring capacity (power of 2).
+///   - `src_engine_id_bytes`: UTF-8 engine_id, NUL-padded externally
+///     OR length must be ≤ 47.
+///   - `src_blocks` / `dest_blocks`: same-length lists of u32 ids.
+///   - `counter_slot`, `counter_target`, `flags`: scalar fields.
+///
+/// Returns True on success; False if the ring was full (drops counter
+/// auto-incremented).
+#[pyfunction]
+#[pyo3(signature = (
+    buf, capacity, src_engine_id_bytes, src_blocks, dest_blocks,
+    counter_slot, counter_target, flags,
+))]
+fn push_record(
+    py: Python<'_>,
+    buf: PyBuffer<u8>,
+    capacity: u32,
+    src_engine_id_bytes: &[u8],
+    src_blocks: Vec<u32>,
+    dest_blocks: Vec<u32>,
+    counter_slot: u32,
+    counter_target: u32,
+    flags: u8,
+) -> PyResult<bool> {
+    let _ = py;
+    if !buf.readonly() || true {
+        // PyBuffer doesn't expose mut directly; we'll use the raw pointer.
+    }
+    if src_blocks.len() != dest_blocks.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "src_blocks and dest_blocks length mismatch",
+        ));
+    }
+    let n_blocks = src_blocks.len();
+    if n_blocks > MAX_BLOCK_PAIRS_PER_RECORD {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "too many block pairs: {} > {}",
+            n_blocks, MAX_BLOCK_PAIRS_PER_RECORD
+        )));
+    }
+    if src_engine_id_bytes.len() >= ENGINE_ID_MAX_LEN {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "engine_id too long: {} >= {}",
+            src_engine_id_bytes.len(),
+            ENGINE_ID_MAX_LEN
+        )));
+    }
+    let mask = (capacity - 1) as u64;
+
+    let ptr = buf.buf_ptr() as *mut u8;
+    let buf_len = buf.len_bytes();
+    let need = HEADER_SIZE + (capacity as usize) * RECORD_SIZE;
+    if buf_len < need {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "buffer too small: {} < {}",
+            buf_len, need
+        )));
+    }
+
+    // Single-producer: head bump is naturally atomic under GIL.
+    unsafe {
+        let head = read_u64(ptr, OFF_HEAD_SEQ);
+        let tail = read_u64(ptr, OFF_TAIL_SEQ);
+        if head.wrapping_sub(tail) >= capacity as u64 {
+            // Full; bump drops + return False.
+            let drops = read_u64(ptr, OFF_DROPS);
+            write_u64(ptr, OFF_DROPS, drops.wrapping_add(1));
+            return Ok(false);
+        }
+
+        let slot_idx = (head & mask) as usize;
+        let base = HEADER_SIZE + slot_idx * RECORD_SIZE;
+
+        // Zero seq first so consumer never observes half-written.
+        write_u64(ptr, base + R_SEQ, 0);
+
+        // Scalar fields
+        *(ptr.add(base + R_OP)) = OP_RESTORE_CHUNK;
+        *(ptr.add(base + R_FLAGS)) = flags;
+        write_u32(ptr, base + R_COUNTER_SLOT, counter_slot);
+        write_u32(ptr, base + R_COUNTER_TARGET, counter_target);
+        write_u32(ptr, base + R_N_BLOCKS, n_blocks as u32);
+
+        // engine_id (NUL-padded). Zero the field first.
+        std::ptr::write_bytes(ptr.add(base + R_ENGINE_ID), 0, ENGINE_ID_MAX_LEN);
+        std::ptr::copy_nonoverlapping(
+            src_engine_id_bytes.as_ptr(),
+            ptr.add(base + R_ENGINE_ID),
+            src_engine_id_bytes.len(),
+        );
+
+        // Block pairs (zero out unused tail)
+        let pairs_base = base + R_BLOCK_PAIRS;
+        for i in 0..n_blocks {
+            write_u32(ptr, pairs_base + i * BLOCK_PAIR_STRIDE, src_blocks[i]);
+            write_u32(ptr, pairs_base + i * BLOCK_PAIR_STRIDE + 4, dest_blocks[i]);
+        }
+        for i in n_blocks..MAX_BLOCK_PAIRS_PER_RECORD {
+            write_u32(ptr, pairs_base + i * BLOCK_PAIR_STRIDE, 0);
+            write_u32(ptr, pairs_base + i * BLOCK_PAIR_STRIDE + 4, 0);
+        }
+
+        // Release: publish seq AFTER payload (x86-TSO; under GIL).
+        // Use atomic store with Release ordering for memory ordering
+        // guarantee.
+        let seq_ptr = ptr.add(base + R_SEQ) as *const AtomicU64;
+        (*seq_ptr).store(head.wrapping_add(1), Ordering::Release);
+
+        // Publish head LAST.
+        let head_ptr = ptr.add(OFF_HEAD_SEQ) as *const AtomicU64;
+        (*head_ptr).store(head.wrapping_add(1), Ordering::Release);
+    }
+    Ok(true)
+}
+
+/// Pop one ready record from the ring. Returns None if empty.
+///
+/// Returns a tuple: (op, flags, counter_slot, counter_target,
+/// engine_id_bytes, [(src_blk, dest_blk), ...]).
+#[pyfunction]
+#[pyo3(signature = (buf, capacity))]
+fn try_pop_record(
+    py: Python<'_>,
+    buf: PyBuffer<u8>,
+    capacity: u32,
+) -> PyResult<Option<(u8, u8, u32, u32, Py<PyBytes>, Vec<(u32, u32)>)>> {
+    let mask = (capacity - 1) as u64;
+    let ptr = buf.buf_ptr() as *mut u8;
+    let buf_len = buf.len_bytes();
+    let need = HEADER_SIZE + (capacity as usize) * RECORD_SIZE;
+    if buf_len < need {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "buffer too small: {} < {}",
+            buf_len, need
+        )));
+    }
+
+    unsafe {
+        let tail_ptr = ptr.add(OFF_TAIL_SEQ) as *const AtomicU64;
+        let head_ptr = ptr.add(OFF_HEAD_SEQ) as *const AtomicU64;
+        let tail = (*tail_ptr).load(Ordering::Acquire);
+        let head = (*head_ptr).load(Ordering::Acquire);
+        if tail >= head {
+            return Ok(None);
+        }
+        let slot_idx = (tail & mask) as usize;
+        let base = HEADER_SIZE + slot_idx * RECORD_SIZE;
+        let seq_ptr = ptr.add(base + R_SEQ) as *const AtomicU64;
+        let seq = (*seq_ptr).load(Ordering::Acquire);
+        if seq != tail.wrapping_add(1) {
+            return Ok(None); // producer hasn't released yet
+        }
+
+        let op = *(ptr.add(base + R_OP));
+        let flags = *(ptr.add(base + R_FLAGS));
+        let counter_slot = read_u32(ptr, base + R_COUNTER_SLOT);
+        let counter_target = read_u32(ptr, base + R_COUNTER_TARGET);
+        let n_blocks_raw = read_u32(ptr, base + R_N_BLOCKS) as usize;
+        let n_blocks = n_blocks_raw.min(MAX_BLOCK_PAIRS_PER_RECORD);
+
+        // engine_id: find NUL or end of field
+        let eid_slice = std::slice::from_raw_parts(ptr.add(base + R_ENGINE_ID), ENGINE_ID_MAX_LEN);
+        let eid_len = eid_slice
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(ENGINE_ID_MAX_LEN);
+        let eid_bytes = PyBytes::new_bound(py, &eid_slice[..eid_len]);
+
+        let mut pairs = Vec::with_capacity(n_blocks);
+        let pairs_base = base + R_BLOCK_PAIRS;
+        for i in 0..n_blocks {
+            let src = read_u32(ptr, pairs_base + i * BLOCK_PAIR_STRIDE);
+            let dest = read_u32(ptr, pairs_base + i * BLOCK_PAIR_STRIDE + 4);
+            pairs.push((src, dest));
+        }
+
+        // Advance tail AFTER reading payload.
+        (*tail_ptr).store(tail.wrapping_add(1), Ordering::Release);
+
+        Ok(Some((
+            op,
+            flags,
+            counter_slot,
+            counter_target,
+            eid_bytes.unbind(),
+            pairs,
+        )))
     }
 }
 
@@ -744,8 +991,90 @@ fn kv_lease_reclaim_foreign(
 }
 
 // IEEE CRC32 polynomial in reversed representation, matching zlib.
+const CRC32_POLY: u32 = 0xEDB8_8320;
+
+#[inline]
+fn gf2_mat_mul(mat: &[u32; 32], mut vec: u32) -> u32 {
+    let mut out = 0;
+    let mut i = 0;
+    while vec != 0 {
+        if vec & 1 != 0 {
+            out ^= mat[i];
+        }
+        vec >>= 1;
+        i += 1;
+    }
+    out
+}
+
+#[inline]
+fn gf2_mat_square(square: &mut [u32; 32], mat: &[u32; 32]) {
+    for i in 0..32 {
+        square[i] = gf2_mat_mul(mat, mat[i]);
+    }
+}
+
+/// Return crc32(A || B) from crc32(A), crc32(B), and len(B).
+fn crc32_combine_one(crc1: u32, crc2: u32, len2: u64) -> u32 {
+    if len2 == 0 {
+        return crc1;
+    }
+    let mut odd = [0u32; 32];
+    let mut even = [0u32; 32];
+    odd[0] = CRC32_POLY;
+    for (n, value) in odd.iter_mut().enumerate().skip(1) {
+        *value = 1u32 << (n - 1);
+    }
+    gf2_mat_square(&mut even, &odd);
+    gf2_mat_square(&mut odd, &even);
+    let mut crc = crc1;
+    let mut len = len2;
+    loop {
+        gf2_mat_square(&mut even, &odd);
+        if len & 1 != 0 {
+            crc = gf2_mat_mul(&even, crc);
+        }
+        len >>= 1;
+        if len == 0 {
+            break;
+        }
+        gf2_mat_square(&mut odd, &even);
+        if len & 1 != 0 {
+            crc = gf2_mat_mul(&odd, crc);
+        }
+        len >>= 1;
+        if len == 0 {
+            break;
+        }
+    }
+    crc ^ crc2
+}
+
+/// Combine ordered GPU-computed chunk CRCs without copying payload bytes.
+#[pyfunction]
+#[pyo3(signature = (crcs, chunk_bytes, total_bytes))]
+fn crc32_combine_chunks(crcs: Vec<u32>, chunk_bytes: u64, total_bytes: u64) -> u32 {
+    if total_bytes == 0 || crcs.is_empty() {
+        return 0;
+    }
+    let mut combined = 0;
+    let mut remaining = total_bytes;
+    for crc in crcs {
+        let this_len = remaining.min(chunk_bytes);
+        if this_len == 0 {
+            break;
+        }
+        combined = crc32_combine_one(combined, crc, this_len);
+        remaining -= this_len;
+    }
+    combined
+}
+
 #[pymodule]
 fn gms_rust_ring(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(push_record, m)?)?;
+    m.add_function(wrap_pyfunction!(try_pop_record, m)?)?;
+    m.add_function(wrap_pyfunction!(crc32_combine_chunks, m)?)?;
     m.add_function(wrap_pyfunction!(kv_lease_init, m)?)?;
     m.add_function(wrap_pyfunction!(kv_lease_free_count, m)?)?;
     m.add_function(wrap_pyfunction!(kv_lease_free_count_for_owner, m)?)?;
@@ -759,6 +1088,11 @@ fn gms_rust_ring(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(kv_lease_seal, m)?)?;
     m.add_function(wrap_pyfunction!(kv_lease_release, m)?)?;
     m.add_function(wrap_pyfunction!(kv_lease_reclaim_foreign, m)?)?;
+    m.add("RECORD_SIZE", RECORD_SIZE)?;
+    m.add("HEADER_SIZE", HEADER_SIZE)?;
+    m.add("MAX_BLOCK_PAIRS", MAX_BLOCK_PAIRS_PER_RECORD)?;
+    m.add("MAX_BLOCK_PAIRS_PER_RECORD", MAX_BLOCK_PAIRS_PER_RECORD)?;
+    m.add("ENGINE_ID_MAX_LEN", ENGINE_ID_MAX_LEN)?;
     m.add("KV_LEASE_HEADER_SIZE", LEASE_HEADER_SIZE)?;
     m.add("KV_LEASE_RECORD_SIZE", LEASE_RECORD_SIZE)?;
     m.add("KV_LEASE_MAGIC", LEASE_MAGIC)?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     # typing.Self is 3.11+; declared minimum is 3.10 (see requires-python),
     # so back-port Self via typing_extensions in dynamo.common.configuration.
     "typing_extensions>=4.10.0",
+    "msgpack==1.1.2",
+    "xxhash>=3.6.0,<4.0",
 ]
 
 classifiers = [
@@ -201,6 +203,8 @@ filterwarnings = [
     # cuda.cudart/cuda.nvrtc deprecated in favor of cuda.bindings.* (cuda-python >=13)
     # Triggered by flashinfer 0.6.7+ during import of comm/mnnvl.py
     "ignore:The cuda\\..*module is deprecated:FutureWarning",
+    # FlashInfer/CUTLASS emits this during TRT-LLM import on Blackwell.
+    "ignore:tcgen05\\..*is deprecated.*:DeprecationWarning",
     # SGLang GGUF quantization emits UserWarning on non-CUDA platforms (arm64 CPU-only CI)
     "ignore:Only CUDA.*support GGUF quantization:UserWarning",
     # protobuf C extension warning


### PR DESCRIPTION
## Summary

Define the engine-neutral contracts for moving KV content between GPU memory, host memory, and durable storage.

## Scope

Adds ring, memory, storage, and transfer interfaces only. Daemon lifecycle, engine adapters, and optional network backends remain separate.

## Stack

Position **6/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-04-sglang-integration`.

Parent: #10450  
Tracking: #10455

## Review migration

This is the current review entry replacing historical merged PR #10472. GitHub does not allow a merged PR to be retargeted; #10472 and all of its comments and reviews remain intact as the historical record.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

Contract and component tests are included with the host-tier implementation; cross-node behavior is completed in positions 8-9.