### PR TITLE
test(e2e): align DGDR Ginkgo labels

### DIFF
--- a/deploy/operator/test/e2e/AGENTS.md
+++ b/deploy/operator/test/e2e/AGENTS.md
@@ -1,0 +1,21 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AGENTS.md
+
+## Labels
+
+| Label | Meaning |
+| --- | --- |
+| `gpu_0` | Runs without schedulable Kubernetes `nvidia.com/gpu` capacity. |
+| `gpu_1`, `gpu_2`, `gpu_4`, `gpu_8` | Requires at least that many schedulable Kubernetes GPUs. |
+| `h100` | Requires H100; combine with `gpu_N`. |
+| `validation` | Webhook, CRD metadata, API discovery, or conversion checks only. |
+| `rapid` | DGDR rapid profiling strategy. |
+| `thorough` | DGDR thorough profiling strategy; usually combine with non-zero `gpu_N`. |
+
+Do not use generic `gpu` or `real-gpu` labels.
+Do not add `mocker` unless selecting explicit mocker/no-mocker variants.
+Place labels at `Describe` or `Context` only when all contained specs match.

--- a/deploy/operator/test/e2e/AGENTS.md
+++ b/deploy/operator/test/e2e/AGENTS.md
@@ -9,9 +9,10 @@ SPDX-License-Identifier: Apache-2.0
 
 | Label | Meaning |
 | --- | --- |
-| `gpu_0` | Runs without schedulable Kubernetes `nvidia.com/gpu` capacity. |
+| `gpu_0` | Does not require schedulable Kubernetes `nvidia.com/gpu` capacity. |
 | `gpu_1`, `gpu_2`, `gpu_4`, `gpu_8` | Requires at least that many schedulable Kubernetes GPUs. |
 | `h100` | Requires H100; combine with `gpu_N`. |
+| `e2e` | End-to-end test against a Kubernetes cluster. |
 | `validation` | Webhook, CRD metadata, API discovery, or conversion checks only. |
 | `rapid` | DGDR rapid profiling strategy. |
 | `thorough` | DGDR thorough profiling strategy; usually combine with non-zero `gpu_N`. |

--- a/deploy/operator/test/e2e/dgdr/README.md
+++ b/deploy/operator/test/e2e/dgdr/README.md
@@ -65,17 +65,19 @@ go test ./test/e2e/dgdr/ -v -ginkgo.v \
 
 ### Ginkgo labels
 
-Each Describe is tagged with one or more labels you can filter on via
-`-ginkgo.label-filter`:
+Specs are tagged with labels you can filter on via `-ginkgo.label-filter`:
 
 | Label | Applies to | Meaning |
 |---|---|---|
-| `validation` | `validation_test.go` only | Webhook dry-run; no resources persisted, no GPUs needed. |
-| `gpu_0` | all suites | Can run on a node with 0 GPUs (validation, plus mocker-mode lifecycle/profiling). |
-| `integration`, `k8s`, `nightly` | all suites | Categorical tags used by CI scheduling. |
+| `validation` | `validation_test.go` | Webhook, CRD metadata, API discovery, and conversion checks. |
+| `rapid` | rapid DGDR profiling specs | Rapid profiling strategy. |
+| `thorough` | thorough DGDR profiling specs | Thorough profiling strategy. |
+| `gpu_0` | validation and rapid mocker specs | Requires no schedulable Kubernetes GPUs. |
+| `gpu_1` | thorough or non-mocker deployment specs | Requires at least one schedulable Kubernetes GPU. |
+| `integration`, `k8s`, `nightly` | full DGDR e2e suite | Categorical tags used by CI scheduling. |
 
-Use `validation` (not `gpu_0`) when you only want the webhook validation
-suite — `gpu_0` matches every Describe in this directory.
+Use `validation` when you only want webhook/metadata/conversion checks. Use
+`rapid && gpu_0` for the GPU-free profiling path.
 
 ## CLI Flags
 

--- a/deploy/operator/test/e2e/dgdr/README.md
+++ b/deploy/operator/test/e2e/dgdr/README.md
@@ -72,9 +72,9 @@ Specs are tagged with labels you can filter on via `-ginkgo.label-filter`:
 | `validation` | `validation_test.go` | Webhook, CRD metadata, API discovery, and conversion checks. |
 | `rapid` | rapid DGDR profiling specs | Rapid profiling strategy. |
 | `thorough` | thorough DGDR profiling specs | Thorough profiling strategy. |
-| `gpu_0` | validation and rapid mocker specs | Requires no schedulable Kubernetes GPUs. |
+| `gpu_0` | validation and rapid mocker specs | Does not require schedulable Kubernetes GPUs. |
 | `gpu_1` | thorough or non-mocker deployment specs | Requires at least one schedulable Kubernetes GPU. |
-| `integration`, `k8s`, `nightly` | full DGDR e2e suite | Categorical tags used by CI scheduling. |
+| `e2e`, `integration`, `k8s`, `nightly` | full DGDR e2e suite | Categorical tags used by CI scheduling. |
 
 Use `validation` when you only want webhook/metadata/conversion checks. Use
 `rapid && gpu_0` for the GPU-free profiling path.

