### PR TITLE
docs: restore per-backend multimodal pages to nav

### DIFF
--- a/docs/features/multimodal/multimodal-sglang.md
+++ b/docs/features/multimodal/multimodal-sglang.md
@@ -26,7 +26,7 @@ This document provides a comprehensive guide for multimodal inference using SGLa
 
 ## Deployment Patterns
 
-SGLang supports EPD, EP/D, E/PD, and E/P/D patterns. See [Multimodal Architecture Patterns](README.md#architecture-patterns) for detailed explanations.
+SGLang supports EPD, EP/D, E/PD, and E/P/D patterns. See [Multimodal Model Serving](README.md) for detailed explanations.
 
 | Pattern | Supported | Launch Script | Notes |
 |---------|-----------|---------------|-------|

--- a/docs/features/multimodal/multimodal-trtllm.md
+++ b/docs/features/multimodal/multimodal-trtllm.md
@@ -30,7 +30,7 @@ You can provide multimodal inputs in the following ways:
 
 ## Deployment Patterns
 
-TRT-LLM supports aggregated and traditional disaggregated patterns. See [Architecture Patterns](README.md#architecture-patterns) for detailed explanations.
+TRT-LLM supports aggregated and traditional disaggregated patterns. See [Multimodal Model Serving](README.md) for detailed explanations.
 
 | Pattern | Supported | Launch Script | Notes |
 |---------|-----------|---------------|-------|

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -320,6 +320,12 @@ navigation:
                 path: features/multimodal/encoder-disaggregation.md
               - page: Multimodal KV Routing
                 path: features/multimodal/multimodal-kv-routing.md
+              - page: SGLang Multimodal
+                path: features/multimodal/multimodal-sglang.md
+              - page: TensorRT-LLM Multimodal
+                path: features/multimodal/multimodal-trtllm.md
+              - page: vLLM Multimodal
+                path: features/multimodal/multimodal-vllm.md
           - section: Diffusion
             slug: diffusion
             path: features/diffusion/README.md


### PR DESCRIPTION
## Summary

The Multimodal overview page (`features/multimodal/README.md`) links to the three per-backend guides — `multimodal-vllm.md`, `multimodal-sglang.md`, `multimodal-trtllm.md` — from its **Security warning**, **Support Matrix**, and **Backend Documentation** sections. But those three pages were dropped from the Fern nav (`docs/index.yml`) during an earlier docs reorg, so they aren't published and the README's cross-references resolve to nothing on the live site.

This PR:

- **Restores the three backend pages to the Multimodal section nav** (alphabetical: SGLang, TensorRT-LLM, vLLM) so the README links resolve and the backend deployment guides are published again.
- **Fixes a stale anchor**: `multimodal-sglang.md` and `multimodal-trtllm.md` linked to `README.md#architecture-patterns`, but the overview page has no such heading — repointed to the overview page itself.

### Background

A docs-health scanner flagged the published "vLLM Multimodal" page for broken `crates.io`-style GitHub file links. Investigation showed those specific file links were already removed from `main` by earlier refactors (#7556, #7663, #7845, #7955) — the page just hadn't been republished. The real, current issue is that the per-backend pages are orphaned from the nav while the README still links to them. This PR fixes that root cause and republishes the (now link-clean) pages.

### Verification

The repo's own broken-link detector reports **0 broken links across all 7 multimodal docs** after these changes:

```
Validation complete: 0 broken links found out of 23 total links checked
total_files_processed: 7, files_with_broken_links: 0, total_broken_links: 0
```

## Test plan

- [x] `detect_broken_links.py` clean on `docs/features/multimodal/`
- [x] All GitHub source links in the three pages resolve on `main`
- [ ] Fern preview renders the three restored pages in the Multimodal nav section
- [ ] Fern CI link check passes
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the multimodal documentation navigation to include additional guides for SGLang, TensorRT-LLM, and vLLM.
  * Updated deployment-pattern references in multimodal docs to point readers to the most relevant guidance sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->