### PR TITLE
feat: PR 3 Worker Pod Discovery for the EPP and standalone Selector Router Integration

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/inference_pool.rs
+++ b/deploy/inference-gateway/ext-proc/src/inference_pool.rs
@@ -1,20 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Read-only watcher for the GAIE `InferencePool` this EPP backs.
+//! Read-only watcher for the GAIE `inference.networking.k8s.io/v1` `InferencePool`
+//! (not `v1alpha2`).
 //!
-//! In standalone mode the `InferencePool` is the single source of truth for
-//! which pods are candidate backends: the gateway routes to it, and the EPP
-//! reads its `spec.selector` and target port to discover the same pods. This
-//! watcher only ever *reads* the pool — it never writes status or manages the
-//! object, so it coexists with the gateway provider's controller (which owns the
-//! pool lifecycle) without conflict.
+//! Returns a [`PoolState`] containing the pool's `match_labels` and `target_port`.
 //!
-//! The pool is watched as a dynamic object (no compiled CRD type), but the
-//! contract is explicitly `inference.networking.k8s.io/v1`: the selector is read
-//! from `spec.selector.matchLabels` and the target port from
-//! `spec.targetPorts[].number`. Legacy `v1alpha2` pools use a different GVK and a
-//! flat `spec.selector` map, so they never reach this watch or parser.
+//! Currently supports only pools with at least one match label and exactly one
+//! target port. Additional configurations may be supported in the future, for
+//! example to enable data-parallel-aware routing.
 
 use std::collections::BTreeMap;
 
@@ -31,9 +25,9 @@ const INFERENCE_POOL_KIND: &str = "InferencePool";
 /// The slice of `InferencePool` spec the EPP needs to discover pods.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PoolState {
-    /// `spec.selector.matchLabels` — the pod label selector (equality only).
+    /// The pod label selector from InferencePool spec
     pub match_labels: BTreeMap<String, String>,
-    /// The OpenAI HTTP target port resolved from the pool.
+    /// The OpenAI HTTP target port resolved from the pool
     pub target_port: u16,
 }
 
@@ -91,28 +85,22 @@ pub async fn spawn_pool_watch(
 }
 
 /// Derive the [`PoolState`] from the observed pool object and publish it **only
