### PR TITLE
feat(epp): reconcile standalone worker topology with the embedded selector

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -22,6 +22,7 @@ pub mod pod_discovery;
 pub mod proto;
 pub mod selector;
 pub mod server;
+pub mod topology_adapter;
 pub mod vllm_render_client;
 
 pub use epp::Router;
@@ -31,4 +32,5 @@ pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use pod_discovery::{PodDiscovery, RawWorker};
 pub use selector::{OverlapSummary, SelectRequest, SelectResponse, Selector, WorkerRegistration};
 pub use server::ExtProcServer;
+pub use topology_adapter::{RegistrationDefaults, TopologyAdapter};
 pub use vllm_render_client::{VllmRenderClient, VllmRenderError};

--- a/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/pod_discovery.rs
@@ -42,7 +42,7 @@ pub struct RawWorker {
 /// plus its pre-stripped `ip:port`, so request-path reads (notably
 /// [`PodDiscovery::resolve_endpoint`]) are O(1) lookups that never re-parse the
 /// endpoint or clone the [`PoolState`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct WorkerEntry {
     worker: RawWorker,
     /// Scheme-less `ip:port` derived once from `worker.http_endpoint`.
@@ -172,7 +172,7 @@ impl PodDiscovery {
                     }
                 };
 
-                match delta {
+                let index_changed = match delta {
                     Delta::Stop => break,
                     Delta::Skip => continue,
                     Delta::Rebuild => rebuild_index(
@@ -190,12 +190,14 @@ impl PodDiscovery {
                         replay_port,
                     ),
                     Delta::Remove(pod) => remove_pod(&index_task, &pod),
-                }
+                };
 
                 // Readiness based on initial pods being synced and the pool being resolved.
                 ready_task.store(pod_synced && pool_rx.borrow().is_some(), Ordering::Release);
-                generation = generation.wrapping_add(1);
-                let _ = changes_tx.send(generation);
+                if index_changed {
+                    generation = generation.wrapping_add(1);
+                    let _ = changes_tx.send(generation);
+                }
             }
             // Watch stream has ended, so stop advertising readiness and clear the index.
             ready_task.store(false, Ordering::Release);
@@ -259,6 +261,22 @@ impl PodDiscovery {
     pub fn subscribe_changes(&self) -> watch::Receiver<u64> {
         self.changes.clone()
     }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(workers: Vec<RawWorker>) -> (Self, watch::Sender<u64>) {
+        let index = workers
+            .into_iter()
+            .map(|worker| (worker.worker_id, WorkerEntry::from_raw(worker)))
+            .collect();
+        let (changes_tx, changes) = watch::channel(0u64);
+        (
+            Self {
+                index: Arc::new(RwLock::new(index)),
+                changes,
+            },
+            changes_tx,
+        )
+    }
 }
 
 /// Return `true` iff the pod is `Ready` and not terminating.
