### PR TITLE
test(gms): add TensorRT-LLM E2E coverage [GMS 13/18]

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -2291,6 +2291,7 @@ def _test_router_decisions_disagg(
     router_aic_config: Optional[dict[str, Any]] = None,
     enable_bootstrap: bool = False,
     strict_timing: bool = True,
+    progressive_request_count: int = 4,
 ):
     """Validate KV cache prefix reuse in disaggregated prefill-decode setup via HTTP frontend.
 
@@ -2315,6 +2316,7 @@ def _test_router_decisions_disagg(
         durable_kv_events: If True, use durable KV events (JetStream). Defaults to False.
         router_aic_config: Optional AIC router perf-model config for frontend KV routing.
         strict_timing: If False, allow backend responses that omit optional timing fields.
+        progressive_request_count: Number of overlapping-prefix requests to send.
 
     Raises:
         AssertionError: If prefill_worker_ids differ across requests (prefix reuse failure)
@@ -2357,6 +2359,9 @@ def _test_router_decisions_disagg(
             )
         )
 
+        if progressive_request_count < 2:
+            raise ValueError("progressive_request_count must be at least 2")
+
         async def send_progressive_requests():
             """Send progressive requests with overlapping prefixes and collect worker IDs."""
             prefill_worker_ids = []
@@ -2366,7 +2371,7 @@ def _test_router_decisions_disagg(
             base_content = test_payload["messages"][0]["content"]
 
             async with aiohttp.ClientSession() as session:
-                for i in range(4):
+                for i in range(progressive_request_count):
                     # Build progressive content by repeating base content
                     # Each iteration adds more content to extend the prefix
                     progressive_content = " ".join([base_content] * (i + 1))
@@ -2385,7 +2390,7 @@ def _test_router_decisions_disagg(
                     }
 
                     logger.info(
-                        f"Sending request {i + 1}/4 with progressive prefix "
+                        f"Sending request {i + 1}/{progressive_request_count} with progressive prefix "
                         f"(~{len(progressive_content)} chars)"
                     )
 
@@ -2483,8 +2488,8 @@ def _test_router_decisions_disagg(
         logger.info(f"Collected decode_worker_ids: {decode_ids}")
 
         # Verify we got worker IDs from all requests
-        assert len(prefill_ids) == 4, (
-            f"Expected 4 prefill_worker_ids, got {len(prefill_ids)}. "
+        assert len(prefill_ids) == progressive_request_count, (
+            f"Expected {progressive_request_count} prefill_worker_ids, got {len(prefill_ids)}. "
             f"Make sure nvext.extra_fields=['worker_id'] is being processed."
         )
 
@@ -2495,12 +2500,12 @@ def _test_router_decisions_disagg(
         # the second request is routed before the first request's KV "stored" events have been
         # fully ingested. After ingestion, routing stabilizes.
         #
-        # So for TCP we assert that requests 2-4 converge to the same prefill worker; for NATS
+        # So for TCP we assert that requests 2-N converge to the same prefill worker; for NATS
         # request plane we keep the stronger assertion that all 4 match.
         if request_plane == "tcp":
             unique_prefill_ids = set(prefill_ids[1:])
             assert len(unique_prefill_ids) == 1, (
-                f"Expected prefill requests 2-4 to route to the same worker due to prefix reuse, "
+                f"Expected prefill requests 2-{progressive_request_count} to route to the same worker due to prefix reuse, "
                 f"but found {len(unique_prefill_ids)} unique prefill_worker_ids: {unique_prefill_ids}. "
                 f"Full list: {prefill_ids}"
             )

--- a/tests/router/configs/trtllm_agg.yaml
+++ b/tests/router/configs/trtllm_agg.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Extra-engine-args for aggregate TRT-LLM router e2e tests.
+#
+# The TRTLLM attention backend currently takes the FMHA NVRTC path on B200 for
+# TinyLlama generation and can fail when runtime include discovery does not
+# populate cuda.h search paths. VANILLA keeps the test on the PyTorch backend
+# path while still exercising real TRT-LLM workers,
+# router discovery, request forwarding, KV events, and local indexer behavior.
+attn_backend: VANILLA

--- a/tests/router/configs/trtllm_disagg_decode.yaml
+++ b/tests/router/configs/trtllm_disagg_decode.yaml
@@ -4,5 +4,8 @@
 # Extra-engine-args for the decode side of disaggregated TRT-LLM in router
 # e2e tests. Only the transceiver backend is required here; the overlap
 # scheduler can stay on for decode workers.
+attn_backend: VANILLA
+
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  max_tokens_in_buffer: 8192

--- a/tests/router/configs/trtllm_disagg_prefill.yaml
+++ b/tests/router/configs/trtllm_disagg_prefill.yaml
@@ -13,6 +13,8 @@
 #     "Context only requests are not supported in pytorch backend when
 #     overlap is enabled with block reuse").
 disable_overlap_scheduler: true
+attn_backend: VANILLA
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  max_tokens_in_buffer: 8192

--- a/tests/router/e2e_harness.py
+++ b/tests/router/e2e_harness.py
@@ -404,6 +404,7 @@ def run_disagg_router_decisions_test(
     test_payload: dict[str, Any] | None = None,
     test_kwargs: dict[str, Any] | None = None,
     strict_timing: bool = True,
+    progressive_request_count: int = 4,
 ):
     shared_namespace = f"test-namespace-{generate_random_suffix()}"
     frontend_port = allocate_frontend_ports(request, 1)[0]
@@ -418,7 +419,11 @@ def run_disagg_router_decisions_test(
     }
 
     def run_test(prefill_workers, decode_workers):
-        scenario_kwargs = {"strict_timing": strict_timing, **(test_kwargs or {})}
+        scenario_kwargs = {
+            "strict_timing": strict_timing,
+            "progressive_request_count": progressive_request_count,
+            **(test_kwargs or {}),
+        }
         _test_router_decisions_disagg(
             prefill_workers=prefill_workers,
             decode_workers=decode_workers,

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -13,6 +13,11 @@ import pytest
 
 from tests.router.e2e_harness import (
     ManagedEngineProcessMixin,
+    env_bool,
+    env_float,
+    env_int,
+    env_optional_int,
+    resolve_router_gpu_start_index,
     run_basic_router_test,
     run_disagg_router_decisions_test,
     run_indexers_sync_test,
@@ -26,7 +31,10 @@ from tests.utils.port_utils import allocate_ports, deallocate_ports
 
 logger = logging.getLogger(__name__)
 
-MODEL_NAME = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+
+MODEL_NAME = os.environ.get(
+    "DYNAMO_ROUTER_E2E_TRTLLM_MODEL", "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+)
 TRTLLM_BLOCK_SIZE = 32  # fixed internally to 32
 
 # Per-mode extra-engine-args YAMLs for disaggregated TRT-LLM. Both files
@@ -39,6 +47,7 @@ DISAGG_EXTRA_ENGINE_ARGS = {
     "prefill": os.path.join(_DISAGG_CONFIG_DIR, "trtllm_disagg_prefill.yaml"),
     "decode": os.path.join(_DISAGG_CONFIG_DIR, "trtllm_disagg_decode.yaml"),
 }
+AGG_EXTRA_ENGINE_ARGS = os.path.join(_DISAGG_CONFIG_DIR, "trtllm_agg.yaml")
 
 pytestmark = [
     pytest.mark.e2e,
@@ -52,8 +61,17 @@ pytestmark = [
 TRTLLM_ARGS: Dict[str, Any] = {
     "kv_block_size": TRTLLM_BLOCK_SIZE,
     "model": MODEL_NAME,
-    "free_gpu_memory_fraction": 0.4,  # Limit VRAM allocation per worker
-    "max_seq_len": 1024,  # Limit context length to reduce KV cache size
+    "free_gpu_memory_fraction": env_float(
+        "DYNAMO_ROUTER_E2E_TRTLLM_FREE_GPU_MEMORY_FRACTION", 0.4
+    ),
+    "max_seq_len": env_int("DYNAMO_ROUTER_E2E_TRTLLM_MAX_SEQ_LEN", 1024),
+    "enable_cuda_graph": env_bool("DYNAMO_ROUTER_E2E_TRTLLM_ENABLE_CUDA_GRAPH", True),
+    "tensor_parallel_size": env_optional_int(
+        "DYNAMO_ROUTER_E2E_TRTLLM_TENSOR_PARALLEL_SIZE"
+    ),
+    "expert_parallel_size": env_optional_int(
+        "DYNAMO_ROUTER_E2E_TRTLLM_EXPERT_PARALLEL_SIZE"
+    ),
 }
 
 
@@ -115,6 +133,7 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
         self.num_workers = num_workers
         self.worker_processes = []
         self.store_backend = store_backend
+        gpu_start_index = resolve_router_gpu_start_index(gpu_start_index)
 
         # Dynamically allocate unique system ports (one per worker) to avoid
         # conflicts when tests run in parallel via pytest-xdist.
@@ -127,21 +146,36 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
         model = trtllm_args.get("model", MODEL_NAME)
         free_gpu_memory_fraction = trtllm_args.get("free_gpu_memory_fraction")
         max_seq_len = trtllm_args.get("max_seq_len")
+        enable_cuda_graph = trtllm_args.get("enable_cuda_graph", True)
         enable_attention_dp = trtllm_args.get("enable_attention_dp", False)
         tensor_parallel_size = trtllm_args.get("tensor_parallel_size")
+        expert_parallel_size = trtllm_args.get("expert_parallel_size")
+        load_format = trtllm_args.get("load_format") or os.environ.get(
+            "DYNAMO_ROUTER_E2E_LOAD_FORMAT"
+        )
+        model_loader_extra_config = trtllm_args.get(
+            "model_loader_extra_config"
+        ) or os.environ.get("DYNAMO_ROUTER_E2E_MODEL_LOADER_EXTRA_CONFIG")
+        extra_engine_args = trtllm_args.get("extra_engine_args") or os.environ.get(
+            "DYNAMO_ROUTER_E2E_TRTLLM_EXTRA_ENGINE_ARGS"
+        )
 
         self.model_name = model
 
         for worker_idx in range(num_workers):
             # Calculate GPU device for this process
             if single_gpu:
-                # Force all processes to GPU 0 (for single-GPU testing)
+                # Force all processes to one GPU (for single-GPU testing)
                 gpu_device = str(gpu_start_index)
-            elif enable_attention_dp and tensor_parallel_size:
-                # For attention DP, TRT-LLM spawns tensor_parallel_size internal MPI workers.
-                # So one process = two attention DP ranks = visibility in to both GPUs.
+            elif tensor_parallel_size:
+                worker_start_gpu = gpu_start_index + worker_idx * int(
+                    tensor_parallel_size
+                )
                 gpu_device = ",".join(
-                    str(gpu_start_index + i) for i in range(tensor_parallel_size)
+                    str(i)
+                    for i in range(
+                        worker_start_gpu, worker_start_gpu + int(tensor_parallel_size)
+                    )
                 )
             else:
                 # Each worker sees one GPU
@@ -169,6 +203,18 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
                         DISAGG_EXTRA_ENGINE_ARGS[disaggregation_mode],
                     ]
                 )
+            elif extra_engine_args is not None:
+                command.extend(["--extra-engine-args", str(extra_engine_args)])
+            elif "DYN_TRTLLM_EXTRA_ENGINE_ARGS" not in os.environ:
+                command.extend(["--extra-engine-args", AGG_EXTRA_ENGINE_ARGS])
+
+            if load_format is not None:
+                command.extend(["--load-format", str(load_format)])
+
+            if model_loader_extra_config is not None:
+                command.extend(
+                    ["--model-loader-extra-config", str(model_loader_extra_config)]
+                )
 
             # Limit VRAM allocation (required for multi-worker on same GPU)
             if free_gpu_memory_fraction is not None:
@@ -180,6 +226,9 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
             if max_seq_len is not None:
                 command.extend(["--max-seq-len", str(max_seq_len)])
 
+            if enable_cuda_graph:
+                command.append("--enable-cuda-graph")
+
             # Use --durable-kv-events to enable JetStream mode (local indexer disabled)
             if durable_kv_events:
                 command.append("--durable-kv-events")
@@ -187,6 +236,9 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
             # Set tensor parallel size if specified (needed for attention DP)
             if tensor_parallel_size is not None:
                 command.extend(["--tensor-parallel-size", str(tensor_parallel_size)])
+
+            if expert_parallel_size is not None:
+                command.extend(["--expert-parallel-size", str(expert_parallel_size)])
 
             # Enable attention data parallelism if requested
             if enable_attention_dp:
@@ -205,7 +257,32 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
                 "DYN_REQUEST_PLANE": request_plane,
                 "PYTHONHASHSEED": "0",  # for deterministic event id's
                 "DYN_SYSTEM_PORT": str(system_port),
+                # Keep OpenMPI's internal control plane off UCX by default. TRT-LLM's
+                # data plane (for example NIXL/UCX KV transfer) still reads UCX_*.
+                "OMPI_MCA_pml": os.environ.get("OMPI_MCA_pml", "ob1"),
+                "OMPI_MCA_btl": os.environ.get("OMPI_MCA_btl", "self,tcp,vader"),
+                "OMPI_MCA_btl_openib_allow_ib": os.environ.get(
+                    "OMPI_MCA_btl_openib_allow_ib", "0"
+                ),
             }
+
+            if disaggregation_mode is not None:
+                # TRT-LLM's UCX cache transceiver is configured inside the
+                # worker process. Keep it off the broad test fixture default
+                # because "^mm,gdr_copy" lets UCX select RDMA devices that may
+                # be unavailable in a local developer shell. IB-only validation
+                # can still opt in explicitly via the DYNAMO_ROUTER_E2E_TRTLLM_*
+                # variables below.
+                env.pop("UCX_NET_DEVICES", None)
+                env_vars["UCX_TLS"] = os.environ.get(
+                    "DYNAMO_ROUTER_E2E_TRTLLM_UCX_TLS",
+                    "tcp,self,sm,cuda_copy,cuda_ipc",
+                )
+                ucx_net_devices = os.environ.get(
+                    "DYNAMO_ROUTER_E2E_TRTLLM_UCX_NET_DEVICES"
+                )
+                if ucx_net_devices:
+                    env_vars["UCX_NET_DEVICES"] = ucx_net_devices
 
             # Add DYN_FILE_KV if using file storage backend
             if self.store_backend == "file" and "DYN_FILE_KV" in os.environ:
@@ -223,6 +300,8 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
                 health_check_urls=[],
                 log_dir=request.node.name,
                 terminate_all_matching_process_names=False,
+                terminate_parent_only_first=True,
+                graceful_shutdown_timeout=30.0,
             )
             self.worker_processes.append(process)
             logger.info(
@@ -345,8 +424,12 @@ def test_router_decisions_trtllm_disagg(
         request_plane=request_plane,
         model_name=MODEL_NAME,
         block_size=TRTLLM_BLOCK_SIZE,
-        num_prefill_workers=2,
-        num_decode_workers=1,
+        num_prefill_workers=int(
+            os.environ.get("DYNAMO_ROUTER_E2E_NUM_PREFILL_WORKERS", "1")
+        ),
+        num_decode_workers=int(
+            os.environ.get("DYNAMO_ROUTER_E2E_NUM_DECODE_WORKERS", "1")
+        ),
         prefill_process_kwargs={
             "single_gpu": True,
             "gpu_start_index": 0,
@@ -357,6 +440,9 @@ def test_router_decisions_trtllm_disagg(
             "gpu_start_index": 1,
             "disaggregation_mode": "decode",
         },
+        progressive_request_count=int(
+            os.environ.get("DYNAMO_ROUTER_E2E_DISAGG_REQUESTS", "3")
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

Isolate TensorRT-LLM end-to-end validation after its engine and host-tier integration, while keeping it before optional backends and router D2D transfer.

## Scope

Adds local and Kubernetes TensorRT-LLM recipes and recovery assertions. It does not add runtime or backend functionality.

## Stack

Position **13/18** in the GMS-managed KV review train. This PR is based on `review/gms-v2-latehost-08-3-4-host-tier-trtllm-adapter`.

Parent: #10450  
Tracking: #10453 #10458

## Review migration

This is the one new review entry required by the reordered train; the earlier train did not isolate TensorRT-LLM E2E coverage into its own PR.

The train is rebased on `main` at `aeda23b483831df2f75b697b8ccf65f4ffd9f3d6`. The reordered functionality is preserved while each PR boundary is independently buildable and lintable: compatibility call sites and the engine-facing placement adapter now appear at first use; missing type imports and test markers were added; repository-pinned formatting was applied; one unused constant was removed; and every commit carries a DCO sign-off. The complete range passes `git diff --check` and the full pre-commit suite.

## Validation

Covers the dedicated TensorRT-LLM execution path; current-cluster IB, CUDA-graph, throughput, and recovery measurements remain tracked in #10458.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->