### PR TITLE
test(gms): add vLLM and SGLang E2E coverage [GMS 10/18]

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -2290,6 +2290,7 @@ def _test_router_decisions_disagg(
     durable_kv_events: bool = False,
     router_aic_config: Optional[dict[str, Any]] = None,
     enable_bootstrap: bool = False,
+    strict_timing: bool = True,
 ):
     """Validate KV cache prefix reuse in disaggregated prefill-decode setup via HTTP frontend.
 
@@ -2313,6 +2314,7 @@ def _test_router_decisions_disagg(
         store_backend: Storage backend to use ("etcd" or "file"). Defaults to "etcd".
         durable_kv_events: If True, use durable KV events (JetStream). Defaults to False.
         router_aic_config: Optional AIC router perf-model config for frontend KV routing.
+        strict_timing: If False, allow backend responses that omit optional timing fields.
 
     Raises:
         AssertionError: If prefill_worker_ids differ across requests (prefix reuse failure)
@@ -2356,7 +2358,7 @@ def _test_router_decisions_disagg(
         )
 
         async def send_progressive_requests():
-            """Send 4 progressive requests with overlapping prefixes and collect worker IDs."""
+            """Send progressive requests with overlapping prefixes and collect worker IDs."""
             prefill_worker_ids = []
             decode_worker_ids = []
 
@@ -2392,10 +2394,13 @@ def _test_router_decisions_disagg(
                             response.status == 200
                         ), f"Request {i + 1} failed with status {response.status}"
 
-                        # Collect all chunks and look for nvext with worker_id and timing
+                        # Collect all chunks and look for nvext with worker_id, timing,
+                        # and actual generated text. A backend can otherwise surface a
+                        # transfer failure as a 200 stream with worker IDs but no tokens.
                         prefill_wid = None
                         decode_wid = None
                         timing_info = None
+                        generated_parts: list[str] = []
 
                         async for line in response.content:
                             if not line:
@@ -2411,6 +2416,12 @@ def _test_router_decisions_disagg(
 
                             try:
                                 data = json.loads(data_str)
+                                for choice in data.get("choices", []):
+                                    delta = choice.get("delta") or {}
+                                    content = delta.get("content")
+                                    if content:
+                                        generated_parts.append(content)
+
                                 # Check for nvext in the response
                                 nvext = data.get("nvext", {})
                                 if nvext:
@@ -2431,9 +2442,15 @@ def _test_router_decisions_disagg(
                             except json.JSONDecodeError:
                                 continue
 
+                        generated_text = "".join(generated_parts)
                         logger.info(
                             f"Request {i + 1}: prefill_worker_id={prefill_wid}, "
-                            f"decode_worker_id={decode_wid}, timing={timing_info}"
+                            f"decode_worker_id={decode_wid}, timing={timing_info}, "
+                            f"generated_chars={len(generated_text)}"
+                        )
+                        assert generated_text.strip(), (
+                            f"Request {i + 1}: Expected generated content in the response stream, "
+                            "but the backend returned no text tokens"
                         )
 
                         if prefill_wid is not None:
@@ -2447,7 +2464,12 @@ def _test_router_decisions_disagg(
                         assert (
                             timing_info is not None
                         ), f"Request {i + 1}: Expected timing info in final chunk, got None"
-                        verify_response_timing(timing_info, disagg=not enable_bootstrap)
+                        verify_response_timing(
+                            timing_info,
+                            disagg=not enable_bootstrap,
+                            require_ttft=strict_timing,
+                            require_kv_transfer_latency=strict_timing,
+                        )
 
                     # Small delay between requests
                     await asyncio.sleep(1)

--- a/tests/router/e2e_harness.py
+++ b/tests/router/e2e_harness.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import time
+from contextlib import ExitStack, contextmanager
 from typing import Any, Callable, ContextManager
 
 from tests.router.common import (
@@ -19,6 +20,71 @@ from tests.utils.port_utils import allocate_ports, deallocate_ports
 from tests.utils.test_output import resolve_test_output_path
 
 logger = logging.getLogger(__name__)
+
+
+def env_int(name: str, default: int) -> int:
+    return int(os.environ.get(name, default))
+
+
+def env_optional_int(name: str) -> int | None:
+    raw = os.environ.get(name)
+    return None if raw is None else int(raw)
+
+
+def env_float(name: str, default: float) -> float:
+    return float(os.environ.get(name, default))
+
+
+def env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    return default if raw is None else raw.lower() not in {"0", "false", "no", "off"}
+
+
+def resolve_router_gpu_start_index(gpu_start_index: int) -> int:
+    override = os.environ.get("DYNAMO_ROUTER_E2E_GPU_START_INDEX")
+    if override is None:
+        return gpu_start_index
+    try:
+        base_index = int(override)
+    except ValueError as exc:
+        raise ValueError(
+            "DYNAMO_ROUTER_E2E_GPU_START_INDEX must be an integer"
+        ) from exc
+    return base_index + gpu_start_index
+
+
+def _resolve_router_e2e_num_requests(default: int = 10) -> int:
+    override = os.environ.get("DYNAMO_ROUTER_E2E_NUM_REQUESTS")
+    if override is None:
+        return default
+    try:
+        value = int(override)
+    except ValueError as exc:
+        raise ValueError("DYNAMO_ROUTER_E2E_NUM_REQUESTS must be an integer") from exc
+    if value <= 0:
+        raise ValueError("DYNAMO_ROUTER_E2E_NUM_REQUESTS must be positive")
+    return value
+
+
+@contextmanager
+def maybe_router_gms_servers():
+    if os.environ.get("DYNAMO_ROUTER_E2E_ENABLE_GMS") != "1":
+        yield
+        return
+
+    from tests.gpu_memory_service.common.gms import GMSServer
+
+    devices = os.environ.get("DYNAMO_ROUTER_E2E_GMS_DEVICES", "0,1")
+    tags = os.environ.get("DYNAMO_ROUTER_E2E_GMS_TAGS", "weights,kv_cache")
+    device_ids = [int(part.strip()) for part in devices.split(",") if part.strip()]
+    tag_names = [part.strip() for part in tags.split(",") if part.strip()]
+
+    with ExitStack() as stack:
+        for device in device_ids:
+            for tag in tag_names:
+                stack.enter_context(GMSServer(device=device, tag=tag))
+        yield
+
 
 TEST_PROMPT = (
     "In a quiet meadow tucked between rolling hills, a plump gray rabbit nibbled on "
@@ -215,7 +281,9 @@ def run_basic_router_test(
         },
         engine_process_kwargs=engine_process_kwargs,
     )
-    with process as engine_workers:
+    with ExitStack() as stack:
+        stack.enter_context(maybe_router_gms_servers())
+        engine_workers = stack.enter_context(process)
         frontend_port = allocate_frontend_ports(request, 1)[0]
         _test_router_basic(
             engine_workers=engine_workers,
@@ -223,7 +291,7 @@ def run_basic_router_test(
             request=request,
             frontend_port=frontend_port,
             test_payload=test_payload or build_test_payload(model_name),
-            num_requests=num_requests,
+            num_requests=_resolve_router_e2e_num_requests(num_requests),
             frontend_timeout=frontend_timeout,
             store_backend="etcd",
             request_plane=request_plane,
@@ -264,7 +332,9 @@ def run_router_decisions_test(
         default_process_kwargs=default_process_kwargs,
         engine_process_kwargs=engine_process_kwargs,
     )
-    with process as engine_workers:
+    with ExitStack() as stack:
+        stack.enter_context(maybe_router_gms_servers())
+        engine_workers = stack.enter_context(process)
         endpoint = get_engine_endpoint(engine_workers, request_plane, component_name)
         scenario_kwargs = dict(test_kwargs or {})
         for argument, attribute in (
@@ -333,6 +403,7 @@ def run_disagg_router_decisions_test(
     | None = None,
     test_payload: dict[str, Any] | None = None,
     test_kwargs: dict[str, Any] | None = None,
+    strict_timing: bool = True,
 ):
     shared_namespace = f"test-namespace-{generate_random_suffix()}"
     frontend_port = allocate_frontend_ports(request, 1)[0]
@@ -347,6 +418,7 @@ def run_disagg_router_decisions_test(
     }
 
     def run_test(prefill_workers, decode_workers):
+        scenario_kwargs = {"strict_timing": strict_timing, **(test_kwargs or {})}
         _test_router_decisions_disagg(
             prefill_workers=prefill_workers,
             decode_workers=decode_workers,
@@ -355,29 +427,35 @@ def run_disagg_router_decisions_test(
             frontend_port=frontend_port,
             test_payload=test_payload or build_test_payload(model_name),
             request_plane=request_plane,
-            **(test_kwargs or {}),
+            **scenario_kwargs,
         )
 
-    if worker_context_factory is not None:
-        with worker_context_factory(shared_namespace) as workers:
+    with ExitStack() as stack:
+        stack.enter_context(maybe_router_gms_servers())
+        if worker_context_factory is not None:
+            workers = stack.enter_context(worker_context_factory(shared_namespace))
             run_test(*workers)
-        return
+            return
 
-    with engine_process_cls(
-        request,
-        num_workers=num_prefill_workers,
-        request_plane=request_plane,
-        **{engine_args_name: engine_args},
-        **prefill_kwargs,
-    ) as prefill_workers:
-        with engine_process_cls(
-            request,
-            num_workers=num_decode_workers,
-            request_plane=request_plane,
-            **{engine_args_name: engine_args},
-            **decode_kwargs,
-        ) as decode_workers:
-            run_test(prefill_workers, decode_workers)
+        prefill_workers = stack.enter_context(
+            engine_process_cls(
+                request,
+                num_workers=num_prefill_workers,
+                request_plane=request_plane,
+                **{engine_args_name: engine_args},
+                **prefill_kwargs,
+            )
+        )
+        decode_workers = stack.enter_context(
+            engine_process_cls(
+                request,
+                num_workers=num_decode_workers,
+                request_plane=request_plane,
+                **{engine_args_name: engine_args},
+                **decode_kwargs,
+            )
+        )
+        run_test(prefill_workers, decode_workers)
 
 
 def run_indexers_sync_test(
@@ -414,7 +492,9 @@ def run_indexers_sync_test(
         },
         engine_process_kwargs=engine_process_kwargs,
     )
-    with process as engine_workers:
+    with ExitStack() as stack:
+        stack.enter_context(maybe_router_gms_servers())
+        engine_workers = stack.enter_context(process)
         _test_router_indexers_sync(
             engine_workers=engine_workers,
             block_size=block_size,

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -132,41 +132,61 @@ def verify_response_worker_ids(
     )
 
 
-def verify_response_timing(timing_info: dict[str, Any], disagg: bool = False) -> None:
-    """Verify timing info has valid values (ttft_ms > 0, total_time_ms > 0).
+def verify_response_timing(
+    timing_info: dict[str, Any],
+    disagg: bool = False,
+    require_ttft: bool = True,
+    require_kv_transfer_latency: bool = True,
+) -> None:
+    """Verify timing info has valid values.
 
     Args:
         timing_info: Dict of timing fields from nvext.timing in the response.
-        disagg: If True, also verify kv_transfer_estimated_latency_ms > 0 (disaggregated mode only).
+        disagg: If True, verify disaggregated-mode transfer timing when required.
+        require_ttft: If True, require ttft_ms > 0. Some backends do not emit it.
+        require_kv_transfer_latency: If True, require kv_transfer_estimated_latency_ms > 0.
     """
     ttft_ms = timing_info.get("ttft_ms")
     total_time_ms = timing_info.get("total_time_ms")
 
