### PR TITLE
docs(backend): cover KV events publishing parity

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -320,6 +320,47 @@ Two surfaces:
 yet" or "no prefix cache" (gauge skipped); `0.0` is a legitimate
 zero-hit measurement.
 
+## KV Event Publishing
+
+On the unified path, `Worker` owns `KvEventPublisher` construction. Engines
+declare sources with `kv_event_sources()`; they do not instantiate
+`KvEventPublisher` directly.
+
+Use `ZmqSource` when the engine already emits Dynamo-compatible KV events on a
+ZMQ socket:
+
+```python
+from dynamo.common.backend.publisher import ZmqSource
+
+async def kv_event_sources(self):
+    return [
+        ZmqSource(endpoint="tcp://127.0.0.1:5557", dp_rank=0),
+    ]
+```
+
+Use `PushSource` when the engine needs a live publisher and drives
+`publish_stored()` / `publish_removed()` from its own thread:
+
+```python
+from dynamo.common.backend.publisher import PushSource
+
+def _on_kv_publisher_ready(self, publisher):
+    self._kv_publisher = publisher
+    self._start_kv_event_thread()
+
+async def kv_event_sources(self):
+    return [PushSource(on_ready=self._on_kv_publisher_ready, dp_rank=0)]
+```
+
+Return one source per DP rank owned by this worker, and keep that rank ownership
+stable for the engine lifetime. `EngineConfig.llm.kv_cache_block_size` must be
+set or `Worker` skips KV event publishers; snapshot publishers still work
+without a block size.
+
+For `PushSource`, cleanup is the engine's responsibility. Stop event threads in
+`cleanup()`, prevent new publishes once cleanup begins, and let any in-flight
+publish loop observe the shutdown signal before resources are released.
+
 ## Telemetry
 
 > **Requires `DYN_LOGGING_JSONL=1` + `OTEL_EXPORT_ENABLED=1`** for engine

--- a/components/src/dynamo/common/backend/tests/test_publisher.py
+++ b/components/src/dynamo/common/backend/tests/test_publisher.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncGenerator
+from types import SimpleNamespace
 from typing import Optional
 
 import pytest
@@ -81,3 +83,126 @@ async def test_abc_source_methods_default_to_empty_list():
 @pytest.mark.asyncio
 async def test_register_prometheus_default_is_noop():
     assert await _MinimalEngine().register_prometheus(metrics=object()) is None
