### PR TITLE
docs(backend): cover metrics publishing parity

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -327,6 +327,21 @@ Two surfaces:
 yet" or "no prefix cache" (gauge skipped); `0.0` is a legitimate
 zero-hit measurement.
 
+Backend shape:
+
+- **vLLM** pushes snapshots from its stat logger for each local DP rank and
+  bridges `vllm:` plus multiprocess-only `lmcache:` metrics from the global
+  registry.
+- **SGLang** pushes scheduler snapshots from the metrics leader node to avoid
+  double-counting DP ranks and bridges `sglang:` metrics from a private
+  multiprocess registry when `--enable-metrics` is set.
+- **TRT-LLM** pushes snapshots from the stats poll thread for each attention-DP
+  rank and bridges the global `trtllm_` registry.
+
+`WorkerConfig.enable_kv_routing=False` skips snapshot publisher construction,
+but the Prometheus bridge still runs. Use it when the worker should expose
+vendor metrics without feeding KV-aware routing signals.
+
 ## KV Event Publishing
 
 On the unified path, `Worker` owns `KvEventPublisher` construction. Engines

--- a/components/src/dynamo/common/backend/tests/test_metrics_helpers.py
+++ b/components/src/dynamo/common/backend/tests/test_metrics_helpers.py
@@ -58,3 +58,22 @@ def test_register_global_registry_splits_on_multiprocesscollector_conflict(
             multiproc_only_prefixes=["lmcache:"],
         )
     assert len(metrics.callbacks) == 2
+
+
+def test_register_global_registry_conflict_without_multiproc_only_prefixes(
+    monkeypatch, tmp_path
+):
+    """Conflict path should not add a duplicate multiprocess callback when
+    the engine has no multiprocess-only metric families."""
+    multiproc_dir = tmp_path / "mp"
+    multiproc_dir.mkdir()
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(multiproc_dir))
+
+    metrics = _StubMetrics()
+    with patch(
+        "prometheus_client.multiprocess.MultiProcessCollector",
+        side_effect=ValueError("metric already registered"),
+    ):
+        register_global_registry(metrics, engine_prefix="trtllm_")
+
+    assert len(metrics.callbacks) == 1

--- a/components/src/dynamo/common/backend/tests/test_publisher.py
+++ b/components/src/dynamo/common/backend/tests/test_publisher.py
@@ -85,6 +85,233 @@ async def test_register_prometheus_default_is_noop():
     assert await _MinimalEngine().register_prometheus(metrics=object()) is None
 
 