-    assert ttft_ms is not None and ttft_ms > 0, f"Expected ttft_ms > 0, got: {ttft_ms}"
     assert (
         total_time_ms is not None and total_time_ms > 0
     ), f"Expected total_time_ms > 0, got: {total_time_ms}"
-    assert (
-        total_time_ms >= ttft_ms
-    ), f"Expected total_time_ms >= ttft_ms, got {total_time_ms} < {ttft_ms}"
-    logger.info(
-        f"✓ Verified timing: ttft_ms={ttft_ms:.2f}, total_time_ms={total_time_ms:.2f}"
-    )
+
+    if ttft_ms is None:
+        assert not require_ttft, "Expected ttft_ms > 0, got: None"
+        logger.info("Timing did not include ttft_ms; verified total_time_ms only")
+    else:
+        assert ttft_ms > 0, f"Expected ttft_ms > 0, got: {ttft_ms}"
+        assert (
+            total_time_ms >= ttft_ms
+        ), f"Expected total_time_ms >= ttft_ms, got {total_time_ms} < {ttft_ms}"
+        logger.info(
+            f"✓ Verified timing: ttft_ms={ttft_ms:.2f}, total_time_ms={total_time_ms:.2f}"
+        )
 
     if disagg:
         kv_transfer_estimated_latency_ms = timing_info.get(
             "kv_transfer_estimated_latency_ms"
         )
