### PR TITLE
refactor(frontend): rename DYN_ENABLE_FRONTEND_{NVEXT,ADMIN_API} to DYN_DISABLE_*

### DIFF
--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -162,19 +162,19 @@ The frontend exposes the following HTTP endpoints:
 | `GET` | `/metrics` | Prometheus metrics |
 | `GET` | `/openapi.json` | OpenAPI specification |
 | `GET` | `/docs` | Swagger UI |
-| `POST` | `/busy_threshold` | Set busy thresholds (gated by `DYN_ENABLE_FRONTEND_ADMIN_API`, see below) |
-| `GET` | `/busy_threshold` | Get current busy thresholds (gated by `DYN_ENABLE_FRONTEND_ADMIN_API`, see below) |
+| `POST` | `/busy_threshold` | Set busy thresholds (gated by `DYN_DISABLE_FRONTEND_ADMIN_API`, see below) |
+| `GET` | `/busy_threshold` | Get current busy thresholds (gated by `DYN_DISABLE_FRONTEND_ADMIN_API`, see below) |
 
 ### Frontend feature switches
 
 Environment variables controlling frontend extensions. Extensions are enabled by default. When deploying, consider whether each is needed for your use case; if not, disable it to prevent accidental abuse.
 
-Set an env value of `0` / `false` / `no` / `off` (case-insensitive) to disable.
+Set an env value of `1` / `true` / `yes` / `on` (case-insensitive) to disable the extension.
 
-| Env Var | Default | Behavior when `false` |
-|---------|---------|------------------------|
-| `DYN_ENABLE_FRONTEND_NVEXT` | `true` | Frontend drops `request.nvext` at handler entry on `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/embeddings`, and `/v1/messages`; ignores Dynamo routing headers (`x-dynamo-worker-instance-id`, `x-dynamo-prefill-instance-id`, `x-dynamo-dp-rank`, `x-dynamo-prefill-dp-rank`, `x-dynamo-request-priority`, `x-dynamo-request-strict-priority`) and their compatibility aliases; silently ignores the response-side `nvext.extra_fields` opt-in. Note: disabling this breaks EPP / GAIE serving, Prime-RL-style training that uses `nvext.cache_salt`, multi-tenant agent platforms that forward `nvext.agent_hints`, and clients that opt into response disclosure via `nvext.extra_fields`. |
-| `DYN_ENABLE_FRONTEND_ADMIN_API` | `true` | `GET /busy_threshold` and `POST /busy_threshold` are not registered (404 instead of 503). Inference, metrics, models, health, and liveness routes are unaffected. |
+| Env Var | Default | Behavior when set (disabled) |
+|---------|---------|------------------------------|
+| `DYN_DISABLE_FRONTEND_NVEXT` | unset (enabled) | Frontend drops `request.nvext` at handler entry on `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/embeddings`, and `/v1/messages`; ignores Dynamo routing headers (`x-dynamo-worker-instance-id`, `x-dynamo-prefill-instance-id`, `x-dynamo-dp-rank`, `x-dynamo-prefill-dp-rank`, `x-dynamo-request-priority`, `x-dynamo-request-strict-priority`) and their compatibility aliases; silently ignores the response-side `nvext.extra_fields` opt-in. Note: disabling this breaks EPP / GAIE serving, Prime-RL-style training that uses `nvext.cache_salt`, multi-tenant agent platforms that forward `nvext.agent_hints`, and clients that opt into response disclosure via `nvext.extra_fields`. |
+| `DYN_DISABLE_FRONTEND_ADMIN_API` | unset (enabled) | `GET /busy_threshold` and `POST /busy_threshold` are not registered (404 instead of 503). Inference, metrics, models, health, and liveness routes are unaffected. |
 
 ### Endpoint Path Customization
 

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -796,7 +796,7 @@ fn gate_anthropic_nvext(request: &mut AnthropicCreateMessageRequest, nvext_enabl
     if request.nvext.is_some() {
         tracing::warn!(
             endpoint = "anthropic_messages",
-            "request carried nvext data but DYN_DISABLE_FRONTEND_NVEXT is set; dropping it"
+            "request carried nvext data but the nvext extension is disabled on this frontend; dropping it"
         );
     }
     request.nvext = None;

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -796,7 +796,7 @@ fn gate_anthropic_nvext(request: &mut AnthropicCreateMessageRequest, nvext_enabl
     if request.nvext.is_some() {
         tracing::warn!(
             endpoint = "anthropic_messages",
-            "request carried nvext data but DYN_ENABLE_FRONTEND_NVEXT is disabled; dropping it"
+            "request carried nvext data but DYN_DISABLE_FRONTEND_NVEXT is set; dropping it"
         );
     }
     request.nvext = None;

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -610,7 +610,7 @@ fn warn_nvext_disabled(endpoint: &str, nvext_present: bool, headers: &HeaderMap)
     if nvext_present || header_present {
         tracing::warn!(
             endpoint,
-            "request carried nvext data but DYN_ENABLE_FRONTEND_NVEXT is disabled; dropping it"
+            "request carried nvext data but DYN_DISABLE_FRONTEND_NVEXT is set; dropping it"
         );
     }
 }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -610,7 +610,7 @@ fn warn_nvext_disabled(endpoint: &str, nvext_present: bool, headers: &HeaderMap)
     if nvext_present || header_present {
         tracing::warn!(
             endpoint,
-            "request carried nvext data but DYN_DISABLE_FRONTEND_NVEXT is set; dropping it"
+            "request carried nvext data but the nvext extension is disabled on this frontend; dropping it"
         );
     }
 }

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -29,8 +29,8 @@ use anyhow::Result;
 use axum_server::tls_rustls::RustlsConfig;
 use derive_builder::Builder;
 use dynamo_runtime::DistributedRuntime;
