### PR TITLE
fix(mocker): include outputs in mooncake delta prompts

### DIFF
--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -5,6 +5,8 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
 use anyhow::{Context, Result, anyhow, bail};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use rustc_hash::FxHashMap;
 use uuid::Uuid;
 
@@ -37,6 +39,8 @@ enum PromptMode {
     Full,
     DeltaCumulative,
 }
+
+const SYNTHETIC_DELTA_OUTPUT_SEED: u64 = 0xD37A_0A7E_5EED;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TurnOutcome {
@@ -384,6 +388,7 @@ impl WorkloadDriver {
             u32::try_from(engine_block_size).context("engine_block_size does not fit in u32")?;
         let trace_block_size = trace.block_size;
         let is_concurrency = matches!(&policy, SchedulingPolicy::Concurrency(_));
+        let mut output_rng = StdRng::seed_from_u64(SYNTHETIC_DELTA_OUTPUT_SEED);
         let sessions: Vec<SessionRuntime> = trace
             .sessions
             .into_iter()
@@ -402,12 +407,22 @@ impl WorkloadDriver {
                         } else {
                             None
                         };
+                        let tokens = turn.synthesize_tokens(trace_block_size)?;
+                        let output_token_ids = match turn.output_token_ids {
+                            Some(output_token_ids) => Some(output_token_ids),
+                            None if prompt_mode == PromptMode::DeltaCumulative => Some(
+                                (0..turn.max_output_tokens)
+                                    .map(|_| output_rng.random::<u32>())
+                                    .collect(),
+                            ),
+                            None => None,
+                        };
                         Ok(TurnRuntime {
                             request_id: None,
-                            tokens: turn.synthesize_tokens(trace_block_size)?,
+                            tokens,
                             replay_key: turn.replay_key,
                             max_output_tokens: turn.max_output_tokens,
-                            output_token_ids: turn.output_token_ids,
+                            output_token_ids,
                             delay_after_previous_ms: turn.delay_after_previous_ms,
                             priority: turn.priority,
                             strict_priority: turn.strict_priority,
@@ -417,7 +432,16 @@ impl WorkloadDriver {
                     })
                     .collect::<Result<Vec<_>>>()?;
                 let cumulative_capacity = if prompt_mode == PromptMode::DeltaCumulative {
-                    turns.iter().map(|turn| turn.tokens.len()).sum()
+                    turns
+                        .iter()
+                        .map(|turn| {
+                            turn.tokens.len()
+                                + turn
+                                    .output_token_ids
+                                    .as_ref()
+                                    .map_or(0, |output| output.len())
+                        })
+                        .sum()
                 } else {
                     0
                 };
@@ -604,6 +628,13 @@ impl WorkloadDriver {
         }
 
         let request_id = turn.request_id.clone();
+        let completed_output_tokens = (outcome == TurnOutcome::Completed
+            && self.prompt_mode == PromptMode::DeltaCumulative)
+            .then(|| {
+                turn.output_token_ids
+                    .clone()
+                    .expect("delta turns must have planned output tokens")
+            });
         let (next_turn_index, next_ready_at_ms, session_ended) = match outcome {
             TurnOutcome::Completed => {
                 let next_turn_index = in_flight
@@ -626,6 +657,11 @@ impl WorkloadDriver {
         session.in_flight = None;
         session.next_turn_index = next_turn_index;
         session.next_ready_at_ms = next_ready_at_ms;
+        if next_ready_at_ms.is_some()
+            && let Some(output_tokens) = completed_output_tokens
+        {
+            session.cumulative_tokens.extend(output_tokens);
+        }
         if let Some(ready_at_ms) = next_ready_at_ms {
             self.ready_sessions.push(ReadySession {
                 ready_at_ms,
@@ -1057,7 +1093,7 @@ mod tests {
     }
 
     #[test]
-    fn accumulating_delta_mode_emits_cumulative_input_tokens() {
+    fn accumulating_delta_mode_includes_previous_output_tokens() {
         let trace = Trace {
             block_size: 4,
             sessions: vec![SessionTrace {
@@ -1066,8 +1102,8 @@ mod tests {
                 turns: vec![
                     TurnTrace {
                         input_length: 6,
-                        max_output_tokens: 1,
-                        output_token_ids: None,
+                        max_output_tokens: 2,
+                        output_token_ids: Some(vec![20, 21]),
                         replay_key: None,
                         hash_ids: vec![10, 11],
                         delay_after_previous_ms: 0.0,
@@ -1094,6 +1130,7 @@ mod tests {
         let first = driver.pop_ready(0.0, usize::MAX);
         assert_eq!(first.len(), 1);
         assert_eq!(first[0].request.tokens, vec![10, 10, 10, 10, 11, 11]);
+        assert_eq!(first[0].request.output_token_ids, Some(vec![20, 21]));
         assert_eq!(first[0].request.priority, 3);
         assert_eq!(first[0].request.strict_priority, 4);
         driver.on_complete(first[0].request_uuid, 10.0).unwrap();
@@ -1102,10 +1139,57 @@ mod tests {
         assert_eq!(second.len(), 1);
         assert_eq!(
             second[0].request.tokens,
-            vec![10, 10, 10, 10, 11, 11, 12, 12, 12]
+            vec![10, 10, 10, 10, 11, 11, 20, 21, 12, 12, 12]
         );
         assert_eq!(second[0].request.priority, -2);
         assert_eq!(second[0].request.strict_priority, 7);
+    }
+
+    #[test]
+    fn accumulating_delta_mode_plans_missing_output_token_ids() {
+        let trace = Trace {
+            block_size: 1,
+            sessions: vec![SessionTrace {
+                session_id: "a".into(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![
+                    TurnTrace {
+                        input_length: 2,
+                        max_output_tokens: 3,
+                        hash_ids: vec![10, 11],
+                        ..Default::default()
+                    },
+                    TurnTrace {
+                        input_length: 1,
+                        max_output_tokens: 1,
+                        hash_ids: vec![12],
+                        ..Default::default()
+                    },
+                ],
+            }],
+        };
+        let mut driver = WorkloadDriver::new_concurrency_accumulating_deltas(trace, 1, 1).unwrap();
+
+        let first = driver.pop_ready(0.0, usize::MAX);
+        assert_eq!(first.len(), 1);
+        let planned_output = first[0]
+            .request
+            .output_token_ids
+            .clone()
+            .expect("delta replay should plan synthetic outputs");
+        assert_eq!(planned_output.len(), 3);
+        driver.on_complete(first[0].request_uuid, 1.0).unwrap();
+
+        let second = driver.pop_ready(1.0, usize::MAX);
+        assert_eq!(second.len(), 1);
+        let mut expected = vec![10, 11];
+        expected.extend(planned_output);
+        expected.push(12);
+        assert_eq!(second[0].request.tokens, expected);
+        assert_eq!(
+            second[0].request.output_token_ids.as_ref().map(Vec::len),
+            Some(1)
+        );
     }
 
     #[test]

--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -45,6 +45,7 @@ const SYNTHETIC_DELTA_OUTPUT_SEED: u64 = 0xD37A_0A7E_5EED;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TurnOutcome {
     Completed,
+    Rejected,
     Cancelled,
 }
 
@@ -82,6 +83,7 @@ struct TurnRuntime {
 struct InFlightTurn {
     session_index: usize,
     turn_index: usize,
+    emitted_output_tokens: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -562,6 +564,7 @@ impl WorkloadDriver {
                 InFlightTurn {
                     session_index,
                     turn_index,
+                    emitted_output_tokens: 0,
                 },
             );
             emitted.push(ReadyTurn {
@@ -577,9 +580,60 @@ impl WorkloadDriver {
         emitted
     }
 
+    pub fn on_output_token(&mut self, request_uuid: Uuid, token_id: u32) -> Result<()> {
+        if self.prompt_mode == PromptMode::Full {
+            return Ok(());
+        }
+        let in_flight = self
+            .in_flight
+            .get(&request_uuid)
+            .copied()
+            .ok_or_else(|| anyhow!("unknown workload request output for {request_uuid}"))?;
+
+        let turn = &self.sessions[in_flight.session_index].turns[in_flight.turn_index];
+        let planned_output_tokens = turn
+            .output_token_ids
+            .as_ref()
+            .expect("delta turns must have planned output tokens");
+        let expected_token = planned_output_tokens
+            .get(in_flight.emitted_output_tokens)
+            .ok_or_else(|| {
+                anyhow!(
+                    "workload request {request_uuid} emitted more than {} planned output tokens",
+                    planned_output_tokens.len()
+                )
+            })?;
+        if token_id != *expected_token {
+            bail!(
+                "workload request {request_uuid} emitted token {token_id} at position {}, expected {}",
+                in_flight.emitted_output_tokens,
+                expected_token
+            );
+        }
+
+        let in_flight = self
+            .in_flight
+            .get_mut(&request_uuid)
+            .expect("validated in-flight request must still exist");
+        in_flight.emitted_output_tokens = in_flight
+            .emitted_output_tokens
+            .checked_add(1)
+            .context("workload emitted output token count overflow")?;
+        Ok(())
+    }
+
     pub fn on_complete(&mut self, request_uuid: Uuid, now_ms: f64) -> Result<()> {
+        self.on_terminal(request_uuid, now_ms, false)
+    }
+
+    pub fn on_terminal(&mut self, request_uuid: Uuid, now_ms: f64, rejected: bool) -> Result<()> {
+        let outcome = if rejected {
+            TurnOutcome::Rejected
+        } else {
+            TurnOutcome::Completed
+        };
         let resolution = self
-            .resolve_turn(request_uuid, now_ms, TurnOutcome::Completed)?
+            .resolve_turn(request_uuid, now_ms, outcome)?
             .expect("completed turns require an in-flight request");
         self.apply_resolution(resolution, now_ms);
         Ok(())
@@ -593,7 +647,7 @@ impl WorkloadDriver {
     ) -> Result<Option<TurnResolution>> {
         let Some(in_flight) = self.in_flight.get(&request_uuid).copied() else {
             return match outcome {
-                TurnOutcome::Completed => Err(anyhow!(
+                TurnOutcome::Completed | TurnOutcome::Rejected => Err(anyhow!(
                     "unknown workload request completion for {request_uuid}"
                 )),
                 TurnOutcome::Cancelled => Ok(None),
@@ -628,15 +682,23 @@ impl WorkloadDriver {
         }
 
         let request_id = turn.request_id.clone();
+        if outcome == TurnOutcome::Rejected && in_flight.emitted_output_tokens != 0 {
+            bail!(
+                "rejected workload request {request_uuid} emitted {} output tokens",
+                in_flight.emitted_output_tokens
+            );
+        }
         let completed_output_tokens = (outcome == TurnOutcome::Completed
             && self.prompt_mode == PromptMode::DeltaCumulative)
             .then(|| {
-                turn.output_token_ids
-                    .clone()
-                    .expect("delta turns must have planned output tokens")
+                let planned_output_tokens = turn
+                    .output_token_ids
+                    .as_ref()
+                    .expect("delta turns must have planned output tokens");
+                planned_output_tokens[..in_flight.emitted_output_tokens].to_vec()
             });
         let (next_turn_index, next_ready_at_ms, session_ended) = match outcome {
-            TurnOutcome::Completed => {
+            TurnOutcome::Completed | TurnOutcome::Rejected => {
                 let next_turn_index = in_flight
                     .turn_index
                     .checked_add(1)
@@ -1133,6 +1195,8 @@ mod tests {
         assert_eq!(first[0].request.output_token_ids, Some(vec![20, 21]));
         assert_eq!(first[0].request.priority, 3);
         assert_eq!(first[0].request.strict_priority, 4);
+        driver.on_output_token(first[0].request_uuid, 20).unwrap();
+        driver.on_output_token(first[0].request_uuid, 21).unwrap();
         driver.on_complete(first[0].request_uuid, 10.0).unwrap();
 
         let second = driver.pop_ready(15.0, usize::MAX);
@@ -1178,6 +1242,11 @@ mod tests {
             .clone()
             .expect("delta replay should plan synthetic outputs");
         assert_eq!(planned_output.len(), 3);
+        for &token_id in &planned_output {
+            driver
+                .on_output_token(first[0].request_uuid, token_id)
+                .unwrap();
+        }
         driver.on_complete(first[0].request_uuid, 1.0).unwrap();
 
         let second = driver.pop_ready(1.0, usize::MAX);
@@ -1190,6 +1259,76 @@ mod tests {
             second[0].request.output_token_ids.as_ref().map(Vec::len),
             Some(1)
         );
+    }
+
+    #[test]
+    fn accumulating_delta_mode_appends_only_emitted_output_tokens() {
+        let trace = Trace {
+            block_size: 1,
+            sessions: vec![SessionTrace {
+                session_id: "a".into(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![
+                    TurnTrace {
+                        input_length: 1,
+                        max_output_tokens: 3,
+                        output_token_ids: Some(vec![20, 21, 22]),
+                        hash_ids: vec![10],
+                        ..Default::default()
+                    },
+                    TurnTrace {
+                        input_length: 1,
+                        max_output_tokens: 1,
+                        hash_ids: vec![12],
+                        ..Default::default()
+                    },
+                ],
+            }],
+        };
+        let mut driver = WorkloadDriver::new_concurrency_accumulating_deltas(trace, 1, 1).unwrap();
+
+        let first = driver.pop_ready(0.0, usize::MAX);
+        driver.on_output_token(first[0].request_uuid, 20).unwrap();
+        driver.on_output_token(first[0].request_uuid, 21).unwrap();
+        driver.on_complete(first[0].request_uuid, 1.0).unwrap();
+
+        let second = driver.pop_ready(1.0, usize::MAX);
+        assert_eq!(second[0].request.tokens, vec![10, 20, 21, 12]);
+    }
+
+    #[test]
+    fn accumulating_delta_mode_does_not_append_rejected_output_tokens() {
+        let trace = Trace {
+            block_size: 1,
+            sessions: vec![SessionTrace {
+                session_id: "a".into(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![
+                    TurnTrace {
+                        input_length: 1,
+                        max_output_tokens: 2,
+                        output_token_ids: Some(vec![20, 21]),
+                        hash_ids: vec![10],
+                        ..Default::default()
+                    },
+                    TurnTrace {
+                        input_length: 1,
+                        max_output_tokens: 1,
+                        hash_ids: vec![12],
+                        ..Default::default()
+                    },
+                ],
+            }],
+        };
+        let mut driver = WorkloadDriver::new_concurrency_accumulating_deltas(trace, 1, 1).unwrap();
+
+        let first = driver.pop_ready(0.0, usize::MAX);
+        driver
+            .on_terminal(first[0].request_uuid, 1.0, true)
+            .unwrap();
+
+        let second = driver.pop_ready(1.0, usize::MAX);
+        assert_eq!(second[0].request.tokens, vec![10, 12]);
     }
 
     #[test]

--- a/lib/mocker/src/loadgen/types.rs
+++ b/lib/mocker/src/loadgen/types.rs
@@ -54,11 +54,11 @@ pub enum DynamoRequestTrace {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TraceFileFormat {
     Mooncake,
-    /// Mooncake-shaped rows where follow-up turns contain input deltas.
-    /// Offline replay accumulates those deltas per session in token space before
-    /// computing engine block hashes. Use this only for delta traces: it expands
-    /// compact session deltas into cumulative prompts and can use much more
-    /// memory than `Mooncake`.
+    /// Mooncake-shaped rows where follow-up turns contain new input deltas.
+    /// Offline replay accumulates each generated output and the next input delta
+    /// per session before computing engine block hashes. Use this only for delta
+    /// traces: it expands compact session turns into cumulative prompts and can
+    /// use much more memory than `Mooncake`.
     MooncakeDelta,
     /// Mooncake request/cache rows plus explicit request-level workflow
     /// dependencies. Each row dispatches after `wait_for` completions plus its

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -479,6 +479,9 @@ impl AggRuntime {
     /// Consume one output signal, updating router state, collector state, and completion counts.
     fn process_output_signal(&mut self, signal: OutputSignal) -> anyhow::Result<()> {
         let mut admissions = Vec::new();
+        if let Some(token_id) = signal.token_id {
+            self.admission.on_output_token(signal.uuid, token_id)?;
+        }
         if signal.completed {
             let status = if signal.rejected {
                 ReplayTerminalStatus::Rejected
@@ -512,7 +515,7 @@ impl AggRuntime {
                 );
             }
             self.admission
-                .on_request_completed(signal.uuid, self.now_ms)?;
+                .on_request_terminal(signal.uuid, self.now_ms, signal.rejected)?;
             self.progress.inc_completed();
             self.dispatch_router_admissions(admissions)?;
             return Ok(());
@@ -1457,6 +1460,7 @@ mod tests {
             multiturn_trace(),
             2,
             ReplayRouterMode::RoundRobin,
+            false,
         );
 
         let first_turn_uuid = *stats
@@ -1497,6 +1501,102 @@ mod tests {
             second_turn.arrival_time_ms >= first_turn.last_token_ms.unwrap() + 10.0,
             "follow-up turn should unlock after completion plus delay"
         );
+    }
+
+    #[test]
+    fn test_delta_workload_reuses_generated_output_blocks() {
+        let args = replay_args(true, true);
+        let trace = Trace {
+            block_size: 4,
+            sessions: vec![SessionTrace {
+                session_id: "session-a".to_string(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![
+                    TurnTrace {
+                        input_length: 4,
+                        max_output_tokens: 5,
+                        hash_ids: vec![1],
+                        ..Default::default()
+                    },
+                    TurnTrace {
+                        input_length: 3,
+                        max_output_tokens: 1,
+                        hash_ids: vec![2],
+                        ..Default::default()
+                    },
+                ],
+            }],
+        };
+
+        let (collector, stats) = run_trace_workload_multi_collect_with_stats(
+            &args,
+            trace,
+            1,
+            ReplayRouterMode::KvRouter,
+            true,
+        );
+        let report = collector.finish();
+
+        assert_eq!(report.request_counts.completed_requests, 2);
+        assert_eq!(report.request_counts.total_input_tokens, 16);
+        assert_eq!(report.request_counts.total_output_tokens, 6);
+        assert_eq!(
+            stats.overlap_history,
+            vec![0, 2],
+            "second delta turn should reuse the input block and one generated-output block"
+        );
+    }
+
+    #[test]
+    fn test_delta_workload_tracks_clamped_and_rejected_outputs() {
+        let trace = Trace {
+            block_size: 1,
+            sessions: vec![SessionTrace {
+                session_id: "session-a".to_string(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![
+                    TurnTrace {
+                        input_length: 4,
+                        max_output_tokens: 20,
+                        hash_ids: vec![1, 2, 3, 4],
+                        ..Default::default()
+                    },
+                    TurnTrace {
+                        input_length: 1,
+                        max_output_tokens: 2,
+                        hash_ids: vec![5],
+                        ..Default::default()
+                    },
+                    TurnTrace {
+                        input_length: 1,
+                        max_output_tokens: 1,
+                        hash_ids: vec![6],
+                        ..Default::default()
+                    },
+                ],
+            }],
+        };
+
+        // The 16-token pool clamps turn 0 from 20 outputs to 12. Turn 1's
+        // resulting 17-token prompt is rejected, so it contributes no output
+        // before turn 2 adds its one-token input delta.
+        let (collector, stats) = run_trace_workload_multi_collect_with_stats(
+            &trtllm_reject_args(),
+            trace,
+            1,
+            ReplayRouterMode::RoundRobin,
+            true,
+        );
+        let input_lengths = stats
+            .dispatch_order
+            .iter()
+            .map(|uuid| collector.snapshot(*uuid).unwrap().input_length)
+            .collect::<Vec<_>>();
+        let report = collector.finish();
+
+        assert_eq!(input_lengths, vec![4, 17, 18]);
+        assert_eq!(report.request_counts.num_requests, 3);
+        assert_eq!(report.request_counts.completed_requests, 1);
     }
 
     #[test]
@@ -1637,6 +1737,7 @@ mod tests {
             workload,
             2,
             ReplayRouterMode::KvRouter,
+            false,
         );
         let request_report = request_collector.finish();
         let workload_report = workload_collector.finish();
@@ -2566,6 +2667,7 @@ mod tests {
             parity_workload(),
             1,
             ReplayRouterMode::RoundRobin,
+            false,
         );
 
         assert_eq!(stats.dispatch_history, vec![0, 0, 0]);

--- a/lib/mocker/src/replay/offline/components/admission.rs
+++ b/lib/mocker/src/replay/offline/components/admission.rs
@@ -141,10 +141,30 @@ impl AdmissionQueue {
         uuid: Uuid,
         now_ms: f64,
     ) -> Result<()> {
+        self.on_request_terminal(uuid, now_ms, false)
+    }
+
+    pub(in crate::replay::offline) fn on_request_terminal(
+        &mut self,
+        uuid: Uuid,
+        now_ms: f64,
+        rejected: bool,
+    ) -> Result<()> {
         let AdmissionSource::Workload(driver) = &mut self.source else {
             return Ok(());
         };
-        driver.on_complete(uuid, now_ms)
+        driver.on_terminal(uuid, now_ms, rejected)
+    }
+
+    pub(in crate::replay::offline) fn on_output_token(
+        &mut self,
+        uuid: Uuid,
+        token_id: u32,
+    ) -> Result<()> {
+        let AdmissionSource::Workload(driver) = &mut self.source else {
+            return Ok(());
+        };
+        driver.on_output_token(uuid, token_id)
     }
 
     pub(in crate::replay::offline) fn is_drained(&self) -> bool {

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -174,8 +174,11 @@ pub(crate) fn generate_trace_worker_artifacts_with_visibility(
 
         let output_timestamp_us = timestamp_us_from_ms(current_time_ms);
         for signal in pass.output_signals {
+            if let Some(token_id) = signal.token_id {
+                driver.on_output_token(signal.uuid, token_id)?;
+            }
             if signal.completed {
-                driver.on_complete(signal.uuid, current_time_ms)?;
+                driver.on_terminal(signal.uuid, current_time_ms, signal.rejected)?;
             }
             artifacts.output_signals.push(ReplayTimedOutputSignal {
                 signal,
@@ -983,14 +986,22 @@ pub(super) fn run_trace_workload_multi_collect_with_stats(
     trace: Trace,
     num_workers: usize,
     router_mode: ReplayRouterMode,
+    accumulate_session_deltas: bool,
 ) -> (TraceCollector, AggRuntimeStats) {
+    let driver = if accumulate_session_deltas {
+        trace
+            .into_delta_accumulating_trace_driver_with_block_size(args.block_size)
+            .unwrap()
+    } else {
+        trace
+            .into_trace_driver_with_block_size(args.block_size)
+            .unwrap()
+    };
     AggRuntime::new_workload(
         args,
         None,
         None,
-        trace
-            .into_trace_driver_with_block_size(args.block_size)
-            .unwrap(),
+        driver,
         num_workers,
         AggReplayMode::Trace,
         router_mode,

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -6,7 +6,7 @@ use super::progress::ReplayProgress;
 use crate::common::protocols::{DirectRequest, MockEngineArgs};
 use crate::loadgen::WorkloadDriver;
 use crate::replay::{ReplayTerminalStatus, TraceCollector};
-use anyhow::bail;
+use anyhow::{Context, bail};
 use std::collections::VecDeque;
 use uuid::Uuid;
 
@@ -226,12 +226,22 @@ impl SingleRuntime {
                 if let Some(token_id) = signal.token_id {
                     driver
                         .on_output_token(signal.uuid, token_id)
-                        .expect("workload output must belong to an in-flight session");
+                        .with_context(|| {
+                            format!(
+                                "failed to record output token for workload request {}",
+                                signal.uuid
+                            )
+                        })?;
                 }
                 if signal.completed {
                     driver
                         .on_terminal(signal.uuid, self.current_time_ms, signal.rejected)
-                        .expect("completed workload request must belong to a session");
+                        .with_context(|| {
+                            format!(
+                                "failed to process terminal signal for workload request {}",
+                                signal.uuid
+                            )
+                        })?;
                 }
             }
         }

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -222,10 +222,17 @@ impl SingleRuntime {
             || !pass.output_signals.is_empty()
             || !pass.kv_events.is_empty();
         if let AdmissionSource::Workload(driver) = &mut self.admission {
-            for signal in pass.output_signals.iter().filter(|signal| signal.completed) {
-                driver
-                    .on_complete(signal.uuid, self.current_time_ms)
-                    .expect("completed workload request must belong to a session");
+            for signal in &pass.output_signals {
+                if let Some(token_id) = signal.token_id {
+                    driver
+                        .on_output_token(signal.uuid, token_id)
+                        .expect("workload output must belong to an in-flight session");
+                }
+                if signal.completed {
+                    driver
+                        .on_terminal(signal.uuid, self.current_time_ms, signal.rejected)
+                        .expect("completed workload request must belong to a session");
+                }
             }
         }
         let completed_requests = pass


### PR DESCRIPTION
## Overview:

Fix `mooncake-delta` prompt reconstruction so replay matches AIPerf's semantics. Each follow-up prompt now includes the previous prompt, the previous generated output, and the current input delta.

## Summary

- Preserve explicit `output_token_ids` from enriched Mooncake traces.
- Deterministically plan output token IDs when a delta trace only provides `output_length`.
- Track output tokens actually emitted by the mock engine and append only that emitted prefix.
- Append no output after a terminal rejection.
- Leave ordinary full-prompt Mooncake and agentic replay behavior unchanged.

## Details:

The existing delta driver accumulated only input deltas. For two turns with `(input=4190, output=592)` followed by `(input=592, output=16)`, it built the second prompt as `4190 + 592 = 4782`. AIPerf builds it as `4190 + 592 previous output + 592 new input delta = 5374`.

The driver now gives the mock engine planned output IDs, validates each emitted ID against that plan, and records the actual emitted count. Subsequent prompts append only the emitted prefix, so capacity-clamped generations and rejected requests cannot introduce nonexistent KV blocks.

## Where should the reviewer start?

Start in `lib/mocker/src/loadgen/driver.rs`:

- `WorkloadDriver::new` plans missing output IDs for delta replay.
- `WorkloadDriver::on_output_token` records and validates actual engine output.
- `WorkloadDriver::on_terminal` distinguishes normal completion from rejection.
- The aggregated replay tests cover capacity clamping, rejection, replay-hash reconstruction, and the expected `2/3` KV-router block hit rate.

## Validation

- `cargo test -p dynamo-mocker` (477 passed, 1 ignored)
- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-mocker --lib -- -D warnings`
- `test_delta_workload_reuses_generated_output_blocks`
- `test_delta_workload_tracks_clamped_and_rejected_outputs`

## Related Issues

**This PR is NOT linked to an issue**:

- [x] Confirmed - no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delta-cumulative replay now preserves generated output tokens across turns, so later requests can replay the full accumulated session history more accurately.
  * Missing output token IDs can now be generated deterministically during replay.

* **Bug Fixes**
  * Improved token planning so cumulative prompts account for both input and output tokens.
  * Updated replay behavior to better match expected token sequences in follow-up turns.

* **Documentation**
  * Clarified offline replay behavior in the format description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->