-        assert (
-            kv_transfer_estimated_latency_ms is not None
-            and kv_transfer_estimated_latency_ms > 0
-        ), (
-            f"Expected kv_transfer_estimated_latency_ms > 0 in disaggregated mode, "
-            f"got: {kv_transfer_estimated_latency_ms}"
-        )
-        logger.info(
-            f"✓ Verified kv_transfer_estimated_latency_ms={kv_transfer_estimated_latency_ms:.2f}"
-        )
+        if kv_transfer_estimated_latency_ms is None:
+            assert not require_kv_transfer_latency, (
+                "Expected kv_transfer_estimated_latency_ms > 0 in disaggregated mode, "
+                "got: None"
+            )
+            prefill_wait_time_ms = timing_info.get("prefill_wait_time_ms")
+            if prefill_wait_time_ms is not None:
+                assert (
+                    prefill_wait_time_ms >= 0
+                ), f"Expected prefill_wait_time_ms >= 0, got: {prefill_wait_time_ms}"
+        else:
+            assert kv_transfer_estimated_latency_ms > 0, (
+                f"Expected kv_transfer_estimated_latency_ms > 0 in disaggregated mode, "
+                f"got: {kv_transfer_estimated_latency_ms}"
+            )
+            logger.info(
+                f"✓ Verified kv_transfer_estimated_latency_ms={kv_transfer_estimated_latency_ms:.2f}"
+            )
 
 
 ########################################################
