### PR TITLE
refactor(validation): make DGD validation structural

### DIFF
--- a/deploy/operator/internal/webhook/validation/AGENTS.md
+++ b/deploy/operator/internal/webhook/validation/AGENTS.md
@@ -1,0 +1,154 @@
+# Validation package
+
+## Structural validation
+
+- Follow the Kubernetes API validation style: typed validators compose
+  `field.ErrorList` through `*field.Path` and report all independent errors.
+- Validation must follow the Go API type tree. Every API struct with custom
+  semantics has one validator named after its exact Go type, for example
+  `validateDynamoGraphDeploymentSpec`,
+  `validateDynamoComponentDeploymentSharedSpec`, and
+  `validateKvTransferPolicy`.
+- A parent validates its own scalar fields and calls child validators in API
+  declaration order. Slice paths use `Index(i)` and map paths use `Key(key)`;
+  sort map keys before emitting errors.
+- Aggregate independent errors. Do not use the presence of an earlier error to
+  skip a validation or lookup unless that operation actually depends on the
+  earlier validation succeeding.
+- Seed root validation with the actual top-level field paths, such as
+  `field.NewPath("metadata")` and `field.NewPath("spec")`, matching upstream
+  Kubernetes validation. Do not invent a synthetic resource path or start
+  child validation from an empty path.
+- Treat embedded `metav1.ObjectMeta` as a structural child. Object metadata
+  and annotation rules belong in `validateObjectMeta`, called with the
+  `metadata` path.
+- Do not name validators after a policy or implementation detail. Start with
+  the lowest common API-type ancestor of the fields a rule relates, then keep
+  the rule there when it coordinates siblings or needs broad aggregation.
+  A child may own a rule when its invalid field and most of its logic are local
+  to that type, and the required ancestor facts are cheap and clear to pass
+  explicitly. Helpers for lookup, sorting, normalization, or deriving context
+  are not validators and must not use a `validate` name.
+- For Kubernetes-owned nested types, delegate to their Kubernetes validator at
+  the exact field path instead of reimplementing their schema validation.
+- Before deleting or moving an existing validation rule, inventory it and map
+  it explicitly to CRD schema, CEL, or a structural validator. Presence rules
+  do not replace value rules; preserve any semantic gap in code or strengthen
+  the schema and prove it with schema-admission coverage.
+- File ownership follows the API type being validated, not the resource that
+  currently reaches it. Keep resource-specific validators in that resource's
+  file and validators for types shared by multiple resources in a
+  `shared_<version>.go` file.
+- Keep every structural `validate<Type>` function in that type and version's
+  main validation file. Put only non-validator helpers in the matching
+  `<owner>_helpers.go` file; do not move shared validators into a caller's file
+  for convenience.
+- Keep compatibility validators for a non-storage API version in a separate
+  `<owner>_<version>.go` file. Keep validators for API types shared by multiple
+  resources in the corresponding `shared_<version>.go` file.
+- Use one `<owner>_helpers.go` file across API versions. Helpers do not get
+  version-specific files; their typed signatures already make the applicable
+  API version clear.
+
+## Validator signatures and context
+
+- Keep structural values first, followed by `fldPath`.
+- Every structural `validate...` function returns `field.ErrorList`.
+- Accumulate warnings during that same structural traversal through
+  core request-scoped receiver methods named `warn` and `warnf`; do not return
+  warnings through every validator signature or implement a second warning
+  traversal.
+- The primary API value and `fldPath` passed to a validator are non-nil
+  invariants and must be documented on the function. Do not add defensive nil
+  checks for required validator arguments.
+- For an optional child pointer, the parent checks for nil and only then calls
+  the child validator. Update parents likewise handle removal before calling a
+  child update validator; when an old value may legitimately be absent, state
+  that explicitly in the child validator's contract.
+- Pass up to three ancestor-derived contextual values as direct, typed
+  parameters.
+- If a validator needs four or more such values, use one final, sparse,
+  type-specific options struct named after that validator's API type.
+- Define an options struct only when it is needed. It contains only data the
+  current API value cannot derive for itself.
+- Construct each child options struct afresh at the call site. Never copy,
+  embed, mutate, or extend a parent options struct. Do not use a generic,
+  accumulating validation-context bag.
+- Keep request-wide immutable dependencies on the validator receiver: context,
+  API reader/client, feature configuration, and caller identity. The receiver
+  may also carry the warnings accumulated by `warn` and `warnf` because it is
+  created once per request. Do not store the current API node, field path,
+  derived traversal data, or accumulated errors on the receiver.
+- Only structural `validate...` functions use validation receivers. Lookup,
+  derivation, sorting, normalization, and comparison helpers are standalone
+  functions with explicit dependencies. Core request-accumulation methods such
+  as `warn` and `warnf` are the exception and stay with their receiver.
+- Dependencies required by a validation path, including its context and
+  manager/client, are non-nil construction invariants. Document and satisfy
+  those invariants at the boundary; do not add nil fallbacks inside helpers.
+- Update validators take `new`, `old`, and `fldPath` as their structural
+  inputs. Apply the same direct-context/typed-options threshold afterward.
+- Update rules consider both old and new state whenever removing or replacing
+  a field could bypass a guard that applies while the field is present.
+- When otherwise identical Go type names from another API version need a
+  distinct validator, suffix the type name with the version, for example
+  `validateVolumeMountV1alpha1`; do not prefix the version.
+- Use the standard `k8s.io/utils/ptr` helpers such as `ptr.Deref` and
+  `ptr.Equal` for simple pointer defaults and equality. Do not add one-line
+  dereference or pointer-comparison helpers.
+
+## Errors, warnings, and compatibility
+
+- All `validate...` functions return `field.ErrorList`; do not return `error`,
+  use `errors.Join`, or build field paths with `fmt.Sprintf`.
+- Use typed Kubernetes errors (`field.Required`, `field.Invalid`,
+  `field.Forbidden`, `field.NotSupported`, and immutable-field validation).
+  The admission boundary converts the final error list to an API invalid error.
+- Keep `field.Invalid` bad values compact and non-sensitive. Never attach a
+  complete resource subtree, pod template, environment list, or other
+  potentially secret-bearing value; use the offending scalar or
+  `field.Forbidden` when no bad value is needed.
+- Emit warnings from their structural owner through the request-scoped
+  receiver during the same recursion that collects errors. Keep warning
+  accumulation outside `field.ErrorList`; do not add a warning-only recursion.
+- Keep storage-version and compatibility-version validation recursions
+  separate. Conversion is a boundary with explicit conversion and fidelity
+  tests; do not build a parallel cross-version validator.
+
+## API types shared by multiple resources
+
+- Give each shared API type one structural validator that every resource
+  recursion reuses. Do not wrap it in a stateful per-type validator object or
+  duplicate it under each caller.
+- Keep the full shared-type subtree, including create and update validators, in
+  the matching `shared_<version>.go` file.
+- Shared-type validators use a shared request receiver. Resource-specific
+  receivers embed that base so they can compose shared validation without
+  attaching shared methods to a resource-specific receiver.
+- Declare a validation receiver alongside the primary structural validation it
+  supports, with its core accumulation methods beside it. Do not create a
+  standalone file solely for receiver plumbing.
+- Keep only dependencies and request accumulation needed by shared validation
+  on the shared receiver. Resource-only state stays on the resource-specific
+  receiver.
+- Rules involving parent-only data stay with the parent validator. Pass parent
+  facts into a child only when the child's rule remains locally understandable
+  and the extraction cost is small.
+
+## Tests
+
+- Keep one table-driven admission-chain test per resource. Run the request's
+  source schema and CEL validation first, convert only accepted requests, then
+  invoke the webhook. Group related rows inside that table with comments; do
+  not create parallel matrix tests for individual validation areas.
+- Add every schema-, CEL-, create-webhook, and update-webhook regression as a
+  row in that table. Use a separate focused unit test only for an internal
+  contract that the effective admission chain cannot reach, such as a fatal
+  defensive conversion failure.
+- Assert typed errors and exact field paths, aggregation of independent errors,
+  and deterministic ordering. Do not assert only rendered error strings.
+- Add regression coverage for every legacy rule retained during a structural
+  migration. When ownership moves to schema or CEL, exercise the real schema
+  admission boundary rather than treating a unit-test assumption as proof.
+- Every newly added nested API type must be directly checked by its parent or
+  delegated to its exact-type validator.

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -19,28 +19,24 @@ package validation
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
-	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	k8sptr "k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
-
-var betaTopologyDomainRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 // DynamoGraphDeploymentValidator validates v1beta1 DynamoGraphDeployment resources.
 type DynamoGraphDeploymentValidator struct {
@@ -49,6 +45,7 @@ type DynamoGraphDeploymentValidator struct {
 }
 
 // NewDynamoGraphDeploymentValidator creates a validator for v1beta1 DynamoGraphDeployment.
+// mgr must not be nil.
 func NewDynamoGraphDeploymentValidator(
 	mgr ctrl.Manager,
 	groveEnabled bool,
@@ -59,1128 +56,578 @@ func NewDynamoGraphDeploymentValidator(
 	}
 }
 
+// dynamoGraphDeploymentValidation carries DGD-specific request state.
+// API values and derived traversal state remain explicit validator arguments.
 type dynamoGraphDeploymentValidation struct {
-	deployment   *nvidiacomv1beta1.DynamoGraphDeployment
-	mgr          ctrl.Manager
-	groveEnabled bool
+	sharedValidation
+	groveEnabled      bool
+	userInfo          *authenticationv1.UserInfo
+	operatorPrincipal string
+}
+
+type dynamoGraphDeploymentSpecValidationOptions struct {
+	dgdName                 string
+	generation              int64
+	grovePathway            bool
+	grovePathwayRequirement string
 }
 
 // Validate performs stateless validation on the v1beta1 DynamoGraphDeployment.
+// ctx and deployment must not be nil.
 func (v *DynamoGraphDeploymentValidator) Validate(
 	ctx context.Context,
 	deployment *nvidiacomv1beta1.DynamoGraphDeployment,
 ) (admission.Warnings, error) {
-	return (&dynamoGraphDeploymentValidation{
-		deployment:   deployment,
-		mgr:          v.mgr,
-		groveEnabled: v.groveEnabled,
-	}).validate(ctx)
+	validation := &dynamoGraphDeploymentValidation{
+		sharedValidation: sharedValidation{ctx: ctx, mgr: v.mgr},
+		groveEnabled:     v.groveEnabled,
+	}
+
+	allErrs := validation.validateDynamoGraphDeployment(deployment)
+	alpha, err := alphaDynamoGraphDeploymentForValidation(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("cannot validate preserved v1alpha1 DynamoGraphDeployment fields: %w", err)
+	}
+	allErrs = append(allErrs, validation.validateDynamoGraphDeploymentV1alpha1(alpha)...)
+
+	return validation.warnings, invalidDynamoGraphDeploymentError(deployment, allErrs)
 }
 
 // ValidateUpdate performs stateful validation comparing old and new v1beta1 DGD objects.
-// userInfo is used for identity-based validation (replica protection).
-// If userInfo is nil, replica changes for DGDSA-enabled components are rejected (fail closed).
-// operatorPrincipal is the full Kubernetes SA username of the operator for authorization.
+// ctx, oldDGD, and newDGD must not be nil.
+// If userInfo is nil, replica changes for DGDSA-enabled components fail closed.
 func (v *DynamoGraphDeploymentValidator) ValidateUpdate(
-	old *nvidiacomv1beta1.DynamoGraphDeployment,
-	new *nvidiacomv1beta1.DynamoGraphDeployment,
+	ctx context.Context,
+	oldDGD *nvidiacomv1beta1.DynamoGraphDeployment,
+	newDGD *nvidiacomv1beta1.DynamoGraphDeployment,
 	userInfo *authenticationv1.UserInfo,
 	operatorPrincipal string,
 ) (admission.Warnings, error) {
-	return (&dynamoGraphDeploymentValidation{
-		deployment:   new,
-		mgr:          v.mgr,
-		groveEnabled: v.groveEnabled,
-	}).validateUpdate(old, userInfo, operatorPrincipal)
+	validation := &dynamoGraphDeploymentValidation{
+		sharedValidation:  sharedValidation{ctx: ctx, mgr: v.mgr},
+		groveEnabled:      v.groveEnabled,
+		userInfo:          userInfo,
+		operatorPrincipal: operatorPrincipal,
+	}
+
+	allErrs := validation.validateDynamoGraphDeploymentUpdate(newDGD, oldDGD)
+	return validation.warnings, invalidDynamoGraphDeploymentError(newDGD, allErrs)
 }
 
-func (v *dynamoGraphDeploymentValidation) validate(ctx context.Context) (admission.Warnings, error) {
-	var errs []error
-	components, err := betaComponentsByName(v.deployment)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	if len(v.deployment.Spec.Components) == 0 {
-		errs = append(errs, fmt.Errorf("spec.components must have at least one component"))
-	}
+// validateDynamoGraphDeployment validates dgd. dgd must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeployment(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, v.validateObjectMeta(
+		&dgd.ObjectMeta,
+		field.NewPath("metadata"),
+		hasIntraPodFailover(&dgd.Spec),
+	)...)
 
-	if err := v.validateAnnotations(); err != nil {
-		errs = append(errs, err)
+	grovePathway, grovePathwayRequirement := grovePathwayForDynamoGraphDeployment(v.groveEnabled, dgd)
+	specOpts := dynamoGraphDeploymentSpecValidationOptions{
+		dgdName:                 dgd.Name,
+		generation:              dgd.Generation,
+		grovePathway:            grovePathway,
+		grovePathwayRequirement: grovePathwayRequirement,
 	}
-	if err := v.validateRestart(components); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validatePriorityClassName(); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateTopologyConstraints(ctx, components); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateKvTransferPolicy(ctx); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateFailoverRequiresDiscoveryMode(); err != nil {
-		errs = append(errs, err)
-	}
-	var allWarnings admission.Warnings
-	alphaWarnings, err := v.validateAlphaCompatibility()
-	if err != nil {
-		errs = append(errs, err)
-	}
-	allWarnings = append(allWarnings, alphaWarnings...)
+	allErrs = append(allErrs, v.validateDynamoGraphDeploymentSpec(&dgd.Spec, field.NewPath("spec"), specOpts)...)
 
-	for i := range v.deployment.Spec.Components {
-		component := &v.deployment.Spec.Components[i]
-		warnings, err := v.validateComponent(ctx, component)
-		if err != nil {
-			errs = append(errs, err)
-		}
-		allWarnings = append(allWarnings, warnings...)
-	}
-
-	return allWarnings, errors.Join(errs...)
+	return allErrs
 }
 
