### PR TITLE
perf(frontend): enable tokenizer cache by default

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -30,6 +30,18 @@ use tokenizers::Tokenizer as HfTokenizer;
 use crate::preprocessor::media::{MediaDecoder, MediaFetcher};
 use crate::protocols::TokenIdType;
 
+const DEFAULT_TOKENIZER_CACHE_BYTES: usize = 64 * 1024 * 1024;
+
+fn tokenizer_cache_enabled(value: Option<&str>) -> bool {
+    !matches!(value, Some("0"))
+}
+
+fn tokenizer_cache_bytes(value: Option<&str>) -> usize {
+    value
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_TOKENIZER_CACHE_BYTES)
+}
+
 /// Identify model deployment cards in the key-value store
 pub const ROOT_PATH: &str = "v1/mdc";
 
@@ -1019,10 +1031,9 @@ impl ModelDeploymentCard {
     /// Tokenizer backend controls:
     /// - `runtime_config.tokenizer_backend=fastokens` — use `fastokens` as the encoding backend
     /// - `DYN_TOKENIZER=fastokens` — fallback backend for callers without explicit runtime config
-    /// - `DYN_TOKENIZER_CACHE=1` — wrap the tokenizer in an L1 prefix cache that records
-    ///   tokenizations at special-token boundaries (massive speed-up for shared chat
-    ///   prefixes; default off, zero cost when unset)
-    /// - `DYN_TOKENIZER_CACHE_BYTES=<n>` — L1 cache byte budget (default 50 MB)
+    /// - `DYN_TOKENIZER_CACHE=0` — disable the L1 prefix cache that records tokenizations
+    ///   at special-token boundaries (enabled by default; any other value keeps it enabled)
+    /// - `DYN_TOKENIZER_CACHE_BYTES=<n>` — L1 cache byte budget (default 64 MiB)
     /// - `DYN_TOKENIZER_CACHE_EXTEND=0` — disable partial-hit extension. By default
     ///   (when the cache is enabled) a partial hit also caches the new suffix so each
     ///   turn of a growing multi-turn conversation hits deeper than the last, keeping
@@ -1034,14 +1045,10 @@ impl ModelDeploymentCard {
             .effective_tokenizer_backend()
             .is_fastokens();
 
-        let cache_enabled = matches!(
-            std::env::var("DYN_TOKENIZER_CACHE").ok().as_deref(),
-            Some("1")
-        );
-        let cache_bytes = std::env::var("DYN_TOKENIZER_CACHE_BYTES")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(50 * 1024 * 1024);
+        let cache_enabled =
+            tokenizer_cache_enabled(std::env::var("DYN_TOKENIZER_CACHE").ok().as_deref());
+        let cache_bytes =
+            tokenizer_cache_bytes(std::env::var("DYN_TOKENIZER_CACHE_BYTES").ok().as_deref());
         // Partial-hit extension is on by default; disable with DYN_TOKENIZER_CACHE_EXTEND=0.
         let cache_extend = !matches!(
             std::env::var("DYN_TOKENIZER_CACHE_EXTEND").ok().as_deref(),
@@ -2075,6 +2082,27 @@ mod tests {
     use super::{HFConfig, ModelDeploymentCard};
     use std::collections::HashSet;
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn tokenizer_cache_is_enabled_by_default_and_disabled_only_by_zero() {
+        assert!(super::tokenizer_cache_enabled(None));
+        assert!(super::tokenizer_cache_enabled(Some("1")));
+        assert!(!super::tokenizer_cache_enabled(Some("0")));
+        assert!(super::tokenizer_cache_enabled(Some("true")));
+    }
+
+    #[test]
+    fn tokenizer_cache_bytes_defaults_to_64_mib_and_accepts_valid_overrides() {
+        assert_eq!(
+            super::tokenizer_cache_bytes(None),
+            super::DEFAULT_TOKENIZER_CACHE_BYTES
+        );
+        assert_eq!(super::tokenizer_cache_bytes(Some("1024")), 1024);
+        assert_eq!(
+            super::tokenizer_cache_bytes(Some("invalid")),
+            super::DEFAULT_TOKENIZER_CACHE_BYTES
+        );
+    }
 
     #[test]
     pub fn test_config_json_llama3() -> anyhow::Result<()> {

--- a/lib/runtime/src/metrics/frontend_perf.rs
+++ b/lib/runtime/src/metrics/frontend_perf.rs
@@ -120,7 +120,7 @@ pub static DETOKENIZE_TOKEN_COUNT: Lazy<Counter> = Lazy::new(|| {
     .expect("detokenize_token_count counter")
 });
 
-/// Cumulative L1 tokenizer cache hits. Only nonzero when `DYN_TOKENIZER_CACHE=1`.
+/// Cumulative L1 tokenizer cache hits. The cache is enabled unless `DYN_TOKENIZER_CACHE=0`.
 pub static TOKENIZER_CACHE_HITS_TOTAL: Lazy<Counter> = Lazy::new(|| {
     Counter::with_opts(Opts::new(
         frontend_metric_name(frontend_perf::TOKENIZER_CACHE_HITS_TOTAL),
@@ -129,7 +129,7 @@ pub static TOKENIZER_CACHE_HITS_TOTAL: Lazy<Counter> = Lazy::new(|| {
     .expect("tokenizer_cache_hits_total counter")
 });
 
-/// Cumulative L1 tokenizer cache misses. Only nonzero when `DYN_TOKENIZER_CACHE=1`.
+/// Cumulative L1 tokenizer cache misses. The cache is enabled unless `DYN_TOKENIZER_CACHE=0`.
 pub static TOKENIZER_CACHE_MISSES_TOTAL: Lazy<Counter> = Lazy::new(|| {
     Counter::with_opts(Opts::new(
         frontend_metric_name(frontend_perf::TOKENIZER_CACHE_MISSES_TOTAL),

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -642,9 +642,9 @@ pub mod frontend_perf {
     pub const TOKENIZE_SECONDS: &str = "tokenize_seconds";
     /// Template application time in preprocessor
     pub const TEMPLATE_SECONDS: &str = "template_seconds";
-    /// L1 tokenizer cache hits (cumulative); only incremented when DYN_TOKENIZER_CACHE is enabled
+    /// L1 tokenizer cache hits (cumulative); enabled unless DYN_TOKENIZER_CACHE=0
     pub const TOKENIZER_CACHE_HITS_TOTAL: &str = "tokenizer_cache_hits_total";
-    /// L1 tokenizer cache misses (cumulative); only incremented when DYN_TOKENIZER_CACHE is enabled
+    /// L1 tokenizer cache misses (cumulative); enabled unless DYN_TOKENIZER_CACHE=0
     pub const TOKENIZER_CACHE_MISSES_TOTAL: &str = "tokenizer_cache_misses_total";
     /// Cumulative detokenization time (microseconds); pair with DETOKENIZE_TOKEN_COUNT
     pub const DETOKENIZE_TOTAL_US: &str = "detokenize_total_us";


### PR DESCRIPTION
## Overview:

Enable Dynamo's process-local L1 tokenizer prefix cache by default. The cache remains configurable and can be disabled with `DYN_TOKENIZER_CACHE=0`; its default byte budget increases from 50 MiB to 64 MiB.

## Details:

- Treat an unset `DYN_TOKENIZER_CACHE`, or any value other than exact `0`, as enabled.
- Preserve the existing Hugging Face, fastokens, and tiktoken wrapper paths without changing cache lookup, extension, eviction, or metrics behavior.
- Change the fallback for `DYN_TOKENIZER_CACHE_BYTES` to `64 * 1024 * 1024`; valid explicit overrides continue to take precedence and invalid values fall back to the default.
- Add focused tests for the enable/disable policy and byte-budget default and overrides.
- Update tokenizer and metric documentation to describe the new default and opt-out.

The cache is local to each process. This change also preserves the existing tiktoken behavior: the wrapper remains a thin no-hit passthrough until tiktoken special-token extraction is implemented.

Validation:

- `cargo fmt --all --check`
- `cargo test -p dynamo-llm tokenizer_cache_` (2 passed)

## Where should the reviewer start?

Start in `lib/llm/src/model_card.rs`, where the environment-value helpers define the new policy and are used by `ModelDeploymentCard::tokenizer()`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tokenizer caching is now enabled by default, with a default cache size of 64 MiB.
  * You can now disable caching only by setting the cache toggle to `0`, and invalid or missing size values will safely fall back to the default.

* **Documentation**
  * Updated cache-related metric and configuration descriptions to match the new default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->