@@ -308,16 +326,16 @@ fn defer_pool_rebuild(relisting: bool, pool_present: bool) -> bool {
 
 /// Apply a single pod delta to the index: upsert the worker if it is `Ready` and
 /// pool-selected, otherwise drop any existing entry (a pod that went NotReady,
-/// terminating, or unselected).
+/// terminating, or unselected). Returns whether the derived index changed.
 fn upsert_pod(
     index: &RwLock<WorkerIndex>,
     pod: &Pod,
     pool: Option<&PoolState>,
     kv_event_port: u16,
     replay_port: Option<u16>,
-) {
+) -> bool {
     let Some(worker_id) = pod_worker_id(pod) else {
-        return;
+        return false;
     };
     let entry = pool
         .and_then(|pool| raw_worker_from_pod(pod, pool, kv_event_port, replay_port))
@@ -325,32 +343,36 @@ fn upsert_pod(
     let mut index = index.write().unwrap();
     match entry {
         Some(entry) => {
-            index.insert(worker_id, entry);
+            if index.get(&worker_id) == Some(&entry) {
+                false
+            } else {
+                index.insert(worker_id, entry);
+                true
+            }
         }
-        None => {
-            index.remove(&worker_id);
-        }
+        None => index.remove(&worker_id).is_some(),
     }
 }
 
-/// Drop a deleted pod's worker from the index. O(1).
-fn remove_pod(index: &RwLock<WorkerIndex>, pod: &Pod) {
-    if let Some(worker_id) = pod_worker_id(pod) {
-        index.write().unwrap().remove(&worker_id);
-    }
+/// Drop a deleted pod's worker from the index. Returns whether an entry existed.
+fn remove_pod(index: &RwLock<WorkerIndex>, pod: &Pod) -> bool {
+    pod_worker_id(pod)
+        .and_then(|worker_id| index.write().unwrap().remove(&worker_id))
+        .is_some()
 }
 
 /// Recompute the whole index from the current pod store and pool selector.
 /// Empty until the `InferencePool` has resolved. Used only for the initial LIST,
 /// watch relists (which may have dropped pods without a `Delete`), and
-/// pool-selector changes (which re-classify every pod).
+/// pool-selector changes (which re-classify every pod). Returns whether the
+/// rebuilt index differs from the current one.
 fn rebuild_index(
     store: &kube::runtime::reflector::Store<Pod>,
     pool: Option<&PoolState>,
     kv_event_port: u16,
     replay_port: Option<u16>,
     index: &RwLock<WorkerIndex>,
-) {
+) -> bool {
     let mut fresh = WorkerIndex::new();
     if let Some(pool) = pool {
         for pod in store.state().iter() {
@@ -359,7 +381,13 @@ fn rebuild_index(
             }
         }
     }
-    *index.write().unwrap() = fresh;
+    let mut current = index.write().unwrap();
+    if *current == fresh {
+        false
+    } else {
+        *current = fresh;
+        true
+    }
 }
 
 /// Build a [`RawWorker`] from a pod, or `None` if it is not `Ready`, not
@@ -578,7 +606,20 @@ mod tests {
         ]);
 
         let index = RwLock::new(WorkerIndex::new());
-        rebuild_index(&store, Some(&pool()), 5557, Some(5560), &index);
+        assert!(rebuild_index(
+            &store,
+            Some(&pool()),
+            5557,
+            Some(5560),
+            &index
+        ));
+        assert!(!rebuild_index(
+            &store,
+            Some(&pool()),
+            5557,
+            Some(5560),
+            &index
+        ));
 
         // Only the ready, correctly-labeled pod is materialized.
         let index = index.read().unwrap();
@@ -599,7 +640,7 @@ mod tests {
             &[("app", "vllm-qwen")],
         )]);
         let index = RwLock::new(WorkerIndex::new());
-        rebuild_index(&store, None, 5557, None, &index);
+        assert!(!rebuild_index(&store, None, 5557, None, &index));
         assert!(index.read().unwrap().is_empty());
     }
 
@@ -615,7 +656,8 @@ mod tests {
         );
 
         // Ready + selected -> inserted, with a pre-stripped endpoint.
-        upsert_pod(&index, &ready, Some(&pool()), 5557, None);
+        assert!(upsert_pod(&index, &ready, Some(&pool()), 5557, None));
+        assert!(!upsert_pod(&index, &ready, Some(&pool()), 5557, None));
         assert_eq!(
             index.read().unwrap().get(&id).map(|e| e.endpoint.as_str()),
             Some("10.0.0.1:8000")
@@ -628,14 +670,20 @@ mod tests {
             Some(false),
             &[("app", "vllm-qwen")],
         );
-        upsert_pod(&index, &not_ready, Some(&pool()), 5557, None);
+        assert!(upsert_pod(&index, &not_ready, Some(&pool()), 5557, None));
+        assert!(!upsert_pod(&index, &not_ready, Some(&pool()), 5557, None));
         assert!(!index.read().unwrap().contains_key(&id));
 
         // Re-add, then a Delete removes it.
-        upsert_pod(&index, &ready, Some(&pool()), 5557, None);
+        assert!(upsert_pod(&index, &ready, Some(&pool()), 5557, None));
         assert!(index.read().unwrap().contains_key(&id));
-        remove_pod(&index, &ready);
+        assert!(remove_pod(&index, &ready));
+        assert!(!remove_pod(&index, &ready));
         assert!(!index.read().unwrap().contains_key(&id));
+
+        // An unrelated namespace pod does not change the derived worker index.
+        let unselected = pod("other-0", Some("10.0.0.2"), Some(true), &[("app", "other")]);
+        assert!(!upsert_pod(&index, &unselected, Some(&pool()), 5557, None));
     }
 
     #[test]