-// validateUpdate performs stateful validation comparing old and new v1beta1 DGD objects.
-func (v *dynamoGraphDeploymentValidation) validateUpdate(
-	old *nvidiacomv1beta1.DynamoGraphDeployment,
-	userInfo *authenticationv1.UserInfo,
-	operatorPrincipal string,
-) (admission.Warnings, error) {
-	var warnings admission.Warnings
-	var errs []error
-
-	if old == nil {
-		errs = append(errs, fmt.Errorf("old DynamoGraphDeployment is nil"))
-	}
-	if len(errs) > 0 {
-		return warnings, errors.Join(errs...)
-	}
-
-	oldComponents, err := betaComponentsByName(old)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	newComponents, err := betaComponentsByName(v.deployment)
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	if err := v.validateImmutableFields(old, oldComponents, newComponents, &warnings); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateComponentTopology(oldComponents, newComponents); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateReplicasChanges(oldComponents, newComponents, userInfo, operatorPrincipal); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateNoRestartDuringRollingUpdate(old); err != nil {
-		errs = append(errs, err)
-	}
-
-	return warnings, errors.Join(errs...)
-}
-
-func (v *dynamoGraphDeploymentValidation) validateImmutableFields(
-	old *nvidiacomv1beta1.DynamoGraphDeployment,
-	oldComponents map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	newComponents map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	warnings *admission.Warnings,
-) error {
-	var errs []error
-
-	if v.deployment.Spec.BackendFramework != old.Spec.BackendFramework {
-		*warnings = append(*warnings, "Changing spec.backendFramework may cause unexpected behavior")
-		errs = append(errs, fmt.Errorf("spec.backendFramework is immutable and cannot be changed after creation"))
-	}
-
-	componentNames := sortedBetaComponentNames(newComponents)
-	for _, componentName := range componentNames {
-		newComponent := newComponents[componentName]
-		oldComponent, exists := oldComponents[componentName]
-		if !exists {
-			continue
-		}
-		if oldComponent.IsMultinode() != newComponent.IsMultinode() {
-			errs = append(errs, fmt.Errorf(
-				"spec.components[%s] cannot change node topology (between single-node and multi-node) after creation",
-				componentName,
+// validateObjectMeta validates objectMeta. objectMeta and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateObjectMeta(
+	objectMeta *metav1.ObjectMeta,
+	fldPath *field.Path,
+	hasIntraPodFailover bool,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	annotationsPath := fldPath.Child("annotations")
+	if value, exists := objectMeta.Annotations[consts.KubeAnnotationDynamoOperatorOriginVersion]; exists {
+		if _, err := semver.NewVersion(value); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(consts.KubeAnnotationDynamoOperatorOriginVersion),
+				value,
+				"must be valid semver",
 			))
 		}
-		if oldComponent.MinAvailable != nil {
-			if newComponent.MinAvailable == nil || *newComponent.MinAvailable != *oldComponent.MinAvailable {
-				errs = append(errs, fmt.Errorf(
-					"spec.components[%s].minAvailable is immutable after creation",
-					componentName,
+	}
+	if value, invalid := invalidVLLMDistributedExecutorBackendAnnotation(objectMeta.Annotations); invalid {
+		allErrs = append(allErrs, field.Invalid(
+			annotationsPath.Key(consts.KubeAnnotationVLLMDistributedExecutorBackend),
+			value,
+			`must be "mp" or "ray"`,
+		))
+	}
+	if value, exists := objectMeta.Annotations[consts.KubeAnnotationDynamoKubeDiscoveryMode]; exists && value != "pod" && value != "container" {
+		allErrs = append(allErrs, field.NotSupported(
+			annotationsPath.Key(consts.KubeAnnotationDynamoKubeDiscoveryMode),
+			value,
+			[]string{"pod", "container"},
+		))
+	}
+
+	if hasIntraPodFailover && objectMeta.Annotations[consts.KubeAnnotationDynamoKubeDiscoveryMode] != "container" {
+		allErrs = append(allErrs, field.Invalid(
+			annotationsPath.Key(consts.KubeAnnotationDynamoKubeDiscoveryMode),
+			objectMeta.Annotations[consts.KubeAnnotationDynamoKubeDiscoveryMode],
+			`must be "container" when intra-pod failover is configured`,
+		))
+	}
+
+	return allErrs
+}
+
+// validateDynamoGraphDeploymentSpec validates spec. spec and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpec(
+	spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec,
+	fldPath *field.Path,
+	opts dynamoGraphDeploymentSpecValidationOptions,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if spec.PriorityClassName != "" && !opts.grovePathway {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("priorityClassName"), opts.grovePathwayRequirement))
+	}
+
+	componentsPath := fldPath.Child("components")
+	if len(spec.Components) == 0 {
+		allErrs = append(allErrs, field.Required(componentsPath, "must have at least one component"))
+	}
+	components := componentsByName(spec.Components)
+	for i := range spec.Components {
+		component := &spec.Components[i]
+		componentPath := componentsPath.Index(i)
+
+		if opts.grovePathway {
+			combinedLength, detail := dgdComponentResourceNameLength(opts.dgdName, spec.Components, component)
+			if combinedLength > maxCombinedResourceNameLength {
+				allErrs = append(allErrs, field.Invalid(
+					componentPath.Child("name"),
+					component.ComponentName,
+					fmt.Sprintf(
+						"combined resource name length %d exceeds the %d-character pod-name limit (%s); shorten DynamoGraphDeployment name %q or component name %q",
+						combinedLength,
+						maxCombinedResourceNameLength,
+						detail,
+						opts.dgdName,
+						component.ComponentName,
+					),
 				))
 			}
 		}
 
-		// Validate inter-pod GMS layout and failover immutability.
-		//
-		// Flipping the inter-pod GMS layout or toggling failover within an
-		// inter-pod layout both change the PodClique topology (weight-server PCLQ,
-		// per-rank engine PCLQs, shadow PCLQs, DRA ResourceClaimTemplates), which
-		// Grove cannot transform in place. Force the user to delete and recreate.
-		oldInterPodGMS := oldComponent.IsInterPodGMSEnabled()
-		newInterPodGMS := newComponent.IsInterPodGMSEnabled()
-		if oldInterPodGMS != newInterPodGMS {
-			errs = append(errs, fmt.Errorf(
-				"spec.components[%s].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; "+
-					"delete and recreate the DynamoGraphDeployment",
-				componentName,
-			))
-		}
-		oldInterPodFailover := oldComponent.IsInterPodFailoverEnabled()
-		newInterPodFailover := newComponent.IsInterPodFailoverEnabled()
-		if oldInterPodFailover != newInterPodFailover {
-			errs = append(errs, fmt.Errorf(
-				"spec.components[%s].experimental.failover: inter-pod GMS failover cannot be toggled after creation; "+
-					"delete and recreate the DynamoGraphDeployment",
-				componentName,
-			))
-		}
-		if oldInterPodFailover && newInterPodFailover && oldComponent.GetNumShadows() != newComponent.GetNumShadows() {
-			errs = append(errs, fmt.Errorf(
-				"spec.components[%s].experimental.failover.numShadows is immutable for inter-pod GMS failover; "+
-					"delete and recreate the DynamoGraphDeployment to change it",
-				componentName,
-			))
-		}
-	}
-
-	if err := v.validateTopologyConstraintImmutability(old, oldComponents, newComponents); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateKvTransferPolicyImmutability(old); err != nil {
-		errs = append(errs, err)
-	}
-
-	return errors.Join(errs...)
-}
-
-func (v *dynamoGraphDeploymentValidation) validateComponentTopology(
-	oldComponents map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	newComponents map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-) error {
-	oldNames := betaComponentNameSet(oldComponents)
-	newNames := betaComponentNameSet(newComponents)
-
-	added := difference(newNames, oldNames)
-	removed := difference(oldNames, newNames)
-	if len(added) == 0 && len(removed) == 0 {
-		return nil
-	}
-
-	sort.Strings(added)
-	sort.Strings(removed)
-
-	switch {
-	case len(added) > 0 && len(removed) > 0:
-		return fmt.Errorf("component topology is immutable and cannot be modified after creation: components added: %v, components removed: %v", added, removed)
-	case len(added) > 0:
-		return fmt.Errorf("component topology is immutable and cannot be modified after creation: components added: %v", added)
-	default:
-		return fmt.Errorf("component topology is immutable and cannot be modified after creation: components removed: %v", removed)
-	}
-}
-
-func (v *dynamoGraphDeploymentValidation) validateReplicasChanges(
-	oldComponents map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	newComponents map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	userInfo *authenticationv1.UserInfo,
-	operatorPrincipal string,
-) error {
-	if userInfo != nil && internalwebhook.CanModifyDGDReplicas(operatorPrincipal, *userInfo) {
-		return nil
-	}
-
-	var errs []error
-	for _, componentName := range sortedBetaComponentNames(newComponents) {
-		newComponent := newComponents[componentName]
-		if newComponent.ScalingAdapter == nil {
-			continue
-		}
-		oldComponent, exists := oldComponents[componentName]
-		if !exists {
-			continue
-		}
-
-		oldReplicas := int32(1)
-		if oldComponent.Replicas != nil {
-			oldReplicas = *oldComponent.Replicas
-		}
-		newReplicas := int32(1)
-		if newComponent.Replicas != nil {
-			newReplicas = *newComponent.Replicas
-		}
-
-		if oldReplicas != newReplicas {
-			errs = append(errs, fmt.Errorf(
-				"spec.components[%s].replicas cannot be modified directly when scaling adapter is enabled; "+
-					"scale or update the related DynamoGraphDeploymentScalingAdapter instead",
-				componentName))
-		}
-	}
-
-	return errors.Join(errs...)
-}
-
-func (v *dynamoGraphDeploymentValidation) validateComponent(
-	ctx context.Context,
-	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-) (admission.Warnings, error) {
-	componentName := component.ComponentName
-	fieldPath := fmt.Sprintf("spec.components[%s]", componentName)
-
-	// The inter-pod GMS layout (with or without failover) requires the Grove
-	// pathway: the weight-server pod, per-rank PCLQs, and DRA ResourceClaim
-	// templates are all wired at the PodCliqueScalingGroup level, which only
-	// the Grove renderer produces.
-	if component.IsInterPodGMSEnabled() && !v.isGrovePathway() {
-		return nil, v.grovePathwayRequiredError(fmt.Sprintf(
-			"%s: experimental.gpuMemoryService.mode=%q",
-			fieldPath, nvidiacomv1beta1.GMSModeInterPod))
-	}
-
-	// The inter-pod GMS layout is currently implemented only for vLLM (the
-	// engine relies on vLLM-specific runtime hooks like --load-format gms; the
-	// failover variant additionally enables vLLM shadow mode). Fail fast at
-	// admission rather than producing a broken deployment when another or no
-	// backend is configured; an empty BackendFramework means the operator cannot
-	// confirm the engine speaks vLLM, which is a hard prerequisite for inter-pod
-	// GMS (both standalone and with failover).
-	if component.IsInterPodGMSEnabled() &&
-		v.deployment.Spec.BackendFramework != string(dynamo.BackendFrameworkVLLM) {
-		detected := v.deployment.Spec.BackendFramework
-		if detected == "" {
-			detected = unsetValue
-		}
-		return nil, fmt.Errorf(
-			"%s: the inter-pod GMS layout (experimental.gpuMemoryService.mode=%q) is currently supported only for vLLM (detected: %s); "+
-				"set spec.backendFramework=%q",
-			fieldPath, nvidiacomv1beta1.GMSModeInterPod, detected, dynamo.BackendFrameworkVLLM)
-	}
-
-	if v.isGrovePathway() {
-		if err := v.validateComponentNameLength(componentName, component); err != nil {
-			return nil, err
-		}
-	}
-
-	sharedValidator := NewSharedSpecValidatorV1Beta1(component, fieldPath, v.isGrovePathway(), v.mgr)
-	return sharedValidator.Validate(ctx)
-}
-
-// validateComponentNameLength ensures Grove-rendered resource names stay within
-// the pod-name budget after the PCS, PCSG, and PodClique names are combined.
-//
-// Grove builds pod names from these generated pieces:
-//   - PCS name: derived from the DynamoGraphDeployment name
-//
-// For multi-node and inter-pod GMS components:
-//   - PCSG name: lowercase(componentName)
-//   - PodClique names: rendered role names for the component
-//
-// For single-node components:
-//   - PodClique name: lowercase(componentName)
-//
-// The combined length of these names must not exceed maxCombinedResourceNameLength.
-func (v *dynamoGraphDeploymentValidation) validateComponentNameLength(
-	componentName string,
-	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-) error {
-	pcsName := dynamo.PCSNameForDGD(v.deployment.Name, v.deployment.Spec.Components)
-	lowerComponentName := strings.ToLower(componentName)
-
-	hasPodCliqueScalingGroup := component.GetNumberOfNodes() > 1 || component.IsInterPodGMSEnabled()
-	if !hasPodCliqueScalingGroup {
-		combinedLength := len(pcsName) + len(lowerComponentName)
-		if combinedLength > maxCombinedResourceNameLength {
-			return fmt.Errorf("%s: combined resource name length %d exceeds %d-character limit required for pod naming. "+
-				"Consider shortening the DynamoGraphDeployment name '%s' (length %d) or component name '%s' (length %d). "+
-				"The combined length of PCS name + component name must not exceed %d characters. "+
-				"The PCS name '%s' was auto-truncated from DGD name '%s'",
-				fmt.Sprintf("spec.components[%s]", componentName), combinedLength, maxCombinedResourceNameLength,
-				v.deployment.Name, len(v.deployment.Name), componentName, len(componentName),
-				maxCombinedResourceNameLength,
-				pcsName, v.deployment.Name)
-		}
-		return nil
-	}
-
-	longestPCLQName := dynamo.LongestPodCliqueNameForDGDComponent(componentName, component)
-	combinedLength := len(pcsName) + len(lowerComponentName) + len(longestPCLQName)
-	if combinedLength > maxCombinedResourceNameLength {
-		return fmt.Errorf("spec.components[%s]: combined resource name length %d exceeds %d-character limit required for pod naming. "+
-			"Consider shortening the DynamoGraphDeployment name '%s' (length %d) or component name '%s' (length %d). "+
-			"The combined length of PCS name + PCSG name + longest PodClique name ('%s') must not exceed %d characters. "+
-			"The PCS name '%s' was auto-truncated from DGD name '%s'",
-			componentName, combinedLength, maxCombinedResourceNameLength,
-			v.deployment.Name, len(v.deployment.Name), componentName, len(componentName),
-			longestPCLQName, maxCombinedResourceNameLength,
-			pcsName, v.deployment.Name)
-	}
-
-	return nil
-}
-
-func (v *dynamoGraphDeploymentValidation) isGrovePathway() bool {
-	if !v.groveEnabled {
-		return false
-	}
-	return v.deployment.Annotations == nil ||
-		strings.ToLower(v.deployment.Annotations[consts.KubeAnnotationEnableGrove]) != consts.KubeLabelValueFalse
-}
-
-func (v *dynamoGraphDeploymentValidation) grovePathwayRequiredError(subject string) error {
-	if !v.groveEnabled {
-		return fmt.Errorf("%s requires the Grove pathway, but Grove is disabled in the operator configuration", subject)
-	}
-	return fmt.Errorf("%s requires the Grove pathway; remove or unset the %q annotation (currently %q)",
-		subject, consts.KubeAnnotationEnableGrove, v.deployment.Annotations[consts.KubeAnnotationEnableGrove])
-}
-
-func (v *dynamoGraphDeploymentValidation) validateRestart(
-	components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-) error {
-	if v.deployment.Spec.Restart == nil {
-		return nil
-	}
-
-	restart := v.deployment.Spec.Restart
-	var err error
-	if restart.ID == "" {
-		err = errors.Join(err, fmt.Errorf("spec.restart.id is required"))
-	}
-	return errors.Join(err, v.validateRestartStrategyOrder(components))
-}
-
-func (v *dynamoGraphDeploymentValidation) validateRestartStrategyOrder(
-	components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-) error {
-	restart := v.deployment.Spec.Restart
-	if restart.Strategy == nil || len(restart.Strategy.Order) == 0 {
-		return nil
-	}
-	if restart.Strategy.Type == nvidiacomv1beta1.RestartStrategyTypeParallel {
-		return errors.New("spec.restart.strategy.order cannot be specified when strategy is parallel")
-	}
-
-	var err error
-	uniqueOrder := getUnique(restart.Strategy.Order)
-	if len(uniqueOrder) != len(restart.Strategy.Order) {
-		err = errors.Join(err, fmt.Errorf("spec.restart.strategy.order must be unique"))
-	}
-	if len(uniqueOrder) != len(components) {
-		err = errors.Join(err, fmt.Errorf("spec.restart.strategy.order must have the same number of unique components as the deployment"))
-	}
-	for _, componentName := range uniqueOrder {
-		if _, exists := components[componentName]; !exists {
-			err = errors.Join(err, fmt.Errorf("spec.restart.strategy.order contains unknown component: %s", componentName))
-		}
-	}
-	return err
-}
-
-func (v *dynamoGraphDeploymentValidation) validatePriorityClassName() error {
-	if v.deployment.Spec.PriorityClassName == "" || v.isGrovePathway() {
-		return nil
-	}
-	return v.grovePathwayRequiredError("spec.priorityClassName")
-}
-
-func (v *dynamoGraphDeploymentValidation) validateAnnotations() error {
-	annotations := v.deployment.GetAnnotations()
-	if annotations == nil {
-		return nil
-	}
-
-	var errs []error
-	if value, exists := annotations[consts.KubeAnnotationDynamoOperatorOriginVersion]; exists {
-		if _, err := semver.NewVersion(value); err != nil {
-			errs = append(errs, fmt.Errorf("annotation %s has invalid value %q: must be valid semver",
-				consts.KubeAnnotationDynamoOperatorOriginVersion, value))
-		}
-	}
-	if err := validateVLLMDistributedExecutorBackendAnnotation("", annotations); err != nil {
-		errs = append(errs, err)
-	}
-	if value, exists := annotations[consts.KubeAnnotationDynamoKubeDiscoveryMode]; exists {
-		switch value {
-		case "pod", "container":
-		default:
-			errs = append(errs, fmt.Errorf("annotation %s has invalid value %q: must be \"pod\" or \"container\"",
-				consts.KubeAnnotationDynamoKubeDiscoveryMode, value))
-		}
-	}
-	return errors.Join(errs...)
-}
-
-func (v *dynamoGraphDeploymentValidation) validateTopologyConstraints(
-	ctx context.Context,
-	components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-) error {
-	specConstraint := v.deployment.Spec.TopologyConstraint
-	hasAnyConstraint := specConstraint != nil
-
-	var errs []error
-	if specConstraint != nil {
-		if specConstraint.PackDomain != "" && !isValidBetaTopologyDomainFormat(specConstraint.PackDomain) {
-			errs = append(errs, fmt.Errorf("spec.topologyConstraint.packDomain %q is not a valid topology domain; "+
-				"must match ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", specConstraint.PackDomain))
-		}
-	}
-
-	componentNames := sortedBetaComponentNames(components)
-	for _, componentName := range componentNames {
-		component := components[componentName]
-		if component.TopologyConstraint == nil {
-			continue
-		}
-		hasAnyConstraint = true
-		fieldPath := fmt.Sprintf("spec.components[%s]", componentName)
-
-		if component.TopologyConstraint.PackDomain == "" {
-			errs = append(errs, fmt.Errorf("%s.topologyConstraint.packDomain is required", fieldPath))
-			continue
-		}
-		if !isValidBetaTopologyDomainFormat(component.TopologyConstraint.PackDomain) {
-			errs = append(errs, fmt.Errorf("%s.topologyConstraint.packDomain %q is not a valid topology domain; "+
-				"must match ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", fieldPath, component.TopologyConstraint.PackDomain))
-		}
-	}
-
-	if !hasAnyConstraint {
-		return nil
-	}
-	if specConstraint == nil {
-		errs = append(errs, fmt.Errorf("spec.topologyConstraint with clusterTopologyName is required "+
-			"when any topology constraint is set (at spec or component level)"))
-		return errors.Join(errs...)
-	}
-	if specConstraint.ClusterTopologyName == "" {
-		errs = append(errs, fmt.Errorf("spec.topologyConstraint.clusterTopologyName is required "+
-			"when any topology constraint is set"))
-	}
-	if specConstraint.PackDomain == "" {
-		for _, componentName := range componentNames {
-			component := components[componentName]
-			if component.TopologyConstraint == nil {
-				errs = append(errs, fmt.Errorf("spec.components[%s].topologyConstraint is required "+
-					"because spec.topologyConstraint.packDomain is not set; either set a spec-level "+
-					"packDomain or provide a topologyConstraint for every component", componentName))
+		gms := gpuMemoryServiceFor(component)
+		if gms != nil && effectiveGMSMode(gms.Mode) == nvidiacomv1beta1.GMSModeInterPod {
+			modePath := componentPath.Child("experimental", "gpuMemoryService", "mode")
+			if !opts.grovePathway {
+				allErrs = append(allErrs, field.Forbidden(modePath, opts.grovePathwayRequirement))
+			}
+			if spec.BackendFramework != string(dynamo.BackendFrameworkVLLM) {
+				detected := spec.BackendFramework
+				if detected == "" {
+					detected = unsetValue
+				}
+				allErrs = append(allErrs, field.Invalid(
+					modePath,
+					gms.Mode,
+					fmt.Sprintf("the inter-pod GMS layout is currently supported only for vLLM (detected backend: %s)", detected),
+				))
 			}
 		}
+
+		allErrs = append(allErrs, v.validateDynamoComponentDeploymentSharedSpec(
+			component,
+			componentPath,
+			opts.grovePathway,
+		)...)
 	}
 
-	if v.shouldValidateGroveClusterTopology(errs, specConstraint.ClusterTopologyName != "") {
-		if err := v.validateTopologyDomainsAgainstGroveClusterTopology(ctx, components); err != nil {
-			errs = append(errs, err)
-		}
+	if spec.Restart != nil {
+		allErrs = append(allErrs, v.validateRestart(spec.Restart, fldPath.Child("restart"), components)...)
 	}
 
-	return errors.Join(errs...)
-}
-
-func (v *dynamoGraphDeploymentValidation) shouldValidateGroveClusterTopology(errs []error, hasClusterTopologyRef bool) bool {
-	return len(errs) == 0 &&
-		hasClusterTopologyRef &&
-		v.mgr != nil &&
-		v.deployment.Generation <= 1 &&
-		v.isGrovePathway()
-}
-
-func (v *dynamoGraphDeploymentValidation) readGroveClusterTopology(ctx context.Context, name string) (*clusterTopologyInfo, error) {
-	ct := &grovev1alpha1.ClusterTopology{}
-	if err := v.mgr.GetClient().Get(ctx, types.NamespacedName{Name: name}, ct); err != nil {
-		return nil, err
-	}
-
-	info := &clusterTopologyInfo{
-		domainIndex: make(map[string]int, len(ct.Spec.Levels)),
-		domains:     make([]string, 0, len(ct.Spec.Levels)),
-	}
-	for i, level := range ct.Spec.Levels {
-		domain := string(level.Domain)
-		info.domainIndex[domain] = i
-		info.domains = append(info.domains, domain)
-	}
-	sort.Strings(info.domains)
-	return info, nil
-}
-
-func (v *dynamoGraphDeploymentValidation) validateTopologyDomainsAgainstGroveClusterTopology(
-	ctx context.Context,
-	components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-) error {
-	profileName := v.deployment.Spec.TopologyConstraint.ClusterTopologyName
-	if profileName == "" {
-		return nil
-	}
-
-	info, err := v.readGroveClusterTopology(ctx, profileName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return fmt.Errorf("topology-aware scheduling requires a ClusterTopology resource %q but it was not found; "+
-				"ensure the cluster topology is configured per the framework documentation", profileName)
-		}
-		return fmt.Errorf("failed to read ClusterTopology %q for topology validation: %w", profileName, err)
-	}
-	if info == nil {
-		return nil
-	}
-
-	type domainCheck struct {
-		fieldPath string
-		domain    nvidiacomv1beta1.TopologyDomain
-	}
-	var checks []domainCheck
-	if v.deployment.Spec.TopologyConstraint.PackDomain != "" {
-		checks = append(checks, domainCheck{
-			fieldPath: "spec.topologyConstraint.packDomain",
-			domain:    v.deployment.Spec.TopologyConstraint.PackDomain,
-		})
-	}
-	for _, componentName := range sortedBetaComponentNames(components) {
-		component := components[componentName]
-		if component.TopologyConstraint != nil && component.TopologyConstraint.PackDomain != "" {
-			checks = append(checks, domainCheck{
-				fieldPath: fmt.Sprintf("spec.components[%s].topologyConstraint.packDomain", componentName),
-				domain:    component.TopologyConstraint.PackDomain,
-			})
-		}
-	}
-
-	var errs []error
-	for _, c := range checks {
-		if _, ok := info.domainIndex[string(c.domain)]; !ok {
-			errs = append(errs, fmt.Errorf("%s: domain %q does not exist in ClusterTopology %q; "+
-				"available domains: %v", c.fieldPath, c.domain, profileName, info.domains))
-		}
-	}
-
-	specDomain := v.deployment.Spec.TopologyConstraint.PackDomain
-	if specDomain != "" {
-		specIdx, specOk := info.domainIndex[string(specDomain)]
-		if specOk {
-			for _, componentName := range sortedBetaComponentNames(components) {
-				component := components[componentName]
-				if component.TopologyConstraint == nil || component.TopologyConstraint.PackDomain == "" {
-					continue
-				}
-				componentDomain := component.TopologyConstraint.PackDomain
-				componentIdx, componentOk := info.domainIndex[string(componentDomain)]
-				if componentOk && componentIdx < specIdx {
-					errs = append(errs, fmt.Errorf("spec.components[%s]: topologyConstraint.packDomain %q is broader "+
-						"than spec-level %q; component constraints must be equal to or narrower than the "+
-						"deployment-level constraint", componentName, componentDomain, specDomain))
-				}
-			}
-		}
-	}
-
-	return errors.Join(errs...)
-}
-
-func (v *dynamoGraphDeploymentValidation) validateTopologyConstraintImmutability(
-	old *nvidiacomv1beta1.DynamoGraphDeployment,
-	oldComponents map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	newComponents map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-) error {
-	var errs []error
-
-	if !betaSpecTopologyConstraintsEqual(old.Spec.TopologyConstraint, v.deployment.Spec.TopologyConstraint) {
-		errs = append(errs, fmt.Errorf("spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; "+
-			"delete and recreate the DynamoGraphDeployment to change topology constraints"))
-	}
-
-	for _, componentName := range sortedBetaComponentNames(newComponents) {
-		newComponent := newComponents[componentName]
-		oldComponent, exists := oldComponents[componentName]
-		if !exists {
-			continue
-		}
-		if !betaTopologyConstraintsEqual(oldComponent.TopologyConstraint, newComponent.TopologyConstraint) {
-			errs = append(errs, fmt.Errorf("spec.components[%s].topologyConstraint is immutable and cannot be added, removed, or changed after creation; "+
-				"delete and recreate the DynamoGraphDeployment to change topology constraints", componentName))
-		}
-	}
-
-	return errors.Join(errs...)
-}
-
-func (v *dynamoGraphDeploymentValidation) validateKvTransferPolicyImmutability(
-	old *nvidiacomv1beta1.DynamoGraphDeployment,
-) error {
-	if betaKvTransferPoliciesEqual(betaKvTransferPolicyFor(old), betaKvTransferPolicyFor(v.deployment)) {
-		return nil
-	}
-	return fmt.Errorf("spec.experimental.kvTransferPolicy is immutable and cannot be added, removed, or changed after creation; " +
-		"delete and recreate the DynamoGraphDeployment to change the KV transfer policy")
-}
-
-func (v *dynamoGraphDeploymentValidation) validateNoRestartDuringRollingUpdate(
-	old *nvidiacomv1beta1.DynamoGraphDeployment,
-) error {
-	if old.Status.RollingUpdate == nil {
-		return nil
-	}
-	phase := old.Status.RollingUpdate.Phase
-	if phase != nvidiacomv1beta1.RollingUpdatePhasePending && phase != nvidiacomv1beta1.RollingUpdatePhaseInProgress {
-		return nil
-	}
-
-	oldID := ""
-	if old.Spec.Restart != nil {
-		oldID = old.Spec.Restart.ID
-	}
-	newID := ""
-	if v.deployment.Spec.Restart != nil {
-		newID = v.deployment.Spec.Restart.ID
-	}
-	if oldID != newID {
-		return fmt.Errorf("spec.restart.id cannot be changed while a rolling update is %s", phase)
-	}
-	return nil
-}
-
-func (v *dynamoGraphDeploymentValidation) validateKvTransferPolicy(ctx context.Context) error {
-	if v.deployment.Spec.Experimental == nil {
-		return nil
-	}
-	kvt := v.deployment.Spec.Experimental.KvTransferPolicy
-	if kvt == nil {
-		return nil
-	}
-
-	var errs []error
-	const fieldPath = "spec.experimental.kvTransferPolicy"
-
-	hasLabelKey := kvt.LabelKey != ""
-	hasClusterTopologyName := kvt.ClusterTopologyName != ""
-	if hasLabelKey == hasClusterTopologyName {
-		errs = append(errs, fmt.Errorf("%s: exactly one of labelKey or clusterTopologyName is required", fieldPath))
-	}
-	if hasLabelKey {
-		if labelKeyErrs := k8svalidation.IsQualifiedName(kvt.LabelKey); len(labelKeyErrs) > 0 {
-			errs = append(errs, fmt.Errorf("%s.labelKey %q is not a valid Kubernetes label key: %s",
-				fieldPath, kvt.LabelKey, strings.Join(labelKeyErrs, "; ")))
-		}
-	}
-	if hasClusterTopologyName {
-		if nameErrs := k8svalidation.IsDNS1123Subdomain(kvt.ClusterTopologyName); len(nameErrs) > 0 {
-			errs = append(errs, fmt.Errorf("%s.clusterTopologyName %q is not a valid Kubernetes resource name: %s",
-				fieldPath, kvt.ClusterTopologyName, strings.Join(nameErrs, "; ")))
-		}
-		if !v.isGrovePathway() {
-			errs = append(errs, v.grovePathwayRequiredError("spec.experimental.kvTransferPolicy.clusterTopologyName"))
-		}
-	}
-	if !hasLabelKey && !hasClusterTopologyName {
-		return errors.Join(errs...)
-	}
-
-	if kvt.Domain == "" {
-		errs = append(errs, fmt.Errorf("%s.domain is required", fieldPath))
-	} else if !isValidBetaTopologyDomainFormat(kvt.Domain) {
-		errs = append(errs, fmt.Errorf("%s.domain %q is not a valid topology domain; "+
-			"must match ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", fieldPath, kvt.Domain))
-	}
-
-	enforcement := betaEffectiveKvTransferEnforcement(kvt)
-	if enforcement != nvidiacomv1beta1.KvTransferEnforcementRequired &&
-		enforcement != nvidiacomv1beta1.KvTransferEnforcementPreferred {
-		errs = append(errs, fmt.Errorf("%s.enforcement %q is invalid; "+
-			"must be \"required\" or \"preferred\"", fieldPath, kvt.Enforcement))
-	}
-	if enforcement == nvidiacomv1beta1.KvTransferEnforcementPreferred && kvt.PreferredWeight == nil {
-		errs = append(errs, fmt.Errorf("%s.preferredWeight is required when enforcement is \"preferred\"", fieldPath))
-	}
-	if kvt.PreferredWeight != nil {
-		if *kvt.PreferredWeight < 0 || *kvt.PreferredWeight > 1 {
-			errs = append(errs, fmt.Errorf("%s.preferredWeight %g is invalid; "+
-				"must be >= 0 and <= 1", fieldPath, *kvt.PreferredWeight))
-		}
-		if enforcement == nvidiacomv1beta1.KvTransferEnforcementRequired {
-			errs = append(errs, fmt.Errorf("%s.preferredWeight must not be set when enforcement is \"required\"", fieldPath))
-		}
-	}
-
-	if v.shouldValidateGroveClusterTopology(errs, hasClusterTopologyName) {
-		if err := v.validateKvTransferPolicyAgainstGroveClusterTopology(ctx, kvt); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	return errors.Join(errs...)
-}
-
-func (v *dynamoGraphDeploymentValidation) validateKvTransferPolicyAgainstGroveClusterTopology(
-	ctx context.Context,
-	kvt *nvidiacomv1beta1.KvTransferPolicy,
-) error {
-	info, err := v.readGroveClusterTopology(ctx, kvt.ClusterTopologyName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return fmt.Errorf("spec.experimental.kvTransferPolicy.clusterTopologyName %q references a ClusterTopology resource that was not found",
-				kvt.ClusterTopologyName)
-		}
-		return fmt.Errorf("failed to read ClusterTopology %q for kvTransferPolicy validation: %w", kvt.ClusterTopologyName, err)
-	}
-	if info == nil {
-		return nil
-	}
-	if _, ok := info.domainIndex[string(kvt.Domain)]; ok {
-		return nil
-	}
-	return fmt.Errorf("spec.experimental.kvTransferPolicy.domain %q does not exist in ClusterTopology %q; available domains: %v",
-		kvt.Domain, kvt.ClusterTopologyName, info.domains)
-}
-
-func (v *dynamoGraphDeploymentValidation) validateFailoverRequiresDiscoveryMode() error {
-	hasIntraPodFailover := false
-	for i := range v.deployment.Spec.Components {
-		component := &v.deployment.Spec.Components[i]
-		failover := betaFailover(component)
-		if failover == nil {
-			continue
-		}
-		if betaGMSMode(failover.Mode) == nvidiacomv1beta1.GMSModeIntraPod {
-			hasIntraPodFailover = true
+	constraintPath := fldPath.Child("topologyConstraint")
+	hasAnyConstraint := spec.TopologyConstraint != nil
+	for i := range spec.Components {
+		if spec.Components[i].TopologyConstraint != nil {
+			hasAnyConstraint = true
 			break
 		}
 	}
-	if !hasIntraPodFailover {
+	if hasAnyConstraint {
+		topologyErrs := field.ErrorList{}
+		if spec.TopologyConstraint == nil {
+			topologyErrs = append(topologyErrs, field.Required(
+				constraintPath,
+				"is required when any component topology constraint is set",
+			))
+		} else {
+			if spec.TopologyConstraint.PackDomain == "" {
+				for i := range spec.Components {
+					if spec.Components[i].TopologyConstraint == nil {
+						topologyErrs = append(topologyErrs, field.Required(
+							componentsPath.Index(i).Child("topologyConstraint"),
+							"is required because spec.topologyConstraint.packDomain is not set",
+						))
+					}
+				}
+			}
+
+			var topologyInfo *clusterTopologyInfo
+			if spec.TopologyConstraint.ClusterTopologyName != "" &&
+				opts.generation <= 1 && opts.grovePathway {
+				var err error
+				topologyInfo, err = readGroveClusterTopology(v.ctx, v.mgr, spec.TopologyConstraint.ClusterTopologyName)
+				if err != nil {
+					detail := fmt.Sprintf("failed to read ClusterTopology: %v", err)
+					if k8serrors.IsNotFound(err) {
+						detail = "references a ClusterTopology resource that was not found"
+					}
+					topologyErrs = append(topologyErrs, field.Invalid(
+						constraintPath.Child("clusterTopologyName"),
+						spec.TopologyConstraint.ClusterTopologyName,
+						detail,
+					))
+				}
+			}
+
+			topologyErrs = append(topologyErrs, v.validateSpecTopologyConstraint(
+				spec.TopologyConstraint,
+				constraintPath,
+				topologyInfo,
+			)...)
+			for i := range spec.Components {
+				componentConstraint := spec.Components[i].TopologyConstraint
+				if componentConstraint == nil {
+					continue
+				}
+				topologyErrs = append(topologyErrs, v.validateTopologyConstraint(
+					componentConstraint,
+					componentsPath.Index(i).Child("topologyConstraint"),
+					spec.TopologyConstraint,
+					topologyInfo,
+				)...)
+			}
+		}
+		allErrs = append(allErrs, topologyErrs...)
+	}
+
+	if spec.Experimental != nil {
+		allErrs = append(allErrs, v.validateDynamoGraphDeploymentExperimentalSpec(
+			spec.Experimental,
+			fldPath.Child("experimental"),
+			opts.generation,
+			opts.grovePathway,
+			opts.grovePathwayRequirement,
+		)...)
+	}
+
+	return allErrs
+}
+
+// validateRestart validates restart. restart and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateRestart(
+	restart *nvidiacomv1beta1.Restart,
+	fldPath *field.Path,
+	components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) field.ErrorList {
+	if restart.Strategy == nil {
+		return nil
+	}
+	return v.validateRestartStrategy(restart.Strategy, fldPath.Child("strategy"), components)
+}
+
+// validateRestartStrategy validates strategy. strategy and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateRestartStrategy(
+	strategy *nvidiacomv1beta1.RestartStrategy,
+	fldPath *field.Path,
+	components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) field.ErrorList {
+	if len(strategy.Order) == 0 {
 		return nil
 	}
 
-	annotations := v.deployment.GetAnnotations()
-	if annotations == nil || annotations[consts.KubeAnnotationDynamoKubeDiscoveryMode] != "container" {
-		return fmt.Errorf(
-			"failover requires per-container K8s discovery; set annotation %q to %q on the DynamoGraphDeployment",
-			consts.KubeAnnotationDynamoKubeDiscoveryMode, "container")
-	}
-	return nil
-}
-
-func (v *dynamoGraphDeploymentValidation) validateAlphaCompatibility() (admission.Warnings, error) {
-	// Reconstruct the v1alpha1 view so alpha-only fields preserved by
-	// conversion still get the webhook validation they had before the DGD
-	// webhook moved to v1beta1.
-	alpha := &nvidiacomv1alpha1.DynamoGraphDeployment{}
-	if err := alpha.ConvertFrom(v.deployment); err != nil {
-		return nil, fmt.Errorf("cannot validate preserved v1alpha1 DynamoGraphDeployment fields: failed to reconstruct compatibility view: %w", err)
-	}
-	if !hasAlphaCompatibilityFields(alpha) {
-		return nil, nil
+	orderPath := fldPath.Child("order")
+	if strategy.Type == nvidiacomv1beta1.RestartStrategyTypeParallel {
+		return field.ErrorList{field.Forbidden(orderPath, "cannot be specified when strategy is parallel")}
 	}
 
-	return validateAlphaCompatibility(alpha)
-}
-
-func hasAlphaCompatibilityFields(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) bool {
-	if len(dgd.Spec.PVCs) > 0 {
-		return true
+	allErrs := field.ErrorList{}
+	uniqueOrder := getUnique(strategy.Order)
+	if len(uniqueOrder) != len(strategy.Order) {
+		allErrs = append(allErrs, field.Invalid(orderPath, strategy.Order, "must be unique"))
 	}
-	for _, service := range dgd.Spec.Services {
-		if service == nil {
-			return true
-		}
-		hasDeprecatedAutoscaling := false
-		//nolint:staticcheck // SA1019: Intentionally checking deprecated field to preserve v1alpha1 warnings.
-		if service.Autoscaling != nil {
-			hasDeprecatedAutoscaling = true
-		}
-		if service.Ingress != nil ||
-			len(service.Annotations) > 0 ||
-			service.DynamoNamespace != nil ||
-			hasDeprecatedAutoscaling ||
-			len(service.VolumeMounts) > 0 ||
-			service.SharedMemory != nil ||
-			service.FrontendSidecar != nil ||
-			(service.GPUMemoryService != nil && !service.GPUMemoryService.Enabled) {
-			return true
+	if len(uniqueOrder) != len(components) {
+		allErrs = append(allErrs, field.Invalid(
+			orderPath,
+			strategy.Order,
+			"must have the same number of unique components as the deployment",
+		))
+	}
+	for i, componentName := range strategy.Order {
+		if _, exists := components[componentName]; !exists {
+			allErrs = append(allErrs, field.NotSupported(orderPath.Index(i), componentName, sortedComponentNames(components)))
 		}
 	}
-	return false
+	return allErrs
 }
 
-func validateAlphaCompatibility(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) (admission.Warnings, error) {
-	var warnings admission.Warnings
-	var errs []error
-
-	if err := validateAlphaCompatibilityPVCs(dgd.Spec.PVCs); err != nil {
-		errs = append(errs, err)
+// validateSpecTopologyConstraint validates constraint. constraint and fldPath must not be nil.
+// topologyInfo may be nil when live topology validation is not applicable.
+func (v *dynamoGraphDeploymentValidation) validateSpecTopologyConstraint(
+	constraint *nvidiacomv1beta1.SpecTopologyConstraint,
+	fldPath *field.Path,
+	topologyInfo *clusterTopologyInfo,
+) field.ErrorList {
+	if topologyInfo == nil || constraint.PackDomain == "" {
+		return nil
 	}
-	for serviceName, service := range dgd.Spec.Services {
-		fieldPath := fmt.Sprintf("spec.services[%s]", serviceName)
-		if service == nil {
-			errs = append(errs, fmt.Errorf("%s must not be null", fieldPath))
+	if _, exists := topologyInfo.domainIndex[string(constraint.PackDomain)]; exists {
+		return nil
+	}
+	return field.ErrorList{field.Invalid(
+		fldPath.Child("packDomain"),
+		constraint.PackDomain,
+		fmt.Sprintf("does not exist in ClusterTopology %q; available domains: %v", topologyInfo.name, topologyInfo.domains),
+	)}
+}
+
+// validateDynamoGraphDeploymentExperimentalSpec validates experimental. experimental and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentExperimentalSpec(
+	experimental *nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec,
+	fldPath *field.Path,
+	generation int64,
+	grovePathway bool,
+	grovePathwayRequirement string,
+) field.ErrorList {
+	if experimental.KvTransferPolicy == nil {
+		return nil
+	}
+	return v.validateKvTransferPolicy(
+		experimental.KvTransferPolicy,
+		fldPath.Child("kvTransferPolicy"),
+		generation,
+		grovePathway,
+		grovePathwayRequirement,
+	)
+}
+
+// validateKvTransferPolicy validates policy. policy and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateKvTransferPolicy(
+	policy *nvidiacomv1beta1.KvTransferPolicy,
+	fldPath *field.Path,
+	generation int64,
+	grovePathway bool,
+	grovePathwayRequirement string,
+) field.ErrorList {
+	if policy.ClusterTopologyName == "" {
+		return nil
+	}
+
+	allErrs := field.ErrorList{}
+	namePath := fldPath.Child("clusterTopologyName")
+	if nameErrs := k8svalidation.IsDNS1123Subdomain(policy.ClusterTopologyName); len(nameErrs) > 0 {
+		allErrs = append(allErrs, field.Invalid(
+			namePath,
+			policy.ClusterTopologyName,
+			strings.Join(nameErrs, "; "),
+		))
+	}
+	if !grovePathway {
+		allErrs = append(allErrs, field.Forbidden(namePath, grovePathwayRequirement))
+	}
+	if len(allErrs) != 0 || generation > 1 {
+		return allErrs
+	}
+
+	topologyInfo, err := readGroveClusterTopology(v.ctx, v.mgr, policy.ClusterTopologyName)
+	if err != nil {
+		detail := fmt.Sprintf("failed to read ClusterTopology: %v", err)
+		if k8serrors.IsNotFound(err) {
+			detail = "references a ClusterTopology resource that was not found"
+		}
+		return append(allErrs, field.Invalid(namePath, policy.ClusterTopologyName, detail))
+	}
+	if _, exists := topologyInfo.domainIndex[string(policy.Domain)]; !exists {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("domain"),
+			policy.Domain,
+			fmt.Sprintf("does not exist in ClusterTopology %q; available domains: %v", topologyInfo.name, topologyInfo.domains),
+		))
+	}
+	return allErrs
+}
+
+// validateDynamoGraphDeploymentUpdate validates an update. newDGD and oldDGD must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentUpdate(
+	newDGD *nvidiacomv1beta1.DynamoGraphDeployment,
+	oldDGD *nvidiacomv1beta1.DynamoGraphDeployment,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, v.validateDynamoGraphDeploymentSpecUpdate(
+		&newDGD.Spec,
+		&oldDGD.Spec,
+		field.NewPath("spec"),
+	)...)
+
+	if oldDGD.Status.RollingUpdate != nil {
+		phase := oldDGD.Status.RollingUpdate.Phase
+		if phase == nvidiacomv1beta1.RollingUpdatePhasePending || phase == nvidiacomv1beta1.RollingUpdatePhaseInProgress {
+			oldID := k8sptr.Deref(oldDGD.Spec.Restart, nvidiacomv1beta1.Restart{}).ID
+			newID := k8sptr.Deref(newDGD.Spec.Restart, nvidiacomv1beta1.Restart{}).ID
+			if oldID != newID {
+				allErrs = append(allErrs, field.Invalid(
+					field.NewPath("spec", "restart", "id"),
+					newID,
+					fmt.Sprintf("cannot be changed while a rolling update is %s", phase),
+				))
+			}
+		}
+	}
+	return allErrs
+}
+
+// validateDynamoGraphDeploymentSpecUpdate validates a spec update. newSpec, oldSpec, and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecUpdate(
+	newSpec *nvidiacomv1beta1.DynamoGraphDeploymentSpec,
+	oldSpec *nvidiacomv1beta1.DynamoGraphDeploymentSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	newComponents := componentsByName(newSpec.Components)
+	oldComponents := componentsByName(oldSpec.Components)
+
+	added := difference(componentNameSet(newComponents), componentNameSet(oldComponents))
+	removed := difference(componentNameSet(oldComponents), componentNameSet(newComponents))
+	sort.Strings(added)
+	sort.Strings(removed)
+	if len(added) != 0 || len(removed) != 0 {
+		detail := "component topology is immutable and cannot be modified after creation"
+		switch {
+		case len(added) != 0 && len(removed) != 0:
+			detail = fmt.Sprintf("%s: components added: %v, components removed: %v", detail, added, removed)
+		case len(added) != 0:
+			detail = fmt.Sprintf("%s: components added: %v", detail, added)
+		default:
+			detail = fmt.Sprintf("%s: components removed: %v", detail, removed)
+		}
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("components"), detail))
+	}
+
+	canModifyReplicas := v.userInfo != nil && internalwebhook.CanModifyDGDReplicas(v.operatorPrincipal, *v.userInfo)
+	componentsPath := fldPath.Child("components")
+	for i := range newSpec.Components {
+		newComponent := &newSpec.Components[i]
+		oldComponent, exists := oldComponents[newComponent.ComponentName]
+		if !exists {
 			continue
 		}
-		warnings = append(warnings, alphaCompatibilityWarningsForService(dgd, fieldPath, service)...)
-		if err := validateAlphaCompatibilityService(fieldPath, service); err != nil {
-			errs = append(errs, err)
-		}
+		allErrs = append(allErrs, v.validateDynamoComponentDeploymentSharedSpecUpdate(
+			newComponent,
+			oldComponent,
+			componentsPath.Index(i),
+			canModifyReplicas,
+		)...)
 	}
 
-	return warnings, errors.Join(errs...)
+	if newSpec.BackendFramework != oldSpec.BackendFramework {
+		v.warn("Changing spec.backendFramework may cause unexpected behavior")
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("backendFramework"),
+			newSpec.BackendFramework,
+			"is immutable and cannot be changed after creation",
+		))
+	}
+
+	topologyPath := fldPath.Child("topologyConstraint")
+	if newSpec.TopologyConstraint != nil {
+		allErrs = append(allErrs, v.validateSpecTopologyConstraintUpdate(
+			newSpec.TopologyConstraint,
+			oldSpec.TopologyConstraint,
+			topologyPath,
+		)...)
+	} else if oldSpec.TopologyConstraint != nil {
+		allErrs = append(allErrs, field.Invalid(
+			topologyPath,
+			newSpec.TopologyConstraint,
+			"is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints",
+		))
+	}
+
+	if newSpec.Experimental != nil {
+		allErrs = append(allErrs, v.validateDynamoGraphDeploymentExperimentalSpecUpdate(
+			newSpec.Experimental,
+			oldSpec.Experimental,
+			fldPath.Child("experimental"),
+		)...)
+	} else if oldPolicy := kvTransferPolicyFor(oldSpec.Experimental); oldPolicy != nil {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("experimental", "kvTransferPolicy"),
+			newSpec.Experimental,
+			"is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy",
+		))
+	}
+
+	return allErrs
 }
 