@@ -541,9 +561,15 @@ async def send_request_with_retry(url: str, payload: dict, max_retries: int = 8)
             async with aiohttp.ClientSession() as session:
                 async with session.post(url, json=payload) as response:
                     if response.status == 200:
-                        # Read the response to ensure it's valid
-                        async for _ in response.content:
-                            pass
+                        # Read and validate the response to ensure the stream
+                        # completed rather than failing inside an HTTP 200 body.
+                        chunks = []
+                        async for chunk in response.content:
+                            if chunk:
+                                chunks.append(chunk)
+                        _validate_stream_response_chunks(
+                            chunks, f"Initial request to {url}"
+                        )
                         logger.debug(
                             f"First request succeeded on attempt {attempt + 1}"
                         )
@@ -583,6 +609,54 @@ def get_runtime(
     return DistributedRuntime(
         loop, store_backend, request_plane, event_plane=event_plane
     )
+
+
+def _validate_stream_response_chunks(chunks: list[bytes], context: str) -> None:
+    """Validate an OpenAI-compatible SSE stream completed cleanly.
+
+    Some backends surface generation errors as HTTP 200 streams that terminate
+    early. Treat those as failed requests instead of counting the transport as
+    success.
+    """
+    body = b"".join(chunks).decode("utf-8", errors="replace")
+    saw_sse_payload = False
+    saw_done = False
+
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(":"):
+            continue
+        if not line.startswith("data:"):
+            continue
+
+        saw_sse_payload = True
+        data_str = line[5:].strip()
+        if data_str == "[DONE]":
+            saw_done = True
+            continue
+
+        try:
+            data = json.loads(data_str)
+        except json.JSONDecodeError:
+            continue
+
+        error = data.get("error")
+        if error:
+            raise AssertionError(f"{context} returned stream error payload: {error}")
+
+    if saw_sse_payload and not saw_done:
+        raise AssertionError(f"{context} stream ended without data: [DONE]")
+
+    if not saw_sse_payload:
+        if not body.strip():
+            raise AssertionError(f"{context} stream returned no SSE payload")
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            return
+        error = data.get("error") if isinstance(data, dict) else None
+        if error:
+            raise AssertionError(f"{context} returned error payload: {error}")
 
 
 async def check_nats_consumers(namespace: str, expected_count: Optional[int] = None):
@@ -650,11 +724,14 @@ async def send_inflight_requests(urls: list, payload: dict, num_requests: int):
                     )
                     return False
 
-                # For streaming responses, read the entire stream
+                # For streaming responses, read and validate the entire stream.
                 chunks = []
                 async for line in response.content:
                     if line:
                         chunks.append(line)
