### PR TITLE
feat(mocker): add explicit max_model_len support to vLLM mocker

### DIFF
--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -18,6 +18,16 @@ DEFAULT_PREFILL_ENDPOINT = f"dyn://{DYN_NAMESPACE}.prefill.generate"
 logger = logging.getLogger(__name__)
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"must be positive, got {parsed}")
+    return parsed
+
+
 def non_negative_int(value: str) -> int:
     try:
         parsed = int(value)
@@ -210,6 +220,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Token block size for KV cache blocks. When unset, the default "
         "depends on engine: vLLM 64, SGLang 1, TRTLLM 32.",
+    )
+    parser.add_argument(
+        "--max-model-len",
+        type=positive_int,
+        default=None,
+        help="Maximum vLLM sequence length, including prompt and generated tokens. "
+        "When omitted, no model-length limit is enforced.",
     )
     parser.add_argument(
         "--max-num-seqs",

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -243,6 +243,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         aic_moe_ep_size = getattr(args, "aic_moe_ep_size", None)
         aic_attention_dp_size = getattr(args, "aic_attention_dp_size", None)
     engine_type = getattr(args, "engine_type", None) or "vllm"
+    max_model_len = getattr(args, "max_model_len", None)
     num_gpu_blocks = _resolve_num_gpu_blocks(
         explicit_num_gpu_blocks=getattr(args, "num_gpu_blocks", None),
         engine_type=engine_type,
@@ -267,6 +268,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         engine_type=engine_type,
         num_gpu_blocks=num_gpu_blocks,
         block_size=getattr(args, "block_size", 0) or 0,
+        max_model_len=max_model_len,
         max_num_seqs=getattr(args, "max_num_seqs", _DEFAULT_MAX_NUM_SEQS),
         max_num_batched_tokens=getattr(
             args, "max_num_batched_tokens", _DEFAULT_MAX_NUM_BATCHED_TOKENS
@@ -349,8 +351,7 @@ def build_runtime_config(
     engine_args: MockEngineArgs,
 ) -> tuple[int, ModelRuntimeConfig]:
     rc = ModelRuntimeConfig()
-    # Mocker does not enforce a model context limit.
-    rc.context_length = 0
+    rc.context_length = engine_args.max_model_len or 0
     rc.total_kv_blocks = engine_args.num_gpu_blocks
     rc.max_num_seqs = engine_args.max_num_seqs
     if rc.max_num_seqs is None:

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -35,6 +35,7 @@ def make_args(**overrides):
         "engine_type": "vllm",
         "num_gpu_blocks": None,
         "block_size": None,
+        "max_model_len": None,
         "max_num_seqs": 256,
         "max_num_batched_tokens": 8192,
         "enable_prefix_caching": True,
@@ -395,6 +396,73 @@ def test_mocker_cli_accepts_mtp_configuration():
     assert args.aic_nextn == 3
     assert args.aic_nextn_accept_rates == "1,0.5"
     assert args.aic_mtp_seed == 99
+
+
+def test_mocker_cli_accepts_max_model_len():
+    args = parse_args(["--max-model-len", "32768"])
+
+    engine_args = CONFIG.build_mocker_engine_args(args)
+    _, runtime_config = CONFIG.build_runtime_config(engine_args)
+
+    assert engine_args.max_model_len == 32768
+    assert runtime_config.context_length == 32768
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_mocker_cli_rejects_non_positive_max_model_len(value):
+    with pytest.raises(SystemExit):
+        parse_args(["--max-model-len", value])
+
+
+def test_build_mocker_engine_args_keeps_max_model_len_explicit_only():
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(model_path="/models/mock", num_gpu_blocks=4096)
+    )
+
+    assert engine_args.max_model_len is None
+
+
+def test_build_mocker_engine_args_preserves_explicit_max_model_len():
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(
+            model_path="/models/mock",
+            max_model_len=32768,
+            num_gpu_blocks=4096,
+        )
+    )
+
+    assert engine_args.max_model_len == 32768
+
+
+def test_replay_engine_args_keeps_max_model_len_explicit_only():
+    import dynamo.replay.main as replay_main
+
+    engine_args = replay_main._load_engine_args(
+        json.dumps(
+            {
+                "num_gpu_blocks": 4096,
+                "aic_model_path": "/models/mock",
+            }
+        )
+    )
+
+    assert engine_args.max_model_len is None
+
+
+def test_replay_engine_args_preserves_explicit_max_model_len():
+    import dynamo.replay.main as replay_main
+
+    engine_args = replay_main._load_engine_args(
+        json.dumps(
+            {
+                "num_gpu_blocks": 4096,
+                "max_model_len": 32768,
+                "aic_model_path": "/models/mock",
+            }
+        )
+    )
+
+    assert engine_args.max_model_len == 32768
 
 
 def test_replay_engine_args_compute_kv_bytes_for_g3_before_validation(monkeypatch):

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -295,7 +295,7 @@ def _engine_caps(args: MockEngineArgs) -> EngineCapabilities:
         num_gpu=1,
         max_num_batched_tokens=args.max_num_batched_tokens,
         max_num_seqs=args.max_num_seqs,
-        context_length=max_kv_tokens if max_kv_tokens > 0 else None,
+        context_length=args.max_model_len,
         max_kv_tokens=max_kv_tokens if max_kv_tokens > 0 else None,
         speculative_nextn=args.aic_nextn,
     )

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -171,7 +171,7 @@ impl MockEngineArgs {
 #[pymethods]
 impl MockEngineArgs {
     #[new]
-    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=42, aic_gemm_dtype=None, aic_moe_dtype=None, aic_fmha_dtype=None, aic_kv_cache_dtype=None, aic_comm_dtype=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, handoff_session_timeout_ms=300000, kv_bytes_per_token=None, kv_transfer_bandwidth=None, kv_transfer_timing_mode="full_prompt", reasoning=None, response_replay_trace_path=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
+    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=42, aic_gemm_dtype=None, aic_moe_dtype=None, aic_fmha_dtype=None, aic_kv_cache_dtype=None, aic_comm_dtype=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, handoff_session_timeout_ms=300000, kv_bytes_per_token=None, kv_transfer_bandwidth=None, kv_transfer_timing_mode="full_prompt", reasoning=None, response_replay_trace_path=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None, max_model_len=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         engine_type: &str,
@@ -230,6 +230,7 @@ impl MockEngineArgs {
         enable_g4_storage: bool,
         bandwidth_g2_to_g4_gbps: Option<f64>,
         bandwidth_g4_to_g2_gbps: Option<f64>,
+        max_model_len: Option<usize>,
     ) -> PyResult<Self> {
         let engine_type = parse_mocker_engine_type(engine_type)?;
         let worker_type = parse_worker_type(worker_type)?;
@@ -248,6 +249,7 @@ impl MockEngineArgs {
         let mut builder = RsMockEngineArgs::builder()
             .engine_type(engine_type)
             .block_size(block_size)
+            .max_model_len(max_model_len)
             .max_num_seqs(max_num_seqs)
             .max_num_batched_tokens(max_num_batched_tokens)
             .enable_prefix_caching(enable_prefix_caching)
@@ -363,6 +365,11 @@ impl MockEngineArgs {
     #[getter]
     fn num_gpu_blocks(&self) -> usize {
         self.inner.num_gpu_blocks
+    }
+
+    #[getter]
+    fn max_model_len(&self) -> Option<usize> {
+        self.inner.max_model_len
     }
 
     #[getter]

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1958,6 +1958,7 @@ class MockEngineArgs:
         enable_g4_storage: bool = False,
         bandwidth_g2_to_g4_gbps: Optional[float] = None,
         bandwidth_g4_to_g2_gbps: Optional[float] = None,
+        max_model_len: Optional[int] = None,
     ) -> None:
         ...
 
@@ -1975,6 +1976,9 @@ class MockEngineArgs:
 
     @num_gpu_blocks.setter
     def num_gpu_blocks(self, value: int) -> None: ...
+
+    @property
+    def max_model_len(self) -> Optional[int]: ...
 
     @property
     def max_num_seqs(self) -> Optional[int]: ...

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -791,6 +791,12 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
         let max_output_tokens = planned_output_token_ids
             .as_ref()
             .map_or(requested_max_output_tokens, Vec::len);
+        let effective_max_output_tokens =
+            self.engine_args
+                .max_model_len
+                .map_or(max_output_tokens, |max_model_len| {
+                    max_output_tokens.min(max_model_len.saturating_sub(request.token_ids.len()))
+                });
         let native_timing = self
             .native_metrics
             .request_timing(&request.model, dp_rank, is_prefill, request_start)
@@ -1013,14 +1019,14 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                             break;
                         };
 
-                        // A terminally rejected request never ran (its footprint
-                        // exceeds the KV pool): emit no token and do not complete the
-                        // bootstrap room — surface the rejection and end the stream
-                        // before any token/prefill bookkeeping.
+                        // A terminally rejected request never ran because it violated
+                        // a worker admission limit. Emit no token and do not complete
+                        // the bootstrap room; surface the rejection before any
+                        // token/prefill bookkeeping.
                         if signal.rejected {
                             handoff_cancel.cancel();
                             let _ = stream_tx.send(LLMEngineOutput::error(
-                                "request rejected: KV footprint exceeds pool capacity".to_string(),
+                                "request rejected: request exceeds worker admission limits".to_string(),
                             ));
                             break;
                         }
@@ -1043,7 +1049,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                             ..Default::default()
                         };
 
-                        if signal.completed && token_count < max_output_tokens {
+                        if signal.completed && token_count < effective_max_output_tokens {
                             let _ = stream_tx.send(LLMEngineOutput::error("Completion signal received before max tokens reached".to_string()));
                             break;
                         }
@@ -1239,6 +1245,22 @@ mod tests {
             .unwrap()
     }
 
+    fn decode_request(prompt_tokens: usize, max_tokens: u32) -> PreprocessedRequest {
+        PreprocessedRequest::builder()
+            .model("mock".to_string())
+            .token_ids(vec![1; prompt_tokens])
+            .stop_conditions(StopConditions {
+                max_tokens: Some(max_tokens),
+                ..Default::default()
+            })
+            .sampling_options(SamplingOptions::default())
+            .output_options(OutputOptions::default())
+            .eos_token_ids(vec![])
+            .annotations(vec![])
+            .build()
+            .unwrap()
+    }
+
     #[tokio::test(start_paused = true)]
     async fn no_bootstrap_prefill_delays_terminal_finish_once() {
         let args = MockEngineArgs::builder()
@@ -1281,6 +1303,43 @@ mod tests {
         let finish = stream.next().await.unwrap();
         assert!(finish.token_ids.is_empty());
         assert!(finish.finish_reason.is_some());
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn context_capped_completion_maps_to_length() {
+        let args = MockEngineArgs::builder()
+            .max_model_len(Some(4))
+            .build()
+            .unwrap();
+        let engine = MockEngine::new(args);
+        let (request_tx, mut request_rx) = tokio::sync::mpsc::unbounded_channel();
+        engine.request_senders.set(vec![request_tx]).unwrap();
+
+        let mut stream = engine
+            .generate(SingleIn::new(decode_request(3, 4)))
+            .await
+            .unwrap();
+        let request = request_rx.recv().await.unwrap();
+        assert_eq!(request.max_output_tokens, 4);
+        let request_id = request.uuid.unwrap();
+        engine
+            .active_requests
+            .get(&request_id)
+            .unwrap()
+            .send(OutputSignal {
+                uuid: request_id,
+                token_id: Some(42),
+                completed: true,
+                rejected: false,
+                handoff_delay_ms: None,
+            })
+            .unwrap();
+
+        let token = stream.next().await.unwrap();
+        assert_eq!(token.token_ids.len(), 1);
+        assert!(token.finish_reason.is_none());
+        assert_eq!(stream.next().await.unwrap(), LLMEngineOutput::length());
         assert!(stream.next().await.is_none());
     }
 

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -519,6 +519,7 @@ struct MockEngineArgsSerde {
     engine_type: OptionalConfigValue<String>,
     num_gpu_blocks: OptionalConfigValue<usize>,
     block_size: OptionalConfigValue<usize>,
+    max_model_len: OptionalConfigValue<usize>,
     max_num_seqs: OptionalConfigValue<usize>,
     max_num_batched_tokens: OptionalConfigValue<usize>,
     enable_prefix_caching: OptionalConfigValue<bool>,
@@ -611,6 +612,12 @@ pub struct MockEngineArgs {
 
     #[builder(default = "0")]
     pub block_size: usize,
+
+    /// Optional vLLM sequence-length limit, including prompt and generated
+    /// tokens. Requests with no room to generate are rejected before admission.
+    #[builder(default = "None")]
+    #[validate(range(min = 1))]
+    pub max_model_len: Option<usize>,
 
     // This was 1024 in the past but reverted back to 256
     #[builder(default = Some(256))]
@@ -927,6 +934,16 @@ fn validate_mock_engine_args(args: &MockEngineArgs) -> Result<(), ValidationErro
             "num_g3_blocks requires num_g2_blocks because mocker stages G3 through G2".to_string(),
         ));
     }
+
+    if args.max_model_len.is_some() && args.engine_type != EngineType::Vllm {
+        return Err(mock_engine_args_validation_error(
+            "max_model_len_requires_vllm",
+            format!(
+                "max_model_len is supported only for engine_type=vllm, got engine_type={:?}",
+                args.engine_type
+            ),
+        ));
+    }
     if args.enable_g4_storage && args.num_g2_blocks.is_none() {
         return Err(mock_engine_args_validation_error(
             "g4_requires_g2",
@@ -1014,6 +1031,9 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         }
         if let Some(block_size) = compat.block_size.into_non_null("block_size")? {
             builder = builder.block_size(block_size);
+        }
+        if let Some(max_model_len) = compat.max_model_len.into_nullable() {
+            builder = builder.max_model_len(max_model_len);
         }
         if let Some(max_num_seqs) = compat.max_num_seqs.into_nullable() {
             builder = builder.max_num_seqs(max_num_seqs);
@@ -1428,6 +1448,7 @@ mod tests {
     fn test_mock_engine_args_json_round_trip_preserves_worker_type_and_nulls() {
         let args = MockEngineArgs::builder()
             .worker_type(WorkerType::Decode)
+            .max_model_len(Some(32768))
             .max_num_seqs(None)
             .max_num_batched_tokens(None)
             .reasoning(None)
@@ -1437,7 +1458,7 @@ mod tests {
             .normalized()
             .unwrap();
 
-        let payload = serde_json::json!({
+        let mut payload = serde_json::json!({
             "engine_type": "vllm",
             "num_gpu_blocks": args.num_gpu_blocks,
             "block_size": args.block_size,
@@ -1480,10 +1501,12 @@ mod tests {
             "sglang": args.sglang,
             "has_perf_model": true,
         });
+        payload["max_model_len"] = serde_json::json!(args.max_model_len);
 
         let restored = MockEngineArgs::from_json_str(&payload.to_string()).unwrap();
 
         assert_eq!(restored.worker_type, WorkerType::Decode);
+        assert_eq!(restored.max_model_len, Some(32768));
         assert_eq!(restored.max_num_seqs, None);
         assert_eq!(restored.max_num_batched_tokens, None);
         assert_eq!(
@@ -1688,6 +1711,21 @@ mod tests {
             .unwrap()
             .normalized()
             .expect("in-range aic_nextn should validate");
+    }
+
+    #[test]
+    fn test_normalized_rejects_zero_max_model_len() {
+        let error = MockEngineArgs::builder()
+            .max_model_len(Some(0))
+            .build()
+            .unwrap()
+            .normalized()
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("max_model_len"),
+            "unexpected error: {error}",
+        );
     }
 
     #[test]

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -372,8 +372,14 @@ impl ActiveSequence {
         }
 
         // Free all blocks when we reach max tokens
-        signals.extend(self.free_signal_for_tokens(self.len()));
+        signals.extend(self.terminal_signals());
         (token, signals)
+    }
+
+    /// Release the full sequence footprint after an independent terminal
+    /// condition, such as the model context-length limit, is reached.
+    pub(crate) fn terminal_signals(&self) -> Vec<MoveBlock> {
+        self.free_signal_for_tokens(self.len())
     }
 
     fn free_signal_for_tokens(&self, active_tokens: usize) -> Vec<MoveBlock> {

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -325,7 +325,7 @@ struct TraceRequestStats {
     first_admit_ms: Option<f64>,
     token_times_ms: Vec<f64>,
     input_length: usize,
-    output_length: usize,
+    requested_output_length: usize,
     reused_input_tokens: usize,
     first_admission_reused_input_tokens: usize,
     /// Index of the prefill worker that handled this request, if any.
@@ -397,6 +397,9 @@ pub struct PerRequestRecord {
     /// AIPerf's `inter_token_latency` field — one scalar per request.
     pub itl_ms: Option<f64>,
     pub input_length: usize,
+    /// Number of output tokens requested by the workload trace.
+    pub requested_output_length: usize,
+    /// Number of output tokens actually emitted by the mock engine.
     pub output_length: usize,
     pub reused_input_tokens: usize,
     pub prefill_worker_idx: Option<usize>,
@@ -421,6 +424,7 @@ pub(crate) struct TraceRequestStatsSnapshot {
     pub first_token_ms: Option<f64>,
     pub last_token_ms: Option<f64>,
     pub input_length: usize,
+    pub requested_output_length: usize,
     pub output_length: usize,
     pub reused_input_tokens: usize,
     pub first_admission_reused_input_tokens: usize,
@@ -512,6 +516,10 @@ impl TraceRequestStats {
         self.token_times_ms.last().copied()
     }
 
+    fn actual_output_length(&self) -> usize {
+        self.token_times_ms.len()
+    }
+
     fn mean_tpot_ms(&self) -> Option<f64> {
         let num_gaps = self.token_times_ms.len().saturating_sub(1);
         if num_gaps == 0 {
@@ -580,16 +588,16 @@ impl TraceCollector {
         uuid: Uuid,
         arrival_time_ms: f64,
         input_length: usize,
-        output_length: usize,
+        requested_output_length: usize,
     ) {
         self.requests.insert(
             uuid,
             TraceRequestStats {
                 arrival_time_ms,
                 first_admit_ms: None,
-                token_times_ms: Vec::with_capacity(output_length),
+                token_times_ms: Vec::with_capacity(requested_output_length),
                 input_length,
-                output_length,
+                requested_output_length,
                 reused_input_tokens: 0,
                 prefill_worker_idx: None,
                 decode_worker_idx: None,
@@ -757,6 +765,12 @@ impl TraceCollector {
         Some((ttft_ms, mean_itl_ms))
     }
 
+    pub(crate) fn actual_output_length(&self, uuid: Uuid) -> Option<usize> {
+        self.requests
+            .get(&uuid)
+            .map(TraceRequestStats::actual_output_length)
+    }
+
     pub(crate) fn finish(self) -> TraceSimulationReport {
         // Build per-request records before we move `self.requests` into the
         // summary aggregation below. Gated on `capture_per_request` — the
@@ -805,7 +819,8 @@ impl TraceCollector {
 
             completed_requests += 1;
             total_input_tokens += stats.input_length;
-            total_output_tokens += stats.output_length;
+            let output_length = stats.actual_output_length();
+            total_output_tokens += output_length;
             total_reused_tokens += stats.reused_input_tokens;
             total_first_admission_reused_tokens += stats.first_admission_reused_input_tokens;
             duration_ms = duration_ms.max(last_token_ms);
@@ -816,9 +831,9 @@ impl TraceCollector {
             e2e_latencies.push(e2e_ms);
 
             // Goodput classification (aiperf avg-ITL; see SlaThresholds::is_good).
-            if sla.is_set() && sla.is_good(ttft_ms, e2e_ms, stats.output_length) {
+            if sla.is_set() && sla.is_good(ttft_ms, e2e_ms, output_length) {
                 goodput_requests += 1;
-                goodput_output_tokens += stats.output_length;
+                goodput_output_tokens += output_length;
             }
 
             if let Some(ttst_ms) = stats.ttst_ms() {
@@ -937,7 +952,8 @@ impl TraceCollector {
                 e2e_latency_ms: last_token_ms.map(|time| (time - stats.arrival_time_ms).max(0.0)),
                 itl_ms: stats.mean_tpot_ms(),
                 input_length: stats.input_length,
-                output_length: stats.output_length,
+                requested_output_length: stats.requested_output_length,
+                output_length: stats.actual_output_length(),
                 reused_input_tokens: detail
                     .prefill_reused_input_tokens
                     .unwrap_or(stats.reused_input_tokens),
@@ -976,7 +992,8 @@ impl TraceCollector {
                 first_token_ms: stats.first_token_ms(),
                 last_token_ms: stats.last_token_ms(),
                 input_length: stats.input_length,
-                output_length: stats.output_length,
+                requested_output_length: stats.requested_output_length,
+                output_length: stats.actual_output_length(),
                 reused_input_tokens: stats.reused_input_tokens,
                 first_admission_reused_input_tokens: stats.first_admission_reused_input_tokens,
             })
@@ -992,7 +1009,8 @@ impl TraceCollector {
                 first_token_ms: stats.first_token_ms(),
                 last_token_ms: stats.last_token_ms(),
                 input_length: stats.input_length,
-                output_length: stats.output_length,
+                requested_output_length: stats.requested_output_length,
+                output_length: stats.actual_output_length(),
                 reused_input_tokens: stats.reused_input_tokens,
                 first_admission_reused_input_tokens: stats.first_admission_reused_input_tokens,
             })

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -508,9 +508,19 @@ impl AggRuntime {
             // traffic deltas (they still free their slot and advance below).
             if !signal.rejected {
                 let latencies = self.collector.request_latencies(signal.uuid);
+                let actual_output_tokens = self
+                    .collector
+                    .actual_output_length(signal.uuid)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "offline replay missing collector state for {}",
+                            signal.uuid
+                        )
+                    })?;
+                debug_assert!(actual_output_tokens <= removed_state.output_tokens);
                 self.traffic.on_request(
                     removed_state.input_tokens,
-                    removed_state.output_tokens,
+                    actual_output_tokens,
                     latencies,
                 );
             }
@@ -2955,6 +2965,43 @@ mod tests {
             "expected MTP accept_length 3.0, got {:?}",
             stats.avg_accept_length
         );
+    }
+
+    #[test]
+    fn test_drain_traffic_uses_context_capped_output_length() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(32)
+            .max_model_len(Some(8))
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_prefix_caching(false)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let requests = VecDeque::from([DirectRequest {
+            tokens: vec![1; 7],
+            max_output_tokens: 4,
+            uuid: Some(Uuid::from_u128(1)),
+            dp_rank: 0,
+            arrival_timestamp_ms: Some(0.0),
+            ..Default::default()
+        }]);
+        let mut rt = AggRuntime::new(
+            &args,
+            None,
+            None,
+            requests,
+            1,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        assert!(rt.advance_to(1000.0).unwrap());
+        let stats = rt.drain_traffic();
+        assert_eq!(stats.num_req, 1);
+        assert_eq!(stats.avg_osl, 1.0);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -1420,13 +1420,21 @@ impl DisaggRuntime {
         // latency — keep it out of the planner-facing traffic deltas (mirror the
         // aggregated path). It still frees its slot, advances, and is marked done.
         if !signal.rejected {
-            let state = self.state(signal.uuid)?;
-            let original = state.original_request()?;
-            let input_tokens = original.tokens.len();
-            let output_tokens = original.max_output_tokens;
+            let (input_tokens, requested_output_tokens) = {
+                let state = self.state(signal.uuid)?;
+                let original = state.original_request()?;
+                (original.tokens.len(), original.max_output_tokens)
+            };
+            let actual_output_tokens = self
+                .collector
+                .actual_output_length(signal.uuid)
+                .ok_or_else(|| {
+                    anyhow!("offline replay missing collector state for {}", signal.uuid)
+                })?;
+            debug_assert!(actual_output_tokens <= requested_output_tokens);
             let latencies = self.collector.request_latencies(signal.uuid);
             self.traffic
-                .on_request(input_tokens, output_tokens, latencies);
+                .on_request(input_tokens, actual_output_tokens, latencies);
         }
         let terminal_status = if signal.rejected {
             ReplayTerminalStatus::Rejected

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -1215,6 +1215,27 @@ fn test_advance_to_moves_clock_across_idle_gap() {
     assert!((stats.duration_s - 0.5).abs() < 1e-9);
 }
 
+#[test]
+fn test_disagg_traffic_uses_context_capped_output_length() {
+    let mut config = disagg_config();
+    config.prefill_args.max_model_len = Some(8);
+    config.decode_args.max_model_len = Some(8);
+    let mut runtime = DisaggRuntime::new(
+        &config,
+        None,
+        None,
+        VecDeque::from([request(1, 7, 4, 0.0)]),
+        ReplayMode::Trace,
+        ReplayRouterMode::RoundRobin,
+    )
+    .unwrap();
+
+    assert!(runtime.advance_to(1000.0).unwrap());
+    let stats = runtime.drain_traffic();
+    assert_eq!(stats.num_req, 1);
+    assert_eq!(stats.avg_osl, 1.0);
+}
+
 /// Setting `max_sim_time_ms` causes `run()` to break before scheduled
 /// arrivals past the cap. This test verifies the cap operates on
 /// **simulated** time (`now_ms`), not real wall-clock time: with

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -331,7 +331,7 @@ mod tests {
     use super::*;
     use crate::common::protocols::EngineType;
     use crate::loadgen::{SessionTrace, Trace, TurnTrace};
-    use crate::replay::{TraceRequestStatsSnapshot, TraceSimulationReport};
+    use crate::replay::{ReplayTerminalStatus, TraceRequestStatsSnapshot, TraceSimulationReport};
     use rstest::rstest;
     use std::collections::{HashMap, VecDeque};
     use uuid::Uuid;
@@ -1005,6 +1005,47 @@ mod tests {
         assert_eq!(report.request_counts.num_requests, 2);
         assert_eq!(report.request_counts.completed_requests, 1);
         assert_eq!(report.request_counts.total_output_tokens, 4);
+    }
+
+    #[test]
+    fn max_model_len_reports_actual_output_and_preserves_requested_output() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(4)
+            .max_model_len(Some(8))
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_prefix_caching(false)
+            .enable_chunked_prefill(true)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let uuid = Uuid::from_u128(3);
+        let report = simulate_concurrency_single(
+            args,
+            vec![DirectRequest {
+                tokens: vec![1; 7],
+                max_output_tokens: 4,
+                uuid: Some(uuid),
+                dp_rank: 0,
+                arrival_timestamp_ms: Some(0.0),
+                ..Default::default()
+            }],
+            1,
+            true,
+            None,
+            crate::replay::SlaThresholds::default(),
+        )
+        .unwrap();
+
+        assert_eq!(report.request_counts.completed_requests, 1);
+        assert_eq!(report.request_counts.total_output_tokens, 1);
+        assert_eq!(report.per_request.len(), 1);
+        let record = &report.per_request[0];
+        assert_eq!(record.uuid, uuid.to_string());
+        assert_eq!(record.requested_output_length, 4);
+        assert_eq!(record.output_length, 1);
+        assert_eq!(record.terminal_status, ReplayTerminalStatus::Completed);
     }
 
     fn cap_request(uuid: u128, arrival_ms: f64) -> DirectRequest {

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1387,26 +1387,37 @@ impl VllmCore {
                     .iter()
                     .filter_map(|running_uuid| self.state.requests.get(running_uuid))
                     .map(|request| &request.sequence);
-                let prompt_is_prebuilt = request.prompt_is_prebuilt();
-                match admission.stage_for(prompt_is_prebuilt) {
-                    AdmissionStage::Materialized => AdmissionDecision::Admit {
-                        prefill_cost: PrefillCost {
-                            new_blocks: 0,
-                            new_tokens: 0,
-                            cached_tokens: request.sequence.num_input_tokens(),
-                            active_cached_tokens: request.sequence.num_input_tokens(),
+                if policy::should_reject_for_model_len(
+                    scheduling_policy,
+                    &request.sequence,
+                    self.args.max_model_len,
+                ) {
+                    AdmissionDecision::Reject
+                } else {
+                    let prompt_is_prebuilt = request.prompt_is_prebuilt();
+                    match admission.stage_for(prompt_is_prebuilt) {
+                        AdmissionStage::Materialized => AdmissionDecision::Admit {
+                            prefill_cost: PrefillCost {
+                                new_blocks: 0,
+                                new_tokens: 0,
+                                cached_tokens: request.sequence.num_input_tokens(),
+                                active_cached_tokens: request.sequence.num_input_tokens(),
+                            },
                         },
-                    },
-                    AdmissionStage::PendingDestinationHead => break,
-                    AdmissionStage::FreshKv => policy::decide_waiting_admission(
-                        scheduling_policy,
-                        &request.sequence,
-                        request.status == RequestStatus::Waiting,
-                        running_seqs,
-                        self.args.num_gpu_blocks,
-                        self.args.block_size,
-                        &self.kv_manager,
-                    ),
+                        AdmissionStage::PendingDestinationHead => break,
+                        AdmissionStage::FreshKv => {
+                            let is_fresh = request.status == RequestStatus::Waiting;
+                            policy::decide_waiting_admission(
+                                scheduling_policy,
+                                &request.sequence,
+                                is_fresh,
+                                running_seqs,
+                                self.args.num_gpu_blocks,
+                                self.args.block_size,
+                                &self.kv_manager,
+                            )
+                        }
+                    }
                 }
             };
             let prefill_cost = match decision {
@@ -1418,8 +1429,14 @@ impl VllmCore {
                     tracing::warn!(
                         %uuid,
                         ?scheduling_policy,
+                        prompt_tokens = self
+                            .state
+                            .requests
+                            .get(&uuid)
+                            .map(|request| request.sequence.num_input_tokens()),
+                        max_model_len = self.args.max_model_len,
                         num_gpu_blocks = self.args.num_gpu_blocks,
-                        "rejecting request whose admission footprint exceeds the entire KV pool"
+                        "rejecting request that exceeds a worker admission limit"
                     );
                     rejected_uuids.push(uuid);
                     self.drop_request(uuid);
@@ -1893,7 +1910,7 @@ impl VllmCore {
                 continue;
             };
             if request.num_computed_tokens < request.sequence.len()
-                || request.sequence.generated_tokens() >= request.sequence.max_output_tokens()
+                || policy::generation_complete(&request.sequence, self.args.max_model_len)
             {
                 continue;
             }
@@ -1941,8 +1958,11 @@ impl VllmCore {
                 let Some(sequence) = self.state.running_sequence_mut(uuid) else {
                     break;
                 };
-                let (token_id, signals) = sequence.generate_token();
-                completed = sequence.generated_tokens() >= sequence.max_output_tokens();
+                let (token_id, mut signals) = sequence.generate_token();
+                completed = policy::generation_complete(sequence, self.args.max_model_len);
+                if completed && sequence.generated_tokens() < sequence.max_output_tokens() {
+                    signals.extend(sequence.terminal_signals());
+                }
                 let effects = if completed {
                     split_terminal_effects(signals)
                 } else {
@@ -2072,10 +2092,10 @@ impl VllmCore {
                 .iter()
                 .filter_map(|uuid| self.state.requests.get(uuid))
                 .map(|request| {
-                    let remaining = request
-                        .sequence
-                        .max_output_tokens()
-                        .saturating_sub(request.sequence.generated_tokens());
+                    let remaining = policy::remaining_generation_tokens(
+                        &request.sequence,
+                        self.args.max_model_len,
+                    );
                     let burst = max_burst.min(remaining);
                     let current_blocks = request.sequence.len().div_ceil(self.args.block_size);
                     let target_blocks =
@@ -2130,7 +2150,7 @@ impl VllmCore {
                     continue;
                 };
                 if request.num_computed_tokens == request.sequence.len()
-                    && request.sequence.generated_tokens() < request.sequence.max_output_tokens()
+                    && !policy::generation_complete(&request.sequence, self.args.max_model_len)
                 {
                     ready.push(uuid);
                 }
@@ -2179,10 +2199,10 @@ impl VllmCore {
                         .requests
                         .get(uuid)
                         .expect("ready request must remain active");
-                    let remaining = request
-                        .sequence
-                        .max_output_tokens()
-                        .saturating_sub(request.sequence.generated_tokens());
+                    let remaining = policy::remaining_generation_tokens(
+                        &request.sequence,
+                        self.args.max_model_len,
+                    );
                     let burst = if self.args.worker_type == WorkerType::Prefill {
                         remaining.min(1)
                     } else {
@@ -2205,9 +2225,15 @@ impl VllmCore {
                         .requests
                         .get_mut(&uuid)
                         .expect("sampled request must remain active");
-                    let (token_id, signals) = request.sequence.generate_token();
+                    let (token_id, mut signals) = request.sequence.generate_token();
                     let is_complete =
-                        request.sequence.generated_tokens() >= request.sequence.max_output_tokens();
+                        policy::generation_complete(&request.sequence, self.args.max_model_len);
+                    if is_complete
+                        && request.sequence.generated_tokens()
+                            < request.sequence.max_output_tokens()
+                    {
+                        signals.extend(request.sequence.terminal_signals());
+                    }
                     (token_id, signals, is_complete)
                 };
                 let effects = if is_complete {

--- a/lib/mocker/src/scheduler/vllm/policy.rs
+++ b/lib/mocker/src/scheduler/vllm/policy.rs
@@ -3,8 +3,7 @@
 
 //! Engine-specific policy for the shared vLLM/TRT-LLM scheduler core.
 
-use crate::common::protocols::PrefillCost;
-use crate::common::protocols::SchedulingPolicy;
+use crate::common::protocols::{PrefillCost, SchedulingPolicy};
 use crate::common::sequence::ActiveSequence;
 use crate::kv_manager::KvManager;
 
@@ -13,6 +12,34 @@ pub(super) enum AdmissionDecision {
     Admit { prefill_cost: PrefillCost },
     Wait,
     Reject,
+}
+
+pub(super) fn should_reject_for_model_len(
+    policy: SchedulingPolicy,
+    sequence: &ActiveSequence,
+    max_model_len: Option<usize>,
+) -> bool {
+    policy == SchedulingPolicy::Vllm
+        && max_model_len.is_some_and(|limit| sequence.num_input_tokens() >= limit)
+}
+
+/// Number of additional tokens the request may generate before reaching
+/// either its requested output length or the model sequence-length limit.
+pub(super) fn remaining_generation_tokens(
+    sequence: &ActiveSequence,
+    max_model_len: Option<usize>,
+) -> usize {
+    let requested_remaining = sequence
+        .max_output_tokens()
+        .saturating_sub(sequence.generated_tokens());
+    let context_remaining = max_model_len
+        .map(|limit| limit.saturating_sub(sequence.len()))
+        .unwrap_or(usize::MAX);
+    requested_remaining.min(context_remaining)
+}
+
+pub(super) fn generation_complete(sequence: &ActiveSequence, max_model_len: Option<usize>) -> bool {
+    remaining_generation_tokens(sequence, max_model_len) == 0
 }
 
 /// Decide whether the FIFO head can enter the shared scheduler core.
@@ -32,11 +59,8 @@ pub(super) fn decide_waiting_admission<'a>(
     if is_fresh {
         match policy {
             SchedulingPolicy::Vllm => {
-                // TODO: Carry vLLM's max_model_len explicitly. Upstream bounds prompt
-                // plus generated tokens by max_model_len and sizes KV for one
-                // max-length sequence. Until the mocker models that value, total
-                // worker KV is only a proxy for the one-time fresh-sequence admission
-                // cap; it does not cap future output length.
+                // Total worker KV remains a fallback one-time admission cap
+                // when max_model_len is unset or larger than the KV pool.
                 if sequence.current_known_blocks() > num_gpu_blocks {
                     return AdmissionDecision::Reject;
                 }

--- a/lib/mocker/src/scheduler/vllm/policy/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/policy/tests.rs
@@ -16,7 +16,7 @@ use crate::kv_manager::KvManager;
 use crate::kv_manager::kvbm_backend::G1Acquire;
 use crate::scheduler::vllm::{RequestStatus, VllmCore};
 
-use super::{AdmissionDecision, decide_waiting_admission};
+use super::{AdmissionDecision, decide_waiting_admission, should_reject_for_model_len};
 
 mod vllm {
     use super::*;
@@ -80,6 +80,152 @@ mod vllm {
         );
 
         assert!(matches!(decision, AdmissionDecision::Reject));
+    }
+
+    #[test]
+    fn rejects_prompt_at_max_model_len() {
+        let sequence = ActiveSequence::new((0..8).collect(), 1, Some(4), false, false);
+
+        assert!(should_reject_for_model_len(
+            SchedulingPolicy::Vllm,
+            &sequence,
+            Some(8)
+        ));
+    }
+
+    #[test]
+    fn rejects_prompt_above_max_model_len() {
+        let sequence = ActiveSequence::new((0..9).collect(), 1, Some(4), false, false);
+
+        assert!(should_reject_for_model_len(
+            SchedulingPolicy::Vllm,
+            &sequence,
+            Some(8)
+        ));
+    }
+
+    #[test]
+    fn trtllm_does_not_apply_vllm_max_model_len() {
+        let sequence = ActiveSequence::new((0..9).collect(), 1, Some(4), false, false);
+
+        assert!(!should_reject_for_model_len(
+            SchedulingPolicy::TrtllmGuaranteedNoEvict,
+            &sequence,
+            Some(8)
+        ));
+    }
+
+    #[test]
+    fn core_rejects_prompt_above_max_model_len() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Vllm)
+            .block_size(4)
+            .num_gpu_blocks(4)
+            .max_model_len(Some(8))
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(false)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let uuid = Uuid::from_u128(1);
+        core.receive(DirectRequest {
+            tokens: (0..9).collect(),
+            max_output_tokens: 1,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            ..Default::default()
+        });
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let pass = core.execute_pass(&mut collector, 0.0);
+
+        assert!(
+            pass.output_signals
+                .iter()
+                .any(|signal| signal.uuid == uuid && signal.completed && signal.rejected)
+        );
+        assert!(!core.state().requests.contains_key(&uuid));
+    }
+
+    #[test]
+    fn core_completes_at_max_model_len_without_rejecting() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Vllm)
+            .block_size(4)
+            .num_gpu_blocks(4)
+            .max_model_len(Some(8))
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(false)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let uuid = Uuid::from_u128(2);
+        core.receive(DirectRequest {
+            tokens: (0..7).collect(),
+            max_output_tokens: 4,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            ..Default::default()
+        });
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let pass = core.execute_pass(&mut collector, 0.0);
+
+        assert_eq!(pass.output_signals.len(), 1);
+        let terminal = &pass.output_signals[0];
+        assert_eq!(terminal.uuid, uuid);
+        assert!(terminal.token_id.is_some());
+        assert!(terminal.completed);
+        assert!(!terminal.rejected);
+        assert!(!core.state().requests.contains_key(&uuid));
+    }
+
+    #[test]
+    fn speculative_decode_does_not_burst_past_max_model_len() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Vllm)
+            .block_size(4)
+            .num_gpu_blocks(4)
+            .max_model_len(Some(8))
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(false)
+            .speedup_ratio(0.0)
+            .aic_nextn(Some(2))
+            .aic_nextn_accept_rates(Some("1,1".to_string()))
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let uuid = Uuid::from_u128(3);
+        core.receive(DirectRequest {
+            tokens: (0..5).collect(),
+            max_output_tokens: 8,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            ..Default::default()
+        });
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let pass = core.execute_pass(&mut collector, 0.0);
+
+        assert_eq!(pass.output_signals.len(), 3);
+        assert!(
+            pass.output_signals
+                .iter()
+                .take(2)
+                .all(|signal| !signal.completed)
+        );
+        let terminal = pass.output_signals.last().unwrap();
+        assert!(terminal.completed);
+        assert!(!terminal.rejected);
+        assert!(!core.state().requests.contains_key(&uuid));
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -255,6 +255,52 @@ mod destination_lifecycle {
         assert!(later.iter().all(|hash| !activation.contains(hash)));
     }
 
+    #[test]
+    fn materialized_prompt_above_max_model_len_is_rejected() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(12)
+            .max_model_len(Some(8))
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(1))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(true)
+            .worker_type(WorkerType::Decode)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let handoff_id = HandoffId::from(Uuid::from_u128(30_001));
+        let uuid = Uuid::from_u128(30_002);
+
+        assert!(matches!(
+            core.apply_command(SchedulerCommand::ReserveDestination {
+                handoff_id,
+                request: request(uuid, vec![1; 9], 1),
+            })
+            .unwrap(),
+            SchedulerCommandResult::DestinationAccepted { request_id } if request_id == uuid
+        ));
+        assert_eq!(
+            core.apply_command(SchedulerCommand::ActivateDestination { handoff_id })
+                .unwrap(),
+            SchedulerCommandResult::Applied
+        );
+
+        let pass = execute(&mut core, 0.0);
+        assert!(matches!(
+            pass.output_signals.as_slice(),
+            [OutputSignal {
+                uuid: signal_uuid,
+                token_id: None,
+                completed: true,
+                rejected: true,
+                ..
+            }] if *signal_uuid == uuid
+        ));
+        assert!(!core.state().requests.contains_key(&uuid));
+    }
+
     fn drive_source_to_hold(core: &mut VllmCore, handoff_id: HandoffId, req: DirectRequest) {
         assert!(matches!(
             core.apply_command(SchedulerCommand::SubmitHandoffPrefill {


### PR DESCRIPTION
## Summary

Add explicit `max_model_len` support to vLLM mocker and replay so they model the same total sequence-length behavior as Dynamo frontend/router plus a vLLM worker.

Requests with no output position remaining are rejected before generation. Requests that reach the context limit after generation starts complete normally with `finish_reason="length"`.

## Details

- Add an optional, vLLM-only `max_model_len` scalar across the CLI, Python bindings, JSON engine args, and Rust mock engine args.
- Keep resolution explicit-only. This PR does not infer an effective vLLM limit from architectural model metadata.
- Reject fresh and materialized destination requests when `prompt_len >= max_model_len`.
- Preserve the original requested output length and independently stop generation when either the requested output limit or total sequence limit is reached.
- Prevent speculative decode bursts from crossing `max_model_len`.
- Map context-capped live completions to the existing `length` finish reason instead of treating them as early-completion errors.
- Preserve `requested_output_length` in replay while deriving actual `output_length` from emitted token signals.
- Use actual output length for replay totals, throughput/goodput, SLA calculations, and aggregated/disaggregated planner traffic.
- Publish `ModelRuntimeConfig.context_length` only when an explicit limit is enforced, while keeping physical `max_kv_tokens` separate.

## Where should the reviewer start?

- `lib/mocker/src/scheduler/vllm/policy.rs` and `lib/mocker/src/scheduler/vllm/core.rs` for admission and generation-stop semantics.
- `lib/llm/src/mocker.rs` for live context-capped completion handling.
- `lib/mocker/src/replay/collector.rs` and `lib/mocker/src/replay/offline/` for requested-versus-actual output accounting.
- `components/src/dynamo/mocker/config.py` and `components/src/dynamo/replay/main.py` for explicit scalar propagation and runtime capability publication.

## Related Issues

**This PR is NOT linked to an issue:**

- [x] Confirmed - no related issue

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-mocker --lib -- -D warnings`
- `cargo test -p dynamo-mocker` (`488 passed`, `1 ignored`)
- `dynamo/bin/pytest -q components/src/dynamo/mocker/tests/unit/test_config.py -k max_model_len` (`7 passed`, `27 deselected`)

Real-GPU validation on an H100 with Dynamo frontend + KV router + vLLM worker:

- Image: `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-dev.1-cuda13`
- Dynamo: `1.3.0.dev1`
- vLLM: `0.22.0`
- Model: `Qwen/Qwen3-0.6B`
- Effective `max_model_len`: `32`

| Prompt tokens | Requested output | HTTP status | Actual output | Finish reason |
| ---: | ---: | ---: | ---: | --- |
| 28 | 8 | 200 | 4 | `length` |
| 31 | 2 | 200 | 1 | `length` |
| 32 | 1 | 400 | 0 | rejected before generation |