-func alphaCompatibilityWarningsForService(
-	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
-	fieldPath string,
-	service *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
-) admission.Warnings {
-	var warnings admission.Warnings
-	if service.DynamoNamespace != nil && *service.DynamoNamespace != "" {
-		warnings = append(warnings, fmt.Sprintf(
-			"%s.dynamoNamespace is deprecated and ignored. Value '%s' will be replaced with '%s'. "+
-				"Remove this field from your configuration",
-			fieldPath, *service.DynamoNamespace, dgd.GetDynamoNamespaceForService(service)))
-	}
-
-	//nolint:staticcheck // SA1019: Intentionally checking deprecated field to warn users.
-	if service.Autoscaling != nil {
-		warnings = append(warnings, fmt.Sprintf(
-			"%s.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter "+
-				"with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md",
-			fieldPath))
-	}
-	return warnings
-}
-
-func validateAlphaCompatibilityPVCs(pvcs []nvidiacomv1alpha1.PVC) error {
-	var errs []error
-	for i := range pvcs {
-		if err := validateAlphaCompatibilityPVC(i, &pvcs[i]); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
-}
-
-func validateAlphaCompatibilityPVC(index int, pvc *nvidiacomv1alpha1.PVC) error {
-	var err error
-	if pvc.Name == nil || *pvc.Name == "" {
-		err = errors.Join(err, fmt.Errorf("spec.pvcs[%d].name is required", index))
-	}
-	if pvc.Create != nil && *pvc.Create {
-		if pvc.StorageClass == "" {
-			err = errors.Join(err, fmt.Errorf("spec.pvcs[%d].storageClass is required when create is true", index))
-		}
-		if pvc.Size.IsZero() {
-			err = errors.Join(err, fmt.Errorf("spec.pvcs[%d].size is required when create is true", index))
-		}
-		if pvc.VolumeAccessMode == "" {
-			err = errors.Join(err, fmt.Errorf("spec.pvcs[%d].volumeAccessMode is required when create is true", index))
-		}
-	}
-	return err
-}
-
-func validateAlphaCompatibilityService(
-	fieldPath string,
-	service *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
-) error {
-	var errs []error
-	if service.Ingress != nil && service.Ingress.Enabled && service.Ingress.Host == "" {
-		errs = append(errs, fmt.Errorf("%s.ingress.host is required when ingress is enabled", fieldPath))
-	}
-	if err := validateAlphaCompatibilityServiceAnnotations(fieldPath, service.Annotations); err != nil {
-		errs = append(errs, err)
-	}
-	if err := validateAlphaCompatibilityVolumeMounts(fieldPath, service.VolumeMounts); err != nil {
-		errs = append(errs, err)
-	}
-	if service.SharedMemory != nil && !service.SharedMemory.Disabled && service.SharedMemory.Size.IsZero() {
-		errs = append(errs, fmt.Errorf("%s.sharedMemory.size is required when disabled is false", fieldPath))
-	}
-	if err := validateAlphaCompatibilityFrontendSidecar(fieldPath, service); err != nil {
-		errs = append(errs, err)
-	}
-	if err := validateAlphaCompatibilityGMSClientContainerNames(fieldPath, service.GPUMemoryService); err != nil {
-		errs = append(errs, err)
-	}
-	return errors.Join(errs...)
-}
-
-func validateAlphaCompatibilityServiceAnnotations(fieldPath string, annotations map[string]string) error {
-	return validateVLLMDistributedExecutorBackendAnnotation(fieldPath+".annotations", annotations)
-}
-
-func validateAlphaCompatibilityFrontendSidecar(
-	fieldPath string,
-	service *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
-) error {
-	if service.FrontendSidecar == nil ||
-		service.ExtraPodSpec == nil ||
-		service.ExtraPodSpec.PodSpec == nil {
+// validateSpecTopologyConstraintUpdate validates a topology constraint update.
+// newConstraint and fldPath must not be nil; oldConstraint may be nil for an addition.
+func (v *dynamoGraphDeploymentValidation) validateSpecTopologyConstraintUpdate(
+	newConstraint *nvidiacomv1beta1.SpecTopologyConstraint,
+	oldConstraint *nvidiacomv1beta1.SpecTopologyConstraint,
+	fldPath *field.Path,
+) field.ErrorList {
+	if oldConstraint != nil &&
+		newConstraint.ClusterTopologyName == oldConstraint.ClusterTopologyName &&
+		newConstraint.PackDomain == oldConstraint.PackDomain {
 		return nil
 	}
-	for _, container := range service.ExtraPodSpec.PodSpec.Containers {
-		if container.Name == consts.FrontendSidecarContainerName {
-			return fmt.Errorf(
-				"%s: cannot inject frontend sidecar: a container named %q already exists in extraPodSpec.containers",
-				fieldPath, consts.FrontendSidecarContainerName)
-		}
-	}
-	return nil
+	return field.ErrorList{field.Invalid(
+		fldPath,
+		newConstraint,
+		"is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints",
+	)}
 }
 
-func validateAlphaCompatibilityVolumeMounts(
-	fieldPath string,
-	volumeMounts []nvidiacomv1alpha1.VolumeMount,
-) error {
-	var errs []error
-	for i := range volumeMounts {
-		volumeMount := &volumeMounts[i]
-		if !volumeMount.UseAsCompilationCache && volumeMount.MountPoint == "" {
-			errs = append(errs, fmt.Errorf("%s.volumeMounts[%d].mountPoint is required when useAsCompilationCache is false",
-				fieldPath, i))
-		}
+// validateDynamoGraphDeploymentExperimentalSpecUpdate validates an experimental spec update.
+// newExperimental and fldPath must not be nil; oldExperimental may be nil for an addition.
+func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentExperimentalSpecUpdate(
+	newExperimental *nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec,
+	oldExperimental *nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	newPolicy := newExperimental.KvTransferPolicy
+	oldPolicy := kvTransferPolicyFor(oldExperimental)
+	if newPolicy != nil {
+		return v.validateKvTransferPolicyUpdate(newPolicy, oldPolicy, fldPath.Child("kvTransferPolicy"))
 	}
-	return errors.Join(errs...)
-}
-
-func validateAlphaCompatibilityGMSClientContainerNames(
-	fieldPath string,
-	gms *nvidiacomv1alpha1.GPUMemoryServiceSpec,
-) error {
-	if gms == nil {
+	if oldPolicy == nil {
 		return nil
 	}
-	var errs []error
-	for i, name := range gms.ExtraClientContainers {
-		if validationErrs := k8svalidation.IsDNS1123Label(name); len(validationErrs) > 0 {
-			errs = append(errs, fmt.Errorf(
-				"%s.gpuMemoryService.extraClientContainers[%d] %q is not a valid Kubernetes container name: %s",
-				fieldPath,
-				i,
-				name,
-				strings.Join(validationErrs, "; "),
-			))
-		}
-	}
-	return errors.Join(errs...)
+	return field.ErrorList{field.Invalid(
+		fldPath.Child("kvTransferPolicy"),
+		newPolicy,
+		"is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy",
+	)}
 }
 
-func betaComponentsByName(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-) (map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec, error) {
-	if dgd == nil {
-		return nil, fmt.Errorf("DynamoGraphDeployment is nil")
-	}
-	components := make(map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec, len(dgd.Spec.Components))
-	for i := range dgd.Spec.Components {
-		component := &dgd.Spec.Components[i]
-		components[component.ComponentName] = component
-	}
-	return components, nil
-}
-
-func sortedBetaComponentNames(components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) []string {
-	names := make([]string, 0, len(components))
-	for name := range components {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
-}
-
-func betaComponentNameSet(components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) map[string]struct{} {
-	names := make(map[string]struct{}, len(components))
-	for name := range components {
-		names[name] = struct{}{}
-	}
-	return names
-}
-
-func betaSpecTopologyConstraintsEqual(a, b *nvidiacomv1beta1.SpecTopologyConstraint) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return a.ClusterTopologyName == b.ClusterTopologyName && a.PackDomain == b.PackDomain
-}
-
-func betaTopologyConstraintsEqual(a, b *nvidiacomv1beta1.TopologyConstraint) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return a.PackDomain == b.PackDomain
-}
-
-func betaKvTransferPolicyFor(dgd *nvidiacomv1beta1.DynamoGraphDeployment) *nvidiacomv1beta1.KvTransferPolicy {
-	if dgd == nil || dgd.Spec.Experimental == nil {
+// validateKvTransferPolicyUpdate validates a policy update.
+// newPolicy and fldPath must not be nil; oldPolicy may be nil for an addition.
+func (v *dynamoGraphDeploymentValidation) validateKvTransferPolicyUpdate(
+	newPolicy *nvidiacomv1beta1.KvTransferPolicy,
+	oldPolicy *nvidiacomv1beta1.KvTransferPolicy,
+	fldPath *field.Path,
+) field.ErrorList {
+	if kvTransferPoliciesEqual(newPolicy, oldPolicy) {
 		return nil
 	}
-	return dgd.Spec.Experimental.KvTransferPolicy
-}
-
-func betaKvTransferPoliciesEqual(a, b *nvidiacomv1beta1.KvTransferPolicy) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return a.ClusterTopologyName == b.ClusterTopologyName &&
-		a.LabelKey == b.LabelKey &&
-		a.Domain == b.Domain &&
-		betaEffectiveKvTransferEnforcement(a) == betaEffectiveKvTransferEnforcement(b) &&
-		betaKvTransferPreferredWeightsEqual(a.PreferredWeight, b.PreferredWeight)
-}
-
-func betaEffectiveKvTransferEnforcement(kvt *nvidiacomv1beta1.KvTransferPolicy) nvidiacomv1beta1.KvTransferEnforcement {
-	if kvt == nil || kvt.Enforcement == "" {
-		return nvidiacomv1beta1.KvTransferEnforcementRequired
-	}
-	return kvt.Enforcement
-}
-
-func betaKvTransferPreferredWeightsEqual(a, b *float32) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	return *a == *b
-}
-
-func betaGPUMemoryService(component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) *nvidiacomv1beta1.GPUMemoryServiceSpec {
-	if component == nil || component.Experimental == nil {
-		return nil
-	}
-	return component.Experimental.GPUMemoryService
-}
-
-func betaFailover(component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) *nvidiacomv1beta1.FailoverSpec {
-	if component == nil || component.Experimental == nil {
-		return nil
-	}
-	return component.Experimental.Failover
-}
-
-func betaCheckpoint(component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) *nvidiacomv1beta1.ComponentCheckpointConfig {
-	if component == nil || component.Experimental == nil {
-		return nil
-	}
-	return component.Experimental.Checkpoint
-}
-
-func betaGMSMode(mode nvidiacomv1beta1.GPUMemoryServiceMode) nvidiacomv1beta1.GPUMemoryServiceMode {
-	if mode == "" {
-		return nvidiacomv1beta1.GMSModeIntraPod
-	}
-	return mode
-}
-
-func isValidBetaTopologyDomainFormat(d nvidiacomv1beta1.TopologyDomain) bool {
-	return betaTopologyDomainRegex.MatchString(string(d))
+	return field.ErrorList{field.Invalid(
+		fldPath,
+		newPolicy,
+		"is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy",
+	)}
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
@@ -58,6 +58,7 @@ type dynamoGraphDeploymentV1Alpha1Handler struct {
 }
 
 // NewDynamoGraphDeploymentHandler creates a new handler for DynamoGraphDeployment Webhook.
+// mgr must not be nil.
 // operatorPrincipal is the full Kubernetes SA username of the operator, used to authorize
 // replica changes on scaling-adapter-enabled components (#7656).
 // groveEnabled reflects the operator's runtime Grove configuration.
@@ -143,13 +144,13 @@ func (h *DynamoGraphDeploymentHandler) validateUpdate(
 	req, err := admission.RequestFromContext(ctx)
 	if err != nil {
 		logger.Error(err, "failed to get admission request from context, replica changes for DGDSA-enabled services will be rejected")
-		// userInfo remains nil - validateReplicasChanges will fail closed
+		// userInfo remains nil, so scaling-adapter replica validation fails closed.
 	} else {
 		userInfo = &req.UserInfo
 	}
 
 	// Validate stateful rules (immutability + replicas protection)
-	updateWarnings, err := validator.ValidateUpdate(oldDeployment, newDeployment, userInfo, h.operatorPrincipal)
+	updateWarnings, err := validator.ValidateUpdate(ctx, oldDeployment, newDeployment, userInfo, h.operatorPrincipal)
 	if err != nil {
 		username := "<unknown>"
 		if userInfo != nil {

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler_test.go
@@ -161,7 +161,7 @@ func TestDynamoGraphDeploymentHandlerValidateUpdate(t *testing.T) {
 		invalid := newBetaDGDForValidation()
 		invalid.Spec.Components = nil
 		_, err := handler.ValidateUpdate(ctx, newBetaDGDForValidation(), invalid)
-		assertBetaValidationErrors(t, err, []string{"spec.components must have at least one component"})
+		assertBetaValidationErrors(t, err, []string{"spec.components: Required value: must have at least one component"})
 	})
 
 	t.Run("stateful validation failure", func(t *testing.T) {
@@ -170,7 +170,7 @@ func TestDynamoGraphDeploymentHandlerValidateUpdate(t *testing.T) {
 		oldDGD.Spec.BackendFramework = "vllm"
 		newDGD.Spec.BackendFramework = sglangBackendFramework
 		_, err := handler.ValidateUpdate(ctx, oldDGD, newDGD)
-		assertBetaValidationErrors(t, err, []string{"spec.backendFramework is immutable and cannot be changed after creation"})
+		assertBetaValidationErrors(t, err, []string{`spec.backendFramework: Invalid value: "sglang": is immutable and cannot be changed after creation`})
 	})
 }
 

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler_test.go
@@ -19,40 +19,236 @@ package validation
 
 import (
 	"context"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	k8sptr "k8s.io/utils/ptr"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-func TestDynamoGraphDeploymentV1Alpha1Handler_ValidateCreate(t *testing.T) {
-	dgd := newAlphaDGDForCompatibilityValidation()
-	dgd.Spec.Services["worker"].Replicas = k8sptr.To(int32(-1))
-
+func TestDynamoGraphDeploymentV1Alpha1Handler(t *testing.T) {
 	handler := &dynamoGraphDeploymentV1Alpha1Handler{
-		handler: NewDynamoGraphDeploymentHandler(nil, "", false),
+		handler: NewDynamoGraphDeploymentHandler(newGroveTopologyTestManager(t), "", false),
 	}
-	_, err := handler.ValidateCreate(
-		dgdAdmissionContext(admissionv1.Create, nvidiacomv1alpha1.DynamoGraphDeploymentGVK),
+
+	t.Run("create", func(t *testing.T) {
+		dgd := newAlphaDGDForCompatibilityValidation()
+		dgd.Spec.Services["worker"].Annotations = map[string]string{
+			consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid",
+		}
+
+		_, err := handler.ValidateCreate(
+			dgdAdmissionContext(admissionv1.Create, nvidiacomv1alpha1.DynamoGraphDeploymentGVK),
+			dgd,
+		)
+		if err == nil {
+			t.Fatal("ValidateCreate() error = nil, want preserved v1alpha1 validation error")
+		}
+		if !strings.Contains(err.Error(), "spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend]") {
+			t.Fatalf("ValidateCreate() error = %q, want v1alpha1 service annotation validation error", err)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		oldDGD := newAlphaDGDForCompatibilityValidation()
+		newDGD := oldDGD.DeepCopy()
+		newDGD.Labels = map[string]string{"updated": "true"}
+		warnings, err := handler.ValidateUpdate(
+			dgdAdmissionContext(admissionv1.Update, nvidiacomv1alpha1.DynamoGraphDeploymentGVK),
+			oldDGD,
+			newDGD,
+		)
+		if err != nil || len(warnings) != 0 {
+			t.Fatalf("ValidateUpdate() = (%v, %v), want no warnings or error", warnings, err)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		warnings, err := handler.ValidateDelete(
+			dgdAdmissionContext(admissionv1.Delete, nvidiacomv1alpha1.DynamoGraphDeploymentGVK),
+			newAlphaDGDForCompatibilityValidation(),
+		)
+		if err != nil || len(warnings) != 0 {
+			t.Fatalf("ValidateDelete() = (%v, %v), want no warnings or error", warnings, err)
+		}
+	})
+}
+
+func TestDynamoGraphDeploymentHandlerValidateCreate(t *testing.T) {
+	handler := NewDynamoGraphDeploymentHandler(newGroveTopologyTestManager(t), "system:serviceaccount:dynamo:dynamo-operator", false)
+	dgd := newBetaDGDForValidation()
+
+	warnings, err := handler.ValidateCreate(dgdAdmissionContext(admissionv1.Create, nvidiacomv1beta1.DynamoGraphDeploymentGVK), dgd)
+	if err != nil {
+		t.Fatalf("ValidateCreate() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("ValidateCreate() warnings = %v, want none", warnings)
+	}
+
+	_, err = handler.ValidateCreate(context.Background(), dgd)
+	if err == nil || !strings.Contains(err.Error(), "admission request missing from context") {
+		t.Fatalf("ValidateCreate() error = %v, want missing admission request", err)
+	}
+
+	_, err = handler.ValidateCreate(
+		dgdAdmissionContext(admissionv1.Create, schema.GroupVersionKind{Group: "wrong.example.com", Version: "v1", Kind: "Wrong"}),
 		dgd,
 	)
-	if err == nil {
-		t.Fatal("ValidateCreate() error = nil, want converted v1beta1 validation error")
+	if err == nil || !strings.Contains(err.Error(), "admission requires") {
+		t.Fatalf("ValidateCreate() error = %v, want GVK mismatch", err)
 	}
-	if !strings.Contains(err.Error(), "spec.components[worker].replicas must be non-negative") {
-		t.Fatalf("ValidateCreate() error = %q, want v1beta1 component validation error", err)
+
+	_, err = handler.ValidateCreate(
+		dgdAdmissionContext(admissionv1.Create, nvidiacomv1beta1.DynamoGraphDeploymentGVK),
+		&runtime.Unknown{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "expected v1alpha1 or v1beta1 DynamoGraphDeployment") {
+		t.Fatalf("ValidateCreate() error = %v, want type mismatch", err)
 	}
 }
 
-func dgdAdmissionContext(op admissionv1.Operation, gvk schema.GroupVersionKind) context.Context {
+func TestDynamoGraphDeploymentHandlerValidateUpdate(t *testing.T) {
+	handler := NewDynamoGraphDeploymentHandler(newGroveTopologyTestManager(t), "system:serviceaccount:dynamo:dynamo-operator", false)
+	ctx := dgdAdmissionContext(admissionv1.Update, nvidiacomv1beta1.DynamoGraphDeploymentGVK)
+
+	t.Run("valid", func(t *testing.T) {
+		oldDGD := newBetaDGDForValidation()
+		newDGD := oldDGD.DeepCopy()
+		warnings, err := handler.ValidateUpdate(ctx, oldDGD, newDGD)
+		if err != nil {
+			t.Fatalf("ValidateUpdate() error = %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("ValidateUpdate() warnings = %v, want none", warnings)
+		}
+	})
+
+	t.Run("deleting", func(t *testing.T) {
+		oldDGD := newBetaDGDForValidation()
+		newDGD := oldDGD.DeepCopy()
+		now := metav1.Now()
+		newDGD.DeletionTimestamp = &now
+		if _, err := handler.ValidateUpdate(ctx, &runtime.Unknown{}, newDGD); err != nil {
+			t.Fatalf("ValidateUpdate() error = %v", err)
+		}
+	})
+
+	t.Run("invalid new object", func(t *testing.T) {
+		_, err := handler.ValidateUpdate(ctx, newBetaDGDForValidation(), &runtime.Unknown{})
+		if err == nil || !strings.Contains(err.Error(), "expected v1alpha1 or v1beta1 DynamoGraphDeployment") {
+			t.Fatalf("ValidateUpdate() error = %v, want new object type mismatch", err)
+		}
+	})
+
+	t.Run("invalid old object", func(t *testing.T) {
+		_, err := handler.ValidateUpdate(ctx, &runtime.Unknown{}, newBetaDGDForValidation())
+		if err == nil || !strings.Contains(err.Error(), "expected v1alpha1 or v1beta1 DynamoGraphDeployment") {
+			t.Fatalf("ValidateUpdate() error = %v, want old object type mismatch", err)
+		}
+	})
+
+	t.Run("stateless validation failure", func(t *testing.T) {
+		invalid := newBetaDGDForValidation()
+		invalid.Spec.Components = nil
+		_, err := handler.ValidateUpdate(ctx, newBetaDGDForValidation(), invalid)
+		assertBetaValidationErrors(t, err, []string{"spec.components must have at least one component"})
+	})
+
+	t.Run("stateful validation failure", func(t *testing.T) {
+		oldDGD := newBetaDGDForValidation()
+		newDGD := oldDGD.DeepCopy()
+		oldDGD.Spec.BackendFramework = "vllm"
+		newDGD.Spec.BackendFramework = sglangBackendFramework
+		_, err := handler.ValidateUpdate(ctx, oldDGD, newDGD)
+		assertBetaValidationErrors(t, err, []string{"spec.backendFramework is immutable and cannot be changed after creation"})
+	})
+}
+
+func TestDynamoGraphDeploymentHandlerValidateDelete(t *testing.T) {
+	handler := NewDynamoGraphDeploymentHandler(newGroveTopologyTestManager(t), "", false)
+	ctx := dgdAdmissionContext(admissionv1.Delete, nvidiacomv1beta1.DynamoGraphDeploymentGVK)
+
+	warnings, err := handler.ValidateDelete(ctx, newBetaDGDForValidation())
+	if err != nil {
+		t.Fatalf("ValidateDelete() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("ValidateDelete() warnings = %v, want none", warnings)
+	}
+
+	_, err = handler.ValidateDelete(ctx, &runtime.Unknown{})
+	if err == nil || !strings.Contains(err.Error(), "expected DynamoGraphDeployment") {
+		t.Fatalf("ValidateDelete() error = %v, want type mismatch", err)
+	}
+}
+
+func TestCastToDynamoGraphDeployment(t *testing.T) {
+	dgd := newBetaDGDForValidation()
+	got, err := castToDynamoGraphDeployment(dgd)
+	if err != nil || got != dgd {
+		t.Fatalf("castToDynamoGraphDeployment() = (%v, %v), want original DGD", got, err)
+	}
+
+	if _, err := castToDynamoGraphDeployment(nil); err == nil {
+		t.Fatal("castToDynamoGraphDeployment() error = nil, want type mismatch")
+	}
+}
+
+func TestDynamoGraphDeploymentHandlerRegisterWithManager(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := nvidiacomv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1alpha1 scheme: %v", err)
+	}
+	if err := nvidiacomv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1beta1 scheme: %v", err)
+	}
+
+	server := ctrlwebhook.NewServer(ctrlwebhook.Options{})
+	mgr := &fakeManager{scheme: scheme, webhookServer: server}
+	handler := NewDynamoGraphDeploymentHandler(mgr, "", false)
+	if err := handler.RegisterWithManager(mgr); err != nil {
+		t.Fatalf("RegisterWithManager() error = %v", err)
+	}
+
+	for _, path := range []string{
+		dynamoGraphDeploymentV1Alpha1WebhookPath,
+		dynamoGraphDeploymentV1Beta1WebhookPath,
+	} {
+		request := httptest.NewRequest("POST", path, nil)
+		_, pattern := server.WebhookMux().Handler(request)
+		if pattern != path {
+			t.Fatalf("registered pattern = %q, want %q", pattern, path)
+		}
+	}
+}
+
+func dgdAdmissionContext(operation admissionv1.Operation, gvk schema.GroupVersionKind) context.Context {
+	return dgdAdmissionContextWithUserInfo(operation, gvk, nil)
+}
+
+func dgdAdmissionContextWithUserInfo(
+	operation admissionv1.Operation,
+	gvk schema.GroupVersionKind,
+	userInfo *authenticationv1.UserInfo,
+) context.Context {
+	requestUserInfo := authenticationv1.UserInfo{}
+	if userInfo != nil {
+		requestUserInfo = *userInfo.DeepCopy()
+	}
 	return admission.NewContextWithRequest(context.Background(), admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
-			Operation: op,
+			Operation: operation,
+			UserInfo:  requestUserInfo,
 			Kind: metav1.GroupVersionKind{
 				Group:   gvk.Group,
 				Version: gvk.Version,

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_helpers.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_helpers.go
@@ -18,25 +18,221 @@
 package validation
 
 import (
+	"context"
 	"fmt"
+	"sort"
 	"strings"
 
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	k8sptr "k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
 	// maxCombinedResourceNameLength is kept as a local alias for readability.
 	maxCombinedResourceNameLength = consts.MaxCombinedGroveResourceNameLength
-
-	unsetValue = "<unset>"
-
-	vllmDistributedExecutorBackendMP  = "mp"
-	vllmDistributedExecutorBackendRay = "ray"
 )
 
 type clusterTopologyInfo struct {
+	name        string
 	domainIndex map[string]int
 	domains     []string
+}
+
+// invalidDynamoGraphDeploymentError converts allErrs for dgd into an API error.
+// dgd must not be nil.
+func invalidDynamoGraphDeploymentError(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	allErrs field.ErrorList,
+) error {
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return k8serrors.NewInvalid(nvidiacomv1beta1.DynamoGraphDeploymentGVK.GroupKind(), dgd.Name, allErrs)
+}
+
+// alphaDynamoGraphDeploymentForValidation reconstructs the compatibility view.
+// dgd must not be nil.
+func alphaDynamoGraphDeploymentForValidation(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) (*nvidiacomv1alpha1.DynamoGraphDeployment, error) {
+	alpha := &nvidiacomv1alpha1.DynamoGraphDeployment{}
+	if err := alpha.ConvertFrom(dgd); err != nil {
+		return nil, fmt.Errorf("failed to reconstruct compatibility view: %w", err)
+	}
+	return alpha, nil
+}
+
+func hasV1Alpha1CompatibilityFields(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) bool {
+	if len(dgd.Spec.PVCs) > 0 {
+		return true
+	}
+	for _, service := range dgd.Spec.Services {
+		if service == nil {
+			return true
+		}
+		hasDeprecatedAutoscaling := false
+		//nolint:staticcheck // SA1019: Intentionally checking deprecated fields preserved by conversion.
+		if service.Autoscaling != nil {
+			hasDeprecatedAutoscaling = true
+		}
+		if service.Ingress != nil ||
+			len(service.Annotations) > 0 ||
+			service.DynamoNamespace != nil ||
+			hasDeprecatedAutoscaling ||
+			len(service.VolumeMounts) > 0 ||
+			service.SharedMemory != nil ||
+			service.EPPConfig != nil ||
+			service.FrontendSidecar != nil ||
+			service.Failover != nil ||
+			(service.GPUMemoryService != nil && !service.GPUMemoryService.Enabled) {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedV1Alpha1ServiceNames(
+	services map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+) []string {
+	names := make([]string, 0, len(services))
+	for name := range services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// readGroveClusterTopology reads a topology by name. ctx and mgr must not be nil.
+func readGroveClusterTopology(ctx context.Context, mgr ctrl.Manager, name string) (*clusterTopologyInfo, error) {
+	clusterTopology := &grovev1alpha1.ClusterTopology{}
+	if err := mgr.GetClient().Get(ctx, types.NamespacedName{Name: name}, clusterTopology); err != nil {
+		return nil, err
+	}
+
+	info := &clusterTopologyInfo{
+		name:        name,
+		domainIndex: make(map[string]int, len(clusterTopology.Spec.Levels)),
+		domains:     make([]string, 0, len(clusterTopology.Spec.Levels)),
+	}
+	for i, level := range clusterTopology.Spec.Levels {
+		domain := string(level.Domain)
+		info.domainIndex[domain] = i
+		info.domains = append(info.domains, domain)
+	}
+	sort.Strings(info.domains)
+	return info, nil
+}
+
+func grovePathwayForDynamoGraphDeployment(
+	groveEnabled bool,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) (bool, string) {
+	if !groveEnabled {
+		return false, "requires the Grove pathway, but Grove is disabled in the operator configuration"
+	}
+	annotationValue := strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableGrove])
+	if annotationValue == consts.KubeLabelValueFalse {
+		return false, fmt.Sprintf(
+			"requires the Grove pathway; remove or unset annotation %q (currently %q)",
+			consts.KubeAnnotationEnableGrove,
+			dgd.Annotations[consts.KubeAnnotationEnableGrove],
+		)
+	}
+	return true, ""
+}
+
+func dgdComponentResourceNameLength(
+	dgdName string,
+	components []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) (int, string) {
+	pcsName := dynamo.PCSNameForDGD(dgdName, components)
+	componentName := component.ComponentName
+	combinedLength := len(pcsName) + len(strings.ToLower(componentName))
+	detail := "PCS name + component name"
+
+	if component.GetNumberOfNodes() > 1 || component.IsInterPodGMSEnabled() {
+		longestPodCliqueName := dynamo.LongestPodCliqueNameForDGDComponent(componentName, component)
+		combinedLength += len(longestPodCliqueName)
+		detail = fmt.Sprintf("PCS name + PCSG name + longest PodClique name %q", longestPodCliqueName)
+	}
+	return combinedLength, detail
+}
+
+func hasIntraPodFailover(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) bool {
+	for i := range spec.Components {
+		failover := failoverFor(&spec.Components[i])
+		if failover != nil && effectiveGMSMode(failover.Mode) == nvidiacomv1beta1.GMSModeIntraPod {
+			return true
+		}
+	}
+	return false
+}
+
+func componentsByName(
+	components []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec {
+	byName := make(map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec, len(components))
+	for i := range components {
+		byName[components[i].ComponentName] = &components[i]
+	}
+	return byName
+}
+
+func sortedComponentNames(
+	components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) []string {
+	names := make([]string, 0, len(components))
+	for name := range components {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func componentNameSet(
+	components map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) map[string]struct{} {
+	names := make(map[string]struct{}, len(components))
+	for name := range components {
+		names[name] = struct{}{}
+	}
+	return names
+}
+
+func kvTransferPolicyFor(
+	experimental *nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec,
+) *nvidiacomv1beta1.KvTransferPolicy {
+	if experimental == nil {
+		return nil
+	}
+	return experimental.KvTransferPolicy
+}
+
+func kvTransferPoliciesEqual(a, b *nvidiacomv1beta1.KvTransferPolicy) bool {
+	if b == nil {
+		return false
+	}
+	return a.ClusterTopologyName == b.ClusterTopologyName &&
+		a.LabelKey == b.LabelKey &&
+		a.Domain == b.Domain &&
+		effectiveKvTransferEnforcement(a) == effectiveKvTransferEnforcement(b) &&
+		k8sptr.Equal(a.PreferredWeight, b.PreferredWeight)
+}
+
+func effectiveKvTransferEnforcement(policy *nvidiacomv1beta1.KvTransferPolicy) nvidiacomv1beta1.KvTransferEnforcement {
+	if policy.Enforcement == "" {
+		return nvidiacomv1beta1.KvTransferEnforcementRequired
+	}
+	return policy.Enforcement
 }
 
 func getUnique[T comparable](slice []T) []T {
@@ -60,27 +256,4 @@ func difference(a, b map[string]struct{}) []string {
 		}
 	}
 	return result
-}
-
-func validateVLLMDistributedExecutorBackendAnnotation(fieldPath string, annotations map[string]string) error {
-	if annotations == nil {
-		return nil
-	}
-
-	value, exists := annotations[consts.KubeAnnotationVLLMDistributedExecutorBackend]
-	if !exists {
-		return nil
-	}
-
-	switch strings.ToLower(value) {
-	case vllmDistributedExecutorBackendMP, vllmDistributedExecutorBackendRay:
-		return nil
-	default:
-		if fieldPath == "" {
-			return fmt.Errorf("annotation %s has invalid value %q: must be \"mp\" or \"ray\"",
-				consts.KubeAnnotationVLLMDistributedExecutorBackend, value)
-		}
-		return fmt.Errorf("%s[%s] has invalid value %q: must be \"mp\" or \"ray\"",
-			fieldPath, consts.KubeAnnotationVLLMDistributedExecutorBackend, value)
-	}
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -18,6 +18,7 @@
 package validation
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/rest"
 	k8sptr "k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -90,7 +92,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.Components = nil
 			}),
-			wantWebhookErrs: []string{"spec.components must have at least one component"},
+			wantWebhookErrs: []string{"spec.components: Required value: must have at least one component"},
 		},
 		{
 			name: "component replicas must be non-negative",
@@ -105,7 +107,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].minAvailable is currently supported only for Grove-backed DynamoGraphDeployment components"},
+			wantWebhookErrs: []string{"spec.components[1].minAvailable: Forbidden: is currently supported only for Grove-backed DynamoGraphDeployment components"},
 		},
 		{
 			name: "restart on create is rejected by CEL before webhook validation",
@@ -125,7 +127,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				betaWorkerComponent(dgd).TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
 			}),
-			wantWebhookErrs: []string{"spec.topologyConstraint with clusterTopologyName is required when any topology constraint is set (at spec or component level)"},
+			wantWebhookErrs: []string{"spec.topologyConstraint: Required value: is required when any component topology constraint is set"},
 		},
 		{
 			name:          "inter-pod GMS requires Grove",
@@ -133,7 +135,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				enableBetaInterPodGMS(betaWorkerComponent(dgd))
 			}),
-			wantWebhookErrs: []string{"spec.components[worker]: experimental.gpuMemoryService.mode=\"InterPod\" requires the Grove pathway, but Grove is disabled in the operator configuration"},
+			wantWebhookErrs: []string{"spec.components[1].experimental.gpuMemoryService.mode: Forbidden: requires the Grove pathway, but Grove is disabled in the operator configuration"},
 		},
 		{
 			name: "inter-pod GMS requires vLLM backend",
@@ -141,7 +143,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				dgd.Spec.BackendFramework = "sglang"
 				enableBetaInterPodGMS(betaWorkerComponent(dgd))
 			}),
-			wantWebhookErrs: []string{"spec.components[worker]: the inter-pod GMS layout (experimental.gpuMemoryService.mode=\"InterPod\") is currently supported only for vLLM (detected: sglang); set spec.backendFramework=\"vllm\""},
+			wantWebhookErrs: []string{"spec.components[1].experimental.gpuMemoryService.mode: Invalid value: \"InterPod\": the inter-pod GMS layout is currently supported only for vLLM (detected backend: sglang)"},
 		},
 		{
 			name: "KV transfer policy selector is rejected by CEL before webhook validation",
@@ -163,7 +165,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Mode: nvidiacomv1beta1.GMSModeIntraPod,
 				}
 			}),
-			wantWebhookErrs: []string{"failover requires per-container K8s discovery; set annotation \"nvidia.com/dynamo-kube-discovery-mode\" to \"container\" on the DynamoGraphDeployment"},
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/dynamo-kube-discovery-mode]: Invalid value: "": must be "container" when intra-pod failover is configured`},
 		},
 		{
 			name: "checkpoint job with checkpointRef is rejected by CEL before webhook validation",
@@ -189,7 +191,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1"},
+			wantWebhookErrs: []string{"spec.components[1].experimental.gpuMemoryService: Forbidden: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1"},
 		},
 
 		// Cross-version schema and conversion boundaries.
@@ -336,7 +338,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid",
 				}
 			}),
-			wantWebhookErrs: []string{"spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value \"invalid\": must be \"mp\" or \"ray\""},
+			wantWebhookErrs: []string{`spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend]: Invalid value: "invalid": must be "mp" or "ray"`},
 		},
 		{
 			name: "v1beta1 frontend sidecar must reference an existing container",
@@ -347,7 +349,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Containers: []corev1.Container{{Name: consts.MainContainerName}},
 				}}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].frontendSidecar \"missing\" does not match any podTemplate.spec.containers name"},
+			wantWebhookErrs: []string{`spec.components[1].frontendSidecar: Invalid value: "missing": must match a podTemplate.spec.containers name`},
 		},
 		{
 			name:       "valid v1alpha1 deployment reaches the webhook",
@@ -524,7 +526,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "Bad_Name", Domain: "zone"},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.clusterTopologyName \"Bad_Name\" is not a valid Kubernetes resource name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"},
+			wantWebhookErrs: []string{`spec.experimental.kvTransferPolicy.clusterTopologyName: Invalid value: "Bad_Name": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`},
 		},
 		{
 			name: "KV-transfer cluster topology name requires Grove pathway",
@@ -534,7 +536,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "grove-topology", Domain: "zone"},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.clusterTopologyName requires the Grove pathway; remove or unset the \"nvidia.com/enable-grove\" annotation (currently \"false\")"},
+			wantWebhookErrs: []string{`spec.experimental.kvTransferPolicy.clusterTopologyName: Forbidden: requires the Grove pathway; remove or unset annotation "nvidia.com/enable-grove" (currently "false")`},
 		},
 		{
 			name: "KV-transfer domain is required by the schema",
@@ -595,7 +597,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "missing-topology", Domain: "rack"},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.clusterTopologyName \"missing-topology\" references a ClusterTopology resource that was not found"},
+			wantWebhookErrs: []string{`spec.experimental.kvTransferPolicy.clusterTopologyName: Invalid value: "missing-topology": references a ClusterTopology resource that was not found`},
 		},
 		{
 			name: "KV-transfer cluster topology policy rejects missing domain",
@@ -604,7 +606,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "grove-topology", Domain: "host"},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.domain \"host\" does not exist in ClusterTopology \"grove-topology\"; available domains: [rack zone]"},
+			wantWebhookErrs: []string{`spec.experimental.kvTransferPolicy.domain: Invalid value: "host": does not exist in ClusterTopology "grove-topology"; available domains: [rack zone]`},
 		},
 
 		// GMS and failover rules.
@@ -637,7 +639,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				enableBetaIntraPodGMS(&dgd.Spec.Components[0])
 			}),
-			wantWebhookErrs: []string{"spec.components[frontend].experimental.gpuMemoryService: GPU memory service is only supported for worker components (type must be worker, prefill, or decode)"},
+			wantWebhookErrs: []string{"spec.components[0].experimental.gpuMemoryService: Forbidden: GPU memory service is only supported for worker, prefill, or decode components"},
 		},
 		{
 			name: "GMS client container names are validated by the schema",
@@ -656,7 +658,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeIntraPod},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: intraPod failover requires gpuMemoryService to be set"},
+			wantWebhookErrs: []string{`spec.components[1].experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "IntraPod"`},
 		},
 		{
 			name: "failover mode must match GMS mode",
@@ -668,7 +670,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					NumShadows: 1,
 				}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode=\"InterPod\" (got \"IntraPod\")"},
+			wantWebhookErrs: []string{`spec.components[1].experimental.failover.mode: Invalid value: "InterPod": must match gpuMemoryService.mode "IntraPod"`},
 		},
 		{
 			name: "intra-pod failover shadow maximum is validated by the schema",
@@ -690,7 +692,10 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeInterPod, NumShadows: 1},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode=\"InterPod\"", "spec.components[worker]: GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu"},
+			wantWebhookErrs: []string{
+				`spec.components[1].experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "InterPod"`,
+				"spec.components[1].experimental.failover: Forbidden: GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu",
+			},
 		},
 		{
 			name: "inter-pod failover shadow-count minimum is validated by the schema",
@@ -708,7 +713,11 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeInterPod, NumShadows: 1},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.components[frontend].experimental.failover: interPod failover requires gpuMemoryService.mode=\"InterPod\"", "spec.components[frontend]: GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu", "spec.components[frontend]: GMS failover is not supported for type \"frontend\""},
+			wantWebhookErrs: []string{
+				`spec.components[0].experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "InterPod"`,
+				"spec.components[0].experimental.failover: Forbidden: GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu",
+				`spec.components[0].experimental.failover: Forbidden: GMS failover is not supported for component type "frontend"`,
+			},
 		},
 		{
 			name:        "GMS snapshot combination requires env gate",
@@ -718,7 +727,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				enableBetaIntraPodGMS(worker)
 				worker.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.checkpoint: GMS + Snapshot is temporarily disabled; disable gpuMemoryService or enable the internal GMS + Snapshot gate"},
+			wantWebhookErrs: []string{"spec.components[1].experimental.checkpoint: Forbidden: GMS + Snapshot is temporarily disabled; disable gpuMemoryService or enable the internal GMS + Snapshot gate"},
 		},
 
 		// Source-version compatibility rules.
@@ -730,7 +739,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Create: k8sptr.To(false),
 				}}
 			}),
-			wantWebhookErrs: []string{"spec.pvcs[0].name is required"},
+			wantWebhookErrs: []string{"spec.pvcs[0].name: Required value: is required"},
 		},
 		{
 			name: "alpha ingress requires host",
@@ -744,14 +753,14 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.services[frontend].ingress.host is required when ingress is enabled"},
+			wantWebhookErrs: []string{"spec.services[frontend].ingress.host: Required value: is required when ingress is enabled"},
 		},
 		{
 			name: "alpha volume mounts require mount point unless used as compilation cache",
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				dgd.Spec.Services["worker"].VolumeMounts = []nvidiacomv1alpha1.VolumeMount{{Name: "cache"}}
 			}),
-			wantWebhookErrs: []string{"spec.services[worker].volumeMounts[0].mountPoint is required when useAsCompilationCache is false"},
+			wantWebhookErrs: []string{"spec.services[worker].volumeMounts[0].mountPoint: Required value: is required when useAsCompilationCache is false"},
 		},
 		{
 			name:    "alpha EPP config sources are mutually exclusive",
@@ -767,7 +776,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].eppConfig: configMapRef and config are mutually exclusive, only one can be specified"},
+			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Invalid value: null: exactly one of configMapRef or config is required"},
 		},
 		{
 			name: "alpha intra-pod failover shadow maximum is preserved structurally",
@@ -778,7 +787,11 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					NumShadows: 2,
 				}
 			}),
-			wantWebhookErrs: []string{"failover requires per-container K8s discovery; set annotation \"nvidia.com/dynamo-kube-discovery-mode\" to \"container\" on the DynamoGraphDeployment", "spec.components[worker].experimental.failover: intraPod failover requires gpuMemoryService to be set", "spec.components[worker].experimental.failover.numShadows=2 is invalid for mode=\"IntraPod\": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode=\"InterPod\" to configure numShadows"},
+			wantWebhookErrs: []string{
+				`metadata.annotations[nvidia.com/dynamo-kube-discovery-mode]: Invalid value: "": must be "container" when intra-pod failover is configured`,
+				`spec.components[0].experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "IntraPod"`,
+				`spec.services[worker].failover.numShadows: Invalid value: 2: is invalid for mode="intraPod": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode="interPod" to configure numShadows`,
+			},
 		},
 		{
 			name: "alpha frontend sidecar rejects generated container name conflict",
@@ -796,7 +809,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					}},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.services[frontend]: cannot inject frontend sidecar: a container named \"sidecar-frontend\" already exists in extraPodSpec.containers"},
+			wantWebhookErrs: []string{`spec.services[frontend].frontendSidecar: Forbidden: cannot inject frontend sidecar: a container named "sidecar-frontend" already exists in extraPodSpec.containers`},
 		},
 		{
 			name: "alpha GMS client container names are validated by the source schema",
@@ -856,7 +869,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				service.Autoscaling = &nvidiacomv1alpha1.Autoscaling{Enabled: true}
 			}),
 			wantWarnings: []string{
-				"spec.services[worker].dynamoNamespace is deprecated and ignored. Value 'legacy-namespace' will be replaced with 'default-test-graph'. Remove this field from your configuration",
+				`spec.services[worker].dynamoNamespace is deprecated and ignored. Value "legacy-namespace" will be replaced with "default-test-graph". Remove this field from your configuration`,
 				"spec.services[worker].autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md",
 			},
 		},
@@ -913,7 +926,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				worker.ComponentType = consts.ComponentTypeEPP
 				worker.EPPConfig = &nvidiacomv1alpha1.EPPConfig{}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].eppConfig: either configMapRef or config must be specified (no default configuration provided)"},
+			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Invalid value: null: exactly one of configMapRef or config is required"},
 		},
 		{
 			name: "v1beta1 EPP config without a source is rejected by CEL",
@@ -959,7 +972,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.PriorityClassName = "high-priority"
 			}),
-			wantWebhookErrs: []string{"spec.priorityClassName requires the Grove pathway, but Grove is disabled in the operator configuration"},
+			wantWebhookErrs: []string{"spec.priorityClassName: Forbidden: requires the Grove pathway, but Grove is disabled in the operator configuration"},
 		},
 		{
 			name: "priority class is allowed with Grove",
@@ -995,7 +1008,12 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				dgd.Name = longDGDName
 				betaWorkerComponent(dgd).ComponentName = tooLongComponentName
 			}),
-			wantWebhookErrs: []string{"spec.components[wxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]: combined resource name length 46 exceeds 45-character limit required for pod naming. Consider shortening the DynamoGraphDeployment name 'test-graph-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' (length 61) or component name 'wxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' (length 38). The combined length of PCS name + component name must not exceed 45 characters. The PCS name 'tes-cafb' was auto-truncated from DGD name 'test-graph-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"},
+			wantWebhookErrs: []string{fmt.Sprintf(
+				"spec.components[1].name: Invalid value: %q: combined resource name length 46 exceeds the 45-character pod-name limit (PCS name + component name); shorten DynamoGraphDeployment name %q or component name %q",
+				tooLongComponentName,
+				longDGDName,
+				tooLongComponentName,
+			)},
 		},
 		{
 			name:          "rendered Grove resource name length is skipped outside Grove",
@@ -1035,7 +1053,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
 				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
 			}),
-			wantWebhookErrs: []string{"spec.components[frontend].topologyConstraint is required because spec.topologyConstraint.packDomain is not set; either set a spec-level packDomain or provide a topologyConstraint for every component"},
+			wantWebhookErrs: []string{"spec.components[0].topologyConstraint: Required value: is required because spec.topologyConstraint.packDomain is not set"},
 		},
 		{
 			name: "deployment pack domain can be inherited",
@@ -1073,7 +1091,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					PackDomain:          "rack",
 				}
 			}),
-			wantWebhookErrs: []string{"topology-aware scheduling requires a ClusterTopology resource \"missing-topology\" but it was not found; ensure the cluster topology is configured per the framework documentation"},
+			wantWebhookErrs: []string{`spec.topologyConstraint.clusterTopologyName: Invalid value: "missing-topology": references a ClusterTopology resource that was not found`},
 		},
 		{
 			name:    "independent topology errors aggregate",
@@ -1082,7 +1100,10 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "missing-topology"}
 				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
 			}),
-			wantWebhookErrs: []string{"spec.components[frontend].topologyConstraint is required because spec.topologyConstraint.packDomain is not set; either set a spec-level packDomain or provide a topologyConstraint for every component"},
+			wantWebhookErrs: []string{
+				"spec.components[0].topologyConstraint: Required value: is required because spec.topologyConstraint.packDomain is not set",
+				`spec.topologyConstraint.clusterTopologyName: Invalid value: "missing-topology": references a ClusterTopology resource that was not found`,
+			},
 		},
 		{
 			name: "pack domain must exist in cluster topology",
@@ -1092,7 +1113,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					PackDomain:          "host",
 				}
 			}),
-			wantWebhookErrs: []string{"spec.topologyConstraint.packDomain: domain \"host\" does not exist in ClusterTopology \"grove-topology\"; available domains: [rack zone]"},
+			wantWebhookErrs: []string{`spec.topologyConstraint.packDomain: Invalid value: "host": does not exist in ClusterTopology "grove-topology"; available domains: [rack zone]`},
 		},
 		{
 			name: "component topology cannot be broader than spec topology",
@@ -1103,7 +1124,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				}
 				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker]: topologyConstraint.packDomain \"zone\" is broader than spec-level \"rack\"; component constraints must be equal to or narrower than the deployment-level constraint"},
+			wantWebhookErrs: []string{`spec.components[1].topologyConstraint.packDomain: Invalid value: "zone": must be equal to or narrower than the deployment-level domain "rack"`},
 		},
 
 		// Metadata annotation rules.
@@ -1118,7 +1139,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoOperatorOriginVersion: "not-semver"}
 			}),
-			wantWebhookErrs: []string{"annotation nvidia.com/dynamo-operator-origin-version has invalid value \"not-semver\": must be valid semver"},
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/dynamo-operator-origin-version]: Invalid value: "not-semver": must be valid semver`},
 		},
 		{
 			name: "vLLM backend annotation accepts mp",
@@ -1137,7 +1158,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Annotations = map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "typo"}
 			}),
-			wantWebhookErrs: []string{"annotation nvidia.com/vllm-distributed-executor-backend has invalid value \"typo\": must be \"mp\" or \"ray\""},
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/vllm-distributed-executor-backend]: Invalid value: "typo": must be "mp" or "ray"`},
 		},
 		{
 			name: "discovery mode accepts pod",
@@ -1156,7 +1177,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "endpoint"}
 			}),
-			wantWebhookErrs: []string{"annotation nvidia.com/dynamo-kube-discovery-mode has invalid value \"endpoint\": must be \"pod\" or \"container\""},
+			wantWebhookErrs: []string{`metadata.annotations[nvidia.com/dynamo-kube-discovery-mode]: Unsupported value: "endpoint": supported values: "pod", "container"`},
 		},
 		{
 			name: "independent root errors aggregate with exact field paths",
@@ -1168,7 +1189,12 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					consts.KubeAnnotationDynamoKubeDiscoveryMode:        "invalid",
 				}
 			}),
-			wantWebhookErrs: []string{"spec.components must have at least one component", "annotation nvidia.com/dynamo-operator-origin-version has invalid value \"not-semver\": must be valid semver", "annotation nvidia.com/vllm-distributed-executor-backend has invalid value \"invalid\": must be \"mp\" or \"ray\"", "annotation nvidia.com/dynamo-kube-discovery-mode has invalid value \"invalid\": must be \"pod\" or \"container\""},
+			wantWebhookErrs: []string{
+				`metadata.annotations[nvidia.com/dynamo-operator-origin-version]: Invalid value: "not-semver": must be valid semver`,
+				`metadata.annotations[nvidia.com/vllm-distributed-executor-backend]: Invalid value: "invalid": must be "mp" or "ray"`,
+				`metadata.annotations[nvidia.com/dynamo-kube-discovery-mode]: Unsupported value: "invalid": supported values: "pod", "container"`,
+				"spec.components: Required value: must have at least one component",
+			},
 		},
 
 		// Component-set updates.
@@ -1185,7 +1211,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					}}}},
 				})
 			}),
-			wantWebhookErrs: []string{"component topology is immutable and cannot be modified after creation: components added: [extra]"},
+			wantWebhookErrs: []string{"spec.components: Forbidden: component topology is immutable and cannot be modified after creation: components added: [extra]"},
 			notWantErr:      "do-not-leak-this-value",
 		},
 		{
@@ -1194,7 +1220,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
 				spec.Components = spec.Components[:1]
 			}),
-			wantWebhookErrs: []string{"component topology is immutable and cannot be modified after creation: components removed: [worker]"},
+			wantWebhookErrs: []string{"spec.components: Forbidden: component topology is immutable and cannot be modified after creation: components removed: [worker]"},
 		},
 		{
 			name:          "component add and remove reports both sides",
@@ -1208,7 +1234,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantWebhookErrs: []string{"component topology is immutable and cannot be modified after creation: components added: [extra], components removed: [frontend]"},
+			wantWebhookErrs: []string{"spec.components: Forbidden: component topology is immutable and cannot be modified after creation: components added: [extra], components removed: [frontend]"},
 		},
 		{
 			name:          "component reorder is allowed",
@@ -1225,7 +1251,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
 				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker] cannot change node topology (between single-node and multi-node) after creation"},
+			wantWebhookErrs: []string{`spec.components[1].multinode: Invalid value: {"nodeCount":2}: cannot change node topology between single-node and multi-node after creation`},
 		},
 		{
 			name: "node count-only update remains allowed",
@@ -1247,7 +1273,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					PackDomain:          "rack",
 				}
 			}),
-			wantWebhookErrs: []string{"spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+			wantWebhookErrs: []string{`spec.topologyConstraint: Invalid value: {"clusterTopologyName":"grove-topology","packDomain":"rack"}: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints`},
 		},
 		{
 			name: "spec topology constraint change is immutable",
@@ -1263,7 +1289,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					PackDomain:          "zone",
 				}
 			}),
-			wantWebhookErrs: []string{"spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+			wantWebhookErrs: []string{`spec.topologyConstraint: Invalid value: {"clusterTopologyName":"grove-topology","packDomain":"zone"}: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints`},
 		},
 		{
 			name: "spec topology constraint removal is immutable",
@@ -1274,7 +1300,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				}
 			}),
 			deployment:      newBetaDGDForValidation(),
-			wantWebhookErrs: []string{"spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+			wantWebhookErrs: []string{"spec.topologyConstraint: Invalid value: null: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
 		},
 		{
 			name: "unchanged topology constraints are allowed",
@@ -1296,7 +1322,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
 				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+			wantWebhookErrs: []string{`spec.components[1].topologyConstraint: Invalid value: {"packDomain":"rack"}: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints`},
 		},
 		{
 			name: "component topology constraint change is immutable",
@@ -1308,7 +1334,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
 				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+			wantWebhookErrs: []string{`spec.components[1].topologyConstraint: Invalid value: {"packDomain":"zone"}: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints`},
 		},
 		{
 			name: "component topology constraint removal is immutable",
@@ -1319,7 +1345,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
 				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+			wantWebhookErrs: []string{"spec.components[1].topologyConstraint: Invalid value: null: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
 		},
 
 		// KV-transfer updates.
@@ -1330,7 +1356,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				LabelKey: "topology.kubernetes.io/zone",
 				Domain:   "zone",
 			}),
-			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy"},
+			wantWebhookErrs: []string{`spec.experimental.kvTransferPolicy: Invalid value: {"labelKey":"topology.kubernetes.io/zone","domain":"zone"}: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy`},
 		},
 		{
 			name: "unchanged kv transfer policy is allowed",
@@ -1351,7 +1377,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				Domain:   "zone",
 			}),
 			deployment:      newBetaDGDForValidation(),
-			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy"},
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy: Invalid value: null: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy"},
 		},
 
 		// GMS and failover updates.
@@ -1361,7 +1387,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
 				enableBetaInterPodGMS(worker)
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+			wantWebhookErrs: []string{`spec.components[1].experimental.gpuMemoryService.mode: Invalid value: "InterPod": the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment`},
 		},
 		{
 			name: "inter-pod GMS layout removal is immutable",
@@ -1369,7 +1395,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				enableBetaInterPodGMS(worker)
 			}),
 			deployment:      newBetaDGDForValidation(),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+			wantWebhookErrs: []string{"spec.components[1].experimental.gpuMemoryService.mode: Invalid value: null: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
 		},
 		{
 			name: "inter-pod failover toggle is immutable",
@@ -1380,7 +1406,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				enableBetaInterPodGMS(worker)
 				enableBetaInterPodFailover(worker, 1)
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+			wantWebhookErrs: []string{`spec.components[1].experimental.failover: Invalid value: {"mode":"InterPod","numShadows":1}: inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment`},
 		},
 		{
 			name: "inter-pod failover removal is immutable",
@@ -1388,8 +1414,11 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				enableBetaInterPodGMS(worker)
 				enableBetaInterPodFailover(worker, 1)
 			}),
-			deployment:      newBetaDGDForValidation(),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment", "spec.components[worker].experimental.failover: inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+			deployment: newBetaDGDForValidation(),
+			wantWebhookErrs: []string{
+				"spec.components[1].experimental.gpuMemoryService.mode: Invalid value: null: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+				"spec.components[1].experimental.failover: Invalid value: null: inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+			},
 		},
 		{
 			name: "inter-pod failover shadow count is immutable",
@@ -1399,7 +1428,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				enableAlphaInterPodGMSFailover(dgd.Spec.Services["worker"], 2)
 			}),
-			wantWebhookErrs: []string{"spec.components[worker].experimental.failover.numShadows is immutable for inter-pod GMS failover; delete and recreate the DynamoGraphDeployment to change it"},
+			wantWebhookErrs: []string{"spec.components[0].experimental.failover.numShadows: Invalid value: 2: is immutable for inter-pod GMS failover; delete and recreate the DynamoGraphDeployment to change it"},
 		},
 
 		// Scaling adapter updates.
@@ -1417,7 +1446,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				Username: "system:serviceaccount:default:regular-user",
 			},
 			operator:        dgdAdmissionOperator,
-			wantWebhookErrs: []string{"spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
+			wantWebhookErrs: []string{"spec.components[1].replicas: Forbidden: cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
 		},
 		{
 			name: "scaling adapter fails closed without user info",
@@ -1430,7 +1459,23 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				worker.Replicas = k8sptr.To(int32(3))
 			}),
 			operator:        dgdAdmissionOperator,
-			wantWebhookErrs: []string{"spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
+			wantWebhookErrs: []string{"spec.components[1].replicas: Forbidden: cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
+		},
+		{
+			name: "scaling adapter removal cannot bypass replica ownership",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(2))
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = nil
+				worker.Replicas = k8sptr.To(int32(3))
+			}),
+			userInfo: &authenticationv1.UserInfo{
+				Username: "system:serviceaccount:default:regular-user",
+			},
+			operator:        dgdAdmissionOperator,
+			wantWebhookErrs: []string{"spec.components[1].replicas: Forbidden: cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
 		},
 		{
 			name: "operator can change scaling-adapter-owned replicas",
@@ -1464,7 +1509,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
 				spec.Restart = &nvidiacomv1beta1.Restart{ID: "new"}
 			}),
-			wantWebhookErrs: []string{"spec.restart.id cannot be changed while a rolling update is InProgress"},
+			wantWebhookErrs: []string{"spec.restart.id: Invalid value: \"new\": cannot be changed while a rolling update is InProgress"},
 		},
 		{
 			name: "restart id can stay unchanged during active rolling update",
@@ -1512,7 +1557,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "worker", "worker")
 			}),
-			wantWebhookErrs: []string{"spec.restart.strategy.order must be unique"},
+			wantWebhookErrs: []string{`spec.restart.strategy.order: Invalid value: ["frontend","worker","worker"]: must be unique`},
 		},
 		{
 			name:          "unknown restart order component is rejected on update",
@@ -1520,7 +1565,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "ghost")
 			}),
-			wantWebhookErrs: []string{"spec.restart.strategy.order contains unknown component: ghost"},
+			wantWebhookErrs: []string{`spec.restart.strategy.order[1]: Unsupported value: "ghost": supported values: "frontend", "worker"`},
 		},
 		{
 			name:          "incomplete restart order is rejected on update",
@@ -1528,7 +1573,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "worker")
 			}),
-			wantWebhookErrs: []string{"spec.restart.strategy.order must have the same number of unique components as the deployment"},
+			wantWebhookErrs: []string{`spec.restart.strategy.order: Invalid value: ["worker"]: must have the same number of unique components as the deployment`},
 		},
 		{
 			name:          "empty sequential restart order is valid on update",
@@ -1557,7 +1602,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeParallel, "frontend", "worker")
 			}),
-			wantWebhookErrs: []string{"spec.restart.strategy.order cannot be specified when strategy is parallel"},
+			wantWebhookErrs: []string{"spec.restart.strategy.order: Forbidden: cannot be specified when strategy is parallel"},
 		},
 		{
 			name:          "v1beta1 backend framework update reaches the webhook and warns",
@@ -1565,7 +1610,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.BackendFramework = sglangBackendFramework
 			}),
-			wantWebhookErrs: []string{"spec.backendFramework is immutable and cannot be changed after creation"},
+			wantWebhookErrs: []string{"spec.backendFramework: Invalid value: \"sglang\": is immutable and cannot be changed after creation"},
 			wantWarnings:    []string{"Changing spec.backendFramework may cause unexpected behavior"},
 		},
 	}
@@ -1637,6 +1682,31 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				t.Fatalf("warnings = %v, want %v", warnings, tt.wantWarnings)
 			}
 		})
+	}
+}
+
+func TestDynamoGraphDeploymentConversionFailureIsFatal(t *testing.T) {
+	dgd := newBetaDGDForValidation()
+	dgd.Spec.Components = append(dgd.Spec.Components, dgd.Spec.Components[0])
+
+	validator := newDynamoGraphDeploymentTestValidator(t, true)
+	_, err := validator.Validate(context.Background(), dgd)
+	if err == nil || !strings.Contains(err.Error(), "failed to reconstruct compatibility view") {
+		t.Fatalf("Validate() error = %v, want fatal conversion error", err)
+	}
+	if k8serrors.IsInvalid(err) {
+		t.Fatalf("Validate() error = %v, want fatal conversion error rather than field validation error", err)
+	}
+}
+
+func assertFieldPaths(t *testing.T, errs field.ErrorList, want []string) {
+	t.Helper()
+	got := make([]string, len(errs))
+	for i := range errs {
+		got[i] = errs[i].Field
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("field paths = %v, want %v", got, want)
 	}
 }
 
@@ -1940,6 +2010,11 @@ func (m *fakeManager) GetConfig() *rest.Config              { return m.config }
 func (m *fakeManager) GetScheme() *runtime.Scheme           { return m.scheme }
 func (m *fakeManager) GetWebhookServer() ctrlwebhook.Server { return m.webhookServer }
 
+func newDynamoGraphDeploymentTestValidator(t *testing.T, groveEnabled bool) *DynamoGraphDeploymentValidator {
+	t.Helper()
+	return NewDynamoGraphDeploymentValidator(newGroveTopologyTestManager(t), groveEnabled)
+}
+
 func newGroveTopologyTestManager(t *testing.T, objects ...runtime.Object) ctrl.Manager {
 	t.Helper()
 
@@ -2020,11 +2095,7 @@ func assertBetaValidationErrors(t *testing.T, err error, wantErrs []string) {
 	}
 	statusErr, ok := err.(*k8serrors.StatusError)
 	if !ok || !k8serrors.IsInvalid(err) {
-		gotErrs := strings.Split(err.Error(), "\n")
-		if !slices.Equal(gotErrs, wantErrs) {
-			t.Fatalf("webhook errors = %v, want %v", gotErrs, wantErrs)
-		}
-		return
+		t.Fatalf("error = %T %v, want typed Kubernetes invalid error", err, err)
 	}
 	if statusErr.ErrStatus.Details == nil {
 		t.Fatalf("error = %v, want typed field causes", err)

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -18,8 +18,11 @@
 package validation
 
 import (
-	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -30,6 +33,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,26 +42,45 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	apixv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
 )
 
 const (
 	dgdAdmissionWorkerName      = "worker"
 	dgdAdmissionUpperWorkerName = "WORKER"
+	dgdAdmissionOperator        = "system:serviceaccount:dynamo-system:dynamo-operator"
 )
+
+const sglangBackendFramework = "sglang"
 
 func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 	requestValidators := requestValidatorsFromCRD(t, "nvidia.com_dynamographdeployments.yaml")
+	defaultManager := newGroveTopologyTestManager(t, newTestClusterTopology())
+	missingTopologyManager := newGroveTopologyTestManager(t)
+	inferencePoolManager := newInferencePoolTestManager(t)
+	longDGDName := "test-graph-" + strings.Repeat("x", 50)
+	boundaryComponentName := "w" + strings.Repeat("x", 36)
+	tooLongComponentName := boundaryComponentName + "x"
 
 	tests := []struct {
-		name           string
-		deployment     runtime.Object
-		oldDeployment  runtime.Object
-		mutateRequest  func(*testing.T, map[string]any)
-		groveEnabled   bool
-		wantSchemaErr  string
-		wantCELErr     string
-		wantWebhookErr string
+		name          string
+		deployment    runtime.Object
+		oldDeployment runtime.Object
+		mutateRequest func(*testing.T, map[string]any) // mutates the source-version request map
+		manager       ctrl.Manager                     // supplies webhook dependencies
+		groveDisabled bool                             // disables the configured Grove pathway
+		environment   map[string]string                // sets process environment for the case
+		userInfo      *authenticationv1.UserInfo       // supplies the admission request identity
+		operator      string                           // sets the configured operator principal
+
+		wantSchemaErr   string
+		wantCELErr      string
+		wantWebhookErrs []string
+		wantWarnings    []string
+		notWantErr      string
 	}{
+		// Baseline create-path rules.
 		{
 			name:       "valid deployment with components",
 			deployment: betaDGDForAdmission(nil),
@@ -67,7 +90,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.Components = nil
 			}),
-			wantWebhookErr: "spec.components must have at least one component",
+			wantWebhookErrs: []string{"spec.components must have at least one component"},
 		},
 		{
 			name: "component replicas must be non-negative",
@@ -77,11 +100,12 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantSchemaErr: "spec.components[1].replicas: Invalid value: -1: spec.components[1].replicas in body should be greater than or equal to 0",
 		},
 		{
-			name: "component minAvailable requires Grove",
+			name:          "component minAvailable requires Grove",
+			groveDisabled: true,
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
 			}),
-			wantWebhookErr: "spec.components[worker].minAvailable is currently supported only for Grove-backed DynamoGraphDeployment components",
+			wantWebhookErrs: []string{"spec.components[worker].minAvailable is currently supported only for Grove-backed DynamoGraphDeployment components"},
 		},
 		{
 			name: "restart on create is rejected by CEL before webhook validation",
@@ -101,24 +125,23 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				betaWorkerComponent(dgd).TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
 			}),
-			wantWebhookErr: "spec.topologyConstraint with clusterTopologyName is required when any topology constraint is set",
+			wantWebhookErrs: []string{"spec.topologyConstraint with clusterTopologyName is required when any topology constraint is set (at spec or component level)"},
 		},
 		{
-			name:         "inter-pod GMS requires Grove",
-			groveEnabled: false,
+			name:          "inter-pod GMS requires Grove",
+			groveDisabled: true,
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				enableBetaInterPodGMS(betaWorkerComponent(dgd))
 			}),
-			wantWebhookErr: `spec.components[worker]: experimental.gpuMemoryService.mode="InterPod" requires the Grove pathway`,
+			wantWebhookErrs: []string{"spec.components[worker]: experimental.gpuMemoryService.mode=\"InterPod\" requires the Grove pathway, but Grove is disabled in the operator configuration"},
 		},
 		{
-			name:         "inter-pod GMS requires vLLM backend",
-			groveEnabled: true,
+			name: "inter-pod GMS requires vLLM backend",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.BackendFramework = "sglang"
 				enableBetaInterPodGMS(betaWorkerComponent(dgd))
 			}),
-			wantWebhookErr: `spec.components[worker]: the inter-pod GMS layout (experimental.gpuMemoryService.mode="InterPod") is currently supported only for vLLM`,
+			wantWebhookErrs: []string{"spec.components[worker]: the inter-pod GMS layout (experimental.gpuMemoryService.mode=\"InterPod\") is currently supported only for vLLM (detected: sglang); set spec.backendFramework=\"vllm\""},
 		},
 		{
 			name: "KV transfer policy selector is rejected by CEL before webhook validation",
@@ -140,7 +163,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Mode: nvidiacomv1beta1.GMSModeIntraPod,
 				}
 			}),
-			wantWebhookErr: `failover requires per-container K8s discovery; set annotation "nvidia.com/dynamo-kube-discovery-mode" to "container"`,
+			wantWebhookErrs: []string{"failover requires per-container K8s discovery; set annotation \"nvidia.com/dynamo-kube-discovery-mode\" to \"container\" on the DynamoGraphDeployment"},
 		},
 		{
 			name: "checkpoint job with checkpointRef is rejected by CEL before webhook validation",
@@ -166,10 +189,10 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantWebhookErr: "spec.components[worker].experimental.gpuMemoryService: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1",
+			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1"},
 		},
 
-		// Pair every validation rule changed by this PR across both served source versions.
+		// Cross-version schema and conversion boundaries.
 		{
 			name: "v1beta1 component name is required by the schema",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
@@ -313,7 +336,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid",
 				}
 			}),
-			wantWebhookErr: `spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value "invalid": must be "mp" or "ray"`,
+			wantWebhookErrs: []string{"spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value \"invalid\": must be \"mp\" or \"ray\""},
 		},
 		{
 			name: "v1beta1 frontend sidecar must reference an existing container",
@@ -324,7 +347,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Containers: []corev1.Container{{Name: consts.MainContainerName}},
 				}}
 			}),
-			wantWebhookErr: `spec.components[worker].frontendSidecar "missing" does not match any podTemplate.spec.containers name`,
+			wantWebhookErrs: []string{"spec.components[worker].frontendSidecar \"missing\" does not match any podTemplate.spec.containers name"},
 		},
 		{
 			name:       "valid v1alpha1 deployment reaches the webhook",
@@ -354,10 +377,1204 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				betaWorkerComponent(dgd).PodTemplate = podTemplate
 			}),
 		},
+
+		// Replica availability rules.
+		{
+			name: "v1beta1 replicas below minAvailable are rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.Replicas = k8sptr.To(int32(1))
+				worker.MinAvailable = k8sptr.To(int32(2))
+			}),
+			wantCELErr: "spec.components[1]: Invalid value: minAvailable must be less than or equal to replicas unless replicas is 0",
+		},
+		{
+			name: "v1beta1 valid replicas and minAvailable reach the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.Replicas = k8sptr.To(int32(2))
+				worker.MinAvailable = k8sptr.To(int32(1))
+			}),
+		},
+		{
+			name: "v1beta1 unchanged minAvailable update reaches the webhook",
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
+			}),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
+			}),
+		},
+		{
+			name: "v1beta1 changed minAvailable update is rejected by CEL",
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
+			}),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(2))
+			}),
+			wantCELErr: "spec.components[1]: Invalid value: minAvailable is immutable after creation",
+		},
+		{
+			name: "v1beta1 removed minAvailable update is rejected by CEL",
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
+			}),
+			deployment: betaDGDForAdmission(nil),
+			wantCELErr: "spec.components[1]: Invalid value: minAvailable is immutable after creation",
+		},
+
+		// Checkpoint rules.
+		{
+			name: "v1beta1 valid checkpoint configuration reaches the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Checkpoint: &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true},
+				}
+			}),
+		},
+
+		// KV-transfer CEL rules.
+		{
+			name: "v1beta1 conflicting KV-transfer selectors are rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:            "topology.kubernetes.io/zone",
+						ClusterTopologyName: "grove-topology",
+						Domain:              "zone",
+					},
+				}
+			}),
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: exactly one of labelKey or clusterTopologyName is required",
+		},
+		{
+			name: "v1beta1 label-key KV-transfer policy reaches the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey: "topology.kubernetes.io/zone",
+						Domain:   "zone",
+					},
+				}
+			}),
+		},
+		{
+			name: "v1beta1 preferred KV-transfer enforcement without weight is rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:    "topology.kubernetes.io/zone",
+						Domain:      "zone",
+						Enforcement: nvidiacomv1beta1.KvTransferEnforcementPreferred,
+					},
+				}
+			}),
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: preferredWeight is required when enforcement is preferred",
+		},
+		{
+			name: "v1beta1 required KV-transfer enforcement with weight is rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:        "topology.kubernetes.io/zone",
+						Domain:          "zone",
+						Enforcement:     nvidiacomv1beta1.KvTransferEnforcementRequired,
+						PreferredWeight: k8sptr.To(float32(1)),
+					},
+				}
+			}),
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: preferredWeight may only be set when enforcement is preferred",
+		},
+		{
+			name: "v1beta1 valid preferred KV-transfer enforcement reaches the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:        "topology.kubernetes.io/zone",
+						Domain:          "zone",
+						Enforcement:     nvidiacomv1beta1.KvTransferEnforcementPreferred,
+						PreferredWeight: k8sptr.To(float32(1)),
+					},
+				}
+			}),
+		},
+		{
+			name: "KV-transfer label key format is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{LabelKey: "bad prefix/zone", Domain: "zone"},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.labelKey: Invalid value: "bad prefix/zone": spec.experimental.kvTransferPolicy.labelKey in body should match '^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)*/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'`,
+		},
+		{
+			name: "KV-transfer label key name segment is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{LabelKey: "topology.kubernetes.io/-zone", Domain: "zone"},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.labelKey: Invalid value: "topology.kubernetes.io/-zone": spec.experimental.kvTransferPolicy.labelKey in body should match '^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)*/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'`,
+		},
+		{
+			name: "KV-transfer cluster topology name must be a DNS-1123 subdomain",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "Bad_Name", Domain: "zone"},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.clusterTopologyName \"Bad_Name\" is not a valid Kubernetes resource name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"},
+		},
+		{
+			name: "KV-transfer cluster topology name requires Grove pathway",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationEnableGrove: consts.KubeLabelValueFalse}
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "grove-topology", Domain: "zone"},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.clusterTopologyName requires the Grove pathway; remove or unset the \"nvidia.com/enable-grove\" annotation (currently \"false\")"},
+		},
+		{
+			name: "KV-transfer domain is required by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{LabelKey: "topology.kubernetes.io/zone"},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.domain: Invalid value: "": spec.experimental.kvTransferPolicy.domain in body should match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'`,
+		},
+		{
+			name: "KV-transfer domain format is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{LabelKey: "topology.kubernetes.io/zone", Domain: "Zone"},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.domain: Invalid value: "Zone": spec.experimental.kvTransferPolicy.domain in body should match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'`,
+		},
+		{
+			name: "KV-transfer enforcement enum is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey: "topology.kubernetes.io/zone", Domain: "zone", Enforcement: "sometimes",
+					},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.enforcement: Unsupported value: "sometimes": supported values: "required", "preferred"`,
+		},
+		{
+			name: "KV-transfer preferred weight range is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:        "topology.kubernetes.io/zone",
+						Domain:          "zone",
+						Enforcement:     nvidiacomv1beta1.KvTransferEnforcementPreferred,
+						PreferredWeight: k8sptr.To(float32(1.2)),
+					},
+				}
+			}),
+			wantSchemaErr: "spec.experimental.kvTransferPolicy.preferredWeight: Invalid value: 1.2: spec.experimental.kvTransferPolicy.preferredWeight in body should be less than or equal to 1",
+		},
+		{
+			name: "KV-transfer cluster topology policy is valid",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "grove-topology", Domain: "rack"},
+				}
+			}),
+		},
+		{
+			name:    "KV-transfer cluster topology policy rejects missing topology",
+			manager: missingTopologyManager,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "missing-topology", Domain: "rack"},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.clusterTopologyName \"missing-topology\" references a ClusterTopology resource that was not found"},
+		},
+		{
+			name: "KV-transfer cluster topology policy rejects missing domain",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "grove-topology", Domain: "host"},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.domain \"host\" does not exist in ClusterTopology \"grove-topology\"; available domains: [rack zone]"},
+		},
+
+		// GMS and failover rules.
+		{
+			name: "v1beta1 inter-pod GMS client containers are rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaInterPodGMS(worker)
+				worker.Experimental.GPUMemoryService.ExtraClientContainers = []string{"metrics"}
+			}),
+			wantCELErr: "spec.components[1].experimental.gpuMemoryService: Invalid value: extraClientContainers is only supported with mode=IntraPod",
+		},
+		{
+			name: "v1beta1 non-empty GMS extra client pods are rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaInterPodGMS(worker)
+				worker.Experimental.GPUMemoryService.ExtraClientPods = []nvidiacomv1beta1.GMSClientPodSpec{{Name: "client"}}
+			}),
+			wantCELErr: "spec.components[1].experimental.gpuMemoryService: Invalid value: extraClientPods is reserved for inter-pod GMS and is not implemented yet",
+		},
+		{
+			name: "v1beta1 valid GMS configuration reaches the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaIntraPodGMS(betaWorkerComponent(dgd))
+			}),
+		},
+		{
+			name: "GMS rejects frontend component",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaIntraPodGMS(&dgd.Spec.Components[0])
+			}),
+			wantWebhookErrs: []string{"spec.components[frontend].experimental.gpuMemoryService: GPU memory service is only supported for worker components (type must be worker, prefill, or decode)"},
+		},
+		{
+			name: "GMS client container names are validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.GPUMemoryService.ExtraClientContainers = []string{"Bad_Name"}
+			}),
+			wantSchemaErr: `spec.components[1].experimental.gpuMemoryService.extraClientContainers[0]: Invalid value: "Bad_Name": spec.components[1].experimental.gpuMemoryService.extraClientContainers[0] in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'`,
+		},
+		{
+			name: "intra-pod failover requires GMS",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaContainerDiscovery(dgd)
+				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeIntraPod},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: intraPod failover requires gpuMemoryService to be set"},
+		},
+		{
+			name: "failover mode must match GMS mode",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
+					Mode:       nvidiacomv1beta1.GMSModeInterPod,
+					NumShadows: 1,
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode=\"InterPod\" (got \"IntraPod\")"},
+		},
+		{
+			name: "intra-pod failover shadow maximum is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaContainerDiscovery(dgd)
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
+					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
+					NumShadows: 2,
+				}
+			}),
+			wantSchemaErr: "spec.components[1].experimental.failover.numShadows: Invalid value: 2: spec.components[1].experimental.failover.numShadows in body should be less than or equal to 1",
+		},
+		{
+			name: "inter-pod failover requires GMS",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeInterPod, NumShadows: 1},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode=\"InterPod\"", "spec.components[worker]: GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu"},
+		},
+		{
+			name: "inter-pod failover shadow-count minimum is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaInterPodGMS(worker)
+				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeInterPod, NumShadows: -1}
+			}),
+			wantSchemaErr: "spec.components[1].experimental.failover.numShadows: Invalid value: -1: spec.components[1].experimental.failover.numShadows in body should be greater than or equal to 1",
+		},
+		{
+			name: "inter-pod failover rejects frontend component",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Components[0].Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeInterPod, NumShadows: 1},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[frontend].experimental.failover: interPod failover requires gpuMemoryService.mode=\"InterPod\"", "spec.components[frontend]: GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu", "spec.components[frontend]: GMS failover is not supported for type \"frontend\""},
+		},
+		{
+			name:        "GMS snapshot combination requires env gate",
+			environment: map[string]string{consts.DynamoOperatorAllowGMSSnapshotEnvVar: ""},
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.checkpoint: GMS + Snapshot is temporarily disabled; disable gpuMemoryService or enable the internal GMS + Snapshot gate"},
+		},
+
+		// Source-version compatibility rules.
+		{
+			name: "alpha PVC empty name requirement is preserved structurally",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{
+					Name:   k8sptr.To(""),
+					Create: k8sptr.To(false),
+				}}
+			}),
+			wantWebhookErrs: []string{"spec.pvcs[0].name is required"},
+		},
+		{
+			name: "alpha ingress requires host",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				className := "nginx"
+				dgd.Spec.Services["frontend"] = &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: consts.ComponentTypeFrontend,
+					Ingress: &nvidiacomv1alpha1.IngressSpec{
+						Enabled:                    true,
+						IngressControllerClassName: &className,
+					},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.services[frontend].ingress.host is required when ingress is enabled"},
+		},
+		{
+			name: "alpha volume mounts require mount point unless used as compilation cache",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].VolumeMounts = []nvidiacomv1alpha1.VolumeMount{{Name: "cache"}}
+			}),
+			wantWebhookErrs: []string{"spec.services[worker].volumeMounts[0].mountPoint is required when useAsCompilationCache is false"},
+		},
+		{
+			name:    "alpha EPP config sources are mutually exclusive",
+			manager: inferencePoolManager,
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				worker := dgd.Spec.Services["worker"]
+				worker.ComponentType = consts.ComponentTypeEPP
+				worker.EPPConfig = &nvidiacomv1alpha1.EPPConfig{
+					ConfigMapRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "epp"}},
+					Config: &apixv1alpha1.EndpointPickerConfig{
+						Plugins:            []apixv1alpha1.PluginSpec{},
+						SchedulingProfiles: []apixv1alpha1.SchedulingProfile{},
+					},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].eppConfig: configMapRef and config are mutually exclusive, only one can be specified"},
+		},
+		{
+			name: "alpha intra-pod failover shadow maximum is preserved structurally",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].Failover = &nvidiacomv1alpha1.FailoverSpec{
+					Enabled:    true,
+					Mode:       nvidiacomv1alpha1.GMSModeIntraPod,
+					NumShadows: 2,
+				}
+			}),
+			wantWebhookErrs: []string{"failover requires per-container K8s discovery; set annotation \"nvidia.com/dynamo-kube-discovery-mode\" to \"container\" on the DynamoGraphDeployment", "spec.components[worker].experimental.failover: intraPod failover requires gpuMemoryService to be set", "spec.components[worker].experimental.failover.numShadows=2 is invalid for mode=\"IntraPod\": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode=\"InterPod\" to configure numShadows"},
+		},
+		{
+			name: "alpha frontend sidecar rejects generated container name conflict",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["frontend"] = &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: consts.ComponentTypeFrontend,
+					FrontendSidecar: &nvidiacomv1alpha1.FrontendSidecarSpec{
+						Image: "custom/frontend:latest",
+					},
+					ExtraPodSpec: &nvidiacomv1alpha1.ExtraPodSpec{PodSpec: &corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  consts.FrontendSidecarContainerName,
+							Image: "custom/frontend:latest",
+						}},
+					}},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.services[frontend]: cannot inject frontend sidecar: a container named \"sidecar-frontend\" already exists in extraPodSpec.containers"},
+		},
+		{
+			name: "alpha GMS client container names are validated by the source schema",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled:               false,
+					ExtraClientContainers: []string{"Bad_Name"},
+				}
+			}),
+			wantSchemaErr: `spec.services.worker.gpuMemoryService.extraClientContainers[0]: Invalid value: "Bad_Name": spec.services.worker.gpuMemoryService.extraClientContainers[0] in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'`,
+		},
+		{
+			name: "nil alpha service entry is rejected",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["ghost"] = nil
+			}),
+			wantSchemaErr: `spec.services.ghost: Invalid value: "null": spec.services.ghost in body must be of type object: "null"`,
+		},
+		{
+			name: "valid preserved alpha-only fields are accepted",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				host := "worker.example.com"
+				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{Name: k8sptr.To("cache"), Create: k8sptr.To(false)}}
+				service := dgd.Spec.Services["worker"]
+				service.Ingress = &nvidiacomv1alpha1.IngressSpec{Enabled: true, Host: host}
+				service.Annotations = map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "ray"}
+				service.VolumeMounts = []nvidiacomv1alpha1.VolumeMount{{Name: "cache", UseAsCompilationCache: true}}
+				service.SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{Disabled: true}
+				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled:               false,
+					Mode:                  nvidiacomv1alpha1.GMSModeIntraPod,
+					ExtraClientContainers: []string{"metrics"},
+				}
+			}),
+		},
+		{
+			name: "alpha PVC name requirement is preserved structurally",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{}}
+			}),
+			wantSchemaErr: "spec.pvcs[0].name: Required value",
+		},
+		{
+			name: "alpha PVC create value constraints are preserved structurally",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{Name: k8sptr.To("cache"), Create: k8sptr.To(true)}}
+			}),
+			wantCELErr: "spec.pvcs[0]: Invalid value: When create is true, size, storageClass, and volumeAccessMode are required",
+		},
+		{
+			name: "alpha compatibility warnings are preserved",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				legacyNamespace := "legacy-namespace"
+				service := dgd.Spec.Services["worker"]
+				service.DynamoNamespace = &legacyNamespace
+				//nolint:staticcheck // SA1019: Intentionally testing deprecated field warnings.
+				service.Autoscaling = &nvidiacomv1alpha1.Autoscaling{Enabled: true}
+			}),
+			wantWarnings: []string{
+				"spec.services[worker].dynamoNamespace is deprecated and ignored. Value 'legacy-namespace' will be replaced with 'default-test-graph'. Remove this field from your configuration",
+				"spec.services[worker].autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md",
+			},
+		},
+		{
+			name: "GMS accepts GPU from alpha dedicated resources",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				service := dgd.Spec.Services["worker"]
+				service.Resources = &nvidiacomv1alpha1.Resources{Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"}}
+				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true, Mode: nvidiacomv1alpha1.GMSModeIntraPod}
+			}),
+		},
+		{
+			name: "GMS accepts GPU from alpha extraPodSpec main container resources",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				service := dgd.Spec.Services["worker"]
+				service.ExtraPodSpec = &nvidiacomv1alpha1.ExtraPodSpec{MainContainer: &corev1.Container{
+					Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+						corev1.ResourceName(consts.KubeResourceGPUNvidia): resource.MustParse("1"),
+					}},
+				}}
+				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true, Mode: nvidiacomv1alpha1.GMSModeIntraPod}
+			}),
+		},
+		{
+			name: "GMS accepts alpha GPUType resource after conversion",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				service := dgd.Spec.Services["worker"]
+				service.Resources = &nvidiacomv1alpha1.Resources{
+					Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1", GPUType: "example.com/gpu"},
+				}
+				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true, Mode: nvidiacomv1alpha1.GMSModeIntraPod}
+			}),
+		},
+		{
+			name: "v1alpha1 enabled shared memory without a positive size is rejected by source CEL",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{}
+			}),
+			wantCELErr: "spec.services[worker].sharedMemory: Invalid value: size is required when disabled is false",
+		},
+		{
+			name: "v1alpha1 valid shared memory reaches the webhook",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{
+					Size: resource.MustParse("1Gi"),
+				}
+			}),
+		},
+		{
+			name:    "v1alpha1 EPP config without a source reaches the webhook without v1beta1 CEL",
+			manager: inferencePoolManager,
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				worker := dgd.Spec.Services["worker"]
+				worker.ComponentType = consts.ComponentTypeEPP
+				worker.EPPConfig = &nvidiacomv1alpha1.EPPConfig{}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].eppConfig: either configMapRef or config must be specified (no default configuration provided)"},
+		},
+		{
+			name: "v1beta1 EPP config without a source is rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
+				worker.EPPConfig = &nvidiacomv1beta1.EPPConfig{}
+			}),
+			wantCELErr: "spec.components[1].eppConfig: Invalid value: exactly one of configMapRef or config must be specified",
+		},
+		{
+			name: "v1beta1 EPP config with both sources is rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
+				worker.EPPConfig = &nvidiacomv1beta1.EPPConfig{
+					ConfigMapRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "epp"}},
+					Config: &apixv1alpha1.EndpointPickerConfig{
+						Plugins:            []apixv1alpha1.PluginSpec{},
+						SchedulingProfiles: []apixv1alpha1.SchedulingProfile{},
+					},
+				}
+			}),
+			wantCELErr: "spec.components[1].eppConfig: Invalid value: exactly one of configMapRef or config must be specified",
+		},
+		{
+			name:    "v1beta1 valid EPP config reaches the webhook",
+			manager: inferencePoolManager,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
+				worker.Replicas = k8sptr.To(int32(1))
+				worker.EPPConfig = &nvidiacomv1beta1.EPPConfig{
+					ConfigMapRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "epp"}},
+				}
+			}),
+		},
+
+		// Structural root and scheduling rules.
+		{
+			name:          "priority class requires Grove",
+			groveDisabled: true,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.PriorityClassName = "high-priority"
+			}),
+			wantWebhookErrs: []string{"spec.priorityClassName requires the Grove pathway, but Grove is disabled in the operator configuration"},
+		},
+		{
+			name: "priority class is allowed with Grove",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.PriorityClassName = "high-priority"
+			}),
+		},
+		{
+			name: "minAvailable must be positive",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(0))
+			}),
+			wantSchemaErr: "spec.components[1].minAvailable: Invalid value: 0: spec.components[1].minAvailable in body should be greater than or equal to 1",
+		},
+		{
+			name: "replicas zero can keep minAvailable for scale-up intent",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.Replicas = k8sptr.To(int32(0))
+				worker.MinAvailable = k8sptr.To(int32(2))
+			}),
+		},
+		{
+			name: "rendered Grove resource name length accepts boundary",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Name = longDGDName
+				betaWorkerComponent(dgd).ComponentName = boundaryComponentName
+			}),
+		},
+		{
+			name: "rendered Grove resource name length rejects overflow",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Name = longDGDName
+				betaWorkerComponent(dgd).ComponentName = tooLongComponentName
+			}),
+			wantWebhookErrs: []string{"spec.components[wxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]: combined resource name length 46 exceeds 45-character limit required for pod naming. Consider shortening the DynamoGraphDeployment name 'test-graph-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' (length 61) or component name 'wxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' (length 38). The combined length of PCS name + component name must not exceed 45 characters. The PCS name 'tes-cafb' was auto-truncated from DGD name 'test-graph-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"},
+		},
+		{
+			name:          "rendered Grove resource name length is skipped outside Grove",
+			groveDisabled: true,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Name = longDGDName
+				betaWorkerComponent(dgd).ComponentName = tooLongComponentName
+			}),
+		},
+
+		// Topology rules.
+		{
+			name: "spec pack domain format is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Generation = 2
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "Bad_Domain",
+				}
+			}),
+			wantSchemaErr: `spec.topologyConstraint.packDomain: Invalid value: "Bad_Domain": spec.topologyConstraint.packDomain in body should match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'`,
+		},
+		{
+			name: "component topology pack domain is required by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Generation = 2
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
+				dgd.Spec.Components[0].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			wantSchemaErr: `spec.components[0].topologyConstraint.packDomain: Invalid value: "": spec.components[0].topologyConstraint.packDomain in body should match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'`,
+		},
+		{
+			name: "deployment topology without pack domain requires every component topology",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Generation = 2
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			wantWebhookErrs: []string{"spec.components[frontend].topologyConstraint is required because spec.topologyConstraint.packDomain is not set; either set a spec-level packDomain or provide a topologyConstraint for every component"},
+		},
+		{
+			name: "deployment pack domain can be inherited",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+			}),
+		},
+		{
+			name: "deployment pack domain can be mixed with narrower component topology",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "zone",
+				}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+		},
+		{
+			name: "component topology with deployment topology is valid",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
+				dgd.Spec.Components[0].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+		},
+		{
+			name:    "missing cluster topology is rejected",
+			manager: missingTopologyManager,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "missing-topology",
+					PackDomain:          "rack",
+				}
+			}),
+			wantWebhookErrs: []string{"topology-aware scheduling requires a ClusterTopology resource \"missing-topology\" but it was not found; ensure the cluster topology is configured per the framework documentation"},
+		},
+		{
+			name:    "independent topology errors aggregate",
+			manager: missingTopologyManager,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "missing-topology"}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			wantWebhookErrs: []string{"spec.components[frontend].topologyConstraint is required because spec.topologyConstraint.packDomain is not set; either set a spec-level packDomain or provide a topologyConstraint for every component"},
+		},
+		{
+			name: "pack domain must exist in cluster topology",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "host",
+				}
+			}),
+			wantWebhookErrs: []string{"spec.topologyConstraint.packDomain: domain \"host\" does not exist in ClusterTopology \"grove-topology\"; available domains: [rack zone]"},
+		},
+		{
+			name: "component topology cannot be broader than spec topology",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker]: topologyConstraint.packDomain \"zone\" is broader than spec-level \"rack\"; component constraints must be equal to or narrower than the deployment-level constraint"},
+		},
+
+		// Metadata annotation rules.
+		{
+			name: "origin version accepts semver",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoOperatorOriginVersion: "1.2.3"}
+			}),
+		},
+		{
+			name: "origin version rejects non-semver",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoOperatorOriginVersion: "not-semver"}
+			}),
+			wantWebhookErrs: []string{"annotation nvidia.com/dynamo-operator-origin-version has invalid value \"not-semver\": must be valid semver"},
+		},
+		{
+			name: "vLLM backend annotation accepts mp",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "mp"}
+			}),
+		},
+		{
+			name: "vLLM backend annotation accepts ray case-insensitively",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "RAY"}
+			}),
+		},
+		{
+			name: "vLLM backend annotation rejects unknown value",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "typo"}
+			}),
+			wantWebhookErrs: []string{"annotation nvidia.com/vllm-distributed-executor-backend has invalid value \"typo\": must be \"mp\" or \"ray\""},
+		},
+		{
+			name: "discovery mode accepts pod",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "pod"}
+			}),
+		},
+		{
+			name: "discovery mode accepts container",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "container"}
+			}),
+		},
+		{
+			name: "discovery mode rejects unknown value",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "endpoint"}
+			}),
+			wantWebhookErrs: []string{"annotation nvidia.com/dynamo-kube-discovery-mode has invalid value \"endpoint\": must be \"pod\" or \"container\""},
+		},
+		{
+			name: "independent root errors aggregate with exact field paths",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Components = nil
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationDynamoOperatorOriginVersion:    "not-semver",
+					consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid",
+					consts.KubeAnnotationDynamoKubeDiscoveryMode:        "invalid",
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components must have at least one component", "annotation nvidia.com/dynamo-operator-origin-version has invalid value \"not-semver\": must be valid semver", "annotation nvidia.com/vllm-distributed-executor-backend has invalid value \"invalid\": must be \"mp\" or \"ray\"", "annotation nvidia.com/dynamo-kube-discovery-mode has invalid value \"invalid\": must be \"pod\" or \"container\""},
+		},
+
+		// Component-set updates.
+		{
+			name:          "component topology is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Components = append(spec.Components, nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+					ComponentName: "extra",
+					Replicas:      k8sptr.To(int32(1)),
+					PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Name: consts.MainContainerName,
+						Env:  []corev1.EnvVar{{Name: "TOKEN", Value: "do-not-leak-this-value"}},
+					}}}},
+				})
+			}),
+			wantWebhookErrs: []string{"component topology is immutable and cannot be modified after creation: components added: [extra]"},
+			notWantErr:      "do-not-leak-this-value",
+		},
+		{
+			name:          "component removal is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Components = spec.Components[:1]
+			}),
+			wantWebhookErrs: []string{"component topology is immutable and cannot be modified after creation: components removed: [worker]"},
+		},
+		{
+			name:          "component add and remove reports both sides",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Components = []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+					spec.Components[1],
+					{
+						ComponentName: "extra",
+						Replicas:      k8sptr.To(int32(1)),
+					},
+				}
+			}),
+			wantWebhookErrs: []string{"component topology is immutable and cannot be modified after creation: components added: [extra], components removed: [frontend]"},
+		},
+		{
+			name:          "component reorder is allowed",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Components[0], spec.Components[1] = spec.Components[1], spec.Components[0]
+			}),
+		},
+
+		// Multinode updates.
+		{
+			name:          "single-node to multinode transition is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker] cannot change node topology (between single-node and multi-node) after creation"},
+		},
+		{
+			name: "node count-only update remains allowed",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 3}
+			}),
+		},
+
+		// Topology updates.
+		{
+			name:          "spec topology constraint is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+			}),
+			wantWebhookErrs: []string{"spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "spec topology constraint change is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "zone",
+				}
+			}),
+			wantWebhookErrs: []string{"spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "spec topology constraint removal is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+			}),
+			deployment:      newBetaDGDForValidation(),
+			wantWebhookErrs: []string{"spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "unchanged topology constraints are allowed",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+		},
+		{
+			name: "component topology constraint is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "component topology constraint change is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "component topology constraint removal is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+
+		// KV-transfer updates.
+		{
+			name:          "kv transfer policy is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
+				LabelKey: "topology.kubernetes.io/zone",
+				Domain:   "zone",
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy"},
+		},
+		{
+			name: "unchanged kv transfer policy is allowed",
+			oldDeployment: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
+				LabelKey: "topology.kubernetes.io/zone",
+				Domain:   "zone",
+			}),
+			deployment: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
+				LabelKey:    "topology.kubernetes.io/zone",
+				Domain:      "zone",
+				Enforcement: nvidiacomv1beta1.KvTransferEnforcementRequired,
+			}),
+		},
+		{
+			name: "kv transfer policy removal is immutable",
+			oldDeployment: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
+				LabelKey: "topology.kubernetes.io/zone",
+				Domain:   "zone",
+			}),
+			deployment:      newBetaDGDForValidation(),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy"},
+		},
+
+		// GMS and failover updates.
+		{
+			name:          "inter-pod GMS layout is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+		},
+		{
+			name: "inter-pod GMS layout removal is immutable",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+			}),
+			deployment:      newBetaDGDForValidation(),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+		},
+		{
+			name: "inter-pod failover toggle is immutable",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+				enableBetaInterPodFailover(worker, 1)
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+		},
+		{
+			name: "inter-pod failover removal is immutable",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+				enableBetaInterPodFailover(worker, 1)
+			}),
+			deployment:      newBetaDGDForValidation(),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment", "spec.components[worker].experimental.failover: inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+		},
+		{
+			name: "inter-pod failover shadow count is immutable",
+			oldDeployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				enableAlphaInterPodGMSFailover(dgd.Spec.Services["worker"], 1)
+			}),
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				enableAlphaInterPodGMSFailover(dgd.Spec.Services["worker"], 2)
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover.numShadows is immutable for inter-pod GMS failover; delete and recreate the DynamoGraphDeployment to change it"},
+		},
+
+		// Scaling adapter updates.
+		{
+			name: "scaling adapter blocks direct replica changes",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(2))
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(3))
+			}),
+			userInfo: &authenticationv1.UserInfo{
+				Username: "system:serviceaccount:default:regular-user",
+			},
+			operator:        dgdAdmissionOperator,
+			wantWebhookErrs: []string{"spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
+		},
+		{
+			name: "scaling adapter fails closed without user info",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(2))
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(3))
+			}),
+			operator:        dgdAdmissionOperator,
+			wantWebhookErrs: []string{"spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
+		},
+		{
+			name: "operator can change scaling-adapter-owned replicas",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(2))
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(3))
+			}),
+			userInfo: &authenticationv1.UserInfo{
+				Username: dgdAdmissionOperator,
+			},
+			operator: dgdAdmissionOperator,
+		},
+
+		// Backend and restart updates.
+		{
+			name: "restart id cannot change during active rolling update",
+			oldDeployment: betaDGDWithStatus(
+				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+					spec.Restart = &nvidiacomv1beta1.Restart{ID: "old"}
+				},
+				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
+					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
+						Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
+					}
+				},
+			),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Restart = &nvidiacomv1beta1.Restart{ID: "new"}
+			}),
+			wantWebhookErrs: []string{"spec.restart.id cannot be changed while a rolling update is InProgress"},
+		},
+		{
+			name: "restart id can stay unchanged during active rolling update",
+			oldDeployment: betaDGDWithStatus(
+				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+					spec.Restart = &nvidiacomv1beta1.Restart{ID: "same"}
+				},
+				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
+					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
+						Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
+					}
+				},
+			),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Restart = &nvidiacomv1beta1.Restart{ID: "same"}
+			}),
+		},
+		{
+			name: "restart id can change after completed rolling update",
+			oldDeployment: betaDGDWithStatus(
+				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+					spec.Restart = &nvidiacomv1beta1.Restart{ID: "old"}
+				},
+				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
+					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
+						Phase: nvidiacomv1beta1.RollingUpdatePhaseCompleted,
+					}
+				},
+			),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Restart = &nvidiacomv1beta1.Restart{ID: "new"}
+			}),
+		},
+		{
+			name:          "restart id is required on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = &nvidiacomv1beta1.Restart{}
+			}),
+			wantSchemaErr: `spec.restart.id: Invalid value: "": spec.restart.id in body should be at least 1 chars long`,
+		},
+		{
+			name:          "duplicate restart order is rejected on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "worker", "worker")
+			}),
+			wantWebhookErrs: []string{"spec.restart.strategy.order must be unique"},
+		},
+		{
+			name:          "unknown restart order component is rejected on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "ghost")
+			}),
+			wantWebhookErrs: []string{"spec.restart.strategy.order contains unknown component: ghost"},
+		},
+		{
+			name:          "incomplete restart order is rejected on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "worker")
+			}),
+			wantWebhookErrs: []string{"spec.restart.strategy.order must have the same number of unique components as the deployment"},
+		},
+		{
+			name:          "empty sequential restart order is valid on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential)
+			}),
+		},
+		{
+			name:          "complete sequential restart order is valid on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "worker")
+			}),
+		},
+		{
+			name:          "parallel restart without order is valid on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeParallel)
+			}),
+		},
+		{
+			name:          "parallel restart rejects order on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeParallel, "frontend", "worker")
+			}),
+			wantWebhookErrs: []string{"spec.restart.strategy.order cannot be specified when strategy is parallel"},
+		},
+		{
+			name:          "v1beta1 backend framework update reaches the webhook and warns",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.BackendFramework = sglangBackendFramework
+			}),
+			wantWebhookErrs: []string{"spec.backendFramework is immutable and cannot be changed after creation"},
+			wantWarnings:    []string{"Changing spec.backendFramework may cause unexpected behavior"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			for name, value := range tt.environment {
+				t.Setenv(name, value)
+			}
 			current := admissionUnstructured(t, tt.deployment)
 			if tt.mutateRequest != nil {
 				tt.mutateRequest(t, current)
@@ -392,1283 +1609,32 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 
 			oldBeta := dgdAdmissionBeta(t, tt.oldDeployment)
 			currentBeta := dgdAdmissionBeta(t, tt.deployment)
-			handler := NewDynamoGraphDeploymentHandler(nil, "", tt.groveEnabled)
-			ctx := dgdAdmissionContext(dgdAdmissionOperation(tt.oldDeployment), nvidiacomv1beta1.DynamoGraphDeploymentGVK)
+			manager := tt.manager
+			if manager == nil {
+				manager = defaultManager
+			}
+			handler := NewDynamoGraphDeploymentHandler(manager, tt.operator, !tt.groveDisabled)
+			ctx := dgdAdmissionContextWithUserInfo(
+				dgdAdmissionOperation(tt.oldDeployment),
+				nvidiacomv1beta1.DynamoGraphDeploymentGVK,
+				tt.userInfo,
+			)
 
-			var err error
+			var (
+				warnings []string
+				err      error
+			)
 			if tt.oldDeployment == nil {
-				_, err = handler.ValidateCreate(ctx, currentBeta)
+				warnings, err = handler.ValidateCreate(ctx, currentBeta)
 			} else {
-				_, err = handler.ValidateUpdate(ctx, oldBeta, currentBeta)
+				warnings, err = handler.ValidateUpdate(ctx, oldBeta, currentBeta)
 			}
-			assertBetaValidationError(t, err, tt.wantWebhookErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateCheckpointFallback(t *testing.T) {
-	deployment := betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-		worker.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-			Checkpoint: &nvidiacomv1beta1.ComponentCheckpointConfig{
-				Enabled:       true,
-				CheckpointRef: k8sptr.To("existing-checkpoint"),
-				Job:           &nvidiacomv1beta1.ComponentCheckpointJobConfig{},
-			},
-		}
-	})
-
-	validator := NewDynamoGraphDeploymentValidator(nil, false)
-	_, err := validator.Validate(context.Background(), deployment)
-	assertBetaValidationError(
-		t,
-		err,
-		"spec.components[worker].experimental.checkpoint.job cannot be set when checkpointRef is specified",
-	)
-}
-
-func TestDynamoGraphDeploymentValidator_GroveSchedulingMatrix(t *testing.T) {
-	longDGDName := "test-graph-" + strings.Repeat("x", 50)
-	boundaryComponentName := "w" + strings.Repeat("x", 36)
-	tooLongComponentName := boundaryComponentName + "x"
-
-	tests := []struct {
-		name         string
-		groveEnabled bool
-		mutate       func(*nvidiacomv1beta1.DynamoGraphDeployment)
-		wantErr      string
-	}{
-		{
-			name:         "priority class requires Grove",
-			groveEnabled: false,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Spec.PriorityClassName = "high-priority"
-			},
-			wantErr: "spec.priorityClassName requires the Grove pathway",
-		},
-		{
-			name:         "priority class is allowed with Grove",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Spec.PriorityClassName = "high-priority"
-			},
-		},
-		{
-			name:         "minAvailable must be positive",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(0))
-			},
-			wantErr: "spec.components[worker].minAvailable must be greater than 0",
-		},
-		{
-			name:         "replicas must cover minAvailable unless scaled to zero",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				worker.Replicas = k8sptr.To(int32(1))
-				worker.MinAvailable = k8sptr.To(int32(2))
-			},
-			wantErr: "spec.components[worker].replicas must be 0 or greater than or equal to minAvailable",
-		},
-		{
-			name:         "replicas zero can keep minAvailable for scale-up intent",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				worker.Replicas = k8sptr.To(int32(0))
-				worker.MinAvailable = k8sptr.To(int32(2))
-			},
-		},
-		{
-			name:         "rendered Grove resource name length accepts boundary",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Name = longDGDName
-				betaWorkerComponent(dgd).ComponentName = boundaryComponentName
-			},
-		},
-		{
-			name:         "rendered Grove resource name length rejects overflow",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Name = longDGDName
-				betaWorkerComponent(dgd).ComponentName = tooLongComponentName
-			},
-			wantErr: "combined resource name length",
-		},
-		{
-			name:         "rendered Grove resource name length is skipped outside Grove",
-			groveEnabled: false,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Name = longDGDName
-				betaWorkerComponent(dgd).ComponentName = tooLongComponentName
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := newBetaDGDForValidation()
-			tt.mutate(deployment)
-
-			validator := NewDynamoGraphDeploymentValidator(nil, tt.groveEnabled)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateAggregatesErrors(t *testing.T) {
-	deployment := betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-		spec.Restart = &nvidiacomv1beta1.Restart{}
-		spec.Components[0].Replicas = k8sptr.To(int32(-1))
-		spec.Components[1].Replicas = k8sptr.To(int32(-2))
-	})
-	deployment.Annotations = map[string]string{
-		consts.KubeAnnotationDynamoOperatorOriginVersion: "not-semver",
-		consts.KubeAnnotationDynamoKubeDiscoveryMode:     "bad-mode",
-	}
-
-	validator := NewDynamoGraphDeploymentValidator(nil, true)
-	_, err := validator.Validate(context.Background(), deployment)
-	for _, wantErr := range []string{
-		"annotation nvidia.com/dynamo-operator-origin-version has invalid value",
-		"annotation nvidia.com/dynamo-kube-discovery-mode has invalid value",
-		"spec.restart.id is required",
-		"spec.components[frontend].replicas must be non-negative",
-		"spec.components[worker].replicas must be non-negative",
-	} {
-		assertBetaValidationError(t, err, wantErr)
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_AnnotationMatrix(t *testing.T) {
-	tests := []struct {
-		name       string
-		annotation string
-		value      string
-		wantErr    string
-	}{
-		{
-			name:       "origin version accepts semver",
-			annotation: consts.KubeAnnotationDynamoOperatorOriginVersion,
-			value:      "1.2.3",
-		},
-		{
-			name:       "origin version rejects non-semver",
-			annotation: consts.KubeAnnotationDynamoOperatorOriginVersion,
-			value:      "not-semver",
-			wantErr:    "annotation nvidia.com/dynamo-operator-origin-version has invalid value",
-		},
-		{
-			name:       "vLLM backend accepts mp",
-			annotation: consts.KubeAnnotationVLLMDistributedExecutorBackend,
-			value:      "mp",
-		},
-		{
-			name:       "vLLM backend accepts ray case-insensitively",
-			annotation: consts.KubeAnnotationVLLMDistributedExecutorBackend,
-			value:      "RAY",
-		},
-		{
-			name:       "vLLM backend rejects unknown value",
-			annotation: consts.KubeAnnotationVLLMDistributedExecutorBackend,
-			value:      "typo",
-			wantErr:    "annotation nvidia.com/vllm-distributed-executor-backend has invalid value",
-		},
-		{
-			name:       "discovery mode accepts pod",
-			annotation: consts.KubeAnnotationDynamoKubeDiscoveryMode,
-			value:      "pod",
-		},
-		{
-			name:       "discovery mode accepts container",
-			annotation: consts.KubeAnnotationDynamoKubeDiscoveryMode,
-			value:      "container",
-		},
-		{
-			name:       "discovery mode rejects unknown value",
-			annotation: consts.KubeAnnotationDynamoKubeDiscoveryMode,
-			value:      "endpoint",
-			wantErr:    "annotation nvidia.com/dynamo-kube-discovery-mode has invalid value",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := newBetaDGDForValidation()
-			deployment.Annotations = map[string]string{tt.annotation: tt.value}
-
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateAlphaCompatibility(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*nvidiacomv1alpha1.DynamoGraphDeployment)
-		wantErr string
-	}{
-		{
-			name: "alpha PVC create requires storage fields",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{
-					{
-						Name:   k8sptr.To("cache"),
-						Create: k8sptr.To(true),
-					},
-				}
-			},
-			wantErr: "spec.pvcs[0].storageClass is required when create is true",
-		},
-		{
-			name: "alpha ingress requires host",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				className := "nginx"
-				dgd.Spec.Services["frontend"] = &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-					ComponentType: consts.ComponentTypeFrontend,
-					Ingress: &nvidiacomv1alpha1.IngressSpec{
-						Enabled:                    true,
-						IngressControllerClassName: &className,
-					},
-				}
-			},
-			wantErr: "spec.services[frontend].ingress.host is required when ingress is enabled",
-		},
-		{
-			name: "alpha service annotations are validated",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].Annotations = map[string]string{
-					consts.KubeAnnotationVLLMDistributedExecutorBackend: "typo",
-				}
-			},
-			wantErr: `spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value "typo"`,
-		},
-		{
-			name: "alpha volume mounts require mount point unless used as compilation cache",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].VolumeMounts = []nvidiacomv1alpha1.VolumeMount{
-					{
-						Name: "cache",
-					},
-				}
-			},
-			wantErr: "spec.services[worker].volumeMounts[0].mountPoint is required when useAsCompilationCache is false",
-		},
-		{
-			name: "alpha sharedMemory requires size when enabled",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{
-					Disabled: false,
-				}
-			},
-			wantErr: "spec.services[worker].sharedMemory.size is required when disabled is false",
-		},
-		{
-			name: "alpha frontend sidecar rejects generated container name conflict",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["frontend"] = &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-					ComponentType: consts.ComponentTypeFrontend,
-					FrontendSidecar: &nvidiacomv1alpha1.FrontendSidecarSpec{
-						Image: "custom/frontend:latest",
-					},
-					ExtraPodSpec: &nvidiacomv1alpha1.ExtraPodSpec{
-						PodSpec: &corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  consts.FrontendSidecarContainerName,
-									Image: "custom/frontend:latest",
-								},
-							},
-						},
-					},
-				}
-			},
-			wantErr: `spec.services[frontend]: cannot inject frontend sidecar: a container named "sidecar-frontend" already exists in extraPodSpec.containers`,
-		},
-		{
-			name: "disabled alpha GMS still validates extra client container names",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-					Enabled:               false,
-					ExtraClientContainers: []string{"Bad_Name"},
-				}
-			},
-			wantErr: `spec.services[worker].gpuMemoryService.extraClientContainers[0] "Bad_Name" is not a valid Kubernetes container name`,
-		},
-		{
-			name: "nil alpha service entry is rejected",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["ghost"] = nil
-			},
-			wantErr: "spec.services[ghost] must not be null",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDFromAlpha(t, tt.mutate)
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateAlphaCompatibilityAdditionalEdges(t *testing.T) {
-	t.Run("valid preserved alpha-only fields are accepted", func(t *testing.T) {
-		deployment := betaDGDFromAlpha(t, func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-			host := "worker.example.com"
-			dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{
-				{
-					Name:   k8sptr.To("cache"),
-					Create: k8sptr.To(false),
-				},
+			assertBetaValidationErrors(t, err, tt.wantWebhookErrs)
+			if tt.notWantErr != "" && err != nil && strings.Contains(err.Error(), tt.notWantErr) {
+				t.Fatalf("webhook error = %q, must not contain %q", err.Error(), tt.notWantErr)
 			}
-			service := dgd.Spec.Services["worker"]
-			service.Ingress = &nvidiacomv1alpha1.IngressSpec{
-				Enabled: true,
-				Host:    host,
-			}
-			service.Annotations = map[string]string{
-				consts.KubeAnnotationVLLMDistributedExecutorBackend: "ray",
-			}
-			service.VolumeMounts = []nvidiacomv1alpha1.VolumeMount{
-				{
-					Name:                  "cache",
-					UseAsCompilationCache: true,
-				},
-			}
-			service.SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{Disabled: true}
-			service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-				Enabled:               false,
-				ExtraClientContainers: []string{"metrics"},
-			}
-		})
-
-		validator := NewDynamoGraphDeploymentValidator(nil, true)
-		_, err := validator.Validate(context.Background(), deployment)
-		assertBetaValidationError(t, err, "")
-	})
-
-	t.Run("missing alpha PVC name is rejected", func(t *testing.T) {
-		deployment := betaDGDFromAlpha(t, func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-			dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{}}
-		})
-
-		validator := NewDynamoGraphDeploymentValidator(nil, true)
-		_, err := validator.Validate(context.Background(), deployment)
-		assertBetaValidationError(t, err, "spec.pvcs[0].name is required")
-	})
-
-	t.Run("multiple alpha PVC errors are returned together", func(t *testing.T) {
-		deployment := betaDGDFromAlpha(t, func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-			dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{
-				{
-					Create: k8sptr.To(true),
-				},
-			}
-		})
-
-		validator := NewDynamoGraphDeploymentValidator(nil, true)
-		_, err := validator.Validate(context.Background(), deployment)
-		for _, wantErr := range []string{
-			"spec.pvcs[0].name is required",
-			"spec.pvcs[0].storageClass is required when create is true",
-			"spec.pvcs[0].size is required when create is true",
-			"spec.pvcs[0].volumeAccessMode is required when create is true",
-		} {
-			assertBetaValidationError(t, err, wantErr)
-		}
-	})
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateAlphaCompatibilityWarnings(t *testing.T) {
-	legacyNamespace := "legacy-namespace"
-	deployment := betaDGDFromAlpha(t, func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-		service := dgd.Spec.Services["worker"]
-		service.DynamoNamespace = &legacyNamespace
-		//nolint:staticcheck // SA1019: Intentionally testing deprecated field warnings.
-		service.Autoscaling = &nvidiacomv1alpha1.Autoscaling{Enabled: true}
-	})
-
-	validator := NewDynamoGraphDeploymentValidator(nil, true)
-	warnings, err := validator.Validate(context.Background(), deployment)
-	if err != nil {
-		t.Fatalf("Validate() error = %v", err)
-	}
-	assertWarningsContain(t, warnings, "spec.services[worker].dynamoNamespace is deprecated and ignored")
-	assertWarningsContain(t, warnings, "spec.services[worker].autoscaling is deprecated and ignored")
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateConvertedAlphaResourceSemantics(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*nvidiacomv1alpha1.DynamoGraphDeployment)
-		wantErr string
-	}{
-		{
-			name: "GMS accepts GPU from alpha dedicated resources",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				service := dgd.Spec.Services["worker"]
-				service.Resources = &nvidiacomv1alpha1.Resources{
-					Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"},
-				}
-				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-					Enabled: true,
-					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
-				}
-			},
-		},
-		{
-			name: "GMS accepts GPU from alpha extraPodSpec main container resources",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				service := dgd.Spec.Services["worker"]
-				service.ExtraPodSpec = &nvidiacomv1alpha1.ExtraPodSpec{
-					MainContainer: &corev1.Container{
-						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
-								corev1.ResourceName(consts.KubeResourceGPUNvidia): resource.MustParse("1"),
-							},
-						},
-					},
-				}
-				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-					Enabled: true,
-					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
-				}
-			},
-		},
-		{
-			name: "GMS accepts alpha GPUType resource after conversion",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				service := dgd.Spec.Services["worker"]
-				service.Resources = &nvidiacomv1alpha1.Resources{
-					Limits: &nvidiacomv1alpha1.ResourceItem{
-						GPU:     "1",
-						GPUType: "example.com/gpu",
-					},
-				}
-				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-					Enabled: true,
-					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDFromAlpha(t, tt.mutate)
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_RestartMatrix(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*nvidiacomv1beta1.DynamoGraphDeploymentSpec)
-		wantErr string
-	}{
-		{
-			name: "missing restart id",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = &nvidiacomv1beta1.Restart{}
-			},
-			wantErr: "spec.restart.id is required",
-		},
-		{
-			name: "duplicate restart order",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "worker", "worker")
-			},
-			wantErr: "spec.restart.strategy.order must be unique",
-		},
-		{
-			name: "unknown restart order component",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "ghost")
-			},
-			wantErr: "spec.restart.strategy.order contains unknown component: ghost",
-		},
-		{
-			name: "restart order missing component",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "worker")
-			},
-			wantErr: "spec.restart.strategy.order must have the same number of unique components as the deployment",
-		},
-		{
-			name: "empty sequential restart order is valid",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential)
-			},
-		},
-		{
-			name: "complete sequential restart order is valid",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "worker")
-			},
-		},
-		{
-			name: "parallel restart without order is valid",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeParallel)
-			},
-		},
-		{
-			name: "parallel restart rejects order",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeParallel, "frontend", "worker")
-			},
-			wantErr: "spec.restart.strategy.order cannot be specified when strategy is parallel",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDWithSpec(tt.mutate)
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_TopologyMatrix(t *testing.T) {
-	topologyManager := newGroveTopologyTestManager(t, newTestClusterTopology())
-	missingTopologyManager := newGroveTopologyTestManager(t)
-
-	tests := []struct {
-		name    string
-		mgr     ctrl.Manager
-		mutate  func(*nvidiacomv1beta1.DynamoGraphDeploymentSpec)
-		wantErr string
-	}{
-		{
-			name: "spec pack domain format is validated",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "Bad_Domain",
-				}
-			},
-			wantErr: `spec.topologyConstraint.packDomain "Bad_Domain" is not a valid topology domain`,
-		},
-		{
-			name: "component topology requires deployment topology",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-			wantErr: "spec.topologyConstraint with clusterTopologyName is required when any topology constraint is set",
-		},
-		{
-			name: "component topology requires pack domain",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[0].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-			wantErr: "spec.components[frontend].topologyConstraint.packDomain is required",
-		},
-		{
-			name: "deployment topology without pack domain requires every component topology",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-			wantErr: "spec.components[frontend].topologyConstraint is required because spec.topologyConstraint.packDomain is not set",
-		},
-		{
-			name: "deployment pack domain can be inherited",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "rack",
-				}
-			},
-		},
-		{
-			name: "deployment pack domain can be mixed with narrower component topology",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "zone",
-				}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-		},
-		{
-			name: "component topology with deployment topology is valid",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[0].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-		},
-		{
-			name: "missing cluster topology is rejected",
-			mgr:  missingTopologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "missing-topology",
-					PackDomain:          "rack",
-				}
-			},
-			wantErr: `topology-aware scheduling requires a ClusterTopology resource "missing-topology" but it was not found`,
-		},
-		{
-			name: "pack domain must exist in cluster topology",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "host",
-				}
-			},
-			wantErr: `spec.topologyConstraint.packDomain: domain "host" does not exist in ClusterTopology "grove-topology"`,
-		},
-		{
-			name: "component topology cannot be broader than spec topology",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "rack",
-				}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
-			},
-			wantErr: `spec.components[worker]: topologyConstraint.packDomain "zone" is broader than spec-level "rack"`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDWithSpec(tt.mutate)
-			validator := NewDynamoGraphDeploymentValidator(tt.mgr, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_KvTransferPolicyMatrix(t *testing.T) {
-	topologyManager := newGroveTopologyTestManager(t, newTestClusterTopology())
-	missingTopologyManager := newGroveTopologyTestManager(t)
-
-	tests := []struct {
-		name      string
-		mgr       ctrl.Manager
-		mutateDGD func(*nvidiacomv1beta1.DynamoGraphDeployment)
-		policy    *nvidiacomv1beta1.KvTransferPolicy
-		wantErr   string
-	}{
-		{
-			name:    "missing topology selector",
-			policy:  &nvidiacomv1beta1.KvTransferPolicy{Domain: "zone"},
-			wantErr: "spec.experimental.kvTransferPolicy: exactly one of labelKey or clusterTopologyName is required",
-		},
-		{
-			name: "both topology selectors",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:            "topology.kubernetes.io/zone",
-				ClusterTopologyName: "grove-topology",
-				Domain:              "zone",
-			},
-			wantErr: "spec.experimental.kvTransferPolicy: exactly one of labelKey or clusterTopologyName is required",
-		},
-		{
-			name: "invalid label key",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "bad prefix/zone",
-				Domain:   "zone",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.labelKey "bad prefix/zone" is not a valid Kubernetes label key`,
-		},
-		{
-			name: "invalid label key name segment",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/-zone",
-				Domain:   "zone",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.labelKey "topology.kubernetes.io/-zone" is not a valid Kubernetes label key`,
-		},
-		{
-			name: "label key policy is valid",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-				Domain:   "zone",
-			},
-		},
-		{
-			name: "invalid cluster topology name",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "Bad_Name",
-				Domain:              "zone",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.clusterTopologyName "Bad_Name" is not a valid Kubernetes resource name`,
-		},
-		{
-			name: "cluster topology name requires Grove pathway",
-			mutateDGD: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Annotations = map[string]string{consts.KubeAnnotationEnableGrove: consts.KubeLabelValueFalse}
-			},
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "grove-topology",
-				Domain:              "zone",
-			},
-			wantErr: "spec.experimental.kvTransferPolicy.clusterTopologyName requires the Grove pathway",
-		},
-		{
-			name: "domain is required",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-			},
-			wantErr: "spec.experimental.kvTransferPolicy.domain is required",
-		},
-		{
-			name: "domain format is validated",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-				Domain:   "Zone",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.domain "Zone" is not a valid topology domain`,
-		},
-		{
-			name: "enforcement value is validated",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:    "topology.kubernetes.io/zone",
-				Domain:      "zone",
-				Enforcement: "sometimes",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.enforcement "sometimes" is invalid`,
-		},
-		{
-			name: "preferred enforcement requires weight",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:    "topology.kubernetes.io/zone",
-				Domain:      "zone",
-				Enforcement: nvidiacomv1beta1.KvTransferEnforcementPreferred,
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.preferredWeight is required when enforcement is "preferred"`,
-		},
-		{
-			name: "preferred weight must be in range",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:        "topology.kubernetes.io/zone",
-				Domain:          "zone",
-				Enforcement:     nvidiacomv1beta1.KvTransferEnforcementPreferred,
-				PreferredWeight: k8sptr.To(float32(1.2)),
-			},
-			wantErr: "spec.experimental.kvTransferPolicy.preferredWeight 1.2 is invalid",
-		},
-		{
-			name: "required enforcement cannot set preferred weight",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:        "topology.kubernetes.io/zone",
-				Domain:          "zone",
-				Enforcement:     nvidiacomv1beta1.KvTransferEnforcementRequired,
-				PreferredWeight: k8sptr.To(float32(0.5)),
-			},
-			wantErr: "spec.experimental.kvTransferPolicy.preferredWeight must not be set when enforcement is \"required\"",
-		},
-		{
-			name: "cluster topology policy is valid",
-			mgr:  topologyManager,
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "grove-topology",
-				Domain:              "rack",
-			},
-		},
-		{
-			name: "cluster topology policy rejects missing topology",
-			mgr:  missingTopologyManager,
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "missing-topology",
-				Domain:              "rack",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.clusterTopologyName "missing-topology" references a ClusterTopology resource that was not found`,
-		},
-		{
-			name: "cluster topology policy rejects missing domain",
-			mgr:  topologyManager,
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "grove-topology",
-				Domain:              "host",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.domain "host" does not exist in ClusterTopology "grove-topology"`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDWithKvTransferPolicy(tt.policy)
-			if tt.mutateDGD != nil {
-				tt.mutateDGD(deployment)
-			}
-			validator := NewDynamoGraphDeploymentValidator(tt.mgr, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_GMSFailoverMatrix(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*nvidiacomv1beta1.DynamoGraphDeployment)
-		wantErr string
-	}{
-		{
-			name: "GMS rejects frontend component",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				enableBetaIntraPodGMS(&dgd.Spec.Components[0])
-			},
-			wantErr: "spec.components[frontend].experimental.gpuMemoryService: GPU memory service is only supported for worker components",
-		},
-		{
-			name: "GMS requires main container GPU",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				worker.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-					GPUMemoryService: &nvidiacomv1beta1.GPUMemoryServiceSpec{Mode: nvidiacomv1beta1.GMSModeIntraPod},
-				}
-			},
-			wantErr: "spec.components[worker].experimental.gpuMemoryService: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1",
-		},
-		{
-			name: "GMS validates extra client container names",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.GPUMemoryService.ExtraClientContainers = []string{"Bad_Name"}
-			},
-			wantErr: `spec.components[worker].experimental.gpuMemoryService.extraClientContainers[0] "Bad_Name" is not a valid Kubernetes container name`,
-		},
-		{
-			name: "inter-pod GMS rejects extra client containers",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaInterPodGMS(worker)
-				worker.Experimental.GPUMemoryService.ExtraClientContainers = []string{"metrics"}
-			},
-			wantErr: "spec.components[worker].experimental.gpuMemoryService.extraClientContainers is only supported with mode=IntraPod",
-		},
-		{
-			name: "GMS extra client pods are still reserved",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaInterPodGMS(worker)
-				worker.Experimental.GPUMemoryService.ExtraClientPods = []nvidiacomv1beta1.GMSClientPodSpec{
-					{Name: "client"},
-				}
-			},
-			wantErr: "spec.components[worker].experimental.gpuMemoryService.extraClientPods is reserved for inter-pod GMS and is not implemented yet",
-		},
-		{
-			name: "intra-pod failover requires GMS",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				enableBetaContainerDiscovery(dgd)
-				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeIntraPod},
-				}
-			},
-			wantErr: "spec.components[worker].experimental.failover: intraPod failover requires gpuMemoryService to be set",
-		},
-		{
-			name: "failover mode must match GMS mode",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-					Mode:       nvidiacomv1beta1.GMSModeInterPod,
-					NumShadows: 1,
-				}
-			},
-			wantErr: `spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode="InterPod"`,
-		},
-		{
-			name: "intra-pod failover rejects custom shadow count",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				enableBetaContainerDiscovery(dgd)
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
-					NumShadows: 2,
-				}
-			},
-			wantErr: `spec.components[worker].experimental.failover.numShadows=2 is invalid for mode="IntraPod"`,
-		},
-		{
-			name: "inter-pod failover requires GMS",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-					Failover: &nvidiacomv1beta1.FailoverSpec{
-						Mode:       nvidiacomv1beta1.GMSModeInterPod,
-						NumShadows: 1,
-					},
-				}
-			},
-			wantErr: `spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode="InterPod"`,
-		},
-		{
-			name: "inter-pod failover requires positive shadow count",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaInterPodGMS(worker)
-				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-					Mode: nvidiacomv1beta1.GMSModeInterPod,
-				}
-			},
-			wantErr: "spec.components[worker].experimental.failover.numShadows must be >= 1",
-		},
-		{
-			name: "inter-pod failover rejects frontend component",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				frontend := &dgd.Spec.Components[0]
-				frontend.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-					Failover: &nvidiacomv1beta1.FailoverSpec{
-						Mode:       nvidiacomv1beta1.GMSModeInterPod,
-						NumShadows: 1,
-					},
-				}
-			},
-			wantErr: `spec.components[frontend]: GMS failover is not supported for type "frontend"`,
-		},
-		{
-			name: "GMS snapshot combination requires env gate",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				t.Setenv(consts.DynamoOperatorAllowGMSSnapshotEnvVar, "")
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true}
-			},
-			wantErr: "spec.components[worker].experimental.checkpoint: GMS + Snapshot is temporarily disabled",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := newBetaDGDForValidation()
-			tt.mutate(deployment)
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateUpdate(t *testing.T) {
-	const operatorPrincipal = "system:serviceaccount:dynamo-system:dynamo-operator"
-
-	tests := []struct {
-		name      string
-		oldDGD    *nvidiacomv1beta1.DynamoGraphDeployment
-		newDGD    *nvidiacomv1beta1.DynamoGraphDeployment
-		userInfo  *authenticationv1.UserInfo
-		principal string
-		wantErr   string
-		wantWarns bool
-	}{
-		{
-			name:   "component topology is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components = append(spec.Components, nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
-					ComponentName: "extra",
-					Replicas:      k8sptr.To(int32(1)),
-				})
-			}),
-			wantErr: "component topology is immutable and cannot be modified after creation: components added: [extra]",
-		},
-		{
-			name:   "component removal is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components = spec.Components[:1]
-			}),
-			wantErr: "component topology is immutable and cannot be modified after creation: components removed: [worker]",
-		},
-		{
-			name:   "component add and remove reports both sides",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components = []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
-					spec.Components[1],
-					{
-						ComponentName: "extra",
-						Replicas:      k8sptr.To(int32(1)),
-					},
-				}
-			}),
-			wantErr: "component topology is immutable and cannot be modified after creation: components added: [extra], components removed: [frontend]",
-		},
-		{
-			name:   "component reorder is allowed",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components[0], spec.Components[1] = spec.Components[1], spec.Components[0]
-			}),
-		},
-		{
-			name:   "single-node to multinode transition is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
-			}),
-			wantErr: "spec.components[worker] cannot change node topology (between single-node and multi-node) after creation",
-		},
-		{
-			name: "node count-only update remains allowed",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 3}
-			}),
-		},
-		{
-			name:   "spec topology constraint is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "rack",
-				}
-			}),
-			wantErr: "spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name: "spec topology constraint change is immutable",
-			oldDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "rack",
-				}
-			}),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "zone",
-				}
-			}),
-			wantErr: "spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name: "unchanged topology constraints are allowed",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			}),
-		},
-		{
-			name:   "component topology constraint is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			}),
-			wantErr: "spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name: "component topology constraint change is immutable",
-			oldDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			}),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
-			}),
-			wantErr: "spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name:   "kv transfer policy is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-				Domain:   "zone",
-			}),
-			wantErr: "spec.experimental.kvTransferPolicy is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name: "unchanged kv transfer policy is allowed",
-			oldDGD: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-				Domain:   "zone",
-			}),
-			newDGD: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:    "topology.kubernetes.io/zone",
-				Domain:      "zone",
-				Enforcement: nvidiacomv1beta1.KvTransferEnforcementRequired,
-			}),
-		},
-		{
-			name:   "inter-pod GMS layout is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-			}),
-			wantErr: "spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation",
-		},
-		{
-			name: "inter-pod failover toggle is immutable",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-				enableBetaInterPodFailover(worker, 1)
-			}),
-			wantErr: "spec.components[worker].experimental.failover: inter-pod GMS failover cannot be toggled after creation",
-		},
-		{
-			name: "inter-pod failover shadow count is immutable",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-				enableBetaInterPodFailover(worker, 1)
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-				enableBetaInterPodFailover(worker, 2)
-			}),
-			wantErr: "spec.components[worker].experimental.failover.numShadows is immutable for inter-pod GMS failover",
-		},
-		{
-			name: "scaling adapter blocks direct replica changes",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(2))
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(3))
-			}),
-			userInfo: &authenticationv1.UserInfo{
-				Username: "system:serviceaccount:default:regular-user",
-			},
-			principal: operatorPrincipal,
-			wantErr:   "spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled",
-		},
-		{
-			name: "scaling adapter fails closed without user info",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(2))
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(3))
-			}),
-			principal: operatorPrincipal,
-			wantErr:   "spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled",
-		},
-		{
-			name: "operator can change scaling-adapter-owned replicas",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(2))
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(3))
-			}),
-			userInfo: &authenticationv1.UserInfo{
-				Username: operatorPrincipal,
-			},
-			principal: operatorPrincipal,
-		},
-		{
-			name: "minAvailable is immutable once set",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.MinAvailable = k8sptr.To(int32(1))
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.MinAvailable = k8sptr.To(int32(2))
-			}),
-			wantErr: "spec.components[worker].minAvailable is immutable after creation",
-		},
-		{
-			name:   "backend framework changes warn and fail",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.BackendFramework = "sglang"
-			}),
-			wantErr:   "spec.backendFramework is immutable and cannot be changed after creation",
-			wantWarns: true,
-		},
-		{
-			name: "restart id cannot change during active rolling update",
-			oldDGD: betaDGDWithStatus(
-				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-					spec.Restart = &nvidiacomv1beta1.Restart{ID: "old"}
-				},
-				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
-					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
-						Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
-					}
-				},
-			),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = &nvidiacomv1beta1.Restart{ID: "new"}
-			}),
-			wantErr: "spec.restart.id cannot be changed while a rolling update is InProgress",
-		},
-		{
-			name: "restart id can stay unchanged during active rolling update",
-			oldDGD: betaDGDWithStatus(
-				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-					spec.Restart = &nvidiacomv1beta1.Restart{ID: "same"}
-				},
-				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
-					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
-						Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
-					}
-				},
-			),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = &nvidiacomv1beta1.Restart{ID: "same"}
-			}),
-		},
-		{
-			name: "restart id can change after completed rolling update",
-			oldDGD: betaDGDWithStatus(
-				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-					spec.Restart = &nvidiacomv1beta1.Restart{ID: "old"}
-				},
-				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
-					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
-						Phase: nvidiacomv1beta1.RollingUpdatePhaseCompleted,
-					}
-				},
-			),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = &nvidiacomv1beta1.Restart{ID: "new"}
-			}),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			warnings, err := validator.ValidateUpdate(tt.oldDGD, tt.newDGD, tt.userInfo, tt.principal)
-			assertBetaValidationError(t, err, tt.wantErr)
-			if tt.wantWarns && len(warnings) == 0 {
-				t.Fatal("ValidateUpdate() expected warnings but got none")
-			}
-			if !tt.wantWarns && len(warnings) != 0 {
-				t.Fatalf("ValidateUpdate() unexpected warnings: %v", warnings)
+			if !slices.Equal(warnings, tt.wantWarnings) {
+				t.Fatalf("warnings = %v, want %v", warnings, tt.wantWarnings)
 			}
 		})
 	}
