### PR TITLE
feat(examples): RIVA NIM cascaded voice pipeline (ASR -> LLM -> TTS)

### DIFF
--- a/examples/riva_cascaded_pipeline/README.md
+++ b/examples/riva_cascaded_pipeline/README.md
@@ -1,0 +1,187 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# RIVA cascaded voice pipeline (ASR → LLM → TTS)
+
+A proof-of-concept that expresses a cascaded voice agent as Dynamo workers instead of a pipecat pipeline. RIVA NIM speech connectors are wrapped as Dynamo workers (ASR, TTS), an LLM runs as a standard Dynamo vLLM backend, and a realtime orchestrator worker chains them together behind the Dynamo frontend's OpenAI Realtime WebSocket API.
+
+```
+realtime WS client ──> dynamo.frontend (/v1/realtime, typed realtime PushRouter)
+                          │  (ModelType.Realtime, bidirectional)
+                          ▼
+                   orchestrator worker  ── serve_bidirectional_endpoint
+                     │            │            │
+              ASR client    LLM client    TTS client
+                     │            │            │
+               ASR worker    vLLM worker   TTS worker
+            (RIVA recognize) (text-in-out) (RIVA synthesize)
+```
+
+A turn: the client streams microphone audio as `input_audio_buffer.append` events; an `input_audio_buffer.commit` marks end-of-turn. The orchestrator then runs ASR (audio → transcript) → LLM (chat, text → text) → TTS (text → audio) and streams the reply back as `response.output_audio.delta` / `response.done` events.
+
+## Layout
+
+```
+riva_nim/        Portable building-block package (relative imports only).
+  config.py        RIVA connection config + CLI flags.
+  riva_client.py   build_auth / build_asr_service / build_tts_service.
+  asr_worker.py    Audio → transcript (RIVA offline_recognize).
+  tts_worker.py    Text → audio (RIVA synthesize).
+  orchestrator.py  ModelType.Realtime engine chaining ASR → LLM → TTS.
+container/       Dockerfile + build.sh that layer nvidia-riva-client on a Dynamo image.
+tests/           Unit tests (run inside the layered image).
+```
+
+`riva_nim/` is self-contained and named `riva_nim` (not `riva`) so it does not shadow the `nvidia-riva-client` package, which imports as top-level `riva`. It can be relocated to `components/src/dynamo/riva/` without import changes.
+
+## Prerequisites
+
+- A Dynamo vLLM image (e.g. `dynamo:latest-vllm-runtime`) — carries the Dynamo Python bindings.
+- A reachable RIVA server providing ASR and TTS — either a local [RIVA Skills](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/) / NIM deployment, or the hosted NVCF endpoint (see [NVCF route](#nvcf-route)).
+- Dynamo's runtime dependencies for local discovery: `etcd` and `nats` (the workers default to the `etcd` discovery backend and `tcp` request plane).
+
+## 1. Build the image
+
+`nvidia-riva-client` is not in stock Dynamo images, so build one that layers it on:
+
+```bash
+cd examples/riva_cascaded_pipeline
+BASE_IMAGE=dynamo:latest-vllm-runtime TAG=dynamo-riva:latest container/build.sh
+```
+
+## 2. Start the RIVA NIMs
+
+The ASR and TTS workers each talk to a RIVA NIM over gRPC. Start one NIM per service — they are separate containers, so give each its own gRPC port. The images come from NGC, so log in and set your key first:
+
+```bash
+docker login nvcr.io          # username: $oauthtoken, password: <NGC API key>
+export NGC_API_KEY=<your-ngc-api-key>
+```
+
+ASR NIM — Parakeet CTC 1.1B (en-US), the ASR NIM the [nemotron-voice-agent blueprint](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent) uses (check the [NGC catalog](https://catalog.ngc.nvidia.com/) for newer tags):
+
+```bash
+docker run -d --name riva-asr --gpus '"device=0"' --shm-size=8g \
+  -e NGC_API_KEY -v ~/.cache/nim:/opt/nim/.cache \
+  -e NIM_GRPC_API_PORT=50051 -p 50051:50051 \
+  nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.4.0
+```
+
+TTS NIM — Magpie TTS Multilingual (the source of the default `Magpie-Multilingual.EN-US.Aria` voice), on a separate gRPC port so both NIMs run on one host:
+
+```bash
+docker run -d --name riva-tts --gpus '"device=0"' --shm-size=8g \
+  -e NGC_API_KEY -v ~/.cache/nim:/opt/nim/.cache \
+  -e NIM_GRPC_API_PORT=50052 -p 50052:50052 \
+  nvcr.io/nim/nvidia/magpie-tts-multilingual:1.6.0
+```
+
+The blueprint runs both speech NIMs on one GPU and the LLM on another; adjust `--gpus` to your hardware.
+
+Each worker's `--riva-server` must point at the matching NIM's gRPC port (ASR → `localhost:50051`, TTS → `localhost:50052` above). A single RIVA Skills server that hosts both ASR and TTS on one port works too — then point both workers at that one address. The URL is always configurable; the NIM need not be on `localhost`.
+
+## 3. Start runtime dependencies
+
+Start `etcd` and `nats` (the standard Dynamo local dependencies) — the workers default to the `etcd` discovery backend and `tcp` request plane.
+
+## 4. Launch the workers
+
+Run each inside the `dynamo-riva:latest` image with this directory as the working directory (so `python -m riva_nim.<worker>` resolves the package), sharing the host network with `etcd`/`nats`/the NIMs. `launch_workers.sh` starts all of them — ASR, TTS, the vLLM LLM worker, and the orchestrator (`LLM_MODEL=nvidia/Llama-3.3-Nemotron-Super-49B-v1.5 ./launch_workers.sh`); only the frontend is launched separately. The individual commands below show what it runs.
+
+ASR worker (points at the ASR NIM):
+
+```bash
+python -m riva_nim.asr_worker --riva-server localhost:50051 --endpoint dynamo.riva-asr.generate
+```
+
+TTS worker (points at the TTS NIM):
+
+```bash
+python -m riva_nim.tts_worker --riva-server localhost:50052 --voice Magpie-Multilingual.EN-US.Aria --endpoint dynamo.riva-tts.generate
+```
+
+LLM worker (text-in-text-out). `--use-vllm-tokenizer` makes the worker register as `ModelInput.Text` and accept chat `messages` directly; `chat` is in the default `--endpoint-types`. The worker serves `dynamo.backend.generate` by default. The blueprint pairs the speech NIMs with an NVIDIA Nemotron chat model; serve the corresponding Hugging Face weights with vLLM — e.g. `nvidia/Llama-3.3-Nemotron-Super-49B-v1.5` (large, multi-GPU). Swap in a smaller chat model such as `Qwen/Qwen3-0.6B` to try the pipeline on a single small GPU:
+
+```bash
+python -m dynamo.vllm --model nvidia/Llama-3.3-Nemotron-Super-49B-v1.5 --use-vllm-tokenizer
+```
+
+Orchestrator (the realtime model the frontend exposes). Point its client flags at the three endpoints above; set `--llm-model` to the model name the vLLM worker serves:
+
+```bash
+python -m riva_nim.orchestrator \
+  --model-name riva-voice-agent \
+  --asr-endpoint dynamo.riva-asr.generate \
+  --llm-endpoint dynamo.backend.generate \
+  --tts-endpoint dynamo.riva-tts.generate \
+  --llm-model nvidia/Llama-3.3-Nemotron-Super-49B-v1.5 \
+  --endpoint dynamo.riva-orchestrator.generate
+```
+
+Frontend:
+
+```bash
+python -m dynamo.frontend
+```
+
+## 5. Talk to it
+
+Connect a WebSocket to the frontend's `/v1/realtime` endpoint and drive a turn with OpenAI-Realtime events:
+
+- `session.update` — configure the session (echoed back as `session.updated`).
+- `input_audio_buffer.append` — stream base64 LINEAR_PCM audio chunks (repeat).
+- `input_audio_buffer.commit` — end the turn; the agent replies with `response.created` → `response.output_audio.delta` (base64 audio) → `response.output_audio.done` → `response.done`.
+
+## Endpoint wiring
+
+| Worker       | Default endpoint                  | Orchestrator flag |
+|--------------|-----------------------------------|-------------------|
+| ASR          | `dynamo.riva-asr.generate`        | `--asr-endpoint`  |
+| TTS          | `dynamo.riva-tts.generate`        | `--tts-endpoint`  |
+| LLM (vLLM)   | `dynamo.backend.generate`         | `--llm-endpoint`  |
+| Orchestrator | `dynamo.riva-orchestrator.generate` | `--endpoint`    |
+
+The orchestrator's `--*-endpoint` flags must match each worker's served endpoint. If your vLLM worker uses a non-default namespace, update `--llm-endpoint` accordingly.
+
+## NVCF route
+
+The same workers can target the hosted NVCF endpoint instead of a local server — no code change, just connection flags on the ASR and TTS workers:
+
+```bash
+python -m riva_nim.asr_worker \
+  --riva-server grpc.nvcf.nvidia.com:443 \
+  --riva-use-ssl \
+  --riva-function-id <ASR_FUNCTION_ID> \
+  --riva-api-key <NVCF_API_KEY>
+```
+
+`--riva-use-ssl` selects a TLS channel; `--riva-function-id` and `--riva-api-key` are sent as the `function-id` and `authorization: Bearer …` gRPC metadata RIVA NVCF expects. TTS takes the same flags with its own function id.
+
+## RIVA connection flags (shared)
+
+| Flag                  | Default            | Meaning |
+|-----------------------|--------------------|---------|
+| `--riva-server`       | `localhost:50051`  | `host:port` of the RIVA gRPC server. |
+| `--riva-use-ssl`      | off                | Use a TLS channel (required for NVCF). |
+| `--riva-api-key`      | unset              | NVCF API key → `authorization: Bearer` metadata. |
+| `--riva-function-id`  | unset              | NVCF function id → `function-id` metadata. |
+| `--riva-ssl-root-cert`| unset              | Path to a TLS root certificate. |
+
+## Tests
+
+The unit tests run inside the layered image (Dynamo bindings + RIVA client present); they mock RIVA and the downstream clients, so no server is needed:
+
+```bash
+docker run --rm -v "$PWD":/work -w /work dynamo-riva:latest \
+  bash -c 'pip install -q pytest pytest-asyncio && pytest tests/ -p no:cacheprovider'
+```
+
+## Limitations (proof-of-concept scope)
+
+- **Offline speech, not streaming.** ASR uses `offline_recognize` and TTS `synthesize` (one request → one result) per turn. RIVA streaming and interim transcripts are out of scope.
+- **Single-turn LLM.** Each turn sends only the current transcript; no conversation history is carried across turns.
+- **Cancellation is observed between stages.** A turn cancelled mid-chain stops before the next stage, but an already-in-flight ASR/LLM/TTS call still completes. Barge-in / interruption is not implemented.
+- **Audio format assumptions.** ASR expects 16 kHz LINEAR_PCM, TTS emits 22.05 kHz LINEAR_PCM. No resampling is done between the realtime transport and RIVA; match the client's audio format to the workers' configured rates.
+- **NVCF path is documented, not validated here.** The local path is what the tests and manual flow exercise.

--- a/examples/riva_cascaded_pipeline/README.md
+++ b/examples/riva_cascaded_pipeline/README.md
@@ -182,7 +182,7 @@ docker run --rm -v "$PWD":/work -w /work dynamo-riva:latest \
 
 ## Limitations (proof-of-concept scope)
 
-- **Offline speech, not streaming.** ASR uses `offline_recognize` and TTS `synthesize` (one request → one result) per turn. RIVA streaming and interim transcripts are out of scope.
+- **ASR streams, TTS is offline.** ASR uses RIVA streaming recognition (the Parakeet NIM serves a streaming model), with interim results disabled — only final transcripts are collected per turn. TTS uses offline `synthesize` (one request → one audio result). Streaming TTS (`synthesize_online`) and interim ASR transcripts are out of scope.
 - **Single-turn LLM.** Each turn sends only the current transcript; no conversation history is carried across turns.
 - **Cancellation is observed between stages.** A turn cancelled mid-chain stops before the next stage, but an already-in-flight ASR/LLM/TTS call still completes. Barge-in / interruption is not implemented.
 - **Audio format assumptions.** ASR expects 16 kHz LINEAR_PCM, TTS emits 22.05 kHz LINEAR_PCM. No resampling is done between the realtime transport and RIVA; match the client's audio format to the workers' configured rates.

--- a/examples/riva_cascaded_pipeline/README.md
+++ b/examples/riva_cascaded_pipeline/README.md
@@ -88,7 +88,7 @@ Start `etcd` and `nats` (the standard Dynamo local dependencies) — the workers
 
 ## 4. Launch the workers
 
-Run each inside the `dynamo-riva:latest` image, sharing the host network with `etcd`/`nats`/the NIMs. The image bakes in the `riva_nim` package (on `PYTHONPATH`), so `python -m riva_nim.<worker>` runs without mounting the source. `launch_workers.sh` starts all of them — ASR, TTS, the vLLM LLM worker, and the orchestrator (`LLM_MODEL=nvidia/Llama-3.3-Nemotron-Super-49B-v1.5 ./launch_workers.sh`); only the frontend is launched separately. It sources the repo's `examples/common/launch_utils.sh`, so run it from a checkout / mounted worktree (the individual commands below work in the bare image too).
+Run each inside the `dynamo-riva:latest` image, sharing the host network with `etcd`/`nats`/the NIMs. The image bakes in the `riva_nim` package (on `PYTHONPATH`), so `python -m riva_nim.<worker>` runs without mounting the source. `launch_workers.sh` starts the whole stack — ASR, TTS, the vLLM LLM worker, the orchestrator, and the `dynamo.frontend` (`LLM_MODEL=nvidia/Llama-3.3-Nemotron-Super-49B-v1.5 ./launch_workers.sh`). It sources the repo's `examples/common/launch_utils.sh`, so run it from a checkout / mounted worktree (the individual commands below work in the bare image too).
 
 ASR worker (points at the ASR NIM):
 

--- a/examples/riva_cascaded_pipeline/README.md
+++ b/examples/riva_cascaded_pipeline/README.md
@@ -102,6 +102,8 @@ TTS worker (points at the TTS NIM):
 python -m riva_nim.tts_worker --riva-server localhost:50052 --voice Magpie-Multilingual.EN-US.Aria --endpoint dynamo.riva-tts.generate
 ```
 
+Both speech workers accept `--timeout-s` (default 30) — a client-side gRPC deadline that cancels the RIVA call if the backend hangs, so an unresponsive NIM can't tie up worker threads.
+
 LLM worker (text-in-text-out). `--use-vllm-tokenizer` makes the worker register as `ModelInput.Text` and accept chat `messages` directly; `chat` is in the default `--endpoint-types`. The worker serves `dynamo.backend.generate` by default. The blueprint pairs the speech NIMs with an NVIDIA Nemotron chat model; serve the corresponding Hugging Face weights with vLLM — e.g. `nvidia/Llama-3.3-Nemotron-Super-49B-v1.5` (large, multi-GPU). Swap in a smaller chat model such as `Qwen/Qwen3-0.6B` to try the pipeline on a single small GPU:
 
 ```bash

--- a/examples/riva_cascaded_pipeline/README.md
+++ b/examples/riva_cascaded_pipeline/README.md
@@ -88,7 +88,7 @@ Start `etcd` and `nats` (the standard Dynamo local dependencies) — the workers
 
 ## 4. Launch the workers
 
-Run each inside the `dynamo-riva:latest` image with this directory as the working directory (so `python -m riva_nim.<worker>` resolves the package), sharing the host network with `etcd`/`nats`/the NIMs. `launch_workers.sh` starts all of them — ASR, TTS, the vLLM LLM worker, and the orchestrator (`LLM_MODEL=nvidia/Llama-3.3-Nemotron-Super-49B-v1.5 ./launch_workers.sh`); only the frontend is launched separately. The individual commands below show what it runs.
+Run each inside the `dynamo-riva:latest` image, sharing the host network with `etcd`/`nats`/the NIMs. The image bakes in the `riva_nim` package (on `PYTHONPATH`), so `python -m riva_nim.<worker>` runs without mounting the source. `launch_workers.sh` starts all of them — ASR, TTS, the vLLM LLM worker, and the orchestrator (`LLM_MODEL=nvidia/Llama-3.3-Nemotron-Super-49B-v1.5 ./launch_workers.sh`); only the frontend is launched separately. It sources the repo's `examples/common/launch_utils.sh`, so run it from a checkout / mounted worktree (the individual commands below work in the bare image too).
 
 ASR worker (points at the ASR NIM):
 

--- a/examples/riva_cascaded_pipeline/container/Dockerfile
+++ b/examples/riva_cascaded_pipeline/container/Dockerfile
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Layer the RIVA NIM Python client on top of a Dynamo image so the cascaded
+# voice pipeline workers (ASR/TTS) can reach RIVA gRPC services. The base
+# defaults to the vLLM runtime image (which carries the Dynamo Python bindings);
+# override with --build-arg BASE_IMAGE=... to layer on a different Dynamo image.
+ARG BASE_IMAGE=dynamo:latest-vllm-runtime
+FROM ${BASE_IMAGE}
+
+COPY requirements.txt /tmp/riva-requirements.txt
+RUN python3 -m pip install --no-cache-dir -r /tmp/riva-requirements.txt

--- a/examples/riva_cascaded_pipeline/container/Dockerfile
+++ b/examples/riva_cascaded_pipeline/container/Dockerfile
@@ -10,3 +10,8 @@ FROM ${BASE_IMAGE}
 
 COPY requirements.txt /tmp/riva-requirements.txt
 RUN python3 -m pip install --no-cache-dir -r /tmp/riva-requirements.txt
+
+# Bake the worker package in (on PYTHONPATH) so `python -m riva_nim.<worker>`
+# runs without bind-mounting the source. A mounted checkout still overrides it.
+COPY riva_nim/ /opt/riva-cascaded-pipeline/riva_nim/
+ENV PYTHONPATH=/opt/riva-cascaded-pipeline

--- a/examples/riva_cascaded_pipeline/container/build.sh
+++ b/examples/riva_cascaded_pipeline/container/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Build a Dynamo image with the RIVA NIM Python client layered on top, for the
+# cascaded voice pipeline example.
+#
+#   BASE_IMAGE  Dynamo image to layer on (default: dynamo:latest-vllm-runtime)
+#   TAG         Output image tag        (default: dynamo-riva:latest)
+
+set -euo pipefail
+
+BASE_IMAGE="${BASE_IMAGE:-dynamo:latest-vllm-runtime}"
+TAG="${TAG:-dynamo-riva:latest}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(dirname "${SCRIPT_DIR}")"
+
+echo "Building ${TAG} from base ${BASE_IMAGE}"
+docker build \
+  --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+  -t "${TAG}" \
+  -f "${SCRIPT_DIR}/Dockerfile" \
+  "${EXAMPLE_DIR}"
+
+echo "Built ${TAG}"

--- a/examples/riva_cascaded_pipeline/launch_workers.sh
+++ b/examples/riva_cascaded_pipeline/launch_workers.sh
@@ -2,15 +2,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Launch the cascaded voice pipeline workers (ASR, TTS, vLLM LLM, orchestrator).
-# Run from a checkout / mounted worktree inside the dynamo-riva image, with
-# etcd/nats and the RIVA NIMs already reachable. The dynamo.frontend is launched
-# separately (see README.md).
+# Launch the full cascaded voice pipeline (ASR, TTS, vLLM LLM, orchestrator,
+# and the dynamo.frontend). Run from a checkout / mounted worktree inside the
+# dynamo-riva image, with etcd/nats and the RIVA NIMs already reachable.
 #
-#   LLM_MODEL        HF model the vLLM worker serves (required)
-#   ASR_RIVA_SERVER  ASR NIM gRPC host:port (default: localhost:50051)
-#   TTS_RIVA_SERVER  TTS NIM gRPC host:port (default: localhost:50052)
-#   VLLM_EXTRA_ARGS  Extra args for the vLLM worker (optional, e.g. "--tensor-parallel-size 2")
+#   LLM_MODEL           HF model the vLLM worker serves (required)
+#   ASR_RIVA_SERVER     ASR NIM gRPC host:port (default: localhost:50051)
+#   TTS_RIVA_SERVER     TTS NIM gRPC host:port (default: localhost:50052)
+#   VLLM_EXTRA_ARGS     Extra args for the vLLM worker (optional, e.g. "--tensor-parallel-size 2")
+#   FRONTEND_EXTRA_ARGS Extra args for dynamo.frontend (optional, e.g. "--http-port 8000")
 
 set -euo pipefail
 
@@ -23,6 +23,7 @@ ASR_RIVA_SERVER="${ASR_RIVA_SERVER:-localhost:50051}"
 TTS_RIVA_SERVER="${TTS_RIVA_SERVER:-localhost:50052}"
 LLM_MODEL="${LLM_MODEL:-}"
 VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS:-}"
+FRONTEND_EXTRA_ARGS="${FRONTEND_EXTRA_ARGS:-}"
 
 if [[ -z "${LLM_MODEL}" ]]; then
   echo "LLM_MODEL is required (the HF model the vLLM worker serves)." >&2
@@ -51,5 +52,10 @@ python -m riva_nim.orchestrator \
   --tts-endpoint "${TTS_ENDPOINT}" \
   --llm-model "${LLM_MODEL}" &
 
-echo "Workers started. Launch dynamo.frontend separately. Ctrl-C to stop."
+echo "Starting dynamo.frontend (realtime WS at /v1/realtime) ..."
+# Word-splitting on FRONTEND_EXTRA_ARGS is intentional so callers can pass flags.
+# shellcheck disable=SC2086
+python -m dynamo.frontend ${FRONTEND_EXTRA_ARGS} &
+
+echo "All components started (ASR, TTS, vLLM, orchestrator, frontend). Ctrl-C to stop."
 wait_any_exit

--- a/examples/riva_cascaded_pipeline/launch_workers.sh
+++ b/examples/riva_cascaded_pipeline/launch_workers.sh
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Launch the cascaded voice pipeline workers (ASR, TTS, vLLM LLM, orchestrator).
-# Run from this directory inside the dynamo-riva image, with etcd/nats and the
-# RIVA NIMs already reachable. The dynamo.frontend is launched separately
-# (see README.md).
+# Run from a checkout / mounted worktree inside the dynamo-riva image, with
+# etcd/nats and the RIVA NIMs already reachable. The dynamo.frontend is launched
+# separately (see README.md).
 #
 #   LLM_MODEL        HF model the vLLM worker serves (required)
 #   ASR_RIVA_SERVER  ASR NIM gRPC host:port (default: localhost:50051)
@@ -13,6 +13,11 @@
 #   VLLM_EXTRA_ARGS  Extra args for the vLLM worker (optional, e.g. "--tensor-parallel-size 2")
 
 set -euo pipefail
+
+# Shared launch helper; wait_any_exit tears everything down as soon as any
+# worker exits, so a crash surfaces immediately instead of hanging.
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../common/launch_utils.sh" # wait_any_exit
 
 ASR_RIVA_SERVER="${ASR_RIVA_SERVER:-localhost:50051}"
 TTS_RIVA_SERVER="${TTS_RIVA_SERVER:-localhost:50052}"
@@ -28,23 +33,16 @@ ASR_ENDPOINT="dynamo.riva-asr.generate"
 TTS_ENDPOINT="dynamo.riva-tts.generate"
 LLM_ENDPOINT="dynamo.backend.generate"
 
-pids=()
-cleanup() { kill "${pids[@]}" 2>/dev/null || true; }
-trap cleanup EXIT
-
 echo "Starting ASR worker (riva=${ASR_RIVA_SERVER}) ..."
 python -m riva_nim.asr_worker --riva-server "${ASR_RIVA_SERVER}" --endpoint "${ASR_ENDPOINT}" &
-pids+=($!)
 
 echo "Starting TTS worker (riva=${TTS_RIVA_SERVER}) ..."
 python -m riva_nim.tts_worker --riva-server "${TTS_RIVA_SERVER}" --endpoint "${TTS_ENDPOINT}" &
-pids+=($!)
 
 echo "Starting vLLM LLM worker (model=${LLM_MODEL}) ..."
 # Word-splitting on VLLM_EXTRA_ARGS is intentional so callers can pass flags.
 # shellcheck disable=SC2086
 python -m dynamo.vllm --model "${LLM_MODEL}" --use-vllm-tokenizer ${VLLM_EXTRA_ARGS} &
-pids+=($!)
 
 echo "Starting orchestrator ..."
 python -m riva_nim.orchestrator \
@@ -52,7 +50,6 @@ python -m riva_nim.orchestrator \
   --llm-endpoint "${LLM_ENDPOINT}" \
   --tts-endpoint "${TTS_ENDPOINT}" \
   --llm-model "${LLM_MODEL}" &
-pids+=($!)
 
 echo "Workers started. Launch dynamo.frontend separately. Ctrl-C to stop."
-wait
+wait_any_exit

--- a/examples/riva_cascaded_pipeline/launch_workers.sh
+++ b/examples/riva_cascaded_pipeline/launch_workers.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Launch the cascaded voice pipeline workers (ASR, TTS, vLLM LLM, orchestrator).
+# Run from this directory inside the dynamo-riva image, with etcd/nats and the
+# RIVA NIMs already reachable. The dynamo.frontend is launched separately
+# (see README.md).
+#
+#   LLM_MODEL        HF model the vLLM worker serves (required)
+#   ASR_RIVA_SERVER  ASR NIM gRPC host:port (default: localhost:50051)
+#   TTS_RIVA_SERVER  TTS NIM gRPC host:port (default: localhost:50052)
+#   VLLM_EXTRA_ARGS  Extra args for the vLLM worker (optional, e.g. "--tensor-parallel-size 2")
+
+set -euo pipefail
+
+ASR_RIVA_SERVER="${ASR_RIVA_SERVER:-localhost:50051}"
+TTS_RIVA_SERVER="${TTS_RIVA_SERVER:-localhost:50052}"
+LLM_MODEL="${LLM_MODEL:-}"
+VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS:-}"
+
+if [[ -z "${LLM_MODEL}" ]]; then
+  echo "LLM_MODEL is required (the HF model the vLLM worker serves)." >&2
+  exit 1
+fi
+
+ASR_ENDPOINT="dynamo.riva-asr.generate"
+TTS_ENDPOINT="dynamo.riva-tts.generate"
+LLM_ENDPOINT="dynamo.backend.generate"
+
+pids=()
+cleanup() { kill "${pids[@]}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "Starting ASR worker (riva=${ASR_RIVA_SERVER}) ..."
+python -m riva_nim.asr_worker --riva-server "${ASR_RIVA_SERVER}" --endpoint "${ASR_ENDPOINT}" &
+pids+=($!)
+
+echo "Starting TTS worker (riva=${TTS_RIVA_SERVER}) ..."
+python -m riva_nim.tts_worker --riva-server "${TTS_RIVA_SERVER}" --endpoint "${TTS_ENDPOINT}" &
+pids+=($!)
+
+echo "Starting vLLM LLM worker (model=${LLM_MODEL}) ..."
+# Word-splitting on VLLM_EXTRA_ARGS is intentional so callers can pass flags.
+# shellcheck disable=SC2086
+python -m dynamo.vllm --model "${LLM_MODEL}" --use-vllm-tokenizer ${VLLM_EXTRA_ARGS} &
+pids+=($!)
+
+echo "Starting orchestrator ..."
+python -m riva_nim.orchestrator \
+  --asr-endpoint "${ASR_ENDPOINT}" \
+  --llm-endpoint "${LLM_ENDPOINT}" \
+  --tts-endpoint "${TTS_ENDPOINT}" \
+  --llm-model "${LLM_MODEL}" &
+pids+=($!)
+
+echo "Workers started. Launch dynamo.frontend separately. Ctrl-C to stop."
+wait

--- a/examples/riva_cascaded_pipeline/pytest.ini
+++ b/examples/riva_cascaded_pipeline/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Run async tests without per-test markers, and use this file as the rootdir
+# config so the example's tests don't inherit the repo-root pytest settings
+# (which reference plugins not present in the lean RIVA test image).
+asyncio_mode = auto

--- a/examples/riva_cascaded_pipeline/pytest.ini
+++ b/examples/riva_cascaded_pipeline/pytest.ini
@@ -3,3 +3,8 @@
 # config so the example's tests don't inherit the repo-root pytest settings
 # (which reference plugins not present in the lean RIVA test image).
 asyncio_mode = auto
+# Mirror the repo-registered markers so runs rooted at this dir don't warn.
+markers =
+    pre_merge: marks tests to run before merging
+    unit: marks tests as unit tests
+    gpu_0: marks tests that don't require GPU

--- a/examples/riva_cascaded_pipeline/requirements.txt
+++ b/examples/riva_cascaded_pipeline/requirements.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # RIVA NIM Python client used by the cascaded voice pipeline workers.
 # Pure-Python wheel; pinned for reproducible image builds.
 nvidia-riva-client==2.26.0

--- a/examples/riva_cascaded_pipeline/requirements.txt
+++ b/examples/riva_cascaded_pipeline/requirements.txt
@@ -1,0 +1,3 @@
+# RIVA NIM Python client used by the cascaded voice pipeline workers.
+# Pure-Python wheel; pinned for reproducible image builds.
+nvidia-riva-client==2.26.0

--- a/examples/riva_cascaded_pipeline/riva_nim/__init__.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RIVA NIM worker building blocks for a Dynamo cascaded voice pipeline.
+
+This package wraps RIVA NIM speech connectors (ASR, TTS) as Dynamo workers and
+provides a realtime orchestrator that chains ASR -> LLM -> TTS. It is kept
+self-contained (relative imports only, no dependency on the surrounding
+example) so it can be moved to ``components/src/dynamo/riva/`` by relocating the
+directory without changing import statements.
+
+The package is named ``riva_nim`` rather than ``riva`` so it does not shadow the
+``nvidia-riva-client`` package, which is imported as top-level ``riva``.
+"""

--- a/examples/riva_cascaded_pipeline/riva_nim/asr_worker.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/asr_worker.py
@@ -26,7 +26,7 @@ from .config import (
     add_riva_connection_args,
     riva_connection_config_from_namespace,
 )
-from .riva_client import build_asr_service
+from .riva_client import await_riva_call, build_asr_service
 
 logger = logging.getLogger(__name__)
 configure_dynamo_logging(service_name="riva-asr")
@@ -35,6 +35,7 @@ configure_dynamo_logging(service_name="riva-asr")
 DEFAULT_SAMPLE_RATE_HZ = 16000
 DEFAULT_LANGUAGE_CODE = "en-US"
 DEFAULT_MODEL = ""
+DEFAULT_TIMEOUT_S = 30.0
 
 
 class AsrRequest(BaseModel):
@@ -55,6 +56,7 @@ class AsrBackend:
         sample_rate_hz: Sample rate of the incoming LINEAR_PCM audio.
         language_code: BCP-47 language code passed to RIVA.
         model: RIVA ASR model name; empty lets the server choose.
+        timeout_s: Client-side deadline for the recognize RPC, in seconds.
     """
 
     def __init__(
@@ -63,10 +65,12 @@ class AsrBackend:
         sample_rate_hz: int,
         language_code: str,
         model: str,
+        timeout_s: float,
     ) -> None:
         self.sample_rate_hz = sample_rate_hz
         self.language_code = language_code
         self.model = model
+        self.timeout_s = timeout_s
         self.asr = build_asr_service(connection)
 
     async def generate(self, request: AsrRequest) -> AsrResponse:
@@ -87,10 +91,10 @@ class AsrBackend:
             max_alternatives=1,
             enable_automatic_punctuation=True,
         )
-        # offline_recognize() is a blocking gRPC call; keep it off the event loop.
-        response = await asyncio.to_thread(
-            self.asr.offline_recognize, audio, recognition_config
-        )
+        # future=True submits the RPC and returns a gRPC future; await_riva_call
+        # waits off the event loop with a deadline and cancels on timeout.
+        rpc_future = self.asr.offline_recognize(audio, recognition_config, future=True)
+        response = await await_riva_call(rpc_future, self.timeout_s)
         transcript = " ".join(
             result.alternatives[0].transcript
             for result in response.results
@@ -123,6 +127,12 @@ def _parse_args() -> argparse.Namespace:
         help="RIVA ASR model name (empty lets the server choose).",
     )
     parser.add_argument(
+        "--timeout-s",
+        type=float,
+        default=DEFAULT_TIMEOUT_S,
+        help="Client-side deadline for the recognize RPC, in seconds.",
+    )
+    parser.add_argument(
         "--endpoint",
         default="dynamo.riva-asr.generate",
         help="Dynamo endpoint to serve (namespace.component.endpoint).",
@@ -137,6 +147,7 @@ async def worker(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
         sample_rate_hz=args.sample_rate_hz,
         language_code=args.language_code,
         model=args.model,
+        timeout_s=args.timeout_s,
     )
     endpoint = runtime.endpoint(args.endpoint)
     logger.info("Serving RIVA ASR endpoint %s", args.endpoint)

--- a/examples/riva_cascaded_pipeline/riva_nim/asr_worker.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/asr_worker.py
@@ -4,7 +4,10 @@
 """RIVA ASR worker: transcribe speech to text via a RIVA NIM.
 
 Internal Dynamo worker (called by the orchestrator, not the frontend). Takes a
-base64-encoded audio buffer and returns the recognized transcript.
+base64-encoded audio buffer and returns the recognized transcript. Uses RIVA's
+streaming recognition API (the deployed Parakeet NIM serves a streaming model);
+the full buffer is fed as a sequence of chunks and the final transcript is
+collected.
 """
 
 from __future__ import annotations
@@ -16,7 +19,7 @@ import logging
 
 import uvloop
 from pydantic import BaseModel, Field
-from riva.client import AudioEncoding, RecognitionConfig
+from riva.client import AudioEncoding, RecognitionConfig, StreamingRecognitionConfig
 
 from dynamo.runtime import DistributedRuntime, dynamo_endpoint, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -26,16 +29,20 @@ from .config import (
     add_riva_connection_args,
     riva_connection_config_from_namespace,
 )
-from .riva_client import await_riva_call, build_asr_service
+from .riva_client import build_asr_service
 
 logger = logging.getLogger(__name__)
 configure_dynamo_logging(service_name="riva-asr")
 
-# RIVA ASR default: 16 kHz LINEAR_PCM input. Empty model lets the server pick.
+# RIVA ASR: 16 kHz LINEAR_PCM input, Parakeet streaming model.
 DEFAULT_SAMPLE_RATE_HZ = 16000
 DEFAULT_LANGUAGE_CODE = "en-US"
-DEFAULT_MODEL = ""
+DEFAULT_MODEL = "parakeet-1.1b-en-US-asr-streaming"
 DEFAULT_TIMEOUT_S = 30.0
+
+# Feed the buffered utterance to the streaming API in fixed-size PCM frames
+# (even byte count keeps 16-bit samples intact).
+_CHUNK_BYTES = 8192
 
 
 class AsrRequest(BaseModel):
@@ -80,27 +87,43 @@ class AsrBackend:
             request: The base64-encoded LINEAR_PCM audio buffer.
 
         Returns:
-            The recognized transcript (concatenated across result segments).
+            The recognized transcript (concatenated across final segments).
         """
         audio = base64.b64decode(request.audio_base64)
-        recognition_config = RecognitionConfig(
-            encoding=AudioEncoding.LINEAR_PCM,
-            sample_rate_hertz=self.sample_rate_hz,
-            language_code=self.language_code,
-            model=self.model,
-            max_alternatives=1,
-            enable_automatic_punctuation=True,
-        )
-        # future=True submits the RPC and returns a gRPC future; await_riva_call
-        # waits off the event loop with a deadline and cancels on timeout.
-        rpc_future = self.asr.offline_recognize(audio, recognition_config, future=True)
-        response = await await_riva_call(rpc_future, self.timeout_s)
-        transcript = " ".join(
-            result.alternatives[0].transcript
-            for result in response.results
-            if result.alternatives
+        if not audio:
+            return AsrResponse(transcript="")
+        # streaming_response_generator is a blocking generator; run it off the
+        # event loop and bound the whole exchange with the client-side deadline.
+        transcript = await asyncio.wait_for(
+            asyncio.to_thread(self._transcribe, audio), self.timeout_s
         )
         return AsrResponse(transcript=transcript)
+
+    def _transcribe(self, audio: bytes) -> str:
+        """Stream ``audio`` to RIVA and join the final transcript segments."""
+        streaming_config = StreamingRecognitionConfig(
+            config=RecognitionConfig(
+                encoding=AudioEncoding.LINEAR_PCM,
+                sample_rate_hertz=self.sample_rate_hz,
+                language_code=self.language_code,
+                model=self.model,
+                max_alternatives=1,
+                enable_automatic_punctuation=True,
+            ),
+            interim_results=False,
+        )
+        chunks = [
+            audio[i : i + _CHUNK_BYTES] for i in range(0, len(audio), _CHUNK_BYTES)
+        ]
+        responses = self.asr.streaming_response_generator(
+            audio_chunks=chunks, streaming_config=streaming_config
+        )
+        return " ".join(
+            result.alternatives[0].transcript
+            for response in responses
+            for result in response.results
+            if result.is_final and result.alternatives
+        )
 
     @dynamo_endpoint(AsrRequest, AsrResponse)
     async def recognize_endpoint(self, request: AsrRequest):

--- a/examples/riva_cascaded_pipeline/riva_nim/asr_worker.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/asr_worker.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RIVA ASR worker: transcribe speech to text via a RIVA NIM.
+
+Internal Dynamo worker (called by the orchestrator, not the frontend). Takes a
+base64-encoded audio buffer and returns the recognized transcript.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import logging
+
+import uvloop
+from pydantic import BaseModel, Field
+from riva.client import AudioEncoding, RecognitionConfig
+
+from dynamo.runtime import DistributedRuntime, dynamo_endpoint, dynamo_worker
+from dynamo.runtime.logging import configure_dynamo_logging
+
+from .config import (
+    RivaConnectionConfig,
+    add_riva_connection_args,
+    riva_connection_config_from_namespace,
+)
+from .riva_client import build_asr_service
+
+logger = logging.getLogger(__name__)
+configure_dynamo_logging(service_name="riva-asr")
+
+# RIVA ASR default: 16 kHz LINEAR_PCM input. Empty model lets the server pick.
+DEFAULT_SAMPLE_RATE_HZ = 16000
+DEFAULT_LANGUAGE_CODE = "en-US"
+DEFAULT_MODEL = ""
+
+
+class AsrRequest(BaseModel):
+    audio_base64: str = Field(
+        description="Base64-encoded LINEAR_PCM audio to transcribe."
+    )
+
+
+class AsrResponse(BaseModel):
+    transcript: str = Field(description="Recognized transcript text.")
+
+
+class AsrBackend:
+    """Wraps a RIVA ``ASRService`` as an audio-to-text endpoint.
+
+    Args:
+        connection: RIVA gRPC connection settings.
+        sample_rate_hz: Sample rate of the incoming LINEAR_PCM audio.
+        language_code: BCP-47 language code passed to RIVA.
+        model: RIVA ASR model name; empty lets the server choose.
+    """
+
+    def __init__(
+        self,
+        connection: RivaConnectionConfig,
+        sample_rate_hz: int,
+        language_code: str,
+        model: str,
+    ) -> None:
+        self.sample_rate_hz = sample_rate_hz
+        self.language_code = language_code
+        self.model = model
+        self.asr = build_asr_service(connection)
+
+    async def generate(self, request: AsrRequest) -> AsrResponse:
+        """Transcribe ``request.audio_base64`` and return the recognized text.
+
+        Args:
+            request: The base64-encoded LINEAR_PCM audio buffer.
+
+        Returns:
+            The recognized transcript (concatenated across result segments).
+        """
+        audio = base64.b64decode(request.audio_base64)
+        recognition_config = RecognitionConfig(
+            encoding=AudioEncoding.LINEAR_PCM,
+            sample_rate_hertz=self.sample_rate_hz,
+            language_code=self.language_code,
+            model=self.model,
+            max_alternatives=1,
+            enable_automatic_punctuation=True,
+        )
+        # offline_recognize() is a blocking gRPC call; keep it off the event loop.
+        response = await asyncio.to_thread(
+            self.asr.offline_recognize, audio, recognition_config
+        )
+        transcript = " ".join(
+            result.alternatives[0].transcript
+            for result in response.results
+            if result.alternatives
+        )
+        return AsrResponse(transcript=transcript)
+
+    @dynamo_endpoint(AsrRequest, AsrResponse)
+    async def recognize_endpoint(self, request: AsrRequest):
+        yield (await self.generate(request)).model_dump()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="RIVA ASR worker for Dynamo")
+    add_riva_connection_args(parser)
+    parser.add_argument(
+        "--sample-rate-hz",
+        type=int,
+        default=DEFAULT_SAMPLE_RATE_HZ,
+        help="Sample rate of the incoming audio in Hz.",
+    )
+    parser.add_argument(
+        "--language-code",
+        default=DEFAULT_LANGUAGE_CODE,
+        help="BCP-47 language code.",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help="RIVA ASR model name (empty lets the server choose).",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default="dynamo.riva-asr.generate",
+        help="Dynamo endpoint to serve (namespace.component.endpoint).",
+    )
+    return parser.parse_args()
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
+    backend = AsrBackend(
+        riva_connection_config_from_namespace(args),
+        sample_rate_hz=args.sample_rate_hz,
+        language_code=args.language_code,
+        model=args.model,
+    )
+    endpoint = runtime.endpoint(args.endpoint)
+    logger.info("Serving RIVA ASR endpoint %s", args.endpoint)
+    await endpoint.serve_endpoint(backend.recognize_endpoint)
+
+
+if __name__ == "__main__":
+    uvloop.install()
+    asyncio.run(worker(_parse_args()))

--- a/examples/riva_cascaded_pipeline/riva_nim/config.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/config.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Connection configuration for RIVA NIM gRPC services."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Optional
+
+# Default RIVA gRPC target for a local deployment. Shared by the dataclass
+# default and the CLI default so the two never drift.
+DEFAULT_RIVA_SERVER = "localhost:50051"
+
+
+@dataclass
+class RivaConnectionConfig:
+    """Connection settings for a RIVA NIM gRPC endpoint.
+
+    Attributes:
+        server: ``host:port`` of the RIVA gRPC server. Defaults to a local
+            deployment; override for a remote host or the NVCF endpoint
+            (``grpc.nvcf.nvidia.com:443``).
+        use_ssl: Whether to use a TLS channel. Required for NVCF.
+        api_key: NVCF API key. When set, sent as an ``authorization: Bearer``
+            gRPC metadata entry on every call.
+        function_id: NVCF function id. When set, sent as a ``function-id``
+            gRPC metadata entry on every call.
+        ssl_root_cert: Optional path to a TLS root certificate.
+    """
+
+    server: str = DEFAULT_RIVA_SERVER
+    use_ssl: bool = False
+    api_key: Optional[str] = None
+    function_id: Optional[str] = None
+    ssl_root_cert: Optional[str] = None
+
+
+def add_riva_connection_args(parser: argparse.ArgumentParser) -> None:
+    """Add a "RIVA connection" argument group to ``parser``."""
+    group = parser.add_argument_group("RIVA connection")
+    group.add_argument(
+        "--riva-server",
+        default=DEFAULT_RIVA_SERVER,
+        help=f"host:port of the RIVA gRPC server (default: {DEFAULT_RIVA_SERVER}).",
+    )
+    group.add_argument(
+        "--riva-use-ssl",
+        action="store_true",
+        help="Use a TLS channel (required for NVCF).",
+    )
+    group.add_argument(
+        "--riva-api-key",
+        default=None,
+        help="NVCF API key, sent as an authorization Bearer token.",
+    )
+    group.add_argument(
+        "--riva-function-id",
+        default=None,
+        help="NVCF function id, sent as function-id metadata.",
+    )
+    group.add_argument(
+        "--riva-ssl-root-cert",
+        default=None,
+        help="Path to a TLS root certificate.",
+    )
+
+
+def riva_connection_config_from_namespace(
+    args: argparse.Namespace,
+) -> RivaConnectionConfig:
+    """Build a :class:`RivaConnectionConfig` from args parsed by :func:`add_riva_connection_args`."""
+    return RivaConnectionConfig(
+        server=args.riva_server,
+        use_ssl=args.riva_use_ssl,
+        api_key=args.riva_api_key,
+        function_id=args.riva_function_id,
+        ssl_root_cert=args.riva_ssl_root_cert,
+    )

--- a/examples/riva_cascaded_pipeline/riva_nim/orchestrator.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/orchestrator.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import base64
+import binascii
 import logging
 import uuid
 from typing import AsyncIterator
@@ -40,6 +41,14 @@ DEFAULT_LLM_MODEL = ""
 
 def _event_id() -> str:
     return f"event_{uuid.uuid4().hex}"
+
+
+def _error_event(error_type: str, code: str, message: str) -> dict:
+    return {
+        "type": "error",
+        "event_id": _event_id(),
+        "error": {"type": error_type, "code": code, "message": message},
+    }
 
 
 def _response_payload(response_id: str, status: str) -> dict:
@@ -170,10 +179,23 @@ class CascadedPipeline:
             elif event_type == "input_audio_buffer.append":
                 audio_chunks.append(event.get("audio", ""))
             elif event_type == "input_audio_buffer.commit":
-                # Concatenate the raw PCM bytes (not the base64 strings) before
-                # handing the full utterance to ASR, then reset for the next turn.
-                audio = b"".join(base64.b64decode(chunk) for chunk in audio_chunks)
+                chunks = audio_chunks
                 audio_chunks = []
+                if not chunks:
+                    # Commit with no buffered audio: nothing to respond to.
+                    continue
+                # Concatenate the raw PCM bytes (not the base64 strings). Malformed
+                # client audio is a client error, so report it rather than letting
+                # the decode exception tear down the realtime stream.
+                try:
+                    audio = b"".join(
+                        base64.b64decode(chunk, validate=True) for chunk in chunks
+                    )
+                except (binascii.Error, ValueError) as exc:
+                    yield _error_event(
+                        "invalid_request_error", "invalid_audio", str(exc)
+                    )
+                    continue
                 # A downstream worker failure should surface to the realtime
                 # client as an error event, not tear down the whole session.
                 try:
@@ -183,25 +205,13 @@ class CascadedPipeline:
                         yield output
                 except Exception as exc:
                     logger.exception("Cascaded pipeline turn failed")
-                    yield {
-                        "type": "error",
-                        "event_id": _event_id(),
-                        "error": {
-                            "type": "server_error",
-                            "code": "pipeline_error",
-                            "message": str(exc),
-                        },
-                    }
+                    yield _error_event("server_error", "pipeline_error", str(exc))
             else:
-                yield {
-                    "type": "error",
-                    "event_id": _event_id(),
-                    "error": {
-                        "type": "invalid_request_error",
-                        "code": "unsupported_client_event",
-                        "message": f"orchestrator does not support {event_type}",
-                    },
-                }
+                yield _error_event(
+                    "invalid_request_error",
+                    "unsupported_client_event",
+                    f"orchestrator does not support {event_type}",
+                )
 
 
 def _parse_args() -> argparse.Namespace:

--- a/examples/riva_cascaded_pipeline/riva_nim/orchestrator.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/orchestrator.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Realtime orchestrator for the RIVA cascaded voice pipeline.
+
+Serves a ``ModelType.Realtime`` bidirectional endpoint. The user's utterance
+streams in as ``input_audio_buffer.append`` events, which are accumulated; an
+``input_audio_buffer.commit`` marks end-of-turn and triggers the response:
+ASR (audio -> transcript) -> LLM (chat, text -> text) -> TTS (text -> audio),
+emitted back as the OpenAI-realtime ``response.*`` event sequence.
+
+The downstream ASR / LLM / TTS workers are reached as Dynamo endpoint clients,
+so this engine holds no RIVA connection itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import logging
+import uuid
+from typing import AsyncIterator
+
+import uvloop
+
+from dynamo.llm import ModelInput, ModelType, WorkerType, register_model
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime.logging import configure_dynamo_logging
+
+logger = logging.getLogger(__name__)
+configure_dynamo_logging(service_name="riva-orchestrator")
+
+DEFAULT_MODEL_NAME = "riva-voice-agent"
+DEFAULT_ASR_ENDPOINT = "dynamo.riva-asr.generate"
+DEFAULT_TTS_ENDPOINT = "dynamo.riva-tts.generate"
+DEFAULT_LLM_ENDPOINT = "dynamo.backend.generate"
+DEFAULT_LLM_MODEL = ""
+
+
+def _event_id() -> str:
+    return f"event_{uuid.uuid4().hex}"
+
+
+def _response_payload(response_id: str, status: str) -> dict:
+    """Minimal ``RealtimeResponse`` payload accepted by the frontend's typed reader."""
+    return {
+        "id": response_id,
+        "max_output_tokens": "inf",
+        "object": "realtime.response",
+        "output": [],
+        "output_modalities": ["audio"],
+        "status": status,
+    }
+
+
+class CascadedPipeline:
+    """Drives ASR -> LLM -> TTS for one realtime session.
+
+    Args:
+        asr_client: Dynamo client for the RIVA ASR worker.
+        llm_client: Dynamo client for the LLM chat worker (text-in-text-out).
+        tts_client: Dynamo client for the RIVA TTS worker.
+        llm_model: Model name sent in the chat request to the LLM worker.
+    """
+
+    def __init__(self, asr_client, llm_client, tts_client, llm_model: str) -> None:
+        self.asr_client = asr_client
+        self.llm_client = llm_client
+        self.tts_client = tts_client
+        self.llm_model = llm_model
+
+    async def _recognize(self, audio_base64: str) -> str:
+        """Send accumulated audio to the ASR worker and return the transcript."""
+        stream = await self.asr_client.round_robin({"audio_base64": audio_base64})
+        async for response in stream:
+            return response.data()["transcript"]
+        return ""
+
+    async def _chat(self, text: str) -> str:
+        """Send the transcript to the LLM chat worker and return the reply text.
+
+        The LLM worker (vLLM with ``--use-vllm-tokenizer``) streams
+        ``chat.completion.chunk`` dicts; the reply is the concatenation of the
+        ``choices[0].delta.content`` deltas.
+        """
+        request = {
+            "model": self.llm_model,
+            "messages": [{"role": "user", "content": text}],
+            "stream": True,
+        }
+        stream = await self.llm_client.round_robin(request)
+        parts = []
+        async for response in stream:
+            choices = response.data().get("choices") or []
+            if choices:
+                content = choices[0].get("delta", {}).get("content")
+                if content:
+                    parts.append(content)
+        return "".join(parts)
+
+    async def _synthesize(self, text: str) -> str:
+        """Send the reply text to the TTS worker and return base64 audio."""
+        stream = await self.tts_client.round_robin({"text": text})
+        async for response in stream:
+            return response.data()["audio_base64"]
+        return ""
+
+    async def _respond(self, audio_base64: str, context) -> AsyncIterator[dict]:
+        """Run ASR -> LLM -> TTS for one turn and emit the response.* events.
+
+        Checks ``context.is_stopped()`` between stages so a cancelled turn stops
+        before doing further work; cancellation is observed between stages, not
+        mid-stage (the in-flight downstream call still completes).
+        """
+        transcript = await self._recognize(audio_base64)
+        if context.is_stopped():
+            return
+        reply_text = await self._chat(transcript)
+        if context.is_stopped():
+            return
+        reply_audio = await self._synthesize(reply_text)
+        if context.is_stopped():
+            return
+
+        response_id = f"resp_{uuid.uuid4().hex}"
+        item_id = f"item_{uuid.uuid4().hex}"
+        yield {
+            "type": "response.created",
+            "event_id": _event_id(),
+            "response": _response_payload(response_id, "in_progress"),
+        }
+        yield {
+            "type": "response.output_audio.delta",
+            "event_id": _event_id(),
+            "response_id": response_id,
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "delta": reply_audio,
+        }
+        yield {
+            "type": "response.output_audio.done",
+            "event_id": _event_id(),
+            "response_id": response_id,
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+        }
+        yield {
+            "type": "response.done",
+            "event_id": _event_id(),
+            "response": _response_payload(response_id, "completed"),
+        }
+
+    async def handle(self, request_stream, context) -> AsyncIterator[dict]:
+        """Bidirectional realtime engine: accumulate audio, respond on commit."""
+        audio_chunks: list[str] = []
+        async for event in request_stream:
+            if context.is_stopped():
+                return
+            event_type = event.get("type") if isinstance(event, dict) else None
+
+            if event_type == "session.update":
+                yield {
+                    "type": "session.updated",
+                    "event_id": _event_id(),
+                    "session": event.get("session"),
+                }
+            elif event_type == "input_audio_buffer.append":
+                audio_chunks.append(event.get("audio", ""))
+            elif event_type == "input_audio_buffer.commit":
+                # Concatenate the raw PCM bytes (not the base64 strings) before
+                # handing the full utterance to ASR, then reset for the next turn.
+                audio = b"".join(base64.b64decode(chunk) for chunk in audio_chunks)
+                audio_chunks = []
+                # A downstream worker failure should surface to the realtime
+                # client as an error event, not tear down the whole session.
+                try:
+                    async for output in self._respond(
+                        base64.b64encode(audio).decode(), context
+                    ):
+                        yield output
+                except Exception as exc:
+                    logger.exception("Cascaded pipeline turn failed")
+                    yield {
+                        "type": "error",
+                        "event_id": _event_id(),
+                        "error": {
+                            "type": "server_error",
+                            "code": "pipeline_error",
+                            "message": str(exc),
+                        },
+                    }
+            else:
+                yield {
+                    "type": "error",
+                    "event_id": _event_id(),
+                    "error": {
+                        "type": "invalid_request_error",
+                        "code": "unsupported_client_event",
+                        "message": f"orchestrator does not support {event_type}",
+                    },
+                }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="RIVA cascaded-pipeline orchestrator")
+    parser.add_argument(
+        "--model-name",
+        default=DEFAULT_MODEL_NAME,
+        help="Realtime model name to register.",
+    )
+    parser.add_argument(
+        "--asr-endpoint", default=DEFAULT_ASR_ENDPOINT, help="ASR worker endpoint."
+    )
+    parser.add_argument(
+        "--llm-endpoint", default=DEFAULT_LLM_ENDPOINT, help="LLM chat worker endpoint."
+    )
+    parser.add_argument(
+        "--tts-endpoint", default=DEFAULT_TTS_ENDPOINT, help="TTS worker endpoint."
+    )
+    parser.add_argument(
+        "--llm-model",
+        default=DEFAULT_LLM_MODEL,
+        help="Model name sent to the LLM worker.",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default="dynamo.riva-orchestrator.generate",
+        help="Realtime endpoint to serve.",
+    )
+    return parser.parse_args()
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
+    asr_client = await runtime.endpoint(args.asr_endpoint).client()
+    llm_client = await runtime.endpoint(args.llm_endpoint).client()
+    tts_client = await runtime.endpoint(args.tts_endpoint).client()
+    pipeline = CascadedPipeline(asr_client, llm_client, tts_client, args.llm_model)
+
+    endpoint = runtime.endpoint(args.endpoint)
+    await register_model(
+        ModelInput.Text,
+        ModelType.Realtime,
+        endpoint,
+        args.model_name,
+        model_name=args.model_name,
+        worker_type=WorkerType.Aggregated,
+    )
+    logger.info("Serving realtime orchestrator endpoint %s", args.endpoint)
+    await endpoint.serve_bidirectional_endpoint(pipeline.handle)
+
+
+if __name__ == "__main__":
+    uvloop.install()
+    asyncio.run(worker(_parse_args()))

--- a/examples/riva_cascaded_pipeline/riva_nim/riva_client.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/riva_client.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import asyncio
+
+import grpc
 from riva.client import ASRService, Auth, SpeechSynthesisService
 
 from .config import RivaConnectionConfig
@@ -45,3 +48,29 @@ def build_tts_service(config: RivaConnectionConfig) -> SpeechSynthesisService:
 def build_asr_service(config: RivaConnectionConfig) -> ASRService:
     """Create a RIVA ``ASRService`` for the given connection config."""
     return ASRService(build_auth(config))
+
+
+async def await_riva_call(rpc_future: grpc.Future, timeout_s: float):
+    """Await a RIVA gRPC future with a client-side deadline, off the event loop.
+
+    RIVA's ``ASRService`` / ``SpeechSynthesisService`` methods accept
+    ``future=True`` to return a gRPC future. Waiting via ``future.result(timeout)``
+    bounds the wait and — unlike ``asyncio.wait_for`` around a blocking call —
+    ``future.cancel()`` on timeout actually terminates the in-flight RPC and
+    frees the worker thread, so an unresponsive backend can't tie up capacity.
+
+    Args:
+        rpc_future: A gRPC future from a ``future=True`` RIVA call.
+        timeout_s: Client-side deadline in seconds.
+
+    Returns:
+        The RPC response.
+
+    Raises:
+        grpc.FutureTimeoutError: If the deadline elapses (the RPC is cancelled).
+    """
+    try:
+        return await asyncio.to_thread(rpc_future.result, timeout_s)
+    except grpc.FutureTimeoutError:
+        rpc_future.cancel()
+        raise

--- a/examples/riva_cascaded_pipeline/riva_nim/riva_client.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/riva_client.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RIVA gRPC connection helpers shared by the ASR and TTS workers."""
+
+from __future__ import annotations
+
+from riva.client import ASRService, Auth, SpeechSynthesisService
+
+from .config import RivaConnectionConfig
+
+
+def build_auth(config: RivaConnectionConfig) -> Auth:
+    """Create a RIVA ``Auth`` for the given connection config.
+
+    A local RIVA server uses an insecure channel with no metadata. The NVCF
+    endpoint uses a TLS channel (``use_ssl``) plus per-call gRPC metadata: the
+    ``function-id`` and an ``authorization`` Bearer token, attached only when
+    the corresponding config fields are set.
+
+    Args:
+        config: The RIVA connection settings.
+
+    Returns:
+        A ``riva.client.Auth`` configured for the target server.
+    """
+    metadata = []
+    if config.function_id:
+        metadata.append(["function-id", config.function_id])
+    if config.api_key:
+        metadata.append(["authorization", f"Bearer {config.api_key}"])
+    return Auth(
+        ssl_root_cert=config.ssl_root_cert,
+        use_ssl=config.use_ssl,
+        uri=config.server,
+        metadata_args=metadata or None,
+    )
+
+
+def build_tts_service(config: RivaConnectionConfig) -> SpeechSynthesisService:
+    """Create a RIVA ``SpeechSynthesisService`` (TTS) for the given connection config."""
+    return SpeechSynthesisService(build_auth(config))
+
+
+def build_asr_service(config: RivaConnectionConfig) -> ASRService:
+    """Create a RIVA ``ASRService`` for the given connection config."""
+    return ASRService(build_auth(config))

--- a/examples/riva_cascaded_pipeline/riva_nim/tts_worker.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/tts_worker.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RIVA TTS worker: synthesize speech from text via a RIVA NIM.
+
+Internal Dynamo worker (called by the orchestrator, not the frontend). Takes a
+text request and returns the synthesized audio base64-encoded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import logging
+
+import uvloop
+from pydantic import BaseModel, Field
+
+from dynamo.runtime import DistributedRuntime, dynamo_endpoint, dynamo_worker
+from dynamo.runtime.logging import configure_dynamo_logging
+
+from .config import (
+    RivaConnectionConfig,
+    add_riva_connection_args,
+    riva_connection_config_from_namespace,
+)
+from .riva_client import build_tts_service
+
+logger = logging.getLogger(__name__)
+configure_dynamo_logging(service_name="riva-tts")
+
+# RIVA TTS defaults: Magpie multilingual voice at 22.05 kHz LINEAR_PCM.
+DEFAULT_VOICE = "Magpie-Multilingual.EN-US.Aria"
+DEFAULT_LANGUAGE_CODE = "en-US"
+DEFAULT_SAMPLE_RATE_HZ = 22050
+
+
+class TtsRequest(BaseModel):
+    text: str = Field(description="Text to synthesize into speech.")
+
+
+class TtsResponse(BaseModel):
+    audio_base64: str = Field(description="Base64-encoded synthesized audio.")
+    sample_rate_hz: int = Field(description="Sample rate of the audio, in Hz.")
+    encoding: str = Field(default="LINEAR_PCM", description="Audio sample encoding.")
+
+
+class TtsBackend:
+    """Wraps a RIVA ``SpeechSynthesisService`` as a text-to-audio endpoint.
+
+    Args:
+        connection: RIVA gRPC connection settings.
+        voice: RIVA voice name to synthesize with.
+        language_code: BCP-47 language code passed to RIVA.
+        sample_rate_hz: Output sample rate requested from RIVA.
+    """
+
+    def __init__(
+        self,
+        connection: RivaConnectionConfig,
+        voice: str,
+        language_code: str,
+        sample_rate_hz: int,
+    ) -> None:
+        self.voice = voice
+        self.language_code = language_code
+        self.sample_rate_hz = sample_rate_hz
+        self.tts = build_tts_service(connection)
+
+    async def generate(self, request: TtsRequest) -> TtsResponse:
+        """Synthesize ``request.text`` and return the audio base64-encoded.
+
+        Args:
+            request: The text to synthesize.
+
+        Returns:
+            The synthesized audio as base64-encoded ``LINEAR_PCM`` at the
+            worker's configured sample rate.
+        """
+        # synthesize() is a blocking gRPC call; keep it off the event loop.
+        response = await asyncio.to_thread(
+            self.tts.synthesize,
+            request.text,
+            voice_name=self.voice,
+            language_code=self.language_code,
+            sample_rate_hz=self.sample_rate_hz,
+        )
+        return TtsResponse(
+            audio_base64=base64.b64encode(response.audio).decode(),
+            sample_rate_hz=self.sample_rate_hz,
+        )
+
+    @dynamo_endpoint(TtsRequest, TtsResponse)
+    async def synthesize_endpoint(self, request: TtsRequest):
+        yield (await self.generate(request)).model_dump()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="RIVA TTS worker for Dynamo")
+    add_riva_connection_args(parser)
+    parser.add_argument("--voice", default=DEFAULT_VOICE, help="RIVA voice name.")
+    parser.add_argument(
+        "--language-code",
+        default=DEFAULT_LANGUAGE_CODE,
+        help="BCP-47 language code.",
+    )
+    parser.add_argument(
+        "--sample-rate-hz",
+        type=int,
+        default=DEFAULT_SAMPLE_RATE_HZ,
+        help="Output sample rate in Hz.",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default="dynamo.riva-tts.generate",
+        help="Dynamo endpoint to serve (namespace.component.endpoint).",
+    )
+    return parser.parse_args()
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
+    backend = TtsBackend(
+        riva_connection_config_from_namespace(args),
+        voice=args.voice,
+        language_code=args.language_code,
+        sample_rate_hz=args.sample_rate_hz,
+    )
+    endpoint = runtime.endpoint(args.endpoint)
+    logger.info("Serving RIVA TTS endpoint %s", args.endpoint)
+    await endpoint.serve_endpoint(backend.synthesize_endpoint)
+
+
+if __name__ == "__main__":
+    uvloop.install()
+    asyncio.run(worker(_parse_args()))

--- a/examples/riva_cascaded_pipeline/riva_nim/tts_worker.py
+++ b/examples/riva_cascaded_pipeline/riva_nim/tts_worker.py
@@ -25,7 +25,7 @@ from .config import (
     add_riva_connection_args,
     riva_connection_config_from_namespace,
 )
-from .riva_client import build_tts_service
+from .riva_client import await_riva_call, build_tts_service
 
 logger = logging.getLogger(__name__)
 configure_dynamo_logging(service_name="riva-tts")
@@ -34,6 +34,7 @@ configure_dynamo_logging(service_name="riva-tts")
 DEFAULT_VOICE = "Magpie-Multilingual.EN-US.Aria"
 DEFAULT_LANGUAGE_CODE = "en-US"
 DEFAULT_SAMPLE_RATE_HZ = 22050
+DEFAULT_TIMEOUT_S = 30.0
 
 
 class TtsRequest(BaseModel):
@@ -54,6 +55,7 @@ class TtsBackend:
         voice: RIVA voice name to synthesize with.
         language_code: BCP-47 language code passed to RIVA.
         sample_rate_hz: Output sample rate requested from RIVA.
+        timeout_s: Client-side deadline for the synthesize RPC, in seconds.
     """
 
     def __init__(
@@ -62,10 +64,12 @@ class TtsBackend:
         voice: str,
         language_code: str,
         sample_rate_hz: int,
+        timeout_s: float,
     ) -> None:
         self.voice = voice
         self.language_code = language_code
         self.sample_rate_hz = sample_rate_hz
+        self.timeout_s = timeout_s
         self.tts = build_tts_service(connection)
 
     async def generate(self, request: TtsRequest) -> TtsResponse:
@@ -78,14 +82,16 @@ class TtsBackend:
             The synthesized audio as base64-encoded ``LINEAR_PCM`` at the
             worker's configured sample rate.
         """
-        # synthesize() is a blocking gRPC call; keep it off the event loop.
-        response = await asyncio.to_thread(
-            self.tts.synthesize,
+        # future=True submits the RPC and returns a gRPC future; await_riva_call
+        # waits off the event loop with a deadline and cancels on timeout.
+        rpc_future = self.tts.synthesize(
             request.text,
             voice_name=self.voice,
             language_code=self.language_code,
             sample_rate_hz=self.sample_rate_hz,
+            future=True,
         )
+        response = await await_riva_call(rpc_future, self.timeout_s)
         return TtsResponse(
             audio_base64=base64.b64encode(response.audio).decode(),
             sample_rate_hz=self.sample_rate_hz,
@@ -112,6 +118,12 @@ def _parse_args() -> argparse.Namespace:
         help="Output sample rate in Hz.",
     )
     parser.add_argument(
+        "--timeout-s",
+        type=float,
+        default=DEFAULT_TIMEOUT_S,
+        help="Client-side deadline for the synthesize RPC, in seconds.",
+    )
+    parser.add_argument(
         "--endpoint",
         default="dynamo.riva-tts.generate",
         help="Dynamo endpoint to serve (namespace.component.endpoint).",
@@ -126,6 +138,7 @@ async def worker(runtime: DistributedRuntime, args: argparse.Namespace) -> None:
         voice=args.voice,
         language_code=args.language_code,
         sample_rate_hz=args.sample_rate_hz,
+        timeout_s=args.timeout_s,
     )
     endpoint = runtime.endpoint(args.endpoint)
     logger.info("Serving RIVA TTS endpoint %s", args.endpoint)

--- a/examples/riva_cascaded_pipeline/tests/conftest.py
+++ b/examples/riva_cascaded_pipeline/tests/conftest.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+# Put the example root on sys.path so `import riva_nim` resolves to the local
+# package. The package is deliberately NOT named `riva`, so it does not shadow
+# the nvidia-riva-client package (imported as top-level `riva`).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/examples/riva_cascaded_pipeline/tests/test_asr_worker.py
+++ b/examples/riva_cascaded_pipeline/tests/test_asr_worker.py
@@ -9,6 +9,7 @@ Mocks ``riva.client.ASRService`` so it runs without a RIVA server.
 import base64
 from unittest.mock import MagicMock
 
+import grpc
 import pytest
 from riva.client import AudioEncoding
 from riva_nim import asr_worker, config
@@ -23,6 +24,7 @@ def backend():
         sample_rate_hz=16000,
         language_code="en-US",
         model="",
+        timeout_s=5.0,
     )
     be.asr = MagicMock()
     return be
@@ -35,7 +37,10 @@ async def test_generate_recognizes_audio_to_transcript(backend):
     result.alternatives = [alternative]
     recognize_response = MagicMock()
     recognize_response.results = [result]
-    backend.asr.offline_recognize.return_value = recognize_response
+    # future=True returns a gRPC future whose result() carries the response.
+    rpc_future = MagicMock()
+    rpc_future.result.return_value = recognize_response
+    backend.asr.offline_recognize.return_value = rpc_future
 
     audio = b"\x00\x01fake-pcm"
     resp = await backend.generate(
@@ -43,13 +48,27 @@ async def test_generate_recognizes_audio_to_transcript(backend):
     )
 
     # The decoded PCM is forwarded to RIVA with a config carrying the worker's
-    # recognition settings.
+    # recognition settings, submitted as a future with the configured deadline.
     backend.asr.offline_recognize.assert_called_once()
-    args, _ = backend.asr.offline_recognize.call_args
+    args, kwargs = backend.asr.offline_recognize.call_args
     assert args[0] == audio
     recognition_config = args[1]
     assert recognition_config.sample_rate_hertz == 16000
     assert recognition_config.language_code == "en-US"
     assert recognition_config.encoding == AudioEncoding.LINEAR_PCM
+    assert kwargs["future"] is True
+    rpc_future.result.assert_called_once_with(5.0)
 
     assert resp.transcript == "hello world"
+
+
+async def test_generate_cancels_rpc_on_timeout(backend):
+    rpc_future = MagicMock()
+    rpc_future.result.side_effect = grpc.FutureTimeoutError()
+    backend.asr.offline_recognize.return_value = rpc_future
+
+    with pytest.raises(grpc.FutureTimeoutError):
+        await backend.generate(asr_worker.AsrRequest(audio_base64=""))
+
+    # The in-flight RPC is cancelled rather than left to tie up a thread.
+    rpc_future.cancel.assert_called_once()

--- a/examples/riva_cascaded_pipeline/tests/test_asr_worker.py
+++ b/examples/riva_cascaded_pipeline/tests/test_asr_worker.py
@@ -13,6 +13,8 @@ import pytest
 from riva.client import AudioEncoding
 from riva_nim import asr_worker, config
 
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
 
 @pytest.fixture
 def backend():

--- a/examples/riva_cascaded_pipeline/tests/test_asr_worker.py
+++ b/examples/riva_cascaded_pipeline/tests/test_asr_worker.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit test for the ASR worker: audio in, RIVA offline_recognize, transcript out.
+
+Mocks ``riva.client.ASRService`` so it runs without a RIVA server.
+"""
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+from riva.client import AudioEncoding
+from riva_nim import asr_worker, config
+
+
+@pytest.fixture
+def backend():
+    be = asr_worker.AsrBackend(
+        config.RivaConnectionConfig(),
+        sample_rate_hz=16000,
+        language_code="en-US",
+        model="",
+    )
+    be.asr = MagicMock()
+    return be
+
+
+async def test_generate_recognizes_audio_to_transcript(backend):
+    alternative = MagicMock()
+    alternative.transcript = "hello world"
+    result = MagicMock()
+    result.alternatives = [alternative]
+    recognize_response = MagicMock()
+    recognize_response.results = [result]
+    backend.asr.offline_recognize.return_value = recognize_response
+
+    audio = b"\x00\x01fake-pcm"
+    resp = await backend.generate(
+        asr_worker.AsrRequest(audio_base64=base64.b64encode(audio).decode())
+    )
+
+    # The decoded PCM is forwarded to RIVA with a config carrying the worker's
+    # recognition settings.
+    backend.asr.offline_recognize.assert_called_once()
+    args, _ = backend.asr.offline_recognize.call_args
+    assert args[0] == audio
+    recognition_config = args[1]
+    assert recognition_config.sample_rate_hertz == 16000
+    assert recognition_config.language_code == "en-US"
+    assert recognition_config.encoding == AudioEncoding.LINEAR_PCM
+
+    assert resp.transcript == "hello world"

--- a/examples/riva_cascaded_pipeline/tests/test_asr_worker.py
+++ b/examples/riva_cascaded_pipeline/tests/test_asr_worker.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit test for the ASR worker: audio in, RIVA offline_recognize, transcript out.
+"""Unit test for the ASR worker: audio in, RIVA streaming recognition, transcript out.
 
 Mocks ``riva.client.ASRService`` so it runs without a RIVA server.
 """
@@ -9,7 +9,6 @@ Mocks ``riva.client.ASRService`` so it runs without a RIVA server.
 import base64
 from unittest.mock import MagicMock
 
-import grpc
 import pytest
 from riva.client import AudioEncoding
 from riva_nim import asr_worker, config
@@ -23,52 +22,48 @@ def backend():
         config.RivaConnectionConfig(),
         sample_rate_hz=16000,
         language_code="en-US",
-        model="",
+        model="parakeet-1.1b-en-US-asr-streaming",
         timeout_s=5.0,
     )
     be.asr = MagicMock()
     return be
 
 
-async def test_generate_recognizes_audio_to_transcript(backend):
+def _final_response(transcript):
     alternative = MagicMock()
-    alternative.transcript = "hello world"
+    alternative.transcript = transcript
     result = MagicMock()
+    result.is_final = True
     result.alternatives = [alternative]
-    recognize_response = MagicMock()
-    recognize_response.results = [result]
-    # future=True returns a gRPC future whose result() carries the response.
-    rpc_future = MagicMock()
-    rpc_future.result.return_value = recognize_response
-    backend.asr.offline_recognize.return_value = rpc_future
+    response = MagicMock()
+    response.results = [result]
+    return response
 
-    audio = b"\x00\x01fake-pcm"
+
+async def test_generate_streams_audio_and_joins_final_transcript(backend):
+    backend.asr.streaming_response_generator.return_value = [
+        _final_response("hello world")
+    ]
+
+    audio = b"\x00\x01" * 6000  # ~larger than one chunk, forces multiple frames
     resp = await backend.generate(
         asr_worker.AsrRequest(audio_base64=base64.b64encode(audio).decode())
     )
 
-    # The decoded PCM is forwarded to RIVA with a config carrying the worker's
-    # recognition settings, submitted as a future with the configured deadline.
-    backend.asr.offline_recognize.assert_called_once()
-    args, kwargs = backend.asr.offline_recognize.call_args
-    assert args[0] == audio
-    recognition_config = args[1]
-    assert recognition_config.sample_rate_hertz == 16000
-    assert recognition_config.language_code == "en-US"
-    assert recognition_config.encoding == AudioEncoding.LINEAR_PCM
-    assert kwargs["future"] is True
-    rpc_future.result.assert_called_once_with(5.0)
+    backend.asr.streaming_response_generator.assert_called_once()
+    kwargs = backend.asr.streaming_response_generator.call_args.kwargs
+    # The full buffer is streamed as chunks with the worker's recognition config.
+    assert b"".join(kwargs["audio_chunks"]) == audio
+    rec_config = kwargs["streaming_config"].config
+    assert rec_config.sample_rate_hertz == 16000
+    assert rec_config.language_code == "en-US"
+    assert rec_config.encoding == AudioEncoding.LINEAR_PCM
+    assert rec_config.model == "parakeet-1.1b-en-US-asr-streaming"
 
     assert resp.transcript == "hello world"
 
 
-async def test_generate_cancels_rpc_on_timeout(backend):
-    rpc_future = MagicMock()
-    rpc_future.result.side_effect = grpc.FutureTimeoutError()
-    backend.asr.offline_recognize.return_value = rpc_future
-
-    with pytest.raises(grpc.FutureTimeoutError):
-        await backend.generate(asr_worker.AsrRequest(audio_base64=""))
-
-    # The in-flight RPC is cancelled rather than left to tie up a thread.
-    rpc_future.cancel.assert_called_once()
+async def test_generate_returns_empty_for_empty_audio(backend):
+    resp = await backend.generate(asr_worker.AsrRequest(audio_base64=""))
+    assert resp.transcript == ""
+    backend.asr.streaming_response_generator.assert_not_called()

--- a/examples/riva_cascaded_pipeline/tests/test_orchestrator.py
+++ b/examples/riva_cascaded_pipeline/tests/test_orchestrator.py
@@ -13,6 +13,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from riva_nim import orchestrator
 
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
 
 class _FakeResponse:
     def __init__(self, data):
@@ -160,6 +162,36 @@ async def test_downstream_failure_emits_error_event(context):
     assert [e["type"] for e in out] == ["error"]
     llm_client.round_robin.assert_not_called()
     tts_client.round_robin.assert_not_called()
+
+
+async def test_empty_commit_emits_nothing(context):
+    asr_client, llm_client, tts_client = _client([]), _client([]), _client([])
+    pipeline = orchestrator.CascadedPipeline(
+        asr_client, llm_client, tts_client, llm_model="my-llm"
+    )
+
+    events = [{"type": "input_audio_buffer.commit"}]
+    out = [e async for e in pipeline.handle(_events(events), context)]
+
+    assert out == []  # nothing buffered → no chain run, no events
+    asr_client.round_robin.assert_not_called()
+
+
+async def test_malformed_audio_emits_invalid_request_error(context):
+    asr_client, llm_client, tts_client = _client([]), _client([]), _client([])
+    pipeline = orchestrator.CascadedPipeline(
+        asr_client, llm_client, tts_client, llm_model="my-llm"
+    )
+
+    events = [
+        {"type": "input_audio_buffer.append", "audio": "!!!not-base64!!!"},
+        {"type": "input_audio_buffer.commit"},
+    ]
+    out = [e async for e in pipeline.handle(_events(events), context)]
+
+    assert [e["type"] for e in out] == ["error"]
+    assert out[0]["error"]["type"] == "invalid_request_error"
+    asr_client.round_robin.assert_not_called()  # never reaches the chain
 
 
 async def test_buffer_resets_between_turns(context):

--- a/examples/riva_cascaded_pipeline/tests/test_orchestrator.py
+++ b/examples/riva_cascaded_pipeline/tests/test_orchestrator.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the realtime orchestrator's turn handling and ASR->LLM->TTS chaining.
+
+The downstream ASR/LLM/TTS clients are faked so the test exercises the
+orchestration state machine without a runtime or real workers.
+"""
+
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from riva_nim import orchestrator
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def data(self):
+        return self._data
+
+
+class _FakeStream:
+    """Async-iterable matching the Dynamo client response stream (items expose .data())."""
+
+    def __init__(self, items):
+        self._items = [_FakeResponse(d) for d in items]
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _client(streams):
+    """A mock endpoint client whose round_robin() yields one fresh stream per call."""
+    client = MagicMock()
+    client.round_robin = AsyncMock(
+        side_effect=[_FakeStream(items) for items in streams]
+    )
+    return client
+
+
+async def _events(events):
+    for event in events:
+        yield event
+
+
+def _llm_chunk(content):
+    return {"choices": [{"delta": {"role": "assistant", "content": content}}]}
+
+
+@pytest.fixture
+def context():
+    ctx = MagicMock()
+    ctx.is_stopped.return_value = False
+    return ctx
+
+
+async def test_accumulates_audio_and_runs_chain_on_commit(context):
+    asr_client = _client([[{"transcript": "what is the capital of france"}]])
+    llm_client = _client([[_llm_chunk("The capital "), _llm_chunk("is Paris.")]])
+    tts_audio = base64.b64encode(b"reply-pcm").decode()
+    tts_client = _client([[{"audio_base64": tts_audio, "sample_rate_hz": 22050}]])
+
+    pipeline = orchestrator.CascadedPipeline(
+        asr_client, llm_client, tts_client, llm_model="my-llm"
+    )
+
+    chunk_a = base64.b64encode(b"AAAA").decode()
+    chunk_b = base64.b64encode(b"BBBB").decode()
+    events = [
+        {"type": "session.update", "session": {"voice": "aria"}},
+        {"type": "input_audio_buffer.append", "audio": chunk_a},
+        {"type": "input_audio_buffer.append", "audio": chunk_b},
+        {"type": "input_audio_buffer.commit"},
+    ]
+    out = [e async for e in pipeline.handle(_events(events), context)]
+
+    # Appends emit nothing; the response sequence appears only after commit.
+    assert [e["type"] for e in out] == [
+        "session.updated",
+        "response.created",
+        "response.output_audio.delta",
+        "response.output_audio.done",
+        "response.done",
+    ]
+
+    # ASR receives the decoded, concatenated audio of both append chunks.
+    asr_req = asr_client.round_robin.call_args.args[0]
+    assert base64.b64decode(asr_req["audio_base64"]) == b"AAAABBBB"
+
+    # The transcript is sent to the LLM as a chat message with the configured model.
+    llm_req = llm_client.round_robin.call_args.args[0]
+    assert llm_req["model"] == "my-llm"
+    assert llm_req["messages"] == [
+        {"role": "user", "content": "what is the capital of france"}
+    ]
+
+    # The accumulated LLM delta text is what gets synthesized.
+    tts_req = tts_client.round_robin.call_args.args[0]
+    assert tts_req["text"] == "The capital is Paris."
+
+    # The synthesized audio is carried in the output_audio delta.
+    delta = next(e for e in out if e["type"] == "response.output_audio.delta")
+    assert delta["delta"] == tts_audio
+
+
+async def test_cancelled_mid_turn_aborts_without_responding(context):
+    # is_stopped() is False for the two event-loop checks (append, commit), then
+    # True once the chain checks it after ASR — so the turn aborts post-ASR.
+    calls = {"n": 0}
+
+    def stopped():
+        calls["n"] += 1
+        return calls["n"] > 2
+
+    context.is_stopped.side_effect = stopped
+
+    asr_client = _client([[{"transcript": "hello"}]])
+    llm_client = _client([])
+    tts_client = _client([])
+    pipeline = orchestrator.CascadedPipeline(
+        asr_client, llm_client, tts_client, llm_model="my-llm"
+    )
+
+    events = [
+        {"type": "input_audio_buffer.append", "audio": base64.b64encode(b"X").decode()},
+        {"type": "input_audio_buffer.commit"},
+    ]
+    out = [e async for e in pipeline.handle(_events(events), context)]
+
+    assert out == []  # cancelled mid-turn: no response.* events emitted
+    asr_client.round_robin.assert_called_once()
+    llm_client.round_robin.assert_not_called()
+    tts_client.round_robin.assert_not_called()
+
+
+async def test_downstream_failure_emits_error_event(context):
+    asr_client = MagicMock()
+    asr_client.round_robin = AsyncMock(side_effect=RuntimeError("asr unavailable"))
+    llm_client = _client([])
+    tts_client = _client([])
+    pipeline = orchestrator.CascadedPipeline(
+        asr_client, llm_client, tts_client, llm_model="my-llm"
+    )
+
+    events = [
+        {"type": "input_audio_buffer.append", "audio": base64.b64encode(b"X").decode()},
+        {"type": "input_audio_buffer.commit"},
+    ]
+    out = [e async for e in pipeline.handle(_events(events), context)]
+
+    # The failure surfaces as a realtime error event, not an unhandled exception.
+    assert [e["type"] for e in out] == ["error"]
+    llm_client.round_robin.assert_not_called()
+    tts_client.round_robin.assert_not_called()
+
+
+async def test_buffer_resets_between_turns(context):
+    asr_client = _client([[{"transcript": "first"}], [{"transcript": "second"}]])
+    llm_client = _client([[_llm_chunk("one")], [_llm_chunk("two")]])
+    tts_client = _client(
+        [
+            [
+                {
+                    "audio_base64": base64.b64encode(b"a").decode(),
+                    "sample_rate_hz": 22050,
+                }
+            ],
+            [
+                {
+                    "audio_base64": base64.b64encode(b"b").decode(),
+                    "sample_rate_hz": 22050,
+                }
+            ],
+        ]
+    )
+    pipeline = orchestrator.CascadedPipeline(
+        asr_client, llm_client, tts_client, llm_model="my-llm"
+    )
+
+    turn1 = base64.b64encode(b"TURN1").decode()
+    turn2 = base64.b64encode(b"TURN2").decode()
+    events = [
+        {"type": "input_audio_buffer.append", "audio": turn1},
+        {"type": "input_audio_buffer.commit"},
+        {"type": "input_audio_buffer.append", "audio": turn2},
+        {"type": "input_audio_buffer.commit"},
+    ]
+    _ = [e async for e in pipeline.handle(_events(events), context)]
+
+    # Each turn's ASR call sees only that turn's audio (buffer cleared after commit).
+    first_audio = asr_client.round_robin.call_args_list[0].args[0]["audio_base64"]
+    second_audio = asr_client.round_robin.call_args_list[1].args[0]["audio_base64"]
+    assert base64.b64decode(first_audio) == b"TURN1"
+    assert base64.b64decode(second_audio) == b"TURN2"

--- a/examples/riva_cascaded_pipeline/tests/test_tts_worker.py
+++ b/examples/riva_cascaded_pipeline/tests/test_tts_worker.py
@@ -22,6 +22,7 @@ def backend():
         voice="English-US.Female-1",
         language_code="en-US",
         sample_rate_hz=22050,
+        timeout_s=5.0,
     )
     # Replace the real RIVA service with a mock; the handler must not touch a
     # live server in unit tests.
@@ -32,17 +33,23 @@ def backend():
 async def test_generate_synthesizes_and_base64_encodes_audio(backend):
     synth_response = MagicMock()
     synth_response.audio = b"RIFF....fake-pcm-bytes"
-    backend.tts.synthesize.return_value = synth_response
+    # future=True returns a gRPC future whose result() carries the response.
+    rpc_future = MagicMock()
+    rpc_future.result.return_value = synth_response
+    backend.tts.synthesize.return_value = rpc_future
 
     resp = await backend.generate(tts_worker.TtsRequest(text="hello world"))
 
-    # Text is forwarded to RIVA with the worker's configured voice settings.
+    # Text is forwarded to RIVA with the worker's configured voice settings,
+    # submitted as a future with the configured deadline.
     backend.tts.synthesize.assert_called_once()
     args, kwargs = backend.tts.synthesize.call_args
     assert args[0] == "hello world"
     assert kwargs["voice_name"] == "English-US.Female-1"
     assert kwargs["language_code"] == "en-US"
     assert kwargs["sample_rate_hz"] == 22050
+    assert kwargs["future"] is True
+    rpc_future.result.assert_called_once_with(5.0)
 
     # The synthesized PCM is returned base64-encoded, with the sample rate echoed.
     assert base64.b64decode(resp.audio_base64) == b"RIFF....fake-pcm-bytes"

--- a/examples/riva_cascaded_pipeline/tests/test_tts_worker.py
+++ b/examples/riva_cascaded_pipeline/tests/test_tts_worker.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit test for the TTS worker: text in, RIVA synthesize, base64 audio out.
+
+Mocks ``riva.client.SpeechSynthesisService`` so it runs without a RIVA server.
+"""
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+from riva_nim import config, tts_worker
+
+
+@pytest.fixture
+def backend():
+    be = tts_worker.TtsBackend(
+        config.RivaConnectionConfig(),
+        voice="English-US.Female-1",
+        language_code="en-US",
+        sample_rate_hz=22050,
+    )
+    # Replace the real RIVA service with a mock; the handler must not touch a
+    # live server in unit tests.
+    be.tts = MagicMock()
+    return be
+
+
+async def test_generate_synthesizes_and_base64_encodes_audio(backend):
+    synth_response = MagicMock()
+    synth_response.audio = b"RIFF....fake-pcm-bytes"
+    backend.tts.synthesize.return_value = synth_response
+
+    resp = await backend.generate(tts_worker.TtsRequest(text="hello world"))
+
+    # Text is forwarded to RIVA with the worker's configured voice settings.
+    backend.tts.synthesize.assert_called_once()
+    args, kwargs = backend.tts.synthesize.call_args
+    assert args[0] == "hello world"
+    assert kwargs["voice_name"] == "English-US.Female-1"
+    assert kwargs["language_code"] == "en-US"
+    assert kwargs["sample_rate_hz"] == 22050
+
+    # The synthesized PCM is returned base64-encoded, with the sample rate echoed.
+    assert base64.b64decode(resp.audio_base64) == b"RIFF....fake-pcm-bytes"
+    assert resp.sample_rate_hz == 22050

--- a/examples/riva_cascaded_pipeline/tests/test_tts_worker.py
+++ b/examples/riva_cascaded_pipeline/tests/test_tts_worker.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock
 import pytest
 from riva_nim import config, tts_worker
 
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
 
 @pytest.fixture
 def backend():

--- a/examples/riva_cascaded_pipeline/tests/test_tts_worker.py
+++ b/examples/riva_cascaded_pipeline/tests/test_tts_worker.py
@@ -9,6 +9,7 @@ Mocks ``riva.client.SpeechSynthesisService`` so it runs without a RIVA server.
 import base64
 from unittest.mock import MagicMock
 
+import grpc
 import pytest
 from riva_nim import config, tts_worker
 
@@ -54,3 +55,15 @@ async def test_generate_synthesizes_and_base64_encodes_audio(backend):
     # The synthesized PCM is returned base64-encoded, with the sample rate echoed.
     assert base64.b64decode(resp.audio_base64) == b"RIFF....fake-pcm-bytes"
     assert resp.sample_rate_hz == 22050
+
+
+async def test_generate_cancels_rpc_on_timeout(backend):
+    rpc_future = MagicMock()
+    rpc_future.result.side_effect = grpc.FutureTimeoutError()
+    backend.tts.synthesize.return_value = rpc_future
+
+    with pytest.raises(grpc.FutureTimeoutError):
+        await backend.generate(tts_worker.TtsRequest(text="hello"))
+
+    # The in-flight RPC is cancelled rather than left to tie up a thread.
+    rpc_future.cancel.assert_called_once()


### PR DESCRIPTION
## Overview:

A proof-of-concept that expresses a cascaded voice agent (ASR → LLM → TTS) as Dynamo workers instead of a pipecat pipeline, mirroring the [nemotron-voice-agent blueprint](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent). RIVA NIM speech connectors are wrapped as Dynamo workers, an LLM runs as a standard Dynamo vLLM backend, and a realtime orchestrator worker chains them behind the frontend's OpenAI Realtime WebSocket API. Establishes the reusable RIVA-worker building-block pattern and a minimal end-to-end chain. (Tracked internally as DIS-2303.)

## Details:

All code lands under `examples/riva_cascaded_pipeline/`. The `riva_nim/` building-block package is self-contained (relative imports, named `riva_nim` so it does not shadow the `nvidia-riva-client` package) so it can later move to `components/src/dynamo/riva/` with no import changes.

- **`riva_nim/config.py` + `riva_client.py`** — RIVA connection config (`--riva-*` flags; configurable server URL, default `localhost:50051`) and a `build_auth` wrapper. Local → insecure channel; NVCF → TLS + `function-id`/`authorization` Bearer metadata. Plus ASR/TTS service constructors.
- **`riva_nim/asr_worker.py`** — wraps `ASRService.offline_recognize`: base64 audio in → transcript out.
- **`riva_nim/tts_worker.py`** — wraps `SpeechSynthesisService.synthesize`: text in → base64 audio out.
- **`riva_nim/orchestrator.py`** — `ModelType.Realtime` bidirectional worker. Accumulates `input_audio_buffer.append` audio; on `input_audio_buffer.commit` runs ASR → LLM → TTS and emits the `response.*` event sequence. The LLM is a Dynamo vLLM worker launched with `--use-vllm-tokenizer` (text-in-text-out), called directly worker→worker with chat `messages`. Mid-turn cancellation aborts between stages; downstream failures surface as realtime `error` events.
- **`container/`** — Dockerfile + build script layering `nvidia-riva-client` on a Dynamo image (stock images don't include it).
- **`tests/`** — 6 unit tests (ASR, TTS, orchestrator ×4) with RIVA and downstream clients mocked; run inside the layered image.
- **`README.md` + `launch_workers.sh`** — build/launch (RIVA NIMs, workers, vLLM, frontend `/v1/realtime`), the NVCF route, and limitations.

**Limitations (PoC scope):** offline (non-streaming) RIVA; single-turn LLM (no history); cancellation observed between chain stages, not mid-stage (no barge-in); fixed audio rates (16 kHz ASR in / 22.05 kHz TTS out, no resampling); the NVCF path is documented but not validated here. Manual end-to-end verification requires a live RIVA server + GPU and is not run in CI.

## Where should the reviewer start?

- `examples/riva_cascaded_pipeline/riva_nim/orchestrator.py` — the realtime turn state machine and ASR→LLM→TTS chaining.
- `examples/riva_cascaded_pipeline/riva_nim/riva_client.py` + `config.py` — the RIVA connection layer (local vs NVCF).
- `examples/riva_cascaded_pipeline/README.md` — how the pieces are launched and wired.

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue**:
- [x] Confirmed — no related issue (tracked internally as DIS-2303)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end cascaded voice pipeline example that connects speech-to-text, language model, and text-to-speech stages.
  * Added scripts and setup guidance to build, launch, and run the example locally or against a hosted service.
  * Added support for configurable connection settings, including secure connections and authentication metadata.

* **Bug Fixes**
  * Improved handling of turn boundaries, cancellation, and downstream failures in realtime voice interactions.

* **Tests**
  * Added unit coverage for speech recognition, synthesis, and orchestrated turn flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->