-/// when it changes**. Absence or an unparseable spec both publish `None`, so a
-/// deleted or malformed pool always clears stale discovery state.
-///
-/// The `InferencePool` also receives status- and metadata-only updates
-/// (conditions, `resourceVersion`, `managedFields`) plus re-delivery on every
-/// watch relist, none of which touch `spec.selector` or the target port.
-/// `PodDiscovery` treats every `pool_rx` change as a full O(pods) rebuild, so
-/// `send_if_modified` suppresses those no-op wakes — discovery is disturbed only
-/// on a real presence, selector, or target-port change.
+/// when it changes**. Non-existent or invalid spec both publish `None`, so a
+/// deleted or invalid pool always clears stale discovery state.
 fn publish_pool_state(
     obj: Option<DynamicObject>,
     name: &str,
     tx: &watch::Sender<Option<PoolState>>,
 ) {
     let (state, clear_reason) = match &obj {
-        None => (None, Some("absent".to_string())),
+        None => (None, Some("does not exist".to_string())),
         Some(o) => match parse_pool_state(&o.data) {
             Ok(s) => (Some(s), None),
             Err(reason) => (None, Some(reason)),
         },
     };
 
+    // Only send a notification if the match labels or target port has changed.
     tx.send_if_modified(|current| {
         if *current == state {
             return false;
@@ -127,7 +115,7 @@ fn publish_pool_state(
             None => tracing::warn!(
                 pool = %name,
                 reason = clear_reason.as_deref().unwrap_or("unknown"),
-                "InferencePool unusable; clearing discovery state"
+                "InferencePool is invalid, clearing discovery state"
             ),
         }
         *current = state;
@@ -135,8 +123,7 @@ fn publish_pool_state(
     });
 }
 
-/// Extract a [`PoolState`] from an `InferencePool` `spec`, or a message naming
-/// why it is unusable. Pure function — unit-testable without a cluster.
+/// Extract a [`PoolState`] from an `InferencePool` `spec`, or a message naming why it is invalid.
 fn parse_pool_state(data: &serde_json::Value) -> std::result::Result<PoolState, String> {
     let spec = data
         .get("spec")
@@ -151,18 +138,13 @@ fn parse_pool_state(data: &serde_json::Value) -> std::result::Result<PoolState, 
         .iter()
         .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
         .collect();
-    // An empty selector would match every pod in the namespace; refuse it.
+
     if match_labels.is_empty() {
         return Err(
-            "spec.selector.matchLabels is empty (would select every pod in the namespace)"
-                .to_string(),
+            "spec.selector.matchLabels is empty, needs at least one match label".to_string(),
         );
     }
 
-    // v1 `spec.targetPorts[].number`; exactly one is required. Multi-port pools
-    // (e.g. for DP-aware routing) aren't in scope yet: a worker is keyed by
-    // `hash_pod_name` → a single endpoint, so multiple ports would collide.
-    // Reject rather than silently pick the first.
     let target_ports = spec
         .get("targetPorts")
         .and_then(|tp| tp.as_array())

--- a/deploy/inference-gateway/ext-proc/src/inference_pool.rs
+++ b/deploy/inference-gateway/ext-proc/src/inference_pool.rs
@@ -309,7 +309,7 @@ mod tests {
         });
         assert_eq!(
             parse_pool_state(&data).unwrap_err(),
-            "spec.selector.matchLabels is empty (would select every pod in the namespace)"
+            "spec.selector.matchLabels is empty, needs at least one match label"
         );
     }
 

--- a/deploy/inference-gateway/ext-proc/src/inference_pool.rs
+++ b/deploy/inference-gateway/ext-proc/src/inference_pool.rs
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Read-only watcher for the GAIE `InferencePool` this EPP backs.
+//!
+//! In standalone mode the `InferencePool` is the single source of truth for
+//! which pods are candidate backends: the gateway routes to it, and the EPP
+//! reads its `spec.selector` and target port to discover the same pods. This
+//! watcher only ever *reads* the pool — it never writes status or manages the
+//! object, so it coexists with the gateway provider's controller (which owns the
+//! pool lifecycle) without conflict.
+//!
+//! The pool is watched as a dynamic object (no compiled CRD type), but the
+//! contract is explicitly `inference.networking.k8s.io/v1`: the selector is read
+//! from `spec.selector.matchLabels` and the target port from
+//! `spec.targetPorts[].number`. Legacy `v1alpha2` pools use a different GVK and a
+//! flat `spec.selector` map, so they never reach this watch or parser.
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use kube::core::{ApiResource, DynamicObject, GroupVersionKind};
+use kube::runtime::{WatchStreamExt, watcher};
+use kube::{Api, Client};
+use tokio::sync::watch;
+
+const INFERENCE_POOL_GROUP: &str = "inference.networking.k8s.io";
+const INFERENCE_POOL_VERSION: &str = "v1";
+const INFERENCE_POOL_KIND: &str = "InferencePool";
+
+/// The slice of `InferencePool` spec the EPP needs to discover pods.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PoolState {
+    /// `spec.selector.matchLabels` — the pod label selector (equality only).
+    pub match_labels: BTreeMap<String, String>,
+    /// The OpenAI HTTP target port resolved from the pool.
+    pub target_port: u16,
+}
+
+/// Start a background watch of the named `InferencePool`. The returned receiver
+/// carries the latest [`PoolState`] (or `None` until the pool is first observed,
+/// or after it is deleted).
+pub async fn spawn_pool_watch(
+    client: Client,
+    namespace: String,
+    name: String,
+) -> Result<(
+    watch::Receiver<Option<PoolState>>,
+    tokio::task::JoinHandle<()>,
+)> {
+    let gvk = GroupVersionKind::gvk(
+        INFERENCE_POOL_GROUP,
+        INFERENCE_POOL_VERSION,
+        INFERENCE_POOL_KIND,
+    );
+    let ar = ApiResource::from_gvk(&gvk);
+    let api: Api<DynamicObject> = Api::namespaced_with(client, &namespace, &ar);
+
+    let (tx, rx) = watch::channel::<Option<PoolState>>(None);
+
+    tracing::info!(
+        namespace = %namespace,
+        pool = %name,
+        "Starting InferencePool watch (read-only) for standalone discovery"
+    );
+
+    let handle = tokio::spawn(async move {
+        use futures::StreamExt;
+        // `watch_object` tracks a single named object and yields its current
+        // state as `Option`: `Some` while it exists, `None` once it is gone.
+        // Crucially, deletions that happen while the watch is disconnected are
+        // reported via `None` on the next relist (not a `Delete` event), so
+        // stale `PoolState` can never survive a reconnect.
+        let stream = watcher::watch_object(api, &name).default_backoff();
+        tokio::pin!(stream);
+        loop {
+            match stream.next().await {
+                Some(Ok(obj)) => publish_pool_state(obj, &name, &tx),
+                Some(Err(e)) => {
+                    tracing::warn!(error = %e, pool = %name, "InferencePool watch error; retrying");
+                }
+                None => {
+                    tracing::warn!(pool = %name, "InferencePool watch stream ended");
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok((rx, handle))
+}
+
+/// Publish the latest [`PoolState`] derived from the observed pool object.
+/// Sends `None` when the pool is absent or its spec cannot be parsed, so a
+/// deleted or malformed pool always clears stale discovery state.
+fn publish_pool_state(
+    obj: Option<DynamicObject>,
+    name: &str,
+    tx: &watch::Sender<Option<PoolState>>,
+) {
+    let state = match &obj {
+        None => {
+            tracing::warn!(pool = %name, "InferencePool absent; clearing discovery state");
+            None
+        }
+        Some(o) => match parse_pool_state(&o.data) {
+            Ok(s) => {
+                tracing::info!(
+                    pool = %name,
+                    target_port = s.target_port,
+                    labels = ?s.match_labels,
+                    "InferencePool resolved"
+                );
+                Some(s)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    pool = %name,
+                    reason = %e,
+                    "InferencePool present but unsupported; clearing discovery state"
+                );
+                None
+            }
+        },
+    };
+    let _ = tx.send(state);
+}
+
+/// Why an observed `InferencePool` spec can't be used for discovery. Each
+/// variant names a specific rejection so the watcher can log *why* the pool was
+/// cleared instead of one catch-all warning.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+enum PoolSpecError {
+    #[error("spec is missing")]
+    MissingSpec,
+    #[error("spec.selector.matchLabels is missing or not a string map")]
+    MissingSelector,
+    #[error("spec.selector.matchLabels is empty (would select every pod in the namespace)")]
+    EmptySelector,
+    #[error("spec.targetPorts is missing or not an array")]
+    MissingTargetPorts,
+    #[error("expected exactly one targetPort, found {found}")]
+    NotExactlyOneTargetPort { found: usize },
+    #[error("targetPorts[0].number is missing or not an integer")]
+    MissingTargetPortNumber,
+    #[error("targetPort {0} is outside the valid 1-65535 range")]
+    TargetPortOutOfRange(u64),
+}
+
+/// Extract a [`PoolState`] from an `InferencePool` `spec`, or a [`PoolSpecError`]
+/// naming why it is unusable. Pure function — unit-testable without a cluster.
+fn parse_pool_state(data: &serde_json::Value) -> Result<PoolState, PoolSpecError> {
+    let spec = data.get("spec").ok_or(PoolSpecError::MissingSpec)?;
+
+    let labels_obj = spec
+        .get("selector")
+        .and_then(|s| s.get("matchLabels"))
+        .and_then(|m| m.as_object())
+        .ok_or(PoolSpecError::MissingSelector)?;
+    let match_labels: BTreeMap<String, String> = labels_obj
+        .iter()
+        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+        .collect();
+    // An empty selector would match every pod in the namespace; refuse it.
+    if match_labels.is_empty() {
+        return Err(PoolSpecError::EmptySelector);
+    }
+
+    // v1 `spec.targetPorts[].number`; exactly one is required. Multi-port pools
+    // (e.g. for DP-aware routing) aren't in scope yet: a worker is keyed by
+    // `hash_pod_name` → a single endpoint, so multiple ports would collide.
+    // Reject rather than silently pick the first.
+    let target_ports = spec
+        .get("targetPorts")
+        .and_then(|tp| tp.as_array())
+        .ok_or(PoolSpecError::MissingTargetPorts)?;
+    if target_ports.len() != 1 {
+        return Err(PoolSpecError::NotExactlyOneTargetPort {
+            found: target_ports.len(),
+        });
+    }
+    let target_port_u64 = target_ports[0]
+        .get("number")
+        .and_then(|n| n.as_u64())
+        .ok_or(PoolSpecError::MissingTargetPortNumber)?;
+    let target_port = match u16::try_from(target_port_u64) {
+        Ok(p) if p != 0 => p,
+        _ => return Err(PoolSpecError::TargetPortOutOfRange(target_port_u64)),
+    };
+
+    Ok(PoolState {
+        match_labels,
+        target_port,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_v1_target_ports() {
+        let data = json!({
+            "spec": {
+                "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                "targetPorts": [{"number": 8000}]
+            }
+        });
+        let s = parse_pool_state(&data).expect("v1 pool should parse");
+        assert_eq!(s.target_port, 8000);
+        assert_eq!(s.match_labels.get("app").unwrap(), "vllm-qwen");
+    }
+
+    #[test]
+    fn parses_multiple_match_labels() {
+        let data = json!({
+            "spec": {
+                "selector": {"matchLabels": {"app": "vllm-qwen", "role": "decode"}},
+                "targetPorts": [{"number": 8000}]
+            }
+        });
+        let s = parse_pool_state(&data).expect("v1 pool should parse");
+        assert_eq!(s.target_port, 8000);
+        assert_eq!(s.match_labels.len(), 2);
+    }
+
+    #[test]
+    fn missing_spec_is_rejected() {
+        assert_eq!(
+            parse_pool_state(&json!({})),
+            Err(PoolSpecError::MissingSpec)
+        );
+    }
+
+    #[test]
+    fn v1alpha2_target_port_number_is_rejected() {
+        // Legacy `spec.targetPortNumber` is not part of the v1 contract.
+        let data = json!({
+            "spec": {
+                "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                "targetPortNumber": 8000
+            }
+        });
+        assert_eq!(
+            parse_pool_state(&data),
+            Err(PoolSpecError::MissingTargetPorts)
+        );
+    }
+
+    #[test]
+    fn empty_selector_is_rejected() {
+        let data = json!({
+            "spec": {"selector": {"matchLabels": {}}, "targetPorts": [{"number": 8000}]}
+        });
+        assert_eq!(parse_pool_state(&data), Err(PoolSpecError::EmptySelector));
+    }
+
+    #[test]
+    fn missing_selector_is_rejected() {
+        let data = json!({
+            "spec": {"targetPorts": [{"number": 8000}]}
+        });
+        assert_eq!(parse_pool_state(&data), Err(PoolSpecError::MissingSelector));
+    }
+
+    #[test]
+    fn missing_target_port_is_rejected() {
+        let data = json!({
+            "spec": {"selector": {"matchLabels": {"app": "x"}}}
+        });
+        assert_eq!(
+            parse_pool_state(&data),
+            Err(PoolSpecError::MissingTargetPorts)
+        );
+    }
+
+    #[test]
+    fn multi_port_pool_is_rejected() {
+        // Workers are keyed by hash(pod_name), so a pod maps to one endpoint;
+        // multi-port pools (DP-aware routing) aren't in scope yet.
+        let data = json!({
+            "spec": {
+                "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                "targetPorts": [{"number": 8000}, {"number": 8001}]
+            }
+        });
+        assert_eq!(
+            parse_pool_state(&data),
+            Err(PoolSpecError::NotExactlyOneTargetPort { found: 2 })
+        );
+    }
+
+    #[test]
+    fn empty_target_ports_is_rejected() {
+        let data = json!({
+            "spec": {
+                "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                "targetPorts": []
+            }
+        });
+        assert_eq!(
+            parse_pool_state(&data),
+            Err(PoolSpecError::NotExactlyOneTargetPort { found: 0 })
+        );
+    }
+
+    #[test]
+    fn missing_target_port_number_is_rejected() {
+        let data = json!({
+            "spec": {
+                "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                "targetPorts": [{"protocol": "TCP"}]
+            }
+        });
+        assert_eq!(
+            parse_pool_state(&data),
+            Err(PoolSpecError::MissingTargetPortNumber)
+        );
+    }
+
+    #[test]
+    fn out_of_range_or_zero_target_port_is_rejected() {
+        for port in [0u64, 70_000u64] {
+            let data = json!({
+                "spec": {
+                    "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                    "targetPorts": [{"number": port}]
+                }
+            });
+            assert_eq!(
+                parse_pool_state(&data),
+                Err(PoolSpecError::TargetPortOutOfRange(port))
+            );
+        }
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/inference_pool.rs
+++ b/deploy/inference-gateway/ext-proc/src/inference_pool.rs
@@ -90,40 +90,49 @@ pub async fn spawn_pool_watch(
     Ok((rx, handle))
 }
 
-/// Publish the latest [`PoolState`] derived from the observed pool object.
-/// Sends `None` when the pool is absent or its spec cannot be parsed, so a
+/// Derive the [`PoolState`] from the observed pool object and publish it **only
+/// when it changes**. Absence or an unparseable spec both publish `None`, so a
 /// deleted or malformed pool always clears stale discovery state.
+///
+/// The `InferencePool` also receives status- and metadata-only updates
+/// (conditions, `resourceVersion`, `managedFields`) plus re-delivery on every
+/// watch relist, none of which touch `spec.selector` or the target port.
+/// `PodDiscovery` treats every `pool_rx` change as a full O(pods) rebuild, so
+/// `send_if_modified` suppresses those no-op wakes — discovery is disturbed only
+/// on a real presence, selector, or target-port change.
 fn publish_pool_state(
     obj: Option<DynamicObject>,
     name: &str,
     tx: &watch::Sender<Option<PoolState>>,
 ) {
-    let state = match &obj {
-        None => {
-            tracing::warn!(pool = %name, "InferencePool absent; clearing discovery state");
-            None
-        }
+    let (state, clear_reason) = match &obj {
+        None => (None, Some("absent".to_string())),
         Some(o) => match parse_pool_state(&o.data) {
-            Ok(s) => {
-                tracing::info!(
-                    pool = %name,
-                    target_port = s.target_port,
-                    labels = ?s.match_labels,
-                    "InferencePool resolved"
-                );
-                Some(s)
-            }
-            Err(e) => {
-                tracing::warn!(
-                    pool = %name,
-                    reason = %e,
-                    "InferencePool present but unsupported; clearing discovery state"
-                );
-                None
-            }
+            Ok(s) => (Some(s), None),
+            Err(e) => (None, Some(e.to_string())),
         },
     };
-    let _ = tx.send(state);
+
+    tx.send_if_modified(|current| {
+        if *current == state {
+            return false;
+        }
+        match &state {
+            Some(s) => tracing::info!(
+                pool = %name,
+                target_port = s.target_port,
+                labels = ?s.match_labels,
+                "InferencePool resolved"
+            ),
+            None => tracing::warn!(
+                pool = %name,
+                reason = clear_reason.as_deref().unwrap_or("unknown"),
+                "InferencePool unusable; clearing discovery state"
+            ),
+        }
+        *current = state;
+        true
+    });
 }
 
 /// Why an observed `InferencePool` spec can't be used for discovery. Each
@@ -198,6 +207,83 @@ fn parse_pool_state(data: &serde_json::Value) -> Result<PoolState, PoolSpecError
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// A `DynamicObject` carrying `data` (spec/status live here for a CRD read as
+    /// a dynamic object), enough to exercise `publish_pool_state`.
+    fn dyn_obj(data: serde_json::Value) -> DynamicObject {
+        DynamicObject {
+            types: None,
+            metadata: Default::default(),
+            data,
+        }
+    }
+
+    #[test]
+    fn status_only_update_does_not_wake_discovery() {
+        let (tx, mut rx) = watch::channel::<Option<PoolState>>(None);
+
+        // First real spec resolves the pool -> receiver observes a change.
+        publish_pool_state(
+            Some(dyn_obj(json!({
+                "spec": {
+                    "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                    "targetPorts": [{"number": 8000}]
+                },
+                "status": {"conditions": [{"type": "Accepted", "status": "True"}]}
+            }))),
+            "pool",
+            &tx,
+        );
+        assert!(rx.has_changed().unwrap());
+        assert_eq!(rx.borrow_and_update().as_ref().unwrap().target_port, 8000);
+
+        // Same spec, different status/metadata only -> derived state is identical,
+        // so no notification (this is the churn we must suppress).
+        publish_pool_state(
+            Some(dyn_obj(json!({
+                "metadata": {"resourceVersion": "12345"},
+                "spec": {
+                    "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                    "targetPorts": [{"number": 8000}]
+                },
+                "status": {"conditions": [{"type": "Accepted", "status": "False"}]}
+            }))),
+            "pool",
+            &tx,
+        );
+        assert!(!rx.has_changed().unwrap());
+
+        // A real target-port change wakes discovery again.
+        publish_pool_state(
+            Some(dyn_obj(json!({
+                "spec": {
+                    "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                    "targetPorts": [{"number": 9000}]
+                }
+            }))),
+            "pool",
+            &tx,
+        );
+        assert!(rx.has_changed().unwrap());
+        assert_eq!(rx.borrow_and_update().as_ref().unwrap().target_port, 9000);
+    }
+
+    #[test]
+    fn repeated_unparseable_pool_clears_once() {
+        let (tx, mut rx) = watch::channel::<Option<PoolState>>(Some(PoolState {
+            match_labels: BTreeMap::from([("app".to_string(), "vllm-qwen".to_string())]),
+            target_port: 8000,
+        }));
+
+        // Pool edited into an unusable spec -> clears to None (one notification).
+        publish_pool_state(Some(dyn_obj(json!({"spec": {}}))), "pool", &tx);
+        assert!(rx.has_changed().unwrap());
+        assert!(rx.borrow_and_update().is_none());
+
+        // Still unusable on the next delivery -> already None, so no re-wake.
+        publish_pool_state(Some(dyn_obj(json!({"spec": {}}))), "pool", &tx);
+        assert!(!rx.has_changed().unwrap());
+    }
 
     #[test]
     fn parses_v1_target_ports() {

--- a/deploy/inference-gateway/ext-proc/src/inference_pool.rs
+++ b/deploy/inference-gateway/ext-proc/src/inference_pool.rs
@@ -109,7 +109,7 @@ fn publish_pool_state(
         None => (None, Some("absent".to_string())),
         Some(o) => match parse_pool_state(&o.data) {
             Ok(s) => (Some(s), None),
-            Err(e) => (None, Some(e.to_string())),
+            Err(reason) => (None, Some(reason)),
         },
     };
 
@@ -135,44 +135,28 @@ fn publish_pool_state(
     });
 }
 
-/// Why an observed `InferencePool` spec can't be used for discovery. Each
-/// variant names a specific rejection so the watcher can log *why* the pool was
-/// cleared instead of one catch-all warning.
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
-enum PoolSpecError {
-    #[error("spec is missing")]
-    MissingSpec,
-    #[error("spec.selector.matchLabels is missing or not a string map")]
-    MissingSelector,
-    #[error("spec.selector.matchLabels is empty (would select every pod in the namespace)")]
-    EmptySelector,
-    #[error("spec.targetPorts is missing or not an array")]
-    MissingTargetPorts,
-    #[error("expected exactly one targetPort, found {found}")]
-    NotExactlyOneTargetPort { found: usize },
-    #[error("targetPorts[0].number is missing or not an integer")]
-    MissingTargetPortNumber,
-    #[error("targetPort {0} is outside the valid 1-65535 range")]
-    TargetPortOutOfRange(u64),
-}
-
-/// Extract a [`PoolState`] from an `InferencePool` `spec`, or a [`PoolSpecError`]
-/// naming why it is unusable. Pure function — unit-testable without a cluster.
-fn parse_pool_state(data: &serde_json::Value) -> Result<PoolState, PoolSpecError> {
-    let spec = data.get("spec").ok_or(PoolSpecError::MissingSpec)?;
+/// Extract a [`PoolState`] from an `InferencePool` `spec`, or a message naming
+/// why it is unusable. Pure function — unit-testable without a cluster.
+fn parse_pool_state(data: &serde_json::Value) -> std::result::Result<PoolState, String> {
+    let spec = data
+        .get("spec")
+        .ok_or_else(|| "spec is missing".to_string())?;
 
     let labels_obj = spec
         .get("selector")
         .and_then(|s| s.get("matchLabels"))
         .and_then(|m| m.as_object())
-        .ok_or(PoolSpecError::MissingSelector)?;
+        .ok_or_else(|| "spec.selector.matchLabels is missing or not a string map".to_string())?;
     let match_labels: BTreeMap<String, String> = labels_obj
         .iter()
         .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
         .collect();
     // An empty selector would match every pod in the namespace; refuse it.
     if match_labels.is_empty() {
-        return Err(PoolSpecError::EmptySelector);
+        return Err(
+            "spec.selector.matchLabels is empty (would select every pod in the namespace)"
+                .to_string(),
+        );
     }
 
     // v1 `spec.targetPorts[].number`; exactly one is required. Multi-port pools
@@ -182,19 +166,24 @@ fn parse_pool_state(data: &serde_json::Value) -> Result<PoolState, PoolSpecError
     let target_ports = spec
         .get("targetPorts")
         .and_then(|tp| tp.as_array())
-        .ok_or(PoolSpecError::MissingTargetPorts)?;
+        .ok_or_else(|| "spec.targetPorts is missing or not an array".to_string())?;
     if target_ports.len() != 1 {
-        return Err(PoolSpecError::NotExactlyOneTargetPort {
-            found: target_ports.len(),
-        });
+        return Err(format!(
+            "expected exactly one targetPort, found {}",
+            target_ports.len()
+        ));
     }
     let target_port_u64 = target_ports[0]
         .get("number")
         .and_then(|n| n.as_u64())
-        .ok_or(PoolSpecError::MissingTargetPortNumber)?;
+        .ok_or_else(|| "targetPorts[0].number is missing or not an integer".to_string())?;
     let target_port = match u16::try_from(target_port_u64) {
         Ok(p) if p != 0 => p,
-        _ => return Err(PoolSpecError::TargetPortOutOfRange(target_port_u64)),
+        _ => {
+            return Err(format!(
+                "targetPort {target_port_u64} is outside the valid 1-65535 range"
+            ));
+        }
     };
 
     Ok(PoolState {
@@ -313,10 +302,7 @@ mod tests {
 
     #[test]
     fn missing_spec_is_rejected() {
-        assert_eq!(
-            parse_pool_state(&json!({})),
-            Err(PoolSpecError::MissingSpec)
-        );
+        assert_eq!(parse_pool_state(&json!({})).unwrap_err(), "spec is missing");
     }
 
     #[test]
@@ -329,8 +315,8 @@ mod tests {
             }
         });
         assert_eq!(
-            parse_pool_state(&data),
-            Err(PoolSpecError::MissingTargetPorts)
+            parse_pool_state(&data).unwrap_err(),
+            "spec.targetPorts is missing or not an array"
         );
     }
 
@@ -339,7 +325,10 @@ mod tests {
         let data = json!({
             "spec": {"selector": {"matchLabels": {}}, "targetPorts": [{"number": 8000}]}
         });
-        assert_eq!(parse_pool_state(&data), Err(PoolSpecError::EmptySelector));
+        assert_eq!(
+            parse_pool_state(&data).unwrap_err(),
+            "spec.selector.matchLabels is empty (would select every pod in the namespace)"
+        );
     }
 
     #[test]
@@ -347,7 +336,10 @@ mod tests {
         let data = json!({
             "spec": {"targetPorts": [{"number": 8000}]}
         });
-        assert_eq!(parse_pool_state(&data), Err(PoolSpecError::MissingSelector));
+        assert_eq!(
+            parse_pool_state(&data).unwrap_err(),
+            "spec.selector.matchLabels is missing or not a string map"
+        );
     }
 
     #[test]
@@ -356,8 +348,8 @@ mod tests {
             "spec": {"selector": {"matchLabels": {"app": "x"}}}
         });
         assert_eq!(
-            parse_pool_state(&data),
-            Err(PoolSpecError::MissingTargetPorts)
+            parse_pool_state(&data).unwrap_err(),
+            "spec.targetPorts is missing or not an array"
         );
     }
 
@@ -372,8 +364,8 @@ mod tests {
             }
         });
         assert_eq!(
-            parse_pool_state(&data),
-            Err(PoolSpecError::NotExactlyOneTargetPort { found: 2 })
+            parse_pool_state(&data).unwrap_err(),
+            "expected exactly one targetPort, found 2"
         );
     }
 
@@ -386,8 +378,8 @@ mod tests {
             }
         });
         assert_eq!(
-            parse_pool_state(&data),
-            Err(PoolSpecError::NotExactlyOneTargetPort { found: 0 })
+            parse_pool_state(&data).unwrap_err(),
+            "expected exactly one targetPort, found 0"
         );
     }
 
@@ -400,8 +392,8 @@ mod tests {
             }
         });
         assert_eq!(
-            parse_pool_state(&data),
-            Err(PoolSpecError::MissingTargetPortNumber)
+            parse_pool_state(&data).unwrap_err(),
+            "targetPorts[0].number is missing or not an integer"
         );
     }
 