@@ -1805,22 +1771,6 @@ func newBetaDGDForValidation() *nvidiacomv1beta1.DynamoGraphDeployment {
 	}
 }
 
-func betaDGDFromAlpha(
-	t *testing.T,
-	mutate func(*nvidiacomv1alpha1.DynamoGraphDeployment),
-) *nvidiacomv1beta1.DynamoGraphDeployment {
-	t.Helper()
-
-	alpha := newAlphaDGDForCompatibilityValidation()
-	mutate(alpha)
-
-	beta := &nvidiacomv1beta1.DynamoGraphDeployment{}
-	if err := alpha.ConvertTo(beta); err != nil {
-		t.Fatalf("ConvertTo() error = %v", err)
-	}
-	return beta
-}
-
 func newAlphaDGDForCompatibilityValidation() *nvidiacomv1alpha1.DynamoGraphDeployment {
 	return &nvidiacomv1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1902,6 +1852,24 @@ func enableBetaContainerDiscovery(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 	dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "container"}
 }
 
+func enableAlphaInterPodGMSFailover(
+	component *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+	numShadows int32,
+) {
+	component.Resources = &nvidiacomv1alpha1.Resources{
+		Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"},
+	}
+	component.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+		Enabled: true,
+		Mode:    nvidiacomv1alpha1.GMSModeInterPod,
+	}
+	component.Failover = &nvidiacomv1alpha1.FailoverSpec{
+		Enabled:    true,
+		Mode:       nvidiacomv1alpha1.GMSModeInterPod,
+		NumShadows: numShadows,
+	}
+}
+
 func enableBetaInterPodGMS(component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
 	component.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
 		GPUMemoryService: &nvidiacomv1beta1.GPUMemoryServiceSpec{
@@ -1960,13 +1928,17 @@ func enableBetaInterPodFailover(
 }
 
 type fakeManager struct {
-	ctrl.Manager // satisfies the rest of the interface; panics if unexpected methods are used
-	client       client.Client
-	config       *rest.Config
+	ctrl.Manager  // satisfies the rest of the interface; panics if unexpected methods are used
+	client        client.Client
+	config        *rest.Config
+	scheme        *runtime.Scheme
+	webhookServer ctrlwebhook.Server
 }
 
-func (m *fakeManager) GetClient() client.Client { return m.client }
-func (m *fakeManager) GetConfig() *rest.Config  { return m.config }
+func (m *fakeManager) GetClient() client.Client             { return m.client }
+func (m *fakeManager) GetConfig() *rest.Config              { return m.config }
+func (m *fakeManager) GetScheme() *runtime.Scheme           { return m.scheme }
+func (m *fakeManager) GetWebhookServer() ctrlwebhook.Server { return m.webhookServer }
 
 func newGroveTopologyTestManager(t *testing.T, objects ...runtime.Object) ctrl.Manager {
 	t.Helper()
@@ -1981,6 +1953,48 @@ func newGroveTopologyTestManager(t *testing.T, objects ...runtime.Object) ctrl.M
 	}
 }
 
+func newInferencePoolTestManager(t *testing.T) ctrl.Manager {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var response any
+		switch request.URL.Path {
+		case "/api":
+			response = &metav1.APIVersions{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "APIVersions"},
+				Versions: []string{"v1"},
+			}
+		case "/apis":
+			groupVersion := metav1.GroupVersionForDiscovery{
+				GroupVersion: "inference.networking.k8s.io/v1alpha2",
+				Version:      "v1alpha2",
+			}
+			response = &metav1.APIGroupList{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "APIGroupList"},
+				Groups: []metav1.APIGroup{{
+					Name:             "inference.networking.k8s.io",
+					Versions:         []metav1.GroupVersionForDiscovery{groupVersion},
+					PreferredVersion: groupVersion,
+				}},
+			}
+		default:
+			http.NotFound(w, request)
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	manager := newGroveTopologyTestManager(t).(*fakeManager)
+	manager.config = &rest.Config{Host: server.URL}
+	return manager
+}
+
 func newTestClusterTopology() *grovev1alpha1.ClusterTopology {
 	return &grovev1alpha1.ClusterTopology{
 		ObjectMeta: metav1.ObjectMeta{Name: "grove-topology"},
@@ -1993,28 +2007,38 @@ func newTestClusterTopology() *grovev1alpha1.ClusterTopology {
 	}
 }
 
-func assertBetaValidationError(t *testing.T, err error, wantErr string) {
+func assertBetaValidationErrors(t *testing.T, err error, wantErrs []string) {
 	t.Helper()
-	if wantErr == "" {
+	if len(wantErrs) == 0 {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		return
 	}
 	if err == nil {
-		t.Fatalf("expected error containing %q but got nil", wantErr)
+		t.Fatalf("expected errors %v but got nil", wantErrs)
 	}
-	if !strings.Contains(err.Error(), wantErr) {
-		t.Fatalf("error = %q, want to contain %q", err.Error(), wantErr)
-	}
-}
-
-func assertWarningsContain(t *testing.T, warnings []string, want string) {
-	t.Helper()
-	for _, warning := range warnings {
-		if strings.Contains(warning, want) {
-			return
+	statusErr, ok := err.(*k8serrors.StatusError)
+	if !ok || !k8serrors.IsInvalid(err) {
+		gotErrs := strings.Split(err.Error(), "\n")
+		if !slices.Equal(gotErrs, wantErrs) {
+			t.Fatalf("webhook errors = %v, want %v", gotErrs, wantErrs)
 		}
+		return
 	}
-	t.Fatalf("warnings = %v, want one containing %q", warnings, want)
+	if statusErr.ErrStatus.Details == nil {
+		t.Fatalf("error = %v, want typed field causes", err)
+	}
+
+	causes := statusErr.ErrStatus.Details.Causes
+	gotErrs := make([]string, len(causes))
+	for i, cause := range causes {
+		if cause.Field == "" {
+			t.Fatalf("error cause = %#v, want an exact field path", cause)
+		}
+		gotErrs[i] = fmt.Sprintf("%s: %s", cause.Field, cause.Message)
+	}
+	if !slices.Equal(gotErrs, wantErrs) {
+		t.Fatalf("webhook errors = %v, want %v", gotErrs, wantErrs)
+	}
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation
+
+import (
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// validateDynamoGraphDeploymentV1alpha1 validates dgd. dgd must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentV1alpha1(
+	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
+) field.ErrorList {
+	if !hasV1Alpha1CompatibilityFields(dgd) {
+		return nil
+	}
+	return v.validateDynamoGraphDeploymentSpecV1alpha1(
+		&dgd.Spec,
+		field.NewPath("spec"),
+		dgd.Name,
+		dgd.Namespace,
+	)
+}
+
+// validateDynamoGraphDeploymentSpecV1alpha1 validates spec. spec and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecV1alpha1(
+	spec *nvidiacomv1alpha1.DynamoGraphDeploymentSpec,
+	fldPath *field.Path,
+	dgdName string,
+	dgdNamespace string,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	pvcsPath := fldPath.Child("pvcs")
+	for i := range spec.PVCs {
+		allErrs = append(allErrs, v.validatePVCV1alpha1(&spec.PVCs[i], pvcsPath.Index(i))...)
+	}
+
+	servicesPath := fldPath.Child("services")
+	for _, serviceName := range sortedV1Alpha1ServiceNames(spec.Services) {
+		service := spec.Services[serviceName]
+		servicePath := servicesPath.Key(serviceName)
+		dynamoNamespace := nvidiacomv1alpha1.ComputeDynamoNamespace(service.GlobalDynamoNamespace, dgdNamespace, dgdName)
+		allErrs = append(allErrs, v.validateDynamoComponentDeploymentSharedSpecV1alpha1(
+			service,
+			servicePath,
+			dynamoNamespace,
+		)...)
+	}
+	return allErrs
+}
+
+// validatePVCV1alpha1 validates pvc. pvc and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validatePVCV1alpha1(
+	pvc *nvidiacomv1alpha1.PVC,
+	fldPath *field.Path,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if pvc.Name == nil || *pvc.Name == "" {
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "is required"))
+	}
+	return allErrs
+}

--- a/deploy/operator/internal/webhook/validation/shared_helpers.go
+++ b/deploy/operator/internal/webhook/validation/shared_helpers.go
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	controllercommon "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	unsetValue = "<unset>"
+
+	vllmDistributedExecutorBackendMP  = "mp"
+	vllmDistributedExecutorBackendRay = "ray"
+)
+
+func hasContainerNamed(containers []corev1.Container, name string) bool {
+	for i := range containers {
+		if containers[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func invalidVLLMDistributedExecutorBackendAnnotation(annotations map[string]string) (string, bool) {
+	value, exists := annotations[consts.KubeAnnotationVLLMDistributedExecutorBackend]
+	if !exists {
+		return "", false
+	}
+
+	switch strings.ToLower(value) {
+	case vllmDistributedExecutorBackendMP, vllmDistributedExecutorBackendRay:
+		return "", false
+	default:
+		return value, true
+	}
+}
+
+// inferencePoolAvailabilityError checks the InferencePool API.
+// ctx and mgr must not be nil.
+func inferencePoolAvailabilityError(ctx context.Context, mgr ctrl.Manager) error {
+	if controllercommon.DetectInferencePoolAvailability(ctx, mgr) {
+		return nil
+	}
+	return fmt.Errorf(
+		"InferencePool API group (%s) is not available in the cluster; install the Gateway API Inference Extension before deploying EPP components",
+		epp.InferencePoolGroup,
+	)
+}
+
+func gpuMemoryServiceFor(
+	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) *nvidiacomv1beta1.GPUMemoryServiceSpec {
+	return gpuMemoryServiceForExperimental(component.Experimental)
+}
+
+func gpuMemoryServiceForExperimental(experimental *nvidiacomv1beta1.ExperimentalSpec) *nvidiacomv1beta1.GPUMemoryServiceSpec {
+	if experimental == nil {
+		return nil
+	}
+	return experimental.GPUMemoryService
+}
+
+func failoverFor(
+	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) *nvidiacomv1beta1.FailoverSpec {
+	return failoverForExperimental(component.Experimental)
+}
+
+func failoverForExperimental(experimental *nvidiacomv1beta1.ExperimentalSpec) *nvidiacomv1beta1.FailoverSpec {
+	if experimental == nil {
+		return nil
+	}
+	return experimental.Failover
+}
+
+func effectiveGMSMode(mode nvidiacomv1beta1.GPUMemoryServiceMode) nvidiacomv1beta1.GPUMemoryServiceMode {
+	if mode == "" {
+		return nvidiacomv1beta1.GMSModeIntraPod
+	}
+	return mode
+}
+
+func isInterPodGMS(gms *nvidiacomv1beta1.GPUMemoryServiceSpec) bool {
+	return gms != nil && effectiveGMSMode(gms.Mode) == nvidiacomv1beta1.GMSModeInterPod
+}
+
+func isInterPodFailover(failover *nvidiacomv1beta1.FailoverSpec) bool {
+	return failover != nil && effectiveGMSMode(failover.Mode) == nvidiacomv1beta1.GMSModeInterPod
+}
+
+func effectiveNumShadows(failover *nvidiacomv1beta1.FailoverSpec) int32 {
+	if failover.NumShadows < 1 {
+		return 1
+	}
+	return failover.NumShadows
+}

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -34,6 +34,7 @@ import (
 	apiextensionsvalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	apitest "k8s.io/apiextensions-apiserver/pkg/test"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -372,6 +373,17 @@ func TestSharedSpecValidatorV1Alpha1_Validate(t *testing.T) {
 			calculatedNamespace: "default-my-dgd",
 			wantErr:             true,
 			errMsg:              `spec.services[decode].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value "invalid": must be "mp" or "ray"`,
+		},
+		{
+			name: "invalid service annotation without a field path",
+			spec: &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				Annotations: map[string]string{
+					"nvidia.com/vllm-distributed-executor-backend": "invalid",
+				},
+			},
+			calculatedNamespace: "default-my-dgd",
+			wantErr:             true,
+			errMsg:              `annotation nvidia.com/vllm-distributed-executor-backend has invalid value "invalid": must be "mp" or "ray"`,
 		},
 		{
 			name: "checkpoint without gpuMemoryService is accepted",
@@ -863,6 +875,192 @@ func TestSharedSpecValidatorV1Alpha1_Failover_ModeConstraints(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateDynamoComponentDeploymentSharedSpecFieldPaths(t *testing.T) {
+	minAvailable := int32(1)
+	replicas := int32(2)
+	frontendSidecar := "missing"
+	sharedMemorySize := resource.MustParse("-1Gi")
+	spec := &nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+		ComponentName: "epp",
+		ComponentType: nvidiacomv1beta1.ComponentTypeEPP,
+		PodTemplate: &corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid"},
+			},
+			Spec: corev1.PodSpec{
+				Containers:     []corev1.Container{{Name: consts.MainContainerName}, {Name: "sidecar"}},
+				InitContainers: []corev1.Container{{Name: "init"}},
+			},
+		},
+		Replicas:         &replicas,
+		MinAvailable:     &minAvailable,
+		Multinode:        &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2},
+		SharedMemorySize: &sharedMemorySize,
+		EPPConfig: &nvidiacomv1beta1.EPPConfig{
+			ConfigMapRef: &corev1.ConfigMapKeySelector{},
+		},
+		FrontendSidecar: &frontendSidecar,
+	}
+	validation := &sharedValidation{ctx: context.Background(), mgr: newGroveTopologyTestManager(t)}
+
+	errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, field.NewPath("spec", "components").Index(0), false)
+	assertFieldPaths(t, errs, []string{
+		"spec.components[0].minAvailable",
+		"spec.components[0].sharedMemorySize",
+		"spec.components[0].type",
+		"spec.components[0].multinode",
+		"spec.components[0].replicas",
+		"spec.components[0].eppConfig.configMapRef.name",
+		"spec.components[0].frontendSidecar",
+	})
+}
+
+func TestValidateDynamoComponentDeploymentSharedSpecFrontendSidecar(t *testing.T) {
+	validation := &sharedValidation{ctx: context.Background(), mgr: newGroveTopologyTestManager(t)}
+	componentPath := field.NewPath("spec", "components").Index(0)
+
+	t.Run("requires pod template", func(t *testing.T) {
+		name := "frontend"
+		spec := &nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{FrontendSidecar: &name}
+		errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, componentPath, true)
+		assertFieldPaths(t, errs, []string{
+			"spec.components[0].podTemplate.spec.containers",
+		})
+	})
+
+	t.Run("rejects empty name", func(t *testing.T) {
+		name := ""
+		spec := &nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+			PodTemplate:     &corev1.PodTemplateSpec{},
+			FrontendSidecar: &name,
+		}
+		errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, componentPath, true)
+		assertFieldPaths(t, errs, []string{
+			"spec.components[0].frontendSidecar",
+		})
+	})
+
+	t.Run("accepts matching container", func(t *testing.T) {
+		name := "frontend"
+		spec := &nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+			PodTemplate: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: name, Image: "frontend:latest"}}},
+			},
+			FrontendSidecar: &name,
+		}
+		errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, componentPath, true)
+		assertFieldPaths(t, errs, nil)
+	})
+}
+
+func TestValidateComponentCheckpointJobConfigFieldPaths(t *testing.T) {
+	validation := &sharedValidation{ctx: context.Background(), mgr: newGroveTopologyTestManager(t)}
+	fldPath := field.NewPath("spec", "components").Index(0).Child("experimental", "checkpoint", "job")
+	job := &nvidiacomv1beta1.ComponentCheckpointJobConfig{GMSClientContainers: []string{"saver"}}
+
+	errs := validation.validateComponentCheckpointJobConfig(job, fldPath, nil)
+	assertFieldPaths(t, errs, []string{
+		"spec.components[0].experimental.checkpoint.job.gmsClientContainers",
+	})
+	errs = validation.validateComponentCheckpointJobConfig(
+		job,
+		fldPath,
+		&nvidiacomv1beta1.GPUMemoryServiceSpec{Mode: nvidiacomv1beta1.GMSModeInterPod},
+	)
+	assertFieldPaths(t, errs, []string{"spec.components[0].experimental.checkpoint.job.gmsClientContainers"})
+	errs = validation.validateComponentCheckpointJobConfig(
+		job,
+		fldPath,
+		&nvidiacomv1beta1.GPUMemoryServiceSpec{Mode: nvidiacomv1beta1.GMSModeIntraPod},
+	)
+	assertFieldPaths(t, errs, nil)
+	errs = validation.validateComponentCheckpointJobConfig(
+		&nvidiacomv1beta1.ComponentCheckpointJobConfig{},
+		fldPath,
+		nil,
+	)
+	assertFieldPaths(t, errs, nil)
+}
+
+func TestValidateDynamoComponentDeploymentSharedSpecV1alpha1FrontendSidecarFieldPaths(t *testing.T) {
+	validation := &sharedValidation{ctx: context.Background(), mgr: newGroveTopologyTestManager(t)}
+	fldPath := field.NewPath("spec", "services").Key("frontend")
+	frontendSidecar := &nvidiacomv1alpha1.FrontendSidecarSpec{
+		Image: "frontend:latest",
+		Envs:  []corev1.EnvVar{{Name: "TOKEN", Value: "do-not-leak-this-value"}},
+	}
+	spec := &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{FrontendSidecar: frontendSidecar}
+	errs := validation.validateDynamoComponentDeploymentSharedSpecV1alpha1(spec, fldPath, "dynamo")
+	assertFieldPaths(t, errs, nil)
+	spec.ExtraPodSpec = &nvidiacomv1alpha1.ExtraPodSpec{PodSpec: &corev1.PodSpec{}}
+	errs = validation.validateDynamoComponentDeploymentSharedSpecV1alpha1(spec, fldPath, "dynamo")
+	assertFieldPaths(t, errs, nil)
+	spec.ExtraPodSpec.PodSpec.Containers = []corev1.Container{{Name: consts.FrontendSidecarContainerName}}
+	errs = validation.validateDynamoComponentDeploymentSharedSpecV1alpha1(spec, fldPath, "dynamo")
+	assertFieldPaths(t, errs, []string{"spec.services[frontend].frontendSidecar"})
+	if errs[0].BadValue != "" {
+		t.Fatalf("error BadValue = %#v, want an empty non-sensitive scalar", errs[0].BadValue)
+	}
+	if strings.Contains(errs.ToAggregate().Error(), "do-not-leak-this-value") {
+		t.Fatalf("error = %q, must not expose frontend sidecar environment values", errs.ToAggregate())
+	}
+}
+
+func TestValidateExperimentalSpecDoesNotExposePodTemplate(t *testing.T) {
+	validation := &sharedValidation{ctx: context.Background(), mgr: newGroveTopologyTestManager(t)}
+	fldPath := field.NewPath("spec", "components").Index(0).Child("experimental")
+	gms := &nvidiacomv1beta1.GPUMemoryServiceSpec{
+		ExtraClientPods: []nvidiacomv1beta1.GMSClientPodSpec{{
+			Name: "client",
+			PodTemplate: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+				Name: consts.MainContainerName,
+				Env:  []corev1.EnvVar{{Name: "TOKEN", Value: "do-not-leak-this-value"}},
+			}}}},
+		}},
+	}
+
+	errs := validation.validateExperimentalSpec(
+		&nvidiacomv1beta1.ExperimentalSpec{GPUMemoryService: gms},
+		fldPath,
+		nvidiacomv1beta1.ComponentTypeWorker,
+		corev1.ResourceRequirements{},
+	)
+	assertFieldPaths(t, errs, []string{"spec.components[0].experimental.gpuMemoryService"})
+	if errs[0].BadValue != "" {
+		t.Fatalf("error BadValue = %#v, want an empty non-sensitive scalar", errs[0].BadValue)
+	}
+	if strings.Contains(errs.ToAggregate().Error(), "do-not-leak-this-value") {
+		t.Fatalf("error = %q, must not expose GPU memory service pod template values", errs.ToAggregate())
+	}
+}
+
+func TestValidateDynamoComponentDeploymentSharedSpecV1alpha1WarningsAndErrors(t *testing.T) {
+	legacyNamespace := "legacy"
+	spec := &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		DynamoNamespace: &legacyNamespace,
+		Annotations: map[string]string{
+			consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid",
+		},
+	}
+
+	//nolint:staticcheck // SA1019: Intentionally testing the deprecated compatibility warning.
+	spec.Autoscaling = &nvidiacomv1alpha1.Autoscaling{Enabled: true}
+	fldPath := field.NewPath("spec", "services").Key("worker")
+	validation := &sharedValidation{ctx: context.Background(), mgr: newGroveTopologyTestManager(t)}
+
+	errs := validation.validateDynamoComponentDeploymentSharedSpecV1alpha1(spec, fldPath, "replacement")
+	if len(validation.warnings) != 2 {
+		t.Fatalf("warnings = %v, want 2 compatibility warnings", validation.warnings)
+	}
+	if !strings.Contains(validation.warnings[0], "spec.services[worker].dynamoNamespace") ||
+		!strings.Contains(validation.warnings[1], "spec.services[worker].autoscaling") {
+		t.Fatalf("warnings = %v, want structural field paths", validation.warnings)
+	}
+	assertFieldPaths(t, errs, []string{
+		"spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend]",
+	})
 }
 
 // contains checks if s contains substr

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -30,6 +30,7 @@ import (
 	controllercommon "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -220,7 +221,11 @@ func (v *SharedSpecValidatorV1Alpha1) validateGMSClientContainerNames() error {
 
 // validateServiceAnnotations validates known annotations on the service-level spec.
 func (v *SharedSpecValidatorV1Alpha1) validateServiceAnnotations() error {
-	return validateVLLMDistributedExecutorBackendAnnotation(v.fieldPath+".annotations", v.spec.Annotations)
+	annotationsPath := ""
+	if v.fieldPath != "" {
+		annotationsPath = v.fieldPath + ".annotations"
+	}
+	return vllmDistributedExecutorBackendAnnotationError(annotationsPath, v.spec.Annotations)
 }
 
 // validateEPPConfig validates EPP-specific configuration constraints.
@@ -484,4 +489,133 @@ func (v *SharedSpecValidatorV1Alpha1) validateFrontendSidecar() error {
 		}
 	}
 	return nil