+use dynamo_runtime::config::env_is_truthy;
 use dynamo_runtime::config::environment_names::llm as env_llm;
-use dynamo_runtime::config::{env_is_falsey, env_is_truthy};
 use dynamo_runtime::discovery::Discovery;
 use dynamo_runtime::logging::{make_inference_request_span, make_system_request_span};
 use dynamo_runtime::metrics::{
@@ -426,7 +426,7 @@ impl State {
     }
 
     /// Master switch for the `nvext` extension protocol (see
-    /// [`environment_names::llm::DYN_ENABLE_FRONTEND_NVEXT`]).
+    /// [`environment_names::llm::DYN_DISABLE_FRONTEND_NVEXT`]).
     #[inline]
     pub fn nvext_enabled(&self) -> bool {
         self.nvext_enabled
@@ -555,14 +555,14 @@ pub struct HttpServiceConfig {
     #[builder(default = "false")]
     enable_rl: bool,
 
-    /// Master switch for the `nvext` extension protocol. Default `true`,
-    /// env-falsey on `DYN_ENABLE_FRONTEND_NVEXT` overrides to `false`.
+    /// Master switch for the `nvext` extension protocol. Default `true`;
+    /// env-truthy `DYN_DISABLE_FRONTEND_NVEXT` overrides to `false`.
     #[builder(default = "true")]
     enable_nvext: bool,
 
     /// Master switch for the frontend admin API surface (`GET` /
-    /// `POST /busy_threshold`). Default `true`, env-falsey on
-    /// `DYN_ENABLE_FRONTEND_ADMIN_API` overrides to `false`.
+    /// `POST /busy_threshold`). Default `true`; env-truthy
+    /// `DYN_DISABLE_FRONTEND_ADMIN_API` overrides to `false`.
     #[builder(default = "true")]
     enable_admin_api: bool,
 
@@ -882,11 +882,12 @@ impl HttpServiceConfigBuilder {
                 cancel_token.child_token(),
             )) as Arc<dyn Discovery>
         });
-        // Env-falsey overrides the builder; unset preserves the builder default.
+        // Both surfaces are on by default; an env-truthy DISABLE var turns them
+        // off. The builder flag can also force off (e.g. tests), and wins.
         let nvext_enabled =