@@ -415,8 +407,8 @@ mod tests {
                 }
             });
             assert_eq!(
-                parse_pool_state(&data),
-                Err(PoolSpecError::TargetPortOutOfRange(port))
+                parse_pool_state(&data).unwrap_err(),
+                format!("targetPort {port} is outside the valid 1-65535 range")
             );
         }
     }

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -15,13 +15,17 @@
 pub mod envoy_helpers;
 pub mod epp;
 pub mod epp_standalone_config;
+pub mod inference_pool;
 pub mod picker;
+pub mod pod_discovery;
 pub mod proto;
 pub mod server;
 pub mod vllm_render_client;
 
 pub use epp::Router;
 pub use epp_standalone_config::{EppMode, EppStandaloneConfig, TokenizerProtocol};
+pub use inference_pool::PoolState;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
+pub use pod_discovery::{PodDiscovery, RawWorker};
 pub use server::ExtProcServer;
 pub use vllm_render_client::{VllmRenderClient, VllmRenderError};

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -145,6 +145,10 @@ impl PodDiscovery {
             // The pod cache is "synced" once the reflector's initial LIST lands
             // (InitDone); readiness stays gated on this AND pool presence below.
             let mut pod_synced = false;
+            // True from `Init` until `InitDone`: a (re)list is buffering objects and
+            // the live store still holds the pre-relist Pod set, so a pool edit must
+            // not rebuild from it — defer to `InitDone` instead.
+            let mut relisting = false;
 
             enum Delta {
                 Upsert(Pod),
@@ -162,10 +166,15 @@ impl PodDiscovery {
                         }
                         // During a relist the reflector emits Init + one InitApply
                         // per pod + InitDone. The per-object relist events only
-                        // prime the store; act once at InitDone with a single
-                        // recompute (Errors don't change the store).
-                        Some(Ok(watcher::Event::Init | watcher::Event::InitApply(_))) => Delta::Skip,
+                        // prime the buffered store (the live store still holds the
+                        // pre-relist set until InitDone); mark the relist and act
+                        // once at InitDone with a single recompute.
+                        Some(Ok(watcher::Event::Init | watcher::Event::InitApply(_))) => {
+                            relisting = true;
+                            Delta::Skip
+                        }
                         Some(Ok(watcher::Event::InitDone)) => {
+                            relisting = false;
                             pod_synced = true;
                             Delta::Rebuild
                         }
@@ -180,8 +189,16 @@ impl PodDiscovery {
                         if changed.is_err() {
                             tracing::warn!("InferencePool watch ended");
                             Delta::Stop
+                        } else if defer_pool_rebuild(relisting, pool_rx.borrow().is_some()) {
+                            // A relist is buffering pods and the live store is still
+                            // the pre-relist set. Defer this non-clearing selector/
+                            // port edit to InitDone, which rebuilds from the completed
+                            // pod list + latest PoolState. (A pool deletion/invalid
+                            // spec is not deferred and clears immediately below.)
+                            Delta::Skip
                         } else {
-                            // A selector/target-port edit re-classifies every pod.
+                            // A selector/target-port edit re-classifies every pod;
+                            // a None pool clears discovery.
                             Delta::Rebuild
                         }
                     }
@@ -331,6 +348,16 @@ fn strip_scheme(endpoint: &str) -> &str {
 /// Stable index key for a pod (its `worker_id`). `None` for an unnamed pod.
 fn pod_worker_id(pod: &Pod) -> Option<u64> {
     pod.metadata.name.as_deref().map(hash_pod_name)
+}
+
+/// Whether a pool change observed *during a relist* should be deferred to
+/// `InitDone` rather than rebuilt now. While relisting, the reflector's live
+/// store is still the pre-relist Pod set, so a non-clearing (selector/port) edit
+/// (`pool_present`) would rebuild from stale pods — defer it; `InitDone` rebuilds
+/// from the completed pod list + latest `PoolState`. A pool deletion/invalid spec
+/// (`!pool_present`) is never deferred: clearing stale discovery is always safe.
+fn defer_pool_rebuild(relisting: bool, pool_present: bool) -> bool {
+    relisting && pool_present
 }
 
 /// Apply a single pod delta to the index: upsert the worker if it is `Ready` and
@@ -690,6 +717,18 @@ mod tests {
 
         upsert_pod(&index, &ready, None, 5557, None);
         assert!(!index.read().unwrap().contains_key(&id));
+    }
+
+    #[test]
+    fn pool_edit_during_relist_defers_but_deletion_clears() {
+        // Steady state (not relisting): every pool change rebuilds immediately.
+        assert!(!defer_pool_rebuild(false, true));
+        assert!(!defer_pool_rebuild(false, false));
+        // Mid-relist: a selector/port edit (pool still present) is deferred to
+        // InitDone so it never rebuilds from the stale pre-relist store...
+        assert!(defer_pool_rebuild(true, true));
+        // ...but a pool deletion/invalid spec still clears discovery immediately.
+        assert!(!defer_pool_rebuild(true, false));
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -1,0 +1,800 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pod discovery for standalone router mode, driven by the `InferencePool`.
+//!
+//! The pod label selector and HTTP target port come from the GAIE
+//! [`InferencePool`](crate::inference_pool) this EPP backs — the same object the
+//! gateway routes to — so EPP and gateway can never disagree about pool
+//! membership.
+//!
+//! Pods are `Ready`-filtered (and excluded once terminating), so in-flight
+//! rollouts and crash-looping pods receive no traffic.
+//!
+//! `worker_id = hash_pod_name(pod_name)`, so the IDs produced here line up with
+//! whatever consumes them (the topology adapter and selector catalog).
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+
+use anyhow::Result;
+use dynamo_runtime::discovery::hash_pod_name;
+use k8s_openapi::api::core::v1::Pod;
+use tokio::sync::watch;
+
+use crate::epp_standalone_config::EppStandaloneConfig;
+use crate::inference_pool::{PoolState, spawn_pool_watch};
+
+/// A discovered, `Ready` raw inference engine worker normalized for selector registration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawWorker {
+    /// Stable hash of the pod name; the selector catalog key.
+    pub worker_id: u64,
+    /// Kubernetes pod name.
+    pub pod_name: String,
+    /// Pod IP.
+    pub pod_ip: String,
+    /// OpenAI HTTP inference endpoint, `http://<ip>:<target_port>`.
+    pub http_endpoint: String,
+    /// Inference engine KV-event ZMQ PUB endpoint, `tcp://<ip>:<kv_event_port>`.
+    pub kv_events_endpoint: String,
+    /// Optional ZMQ REQ endpoint for live-stream gap replay.
+    pub replay_endpoint: Option<String>,
+    /// Routing identity fed to the selector's `stable_routing_id`. Currently the
+    /// pod name, so it is NOT yet restart-stable: a Deployment pod restart yields
+    /// a new name and a new identity. A truly stable source (StatefulSet ordinal
+    /// or a pod label) is a follow-up.
+    pub stable_routing_id: String,
+}
+
+/// One indexed worker: the materialized [`RawWorker`] for selector registration
+/// plus its pre-stripped `ip:port`, so request-path reads (notably
+/// [`PodDiscovery::resolve_endpoint`]) are O(1) lookups that never re-parse the
+/// endpoint or clone the [`PoolState`].
+#[derive(Debug, Clone)]
+struct WorkerEntry {
+    worker: RawWorker,
+    /// Scheme-less `ip:port` derived once from `worker.http_endpoint`.
+    endpoint: String,
+}
+
+impl WorkerEntry {
+    fn from_raw(worker: RawWorker) -> Self {
+        let endpoint = strip_scheme(&worker.http_endpoint).to_string();
+        Self { worker, endpoint }
+    }
+}
+
+/// Derived catalog of the `Ready`, pool-selected workers, keyed by `worker_id`.
+type WorkerIndex = HashMap<u64, WorkerEntry>;
+
+/// View over the `Ready` raw inference engine pods selected by the EPP's
+/// `InferencePool`. Reads never touch the Kubernetes API; they take a brief read
+/// lock on a derived [`WorkerIndex`] that a single background task maintains
+/// **incrementally** — each pod `Apply`/`Delete` is an O(1) upsert/remove, and
+/// the whole index is recomputed only on the initial LIST, a watch relist, or a
+/// pool-selector change.
+#[derive(Clone)]
+pub struct PodDiscovery {
+    index: Arc<RwLock<WorkerIndex>>,
+    changes: watch::Receiver<u64>,
+}
+
+impl PodDiscovery {
+    /// Start the InferencePool watch and a namespace-wide pod reflector. Returns
+    /// a *live* readiness flag that is `true` only while the pod cache has synced
+    /// (initial LIST done) **and** the `InferencePool` is resolved. It clears back
+    /// to `false` if the pool is later deleted or edited into an unsupported spec
+    /// (so nothing is routable), and recovers when both are healthy again — this
+    /// is the gRPC health SERVING signal, so it must not latch true.
+    pub async fn spawn(cfg: &EppStandaloneConfig) -> Result<(Self, Arc<AtomicBool>)> {
+        use futures::StreamExt;
+        use kube::{Api, Client, runtime::WatchStreamExt, runtime::reflector, runtime::watcher};
+
+        let client = Client::try_default().await?;
+        let namespace = cfg.namespace.clone();
+
+        let (pool_rx, _pool_task) = spawn_pool_watch(
+            client.clone(),
+            namespace.clone(),
+            cfg.inference_pool_name.clone(),
+        )
+        .await?;
+
+        // Namespace-wide pod watch; membership is decided in memory by the pool
+        // selector so selector edits never require re-spawning this watch.
+        let pods: Api<Pod> = Api::namespaced(client, &namespace);
+        let writer = reflector::store::Writer::default();
+        let store = writer.as_reader();
+        let ready = Arc::new(AtomicBool::new(false));
+        // `default_backoff()` lets the watcher own retry/backoff (exponential +
+        // jitter, capped) on watch errors; the error arm below just logs, so
+        // persistent failures (e.g. RBAC, API-server hiccup) don't hot-loop.
+        let reflect = reflector::reflector(
+            writer,
+            watcher(pods, watcher::Config::default()).default_backoff(),
+        );
+
+        let (changes_tx, changes_rx) = watch::channel(0u64);
+
+        let kv_event_port = cfg.kv_event_port;
+        let replay_port = cfg.replay_port;
+
+        // Derived worker index, maintained incrementally by the task below.
+        let index: Arc<RwLock<WorkerIndex>> = Arc::new(RwLock::new(WorkerIndex::new()));
+
+        tracing::info!(
+            namespace = %namespace,
+            pool = %cfg.inference_pool_name,
+            kv_event_port = cfg.kv_event_port,
+            "Starting namespace pod reflector for standalone mode"
+        );
+
+        // A single task owns both wake sources so index mutations are serialized:
+        // a pod Apply/Delete mutates exactly one entry (O(1)); a full recompute
+        // runs only when the store is known consistent (InitDone, which also drops
+        // pods that vanished during a relist gap) or the pool selector changes.
+        let index_task = index.clone();
+        let ready_task = ready.clone();
+        tokio::spawn(async move {
+            let mut pool_rx = pool_rx;
+            tokio::pin!(reflect);
+            let mut generation = 0u64;
+            // The pod cache is "synced" once the reflector's initial LIST lands
+            // (InitDone); readiness stays gated on this AND pool presence below.
+            let mut pod_synced = false;
+
+            enum Delta {
+                Upsert(Pod),
+                Remove(Pod),
+                Rebuild,
+                Skip,
+                Stop,
+            }
+            loop {
+                let delta = tokio::select! {
+                    ev = reflect.next() => match ev {
+                        None => {
+                            tracing::warn!("Inference engine pod reflector stream ended unexpectedly");
+                            Delta::Stop
+                        }
+                        // During a relist the reflector emits Init + one InitApply
+                        // per pod + InitDone. The per-object relist events only
+                        // prime the store; act once at InitDone with a single
+                        // recompute (Errors don't change the store).
+                        Some(Ok(watcher::Event::Init | watcher::Event::InitApply(_))) => Delta::Skip,
+                        Some(Ok(watcher::Event::InitDone)) => {
+                            pod_synced = true;
+                            Delta::Rebuild
+                        }
+                        Some(Ok(watcher::Event::Apply(pod))) => Delta::Upsert(pod),
+                        Some(Ok(watcher::Event::Delete(pod))) => Delta::Remove(pod),
+                        Some(Err(e)) => {
+                            tracing::warn!(error = %e, "Pod reflector watch error; retrying");
+                            Delta::Skip
+                        }
+                    },
+                    changed = pool_rx.changed() => {
+                        if changed.is_err() {
+                            tracing::warn!("InferencePool watch ended");
+                            Delta::Stop
+                        } else {
+                            // A selector/target-port edit re-classifies every pod.
+                            Delta::Rebuild
+                        }
+                    }
+                };
+
+                match delta {
+                    Delta::Stop => break,
+                    Delta::Skip => continue,
+                    Delta::Rebuild => rebuild_index(
+                        &store,
+                        pool_rx.borrow().as_ref(),
+                        kv_event_port,
+                        replay_port,
+                        &index_task,
+                    ),
+                    Delta::Upsert(pod) => upsert_pod(
+                        &index_task,
+                        &pod,
+                        pool_rx.borrow().as_ref(),
+                        kv_event_port,
+                        replay_port,
+                    ),
+                    Delta::Remove(pod) => remove_pod(&index_task, &pod),
+                }
+
+                // Live readiness: true only once the pod cache has synced AND the
+                // pool is resolved; drops back to false if the pool later
+                // disappears, and recovers once both are healthy again.
+                ready_task.store(pod_synced && pool_rx.borrow().is_some(), Ordering::Release);
+                generation = generation.wrapping_add(1);
+                let _ = changes_tx.send(generation);
+            }
+            // Either watch stream ended: the producer is gone and can no longer
+            // refresh discovery. Stop advertising readiness AND drop the index so
+            // reads can't hand out endpoints for workers we can no longer track.
+            ready_task.store(false, Ordering::Release);
+            index_task.write().unwrap().clear();
+        });
+
+        Ok((
+            Self {
+                index,
+                changes: changes_rx,
+            },
+            ready,
+        ))
+    }
+
+    /// All currently `Ready` workers selected by the pool, normalized for
+    /// selector registration. Empty until the `InferencePool` has resolved.
+    /// Reads the cached index; no per-call filtering or API access.
+    pub fn ready_workers(&self) -> Vec<RawWorker> {
+        self.index
+            .read()
+            .unwrap()
+            .values()
+            .map(|entry| entry.worker.clone())
+            .collect()
+    }
+
+    /// Worker IDs of all currently `Ready`, pool-selected workers. Reads the
+    /// cached index, so it stays consistent with [`Self::resolve_endpoint`].
+    pub fn ready_worker_ids(&self) -> HashSet<u64> {
+        self.index.read().unwrap().keys().copied().collect()
+    }
+
+    /// Resolve a `worker_id` to its current `ip:port` HTTP endpoint, if the pod
+    /// is still `Ready` and pool-selected. On the request hot path: an O(1)
+    /// lookup into the cached index.
+    pub fn resolve_endpoint(&self, worker_id: u64) -> Option<String> {
+        self.index
+            .read()
+            .unwrap()
+            .get(&worker_id)
+            .map(|entry| entry.endpoint.clone())
+    }
+
+    /// Retain the `worker_ids` whose current `ip:port` endpoint satisfies `pred`,
+    /// under a **single** read lock and **without cloning** any endpoint (`pred`
+    /// borrows it). Used on the subset-routing path so membership testing doesn't
+    /// allocate a throwaway `String` per candidate. Unknown workers are dropped.
+    ///
+    /// `pred` runs while the index read lock is held, so it must not re-enter
+    /// `PodDiscovery` (`resolve_endpoint`, `ready_workers`, another read, …):
+    /// `std::sync::RwLock` read locks are not guaranteed re-entrant and a nested
+    /// acquire can deadlock.
+    pub fn filter_workers_by_endpoint(
+        &self,
+        worker_ids: &HashSet<u64>,
+        pred: impl Fn(&str) -> bool,
+    ) -> HashSet<u64> {
+        let index = self.index.read().unwrap();
+        worker_ids
+            .iter()
+            .copied()
+            .filter(|worker_id| {
+                index
+                    .get(worker_id)
+                    .is_some_and(|entry| pred(entry.endpoint.as_str()))
+            })
+            .collect()
+    }
+
+    /// Subscribe to change notifications (a generation counter) bumped on pod or
+    /// pool changes, so a reconciler can re-sync.
+    pub fn subscribe_changes(&self) -> watch::Receiver<u64> {
+        self.changes.clone()
+    }
+}
+
+/// Return `true` iff the pod is `Ready` and not terminating.
+/// A pod with a deletion timestamp is excluded even if it still
+/// reports `Ready=True`, so draining pods stop receiving traffic promptly.
+fn pod_is_ready(pod: &Pod) -> bool {
+    if pod.metadata.deletion_timestamp.is_some() {
+        return false;
+    }
+    pod.status
+        .as_ref()
+        .and_then(|s| s.conditions.as_ref())
+        .map(|conds| {
+            conds
+                .iter()
+                .any(|c| c.type_ == "Ready" && c.status == "True")
+        })
+        .unwrap_or(false)
+}
+
+/// Return `true` iff the pod carries every `match_labels` key with the equal
+/// value (equality-based selector, matching `InferencePool.spec.selector`).
+fn pod_matches(pod: &Pod, match_labels: &BTreeMap<String, String>) -> bool {
+    let Some(labels) = pod.metadata.labels.as_ref() else {
+        return match_labels.is_empty();
+    };
+    match_labels
+        .iter()
+        .all(|(k, v)| labels.get(k).map(|pv| pv == v).unwrap_or(false))
+}
+
+fn strip_scheme(endpoint: &str) -> &str {
+    endpoint
+        .strip_prefix("http://")
+        .or_else(|| endpoint.strip_prefix("https://"))
+        .unwrap_or(endpoint)
+}
+
+/// Stable index key for a pod (its `worker_id`). `None` for an unnamed pod.
+fn pod_worker_id(pod: &Pod) -> Option<u64> {
+    pod.metadata.name.as_deref().map(hash_pod_name)
+}
+
+/// Apply a single pod delta to the index: upsert the worker if it is `Ready` and
+/// pool-selected, otherwise drop any existing entry (a pod that went NotReady,
+/// terminating, or unselected). O(1). A `None` pool means nothing is routable, so
+/// the entry is dropped; the following pool resolution triggers a full rebuild.
+fn upsert_pod(
+    index: &RwLock<WorkerIndex>,
+    pod: &Pod,
+    pool: Option<&PoolState>,
+    kv_event_port: u16,
+    replay_port: Option<u16>,
+) {
+    let Some(worker_id) = pod_worker_id(pod) else {
+        return;
+    };
+    let entry = pool
+        .and_then(|pool| raw_worker_from_pod(pod, pool, kv_event_port, replay_port))
+        .map(WorkerEntry::from_raw);
+    let mut index = index.write().unwrap();
+    match entry {
+        Some(entry) => {
+            index.insert(worker_id, entry);
+        }
+        None => {
+            index.remove(&worker_id);
+        }
+    }
+}
+
+/// Drop a deleted pod's worker from the index. O(1).
+fn remove_pod(index: &RwLock<WorkerIndex>, pod: &Pod) {
+    if let Some(worker_id) = pod_worker_id(pod) {
+        index.write().unwrap().remove(&worker_id);
+    }
+}
+
+/// Recompute the whole index from the current pod store and pool selector.
+/// Empty until the `InferencePool` has resolved. Used only for the initial LIST,
+/// watch relists (which may have dropped pods without a `Delete`), and
+/// pool-selector changes (which re-classify every pod). O(pods), infrequent.
+fn rebuild_index(
+    store: &kube::runtime::reflector::Store<Pod>,
+    pool: Option<&PoolState>,
+    kv_event_port: u16,
+    replay_port: Option<u16>,
+    index: &RwLock<WorkerIndex>,
+) {
+    let mut fresh = WorkerIndex::new();
+    if let Some(pool) = pool {
+        for pod in store.state().iter() {
+            if let Some(worker) = raw_worker_from_pod(pod, pool, kv_event_port, replay_port) {
+                fresh.insert(worker.worker_id, WorkerEntry::from_raw(worker));
+            }
+        }
+    }
+    *index.write().unwrap() = fresh;
+}
+
+/// Build a [`RawWorker`] from a pod, or `None` if it is not `Ready`, not
+/// pool-selected, or lacks an IP/name. Pure function — unit-testable.
+fn raw_worker_from_pod(
+    pod: &Pod,
+    pool: &PoolState,
+    kv_event_port: u16,
+    replay_port: Option<u16>,
+) -> Option<RawWorker> {
+    if !pod_is_ready(pod) || !pod_matches(pod, &pool.match_labels) {
+        return None;
+    }
+    let pod_name = pod.metadata.name.as_deref()?;
+    let pod_ip = pod.status.as_ref()?.pod_ip.as_deref()?;
+    // A Pod IP is always an IP literal (never a hostname). Parse it so each
+    // host/port pair is rendered via `SocketAddr`, which brackets IPv6 as
+    // `[fd00::10]:8000`; a bare IPv6 literal (`fd00::10:8000`) is ambiguous, as
+    // the trailing group can't be told apart from the port. IPv4 is unchanged.
+    // An empty or malformed IP fails to parse and skips the pod.
+    let ip: IpAddr = pod_ip.parse().ok()?;
+
+    Some(RawWorker {
+        worker_id: hash_pod_name(pod_name),
+        pod_name: pod_name.to_string(),
+        pod_ip: pod_ip.to_string(),
+        http_endpoint: format!("http://{}", SocketAddr::new(ip, pool.target_port)),
+        kv_events_endpoint: format!("tcp://{}", SocketAddr::new(ip, kv_event_port)),
+        replay_endpoint: replay_port.map(|p| format!("tcp://{}", SocketAddr::new(ip, p))),
+        stable_routing_id: pod_name.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{PodCondition, PodStatus};
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+    use kube::api::ObjectMeta;
+
+    fn pool() -> PoolState {
+        PoolState {
+            match_labels: BTreeMap::from([("app".to_string(), "vllm-qwen".to_string())]),
+            target_port: 8000,
+        }
+    }
+
+    fn pod(name: &str, ip: Option<&str>, ready: Option<bool>, labels: &[(&str, &str)]) -> Pod {
+        let conditions = ready.map(|r| {
+            vec![PodCondition {
+                type_: "Ready".to_string(),
+                status: if r { "True" } else { "False" }.to_string(),
+                ..Default::default()
+            }]
+        });
+        let label_map = labels
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                labels: Some(label_map),
+                ..Default::default()
+            },
+            status: Some(PodStatus {
+                pod_ip: ip.map(|s| s.to_string()),
+                conditions,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ready_selected_pod_maps_to_worker() {
+        let w = raw_worker_from_pod(
+            &pod(
+                "vllm-0",
+                Some("10.0.0.1"),
+                Some(true),
+                &[("app", "vllm-qwen")],
+            ),
+            &pool(),
+            5557,
+            Some(5560),
+        )
+        .expect("ready, selected pod should map");
+        assert_eq!(w.worker_id, hash_pod_name("vllm-0"));
+        assert_eq!(w.http_endpoint, "http://10.0.0.1:8000");
+        assert_eq!(w.kv_events_endpoint, "tcp://10.0.0.1:5557");
+        assert_eq!(w.replay_endpoint.as_deref(), Some("tcp://10.0.0.1:5560"));
+    }
+
+    #[test]
+    fn ipv6_pod_ip_is_bracketed_in_all_endpoints() {
+        let w = raw_worker_from_pod(
+            &pod(
+                "vllm-0",
+                Some("fd00::10"),
+                Some(true),
+                &[("app", "vllm-qwen")],
+            ),
+            &pool(),
+            5557,
+            Some(5560),
+        )
+        .expect("ready, selected IPv6 pod should map");
+        // SocketAddr brackets the IPv6 host so host and port are unambiguous.
+        assert_eq!(w.http_endpoint, "http://[fd00::10]:8000");
+        assert_eq!(w.kv_events_endpoint, "tcp://[fd00::10]:5557");
+        assert_eq!(w.replay_endpoint.as_deref(), Some("tcp://[fd00::10]:5560"));
+    }
+
+    #[test]
+    fn malformed_pod_ip_is_skipped() {
+        assert!(
+            raw_worker_from_pod(
+                &pod(
+                    "vllm-0",
+                    Some("not-an-ip"),
+                    Some(true),
+                    &[("app", "vllm-qwen")]
+                ),
+                &pool(),
+                5557,
+                None,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn pod_not_matching_selector_is_skipped() {
+        assert!(
+            raw_worker_from_pod(
+                &pod(
+                    "other-0",
+                    Some("10.0.0.1"),
+                    Some(true),
+                    &[("app", "something-else")]
+                ),
+                &pool(),
+                5557,
+                None,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn not_ready_pod_is_skipped() {
+        assert!(
+            raw_worker_from_pod(
+                &pod(
+                    "vllm-0",
+                    Some("10.0.0.1"),
+                    Some(false),
+                    &[("app", "vllm-qwen")]
+                ),
+                &pool(),
+                5557,
+                None,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn terminating_pod_is_skipped() {
+        let mut p = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        );
+        p.metadata.deletion_timestamp = Some(Time(k8s_openapi::chrono::Utc::now()));
+        assert!(raw_worker_from_pod(&p, &pool(), 5557, None).is_none());
+    }
+
+    #[test]
+    fn pod_without_ip_is_skipped() {
+        assert!(
+            raw_worker_from_pod(
+                &pod("vllm-0", None, Some(true), &[("app", "vllm-qwen")]),
+                &pool(),
+                5557,
+                None,
+            )
+            .is_none()
+        );
+    }
+
+    fn store_from_pods(pods: Vec<Pod>) -> kube::runtime::reflector::Store<Pod> {
+        use kube::runtime::watcher;
+        let mut writer = kube::runtime::reflector::store::Writer::<Pod>::default();
+        let store = writer.as_reader();
+        writer.apply_watcher_event(&watcher::Event::Init);
+        for p in pods {
+            writer.apply_watcher_event(&watcher::Event::InitApply(p));
+        }
+        writer.apply_watcher_event(&watcher::Event::InitDone);
+        store
+    }
+
+    #[test]
+    fn rebuild_index_keeps_only_ready_selected_pods() {
+        let store = store_from_pods(vec![
+            pod(
+                "vllm-0",
+                Some("10.0.0.1"),
+                Some(true),
+                &[("app", "vllm-qwen")],
+            ),
+            pod(
+                "vllm-1",
+                Some("10.0.0.2"),
+                Some(false),
+                &[("app", "vllm-qwen")],
+            ),
+            pod("other-0", Some("10.0.0.3"), Some(true), &[("app", "nope")]),
+        ]);
+
+        let index = RwLock::new(WorkerIndex::new());
+        rebuild_index(&store, Some(&pool()), 5557, Some(5560), &index);
+
+        // Only the ready, correctly-labeled pod is materialized.
+        let index = index.read().unwrap();
+        assert_eq!(index.len(), 1);
+        let id = hash_pod_name("vllm-0");
+        let entry = index.get(&id).expect("ready pod is indexed");
+        assert_eq!(entry.worker.worker_id, id);
+        // Endpoint is pre-stripped to a scheme-less ip:port.
+        assert_eq!(entry.endpoint, "10.0.0.1:8000");
+    }
+
+    #[test]
+    fn rebuild_index_is_empty_without_pool() {
+        let store = store_from_pods(vec![pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        )]);
+        let index = RwLock::new(WorkerIndex::new());
+        rebuild_index(&store, None, 5557, None, &index);
+        assert!(index.read().unwrap().is_empty());
+    }
+
+    #[test]
+    fn upsert_and_remove_pod_mutate_index_incrementally() {
+        let index = RwLock::new(WorkerIndex::new());
+        let id = hash_pod_name("vllm-0");
+        let ready = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        );
+
+        // Ready + selected -> inserted, with a pre-stripped endpoint.
+        upsert_pod(&index, &ready, Some(&pool()), 5557, None);
+        assert_eq!(
+            index.read().unwrap().get(&id).map(|e| e.endpoint.as_str()),
+            Some("10.0.0.1:8000")
+        );
+
+        // Same pod goes NotReady -> the upsert drops it (no stale entry).
+        let not_ready = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(false),
+            &[("app", "vllm-qwen")],
+        );
+        upsert_pod(&index, &not_ready, Some(&pool()), 5557, None);
+        assert!(!index.read().unwrap().contains_key(&id));
+
+        // Re-add, then a Delete removes it.
+        upsert_pod(&index, &ready, Some(&pool()), 5557, None);
+        assert!(index.read().unwrap().contains_key(&id));
+        remove_pod(&index, &ready);
+        assert!(!index.read().unwrap().contains_key(&id));
+    }
+
+    #[test]
+    fn upsert_pod_without_pool_drops_entry() {
+        // A `None` pool (unresolved or deleted) means nothing is routable, so an
+        // upsert must evict any existing entry rather than leave stale routing.
+        let index = RwLock::new(WorkerIndex::new());
+        let id = hash_pod_name("vllm-0");
+        let ready = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        );
+
+        upsert_pod(&index, &ready, Some(&pool()), 5557, None);
+        assert!(index.read().unwrap().contains_key(&id));
+
+        upsert_pod(&index, &ready, None, 5557, None);
+        assert!(!index.read().unwrap().contains_key(&id));
+    }
+
+    #[test]
+    fn rebuild_index_drops_workers_absent_from_the_store() {
+        // A relist arrives as a fresh snapshot with no `Delete` events for pods
+        // that disappeared during the disconnect, so the `InitDone`/pool-change
+        // rebuild must *replace* the index, not merge into it — otherwise dead
+        // workers linger and keep receiving traffic. Seed two workers, then
+        // rebuild from a store that holds only one.
+        let index = RwLock::new(WorkerIndex::new());
+        upsert_pod(
+            &index,
+            &pod(
+                "vllm-0",
+                Some("10.0.0.1"),
+                Some(true),
+                &[("app", "vllm-qwen")],
+            ),
+            Some(&pool()),
+            5557,
+            None,
+        );
+        upsert_pod(
+            &index,
+            &pod(
+                "vllm-1",
+                Some("10.0.0.2"),
+                Some(true),
+                &[("app", "vllm-qwen")],
+            ),
+            Some(&pool()),
+            5557,
+            None,
+        );
+        assert_eq!(index.read().unwrap().len(), 2);
+
+        // Relist: vllm-1 vanished during the gap; only vllm-0 remains.
+        let store = store_from_pods(vec![pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        )]);
+        rebuild_index(&store, Some(&pool()), 5557, None, &index);
+
+        let index = index.read().unwrap();
+        assert_eq!(index.len(), 1);
+        assert!(index.contains_key(&hash_pod_name("vllm-0")));
+        assert!(!index.contains_key(&hash_pod_name("vllm-1")));
+    }
+
+    /// Build a `RawWorker` whose HTTP endpoint resolves to `endpoint` (so its
+    /// stripped form equals `endpoint`), for index-backed unit tests.
+    fn raw_worker_with_endpoint(worker_id: u64, endpoint: &str) -> RawWorker {
+        let name = format!("pod-{worker_id}");
+        RawWorker {
+            worker_id,
+            pod_name: name.clone(),
+            pod_ip: endpoint
+                .rsplit_once(':')
+                .map_or(endpoint, |(ip, _)| ip)
+                .to_string(),
+            http_endpoint: format!("http://{endpoint}"),
+            kv_events_endpoint: format!("tcp://{endpoint}"),
+            replay_endpoint: None,
+            stable_routing_id: name,
+        }
+    }
+
+    /// Build a `PodDiscovery` over a fixed index (no cluster) so we can unit-test
+    /// the read-lock-based subset filter.
+    fn discovery_with_endpoints(endpoints: HashMap<u64, String>) -> PodDiscovery {
+        let index: WorkerIndex = endpoints
+            .into_iter()
+            .map(|(id, endpoint)| {
+                (
+                    id,
+                    WorkerEntry::from_raw(raw_worker_with_endpoint(id, &endpoint)),
+                )
+            })
+            .collect();
+        let (_, changes) = watch::channel(0u64);
+        PodDiscovery {
+            index: Arc::new(RwLock::new(index)),
+            changes,
+        }
+    }
+
+    #[test]
+    fn filter_workers_by_endpoint_matches_without_cloning() {
+        let discovery = discovery_with_endpoints(HashMap::from([
+            (1u64, "10.0.0.1:8000".to_string()),
+            (2u64, "10.0.0.2:8000".to_string()),
+            (3u64, "10.0.0.3:8000".to_string()),
+        ]));
+        let allowed: HashSet<u64> = [1, 2, 3].into_iter().collect();
+
+        // Predicate borrows the endpoint; only worker 2 matches.
+        let filtered =
+            discovery.filter_workers_by_endpoint(&allowed, |endpoint| endpoint == "10.0.0.2:8000");
+        assert_eq!(filtered, HashSet::from([2]));
+
+        // A worker id with no endpoint in the snapshot is dropped.
+        let allowed_with_unknown: HashSet<u64> = [1, 99].into_iter().collect();
+        let filtered = discovery.filter_workers_by_endpoint(&allowed_with_unknown, |_| true);
+        assert_eq!(filtered, HashSet::from([1]));
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -720,14 +720,68 @@ mod tests {
     }
 
     #[test]
-    fn pool_edit_during_relist_defers_but_deletion_clears() {
-        // Steady state (not relisting): every pool change rebuilds immediately.
-        assert!(!defer_pool_rebuild(false, true));
-        assert!(!defer_pool_rebuild(false, false));
-        // Mid-relist: a selector/port edit (pool still present) is deferred to
-        // InitDone so it never rebuilds from the stale pre-relist store...
+    fn pool_edit_during_relist_rebuilds_at_init_done_from_completed_store() {
+        use kube::runtime::watcher;
+
+        let vllm_0 = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        );
+        let vllm_1 = pod(
+            "vllm-1",
+            Some("10.0.0.2"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        );
+        let mut writer = kube::runtime::reflector::store::Writer::<Pod>::default();
+        let store = writer.as_reader();
+
+        // Initial LIST has both pods, and the index uses the original Pool port.
+        writer.apply_watcher_event(&watcher::Event::Init);
+        writer.apply_watcher_event(&watcher::Event::InitApply(vllm_0.clone()));
+        writer.apply_watcher_event(&watcher::Event::InitApply(vllm_1.clone()));
+        writer.apply_watcher_event(&watcher::Event::InitDone);
+        let index = RwLock::new(WorkerIndex::new());
+        rebuild_index(&store, Some(&pool()), 5557, None, &index);
+        assert_eq!(index.read().unwrap().len(), 2);
+
+        // During the next LIST, vllm-1 has disappeared. The reflector buffers
+        // vllm-0, but its live Store still exposes the prior two-pod snapshot.
+        writer.apply_watcher_event(&watcher::Event::Init);
+        writer.apply_watcher_event(&watcher::Event::InitApply(vllm_0.clone()));
+        assert_eq!(store.state().len(), 2);
+
+        // A live Pool port edit must not rebuild from that stale Store. The
+        // existing index remains the prior coherent snapshot until InitDone.
+        let mut updated_pool = pool();
+        updated_pool.target_port = 9000;
         assert!(defer_pool_rebuild(true, true));
-        // ...but a pool deletion/invalid spec still clears discovery immediately.
+        assert_eq!(
+            index
+                .read()
+                .unwrap()
+                .get(&hash_pod_name("vllm-0"))
+                .map(|entry| entry.endpoint.as_str()),
+            Some("10.0.0.1:8000")
+        );
+
+        // InitDone makes the staged list live. Its single rebuild uses both the
+        // completed one-pod Store and the latest PoolState.
+        writer.apply_watcher_event(&watcher::Event::InitDone);
+        rebuild_index(&store, Some(&updated_pool), 5557, None, &index);
+        let index = index.read().unwrap();
+        assert_eq!(index.len(), 1);
+        assert_eq!(
+            index
+                .get(&hash_pod_name("vllm-0"))
+                .map(|entry| entry.endpoint.as_str()),
+            Some("10.0.0.1:9000")
+        );
+        assert!(!index.contains_key(&hash_pod_name("vllm-1")));
+
+        // Pool deletion/invalidity remains an immediate clear, even mid-relist.
         assert!(!defer_pool_rebuild(true, false));
     }
 

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -308,7 +308,7 @@ fn defer_pool_rebuild(relisting: bool, pool_present: bool) -> bool {
 
 /// Apply a single pod delta to the index: upsert the worker if it is `Ready` and
 /// pool-selected, otherwise drop any existing entry (a pod that went NotReady,
-/// terminating, or unselected). 
+/// terminating, or unselected).
 fn upsert_pod(
     index: &RwLock<WorkerIndex>,
     pod: &Pod,

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -1,18 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Pod discovery for standalone router mode, driven by the `InferencePool`.
+//! Discovers inference workers from pods selected by the standalone EPP's
+//! [`InferencePool`](crate::inference_pool).
 //!
-//! The pod label selector and HTTP target port come from the GAIE
-//! [`InferencePool`](crate::inference_pool) this EPP backs — the same object the
-//! gateway routes to — so EPP and gateway can never disagree about pool
-//! membership.
-//!
-//! Pods are `Ready`-filtered (and excluded once terminating), so in-flight
-//! rollouts and crash-looping pods receive no traffic.
-//!
-//! `worker_id = hash_pod_name(pod_name)`, so the IDs produced here line up with
-//! whatever consumes them (the topology adapter and selector catalog).
+//! Maintains an index of `Ready`, non-terminating pods using the pool's match
+//! labels and target port. Workers are keyed by `hash_pod_name(pod_name)` for
+//! selector registration and endpoint resolution.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr};
@@ -42,11 +36,6 @@ pub struct RawWorker {
     pub kv_events_endpoint: String,
     /// Optional ZMQ REQ endpoint for live-stream gap replay.
     pub replay_endpoint: Option<String>,
-    /// Routing identity fed to the selector's `stable_routing_id`. Currently the
-    /// pod name, so it is NOT yet restart-stable: a Deployment pod restart yields
-    /// a new name and a new identity. A truly stable source (StatefulSet ordinal
-    /// or a pod label) is a follow-up.
-    pub stable_routing_id: String,
 }
 
 /// One indexed worker: the materialized [`RawWorker`] for selector registration
@@ -70,12 +59,7 @@ impl WorkerEntry {
 /// Derived catalog of the `Ready`, pool-selected workers, keyed by `worker_id`.
 type WorkerIndex = HashMap<u64, WorkerEntry>;
 
-/// View over the `Ready` raw inference engine pods selected by the EPP's
-/// `InferencePool`. Reads never touch the Kubernetes API; they take a brief read
-/// lock on a derived [`WorkerIndex`] that a single background task maintains
-/// **incrementally** — each pod `Apply`/`Delete` is an O(1) upsert/remove, and
-/// the whole index is recomputed only on the initial LIST, a watch relist, or a
-/// pool-selector change.
+/// Provides an index of `Ready` workers selected by the EPP's `InferencePool`.
 #[derive(Clone)]
 pub struct PodDiscovery {
     index: Arc<RwLock<WorkerIndex>>,
@@ -109,9 +93,6 @@ impl PodDiscovery {
         let writer = reflector::store::Writer::default();
         let store = writer.as_reader();
         let ready = Arc::new(AtomicBool::new(false));
-        // `default_backoff()` lets the watcher own retry/backoff (exponential +
-        // jitter, capped) on watch errors; the error arm below just logs, so
-        // persistent failures (e.g. RBAC, API-server hiccup) don't hot-loop.
         let reflect = reflector::reflector(
             writer,
             watcher(pods, watcher::Config::default()).default_backoff(),
@@ -122,7 +103,6 @@ impl PodDiscovery {
         let kv_event_port = cfg.kv_event_port;
         let replay_port = cfg.replay_port;
 
-        // Derived worker index, maintained incrementally by the task below.
         let index: Arc<RwLock<WorkerIndex>> = Arc::new(RwLock::new(WorkerIndex::new()));
 
         tracing::info!(
@@ -132,10 +112,6 @@ impl PodDiscovery {
             "Starting namespace pod reflector for standalone mode"
         );
 
-        // A single task owns both wake sources so index mutations are serialized:
-        // a pod Apply/Delete mutates exactly one entry (O(1)); a full recompute
-        // runs only when the store is known consistent (InitDone, which also drops
-        // pods that vanished during a relist gap) or the pool selector changes.
         let index_task = index.clone();
         let ready_task = ready.clone();
         tokio::spawn(async move {
@@ -165,10 +141,7 @@ impl PodDiscovery {
                             Delta::Stop
                         }
                         // During a relist the reflector emits Init + one InitApply
-                        // per pod + InitDone. The per-object relist events only
-                        // prime the buffered store (the live store still holds the
-                        // pre-relist set until InitDone); mark the relist and act
-                        // once at InitDone with a single recompute.
+                        // per pod + InitDone.
                         Some(Ok(watcher::Event::Init | watcher::Event::InitApply(_))) => {
                             relisting = true;
                             Delta::Skip
@@ -190,15 +163,10 @@ impl PodDiscovery {
                             tracing::warn!("InferencePool watch ended");
                             Delta::Stop
                         } else if defer_pool_rebuild(relisting, pool_rx.borrow().is_some()) {
-                            // A relist is buffering pods and the live store is still
-                            // the pre-relist set. Defer this non-clearing selector/
-                            // port edit to InitDone, which rebuilds from the completed
-                            // pod list + latest PoolState. (A pool deletion/invalid
-                            // spec is not deferred and clears immediately below.)
+                            // Wait for the relist to complete and InitDone to be emitted.
+                            // To then rebuild the index from the completed pod list + latest PoolState.
                             Delta::Skip
                         } else {
-                            // A selector/target-port edit re-classifies every pod;
-                            // a None pool clears discovery.
                             Delta::Rebuild
                         }
                     }
@@ -224,16 +192,12 @@ impl PodDiscovery {
                     Delta::Remove(pod) => remove_pod(&index_task, &pod),
                 }
 
-                // Live readiness: true only once the pod cache has synced AND the
-                // pool is resolved; drops back to false if the pool later
-                // disappears, and recovers once both are healthy again.
+                // Readiness based on initial pods being synced and the pool being resolved.
                 ready_task.store(pod_synced && pool_rx.borrow().is_some(), Ordering::Release);
                 generation = generation.wrapping_add(1);
                 let _ = changes_tx.send(generation);
             }
-            // Either watch stream ended: the producer is gone and can no longer
-            // refresh discovery. Stop advertising readiness AND drop the index so
-            // reads can't hand out endpoints for workers we can no longer track.
+            // Watch stream has ended, so stop advertising readiness and clear the index.
             ready_task.store(false, Ordering::Release);
             index_task.write().unwrap().clear();
         });
@@ -247,9 +211,7 @@ impl PodDiscovery {
         ))
     }
 
-    /// All currently `Ready` workers selected by the pool, normalized for
-    /// selector registration. Empty until the `InferencePool` has resolved.
-    /// Reads the cached index; no per-call filtering or API access.
+    // Return all currently `Ready` workers selected by the pool.
     pub fn ready_workers(&self) -> Vec<RawWorker> {
         self.index
             .read()
@@ -259,15 +221,12 @@ impl PodDiscovery {
             .collect()
     }
 
-    /// Worker IDs of all currently `Ready`, pool-selected workers. Reads the
-    /// cached index, so it stays consistent with [`Self::resolve_endpoint`].
+    // Return the IDs of all currently `Ready`, pool-selected workers.
     pub fn ready_worker_ids(&self) -> HashSet<u64> {
         self.index.read().unwrap().keys().copied().collect()
     }
 
-    /// Resolve a `worker_id` to its current `ip:port` HTTP endpoint, if the pod
-    /// is still `Ready` and pool-selected. On the request hot path: an O(1)
-    /// lookup into the cached index.
+    // Resolve a `worker_id` to its current `ip:port` HTTP endpoint.
     pub fn resolve_endpoint(&self, worker_id: u64) -> Option<String> {
         self.index
             .read()
@@ -280,11 +239,6 @@ impl PodDiscovery {
     /// under a **single** read lock and **without cloning** any endpoint (`pred`
     /// borrows it). Used on the subset-routing path so membership testing doesn't
     /// allocate a throwaway `String` per candidate. Unknown workers are dropped.
-    ///
-    /// `pred` runs while the index read lock is held, so it must not re-enter
-    /// `PodDiscovery` (`resolve_endpoint`, `ready_workers`, another read, …):
-    /// `std::sync::RwLock` read locks are not guaranteed re-entrant and a nested
-    /// acquire can deadlock.
     pub fn filter_workers_by_endpoint(
         &self,
         worker_ids: &HashSet<u64>,
@@ -302,16 +256,12 @@ impl PodDiscovery {
             .collect()
     }
 
-    /// Subscribe to change notifications (a generation counter) bumped on pod or
-    /// pool changes, so a reconciler can re-sync.
     pub fn subscribe_changes(&self) -> watch::Receiver<u64> {
         self.changes.clone()
     }
 }
 
 /// Return `true` iff the pod is `Ready` and not terminating.
-/// A pod with a deletion timestamp is excluded even if it still
-/// reports `Ready=True`, so draining pods stop receiving traffic promptly.
 fn pod_is_ready(pod: &Pod) -> bool {
     if pod.metadata.deletion_timestamp.is_some() {
         return false;
@@ -350,20 +300,15 @@ fn pod_worker_id(pod: &Pod) -> Option<u64> {
     pod.metadata.name.as_deref().map(hash_pod_name)
 }
 
-/// Whether a pool change observed *during a relist* should be deferred to
-/// `InitDone` rather than rebuilt now. While relisting, the reflector's live
-/// store is still the pre-relist Pod set, so a non-clearing (selector/port) edit
-/// (`pool_present`) would rebuild from stale pods — defer it; `InitDone` rebuilds
-/// from the completed pod list + latest `PoolState`. A pool deletion/invalid spec
-/// (`!pool_present`) is never deferred: clearing stale discovery is always safe.
+/// Whether a pool update should wait for an in-progress pod relist to complete.
+/// Pool removal is never deferred.
 fn defer_pool_rebuild(relisting: bool, pool_present: bool) -> bool {
     relisting && pool_present
 }
 
 /// Apply a single pod delta to the index: upsert the worker if it is `Ready` and
 /// pool-selected, otherwise drop any existing entry (a pod that went NotReady,
-/// terminating, or unselected). O(1). A `None` pool means nothing is routable, so
-/// the entry is dropped; the following pool resolution triggers a full rebuild.
+/// terminating, or unselected). 
 fn upsert_pod(
     index: &RwLock<WorkerIndex>,
     pod: &Pod,
@@ -398,7 +343,7 @@ fn remove_pod(index: &RwLock<WorkerIndex>, pod: &Pod) {
 /// Recompute the whole index from the current pod store and pool selector.
 /// Empty until the `InferencePool` has resolved. Used only for the initial LIST,
 /// watch relists (which may have dropped pods without a `Delete`), and
-/// pool-selector changes (which re-classify every pod). O(pods), infrequent.
+/// pool-selector changes (which re-classify every pod).
 fn rebuild_index(
     store: &kube::runtime::reflector::Store<Pod>,
     pool: Option<&PoolState>,
@@ -430,11 +375,6 @@ fn raw_worker_from_pod(
     }
     let pod_name = pod.metadata.name.as_deref()?;
     let pod_ip = pod.status.as_ref()?.pod_ip.as_deref()?;
-    // A Pod IP is always an IP literal (never a hostname). Parse it so each
-    // host/port pair is rendered via `SocketAddr`, which brackets IPv6 as
-    // `[fd00::10]:8000`; a bare IPv6 literal (`fd00::10:8000`) is ambiguous, as
-    // the trailing group can't be told apart from the port. IPv4 is unchanged.
-    // An empty or malformed IP fails to parse and skips the pod.
     let ip: IpAddr = pod_ip.parse().ok()?;
 
     Some(RawWorker {
@@ -444,7 +384,6 @@ fn raw_worker_from_pod(
         http_endpoint: format!("http://{}", SocketAddr::new(ip, pool.target_port)),
         kv_events_endpoint: format!("tcp://{}", SocketAddr::new(ip, kv_event_port)),
         replay_endpoint: replay_port.map(|p| format!("tcp://{}", SocketAddr::new(ip, p))),
-        stable_routing_id: pod_name.to_string(),
     })
 }
 
@@ -848,7 +787,6 @@ mod tests {
             http_endpoint: format!("http://{endpoint}"),
             kv_events_endpoint: format!("tcp://{endpoint}"),
             replay_endpoint: None,
-            stable_routing_id: name,
         }
     }
 

--- a/lib/truthy/tests/no_bool_parse_forks.rs
+++ b/lib/truthy/tests/no_bool_parse_forks.rs
@@ -20,7 +20,12 @@ use std::path::{Path, PathBuf};
 
 /// Known non-fork matches, as (path suffix, line substring) pairs. A multiline
 /// (file-level) match is allowed when any entry's path suffix matches the file.
-const ALLOWED: &[(&str, &str)] = &[];
+const ALLOWED: &[(&str, &str)] = &[(
+    "deploy/inference-gateway/ext-proc/src/pod_discovery.rs",
+    // Kubernetes condition statuses are stringly typed API enum values, not
+    // user-provided configuration booleans.
+    r#"c.status == "True""#,
+)];
 
 /// Substring patterns that indicate a hand-rolled bool parser. Matched against
 /// lowercased text, so `"TRUE"` / `"False"` variants are caught too.


### PR DESCRIPTION
## Overview

Discover standalone EPP workers from the InferencePool targeted by the gateway, so both components use the same pool membership and target port. This PR provides discovery only; wiring the discovered workers into the embedded SelectionService/EPP occurs in later PRs in the train.

## Details

- Watch the configured GAIE `InferencePool` and derive its backend Pod `matchLabels` selector and HTTP target port into `PoolState`.
- Watch Pods in the namespace through kube-rs' reflector store and maintain an incremental index of Ready, selector-matching workers rather than rebuilding all workers for every Pod event.
- Rebuild the index after a completed reflector relist. A valid Pool selector/port edit observed during `Init`/`InitApply` is deferred to `InitDone`, so the rebuilt index is derived from the completed Pod set and latest PoolState.
- Clear the index immediately when the Pool is deleted or becomes invalid, preventing routing with a stale selector or port.
- Publish discovery readiness and indexed workers/endpoints for the later topology-adapter and router PRs.
- Add coverage for a Pool edit interleaved with a Pod relist.

## Where should the reviewer start?

- `deploy/inference-gateway/ext-proc/src/pod_discovery.rs` — reflector event loop, incremental worker index, and Pool-change/relist interaction.
- `deploy/inference-gateway/ext-proc/src/inference_pool.rs` — InferencePool watch and PoolState parsing/validation.

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of ready inference workers from Kubernetes pods.
  * Workers are matched to their configured inference pool and exposed with HTTP, key-value events, and optional replay endpoints.
  * Added live readiness tracking as pool and pod information becomes available.
  * Added support for IPv4 and IPv6 worker endpoints.

* **Bug Fixes**
  * Invalid or incomplete inference pool configurations no longer leave stale worker state.
  * Unready, malformed, unmatched, or terminating pods are excluded from routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->