### PR TITLE
perf(mocker): reduce KV block bookkeeping overhead

### DIFF
--- a/lib/kvbm-logical/README.md
+++ b/lib/kvbm-logical/README.md
@@ -102,10 +102,10 @@ All metrics carry a `pool` label identifying the storage tier.
 | `kvbm_duplicate_blocks_total` | Total duplicate blocks created (Allow policy) |
 | `kvbm_registration_dedup_total` | Total block registrations deduplicated (Reject policy) |
 | `kvbm_stagings_total` | Total MutableBlock → CompleteBlock transitions |
-| `kvbm_match_hashes_requested_total` | Total hashes requested in match_blocks calls |
-| `kvbm_match_blocks_returned_total` | Total blocks returned from match_blocks calls |
-| `kvbm_scan_hashes_requested_total` | Total hashes requested in scan_matches calls |
-| `kvbm_scan_blocks_returned_total` | Total blocks returned from scan_matches calls |
+| `kvbm_match_hashes_requested_total` | Total input hash occurrences requested in `match_blocks` and `match_blocks_scattered` calls |
+| `kvbm_match_blocks_returned_total` | Total block hit occurrences returned from `match_blocks` and `match_blocks_scattered` calls |
+| `kvbm_scan_hashes_requested_total` | Total input hash occurrences requested in `scan_matches` calls |
+| `kvbm_scan_blocks_returned_total` | Total distinct matching hashes returned from `scan_matches` calls |
 
 ### Gauges
 

