### PR TITLE
ci(deploy-test): force operator imagePullPolicy=Always for floating tags

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -342,9 +342,18 @@ runs:
         if [ -n "${REGISTRY}" ]; then
           OPERATOR_REPO="${REGISTRY}/ai-dynamo/dynamo"
           echo "Using operator image: ${OPERATOR_REPO}:${OPERATOR_TAG}"
+          # OPERATOR_TAG is a mutable, floating tag (e.g. main-operator) that is
+          # re-pushed on every main build. The chart default
+          # imagePullPolicy=IfNotPresent means a CI node that cached an older copy
+          # never re-pulls it, so a PR that doesn't rebuild the operator can run a
+          # stale crd-apply/manager binary (e.g. missing a newly-added flag) and
+          # land in CrashLoopBackOff. Force Always so the floating tag is refreshed
+          # on every pod start; the chart applies this value to both the manager
+          # and the crd-apply init container.
           IMAGE_ARGS+=(
             --set dynamo-operator.controllerManager.manager.image.repository="${OPERATOR_REPO}"
             --set dynamo-operator.controllerManager.manager.image.tag="${OPERATOR_TAG}"
+            --set dynamo-operator.controllerManager.manager.image.pullPolicy=Always
           )
         else
           echo "Using default operator image from Helm chart (nvcr.io/nvidia/ai-dynamo/kubernetes-operator)"


### PR DESCRIPTION
## Problem

`deploy-operator` (`.github/actions/setup-dynamo-operator/action.yml`) installs the operator from the **mutable `main-operator` tag** but relies on the chart default `imagePullPolicy: IfNotPresent`. A CI node that already has an older `:main-operator` cached **never re-pulls** it, so a PR that doesn't rebuild the operator (changed-files skips the `Operator` build) runs whatever stale `:main-operator` the node happens to hold.

This blocked #10945 (a tests-only change). #10668 (2026-06-24) added `--conversion-webhook-service-name` to **both** the chart and the `crd-apply` binary in the same commit, but nodes still holding a pre-#10668 `:main-operator` ran the old `crd-apply`, which doesn't define the flag:

```
flag provided but not defined: -conversion-webhook-service-name
```

→ `Init:CrashLoopBackOff` → `Operator pod not Ready after 1800s`. It failed repeatedly on the same node (`aks-default-x6hw5`), and **rebasing didn't help** (the node image cache is independent of branch content). Meanwhile **main was green**, because main rebuilds the operator image every run.

## Fix

Set `imagePullPolicy=Always` for the operator image whenever a registry/floating tag is used (the CI path — `REGISTRY` non-empty). The chart templates this single value (`controllerManager.manager.image.pullPolicy`) onto **both** the `manager` container and the `crd-apply` init container, so both always refresh the floating tag.

- **Scoped to CI**: added only inside the `if [ -n "${REGISTRY}" ]` branch. Production/release deploys use the default `nvcr.io` image with a pinned `AppVersion` tag (`REGISTRY` empty) and are **unaffected** (still `IfNotPresent`).
- **Safe**: the deploy namespace already carries the image-pull secret/labels, so re-pull works; for an immutable per-commit tag, `Always` is a harmless no-op (same digest).

## Alternatives considered
- Evicting the stale image from nodes — manual, not durable.
- Pinning `:main-operator` by digest — also works, but requires threading the digest through the deploy path; `Always` is the minimal durable fix for a mutable tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator installs from a custom container registry by always pulling the latest image on pod start.
  * Reduced the risk of running stale cached images or mismatched versions during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->