@@ -651,10 +699,11 @@ mod tests {
             &[("app", "vllm-qwen")],
         );
 
-        upsert_pod(&index, &ready, Some(&pool()), 5557, None);
+        assert!(upsert_pod(&index, &ready, Some(&pool()), 5557, None));
         assert!(index.read().unwrap().contains_key(&id));
 
-        upsert_pod(&index, &ready, None, 5557, None);
+        assert!(upsert_pod(&index, &ready, None, 5557, None));
+        assert!(!upsert_pod(&index, &ready, None, 5557, None));
         assert!(!index.read().unwrap().contains_key(&id));
     }
 
@@ -683,7 +732,7 @@ mod tests {
         writer.apply_watcher_event(&watcher::Event::InitApply(vllm_1.clone()));
         writer.apply_watcher_event(&watcher::Event::InitDone);
         let index = RwLock::new(WorkerIndex::new());
-        rebuild_index(&store, Some(&pool()), 5557, None, &index);
+        assert!(rebuild_index(&store, Some(&pool()), 5557, None, &index));
         assert_eq!(index.read().unwrap().len(), 2);
 
         // During the next LIST, vllm-1 has disappeared. The reflector buffers
@@ -709,7 +758,13 @@ mod tests {
         // InitDone makes the staged list live. Its single rebuild uses both the
         // completed one-pod Store and the latest PoolState.
         writer.apply_watcher_event(&watcher::Event::InitDone);
-        rebuild_index(&store, Some(&updated_pool), 5557, None, &index);
+        assert!(rebuild_index(
+            &store,
+            Some(&updated_pool),
+            5557,
+            None,
+            &index
+        ));
         let index = index.read().unwrap();
         assert_eq!(index.len(), 1);
         assert_eq!(
@@ -765,7 +820,7 @@ mod tests {
             Some(true),
             &[("app", "vllm-qwen")],
         )]);
-        rebuild_index(&store, Some(&pool()), 5557, None, &index);
+        assert!(rebuild_index(&store, Some(&pool()), 5557, None, &index));
 
         let index = index.read().unwrap();
         assert_eq!(index.len(), 1);

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -37,7 +37,6 @@ pub struct WorkerRegistration {
     pub replay_endpoint: Option<String>,
     pub total_kv_blocks: Option<u64>,
     pub max_num_batched_tokens: Option<u64>,
-    pub stable_routing_id: Option<String>,
 }
 
 /// A worker-selection request.
@@ -203,7 +202,6 @@ impl Selector {
             replay_endpoint: reg.replay_endpoint.clone(),
             total_kv_blocks: reg.total_kv_blocks,
             max_num_batched_tokens: reg.max_num_batched_tokens,
-            stable_routing_id: reg.stable_routing_id.clone(),
             ..Default::default()
         }
     }
@@ -403,7 +401,6 @@ models:
             replay_endpoint: None,
             total_kv_blocks: None,
             max_num_batched_tokens: None,