-            config.enable_nvext && !env_is_falsey(env_llm::DYN_ENABLE_FRONTEND_NVEXT);
+            config.enable_nvext && !env_is_truthy(env_llm::DYN_DISABLE_FRONTEND_NVEXT);
         let admin_api_enabled =
-            config.enable_admin_api && !env_is_falsey(env_llm::DYN_ENABLE_FRONTEND_ADMIN_API);
+            config.enable_admin_api && !env_is_truthy(env_llm::DYN_DISABLE_FRONTEND_ADMIN_API);
 
         let state = Arc::new(State::new(
             model_manager,
@@ -998,7 +999,7 @@ impl HttpServiceConfigBuilder {
             ));
         } else {
             tracing::info!(
-                env = env_llm::DYN_ENABLE_FRONTEND_ADMIN_API,
+                env = env_llm::DYN_DISABLE_FRONTEND_ADMIN_API,
                 "frontend admin API disabled — busy_threshold routes not registered"
             );
         }
@@ -1389,13 +1390,13 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_enable_nvext_propagates_through_builder_to_state() {
-        use dynamo_runtime::config::environment_names::llm::DYN_ENABLE_FRONTEND_NVEXT;
+        use dynamo_runtime::config::environment_names::llm::DYN_DISABLE_FRONTEND_NVEXT;
 
         // `build()` ANDs the builder flag with the env var, so this test must
         // pin the env to unset. Going through `temp_env` also serializes it
-        // against `test_dyn_enable_frontend_nvext_env_var_mirror`, which mutates
+        // against `test_dyn_disable_frontend_nvext_env_var_mirror`, which mutates
         // the same process-global var in parallel.
-        temp_env::with_var_unset(DYN_ENABLE_FRONTEND_NVEXT, || {
+        temp_env::with_var_unset(DYN_DISABLE_FRONTEND_NVEXT, || {
             let on = HttpService::builder().enable_nvext(true).build().unwrap();
             assert!(on.state.nvext_enabled());
 
@@ -1410,17 +1411,17 @@ mod tests {
         });
     }
 
-    /// `DYN_ENABLE_FRONTEND_NVEXT` is the env-var mirror of the builder
-    /// flag. Unset -> builder default wins (on). Truthy strings -> on.
-    /// Falsey strings (`0` / `false` / `no` / `off`, case-insensitive) ->
+    /// `DYN_DISABLE_FRONTEND_NVEXT` is the env-var mirror of the builder
+    /// flag. Unset -> builder default wins (on). Falsey strings -> on.
+    /// Truthy strings (`1` / `true` / `yes` / `on`, case-insensitive) ->
     /// off, regardless of what the builder asked for.
     #[test]
     #[serial_test::serial]
-    fn test_dyn_enable_frontend_nvext_env_var_mirror() {
-        use dynamo_runtime::config::environment_names::llm::DYN_ENABLE_FRONTEND_NVEXT;
+    fn test_dyn_disable_frontend_nvext_env_var_mirror() {
+        use dynamo_runtime::config::environment_names::llm::DYN_DISABLE_FRONTEND_NVEXT;
 
         // Unset -> builder default (true) wins.
-        temp_env::with_var_unset(DYN_ENABLE_FRONTEND_NVEXT, || {
+        temp_env::with_var_unset(DYN_DISABLE_FRONTEND_NVEXT, || {
             let svc = HttpService::builder().build().unwrap();
             assert!(
                 svc.state.nvext_enabled(),
@@ -1428,29 +1429,32 @@ mod tests {
             );
         });
 
-        // Explicit truthy -> on (builder default also on; env doesn't flip it off).
-        temp_env::with_var(DYN_ENABLE_FRONTEND_NVEXT, Some("true"), || {
+        // Explicit falsey -> still on (disable not requested).
+        temp_env::with_var(DYN_DISABLE_FRONTEND_NVEXT, Some("false"), || {
             let svc = HttpService::builder().build().unwrap();
-            assert!(svc.state.nvext_enabled(), "env=true + default builder = on");
+            assert!(
+                svc.state.nvext_enabled(),
+                "disable=false + default builder = on"
+            );
         });
 
-        // Explicit falsey -> off, even though the builder default is on.
-        for falsey in ["false", "0", "no", "off", "FALSE"] {
-            temp_env::with_var(DYN_ENABLE_FRONTEND_NVEXT, Some(falsey), || {
+        // Explicit truthy -> off, even though the builder default is on.
+        for truthy in ["true", "1", "yes", "on", "TRUE"] {
+            temp_env::with_var(DYN_DISABLE_FRONTEND_NVEXT, Some(truthy), || {
                 let svc = HttpService::builder().build().unwrap();
                 assert!(
                     !svc.state.nvext_enabled(),
-                    "env={falsey:?} should override builder default to off"
+                    "disable={truthy:?} should override builder default to off"
                 );
             });
         }
 
         // Builder=false short-circuits regardless of env.
-        temp_env::with_var(DYN_ENABLE_FRONTEND_NVEXT, Some("true"), || {
+        temp_env::with_var_unset(DYN_DISABLE_FRONTEND_NVEXT, || {
             let svc = HttpService::builder().enable_nvext(false).build().unwrap();
             assert!(
                 !svc.state.nvext_enabled(),
-                "builder=false wins even if env=true"
+                "builder=false wins even if disable is unset"
             );
         });
     }

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -307,13 +307,14 @@ pub mod llm {
     pub const DYN_ENABLE_ANTHROPIC_API: &str = "DYN_ENABLE_ANTHROPIC_API";
 
     /// Master switch for the `nvext` extension protocol on the frontend.
-    /// Default `true`. Falsy values (`0` / `false` / `no` / `off`,
-    /// case-insensitive) cause the frontend to drop `request.nvext` at
-    /// handler entry, ignore the routing-override headers
-    /// (`x-dynamo-worker-instance-id`, `x-dynamo-prefill-instance-id`,
-    /// `x-dynamo-dp-rank`, `x-dynamo-prefill-dp-rank`), and silently ignore the response-side
+    /// The protocol is **enabled by default**; this variable disables it.
+    /// Truthy values (`1` / `true` / `yes` / `on`, case-insensitive) cause
+    /// the frontend to drop `request.nvext` at handler entry, ignore the
+    /// routing-override headers (`x-dynamo-worker-instance-id`,
+    /// `x-dynamo-prefill-instance-id`, `x-dynamo-dp-rank`,
+    /// `x-dynamo-prefill-dp-rank`), and silently ignore the response-side
     /// `extra_fields` opt-in.
-    pub const DYN_ENABLE_FRONTEND_NVEXT: &str = "DYN_ENABLE_FRONTEND_NVEXT";
+    pub const DYN_DISABLE_FRONTEND_NVEXT: &str = "DYN_DISABLE_FRONTEND_NVEXT";
 
     /// Ignore unknown OpenAI frontend request fields. Unknown fields are dropped,
     /// not handled; known pass-through fields remain type-validated.
@@ -321,10 +322,11 @@ pub mod llm {
         "DYN_IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS";
 
     /// Master switch for the frontend's HTTP admin API surface.
-    /// Default `true`. Falsy values prevent registration of `GET` /
-    /// `POST /busy_threshold`. Inference, metrics, models, health, and
-    /// liveness routes are unaffected.
-    pub const DYN_ENABLE_FRONTEND_ADMIN_API: &str = "DYN_ENABLE_FRONTEND_ADMIN_API";
+    /// The admin API is **enabled by default**; this variable disables it.
+    /// Truthy values (`1` / `true` / `yes` / `on`, case-insensitive) prevent
+    /// registration of `GET` / `POST /busy_threshold`. Inference, metrics,
+    /// models, health, and liveness routes are unaffected.
+    pub const DYN_DISABLE_FRONTEND_ADMIN_API: &str = "DYN_DISABLE_FRONTEND_ADMIN_API";
 
     /// Strip the Claude Code billing preamble (`x-anthropic-billing-header: ...`)
     /// from the system prompt before forwarding to the target model. The preamble
@@ -717,9 +719,9 @@ mod tests {
             llm::DYN_LORA_ENABLED,
             llm::DYN_LORA_PATH,
             llm::DYN_ENABLE_ANTHROPIC_API,
-            llm::DYN_ENABLE_FRONTEND_NVEXT,
+            llm::DYN_DISABLE_FRONTEND_NVEXT,
             llm::DYN_IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS,
-            llm::DYN_ENABLE_FRONTEND_ADMIN_API,
+            llm::DYN_DISABLE_FRONTEND_ADMIN_API,
             llm::DYN_STRIP_ANTHROPIC_PREAMBLE,
             llm::DYN_ENABLE_STREAMING_TOOL_DISPATCH,
             llm::DYN_ENABLE_STREAMING_REASONING_DISPATCH,

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -527,7 +527,8 @@ def test_frontend_api_surface_compliance(
         # agg.sh doesn't forward frontend args, but the frontend reads this
         # env var directly. Enables /v1/messages for the claude smoke step.
         "DYN_ENABLE_ANTHROPIC_API": "1",
-        "DYN_ENABLE_FRONTEND_NVEXT": "1",
+        # nvext is enabled by default; no env needed. (Set
+        # DYN_DISABLE_FRONTEND_NVEXT=1 to turn it off.)
         "DYN_REQUEST_TRACE": "1",
         "DYN_REQUEST_TRACE_SINKS": "jsonl",
         "DYN_REQUEST_TRACE_OUTPUT_PATH": str(request_trace_path),


### PR DESCRIPTION
## Summary

Renames the two frontend master switches to follow the repo's env-var naming convention:

- `DYN_ENABLE_FRONTEND_NVEXT` → **`DYN_DISABLE_FRONTEND_NVEXT`**
- `DYN_ENABLE_FRONTEND_ADMIN_API` → **`DYN_DISABLE_FRONTEND_ADMIN_API`**

## Why

Both surfaces are **enabled by default**. The rest of the codebase encodes default polarity in the name: features that default **off** use `ENABLE_*` (`DYN_ENABLE_RL`, `DYN_ENABLE_ANTHROPIC_API`, `DYN_KVBM_ENABLE_NUMA`, …), and features that default **on** use `DISABLE_*` (`DYN_KVBM_DISABLE_WRITE_COMBINED`, `DYN_MEMORY_DISABLE_NUMA`, `DYN_SDK_DISABLE_ANSI_LOGGING`, …). These two were the outliers: `ENABLE_*` names that default on. The rename makes them consistent and the operator action clearer ("set `DYN_DISABLE_FRONTEND_NVEXT=1` to turn it off").

## Behavior

Unchanged. Both surfaces remain **on by default**. The read flips from `!env_is_falsey(DYN_ENABLE_…)` to `!env_is_truthy(DYN_DISABLE_…)`, and the builder flag still wins (used by tests). Only the variable name and the polarity of the value an operator sets change.

## Migration

These vars were introduced recently (#10556) and aren't in a stable release yet, so adoption should be minimal. **If you currently set `DYN_ENABLE_FRONTEND_NVEXT=false` (or the admin-api equivalent) to disable a surface, switch to `DYN_DISABLE_FRONTEND_NVEXT=true`** — the old variable is no longer read, so a stale `=false` would silently leave the surface enabled.

## Changed

- `lib/runtime/src/config/environment_names.rs` — const + value + docs
- `lib/llm/src/http/service/service_v2.rs` — read sites (falsey→truthy flip), builder docs, env tests
- `lib/llm/src/http/service/{openai,anthropic}.rs` — warn message
- `docs/components/frontend/configuration.md` — feature-switch table
- `tests/frontend/test_frontend_api_surface_compliance.py` — drop the now-default-on override

## Validation

- `cargo build`/`clippy`/`fmt` clean; env-var mirror + builder tests pass.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified frontend configuration docs for busy-threshold endpoints and feature switches.
  * Updated environment variable guidance to reflect the new disable-based settings and default behavior.

* **Bug Fixes**
  * Aligned warning messages and configuration behavior with the updated frontend feature toggle names.
  * Improved consistency so disabled frontend features now return the expected unavailable response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->