### PR TITLE
fix(vllm): propagate cache salt in text mode

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3393,6 +3393,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         else:
             prompt = TextPrompt(prompt=input_data)
 
+        _apply_nvext_cache_salt(request, prompt)
+
         # Build sampling params from OpenAI-style request
         sampling_params = build_sampling_params_openai(
             request, self.default_sampling_params

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -9,6 +9,7 @@ import re
 import socket
 import sys
 import warnings
+from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -1228,3 +1229,56 @@ def test_build_sampling_params_openai_maps_max_thinking_tokens():
     }
     sp = build_sampling_params_openai(request, default_sampling_params={})
     assert sp.thinking_token_budget == 1024
+
+
+@pytest.mark.asyncio
+async def test_generate_text_mode_applies_nvext_cache_salt():
+    from dynamo.vllm.handlers import DecodeWorkerHandler
+
+    captured = {}
+
+    class InputParams:
+        def get_input_param(self, request, use_tokenizer):
+            assert use_tokenizer is True
+            return [1, 2, 3]
+
+    class EngineClient:
+        def generate(self, prompt, *args, **kwargs):
+            captured["prompt"] = prompt
+
+            async def gen():
+                output = SimpleNamespace(index=0, text="ok", finish_reason=None)
+                yield SimpleNamespace(outputs=[output])
+
+            return gen()
+
+    @asynccontextmanager
+    async def abort_monitor(*args, **kwargs):
+        yield
+
+    handler = SimpleNamespace(
+        input_param_manager=InputParams(),
+        default_sampling_params={},
+        config=SimpleNamespace(disaggregation_mode=DisaggregationMode.AGGREGATED),
+        engine_client=EngineClient(),
+        _deferred_aborts={},
+        _shutdown_on_engine_dead=lambda exc: None,
+        _abort_monitor=abort_monitor,
+        _to_local_dp_rank=lambda rank: None,
+    )
+    context = SimpleNamespace(trace_headers=lambda: {})
+    request = {
+        "model": "test-model",
+        "prompt": "ignored after tokenization",
+        "nvext": {"cache_salt": "tenant-a"},
+    }
+
+    chunks = [
+        chunk
+        async for chunk in DecodeWorkerHandler._generate_text_mode(
+            handler, request, context, "req-1"
+        )
+    ]
+
+    assert chunks
+    assert captured["prompt"]["cache_salt"] == "tenant-a"


### PR DESCRIPTION
## Overview:

propagate cache salt in text mode

## Details:


In the --use-vllm-tokenizer scenario, an OpenAI-compatible v1/chat/completions request may carry nvext.cache_salt, but the current text-mode path loses that value before calling vLLM.

The fix extracts nvext.cache_salt from the HTTP request-derived Python request dict and writes it into the prompt object passed to the vLLM engine:

```
  Client HTTP body
    {"messages": [...], "nvext": {"cache_salt": "tenant-a"}}
          ↓
  Dynamo frontend / runtime converts it into a Python request dict
          ↓
  DecodeWorkerHandler._generate_text_mode()
          ↓
  Builds vLLM internal prompt object: TokensPrompt/TextPrompt
          ↓
  Copies request.nvext.cache_salt into prompt["cache_salt"]
          ↓
  engine_client.generate(prompt, sampling_params, ...)
```

It translates Dynamo’s OpenAI extension field, nvext.cache_salt, into vLLM prompt metadata, cache_salt, so vLLM can apply it when handling KV cache keys.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-generation handling so cache-salt settings are applied earlier in the request flow, helping ensure consistent generation behavior.
* **Tests**
  * Added coverage to verify cache-salt values are preserved through text-mode generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->