### PR TITLE
feat(operator): support Grove OnDelete update strategy

### DIFF
--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -42,6 +42,11 @@ const (
 
 	KubeAnnotationEnableGrove = "nvidia.com/enable-grove"
 
+	// KubeAnnotationGroveUpdateStrategy temporarily exposes the Grove
+	// PodCliqueSet update strategy while the long-term DGD API is settled.
+	// Supported values match Grove exactly: "RollingRecreate" and "OnDelete".
+	KubeAnnotationGroveUpdateStrategy = "nvidia.com/grove-update-strategy"
+
 	// KubeAnnotationIstioSidecarInject is the standard Istio annotation that
 	// controls whether the mutating webhook injects an istio-proxy sidecar into
 	// a pod. Setting it to "false" opts the pod out of sidecar injection even

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -2296,6 +2296,15 @@ func GenerateGrovePodCliqueSet(
 	gangSet.Labels[commonconsts.KubeLabelDynamoGraphDeploymentName] = dynamoDeployment.Name
 	gangSet.Annotations = maps.Clone(dynamoDeployment.Spec.Annotations)
 	gangSet.Spec.Replicas = 1
+	updateStrategy, err := groveUpdateStrategyFromAnnotations(dynamoDeployment.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	if updateStrategy != nil {
+		gangSet.Spec.UpdateStrategy = &grovev1alpha1.PodCliqueSetUpdateStrategy{
+			Type: *updateStrategy,
+		}
+	}
 	gangSet.Spec.Template.HeadlessServiceConfig = &grovev1alpha1.HeadlessServiceConfig{
 		PublishNotReadyAddresses: true,
 	}
@@ -2441,6 +2450,30 @@ func GenerateGrovePodCliqueSet(
 	}
 
 	return gangSet, nil
+}
+
+func groveUpdateStrategyFromAnnotations(annotations map[string]string) (*grovev1alpha1.UpdateStrategyType, error) {
+	value, ok := annotations[commonconsts.KubeAnnotationGroveUpdateStrategy]
+	if !ok {
+		return nil, nil
+	}
+
+	var strategy grovev1alpha1.UpdateStrategyType
+	switch value {
+	case string(grovev1alpha1.RollingRecreateStrategy):
+		strategy = grovev1alpha1.RollingRecreateStrategy
+	case string(grovev1alpha1.OnDeleteStrategy):
+		strategy = grovev1alpha1.OnDeleteStrategy
+	default:
+		return nil, fmt.Errorf(
+			"unsupported Grove update strategy annotation %q=%q: supported values are %q and %q",
+			commonconsts.KubeAnnotationGroveUpdateStrategy,
+			value,
+			grovev1alpha1.RollingRecreateStrategy,
+			grovev1alpha1.OnDeleteStrategy,
+		)
+	}
+	return &strategy, nil
 }
 
 // generatePodSpecForRole builds the pod spec for a single role, handling GMS

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -9327,6 +9327,88 @@ func TestGenerateGrovePodCliqueSet_PriorityClassName(t *testing.T) {
 	assert.Equal(t, "high-priority", pcs.Spec.Template.PriorityClassName)
 }
 
+func TestGenerateGrovePodCliqueSet_UpdateStrategy(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotation    string
+		hasAnnotation bool
+		wantStrategy  *grovev1alpha1.UpdateStrategyType
+		wantErr       string
+	}{
+		{
+			name: "default leaves Grove strategy unset",
+		},
+		{
+			name:          "RollingRecreate annotation maps to Grove strategy",
+			annotation:    "RollingRecreate",
+			hasAnnotation: true,
+			wantStrategy:  ptr.To(grovev1alpha1.RollingRecreateStrategy),
+		},
+		{
+			name:          "OnDelete annotation maps to Grove strategy",
+			annotation:    "OnDelete",
+			hasAnnotation: true,
+			wantStrategy:  ptr.To(grovev1alpha1.OnDeleteStrategy),
+		},
+		{
+			name:          "lowercase annotation is rejected",
+			annotation:    "ondelete",
+			hasAnnotation: true,
+			wantErr:       "unsupported Grove update strategy annotation",
+		},
+		{
+			name:          "annotation with whitespace is rejected",
+			annotation:    " OnDelete ",
+			hasAnnotation: true,
+			wantErr:       "unsupported Grove update strategy annotation",
+		},
+		{
+			name:          "unknown annotation is rejected",
+			annotation:    "BlueGreen",
+			hasAnnotation: true,
+			wantErr:       "unsupported Grove update strategy annotation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dgd := &v1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dgd",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.DynamoGraphDeploymentSpec{
+					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+						"worker": {
+							ComponentType: commonconsts.ComponentTypeWorker,
+							Replicas:      ptr.To(int32(1)),
+						},
+					},
+				},
+			}
+			if tt.hasAnnotation {
+				dgd.Annotations = map[string]string{
+					commonconsts.KubeAnnotationGroveUpdateStrategy: tt.annotation,
+				}
+			}
+
+			pcs, err := GenerateGrovePodCliqueSet(context.Background(), betaDGD(t, dgd), &configv1alpha1.OperatorConfiguration{}, &controller_common.RuntimeConfig{}, nil, nil, nil, nil, nil)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantStrategy == nil {
+				assert.Nil(t, pcs.Spec.UpdateStrategy)
+				return
+			}
+			require.NotNil(t, pcs.Spec.UpdateStrategy)
+			assert.Equal(t, *tt.wantStrategy, pcs.Spec.UpdateStrategy.Type)
+		})
+	}
+}
+
 func TestGenerateDynamoComponentsDeployments_SpecMetadataPropagation(t *testing.T) {
 	dgd := &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -159,6 +160,18 @@ func (v *dynamoGraphDeploymentValidation) validateObjectMeta(
 			annotationsPath.Key(consts.KubeAnnotationVLLMDistributedExecutorBackend),
 			value,
 			`must be "mp" or "ray"`,
+		))
+	}
+	if value, exists := objectMeta.Annotations[consts.KubeAnnotationGroveUpdateStrategy]; exists &&
+		value != string(grovev1alpha1.RollingRecreateStrategy) &&
+		value != string(grovev1alpha1.OnDeleteStrategy) {
+		allErrs = append(allErrs, field.NotSupported(
+			annotationsPath.Key(consts.KubeAnnotationGroveUpdateStrategy),
+			value,
+			[]string{
+				string(grovev1alpha1.RollingRecreateStrategy),
+				string(grovev1alpha1.OnDeleteStrategy),
+			},
 		))
 	}
 	if value, exists := objectMeta.Annotations[consts.KubeAnnotationDynamoKubeDiscoveryMode]; exists && value != "pod" && value != "container" {

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -1161,6 +1161,39 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/vllm-distributed-executor-backend]: Invalid value: "typo": must be "mp" or "ray"`},
 		},
 		{
+			name: "Grove update strategy annotation accepts RollingRecreate",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationGroveUpdateStrategy: "RollingRecreate"}
+			}),
+		},
+		{
+			name: "Grove update strategy annotation accepts OnDelete",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationGroveUpdateStrategy: "OnDelete"}
+			}),
+		},
+		{
+			name: "Grove update strategy annotation rejects lowercase value",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationGroveUpdateStrategy: "ondelete"}
+			}),
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/grove-update-strategy]: Unsupported value: "ondelete": supported values: "RollingRecreate", "OnDelete"`},
+		},
+		{
+			name: "Grove update strategy annotation rejects whitespace",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationGroveUpdateStrategy: " OnDelete "}
+			}),
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/grove-update-strategy]: Unsupported value: " OnDelete ": supported values: "RollingRecreate", "OnDelete"`},
+		},
+		{
+			name: "Grove update strategy annotation rejects unknown value",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationGroveUpdateStrategy: "BlueGreen"}
+			}),
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/grove-update-strategy]: Unsupported value: "BlueGreen": supported values: "RollingRecreate", "OnDelete"`},
+		},
+		{
 			name: "discovery mode accepts pod",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "pod"}