+def test_vllm_stat_logger_pushes_component_snapshot_to_publisher():
+    mod = pytest.importorskip(
+        "dynamo.vllm.llm_engine", reason="vLLM backend dependencies not installed"
+    )
+
+    published: list[tuple[int, ComponentSnapshot]] = []
+    publisher = SimpleNamespace(
+        publish=lambda rank, snap: published.append((rank, snap))
+    )
+    factory = mod._UnifiedStatLoggerFactory()
+    factory.snapshot_publisher = publisher
+    factory.num_gpu_blocks = 100
+    logger = factory(vllm_config=object(), dp_rank=3)
+
+    logger.record(
+        SimpleNamespace(
+            kv_cache_usage=0.25,
+            prefix_cache_stats=SimpleNamespace(hits=3, queries=4),
+        ),
+        iteration_stats=None,
+    )
+
+    assert len(published) == 1
+    rank, snapshot = published[0]
+    assert rank == 3
+    assert snapshot == ComponentSnapshot(
+        kv_used_blocks=25,
+        kv_total_blocks=100,
+        gpu_cache_usage=0.25,
+        kv_cache_hit_rate=0.75,
+        dp_rank=3,
+    )
+
+
+@pytest.mark.asyncio
+async def test_vllm_metrics_hooks_cover_dp_ranks_and_prometheus(monkeypatch):
+    mod = pytest.importorskip(
+        "dynamo.vllm.llm_engine", reason="vLLM backend dependencies not installed"
+    )
+
+    calls: list[tuple[object, dict]] = []
+    monkeypatch.setattr(
+        mod,
+        "register_global_registry",
+        lambda metrics, **kwargs: calls.append((metrics, kwargs)),
+    )
+
+    engine = mod.VllmLLMEngine.__new__(mod.VllmLLMEngine)
+    engine._dp_range = (2, 3)
+    engine._stat_logger_factory = mod._UnifiedStatLoggerFactory()
+    engine.engine_args = SimpleNamespace(disable_log_stats=False)
+
+    assert engine.component_metrics_dp_ranks() == [2, 3, 4]
+
+    publisher = object()
+    engine.attach_snapshot_publisher(publisher)
+    assert engine._stat_logger_factory.snapshot_publisher is publisher
+
+    metrics = object()
+    await engine.register_prometheus(metrics)
+    assert calls == [
+        (
+            metrics,
+            {
+                "engine_prefix": "vllm:",
+                "multiproc_only_prefixes": ["lmcache:"],
+            },
+        )
+    ]
+
+    engine.engine_args.disable_log_stats = True
+    calls.clear()
+    await engine.register_prometheus(metrics)
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_sglang_metrics_hooks_are_leader_only_and_register_prometheus(
+    monkeypatch,
+):
+    mod = pytest.importorskip(
+        "dynamo.sglang.llm_engine", reason="SGLang backend dependencies not installed"
+    )
+    prometheus_client = pytest.importorskip("prometheus_client")
+    from prometheus_client import multiprocess as prometheus_multiprocess
+
+    class FakeRegistry:
+        pass
+
+    collector_registries: list[FakeRegistry] = []
+    register_calls: list[tuple[object, object, list[str]]] = []
+
+    monkeypatch.setattr(prometheus_client, "CollectorRegistry", FakeRegistry)
+    monkeypatch.setattr(
+        prometheus_multiprocess,
+        "MultiProcessCollector",
+        lambda registry: collector_registries.append(registry),
+    )
+
+    from dynamo.common.backend import metrics as metrics_mod
+
+    monkeypatch.setattr(
+        metrics_mod,
+        "register_engine_registry",
+        lambda metrics, registry, prefix_filters: register_calls.append(
+            (metrics, registry, prefix_filters)
+        ),
+    )
+
+    engine = mod.SglangLLMEngine.__new__(mod.SglangLLMEngine)
+    engine.server_args = SimpleNamespace(
+        dp_size=8,
+        enable_dp_attention=True,
+        nnodes=2,
+        node_rank=0,
+        enable_metrics=True,
+    )
+
+    assert engine.component_metrics_dp_ranks() == [0, 1, 2, 3]
+
+    publisher = object()
+    engine.attach_snapshot_publisher(publisher)
+    assert engine._snapshot_publisher is publisher
+
+    metrics = object()
+    await engine.register_prometheus(metrics)
+    assert len(collector_registries) == 1
+    assert register_calls == [(metrics, collector_registries[0], ["sglang:"])]
+
+    engine.server_args.node_rank = 1
+    assert engine.component_metrics_dp_ranks() == []
+
+    engine.server_args.enable_metrics = False
+    collector_registries.clear()
+    register_calls.clear()
+    await engine.register_prometheus(metrics)
+    assert collector_registries == []
+    assert register_calls == []
+
+
+@pytest.mark.asyncio
+async def test_trtllm_metrics_hooks_cover_attention_dp_and_prometheus(monkeypatch):
+    mod = pytest.importorskip(
+        "dynamo.trtllm.llm_engine",
+        reason="TensorRT-LLM backend dependencies not installed",
+    )
+
+    calls: list[tuple[object, dict]] = []
+    monkeypatch.setattr(
+        mod,
+        "register_global_registry",
+        lambda metrics, **kwargs: calls.append((metrics, kwargs)),
+    )
+
+    engine = mod.TrtllmLLMEngine.__new__(mod.TrtllmLLMEngine)
+    engine._attention_dp_size = 3
+    engine._snapshot_publisher = None
+
+    assert engine.component_metrics_dp_ranks() == [0, 1, 2]
+
+    publisher = object()
+    engine.attach_snapshot_publisher(publisher)
+    assert engine._snapshot_publisher is publisher
+
+    metrics = object()
+    await engine.register_prometheus(metrics)
+    assert calls == [(metrics, {"engine_prefix": "trtllm_"})]
+
+
+def test_trtllm_metrics_poll_loop_publishes_component_snapshots():
+    mod = pytest.importorskip(
+        "dynamo.trtllm.llm_engine",
+        reason="TensorRT-LLM backend dependencies not installed",
+    )
+
+    published: list[tuple[int, ComponentSnapshot]] = []
+    iteration_stats: list[dict] = []
+
+    class FakeLlm:
+        def get_stats(self, timeout):
+            engine._publish_stop.set()
+            return [
+                {
+                    "attentionDpRank": 2,
+                    "kvCacheStats": {
+                        "usedNumBlocks": 5,
+                        "maxNumBlocks": 10,
+                        "cacheHitRate": 0.4,
+                    },
+                }
+            ]
+
+    engine = mod.TrtllmLLMEngine.__new__(mod.TrtllmLLMEngine)
+    engine._engine = SimpleNamespace(llm=FakeLlm())
+    engine._publish_stop = mod.threading.Event()
+    engine._snapshot_publisher = SimpleNamespace(
+        publish=lambda rank, snap: published.append((rank, snap))
+    )
+    engine._additional_metrics = None
+    engine._log_iteration_stats = iteration_stats.append
+
+    engine._metrics_poll_loop()
+
+    assert published == [
+        (
+            2,
+            ComponentSnapshot(
+                kv_used_blocks=5,
+                kv_total_blocks=10,
+                gpu_cache_usage=0.5,
+                kv_cache_hit_rate=0.4,
+                dp_rank=2,
+            ),
+        )
+    ]
+    assert iteration_stats == [
+        {
+            "attentionDpRank": 2,
+            "kvCacheStats": {
+                "usedNumBlocks": 5,
+                "maxNumBlocks": 10,
+                "cacheHitRate": 0.4,
+            },
+        }
+    ]
+
+
 @pytest.mark.asyncio
 async def test_vllm_kv_event_sources_return_one_zmq_source_per_dp_rank(monkeypatch):
     mod = pytest.importorskip(

--- a/components/src/dynamo/common/backend/worker.py
+++ b/components/src/dynamo/common/backend/worker.py
@@ -120,7 +120,7 @@ class WorkerConfig:
     exclude_tools_when_tool_choice_none: bool = True
     enable_local_indexer: bool = True
     # Operator-level kill switch for KV-aware-routing publishers. When False,
-    # Worker skips engine.kv_event_sources() and engine.metrics_sources() so
+    # Worker skips engine.kv_event_sources() and SnapshotPublisher setup so
     # the worker ships no KV events or worker-load metrics.
     enable_kv_routing: bool = True
     metrics_labels: list[tuple[str, str]] = field(default_factory=list)

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -88,10 +88,8 @@ logger = logging.getLogger(__name__)
 
 
 class _UnifiedStatLogger(StatLoggerBase):
-    """vLLM stat-logger that writes a :class:`ComponentSnapshot` into the
-    factory's shared dict on every iteration. The framework's poll task
-    reads the dict and drives both the router-input signal and the
-    ``dynamo_component_*`` gauges."""
+    """vLLM stat-logger that pushes :class:`ComponentSnapshot` values into
+    the Rust-owned :class:`SnapshotPublisher` on every iteration."""
 
     def __init__(self, factory: _UnifiedStatLoggerFactory, dp_rank: int) -> None:
         self._factory = factory

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -498,6 +498,58 @@ async def cleanup(self) -> None:
         self._engine = None
 ```
 
+#### Python: Metrics and Prometheus (optional)
+
+Unified backends have two metrics surfaces.
+
+Use `register_prometheus(metrics)` to bridge vendor-prefixed Prometheus
+families into the worker's `/metrics` output. The framework owns the
+`metrics` handle; do not retain it after the method returns.
+
+```python
+from dynamo.common.backend.metrics import register_global_registry
+
+async def register_prometheus(self, metrics):
+    register_global_registry(metrics, engine_prefix="vllm:")
+```
+
+Use `component_metrics_dp_ranks()` plus
+`attach_snapshot_publisher(publisher)` when the engine can push per-rank
+`ComponentSnapshot` values for `dynamo_component_*` gauges and the
+router's `kv_used_blocks` signal:
+
+```python
+from dynamo.common.backend.publisher import ComponentSnapshot
+
+def component_metrics_dp_ranks(self):
+    return [0]
+
+def attach_snapshot_publisher(self, publisher):
+    self._snapshot_publisher = publisher
+
+def _on_stats(self, used_blocks, total_blocks):
+    self._snapshot_publisher.publish(
+        0,
+        ComponentSnapshot(
+            kv_used_blocks=used_blocks,
+            kv_total_blocks=total_blocks,
+            gpu_cache_usage=used_blocks / total_blocks if total_blocks else 0.0,
+            dp_rank=0,
+        ),
+    )
+```
+
+Keep the rank list stable for the engine lifetime. `Worker` invokes
+`attach_snapshot_publisher()` only when the rank list is non-empty and
+`WorkerConfig.enable_kv_routing` is enabled. `register_prometheus()` still
+runs when `enable_kv_routing=False`.
+
+Use the in-tree backends as references: vLLM pushes snapshots from its
+stat logger and bridges `vllm:` / `lmcache:` metrics, SGLang pushes
+leader-node scheduler snapshots and bridges `sglang:` when
+`--enable-metrics` is set, and TRT-LLM pushes snapshots from its stats
+poll thread while bridging `trtllm_` metrics.
+
 #### Python: KV event publishing (optional)
 
 Unified backends declare KV event sources; the framework constructs and owns

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -147,7 +147,7 @@ pub struct WorkerConfig {
     /// Whether this worker should keep an in-process KV indexer.
     pub enable_local_indexer: bool,
     /// Kill switch for KV-aware-routing publishers. When `false`, skip
-    /// `engine.kv_event_sources()` / `metrics_sources()` entirely.
+    /// `engine.kv_event_sources()` and `SnapshotPublisher` setup.
     pub enable_kv_routing: bool,
     /// Per-endpoint Prometheus metric labels appended to every metric.
     /// Common labels: `("model", "<served-name>")`.


### PR DESCRIPTION
## Overview:

Documents unified-backend metrics publishing parity and adds targeted coverage for the remaining metrics parity gaps.

## Details:

- Documented the unified backend metrics surfaces: vendor Prometheus bridging and per-rank `ComponentSnapshot` publishing.
- Added backend-level tests for vLLM, SGLang, and TRT-LLM metrics hooks and snapshot publishing.
- Added coverage for the Prometheus multiprocess conflict path when no multiprocess-only prefixes are configured.
- Cleaned stale metrics comments to refer to `SnapshotPublisher` rather than the removed metrics source path.

## Where should the reviewer start?

- `docs/development/unified-backends.md`
- `components/src/dynamo/common/backend/tests/test_publisher.py`
- `components/src/dynamo/common/backend/tests/test_metrics_helpers.py`

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue**:
- [x] Confirmed — no related GitHub issue

Related Linear work: DIS-1984, DIS-1997, DIS-1998.

## Validation

- `python3 -m py_compile components/src/dynamo/common/backend/tests/test_publisher.py components/src/dynamo/common/backend/tests/test_metrics_helpers.py components/src/dynamo/vllm/llm_engine.py components/src/dynamo/common/backend/worker.py`
- `git diff --check`
- `cargo test -p dynamo-backend-common --features testing --lib`

Focused Python pytest was not runnable locally because `dynamo._core` / `dynamo._core.backend` is not built; `test_publisher.py` uses the existing `maturin develop` guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded backend metrics support so snapshot publishing and Prometheus metrics work consistently across supported engines.
  * Metrics now continue to be exported even when KV routing is turned off.

* **Bug Fixes**
  * Improved handling of metrics registration conflicts to avoid duplicate callbacks in edge cases.
  * Clarified and aligned backend metrics behavior for different runtime modes.

* **Documentation**
  * Added guidance on backend metrics, snapshot publishing, and Prometheus integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->