+}
+
+// validateDynamoComponentDeploymentSharedSpecV1alpha1 validates spec. spec and fldPath must not be nil.
+func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
+	spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+	dynamoNamespace string,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if spec.DynamoNamespace != nil && *spec.DynamoNamespace != "" {
+		v.warnf(
+			"%s.dynamoNamespace is deprecated and ignored. Value %q will be replaced with %q. Remove this field from your configuration",
+			fldPath,
+			*spec.DynamoNamespace,
+			dynamoNamespace,
+		)
+	}
+	//nolint:staticcheck // SA1019: Intentionally warning about a deprecated preserved field.
+	if spec.Autoscaling != nil {
+		v.warnf(
+			"%s.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md",
+			fldPath,
+		)
+	}
+
+	if value, invalid := invalidVLLMDistributedExecutorBackendAnnotation(spec.Annotations); invalid {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("annotations").Key(consts.KubeAnnotationVLLMDistributedExecutorBackend),
+			value,
+			`must be "mp" or "ray"`,
+		))
+	}
+
+	volumeMountsPath := fldPath.Child("volumeMounts")
+	for i := range spec.VolumeMounts {
+		allErrs = append(allErrs, v.validateVolumeMountV1alpha1(&spec.VolumeMounts[i], volumeMountsPath.Index(i))...)
+	}
+	if spec.Ingress != nil {
+		allErrs = append(allErrs, v.validateIngressSpecV1alpha1(spec.Ingress, fldPath.Child("ingress"))...)
+	}
+	if spec.EPPConfig != nil {
+		allErrs = append(allErrs, v.validateEPPConfigV1alpha1(spec.EPPConfig, fldPath.Child("eppConfig"))...)
+	}
+	if spec.FrontendSidecar != nil && spec.ExtraPodSpec != nil && spec.ExtraPodSpec.PodSpec != nil &&
+		hasContainerNamed(spec.ExtraPodSpec.PodSpec.Containers, consts.FrontendSidecarContainerName) {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath.Child("frontendSidecar"),
+			fmt.Sprintf("cannot inject frontend sidecar: a container named %q already exists in extraPodSpec.containers", consts.FrontendSidecarContainerName),
+		))
+	}
+	if spec.Failover != nil {
+		allErrs = append(allErrs, v.validateFailoverSpecV1alpha1(spec.Failover, fldPath.Child("failover"))...)
+	}
+	return allErrs
+}
+
+// validateVolumeMountV1alpha1 validates volumeMount. volumeMount and fldPath must not be nil.
+func (v *sharedValidation) validateVolumeMountV1alpha1(
+	volumeMount *nvidiacomv1alpha1.VolumeMount,
+	fldPath *field.Path,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if !volumeMount.UseAsCompilationCache && volumeMount.MountPoint == "" {
+		allErrs = append(allErrs, field.Required(
+			fldPath.Child("mountPoint"),
+			"is required when useAsCompilationCache is false",
+		))
+	}
+	return allErrs
+}
+
+// validateIngressSpecV1alpha1 validates ingress. ingress and fldPath must not be nil.
+func (v *sharedValidation) validateIngressSpecV1alpha1(
+	ingress *nvidiacomv1alpha1.IngressSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	if !ingress.Enabled || ingress.Host != "" {
+		return nil
+	}
+	return field.ErrorList{field.Required(fldPath.Child("host"), "is required when ingress is enabled")}
+}
+
+// validateEPPConfigV1alpha1 validates config. config and fldPath must not be nil.
+func (v *sharedValidation) validateEPPConfigV1alpha1(
+	config *nvidiacomv1alpha1.EPPConfig,
+	fldPath *field.Path,
+) field.ErrorList {
+	if (config.ConfigMapRef == nil) == (config.Config == nil) {
+		return field.ErrorList{field.Invalid(
+			fldPath,
+			nil,
+			"exactly one of configMapRef or config is required",
+		)}
+	}
+	if config.ConfigMapRef == nil || config.ConfigMapRef.Name != "" {
+		return nil
+	}
+	return field.ErrorList{field.Required(fldPath.Child("configMapRef", "name"), "is required")}
+}
+
+// validateFailoverSpecV1alpha1 validates failover. failover and fldPath must not be nil.
+func (v *sharedValidation) validateFailoverSpecV1alpha1(
+	failover *nvidiacomv1alpha1.FailoverSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	if !failover.Enabled || failover.Mode != nvidiacomv1alpha1.GMSModeIntraPod {
+		return nil
+	}
+	if failover.NumShadows == 0 || failover.NumShadows == 1 {
+		return nil
+	}
+	return field.ErrorList{field.Invalid(
+		fldPath.Child("numShadows"),
+		failover.NumShadows,
+		fmt.Sprintf("is invalid for mode=%q: intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode=%q to configure numShadows", nvidiacomv1alpha1.GMSModeIntraPod, nvidiacomv1alpha1.GMSModeInterPod),
+	)}
+}
+
+func vllmDistributedExecutorBackendAnnotationError(fieldPath string, annotations map[string]string) error {
+	value, invalid := invalidVLLMDistributedExecutorBackendAnnotation(annotations)
+	if !invalid {
+		return nil
+	}
+	if fieldPath == "" {
+		return fmt.Errorf("annotation %s has invalid value %q: must be \"mp\" or \"ray\"",
+			consts.KubeAnnotationVLLMDistributedExecutorBackend, value)
+	}
+	return fmt.Errorf("%s[%s] has invalid value %q: must be \"mp\" or \"ray\"",
+		fieldPath, consts.KubeAnnotationVLLMDistributedExecutorBackend, value)
 }

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -19,351 +19,419 @@ package validation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	controllercommon "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
-	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	k8sptr "k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// SharedSpecValidatorV1Beta1 validates v1beta1 DynamoComponentDeploymentSharedSpec fields.
-// DGD components use it directly; DCD can move to it when its admission path is ported to v1beta1.
-type SharedSpecValidatorV1Beta1 struct {
-	spec         *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec
-	fieldPath    string
-	grovePathway bool
-	mgr          ctrl.Manager
+// sharedValidation carries request-wide dependencies and accumulation used by
+// validation for API types shared by multiple resources.
+type sharedValidation struct {
+	ctx      context.Context
+	mgr      ctrl.Manager
+	warnings admission.Warnings
 }
 
-func NewSharedSpecValidatorV1Beta1(
+func (v *sharedValidation) warn(message string) {
+	v.warnings = append(v.warnings, message)
+}
+
+func (v *sharedValidation) warnf(format string, args ...any) {
+	v.warn(fmt.Sprintf(format, args...))
+}
+
+// validateDynamoComponentDeploymentSharedSpec validates spec. spec and fldPath must not be nil.
+func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpec(
 	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	fieldPath string,
+	fldPath *field.Path,
 	grovePathway bool,
-	mgr ctrl.Manager,
-) *SharedSpecValidatorV1Beta1 {
-	return &SharedSpecValidatorV1Beta1{
-		spec:         spec,
-		fieldPath:    fieldPath,
-		grovePathway: grovePathway,
-		mgr:          mgr,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if spec.MinAvailable != nil && !grovePathway {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath.Child("minAvailable"),
+			"is currently supported only for Grove-backed DynamoGraphDeployment components",
+		))
 	}
+	if spec.SharedMemorySize != nil && spec.SharedMemorySize.Sign() < 0 {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("sharedMemorySize"),
+			spec.SharedMemorySize.String(),
+			"must be non-negative",
+		))
+	}
+
+	if spec.ComponentType == nvidiacomv1beta1.ComponentTypeEPP {
+		if err := inferencePoolAvailabilityError(v.ctx, v.mgr); err != nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("type"), fmt.Sprintf("cannot deploy EPP component: %v", err)))
+		}
+		if spec.IsMultinode() {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("multinode"), "EPP component cannot be multinode"))
+		}
+		if spec.Replicas != nil && *spec.Replicas != 1 {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("replicas"),
+				*spec.Replicas,
+				"EPP component must have exactly 1 replica",
+			))
+		}
+		if spec.EPPConfig == nil {
+			allErrs = append(allErrs, field.Required(fldPath.Child("eppConfig"), "is required for EPP components"))
+		}
+	}
+	if spec.EPPConfig != nil {
+		allErrs = append(allErrs, v.validateEPPConfig(spec.EPPConfig, fldPath.Child("eppConfig"))...)
+	}
+
+	if spec.FrontendSidecar != nil {
+		frontendSidecarPath := fldPath.Child("frontendSidecar")
+		if spec.PodTemplate == nil {
+			allErrs = append(allErrs, field.Required(
+				fldPath.Child("podTemplate", "spec", "containers"),
+				"is required when frontendSidecar is set",
+			))
+		} else if *spec.FrontendSidecar == "" {
+			allErrs = append(allErrs, field.Invalid(frontendSidecarPath, *spec.FrontendSidecar, "must not be empty"))
+		} else if !hasContainerNamed(spec.PodTemplate.Spec.Containers, *spec.FrontendSidecar) {
+			allErrs = append(allErrs, field.Invalid(
+				frontendSidecarPath,
+				*spec.FrontendSidecar,
+				"must match a podTemplate.spec.containers name",
+			))
+		}
+	}
+
+	if spec.Experimental != nil {
+		allErrs = append(allErrs, v.validateExperimentalSpec(
+			spec.Experimental,
+			fldPath.Child("experimental"),
+			spec.ComponentType,
+			dynamo.GetMainContainerResources(spec),
+		)...)
+	}
+
+	return allErrs
 }
 
