### PR TITLE
fix(runtime): bound endpoint drain + route etcd lease loss through Runtime::shutdown()

### DIFF
--- a/lib/runtime/src/pipeline/network/ingress.rs
+++ b/lib/runtime/src/pipeline/network/ingress.rs
@@ -8,3 +8,96 @@ pub mod shared_tcp_endpoint;
 pub mod unified_server;
 
 use super::*;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::sync::Notify;
+
+/// Wait for inflight requests to drain, bounded by `timeout`. Returns the count
+/// still inflight when the wait ends: `0` on a clean drain, `>0` if the timeout
+/// fired (a stuck request must not wedge teardown). Shared by the NATS push and
+/// TCP request planes.
+async fn drain_inflight(
+    inflight: Arc<AtomicU64>,
+    notify: Arc<Notify>,
+    endpoint_name: &str,
+    timeout: Duration,
+) -> u64 {
+    let inflight_count = inflight.load(Ordering::SeqCst);
+    if inflight_count == 0 {
+        return 0;
+    }
+
+    tracing::info!(
+        endpoint_name,
+        inflight_count,
+        "Waiting for inflight requests to complete"
+    );
+
+    let wait = async {
+        while inflight.load(Ordering::SeqCst) > 0 {
+            notify.notified().await;
+        }
+    };
+
+    match tokio::time::timeout(timeout, wait).await {
+        Ok(()) => {
+            tracing::info!(endpoint_name, "All inflight requests completed");
+            0
+        }
+        Err(_) => {
+            let remaining = inflight.load(Ordering::SeqCst);
+            tracing::warn!(
+                endpoint_name,
+                timeout_secs = timeout.as_secs(),
+                remaining,
+                "Timed out waiting for inflight requests to drain; proceeding with shutdown"
+            );
+            remaining
+        }
+    }
+}
+
+#[cfg(test)]
+mod drain_tests {
+    use super::*;
+
+    /// Drain returns within the bound even if the request never completes.
+    #[tokio::test(start_paused = true)]
+    async fn drain_inflight_is_bounded_when_request_never_completes() {
+        let inflight = Arc::new(AtomicU64::new(1));
+        let notify = Arc::new(Notify::new());
+
+        let remaining = tokio::time::timeout(
+            Duration::from_secs(3600),
+            drain_inflight(inflight, notify, "test-endpoint", Duration::from_secs(5)),
+        )
+        .await
+        .expect("drain_inflight must be bounded; it hung past the outer guard");
+
+        assert_eq!(
+            remaining, 1,
+            "the stuck inflight request should still be counted as remaining"
+        );
+    }
+
+    /// A clean drain (request completes) returns 0 promptly.
+    #[tokio::test(start_paused = true)]
+    async fn drain_inflight_returns_zero_when_requests_complete() {
+        let inflight = Arc::new(AtomicU64::new(1));
+        let notify = Arc::new(Notify::new());
+
+        let inflight_clone = inflight.clone();
+        let notify_clone = notify.clone();
+        tokio::spawn(async move {
+            inflight_clone.fetch_sub(1, Ordering::SeqCst);
+            notify_clone.notify_one();
+        });
+
+        let remaining =
+            drain_inflight(inflight, notify, "test-endpoint", Duration::from_secs(5)).await;
+
+        assert_eq!(remaining, 0, "a completed request should drain cleanly");
+    }
+}