--- a/deploy/operator/test/e2e/dgdr/dgdr_h100_e2e_test.go
+++ b/deploy/operator/test/e2e/dgdr/dgdr_h100_e2e_test.go
@@ -113,7 +113,7 @@ func disaggPlannerBase(
 
 // DGDR Support Matrix on H100 SKU exercises the full DGDR lifecycle (create -> profile ->
 // DGD generation -> DGD readiness) across a curated
-var _ = Describe("DGDR Support Matrix on H100 SKU", Label("gpu_0", "nightly", "integration", "k8s"), func() {
+var _ = Describe("DGDR Support Matrix on H100 SKU", Label("gpu_0", "nightly", "e2e", "integration", "k8s"), func() {
 	// -----------------------------------------------------------------------
 	// Support matrix — rapid profiling (in AIC matrix)
 	// Models with pre-validated configs where rapid search finds a viable

--- a/deploy/operator/test/e2e/dgdr/dgdr_test.go
+++ b/deploy/operator/test/e2e/dgdr/dgdr_test.go
@@ -29,13 +29,13 @@ import (
 // configurations. Modeled after the CAAPH helm_test.go pattern: each It block calls
 // DGDRLifecycleSpec with a different input, and multiple specs can be composed
 // sequentially within a single It to test multi-step workflows.
-var _ = Describe("DGDR Lifecycle Scenarios", Label("gpu_0", "nightly", "integration", "k8s"), func() {
+var _ = Describe("DGDR Lifecycle Scenarios", Label("nightly", "integration", "k8s"), func() {
 
 	// -----------------------------------------------------------------------
 	// Backend variations — rapid profiling with each supported backend
 	// -----------------------------------------------------------------------
 
-	Context("Backend variations with rapid profiling", func() {
+	Context("Backend variations with rapid profiling", Label("rapid", "gpu_0"), func() {
 
 		It("should complete full lifecycle with vllm backend", func() {
 			By("Running DGDR lifecycle with vllm + rapid + autoApply")
@@ -65,7 +65,7 @@ var _ = Describe("DGDR Lifecycle Scenarios", Label("gpu_0", "nightly", "integrat
 
 	Context("Search strategy and autoApply variations", func() {
 
-		It("should complete thorough profiling without deploying", func() {
+		It("should complete thorough profiling without deploying", Label("thorough", "gpu_1"), func() {
 			By("Running DGDR lifecycle with thorough + autoApply=false")
 			DGDRLifecycleSpec(ctx, func() DGDRLifecycleInput {
 				return DGDRLifecycleInput{
@@ -79,7 +79,7 @@ var _ = Describe("DGDR Lifecycle Scenarios", Label("gpu_0", "nightly", "integrat
 			})
 		})
 
-		It("should reach Ready but not Deployed with autoApply=false", func() {
+		It("should reach Ready but not Deployed with autoApply=false", Label("rapid", "gpu_0"), func() {
 			By("Running DGDR lifecycle with rapid + autoApply=false")
 			DGDRLifecycleSpec(ctx, func() DGDRLifecycleInput {
 				return DGDRLifecycleInput{
@@ -96,7 +96,7 @@ var _ = Describe("DGDR Lifecycle Scenarios", Label("gpu_0", "nightly", "integrat
 	// Feature combinations
 	// -----------------------------------------------------------------------
 
-	Context("Feature combinations", func() {
+	Context("Feature combinations", Label("rapid", "gpu_0"), func() {
 
 		It("should include Planner service when planner is enabled", func() {
 			By("Running DGDR lifecycle with trtllm + planner enabled")
@@ -127,7 +127,7 @@ var _ = Describe("DGDR Lifecycle Scenarios", Label("gpu_0", "nightly", "integrat
 	// SLA and workload parameter variations
 	// -----------------------------------------------------------------------
 
-	Context("SLA and workload parameter variations", func() {
+	Context("SLA and workload parameter variations", Label("rapid", "gpu_0"), func() {
 
 		It("should profile with custom SLA and workload constraints", func() {
 			By("Running DGDR lifecycle with custom TTFT/ITL and ISL/OSL")
@@ -190,7 +190,7 @@ var _ = Describe("DGDR Lifecycle Scenarios", Label("gpu_0", "nightly", "integrat
 	// Hardware configuration
 	// -----------------------------------------------------------------------
 
-	Context("Hardware configuration", func() {
+	Context("Hardware configuration", Label("rapid", "gpu_0"), func() {
 
 		It("should profile with specified GPU configuration", func() {
 			By("Running DGDR lifecycle with custom A100 hardware spec")
@@ -216,7 +216,7 @@ var _ = Describe("DGDR Lifecycle Scenarios", Label("gpu_0", "nightly", "integrat
 	// a single It block to test sequential scenarios (CAAPH helm_test.go style).
 	// -----------------------------------------------------------------------
 
-	Context("Multi-step workflows", func() {
+	Context("Multi-step workflows", Label("rapid", "gpu_0"), func() {
 
 		It("should run rapid profiling across multiple backends sequentially", func() {
 			By("Running vllm rapid lifecycle")

--- a/deploy/operator/test/e2e/dgdr/dgdr_test.go
+++ b/deploy/operator/test/e2e/dgdr/dgdr_test.go
@@ -29,7 +29,7 @@ import (
 // configurations. Modeled after the CAAPH helm_test.go pattern: each It block calls
 // DGDRLifecycleSpec with a different input, and multiple specs can be composed
 // sequentially within a single It to test multi-step workflows.
-var _ = Describe("DGDR Lifecycle Scenarios", Label("nightly", "integration", "k8s"), func() {
+var _ = Describe("DGDR Lifecycle Scenarios", Label("nightly", "e2e", "integration", "k8s"), func() {
 
 	// -----------------------------------------------------------------------
 	// Backend variations — rapid profiling with each supported backend

--- a/deploy/operator/test/e2e/dgdr/lifecycle_test.go
+++ b/deploy/operator/test/e2e/dgdr/lifecycle_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("DGDR Lifecycle", Label("nightly", "integration", "k8s"), func() {
+var _ = Describe("DGDR Lifecycle", Label("nightly", "e2e", "integration", "k8s"), func() {
 
 	Context("Rapid profiling", Label("rapid"), func() {
 

--- a/deploy/operator/test/e2e/dgdr/lifecycle_test.go
+++ b/deploy/operator/test/e2e/dgdr/lifecycle_test.go
@@ -25,11 +25,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("DGDR Lifecycle", Label("gpu_0", "nightly", "integration", "k8s"), func() {
+var _ = Describe("DGDR Lifecycle", Label("nightly", "integration", "k8s"), func() {
 
-	Context("Rapid profiling", func() {
+	Context("Rapid profiling", Label("rapid"), func() {
 
-		It("should reach Ready with autoApply=false", func() {
+		It("should reach Ready with autoApply=false", Label("gpu_0"), func() {
 			name := uniqueName("lifecycle-ready")
 			dgdr := newDGDR(name, withAutoApply(false))
 			createAndCleanup(dgdr)
@@ -45,7 +45,7 @@ var _ = Describe("DGDR Lifecycle", Label("gpu_0", "nightly", "integration", "k8s
 			verifyProfilingJobCompleted(result.Status.ProfilingJobName)
 		})
 
-		It("should reach Deployed with autoApply=true (non-mocker only)", func() {
+		It("should reach Deployed with autoApply=true (non-mocker only)", Label("gpu_1"), func() {
 			if useMocker() {
 				Skip("In mocker mode, autoApply=true can race on generated DGD; " +
 					"lifecycle deployment coverage is run with --dgdr-no-mocker")

--- a/deploy/operator/test/e2e/dgdr/profiling_test.go
+++ b/deploy/operator/test/e2e/dgdr/profiling_test.go
@@ -28,9 +28,9 @@ import (
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
-var _ = Describe("DGDR Profiling", Label("gpu_0", "nightly", "integration", "k8s"), func() {
+var _ = Describe("DGDR Profiling", Label("nightly", "integration", "k8s"), func() {
 
-	Context("Rapid search strategy", func() {
+	Context("Rapid search strategy", Label("rapid", "gpu_0"), func() {
 
 		It("should emit an output ConfigMap with final_config.yaml", func() {
 			name := uniqueName("rapid-cm")

--- a/deploy/operator/test/e2e/dgdr/profiling_test.go
+++ b/deploy/operator/test/e2e/dgdr/profiling_test.go
@@ -28,7 +28,7 @@ import (
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
-var _ = Describe("DGDR Profiling", Label("nightly", "integration", "k8s"), func() {
+var _ = Describe("DGDR Profiling", Label("nightly", "e2e", "integration", "k8s"), func() {
 
 	Context("Rapid search strategy", Label("rapid", "gpu_0"), func() {
 

--- a/deploy/operator/test/e2e/dgdr/validation_test.go
+++ b/deploy/operator/test/e2e/dgdr/validation_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("DGDR Validation", Label("validation", "gpu_0", "nightly", "integration", "k8s"), func() {
+var _ = Describe("DGDR Validation", Label("validation", "gpu_0", "nightly", "e2e", "integration", "k8s"), func() {
 
 	// -----------------------------------------------------------------------
 	// Webhook validation (server-side dry-run — no resources persisted)


### PR DESCRIPTION
## Summary

- document the DGDR e2e label taxonomy close to the tests
- classify existing specs by GPU count and profiling strategy
- remove ambiguous generic GPU and mocker labels

## Validation

- `go test ./test/e2e/dgdr -run TestDGDR -ginkgo.dry-run -ginkgo.v -dgdr-namespace=dummy -dgdr-image=dummy`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated end-user guidance for test labels and scheduling expectations.
  * Clarified which labels apply to GPU-free validation, rapid checks, thorough runs, and broader CI coverage.

* **Tests**
  * Adjusted e2e test labeling to better separate rapid and thorough scenarios.
  * Updated lifecycle and profiling test labels to reflect GPU requirements more clearly, without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->