--- a/lib/kvbm-logical/src/manager/mod.rs
+++ b/lib/kvbm-logical/src/manager/mod.rs
@@ -176,17 +176,18 @@ impl<T: BlockMetadata + Sync> BlockManager<T> {
     /// tracking is applied after releasing that lock, exactly once per hit
     /// (including repeated hashes and inactive resurrections).
     ///
-    /// This operation contributes to the existing scan metrics because it has
-    /// scan, rather than prefix, semantics.
+    /// This operation contributes to the existing match metrics. Requested
+    /// and returned values are counted as occurrences, so repeated input
+    /// hashes and their repeated hits are counted repeatedly.
     pub fn match_blocks_scattered(
         &self,
         seq_hash: &[SequenceHash],
     ) -> Vec<Option<ImmutableBlock<T>>> {
         self.metrics
-            .inc_scan_hashes_requested(seq_hash.len() as u64);
+            .inc_match_hashes_requested(seq_hash.len() as u64);
 
         if seq_hash.is_empty() {
-            self.metrics.inc_scan_blocks_returned(0);
+            self.metrics.inc_match_blocks_returned(0);
             return Vec::new();
         }
 
@@ -208,7 +209,7 @@ impl<T: BlockMetadata + Sync> BlockManager<T> {
             .map(|inner| inner.map(ImmutableBlock::from_inner))
             .collect();
 
-        self.metrics.inc_scan_blocks_returned(hit_count as u64);
+        self.metrics.inc_match_blocks_returned(hit_count as u64);
         tracing::debug!(
             num_hashes = seq_hash.len(),
             total_matched = hit_count,
@@ -218,7 +219,8 @@ impl<T: BlockMetadata + Sync> BlockManager<T> {
     }
 
     /// Scatter-gather scan: finds all blocks matching any hash, without
-    /// stopping on misses.
+    /// stopping on misses. Requested hashes are counted as input occurrences,
+    /// while returned blocks are counted as distinct hashes in the result map.
     pub fn scan_matches(
         &self,
         seq_hashes: &[SequenceHash],

--- a/lib/kvbm-logical/src/manager/mod.rs
+++ b/lib/kvbm-logical/src/manager/mod.rs
@@ -168,6 +168,56 @@ impl<T: BlockMetadata + Sync> BlockManager<T> {
         matched
     }
 
+    /// Scattered batch match: resolves every input hash against the active or
+    /// inactive pool without stopping at a miss.
+    ///
+    /// The returned vector is aligned with `seq_hash`: each hit is `Some`,
+    /// each miss is `None`, and input order and duplicates are preserved. The
+    /// complete batch is resolved under one store-mutex acquisition. Frequency
+    /// tracking is applied after releasing that lock, exactly once per hit
+    /// (including repeated hashes and inactive resurrections).
+    ///
+    /// This operation contributes to the existing scan metrics because it has
+    /// scan, rather than prefix, semantics.
+    pub fn match_blocks_scattered(
+        &self,
+        seq_hash: &[SequenceHash],
+    ) -> Vec<Option<ImmutableBlock<T>>> {
+        self.metrics
+            .inc_scan_hashes_requested(seq_hash.len() as u64);
+
+        if seq_hash.is_empty() {
+            self.metrics.inc_scan_blocks_returned(0);
+            return Vec::new();
+        }
+
+        // ONE store-lock acquisition for all active+inactive probes, including
+        // misses and repeated hashes.
+        let inners = self.store.match_scattered_locked_batch(seq_hash);
+
+        // Keep TinyLFU work outside the store critical section. A duplicate
+        // input is a duplicate access, so each returned occurrence is touched.
+        if self.block_registry.has_frequency_tracking() {
+            for inner in inners.iter().flatten() {
+                self.block_registry.touch(inner.sequence_hash());
+            }
+        }
+
+        let hit_count = inners.iter().filter(|inner| inner.is_some()).count();
+        let matched = inners
+            .into_iter()
+            .map(|inner| inner.map(ImmutableBlock::from_inner))
+            .collect();
+
+        self.metrics.inc_scan_blocks_returned(hit_count as u64);
+        tracing::debug!(
+            num_hashes = seq_hash.len(),
+            total_matched = hit_count,
+            "match_blocks_scattered result"
+        );
+        matched
+    }
+
     /// Scatter-gather scan: finds all blocks matching any hash, without
     /// stopping on misses.
     pub fn scan_matches(

--- a/lib/kvbm-logical/src/manager/mod.rs
+++ b/lib/kvbm-logical/src/manager/mod.rs
@@ -99,10 +99,9 @@ impl<T: BlockMetadata + Sync> BlockManager<T> {
             .block_registry
             .register_sequence_hashes(blocks.iter().map(CompleteBlock::sequence_hash));
         let batch_size = blocks.len();
-        let registered = self.store.register_completed_blocks(
-            blocks.into_iter().zip(handles).collect(),
-            self.duplication_policy,
-        );
+        let registered =
+            self.store
+                .register_completed_blocks(blocks, handles, self.duplication_policy);
         // The offline settlement bridge observes this counter as a
         // publication watermark, so publish only after every store transition
         // and presence marker in the batch is complete.

--- a/lib/kvbm-logical/src/manager/tests.rs
+++ b/lib/kvbm-logical/src/manager/tests.rs
@@ -1377,6 +1377,136 @@ mod single_lock_match_tests {
 }
 
 // ============================================================================
+// ALIGNED SCATTERED MATCH TESTS
+// ============================================================================
+
+mod scattered_match_tests {
+    use super::*;
+
+    fn create_backend_manager(
+        block_count: usize,
+        backend_builder: fn(
+            BlockManagerConfigBuilder<TestBlockData>,
+        ) -> BlockManagerConfigBuilder<TestBlockData>,
+    ) -> BlockManager<TestBlockData> {
+        let registry = BlockRegistry::builder()
+            .frequency_tracker(FrequencyTrackingCapacity::default().create_tracker())
+            .build();
+        backend_builder(
+            BlockManager::<TestBlockData>::builder()
+                .block_count(block_count)
+                .block_size(4)
+                .registry(registry),
+        )
+        .build()
+        .expect("build manager")
+    }
+
+    fn register_one(
+        manager: &BlockManager<TestBlockData>,
+        base: u32,
+    ) -> (SequenceHash, ImmutableBlock<TestBlockData>) {
+        let token_block = create_token_block(&[base, base + 1, base + 2, base + 3]);
+        let seq_hash = token_block.kvbm_sequence_hash();
+        let mutable = manager
+            .allocate_blocks(1)
+            .expect("allocate")
+            .into_iter()
+            .next()
+            .unwrap();
+        let complete = mutable.complete(&token_block).expect("complete");
+        let immutable = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        (seq_hash, immutable)
+    }
+
+    /// Active and inactive hits remain aligned around a miss; duplicate
+    /// inactive hashes are returned at both positions and later hits are not
+    /// truncated. Run against every supported inactive backend.
+    #[rstest]
+    #[case("lru", |b: BlockManagerConfigBuilder<TestBlockData>| b.with_lru_backend())]
+    #[case("multi_lru", |b: BlockManagerConfigBuilder<TestBlockData>| b.with_multi_lru_backend())]
+    #[case("lineage", |b: BlockManagerConfigBuilder<TestBlockData>| b.with_lineage_backend())]
+    fn scattered_preserves_alignment_misses_duplicates_and_later_hits(
+        #[case] _backend_name: &str,
+        #[case] backend_builder: fn(
+            BlockManagerConfigBuilder<TestBlockData>,
+        ) -> BlockManagerConfigBuilder<TestBlockData>,
+    ) {
+        let manager = create_backend_manager(4, backend_builder);
+        let (active_hash, _active) = register_one(&manager, 20_000);
+        let (inactive_hash, inactive) = register_one(&manager, 20_010);
+        let (later_hash, _later) = register_one(&manager, 20_020);
+        drop(inactive);
+
+        let miss = create_token_block(&[90_000, 90_001, 90_002, 90_003]).kvbm_sequence_hash();
+        let input = [active_hash, miss, inactive_hash, inactive_hash, later_hash];
+        let before = manager.metrics().snapshot();
+
+        let matched = manager.match_blocks_scattered(&input);
+
+        assert_eq!(matched.len(), input.len());
+        assert_eq!(matched[0].as_ref().unwrap().sequence_hash(), active_hash);
+        assert!(matched[1].is_none(), "miss must retain its aligned slot");
+        assert_eq!(matched[2].as_ref().unwrap().sequence_hash(), inactive_hash);
+        assert_eq!(matched[3].as_ref().unwrap().sequence_hash(), inactive_hash);
+        assert_eq!(
+            matched[2].as_ref().unwrap().block_id(),
+            matched[3].as_ref().unwrap().block_id(),
+            "duplicate hashes must resolve to the same physical primary"
+        );
+        assert_eq!(matched[4].as_ref().unwrap().sequence_hash(), later_hash);
+
+        let after = manager.metrics().snapshot();
+        assert_eq!(
+            after.scan_hashes_requested - before.scan_hashes_requested,
+            input.len() as u64
+        );
+        assert_eq!(
+            after.scan_blocks_returned - before.scan_blocks_returned,
+            4,
+            "scan return metric counts hit occurrences, including duplicates"
+        );
+    }
+
+    #[test]
+    fn scattered_empty_input_returns_empty() {
+        let manager = create_test_manager(1);
+        let before = manager.metrics().snapshot();
+        assert!(manager.match_blocks_scattered(&[]).is_empty());
+        let after = manager.metrics().snapshot();
+        assert_eq!(
+            after.scan_hashes_requested - before.scan_hashes_requested,
+            0
+        );
+        assert_eq!(after.scan_blocks_returned - before.scan_blocks_returned, 0);
+    }
+
+    #[test]
+    fn scattered_touches_once_per_hit_occurrence() {
+        let (manager, metered) = crate::testing::create_test_manager_metered::<TestBlockData>(3);
+        let (active_hash, _active) = register_one(&manager, 30_000);
+        let (inactive_hash, inactive) = register_one(&manager, 30_010);
+        drop(inactive);
+        let miss = create_token_block(&[91_000, 91_001, 91_002, 91_003]).kvbm_sequence_hash();
+
+        metered.reset();
+        let matched =
+            manager.match_blocks_scattered(&[active_hash, miss, inactive_hash, inactive_hash]);
+
+        assert_eq!(matched.iter().filter(|block| block.is_some()).count(), 3);
+        assert_eq!(
+            metered.touches(),
+            3,
+            "each aligned hit occurrence must touch exactly once; misses never touch"
+        );
+    }
+}
+
+// ============================================================================
 // IMMUTABLE BLOCK AND WEAK BLOCK TESTS
 // ============================================================================
 

--- a/lib/kvbm-logical/src/manager/tests.rs
+++ b/lib/kvbm-logical/src/manager/tests.rs
@@ -896,6 +896,129 @@ mod registration_tests {
         assert_eq!(snap.stagings, 3);
     }
 
+    #[test]
+    fn test_batch_registration_mixed_rejects_preserves_order_presence_and_guards() {
+        let registry = BlockRegistry::new();
+        let manager = BlockManager::<TestBlockData>::builder()
+            .block_count(5)
+            .block_size(4)
+            .registry(registry)
+            .duplication_policy(BlockDuplicationPolicy::Reject)
+            .build()
+            .expect("Should build manager");
+
+        let token_a = create_test_token_block_from_iota(100);
+        let token_b = create_test_token_block_from_iota(200);
+        let token_c = create_test_token_block_from_iota(300);
+        let hash_a = token_a.kvbm_sequence_hash();
+        let hash_b = token_b.kvbm_sequence_hash();
+        let hash_c = token_c.kvbm_sequence_hash();
+
+        let primary_a = manager
+            .allocate_blocks(1)
+            .expect("allocate primary")
+            .pop()
+            .unwrap()
+            .complete(&token_a)
+            .unwrap();
+        let primary_a_id = primary_a.block_id();
+        let primary_a = manager.register_blocks(vec![primary_a]).pop().unwrap();
+
+        let mut candidates = manager
+            .allocate_blocks(4)
+            .expect("allocate batch candidates")
+            .into_iter();
+        let candidate_b = candidates.next().unwrap();
+        let duplicate_a = candidates.next().unwrap();
+        let duplicate_b = candidates.next().unwrap();
+        let candidate_c = candidates.next().unwrap();
+        let candidate_b_id = candidate_b.block_id();
+        let duplicate_a_id = duplicate_a.block_id();
+        let duplicate_b_id = duplicate_b.block_id();
+        let candidate_c_id = candidate_c.block_id();
+
+        let registered = manager.register_blocks(vec![
+            candidate_b.complete(&token_b).unwrap(),
+            duplicate_a.complete(&token_a).unwrap(),
+            duplicate_b.complete(&token_b).unwrap(),
+            candidate_c.complete(&token_c).unwrap(),
+        ]);
+
+        assert_eq!(
+            registered
+                .iter()
+                .map(|block| (block.sequence_hash(), block.block_id()))
+                .collect::<Vec<_>>(),
+            vec![
+                (hash_b, candidate_b_id),
+                (hash_a, primary_a_id),
+                (hash_b, candidate_b_id),
+                (hash_c, candidate_c_id),
+            ]
+        );
+        assert_eq!(
+            manager
+                .block_registry()
+                .check_presence::<TestBlockData>(&[hash_a, hash_b, hash_c]),
+            vec![(hash_a, true), (hash_b, true), (hash_c, true)]
+        );
+        assert_eq!(manager.metrics().snapshot().registration_dedup, 2);
+
+        // Both rejected candidates must have dropped their re-armed guards
+        // after the store critical section and returned to the reset pool.
+        assert_eq!(manager.available_blocks(), 2);
+        let mut returned_ids = manager
+            .allocate_blocks(2)
+            .expect("rejected candidates returned to reset")
+            .into_iter()
+            .map(|block| block.block_id())
+            .collect::<Vec<_>>();
+        returned_ids.sort_unstable();
+        let mut rejected_ids = vec![duplicate_a_id, duplicate_b_id];
+        rejected_ids.sort_unstable();
+        assert_eq!(returned_ids, rejected_ids);
+
+        drop(primary_a);
+        drop(registered);
+    }
+
+    #[test]
+    fn test_batch_registration_allow_marks_each_same_hash_slot_present() {
+        let registry = BlockRegistry::new();
+        let manager = BlockManager::<TestBlockData>::builder()
+            .block_count(2)
+            .block_size(4)
+            .registry(registry)
+            .duplication_policy(BlockDuplicationPolicy::Allow)
+            .build()
+            .expect("Should build manager");
+
+        let token = create_test_token_block_from_iota(400);
+        let seq_hash = token.kvbm_sequence_hash();
+        let completed = manager
+            .allocate_blocks(2)
+            .expect("allocate same-hash batch")
+            .into_iter()
+            .map(|block| block.complete(&token).unwrap())
+            .collect();
+
+        let mut registered = manager.register_blocks(completed);
+        assert_eq!(registered.len(), 2);
+        assert_ne!(registered[0].block_id(), registered[1].block_id());
+        assert_eq!(manager.metrics().snapshot().duplicate_blocks, 1);
+
+        // The duplicate releases one presence reference. Presence must remain
+        // set for the primary, proving both same-batch outcomes were marked.
+        let duplicate = registered.pop().unwrap();
+        drop(duplicate);
+        assert_eq!(
+            manager
+                .block_registry()
+                .check_presence::<TestBlockData>(&[seq_hash]),
+            vec![(seq_hash, true)]
+        );
+    }
+
     #[rstest]
     #[case(BlockDuplicationPolicy::Allow, 200, "allow", false)]
     #[case(BlockDuplicationPolicy::Reject, 300, "reject", true)]

--- a/lib/kvbm-logical/src/manager/tests.rs
+++ b/lib/kvbm-logical/src/manager/tests.rs
@@ -1585,14 +1585,19 @@ mod scattered_match_tests {
 
         let after = manager.metrics().snapshot();
         assert_eq!(
-            after.scan_hashes_requested - before.scan_hashes_requested,
+            after.match_hashes_requested - before.match_hashes_requested,
             input.len() as u64
         );
         assert_eq!(
-            after.scan_blocks_returned - before.scan_blocks_returned,
+            after.match_blocks_returned - before.match_blocks_returned,
             4,
-            "scan return metric counts hit occurrences, including duplicates"
+            "match return metric counts hit occurrences, including duplicates"
         );
+        assert_eq!(
+            after.scan_hashes_requested - before.scan_hashes_requested,
+            0
+        );
+        assert_eq!(after.scan_blocks_returned - before.scan_blocks_returned, 0);
     }
 
     #[test]
@@ -1601,6 +1606,14 @@ mod scattered_match_tests {
         let before = manager.metrics().snapshot();
         assert!(manager.match_blocks_scattered(&[]).is_empty());
         let after = manager.metrics().snapshot();
+        assert_eq!(
+            after.match_hashes_requested - before.match_hashes_requested,
+            0
+        );
+        assert_eq!(
+            after.match_blocks_returned - before.match_blocks_returned,
+            0
+        );
         assert_eq!(
             after.scan_hashes_requested - before.scan_hashes_requested,
             0
@@ -2539,6 +2552,51 @@ mod capacity_lifecycle_tests {
 
 mod scan_matches_tests {
     use super::*;
+
+    #[test]
+    fn scan_metrics_count_input_occurrences_and_distinct_results() {
+        let manager = create_test_manager(2);
+        let token_block = create_iota_token_block(12_000, 4);
+        let hash = token_block.kvbm_sequence_hash();
+        let mutable = manager
+            .allocate_blocks(1)
+            .expect("allocate")
+            .into_iter()
+            .next()
+            .unwrap();
+        let complete = mutable.complete(&token_block).expect("complete");
+        let _active = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        let missing_hash = create_iota_token_block(99_000, 4).kvbm_sequence_hash();
+        let before = manager.metrics().snapshot();
+
+        let found = manager.scan_matches(&[hash, hash, missing_hash], true);
+
+        assert_eq!(found.len(), 1);
+        assert!(found.contains_key(&hash));
+        let after = manager.metrics().snapshot();
+        assert_eq!(
+            after.scan_hashes_requested - before.scan_hashes_requested,
+            3,
+            "scan request metrics count duplicate input occurrences"
+        );
+        assert_eq!(
+            after.scan_blocks_returned - before.scan_blocks_returned,
+            1,
+            "scan return metrics count distinct result-map entries"
+        );
+        assert_eq!(
+            after.match_hashes_requested - before.match_hashes_requested,
+            0
+        );
+        assert_eq!(
+            after.match_blocks_returned - before.match_blocks_returned,
+            0
+        );
+    }
 
     #[test]
     fn test_scan_matches_with_pool_size_gauges() {

--- a/lib/kvbm-logical/src/metrics/collector.rs
+++ b/lib/kvbm-logical/src/metrics/collector.rs
@@ -45,19 +45,19 @@ const COUNTER_DEFS: &[(&str, &str)] = &[
     ),
     (
         "kvbm_match_hashes_requested_total",
-        "Total hashes requested in match_blocks calls",
+        "Total input hash occurrences requested in match_blocks and match_blocks_scattered calls",
     ),
     (
         "kvbm_match_blocks_returned_total",
-        "Total blocks returned from match_blocks calls",
+        "Total block hit occurrences returned from match_blocks and match_blocks_scattered calls",
     ),
     (
         "kvbm_scan_hashes_requested_total",
-        "Total hashes requested in scan_matches calls",
+        "Total input hash occurrences requested in scan_matches calls",
     ),
     (
         "kvbm_scan_blocks_returned_total",
-        "Total blocks returned from scan_matches calls",
+        "Total distinct matching hashes returned from scan_matches calls",
     ),
     (
         "kvbm_eager_primary_to_inactive_total",

--- a/lib/kvbm-logical/src/metrics/stats.rs
+++ b/lib/kvbm-logical/src/metrics/stats.rs
@@ -38,9 +38,11 @@ pub struct StatsSnapshot {
     pub allocation_rate: f64,
     /// Evictions per second.
     pub eviction_rate: f64,
-    /// Ratio of blocks returned to hashes requested in match_blocks.
+    /// Ratio of block hit occurrences returned to input hash occurrences
+    /// requested in match_blocks and match_blocks_scattered.
     pub match_hit_rate: f64,
-    /// Ratio of blocks returned to hashes requested in scan_matches.
+    /// Ratio of distinct matching hashes returned to input hash occurrences
+    /// requested in scan_matches.
     pub scan_hit_rate: f64,
     /// Rate of change of allocation_rate (d(alloc_rate)/dt).
     pub allocation_gradient: f64,

--- a/lib/kvbm-logical/src/pools/store.rs
+++ b/lib/kvbm-logical/src/pools/store.rs
@@ -612,6 +612,31 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         out
     }
 
+    /// Batched active-or-inactive scattered lookup under **one** store-mutex
+    /// acquisition. Unlike [`match_prefix_locked_batch`](Self::match_prefix_locked_batch),
+    /// this preserves one output position per input hash and continues after
+    /// misses.
+    ///
+    /// Each position uses [`acquire_for_hash_locked`](Self::acquire_for_hash_locked),
+    /// so active lookup, eager `Primary -> Inactive` recovery, and inactive
+    /// resurrection remain atomic with respect to every other position in the
+    /// batch. Repeated hashes are resolved independently: an inactive hit in
+    /// the first occurrence is resurrected, and subsequent occurrences clone
+    /// that now-active primary.
+    ///
+    /// Frequency tracking is deliberately disabled while the store lock is
+    /// held. The caller applies one touch per hit after this method returns.
+    pub(crate) fn match_scattered_locked_batch(
+        self: &Arc<Self>,
+        hashes: &[SequenceHash],
+    ) -> Vec<Option<Arc<ImmutableBlockInner<T>>>> {
+        let mut inner = self.inner.lock();
+        hashes
+            .iter()
+            .map(|&hash| self.acquire_for_hash_locked(&mut inner, hash, /*touch*/ false))
+            .collect()
+    }
+
     /// Atomic registration of a [`CompleteBlock`]: lookup-then-transition
     /// under one store-mutex acquisition. Closes the register-vs-register
     /// race for the same sequence hash.

--- a/lib/kvbm-logical/src/pools/store.rs
+++ b/lib/kvbm-logical/src/pools/store.rs
@@ -667,7 +667,8 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         // slot was created. The locked helper guarantees that fresh/Allow
         // outcomes use the candidate slot, while Reject returns the distinct
         // existing primary (enforced by its same-block collision assertion).
-        if result.block_id() == block.block_id() {
+        let presence_added = result.block_id() == block.block_id();
+        if presence_added {
             handle.mark_present::<T>();
         }
 
@@ -708,7 +709,8 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         for ((block, handle), outcome) in blocks.iter().zip(&handles).zip(&outcomes) {
             // Fresh and Allow outcomes retain the candidate block ID; Reject
             // returns the different existing primary ID and re-arms `block`.
-            if outcome.block_id() == block.block_id() {
+            let presence_added = outcome.block_id() == block.block_id();
+            if presence_added {
                 handle.mark_present::<T>();
             }
         }
@@ -716,6 +718,13 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         outcomes
     }
 
+    /// Register a completed candidate while the store mutex is held.
+    ///
+    /// The returned block ID equals the candidate block ID exactly when this
+    /// call creates a presence-bearing slot (fresh primary or allowed
+    /// duplicate). A rejected duplicate re-arms the candidate guard and
+    /// returns the existing primary, whose distinct ID is enforced by the
+    /// same-block collision assertion below.
     fn register_completed_block_locked(
         self: &Arc<Self>,
         inner: &mut BlockStoreInner<T>,

--- a/lib/kvbm-logical/src/pools/store.rs
+++ b/lib/kvbm-logical/src/pools/store.rs
@@ -657,16 +657,17 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         block.disarm();
 
         let mut inner = self.inner.lock();
-        let (result, presence_added) =
-            self.register_completed_block_locked(&mut inner, &mut block, &handle, policy);
+        let result = self.register_completed_block_locked(&mut inner, &mut block, &handle, policy);
 
         drop(inner);
 
         // mark_present takes the attachments lock; lock-order
         // (attachments → store) is satisfied because the store lock has
         // already been released. Skip on Reject — no new presence-bearing
-        // slot was created.
-        if presence_added {
+        // slot was created. The locked helper guarantees that fresh/Allow
+        // outcomes use the candidate slot, while Reject returns the distinct
+        // existing primary (enforced by its same-block collision assertion).
+        if result.block_id() == block.block_id() {
             handle.mark_present::<T>();
         }
 
@@ -680,28 +681,39 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
     /// Register a batch while acquiring the store mutex only once.
     pub(crate) fn register_completed_blocks(
         self: &Arc<Self>,
-        blocks: Vec<(CompleteBlock<T>, BlockRegistrationHandle)>,
+        mut blocks: Vec<CompleteBlock<T>>,
+        handles: Vec<BlockRegistrationHandle>,
         policy: BlockDuplicationPolicy,
     ) -> Vec<Arc<ImmutableBlockInner<T>>> {
-        let mut registrations = Vec::with_capacity(blocks.len());
-        let mut inner = self.inner.lock();
-        for (mut block, handle) in blocks {
-            block.disarm();
-            let (result, presence_added) =
-                self.register_completed_block_locked(&mut inner, &mut block, &handle, policy);
-            registrations.push((block, handle, presence_added, result));
-        }
-        drop(inner);
+        assert_eq!(
+            blocks.len(),
+            handles.len(),
+            "each completed block must have a registration handle"
+        );
 
-        let mut results = Vec::with_capacity(registrations.len());
-        for (block, handle, presence_added, result) in registrations {
-            if presence_added {
+        let outcomes = {
+            let mut outcomes = Vec::with_capacity(blocks.len());
+            let mut inner = self.inner.lock();
+            for (block, handle) in blocks.iter_mut().zip(&handles) {
+                block.disarm();
+                outcomes
+                    .push(self.register_completed_block_locked(&mut inner, block, handle, policy));
+            }
+            outcomes
+        };
+
+        // Presence attachments and re-armed Reject-guard drops both acquire
+        // locks outside the store. Keep them after the one batch critical
+        // section to preserve attachments -> store lock ordering.
+        for ((block, handle), outcome) in blocks.iter().zip(&handles).zip(&outcomes) {
+            // Fresh and Allow outcomes retain the candidate block ID; Reject
+            // returns the different existing primary ID and re-arms `block`.
+            if outcome.block_id() == block.block_id() {
                 handle.mark_present::<T>();
             }
-            drop(block);
-            results.push(result);
         }
-        results
+        drop(blocks);
+        outcomes
     }
 
     fn register_completed_block_locked(
@@ -710,7 +722,7 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         block: &mut CompleteBlock<T>,
         handle: &BlockRegistrationHandle,
         policy: BlockDuplicationPolicy,
-    ) -> (Arc<ImmutableBlockInner<T>>, bool) {
+    ) -> Arc<ImmutableBlockInner<T>> {
         let block_id = block.block_id();
         let seq_hash = block.sequence_hash();
         debug_assert_eq!(seq_hash, handle.seq_hash());
@@ -741,12 +753,12 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
                         inner: Arc::downgrade(&inner_arc),
                     };
                     self.metrics.inc_duplicate_blocks();
-                    (inner_arc, true)
+                    inner_arc
                 }
                 BlockDuplicationPolicy::Reject => {
                     self.metrics.inc_registration_dedup();
                     block.rearm();
-                    (existing_primary, false)
+                    existing_primary
                 }
             };
         }
@@ -763,7 +775,7 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
             inner: Arc::downgrade(&inner_arc),
         };
         inner.active_by_hash.insert(seq_hash, block_id);
-        (inner_arc, true)
+        inner_arc
     }
 
     /// Internal helper: under the store lock, transition a Primary slot to

--- a/lib/kvbm-logical/src/registry/mod.rs
+++ b/lib/kvbm-logical/src/registry/mod.rs
@@ -43,7 +43,6 @@ use crate::{events::EventsManager, tinylfu::FrequencyTracker};
 
 use crate::blocks::SequenceHash;
 
-use std::collections::BTreeMap;
 use std::sync::{Arc, Weak};
 
 use handle::BlockRegistrationHandleInner;
@@ -261,38 +260,18 @@ impl BlockRegistry {
             return Vec::new();
         }
 
-        let mut by_position = BTreeMap::<u64, Vec<(usize, SequenceHash)>>::new();
-        for (index, seq_hash) in seq_hashes.iter().copied().enumerate() {
-            by_position
-                .entry(seq_hash.position())
-                .or_default()
-                .push((index, seq_hash));
-        }
-
-        let mut registered = vec![None; seq_hashes.len()];
-        let mut newly_created = vec![false; seq_hashes.len()];
-        for hashes in by_position.into_values() {
-            let map = self.prt.prefix(&hashes[0].1);
-            for (index, seq_hash) in hashes {
-                let mut weak = map.entry(seq_hash).or_default();
-                let (inner, is_new) = match weak.upgrade() {
-                    Some(inner) => (inner, false),
-                    None => {
-                        let inner = self.create_registration(seq_hash);
-                        *weak = Arc::downgrade(&inner);
-                        (inner, true)
-                    }
-                };
-                registered[index] = Some(BlockRegistrationHandle::from_inner(inner));
-                newly_created[index] = is_new;
-            }
-        }
+        let positions_are_monotonic = seq_hashes
+            .windows(2)
+            .all(|pair| pair[0].position() <= pair[1].position());
+        let registered = if positions_are_monotonic {
+            self.register_monotonic_sequence_hashes(&seq_hashes)
+        } else {
+            self.register_grouped_sequence_hashes(&seq_hashes)
+        };
 
         registered
             .into_iter()
-            .zip(newly_created)
             .map(|(handle, is_new)| {
-                let handle = handle.expect("every batched sequence hash must be registered");
                 if is_new {
                     if let Some(event_manager) = &self.event_manager
                         && let Err(e) = event_manager.on_block_registered(&handle)
@@ -304,6 +283,99 @@ impl BlockRegistry {
                 handle
             })
             .collect()
+    }
+
+    /// Fast path for the normal sequence-registration shape: non-decreasing
+    /// block positions. Equal positions are adjacent, so each position needs
+    /// only one radix-prefix guard and results can be appended in input order.
+    fn register_monotonic_sequence_hashes(
+        &self,
+        seq_hashes: &[SequenceHash],
+    ) -> Vec<(BlockRegistrationHandle, bool)> {
+        let mut registered = Vec::with_capacity(seq_hashes.len());
+        let mut group_start = 0;
+        while group_start < seq_hashes.len() {
+            let position = seq_hashes[group_start].position();
+            let group_end = seq_hashes[group_start + 1..]
+                .iter()
+                .position(|seq_hash| seq_hash.position() != position)
+                .map_or(seq_hashes.len(), |offset| group_start + 1 + offset);
+
+            self.register_position_group(
+                seq_hashes[group_start..group_end]
+                    .iter()
+                    .copied()
+                    .map(|seq_hash| ((), seq_hash)),
+                |(), handle, is_new| registered.push((handle, is_new)),
+            );
+            group_start = group_end;
+        }
+        registered
+    }
+
+    /// Fallback for callers that supply positions out of order. A flat index
+    /// vector replaces the previous `BTreeMap` of per-position vectors. It is
+    /// sorted by `(position, original_index)` so registration stays grouped by
+    /// radix prefix without changing which duplicate occurrence is considered
+    /// new. Results are restored to input order before observers run.
+    fn register_grouped_sequence_hashes(
+        &self,
+        seq_hashes: &[SequenceHash],
+    ) -> Vec<(BlockRegistrationHandle, bool)> {
+        let mut ordered: Vec<_> = seq_hashes.iter().copied().enumerate().collect();
+        ordered.sort_unstable_by_key(|(index, seq_hash)| (seq_hash.position(), *index));
+
+        let mut registered = Vec::with_capacity(seq_hashes.len());
+        let mut group_start = 0;
+        while group_start < ordered.len() {
+            let position = ordered[group_start].1.position();
+            let group_end = ordered[group_start + 1..]
+                .iter()
+                .position(|(_, seq_hash)| seq_hash.position() != position)
+                .map_or(ordered.len(), |offset| group_start + 1 + offset);
+
+            self.register_position_group(
+                ordered[group_start..group_end].iter().copied(),
+                |index, handle, is_new| registered.push((index, handle, is_new)),
+            );
+            group_start = group_end;
+        }
+
+        registered.sort_unstable_by_key(|(index, _, _)| *index);
+        registered
+            .into_iter()
+            .map(|(_, handle, is_new)| (handle, is_new))
+            .collect()
+    }
+
+    /// Register one same-position group while holding exactly one outer radix
+    /// guard. `record` only stages the result; user-visible callbacks and
+    /// frequency touches run after this method returns and releases the guard.
+    fn register_position_group<K>(
+        &self,
+        entries: impl IntoIterator<Item = (K, SequenceHash)>,
+        mut record: impl FnMut(K, BlockRegistrationHandle, bool),
+    ) {
+        let mut entries = entries.into_iter();
+        let Some(first) = entries.next() else {
+            return;
+        };
+        let position = first.1.position();
+        let map = self.prt.prefix(&first.1);
+
+        for (key, seq_hash) in std::iter::once(first).chain(entries) {
+            debug_assert_eq!(seq_hash.position(), position);
+            let mut weak = map.entry(seq_hash).or_default();
+            let (inner, is_new) = match weak.upgrade() {
+                Some(inner) => (inner, false),
+                None => {
+                    let inner = self.create_registration(seq_hash);
+                    *weak = Arc::downgrade(&inner);
+                    (inner, true)
+                }
+            };
+            record(key, BlockRegistrationHandle::from_inner(inner), is_new);
+        }
     }
 
     /// Internal method for transferring block registration without triggering frequency tracking.

--- a/lib/kvbm-logical/src/registry/mod.rs
+++ b/lib/kvbm-logical/src/registry/mod.rs
@@ -260,9 +260,7 @@ impl BlockRegistry {
             return Vec::new();
         }
 
-        let positions_are_monotonic = seq_hashes
-            .windows(2)
-            .all(|pair| pair[0].position() <= pair[1].position());
+        let positions_are_monotonic = seq_hashes.is_sorted_by_key(|seq_hash| seq_hash.position());
         let registered = if positions_are_monotonic {
             self.register_monotonic_sequence_hashes(&seq_hashes)
         } else {
@@ -293,23 +291,10 @@ impl BlockRegistry {
         seq_hashes: &[SequenceHash],
     ) -> Vec<(BlockRegistrationHandle, bool)> {
         let mut registered = Vec::with_capacity(seq_hashes.len());
-        let mut group_start = 0;
-        while group_start < seq_hashes.len() {
-            let position = seq_hashes[group_start].position();
-            let group_end = seq_hashes[group_start + 1..]
-                .iter()
-                .position(|seq_hash| seq_hash.position() != position)
-                .map_or(seq_hashes.len(), |offset| group_start + 1 + offset);
-
-            self.register_position_group(
-                seq_hashes[group_start..group_end]
-                    .iter()
-                    .copied()
-                    .map(|seq_hash| ((), seq_hash)),
-                |(), handle, is_new| registered.push((handle, is_new)),
-            );
-            group_start = group_end;
-        }
+        self.register_ordered_sequence_hashes(
+            seq_hashes.iter().copied().map(|seq_hash| ((), seq_hash)),
+            |(), handle, is_new| registered.push((handle, is_new)),
+        );
         registered
     }
 
@@ -326,20 +311,9 @@ impl BlockRegistry {
         ordered.sort_unstable_by_key(|(index, seq_hash)| (seq_hash.position(), *index));
 
         let mut registered = Vec::with_capacity(seq_hashes.len());
-        let mut group_start = 0;
-        while group_start < ordered.len() {
-            let position = ordered[group_start].1.position();
-            let group_end = ordered[group_start + 1..]
-                .iter()
-                .position(|(_, seq_hash)| seq_hash.position() != position)
-                .map_or(ordered.len(), |offset| group_start + 1 + offset);
-
-            self.register_position_group(
-                ordered[group_start..group_end].iter().copied(),
-                |index, handle, is_new| registered.push((index, handle, is_new)),
-            );
-            group_start = group_end;
-        }
+        self.register_ordered_sequence_hashes(ordered.iter().copied(), |index, handle, is_new| {
+            registered.push((index, handle, is_new))
+        });
 
         registered.sort_unstable_by_key(|(index, _, _)| *index);
         registered
@@ -348,33 +322,41 @@ impl BlockRegistry {
             .collect()
     }
 
-    /// Register one same-position group while holding exactly one outer radix
-    /// guard. `record` only stages the result; user-visible callbacks and
-    /// frequency touches run after this method returns and releases the guard.
-    fn register_position_group<K>(
+    /// Register position-ordered entries, holding exactly one outer radix
+    /// guard for each adjacent same-position group. `record` only stages the
+    /// result; user-visible callbacks and frequency touches run after this
+    /// method returns and releases every guard.
+    fn register_ordered_sequence_hashes<K>(
         &self,
         entries: impl IntoIterator<Item = (K, SequenceHash)>,
         mut record: impl FnMut(K, BlockRegistrationHandle, bool),
     ) {
-        let mut entries = entries.into_iter();
-        let Some(first) = entries.next() else {
-            return;
-        };
-        let position = first.1.position();
-        let map = self.prt.prefix(&first.1);
+        let mut entries = entries.into_iter().peekable();
+        while let Some(first) = entries.next() {
+            let position = first.1.position();
+            let map = self.prt.prefix(&first.1);
+            let mut current = first;
 
-        for (key, seq_hash) in std::iter::once(first).chain(entries) {
-            debug_assert_eq!(seq_hash.position(), position);
-            let mut weak = map.entry(seq_hash).or_default();
-            let (inner, is_new) = match weak.upgrade() {
-                Some(inner) => (inner, false),
-                None => {
-                    let inner = self.create_registration(seq_hash);
-                    *weak = Arc::downgrade(&inner);
-                    (inner, true)
-                }
-            };
-            record(key, BlockRegistrationHandle::from_inner(inner), is_new);
+            loop {
+                let (key, seq_hash) = current;
+                debug_assert_eq!(seq_hash.position(), position);
+                let mut weak = map.entry(seq_hash).or_default();
+                let (inner, is_new) = match weak.upgrade() {
+                    Some(inner) => (inner, false),
+                    None => {
+                        let inner = self.create_registration(seq_hash);
+                        *weak = Arc::downgrade(&inner);
+                        (inner, true)
+                    }
+                };
+                record(key, BlockRegistrationHandle::from_inner(inner), is_new);
+
+                let Some(next) = entries.next_if(|(_, seq_hash)| seq_hash.position() == position)
+                else {
+                    break;
+                };
+                current = next;
+            }
         }
     }
 

--- a/lib/kvbm-logical/src/registry/tests.rs
+++ b/lib/kvbm-logical/src/registry/tests.rs
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{KvbmSequenceHashProvider, tinylfu::TinyLFUTracker};
+use crate::{
+    KvbmSequenceHashProvider,
+    events::EventEmissionPolicy,
+    tinylfu::{FrequencyTracker, TinyLFUTracker},
+};
 
 use super::attachments::AttachmentError;
 use super::*;
@@ -9,6 +13,7 @@ use super::*;
 use crate::testing::{self, MetadataA, MetadataB, MetadataC, TestMeta};
 use crate::{BlockManager, blocks::BlockDuplicationPolicy};
 
+use parking_lot::Mutex;
 use std::any::TypeId;
 use std::sync::Arc;
 
@@ -17,6 +22,43 @@ type TestMetadata = TestMeta;
 /// Helper to create a token block for testing (auto block_size).
 fn create_test_token_block(tokens: &[u32]) -> dynamo_tokens::TokenBlock {
     testing::create_test_token_block(tokens, tokens.len() as u32)
+}
+
+fn sequence_hash_at(position: u64, current: u64) -> SequenceHash {
+    SequenceHash::new(current, position.checked_sub(1), position)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegistrationHook {
+    Event(u128),
+    Touch(u128),
+}
+
+struct RecordingEventPolicy {
+    hooks: Arc<Mutex<Vec<RegistrationHook>>>,
+}
+
+impl EventEmissionPolicy for RecordingEventPolicy {
+    fn should_emit(&self, seq_hash: SequenceHash) -> bool {
+        self.hooks
+            .lock()
+            .push(RegistrationHook::Event(seq_hash.as_u128()));
+        true
+    }
+}
+
+struct RecordingFrequencyTracker {
+    hooks: Arc<Mutex<Vec<RegistrationHook>>>,
+}
+
+impl FrequencyTracker<u128> for RecordingFrequencyTracker {
+    fn touch(&self, key: u128) {
+        self.hooks.lock().push(RegistrationHook::Touch(key));
+    }
+
+    fn count(&self, _key: u128) -> u32 {
+        0
+    }
 }
 
 /// Helper to construct a manager seeded with a registry that the test owns.
@@ -65,6 +107,90 @@ fn test_batch_registration_preserves_order_and_reuses_duplicate_handle() {
         handles[2].get::<u64>().with_unique(|value| *value),
         Some(17)
     );
+}
+
+#[test]
+fn test_batch_registration_monotonic_positions_groups_adjacent_equals() {
+    let registry = BlockRegistry::new();
+    let hashes = [
+        sequence_hash_at(0, 10),
+        sequence_hash_at(1, 20),
+        sequence_hash_at(1, 21),
+        sequence_hash_at(2, 30),
+    ];
+
+    let handles = registry.register_sequence_hashes(hashes);
+
+    assert_eq!(
+        handles
+            .iter()
+            .map(BlockRegistrationHandle::seq_hash)
+            .collect::<Vec<_>>(),
+        hashes
+    );
+    assert_eq!(registry.registered_count(), hashes.len());
+}
+
+#[test]
+fn test_batch_registration_out_of_order_reuses_existing_and_duplicate_handles() {
+    let registry = BlockRegistry::new();
+    let first = sequence_hash_at(0, 10);
+    let second = sequence_hash_at(1, 20);
+    let third = sequence_hash_at(2, 30);
+    let existing = registry.register_sequence_hash(second);
+
+    let hashes = [third, first, second, third];
+    let handles = registry.register_sequence_hashes(hashes);
+
+    assert_eq!(
+        handles
+            .iter()
+            .map(BlockRegistrationHandle::seq_hash)
+            .collect::<Vec<_>>(),
+        hashes
+    );
+    assert!(Arc::ptr_eq(&handles[2].inner, &existing.inner));
+    assert!(Arc::ptr_eq(&handles[0].inner, &handles[3].inner));
+    assert_eq!(registry.registered_count(), 3);
+}
+
+#[test]
+fn test_batch_registration_runs_observers_in_original_input_order() {
+    let hooks = Arc::new(Mutex::new(Vec::new()));
+    let event_manager = Arc::new(
+        EventsManager::builder()
+            .policy(Arc::new(RecordingEventPolicy {
+                hooks: hooks.clone(),
+            }))
+            .build(),
+    );
+    let tracker = Arc::new(RecordingFrequencyTracker {
+        hooks: hooks.clone(),
+    });
+    let registry = BlockRegistry::builder()
+        .event_manager(event_manager)
+        .frequency_tracker(tracker)
+        .build();
+
+    let existing_hash = sequence_hash_at(0, 10);
+    let later_hash = sequence_hash_at(2, 30);
+    let middle_hash = sequence_hash_at(1, 20);
+    let _existing = registry.register_sequence_hash(existing_hash);
+    hooks.lock().clear();
+
+    let handles =
+        registry.register_sequence_hashes([later_hash, existing_hash, middle_hash, later_hash]);
+
+    assert_eq!(
+        *hooks.lock(),
+        vec![
+            RegistrationHook::Event(later_hash.as_u128()),
+            RegistrationHook::Touch(later_hash.as_u128()),
+            RegistrationHook::Event(middle_hash.as_u128()),
+            RegistrationHook::Touch(middle_hash.as_u128()),
+        ]
+    );
+    assert!(Arc::ptr_eq(&handles[0].inner, &handles[3].inner));
 }
 
 #[test]
@@ -510,8 +636,6 @@ fn test_touch_no_callbacks_is_noop() {
 
 #[test]
 fn test_touch_callback_receives_correct_hash() {
-    use parking_lot::Mutex;
-
     let registry = BlockRegistry::new();
     let seq_hash = create_test_token_block(&[13, 14, 15, 16]).kvbm_sequence_hash();
     let handle = registry.register_sequence_hash(seq_hash);

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -380,18 +380,16 @@ impl ActiveSequence {
         let active_blocks = active_tokens
             .div_ceil(self.block_size)
             .min(self.unique_blocks.len());
-        self.unique_blocks[..active_blocks]
+        if active_blocks == 0 {
+            return Vec::new();
+        }
+
+        let blocks = self.unique_blocks[..active_blocks]
             .iter()
             .rev()
-            .map(|block| match block {
-                UniqueBlock::PartialBlock(uuid) => {
-                    MoveBlock::Deref(vec![UniqueBlock::PartialBlock(*uuid)])
-                }
-                UniqueBlock::FullBlock(hash) => {
-                    MoveBlock::Deref(vec![UniqueBlock::FullBlock(*hash)])
-                }
-            })
-            .collect()
+            .cloned()
+            .collect();
+        vec![MoveBlock::Deref(blocks)]
     }
 
     /// Free the currently active allocation footprint.
@@ -485,23 +483,12 @@ mod tests {
         }
     }
 
-    fn assert_deref_partial(signal: &MoveBlock) {
+    fn assert_deref_blocks(signal: &MoveBlock, expected: &[UniqueBlock]) {
         match signal {
             MoveBlock::Deref(blocks) => {
-                assert_eq!(blocks.len(), 1);
-                assert!(matches!(blocks[0], UniqueBlock::PartialBlock(_)));
+                assert_eq!(blocks, expected);
             }
-            _ => panic!("Expected MoveBlock::Deref for partial block"),
-        }
-    }
-
-    fn assert_deref_full(signal: &MoveBlock) {
-        match signal {
-            MoveBlock::Deref(blocks) => {
-                assert_eq!(blocks.len(), 1);
-                assert!(matches!(blocks[0], UniqueBlock::FullBlock(_)));
-            }
-            _ => panic!("Expected MoveBlock::Deref for full block"),
+            _ => panic!("Expected MoveBlock::Deref"),
         }
     }
 
@@ -614,9 +601,40 @@ mod tests {
 
         let free_signals = seq.reset_with_signal();
 
-        assert!(!free_signals.is_empty());
+        assert_eq!(free_signals.len(), 1);
+        let expected = seq
+            .unique_blocks()
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_deref_blocks(&free_signals[0], &expected);
         assert_eq!(seq.num_allocated_tokens(), 0);
         assert_eq!(seq.generated_tokens(), 2);
+    }
+
+    #[test]
+    fn test_free_signal_is_empty_without_an_active_allocation() {
+        let seq = ActiveSequence::new((0..10).collect(), 4, Some(4), true, false);
+
+        assert!(seq.free_signal().is_empty());
+    }
+
+    #[test]
+    fn test_free_signal_batches_allocated_blocks_in_reverse_order() {
+        let mut seq = ActiveSequence::new((0..10).collect(), 4, Some(4), true, false);
+        seq.commit_allocation(seq.len());
+
+        let expected = seq
+            .unique_blocks()
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>();
+        let signals = seq.free_signal();
+
+        assert_eq!(signals.len(), 1);
+        assert_deref_blocks(&signals[0], &expected);
     }
 
     #[test]
@@ -647,15 +665,17 @@ mod tests {
         let signals_third = seq.generate();
         assert_eq!(signals_third.len(), 0);
 
-        // Generate last token - we reach max_output_tokens, should trigger Deref signals
+        // Generate last token - we reach max_output_tokens, so all blocks should
+        // be dereferenced in one reverse-ordered batch.
+        let expected = seq
+            .unique_blocks()
+            .iter()
+            .rev()
+            .cloned()
+            .collect::<Vec<_>>();
         let signals_last = seq.generate();
-        assert_eq!(signals_last.len(), 2);
-
-        // First signal should be Deref for the partial block
-        assert_deref_partial(&signals_last[0]);
-
-        // Second signal should be Deref for the full block
-        assert_deref_full(&signals_last[1]);
+        assert_eq!(signals_last.len(), 1);
+        assert_deref_blocks(&signals_last[0], &expected);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -148,12 +148,17 @@ enum PreparedUseBlock {
         seq_hash: SequenceHash,
         handle: ImmutableBlock<G1>,
     },
+    /// Not present in `active_full`; resolved by the single aligned scattered
+    /// lookup after the initial classification pass.
+    PendingNonLocalFull {
+        seq_hash: SequenceHash,
+        full_idx: usize,
+    },
     ExistingPartial,
     FreshFull {
         seq_hash: SequenceHash,
         full_idx: usize,
         mutable: Option<MutableBlock<G1>>,
-        candidate_block_id: Option<usize>,
     },
     FreshPartial {
         uuid: Uuid,
@@ -171,6 +176,7 @@ struct UseSignalRef<'a> {
 struct UseTransaction<'a> {
     signal: UseSignalRef<'a>,
     prepared: Vec<PreparedUseBlock>,
+    fresh_full_blocks: usize,
     evicted_plhs: Vec<PositionalLineageHash>,
 }
 
@@ -1541,55 +1547,39 @@ impl KvManager {
             expected_full_blocks,
         );
 
-        // Preserve the existing per-block scattered reuse semantics while
-        // collapsing all non-local lookups into one store-lock acquisition.
-        // `match_blocks` cannot be used here because it stops at the first
-        // miss, whereas the existing singleton loop can still reuse a later
-        // registered block.
-        let mut nonlocal_plhs = Vec::with_capacity(expected_full_blocks);
-        let mut full_idx = 0usize;
-        for block in blocks {
-            if let UniqueBlock::FullBlock(seq_hash) = block {
-                if !self.active_full.contains_key(seq_hash) {
-                    nonlocal_plhs.push(plhs[full_idx]);
-                }
-                full_idx += 1;
-            }
-        }
-        let mut nonlocal_matches = self
-            .block_manager
-            .match_blocks_scattered(&nonlocal_plhs)
-            .into_iter();
-
+        // Classify locally active blocks once, and preserve the existing
+        // per-block scattered reuse semantics while collapsing all non-local
+        // lookups into one store-lock acquisition. `match_blocks` cannot be
+        // used here because it stops at the first miss, whereas the existing
+        // singleton loop can still reuse a later registered block.
+        //
+        // Start empty rather than reserving for every full block: an all-active
+        // request never needs storage for non-local lookup inputs.
         let mut prepared = Vec::with_capacity(blocks.len());
-        let mut evicted_plhs = Vec::new();
+        let mut nonlocal_plhs = Vec::new();
         let mut fresh_blocks = 0usize;
-        full_idx = 0;
+        let mut fresh_full_blocks = 0usize;
+        let mut full_idx = 0usize;
         for block in blocks {
             match block {
                 UniqueBlock::FullBlock(seq_hash) => {
-                    let entry = if self.active_full.contains_key(seq_hash) {
-                        PreparedUseBlock::ExistingActiveFull {
+                    if self.active_full.contains_key(seq_hash) {
+                        prepared.push(PreparedUseBlock::ExistingActiveFull {
                             seq_hash: *seq_hash,
-                        }
-                    } else if let Some(handle) = nonlocal_matches
-                        .next()
-                        .expect("scattered match result must align with non-local full blocks")
-                    {
-                        PreparedUseBlock::ExistingMatchedFull {
-                            seq_hash: *seq_hash,
-                            handle,
-                        }
+                        });
                     } else {
-                        fresh_blocks += 1;
-                        PreparedUseBlock::FreshFull {
+                        prepared.push(PreparedUseBlock::PendingNonLocalFull {
                             seq_hash: *seq_hash,
                             full_idx,
-                            mutable: None,
-                            candidate_block_id: None,
+                        });
+                        // Allocate once, but only when the request actually
+                        // contains a non-local full block. Every remaining
+                        // full block is the largest possible suffix here.
+                        if nonlocal_plhs.is_empty() {
+                            nonlocal_plhs.reserve_exact(expected_full_blocks - full_idx);
                         }
-                    };
-                    prepared.push(entry);
+                        nonlocal_plhs.push(plhs[full_idx]);
+                    }
                     full_idx += 1;
                 }
                 UniqueBlock::PartialBlock(uuid) => {
@@ -1605,10 +1595,40 @@ impl KvManager {
                 }
             }
         }
-        assert!(
-            nonlocal_matches.next().is_none(),
-            "scattered match returned more entries than non-local full blocks"
-        );
+
+        if !nonlocal_plhs.is_empty() {
+            let mut nonlocal_matches = self
+                .block_manager
+                .match_blocks_scattered(&nonlocal_plhs)
+                .into_iter();
+            for entry in &mut prepared {
+                let PreparedUseBlock::PendingNonLocalFull { seq_hash, full_idx } = entry else {
+                    continue;
+                };
+                let seq_hash = *seq_hash;
+                let full_idx = *full_idx;
+                *entry = if let Some(handle) = nonlocal_matches
+                    .next()
+                    .expect("scattered match result must align with non-local full blocks")
+                {
+                    PreparedUseBlock::ExistingMatchedFull { seq_hash, handle }
+                } else {
+                    fresh_blocks += 1;
+                    fresh_full_blocks += 1;
+                    PreparedUseBlock::FreshFull {
+                        seq_hash,
+                        full_idx,
+                        mutable: None,
+                    }
+                };
+            }
+            assert!(
+                nonlocal_matches.next().is_none(),
+                "scattered match returned more entries than non-local full blocks"
+            );
+        }
+
+        let mut evicted_plhs = Vec::new();
 
         if let Some(reservation) = reservation.as_mut() {
             if reservation.len() < fresh_blocks {
@@ -1627,6 +1647,9 @@ impl KvManager {
                     PreparedUseBlock::ExistingActiveFull { .. }
                     | PreparedUseBlock::ExistingMatchedFull { .. }
                     | PreparedUseBlock::ExistingPartial => {}
+                    PreparedUseBlock::PendingNonLocalFull { .. } => {
+                        unreachable!("non-local full block must be resolved before reservation")
+                    }
                 }
             }
         } else {
@@ -1667,6 +1690,9 @@ impl KvManager {
                     PreparedUseBlock::ExistingActiveFull { .. }
                     | PreparedUseBlock::ExistingMatchedFull { .. }
                     | PreparedUseBlock::ExistingPartial => {}
+                    PreparedUseBlock::PendingNonLocalFull { .. } => {
+                        unreachable!("non-local full block must be resolved before reservation")
+                    }
                 }
             }
             assert!(
@@ -1683,6 +1709,7 @@ impl KvManager {
                 parent,
             },
             prepared,
+            fresh_full_blocks,
             evicted_plhs,
         })
     }
@@ -1691,6 +1718,7 @@ impl KvManager {
         let UseTransaction {
             signal,
             mut prepared,
+            fresh_full_blocks,
             evicted_plhs,
         } = transaction;
 
@@ -1698,19 +1726,17 @@ impl KvManager {
         // under one BlockStore lock. Registration results preserve input order,
         // so the second pass can consume them alongside the fresh prepared
         // entries while preserving router-event segmentation and metadata.
-        let mut completed_blocks = Vec::new();
+        let mut completed_blocks = Vec::with_capacity(fresh_full_blocks);
+        let mut candidate_block_ids = Vec::with_capacity(fresh_full_blocks);
         for entry in &mut prepared {
             if let PreparedUseBlock::FreshFull {
-                full_idx,
-                mutable,
-                candidate_block_id,
-                ..
+                full_idx, mutable, ..
             } = entry
             {
                 let mutable = mutable
                     .take()
                     .expect("committing Use must own every fresh full slot");
-                *candidate_block_id = Some(mutable.block_id());
+                candidate_block_ids.push(mutable.block_id());
                 let complete = mutable
                     .stage(signal.plhs[*full_idx], self.block_size)
                     .expect("Use full block stage failed");
@@ -1718,7 +1744,17 @@ impl KvManager {
             }
         }
         let registered_blocks = self.block_manager.register_blocks(completed_blocks);
-        let mut fresh_registrations = registered_blocks.into_iter();
+        assert_eq!(
+            candidate_block_ids.len(),
+            fresh_full_blocks,
+            "prepared fresh full count must match staged candidate IDs"
+        );
+        assert_eq!(
+            candidate_block_ids.len(),
+            registered_blocks.len(),
+            "fresh candidate IDs must align with batch registration results"
+        );
+        let mut fresh_registrations = candidate_block_ids.into_iter().zip(registered_blocks);
 
         let mut metadata_parent_hash = match signal.parent {
             None => None,
@@ -1766,12 +1802,14 @@ impl KvManager {
                     metadata_parent_hash = Some(seq_hash);
                     first_store_parent = metadata_parent_hash;
                 }
+                PreparedUseBlock::PendingNonLocalFull { .. } => {
+                    unreachable!("non-local full block must be resolved before commit")
+                }
                 PreparedUseBlock::ExistingPartial => {}
                 PreparedUseBlock::FreshFull {
                     seq_hash,
                     full_idx,
                     mutable,
-                    candidate_block_id,
                 } => {
                     if blocks_stored.is_empty() {
                         first_store_parent = metadata_parent_hash;
@@ -1781,16 +1819,33 @@ impl KvManager {
                         mutable.is_none(),
                         "fresh full slot must be consumed by batch staging"
                     );
-                    let candidate_block_id = candidate_block_id
-                        .expect("fresh full block must record its staged candidate ID");
-                    let immutable = fresh_registrations
+                    let (candidate_block_id, immutable) = fresh_registrations
                         .next()
                         .expect("fresh full block must have a registration result");
-                    assert_eq!(
-                        immutable.block_id(),
-                        candidate_block_id,
-                        "prepared fresh Use block unexpectedly resolved to an existing registration"
-                    );
+                    if immutable.block_id() != candidate_block_id {
+                        // Reject deduplication can resolve two fresh entries in
+                        // this same batch to one canonical block. Finish the
+                        // preceding Stored group, retain the returned handle as
+                        // another logical owner, and advance the lineage cursor
+                        // without replacing canonical shadow metadata or
+                        // publishing a duplicate Stored event.
+                        if !blocks_stored.is_empty() {
+                            let hashes = std::mem::take(&mut blocks_stored);
+                            let local_hashes = std::mem::take(&mut stored_local_hashes);
+                            let token_ids = stored_token_ids.as_mut().map(std::mem::take);
+                            self.publish_kv_event(
+                                hashes,
+                                &local_hashes,
+                                first_store_parent,
+                                true,
+                                token_ids,
+                            );
+                        }
+                        self.insert_or_retain_active_full(seq_hash, immutable);
+                        metadata_parent_hash = Some(seq_hash);
+                        first_store_parent = metadata_parent_hash;
+                        continue;
+                    }
                     self.insert_or_retain_active_full(seq_hash, immutable);
 
                     let local_hash = signal.local_hashes.get(full_idx).copied();
@@ -2132,7 +2187,7 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
-    use crate::common::protocols::KvCacheEventSink;
+    use crate::common::protocols::{KvCacheEventSink, RawKvEvent, RawKvEventSink};
 
     /// Capturing event sink for router-publication assertions.
     #[derive(Default)]
@@ -2141,6 +2196,18 @@ mod tests {
     }
     impl KvCacheEventSink for CapturingSink {
         fn publish(&self, event: KvCacheEvent) -> anyhow::Result<()> {
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct CapturingRawSink {
+        events: Mutex<Vec<RawKvEvent>>,
+    }
+
+    impl RawKvEventSink for CapturingRawSink {
+        fn publish(&self, event: RawKvEvent) -> anyhow::Result<()> {
             self.events.lock().unwrap().push(event);
             Ok(())
         }
@@ -2167,6 +2234,21 @@ mod tests {
         (
             KvManager::new_with_event_sink(capacity, block_size, publishers, 0),
             sink,
+        )
+    }
+
+    fn make_mgr_capturing_with_raw(
+        capacity: usize,
+        block_size: usize,
+    ) -> (KvManager, Arc<CapturingSink>, Arc<CapturingRawSink>) {
+        let sink = Arc::new(CapturingSink::default());
+        let raw_sink = Arc::new(CapturingRawSink::default());
+        let publishers =
+            KvEventPublishers::new(Some(sink.clone() as _), Some(raw_sink.clone() as _));
+        (
+            KvManager::new_with_event_sink(capacity, block_size, publishers, 0),
+            sink,
+            raw_sink,
         )
     }
 
@@ -2335,6 +2417,50 @@ mod tests {
         assert_eq!(mgr.num_active_blocks(), 0);
         assert_eq!(mgr.num_active_block_refs(), 0);
         assert_eq!(mgr.block_manager.metrics().snapshot().inflight_immutable, 0);
+    }
+
+    #[test]
+    fn all_active_multi_block_use_only_retains_logical_owners() {
+        let (mut mgr, sink) = make_mgr_capturing(4, 4);
+        let blocks = vec![UniqueBlock::FullBlock(10), UniqueBlock::FullBlock(20)];
+        let plhs = vec![plh(100), plh(200)];
+
+        assert_eq!(
+            expect_ready(mgr.process(&MoveBlock::Use(
+                blocks.clone(),
+                vec![101, 201],
+                plhs.clone(),
+                None,
+                None,
+            ))),
+            2
+        );
+        let available_before = mgr.block_manager.available_blocks();
+        let first_block_id = mgr.active_full[&10].handle.block_id();
+        let second_block_id = mgr.active_full[&20].handle.block_id();
+        sink.events.lock().unwrap().clear();
+
+        assert_eq!(
+            expect_ready(mgr.process(&MoveBlock::Use(blocks, vec![101, 201], plhs, None, None,))),
+            2
+        );
+
+        assert_eq!(mgr.block_manager.available_blocks(), available_before);
+        assert_eq!(mgr.num_active_blocks(), 2);
+        assert_eq!(mgr.num_active_block_refs(), 4);
+        assert_eq!(mgr.active_full[&10].handle.block_id(), first_block_id);
+        assert_eq!(mgr.active_full[&20].handle.block_id(), second_block_id);
+        assert!(
+            sink.events.lock().unwrap().is_empty(),
+            "retaining active blocks must not publish another Stored event"
+        );
+
+        for _ in 0..2 {
+            deref_full(&mut mgr, 10);
+            deref_full(&mut mgr, 20);
+        }
+        assert_eq!(mgr.num_active_blocks(), 0);
+        assert_eq!(mgr.num_active_block_refs(), 0);
     }
 
     #[test]
@@ -2520,6 +2646,95 @@ mod tests {
                 expected_local_hashes
             );
         }
+    }
+
+    #[test]
+    fn duplicate_fresh_registration_reuses_canonical_without_duplicate_event() {
+        const CAPACITY: usize = 6;
+        let (mut mgr, sink, raw_sink) = make_mgr_capturing_with_raw(CAPACITY, 4);
+        let a_plh = plh(100);
+        let b_plh = plh(200);
+        let local_hashes = vec![101, 102, 201];
+        let token_ids = vec![vec![1; 4], vec![2; 4], vec![3; 4]];
+        let dedup_before = mgr.block_manager.metrics().snapshot().registration_dedup;
+
+        assert_eq!(
+            expect_ready(mgr.process(&MoveBlock::Use(
+                vec![
+                    UniqueBlock::FullBlock(10),
+                    UniqueBlock::FullBlock(10),
+                    UniqueBlock::FullBlock(20),
+                ],
+                local_hashes.clone(),
+                vec![a_plh, a_plh, b_plh],
+                Some(token_ids.clone()),
+                Some(UniqueBlock::FullBlock(5)),
+            ))),
+            3
+        );
+
+        assert_eq!(mgr.num_active_blocks(), 2);
+        assert_eq!(mgr.num_active_block_refs(), 3);
+        assert_eq!(mgr.block_manager.available_blocks(), CAPACITY - 2);
+        assert_eq!(
+            mgr.block_manager.metrics().snapshot().registration_dedup,
+            dedup_before + 1
+        );
+        assert_eq!(mgr.registered_blocks.len(), 2);
+
+        let a_info = &mgr.registered_blocks[&a_plh];
+        assert_eq!(a_info.seq_hash, 10);
+        assert_eq!(a_info.block_id, mgr.active_full[&10].handle.block_id());
+        assert_eq!(a_info.parent_hash, Some(5));
+        assert_eq!(a_info.local_hash, Some(local_hashes[0]));
+        assert_eq!(a_info.token_ids.as_ref(), Some(&token_ids[0]));
+
+        let b_info = &mgr.registered_blocks[&b_plh];
+        assert_eq!(b_info.seq_hash, 20);
+        assert_eq!(b_info.block_id, mgr.active_full[&20].handle.block_id());
+        assert_eq!(b_info.parent_hash, Some(10));
+        assert_eq!(b_info.local_hash, Some(local_hashes[2]));
+        assert_eq!(b_info.token_ids.as_ref(), Some(&token_ids[2]));
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 2, "the duplicate must split Stored groups");
+        for (event, expected_hash, expected_local_hash, expected_parent) in [
+            (&events[0], 10, local_hashes[0], Some(5)),
+            (&events[1], 20, local_hashes[2], Some(10)),
+        ] {
+            let KvCacheEventData::Stored(stored) = &event.data else {
+                panic!("expected Stored event, got {:?}", event.data);
+            };
+            assert_eq!(stored.parent_hash.map(|hash| hash.0), expected_parent);
+            assert_eq!(stored.blocks.len(), 1);
+            assert_eq!(stored.blocks[0].block_hash.0, expected_hash);
+            assert_eq!(stored.blocks[0].tokens_hash.0, expected_local_hash);
+        }
+        drop(events);
+
+        let raw_events = raw_sink.events.lock().unwrap();
+        assert_eq!(
+            raw_events.len(),
+            2,
+            "the duplicate must split raw Stored groups"
+        );
+        assert_eq!(
+            raw_events[0].block_token_ids.as_deref(),
+            Some(std::slice::from_ref(&token_ids[0]))
+        );
+        assert_eq!(
+            raw_events[1].block_token_ids.as_deref(),
+            Some(std::slice::from_ref(&token_ids[2]))
+        );
+        drop(raw_events);
+
+        deref_full(&mut mgr, 10);
+        deref_full(&mut mgr, 10);
+        deref_full(&mut mgr, 20);
+        assert_eq!(mgr.num_active_blocks(), 0);
+        assert_eq!(mgr.num_active_block_refs(), 0);
+        assert!(mgr.active_full.is_empty());
+        assert_eq!(mgr.block_manager.available_blocks(), CAPACITY);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -29,6 +29,7 @@
 //! - `Lru` — simple recency-based LRU.
 //! - `MultiLru` — 4-tier frequency-aware LRU (requires TinyLFU tracker).
 
+use std::collections::hash_map::Entry;
 use std::sync::Arc;
 #[cfg(feature = "kvbm-offload")]
 use std::sync::Mutex;
@@ -225,6 +226,34 @@ struct FullBlockMetadata {
     token_ids: Option<Vec<u32>>,
 }
 
+/// One physical full-block pin plus the number of logical request owners.
+///
+/// `ImmutableBlock` clones are physical-lifetime guards, not request block
+/// tables. Keeping a clone per logical owner needlessly makes KVBM's handle
+/// count, allocator traffic, and Arc traffic scale with prefix sharing. The
+/// canonical handle pins the physical block while `logical_refs` tracks the
+/// ownership semantics the mocker needs for Deref.
+struct ActiveFullBlock {
+    handle: ImmutableBlock<G1>,
+    logical_refs: usize,
+}
+
+impl ActiveFullBlock {
+    fn new(handle: ImmutableBlock<G1>) -> Self {
+        Self {
+            handle,
+            logical_refs: 1,
+        }
+    }
+
+    fn retain(&mut self) {
+        self.logical_refs = self
+            .logical_refs
+            .checked_add(1)
+            .expect("active full-block logical reference count overflowed");
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum FullBlockCommit {
     Reused,
@@ -244,11 +273,11 @@ pub struct KvManager {
     /// Dropped blocks return to kvbm-logical's reset pool.
     active_partial: FxHashMap<Uuid, MutableBlock<G1>>,
 
-    /// FullBlocks held as `ImmutableBlock`, keyed by `SequenceHash`. The vec
-    /// length is the mocker's reference count — each `Use` pushes a clone,
-    /// each `Deref` pops one. When the vec empties, the block transitions to
-    /// kvbm-logical's inactive pool (RAII return on drop of the last clone).
-    active_full: FxHashMap<SequenceHash, Vec<ImmutableBlock<G1>>>,
+    /// FullBlocks held as one canonical `ImmutableBlock` per physical block,
+    /// keyed by `SequenceHash`, plus the number of logical request owners.
+    /// The final logical `Deref` drops the canonical handle and transitions the
+    /// block to kvbm-logical's inactive pool.
+    active_full: FxHashMap<SequenceHash, ActiveFullBlock>,
 
     /// Shadow registry for every block registered in kvbm-logical. The logical
     /// registry is keyed by `PositionalLineageHash`, while the router's radix
@@ -349,6 +378,45 @@ impl KvManager {
             #[cfg(feature = "kvbm-offload")]
             offload_engine: None,
             capacity_generation: 0,
+        }
+    }
+
+    /// Install a newly acquired physical handle or merge it into an entry that
+    /// became active earlier in the same serial commit.
+    fn insert_or_retain_active_full(&mut self, seq_hash: SequenceHash, handle: ImmutableBlock<G1>) {
+        match self.active_full.entry(seq_hash) {
+            Entry::Vacant(entry) => {
+                entry.insert(ActiveFullBlock::new(handle));
+            }
+            Entry::Occupied(mut entry) => {
+                assert_eq!(
+                    entry.get().handle.block_id(),
+                    handle.block_id(),
+                    "active full-block hash resolved to a different physical block"
+                );
+                entry.get_mut().retain();
+                // `handle` is a redundant physical pin. Dropping it leaves the
+                // canonical entry alive while logical ownership is tracked by
+                // `logical_refs`.
+                drop(handle);
+            }
+        }
+    }
+
+    /// Release one logical owner. Removing the final entry drops the sole
+    /// physical handle and lets KVBM transition the block to inactive.
+    fn release_active_full(&mut self, seq_hash: SequenceHash) {
+        let Entry::Occupied(mut entry) = self.active_full.entry(seq_hash) else {
+            panic!("Deref: full block not in active pool");
+        };
+        assert!(
+            entry.get().logical_refs > 0,
+            "active full block must retain at least one logical owner"
+        );
+        if entry.get().logical_refs == 1 {
+            entry.remove();
+        } else {
+            entry.get_mut().logical_refs -= 1;
         }
     }
 
@@ -1002,7 +1070,7 @@ impl KvManager {
         plh: PositionalLineageHash,
     ) -> Option<ImmutableBlock<G1>> {
         if let Some(active) = self.active_full.get(&seq_hash) {
-            return Some(active[0].clone());
+            return Some(active.handle.clone());
         }
         self.block_manager.match_blocks(&[plh]).into_iter().next()
     }
@@ -1022,10 +1090,7 @@ impl KvManager {
 
         if let Some(canonical) = self.acquire_existing_full(seq_hash, plh) {
             drop(candidate);
-            self.active_full
-                .entry(seq_hash)
-                .or_default()
-                .push(canonical);
+            self.insert_or_retain_active_full(seq_hash, canonical);
             return FullBlockCommit::Reused;
         }
 
@@ -1035,10 +1100,7 @@ impl KvManager {
             .expect("full block stage failed");
         let canonical = self.block_manager.register_block(complete);
         let canonical_block_id = canonical.block_id();
-        self.active_full
-            .entry(seq_hash)
-            .or_default()
-            .push(canonical);
+        self.insert_or_retain_active_full(seq_hash, canonical);
 
         if canonical_block_id != candidate_block_id {
             return FullBlockCommit::Reused;
@@ -1202,7 +1264,7 @@ impl KvManager {
                         let (_, handle) = cached_prefix
                             .next()
                             .expect("reserved prefix handle must exist");
-                        self.active_full.entry(seq_hash).or_default().push(handle);
+                        self.insert_or_retain_active_full(seq_hash, handle);
                         metadata_parent_hash = Some(seq_hash);
                         continue;
                     }
@@ -1471,7 +1533,7 @@ impl KvManager {
                     let entry = if let Some(active) = self.active_full.get(seq_hash) {
                         PreparedUseBlock::ExistingFull {
                             seq_hash: *seq_hash,
-                            handle: active[0].clone(),
+                            handle: active.handle.clone(),
                         }
                     } else if let Some(handle) =
                         self.block_manager.match_blocks(&[plh]).into_iter().next()
@@ -1609,7 +1671,7 @@ impl KvManager {
                             token_ids,
                         );
                     }
-                    self.active_full.entry(seq_hash).or_default().push(handle);
+                    self.insert_or_retain_active_full(seq_hash, handle);
                     metadata_parent_hash = Some(seq_hash);
                     first_store_parent = metadata_parent_hash;
                 }
@@ -1634,10 +1696,7 @@ impl KvManager {
                         candidate_block_id,
                         "prepared fresh Use block unexpectedly resolved to an existing registration"
                     );
-                    self.active_full
-                        .entry(seq_hash)
-                        .or_default()
-                        .push(immutable);
+                    self.insert_or_retain_active_full(seq_hash, immutable);
 
                     let local_hash = signal.local_hashes.get(full_idx).copied();
                     let registry_token_ids = signal
@@ -1801,14 +1860,7 @@ impl KvManager {
                         .expect("Deref: partial block not in active pool");
                 }
                 UniqueBlock::FullBlock(seq_hash) => {
-                    let vec = self
-                        .active_full
-                        .get_mut(seq_hash)
-                        .expect("Deref: full block not in active pool");
-                    vec.pop();
-                    if vec.is_empty() {
-                        self.active_full.remove(seq_hash);
-                    }
+                    self.release_active_full(*seq_hash);
                 }
             }
         }
@@ -1869,11 +1921,17 @@ impl KvManager {
         self.block_manager.total_blocks() - self.block_manager.available_blocks()
     }
 
-    /// Total number of held RAII handles (refcount-style): one per held
-    /// `MutableBlock` plus one per cloned `ImmutableBlock` in `active_full`.
-    /// Shared-prefix reuse inflates this above the distinct-block count.
+    /// Total number of logical block owners: one per held `MutableBlock` plus
+    /// the explicit logical reference count of every full block. This remains
+    /// a request-ownership metric even though KVBM's `inflight_immutable`
+    /// metric now counts only the canonical physical handles retained here.
     pub fn num_active_block_refs(&self) -> usize {
-        self.active_partial.len() + self.active_full.values().map(|v| v.len()).sum::<usize>()
+        self.active_partial.len()
+            + self
+                .active_full
+                .values()
+                .map(|active| active.logical_refs)
+                .sum::<usize>()
     }
 
     #[cfg(test)]
@@ -1885,8 +1943,7 @@ impl KvManager {
                 UniqueBlock::FullBlock(hash) => self
                     .active_full
                     .get(hash)
-                    .and_then(|handles| handles.last())
-                    .map(ImmutableBlock::block_id),
+                    .map(|active| active.handle.block_id()),
                 UniqueBlock::PartialBlock(uuid) => {
                     self.active_partial.get(uuid).map(MutableBlock::block_id)
                 }
@@ -2164,9 +2221,21 @@ mod tests {
         use_full(&mut mgr, 1, plh(100));
         use_full(&mut mgr, 1, plh(100));
         // Same seq_hash used twice: only one distinct physical block is
-        // resident, but the mocker holds two RAII handles.
+        // resident and pinned by one canonical RAII handle, while the mocker
+        // tracks two logical request owners.
         assert_eq!(mgr.num_active_blocks(), 1);
         assert_eq!(mgr.num_active_block_refs(), 2);
+        assert_eq!(mgr.block_manager.metrics().snapshot().inflight_immutable, 1);
+
+        deref_full(&mut mgr, 1);
+        assert_eq!(mgr.num_active_blocks(), 1);
+        assert_eq!(mgr.num_active_block_refs(), 1);
+        assert_eq!(mgr.block_manager.metrics().snapshot().inflight_immutable, 1);
+
+        deref_full(&mut mgr, 1);
+        assert_eq!(mgr.num_active_blocks(), 0);
+        assert_eq!(mgr.num_active_block_refs(), 0);
+        assert_eq!(mgr.block_manager.metrics().snapshot().inflight_immutable, 0);
     }
 
     #[test]
@@ -2350,7 +2419,10 @@ mod tests {
             mgr.process(&MoveBlock::Deref(blocks));
         }
         fn refcount(mgr: &KvManager, id: u64) -> usize {
-            mgr.active_full.get(&id).map(|v| v.len()).unwrap_or(0)
+            mgr.active_full
+                .get(&id)
+                .map(|active| active.logical_refs)
+                .unwrap_or(0)
         }
         fn assert_active(mgr: &KvManager, expected: &[(u64, usize)]) {
             let distinct = expected.len();
@@ -3303,7 +3375,7 @@ mod tests {
             assert!(target_hashes.iter().all(|target| {
                 mgr.active_full
                     .get(target)
-                    .is_some_and(|refs| refs.len() == 1)
+                    .is_some_and(|active| active.logical_refs == 1)
             }));
 
             let committed = sink.take();

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -13,10 +13,11 @@
 //!   transaction, then commit the whole request atomically. Capacity exhaustion
 //!   leaves ownership and sequence state unchanged so the scheduler can decide
 //!   whether to preempt a running request.
-//! - **Deref**: release one request-owned handle. For `PartialBlock` this drops
-//!   the unique `MutableBlock` and returns it to the reset pool. For
-//!   `FullBlock` this pops one `ImmutableBlock` clone; when the vec empties,
-//!   the block transitions to kvbm-logical's inactive pool (RAII return).
+//! - **Deref**: release one logical request owner. For `PartialBlock` this
+//!   drops the unique `MutableBlock` and returns it to the reset pool. For
+//!   `FullBlock` this decrements an explicit logical refcount; the final
+//!   release drops the canonical `ImmutableBlock` and transitions the block to
+//!   kvbm-logical's inactive pool (RAII return).
 //! - **Promote**: PartialBlock (`MutableBlock`) → FullBlock (`ImmutableBlock`).
 //!   Collapses onto an existing registered handle if the PLH / SequenceHash is
 //!   already present; otherwise stages + registers a new block.
@@ -99,9 +100,9 @@ enum SwapInSlotReservation {
 /// Classification for each block processed inside `Use`.
 ///
 /// - `ActiveHit`: block is already pinned in `active_full` / `active_partial`;
-///   we just bump our local refcount (handle clone).
+///   commit bumps its explicit logical refcount without cloning a handle.
 /// - `InactiveHit`: block was in kvbm-logical's inactive pool and was
-///   reactivated via `match_blocks(plh)`.
+///   reactivated by the aligned scattered batch lookup.
 /// - `NewStore`: block was freshly allocated, staged, and registered.
 ///
 /// The router radix tree already knows about `ActiveHit` and `InactiveHit`
@@ -136,7 +137,14 @@ pub struct OffloadDependency {
 }
 
 enum PreparedUseBlock {
-    ExistingFull {
+    /// Already represented in `active_full`; no temporary RAII clone is
+    /// needed while the transaction reserves its fresh suffix.
+    ExistingActiveFull {
+        seq_hash: SequenceHash,
+    },
+    /// Resurrected from KVBM's inactive pool (or otherwise matched outside the
+    /// mocker's active map). The handle pins it until commit or rollback.
+    ExistingMatchedFull {
         seq_hash: SequenceHash,
         handle: ImmutableBlock<G1>,
     },
@@ -401,6 +409,16 @@ impl KvManager {
                 drop(handle);
             }
         }
+    }
+
+    /// Add one logical owner for a block known to be present in the active map.
+    /// This is called only after every fallible reservation for the surrounding
+    /// Use transaction has succeeded.
+    fn retain_active_full(&mut self, seq_hash: SequenceHash) {
+        self.active_full
+            .get_mut(&seq_hash)
+            .unwrap_or_else(|| panic!("active full block {seq_hash:?} disappeared before commit"))
+            .retain();
     }
 
     /// Release one logical owner. Removing the final entry drops the sole
@@ -1522,23 +1540,42 @@ impl KvManager {
             expected_full_blocks,
         );
 
+        // Preserve the existing per-block scattered reuse semantics while
+        // collapsing all non-local lookups into one store-lock acquisition.
+        // `match_blocks` cannot be used here because it stops at the first
+        // miss, whereas the existing singleton loop can still reuse a later
+        // registered block.
+        let mut nonlocal_plhs = Vec::with_capacity(expected_full_blocks);
+        let mut full_idx = 0usize;
+        for block in blocks {
+            if let UniqueBlock::FullBlock(seq_hash) = block {
+                if !self.active_full.contains_key(seq_hash) {
+                    nonlocal_plhs.push(plhs[full_idx]);
+                }
+                full_idx += 1;
+            }
+        }
+        let mut nonlocal_matches = self
+            .block_manager
+            .match_blocks_scattered(&nonlocal_plhs)
+            .into_iter();
+
         let mut prepared = Vec::with_capacity(blocks.len());
         let mut evicted_plhs = Vec::new();
         let mut fresh_blocks = 0usize;
-        let mut full_idx = 0usize;
+        full_idx = 0;
         for block in blocks {
             match block {
                 UniqueBlock::FullBlock(seq_hash) => {
-                    let plh = plhs[full_idx];
-                    let entry = if let Some(active) = self.active_full.get(seq_hash) {
-                        PreparedUseBlock::ExistingFull {
+                    let entry = if self.active_full.contains_key(seq_hash) {
+                        PreparedUseBlock::ExistingActiveFull {
                             seq_hash: *seq_hash,
-                            handle: active.handle.clone(),
                         }
-                    } else if let Some(handle) =
-                        self.block_manager.match_blocks(&[plh]).into_iter().next()
+                    } else if let Some(handle) = nonlocal_matches
+                        .next()
+                        .expect("scattered match result must align with non-local full blocks")
                     {
-                        PreparedUseBlock::ExistingFull {
+                        PreparedUseBlock::ExistingMatchedFull {
                             seq_hash: *seq_hash,
                             handle,
                         }
@@ -1566,6 +1603,10 @@ impl KvManager {
                 }
             }
         }
+        assert!(
+            nonlocal_matches.next().is_none(),
+            "scattered match returned more entries than non-local full blocks"
+        );
 
         if let Some(reservation) = reservation.as_mut() {
             if reservation.len() < fresh_blocks {
@@ -1581,7 +1622,9 @@ impl KvManager {
                                 .expect("prechecked decode reservation must contain a slot"),
                         );
                     }
-                    PreparedUseBlock::ExistingFull { .. } | PreparedUseBlock::ExistingPartial => {}
+                    PreparedUseBlock::ExistingActiveFull { .. }
+                    | PreparedUseBlock::ExistingMatchedFull { .. }
+                    | PreparedUseBlock::ExistingPartial => {}
                 }
             }
         } else {
@@ -1619,7 +1662,9 @@ impl KvManager {
                                 .expect("atomic Use reservation returned too few slots"),
                         );
                     }
-                    PreparedUseBlock::ExistingFull { .. } | PreparedUseBlock::ExistingPartial => {}
+                    PreparedUseBlock::ExistingActiveFull { .. }
+                    | PreparedUseBlock::ExistingMatchedFull { .. }
+                    | PreparedUseBlock::ExistingPartial => {}
                 }
             }
             assert!(
@@ -1643,9 +1688,43 @@ impl KvManager {
     fn commit_use(&mut self, transaction: UseTransaction<'_>) {
         let UseTransaction {
             signal,
-            prepared,
+            mut prepared,
             evicted_plhs,
         } = transaction;
+
+        // Complete every fresh full block first, then register the whole set
+        // under one BlockStore lock. The ordered registration result is joined
+        // back to the original prepared-entry index so the second pass can
+        // preserve router-event segmentation and parent metadata exactly.
+        let mut fresh_registration_order = Vec::new();
+        let mut completed_blocks = Vec::new();
+        for (entry_idx, entry) in prepared.iter_mut().enumerate() {
+            if let PreparedUseBlock::FreshFull {
+                full_idx, mutable, ..
+            } = entry
+            {
+                let mutable = mutable
+                    .take()
+                    .expect("committing Use must own every fresh full slot");
+                let candidate_block_id = mutable.block_id();
+                let complete = mutable
+                    .stage(signal.plhs[*full_idx], self.block_size)
+                    .expect("Use full block stage failed");
+                fresh_registration_order.push((entry_idx, candidate_block_id));
+                completed_blocks.push(complete);
+            }
+        }
+        let registered_blocks = self.block_manager.register_blocks(completed_blocks);
+        assert_eq!(
+            registered_blocks.len(),
+            fresh_registration_order.len(),
+            "batch registration result must align with fresh full blocks"
+        );
+        let mut fresh_registrations = fresh_registration_order
+            .into_iter()
+            .zip(registered_blocks)
+            .peekable();
+
         let mut metadata_parent_hash = match signal.parent {
             None => None,
             Some(UniqueBlock::FullBlock(seq_hash)) => Some(*seq_hash),
@@ -1656,9 +1735,26 @@ impl KvManager {
         let mut stored_local_hashes = Vec::<BlockHash>::new();
         let mut stored_token_ids = signal.token_ids.map(|_| Vec::<Vec<u32>>::new());
 
-        for entry in prepared {
+        for (entry_idx, entry) in prepared.into_iter().enumerate() {
             match entry {
-                PreparedUseBlock::ExistingFull { seq_hash, handle } => {
+                PreparedUseBlock::ExistingActiveFull { seq_hash } => {
+                    if !blocks_stored.is_empty() {
+                        let hashes = std::mem::take(&mut blocks_stored);
+                        let local_hashes = std::mem::take(&mut stored_local_hashes);
+                        let token_ids = stored_token_ids.as_mut().map(std::mem::take);
+                        self.publish_kv_event(
+                            hashes,
+                            &local_hashes,
+                            first_store_parent,
+                            true,
+                            token_ids,
+                        );
+                    }
+                    self.retain_active_full(seq_hash);
+                    metadata_parent_hash = Some(seq_hash);
+                    first_store_parent = metadata_parent_hash;
+                }
+                PreparedUseBlock::ExistingMatchedFull { seq_hash, handle } => {
                     if !blocks_stored.is_empty() {
                         let hashes = std::mem::take(&mut blocks_stored);
                         let local_hashes = std::mem::take(&mut stored_local_hashes);
@@ -1685,12 +1781,18 @@ impl KvManager {
                         first_store_parent = metadata_parent_hash;
                     }
                     let plh = signal.plhs[full_idx];
-                    let mutable = mutable.expect("committing Use must own every fresh full slot");
-                    let candidate_block_id = mutable.block_id();
-                    let complete = mutable
-                        .stage(plh, self.block_size)
-                        .expect("Use full block stage failed");
-                    let immutable = self.block_manager.register_block(complete);
+                    assert!(
+                        mutable.is_none(),
+                        "fresh full slot must be consumed by batch staging"
+                    );
+                    let ((registered_entry_idx, candidate_block_id), immutable) =
+                        fresh_registrations
+                            .next()
+                            .expect("fresh full block must have a registration result");
+                    assert_eq!(
+                        registered_entry_idx, entry_idx,
+                        "fresh registration order must match prepared entries"
+                    );
                     assert_eq!(
                         immutable.block_id(),
                         candidate_block_id,
@@ -1737,6 +1839,10 @@ impl KvManager {
                 }
             }
         }
+        assert!(
+            fresh_registrations.next().is_none(),
+            "unused fresh full registration result"
+        );
 
         if !blocks_stored.is_empty() {
             self.publish_kv_event(
@@ -2259,6 +2365,27 @@ mod tests {
     }
 
     #[test]
+    fn failed_mixed_use_does_not_retain_existing_active_blocks() {
+        let mut mgr = make_mgr(1, 16);
+        use_full(&mut mgr, 1, plh(100));
+
+        assert!(matches!(
+            mgr.process(&MoveBlock::Use(
+                vec![UniqueBlock::FullBlock(1), UniqueBlock::FullBlock(2)],
+                vec![],
+                vec![plh(100), plh(200)],
+                None,
+                None,
+            )),
+            G1Acquire::CapacityExhausted
+        ));
+        assert_eq!(mgr.num_active_blocks(), 1);
+        assert_eq!(mgr.num_active_block_refs(), 1);
+        assert_eq!(mgr.active_full[&1].logical_refs, 1);
+        assert!(!mgr.active_full.contains_key(&2));
+    }
+
+    #[test]
     fn test_deref_returns_to_inactive() {
         let mut mgr = make_mgr(4, 16);
         use_full(&mut mgr, 1, plh(100));
@@ -2274,6 +2401,53 @@ mod tests {
         deref_full(&mut mgr, 1);
         // Use with same PLH reuses the inactive block.
         assert_eq!(use_full(&mut mgr, 2, p), 1);
+    }
+
+    #[test]
+    fn scattered_use_reuses_later_hit_after_a_miss() {
+        let (mut mgr, sink) = make_mgr_capturing(10, 16);
+        let first_plh = plh(100);
+        let missing_plh = plh(200);
+        let later_plh = plh(300);
+
+        use_full(&mut mgr, 10, first_plh);
+        use_full(&mut mgr, 30, later_plh);
+        let later_block_id = mgr.active_full[&30].handle.block_id();
+        deref_full(&mut mgr, 10);
+        deref_full(&mut mgr, 30);
+        sink.events.lock().unwrap().clear();
+
+        assert_eq!(
+            expect_ready(mgr.process(&MoveBlock::Use(
+                vec![
+                    UniqueBlock::FullBlock(10),
+                    UniqueBlock::FullBlock(20),
+                    UniqueBlock::FullBlock(30),
+                ],
+                vec![],
+                vec![first_plh, missing_plh, later_plh],
+                None,
+                None,
+            ))),
+            3
+        );
+
+        assert_eq!(mgr.num_active_blocks(), 3);
+        assert_eq!(mgr.num_active_block_refs(), 3);
+        assert_eq!(
+            mgr.active_full[&30].handle.block_id(),
+            later_block_id,
+            "the registered block after a miss must still be reused"
+        );
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 1, "only the missing middle block is stored");
+        let KvCacheEventData::Stored(stored) = &events[0].data else {
+            panic!("expected Stored event, got {:?}", events[0].data);
+        };
+        assert_eq!(stored.parent_hash.map(|hash| hash.0), Some(10));
+        assert_eq!(stored.blocks.len(), 1);
+        assert_eq!(stored.blocks[0].block_hash.0, 20);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -153,6 +153,7 @@ enum PreparedUseBlock {
         seq_hash: SequenceHash,
         full_idx: usize,
         mutable: Option<MutableBlock<G1>>,
+        candidate_block_id: Option<usize>,
     },
     FreshPartial {
         uuid: Uuid,
@@ -1585,6 +1586,7 @@ impl KvManager {
                             seq_hash: *seq_hash,
                             full_idx,
                             mutable: None,
+                            candidate_block_id: None,
                         }
                     };
                     prepared.push(entry);
@@ -1693,37 +1695,30 @@ impl KvManager {
         } = transaction;
 
         // Complete every fresh full block first, then register the whole set
-        // under one BlockStore lock. The ordered registration result is joined
-        // back to the original prepared-entry index so the second pass can
-        // preserve router-event segmentation and parent metadata exactly.
-        let mut fresh_registration_order = Vec::new();
+        // under one BlockStore lock. Registration results preserve input order,
+        // so the second pass can consume them alongside the fresh prepared
+        // entries while preserving router-event segmentation and metadata.
         let mut completed_blocks = Vec::new();
-        for (entry_idx, entry) in prepared.iter_mut().enumerate() {
+        for entry in &mut prepared {
             if let PreparedUseBlock::FreshFull {
-                full_idx, mutable, ..
+                full_idx,
+                mutable,
+                candidate_block_id,
+                ..
             } = entry
             {
                 let mutable = mutable
                     .take()
                     .expect("committing Use must own every fresh full slot");
-                let candidate_block_id = mutable.block_id();
+                *candidate_block_id = Some(mutable.block_id());
                 let complete = mutable
                     .stage(signal.plhs[*full_idx], self.block_size)
                     .expect("Use full block stage failed");
-                fresh_registration_order.push((entry_idx, candidate_block_id));
                 completed_blocks.push(complete);
             }
         }
         let registered_blocks = self.block_manager.register_blocks(completed_blocks);
-        assert_eq!(
-            registered_blocks.len(),
-            fresh_registration_order.len(),
-            "batch registration result must align with fresh full blocks"
-        );
-        let mut fresh_registrations = fresh_registration_order
-            .into_iter()
-            .zip(registered_blocks)
-            .peekable();
+        let mut fresh_registrations = registered_blocks.into_iter();
 
         let mut metadata_parent_hash = match signal.parent {
             None => None,
@@ -1735,7 +1730,7 @@ impl KvManager {
         let mut stored_local_hashes = Vec::<BlockHash>::new();
         let mut stored_token_ids = signal.token_ids.map(|_| Vec::<Vec<u32>>::new());
 
-        for (entry_idx, entry) in prepared.into_iter().enumerate() {
+        for entry in prepared {
             match entry {
                 PreparedUseBlock::ExistingActiveFull { seq_hash } => {
                     if !blocks_stored.is_empty() {
@@ -1776,6 +1771,7 @@ impl KvManager {
                     seq_hash,
                     full_idx,
                     mutable,
+                    candidate_block_id,
                 } => {
                     if blocks_stored.is_empty() {
                         first_store_parent = metadata_parent_hash;
@@ -1785,14 +1781,11 @@ impl KvManager {
                         mutable.is_none(),
                         "fresh full slot must be consumed by batch staging"
                     );
-                    let ((registered_entry_idx, candidate_block_id), immutable) =
-                        fresh_registrations
-                            .next()
-                            .expect("fresh full block must have a registration result");
-                    assert_eq!(
-                        registered_entry_idx, entry_idx,
-                        "fresh registration order must match prepared entries"
-                    );
+                    let candidate_block_id = candidate_block_id
+                        .expect("fresh full block must record its staged candidate ID");
+                    let immutable = fresh_registrations
+                        .next()
+                        .expect("fresh full block must have a registration result");
                     assert_eq!(
                         immutable.block_id(),
                         candidate_block_id,
@@ -2448,6 +2441,85 @@ mod tests {
         assert_eq!(stored.parent_hash.map(|hash| hash.0), Some(10));
         assert_eq!(stored.blocks.len(), 1);
         assert_eq!(stored.blocks[0].block_hash.0, 20);
+    }
+
+    #[test]
+    fn mixed_use_keeps_fresh_registration_and_event_order() {
+        let (mut mgr, sink) = make_mgr_capturing(8, 4);
+        let reused_plh = plh(200);
+
+        use_full(&mut mgr, 20, reused_plh);
+        sink.events.lock().unwrap().clear();
+
+        let seq_hashes = [10, 11, 20, 30, 31];
+        let plhs = [plh(100), plh(110), reused_plh, plh(300), plh(310)];
+        let local_hashes = vec![1010, 1011, 1020, 1030, 1031];
+        let token_ids = vec![
+            vec![10, 10, 10, 10],
+            vec![11, 11, 11, 11],
+            vec![20, 20, 20, 20],
+            vec![30, 30, 30, 30],
+            vec![31, 31, 31, 31],
+        ];
+        let blocks = seq_hashes.into_iter().map(UniqueBlock::FullBlock).collect();
+
+        assert_eq!(
+            expect_ready(mgr.process(&MoveBlock::Use(
+                blocks,
+                local_hashes.clone(),
+                plhs.to_vec(),
+                Some(token_ids.clone()),
+                Some(UniqueBlock::FullBlock(5)),
+            ))),
+            seq_hashes.len()
+        );
+
+        for (idx, (seq_hash, plh)) in [(10, plhs[0]), (11, plhs[1]), (30, plhs[3]), (31, plhs[4])]
+            .into_iter()
+            .enumerate()
+        {
+            let signal_idx = [0, 1, 3, 4][idx];
+            let info = mgr
+                .registered_blocks
+                .get(&plh)
+                .expect("fresh block must retain registration metadata");
+            assert_eq!(info.seq_hash, seq_hash);
+            assert_eq!(info.block_id, mgr.active_full[&seq_hash].handle.block_id());
+            assert_eq!(info.local_hash, Some(local_hashes[signal_idx]));
+            assert_eq!(info.token_ids.as_ref(), Some(&token_ids[signal_idx]));
+        }
+        assert_eq!(mgr.registered_blocks[&plhs[0]].parent_hash, Some(5));
+        assert_eq!(mgr.registered_blocks[&plhs[1]].parent_hash, Some(10));
+        assert_eq!(mgr.registered_blocks[&plhs[3]].parent_hash, Some(20));
+        assert_eq!(mgr.registered_blocks[&plhs[4]].parent_hash, Some(30));
+
+        let events = sink.events.lock().unwrap();
+        assert_eq!(events.len(), 2, "the reused middle block splits stores");
+        for (event, expected_hashes, expected_local_hashes, expected_parent) in [
+            (&events[0], &[10, 11][..], &[1010, 1011][..], Some(5)),
+            (&events[1], &[30, 31][..], &[1030, 1031][..], Some(20)),
+        ] {
+            let KvCacheEventData::Stored(stored) = &event.data else {
+                panic!("expected Stored event, got {:?}", event.data);
+            };
+            assert_eq!(stored.parent_hash.map(|hash| hash.0), expected_parent);
+            assert_eq!(
+                stored
+                    .blocks
+                    .iter()
+                    .map(|block| block.block_hash.0)
+                    .collect::<Vec<_>>(),
+                expected_hashes
+            );
+            assert_eq!(
+                stored
+                    .blocks
+                    .iter()
+                    .map(|block| block.tokens_hash.0)
+                    .collect::<Vec<_>>(),
+                expected_local_hashes
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Overview:

Reduce mocker KV-management overhead in high-concurrency disaggregated workloads without changing wire protocols, physical capacity, scheduling policy, or KV-event semantics.

The main costs were repeated per-block bookkeeping: one terminal dereference signal per block, cloned immutable handles for logical owners, singleton store-lock acquisitions for scattered matches and fresh registrations, and allocation-heavy registry grouping for normally ordered hashes.

A balanced AgentX A/B measured a **22.2% median improvement in output-token throughput**.

## Details:

- Batch terminal cleanup into zero signals for no allocation or one reverse-ordered `Deref` signal for the complete active allocation.
- Represent an active full block with one canonical immutable handle plus a logical reference count.
  - Physical capacity and `num_active_blocks()` semantics are unchanged.
  - `num_active_block_refs()` still reports logical owners.
  - KVBM's `inflight_immutable` metric counts retained physical handles rather than logical owners.
- Add aligned scattered block matching under one store lock.
  - Preserve input order, misses, duplicates, inactive resurrection, and later hits after a miss.
  - Apply frequency touches after releasing the store lock.
- Classify locally active blocks before matching, reserve fresh capacity atomically, and update logical references only during commit.
- Stage and register all fresh blocks once per request, then consume ordered results directly.
- Optimize sequence-hash registration with an order-preserving monotonic fast path, one radix-prefix guard per adjacent equal-position group, and a grouped fallback for out-of-order input.
- Reduce batch-registration staging to the block, handle, and outcome vectors. Presence updates and armed-guard drops happen after releasing the store lock.

Collision handling, deduplication, result ordering, capacity-failure atomicity, parent anchoring, token IDs, and KV-event grouping are covered by tests and remain unchanged.

### Validation

- `cargo test -p kvbm-logical`: 503 passed.
- `cargo test -p dynamo-mocker`: 482 passed, 1 pre-existing ignored.
- `cargo test -p dynamo-mocker --features kvbm-offload`: 578 passed, 1 pre-existing ignored.
- `cargo fmt --all -- --check` passed.
- Strict KVBM and default-feature mocker clippy passed.
- Strict `kvbm-offload` clippy reports six warnings that reproduce unchanged on baseline commit `4cba833f`; the candidate passes when only those pre-existing lint categories are allowed.

AgentX validation used Qwen3-32B, 2 prefill and 2 decode mockers, KV routing, enforced disaggregation, concurrency 512, 128 warmups, and 8,192 fixed root requests. Baseline and candidate ran as fresh topologies in balanced B-C-C-B order with no profiler active.

| Pair | Baseline output tok/s | Candidate output tok/s | Improvement | Matched p95 TTFT |
| --- | ---: | ---: | ---: | ---: |
| 1 | 99,787 | 121,365 | +21.6% | 0.822x |
| 2 | 99,943 | 122,624 | +22.7% | 0.798x |

Median paired improvement: **22.2%**. Input/output shape deltas remained below 0.3%, and all registration, affinity, KV-event, completion, and error checks passed.

The performance run used pre-rebase candidate `0390c53c26`. A subsequent rebase onto current `main` changed only commit metadata to add DCO sign-offs; `git range-diff` confirms the five code patches are identical at `d8bbb3814a`.

For context, the preceding candidate measured 17.71%; that result was not used in the paired acceptance calculation.

## Where should the reviewer start?

- `lib/mocker/src/kv_manager/kvbm_backend.rs` for active ownership, scattered admission, and batched fresh registration.
- `lib/kvbm-logical/src/registry/mod.rs` for ordered registration and the out-of-order fallback.
- `lib/kvbm-logical/src/pools/store.rs` for single-lock batch registration and post-lock presence handling.
- `lib/mocker/src/common/sequence.rs` for terminal dereference batching.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved block lookups so scan results now preserve input order, including misses and duplicates.
  * Batch registration now handles grouped inputs more efficiently while keeping results aligned with the original request.

* **Bug Fixes**
  * Fixed several edge cases around duplicate block handling and registration presence.
  * Improved block reuse and reference tracking for full blocks, reducing incorrect extra allocations.

* **Tests**
  * Added broader coverage for batch registration, lookup alignment, duplicate behavior, and frequency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->