--- a/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
@@ -148,21 +148,13 @@ impl PushEndpoint {
 
         // await for all inflight requests to complete if graceful shutdown
         if self.graceful_shutdown {
-            let inflight_count = inflight.load(Ordering::SeqCst);
-            if inflight_count > 0 {
-                tracing::info!(
-                    endpoint_name = endpoint_name_local.as_str(),
-                    inflight_count = inflight_count,
-                    "Waiting for inflight NATS requests to complete"
-                );
-                while inflight.load(Ordering::SeqCst) > 0 {
-                    notify.notified().await;
-                }
-                tracing::info!(
-                    endpoint_name = endpoint_name_local.as_str(),
-                    "All inflight NATS requests completed"
-                );
-            }
+            super::drain_inflight(
+                inflight,
+                notify,
+                endpoint_name_local.as_str(),
+                crate::runtime::graceful_shutdown_timeout(),
+            )
+            .await;
         } else {
             tracing::info!(
                 endpoint_name = endpoint_name_local.as_str(),

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -463,21 +463,13 @@ impl SharedTcpServer {
                 "Unregistered TCP endpoint handler"
             );
 
-            let inflight_count = handler.inflight.load(Ordering::SeqCst);
-            if inflight_count > 0 {
-                tracing::info!(
-                    endpoint_name = %endpoint_name,
-                    inflight_count = inflight_count,
-                    "Waiting for inflight TCP requests to complete"
-                );
-                while handler.inflight.load(Ordering::SeqCst) > 0 {
-                    handler.notify.notified().await;
-                }
-                tracing::info!(
-                    endpoint_name = %endpoint_name,
-                    "All inflight TCP requests completed"
-                );
-            }
+            super::drain_inflight(
+                handler.inflight.clone(),
+                handler.notify.clone(),
+                endpoint_name,
+                crate::runtime::graceful_shutdown_timeout(),
+            )
+            .await;
         }
     }
 

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -32,7 +32,7 @@ pub use tokio_util::sync::CancellationToken;
 
 const DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_SECS: u64 = 15 * 60;
 
-fn graceful_shutdown_timeout() -> Duration {
+pub(crate) fn graceful_shutdown_timeout() -> Duration {
     let timeout_secs = std::env::var(
         config::environment_names::runtime::DYN_RUNTIME_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
     )

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -69,10 +69,10 @@ impl Client {
     /// If the lease expires, the [`Runtime`] will be shutdown.
     /// If the [`Runtime`] is shutdown, the lease will be revoked.
     pub async fn new(config: ClientOptions, runtime: Runtime) -> Result<Self> {
-        let token = runtime.primary_token();
+        let runtime_for_lease = runtime.clone();
 
         let ((connector, lease_id), rt) = build_in_runtime(
-            async move { Self::connect_with_startup_retry(&config, token).await },
+            async move { Self::connect_with_startup_retry(&config, runtime_for_lease).await },
             1,
         )
         .await?;
@@ -88,8 +88,9 @@ impl Client {
     /// Connect to etcd during startup, retrying with exponential backoff for up to 2 minutes.
     async fn connect_with_startup_retry(
         config: &ClientOptions,
-        token: CancellationToken,
+        runtime: Runtime,
     ) -> Result<(Arc<Connector>, u64)> {
+        let token = runtime.primary_token();
         let deadline = Instant::now() + STARTUP_CONNECT_TIMEOUT;
         let mut backoff = STARTUP_CONNECT_INITIAL_BACKOFF;
 
@@ -98,7 +99,7 @@ impl Client {
                 anyhow::bail!("etcd startup connection cancelled");
             }
 
-            let attempt = Self::connect_startup_attempt(config, &token).await;
+            let attempt = Self::connect_startup_attempt(config, &runtime).await;
 
             match attempt {
                 Ok(connection) => return Ok(connection),
@@ -134,13 +135,14 @@ impl Client {
 
     async fn connect_startup_attempt(
         config: &ClientOptions,
-        token: &CancellationToken,
+        runtime: &Runtime,
     ) -> Result<(Arc<Connector>, u64)> {
+        let token = runtime.primary_token();
         let connector =
             Connector::new(config.etcd_url.clone(), config.etcd_connect_options.clone()).await?;
 
         let lease_id = if config.attach_lease {
-            create_lease(connector.clone(), config.lease_ttl, token.clone())
+            create_lease(connector.clone(), config.lease_ttl, runtime.clone())
                 .await
                 .with_context(|| {
                     format!(

--- a/lib/runtime/src/transports/etcd/lease.rs
+++ b/lib/runtime/src/transports/etcd/lease.rs
@@ -2,21 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::connector::Connector;
+use crate::runtime::Runtime;
 use etcd_client::{LeaseKeepAliveStream, LeaseKeeper};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
-/// Create an etcd lease with the given TTL, attach it to the provided cancellation token,
+/// Create an etcd lease with the given TTL, tie its lifetime to the [`Runtime`],
 /// spawn a keep-alive task, and return the lease id (u64).
 ///
-/// Note: this function spawns a background task that maintains the lease until the token is
-/// cancelled or an unrecoverable error occurs.
+/// Note: this function spawns a background task that maintains the lease until the runtime is
+/// shut down or an unrecoverable error occurs. On an unrecoverable error the runtime is shut
+/// down, honoring the contract that a lost lease shuts the worker down.
 pub async fn create_lease(
     connector: Arc<Connector>,
     ttl: u64,
-    token: CancellationToken,
+    runtime: Runtime,
 ) -> anyhow::Result<u64> {
+    let token = runtime.primary_token();
     if token.is_cancelled() {
         anyhow::bail!("lease creation cancelled");
     }
@@ -47,7 +50,9 @@ pub async fn create_lease(
                     error = %e,
                     "Unable to maintain lease. Check etcd server status"
                 );
-                token.cancel();
+                // Phased shutdown (endpoint drain -> backend teardown), not a
+                // bare primary-token cancel, so teardown is ordered.
+                runtime.shutdown();
             }
         }
     });
@@ -202,5 +207,46 @@ async fn keep_alive_with_stream(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The lease-loss teardown path (`runtime.shutdown()`) must be phased:
+    /// Phase 1 cancels the endpoint token promptly, but Phase 3 (primary token
+    /// + backend teardown) waits for outstanding graceful tasks.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lease_loss_shutdown_is_phased() {
+        let runtime = Runtime::from_current().unwrap();
+
+        // Stands in for a serving endpoint; Phase 1 cancels the endpoint
+        // shutdown token, cascading to this child.
+        let endpoint_token = runtime.child_token();
+        let primary_token = runtime.primary_token();
+
+        // Hold a graceful task so Phase 2 cannot advance to Phase 3 yet.
+        let guard = runtime.graceful_shutdown_tracker().register_task();
+
+        runtime.shutdown();
+
+        // Phase 1 cancels the endpoint token promptly.
+        tokio::time::timeout(Duration::from_secs(5), endpoint_token.cancelled())
+            .await
+            .expect("Phase 1 must cancel the endpoint token on lease loss");
+
+        // While the graceful task is outstanding, Phase 3 must not have torn
+        // down the primary token. A bare-cancel regression fails this assert.
+        assert!(
+            !primary_token.is_cancelled(),
+            "primary token must not be cancelled while a graceful task is outstanding"
+        );
+
+        // Releasing the task lets Phase 3 proceed and cancel the primary token.
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(5), primary_token.cancelled())
+            .await
+            .expect("Phase 3 must cancel the primary token once graceful tasks complete");
     }
 }

--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -5,9 +5,13 @@ import json
 import logging
 import os
 import shutil
+import threading
+import time
 from enum import Enum
 
+import psutil
 import pytest
+import requests
 
 from tests.conftest import NatsServer
 from tests.fault_tolerance.etcd_ha.utils import (
@@ -443,3 +447,164 @@ def test_etcd_non_ha_shutdown_vllm_disaggregated(
                                 "Frontend": frontend,
                             }
                         )
+
+
+# Lease-loss zombie: a non-cancellable in-flight request (modeled by
+# SIGSTOP-ing the vLLM engine) must not wedge worker teardown.
+ZOMBIE_GRACEFUL_SHUTDOWN_TIMEOUT_SECS = 10  # worker-side drain bound
+# Hold the frontend's drain open so it does not abort the request and mask the
+# worker-side behavior under test.
+ZOMBIE_FRONTEND_DRAIN_TIMEOUT_SECS = 300
+ZOMBIE_WORKER_EXIT_DEADLINE_SECS = ZOMBIE_GRACEFUL_SHUTDOWN_TIMEOUT_SECS + 50
+ZOMBIE_INFLIGHT_MAX_TOKENS = 8000
+
+
+def _zombie_verify_serving():
+    r = requests.post(
+        f"http://localhost:{FRONTEND_PORT}/v1/completions",
+        json={
+            "model": FAULT_TOLERANCE_MODEL_NAME,
+            "prompt": "The capital of France is",
+            "max_tokens": 5,
+            "temperature": 0.0,
+        },
+        timeout=120,
+    )
+    assert (
+        r.status_code == 200
+    ), f"pre-fault completion failed: {r.status_code} {r.text}"
+
+
+def _zombie_start_inflight_request():
+    """Fire a long completion in the background so a request is in flight.
+
+    Non-streaming on purpose: the worker's handle_payload runs the full
+    generation before returning, holding the push-endpoint inflight counter.
+    """
+
+    errors: list = []
+
+    def _run():
+        try:
+            requests.post(
+                f"http://localhost:{FRONTEND_PORT}/v1/completions",
+                json={
+                    "model": FAULT_TOLERANCE_MODEL_NAME,
+                    "prompt": "Tell me a very long story.",
+                    "max_tokens": ZOMBIE_INFLIGHT_MAX_TOKENS,
+                    "temperature": 0.0,
+                },
+                timeout=600,
+            )
+        except requests.RequestException as exc:
+            errors.append(exc)
+            logger.info("in-flight request ended: %s", exc)
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    return t, errors
+
+
+def _freeze_vllm_engine_descendants(worker_pid: int) -> list:
+    """SIGSTOP the vLLM engine (rank) subprocess(es) under this worker.
+
+    Scoped to the worker's process tree so concurrent tests/workers on the same
+    host are untouched. A frozen engine cannot finish or abort the in-flight
+    request, so it stays pinned in the endpoint inflight counter -- a
+    non-cancellable inflight.
+    """
+    frozen = []
+    for child in psutil.Process(worker_pid).children(recursive=True):
+        try:
+            if "EngineCore" in child.name() or "EngineCore" in " ".join(
+                child.cmdline()
+            ):
+                child.suspend()
+                frozen.append(child.pid)
+                logger.info("SIGSTOP vLLM engine pid=%s", child.pid)
+        except psutil.Error:
+            continue
+    assert frozen, "no vLLM EngineCore descendant of the worker to freeze"
+    return frozen
+
+
+def _resume_kill(pids: list) -> None:
+    """Resume then kill frozen engines so they can't hang teardown or hold a GPU."""
+    for pid in pids:
+        try:
+            proc = psutil.Process(pid)
+            proc.resume()
+            proc.kill()
+        except psutil.NoSuchProcess:
+            pass
+
+
+@pytest.mark.gpu_1
+@pytest.mark.xpu_1
+@pytest.mark.e2e
+@pytest.mark.nightly
+@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
+@pytest.mark.timeout(420)
+@pytest.mark.parametrize("request_plane", ["tcp", "nats"])
+def test_etcd_lease_loss_zombie_vllm_frozen_engine(
+    request, monkeypatch, request_plane, predownload_models
+):
+    """A worker that loses its etcd lease with a non-cancellable in-flight
+    request must still exit.
+
+    Repro: freeze the vLLM engine mid-generation so the request can neither
+    complete nor be aborted, then kill etcd. With the bounded endpoint drain the
+    worker times out the drain and exits; the unbounded drain wedges (zombie).
+
+    Parametrized over both request planes: the bounded drain must cover the
+    default ``tcp`` plane (SharedTcpServer) as well as ``nats`` (PushEndpoint).
+    """
+    # Hold the frontend's drain open so only the worker behavior is measured.
+    monkeypatch.setenv("DYN_REQUEST_PLANE", request_plane)
+    monkeypatch.setenv(
+        "DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS",
+        str(ZOMBIE_FRONTEND_DRAIN_TIMEOUT_SECS),
+    )
+
+    with NatsServer(request):
+        with EtcdCluster(request, num_replicas=1) as etcd_cluster:
+            etcd_endpoints = etcd_cluster.get_client_endpoints()
+            with DynamoFrontendProcess(request, etcd_endpoints):
+                worker = DynamoWorkerProcess(
+                    request, etcd_endpoints, mode=WorkerMode.AGGREGATED
+                )
+                worker.env["DYN_RUNTIME_GRACEFUL_SHUTDOWN_TIMEOUT_SECS"] = str(
+                    ZOMBIE_GRACEFUL_SHUTDOWN_TIMEOUT_SECS
+                )
+                with worker:
+                    _zombie_verify_serving()
+
+                    logger.info("Starting long in-flight request")
+                    (
+                        inflight_thread,
+                        inflight_errors,
+                    ) = _zombie_start_inflight_request()
+                    time.sleep(5)  # let it reach decode
+                    assert inflight_thread.is_alive(), (
+                        "in-flight request ended before engine freeze: "
+                        f"{inflight_errors!r}"
+                    )
+
+                    # Freeze the engine: the in-flight request is now
+                    # non-cancellable (cannot complete or be aborted). Resume/kill
+                    # in finally before the worker context unwinds, so a SIGSTOP-ed
+                    # engine can't hang teardown or strand a GPU-holding process.
+                    frozen_pids = _freeze_vllm_engine_descendants(worker.proc.pid)
+                    try:
+                        time.sleep(1)
+
+                        logger.info("Terminating ETCD to induce lease loss")
+                        etcd_cluster.stop()
+
+                        # Bounded drain -> worker exits; unbounded -> zombie.
+                        wait_for_processes_to_terminate(
+                            {"Worker": worker},
+                            timeout=ZOMBIE_WORKER_EXIT_DEADLINE_SECS,
+                        )
+                    finally:
+                        _resume_kill(frozen_pids)


### PR DESCRIPTION
## Summary

Fixes the etcd **lease-loss "zombie worker"** failure mode: when a worker loses its etcd lease while a request is stuck in-flight, it could fail to shut down — staying `Running` with `/health` green but unable to serve, until manually killed.

Two root causes:

1. **Unbounded per-endpoint drain.** On teardown the graceful path waited on `while inflight > 0 { notify.notified().await }` with no timeout. A single stuck in-flight request (e.g. a request whose engine can no longer make progress and cannot be aborted) keeps `inflight > 0` forever, so the drain wedges, the serve future never returns, and `Runtime::shutdown()` is never reached.
2. **Lease loss bypassed `Runtime::shutdown()`.** The keep-alive task called a bare `primary_token().cancel()` instead of `Runtime::shutdown()`, skipping the phased shutdown sequence (and the documented `etcd::Client::new` contract that a lost lease shuts the worker down).

## Changes

- `push_endpoint.rs` — extract the drain into `drain_inflight`, bounded by the existing `graceful_shutdown_timeout()` from #10705 (made `pub(crate)`; no new env var or const). Returns the count still inflight if the bound fires.
- `etcd/lease.rs` — on an unrecoverable keep-alive failure, route through `Runtime::shutdown()` instead of a bare token cancel, so Phases 1–3 run in order.
- Unit tests (paused-time): the bounded drain returns on a stuck counter; lease-loss teardown is phased (endpoint token cancels first, primary token only after graceful tasks complete).
- `tests/fault_tolerance/etcd_ha/test_vllm.py` — GPU regression test reproducing the zombie with a **frozen vLLM engine** (SIGSTOP the engine mid-generation so the in-flight request is non-cancellable, then kill etcd). Verified RED/GREEN on an RTX A6000 / Qwen3-0.6B: without the bound the worker wedges (still running at 60s); with it the worker times out the drain (`remaining=1`) and exits ~27s.

## Notes

- The zombie only reproduces with a *non-cancellable* in-flight request (modeled by freezing the engine). Cancellable requests drain via other backstops, which is why the existing no-inflight shutdown tests pass either way.
- Reuses #10705's bounded Phase-2; relationship to the open #9951 (per-endpoint drain + abortable discovery cleanup) called out in code comments — happy to fold these together.
- Complementary to making the worker `/health` reflect shutdown (so k8s cycles the pod even if a process can't exit); that readiness-side change is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown behavior so in-flight requests are drained with a timeout instead of waiting indefinitely.
  * Endpoints now shut down more reliably when a service lease is lost, helping prevent stuck workers and lingering requests.

* **Tests**
  * Added end-to-end coverage for lease-loss scenarios with long-running requests to verify phased shutdown and worker termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Limitation

The phased shutdown and bounded drain run on the tokio runtime, so they rely on the primary executor staying healthy (the common case: a stuck request on the engine/native side). A fully-stalled tokio executor would defeat any cooperative mechanism here (including the existing `exit(911)` watchdog); guaranteeing termination in that case needs an OS-thread watchdog or the k8s liveness probe — out of scope for this drain fix.
