### PR TITLE
perf(kv-router): skip shape lock for internal CRTC nodes [DYN-3584]

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/matches.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/matches.rs
@@ -121,6 +121,9 @@ impl ConcurrentRadixTreeCompressed {
         }
     }
 
+    // NOTE(perf): Pre-reserving the output maps in these survivor-recording
+    // helpers did not produce a repeatable throughput improvement. Re-profile
+    // before adding eager capacity here.
     fn record_surviving_details(details: &mut MatchDetails, walk_result: &MatchWalkResult) {
         for worker in &walk_result.active {
             details

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -515,6 +515,10 @@ impl Node {
         blocks: &[KvCacheStoredBlockData],
         shape_version: u64,
     ) -> Option<bool> {
+        if self.internal.load(Ordering::Acquire) {
+            return Some(false);
+        }
+
         self.apply_edge_shape_update(shape_version, |state, _children| {
             if self.internal.load(Ordering::Acquire) || blocks.is_empty() || state.edge.is_empty() {
                 return (false, false);

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -34,6 +34,8 @@ fn record_last_matched_hash(
 #[derive(Debug)]
 pub(super) struct Node {
     shape_gate: RwLock<()>,
+    /// NOTE(concurrency): This is a post-commit validation token, not a seqlock.
+    /// Node state and children do not share one immutable publication boundary.
     shape_version: AtomicU64,
     /// Sticky logical-internal marker. Once true, this node is treated as
     /// internal even if cleanup removes all physical children later.
@@ -103,6 +105,9 @@ impl Node {
         children: FxHashMap<LocalBlockHash, SharedNode>,
     ) -> Self {
         let internal = !children.is_empty();
+        // NOTE(perf): Reducing child-map sharding substantially lowered memory
+        // usage but regressed throughput. Treat custom sharding as an explicit
+        // memory tradeoff rather than a throughput optimization.
         let children_map = DashMap::with_hasher(FxBuildHasher);
         for (key, child) in children {
             children_map.insert(key, child);
@@ -121,6 +126,9 @@ impl Node {
         &self,
         plan: impl FnOnce(&NodeState, &NodeChildren, u64) -> R,
     ) -> Option<R> {
+        // NOTE(perf): Replacing these shape-gated reads with state-only snapshots
+        // was neutral or regressive, and profiling did not identify the RwLock
+        // as a hotspot. Re-profile before removing this shape read.
         let _gate = self.shape_gate.read();
         let shape_version = self.shape_version.load(Ordering::Acquire);
         let state = self.state.read();
@@ -404,6 +412,8 @@ impl Node {
         blocks: &[KvCacheStoredBlockData],
     ) -> ParentEdgeAction {
         match plan.action {
+            // NOTE(perf): Removing this validation did not produce a repeatable
+            // benefit and regressed scaled cumulative workloads.
             ParentEdgePlanAction::InsertFromParent => self
                 .validate_shape_read(plan.shape_version, || {
                     ParentEdgeAction::InsertFromParent(None)
@@ -416,6 +426,9 @@ impl Node {
                     }
                 })
                 .unwrap_or(ParentEdgeAction::Stale),
+            // NOTE(perf): An additional sticky-internal rejection before this
+            // commit did not improve throughput. The check inside the gate
+            // closes the split race.
             ParentEdgePlanAction::ReuseSuffixAndExtendLeaf { append_start } => self
                 .apply_edge_shape_update(plan.shape_version, |state, _children| {
                     if !self.internal.load(Ordering::Acquire) {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
@@ -572,4 +572,16 @@ impl ConcurrentRadixTreeCompressed {
 
         Ok(StoreInsertOutcome { duplicate_store })
     }
+
+    #[cfg(test)]
+    pub(super) fn insert_blocks_from_for_test(
+        &self,
+        lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
+        worker: WorkerWithDpRank,
+        parent: &SharedNode,
+        seed_hash: ExternalSequenceBlockHash,
+        blocks: &[KvCacheStoredBlockData],
+    ) -> Result<StoreInsertOutcome, KvCacheEventError> {
+        self.insert_blocks_from(lookup, worker, parent, false, Some(seed_hash), blocks)
+    }
 }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -20,6 +20,13 @@ fn direct_lookup() -> DirectLookup {
     FxHashMap::default()
 }
 
+fn stored_data(event: RouterEvent) -> KvCacheStoreData {
+    match event.event.data {
+        KvCacheEventData::Stored(op) => op,
+        _ => unreachable!("expected a store event"),
+    }
+}
+
 fn worker_lookup_len(lookup: &DirectLookup, worker: WorkerWithDpRank) -> Option<usize> {
     lookup.get(&worker).map(|worker_lookup| worker_lookup.len())
 }
@@ -206,6 +213,151 @@ mod race_tests {
             assert_direct_score(&index, &[1, 2, 3, 7, 8], worker0, 3);
             assert_direct_score(&index, &[1, 2, 3, 7, 8], worker1, 3);
             assert_direct_score(&index, &[1, 2, 3, 7, 8], worker2, 5);
+        }
+
+        #[test]
+        fn stale_scan_cannot_commit_after_split() {
+            let index = ConcurrentRadixTreeCompressed::new();
+            let worker1 = worker(1);
+            let worker2 = worker(2);
+            let worker3 = worker(3);
+            let mut lookup1 = direct_lookup();
+            let mut lookup2 = direct_lookup();
+            let mut lookup3 = direct_lookup();
+
+            apply_direct(
+                &index,
+                &mut lookup1,
+                make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+            );
+            apply_direct(
+                &index,
+                &mut lookup2,
+                make_store_event(2, &[1, 2, 3, 4, 5, 6]),
+            );
+
+            let node = index
+                .root
+                .child_snapshot(LocalBlockHash(1))
+                .expect("root child should exist");
+            let blocks = stored_data(make_store_event(3, &[1, 2, 3, 4, 5, 6])).blocks;
+            let stale_scan = node.scan_store_prefix(&blocks);
+
+            apply_direct(
+                &index,
+                &mut lookup2,
+                make_store_event_with_parent(2, &[1, 2, 3], &[7]),
+            );
+
+            assert!(
+                node.promote_to_full_with_version(worker3, stale_scan.shape_version)
+                    .is_none()
+            );
+
+            apply_direct(
+                &index,
+                &mut lookup3,
+                make_store_event(3, &[1, 2, 3, 4, 5, 6]),
+            );
+
+            assert_eq!(
+                index.edge_topology_for_test(),
+                vec![edge_topology(
+                    &[1, 2, 3],
+                    vec![
+                        edge_topology(&[4, 5, 6], vec![]),
+                        edge_topology(&[7], vec![])
+                    ],
+                )],
+            );
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker2, 6);
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker3, 6);
+        }
+
+        #[test]
+        fn tail_parent_split_before_child_lookup_repairs_to_suffix() {
+            let index = ConcurrentRadixTreeCompressed::new();
+            let worker1 = worker(1);
+            let worker2 = worker(2);
+            let worker3 = worker(3);
+            let worker4 = worker(4);
+            let mut lookup1 = direct_lookup();
+            let mut lookup2 = direct_lookup();
+            let mut lookup3 = direct_lookup();
+            let mut lookup4 = direct_lookup();
+
+            for (worker_id, lookup) in [
+                (1, &mut lookup1),
+                (2, &mut lookup2),
+                (3, &mut lookup3),
+                (4, &mut lookup4),
+            ] {
+                apply_direct(&index, lookup, make_store_event(worker_id, &[1, 2, 3, 4]));
+            }
+            apply_direct(
+                &index,
+                &mut lookup1,
+                make_store_event_with_parent(1, &[1, 2, 3, 4], &[5, 6]),
+            );
+            apply_direct(
+                &index,
+                &mut lookup2,
+                make_store_event_with_parent(2, &[1, 2, 3, 4], &[7, 8]),
+            );
+
+            let stale_parent = index
+                .root
+                .child_snapshot(LocalBlockHash(1))
+                .expect("root child should exist");
+            let continuation = stored_data(make_store_event_with_parent(3, &[1, 2, 3, 4], &[9]));
+            let parent_hash = continuation.parent_hash.expect("continuation has a parent");
+            let plan = stale_parent
+                .plan_store_parent_edge(parent_hash, &continuation.blocks)
+                .expect("tail parent should be present before the split");
+            assert!(matches!(
+                plan.action,
+                ParentEdgePlanAction::InsertFromParent
+            ));
+
+            apply_direct(
+                &index,
+                &mut lookup4,
+                make_store_event_with_parent(4, &[1, 2], &[10]),
+            );
+
+            index
+                .insert_blocks_from_for_test(
+                    &mut lookup3,
+                    worker3,
+                    &stale_parent,
+                    parent_hash,
+                    &continuation.blocks,
+                )
+                .unwrap();
+
+            assert_eq!(
+                index.edge_topology_for_test(),
+                vec![edge_topology(
+                    &[1, 2],
+                    vec![
+                        edge_topology(
+                            &[3, 4],
+                            vec![
+                                edge_topology(&[5, 6], vec![]),
+                                edge_topology(&[7, 8], vec![]),
+                                edge_topology(&[9], vec![]),
+                            ],
+                        ),
+                        edge_topology(&[10], vec![]),
+                    ],
+                )],
+            );
+            assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+            assert_direct_score(&index, &[1, 2, 3, 4, 7, 8], worker2, 6);
+            assert_direct_score(&index, &[1, 2, 3, 4, 9], worker3, 5);
+            assert_direct_score(&index, &[1, 2, 9], worker3, 2);
+            assert_direct_score(&index, &[1, 2, 10], worker4, 3);
         }
     }
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
@@ -19,6 +19,8 @@ pub(super) type SharedNode = Arc<Node>;
 pub(super) type WorkerLookup = FxHashMap<ExternalSequenceBlockHash, SharedNode>;
 
 pub(super) struct MatchWalkResult {
+    // NOTE(perf): Replacing this set with a Vec did not improve throughput. Keep
+    // uniqueness by construction unless a new profile justifies changing it.
     pub(super) active: FxHashSet<WorkerWithDpRank>,
     pub(super) matched_depth: u32,
     pub(super) prev_edge_last_hash: Option<ExternalSequenceBlockHash>,


### PR DESCRIPTION
## Summary

- Skip `apply_edge_shape_update` in `try_extend_leaf_with_version` when the node's sticky `internal` marker is already set.
- Keep the existing revalidation under the shape gate to cover races with a concurrent leaf-to-internal transition.
- Add deterministic regressions for stale scan commits across a split and stale-parent lookup repair after reparenting.
- Keep the broader lock-removal ablations out of this change because their isolated benchmark results were inconsistent or regressive.

The fast path removes a known-unnecessary write-gate acquisition once a node can no longer be extended as a leaf. ComputeLab measurements showed small positive medians, but their confidence intervals include zero: +1.25% on the exact historical 128-worker/8-event-worker workload, +0.45% on the current preferred workload, and +0.30% at 2048 workers/32 event workers. Contaminated overlapping runs were quarantined and affected configurations were rerun sequentially on the same node.

## Experiments not retained

The following low-risk acquisition reductions were tested independently for 20 runs on the exact historical workload. The deltas below are incremental point estimates versus B1; none established a repeatable improvement.

| Candidate | Experiment | Incremental delta vs B1 | Result |
| --- | --- | ---: | --- |
| A | Read `scan_store_prefix` state and shape version from one state snapshot, avoiding `shape_gate.read()` | -3.59% | Negative point estimate; not retained |
| B | Plan `plan_store_parent_edge` from the state snapshot rather than the shape gate | -3.18% | Negative point estimate; not retained |
| C | Combine explicit-parent coverage rejection and edge planning into one snapshot | -5.37% | Negative point estimate; not retained |
| D | Remove the no-op `InsertFromParent` shape validation after proving both callers repair or revalidate | +1.35% (95% CI -2.19% to +8.60%) | Carried into the cumulative variant, then regressed 0.34% at 2048 workers/8 event workers and 1.24% at 2048 workers/32 event workers versus B1; not retained |
| E | Remove the shape read from anchor-only `promote_worker_to_full_edge` | -2.56% | No ordinary workload applicability and no measured benefit; not retained |
| F | Add another sticky-`internal` rejection before the suffix-extension commit gate | -0.24% | No measured benefit; not retained |

All candidates passed the focused CRTC tests, so exclusion was based on inconsistent or negative performance rather than a known correctness failure. Synchronization was deliberately left unchanged in `child_lookup_plan`, ordinary internal child insertion, removal/clear paths, and generic `apply_metadata_update`; those paths still have unresolved split or last-worker-clear races.

## Validation

- `cargo clippy --no-deps --all-targets -- -D warnings` from `lib/kv-router`
- `cargo fmt` from `lib/kv-router`
- `cargo test -p dynamo-kv-router concurrent_radix_tree_compressed -- --nocapture` (22 passed)
- ComputeLab B0/B1 ablation matrix with warmups, repeated measurements, event-thread scaling, larger worker cardinalities, and isolated reruns after overlap detection
