### PR TITLE
fix(frontend): reconcile model registrations

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -198,6 +198,13 @@ impl ModelManager {
         self.cards.iter().map(|r| r.value().clone()).collect()
     }
 
+    /// Return owned discovery instance keys for the locally recorded cards.
+    /// Reconciliation must not hold DashMap guards while it performs
+    /// asynchronous cleanup.
+    pub fn get_model_card_keys(&self) -> Vec<String> {
+        self.cards.iter().map(|r| r.key().clone()).collect()
+    }
+
     /// Save a ModelDeploymentCard from an instance's key so we can fetch it later when the key is
     /// deleted.
     pub fn save_model_card(&self, key: &str, card: ModelDeploymentCard) -> anyhow::Result<()> {

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -3,10 +3,12 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use std::time::Duration;
-use tokio::sync::Notify;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::{Mutex, Notify, mpsc::Sender};
 use tokio::task::{JoinHandle, JoinSet};
 
 use anyhow::Context as _;
@@ -185,9 +187,13 @@ pub struct ModelWatcher {
     /// Wakes tasks blocked in `recover_concurrent_registration` when a
     /// `RegistrationGuard` drops (i.e. a registration completes or panics).
     registration_notify: Notify,
-    /// Tracks in-flight `handle_put` tasks by instance path so that `handle_delete`
-    /// can await a racing put before proceeding with cleanup.
-    pending_puts: DashMap<String, JoinHandle<()>>,
+    /// Tracks in-flight `handle_put` tasks by instance path so a later operation
+    /// can cancel a superseded registration.
+    pending_puts: DashMap<String, PendingPut>,
+    /// Serializes state changes for one model-card instance. The generation
+    /// fence preserves discovery-event order even when spawned tasks acquire
+    /// the per-instance lock in a different order.
+    instance_operations: DashMap<String, Arc<InstanceOperation>>,
     /// Maps an MDC instance path to the LoRA adapter name recorded in the pre-spawn state-tracker
     /// addition, so a removal whose model card was never durably saved (handle_put failed before
     /// save) can still remove exactly that adapter from the tracker instead of leaving phantom
@@ -245,6 +251,46 @@ struct RegistrationGuard<'a> {
     notify: &'a Notify,
 }
 
+struct PendingPut {
+    generation: u64,
+    handle: JoinHandle<()>,
+}
+
+#[derive(Default)]
+struct InstanceOperation {
+    generation: AtomicU64,
+    lock: Mutex<()>,
+}
+
+impl InstanceOperation {
+    fn current_generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    fn begin(&self) -> u64 {
+        self.generation
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1)
+    }
+
+    fn reserve_after(&self, expected: u64) -> Option<u64> {
+        let next = expected.wrapping_add(1);
+        self.generation
+            .compare_exchange(expected, next, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| next)
+    }
+
+    fn is_current(&self, generation: u64) -> bool {
+        self.current_generation() == generation
+    }
+}
+
+enum DeleteOutcome {
+    Superseded,
+    Processed(Option<String>),
+}
+
 impl Drop for RegistrationGuard<'_> {
     fn drop(&mut self) {
         self.set.remove(&self.key);
@@ -278,6 +324,7 @@ impl ModelWatcher {
             registering_worker_sets: DashSet::new(),
             registration_notify: Notify::new(),
             pending_puts: DashMap::new(),
+            instance_operations: DashMap::new(),
             pending_lora_adds: DashMap::new(),
             local_model_path: None,
             tokenizer_backend: None,
@@ -300,6 +347,63 @@ impl ModelWatcher {
         if let Some(tokenizer_backend) = self.tokenizer_backend {
             card.runtime_config.tokenizer_backend = Some(tokenizer_backend);
         }
+    }
+
+    fn instance_operation(&self, key: &str) -> Arc<InstanceOperation> {
+        self.instance_operations
+            .entry(key.to_string())
+            .or_insert_with(|| Arc::new(InstanceOperation::default()))
+            .clone()
+    }
+
+    fn begin_instance_operation(&self, key: &str) -> (Arc<InstanceOperation>, u64) {
+        let operation = self.instance_operation(key);
+        let generation = operation.begin();
+        (operation, generation)
+    }
+
+    fn observe_instance_operation(&self, key: &str) -> (Arc<InstanceOperation>, u64) {
+        let operation = self.instance_operation(key);
+        let generation = operation.current_generation();
+        (operation, generation)
+    }
+
+    fn prune_instance_operation(&self, key: &str, operation: &Arc<InstanceOperation>) {
+        self.instance_operations.remove_if(key, |_, current| {
+            Arc::ptr_eq(current, operation) && Arc::strong_count(current) == 2
+        });
+    }
+
+    fn seed_lora_state_for_put(
+        &self,
+        mcid: &ModelCardInstanceId,
+        card: &ModelDeploymentCard,
+    ) {
+        use crate::kv_router::protocols::WorkerWithDpRank;
+
+        let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
+        if let Some(adapter_name) =
+            seed_lora_state_from_card(self.manager.lora_state_tracker(), worker, card)
+        {
+            self.pending_lora_adds
+                .insert(mcid.to_path(), adapter_name);
+        }
+    }
+
+    async fn handle_put_if_current(
+        &self,
+        mcid: &ModelCardInstanceId,
+        card: &mut ModelDeploymentCard,
+        operation: &InstanceOperation,
+        generation: u64,
+    ) -> Option<anyhow::Result<()>> {
+        let _guard = operation.lock.lock().await;
+        if !operation.is_current(generation) {
+            return None;
+        }
+
+        self.seed_lora_state_for_put(mcid, card);
+        Some(self.handle_put(mcid, card).await)
     }
 
     /// Wait until we have at least one chat completions model and return it's name.
@@ -441,38 +545,23 @@ impl ModelWatcher {
                         continue;
                     }
 
-                    // Feed the LoRA state tracker for every worker registration (before the spawn
-                    // below, so `card` is read before it is moved into the task). An adapter card
-                    // registers the loaded adapter (+capacity); a base card advertising
-                    // runtime_config.max_gpu_lora_count seeds capacity-only so idle LoRA-capable
-                    // workers are visible to the controller before any adapter is loaded there.
-                    {
-                        use crate::kv_router::protocols::WorkerWithDpRank;
-                        let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
-                        if let Some(adapter_name) = seed_lora_state_from_card(
-                            self.manager.lora_state_tracker(),
-                            worker,
-                            &card,
-                        ) {
-                            // Record the adapter name keyed by instance path so a later removal
-                            // whose card was never durably saved can still remove exactly this
-                            // adapter (R4-2).
-                            self.pending_lora_adds.insert(mcid.to_path(), adapter_name);
-                        }
-                    }
-
                     // Spawn each handle_put into its own task so that a slow
                     // HuggingFace config download for one model cannot block
                     // discovery events for all subsequent models.
                     //
-                    // The JoinHandle is stored in `pending_puts` so that a
-                    // subsequent `handle_delete` for the same instance can
-                    // await the in-flight put before attempting cleanup.
+                    // The per-instance operation generation preserves event
+                    // order if this task is scheduled after a later operation.
                     let instance_key = mcid.to_path();
+                    let task_key = instance_key.clone();
+                    let (operation, generation) =
+                        self.begin_instance_operation(&instance_key);
                     let watcher = Arc::clone(&self);
                     let handle = tokio::spawn(async move {
-                        match watcher.handle_put(&mcid, &mut card).await {
-                            Ok(()) => {
+                        match watcher
+                            .handle_put_if_current(&mcid, &mut card, &operation, generation)
+                            .await
+                        {
+                            Some(Ok(())) => {
                                 tracing::info!(
                                     model_name = card.name(),
                                     namespace = mcid.namespace,
@@ -480,7 +569,7 @@ impl ModelWatcher {
                                 );
                                 watcher.notify_on_model.notify_waiters();
                             }
-                            Err(err) => {
+                            Some(Err(err)) => {
                                 tracing::error!(
                                     model_name = card.name(),
                                     namespace = mcid.namespace,
@@ -488,7 +577,15 @@ impl ModelWatcher {
                                     "Error adding model from discovery",
                                 );
                             }
+                            None => {
+                                tracing::debug!(
+                                    key = %task_key,
+                                    generation,
+                                    "Skipping superseded model registration"
+                                );
+                            }
                         }
+                        watcher.prune_instance_operation(&task_key, &operation);
                         // Note: we intentionally do NOT remove from pending_puts here.
                         // Only the watch loop (on duplicate events) and handle_delete
                         // manage pending_puts, avoiding a race where a completed task's
@@ -503,10 +600,16 @@ impl ModelWatcher {
                     // The only case that hits this branch is the etcd watch replaying the same
                     // worker's Added event (reconnect or re-sync) — where cancelling the earlier
                     // redundant task is exactly what we want.
-                    if let Some((_, old_handle)) = self.pending_puts.remove(&instance_key) {
-                        old_handle.abort();
+                    if let Some((_, old_put)) = self.pending_puts.remove(&instance_key) {
+                        old_put.handle.abort();
                     }
-                    self.pending_puts.insert(instance_key, handle);
+                    self.pending_puts.insert(
+                        instance_key,
+                        PendingPut {
+                            generation,
+                            handle,
+                        },
+                    );
                 }
                 DiscoveryEvent::Removed(id) => {
                     // Extract ModelCardInstanceId from the removal event
@@ -520,19 +623,25 @@ impl ModelWatcher {
                         }
                     };
 
-                    // LoRA state-tracker cleanup runs inside handle_delete, after it waits for
-                    // any in-flight handle_put, so the card is reliably present even when a
-                    // Removed event races an in-flight add (N2).
+                    let instance_key = model_card_instance_id.to_path();
+                    let (operation, generation) =
+                        self.begin_instance_operation(&instance_key);
                     match self
-                        .handle_delete(model_card_instance_id, &namespace_filter)
+                        .handle_delete(
+                            model_card_instance_id,
+                            &namespace_filter,
+                            operation,
+                            generation,
+                        )
                         .await
                     {
-                        Ok(Some(model_name)) => {
+                        Ok(DeleteOutcome::Processed(Some(model_name))) => {
                             tracing::info!(model_name, "removed model");
                         }
-                        Ok(None) => {
+                        Ok(DeleteOutcome::Processed(None)) => {
                             // There are other instances running this model, nothing to do
                         }
+                        Ok(DeleteOutcome::Superseded) => {}
                         Err(e) => {
                             tracing::error!(error = %e, "error removing model");
                         }
@@ -551,6 +660,19 @@ impl ModelWatcher {
     /// `handle_delete`. The snapshot is sorted so repeated failures are logged
     /// and retried in a deterministic order.
     async fn reconcile(self: &Arc<Self>, namespace_filter: &NamespaceFilter) -> anyhow::Result<()> {
+        // Snapshot local keys and their operation generations before awaiting
+        // discovery. A registration that starts after this point advances its
+        // generation and prevents this snapshot from deleting the fresh card.
+        let local_entries = self
+            .manager
+            .get_model_card_keys()
+            .into_iter()
+            .map(|key| {
+                let (operation, generation) = self.observe_instance_operation(&key);
+                (key, operation, generation)
+            })
+            .collect::<Vec<_>>();
+
         let mut instances = self.drt.discovery().list(DiscoveryQuery::AllModels).await?;
         instances.sort_by_key(|instance| {
             model_card_instance_id(instance)
@@ -601,8 +723,8 @@ impl ModelWatcher {
             }
         }
 
-        let mut stale_keys = Vec::new();
-        for key in self.manager.get_model_card_keys() {
+        let mut stale_entries = Vec::new();
+        for (key, operation, generation) in local_entries {
             let mcid = match ModelCardInstanceId::from_path(&key) {
                 Ok(mcid) => mcid,
                 Err(err) => {
@@ -611,25 +733,39 @@ impl ModelWatcher {
                 }
             };
             if namespace_filter.matches(&mcid.namespace) && !desired_keys.contains(&key) {
-                stale_keys.push(key);
+                stale_entries.push((key, mcid, operation, generation));
             }
         }
-        stale_keys.sort();
+        stale_entries.sort_by(|left, right| left.0.cmp(&right.0));
+        let stale_entry_count = stale_entries.len();
 
         let mut removed_stale_count = 0usize;
-        for key in &stale_keys {
-            let mcid = match ModelCardInstanceId::from_path(key) {
-                Ok(mcid) => mcid,
-                Err(err) => {
-                    tracing::warn!(%err, key, "Ignoring malformed stale model-card key");
-                    continue;
-                }
+        let mut superseded_stale_count = 0usize;
+        for (key, mcid, operation, snapshot_generation) in stale_entries {
+            let Some(delete_generation) = operation.reserve_after(snapshot_generation) else {
+                superseded_stale_count += 1;
+                tracing::debug!(
+                    key = %key,
+                    snapshot_generation,
+                    current_generation = operation.current_generation(),
+                    "Skipping stale cleanup superseded after reconciliation snapshot"
+                );
+                continue;
             };
-            match self.handle_delete(&mcid, namespace_filter).await {
-                Ok(_) => removed_stale_count += 1,
+            match self
+                .handle_delete(
+                    &mcid,
+                    namespace_filter,
+                    operation,
+                    delete_generation,
+                )
+                .await
+            {
+                Ok(DeleteOutcome::Processed(_)) => removed_stale_count += 1,
+                Ok(DeleteOutcome::Superseded) => superseded_stale_count += 1,
                 Err(err) => {
                     tracing::error!(
-                        key,
+                        key = %key,
                         error = format!("{err:#}"),
                         "Error removing stale model during reconciliation"
                     );
@@ -641,7 +777,9 @@ impl ModelWatcher {
             expected_model_cards = desired_keys.len(),
             retried_model_cards = retry_count,
             removed_stale_model_cards = removed_stale_count,
-            failed_stale_model_cards = stale_keys.len() - removed_stale_count,
+            superseded_stale_model_cards = superseded_stale_count,
+            failed_stale_model_cards = stale_entry_count
+                .saturating_sub(removed_stale_count + superseded_stale_count),
             "Completed frontend model registration reconciliation"
         );
         Ok(())
@@ -659,7 +797,7 @@ impl ModelWatcher {
         if self
             .pending_puts
             .get(&instance_key)
-            .is_some_and(|handle| !handle.is_finished())
+            .is_some_and(|pending| !pending.handle.is_finished())
         {
             return false;
         }
@@ -678,17 +816,6 @@ impl ModelWatcher {
             return false;
         }
 
-        {
-            use crate::kv_router::protocols::WorkerWithDpRank;
-            let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
-            if let Some(adapter_name) =
-                seed_lora_state_from_card(self.manager.lora_state_tracker(), worker, &card)
-            {
-                self.pending_lora_adds
-                    .insert(instance_key.clone(), adapter_name);
-            }
-        }
-
         tracing::warn!(
             model_name = card.name(),
             namespace = mcid.namespace,
@@ -696,10 +823,15 @@ impl ModelWatcher {
             "Retrying incomplete frontend model registration from discovery snapshot"
         );
 
+        let task_key = instance_key.clone();
+        let (operation, generation) = self.begin_instance_operation(&instance_key);
         let watcher = Arc::clone(self);
         let handle = tokio::spawn(async move {
-            match watcher.handle_put(&mcid, &mut card).await {
-                Ok(()) => {
+            match watcher
+                .handle_put_if_current(&mcid, &mut card, &operation, generation)
+                .await
+            {
+                Some(Ok(())) => {
                     tracing::info!(
                         model_name = card.name(),
                         namespace = mcid.namespace,
@@ -707,7 +839,7 @@ impl ModelWatcher {
                     );
                     watcher.notify_on_model.notify_waiters();
                 }
-                Err(err) => {
+                Some(Err(err)) => {
                     tracing::error!(
                         model_name = card.name(),
                         namespace = mcid.namespace,
@@ -715,13 +847,27 @@ impl ModelWatcher {
                         "Model registration reconciliation retry failed"
                     );
                 }
+                None => {
+                    tracing::debug!(
+                        key = %task_key,
+                        generation,
+                        "Skipping superseded model registration retry"
+                    );
+                }
             }
+            watcher.prune_instance_operation(&task_key, &operation);
         });
 
-        if let Some((_, old_handle)) = self.pending_puts.remove(&instance_key) {
-            old_handle.abort();
+        if let Some((_, old_put)) = self.pending_puts.remove(&instance_key) {
+            old_put.handle.abort();
         }
-        self.pending_puts.insert(instance_key, handle);
+        self.pending_puts.insert(
+            instance_key,
+            PendingPut {
+                generation,
+                handle,
+            },
+        );
         true
     }
 
@@ -731,31 +877,76 @@ impl ModelWatcher {
         &self,
         mcid: &ModelCardInstanceId,
         namespace_filter: &NamespaceFilter,
+        operation: Arc<InstanceOperation>,
+        generation: u64,
+    ) -> anyhow::Result<DeleteOutcome> {
+        let key = mcid.to_path();
+
+        let operation_guard = match tokio::time::timeout(
+            Duration::from_secs(60),
+            operation.lock.lock(),
+        )
+        .await
+        {
+            Ok(guard) => guard,
+            Err(_) => {
+                if !operation.is_current(generation) {
+                    self.prune_instance_operation(&key, &operation);
+                    return Ok(DeleteOutcome::Superseded);
+                }
+
+                if let Some((_, pending)) = self.pending_puts.remove_if(&key, |_, pending| {
+                    pending.generation < generation
+                }) {
+                    pending.handle.abort();
+                    let _ = pending.handle.await;
+                }
+                tracing::warn!(
+                    key = %key,
+                    "Timed out waiting for an earlier model registration; aborted it before delete"
+                );
+                operation.lock.lock().await
+            }
+        };
+
+        if !operation.is_current(generation) {
+            drop(operation_guard);
+            self.prune_instance_operation(&key, &operation);
+            tracing::debug!(
+                key = %key,
+                generation,
+                current_generation = operation.current_generation(),
+                "Skipping superseded model removal"
+            );
+            return Ok(DeleteOutcome::Superseded);
+        }
+
+        // An earlier put either released the operation lock or is waiting on
+        // it with an obsolete generation. Cancel its task before mutating the
+        // local card and WorkerSet state.
+        if let Some((_, pending)) = self
+            .pending_puts
+            .remove_if(&key, |_, pending| pending.generation < generation)
+        {
+            pending.handle.abort();
+            let _ = pending.handle.await;
+        }
+
+        let result = self
+            .handle_delete_serialized(mcid, namespace_filter)
+            .await;
+        drop(operation_guard);
+        self.prune_instance_operation(&key, &operation);
+        result.map(DeleteOutcome::Processed)
+    }
+
+    async fn handle_delete_serialized(
+        &self,
+        mcid: &ModelCardInstanceId,
+        namespace_filter: &NamespaceFilter,
     ) -> anyhow::Result<Option<String>> {
         let key = mcid.to_path();
 
-        // If there is an in-flight handle_put for this instance, wait for it
-        // to complete before we attempt cleanup. Without this, a Removed event
-        // arriving while handle_put is still downloading HF config would fail
-        // to find the model card, leaving a stale registration.
-        if let Some((_, mut handle)) = self.pending_puts.remove(&key) {
-            tracing::debug!(key = %key, "awaiting in-flight handle_put before delete");
-            // Ignore join errors (panic in the spawned task) — we still proceed
-            // with cleanup since the put may have partially registered the model.
-            match tokio::time::timeout(Duration::from_secs(60), &mut handle).await {
-                Ok(_) => {}
-                Err(_) => {
-                    // Abort the timed-out task so it cannot register the model
-                    // after we proceed with deletion.
-                    handle.abort();
-                    let _ = handle.await;
-                    tracing::warn!(
-                        key = %key,
-                        "Timed out waiting for in-flight handle_put, aborted and proceeding with delete"
-                    );
-                }
-            }
-        }
         let card = match self.manager.get_model_card(&key) {
             Some(card) => card,
             None => {
@@ -1858,6 +2049,43 @@ mod tests {
 
         manager.remove_model_card(&mcid.to_path());
         assert!(!is_registration_complete(&manager, &mcid, &card));
+    }
+
+    #[test]
+    fn stale_cleanup_cannot_reserve_after_a_new_registration() {
+        let operation = InstanceOperation::default();
+        let snapshot_generation = operation.current_generation();
+
+        let registration_generation = operation.begin();
+
+        assert!(operation.is_current(registration_generation));
+        assert_eq!(operation.reserve_after(snapshot_generation), None);
+    }
+
+    #[tokio::test]
+    async fn newer_registration_waits_for_cleanup_and_remains_current() {
+        let operation = Arc::new(InstanceOperation::default());
+        let cleanup_generation = operation
+            .reserve_after(operation.current_generation())
+            .expect("cleanup should reserve the unchanged snapshot generation");
+        let cleanup_guard = operation.lock.lock().await;
+
+        let registration_generation = operation.begin();
+        assert!(!operation.is_current(cleanup_generation));
+
+        let registration_operation = Arc::clone(&operation);
+        let registration = tokio::spawn(async move {
+            let _guard = registration_operation.lock.lock().await;
+            registration_operation.is_current(registration_generation)
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !registration.is_finished(),
+            "the newer registration must wait until cleanup releases the instance lock"
+        );
+
+        drop(cleanup_guard);
+        assert!(registration.await.unwrap());
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
 use tokio::sync::mpsc::Sender;
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 
 use anyhow::Context as _;
 use dashmap::{DashMap, DashSet};
@@ -120,9 +120,9 @@ fn is_registration_complete(
     manager
         .get_model_card(&mcid.to_path())
         .is_some_and(|saved| saved.name() == card.name() && saved.mdcsum() == card.mdcsum())
-        && manager
-            .get_model(card.name())
-            .is_some_and(|model| model.has_worker_set(&ws_key))
+        && manager.get_model(card.name()).is_some_and(|model| {
+            model.has_worker_set(&ws_key) && model.is_checksum_compatible(&ws_key, card.mdcsum())
+        })
 }
 
 fn uses_multimodal_cache_routing(card: &ModelDeploymentCard) -> bool {
@@ -328,6 +328,7 @@ impl ModelWatcher {
         // list_and_watch supplies the initial snapshot. Consume the immediate
         // first tick so reconciliation begins after one complete interval.
         reconciliation.tick().await;
+        let mut reconciliation_tasks = JoinSet::new();
 
         loop {
             let result = tokio::select! {
@@ -337,11 +338,24 @@ impl ModelWatcher {
                     };
                     result
                 }
-                _ = reconciliation.tick() => {
-                    if let Err(err) = self.reconcile(&namespace_filter).await {
+                _ = reconciliation.tick(), if reconciliation_tasks.is_empty() => {
+                    let watcher = Arc::clone(&self);
+                    let namespace_filter = namespace_filter.clone();
+                    reconciliation_tasks.spawn(async move {
+                        if let Err(err) = watcher.reconcile(&namespace_filter).await {
+                            tracing::warn!(
+                                error = format!("{err:#}"),
+                                "Frontend model registration reconciliation failed"
+                            );
+                        }
+                    });
+                    continue;
+                }
+                result = reconciliation_tasks.join_next(), if !reconciliation_tasks.is_empty() => {
+                    if let Some(Err(err)) = result {
                         tracing::warn!(
-                            error = format!("{err:#}"),
-                            "Frontend model registration reconciliation failed"
+                            error = %err,
+                            "Frontend model registration reconciliation task failed"
                         );
                     }
                     continue;
@@ -526,6 +540,9 @@ impl ModelWatcher {
                 }
             }
         }
+
+        reconciliation_tasks.abort_all();
+        while reconciliation_tasks.join_next().await.is_some() {}
     }
 
     /// Compare the local frontend registry with a fresh discovery snapshot.
@@ -599,15 +616,32 @@ impl ModelWatcher {
         }
         stale_keys.sort();
 
+        let mut removed_stale_count = 0usize;
         for key in &stale_keys {
-            let mcid = ModelCardInstanceId::from_path(key)?;
-            self.handle_delete(&mcid, namespace_filter).await?;
+            let mcid = match ModelCardInstanceId::from_path(key) {
+                Ok(mcid) => mcid,
+                Err(err) => {
+                    tracing::warn!(%err, key, "Ignoring malformed stale model-card key");
+                    continue;
+                }
+            };
+            match self.handle_delete(&mcid, namespace_filter).await {
+                Ok(_) => removed_stale_count += 1,
+                Err(err) => {
+                    tracing::error!(
+                        key,
+                        error = format!("{err:#}"),
+                        "Error removing stale model during reconciliation"
+                    );
+                }
+            }
         }
 
         tracing::debug!(
             expected_model_cards = desired_keys.len(),
             retried_model_cards = retry_count,
-            removed_stale_model_cards = stale_keys.len(),
+            removed_stale_model_cards = removed_stale_count,
+            failed_stale_model_cards = stale_keys.len() - removed_stale_count,
             "Completed frontend model registration reconciliation"
         );
         Ok(())
@@ -722,7 +756,7 @@ impl ModelWatcher {
                 }
             }
         }
-        let card = match self.manager.remove_model_card(&key) {
+        let card = match self.manager.get_model_card(&key) {
             Some(card) => card,
             None => {
                 // The card was never durably saved (e.g. an Added event whose handle_put failed
@@ -758,6 +792,26 @@ impl ModelWatcher {
         };
         let model_name = card.name().to_string();
 
+        // Complete the only fallible discovery query before removing local
+        // state. If discovery is temporarily unavailable, retaining the card
+        // lets the next reconciliation pass retry this stale entry instead of
+        // losing the key while leaving its WorkerSet behind.
+        let active_instances = self
+            .cards_for_model_with_endpoints(&model_name, namespace_filter)
+            .await
+            .with_context(|| model_name.clone())?;
+
+        let card = match self.manager.remove_model_card(&key) {
+            Some(card) => card,
+            None => {
+                tracing::debug!(
+                    key = %key,
+                    "ModelDeploymentCard was removed by concurrent cleanup"
+                );
+                return Ok(None);
+            }
+        };
+
         // Feed the LoRA state tracker now that any in-flight handle_put has completed and the
         // card is available (N2 — avoids the race where a Removed event outran the add). A LoRA
         // adapter card unregisters just that adapter; the base worker card means the worker
@@ -789,12 +843,6 @@ impl ModelWatcher {
         let worker_namespace = &mcid.namespace;
         let worker_component = &mcid.component;
         let ws_key = worker_set_key(&mcid.namespace, card.model_type, card.worker_type);
-
-        // Query discovery for all remaining instances of this model
-        let active_instances = self
-            .cards_for_model_with_endpoints(&model_name, namespace_filter)
-            .await
-            .with_context(|| model_name.clone())?;
 
         // Check if instances of the SAME role and component remain in
         // this namespace. In disaggregated deployments, prefill and
@@ -1783,6 +1831,20 @@ mod tests {
         assert!(!is_registration_complete(&manager, &mcid, &card));
 
         let ws_key = worker_set_key(&mcid.namespace, card.model_type, card.worker_type);
+        manager.add_worker_set(
+            card.name(),
+            &ws_key,
+            WorkerSet::new(
+                mcid.namespace.clone(),
+                "stale-checksum".to_string(),
+                card.clone(),
+            ),
+        );
+        assert!(
+            !is_registration_complete(&manager, &mcid, &card),
+            "a WorkerSet from a different model-card checksum must be retried"
+        );
+
         manager.add_worker_set(
             card.name(),
             &ws_key,

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -374,19 +374,14 @@ impl ModelWatcher {
         });
     }
 
-    fn seed_lora_state_for_put(
-        &self,
-        mcid: &ModelCardInstanceId,
-        card: &ModelDeploymentCard,
-    ) {
+    fn seed_lora_state_for_put(&self, mcid: &ModelCardInstanceId, card: &ModelDeploymentCard) {
         use crate::kv_router::protocols::WorkerWithDpRank;
 
         let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
         if let Some(adapter_name) =
             seed_lora_state_from_card(self.manager.lora_state_tracker(), worker, card)
         {
-            self.pending_lora_adds
-                .insert(mcid.to_path(), adapter_name);
+            self.pending_lora_adds.insert(mcid.to_path(), adapter_name);
         }
     }
 
@@ -553,8 +548,7 @@ impl ModelWatcher {
                     // order if this task is scheduled after a later operation.
                     let instance_key = mcid.to_path();
                     let task_key = instance_key.clone();
-                    let (operation, generation) =
-                        self.begin_instance_operation(&instance_key);
+                    let (operation, generation) = self.begin_instance_operation(&instance_key);
                     let watcher = Arc::clone(&self);
                     let handle = tokio::spawn(async move {
                         match watcher
@@ -603,13 +597,8 @@ impl ModelWatcher {
                     if let Some((_, old_put)) = self.pending_puts.remove(&instance_key) {
                         old_put.handle.abort();
                     }
-                    self.pending_puts.insert(
-                        instance_key,
-                        PendingPut {
-                            generation,
-                            handle,
-                        },
-                    );
+                    self.pending_puts
+                        .insert(instance_key, PendingPut { generation, handle });
                 }
                 DiscoveryEvent::Removed(id) => {
                     // Extract ModelCardInstanceId from the removal event
@@ -624,8 +613,7 @@ impl ModelWatcher {
                     };
 
                     let instance_key = model_card_instance_id.to_path();
-                    let (operation, generation) =
-                        self.begin_instance_operation(&instance_key);
+                    let (operation, generation) = self.begin_instance_operation(&instance_key);
                     match self
                         .handle_delete(
                             model_card_instance_id,
@@ -753,12 +741,7 @@ impl ModelWatcher {
                 continue;
             };
             match self
-                .handle_delete(
-                    &mcid,
-                    namespace_filter,
-                    operation,
-                    delete_generation,
-                )
+                .handle_delete(&mcid, namespace_filter, operation, delete_generation)
                 .await
             {
                 Ok(DeleteOutcome::Processed(_)) => removed_stale_count += 1,
@@ -778,8 +761,8 @@ impl ModelWatcher {
             retried_model_cards = retry_count,
             removed_stale_model_cards = removed_stale_count,
             superseded_stale_model_cards = superseded_stale_count,
-            failed_stale_model_cards = stale_entry_count
-                .saturating_sub(removed_stale_count + superseded_stale_count),
+            failed_stale_model_cards =
+                stale_entry_count.saturating_sub(removed_stale_count + superseded_stale_count),
             "Completed frontend model registration reconciliation"
         );
         Ok(())
@@ -861,13 +844,8 @@ impl ModelWatcher {
         if let Some((_, old_put)) = self.pending_puts.remove(&instance_key) {
             old_put.handle.abort();
         }
-        self.pending_puts.insert(
-            instance_key,
-            PendingPut {
-                generation,
-                handle,
-            },
-        );
+        self.pending_puts
+            .insert(instance_key, PendingPut { generation, handle });
         true
     }
 
@@ -895,9 +873,10 @@ impl ModelWatcher {
                     return Ok(DeleteOutcome::Superseded);
                 }
 
-                if let Some((_, pending)) = self.pending_puts.remove_if(&key, |_, pending| {
-                    pending.generation < generation
-                }) {
+                if let Some((_, pending)) = self
+                    .pending_puts
+                    .remove_if(&key, |_, pending| pending.generation < generation)
+                {
                     pending.handle.abort();
                     let _ = pending.handle.await;
                 }
@@ -932,9 +911,7 @@ impl ModelWatcher {
             let _ = pending.handle.await;
         }
 
-        let result = self
-            .handle_delete_serialized(mcid, namespace_filter)
-            .await;
+        let result = self.handle_delete_serialized(mcid, namespace_filter).await;
         drop(operation_guard);
         self.prune_instance_operation(&key, &operation);
         result.map(DeleteOutcome::Processed)

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -61,6 +62,8 @@ use crate::{
 use super::ModelManager;
 use crate::namespace::NamespaceFilter;
 
+const RECONCILIATION_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Constructs the WorkerSet storage key as `{namespace}:{model_type}:{worker_type}`.
 ///
 /// Each `(namespace, model_type, worker_type)` combination gets its own
@@ -82,6 +85,44 @@ fn worker_set_key(
     let mt = model_type.as_vec().join("|");
     let wt = effective_worker_type(worker_type, model_type).as_str();
     format!("{}:{}:{}", namespace, mt, wt)
+}
+
+fn model_card_instance_id(instance: &DiscoveryInstance) -> anyhow::Result<ModelCardInstanceId> {
+    match instance {
+        DiscoveryInstance::Model {
+            namespace,
+            component,
+            endpoint,
+            instance_id,
+            model_suffix,
+            ..
+        } => Ok(ModelCardInstanceId {
+            namespace: namespace.clone(),
+            component: component.clone(),
+            endpoint: endpoint.clone(),
+            instance_id: *instance_id,
+            model_suffix: model_suffix.clone(),
+        }),
+        _ => anyhow::bail!("Unexpected discovery instance type (expected ModelCard)"),
+    }
+}
+
+/// A source card is fully represented locally only after both the per-instance
+/// card and the shared WorkerSet have been recorded. `handle_put` can save the
+/// card before later pipeline construction fails, so either check alone would
+/// allow a failed registration to escape reconciliation.
+fn is_registration_complete(
+    manager: &ModelManager,
+    mcid: &ModelCardInstanceId,
+    card: &ModelDeploymentCard,
+) -> bool {
+    let ws_key = worker_set_key(&mcid.namespace, card.model_type, card.worker_type);
+    manager
+        .get_model_card(&mcid.to_path())
+        .is_some_and(|saved| saved.name() == card.name() && saved.mdcsum() == card.mdcsum())
+        && manager
+            .get_model(card.name())
+            .is_some_and(|model| model.has_worker_set(&ws_key))
 }
 
 fn uses_multimodal_cache_routing(card: &ModelDeploymentCard) -> bool {
@@ -282,7 +323,30 @@ impl ModelWatcher {
         mut discovery_stream: DiscoveryStream,
         namespace_filter: NamespaceFilter,
     ) {
-        while let Some(result) = discovery_stream.next().await {
+        let mut reconciliation = tokio::time::interval(RECONCILIATION_INTERVAL);
+        reconciliation.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // list_and_watch supplies the initial snapshot. Consume the immediate
+        // first tick so reconciliation begins after one complete interval.
+        reconciliation.tick().await;
+
+        loop {
+            let result = tokio::select! {
+                result = discovery_stream.next() => {
+                    let Some(result) = result else {
+                        break;
+                    };
+                    result
+                }
+                _ = reconciliation.tick() => {
+                    if let Err(err) = self.reconcile(&namespace_filter).await {
+                        tracing::warn!(
+                            error = format!("{err:#}"),
+                            "Frontend model registration reconciliation failed"
+                        );
+                    }
+                    continue;
+                }
+            };
             let event = match result {
                 Ok(event) => event,
                 Err(err) => {
@@ -462,6 +526,169 @@ impl ModelWatcher {
                 }
             }
         }
+    }
+
+    /// Compare the local frontend registry with a fresh discovery snapshot.
+    /// Missing or incomplete source cards are retried through `handle_put`; a
+    /// locally recorded card absent from the snapshot is removed through
+    /// `handle_delete`. The snapshot is sorted so repeated failures are logged
+    /// and retried in a deterministic order.
+    async fn reconcile(self: &Arc<Self>, namespace_filter: &NamespaceFilter) -> anyhow::Result<()> {
+        let mut instances = self.drt.discovery().list(DiscoveryQuery::AllModels).await?;
+        instances.sort_by_key(|instance| {
+            model_card_instance_id(instance)
+                .map(|mcid| mcid.to_path())
+                .unwrap_or_default()
+        });
+
+        let mut desired_keys = HashSet::with_capacity(instances.len());
+        let mut retry_count = 0usize;
+
+        for instance in instances {
+            let mcid = match model_card_instance_id(&instance) {
+                Ok(mcid) => mcid,
+                Err(err) => {
+                    tracing::error!(
+                        error = format!("{err:#}"),
+                        "Unexpected discovery entry during model reconciliation"
+                    );
+                    continue;
+                }
+            };
+            if !namespace_filter.matches(&mcid.namespace) {
+                continue;
+            }
+
+            // Record the source key before deserializing the card. A malformed
+            // source entry must not cause a valid local entry with the same key
+            // to be treated as stale and deleted.
+            desired_keys.insert(mcid.to_path());
+
+            let mut card = match instance.deserialize_model::<ModelDeploymentCard>() {
+                Ok(card) => card,
+                Err(err) => {
+                    tracing::error!(
+                        %err,
+                        instance_id = mcid.instance_id,
+                        "Failed to deserialize model card during reconciliation"
+                    );
+                    continue;
+                }
+            };
+            self.apply_tokenizer_backend_override(&mut card);
+
+            if !is_registration_complete(&self.manager, &mcid, &card)
+                && self.retry_model_registration(mcid, card).await
+            {
+                retry_count += 1;
+            }
+        }
+
+        let mut stale_keys = Vec::new();
+        for key in self.manager.get_model_card_keys() {
+            let mcid = match ModelCardInstanceId::from_path(&key) {
+                Ok(mcid) => mcid,
+                Err(err) => {
+                    tracing::warn!(%err, key, "Ignoring malformed local model-card key");
+                    continue;
+                }
+            };
+            if namespace_filter.matches(&mcid.namespace) && !desired_keys.contains(&key) {
+                stale_keys.push(key);
+            }
+        }
+        stale_keys.sort();
+
+        for key in &stale_keys {
+            let mcid = ModelCardInstanceId::from_path(key)?;
+            self.handle_delete(&mcid, namespace_filter).await?;
+        }
+
+        tracing::debug!(
+            expected_model_cards = desired_keys.len(),
+            retried_model_cards = retry_count,
+            removed_stale_model_cards = stale_keys.len(),
+            "Completed frontend model registration reconciliation"
+        );
+        Ok(())
+    }
+
+    /// Start one reconciliation retry unless the original event-driven
+    /// registration for this instance is still running. Completed failed tasks
+    /// remain in `pending_puts`, so they are replaced here by the retry task.
+    async fn retry_model_registration(
+        self: &Arc<Self>,
+        mcid: ModelCardInstanceId,
+        mut card: ModelDeploymentCard,
+    ) -> bool {
+        let instance_key = mcid.to_path();
+        if self
+            .pending_puts
+            .get(&instance_key)
+            .is_some_and(|handle| !handle.is_finished())
+        {
+            return false;
+        }
+
+        let ws_key = worker_set_key(&mcid.namespace, card.model_type, card.worker_type);
+        if let Some(model) = self.manager.get_model(card.name())
+            && !model.is_checksum_compatible(&ws_key, card.mdcsum())
+        {
+            tracing::error!(
+                model_name = card.name(),
+                namespace = mcid.namespace,
+                new_checksum = card.mdcsum(),
+                "Reconciliation found a model-card checksum that does not match the existing WorkerSet. \
+                 Drain all old workers in this namespace before deploying a new version."
+            );
+            return false;
+        }
+
+        {
+            use crate::kv_router::protocols::WorkerWithDpRank;
+            let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
+            if let Some(adapter_name) =
+                seed_lora_state_from_card(self.manager.lora_state_tracker(), worker, &card)
+            {
+                self.pending_lora_adds
+                    .insert(instance_key.clone(), adapter_name);
+            }
+        }
+
+        tracing::warn!(
+            model_name = card.name(),
+            namespace = mcid.namespace,
+            instance_key,
+            "Retrying incomplete frontend model registration from discovery snapshot"
+        );
+
+        let watcher = Arc::clone(self);
+        let handle = tokio::spawn(async move {
+            match watcher.handle_put(&mcid, &mut card).await {
+                Ok(()) => {
+                    tracing::info!(
+                        model_name = card.name(),
+                        namespace = mcid.namespace,
+                        "Reconciled model registration"
+                    );
+                    watcher.notify_on_model.notify_waiters();
+                }
+                Err(err) => {
+                    tracing::error!(
+                        model_name = card.name(),
+                        namespace = mcid.namespace,
+                        error = format!("{err:#}"),
+                        "Model registration reconciliation retry failed"
+                    );
+                }
+            }
+        });
+
+        if let Some((_, old_handle)) = self.pending_puts.remove(&instance_key) {
+            old_handle.abort();
+        }
+        self.pending_puts.insert(instance_key, handle);
+        true
     }
 
     /// Handle a worker removal. Cleans up per-namespace WorkerSets and the Model itself
@@ -1529,6 +1756,46 @@ mod tests {
         assert_eq!(adapter.as_deref(), Some("adapter-x"));
         assert!(st.is_loaded("adapter-x", &worker));
         assert_eq!(st.total_lora_slots(), 2);
+    }
+
+    #[test]
+    fn registration_is_complete_only_after_card_and_worker_set_exist() {
+        let manager = ModelManager::new();
+        let mcid = ModelCardInstanceId {
+            namespace: "deployment-a".to_string(),
+            component: "backend".to_string(),
+            endpoint: "generate".to_string(),
+            instance_id: 7,
+            model_suffix: None,
+        };
+        let mut card = ModelDeploymentCard::with_name_only("llama");
+        card.model_type = ModelType::Chat;
+        card.worker_type = Some(WorkerType::Aggregated);
+
+        assert!(!is_registration_complete(&manager, &mcid, &card));
+
+        // `do_worker_set_registration` saves the card before all pipeline
+        // construction has completed. A failure after this point must remain a
+        // reconciliation candidate.
+        manager
+            .save_model_card(&mcid.to_path(), card.clone())
+            .unwrap();
+        assert!(!is_registration_complete(&manager, &mcid, &card));
+
+        let ws_key = worker_set_key(&mcid.namespace, card.model_type, card.worker_type);
+        manager.add_worker_set(
+            card.name(),
+            &ws_key,
+            WorkerSet::new(
+                mcid.namespace.clone(),
+                card.mdcsum().to_string(),
+                card.clone(),
+            ),
+        );
+        assert!(is_registration_complete(&manager, &mcid, &card));
+
+        manager.remove_model_card(&mcid.to_path());
+        assert!(!is_registration_complete(&manager, &mcid, &card));
     }
 
     #[test]


### PR DESCRIPTION
## Overview:

Add periodic, source-of-truth reconciliation so a frontend eventually rebuilds its local model registry after missed discovery events or transient registration failures.

The scope follows Neelay Shah’s later clarification, [recorded on issue #10732](https://github.com/ai-dynamo/dynamo/issues/10732#issuecomment-4851303048): `/health`, `/live`, and request-level process readiness remain unchanged, while the existing serving-readiness filter continues to exclude incomplete models from `GET /v1/models`.

## Details:

- Query `DiscoveryQuery::AllModels` every 30 seconds and process model-card identities deterministically.
- Retry a registration when the per-instance card, WorkerSet, or WorkerSet checksum does not match discovery.
- Run reconciliation in a single-flight background task so slow registration or stale cleanup does not pause discovery-event processing.
- Remove stale local cards while keeping deletion retryable after a transient discovery-query failure and continuing past an individual stale-entry error.
- Preserve the existing `/v1/models` serving-readiness filter and leave frontend health and process-readiness semantics unchanged.

Validation:

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-llm --no-default-features discovery::watcher::tests --lib` — 12 passed
- `cargo test -p dynamo-llm --no-default-features serving_ready_excludes_incomplete_namespace --lib` — 1 passed
- `cargo clippy -p dynamo-llm --no-default-features --lib -- -D warnings`
- Repository pre-commit hooks passed

## Where should the reviewer start?

1. `ModelWatcher::watch` in `lib/llm/src/discovery/watcher.rs` for the single-flight background scheduling.
2. `ModelWatcher::reconcile` and `handle_delete` in the same file for retry and stale-removal behavior.
3. `is_registration_complete` for the card, WorkerSet, and checksum convergence condition.
4. `ModelManager::get_model_card_keys` in `lib/llm/src/discovery/model_manager.rs` for the reconciliation snapshot accessor.

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #10732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic periodic reconciliation to keep model discovery state aligned over time.
  * Improved recovery of models that were only partially registered, reducing the need for manual intervention.

* **Bug Fixes**
  * Better handling of stale or missing model entries, helping remove outdated records more reliably.
  * Improved cleanup flow so temporary discovery issues are less likely to disrupt local model state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->