### PR TITLE
feat: PR 4 Selection-service HTTP fleet with EndpointSlice discovery.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "rcgen",
+ "reqwest 0.12.28",
  "rustls 0.23.40",
  "rustls-pemfile",
  "serde",

--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -27,6 +27,7 @@ kube = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rcgen = { workspace = true }
+reqwest = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 serde = { workspace = true }

--- a/deploy/inference-gateway/ext-proc/src/epp_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_config.rs
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Router-only mode configuration.
+//!
+//! `DYN_EPP_MODE` selects the EPP mode: `full-dynamo-stack` (default) or
+//! `router-only` (fronts raw `vllm serve` pods with no Dynamo runtime and
+//! delegates KV-aware selection to the standalone selection service). The pod
+//! selector and target port come from the `InferencePool`; the rest of the
+//! router-only contract comes from the environment and is parsed here.
+
+const DEFAULT_KV_EVENT_PORT: u16 = 5557;
+const DEFAULT_DATA_PARALLEL_SIZE: u32 = 1;
+const DEFAULT_SELECTOR_HTTP_PORT: u16 = 8092;
+const DEFAULT_SELECTOR_REPLICA_SYNC_PORT: u16 = 9092;
+
+/// Environment variable that selects the EPP operating mode.
+pub const DYN_EPP_MODE: &str = "DYN_EPP_MODE";
+/// `DYN_EPP_MODE` value selecting router-only mode.
+pub const ROUTER_ONLY_MODE: &str = "router-only";
+/// `DYN_EPP_MODE` value selecting the default full Dynamo stack.
+pub const FULL_DYNAMO_STACK_MODE: &str = "full-dynamo-stack";
+
+/// Reads an environment variable, matching the injectable getter used in tests.
+type EnvGet<'a> = dyn Fn(&str) -> Option<String> + 'a;
+
+/// Top-level EPP operating mode from `DYN_EPP_MODE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EppMode {
+    /// Default: attach to a Dynamo deployment (etcd/NATS + embedded KV router).
+    FullDynamoStack,
+    /// Front raw `vllm serve` pods with no Dynamo runtime.
+    RouterOnly,
+}
+
+impl EppMode {
+    /// Parse `DYN_EPP_MODE` from the process environment.
+    pub fn from_env() -> anyhow::Result<Self> {
+        Self::parse(&|k| std::env::var(k).ok())
+    }
+
+    /// Parse the mode, failing fast on an unrecognized value so a typo (e.g.
+    /// `router_only`) can never silently fall through to full-dynamo mode.
+    fn parse(get: &EnvGet) -> anyhow::Result<Self> {
+        match trimmed(get(DYN_EPP_MODE)).as_deref() {
+            None | Some(FULL_DYNAMO_STACK_MODE) => Ok(Self::FullDynamoStack),
+            Some(ROUTER_ONLY_MODE) => Ok(Self::RouterOnly),
+            Some(other) => anyhow::bail!(
+                "{DYN_EPP_MODE} has invalid value {other:?}; \
+                 expected {ROUTER_ONLY_MODE:?} or {FULL_DYNAMO_STACK_MODE:?}"
+            ),
+        }
+    }
+}
+
+/// Router-only configuration, built from the environment with fail-fast
+/// validation. The pod selector and target port are NOT here — they come from
+/// the `InferencePool` named by `pool_name` at runtime.
+#[derive(Debug, Clone)]
+pub struct EppConfig {
+    /// Selection-service `Service` whose EndpointSlices the EPP watches.
+    pub selector_service: String,
+    /// Namespace of the selection-service `Service` (default `POD_NAMESPACE`).
+    pub selector_service_namespace: Option<String>,
+    /// HTTP port each selection-service replica serves on.
+    pub selector_http_port: u16,
+    /// ZMQ replica-sync PUB port each selection-service replica binds.
+    pub selector_replica_sync_port: u16,
+    /// `InferencePool` this EPP backs; its selector + target port drive discovery.
+    pub pool_name: String,
+    /// Namespace of the `InferencePool` (default `POD_NAMESPACE`).
+    pub pool_namespace: Option<String>,
+    /// Model id used to build the offline tokenizer (no model card in this mode).
+    pub model_name: String,
+    /// KV-cache block size; MUST equal the vLLM `--block-size`.
+    pub block_size: u32,
+    /// vLLM `--kv-events-config` PUB port the selector subscribes to.
+    pub kv_event_port: u16,
+    /// vLLM `--kv-events-config` topic (default empty).
+    pub kv_event_topic: String,
+    /// Optional ZMQ REQ port the selector uses for live-stream gap replay.
+    pub replay_port: Option<u16>,
+    /// Engine data-parallel size (default 1; aggregated V1 supports DP=1).
+    pub data_parallel_size: u32,
+    /// Optional per-worker total KV blocks hint for the selector's load model.
+    pub total_kv_blocks: Option<u64>,
+    /// Optional per-worker max batched tokens (needed only when queueing is on).
+    pub max_num_batched_tokens: Option<u64>,
+}
+
+impl EppConfig {
+    /// Parse and validate the router-only contract from the process environment.
+    pub fn from_env() -> anyhow::Result<Self> {
+        Self::parse(&|k| std::env::var(k).ok())
+    }
+
+    /// Parse from an injectable getter. Keeps parsing pure so tests supply a map
+    /// instead of mutating the process-global environment.
+    fn parse(get: &EnvGet) -> anyhow::Result<Self> {
+        let selector_service = require(get, "DYN_EPP_SELECTOR_SERVICE")?;
+        let selector_service_namespace = trimmed(get("DYN_EPP_SELECTOR_SERVICE_NAMESPACE"));
+        let selector_http_port =
+            opt_parse::<u16>(get, "DYN_EPP_SELECTOR_HTTP_PORT")?.unwrap_or(DEFAULT_SELECTOR_HTTP_PORT);
+        let selector_replica_sync_port = opt_parse::<u16>(get, "DYN_EPP_SELECTOR_REPLICA_SYNC_PORT")?
+            .unwrap_or(DEFAULT_SELECTOR_REPLICA_SYNC_PORT);
+
+        let pool_name = require(get, "DYN_EPP_POOL_NAME")?;
+        let pool_namespace = trimmed(get("DYN_EPP_POOL_NAMESPACE"));
+        let model_name = require(get, "DYN_MODEL_NAME")?;
+        let block_size = require_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?;
+        if block_size == 0 {
+            anyhow::bail!("DYN_KV_CACHE_BLOCK_SIZE must be greater than zero");
+        }
+
+        let kv_event_port =
+            opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?.unwrap_or(DEFAULT_KV_EVENT_PORT);
+        let kv_event_topic = trimmed(get("DYN_EPP_KV_EVENT_TOPIC")).unwrap_or_default();
+        let replay_port = opt_parse::<u16>(get, "DYN_EPP_REPLAY_PORT")?;
+        let data_parallel_size =
+            opt_parse::<u32>(get, "DYN_DATA_PARALLEL_SIZE")?.unwrap_or(DEFAULT_DATA_PARALLEL_SIZE);
+        if data_parallel_size == 0 {
+            anyhow::bail!("DYN_DATA_PARALLEL_SIZE must be greater than zero");
+        }
+        let total_kv_blocks = opt_parse::<u64>(get, "DYN_TOTAL_KV_BLOCKS")?;
+        let max_num_batched_tokens = opt_parse::<u64>(get, "DYN_MAX_NUM_BATCHED_TOKENS")?;
+
+        Ok(Self {
+            selector_service,
+            selector_service_namespace,
+            selector_http_port,
+            selector_replica_sync_port,
+            pool_name,
+            pool_namespace,
+            model_name,
+            block_size,
+            kv_event_port,
+            kv_event_topic,
+            replay_port,
+            data_parallel_size,
+            total_kv_blocks,
+            max_num_batched_tokens,
+        })
+    }
+}
+
+/// Trim a raw value and treat empty as absent.
+fn trimmed(v: Option<String>) -> Option<String> {
+    v.and_then(|v| {
+        let t = v.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    })
+}
+
+fn require(get: &EnvGet, key: &str) -> anyhow::Result<String> {
+    trimmed(get(key)).ok_or_else(|| anyhow::anyhow!("{key} is required in {ROUTER_ONLY_MODE} mode"))
+}
+
+fn require_parse<T>(get: &EnvGet, key: &str) -> anyhow::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    let raw = require(get, key)?;
+    raw.parse::<T>()
+        .map_err(|e| anyhow::anyhow!("{key} has an invalid value {raw:?}: {e}"))
+}
+
+fn opt_parse<T>(get: &EnvGet, key: &str) -> anyhow::Result<Option<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match trimmed(get(key)) {
+        None => Ok(None),
+        Some(raw) => raw
+            .parse::<T>()
+            .map(Some)
+            .map_err(|e| anyhow::anyhow!("{key} has an invalid value {raw:?}: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Build an injectable env getter from key/value pairs — no process-global
+    /// env mutation, so these tests are isolated and parallel-safe.
+    fn getter(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> =
+            pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+        move |k| map.get(k).cloned()
+    }
+
+    fn parse_mode(pairs: &[(&str, &str)]) -> anyhow::Result<EppMode> {
+        EppMode::parse(&getter(pairs))
+    }
+
+    fn parse_cfg(pairs: &[(&str, &str)]) -> anyhow::Result<EppConfig> {
+        EppConfig::parse(&getter(pairs))
+    }
+
+    #[test]
+    fn mode_defaults_to_full_when_unset() {
+        assert_eq!(parse_mode(&[]).unwrap(), EppMode::FullDynamoStack);
+    }
+
+    #[test]
+    fn mode_parses_known_values() {
+        assert_eq!(
+            parse_mode(&[("DYN_EPP_MODE", "router-only")]).unwrap(),
+            EppMode::RouterOnly
+        );
+        assert_eq!(
+            parse_mode(&[("DYN_EPP_MODE", "full-dynamo-stack")]).unwrap(),
+            EppMode::FullDynamoStack
+        );
+    }
+
+    #[test]
+    fn mode_rejects_unknown_value() {
+        // A typo must fail fast, not silently boot full-dynamo mode.
+        assert!(parse_mode(&[("DYN_EPP_MODE", "router_only")]).is_err());
+    }
+
+    #[test]
+    fn parses_required_and_defaults() {
+        let cfg = parse_cfg(&[
+            ("DYN_EPP_SELECTOR_SERVICE", "dynamo-selector"),
+            ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+        ])
+        .expect("config should parse");
+        assert_eq!(cfg.selector_service, "dynamo-selector");
+        assert!(cfg.selector_service_namespace.is_none());
+        assert_eq!(cfg.selector_http_port, DEFAULT_SELECTOR_HTTP_PORT);
+        assert_eq!(
+            cfg.selector_replica_sync_port,
+            DEFAULT_SELECTOR_REPLICA_SYNC_PORT
+        );
+        assert_eq!(cfg.pool_name, "vllm-qwen-pool");
+        assert!(cfg.pool_namespace.is_none());
+        assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
+        assert_eq!(cfg.block_size, 16);
+        assert_eq!(cfg.kv_event_port, DEFAULT_KV_EVENT_PORT);
+        assert_eq!(cfg.data_parallel_size, 1);
+        assert!(cfg.replay_port.is_none());
+        assert!(cfg.total_kv_blocks.is_none());
+    }
+
+    #[test]
+    fn pool_namespace_is_parsed_when_set() {
+        let cfg = parse_cfg(&[
+            ("DYN_EPP_SELECTOR_SERVICE", "dynamo-selector"),
+            ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+            ("DYN_EPP_POOL_NAMESPACE", "inference"),
+            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+        ])
+        .expect("config should parse");
+        assert_eq!(cfg.pool_namespace.as_deref(), Some("inference"));
+    }
+
+    #[test]
+    fn missing_pool_name_fails() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_SELECTOR_SERVICE", "dynamo-selector"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn missing_selector_service_fails() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn zero_block_size_fails() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_SELECTOR_SERVICE", "dynamo-selector"),
+                ("DYN_EPP_POOL_NAME", "vllm-qwen-pool"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "0"),
+            ])
+            .is_err()
+        );
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/inference_pool.rs
+++ b/deploy/inference-gateway/ext-proc/src/inference_pool.rs
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Read-only watcher for the GAIE `InferencePool` this EPP backs.
+//!
+//! In router-only mode the `InferencePool` is the single source of truth for
+//! which pods are candidate backends: the gateway routes to it, and the EPP
+//! reads its `spec.selector` and target port to discover the same pods. This
+//! watcher only ever *reads* the pool — it never writes status or manages the
+//! object, so it coexists with the gateway provider's controller (which owns the
+//! pool lifecycle) without conflict.
+//!
+//! The pool type is resolved dynamically (no compiled CRD type) so the EPP is
+//! not pinned to a single `InferencePool` schema version. Both the graduated
+//! `spec.targetPorts[].number` (v1) and the older `spec.targetPortNumber`
+//! (v1alpha2) shapes are accepted.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use anyhow::Result;
+use kube::core::{ApiResource, DynamicObject, GroupVersionKind};
+use kube::runtime::watcher;
+use kube::{Api, Client};
+use tokio::sync::watch;
+
+const INFERENCE_POOL_GROUP: &str = "inference.networking.k8s.io";
+const INFERENCE_POOL_VERSION: &str = "v1";
+const INFERENCE_POOL_KIND: &str = "InferencePool";
+
+/// The slice of `InferencePool` spec the EPP needs to discover pods.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PoolState {
+    /// `spec.selector.matchLabels` — the pod label selector (equality only).
+    pub match_labels: BTreeMap<String, String>,
+    /// The OpenAI HTTP target port resolved from the pool.
+    pub target_port: u16,
+}
+
+/// Start a background watch of the named `InferencePool`. The returned receiver
+/// carries the latest [`PoolState`] (or `None` until the pool is first observed,
+/// or after it is deleted).
+pub async fn spawn_pool_watch(
+    client: Client,
+    namespace: String,
+    name: String,
+) -> Result<(
+    watch::Receiver<Option<PoolState>>,
+    tokio::task::JoinHandle<()>,
+)> {
+    let gvk = GroupVersionKind::gvk(
+        INFERENCE_POOL_GROUP,
+        INFERENCE_POOL_VERSION,
+        INFERENCE_POOL_KIND,
+    );
+    let ar = ApiResource::from_gvk(&gvk);
+    let api: Api<DynamicObject> = Api::namespaced_with(client, &namespace, &ar);
+    let wcfg = watcher::Config::default().fields(&format!("metadata.name={name}"));
+
+    let (tx, rx) = watch::channel::<Option<PoolState>>(None);
+
+    tracing::info!(
+        namespace = %namespace,
+        pool = %name,
+        "Starting InferencePool watch (read-only) for router-only discovery"
+    );
+
+    let handle = tokio::spawn(async move {
+        use futures::StreamExt;
+        let stream = watcher(api, wcfg);
+        tokio::pin!(stream);
+        loop {
+            match stream.next().await {
+                Some(Ok(event)) => handle_event(event, &name, &tx),
+                Some(Err(e)) => {
+                    tracing::warn!(error = %e, pool = %name, "InferencePool watch error; retrying");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                None => {
+                    tracing::warn!(pool = %name, "InferencePool watch stream ended");
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok((rx, handle))
+}
+
+fn handle_event(
+    event: watcher::Event<DynamicObject>,
+    name: &str,
+    tx: &watch::Sender<Option<PoolState>>,
+) {
+    match event {
+        watcher::Event::Apply(obj) | watcher::Event::InitApply(obj) => {
+            match parse_pool_state(&obj.data) {
+                Some(state) => {
+                    tracing::info!(
+                        pool = %name,
+                        target_port = state.target_port,
+                        labels = ?state.match_labels,
+                        "InferencePool resolved"
+                    );
+                    let _ = tx.send(Some(state));
+                }
+                None => {
+                    tracing::warn!(
+                        pool = %name,
+                        "InferencePool present but missing matchLabels/targetPort; ignoring"
+                    );
+                }
+            }
+        }
+        watcher::Event::Delete(_) => {
+            tracing::warn!(pool = %name, "InferencePool deleted; clearing discovery state");
+            let _ = tx.send(None);
+        }
+        watcher::Event::Init | watcher::Event::InitDone => {}
+    }
+}
+
+/// Extract a [`PoolState`] from an `InferencePool` `spec` JSON value. Returns
+/// `None` if the selector is empty/missing or no target port can be resolved.
+/// Pure function — unit-testable without a cluster.
+fn parse_pool_state(data: &serde_json::Value) -> Option<PoolState> {
+    let spec = data.get("spec")?;
+
+    let labels_obj = spec.get("selector")?.get("matchLabels")?.as_object()?;
+    let mut match_labels = BTreeMap::new();
+    for (k, v) in labels_obj {
+        if let Some(s) = v.as_str() {
+            match_labels.insert(k.clone(), s.to_string());
+        }
+    }
+    // An empty selector would match every pod in the namespace; refuse it.
+    if match_labels.is_empty() {
+        return None;
+    }
+
+    // v1: spec.targetPorts[0].number; v1alpha2: spec.targetPortNumber.
+    let target_port_u64 = spec
+        .get("targetPorts")
+        .and_then(|tp| tp.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|p| p.get("number"))
+        .and_then(|n| n.as_u64())
+        .or_else(|| spec.get("targetPortNumber").and_then(|n| n.as_u64()))?;
+    let target_port = u16::try_from(target_port_u64).ok()?;
+    if target_port == 0 {
+        return None;
+    }
+
+    Some(PoolState {
+        match_labels,
+        target_port,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_v1_target_ports() {
+        let data = json!({
+            "spec": {
+                "selector": {"matchLabels": {"app": "vllm-qwen"}},
+                "targetPorts": [{"number": 8000}]
+            }
+        });
+        let s = parse_pool_state(&data).expect("v1 pool should parse");
+        assert_eq!(s.target_port, 8000);
+        assert_eq!(s.match_labels.get("app").unwrap(), "vllm-qwen");
+    }
+
+    #[test]
+    fn parses_v1alpha2_target_port_number() {
+        let data = json!({
+            "spec": {
+                "selector": {"matchLabels": {"app": "vllm-qwen", "role": "decode"}},
+                "targetPortNumber": 8000
+            }
+        });
+        let s = parse_pool_state(&data).expect("v1alpha2 pool should parse");
+        assert_eq!(s.target_port, 8000);
+        assert_eq!(s.match_labels.len(), 2);
+    }
+
+    #[test]
+    fn empty_selector_is_rejected() {
+        let data = json!({
+            "spec": {"selector": {"matchLabels": {}}, "targetPorts": [{"number": 8000}]}
+        });
+        assert!(parse_pool_state(&data).is_none());
+    }
+
+    #[test]
+    fn missing_target_port_is_rejected() {
+        let data = json!({
+            "spec": {"selector": {"matchLabels": {"app": "x"}}}
+        });
+        assert!(parse_pool_state(&data).is_none());
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -20,6 +20,8 @@ pub mod offline_preprocessor;
 pub mod picker;
 pub mod pod_discovery;
 pub mod proto;
+pub mod selection_backend;
+pub mod selector_fleet;
 pub mod server;
 
 pub use epp::Router;
@@ -28,4 +30,8 @@ pub use inference_pool::PoolState;
 pub use offline_preprocessor::build_offline_preprocessor;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use pod_discovery::{PodDiscovery, RawWorker};
+pub use selection_backend::{
+    SelectRequest, SelectResponse, SelectionBackend, WorkerPatch, WorkerRegistration,
+};
+pub use selector_fleet::SelectorFleet;
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -15,13 +15,17 @@
 pub mod envoy_helpers;
 pub mod epp;
 pub mod epp_config;
+pub mod inference_pool;
 pub mod offline_preprocessor;
 pub mod picker;
+pub mod pod_discovery;
 pub mod proto;
 pub mod server;
 
 pub use epp::Router;
 pub use epp_config::{EppConfig, EppMode};
+pub use inference_pool::PoolState;
 pub use offline_preprocessor::build_offline_preprocessor;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
+pub use pod_discovery::{PodDiscovery, RawWorker};
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -15,11 +15,13 @@
 pub mod envoy_helpers;
 pub mod epp;
 pub mod epp_config;
+pub mod offline_preprocessor;
 pub mod picker;
 pub mod proto;
 pub mod server;
 
 pub use epp::Router;
 pub use epp_config::{EppConfig, EppMode};
+pub use offline_preprocessor::build_offline_preprocessor;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -14,10 +14,12 @@
 
 pub mod envoy_helpers;
 pub mod epp;
+pub mod epp_config;
 pub mod picker;
 pub mod proto;
 pub mod server;
 
 pub use epp::Router;
+pub use epp_config::{EppConfig, EppMode};
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/main.rs
+++ b/deploy/inference-gateway/ext-proc/src/main.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_ext_proc::{ExtProcServer, Router};
+use dynamo_ext_proc::{EppConfig, EppMode, ExtProcServer, Router};
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 
@@ -123,6 +123,9 @@ async fn main() -> Result<()> {
         )
         .init();
 
+    // Fail fast on an unknown DYN_EPP_MODE rather than silently booting full mode.
+    let router_only = matches!(EppMode::from_env()?, EppMode::RouterOnly);
+
     let config = Config::from_env();
 
     tracing::info!(
@@ -130,8 +133,28 @@ async fn main() -> Result<()> {
         health_port = HEALTH_PORT,
         namespace = %config.namespace,
         component = %config.component,
+        router_only,
         "Starting Dynamo Rust EPP"
     );
+
+    // Router-only (selector) mode fronts raw vLLM pods with no Dynamo runtime and
+    // delegates KV-aware selection to the standalone selection service. The
+    // config surface is validated here; the runtime wiring lands in a follow-up
+    // (see crate::selector_router).
+    if router_only {
+        let selector_cfg = EppConfig::from_env()?;
+        tracing::info!(
+            selector_service = %selector_cfg.selector_service,
+            pool_name = %selector_cfg.pool_name,
+            model_name = %selector_cfg.model_name,
+            block_size = selector_cfg.block_size,
+            "Parsed router-only selector configuration"
+        );
+        anyhow::bail!(
+            "DYN_EPP_MODE=router-only is not yet wired; selector runtime assembly lands in a \
+             follow-up change"
+        );
+    }
 
     // Start plaintext gRPC health server immediately (NOT_SERVING until router ready).
     let (health_reporter, health_service) = tonic_health::server::health_reporter();

--- a/deploy/inference-gateway/ext-proc/src/offline_preprocessor.rs
+++ b/deploy/inference-gateway/ext-proc/src/offline_preprocessor.rs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime-free tokenizer/preprocessor construction for router-only mode.
+//!
+//! In full Dynamo mode the EPP fetches a [`ModelDeploymentCard`] from the
+//! distributed discovery plane and builds an [`OpenAIPreprocessor`] from it
+//! (see [`crate::epp::Router::from_discovery`]). Router-only mode has no
+//! control plane and no Dynamo runtime, so the preprocessor is built entirely
+//! offline from a model id:
+//!
+//! 1. resolve the model files into the local HF cache (download if absent), and
+//! 2. load a [`ModelDeploymentCard`] from that directory, then
+//! 3. build the [`OpenAIPreprocessor`] (tokenizer + chat template).
+//!
+//! Only the tokenizer/config files are fetched — model weights are skipped.
+//! The preprocessor is used solely to tokenize prompts for routing; the worker
+//! re-tokenizes the forwarded request, so no `token_ids` are injected.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use dynamo_llm::hub::from_hf;
+use dynamo_llm::model_card::ModelDeploymentCard;
+use dynamo_llm::preprocessor::OpenAIPreprocessor;
+
+/// Build an [`OpenAIPreprocessor`] offline from a model id (HF repo or local
+/// path), with no Dynamo runtime or discovery plane.
+///
+/// `block_size` MUST equal the engine's `--block-size`; it is recorded on the
+/// card so any block-size-derived preprocessing stays consistent with the
+/// engine that produces the KV-cache events the selector ingests.
+pub async fn build_offline_preprocessor(
+    model_name: &str,
+    block_size: u32,
+) -> Result<Arc<OpenAIPreprocessor>> {
+    // Tokenizer/config only — never download weights for the routing path.
+    let model_path = from_hf(model_name, true)
+        .await
+        .with_context(|| format!("resolving tokenizer/config for model {model_name:?}"))?;
+
+    let mut card = ModelDeploymentCard::load_from_disk(&model_path, None)
+        .with_context(|| format!("loading ModelDeploymentCard from {}", model_path.display()))?;
+    card.set_name(model_name);
+    card.kv_cache_block_size = block_size;
+
+    OpenAIPreprocessor::new(card)
+        .with_context(|| format!("building offline preprocessor for model {model_name:?}"))
+}

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -1,0 +1,392 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pod discovery for router-only (raw-vLLM) mode, driven by the `InferencePool`.
+//!
+//! The pod label selector and HTTP target port come from the GAIE
+//! [`InferencePool`](crate::inference_pool) this EPP backs — the same object the
+//! gateway routes to — so EPP and gateway can never disagree about pool
+//! membership. To pick up live selector/target-port edits without restarting any
+//! watch, the reflector watches **all** pods in the namespace and filters them
+//! in memory against the current [`PoolState`]; the pool watch just swaps the
+//! filter.
+//!
+//! Pods are `Ready`-filtered (and excluded once terminating), so in-flight
+//! rollouts and crash-looping pods receive no traffic.
+//!
+//! `worker_id = hash_pod_name(pod_name)`, so the IDs produced here line up with
+//! whatever consumes them (the topology adapter and selector catalog).
+
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+use dynamo_runtime::discovery::hash_pod_name;
+use k8s_openapi::api::core::v1::Pod;
+use tokio::sync::watch;
+
+use crate::epp_config::EppConfig;
+use crate::inference_pool::{PoolState, spawn_pool_watch};
+
+/// A discovered, `Ready` raw vLLM worker normalized for selector registration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawWorker {
+    /// Stable hash of the pod name; the selector catalog key.
+    pub worker_id: u64,
+    /// Kubernetes pod name.
+    pub pod_name: String,
+    /// Pod IP.
+    pub pod_ip: String,
+    /// OpenAI HTTP inference endpoint, `http://<ip>:<target_port>`.
+    pub http_endpoint: String,
+    /// vLLM KV-event ZMQ PUB endpoint, `tcp://<ip>:<kv_event_port>`.
+    pub kv_events_endpoint: String,
+    /// Optional ZMQ REQ endpoint for live-stream gap replay.
+    pub replay_endpoint: Option<String>,
+    /// Routing identity fed to the selector's `stable_routing_id`. Currently the
+    /// pod name, so it is NOT yet restart-stable: a Deployment pod restart yields
+    /// a new name and a new identity. A truly stable source (StatefulSet ordinal
+    /// or a pod label) is a follow-up.
+    pub stable_routing_id: String,
+}
+
+/// Lock-free view over the `Ready` raw vLLM pods selected by the EPP's
+/// `InferencePool`. Reads never touch the Kubernetes API.
+#[derive(Clone)]
+pub struct PodDiscovery {
+    store: kube::runtime::reflector::Store<Pod>,
+    pool_rx: watch::Receiver<Option<PoolState>>,
+    kv_event_port: u16,
+    replay_port: Option<u16>,
+    changes: watch::Receiver<u64>,
+}
+
+impl PodDiscovery {
+    /// Start the InferencePool watch and a namespace-wide pod reflector. Returns
+    /// a readiness flag that flips once the initial pod LIST has populated the
+    /// store. Pods become selectable only once the pool has also resolved.
+    pub async fn spawn(cfg: &EppConfig) -> Result<(Self, Arc<AtomicBool>)> {
+        use futures::StreamExt;
+        use kube::{Api, Client, runtime::reflector, runtime::watcher};
+
+        let client = Client::try_default().await?;
+        let namespace = match &cfg.pool_namespace {
+            Some(ns) => ns.clone(),
+            None => std::env::var("POD_NAMESPACE").map_err(|_| {
+                anyhow::anyhow!(
+                    "DYN_EPP_POOL_NAMESPACE is unset and POD_NAMESPACE is not available. \
+                     Ensure the EPP pod spec injects POD_NAMESPACE via the downward API \
+                     (fieldRef metadata.namespace), or set DYN_EPP_POOL_NAMESPACE."
+                )
+            })?,
+        };
+
+        let (pool_rx, _pool_task) =
+            spawn_pool_watch(client.clone(), namespace.clone(), cfg.pool_name.clone()).await?;
+
+        // Namespace-wide pod watch; membership is decided in memory by the pool
+        // selector so selector edits never require re-spawning this watch.
+        let pods: Api<Pod> = Api::namespaced(client, &namespace);
+        let writer = reflector::store::Writer::default();
+        let store = writer.as_reader();
+        let ready = Arc::new(AtomicBool::new(false));
+        let reflect = reflector::reflector(writer, watcher(pods, watcher::Config::default()));
+
+        let (changes_tx, changes_rx) = watch::channel(0u64);
+
+        tracing::info!(
+            namespace = %namespace,
+            pool = %cfg.pool_name,
+            kv_event_port = cfg.kv_event_port,
+            "Starting namespace pod reflector for router-only mode"
+        );
+
+        // Pod reflector stream -> bump the change generation.
+        let changes_for_pods = changes_tx.clone();
+        tokio::spawn(async move {
+            tokio::pin!(reflect);
+            let mut generation = 0u64;
+            while reflect.next().await.is_some() {
+                generation = generation.wrapping_add(1);
+                let _ = changes_for_pods.send(generation);
+            }
+            tracing::warn!("Raw-vLLM pod reflector stream ended unexpectedly");
+        });
+
+        // Pool changes also drive reconciliation (membership/target port may move).
+        let mut pool_rx_for_changes = pool_rx.clone();
+        tokio::spawn(async move {
+            let mut generation = u64::MAX / 2; // distinct space from pod bumps
+            while pool_rx_for_changes.changed().await.is_ok() {
+                generation = generation.wrapping_add(1);
+                let _ = changes_tx.send(generation);
+            }
+        });
+
+        let store_for_wait = store.clone();
+        let ready_for_wait = ready.clone();
+        match tokio::time::timeout(Duration::from_secs(30), store_for_wait.wait_until_ready()).await
+        {
+            Ok(Ok(())) => {
+                ready_for_wait.store(true, Ordering::Release);
+                tracing::info!("Pod reflector initial LIST sync complete");
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "Pod reflector writer dropped before initial LIST");
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "Pod reflector initial LIST timed out after 30s; ready in background"
+                );
+                let store_bg = store.clone();
+                let ready_bg = ready.clone();
+                tokio::spawn(async move {
+                    if store_bg.wait_until_ready().await.is_ok() {
+                        ready_bg.store(true, Ordering::Release);
+                        tracing::info!("Pod reflector became ready after startup timeout");
+                    }
+                });
+            }
+        }
+
+        Ok((
+            Self {
+                store,
+                pool_rx,
+                kv_event_port: cfg.kv_event_port,
+                replay_port: cfg.replay_port,
+                changes: changes_rx,
+            },
+            ready,
+        ))
+    }
+
+    /// All currently `Ready` workers selected by the pool, normalized for
+    /// selector registration. Empty until the `InferencePool` has resolved.
+    pub fn ready_workers(&self) -> Vec<RawWorker> {
+        let pool = self.pool_rx.borrow().clone();
+        let Some(pool) = pool else {
+            return Vec::new();
+        };
+        self.store
+            .state()
+            .iter()
+            .filter_map(|pod| raw_worker_from_pod(pod, &pool, self.kv_event_port, self.replay_port))
+            .collect()
+    }
+
+    /// Worker IDs of all currently `Ready`, pool-selected workers.
+    pub fn ready_worker_ids(&self) -> HashSet<u64> {
+        self.ready_workers()
+            .into_iter()
+            .map(|w| w.worker_id)
+            .collect()
+    }
+
+    /// Resolve a `worker_id` to its current `ip:port` HTTP endpoint, if the pod
+    /// is still `Ready` and pool-selected. Short-circuits on the first match
+    /// instead of building the full worker list.
+    pub fn resolve_endpoint(&self, worker_id: u64) -> Option<String> {
+        let pool = self.pool_rx.borrow().clone()?;
+        self.store.state().iter().find_map(|pod| {
+            let worker = raw_worker_from_pod(pod, &pool, self.kv_event_port, self.replay_port)?;
+            (worker.worker_id == worker_id)
+                .then(|| strip_scheme(&worker.http_endpoint).to_string())
+        })
+    }
+
+    /// Subscribe to change notifications (a generation counter) bumped on pod or
+    /// pool changes, so a reconciler can re-sync.
+    pub fn subscribe_changes(&self) -> watch::Receiver<u64> {
+        self.changes.clone()
+    }
+}
+
+fn strip_scheme(endpoint: &str) -> &str {
+    endpoint
+        .strip_prefix("http://")
+        .or_else(|| endpoint.strip_prefix("https://"))
+        .unwrap_or(endpoint)
+}
+
+/// Return `true` iff the pod is `Ready` and not terminating. Mirrors llm-d's
+/// `IsPodReady`: a pod with a deletion timestamp is excluded even if it still
+/// reports `Ready=True`, so draining pods stop receiving traffic promptly.
+fn pod_is_ready(pod: &Pod) -> bool {
+    if pod.metadata.deletion_timestamp.is_some() {
+        return false;
+    }
+    pod.status
+        .as_ref()
+        .and_then(|s| s.conditions.as_ref())
+        .map(|conds| {
+            conds
+                .iter()
+                .any(|c| c.type_ == "Ready" && c.status == "True")
+        })
+        .unwrap_or(false)
+}
+
+/// Return `true` iff the pod carries every `match_labels` key with the equal
+/// value (equality-based selector, matching `InferencePool.spec.selector`).
+fn pod_matches(pod: &Pod, match_labels: &BTreeMap<String, String>) -> bool {
+    let Some(labels) = pod.metadata.labels.as_ref() else {
+        return match_labels.is_empty();
+    };
+    match_labels
+        .iter()
+        .all(|(k, v)| labels.get(k).map(|pv| pv == v).unwrap_or(false))
+}
+
+/// Build a [`RawWorker`] from a pod, or `None` if it is not `Ready`, not
+/// pool-selected, or lacks an IP/name. Pure function — unit-testable.
+fn raw_worker_from_pod(
+    pod: &Pod,
+    pool: &PoolState,
+    kv_event_port: u16,
+    replay_port: Option<u16>,
+) -> Option<RawWorker> {
+    if !pod_is_ready(pod) || !pod_matches(pod, &pool.match_labels) {
+        return None;
+    }
+    let pod_name = pod.metadata.name.as_deref()?;
+    let pod_ip = pod.status.as_ref()?.pod_ip.as_deref()?;
+    if pod_ip.is_empty() {
+        return None;
+    }
+
+    Some(RawWorker {
+        worker_id: hash_pod_name(pod_name),
+        pod_name: pod_name.to_string(),
+        pod_ip: pod_ip.to_string(),
+        http_endpoint: format!("http://{pod_ip}:{}", pool.target_port),
+        kv_events_endpoint: format!("tcp://{pod_ip}:{kv_event_port}"),
+        replay_endpoint: replay_port.map(|p| format!("tcp://{pod_ip}:{p}")),
+        stable_routing_id: pod_name.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{PodCondition, PodStatus};
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+    use kube::api::ObjectMeta;
+
+    fn pool() -> PoolState {
+        PoolState {
+            match_labels: BTreeMap::from([("app".to_string(), "vllm-qwen".to_string())]),
+            target_port: 8000,
+        }
+    }
+
+    fn pod(name: &str, ip: Option<&str>, ready: Option<bool>, labels: &[(&str, &str)]) -> Pod {
+        let conditions = ready.map(|r| {
+            vec![PodCondition {
+                type_: "Ready".to_string(),
+                status: if r { "True" } else { "False" }.to_string(),
+                ..Default::default()
+            }]
+        });
+        let label_map = labels
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                labels: Some(label_map),
+                ..Default::default()
+            },
+            status: Some(PodStatus {
+                pod_ip: ip.map(|s| s.to_string()),
+                conditions,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ready_selected_pod_maps_to_worker() {
+        let w = raw_worker_from_pod(
+            &pod(
+                "vllm-0",
+                Some("10.0.0.1"),
+                Some(true),
+                &[("app", "vllm-qwen")],
+            ),
+            &pool(),
+            5557,
+            Some(5560),
+        )
+        .expect("ready, selected pod should map");
+        assert_eq!(w.worker_id, hash_pod_name("vllm-0"));
+        assert_eq!(w.http_endpoint, "http://10.0.0.1:8000");
+        assert_eq!(w.kv_events_endpoint, "tcp://10.0.0.1:5557");
+        assert_eq!(w.replay_endpoint.as_deref(), Some("tcp://10.0.0.1:5560"));
+    }
+
+    #[test]
+    fn pod_not_matching_selector_is_skipped() {
+        assert!(
+            raw_worker_from_pod(
+                &pod(
+                    "other-0",
+                    Some("10.0.0.1"),
+                    Some(true),
+                    &[("app", "something-else")]
+                ),
+                &pool(),
+                5557,
+                None,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn not_ready_pod_is_skipped() {
+        assert!(
+            raw_worker_from_pod(
+                &pod(
+                    "vllm-0",
+                    Some("10.0.0.1"),
+                    Some(false),
+                    &[("app", "vllm-qwen")]
+                ),
+                &pool(),
+                5557,
+                None,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn terminating_pod_is_skipped() {
+        let mut p = pod(
+            "vllm-0",
+            Some("10.0.0.1"),
+            Some(true),
+            &[("app", "vllm-qwen")],
+        );
+        p.metadata.deletion_timestamp = Some(Time(k8s_openapi::chrono::Utc::now()));
+        assert!(raw_worker_from_pod(&p, &pool(), 5557, None).is_none());
+    }
+
+    #[test]
+    fn pod_without_ip_is_skipped() {
+        assert!(
+            raw_worker_from_pod(
+                &pod("vllm-0", None, Some(true), &[("app", "vllm-qwen")]),
+                &pool(),
+                5557,
+                None,
+            )
+            .is_none()
+        );
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/selection_backend.rs
+++ b/deploy/inference-gateway/ext-proc/src/selection_backend.rs
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backend abstraction over the runtime-free selection service.
+//!
+//! Router-only mode can reach the selector two ways:
+//!
+//! - **HTTP** ([`crate::selector_client`], feature `selector-http`): the EPP is
+//!   a thin client of one or more `python -m dynamo.select_service` replicas.
+//!   Use this in production where the selector is replicated.
+//! - **Embedded** ([`crate::embedded_selector`], feature `selector-embedded`):
+//!   the EPP and a runtime-free `SelectionCore` are compiled into a single image
+//!   and the EPP calls the selector's Rust API in-process — no HTTP client. Use
+//!   this for single-replica evaluation.
+//!
+//! Both backends speak the same plain wire types defined here (which mirror the
+//! documented JSON contract in
+//! `docs/components/router/standalone-selection.md`), so the reflector, topology
+//! adapter, and router are identical across modes.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+/// Worker registration payload (`POST /workers`). Only the fields router-only
+/// mode populates are included; the selector defaults the rest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkerRegistration {
+    pub worker_id: u64,
+    pub model_name: String,
+    pub endpoint: String,
+    pub block_size: u32,
+    pub data_parallel_size: u32,
+    pub kv_events_endpoints: HashMap<u32, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_kv_blocks: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_num_batched_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stable_routing_id: Option<String>,
+}
+
+/// Partial worker update (`PATCH /workers/{id}`). Any `Some` field is applied.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct WorkerPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kv_events_endpoints: Option<HashMap<u32, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_kv_blocks: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stable_routing_id: Option<String>,
+}
+
+/// Select-and-reserve request (`POST /select_and_reserve`): selection and load
+/// booking are one operation. Prompt fields are sent flat; sending raw
+/// `token_ids` lets the selector compute block/sequence hashes.
+#[derive(Debug, Clone, Serialize)]
+pub struct SelectRequest {
+    pub model_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection_id: Option<String>,
+    pub token_ids: Vec<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_worker_ids: Option<HashSet<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority_jump: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict_priority: Option<u32>,
+}
+
+/// Raw observability overlap summary (matched token counts).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OverlapSummary {
+    #[serde(default)]
+    pub longest_matched: u32,
+    #[serde(default)]
+    pub gpu: u32,
+    #[serde(default)]
+    pub cpu: u32,
+    #[serde(default)]
+    pub disk: u32,
+}
+
+/// Selection result returned by `/select_and_reserve`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SelectResponse {
+    #[serde(default)]
+    pub selection_id: Option<String>,
+    pub worker_id: u64,
+    pub dp_rank: u32,
+    pub endpoint: String,
+    pub block_size: u32,
+    #[serde(default)]
+    pub overlap: OverlapSummary,
+    #[serde(default)]
+    pub effective_prefill_tokens: usize,
+}
+
+/// A selection backend: worker-catalog reconciliation, select-and-reserve, and
+/// readiness. Implemented by the HTTP selector fleet and the in-process embedded
+/// core.
+///
+/// The backend owns the "actual" catalog state; the caller only supplies the
+/// desired set. This lets the HTTP fleet reconcile each replica independently
+/// (and bootstrap replicas that appear or restart) without the caller tracking
+/// per-replica state.
+#[tonic::async_trait]
+pub trait SelectionBackend: Send + Sync + 'static {
+    /// Drive the selector catalog toward `desired` (keyed by `worker_id`).
+    /// Idempotent: safe to call repeatedly. The HTTP fleet applies the diff to
+    /// every live replica; the embedded backend applies it to the in-process
+    /// core.
+    async fn reconcile(&self, desired: &HashMap<u64, WorkerRegistration>) -> anyhow::Result<()>;
+
+    /// Select a worker for a prompt and book its load in one atomic operation
+    /// (`POST /select_and_reserve`).
+    async fn select_and_reserve(&self, req: &SelectRequest) -> anyhow::Result<SelectResponse>;
+
+    /// Returns `true` once the selector can schedule at least one worker.
+    async fn any_ready(&self) -> bool;
+
+    /// Change signal the reconcile loop should also wake on, in addition to pod
+    /// changes. The HTTP fleet bumps this when its selector replica set changes;
+    /// the embedded backend never fires (its selector is in-process).
+    fn subscribe_changes(&self) -> tokio::sync::watch::Receiver<u64>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_registration_serializes_expected_fields() {
+        let mut kv = HashMap::new();
+        kv.insert(0u32, "tcp://10.0.0.1:5557".to_string());
+        let req = WorkerRegistration {
+            worker_id: 42,
+            model_name: "Qwen/Qwen3-0.6B".to_string(),
+            endpoint: "http://10.0.0.1:8000".to_string(),
+            block_size: 16,
+            data_parallel_size: 1,
+            kv_events_endpoints: kv,
+            replay_endpoint: None,
+            total_kv_blocks: None,
+            max_num_batched_tokens: None,
+            stable_routing_id: Some("vllm-0".to_string()),
+        };
+        let v: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["worker_id"], 42);
+        assert_eq!(v["block_size"], 16);
+        assert_eq!(v["kv_events_endpoints"]["0"], "tcp://10.0.0.1:5557");
+        assert_eq!(v["stable_routing_id"], "vllm-0");
+        assert!(v.get("replay_endpoint").is_none());
+        assert!(v.get("total_kv_blocks").is_none());
+    }
+
+    #[test]
+    fn select_request_sends_flat_prompt() {
+        let req = SelectRequest {
+            model_name: "m".to_string(),
+            selection_id: Some("s1".to_string()),
+            token_ids: vec![1, 2, 3],
+            allowed_worker_ids: Some(HashSet::from([7u64])),
+            priority_jump: None,
+            strict_priority: None,
+        };
+        let v: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["token_ids"], serde_json::json!([1, 2, 3]));
+        assert_eq!(v["selection_id"], "s1");
+        assert_eq!(v["allowed_worker_ids"], serde_json::json!([7]));
+        assert!(v.get("priority_jump").is_none());
+    }
+
+    #[test]
+    fn select_response_deserializes() {
+        let body = serde_json::json!({
+            "model_name": "m",
+            "tenant_id": "default",
+            "worker_id": 9,
+            "dp_rank": 0,
+            "endpoint": "http://10.0.0.1:8000",
+            "block_size": 16,
+            "overlap": {"longest_matched": 32, "gpu": 16, "cpu": 0, "disk": 0},
+            "effective_prefill_tokens": 64
+        });
+        let resp: SelectResponse = serde_json::from_value(body).unwrap();
+        assert_eq!(resp.worker_id, 9);
+        assert_eq!(resp.dp_rank, 0);
+        assert_eq!(resp.endpoint, "http://10.0.0.1:8000");
+        assert_eq!(resp.effective_prefill_tokens, 64);
+        assert_eq!(resp.overlap.longest_matched, 32);
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/selector_fleet.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector_fleet.rs
@@ -1,0 +1,653 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP selector fleet for the standalone selection service
+//! (`python -m dynamo.select_service`).
+//!
+//! Production/replicated path: the EPP delegates worker selection to a fleet of
+//! selection-service replicas fronted by a Kubernetes `Service`. Rather than a
+//! static list of URLs, the fleet **watches the Service's EndpointSlices** and
+//! keeps an in-memory set of replica endpoints in sync as replicas come and go.
+//!
+//! Because each replica owns its own catalog and KV index, the fleet reconciles
+//! every live replica independently ([`SelectionBackend::reconcile`]): it reads
+//! each replica's actual catalog (`GET /workers`), applies the diff toward the
+//! desired set (`POST`/`DELETE /workers`), and marks the replica routable only
+//! once it reports `GET /ready`. New (or restarted) replicas are therefore
+//! bootstrapped from scratch before they receive any selection traffic.
+//!
+//! As replicas appear and disappear the fleet also wires the selectors'
+//! replica-sync peer mesh (`POST /replica_sync/(de)register_peer`) so
+//! active-load and admission events propagate across the fleet.
+//!
+//! The wire types live in [`crate::selection_backend`]; this module only adds
+//! the HTTP transport, the EndpointSlice watch, and a [`SelectionBackend`]
+//! implementation. Built only with the `selector-http` feature.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use k8s_openapi::api::discovery::v1::EndpointSlice;
+use serde::Deserialize;
+use tokio::sync::{Mutex, watch};
+
+use crate::epp_config::EppConfig;
+use crate::selection_backend::{
+    SelectRequest, SelectResponse, SelectionBackend, WorkerRegistration,
+};
+
+/// Label Kubernetes sets on every EndpointSlice pointing back to its Service.
+const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
+
+/// Per-request timeout for selector HTTP calls. Keeps a dead/slow replica from
+/// stalling reconcile or a selection.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Best-effort bound on how long fleet startup waits for the initial
+/// EndpointSlice LIST before serving anyway.
+const INITIAL_LIST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Backoff before re-establishing the EndpointSlice watch if its stream ends.
+const WATCH_RESTART_BACKOFF: Duration = Duration::from_secs(3);
+
+/// Shared handle to the current EndpointSlice reflector store. The watch task
+/// swaps in a fresh store when it re-establishes the watch, so readers always
+/// see the live snapshot.
+type SharedStore = Arc<StdMutex<kube::runtime::reflector::Store<EndpointSlice>>>;
+
+#[derive(Debug, Clone, Deserialize)]
+struct ReadyResponse {
+    #[serde(default)]
+    ready: bool,
+}
+
+/// Subset of the selector's `/workers` catalog record we compare against to
+/// decide whether a replica already has an up-to-date registration. Unknown
+/// fields are ignored by serde.
+#[derive(Debug, Clone, Deserialize)]
+struct CatalogRecordWire {
+    worker_id: u64,
+    #[serde(default)]
+    model_name: String,
+    #[serde(default)]
+    endpoint: Option<String>,
+    #[serde(default)]
+    kv_events_endpoints: HashMap<u32, String>,
+    #[serde(default)]
+    replay_endpoint: Option<String>,
+    #[serde(default)]
+    block_size: Option<u32>,
+    #[serde(default)]
+    data_parallel_size: Option<u32>,
+    #[serde(default)]
+    max_num_batched_tokens: Option<u64>,
+    #[serde(default)]
+    total_kv_blocks: Option<u64>,
+    #[serde(default)]
+    stable_routing_id: Option<String>,
+}
+
+/// EPP-side state for one selector replica.
+#[derive(Debug, Clone, Default)]
+struct ReplicaState {
+    /// Last `GET /ready` result; gates selection traffic.
+    routable: bool,
+}
+
+/// HTTP-backed [`SelectionBackend`] over a dynamically-discovered fleet of
+/// selection-service replicas.
+pub struct SelectorFleet {
+    http: reqwest::Client,
+    store: SharedStore,
+    http_port: u16,
+    replica_sync_port: u16,
+    /// Tracked replicas keyed by pod IP. `BTreeMap` keeps the routable set
+    /// enumeration deterministic for round-robin selection.
+    replicas: Mutex<BTreeMap<String, ReplicaState>>,
+    /// Rotates selection across routable replicas (round-robin) instead of
+    /// always hitting the lexicographically smallest one.
+    select_cursor: AtomicUsize,
+    changes_rx: watch::Receiver<u64>,
+}
+
+impl SelectorFleet {
+    /// Start the EndpointSlice watch for the configured selector Service and
+    /// return a fleet ready to reconcile. Fails if the config was not built for
+    /// HTTP mode (no service name).
+    pub async fn spawn(cfg: &EppConfig) -> Result<Self> {
+        use kube::{Api, Client, runtime::reflector, runtime::watcher};
+
+        if cfg.selector_service.is_empty() {
+            bail!("SelectorFleet requires DYN_EPP_SELECTOR_SERVICE (selection-service Service name)");
+        }
+
+        let client = Client::try_default()
+            .await
+            .context("building Kubernetes client for selector discovery")?;
+        let namespace = match &cfg.selector_service_namespace {
+            Some(ns) => ns.clone(),
+            None => std::env::var("POD_NAMESPACE").map_err(|_| {
+                anyhow::anyhow!(
+                    "DYN_EPP_SELECTOR_SERVICE_NAMESPACE is unset and POD_NAMESPACE is not \
+                     available. Ensure the EPP pod spec injects POD_NAMESPACE via the downward \
+                     API (fieldRef metadata.namespace), or set DYN_EPP_SELECTOR_SERVICE_NAMESPACE."
+                )
+            })?,
+        };
+
+        let http = reqwest::Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .context("building selection-service HTTP client")?;
+
+        // Watch only the EndpointSlices owned by the selector Service.
+        let slices: Api<EndpointSlice> = Api::namespaced(client, &namespace);
+        let cfg_watch = watcher::Config::default()
+            .labels(&format!("{SERVICE_NAME_LABEL}={}", cfg.selector_service));
+
+        let initial_writer = reflector::store::Writer::default();
+        let store: SharedStore = Arc::new(StdMutex::new(initial_writer.as_reader()));
+        let (changes_tx, changes_rx) = watch::channel(0u64);
+
+        tracing::info!(
+            namespace = %namespace,
+            service = %cfg.selector_service,
+            http_port = cfg.selector_http_port,
+            replica_sync_port = cfg.selector_replica_sync_port,
+            "Starting selector EndpointSlice watch for router-only HTTP mode"
+        );
+
+        // Supervising watch task. The kube `watcher` already reconnects (with
+        // backoff) on transient API errors, so the inner loop rarely ends; if it
+        // does (writer dropped / fatal), we re-establish a fresh reflector +
+        // store after a backoff instead of going permanently stale.
+        let task_store = store.clone();
+        tokio::spawn(watch_loop(
+            slices,
+            cfg_watch,
+            initial_writer,
+            task_store,
+            changes_tx,
+        ));
+
+        let store_for_wait = store.lock().expect("store lock poisoned").clone();
+        match tokio::time::timeout(INITIAL_LIST_TIMEOUT, store_for_wait.wait_until_ready()).await {
+            Ok(Ok(())) => tracing::info!("Selector EndpointSlice initial LIST sync complete"),
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "Selector EndpointSlice writer dropped before initial LIST")
+            }
+            Err(_) => tracing::warn!(
+                "Selector EndpointSlice initial LIST timed out after {}s; continuing",
+                INITIAL_LIST_TIMEOUT.as_secs()
+            ),
+        }
+
+        Ok(Self {
+            http,
+            store,
+            http_port: cfg.selector_http_port,
+            replica_sync_port: cfg.selector_replica_sync_port,
+            replicas: Mutex::new(BTreeMap::new()),
+            select_cursor: AtomicUsize::new(0),
+            changes_rx,
+        })
+    }
+
+    /// Live selector replica IPs from the current EndpointSlice snapshot.
+    fn live_ips(&self) -> BTreeSet<String> {
+        let store = self.store.lock().expect("store lock poisoned").clone();
+        ready_ips(store.state().iter().map(|s| s.as_ref()))
+    }
+
+    fn http_base(&self, ip: &str) -> String {
+        format!("http://{}", authority(ip, self.http_port))
+    }
+
+    fn zmq_endpoint(&self, ip: &str) -> String {
+        format!("tcp://{}", authority(ip, self.replica_sync_port))
+    }
+
+    /// Reconcile the replica set against the live EndpointSlices: track new
+    /// replicas, drop gone ones, and wire the replica-sync peer mesh for the
+    /// delta. Returns the full current replica IP set.
+    async fn sync_replica_set(&self) -> Vec<String> {
+        let live = self.live_ips();
+        let (added, removed, all): (Vec<String>, Vec<String>, Vec<String>) = {
+            let mut replicas = self.replicas.lock().await;
+            let added: Vec<String> = live
+                .iter()
+                .filter(|ip| !replicas.contains_key(*ip))
+                .cloned()
+                .collect();
+            let removed: Vec<String> = replicas
+                .keys()
+                .filter(|ip| !live.contains(*ip))
+                .cloned()
+                .collect();
+            for ip in &removed {
+                replicas.remove(ip);
+            }
+            for ip in &added {
+                replicas.insert(ip.clone(), ReplicaState::default());
+            }
+            let all: Vec<String> = replicas.keys().cloned().collect();
+            (added, removed, all)
+        };
+
+        if !added.is_empty() || !removed.is_empty() {
+            tracing::info!(
+                added = ?added,
+                removed = ?removed,
+                total = all.len(),
+                "Selector replica set changed"
+            );
+        }
+
+        // Wire the peer mesh for the delta (registration is idempotent).
+        for new_ip in &added {
+            let new_zmq = self.zmq_endpoint(new_ip);
+            for other_ip in &all {
+                if other_ip == new_ip {
+                    continue;
+                }
+                self.register_peer(other_ip, &new_zmq).await;
+                self.register_peer(new_ip, &self.zmq_endpoint(other_ip)).await;
+            }
+        }
+        for gone_ip in &removed {
+            let gone_zmq = self.zmq_endpoint(gone_ip);
+            for other_ip in &all {
+                self.deregister_peer(other_ip, &gone_zmq).await;
+            }
+        }
+
+        all
+    }
+
+    /// Drive one replica's catalog toward `desired` and return its routability.
+    async fn reconcile_replica(
+        &self,
+        ip: &str,
+        desired: &HashMap<u64, WorkerRegistration>,
+    ) -> Result<bool> {
+        let base = self.http_base(ip);
+
+        let actual = self.get_workers(&base).await?;
+
+        // Upsert new or changed workers (POST is an upsert, so it covers both).
+        for (worker_id, reg) in desired {
+            let in_sync = actual
+                .get(worker_id)
+                .map(|rec| record_matches(reg, rec))
+                .unwrap_or(false);
+            if in_sync {
+                continue;
+            }
+            let resp = self
+                .http
+                .post(format!("{base}/workers"))
+                .json(reg)
+                .send()
+                .await
+                .with_context(|| format!("POST /workers to {base}"))?;
+            ensure_success(resp, "POST /workers", &base).await?;
+        }
+
+        // Delete workers this replica has that are no longer desired.
+        for worker_id in actual.keys() {
+            if desired.contains_key(worker_id) {
+                continue;
+            }
+            let resp = self
+                .http
+                .delete(format!("{base}/workers/{worker_id}"))
+                .send()
+                .await
+                .with_context(|| format!("DELETE /workers/{worker_id} to {base}"))?;
+            if resp.status() != reqwest::StatusCode::NOT_FOUND {
+                ensure_success(resp, "DELETE /workers/{id}", &base).await?;
+            }
+        }
+
+        Ok(self.ready(&base).await)
+    }
+
+    async fn get_workers(&self, base: &str) -> Result<HashMap<u64, CatalogRecordWire>> {
+        let resp = self
+            .http
+            .get(format!("{base}/workers"))
+            .send()
+            .await
+            .with_context(|| format!("GET /workers from {base}"))?;
+        let resp = ensure_success(resp, "GET /workers", base).await?;
+        let records: Vec<CatalogRecordWire> =
+            resp.json().await.context("decoding /workers response")?;
+        Ok(records.into_iter().map(|r| (r.worker_id, r)).collect())
+    }
+
+    async fn ready(&self, base: &str) -> bool {
+        let Ok(resp) = self.http.get(format!("{base}/ready")).send().await else {
+            return false;
+        };
+        if !resp.status().is_success() {
+            return false;
+        }
+        resp.json::<ReadyResponse>()
+            .await
+            .map(|r| r.ready)
+            .unwrap_or(false)
+    }
+
+    /// Round-robin the next routable replica's base URL, if any.
+    async fn pick_routable_base(&self) -> Option<String> {
+        let routable: Vec<String> = {
+            let replicas = self.replicas.lock().await;
+            replicas
+                .iter()
+                .filter(|(_, s)| s.routable)
+                .map(|(ip, _)| ip.clone())
+                .collect()
+        };
+        if routable.is_empty() {
+            return None;
+        }
+        let idx = self.select_cursor.fetch_add(1, Ordering::Relaxed) % routable.len();
+        Some(self.http_base(&routable[idx]))
+    }
+
+    async fn register_peer(&self, ip: &str, peer_endpoint: &str) {
+        self.peer_op(ip, "register_peer", peer_endpoint).await;
+    }
+
+    async fn deregister_peer(&self, ip: &str, peer_endpoint: &str) {
+        self.peer_op(ip, "deregister_peer", peer_endpoint).await;
+    }
+
+    async fn peer_op(&self, ip: &str, op: &str, peer_endpoint: &str) {
+        let base = self.http_base(ip);
+        let result = self
+            .http
+            .post(format!("{base}/replica_sync/{op}"))
+            .json(&serde_json::json!({ "endpoint": peer_endpoint }))
+            .send()
+            .await;
+        match result {
+            // Replica-sync disabled (single-replica selector) responds 409; not
+            // an error we can act on, so stay quiet at debug level.
+            Ok(resp) if resp.status() == reqwest::StatusCode::CONFLICT => {}
+            Ok(resp) if resp.status().is_success() => {}
+            Ok(resp) => tracing::debug!(
+                %base, op, peer_endpoint, status = %resp.status(),
+                "replica-sync peer op returned non-success"
+            ),
+            Err(e) => tracing::debug!(%base, op, peer_endpoint, error = %e, "replica-sync peer op failed"),
+        }
+    }
+}
+
+/// Long-lived EndpointSlice watch. Runs the reflector forever; if its stream
+/// ends (writer dropped / fatal — transient errors are retried inside the
+/// watcher), it swaps in a fresh store and re-establishes the watch after a
+/// backoff so the fleet never gets stuck on a stale snapshot.
+async fn watch_loop(
+    slices: kube::Api<EndpointSlice>,
+    cfg_watch: kube::runtime::watcher::Config,
+    initial_writer: kube::runtime::reflector::store::Writer<EndpointSlice>,
+    store: SharedStore,
+    changes_tx: watch::Sender<u64>,
+) {
+    use futures::StreamExt;
+    use kube::runtime::{reflector, watcher};
+
+    let mut writer = Some(initial_writer);
+    let mut generation = 0u64;
+    loop {
+        // First pass reuses the initial writer (already published to `store`);
+        // later passes create and publish a fresh one.
+        let writer = match writer.take() {
+            Some(w) => w,
+            None => {
+                let w = reflector::store::Writer::default();
+                *store.lock().expect("store lock poisoned") = w.as_reader();
+                w
+            }
+        };
+
+        let reflect = reflector::reflector(writer, watcher(slices.clone(), cfg_watch.clone()));
+        tokio::pin!(reflect);
+        while reflect.next().await.is_some() {
+            generation = generation.wrapping_add(1);
+            let _ = changes_tx.send(generation);
+        }
+
+        tracing::error!(
+            "Selector EndpointSlice reflector stream ended; re-establishing the watch in {}s",
+            WATCH_RESTART_BACKOFF.as_secs()
+        );
+        tokio::time::sleep(WATCH_RESTART_BACKOFF).await;
+        // Wake the reconcile loop so it re-syncs once the fresh store fills.
+        generation = generation.wrapping_add(1);
+        let _ = changes_tx.send(generation);
+    }
+}
+
+#[tonic::async_trait]
+impl SelectionBackend for SelectorFleet {
+    async fn reconcile(&self, desired: &HashMap<u64, WorkerRegistration>) -> Result<()> {
+        let all = self.sync_replica_set().await;
+        if all.is_empty() {
+            tracing::debug!("No selector replicas discovered yet; nothing to reconcile");
+            return Ok(());
+        }
+
+        // Reconcile every replica WITHOUT holding the replica-state lock, so
+        // concurrent select() calls are never blocked behind these HTTP calls.
+        let mut results = Vec::with_capacity(all.len());
+        for ip in &all {
+            let routable = match self.reconcile_replica(ip, desired).await {
+                Ok(routable) => routable,
+                Err(e) => {
+                    tracing::warn!(replica = %ip, error = %e, "Failed to reconcile selector replica; marking not routable");
+                    false
+                }
+            };
+            results.push((ip.clone(), routable));
+        }
+
+        // Apply the routable flags under a short lock.
+        let mut replicas = self.replicas.lock().await;
+        for (ip, routable) in results {
+            if let Some(state) = replicas.get_mut(&ip) {
+                state.routable = routable;
+            }
+        }
+        Ok(())
+    }
+
+    async fn select_and_reserve(&self, req: &SelectRequest) -> Result<SelectResponse> {
+        let Some(base) = self.pick_routable_base().await else {
+            bail!("no routable selector replica available");
+        };
+        let resp = self
+            .http
+            .post(format!("{base}/select_and_reserve"))
+            .json(req)
+            .send()
+            .await
+            .with_context(|| format!("POST /select_and_reserve to {base}"))?;
+        let resp = ensure_success(resp, "POST /select_and_reserve", &base).await?;
+        resp.json::<SelectResponse>()
+            .await
+            .context("decoding /select_and_reserve response")
+    }
+
+    async fn any_ready(&self) -> bool {
+        self.replicas.lock().await.values().any(|s| s.routable)
+    }
+
+    fn subscribe_changes(&self) -> watch::Receiver<u64> {
+        self.changes_rx.clone()
+    }
+}
+
+/// Format `host:port`, bracketing IPv6 literals (`fd00::1` → `[fd00::1]`) so the
+/// resulting `http://`/`tcp://` URL stays valid on dual-stack clusters.
+fn authority(ip: &str, port: u16) -> String {
+    if ip.contains(':') {
+        format!("[{ip}]:{port}")
+    } else {
+        format!("{ip}:{port}")
+    }
+}
+
+/// Collect the routable replica IPs from a set of EndpointSlices. Endpoints that
+/// are terminating are excluded; not-ready endpoints are kept so the fleet can
+/// bootstrap them before they start reporting ready. Pure function.
+fn ready_ips<'a>(slices: impl Iterator<Item = &'a EndpointSlice>) -> BTreeSet<String> {
+    let mut ips = BTreeSet::new();
+    for slice in slices {
+        for endpoint in &slice.endpoints {
+            if endpoint
+                .conditions
+                .as_ref()
+                .and_then(|c| c.terminating)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            for addr in &endpoint.addresses {
+                if !addr.is_empty() {
+                    ips.insert(addr.clone());
+                }
+            }
+        }
+    }
+    ips
+}
+
+/// Whether a selector's catalog record already matches the desired registration
+/// for the fields router-only mode owns. Pure function — unit-testable.
+fn record_matches(desired: &WorkerRegistration, actual: &CatalogRecordWire) -> bool {
+    actual.model_name == desired.model_name
+        && actual.endpoint.as_deref() == Some(desired.endpoint.as_str())
+        && actual.block_size == Some(desired.block_size)
+        && actual.data_parallel_size == Some(desired.data_parallel_size)
+        && actual.kv_events_endpoints == desired.kv_events_endpoints
+        && actual.replay_endpoint == desired.replay_endpoint
+        && actual.total_kv_blocks == desired.total_kv_blocks
+        && actual.max_num_batched_tokens == desired.max_num_batched_tokens
+        && actual.stable_routing_id == desired.stable_routing_id
+}
+
+async fn ensure_success(resp: reqwest::Response, op: &str, url: &str) -> Result<reqwest::Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    let body = resp.text().await.unwrap_or_default();
+    bail!("{op} to {url} failed with status {status}: {body}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::discovery::v1::{Endpoint, EndpointConditions};
+
+    fn reg(ip: &str) -> WorkerRegistration {
+        let mut kv = HashMap::new();
+        kv.insert(0u32, format!("tcp://{ip}:5557"));
+        WorkerRegistration {
+            worker_id: 1,
+            model_name: "Qwen/Qwen3-0.6B".to_string(),
+            endpoint: format!("http://{ip}:8000"),
+            block_size: 16,
+            data_parallel_size: 1,
+            kv_events_endpoints: kv,
+            replay_endpoint: None,
+            total_kv_blocks: Some(1000),
+            max_num_batched_tokens: None,
+            stable_routing_id: Some("vllm-0".to_string()),
+        }
+    }
+
+    fn record_from(reg: &WorkerRegistration) -> CatalogRecordWire {
+        CatalogRecordWire {
+            worker_id: reg.worker_id,
+            model_name: reg.model_name.clone(),
+            endpoint: Some(reg.endpoint.clone()),
+            kv_events_endpoints: reg.kv_events_endpoints.clone(),
+            replay_endpoint: reg.replay_endpoint.clone(),
+            block_size: Some(reg.block_size),
+            data_parallel_size: Some(reg.data_parallel_size),
+            max_num_batched_tokens: reg.max_num_batched_tokens,
+            total_kv_blocks: reg.total_kv_blocks,
+            stable_routing_id: reg.stable_routing_id.clone(),
+        }
+    }
+
+    #[test]
+    fn record_matches_identical() {
+        let r = reg("10.0.0.1");
+        assert!(record_matches(&r, &record_from(&r)));
+    }
+
+    #[test]
+    fn record_mismatch_on_endpoint() {
+        let r = reg("10.0.0.1");
+        let mut actual = record_from(&r);
+        actual.endpoint = Some("http://10.0.0.9:8000".to_string());
+        assert!(!record_matches(&r, &actual));
+    }
+
+    #[test]
+    fn record_mismatch_when_missing_metadata() {
+        let r = reg("10.0.0.1");
+        let mut actual = record_from(&r);
+        actual.block_size = None;
+        assert!(!record_matches(&r, &actual));
+    }
+
+    #[test]
+    fn authority_brackets_ipv6_only() {
+        assert_eq!(authority("10.0.0.1", 8092), "10.0.0.1:8092");
+        assert_eq!(authority("fd00::1", 8092), "[fd00::1]:8092");
+    }
+
+    fn slice(endpoints: Vec<Endpoint>) -> EndpointSlice {
+        EndpointSlice {
+            address_type: "IPv4".to_string(),
+            endpoints,
+            metadata: Default::default(),
+            ports: None,
+        }
+    }
+
+    fn endpoint(addr: &str, terminating: Option<bool>) -> Endpoint {
+        Endpoint {
+            addresses: vec![addr.to_string()],
+            conditions: Some(EndpointConditions {
+                ready: Some(true),
+                serving: Some(true),
+                terminating,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ready_ips_collects_non_terminating() {
+        let s = slice(vec![
+            endpoint("10.0.0.1", None),
+            endpoint("10.0.0.2", Some(false)),
+            endpoint("10.0.0.3", Some(true)), // terminating -> excluded
+        ]);
+        let ips = ready_ips([&s].into_iter());
+        assert_eq!(
+            ips,
+            BTreeSet::from(["10.0.0.1".to_string(), "10.0.0.2".to_string()])
+        );
+    }
+}


### PR DESCRIPTION
The router-only HTTP backend delegates KV-aware selection to a fleet of dynamo.select_service replicas by a Kubernetes Service, discovered dynamically:

Defines the SelectionBackend trait (reconcile(desired) + select + any_ready + subscribe_changes) and the plain wire types both backends share (mirroring the documented JSON contract).
SelectorFleet watches the selector Service's EndpointSlices and keeps its replica set in sync as replicas come and go: each new/restarted replica is bootstrapped (catalog reconciled from scratch via GET /workers → diff → POST/DELETE /workers) before it receives traffic, routing is gated on GET /ready, and the replica-sync peer mesh is wired dynamically (POST /replica_sync/(de)register_peer).
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue
