### PR TITLE
docs: point Support Matrix crate links to docs.rs

### DIFF
--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -230,14 +230,14 @@ For version-specific artifact details, installation commands, and release histor
   - [Dynamo Graph](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-graph) *(Deprecated in v0.9.0)*
 
 - **Rust Crates**:
-  - [dynamo-runtime](https://crates.io/crates/dynamo-runtime/)
-  - [dynamo-llm](https://crates.io/crates/dynamo-llm/)
-  - [dynamo-protocols](https://crates.io/crates/dynamo-protocols/)
-  - [dynamo-parsers](https://crates.io/crates/dynamo-parsers/)
-  - [dynamo-config](https://crates.io/crates/dynamo-config/) *(New in v0.8.0)*
-  - [dynamo-memory](https://crates.io/crates/dynamo-memory/) *(New in v0.8.0)*
-  - [dynamo-tokens](https://crates.io/crates/dynamo-tokens/) *(New in v0.9.0)*
-  - [dynamo-mocker](https://crates.io/crates/dynamo-mocker/) *(New in v1.0.0)*
-  - [dynamo-kv-router](https://crates.io/crates/dynamo-kv-router/) *(New in v1.0.0)*
+  - [dynamo-runtime](https://docs.rs/dynamo-runtime/)
+  - [dynamo-llm](https://docs.rs/dynamo-llm/)
+  - [dynamo-protocols](https://docs.rs/dynamo-protocols/)
+  - [dynamo-parsers](https://docs.rs/dynamo-parsers/)
+  - [dynamo-config](https://docs.rs/dynamo-config/) *(New in v0.8.0)*
+  - [dynamo-memory](https://docs.rs/dynamo-memory/) *(New in v0.8.0)*
+  - [dynamo-tokens](https://docs.rs/dynamo-tokens/) *(New in v0.9.0)*
+  - [dynamo-mocker](https://docs.rs/dynamo-mocker/) *(New in v1.0.0)*
+  - [dynamo-kv-router](https://docs.rs/dynamo-kv-router/) *(New in v1.0.0)*
 
 Once you've confirmed that your platform and architecture are compatible, you can install **Dynamo** by following the [Quickstart](https://docs.nvidia.com/dynamo/getting-started/quickstart) in the docs.


### PR DESCRIPTION
## Summary

The **Rust Crates** reference list in the Support Matrix linked to crates.io crate pages (`https://crates.io/crates/<name>`). crates.io is a client-rendered SPA that content-negotiates: it returns **HTTP 200** to browsers (`Accept: text/html`) but **HTTP 404** to link checkers and crawlers that send a bare `Accept` header. The crates are published and the links work fine in a browser, but automated docs-health scanners flag these pages as broken links.

This PR repoints the nine crate references to **docs.rs**, which is server-rendered and returns 200 to any client (verified all nine: `302 → 200`). docs.rs is also the more useful destination here — it hosts the rendered API documentation rather than the registry/download page.

### Verification

| Target | Bare `Accept: */*` (scanner) | `Accept: text/html` (browser) |
|--------|------------------------------|-------------------------------|
| `crates.io/crates/<name>` | **404** | 200 |
| `docs.rs/<name>` | 200 (after `302`) | 200 |

The repo's own lychee CI already passed these (it sends an HTML `Accept` header), so this is not fixing a CI failure — it's eliminating false-positive "broken link" reports from external docs-health scanners and pointing readers at the API docs.

### Out of scope (intentionally unchanged)

- The `cargo add` install commands in `release-artifacts.md`.
- The crates.io **registry inventory** on `release-artifacts.md` — that page's "crates.io" columns are a deliberate artifact/registry listing, so crates.io is the semantically correct target there.

## Test plan

- [x] All nine crates resolve on docs.rs (`302 → 200`)
- [x] `git diff` is a 9-line link-target swap, no content changes
- [ ] Fern docs preview renders the Support Matrix crate list correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Rust crate links in the support matrix to point to their documentation pages instead of download pages.
  * Kept the same crate list while making the references easier to browse and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->