+                _validate_stream_response_chunks(
+                    chunks, f"Request {request_id} to URL {url_index}"
+                )
 
                 logger.debug(
                     f"Request {request_id} to URL {url_index} completed with {len(chunks)} chunks"

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -13,6 +13,11 @@ import pytest
 
 from tests.router.e2e_harness import (
     ManagedEngineProcessMixin,
+    env_bool,
+    env_float,
+    env_int,
+    env_optional_int,
+    resolve_router_gpu_start_index,
     run_basic_router_test,
     run_disagg_router_decisions_test,
     run_indexers_sync_test,
@@ -31,7 +36,10 @@ from tests.utils.port_utils import (
 
 logger = logging.getLogger(__name__)
 
-MODEL_NAME = "silence09/DeepSeek-R1-Small-2layers"
+
+MODEL_NAME = os.environ.get(
+    "DYNAMO_ROUTER_E2E_SGLANG_MODEL", "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+)
 
 pytestmark = [
     pytest.mark.router,
@@ -44,9 +52,22 @@ PAGE_SIZE = 16  # SGLang uses "page_size" instead of "block_size"
 SGLANG_ARGS: Dict[str, Any] = {
     "page_size": PAGE_SIZE,
     "model": MODEL_NAME,
-    "mem_fraction_static": 0.4,  # Limit VRAM allocation per worker (equivalent to vLLM's gpu_memory_utilization)
-    "context_length": 1024,  # Limit context length to reduce KV cache size (equivalent to vLLM's max_model_len)
-    "disable_cuda_graph": True,  # Disable CUDA graphs for faster startup & lower memory (equivalent to vLLM's enforce_eager)
+    "mem_fraction_static": env_float(
+        "DYNAMO_ROUTER_E2E_SGLANG_MEM_FRACTION_STATIC", 0.4
+    ),
+    "context_length": env_int("DYNAMO_ROUTER_E2E_SGLANG_CONTEXT_LENGTH", 1024),
+    "disable_cuda_graph": env_bool(
+        "DYNAMO_ROUTER_E2E_SGLANG_DISABLE_CUDA_GRAPH", False
+    ),
+    "tensor_parallel_size": env_optional_int(
+        "DYNAMO_ROUTER_E2E_SGLANG_TENSOR_PARALLEL_SIZE"
+    ),
+    "expert_parallel_size": env_optional_int(
+        "DYNAMO_ROUTER_E2E_SGLANG_EXPERT_PARALLEL_SIZE"
+    ),
+    "moe_a2a_backend": os.environ.get("DYNAMO_ROUTER_E2E_SGLANG_MOE_A2A_BACKEND"),
+    "deepep_mode": os.environ.get("DYNAMO_ROUTER_E2E_SGLANG_DEEPEP_MODE"),
+    "enable_eplb": env_bool("DYNAMO_ROUTER_E2E_SGLANG_ENABLE_EPLB", False),
 }
 
 
@@ -102,6 +123,7 @@ class SGLangProcess(ManagedEngineProcessMixin):
         self.data_parallel_size = data_parallel_size
         self.worker_processes = []
         self.store_backend = store_backend
+        gpu_start_index = resolve_router_gpu_start_index(gpu_start_index)
 
         # Dynamically allocate unique system and KV event ports to avoid
         # conflicts in parallel test runs.
@@ -129,14 +151,38 @@ class SGLangProcess(ManagedEngineProcessMixin):
         mem_fraction_static = sglang_args.get("mem_fraction_static")
         context_length = sglang_args.get("context_length")
         disable_cuda_graph = sglang_args.get("disable_cuda_graph", False)
+        tensor_parallel_size = sglang_args.get("tensor_parallel_size")
+        expert_parallel_size = sglang_args.get("expert_parallel_size")
+        moe_a2a_backend = sglang_args.get("moe_a2a_backend")
+        deepep_mode = sglang_args.get("deepep_mode")
+        enable_eplb = sglang_args.get("enable_eplb", False)
+        load_format = sglang_args.get("load_format") or os.environ.get(
+            "DYNAMO_ROUTER_E2E_LOAD_FORMAT"
+        )
+        model_loader_extra_config = sglang_args.get(
+            "model_loader_extra_config"
+        ) or os.environ.get("DYNAMO_ROUTER_E2E_MODEL_LOADER_EXTRA_CONFIG")
+        enable_memory_saver = sglang_args.get(
+            "enable_memory_saver", load_format == "gms"
+        )
 
         self.model_name = model
 
         for worker_idx in range(num_workers):
             # Calculate GPU device for this process
             if single_gpu:
-                # Force all processes to GPU 0 (for single-GPU testing)
+                # Force all processes to one GPU (for single-GPU testing)
                 gpu_device = str(gpu_start_index)
+            elif tensor_parallel_size is not None and int(tensor_parallel_size) > 1:
+                worker_start_gpu = gpu_start_index + worker_idx * int(
+                    tensor_parallel_size
+                )
+                gpu_device = ",".join(
+                    str(i)
+                    for i in range(
+                        worker_start_gpu, worker_start_gpu + int(tensor_parallel_size)
+                    )
+                )
             elif data_parallel_size is not None:
                 # Worker sees dp_rank GPUs (each DP rank gets its own GPU)
                 worker_start_gpu = gpu_start_index + worker_idx * data_parallel_size
@@ -147,7 +193,7 @@ class SGLangProcess(ManagedEngineProcessMixin):
                     )
                 )
             else:
-                # No DP; worker sees one GPU
+                # No DP/TP; worker sees one GPU
                 gpu_device = str(gpu_start_index + worker_idx)
 
             command = [
@@ -168,6 +214,17 @@ class SGLangProcess(ManagedEngineProcessMixin):
                 command.append("--disable-cuda-graph")
                 command.append("--disable-piecewise-cuda-graph")
 
+            if load_format is not None:
+                command.extend(["--load-format", str(load_format)])
+
+            if model_loader_extra_config is not None:
+                command.extend(
+                    ["--model-loader-extra-config", str(model_loader_extra_config)]
+                )
+
+            if enable_memory_saver:
+                command.append("--enable-memory-saver")
+
             # Limit VRAM allocation (required for multi-worker on same GPU)
             if mem_fraction_static is not None:
                 command.extend(["--mem-fraction-static", str(mem_fraction_static)])
@@ -181,6 +238,30 @@ class SGLangProcess(ManagedEngineProcessMixin):
             if disaggregation_mode is not None:
                 command.extend(["--disaggregation-mode", disaggregation_mode])
                 command.extend(["--disaggregation-transfer-backend", "nixl"])
+                # SGLang's bootstrap server binds to server_args.host. Dynamo
+                # advertises the machine IP to decode workers, so the bootstrap
+                # server must listen beyond localhost for local multi-process PD.
+                command.extend(
+                    [
+                        "--host",
+                        os.environ.get("DYNAMO_ROUTER_E2E_SGLANG_HOST", "0.0.0.0"),
+                    ]
+                )
+
+            if tensor_parallel_size is not None:
+                command.extend(["--tp-size", str(tensor_parallel_size)])
+
+            if expert_parallel_size is not None:
+                command.extend(["--ep-size", str(expert_parallel_size)])
+
+            if moe_a2a_backend:
+                command.extend(["--moe-a2a-backend", str(moe_a2a_backend)])
+
+            if deepep_mode:
+                command.extend(["--deepep-mode", str(deepep_mode)])
+
+            if enable_eplb:
+                command.append("--enable-eplb")
 
             if data_parallel_size is not None:
                 # Add DP configuration
@@ -235,6 +316,8 @@ class SGLangProcess(ManagedEngineProcessMixin):
                 health_check_urls=[],
                 log_dir=request.node.name,
                 terminate_all_matching_process_names=False,
+                terminate_parent_only_first=True,
+                graceful_shutdown_timeout=30.0,
             )
             self.worker_processes.append(process)
             if data_parallel_size is not None:
@@ -350,7 +433,10 @@ def test_router_decisions_sglang_dp(
     )
 
 
-@pytest.mark.skip(reason="Nightly CI failure: https://linear.app/nvidia/issue/DYN-2603")
+@pytest.mark.skipif(
+    os.environ.get("DYNAMO_RUN_SKIPPED_SGLANG_DISAGG") != "1",
+    reason="Nightly CI failure: https://linear.app/nvidia/issue/DYN-2603",
+)
 @pytest.mark.e2e
 @pytest.mark.model(MODEL_NAME)
 @pytest.mark.gpu_2
@@ -372,8 +458,12 @@ def test_router_decisions_sglang_disagg(
         request_plane=request_plane,
         model_name=MODEL_NAME,
         block_size=PAGE_SIZE,
-        num_prefill_workers=2,
-        num_decode_workers=1,
+        num_prefill_workers=int(
+            os.environ.get("DYNAMO_ROUTER_E2E_NUM_PREFILL_WORKERS", "1")
+        ),
+        num_decode_workers=int(
+            os.environ.get("DYNAMO_ROUTER_E2E_NUM_DECODE_WORKERS", "1")
+        ),
         prefill_process_kwargs={
             "single_gpu": True,
             "gpu_start_index": 0,
@@ -384,6 +474,7 @@ def test_router_decisions_sglang_disagg(
             "gpu_start_index": 1,
             "disaggregation_mode": "decode",
         },
+        strict_timing=False,
     )
 
 

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -17,6 +17,11 @@ import pytest
 
 from tests.router.e2e_harness import (
     ManagedEngineProcessMixin,
+    env_bool,
+    env_float,
+    env_int,
+    env_optional_int,
+    resolve_router_gpu_start_index,
     run_basic_router_test,
     run_disagg_router_decisions_test,
     run_indexers_sync_test,
@@ -39,7 +44,10 @@ from tests.utils.port_utils import (
 
 logger = logging.getLogger(__name__)
 
-MODEL_NAME = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+
+MODEL_NAME = os.environ.get(
+    "DYNAMO_ROUTER_E2E_VLLM_MODEL", "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+)
 
 pytestmark = [
     pytest.mark.e2e,
@@ -55,16 +63,36 @@ BLOCK_SIZE = 16
 VLLM_ARGS: Dict[str, Any] = {
     "block_size": BLOCK_SIZE,
     "model": MODEL_NAME,
-    "gpu_memory_utilization": 0.4,  # Limit VRAM allocation per worker
-    "max_model_len": 1024,  # Limit context length to reduce KV cache size
-    "enforce_eager": True,  # Disable CUDA graphs for faster startup & lower memory
+    "gpu_memory_utilization": env_float(
+        "DYNAMO_ROUTER_E2E_VLLM_GPU_MEMORY_UTILIZATION", 0.4
+    ),
+    "max_model_len": env_int("DYNAMO_ROUTER_E2E_VLLM_MAX_MODEL_LEN", 1024),
+    "enforce_eager": env_bool("DYNAMO_ROUTER_E2E_VLLM_ENFORCE_EAGER", False),
+    "tensor_parallel_size": env_optional_int(
+        "DYNAMO_ROUTER_E2E_VLLM_TENSOR_PARALLEL_SIZE"
+    ),
+    "enable_expert_parallel": env_bool(
+        "DYNAMO_ROUTER_E2E_VLLM_ENABLE_EXPERT_PARALLEL", False
+    ),
+    "enable_eplb": env_bool("DYNAMO_ROUTER_E2E_VLLM_ENABLE_EPLB", False),
+    "all2all_backend": os.environ.get("DYNAMO_ROUTER_E2E_VLLM_ALL2ALL_BACKEND"),
 }
 
 VLLM_ARGS_NO_BLOCK_SIZE: Dict[str, Any] = {
     "model": MODEL_NAME,
-    "gpu_memory_utilization": 0.4,  # Limit VRAM allocation per worker
-    "max_model_len": 1024,  # Limit context length to reduce KV cache size
-    "enforce_eager": True,  # Disable CUDA graphs for faster startup & lower memory
+    "gpu_memory_utilization": env_float(
+        "DYNAMO_ROUTER_E2E_VLLM_GPU_MEMORY_UTILIZATION", 0.4
+    ),
+    "max_model_len": env_int("DYNAMO_ROUTER_E2E_VLLM_MAX_MODEL_LEN", 1024),
+    "enforce_eager": env_bool("DYNAMO_ROUTER_E2E_VLLM_ENFORCE_EAGER", False),
+    "tensor_parallel_size": env_optional_int(
+        "DYNAMO_ROUTER_E2E_VLLM_TENSOR_PARALLEL_SIZE"
+    ),
+    "enable_expert_parallel": env_bool(
+        "DYNAMO_ROUTER_E2E_VLLM_ENABLE_EXPERT_PARALLEL", False
+    ),
+    "enable_eplb": env_bool("DYNAMO_ROUTER_E2E_VLLM_ENABLE_EPLB", False),
+    "all2all_backend": os.environ.get("DYNAMO_ROUTER_E2E_VLLM_ALL2ALL_BACKEND"),
 }
 
 
@@ -131,6 +159,7 @@ class VLLMProcess(ManagedEngineProcessMixin):
         self.worker_id_to_zmq_ports: dict[int, dict[int, str]] = {}
         self._worker_id_to_replay_ports: dict[int, dict[int, str]] = {}
         self.store_backend = store_backend
+        gpu_start_index = resolve_router_gpu_start_index(gpu_start_index)
         self._request = request
         self._request_plane = request_plane
         self._standalone_indexer = standalone_indexer
@@ -195,6 +224,16 @@ class VLLMProcess(ManagedEngineProcessMixin):
         num_gpu_blocks_override = vllm_args.get("num_gpu_blocks_override")
         max_model_len = vllm_args.get("max_model_len")
         enforce_eager = vllm_args.get("enforce_eager", False)
+        tensor_parallel_size = vllm_args.get("tensor_parallel_size")
+        enable_expert_parallel = vllm_args.get("enable_expert_parallel", False)
+        enable_eplb = vllm_args.get("enable_eplb", False)
+        all2all_backend = vllm_args.get("all2all_backend")
+        load_format = vllm_args.get("load_format") or os.environ.get(
+            "DYNAMO_ROUTER_E2E_LOAD_FORMAT"
+        )
+        model_loader_extra_config = vllm_args.get(
+            "model_loader_extra_config"
+        ) or os.environ.get("DYNAMO_ROUTER_E2E_MODEL_LOADER_EXTRA_CONFIG")
 
         self.model_name = model
         self.block_size = vllm_args.get("block_size", BLOCK_SIZE)
@@ -209,8 +248,18 @@ class VLLMProcess(ManagedEngineProcessMixin):
         for worker_idx in range(num_workers):
             # Calculate GPU device for this process
             if single_gpu:
-                # Force all processes to GPU 0 (for single-GPU testing)
+                # Force all processes to one GPU (for single-GPU testing)
                 gpu_device = str(gpu_start_index)
+            elif tensor_parallel_size is not None and int(tensor_parallel_size) > 1:
+                worker_start_gpu = gpu_start_index + worker_idx * int(
+                    tensor_parallel_size
+                )
+                gpu_device = ",".join(
+                    str(i)
+                    for i in range(
+                        worker_start_gpu, worker_start_gpu + int(tensor_parallel_size)
+                    )
+                )
             elif data_parallel_size is not None:
                 # Worker sees dp_rank GPUs (each DP rank gets its own GPU)
                 worker_start_gpu = gpu_start_index + worker_idx * data_parallel_size
@@ -221,7 +270,7 @@ class VLLMProcess(ManagedEngineProcessMixin):
                     )
                 )
             else:
-                # No DP; worker sees one GPU
+                # No DP/TP; worker sees one GPU
                 gpu_device = str(gpu_start_index + worker_idx)
 
             command = ["python3", "-m", "dynamo.vllm", "--model", model]
@@ -242,6 +291,14 @@ class VLLMProcess(ManagedEngineProcessMixin):
             if enforce_eager:
                 command.append("--enforce-eager")
 
+            if load_format is not None:
+                command.extend(["--load-format", str(load_format)])
+
+            if model_loader_extra_config is not None:
+                command.extend(
+                    ["--model-loader-extra-config", str(model_loader_extra_config)]
+                )
+
             # Limit VRAM allocation (required for multi-worker on same GPU)
             command.extend(_vllm_gpu_mem_args(gpu_memory_utilization))
 
@@ -254,6 +311,18 @@ class VLLMProcess(ManagedEngineProcessMixin):
                 command.extend(
                     ["--num-gpu-blocks-override", str(num_gpu_blocks_override)]
                 )
+
+            if tensor_parallel_size is not None:
+                command.extend(["--tensor-parallel-size", str(tensor_parallel_size)])
+
+            if enable_expert_parallel:
+                command.append("--enable-expert-parallel")
+
+            if enable_eplb:
+                command.append("--enable-eplb")
+
+            if all2all_backend:
+                command.extend(["--all2all-backend", str(all2all_backend)])
 
             if data_parallel_size is not None:
                 # Add DP configuration for external load balancing
@@ -326,6 +395,8 @@ class VLLMProcess(ManagedEngineProcessMixin):
                 health_check_urls=[],
                 log_dir=request.node.name,
                 terminate_all_matching_process_names=False,
+                terminate_parent_only_first=True,
+                graceful_shutdown_timeout=30.0,
             )
             self.worker_processes.append(process)
             if data_parallel_size is not None:
@@ -659,8 +730,12 @@ def test_router_decisions_vllm_disagg(
         request_plane=request_plane,
         model_name=MODEL_NAME,
         block_size=BLOCK_SIZE,
-        num_prefill_workers=2,
-        num_decode_workers=1,
+        num_prefill_workers=int(
+            os.environ.get("DYNAMO_ROUTER_E2E_NUM_PREFILL_WORKERS", "2")
+        ),
+        num_decode_workers=int(
+            os.environ.get("DYNAMO_ROUTER_E2E_NUM_DECODE_WORKERS", "1")
+        ),
         prefill_process_kwargs={
             "single_gpu": True,
             "gpu_start_index": 0,


### PR DESCRIPTION
## Summary

Make the vLLM and SGLang GMS behavior reproducible before optional plugins, router D2D transfer, or TensorRT-LLM-specific patches enter the stack.

## Scope

Adds local and Kubernetes test recipes for restart, multi-rank failure propagation, CUDA graphs, multi-node operation, and host-tier paths.

## Stack

Position **10/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-08-3-3-host-tier-sglang-adapter`.

Parent: #10450  
Tracking: #10458

## Review migration

This is the current review entry replacing historical merged PR #10484. GitHub does not allow a merged PR to be retargeted; #10484 and all of its comments and reviews remain intact as the historical record.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

This PR provides the authoritative recipes and assertions. Performance, IB, and sub-second recovery evidence remains tracked in #10458 until current-cluster reruns are recorded.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->