### PR TITLE
feat: PR 1: EPP config for the EPP and standalone Selector Router Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,6 +2470,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "validator",
 ]
 
 [[package]]

--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -42,6 +42,7 @@ tonic-health = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 uuid = { workspace = true }
+validator = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["prost"]

--- a/deploy/inference-gateway/ext-proc/src/epp_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_config.rs
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Standalone mode configuration.
+//!
+//! `DYN_EPP_MODE` selects the EPP mode: `full-dynamo-stack` (default) or
+//! `standalone` (fronts raw `vllm serve` pods with no Dynamo runtime and runs an
+//! in-process, runtime-free KV-aware selector). The pod selector and target port
+//! come from the `InferencePool`; the rest of the standalone contract comes from
+//! the environment.
+//!
+//! [`EppConfig::from_env`] separates the two concerns: [`EppConfig::parse`] does
+//! env-read + default resolution only, and [`EppConfig::validate_config`] enforces
+//! the constraints declaratively via the `validator` derive.
+
+use validator::Validate;
+
+const DEFAULT_KV_EVENT_PORT: u16 = 5557;
+const DEFAULT_DATA_PARALLEL_SIZE: u32 = 1;
+const DEFAULT_SELECTOR_THREADS: usize = 4;
+const DEFAULT_PEER_SYNC_PORT: u16 = 9092;
+
+/// Environment variable that selects the EPP operating mode.
+pub const DYN_EPP_MODE: &str = "DYN_EPP_MODE";
+/// `DYN_EPP_MODE` value selecting standalone mode.
+pub const STANDALONE_MODE: &str = "standalone";
+/// `DYN_EPP_MODE` value selecting the default full Dynamo stack.
+pub const FULL_DYNAMO_STACK_MODE: &str = "full-dynamo-stack";
+
+/// Reads an environment variable, matching the injectable getter used in tests.
+type EnvGet<'a> = dyn Fn(&str) -> Option<String> + 'a;
+
+/// Top-level EPP operating mode from `DYN_EPP_MODE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EppMode {
+    /// Default: attach to a Dynamo deployment (etcd/NATS + embedded KV router).
+    FullDynamoStack,
+    /// Front raw `vllm serve` pods with no Dynamo runtime.
+    Standalone,
+}
+
+impl EppMode {
+    /// Parse `DYN_EPP_MODE` from the process environment.
+    pub fn from_env() -> anyhow::Result<Self> {
+        Self::parse(&|k| std::env::var(k).ok())
+    }
+
+    /// Parse the mode, failing fast on an unrecognized value so a typo (e.g.
+    /// `standalone`) can never silently fall through to full-dynamo mode.
+    fn parse(get: &EnvGet) -> anyhow::Result<Self> {
+        match trimmed(get(DYN_EPP_MODE)).as_deref() {
+            None | Some(FULL_DYNAMO_STACK_MODE) => Ok(Self::FullDynamoStack),
+            Some(STANDALONE_MODE) => Ok(Self::Standalone),
+            Some(other) => anyhow::bail!(
+                "{DYN_EPP_MODE} has invalid value {other:?}; \
+                 expected {STANDALONE_MODE:?} or {FULL_DYNAMO_STACK_MODE:?}"
+            ),
+        }
+    }
+}
+
+/// Standalone configuration. The pod selector and target port are NOT here —
+/// they come from the `InferencePool` named by `pool_name` at runtime.
+///
+/// Constraints are declared with `validator` attributes and checked by
+/// [`EppConfig::validate_config`]; `parse` only resolves env + defaults.
+#[derive(Debug, Clone, Validate)]
+pub struct EppConfig {
+    /// KV indexer thread-pool size for the in-process selector.
+    #[validate(range(min = 1))]
+    pub selector_threads: usize,
+    /// Embedded replication: the EPP's OWN `Service` whose EndpointSlices the
+    /// EPP watches to discover sibling replicas and sync active load with them
+    /// over ZMQ. `None` = single-replica (no cross-replica sync).
+    pub peer_service: Option<String>,
+    /// Port each EPP replica binds for peer replica-sync (ZMQ) and dials peers
+    /// on; all replicas must agree. Used only when `peer_service` is set.
+    #[validate(range(min = 1))]
+    pub peer_sync_port: u16,
+    /// `InferencePool` this EPP backs; its selector + target port drive discovery.
+    #[validate(length(min = 1, message = "DYN_EPP_POOL_NAME is required"))]
+    pub pool_name: String,
+    /// Kubernetes namespace the EPP runs in (from `POD_NAMESPACE`, downward API).
+    /// The EPP, its `InferencePool`, the worker pods, and sibling EPP replicas
+    /// all live here — the EPP and the pool it backs are always co-located.
+    #[validate(length(min = 1, message = "POD_NAMESPACE is required (downward API metadata.namespace)"))]
+    pub namespace: String,
+    /// Model id used to build the offline tokenizer (no model card in this mode).
+    #[validate(length(min = 1, message = "DYN_MODEL_NAME is required"))]
+    pub model_name: String,
+    /// KV-cache block size; MUST equal the vLLM `--block-size`.
+    #[validate(range(min = 1, message = "DYN_KV_CACHE_BLOCK_SIZE must be >= 1"))]
+    pub block_size: u32,
+    /// vLLM `--kv-events-config` PUB port the selector subscribes to.
+    #[validate(range(min = 1))]
+    pub kv_event_port: u16,
+    /// vLLM `--kv-events-config` topic (default empty).
+    pub kv_event_topic: String,
+    /// Optional ZMQ REQ port the selector uses for live-stream gap replay.
+    pub replay_port: Option<u16>,
+    /// Engine data-parallel size. Data parallelism is not supported in this
+    /// release, so this must be exactly 1.
+    #[validate(range(min = 1, max = 1))]
+    pub data_parallel_size: u32,
+    /// Optional per-worker total KV blocks hint for the selector's load model.
+    pub total_kv_blocks: Option<u64>,
+    /// Optional per-worker max batched tokens (needed only when queueing is on).
+    pub max_num_batched_tokens: Option<u64>,
+}
+
+impl EppConfig {
+    /// Build and validate the standalone contract from the process environment.
+    pub fn from_env() -> anyhow::Result<Self> {
+        let config = Self::parse(&|k| std::env::var(k).ok())?;
+        config.validate_config()?;
+        Ok(config)
+    }
+
+    /// Resolve env vars + defaults into the struct. No constraint checking — that
+    /// lives in [`Self::validate_config`]. Only fails when a value that IS set
+    /// cannot be parsed into its type (e.g. a non-numeric port). Keeps parsing
+    /// pure so tests supply a map instead of mutating the process environment.
+    fn parse(get: &EnvGet) -> anyhow::Result<Self> {
+        Ok(Self {
+            selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTOR_THREADS")?
+                .unwrap_or(DEFAULT_SELECTOR_THREADS),
+            peer_service: trimmed(get("DYN_EPP_PEER_SERVICE")),
+            peer_sync_port: opt_parse::<u16>(get, "DYN_EPP_PEER_SYNC_PORT")?
+                .unwrap_or(DEFAULT_PEER_SYNC_PORT),
+            pool_name: trimmed(get("DYN_EPP_POOL_NAME")).unwrap_or_default(),
+            // The EPP and its InferencePool are always co-located, so the pod's
+            // own namespace (downward API) is the single source of truth — used
+            // to watch the pool, the worker pods, and sibling EPP replicas.
+            namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
+            model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
+            block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
+            kv_event_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?
+                .unwrap_or(DEFAULT_KV_EVENT_PORT),
+            kv_event_topic: trimmed(get("DYN_EPP_KV_EVENT_TOPIC")).unwrap_or_default(),
+            replay_port: opt_parse::<u16>(get, "DYN_EPP_REPLAY_PORT")?,
+            data_parallel_size: opt_parse::<u32>(get, "DYN_DATA_PARALLEL_SIZE")?
+                .unwrap_or(DEFAULT_DATA_PARALLEL_SIZE),
+            total_kv_blocks: opt_parse::<u64>(get, "DYN_TOTAL_KV_BLOCKS")?,
+            max_num_batched_tokens: opt_parse::<u64>(get, "DYN_MAX_NUM_BATCHED_TOKENS")?,
+        })
+    }
+
+    /// Enforce the `validator` constraints, mapping the failure to `anyhow`.
+    pub fn validate_config(&self) -> anyhow::Result<()> {
+        self.validate()
+            .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))
+    }
+}
+
+/// Trim a raw value and treat empty as absent.
+fn trimmed(v: Option<String>) -> Option<String> {
+    v.and_then(|v| {
+        let t = v.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    })
+}
+
+fn opt_parse<T>(get: &EnvGet, key: &str) -> anyhow::Result<Option<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match trimmed(get(key)) {
+        None => Ok(None),
+        Some(raw) => raw
+            .parse::<T>()
+            .map(Some)
+            .map_err(|e| anyhow::anyhow!("{key} has an invalid value {raw:?}: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Build an injectable env getter from key/value pairs — no process-global
+    /// env mutation, so these tests are isolated and parallel-safe.
+    fn getter(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> =
+            pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+        move |k| map.get(k).cloned()
+    }
+
+    fn parse_mode(pairs: &[(&str, &str)]) -> anyhow::Result<EppMode> {
+        EppMode::parse(&getter(pairs))
+    }
+
+    /// Mirror `from_env`: resolve (parse) then validate.
+    fn parse_cfg(pairs: &[(&str, &str)]) -> anyhow::Result<EppConfig> {
+        let cfg = EppConfig::parse(&getter(pairs))?;
+        cfg.validate_config()?;
+        Ok(cfg)
+    }
+
+    #[test]
+    fn mode_defaults_to_full_when_unset() {
+        assert_eq!(parse_mode(&[]).unwrap(), EppMode::FullDynamoStack);
+    }
+
+    #[test]
+    fn mode_parses_known_values() {
+        assert_eq!(
+            parse_mode(&[("DYN_EPP_MODE", "standalone")]).unwrap(),
+            EppMode::Standalone
+        );
+        assert_eq!(
+            parse_mode(&[("DYN_EPP_MODE", "full-dynamo-stack")]).unwrap(),
+            EppMode::FullDynamoStack
+        );
+    }
+
+    #[test]
+    fn mode_rejects_unknown_value() {
+        // An unknown value must fail fast, not silently boot full-dynamo mode.
+        assert!(parse_mode(&[("DYN_EPP_MODE", "nonsense-mode")]).is_err());
+    }
+
+    #[test]
+    fn parses_required_and_defaults() {
+        let cfg = parse_cfg(&[
+            ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+            ("POD_NAMESPACE", "inference"),
+            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+        ])
+        .expect("config should parse");
+        assert_eq!(cfg.selector_threads, DEFAULT_SELECTOR_THREADS);
+        // No peer service => single-replica (replica sync off).
+        assert!(cfg.peer_service.is_none());
+        assert_eq!(cfg.peer_sync_port, DEFAULT_PEER_SYNC_PORT);
+        assert_eq!(cfg.pool_name, "vllm-qwen-pool");
+        assert_eq!(cfg.namespace, "inference");
+        assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
+        assert_eq!(cfg.block_size, 16);
+        assert_eq!(cfg.kv_event_port, DEFAULT_KV_EVENT_PORT);
+        assert_eq!(cfg.data_parallel_size, 1);
+        assert!(cfg.replay_port.is_none());
+        assert!(cfg.total_kv_blocks.is_none());
+    }
+
+    #[test]
+    fn missing_pod_namespace_fails() {
+        // POD_NAMESPACE is the single namespace source (downward API); without
+        // it the EPP can't watch its pool, pods, or peers.
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn replication_config_parsed() {
+        let cfg = parse_cfg(&[
+            ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+            ("DYN_EPP_PEER_SYNC_PORT", "9191"),
+            ("DYN_EPP_SELECTOR_THREADS", "8"),
+            ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+            ("POD_NAMESPACE", "inference"),
+            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+        ])
+        .expect("replication config should parse");
+        assert_eq!(cfg.peer_service.as_deref(), Some("dynamo-epp"));
+        assert_eq!(cfg.peer_sync_port, 9191);
+        assert_eq!(cfg.selector_threads, 8);
+        assert_eq!(cfg.namespace, "inference");
+    }
+
+    #[test]
+    fn missing_pool_name_fails() {
+        assert!(
+            parse_cfg(&[
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn zero_block_size_fails() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "0"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn data_parallel_size_must_be_one() {
+        // Data parallelism is not supported in this release: only DP=1 is valid.
+        let base = [
+            ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+            ("POD_NAMESPACE", "inference"),
+            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+        ];
+        let with_dp = |dp: &str| {
+            let mut pairs = base.to_vec();
+            pairs.push(("DYN_DATA_PARALLEL_SIZE", dp));
+            parse_cfg(&pairs)
+        };
+        assert!(with_dp("0").is_err());
+        assert!(with_dp("2").is_err());
+        assert_eq!(with_dp("1").unwrap().data_parallel_size, 1);
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -24,8 +24,8 @@ const DEFAULT_PEER_SYNC_PORT: u16 = 9092;
 pub const DYN_EPP_MODE: &str = "DYN_EPP_MODE";
 /// `DYN_EPP_MODE` value selecting standalone mode.
 pub const STANDALONE_MODE: &str = "standalone";
-/// `DYN_EPP_MODE` value selecting the default full Dynamo stack.
-pub const FULL_DYNAMO_STACK_MODE: &str = "full-dynamo-stack";
+/// `DYN_EPP_MODE` value selecting the Dynamo runtime.
+pub const DYNAMO_RUNTIME_MODE: &str = "dynamo";
 
 /// Reads an environment variable, matching the injectable getter used in tests.
 type EnvGet<'a> = dyn Fn(&str) -> Option<String> + 'a;
@@ -33,82 +33,72 @@ type EnvGet<'a> = dyn Fn(&str) -> Option<String> + 'a;
 /// Top-level EPP operating mode from `DYN_EPP_MODE`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EppMode {
-    /// Default: attach to a Dynamo deployment (etcd/NATS + embedded KV router).
-    FullDynamoStack,
-    /// Front raw `vllm serve` pods with no Dynamo runtime.
+    // Connects to the Dynamo runtime and constructs a KvRouter. Requires Dynamo workers
+    // to be connected to the runtime. (default)
+    DynamoRuntime,
+    // No runtime connection. Constructs a ServiceSelector for tracking workers, kv state and selecting best worker.
+    // Workers can be raw vllm serve pods or other OpenAI-compatible backends.
     Standalone,
 }
 
 impl EppMode {
-    /// Parse `DYN_EPP_MODE` from the process environment.
     pub fn from_env() -> anyhow::Result<Self> {
         Self::parse(&|k| std::env::var(k).ok())
     }
 
-    /// Parse the mode, failing fast on an unrecognized value so a typo (e.g.
-    /// `standalone`) can never silently fall through to full-dynamo mode.
     fn parse(get: &EnvGet) -> anyhow::Result<Self> {
         match trimmed(get(DYN_EPP_MODE)).as_deref() {
-            None | Some(FULL_DYNAMO_STACK_MODE) => Ok(Self::FullDynamoStack),
+            None | Some(DYNAMO_RUNTIME_MODE) => Ok(Self::DynamoRuntime),
             Some(STANDALONE_MODE) => Ok(Self::Standalone),
             Some(other) => anyhow::bail!(
                 "{DYN_EPP_MODE} has invalid value {other:?}; \
-                 expected {STANDALONE_MODE:?} or {FULL_DYNAMO_STACK_MODE:?}"
+                 expected {STANDALONE_MODE:?} or {DYNAMO_RUNTIME_MODE:?}"
             ),
         }
     }
 }
 
-/// Standalone configuration. The pod selector and target port are NOT here —
-/// they come from the `InferencePool` named by `pool_name` at runtime.
-///
-/// Constraints are declared with `validator` attributes and checked by
-/// [`EppConfig::validate_config`]; `parse` only resolves env + defaults.
 #[derive(Debug, Clone, Validate)]
-pub struct EppConfig {
+pub struct EppStandaloneConfig {
     /// KV indexer thread-pool size for the in-process selector.
     #[validate(range(min = 1))]
     pub selector_threads: usize,
-    /// Embedded replication: the EPP's OWN `Service` whose EndpointSlices the
-    /// EPP watches to discover sibling replicas and sync active load with them
-    /// over ZMQ. `None` = single-replica (no cross-replica sync).
+    // EPP Service for peer discovery and state synchronization.
+    // `None` = single-replica (no cross-replica sync).
     pub peer_service: Option<String>,
-    /// Port each EPP replica binds for peer replica-sync (ZMQ) and dials peers
-    /// on; all replicas must agree. Used only when `peer_service` is set.
+    // Peer replication sync port.
+    // Required when `peer_service` is set.
     #[validate(range(min = 1))]
     pub peer_sync_port: u16,
     /// `InferencePool` this EPP backs; its selector + target port drive discovery.
-    #[validate(length(min = 1, message = "DYN_EPP_POOL_NAME is required"))]
-    pub pool_name: String,
-    /// Kubernetes namespace the EPP runs in (from `POD_NAMESPACE`, downward API).
-    /// The EPP, its `InferencePool`, the worker pods, and sibling EPP replicas
-    /// all live here — the EPP and the pool it backs are always co-located.
-    #[validate(length(min = 1, message = "POD_NAMESPACE is required (downward API metadata.namespace)"))]
+    #[validate(length(min = 1, message = "DYN_EPP_INFERENCE_POOL_NAME is required"))]
+    pub inference_pool_name: String,
+    // Kubernetes namespace the EPP runs in (from `POD_NAMESPACE`, downward API).
+    #[validate(length(min = 1, message = "POD_NAMESPACE is required"))]
     pub namespace: String,
-    /// Model id used to build the offline tokenizer (no model card in this mode).
+    /// Model id used to build the offline tokenizer and registerd with the selector.
     #[validate(length(min = 1, message = "DYN_MODEL_NAME is required"))]
     pub model_name: String,
-    /// KV-cache block size; MUST equal the vLLM `--block-size`.
+    /// KV-cache block size; MUST equal the inference engine block size.
     #[validate(range(min = 1, message = "DYN_KV_CACHE_BLOCK_SIZE must be >= 1"))]
     pub block_size: u32,
-    /// vLLM `--kv-events-config` PUB port the selector subscribes to.
+    /// KV zmq event port
     #[validate(range(min = 1))]
     pub kv_event_port: u16,
-    /// vLLM `--kv-events-config` topic (default empty).
+    // KV zmq event topic
     pub kv_event_topic: String,
-    /// Optional ZMQ REQ port the selector uses for live-stream gap replay.
+    /// Optional zmq port the selector uses for live-stream gap replay.
     pub replay_port: Option<u16>,
-    /// Engine data-parallel size. Data parallelism is not supported in this
-    /// release, so this must be exactly 1.
+    /// Engine data-parallel size. Currently only support DP=1.
     #[validate(range(min = 1, max = 1))]
     pub data_parallel_size: u32,
-    /// Optional per-worker total KV blocks hint for the selector's load model.
+    /// Optional per-worker total KV blocks.
     pub total_kv_blocks: Option<u64>,
-    /// Optional per-worker max batched tokens (needed only when queueing is on).
+    /// Optional per-worker max batched tokens (required when queuing or policy config is used).
     pub max_num_batched_tokens: Option<u64>,
 }
 
-impl EppConfig {
+impl EppStandaloneConfig {
     /// Build and validate the standalone contract from the process environment.
     pub fn from_env() -> anyhow::Result<Self> {
         let config = Self::parse(&|k| std::env::var(k).ok())?;
@@ -116,10 +106,6 @@ impl EppConfig {
         Ok(config)
     }
 
-    /// Resolve env vars + defaults into the struct. No constraint checking — that
-    /// lives in [`Self::validate_config`]. Only fails when a value that IS set
-    /// cannot be parsed into its type (e.g. a non-numeric port). Keeps parsing
-    /// pure so tests supply a map instead of mutating the process environment.
     fn parse(get: &EnvGet) -> anyhow::Result<Self> {
         Ok(Self {
             selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTOR_THREADS")?
@@ -127,10 +113,7 @@ impl EppConfig {
             peer_service: trimmed(get("DYN_EPP_PEER_SERVICE")),
             peer_sync_port: opt_parse::<u16>(get, "DYN_EPP_PEER_SYNC_PORT")?
                 .unwrap_or(DEFAULT_PEER_SYNC_PORT),
-            pool_name: trimmed(get("DYN_EPP_POOL_NAME")).unwrap_or_default(),
-            // The EPP and its InferencePool are always co-located, so the pod's
-            // own namespace (downward API) is the single source of truth — used
-            // to watch the pool, the worker pods, and sibling EPP replicas.
+            pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
             namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
             model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
             block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
@@ -196,15 +179,15 @@ mod tests {
     }
 
     /// Mirror `from_env`: resolve (parse) then validate.
-    fn parse_cfg(pairs: &[(&str, &str)]) -> anyhow::Result<EppConfig> {
-        let cfg = EppConfig::parse(&getter(pairs))?;
+    fn parse_cfg(pairs: &[(&str, &str)]) -> anyhow::Result<EppStandaloneConfig> {
+        let cfg = EppStandaloneConfig::parse(&getter(pairs))?;
         cfg.validate_config()?;
         Ok(cfg)
     }
 
     #[test]
     fn mode_defaults_to_full_when_unset() {
-        assert_eq!(parse_mode(&[]).unwrap(), EppMode::FullDynamoStack);
+        assert_eq!(parse_mode(&[]).unwrap(), EppMode::DynamoRuntime);
     }
 
     #[test]
@@ -215,7 +198,7 @@ mod tests {
         );
         assert_eq!(
             parse_mode(&[("DYN_EPP_MODE", "full-dynamo-stack")]).unwrap(),
-            EppMode::FullDynamoStack
+            EppMode::DynamoRuntime
         );
     }
 
@@ -228,7 +211,7 @@ mod tests {
     #[test]
     fn parses_required_and_defaults() {
         let cfg = parse_cfg(&[
-            ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+            ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
@@ -254,7 +237,7 @@ mod tests {
         // it the EPP can't watch its pool, pods, or peers.
         assert!(
             parse_cfg(&[
-                ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
@@ -268,7 +251,7 @@ mod tests {
             ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
             ("DYN_EPP_PEER_SYNC_PORT", "9191"),
             ("DYN_EPP_SELECTOR_THREADS", "8"),
-            ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+            ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
@@ -296,7 +279,7 @@ mod tests {
     fn zero_block_size_fails() {
         assert!(
             parse_cfg(&[
-                ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "0"),
@@ -309,7 +292,7 @@ mod tests {
     fn data_parallel_size_must_be_one() {
         // Data parallelism is not supported in this release: only DP=1 is valid.
         let base = [
-            ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+            ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -1,24 +1,21 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Standalone mode configuration.
+//! Standalone EPP mode configuration.
 //!
-//! `DYN_EPP_MODE` selects the EPP mode: `full-dynamo-stack` (default) or
-//! `standalone` (fronts raw `vllm serve` pods with no Dynamo runtime and runs an
-//! in-process, runtime-free KV-aware selector). The pod selector and target port
-//! come from the `InferencePool`; the rest of the standalone contract comes from
-//! the environment.
+//! `DYN_EPP_MODE=dynamo` (default) uses the Dynamo runtime. `standalone` parses
+//! the selector-only config used when the EPP fronts raw OpenAI-compatible
+//! workers without a Dynamo runtime.
 //!
-//! [`EppConfig::from_env`] separates the two concerns: [`EppConfig::parse`] does
-//! env-read + default resolution only, and [`EppConfig::validate_config`] enforces
-//! the constraints declaratively via the `validator` derive.
+//! [`EppStandaloneConfig::from_env`] reads envs, applies defaults, and calls
+//! [`EppStandaloneConfig::validate_config`] for field and cross-field checks.
 
 use validator::Validate;
+use validator::ValidationError;
 
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
 const DEFAULT_DATA_PARALLEL_SIZE: u32 = 1;
 const DEFAULT_SELECTOR_THREADS: usize = 4;
-const DEFAULT_PEER_SYNC_PORT: u16 = 9092;
 
 /// Environment variable that selects the EPP operating mode.
 pub const DYN_EPP_MODE: &str = "DYN_EPP_MODE";
@@ -59,33 +56,36 @@ impl EppMode {
 }
 
 #[derive(Debug, Clone, Validate)]
+#[validate(schema(
+    function = "validate_epp_standalone_config",
+    skip_on_field_errors = true
+))]
 pub struct EppStandaloneConfig {
     /// KV indexer thread-pool size for the in-process selector.
     #[validate(range(min = 1))]
     pub selector_threads: usize,
-    // EPP Service for peer discovery and state synchronization.
-    // `None` = single-replica (no cross-replica sync).
+    /// EPP Service for peer discovery and state synchronization.
+    /// `None` means single-replica with cross-replica sync disabled.
     pub peer_service: Option<String>,
-    // Peer replication sync port.
-    // Required when `peer_service` is set.
+    /// Peer replication sync port. Required when `peer_service` is set.
     #[validate(range(min = 1))]
-    pub peer_sync_port: u16,
+    pub peer_sync_port: Option<u16>,
     /// `InferencePool` this EPP backs; its selector + target port drive discovery.
     #[validate(length(min = 1, message = "DYN_EPP_INFERENCE_POOL_NAME is required"))]
     pub inference_pool_name: String,
-    // Kubernetes namespace the EPP runs in (from `POD_NAMESPACE`, downward API).
+    /// Kubernetes namespace the EPP runs in (from `POD_NAMESPACE`, downward API).
     #[validate(length(min = 1, message = "POD_NAMESPACE is required"))]
     pub namespace: String,
-    /// Model id used to build the offline tokenizer and registerd with the selector.
+    /// Model id used to build the offline tokenizer and register with the selector.
     #[validate(length(min = 1, message = "DYN_MODEL_NAME is required"))]
     pub model_name: String,
     /// KV-cache block size; MUST equal the inference engine block size.
     #[validate(range(min = 1, message = "DYN_KV_CACHE_BLOCK_SIZE must be >= 1"))]
     pub block_size: u32,
-    /// KV zmq event port
+    /// KV zmq event port.
     #[validate(range(min = 1))]
     pub kv_event_port: u16,
-    // KV zmq event topic
+    /// KV zmq event topic.
     pub kv_event_topic: String,
     /// Optional zmq port the selector uses for live-stream gap replay.
     pub replay_port: Option<u16>,
@@ -111,9 +111,8 @@ impl EppStandaloneConfig {
             selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTOR_THREADS")?
                 .unwrap_or(DEFAULT_SELECTOR_THREADS),
             peer_service: trimmed(get("DYN_EPP_PEER_SERVICE")),
-            peer_sync_port: opt_parse::<u16>(get, "DYN_EPP_PEER_SYNC_PORT")?
-                .unwrap_or(DEFAULT_PEER_SYNC_PORT),
-            pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
+            peer_sync_port: opt_parse::<u16>(get, "DYN_EPP_PEER_SYNC_PORT")?,
+            inference_pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
             namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
             model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
             block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
@@ -133,6 +132,17 @@ impl EppStandaloneConfig {
         self.validate()
             .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))
     }
+}
+
+fn validate_epp_standalone_config(config: &EppStandaloneConfig) -> Result<(), ValidationError> {
+    if config.peer_service.is_some() && config.peer_sync_port.is_none() {
+        let mut error = ValidationError::new("peer_sync_port_required");
+        error.message =
+            Some("DYN_EPP_PEER_SYNC_PORT is required when DYN_EPP_PEER_SERVICE is set".into());
+        return Err(error);
+    }
+
+    Ok(())
 }
 
 /// Trim a raw value and treat empty as absent.
@@ -186,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    fn mode_defaults_to_full_when_unset() {
+    fn mode_defaults_to_dynamo_when_unset() {
         assert_eq!(parse_mode(&[]).unwrap(), EppMode::DynamoRuntime);
     }
 
@@ -197,7 +207,7 @@ mod tests {
             EppMode::Standalone
         );
         assert_eq!(
-            parse_mode(&[("DYN_EPP_MODE", "full-dynamo-stack")]).unwrap(),
+            parse_mode(&[(DYN_EPP_MODE, DYNAMO_RUNTIME_MODE)]).unwrap(),
             EppMode::DynamoRuntime
         );
     }
@@ -220,8 +230,8 @@ mod tests {
         assert_eq!(cfg.selector_threads, DEFAULT_SELECTOR_THREADS);
         // No peer service => single-replica (replica sync off).
         assert!(cfg.peer_service.is_none());
-        assert_eq!(cfg.peer_sync_port, DEFAULT_PEER_SYNC_PORT);
-        assert_eq!(cfg.pool_name, "vllm-qwen-pool");
+        assert!(cfg.peer_sync_port.is_none());
+        assert_eq!(cfg.inference_pool_name, "vllm-qwen-pool");
         assert_eq!(cfg.namespace, "inference");
         assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
         assert_eq!(cfg.block_size, 16);
@@ -258,13 +268,27 @@ mod tests {
         ])
         .expect("replication config should parse");
         assert_eq!(cfg.peer_service.as_deref(), Some("dynamo-epp"));
-        assert_eq!(cfg.peer_sync_port, 9191);
+        assert_eq!(cfg.peer_sync_port, Some(9191));
         assert_eq!(cfg.selector_threads, 8);
         assert_eq!(cfg.namespace, "inference");
     }
 
     #[test]
-    fn missing_pool_name_fails() {
+    fn peer_service_requires_sync_port() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn missing_inference_pool_name_fails() {
         assert!(
             parse_cfg(&[
                 ("POD_NAMESPACE", "inference"),

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -105,7 +105,7 @@ impl EppStandaloneConfig {
 
     fn parse(get: &EnvGet) -> anyhow::Result<Self> {
         Ok(Self {
-            selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTOR_THREADS")?
+            selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTION_INDEXER_THREADS")?
                 .unwrap_or(DEFAULT_SELECTOR_THREADS),
             peer_service: trimmed(get("DYN_EPP_PEER_SERVICE")),
             peer_sync_port: opt_parse::<u16>(get, "DYN_EPP_PEER_SYNC_PORT")?,
@@ -118,8 +118,8 @@ impl EppStandaloneConfig {
             replay_port: opt_parse::<u16>(get, "DYN_EPP_REPLAY_PORT")?,
             data_parallel_size: opt_parse::<u32>(get, "DYN_DATA_PARALLEL_SIZE")?
                 .unwrap_or(DEFAULT_DATA_PARALLEL_SIZE),
-            total_kv_blocks: opt_parse::<u64>(get, "DYN_TOTAL_KV_BLOCKS")?,
-            max_num_batched_tokens: opt_parse::<u64>(get, "DYN_MAX_NUM_BATCHED_TOKENS")?,
+            total_kv_blocks: opt_parse::<u64>(get, "DYN_EPP_TOTAL_KV_BLOCKS")?,
+            max_num_batched_tokens: opt_parse::<u64>(get, "DYN_EPP_MAX_NUM_BATCHED_TOKENS")?,
         })
     }
 
@@ -258,7 +258,7 @@ mod tests {
         let cfg = parse_cfg(&[
             ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
             ("DYN_EPP_PEER_SYNC_PORT", "9191"),
-            ("DYN_EPP_SELECTOR_THREADS", "8"),
+            ("DYN_EPP_SELECTION_INDEXER_THREADS", "8"),
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -11,10 +11,8 @@
 //! [`EppStandaloneConfig::validate_config`] for field and cross-field checks.
 
 use validator::Validate;
-use validator::ValidationError;
 
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
-const DEFAULT_DATA_PARALLEL_SIZE: u32 = 1;
 const DEFAULT_SELECTOR_THREADS: usize = 4;
 
 /// Environment variable that selects the EPP operating mode.
@@ -55,27 +53,20 @@ impl EppMode {
 }
 
 #[derive(Debug, Clone, Validate)]
-#[validate(schema(
-    function = "validate_epp_standalone_config",
-    skip_on_field_errors = true
-))]
 pub struct EppStandaloneConfig {
     /// KV indexer thread-pool size for the in-process selector.
     #[validate(range(min = 1))]
     pub selector_threads: usize,
-    /// EPP Service for peer discovery and state synchronization.
-    /// `None` means single-replica with cross-replica sync disabled.
+    /// EPP Service for peer discovery and state synchronization. The eventual
+    /// selector resolves its named `replica-agg` port from EndpointSlices.
     pub peer_service: Option<String>,
-    /// Peer replication sync port. Required when `peer_service` is set.
-    #[validate(range(min = 1))]
-    pub peer_sync_port: Option<u16>,
     /// `InferencePool` this EPP backs; its selector + target port drive discovery.
     #[validate(length(min = 1, message = "DYN_EPP_INFERENCE_POOL_NAME is required"))]
     pub inference_pool_name: String,
     /// Kubernetes namespace the EPP runs in (from `POD_NAMESPACE`, downward API).
     #[validate(length(min = 1, message = "POD_NAMESPACE is required"))]
     pub namespace: String,
-    /// Model id used to build the offline tokenizer and register with the selector.
+    /// Served/catalog model identity used to group discovered workers.
     #[validate(length(min = 1, message = "DYN_MODEL_NAME is required"))]
     pub model_name: String,
     /// KV-cache block size; MUST equal the inference engine block size.
@@ -84,14 +75,20 @@ pub struct EppStandaloneConfig {
     /// KV zmq event port.
     #[validate(range(min = 1))]
     pub kv_event_port: u16,
-    /// Optional zmq port the selector uses for live-stream gap replay.
+    /// Optional ZMQ port the selector uses for live-stream gap replay. This
+    /// must match the worker's explicitly configured replay endpoint.
+    #[validate(range(
+        min = 1,
+        message = "DYN_EPP_KV_EVENT_REPLAY_PORT must be greater than zero when set"
+    ))]
     pub replay_port: Option<u16>,
-    /// Engine data-parallel size. Currently only support DP=1.
-    #[validate(range(min = 1, max = 1))]
-    pub data_parallel_size: u32,
     /// Optional per-worker total KV blocks.
     pub total_kv_blocks: Option<u64>,
-    /// Optional per-worker max batched tokens (required when queuing or policy config is used).
+    /// Optional per-worker max batched tokens.
+    #[validate(range(
+        min = 1,
+        message = "DYN_EPP_MAX_NUM_BATCHED_TOKENS must be greater than zero when set"
+    ))]
     pub max_num_batched_tokens: Option<u64>,
 }
 
@@ -108,16 +105,13 @@ impl EppStandaloneConfig {
             selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTION_INDEXER_THREADS")?
                 .unwrap_or(DEFAULT_SELECTOR_THREADS),
             peer_service: trimmed(get("DYN_EPP_PEER_SERVICE")),
-            peer_sync_port: opt_parse::<u16>(get, "DYN_EPP_PEER_SYNC_PORT")?,
             inference_pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
             namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
             model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
             block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
             kv_event_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?
                 .unwrap_or(DEFAULT_KV_EVENT_PORT),
-            replay_port: opt_parse::<u16>(get, "DYN_EPP_REPLAY_PORT")?,
-            data_parallel_size: opt_parse::<u32>(get, "DYN_DATA_PARALLEL_SIZE")?
-                .unwrap_or(DEFAULT_DATA_PARALLEL_SIZE),
+            replay_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_REPLAY_PORT")?,
             total_kv_blocks: opt_parse::<u64>(get, "DYN_EPP_TOTAL_KV_BLOCKS")?,
             max_num_batched_tokens: opt_parse::<u64>(get, "DYN_EPP_MAX_NUM_BATCHED_TOKENS")?,
         })
@@ -128,17 +122,6 @@ impl EppStandaloneConfig {
         self.validate()
             .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))
     }
-}
-
-fn validate_epp_standalone_config(config: &EppStandaloneConfig) -> Result<(), ValidationError> {
-    if config.peer_service.is_some() && config.peer_sync_port.is_none() {
-        let mut error = ValidationError::new("peer_sync_port_required");
-        error.message =
-            Some("DYN_EPP_PEER_SYNC_PORT is required when DYN_EPP_PEER_SERVICE is set".into());
-        return Err(error);
-    }
-
-    Ok(())
 }
 
 /// Trim a raw value and treat empty as absent.
@@ -228,13 +211,11 @@ mod tests {
         assert_eq!(cfg.selector_threads, DEFAULT_SELECTOR_THREADS);
         // No peer service => single-replica (replica sync off).
         assert!(cfg.peer_service.is_none());
-        assert!(cfg.peer_sync_port.is_none());
         assert_eq!(cfg.inference_pool_name, "vllm-qwen-pool");
         assert_eq!(cfg.namespace, "inference");
         assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
         assert_eq!(cfg.block_size, 16);
         assert_eq!(cfg.kv_event_port, DEFAULT_KV_EVENT_PORT);
-        assert_eq!(cfg.data_parallel_size, 1);
         assert!(cfg.replay_port.is_none());
         assert!(cfg.total_kv_blocks.is_none());
     }
@@ -254,35 +235,19 @@ mod tests {
     }
 
     #[test]
-    fn replication_config_parsed() {
+    fn peer_service_config_parsed() {
         let cfg = parse_cfg(&[
             ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
-            ("DYN_EPP_PEER_SYNC_PORT", "9191"),
             ("DYN_EPP_SELECTION_INDEXER_THREADS", "8"),
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
         ])
-        .expect("replication config should parse");
+        .expect("peer service config should parse");
         assert_eq!(cfg.peer_service.as_deref(), Some("dynamo-epp"));
-        assert_eq!(cfg.peer_sync_port, Some(9191));
         assert_eq!(cfg.selector_threads, 8);
         assert_eq!(cfg.namespace, "inference");
-    }
-
-    #[test]
-    fn peer_service_requires_sync_port() {
-        assert!(
-            parse_cfg(&[
-                ("DYN_EPP_PEER_SERVICE", "dynamo-epp"),
-                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
-                ("POD_NAMESPACE", "inference"),
-                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
-            ])
-            .is_err()
-        );
     }
 
     #[test]
@@ -311,21 +276,43 @@ mod tests {
     }
 
     #[test]
-    fn data_parallel_size_must_be_one() {
-        // Data parallelism is not supported in this release: only DP=1 is valid.
-        let base = [
+    fn replay_port_is_optional_and_uses_the_kv_event_name() {
+        let cfg = parse_cfg(&[
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
-        ];
-        let with_dp = |dp: &str| {
-            let mut pairs = base.to_vec();
-            pairs.push(("DYN_DATA_PARALLEL_SIZE", dp));
-            parse_cfg(&pairs)
-        };
-        assert!(with_dp("0").is_err());
-        assert!(with_dp("2").is_err());
-        assert_eq!(with_dp("1").unwrap().data_parallel_size, 1);
+            ("DYN_EPP_KV_EVENT_REPLAY_PORT", "5558"),
+        ])
+        .unwrap();
+        assert_eq!(cfg.replay_port, Some(5558));
+    }
+
+    #[test]
+    fn zero_replay_port_fails() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+                ("DYN_EPP_KV_EVENT_REPLAY_PORT", "0"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn zero_max_num_batched_tokens_fails() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+                ("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "0"),
+            ])
+            .is_err()
+        );
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -34,7 +34,6 @@ pub enum EppMode {
     // to be connected to the runtime. (default)
     DynamoRuntime,
     // No runtime connection. Constructs a ServiceSelector for tracking workers, kv state and selecting best worker.
-    // Workers can be raw vllm serve pods or other OpenAI-compatible backends.
     Standalone,
 }
 
@@ -85,8 +84,6 @@ pub struct EppStandaloneConfig {
     /// KV zmq event port.
     #[validate(range(min = 1))]
     pub kv_event_port: u16,
-    /// KV zmq event topic.
-    pub kv_event_topic: String,
     /// Optional zmq port the selector uses for live-stream gap replay.
     pub replay_port: Option<u16>,
     /// Engine data-parallel size. Currently only support DP=1.
@@ -118,7 +115,6 @@ impl EppStandaloneConfig {
             block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
             kv_event_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?
                 .unwrap_or(DEFAULT_KV_EVENT_PORT),
-            kv_event_topic: trimmed(get("DYN_EPP_KV_EVENT_TOPIC")).unwrap_or_default(),
             replay_port: opt_parse::<u16>(get, "DYN_EPP_REPLAY_PORT")?,
             data_parallel_size: opt_parse::<u32>(get, "DYN_DATA_PARALLEL_SIZE")?
                 .unwrap_or(DEFAULT_DATA_PARALLEL_SIZE),

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -179,8 +179,10 @@ mod tests {
     /// Build an injectable env getter from key/value pairs — no process-global
     /// env mutation, so these tests are isolated and parallel-safe.
     fn getter(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
-        let map: HashMap<String, String> =
-            pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
         move |k| map.get(k).cloned()
     }
 

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -14,12 +14,12 @@
 
 pub mod envoy_helpers;
 pub mod epp;
-pub mod epp_config;
+pub mod epp_standalone_config;
 pub mod picker;
 pub mod proto;
 pub mod server;
 
 pub use epp::Router;
-pub use epp_config::{EppStandaloneConfig, EppMode};
+pub use epp_standalone_config::{EppStandaloneConfig, EppMode};
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -20,6 +20,6 @@ pub mod proto;
 pub mod server;
 
 pub use epp::Router;
-pub use epp_standalone_config::{EppStandaloneConfig, EppMode};
+pub use epp_standalone_config::{EppMode, EppStandaloneConfig};
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -14,10 +14,12 @@
 
 pub mod envoy_helpers;
 pub mod epp;
+pub mod epp_config;
 pub mod picker;
 pub mod proto;
 pub mod server;
 
 pub use epp::Router;
+pub use epp_config::{EppConfig, EppMode};
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -20,6 +20,6 @@ pub mod proto;
 pub mod server;
 
 pub use epp::Router;
-pub use epp_config::{EppConfig, EppMode};
+pub use epp_config::{EppStandaloneConfig, EppMode};
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/main.rs
+++ b/deploy/inference-gateway/ext-proc/src/main.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_ext_proc::{EppStandaloneConfig, EppMode, ExtProcServer, Router};
+use dynamo_ext_proc::{EppMode, EppStandaloneConfig, ExtProcServer, Router};
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 
@@ -145,9 +145,7 @@ async fn main() -> Result<()> {
             block_size = selector_cfg.block_size,
             "Parsed standalone selector configuration"
         );
-        anyhow::bail!(
-            "DYN_EPP_MODE=standalone is not yet supported"
-        );
+        anyhow::bail!("DYN_EPP_MODE=standalone is not yet supported");
     }
 
     // Start plaintext gRPC health server immediately (NOT_SERVING until router ready).

--- a/deploy/inference-gateway/ext-proc/src/main.rs
+++ b/deploy/inference-gateway/ext-proc/src/main.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_ext_proc::{EppConfig, EppMode, ExtProcServer, Router};
+use dynamo_ext_proc::{EppStandaloneConfig, EppMode, ExtProcServer, Router};
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 
@@ -123,7 +123,6 @@ async fn main() -> Result<()> {
         )
         .init();
 
-    // Fail fast on an unknown DYN_EPP_MODE rather than silently booting full mode.
     let standalone = matches!(EppMode::from_env()?, EppMode::Standalone);
 
     let config = Config::from_env();
@@ -137,12 +136,9 @@ async fn main() -> Result<()> {
         "Starting Dynamo Rust EPP"
     );
 
-    // Standalone (selector) mode fronts raw vLLM pods with no Dynamo runtime and
-    // delegates KV-aware selection to the standalone selection service. The
-    // config surface is validated here; the runtime wiring lands in a follow-up
-    // (see crate::selector_router).
+    // Standalone (selector) mode to be supported in a follow-up PR.
     if standalone {
-        let selector_cfg = EppConfig::from_env()?;
+        let selector_cfg = EppStandaloneConfig::from_env()?;
         tracing::info!(
             pool_name = %selector_cfg.pool_name,
             model_name = %selector_cfg.model_name,
@@ -150,8 +146,7 @@ async fn main() -> Result<()> {
             "Parsed standalone selector configuration"
         );
         anyhow::bail!(
-            "DYN_EPP_MODE=standalone is not yet wired; selector runtime assembly lands in a \
-             follow-up change"
+            "DYN_EPP_MODE=standalone is not yet supported"
         );
     }
 

--- a/deploy/inference-gateway/ext-proc/src/main.rs
+++ b/deploy/inference-gateway/ext-proc/src/main.rs
@@ -140,7 +140,7 @@ async fn main() -> Result<()> {
     if standalone {
         let selector_cfg = EppStandaloneConfig::from_env()?;
         tracing::info!(
-            pool_name = %selector_cfg.pool_name,
+            inference_pool_name = %selector_cfg.inference_pool_name,
             model_name = %selector_cfg.model_name,
             block_size = selector_cfg.block_size,
             "Parsed standalone selector configuration"

--- a/deploy/inference-gateway/ext-proc/src/main.rs
+++ b/deploy/inference-gateway/ext-proc/src/main.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_ext_proc::{ExtProcServer, Router};
+use dynamo_ext_proc::{EppConfig, EppMode, ExtProcServer, Router};
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 
@@ -123,6 +123,9 @@ async fn main() -> Result<()> {
         )
         .init();
 
+    // Fail fast on an unknown DYN_EPP_MODE rather than silently booting full mode.
+    let standalone = matches!(EppMode::from_env()?, EppMode::Standalone);
+
     let config = Config::from_env();
 
     tracing::info!(
@@ -130,8 +133,27 @@ async fn main() -> Result<()> {
         health_port = HEALTH_PORT,
         namespace = %config.namespace,
         component = %config.component,
+        standalone,
         "Starting Dynamo Rust EPP"
     );
+
+    // Standalone (selector) mode fronts raw vLLM pods with no Dynamo runtime and
+    // delegates KV-aware selection to the standalone selection service. The
+    // config surface is validated here; the runtime wiring lands in a follow-up
+    // (see crate::selector_router).
+    if standalone {
+        let selector_cfg = EppConfig::from_env()?;
+        tracing::info!(
+            pool_name = %selector_cfg.pool_name,
+            model_name = %selector_cfg.model_name,
+            block_size = selector_cfg.block_size,
+            "Parsed standalone selector configuration"
+        );
+        anyhow::bail!(
+            "DYN_EPP_MODE=standalone is not yet wired; selector runtime assembly lands in a \
+             follow-up change"
+        );
+    }
 
     // Start plaintext gRPC health server immediately (NOT_SERVING until router ready).
     let (health_reporter, health_service) = tonic_health::server::health_reporter();


### PR DESCRIPTION
## Summary

This PR adds the first configuration-only slice of standalone EPP mode.

- Adds `DYN_EPP_MODE`: `dynamo` remains the default existing runtime-backed mode; `standalone` selects the future selector-only path.
- Adds `EppStandaloneConfig` to parse and validate the standalone environment contract.
- Treats `DYN_MODEL_NAME` as the served/catalog identity used to group discovered workers, not as an offline-tokenizer input.
- Fails fast in standalone mode after parsing and logging the validated config. It does not yet construct a selector, discover workers, or route requests.
- Leaves the existing Dynamo-runtime EPP path unchanged.

## Details

### Standalone configuration

`DYN_EPP_MODE=standalone` requires:

- `DYN_EPP_INFERENCE_POOL_NAME`: the `InferencePool` this EPP backs.
- `POD_NAMESPACE`: namespace supplied through the downward API.
- `DYN_MODEL_NAME`: served/catalog model identity.
- `DYN_KV_CACHE_BLOCK_SIZE`: positive KV-cache block size that must match the inference engine.

Optional settings:

- `DYN_EPP_SELECTION_INDEXER_THREADS`: positive selector indexer thread count; defaults to `4`.
- `DYN_EPP_PEER_SERVICE`: peer Service identity. Future selector wiring resolves its named `replica-agg` port from EndpointSlices; this PR does not configure a replication port.
- `DYN_EPP_KV_EVENT_PORT`: positive KV-event ZMQ port; defaults to `5557`.
- `DYN_EPP_KV_EVENT_REPLAY_PORT`: optional replay endpoint port; unset by default and must match the worker endpoint when provided.
- `DYN_EPP_TOTAL_KV_BLOCKS`: optional per-worker total KV-block count.
- `DYN_EPP_MAX_NUM_BATCHED_TOKENS`: optional per-worker batching limit; when set, it must be greater than zero.

There is no `DYN_DATA_PARALLEL_SIZE` or `DYN_EPP_PEER_SYNC_PORT` configuration in this milestone.

### Scope boundary

This milestone only establishes the mode switch and validates the configuration contract. Standalone startup intentionally exits with `DYN_EPP_MODE=standalone is not yet supported` after parsing the config. Offline tokenization, Kubernetes discovery, EndpointSlice port resolution, selector construction, KV-router-policy validation, replication, and request routing remain follow-on work.

## Where should the reviewer start?

- `deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs`
- `deploy/inference-gateway/ext-proc/src/main.rs`

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-ext-proc epp_standalone_config`

## Related

- [Linear Project](https://linear.app/nvidia/project/dynamo-standalone-router-and-raw-workers-bc6d4f9a81ca/overview)
