### PR TITLE
docs: PR 7 Docs and manifests for the EPP and standalone Selector Router Integration

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -39,3 +39,8 @@
 ^https://docs\.nvidia\.com/dynamo/dev/reference/releases/(release-history|v1-[0-9]+-[0-9]+)$
 ^https://github\.com/ai-dynamo/dynamo/blob/main/docs/fern/components/releases\.data\.ts$
 
+# The standalone on-ramp agg.yaml is added in this same PR, so blob/main links to
+# it 404 from CI until the PR merges. Remove this entry once agg.yaml lands on main
+# (afterwards lychee validates the URL again, catching any later rename/move).
+^https://github\.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg\.yaml
+

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -1,0 +1,89 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Dynamo EPP on-ramp for vanilla vLLM
+
+This directory contains raw Kubernetes manifests for an on-ramp that runs Dynamo's
+Endpoint Picker Plugin (EPP) behind Gateway API Inference Extension (GAIE) with stock `vLLM serve`
+pods. It does not install the Dynamo operator, create a `DynamoGraphDeployment`, or run Dynamo's
+NATS/JetStream event plane.
+
+For the user-facing walkthrough, start with
+[Vanilla vLLM GAIE On-ramp](../../../../../docs/kubernetes/gateway-api/vanilla-vllm-onramp.mdx).
+
+## How the on-ramp works
+
+This on-ramp is available for Aggregated serving only at this time.
+
+The aggregated on-ramp uses the public `vllm/vllm-openai:latest` image. Replace it with the vLLM
+image your platform standardizes on if you need a pinned or internally mirrored image.
+KV-aware selection is provided by the runtime-free
+[selection service](../../../../../docs/components/router/standalone-selection.md),
+which the EPP runs **in-process**: the EPP and the selection service are compiled
+into one binary, so there is no separate selector Deployment and no HTTP hop. The
+EPP can run single-replica, or **replicated** with cross-replica active-load sync
+between EPP pods (see [Replicated mode](../../../../../docs/kubernetes/gateway-api/vanilla-vllm-onramp.mdx#replicated-mode)).
+
+No special EPP image is needed. Use the EPP image provided with Dynamo releases.
+Whether EPP uses the Dynamo runtime or not is controlled with the `DYN_EPP_MODE` env var: dynamo vs standalone
+
+```yaml
+- name: DYN_EPP_MODE
+  value: "standalone"
+```
+
+The EPP watches ready vLLM pods in the `InferencePool`, subscribes to native vLLM KV cache
+events , tokenizes prompts for routing, and returns the selected
+endpoint to the gateway.
+
+```mermaid
+flowchart LR
+    subgraph Workers["vLLM pods"]
+      W1["vLLM pod A<br/>KV PUB :5557"]
+      W2["vLLM pod B<br/>KV PUB :5557"]
+    end
+
+    W1 -. "publishes ZMQ KV events" .-> Subscribers["EPP ZMQ subscribers"]
+    W2 -. "publishes ZMQ KV events" .-> Subscribers
+    Subscribers -->|"receive"| Normalize["Normalize events"]
+    Normalize -->|"updates"| Index["In-memory KV index"]
+    Index -->|"scores"| Picker["Endpoint picker"]
+```
+
+
+## What Dynamo-managed GAIE adds
+
+
+- Disaggregated prefill/decode (Aggregated  serving is planned follow-up in the standalone mode.)
+- Operator-managed lifecycle for Workers, Services, `InferencePool`, and EPP resources.
+- Request migration, rejection, cancellation - overall admission control 
+- Data parallelism (The standalone mode which targets DP=1.)
+- Cross-replica KV-index warm-up when new replica re-warms from live traffic + replay.
+- Initial worker cache-state synchronization instead of rebuilding the index only from live traffic.
+- Per-tenant KV cache isolation with x-tenant-id / cache_salt. This requires per-engine support and as such is not supported in the Standalone mode.
+- Management of Transient disconnects. In the Dynamo mode the KV-cache updates the worker sent during the gap are recovered from the worker's **replay** socket when `DYN_EPP_KV_EVENT_REPLAY_PORT` is set (and the vLLM worker exposes one); otherwise the index refreshes from new traffic.
+- Dropped events / gaps management. The `SelectionCore` indexer does seq-watermark gap detection and replays missed events from the worker's replay socket when `DYN_EPP_KV_EVENT_REPLAY_PORT` is configured. Without a replay socket, gaps are dropped and the index re-warms from new traffic.
+- Multi-modal support
+- Topology / Zone aware routing
+- Speculative Decoding awareness 
+- Session affinity 
+- Full list of OpenAI HTTP endpoints
+- Metrics/observability 
+
+## How it works
+
+1. The EPP reads the `InferencePool` it backs to learn the pod
+   selector and HTTP target port — the same object the gateway routes to — and
+   watches those pods, Ready-filtered.
+2. For each Ready pod, the EPP registers a worker into its **in-process**
+   selector with the pod's endpoint, block size, and KV-event socket.
+3. The selector subscribes directly to each pod's KV-cache event socket and
+   maintains the KV index, scheduler, and load accounting.
+4. On each request the EPP sends the unchanged body to the configured vLLM
+   `/v1/chat/completions/render` endpoint, uses the returned tokens to select a
+   currently-Ready worker (booking its load via select-and-reserve), and returns
+   the worker's endpoint to Envoy as routing headers. The selected
+   worker processes the original forwarded request.
+

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -11,7 +11,7 @@ pods. It does not install the Dynamo operator, create a `DynamoGraphDeployment`,
 NATS/JetStream event plane.
 
 For the user-facing walkthrough, start with
-[Vanilla vLLM GAIE On-ramp](../../../../../docs/kubernetes/gateway-api/vanilla-vllm-onramp.mdx).
+[Vanilla vLLM GAIE On-ramp](../../../../../docs/fern/kubernetes/vanilla-vllm-onramp.mdx).
 
 ## How the on-ramp works
 
@@ -20,11 +20,11 @@ This on-ramp is available for Aggregated serving only at this time.
 The aggregated on-ramp uses the public `vllm/vllm-openai:latest` image. Replace it with the vLLM
 image your platform standardizes on if you need a pinned or internally mirrored image.
 KV-aware selection is provided by the runtime-free
-[selection service](../../../../../docs/components/router/standalone-selection.md),
+[selection service](../../../../../docs/fern/components/router/standalone-selection.md),
 which the EPP runs **in-process**: the EPP and the selection service are compiled
 into one binary, so there is no separate selector Deployment and no HTTP hop. The
 EPP can run single-replica, or **replicated** with cross-replica active-load sync
-between EPP pods (see [Replicated mode](../../../../../docs/kubernetes/gateway-api/vanilla-vllm-onramp.mdx#replicated-mode)).
+between EPP pods (see [Replicated mode](../../../../../docs/fern/kubernetes/vanilla-vllm-onramp.mdx#replicated-mode)).
 
 No special EPP image is needed. Use the EPP image provided with Dynamo releases.
 Whether EPP uses the Dynamo runtime or not is controlled with the `DYN_EPP_MODE` env var: dynamo vs standalone
@@ -56,9 +56,9 @@ flowchart LR
 ## What Dynamo-managed GAIE adds
 
 
-- Disaggregated prefill/decode (Aggregated  serving is planned follow-up in the standalone mode.)
+- Disaggregated prefill/decode (Disaggregated serving is planned follow-up in the standalone mode.)
 - Operator-managed lifecycle for Workers, Services, `InferencePool`, and EPP resources.
-- Request migration, rejection, cancellation - overall admission control 
+- Request migration, rejection, cancellation - overall admission control
 - Data parallelism (The standalone mode which targets DP=1.)
 - Cross-replica KV-index warm-up when new replica re-warms from live traffic + replay.
 - Initial worker cache-state synchronization instead of rebuilding the index only from live traffic.
@@ -67,10 +67,10 @@ flowchart LR
 - Dropped events / gaps management. The `SelectionCore` indexer does seq-watermark gap detection and replays missed events from the worker's replay socket when `DYN_EPP_KV_EVENT_REPLAY_PORT` is configured. Without a replay socket, gaps are dropped and the index re-warms from new traffic.
 - Multi-modal support
 - Topology / Zone aware routing
-- Speculative Decoding awareness 
-- Session affinity 
+- Speculative Decoding awareness
+- Session affinity
 - Full list of OpenAI HTTP endpoints
-- Metrics/observability 
+- Metrics/observability
 
 ## How it works
 

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Standalone (selector) on-ramp: aggregated serving, REPLICATED
+# (multiple EPP replicas that sync active load with each other).
+#
+# Puts the Dynamo EPP in front of an existing vanilla `vllm serve` fleet behind
+# a GAIE gateway, with NO Dynamo operator, NO etcd/NATS, and NO Dynamo runtime.
+# The EPP runs the runtime-free selection service in-process, so there is NO
+# separate selection-service Deployment. The EPP discovers raw vLLM pods from the
+# InferencePool it backs, registers them with its in-process selector, and on
+# each request asks the selector for a worker, then tells Envoy where to send the
+# request.
+#
+# Replication: each EPP replica runs its own in-process selector. To keep the
+# load-aware routing view consistent, replicas discover each other from this
+# Deployment's own Service (EndpointSlices) and sync admission/prefill-complete/
+# free over ZMQ. This is enabled by DYN_EPP_PEER_SERVICE below; set replicas: 1
+# and drop that env for a single, fully-local replica. (A freshly started replica
+# has an empty KV index and re-warms from live traffic + replay.)
+#
+# Prerequisites:
+#   - A GAIE-compatible Gateway named `inference-gateway` in this namespace.
+#   - A secret `hf-token-secret` with key `HF_TOKEN` for the vLLM worker.
+# Apply with: kubectl apply -n <ns> -f agg.yaml
+# Test:
+#   GW=$(kubectl get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
+#   curl http://$GW/v1/chat/completions -H 'content-type: application/json' -d '{
+#     "model": "Qwen/Qwen3-0.6B",   # MUST match DYN_MODEL_NAME below
+#     "messages": [{"role":"user","content":"hello"}]
+#   }'
+---
+# Raw vLLM aggregated worker pool. Vanilla image; prefix caching + native
+# KV-cache events on a ZMQ PUB socket the embedded selector subscribes to.
+# --block-size MUST match the EPP's DYN_KV_CACHE_BLOCK_SIZE.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--served-model-name"
+            - "Qwen/Qwen3-0.6B"
+            - "--port"
+            - "8000"
+            - "--enable-prefix-caching"
+            - "--block-size"
+            - "16"
+            - "--kv-events-config"
+            - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: kv-events
+              containerPort: 5557
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+---
+# Stable renderer address used by the EPP for vLLM's
+# /v1/chat/completions/render tokenization endpoint.
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-qwen-render
+spec:
+  selector:
+    app: vllm-qwen
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+---
+# RBAC: the EPP reads the InferencePool (read-only), lists/watches its pods, and
+# watches EndpointSlices to discover both worker pods and its own sibling EPP
+# replicas (embedded replication peer sync).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynamo-epp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dynamo-epp
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["inference.networking.k8s.io"]
+    resources: ["inferencepools"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dynamo-epp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dynamo-epp
+subjects:
+  - kind: ServiceAccount
+    name: dynamo-epp
+---
+# The Dynamo EPP in standalone mode with the selector EMBEDDED in-process,
+# replicated: DYN_EPP_PEER_SERVICE turns on cross-replica active-load sync so
+# these replicas do not each under-count load and herd onto the same worker.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dynamo-epp
+  labels:
+    app: dynamo-epp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dynamo-epp
+  template:
+    metadata:
+      labels:
+        app: dynamo-epp
+    spec:
+      serviceAccountName: dynamo-epp
+      containers:
+        - name: epp
+          image: docker.io/lambda108/rust-epp:st_1
+          imagePullPolicy: IfNotPresent
+          env:
+            # Standalone mode: runtime-free selector in-process (no Dynamo
+            # runtime, no separate selection-service Deployment).
+            - name: DYN_EPP_MODE
+              value: "standalone"
+            # Replication: watch THIS Deployment's own Service
+            # (EndpointSlices) to find sibling EPP replicas and sync active load
+            # over its required named replica-agg port. Omit this env to run a
+            # single fully-local replica (and set replicas: 1).
+            - name: DYN_EPP_PEER_SERVICE
+              value: "dynamo-epp"
+            # Pod discovery: read the InferencePool this EPP backs. Its selector
+            # and target port are the single source of truth (same object the
+            # gateway routes to). Pool namespace defaults to POD_NAMESPACE.
+            - name: DYN_EPP_INFERENCE_POOL_NAME
+              value: "vllm-qwen-pool"
+            # KV-event port can't live in the InferencePool, so it stays here.
+            - name: DYN_EPP_KV_EVENT_PORT
+              value: "5557"
+            # Model identity and tokenizer service used for routing tokens.
+            - name: DYN_MODEL_NAME
+              value: "Qwen/Qwen3-0.6B"
+            # Tokenizer service base URL + wire protocol. Points at vLLM's
+            # /v1/chat/completions/render endpoint; "vllm-render" is the only
+            # supported protocol today. Both are required.
+            - name: DYN_EPP_TOKENIZER_SERVICE_URL
+              value: "http://vllm-qwen-render:8000"
+            - name: DYN_EPP_TOKENIZER_PROTOCOL
+              value: "vllm-render"
+            - name: DYN_KV_CACHE_BLOCK_SIZE
+              value: "16"
+            # Per-worker max batched tokens. REQUIRED: the router's
+            # queue-threshold admission is on by default, and a worker missing
+            # this is left unschedulable ("no schedulable workers"). Set it to
+            # the vLLM engine's --max-num-batched-tokens.
+            - name: DYN_EPP_MAX_NUM_BATCHED_TOKENS
+              value: "8192"
+            # The reflector watches pods in the EPP's own namespace.
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # Own pod IP, so a replica excludes itself from its peer set.
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          ports:
+            - name: grpc
+              containerPort: 9002
+            - name: grpc-health
+              containerPort: 9003
+            # ZMQ replica-sync between EPP replicas (embedded replication).
+            - name: replica-agg
+              containerPort: 9092
+          readinessProbe:
+            grpc:
+              port: 9003
+              service: inference-extension
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamo-epp
+spec:
+  selector:
+    app: dynamo-epp
+  ports:
+    - name: grpc
+      appProtocol: http2
+      port: 9002
+      targetPort: 9002
+    - name: replica-agg
+      port: 9092
+      targetPort: replica-agg
+---
+# InferencePool selects the raw vLLM pods and delegates endpoint selection to
+# the EPP. The EPP reads this object (read-only) to learn the pod selector and
+# target port — the same object the gateway routes to.
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: vllm-qwen-pool
+spec:
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  targetPorts:
+    - number: 8000
+  endpointPickerRef:
+    name: dynamo-epp
+    port:
+      number: 9002
+---
+# Route gateway traffic to the pool.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vllm-qwen-route
+spec:
+  parentRefs:
+    # The Gateway commonly lives in its own namespace, separate from this route
+    # (e.g. the agentgateway controller installs `inference-gateway` in
+    # `agentgateway-system`). `namespace` MUST name the Gateway's namespace and
+    # `sectionName` its listener, or the route silently fails to attach
+    # (status.parents stays empty). Change these to match your Gateway; drop
+    # `namespace` only if the Gateway is in THIS namespace. The Gateway listener
+    # must also allow routes from this namespace (allowedRoutes.namespaces).
+    - name: inference-gateway
+      namespace: agentgateway-system
+      sectionName: http
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-qwen-pool
+      timeouts:
+        request: "300s"

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -20,11 +20,14 @@
 # has an empty KV index and re-warms from live traffic + replay.)
 #
 # Prerequisites:
-#   - A GAIE-compatible Gateway named `inference-gateway` in this namespace.
+#   - A GAIE-compatible Gateway named `inference-gateway` in the
+#     `agentgateway-system` namespace (the installer script deploys it there),
+#     with a listener that allows routes from other namespaces
+#     (allowedRoutes.namespaces.from: All).
 #   - A secret `hf-token-secret` with key `HF_TOKEN` for the vLLM worker.
 # Apply with: kubectl apply -n <ns> -f agg.yaml
 # Test:
-#   GW=$(kubectl get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
+#   GW=$(kubectl get gateway inference-gateway -n agentgateway-system -o jsonpath='{.status.addresses[0].value}')
 #   curl http://$GW/v1/chat/completions -H 'content-type: application/json' -d '{
 #     "model": "Qwen/Qwen3-0.6B",   # MUST match DYN_MODEL_NAME below
 #     "messages": [{"role":"user","content":"hello"}]
@@ -69,12 +72,33 @@ spec:
               containerPort: 8000
             - name: kv-events
               containerPort: 5557
+          # vLLM's /health returns 200 only once the model is loaded and :8000
+          # accepts requests. Without this probe, kubelet marks the pod Ready as
+          # soon as the container starts, and the standalone EPP (which registers
+          # Ready=True pods) would advertise this worker and the renderer Service
+          # before it can serve. The pod stays NotReady until /health passes, so
+          # arbitrarily long model loads are handled without a large initial delay.
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           env:
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: hf-token-secret
                   key: HF_TOKEN
+            # As non-root (UID 1000) the image's default HOME is not writable, so
+            # point HOME and the HF/model cache at world-writable /tmp — the worker
+            # can then download the model without a mounted volume for this example.
+            - name: HOME
+              value: /tmp
+            - name: HF_HOME
+              value: /tmp/huggingface
           resources:
             limits:
               nvidia.com/gpu: "1"
@@ -82,6 +106,12 @@ spec:
               nvidia.com/gpu: "1"
           securityContext:
             allowPrivilegeEscalation: false
+            # allowPrivilegeEscalation=false + dropped caps still permit UID 0, so
+            # enforce non-root explicitly: pin a non-root UID/GID and require it
+            # (kubelet refuses to start the container if the image would run as root).
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
             capabilities:
               drop:
                 - ALL
@@ -149,7 +179,7 @@ metadata:
   labels:
     app: dynamo-epp
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: dynamo-epp
@@ -161,7 +191,7 @@ spec:
       serviceAccountName: dynamo-epp
       containers:
         - name: epp
-          image: docker.io/lambda108/rust-epp:st_1
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:latest
           imagePullPolicy: IfNotPresent
           env:
             # Standalone mode: runtime-free selector in-process (no Dynamo

--- a/deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
+++ b/deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
@@ -18,11 +18,12 @@
 set -euo pipefail
 trap 'echo "Error at line $LINENO. Exiting."' ERR
 
-# Namespace where the Gateway will be deployed.
+# Namespace for the workload (model, EPP, InferencePool, HTTPRoute).
 # Defaults to 'default' if NAMESPACE env var is not set.
 NAMESPACE=${NAMESPACE:-default}
+# Namespace for the agentgateway controller and the Gateway it manages.
 AGW_NAMESPACE=${AGW_NAMESPACE:-agentgateway-system}
-echo "Installing inference-gateway into namespace: $NAMESPACE"
+echo "Installing workload namespace: $NAMESPACE; Gateway into namespace: $AGW_NAMESPACE"
 
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 
@@ -57,7 +58,7 @@ helm upgrade -i --namespace "$AGW_NAMESPACE" --version "$AGW_VERSION" agentgatew
 # AgentgatewayParameters must live in the same namespace as the Gateway because
 # Gateway API's infrastructure.parametersRef is a LocalParametersReference
 # (no namespace field).
-kubectl apply --server-side -n "$NAMESPACE" -f - <<'EOF'
+kubectl apply --server-side -n "$AGW_NAMESPACE" -f - <<'EOF'
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayParameters
 metadata:
@@ -71,7 +72,7 @@ spec:
             sidecar.istio.io/inject: "false"
 EOF
 
-kubectl apply -n "$NAMESPACE" -f - <<EOF
+kubectl apply -n "$AGW_NAMESPACE" -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -87,7 +88,14 @@ spec:
     - name: http
       port: 80
       protocol: HTTP
+      # The Gateway lives in \$AGW_NAMESPACE but workloads (and their
+      # HTTPRoutes) live in \$NAMESPACE, so allow routes from any namespace.
+      # The default (same-namespace only) would leave the workload route
+      # unattached.
+      allowedRoutes:
+        namespaces:
+          from: All
 EOF
 
-kubectl wait gateway/inference-gateway -n "$NAMESPACE" \
+kubectl wait gateway/inference-gateway -n "$AGW_NAMESPACE" \
   --for=condition=Programmed --timeout=180s

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -158,6 +158,9 @@ navigation:
                     path: kubernetes/dgd-kv-routing.md
                   - page: Gateway API
                     path: kubernetes/inference-gateway.mdx
+                  - page: Vanilla vLLM On-ramp
+                    path: kubernetes/vanilla-vllm-onramp.mdx
+                    slug: vanilla-vllm-onramp
               - page: Disaggregated Serving
                 path: features/disaggregated-serving/README.md
               - page: Sizing with AIConfigurator

--- a/docs/fern/kubernetes/gateway-api-installation.mdx
+++ b/docs/fern/kubernetes/gateway-api-installation.mdx
@@ -34,8 +34,9 @@ Other Gateway implementations can work when they support the same GAIE endpoint-
 
 <Step title="Set the installation variables">
 
-Set the namespace where the Gateway and model routes will live. Keep the Dynamo version aligned with
-the platform installation.
+Set `NAMESPACE` for the model, EPP, `InferencePool`, and `HTTPRoute`. With the agentgateway install
+method the `Gateway` itself lives in `AGW_NAMESPACE` alongside its controller; the Istio method
+creates the Gateway in `NAMESPACE`. Keep the Dynamo version aligned with the platform installation.
 
 ```bash
 export NAMESPACE=my-model
@@ -63,7 +64,12 @@ The script installs:
 - GAIE CRDs.
 - agentgateway with the inference extension enabled.
 - An `AgentgatewayParameters` resource that prevents Istio sidecar injection into Gateway proxy pods.
-- A `Gateway` named `inference-gateway` in `$NAMESPACE`.
+- A `Gateway` named `inference-gateway` in `$AGW_NAMESPACE` (co-located with the agentgateway
+  controller). Its `http` listener sets `allowedRoutes.namespaces.from: All`, so `HTTPRoute` objects
+  in `$NAMESPACE` attach to it across namespaces.
+
+The workload namespace `$NAMESPACE` still holds the model, EPP, `InferencePool`, and `HTTPRoute`.
+Only the Gateway itself lives in `$AGW_NAMESPACE`.
 
 The script pins compatible dependency versions. Review it before running it when your platform team
 owns Gateway API or agentgateway lifecycle.
@@ -134,6 +140,31 @@ inference.networking.k8s.io
 
 <Step title="Verify the Gateway">
 
+The Gateway namespace depends on the install method: the agentgateway script creates it in
+`$AGW_NAMESPACE`, while the Istio flow creates it in `$NAMESPACE`.
+
+<Tabs>
+<Tab title="agentgateway">
+
+Wait for the `inference-gateway` resource to become programmed:
+
+```bash
+kubectl wait gateway/inference-gateway -n "$AGW_NAMESPACE" \
+  --for=condition=Programmed --timeout=180s
+
+kubectl get gateway inference-gateway -n "$AGW_NAMESPACE"
+```
+
+If `Programmed` remains false, inspect the Gateway and the controller:
+
+```bash
+kubectl describe gateway inference-gateway -n "$AGW_NAMESPACE"
+kubectl get pods --all-namespaces | grep agentgateway
+```
+
+</Tab>
+<Tab title="Istio">
+
 Wait for the `inference-gateway` resource to become programmed:
 
 ```bash
@@ -143,12 +174,15 @@ kubectl wait gateway/inference-gateway -n "$NAMESPACE" \
 kubectl get gateway inference-gateway -n "$NAMESPACE"
 ```
 
-If `Programmed` remains false, inspect the Gateway and the controller for your implementation:
+If `Programmed` remains false, inspect the Gateway and the controller:
 
 ```bash
 kubectl describe gateway inference-gateway -n "$NAMESPACE"
-kubectl get pods --all-namespaces | grep -E 'agentgateway|istio'
+kubectl get pods --all-namespaces | grep istio
 ```
+
+</Tab>
+</Tabs>
 
 </Step>
 

--- a/docs/fern/kubernetes/vanilla-vllm-onramp.mdx
+++ b/docs/fern/kubernetes/vanilla-vllm-onramp.mdx
@@ -27,7 +27,7 @@ flowchart LR
     EPP -->|"updates"| Index["In-memory KV index"]
 ```
 
-This is intentionally not the same lifecycle model as the operator-managed GAIE quickstart. There is no `DynamoGraphDeployment`, no Dynamo worker runtime, and no Dynamo event plane in this on-ramp.
+This is intentionally not the same lifecycle model as the operator-managed GAIE quickstart. There is no `DynamoGraphDeployment`, no Dynamo worker runtime, and no Dynamo event plane in this on-ramp. We will be starting with a simple Kubernetes `apps/v1` Deployment of `vllm serve` pods.
 
 | | This on-ramp (standalone mode) | Full Dynamo (dynamo mode) |
 |---|---|---|
@@ -47,7 +47,7 @@ the replicas discover each other and sync active load (admission/prefill/free)
 over ZMQ.
 
 
-## Prerequisites
+### 1. Prerequisites
 
 - Kubernetes cluster with GPU nodes.
 - `kubectl`, [Helm](https://helm.sh/docs/intro/install/), and
@@ -55,18 +55,25 @@ over ZMQ.
 - Baseline Gateway API knowledge from the upstream
   [Gateway API getting started guide](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/)
   and the upstream
-  [GAIE guide](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/index.md).
+  [Inference Extension GAIE guide](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/index.md).
 - A Gateway API implementation that supports GAIE `InferencePool` resources and `endpointPickerRef`
   calls. This walkthrough shows the same verified agentgateway path as the GAIE
   quickstart; other implementations might work when they support that same EPP path. See the upstream
   [GAIE gateway implementation list](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/implementations/gateways.md)
-  for other implementations.
+  for other implementations. The example below uses the [AgentGateway](https://agentgateway.dev/docs/kubernetes/main/quickstart/install/) in the `agentgateway-system` namespace.
 - A model namespace that can run GPU workloads.
 - Hugging Face credentials if the model requires them. The
   [Kubernetes Quickstart](quickstart.mdx) explains the general secret
   pattern; it is not GAIE-specific.
 - Access to a Dynamo EPP image.
+Set up a Gateway-API gateway + Inference Extension (GAIE) if you don't have one
+yet. Follow the instructions for your gateway (e.g.
 
+We provide a convenience script if you are installing from scratch for experimentation.
+```bash
+# Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`
+deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
+```
 
 If you are starting from scratch install the [Prerequisites](#1-prerequisites) and apply the provided example file [`agg.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml).
 
@@ -128,20 +135,6 @@ spec:
       port: 8000
       targetPort: 8000
 ```
-
-### 1. Prerequisites
-
-Set up a Gateway-API gateway + Inference Extension (GAIE) if you don't have one
-yet. Follow the instructions for your gateway (e.g. [AgentGateway](https://agentgateway.dev/docs/kubernetes/main/quickstart/install/)) and [Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/guides/).
-
-We provide a convenience script if you are installing from scratch for experimentation.
-```bash
-# Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`
-deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
-```
-
-Create the HuggingFace token secret the vLLM worker uses to download the
-model.
 
 ```bash
 # HF token secret for the vLLM worker (required for gated models)
@@ -315,7 +308,7 @@ metadata:
    See the full list in the
    [environment contract](#standalone-mode-environment-contract) below.
 
-In the end your Final vLLM deployment will look like below:
+In the end your final vLLM deployment will look like below:
 
 ```yaml
 apiVersion: apps/v1

--- a/docs/fern/kubernetes/vanilla-vllm-onramp.mdx
+++ b/docs/fern/kubernetes/vanilla-vllm-onramp.mdx
@@ -71,7 +71,10 @@ yet. Follow the instructions for your gateway (e.g.
 
 We provide a convenience script if you are installing from scratch for experimentation.
 ```bash
-# Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`
+# Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`.
+# The Gateway is created in the `agentgateway-system` namespace, and its
+# listener allows routes from other namespaces (allowedRoutes.namespaces.from:
+# All) so the HTTPRoute in your workload namespace attaches.
 deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
 ```
 
@@ -79,7 +82,7 @@ If you are starting from scratch install the [Prerequisites](#1-prerequisites) a
 
 ```bash
 kubectl apply -n <ns> -f agg.yaml
-# The Gateway may live in another namespace (e.g. agentgateway-system):
+# The Gateway lives in the `agentgateway-system` namespace:
 GW=$(kubectl get gateway inference-gateway -n agentgateway-system -o jsonpath='{.status.addresses[0].value}')
 curl http://$GW/v1/chat/completions -H 'content-type: application/json' -d '{
   "model": "Qwen/Qwen3-0.6B",

--- a/docs/fern/kubernetes/vanilla-vllm-onramp.mdx
+++ b/docs/fern/kubernetes/vanilla-vllm-onramp.mdx
@@ -1,0 +1,471 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Vanilla vLLM GAIE On-ramp"
+sidebar-title: "Vanilla vLLM On-ramp"
+subtitle: Dynamo EPP routing for existing GAIE deployments that run vanilla vLLM pods
+---
+This on-ramp is for Kubernetes users who already use
+[Gateway API Inference Extension (GAIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) with
+vanilla `vLLM serve` pods and want to evaluate the Dynamo kv aware router without installing the Dynamo operator
+first. GAIE still owns endpoint selection at the Gateway API layer. The difference is that the
+Endpoint Picker uses Dynamo Router without the rest of the Dynamo stack.
+
+If you already run GAIE + vLLM, you **replace only your EndpointPicker (EPP) image**
+with the Dynamo EPP image, specify the `DYN_EPP_MODE="standalone"` environment variable, and you are done — no need to install the Dynamo operator, Dynamo runtime, or Dynamo worker.
+
+## What This Deploys
+
+```mermaid
+flowchart LR
+    Client["Client"] -->|"sends request"| Gateway["Gateway API<br/>Gateway"]
+    Gateway -->|"matches"| Route["HTTPRoute"]
+    Route -->|"targets"| Pool["InferencePool"]
+    Pool -->|"calls"| EPP["Dynamo EPP<br/>standalone mode"]
+    EPP -->|"selects endpoint"| VLLM["raw vLLM pod"]
+    VLLM -. "publishes KV events<br/>ZMQ :5557" .-> EPP
+    EPP -->|"updates"| Index["In-memory KV index"]
+```
+
+This is intentionally not the same lifecycle model as the operator-managed GAIE quickstart. There is no `DynamoGraphDeployment`, no Dynamo worker runtime, and no Dynamo event plane in this on-ramp.
+
+| | This on-ramp (standalone mode) | Full Dynamo (dynamo mode) |
+|---|---|---|
+| Workers | stock `vllm serve` | Dynamo workers (vLLM/SGLang/TRT-LLM) |
+| Discovery | K8s pod reflector; membership comes from the `InferencePool` (selector + target port) | Dynamo discovery (etcd/K8s) |
+| KV events | per-pod vLLM ZMQ → the in-process `SelectionCore` indexer subscribes directly | Dynamo event plane |
+| Runtime | none — runtime-free (no etcd, no NATS, no event plane) | etcd + NATS |
+| Operator | not required | required (DynamoGraphDeployment) |
+| Tokenization | EPP calls vLLM `/v1/chat/completions/render` for routing tokens | model-card preprocessor, no extra render call |
+
+The EPP is served in one of two modes, selected at startup by **`DYN_EPP_MODE`**
+(`dynamo` | `standalone`); the same binary serves both. In
+standalone mode the EPP and a runtime-free `SelectionService` are compiled into
+one process, so there is no separate selection-service Deployment and no HTTP
+hop. It runs single-replica, or **replicated** — set `DYN_EPP_PEER_SERVICE` and
+the replicas discover each other and sync active load (admission/prefill/free)
+over ZMQ.
+
+
+## Prerequisites
+
+- Kubernetes cluster with GPU nodes.
+- `kubectl`, [Helm](https://helm.sh/docs/intro/install/), and
+  [jq](https://jqlang.org/download/) configured for the cluster.
+- Baseline Gateway API knowledge from the upstream
+  [Gateway API getting started guide](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/)
+  and the upstream
+  [GAIE guide](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/index.md).
+- A Gateway API implementation that supports GAIE `InferencePool` resources and `endpointPickerRef`
+  calls. This walkthrough shows the same verified agentgateway path as the GAIE
+  quickstart; other implementations might work when they support that same EPP path. See the upstream
+  [GAIE gateway implementation list](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/implementations/gateways.md)
+  for other implementations.
+- A model namespace that can run GPU workloads.
+- Hugging Face credentials if the model requires them. The
+  [Kubernetes Quickstart](quickstart.mdx) explains the general secret
+  pattern; it is not GAIE-specific.
+- Access to a Dynamo EPP image.
+
+
+If you are starting from scratch install the [Prerequisites](#1-prerequisites) and apply the provided example file [`agg.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml).
+
+```bash
+kubectl apply -n <ns> -f agg.yaml
+# The Gateway may live in another namespace (e.g. agentgateway-system):
+GW=$(kubectl get gateway inference-gateway -n agentgateway-system -o jsonpath='{.status.addresses[0].value}')
+curl http://$GW/v1/chat/completions -H 'content-type: application/json' -d '{
+  "model": "Qwen/Qwen3-0.6B",
+  "messages": [{"role":"user","content":"hello"}]
+}'
+```
+Otherwise, if you already have GAIE and raw vLLM workers running follow the steps below.
+
+
+## Example Progression from vLLM to vLLM + Dynamo + GAIE
+
+### Initial Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-qwen
+spec:
+  selector:
+    app: vllm-qwen
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+```
+
+### 1. Prerequisites
+
+Set up a Gateway-API gateway + Inference Extension (GAIE) if you don't have one
+yet. Follow the instructions for your gateway (e.g. [AgentGateway](https://agentgateway.dev/docs/kubernetes/main/quickstart/install/)) and [Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/guides/).
+
+We provide a convenience script if you are installing from scratch for experimentation.
+```bash
+# Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`
+deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
+```
+
+Create the HuggingFace token secret the vLLM worker uses to download the
+model.
+
+```bash
+# HF token secret for the vLLM worker (required for gated models)
+kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-token>
+```
+
+### 2. Create / Wire the InferencePool and HTTPRoute
+
+Now that Gateway and GAIE is installed, we can create an InferencePool and an accompanying Dynamo EPP.
+
+Point the `InferencePool` at your vLLM workers (see the
+[`vllm-qwen-pool` InferencePool in `agg.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml#L254) for a complete example):
+
+Specifically, these fields depend on the model you deploy, so make sure the settings below are adjusted to match your workers.
+
+- `spec.selector` — labels matching your vLLM pods.
+```yaml
+  selector:
+    matchLabels:
+      app: vllm-qwen
+```
+
+- `spec.targetPorts[].number` — the vLLM serving port (usually `8000`).
+```yaml
+  targetPorts:
+    - number: 8000
+```
+
+- `spec.endpointPickerRef` (a.k.a. `spec.extensionRef`) — the EPP service + port.
+```yaml
+  endpointPickerRef:
+    kind: Service
+    name: dynamo-epp
+    port:
+      number: 9002
+```
+
+Attach the `HTTPRoute` to the gateway and target the pool (see the
+[`vllm-qwen-route` HTTPRoute in `agg.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml#L270) for a complete example):
+
+- `spec.rules[].backendRefs[]` — targets the `InferencePool`.
+```yaml
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-qwen-pool
+          port: 8000
+          weight: 1
+```
+
+- `spec.parentRefs[]` — your gateway (set `namespace` + `sectionName` when the
+  gateway lives in another namespace, e.g. `agentgateway-system`).
+```yaml
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+      # Name the Gateway's namespace + listener when it lives elsewhere (drop
+      # `namespace` only if the Gateway is in this namespace). Otherwise the
+      # route silently fails to attach (status.parents stays empty).
+      namespace: agentgateway-system
+      sectionName: http
+```
+
+### 3. Update vLLM deployment
+
+Add labels to your vLLM pods that match `InferencePool.spec.selector` (the EPP
+reads the pool to learn which pods to watch — there is no separate selector env
+var):
+
+```yaml
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+```
+
+or
+```bash
+kubectl -n <ns> label deployment <vllm-deployment> app=vllm-qwen --overwrite
+```
+
+### 4. Add the EPP to your deployment
+
+Remove the vLLM router (if you have it already installed) and replace it with the EPP (Dynamo Router).
+Add the EPP as a `Deployment` + `Service` (see the
+[`dynamo-epp` Deployment in `agg.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml#L146) for a complete example) and set:
+
+```yaml
+kind: Deployment
+metadata:
+  name: dynamo-epp
+  labels:
+    app: dynamo-epp
+```
+
+1. **Set the EPP image.** The Dynamo EPP ships as the "frontend" image with each
+   release; standalone mode is a pure runtime flag, no special build.
+
+2. **Select standalone mode and point at the pool.** The EPP reads the
+   `InferencePool` it backs (the same object the gateway routes to) to learn the
+   pod selector and HTTP target port — so no pod-selector/target-port env is
+   needed. It watches pods in its own namespace (`POD_NAMESPACE`, via the
+   downward API):
+
+   ```yaml
+   - name: DYN_EPP_MODE
+     value: "standalone"       # in-process selector; no separate service
+   - name: DYN_EPP_INFERENCE_POOL_NAME
+     value: "vllm-qwen-pool"    # the InferencePool this EPP backs
+   - name: POD_NAMESPACE
+     valueFrom:
+       fieldRef:
+         fieldPath: metadata.namespace
+   ```
+
+3. **Point at the workers' KV-event socket.** The worker publishes KV events via
+   `--kv-events-config`; the in-process `SelectionCore` indexer subscribes on the
+   matching port at each Ready pod's IP.
+
+   vLLM worker arg:
+
+   ```text
+   --kv-events-config '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+   ```
+
+   EPP env:
+
+   ```yaml
+   - name: DYN_EPP_KV_EVENT_PORT
+     value: "5557"
+   ```
+
+4. **Set the model, tokenizer service, and block size.** The tokenizer service
+   URL points to a vLLM HTTP Service exposing `/v1/chat/completions/render`; it
+   may select the same homogeneous worker pods. `DYN_EPP_TOKENIZER_PROTOCOL`
+   selects its wire protocol (only `vllm-render` is supported today). The block
+   size MUST equal the vLLM `--block-size`:
+
+   ```yaml
+   - name: DYN_MODEL_NAME
+     value: "Qwen/Qwen3-0.6B"
+   - name: DYN_EPP_TOKENIZER_SERVICE_URL
+     value: "http://vllm-qwen-render:8000"
+   - name: DYN_EPP_TOKENIZER_PROTOCOL
+     value: "vllm-render"
+   - name: DYN_KV_CACHE_BLOCK_SIZE
+     value: "16"
+   ```
+
+5. **(Optional) Tune KV routing and recovery:**
+
+   ```yaml
+   # KV indexer thread pool for the in-process selector.
+   - name: DYN_EPP_SELECTION_INDEXER_THREADS
+     value: "4"
+   # ZMQ replay socket for gap recovery (only if the vLLM worker exposes one).
+   - name: DYN_EPP_KV_EVENT_REPLAY_PORT
+     value: "5558"
+   # Scoring / queueing behavior use the standard router env, e.g.:
+   - name: DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT
+     value: "1.0"
+   ```
+
+   To run **more than one** EPP replica, set `DYN_EPP_PEER_SERVICE` to the EPP's
+   own `Service` so replicas discover each other and sync active load over its
+   required named `replica-agg` port (see the `README.md` "Replicated mode"
+   section), and add `POD_IP` (downward API `status.podIP`) so a replica excludes
+   itself.
+
+   See the full list in the
+   [environment contract](#standalone-mode-environment-contract) below.
+
+In the end your Final vLLM deployment will look like below:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--served-model-name"     # NEW: pin the OpenAI model id
+            - "Qwen/Qwen3-0.6B"
+            - "--port"                  # NEW: explicit (8000 is vLLM's default)
+            - "8000"
+            - "--enable-prefix-caching" # NEW: required so vLLM emits prefix KV events
+            - "--block-size"            # NEW: MUST equal the EPP's DYN_KV_CACHE_BLOCK_SIZE
+            - "16"
+            - "--kv-events-config"      # NEW: publish KV events on a ZMQ PUB socket for the EPP
+            - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: kv-events           # NEW: KV-event PUB port the EPP subscribes to
+              containerPort: 5557
+          env:                          # NEW: HF token lets the worker pull the model (required for gated models)
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+```
+
+## Test
+
+```bash
+# terminal 1
+kubectl -n agentgateway-system port-forward svc/inference-gateway 8000:80
+
+# terminal 2
+GATEWAY_URL=http://localhost:8000
+
+# quick health/smoke first
+curl --max-time 20 -sS "$GATEWAY_URL/v1/models" | jq .
+
+# then chat completion
+curl --max-time 120 -sS "$GATEWAY_URL/v1/chat/completions" \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role":"user","content":"hello"}]
+  }' | jq .
+
+```
+
+## Standalone mode environment contract
+
+
+> [!NOTE]
+> The `model` field MUST match `DYN_MODEL_NAME` in the EPP deployment, and the
+> EPP's `DYN_KV_CACHE_BLOCK_SIZE` MUST equal the vLLM `--block-size`.
+
+| Env | Meaning | Required? |
+|---|---|---|
+| `DYN_EPP_MODE=standalone` | Select standalone (selector) mode | required |
+| `DYN_EPP_INFERENCE_POOL_NAME` | Name of the `InferencePool` this EPP backs (its selector + target port drive pod discovery) | required |
+| `DYN_MODEL_NAME` | Model id (no model card in this mode) | required |
+| `DYN_EPP_TOKENIZER_SERVICE_URL` | Base URL of the tokenizer service (vLLM `/v1/chat/completions/render`) | required |
+| `DYN_EPP_TOKENIZER_PROTOCOL` | Tokenizer service wire protocol; only `vllm-render` is supported | required |
+| `DYN_KV_CACHE_BLOCK_SIZE` | MUST equal vLLM `--block-size` | required |
+| `DYN_EPP_KV_EVENT_PORT` | vLLM KV-events PUB port (not in the pool spec) | optional; default 5557 |
+| `DYN_EPP_KV_EVENT_REPLAY_PORT` | ZMQ REQ port for live-stream gap replay | optional |
+| `DYN_EPP_TOKENIZATION_TIMEOUT_MS` | Deadline for the tokenizer service request | optional; default 5000 |
+| `DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES` | Max tokenizer response body accepted | optional; default 16777216 (16 MiB) |
+| `DYN_EPP_TOTAL_KV_BLOCKS` | Per-worker total KV blocks hint | optional |
+| `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | Per-worker max batched tokens | optional |
+| `DYN_EPP_SELECTION_INDEXER_THREADS` | KV indexer thread pool | optional; default 4 |
+| `DYN_EPP_PEER_SERVICE` | The EPP's own Service. Set = replicated; the Service must expose named port `replica-agg`. Unset = single local replica | optional; unset by default |
+| `POD_NAMESPACE` | The namespace the EPP, its `InferencePool`, worker pods, and sibling replicas all live in (downward API) | required |
+| `POD_IP` | EPP's own pod IP (downward API); needed only for replication, so a replica excludes itself from its peer set | required when `DYN_EPP_PEER_SERVICE` is set |
+
+
+## Replicated mode
+
+You can run **more than one** EPP replica. Each replica still runs its own
+in-process selector, but the replicas discover each other and synchronize active
+load so they don't each under-count load and herd onto the same worker. This is
+what `agg.yaml` deploys (`replicas: 2`); set `replicas: 1` and drop
+`DYN_EPP_PEER_SERVICE` for a single local replica.
+
+```yaml
+spec:
+  replicas: 2
+  # ...
+        env:
+          # Watch THIS Deployment's own Service to find sibling replicas:
+          - name: DYN_EPP_PEER_SERVICE
+            value: "dynamo-epp"
+          # Own pod IP, so a replica excludes itself from its peer set:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+        ports:
+          - name: replica-agg
+            containerPort: 9092
+---
+apiVersion: v1
+kind: Service
+spec:
+  ports:
+    - name: replica-agg
+      port: 9092
+      targetPort: replica-agg
+```
+
+How it works:
+
+1. Each replica builds its in-process selector with **replica-sync enabled**
+   (resolving and binding the Service's named `replica-agg` port).
+2. It watches its **own** `Service`'s EndpointSlices (the `DYN_EPP_PEER_SERVICE`
+   above) and registers/deregisters every other replica as a replica-sync peer
+   as pods come and go — excluding itself via `POD_IP`. Peers connect pod-to-pod
+   on the resolved `replica-agg` endpoint port.
+3. Admission (`select_and_reserve`), `prefill_complete`, and `free` are broadcast
+   over ZMQ, so every replica's selector converges on the same active-load view.
+   This is the same consistency model as the standalone selector — output-block
+   growth stays local by design; admission/prefill/free are synchronized.
+
+
+Replica synchronization is best-effort; see the
+[selection service docs](../components/router/standalone-selection.md)
+for the consistency invariants.

--- a/examples/backends/vllm/deploy/gaie/http-route.yaml
+++ b/examples/backends/vllm/deploy/gaie/http-route.yaml
@@ -22,6 +22,12 @@ spec:
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: inference-gateway
+      # The installer creates the Gateway in agentgateway-system (co-located with
+      # its controller) with a listener that allows routes from any namespace, so
+      # name the Gateway's namespace + listener for cross-namespace attachment.
+      # Otherwise this route (applied in the workload namespace) stays unattached.
+      namespace: agentgateway-system
+      sectionName: http
   rules:
     - backendRefs:
         - group: inference.networking.k8s.io


### PR DESCRIPTION
**This PR will be super-seeded by https://github.com/ai-dynamo/dynamo/pull/10957
Please review the new PR**

Add an operator-free, runtime-free aggregated on-ramp example that fronts a raw vLLM fleet with the Dynamo EPP in the "Standalone" mode with the standalone selection service.

- examples/onramp/agg.yaml: raw vLLM  - embedded example with EPP replication


## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes on-ramp for connecting vanilla vLLM deployments to a Gateway API Inference Extension.
  * Supports standalone and replicated Endpoint Picker modes for KV-aware request routing.
  * Includes ready-to-use manifests for vLLM workers, routing, discovery, permissions, and traffic management.
  * Adds KV-cache event handling, peer synchronization, tokenizer rendering, and configurable request timeouts.

* **Documentation**
  * Added setup instructions, architecture diagrams, configuration guidance, smoke tests, and mode comparisons.
  * Added the Vanilla vLLM On-ramp to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->