### PR TITLE
chore(operator): pin PR deploy tests to commit image

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -19,9 +19,9 @@ inputs:
     required: false
     default: ''
   operator_tag:
-    description: 'Operator image tag (default: main-operator)'
+    description: 'Operator image tag. Required when registry is set.'
     required: false
-    default: 'main-operator'
+    default: ''
   hf_token:
     description: 'HuggingFace token for model access'
     required: false
@@ -340,16 +340,16 @@ runs:
 
         IMAGE_ARGS=()
         if [ -n "${REGISTRY}" ]; then
+          if [ -z "${OPERATOR_TAG}" ]; then
+            echo "::error::operator_tag is required when registry is set"
+            exit 1
+          fi
           OPERATOR_REPO="${REGISTRY}/ai-dynamo/dynamo"
           echo "Using operator image: ${OPERATOR_REPO}:${OPERATOR_TAG}"
-          # OPERATOR_TAG is a mutable, floating tag (e.g. main-operator) that is
-          # re-pushed on every main build. The chart default
-          # imagePullPolicy=IfNotPresent means a CI node that cached an older copy
-          # never re-pulls it, so a PR that doesn't rebuild the operator can run a
-          # stale crd-apply/manager binary (e.g. missing a newly-added flag) and
-          # land in CrashLoopBackOff. Force Always so the floating tag is refreshed
-          # on every pod start; the chart applies this value to both the manager
-          # and the crd-apply init container.
+          # Automated CI passes a commit-scoped tag so the chart, CRDs,
+          # and manager binary stay in sync. Manual workflows may still pass a
+          # mutable tag, so force a registry lookup on every pod start. The chart
+          # applies this policy to both the manager and crd-apply init container.
           IMAGE_ARGS+=(
             --set dynamo-operator.controllerManager.manager.image.repository="${OPERATOR_REPO}"
             --set dynamo-operator.controllerManager.manager.image.tag="${OPERATOR_TAG}"
@@ -439,6 +439,105 @@ runs:
           wait --for=condition=established \
           crd/dynamographdeployments.nvidia.com \
           --timeout=120s
+
+    - name: Verify operator image and admission webhooks
+      shell: bash
+      env:
+        NAMESPACE: ${{ steps.resolve-names.outputs.namespace }}
+      run: |
+        set -euo pipefail
+        VKUBECONFIG=${{ github.workspace }}/.kubeconfig-vcluster
+
+        OPERATOR_POD=$(kubectl get pods -n "${NAMESPACE}" -o name \
+          | grep 'dynamo-platform-dynamo-operator-controller-manager' \
+          | head -1 || true)
+        if [ -z "${OPERATOR_POD}" ]; then
+          echo "::error::Ready operator pod disappeared before verification"
+          exit 1
+        fi
+
+        echo "::group::Resolved operator image identity"
+        kubectl get "${OPERATOR_POD}" -n "${NAMESPACE}" \
+          -o jsonpath='{range .status.initContainerStatuses[*]}initContainer={.name} image={.image} imageID={.imageID}{"\n"}{end}{range .status.containerStatuses[*]}container={.name} image={.image} imageID={.imageID}{"\n"}{end}'
+        echo "::endgroup::"
+
+        echo "::group::DynamoGraphDeployment admission smoke tests"
+        smoke_v1alpha1() {
+          kubectl --kubeconfig="${VKUBECONFIG}" --request-timeout=15s \
+            create --namespace=default --dry-run=server \
+            -o json \
+            -f - <<'EOF'
+        apiVersion: nvidia.com/v1alpha1
+        kind: DynamoGraphDeployment
+        metadata:
+          name: ci-webhook-smoke-v1alpha1
+        spec:
+          services:
+            Smoke:
+              componentType: worker
+              replicas: 0
+        EOF
+        }
+
+        smoke_v1beta1() {
+          kubectl --kubeconfig="${VKUBECONFIG}" --request-timeout=15s \
+            create --namespace=default --dry-run=server \
+            -o json \
+            -f - <<'EOF'
+        apiVersion: nvidia.com/v1beta1
+        kind: DynamoGraphDeployment
+        metadata:
+          name: ci-webhook-smoke-v1beta1
+        spec:
+          components:
+          - name: Smoke
+            type: worker
+            replicas: 0
+        EOF
+        }
+
+        run_admission_smoke_test() {
+          local version="$1"
+          local output
+          local origin_version
+          local deadline=$((SECONDS + 120))
+          local attempt=1
+          shift
+
+          while true; do
+            if output=$("$@" 2>&1); then
+              origin_version=$(sed -n 's/.*"nvidia\.com\/dynamo-operator-origin-version":[[:space:]]*"\([^"]*\)".*/\1/p' <<<"${output}" | tail -1)
+              if [ -z "${origin_version}" ]; then
+                echo "::error::${version} request succeeded without the operator origin-version mutation"
+                printf '%s\n' "${output}" >&2
+                return 1
+              fi
+              echo "${version} admission succeeded (operator origin version: ${origin_version})"
+              return 0
+            fi
+
+            if ! grep -Eiq \
+              'no endpoints available|connection refused|connection reset by peer|TLS handshake timeout|context deadline exceeded|service .* not found|temporarily unavailable|unable to handle the request|timed out|timeout|i/o timeout|unexpected EOF|^EOF$' \
+              <<<"${output}"; then
+              printf '%s\n' "${output}" >&2
+              return 1
+            fi
+
+            if [ "${SECONDS}" -ge "${deadline}" ]; then
+              echo "::error::${version} admission smoke test did not become reachable within 120s"
+              printf '%s\n' "${output}" >&2
+              return 1
+            fi
+
+            echo "::warning::${version} admission endpoint not ready (attempt ${attempt}); retrying in 2s"
+            attempt=$((attempt + 1))
+            sleep 2
+          done
+        }
+
+        run_admission_smoke_test v1alpha1 smoke_v1alpha1
+        run_admission_smoke_test v1beta1 smoke_v1beta1
+        echo "::endgroup::"
 
     - name: Debug deployment failure
       if: failure()

--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -517,7 +517,7 @@ runs:
             fi
 
             if ! grep -Eiq \
-              'no endpoints available|connection refused|connection reset by peer|TLS handshake timeout|context deadline exceeded|service .* not found|temporarily unavailable|unable to handle the request|timed out|timeout|i/o timeout|unexpected EOF|^EOF$' \
+              'no endpoints available|connection refused|connection reset by peer|TLS handshake timeout|service .* not found|unexpected EOF|^EOF$' \
               <<<"${output}"; then
               printf '%s\n' "${output}" >&2
               return 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -131,7 +131,6 @@ jobs:
 
   operator:
     needs: changed-files
-    if: needs.changed-files.outputs.operator == 'true'
     name: Operator
     runs-on: prod-default-v2
     outputs:
@@ -859,7 +858,7 @@ jobs:
        needs.changed-files.outputs.sglang == 'true' ||
        needs.changed-files.outputs.trtllm == 'true' ||
        needs.changed-files.outputs.deploy == 'true') &&