-            stable_routing_id: None,
         }
     }
 

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Engine topology adapter: reconcile discovered raw vLLM pods into the
+//! selection-service worker catalog.
+//!
+//! Raw vLLM pods never register a `ModelRuntimeConfig` in any Dynamo discovery
+//! plane, so the per-worker metadata the selector needs to admit a worker
+//! (endpoint, block size, KV-event endpoints, DP size, capacity hints) is
+//! produced here instead. For each `Ready` pod the [`PodDiscovery`]
+//! surfaces, this adapter normalizes a [`WorkerRegistration`] from environment
+//! defaults plus the pod's resolved endpoints, and hands the whole desired set
+//! to the [`Selector`], which owns the actual-vs-desired diff against its
+//! in-process catalog.
+//!
+//! The adapter owns `worker_id` generation (via the reflector's stable hash) and
+//! applies the same id everywhere, so each replica's catalog agrees.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::epp_standalone_config::EppStandaloneConfig;
+use crate::pod_discovery::{PodDiscovery, RawWorker};
+use crate::selector::{Selector, WorkerRegistration};
+
+/// Environment-derived defaults applied to every worker registration. Raw vLLM
+/// pods carry no model card, so these come from the EPP's configuration.
+#[derive(Debug, Clone)]
+pub struct RegistrationDefaults {
+    pub model_name: String,
+    pub block_size: u32,
+    pub data_parallel_size: u32,
+    pub total_kv_blocks: Option<u64>,
+    pub max_num_batched_tokens: Option<u64>,
+}
+
+impl RegistrationDefaults {
+    pub fn from_config(cfg: &EppStandaloneConfig) -> Self {
+        Self {
+            model_name: cfg.model_name.clone(),
+            block_size: cfg.block_size,
+            data_parallel_size: cfg.data_parallel_size,
+            total_kv_blocks: cfg.total_kv_blocks,
+            max_num_batched_tokens: cfg.max_num_batched_tokens,
+        }
+    }
+}
+
+/// Background task that keeps the selector catalog in sync with the reflector.
+pub struct TopologyAdapter {
+    _task: tokio::task::JoinHandle<()>,
+}
+
+impl TopologyAdapter {
+    /// Spawn the reconciliation loop. Performs an initial reconcile immediately,
+    /// then re-reconciles whenever the reflector reports a pod change.
+    pub fn spawn(
+        reflector: Arc<PodDiscovery>,
+        selector: Arc<Selector>,
+        defaults: RegistrationDefaults,
+    ) -> Self {
+        let task = tokio::spawn(async move {
+            let mut pod_changes = reflector.subscribe_changes();
+            loop {
+                reconcile_once(&reflector, selector.as_ref(), &defaults).await;
+                // Re-reconcile on a pod change. Exit if the pod-change sender
+                // drops (reflector gone).
+                if pod_changes.changed().await.is_err() {
+                    tracing::warn!("Reflector change channel closed; topology adapter stopping");
+                    break;
+                }
+            }
+        });
+        Self { _task: task }
+    }
+}
+
+/// Run one reconcile pass: build the desired catalog from the Ready pods and
+/// hand it to the selector, which owns the actual-vs-desired diff.
+async fn reconcile_once(
+    reflector: &PodDiscovery,
+    selector: &Selector,
+    defaults: &RegistrationDefaults,
+) {
+    let desired: HashMap<u64, WorkerRegistration> = reflector
+        .ready_workers()
+        .iter()
+        .map(|w| (w.worker_id, build_registration(w, defaults)))
+        .collect();
+
+    if let Err(e) = selector.reconcile(&desired).await {
+        tracing::warn!(error = %e, "Selector reconcile failed; will retry on next change");
+    }
+}
+
+/// Normalize a discovered worker into a selector registration payload.
+fn build_registration(w: &RawWorker, defaults: &RegistrationDefaults) -> WorkerRegistration {
+    // Aggregated V1: a single dp_rank 0 maps to the pod's KV-event PUB socket.
+    let mut kv_events_endpoints = HashMap::new();
+    kv_events_endpoints.insert(0u32, w.kv_events_endpoint.clone());
+
+    WorkerRegistration {
+        worker_id: w.worker_id,
+        model_name: defaults.model_name.clone(),
+        endpoint: w.http_endpoint.clone(),
+        block_size: defaults.block_size,
+        data_parallel_size: defaults.data_parallel_size,
+        kv_events_endpoints,
+        replay_endpoint: w.replay_endpoint.clone(),
+        total_kv_blocks: defaults.total_kv_blocks,
+        max_num_batched_tokens: defaults.max_num_batched_tokens,
+        stable_routing_id: Some(w.stable_routing_id.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults() -> RegistrationDefaults {
+        RegistrationDefaults {
+            model_name: "Qwen/Qwen3-0.6B".to_string(),
+            block_size: 16,
+            data_parallel_size: 1,
+            total_kv_blocks: Some(1000),
+            max_num_batched_tokens: None,
+        }
+    }
+
+    fn worker(id: u64, ip: &str) -> RawWorker {
+        RawWorker {
+            worker_id: id,
+            pod_name: format!("vllm-{id}"),
+            pod_ip: ip.to_string(),
+            http_endpoint: format!("http://{ip}:8000"),
+            kv_events_endpoint: format!("tcp://{ip}:5557"),
+            replay_endpoint: None,
+            stable_routing_id: format!("vllm-{id}"),
+        }
+    }
+
+    #[test]
+    fn registration_maps_env_and_endpoints() {
+        let reg = build_registration(&worker(7, "10.0.0.1"), &defaults());
+        assert_eq!(reg.worker_id, 7);
+        assert_eq!(reg.model_name, "Qwen/Qwen3-0.6B");
+        assert_eq!(reg.endpoint, "http://10.0.0.1:8000");
+        assert_eq!(reg.block_size, 16);
+        assert_eq!(reg.data_parallel_size, 1);
+        assert_eq!(
+            reg.kv_events_endpoints.get(&0).unwrap(),
+            "tcp://10.0.0.1:5557"
+        );
+        assert_eq!(reg.total_kv_blocks, Some(1000));
+        assert_eq!(reg.stable_routing_id.as_deref(), Some("vllm-7"));
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -13,11 +13,13 @@
 //! to the [`Selector`], which owns the actual-vs-desired diff against its
 //! in-process catalog.
 //!
-//! The adapter owns `worker_id` generation (via the reflector's stable hash) and
-//! applies the same id everywhere, so each replica's catalog agrees.
+//! The adapter reuses the `worker_id` the reflector derives (a stable hash of the
+//! pod name) and applies the same id everywhere, so each replica's catalog agrees.
 
 use std::collections::HashMap;
 use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
 
 use crate::epp_standalone_config::EppStandaloneConfig;
 use crate::pod_discovery::{PodDiscovery, RawWorker};
@@ -29,7 +31,6 @@ use crate::selector::{Selector, WorkerRegistration};
 pub struct RegistrationDefaults {
     pub model_name: String,
     pub block_size: u32,
-    pub data_parallel_size: u32,
     pub total_kv_blocks: Option<u64>,
     pub max_num_batched_tokens: Option<u64>,
 }
@@ -39,7 +40,6 @@ impl RegistrationDefaults {
         Self {
             model_name: cfg.model_name.clone(),
             block_size: cfg.block_size,
-            data_parallel_size: cfg.data_parallel_size,
             total_kv_blocks: cfg.total_kv_blocks,
             max_num_batched_tokens: cfg.max_num_batched_tokens,
         }
@@ -47,31 +47,48 @@ impl RegistrationDefaults {
 }
 
 /// Background task that keeps the selector catalog in sync with the reflector.
+/// Dropping the adapter cancels the task so it stops promptly and releases its
+/// `Selector`/`PodDiscovery` handles.
 pub struct TopologyAdapter {
-    _task: tokio::task::JoinHandle<()>,
+    cancel: CancellationToken,
 }
 
 impl TopologyAdapter {
     /// Spawn the reconciliation loop. Performs an initial reconcile immediately,
     /// then re-reconciles whenever the reflector reports a pod change.
     pub fn spawn(
-        reflector: Arc<PodDiscovery>,
+        reflector: PodDiscovery,
         selector: Arc<Selector>,
         defaults: RegistrationDefaults,
     ) -> Self {
-        let task = tokio::spawn(async move {
+        let cancel = CancellationToken::new();
+        let cancel_child = cancel.clone();
+        tokio::spawn(async move {
             let mut pod_changes = reflector.subscribe_changes();
             loop {
                 reconcile_once(&reflector, selector.as_ref(), &defaults).await;
-                // Re-reconcile on a pod change. Exit if the pod-change sender
-                // drops (reflector gone).
-                if pod_changes.changed().await.is_err() {
-                    tracing::warn!("Reflector change channel closed; topology adapter stopping");
-                    break;
+                tokio::select! {
+                    _ = cancel_child.cancelled() => break,
+                    // Re-reconcile on a pod change. Exit if the sender drops
+                    // (reflector gone).
+                    changed = pod_changes.changed() => {
+                        if changed.is_err() {
+                            tracing::warn!(
+                                "Reflector change channel closed; topology adapter stopping"
+                            );
+                            break;
+                        }
+                    }
                 }
             }
         });
-        Self { _task: task }
+        Self { cancel }
+    }
+}
+
+impl Drop for TopologyAdapter {
+    fn drop(&mut self) {
+        self.cancel.cancel();
     }
 }
 
@@ -84,7 +101,7 @@ async fn reconcile_once(
 ) {
     let desired: HashMap<u64, WorkerRegistration> = reflector
         .ready_workers()
-        .iter()
+        .into_iter()
         .map(|w| (w.worker_id, build_registration(w, defaults)))
         .collect();
 
@@ -93,23 +110,25 @@ async fn reconcile_once(
     }
 }
 
-/// Normalize a discovered worker into a selector registration payload.
-fn build_registration(w: &RawWorker, defaults: &RegistrationDefaults) -> WorkerRegistration {
-    // Aggregated V1: a single dp_rank 0 maps to the pod's KV-event PUB socket.
+/// Normalize a discovered worker into a selector registration payload. Consumes
+/// the worker so its endpoint strings move into the registration instead of
+/// being cloned.
+fn build_registration(w: RawWorker, defaults: &RegistrationDefaults) -> WorkerRegistration {
+    // Register the pod's single KV-event PUB socket under rank 0 (the core keys
+    // its KV-event endpoints by rank).
     let mut kv_events_endpoints = HashMap::new();
-    kv_events_endpoints.insert(0u32, w.kv_events_endpoint.clone());
+    kv_events_endpoints.insert(0u32, w.kv_events_endpoint);
 
     WorkerRegistration {
         worker_id: w.worker_id,
         model_name: defaults.model_name.clone(),
-        endpoint: w.http_endpoint.clone(),
+        endpoint: w.http_endpoint,
         block_size: defaults.block_size,
-        data_parallel_size: defaults.data_parallel_size,
         kv_events_endpoints,
-        replay_endpoint: w.replay_endpoint.clone(),
+        replay_endpoint: w.replay_endpoint,
         total_kv_blocks: defaults.total_kv_blocks,
         max_num_batched_tokens: defaults.max_num_batched_tokens,
-        stable_routing_id: Some(w.stable_routing_id.clone()),
+        stable_routing_id: Some(w.pod_name),
     }
 }
 
@@ -121,7 +140,6 @@ mod tests {
         RegistrationDefaults {
             model_name: "Qwen/Qwen3-0.6B".to_string(),
             block_size: 16,
-            data_parallel_size: 1,
             total_kv_blocks: Some(1000),
             max_num_batched_tokens: None,
         }
@@ -135,18 +153,16 @@ mod tests {
             http_endpoint: format!("http://{ip}:8000"),
             kv_events_endpoint: format!("tcp://{ip}:5557"),
             replay_endpoint: None,
-            stable_routing_id: format!("vllm-{id}"),
         }
     }
 
     #[test]
     fn registration_maps_env_and_endpoints() {
-        let reg = build_registration(&worker(7, "10.0.0.1"), &defaults());
+        let reg = build_registration(worker(7, "10.0.0.1"), &defaults());
         assert_eq!(reg.worker_id, 7);
         assert_eq!(reg.model_name, "Qwen/Qwen3-0.6B");
         assert_eq!(reg.endpoint, "http://10.0.0.1:8000");
         assert_eq!(reg.block_size, 16);
-        assert_eq!(reg.data_parallel_size, 1);
         assert_eq!(
             reg.kv_events_endpoints.get(&0).unwrap(),
             "tcp://10.0.0.1:5557"

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -1,20 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Engine topology adapter: reconcile discovered raw vLLM pods into the
-//! selection-service worker catalog.
+//! Reconciles discovered vLLM pods with the selection-service worker catalog.
 //!
-//! Raw vLLM pods never register a `ModelRuntimeConfig` in any Dynamo discovery
-//! plane, so the per-worker metadata the selector needs to admit a worker
-//! (endpoint, block size, KV-event endpoints, DP size, capacity hints) is
-//! produced here instead. For each `Ready` pod the [`PodDiscovery`]
-//! surfaces, this adapter normalizes a [`WorkerRegistration`] from environment
-//! defaults plus the pod's resolved endpoints, and hands the whole desired set
-//! to the [`Selector`], which owns the actual-vs-desired diff against its
-//! in-process catalog.
-//!
-//! The adapter reuses the `worker_id` the reflector derives (a stable hash of the
-//! pod name) and applies the same id everywhere, so each replica's catalog agrees.
+//! The adapter converts each ready pod into a [`WorkerRegistration`] using its
+//! resolved endpoints and configured defaults, then passes the desired worker
+//! set to the [`Selector`].
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -25,8 +16,6 @@ use crate::epp_standalone_config::EppStandaloneConfig;
 use crate::pod_discovery::{PodDiscovery, RawWorker};
 use crate::selector::{Selector, WorkerRegistration};
 
-/// Environment-derived defaults applied to every worker registration. Raw vLLM
-/// pods carry no model card, so these come from the EPP's configuration.
 #[derive(Debug, Clone)]
 pub struct RegistrationDefaults {
     pub model_name: String,
@@ -54,8 +43,6 @@ pub struct TopologyAdapter {
 }
 
 impl TopologyAdapter {
-    /// Spawn the reconciliation loop. Performs an initial reconcile immediately,
-    /// then re-reconciles whenever the reflector reports a pod change.
     pub fn spawn(
         reflector: PodDiscovery,
         selector: Arc<Selector>,
@@ -110,12 +97,7 @@ async fn reconcile_once(
     }
 }
 
-/// Normalize a discovered worker into a selector registration payload. Consumes
-/// the worker so its endpoint strings move into the registration instead of
-/// being cloned.
 fn build_registration(w: RawWorker, defaults: &RegistrationDefaults) -> WorkerRegistration {
-    // Register the pod's single KV-event PUB socket under rank 0 (the core keys
-    // its KV-event endpoints by rank).
     let mut kv_events_endpoints = HashMap::new();
     kv_events_endpoints.insert(0u32, w.kv_events_endpoint);
 
@@ -128,7 +110,6 @@ fn build_registration(w: RawWorker, defaults: &RegistrationDefaults) -> WorkerRe
         replay_endpoint: w.replay_endpoint,
         total_kv_blocks: defaults.total_kv_blocks,
         max_num_batched_tokens: defaults.max_num_batched_tokens,
-        stable_routing_id: Some(w.pod_name),
     }
 }
 
@@ -168,6 +149,5 @@ mod tests {
             "tcp://10.0.0.1:5557"
         );
         assert_eq!(reg.total_kv_blocks, Some(1000));
-        assert_eq!(reg.stable_routing_id.as_deref(), Some("vllm-7"));
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -99,10 +99,10 @@ async fn reconcile_once(
     selector: &Selector,
     defaults: &RegistrationDefaults,
 ) {
-    let desired: HashMap<u64, WorkerRegistration> = reflector
+    let desired: Vec<WorkerRegistration> = reflector
         .ready_workers()
         .into_iter()
-        .map(|w| (w.worker_id, build_registration(w, defaults)))
+        .map(|w| build_registration(w, defaults))
         .collect();
 
     if let Err(e) = selector.reconcile(&desired).await {

--- a/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
+++ b/deploy/inference-gateway/ext-proc/src/topology_adapter.rs
@@ -61,8 +61,14 @@ impl TopologyAdapter {
                     changed = pod_changes.changed() => {
                         if changed.is_err() {
                             tracing::warn!(
-                                "Reflector change channel closed; topology adapter stopping"
+                                "Reflector change channel closed; clearing selector topology"
                             );
+                            if let Err(e) = selector.reconcile(&[]).await {
+                                tracing::warn!(
+                                    error = %e,
+                                    "Failed to clear selector topology after reflector stopped"
+                                );
+                            }
                             break;
                         }
                     }
@@ -115,7 +121,29 @@ fn build_registration(w: RawWorker, defaults: &RegistrationDefaults) -> WorkerRe
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
+    use crate::epp_standalone_config::TokenizerProtocol;
+
+    fn config() -> EppStandaloneConfig {
+        EppStandaloneConfig {
+            selector_threads: 1,
+            peer_service: None,
+            inference_pool_name: "test-pool".to_string(),
+            namespace: "test-ns".to_string(),
+            model_name: "Qwen/Qwen3-0.6B".to_string(),
+            tokenizer_service_url: "http://vllm-render:8000".to_string(),
+            tokenizer_protocol: TokenizerProtocol::VllmRender,
+            tokenizer_max_response_bytes: 16 * 1024 * 1024,
+            tokenization_timeout_ms: 5_000,
+            block_size: 16,
+            kv_event_port: 5557,
+            replay_port: None,
+            total_kv_blocks: Some(1000),
+            max_num_batched_tokens: Some(8192),
+        }
+    }
 
     fn defaults() -> RegistrationDefaults {
         RegistrationDefaults {
@@ -149,5 +177,37 @@ mod tests {
             "tcp://10.0.0.1:5557"
         );
         assert_eq!(reg.total_kv_blocks, Some(1000));
+    }
+
+    #[tokio::test]
+    async fn channel_close_clears_selector_topology() {
+        let selector = Arc::new(
+            Selector::new(&config())
+                .await
+                .expect("selector should build"),
+        );
+        let (discovery, changes_tx) = PodDiscovery::for_test(vec![worker(7, "10.0.0.1")]);
+        let adapter = TopologyAdapter::spawn(discovery, selector.clone(), defaults());
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !selector.any_ready().await {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("initial topology was not reconciled");
+
+        // There is no unseen generation when the sole sender closes.
+        drop(changes_tx);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while selector.any_ready().await {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal empty topology was not reconciled");
+
+        drop(adapter);
     }
 }


### PR DESCRIPTION
## Overview

Adds the worker topology adapter for standalone EPP. Raw vLLM pods do not publish a `ModelRuntimeConfig`, so the adapter converts each ready worker into a `WorkerRegistration` using resolved pod endpoints and environment-derived defaults, then reconciles the desired worker set with the in-process `Selector`.

## Behavior

- Runs an initial reconciliation when spawned, then reconciles on `PodDiscovery` changes.
- Reuses the stable `worker_id` produced by `PodDiscovery` so each EPP replica builds the same catalog.
- Registers the milestone-1 single-rank topology: DP size 1 in `Selector`, with the worker's KV-event endpoint assigned to rank 0.
- Propagates model name, block size, optional KV capacity and batching limits, HTTP endpoint, and optional replay endpoint.
- Cancels the background reconciliation task when `TopologyAdapter` is dropped.
- Removes the unused `stable_routing_id` field from the EPP `WorkerRegistration` contract.
- Fixes the feature-gated `kvbm-offload` test imports required by the Pre Merge Rust test.

## Lifecycle

`Selector` owns an embedded `SelectionService` and shares the EPP process lifecycle. When an EPP replica restarts, it constructs a fresh selector and the topology adapter performs an immediate reconciliation before waiting for pod changes. There is no external selector fleet or selector-fleet watch; optional peer discovery manages only the replication peer set.

## Scope

This PR exports `TopologyAdapter` and its registration defaults. It does not yet wire the adapter into the standalone EPP request path; request-path wiring remains in the follow-up PR.

## Validation

- `cargo fmt -- --check`
- `cargo test --locked -p dynamo-ext-proc`: 82 unit tests and 1 integration test passed
- `cargo clippy --locked -p dynamo-ext-proc --no-deps --all-targets -- -D warnings`
- `cargo test --locked -p dynamo-mocker --features replay-bench,kvbm-offload replay_forces_g1_to_g2 -- --nocapture`: 2 passed
- `cargo test --locked -p dynamo-bench --test mooncake_trace --features mocker-kvbm-offload g2 -- --nocapture`: 1 passed, 18,340 events processed

## Related Issues

None specified.