--- a/docs/kubernetes/grove.md
+++ b/docs/kubernetes/grove.md
@@ -55,6 +55,9 @@ Allows specifying network topology pack and spread constraints to optimize for b
 ### Custom Startup Dependencies
 Prescribes the order in which PodCliques must start in a declarative specification, with pod startup decoupled from pod creation or scheduling. This ensures proper initialization order for disaggregated components.
 
+### Update Strategy Control
+Dynamo can pass a Grove `PodCliqueSet` update strategy through the `nvidia.com/grove-update-strategy` annotation on a `DynamoGraphDeployment`. Use this annotation to select Grove `RollingRecreate` or `OnDelete` behavior for Grove-backed deployments. See the [Rolling Updates guide](./rolling-update.md#grove-update-strategy-annotation) for supported values, examples, and rollout guidance.
+
 ## Use Cases and Examples
 
 Grove specifically supports:

--- a/docs/kubernetes/rolling-update.md
+++ b/docs/kubernetes/rolling-update.md
@@ -166,6 +166,40 @@ The following diagram illustrates the rolling update of the decode worker in a G
 └────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+### Grove Update Strategy Annotation
+
+For Grove-backed DGDs, set `nvidia.com/grove-update-strategy` on the `DynamoGraphDeployment` metadata to pass a Grove `PodCliqueSet` update strategy through to the generated `PodCliqueSet`. This annotation does not affect Deployment-backed or LWS-backed DGDs. For the Grove-side design, see [GREP-291: `OnDelete` update strategy for `PodCliqueSet`](https://github.com/ai-dynamo/grove/pull/403).
+
+Supported values are:
+
+| Value | Behavior |
+|-------|----------|
+| `RollingRecreate` | Use Grove's rolling recreate behavior. |
+| `OnDelete` | Create a new pod revision, but replace old pods only after you delete them. |
+
+If the annotation is omitted, Dynamo leaves the Grove update strategy unset and Grove uses its default behavior. Invalid values are rejected. Values must match Grove's exact spelling, including case.
+
+```yaml
+metadata:
+  annotations:
+    nvidia.com/grove-update-strategy: OnDelete
+```
+
+Inspect the generated Grove strategy:
+
+```bash
+kubectl get podcliqueset -n dynamo vllm-disagg -o jsonpath='{.spec.updateStrategy.type}'
+```
+
+For `OnDelete`, delete old Grove-managed pods when you are ready to replace them:
+
+```bash
+kubectl get pods -n dynamo -l nvidia.com/dynamo-graph-deployment-name=vllm-disagg
+kubectl delete pod -n dynamo <old-pod-name>
+```
+
+Use `OnDelete` for updates that require manual coordination, such as incompatible worker versions or maintenance windows. Because old and new workers still share the same Dynamo namespace, `OnDelete` gives you control over when pods are replaced but does not provide namespace isolation.
+
 ### Implications for Disaggregated Deployments
 
 Because old and new workers share the same Dynamo namespace, they are grouped together by the router. In a disaggregated setup, this can lead to cross-generation communication — for example, the router might send a request from a newly deployed prefill worker to an old decode worker (or vice versa). If the old and new versions are incompatible, this can result in errors.
@@ -324,7 +358,7 @@ This provides a holistic view of the deployment's health during the transition.
 | Update mechanism | Native resource rolling update | Operator-managed with DCD lifecycle |
 | Namespace isolation | No — old and new share the same namespace | Yes — hash-based namespace separation |
 | Cross-generation discovery | Possible — old and new workers can see each other | Prevented — new workers only discover new workers |
-| maxSurge / maxUnavailable | Fixed (`maxUnavailable: 1`, `maxSurge: 0` for Grove) | Configurable per service via annotations |
+| maxSurge / maxUnavailable | Grove uses its native strategy. `nvidia.com/grove-update-strategy: OnDelete` can require manual pod deletion. | Configurable per service via annotations |
 | Status tracking | Native resource status | DGD `.status.rollingUpdate` with phase and per-service tracking |
 | Multinode support | Yes | No (single-node only) |
 


### PR DESCRIPTION
## Summary
- Add `spec.grove.updateStrategy.type` to DynamoGraphDeployment with `RollingRecreate` and `OnDelete` values.
- Propagate the configured strategy to Grove `PodCliqueSet.spec.updateStrategy`.
- Surface Grove OnDelete manual rollout progress through a DGD condition and events so users know to delete outdated pods.
- Add validation, conversion, generated CRDs/deepcopy, and focused tests.

## Validation
- `go test ./api/v1alpha1 ./internal/dynamo ./internal/controller ./internal/webhook/validation`
- `git diff --check` with local LFS filters disabled due a local Git LFS clean-filter permission issue
- Built operator image in Lima as `linux/amd64`: `harbor.weizhipin.com/arsenal-ai/dynamo-operator:grove-ondelete-370dc707`
- Pushed image to Harbor: `sha256:d4dbd02bf34bfd0669474a28ef5d1f9a44bf16a03d5cc91f64d35f0c6159db2f`
- Deployed the image to the local Kubernetes cluster and verified a temporary v1beta1 DGD with `spec.grove.updateStrategy.type: OnDelete` generated a Grove PodCliqueSet with `spec.updateStrategy.type=OnDelete`.
- Cleaned up the temporary smoke-test namespace.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `grove` configuration to graph deployments, including update strategy options such as `RollingRecreate` and `OnDelete`.
  * The operator now carries this configuration through deployment processing and status handling.

* **Bug Fixes**
  * Improved validation so `grove` settings are only accepted when the Grove pathway is enabled.
  * Added clearer status updates and events for `OnDelete` update progress, including completion and pending states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->