-      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
+      needs.operator.result == 'success'
     needs: [changed-files, operator]
     runs-on: prod-deploy-tester-v1
     permissions:
@@ -877,7 +876,7 @@ jobs:
         uses: ./.github/actions/setup-dynamo-operator
         with:
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.operator.result == 'success' && needs.operator.outputs.operator_default_tag || 'main-operator' }}
+          operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -937,7 +936,7 @@ jobs:
       (needs.changed-files.outputs.operator == 'true' ||
        needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.deploy == 'true') &&
-      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
+      needs.operator.result == 'success'
     needs: [changed-files, operator]
     runs-on: prod-deploy-tester-v1
     permissions:
@@ -955,7 +954,7 @@ jobs:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-vllm
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-vllm-dt
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.operator.result == 'success' && needs.operator.outputs.operator_default_tag || 'main-operator' }}
+          operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
@@ -969,7 +968,7 @@ jobs:
       (needs.changed-files.outputs.operator == 'true' ||
        needs.changed-files.outputs.snapshot == 'true' ||
        needs.changed-files.outputs.deploy == 'true') &&
-      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
+      needs.operator.result == 'success'
     needs: [changed-files, operator]
     runs-on: prod-deploy-tester-v1
     permissions:
@@ -987,7 +986,7 @@ jobs:
           vcluster_name: ci-${{ github.run_id }}-checkpoint-sglang
           vcluster_namespace: gh-id-${{ github.run_id }}-checkpoint-sglang-dt
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          operator_tag: ${{ needs.operator.result == 'success' && needs.operator.outputs.operator_default_tag || 'main-operator' }}
+          operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -131,6 +131,13 @@ jobs:
 
   operator:
     needs: changed-files
+    if: |
+      needs.changed-files.outputs.operator == 'true' ||
+      needs.changed-files.outputs.vllm == 'true' ||
+      needs.changed-files.outputs.sglang == 'true' ||
+      needs.changed-files.outputs.trtllm == 'true' ||
+      needs.changed-files.outputs.deploy == 'true' ||
+      needs.changed-files.outputs.snapshot == 'true'
     name: Operator
     runs-on: prod-default-v2
     outputs:


### PR DESCRIPTION
## Summary

- Always build and push the operator image from the PR commit.
- Require deploy jobs to use the resulting commit-scoped operator tag instead of falling back to `main-operator`.
- Require an explicit operator tag whenever a custom registry is configured.
- Log the resolved manager and CRD init-container image IDs.
- Add bounded server-side admission smoke tests for both `v1alpha1` and `v1beta1` DynamoGraphDeployments.
- Verify the mutating webhook ran by checking the operator origin-version annotation.
- Retry transient webhook readiness failures while immediately surfacing permanent errors such as an incorrect webhook path.

This keeps the checked-out Helm chart, CRDs, conversion webhooks, and operator binary on the same commit and prevents stale operator images from producing `server could not find the requested resource` admission failures.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger deployment verification for the operator, including image checks and admission smoke tests for deployment resources.
* **Bug Fixes**
  * Prevents deployments from proceeding when a custom registry is set without an operator image tag.
  * Improves workflow gating so operator-related deployment steps only continue after the operator job succeeds.
  * Makes operator tag selection more consistent across deployment paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->