+
+
+@pytest.mark.asyncio
+async def test_vllm_kv_event_sources_return_one_zmq_source_per_dp_rank(monkeypatch):
+    mod = pytest.importorskip(
+        "dynamo.vllm.llm_engine", reason="vLLM backend dependencies not installed"
+    )
+    from dynamo.common.constants import DisaggregationMode
+
+    engine = mod.VllmLLMEngine.__new__(mod.VllmLLMEngine)
+    engine.engine_args = SimpleNamespace(
+        enable_prefix_caching=True,
+        kv_events_config=SimpleNamespace(
+            enable_kv_cache_events=True,
+            endpoint="tcp://*:5557",
+        ),
+    )
+    engine.disaggregation_mode = DisaggregationMode.AGGREGATED
+    engine._vllm_config = object()
+    engine._dp_range = (2, 3)
+
+    monkeypatch.setattr(
+        mod.ZmqEventPublisher,
+        "offset_endpoint_port",
+        staticmethod(
+            lambda endpoint, data_parallel_rank: f"{endpoint}-{data_parallel_rank}"
+        ),
+    )
+
+    sources = await engine.kv_event_sources()
+
+    assert all(isinstance(source, ZmqSource) for source in sources)
+    assert [(source.endpoint, source.dp_rank) for source in sources] == [
+        ("tcp://127.0.0.1:5557-2", 2),
+        ("tcp://127.0.0.1:5557-3", 3),
+        ("tcp://127.0.0.1:5557-4", 4),
+    ]
+
+    engine.engine_args.enable_prefix_caching = False
+    assert await engine.kv_event_sources() == []
+
+
+@pytest.mark.asyncio
+async def test_sglang_kv_event_sources_return_one_zmq_source_per_local_dp_rank(
+    monkeypatch,
+):
+    mod = pytest.importorskip(
+        "dynamo.sglang.llm_engine", reason="SGLang backend dependencies not installed"
+    )
+
+    engine = mod.SglangLLMEngine.__new__(mod.SglangLLMEngine)
+    engine.server_args = SimpleNamespace(
+        kv_events_config=json.dumps({"endpoint": "tcp://*:5557"}),
+        dp_size=8,
+        enable_dp_attention=True,
+        nnodes=2,
+        node_rank=1,
+    )
+
+    monkeypatch.setattr(mod, "get_local_ip_auto", lambda: "127.0.0.1")
+    monkeypatch.setattr(
+        mod.ZmqEventPublisher,
+        "offset_endpoint_port",
+        staticmethod(lambda _endpoint, dp_rank: f"tcp://*:{6000 + dp_rank}"),
+    )
+
+    sources = await engine.kv_event_sources()
+
+    assert all(isinstance(source, ZmqSource) for source in sources)
+    assert [(source.endpoint, source.dp_rank) for source in sources] == [
+        ("tcp://127.0.0.1:6004", 4),
+        ("tcp://127.0.0.1:6005", 5),
+        ("tcp://127.0.0.1:6006", 6),
+        ("tcp://127.0.0.1:6007", 7),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_trtllm_push_sources_wait_for_all_attention_dp_publishers(monkeypatch):
+    mod = pytest.importorskip(
+        "dynamo.trtllm.llm_engine",
+        reason="TensorRT-LLM backend dependencies not installed",
+    )
+
+    started_threads: list[str] = []
+
+    class FakeThread:
+        def __init__(self, *, target, daemon, name):
+            self.target = target
+            self.daemon = daemon
+            self.name = name
+
+        def start(self):
+            started_threads.append(self.name)
+
+    engine = mod.TrtllmLLMEngine.__new__(mod.TrtllmLLMEngine)
+    engine.publish_events_and_metrics = True
+    engine._attention_dp_size = 3
+    engine._kv_publishers = {}
+    engine._kv_events_thread = None
+    engine._kv_events_poll_loop = lambda: None
+
+    monkeypatch.setattr(mod.threading, "Thread", FakeThread)
+
+    sources = await engine.kv_event_sources()
+
+    assert all(isinstance(source, PushSource) for source in sources)
+    assert [source.dp_rank for source in sources] == [0, 1, 2]
+
+    sources[0].on_ready("publisher-0")
+    sources[2].on_ready("publisher-2")
+    assert started_threads == []
+
+    sources[1].on_ready("publisher-1")
+    assert sorted(engine._kv_publishers.items()) == [
+        (0, "publisher-0"),
+        (1, "publisher-1"),
+        (2, "publisher-2"),
+    ]
+    assert started_threads == ["trtllm-kv-events-poll"]
+
+    engine.publish_events_and_metrics = False
+    assert await engine.kv_event_sources() == []

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -498,13 +498,17 @@ async def cleanup(self) -> None:
         self._engine = None
 ```
 
-### KV Event Publishing for Unified Backends
+#### Python: KV event publishing (optional)
 
 Unified backends declare KV event sources; the framework constructs and owns
 the `KvEventPublisher` instances. Do not instantiate `KvEventPublisher`
 directly from a unified `LLMEngine`. Instead, implement
 `kv_event_sources()` and return one source for each data-parallel rank hosted
 by the worker.
+
+Rust backends use the equivalent `LLMEngine::kv_event_sources()` trait method;
+see [Rust Step 4](#rust-step-4-implement-the-llmengine-trait) and the
+[`LLMEngine` trait](../../lib/backend-common/src/engine.rs).
 
 Use `ZmqSource` when the engine already emits Dynamo-compatible KV events on a
 ZMQ socket, as vLLM and SGLang do:
@@ -520,7 +524,8 @@ async def kv_event_sources(self):
 ```
 
 Use `PushSource` when the engine needs a live publisher object and drives
-`publish_stored()` / `publish_removed()` from its own event thread:
+`publish_stored()` / `publish_removed()` from its own event thread. The in-tree
+TRT-LLM backend is the reference implementation for this path:
 
 ```python
 from dynamo.common.backend.publisher import PushSource
@@ -547,12 +552,6 @@ published event streams.
 `PushSource` engines own cleanup of their event producer. Stop publisher
 threads or tasks in `cleanup()` before returning, and do not publish after
 cleanup begins.
-
-Snapshot publishing is separate from KV event publishing. Use
-`component_metrics_dp_ranks()` plus `attach_snapshot_publisher()` when the
-engine can push per-rank `ComponentSnapshot` values for metrics and the
-router's load signal. Snapshot publishers do not require
-`kv_cache_block_size`.
 
 ### Python Step 5: Write `main.py`
 

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -498,6 +498,62 @@ async def cleanup(self) -> None:
         self._engine = None
 ```
 
+### KV Event Publishing for Unified Backends
+
+Unified backends declare KV event sources; the framework constructs and owns
+the `KvEventPublisher` instances. Do not instantiate `KvEventPublisher`
+directly from a unified `LLMEngine`. Instead, implement
+`kv_event_sources()` and return one source for each data-parallel rank hosted
+by the worker.
+
+Use `ZmqSource` when the engine already emits Dynamo-compatible KV events on a
+ZMQ socket, as vLLM and SGLang do:
+
+```python
+from dynamo.common.backend.publisher import ZmqSource
+
+async def kv_event_sources(self):
+    return [
+        ZmqSource(endpoint="tcp://127.0.0.1:5557", dp_rank=0),
+        ZmqSource(endpoint="tcp://127.0.0.1:5558", dp_rank=1),
+    ]
+```
+
+Use `PushSource` when the engine needs a live publisher object and drives
+`publish_stored()` / `publish_removed()` from its own event thread:
+
+```python
+from dynamo.common.backend.publisher import PushSource
+
+def _on_kv_publisher_ready(self, publisher):
+    self._kv_publisher = publisher
+    self._start_kv_event_thread()
+
+async def kv_event_sources(self):
+    return [PushSource(on_ready=self._on_kv_publisher_ready, dp_rank=0)]
+```
+
+KV event publishers require `EngineConfig.llm.kv_cache_block_size`. If the
+engine declares sources but does not return a block size, `Worker` skips KV
+event publishers because the router cannot map token IDs to cache blocks.
+`WorkerConfig.enable_kv_routing=False` is the operator-level kill switch; when
+it is disabled, the worker does not call `kv_event_sources()`.
+
+Keep rank ownership stable for the engine lifetime. DP-capable engines should
+also advertise the same rank shape in `EngineConfig.llm.data_parallel_size` and
+`data_parallel_start_rank` so router-forced `dp_rank` values line up with the
+published event streams.
+
+`PushSource` engines own cleanup of their event producer. Stop publisher
+threads or tasks in `cleanup()` before returning, and do not publish after
+cleanup begins.
+
+Snapshot publishing is separate from KV event publishing. Use
+`component_metrics_dp_ranks()` plus `attach_snapshot_publisher()` when the
+engine can push per-rank `ComponentSnapshot` values for metrics and the
+router's load signal. Snapshot publishers do not require
+`kv_cache_block_size`.
+
 ### Python Step 5: Write `main.py`
 
 Three lines.

--- a/docs/integrations/kv-events-custom-engines.md
+++ b/docs/integrations/kv-events-custom-engines.md
@@ -10,7 +10,7 @@ This document explains how to implement KV event publishing for custom inference
 > This guide covers lower-level Python workers and custom runtime integrations
 > that instantiate `KvEventPublisher` directly. Unified backends should prefer
 > `LLMEngine.kv_event_sources()` and let `Worker` construct publishers; see
-> [KV Event Publishing for Unified Backends](../development/unified-backends.md#kv-event-publishing-for-unified-backends).
+> [KV event publishing for unified backends](../development/unified-backends.md#python-kv-event-publishing-optional).
 
 ## Overview
 

--- a/docs/integrations/kv-events-custom-engines.md
+++ b/docs/integrations/kv-events-custom-engines.md
@@ -6,6 +6,12 @@ title: KV Events for Custom Engines
 
 This document explains how to implement KV event publishing for custom inference engines, enabling them to participate in Dynamo's KV cache-aware routing.
 
+> [!NOTE]
+> This guide covers lower-level Python workers and custom runtime integrations
+> that instantiate `KvEventPublisher` directly. Unified backends should prefer
+> `LLMEngine.kv_event_sources()` and let `Worker` construct publishers; see
+> [KV Event Publishing for Unified Backends](../development/unified-backends.md#kv-event-publishing-for-unified-backends).
+
 ## Overview
 
 The KV Router relies on real-time events from backend workers to track which KV cache blocks are stored on each worker. When your custom engine allocates or evicts KV cache blocks, it should publish these events so the router can make optimal routing decisions.


### PR DESCRIPTION
## Overview:

Add focused test and documentation coverage for unified backend KV event publishing parity without changing runtime implementation behavior.

## Summary

- Add backend parity tests for vLLM/SGLang ZMQ KV event source declarations and TRT-LLM push-source readiness behavior.
- Document the unified backend `kv_event_sources()` contract, DP-rank ownership expectations, `kv_cache_block_size` requirement, and push-source cleanup responsibilities.
- Clarify that the custom KV events guide is for lower-level integrations that instantiate `KvEventPublisher` directly.

## Details:

The unified backend worker owns `KvEventPublisher` construction. These changes codify that contract in docs and add lightweight tests that exercise each backend's source declaration behavior without requiring a live GPU runtime.

No core implementation changes are included.

## Where should the reviewer start?

- `components/src/dynamo/common/backend/tests/test_publisher.py`
- `docs/development/unified-backends.md`
- `components/src/dynamo/common/backend/README.md`
- `docs/integrations/kv-events-custom-engines.md`

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue**:
- [x] Confirmed — no related GitHub issue

Related Linear issues: DIS-2000, DIS-2001.

## Validation

- `git diff --check`
- `cargo test -p dynamo-backend-common --features testing`
- `python3 -m py_compile components/src/dynamo/common/backend/tests/test_publisher.py`
- `pytest components/src/dynamo/common/backend/tests/test_publisher.py` skipped locally because `dynamo._core.backend` is not built in this environment.

GPU validation was attempted on computelab and dlcluster. computelab allocated H100/A100 jobs and the A100 node had working GPUs, but the MCP shell promotion/container launch path failed; dlcluster stayed pending on priority. All sessions were released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for KV event publishing in unified backends, including when to use ZMQ-based sources vs. push-based sources.
  * Clarified setup and shutdown requirements, including rank ownership, cache configuration, and cleanup behavior.
  * Updated the custom engine guide to point unified backends to the newer integration path.

* **Tests**
  * Added coverage for KV event source behavior across multiple backend types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->