-func (v *SharedSpecValidatorV1Beta1) Validate(ctx context.Context) (admission.Warnings, error) {
-	var errs []error
-	if v.spec.Replicas != nil && *v.spec.Replicas < 0 {
-		errs = append(errs, fmt.Errorf("%s.replicas must be non-negative", v.fieldPath))
-	}
-	if err := v.validateMinAvailable(); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateFrontendSidecar(); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateSharedMemory(); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateCheckpointConfig(); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateGMSClientContainerNames(); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateEPPConfig(ctx); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateGPUMemoryService(); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateFailover(); err != nil {
-		errs = append(errs, err)
-	}
-	if err := v.validateSnapshotWithGPUMemoryService(); err != nil {
-		errs = append(errs, err)
-	}
-	return nil, errors.Join(errs...)
-}
-
-func (v *SharedSpecValidatorV1Beta1) validateMinAvailable() error {
-	if v.spec.MinAvailable == nil {
+// validateEPPConfig validates config. config and fldPath must not be nil.
+func (v *sharedValidation) validateEPPConfig(
+	config *nvidiacomv1beta1.EPPConfig,
+	fldPath *field.Path,
+) field.ErrorList {
+	if config.ConfigMapRef == nil || config.ConfigMapRef.Name != "" {
 		return nil
 	}
-	if !v.grovePathway {
-		return fmt.Errorf("%s.minAvailable is currently supported only for Grove-backed DynamoGraphDeployment components", v.fieldPath)
+	return field.ErrorList{field.Required(fldPath.Child("configMapRef", "name"), "is required")}
+}
+
+// validateTopologyConstraint validates constraint. constraint, specConstraint, and fldPath must not be nil.
+// topologyInfo may be nil when live topology validation is not applicable.
+func (v *sharedValidation) validateTopologyConstraint(
+	constraint *nvidiacomv1beta1.TopologyConstraint,
+	fldPath *field.Path,
+	specConstraint *nvidiacomv1beta1.SpecTopologyConstraint,
+	topologyInfo *clusterTopologyInfo,
+) field.ErrorList {
+	if topologyInfo == nil {
+		return nil
 	}
-	if *v.spec.MinAvailable <= 0 {
-		return fmt.Errorf("%s.minAvailable must be greater than 0", v.fieldPath)
+
+	packDomainPath := fldPath.Child("packDomain")
+	componentIndex, exists := topologyInfo.domainIndex[string(constraint.PackDomain)]
+	if !exists {
+		return field.ErrorList{field.Invalid(
+			packDomainPath,
+			constraint.PackDomain,
+			fmt.Sprintf("does not exist in ClusterTopology %q; available domains: %v", topologyInfo.name, topologyInfo.domains),
+		)}
 	}
-	replicas := int32(1)
-	if v.spec.Replicas != nil {
-		replicas = *v.spec.Replicas
+	if specConstraint.PackDomain == "" {
+		return nil
 	}
-	if replicas > 0 && replicas < *v.spec.MinAvailable {
-		return fmt.Errorf("%s.replicas must be 0 or greater than or equal to minAvailable", v.fieldPath)
+	specIndex, exists := topologyInfo.domainIndex[string(specConstraint.PackDomain)]
+	if exists && componentIndex < specIndex {
+		return field.ErrorList{field.Invalid(
+			packDomainPath,
+			constraint.PackDomain,
+			fmt.Sprintf("must be equal to or narrower than the deployment-level domain %q", specConstraint.PackDomain),
+		)}
 	}
 	return nil
 }
 
-func (v *SharedSpecValidatorV1Beta1) validateFrontendSidecar() error {
-	if v.spec.PodTemplate == nil {
-		if v.spec.FrontendSidecar != nil {
-			return fmt.Errorf("%s.frontendSidecar requires podTemplate.spec.containers", v.fieldPath)
+// validateExperimentalSpec validates experimental. experimental and fldPath must not be nil.
+func (v *sharedValidation) validateExperimentalSpec(
+	experimental *nvidiacomv1beta1.ExperimentalSpec,
+	fldPath *field.Path,
+	componentType nvidiacomv1beta1.ComponentType,
+	resources corev1.ResourceRequirements,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if experimental.GPUMemoryService != nil {
+		gpuMemoryServicePath := fldPath.Child("gpuMemoryService")
+		switch componentType {
+		case nvidiacomv1beta1.ComponentTypeWorker,
+			nvidiacomv1beta1.ComponentTypePrefill,
+			nvidiacomv1beta1.ComponentTypeDecode:
+		default:
+			allErrs = append(allErrs, field.Forbidden(
+				gpuMemoryServicePath,
+				"GPU memory service is only supported for worker, prefill, or decode components",
+			))
 		}
-		return nil
+
+		gpuCount, err := dra.ExtractGPUCountFromResourceRequirements(resources)
+		if err != nil || gpuCount < 1 {
+			allErrs = append(allErrs, field.Forbidden(
+				gpuMemoryServicePath,
+				"GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1",
+			))
+		}
+	}
+	if experimental.Failover != nil {
+		allErrs = append(allErrs, v.validateFailoverSpec(
+			experimental.Failover,
+			fldPath.Child("failover"),
+			experimental.GPUMemoryService,
+			componentType,
+			resources,
+		)...)
+	}
+	if experimental.Checkpoint != nil {
+		allErrs = append(allErrs, v.validateComponentCheckpointConfig(
+			experimental.Checkpoint,
+			fldPath.Child("checkpoint"),
+			experimental.GPUMemoryService,
+		)...)
 	}
 
-	containers := v.spec.PodTemplate.Spec.Containers
-	if v.spec.FrontendSidecar != nil {
-		target := *v.spec.FrontendSidecar
-		if target == "" {
-			return fmt.Errorf("%s.frontendSidecar must not be empty", v.fieldPath)
-		}
-		found := false
-		for i := range containers {
-			if containers[i].Name == target {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("%s.frontendSidecar %q does not match any podTemplate.spec.containers name",
-				v.fieldPath, target)
-		}
+	if experimental.Checkpoint != nil && experimental.Checkpoint.Enabled &&
+		experimental.GPUMemoryService != nil && os.Getenv(consts.DynamoOperatorAllowGMSSnapshotEnvVar) != "1" {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath.Child("checkpoint"),
+			"GMS + Snapshot is temporarily disabled; disable gpuMemoryService or enable the internal GMS + Snapshot gate",
+		))
 	}
-
-	return nil
+	return allErrs
 }
 
-func (v *SharedSpecValidatorV1Beta1) validateSharedMemory() error {
-	if v.spec.SharedMemorySize == nil {
-		return nil
+// validateFailoverSpec validates failover. failover and fldPath must not be nil.
+// gms may be nil because failover validates that sibling relationship.
+func (v *sharedValidation) validateFailoverSpec(
+	failover *nvidiacomv1beta1.FailoverSpec,
+	fldPath *field.Path,
+	gms *nvidiacomv1beta1.GPUMemoryServiceSpec,
+	componentType nvidiacomv1beta1.ComponentType,
+	resources corev1.ResourceRequirements,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	failoverMode := effectiveGMSMode(failover.Mode)
+	if gms == nil {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath,
+			fmt.Sprintf("gpuMemoryService is required when failover mode is %q", failoverMode),
+		))
+	} else if effectiveGMSMode(gms.Mode) != failoverMode {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("mode"),
+			failover.Mode,
+			fmt.Sprintf("must match gpuMemoryService.mode %q", gms.Mode),
+		))
 	}
-	if v.spec.SharedMemorySize.Sign() < 0 {
-		return fmt.Errorf("%s.sharedMemorySize must be non-negative", v.fieldPath)
-	}
-	return nil
-}
 
-func (v *SharedSpecValidatorV1Beta1) validateCheckpointConfig() error {
-	checkpoint := betaCheckpoint(v.spec)
-	if checkpoint == nil {
-		return nil
-	}
-	if checkpoint.Job != nil && checkpoint.CheckpointRef != nil && *checkpoint.CheckpointRef != "" {
-		return fmt.Errorf("%s.experimental.checkpoint.job cannot be set when checkpointRef is specified", v.fieldPath)
-	}
-	if checkpoint.TargetContainerName != "" {
-		if errs := k8svalidation.IsDNS1123Label(checkpoint.TargetContainerName); len(errs) > 0 {
-			return fmt.Errorf(
-				"%s.experimental.checkpoint.targetContainerName %q is not a valid Kubernetes container name: %s",
-				v.fieldPath,
-				checkpoint.TargetContainerName,
-				strings.Join(errs, "; "),
-			)
+	if failoverMode == nvidiacomv1beta1.GMSModeInterPod {
+		gpuCount, err := dra.ExtractGPUCountFromResourceRequirements(resources)
+		if err != nil {
+			allErrs = append(allErrs, field.Forbidden(
+				fldPath,
+				fmt.Sprintf("failed to read main-container GPU limit: %v", err),
+			))
+		} else if gpuCount < 1 {
+			allErrs = append(allErrs, field.Forbidden(
+				fldPath,
+				"GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu",
+			))
+		}
+
+		switch componentType {
+		case nvidiacomv1beta1.ComponentTypeEPP,
+			nvidiacomv1beta1.ComponentTypeFrontend,
+			nvidiacomv1beta1.ComponentTypePlanner:
+			allErrs = append(allErrs, field.Forbidden(
+				fldPath,
+				fmt.Sprintf("GMS failover is not supported for component type %q", componentType),
+			))
 		}
 	}
+	return allErrs
+}
+
+// validateComponentCheckpointConfig validates checkpoint. checkpoint and fldPath must not be nil.
+// gms may be nil because checkpoint validates that sibling relationship.
+func (v *sharedValidation) validateComponentCheckpointConfig(
+	checkpoint *nvidiacomv1beta1.ComponentCheckpointConfig,
+	fldPath *field.Path,
+	gms *nvidiacomv1beta1.GPUMemoryServiceSpec,
+) field.ErrorList {
 	if checkpoint.Job == nil {
 		return nil
 	}
-	if len(checkpoint.Job.GMSClientContainers) > 0 {
-		gms := betaGPUMemoryService(v.spec)
-		if gms == nil {
-			return fmt.Errorf("%s.experimental.checkpoint.job.gmsClientContainers requires gpuMemoryService to be set", v.fieldPath)
-		}
-		if betaGMSMode(gms.Mode) == nvidiacomv1beta1.GMSModeInterPod {
-			return fmt.Errorf("%s.experimental.checkpoint.job.gmsClientContainers is only supported with gpuMemoryService.mode=IntraPod", v.fieldPath)
-		}
-	}
-	for i, name := range checkpoint.Job.GMSClientContainers {
-		if errs := k8svalidation.IsDNS1123Label(name); len(errs) > 0 {
-			return fmt.Errorf(
-				"%s.experimental.checkpoint.job.gmsClientContainers[%d] %q is not a valid Kubernetes container name: %s",
-				v.fieldPath,
-				i,
-				name,
-				strings.Join(errs, "; "),
-			)
-		}
-	}
-	return nil
+	return v.validateComponentCheckpointJobConfig(checkpoint.Job, fldPath.Child("job"), gms)
 }
 
-func (v *SharedSpecValidatorV1Beta1) validateGMSClientContainerNames() error {
-	gms := betaGPUMemoryService(v.spec)
+// validateComponentCheckpointJobConfig validates job. job and fldPath must not be nil.
+// gms may be nil because the job validates that sibling relationship.
+func (v *sharedValidation) validateComponentCheckpointJobConfig(
+	job *nvidiacomv1beta1.ComponentCheckpointJobConfig,
+	fldPath *field.Path,
+	gms *nvidiacomv1beta1.GPUMemoryServiceSpec,
+) field.ErrorList {
+	if len(job.GMSClientContainers) == 0 {
+		return nil
+	}
 	if gms == nil {
-		return nil
+		return field.ErrorList{field.Forbidden(
+			fldPath.Child("gmsClientContainers"),
+			"requires gpuMemoryService to be set",
+		)}
 	}
-	for i, name := range gms.ExtraClientContainers {
-		if errs := k8svalidation.IsDNS1123Label(name); len(errs) > 0 {
-			return fmt.Errorf(
-				"%s.experimental.gpuMemoryService.extraClientContainers[%d] %q is not a valid Kubernetes container name: %s",
-				v.fieldPath,
-				i,
-				name,
-				strings.Join(errs, "; "),
-			)
-		}
-	}
-	if len(gms.ExtraClientContainers) > 0 && betaGMSMode(gms.Mode) == nvidiacomv1beta1.GMSModeInterPod {
-		return fmt.Errorf("%s.experimental.gpuMemoryService.extraClientContainers is only supported with mode=IntraPod", v.fieldPath)
-	}
-	if len(gms.ExtraClientPods) > 0 {
-		return fmt.Errorf("%s.experimental.gpuMemoryService.extraClientPods is reserved for inter-pod GMS and is not implemented yet", v.fieldPath)
+	if effectiveGMSMode(gms.Mode) == nvidiacomv1beta1.GMSModeInterPod {
+		return field.ErrorList{field.Forbidden(
+			fldPath.Child("gmsClientContainers"),
+			"is only supported with gpuMemoryService.mode=IntraPod",
+		)}
 	}
 	return nil
 }
 
-func (v *SharedSpecValidatorV1Beta1) validateEPPConfig(ctx context.Context) error {
-	if v.spec.ComponentType != nvidiacomv1beta1.ComponentTypeEPP {
-		return nil
+// validateDynamoComponentDeploymentSharedSpecUpdate validates a component update.
+// newComponent, oldComponent, and fldPath must not be nil.
+func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
+	newComponent *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	oldComponent *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+	canModifyReplicas bool,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if (newComponent.ScalingAdapter != nil || oldComponent.ScalingAdapter != nil) && !canModifyReplicas &&
+		k8sptr.Deref(newComponent.Replicas, int32(1)) != k8sptr.Deref(oldComponent.Replicas, int32(1)) {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath.Child("replicas"),
+			"cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead",
+		))
 	}
-	if err := v.checkInferencePoolAPIAvailability(ctx); err != nil {
-		return fmt.Errorf("%s: cannot deploy EPP component: %w", v.fieldPath, err)
+
+	if newComponent.IsMultinode() != oldComponent.IsMultinode() {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("multinode"),
+			newComponent.Multinode,
+			"cannot change node topology between single-node and multi-node after creation",
+		))
 	}
-	if v.spec.IsMultinode() {
-		return fmt.Errorf("%s: EPP component cannot be multinode (multinode field must be nil or nodeCount must be 1)", v.fieldPath)
+
+	topologyPath := fldPath.Child("topologyConstraint")
+	if newComponent.TopologyConstraint != nil {
+		allErrs = append(allErrs, v.validateTopologyConstraintUpdate(
+			newComponent.TopologyConstraint,
+			oldComponent.TopologyConstraint,
+			topologyPath,
+		)...)
+	} else if oldComponent.TopologyConstraint != nil {
+		allErrs = append(allErrs, field.Invalid(
+			topologyPath,
+			newComponent.TopologyConstraint,
+			"is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints",
+		))
 	}
-	if v.spec.Replicas != nil && *v.spec.Replicas != 1 {
-		return fmt.Errorf("%s: EPP component must have exactly 1 replica (found %d replicas)", v.fieldPath, *v.spec.Replicas)
+
+	if newComponent.Experimental != nil {
+		allErrs = append(allErrs, v.validateExperimentalSpecUpdate(
+			newComponent.Experimental,
+			oldComponent.Experimental,
+			fldPath.Child("experimental"),
+		)...)
+	} else if oldComponent.Experimental != nil {
+		oldGMS := gpuMemoryServiceForExperimental(oldComponent.Experimental)
+		if isInterPodGMS(oldGMS) {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("experimental", "gpuMemoryService", "mode"),
+				nil,
+				"the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+			))
+		}
+		oldFailover := failoverForExperimental(oldComponent.Experimental)
+		if isInterPodFailover(oldFailover) {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("experimental", "failover"),
+				nil,
+				"inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+			))
+		}
 	}
-	if v.spec.EPPConfig == nil {
-		return fmt.Errorf("%s.eppConfig is required for EPP components", v.fieldPath)
-	}
-	if v.spec.EPPConfig.ConfigMapRef == nil && v.spec.EPPConfig.Config == nil {
-		return fmt.Errorf("%s.eppConfig: either configMapRef or config must be specified (no default configuration provided)", v.fieldPath)
-	}
-	if v.spec.EPPConfig.ConfigMapRef != nil && v.spec.EPPConfig.Config != nil {
-		return fmt.Errorf("%s.eppConfig: configMapRef and config are mutually exclusive, only one can be specified", v.fieldPath)
-	}
-	if v.spec.EPPConfig.ConfigMapRef != nil && v.spec.EPPConfig.ConfigMapRef.Name == "" {
-		return fmt.Errorf("%s.eppConfig.configMapRef.name is required", v.fieldPath)
-	}
-	return nil
+	return allErrs
 }
 
-func (v *SharedSpecValidatorV1Beta1) checkInferencePoolAPIAvailability(ctx context.Context) error {
-	if v.mgr == nil {
-		return fmt.Errorf("manager is required to detect InferencePool API availability")
+// validateTopologyConstraintUpdate validates a topology constraint update.
+// newConstraint and fldPath must not be nil; oldConstraint may be nil for an addition.
+func (v *sharedValidation) validateTopologyConstraintUpdate(
+	newConstraint *nvidiacomv1beta1.TopologyConstraint,
+	oldConstraint *nvidiacomv1beta1.TopologyConstraint,
+	fldPath *field.Path,
+) field.ErrorList {
+	if oldConstraint != nil && newConstraint.PackDomain == oldConstraint.PackDomain {
+		return nil
 	}
-	if !controllercommon.DetectInferencePoolAvailability(ctx, v.mgr) {
-		return fmt.Errorf(
-			"InferencePool API group (%s) is not available in the cluster. "+
-				"EPP requires the Gateway API Inference Extension to be installed. "+
-				"Please install the Gateway API Inference Extension before deploying EPP components",
-			epp.InferencePoolGroup)
-	}
-	return nil
+	return field.ErrorList{field.Invalid(
+		fldPath,
+		newConstraint,
+		"is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints",
+	)}
 }
 
-func (v *SharedSpecValidatorV1Beta1) validateGPUMemoryService() error {
-	gms := betaGPUMemoryService(v.spec)
-	if gms == nil {
-		return nil
+// validateExperimentalSpecUpdate validates an experimental spec update.
+// newExperimental and fldPath must not be nil; oldExperimental may be nil for an addition.
+func (v *sharedValidation) validateExperimentalSpecUpdate(
+	newExperimental *nvidiacomv1beta1.ExperimentalSpec,
+	oldExperimental *nvidiacomv1beta1.ExperimentalSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	newGMS := newExperimental.GPUMemoryService
+	oldGMS := gpuMemoryServiceForExperimental(oldExperimental)
+	if isInterPodGMS(newGMS) != isInterPodGMS(oldGMS) {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("gpuMemoryService", "mode"),
+			k8sptr.Deref(newGMS, nvidiacomv1beta1.GPUMemoryServiceSpec{}).Mode,
+			"the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+		))
 	}
 
-	isWorker := v.spec.ComponentType == nvidiacomv1beta1.ComponentTypeWorker ||
-		v.spec.ComponentType == nvidiacomv1beta1.ComponentTypePrefill ||
-		v.spec.ComponentType == nvidiacomv1beta1.ComponentTypeDecode
-	if !isWorker {
-		return fmt.Errorf(
-			"%s.experimental.gpuMemoryService: GPU memory service is only supported for worker components (type must be worker, prefill, or decode)",
-			v.fieldPath)
+	newFailover := newExperimental.Failover
+	oldFailover := failoverForExperimental(oldExperimental)
+	if isInterPodFailover(newFailover) != isInterPodFailover(oldFailover) {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("failover"),
+			newFailover,
+			"inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+		))
 	}
-
-	gpuCount, err := dra.ExtractGPUCountFromResourceRequirements(dynamo.GetMainContainerResources(v.spec))
-	if err != nil || gpuCount < 1 {
-		return fmt.Errorf(
-			"%s.experimental.gpuMemoryService: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1",
-			v.fieldPath)
+	if isInterPodFailover(newFailover) && isInterPodFailover(oldFailover) &&
+		effectiveNumShadows(newFailover) != effectiveNumShadows(oldFailover) {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("failover", "numShadows"),
+			newFailover.NumShadows,
+			"is immutable for inter-pod GMS failover; delete and recreate the DynamoGraphDeployment to change it",
+		))
 	}
-
-	return nil
-}
-
-func (v *SharedSpecValidatorV1Beta1) validateFailover() error {
-	failover := betaFailover(v.spec)
-	if failover == nil {
-		return nil
-	}
-
-	var errs []error
-	gms := betaGPUMemoryService(v.spec)
-	failoverMode := betaGMSMode(failover.Mode)
-
-	switch failoverMode {
-	case nvidiacomv1beta1.GMSModeIntraPod:
-		if gms == nil {
-			errs = append(errs, fmt.Errorf(
-				"%s.experimental.failover: intraPod failover requires gpuMemoryService to be set",
-				v.fieldPath))
-		} else if betaGMSMode(gms.Mode) != nvidiacomv1beta1.GMSModeIntraPod {
-			errs = append(errs, fmt.Errorf(
-				"%s.experimental.failover: failover.mode %q must match gpuMemoryService.mode %q",
-				v.fieldPath, failoverMode, gms.Mode))
-		}
-		if failover.NumShadows != 0 && failover.NumShadows != 1 {
-			errs = append(errs, fmt.Errorf(
-				"%s.experimental.failover.numShadows=%d is invalid for mode=%q: intraPod uses a fixed 1 primary + 1 shadow sidecar; "+
-					"use failover.mode=%q to configure numShadows",
-				v.fieldPath, failover.NumShadows, nvidiacomv1beta1.GMSModeIntraPod, nvidiacomv1beta1.GMSModeInterPod))
-		}
-
-	case nvidiacomv1beta1.GMSModeInterPod:
-		if gms == nil {
-			errs = append(errs, fmt.Errorf(
-				"%s.experimental.failover: interPod failover requires gpuMemoryService.mode=%q",
-				v.fieldPath, nvidiacomv1beta1.GMSModeInterPod))
-		} else if betaGMSMode(gms.Mode) != nvidiacomv1beta1.GMSModeInterPod {
-			detected := string(gms.Mode)
-			if detected == "" {
-				detected = unsetValue
-			}
-			errs = append(errs, fmt.Errorf(
-				"%s.experimental.failover: interPod failover requires gpuMemoryService.mode=%q (got %q)",
-				v.fieldPath, nvidiacomv1beta1.GMSModeInterPod, detected))
-		}
-		if failover.NumShadows < 1 {
-			errs = append(errs, fmt.Errorf("%s.experimental.failover.numShadows must be >= 1", v.fieldPath))
-		}
-
-		gpuCount, err := dra.ExtractGPUCountFromResourceRequirements(dynamo.GetMainContainerResources(v.spec))
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s.podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu: %w", v.fieldPath, err))
-		} else if gpuCount < 1 {
-			errs = append(errs, fmt.Errorf("%s: GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu", v.fieldPath))
-		}
-
-		switch v.spec.ComponentType {
-		case nvidiacomv1beta1.ComponentTypeEPP, nvidiacomv1beta1.ComponentTypeFrontend, nvidiacomv1beta1.ComponentTypePlanner:
-			errs = append(errs, fmt.Errorf("%s: GMS failover is not supported for type %q", v.fieldPath, v.spec.ComponentType))
-		}
-
-	default:
-		errs = append(errs, fmt.Errorf("%s.experimental.failover.mode %q is invalid", v.fieldPath, failover.Mode))
-	}
-
-	return errors.Join(errs...)
-}
-
-func (v *SharedSpecValidatorV1Beta1) validateSnapshotWithGPUMemoryService() error {
-	checkpoint := betaCheckpoint(v.spec)
-	gms := betaGPUMemoryService(v.spec)
-	if checkpoint == nil || !checkpoint.Enabled || gms == nil {
-		return nil
-	}
-	if os.Getenv(consts.DynamoOperatorAllowGMSSnapshotEnvVar) == "1" {
-		return nil
-	}
-	return fmt.Errorf(
-		"%s.experimental.checkpoint: GMS + Snapshot is temporarily disabled; disable gpuMemoryService or enable the internal GMS + Snapshot gate",
-		v.fieldPath)
+	return allErrs
 }


### PR DESCRIPTION
## Dependency

Depends on #11216, which owns the admission-chain test prefactor. Until that PR merges, GitHub includes its test-only commits in this PR's aggregate diff. The structural-only stacked diff is available at https://github.com/sttts/dynamo/compare/sttts-dgd-admission-test-prefactor...sttts-structural-validation.

## Overview

Refactor DynamoGraphDeployment validation into a structural recursion that systematically follows the Go API type tree.

## Details

- split v1beta1 and v1alpha1 structural validation by their owning API types
- standardize typed field paths, field error lists, validator signatures, and sparse context propagation
- keep helpers receiver-free and colocate validators with their owning types
- leave source-schema and CEL-owned constraints declarative
- preserve fatal conversion failures and served-version compatibility boundaries
- add only structural error expectations and newly discovered regression cases on top of #11216

## Where should the reviewer start?

Start with `deploy/operator/internal/webhook/validation/AGENTS.md`, then follow the root validation recursion in `dynamographdeployment.go`.

## Related Issues

- [x] Confirmed — no related issue

## Summary

- make DGD validation structural and type-directed
- preserve v1alpha1 admission compatibility while validating the v1beta1 hub
- keep the unified schema/CEL/conversion/webhook test chain from #11216

## Validation

- `make check`
- `make test`
- `make lint`
- validation package coverage: 79.7%
