### PR TITLE
feat(frontend): register experimental /inference/v1/generate endpoint

### DIFF
--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -24,7 +24,8 @@ use crate::types::{
         audios::OpenAIAudiosStreamingEngine,
         chat_completions::OpenAIChatCompletionsStreamingEngine,
         completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
-        images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
+        generate::GenerateStreamingEngine, images::OpenAIImagesStreamingEngine,
+        videos::OpenAIVideosStreamingEngine,
     },
 };
 
@@ -221,6 +222,13 @@ impl Model {
         self.worker_sets
             .iter()
             .any(|entry| entry.value().has_realtime_engine())
+    }
+
+    /// Check if any WorkerSet has a generate engine.
+    pub fn has_generate_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_generate_engine())
     }
 
     // -- Model serving readiness --
@@ -564,6 +572,11 @@ impl Model {
             .ok_or_else(|| self.engine_error(self.has_realtime_engine()))
     }
 
+    pub fn get_generate_engine(&self) -> Result<GenerateStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.generate_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_generate_engine()))
+    }
+
     // -- Combined engine + parsing options (atomically from one WorkerSet) --
 
     pub fn get_chat_engine_with_parsing(
@@ -582,6 +595,17 @@ impl Model {
                 .map(|e| (e, ws.parsing_options()))
         })
         .ok_or_else(|| self.engine_error(self.has_completions_engine()))
+    }
+
+    pub fn get_generate_engine_with_parsing(
+        &self,
+    ) -> Result<(GenerateStreamingEngine, ParsingOptions), ModelManagerError> {
+        self.select_worker_set_with(|ws| {
+            ws.generate_engine
+                .clone()
+                .map(|e| (e, ws.parsing_options()))
+        })
+        .ok_or_else(|| self.engine_error(self.has_generate_engine()))
     }
 
     // -- Worker monitoring (aggregated across WorkerSets) --

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -39,8 +39,8 @@ use crate::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
-            embeddings::OpenAIEmbeddingsStreamingEngine, images::OpenAIImagesStreamingEngine,
-            videos::OpenAIVideosStreamingEngine,
+            embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
+            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
         },
     },
 };
@@ -361,6 +361,14 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_generate_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_generate_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_prefill_models(&self) -> Vec<String> {
         self.models
             .iter()
@@ -449,6 +457,16 @@ impl ModelManager {
             .get_realtime_engine()
     }
 
+    pub fn get_generate_engine(
+        &self,
+        model: &str,
+    ) -> Result<GenerateStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_generate_engine()
+    }
+
     // -- Combined engine + parsing options (atomically from one WorkerSet) --
 
     pub fn get_chat_completions_engine_with_parsing(
@@ -481,6 +499,22 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_completions_engine_with_parsing()
+    }
+
+    pub fn get_generate_engine_with_parsing(
+        &self,
+        model: &str,
+    ) -> Result<
+        (
+            GenerateStreamingEngine,
+            crate::protocols::openai::ParsingOptions,
+        ),
+        ModelManagerError,
+    > {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_generate_engine_with_parsing()
     }
 
     // -- Convenience methods for in-process models (http.rs, grpc.rs) --
@@ -669,6 +703,27 @@ impl ModelManager {
         Ok(())
     }
 
+    pub fn add_generate_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: GenerateStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_generate_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_generate_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            Self::aggregated_local_card(),
+        );
+        ws.generate_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
     pub fn add_prefill_model(
         &self,
         model: &str,
@@ -742,6 +797,13 @@ impl ModelManager {
 
     pub fn remove_realtime_model(&self, model: &str) -> Result<(), ModelManagerError> {
         let namespace = format!("__local_realtime_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_generate_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_generate_{}", model);
         self.remove_worker_set(model, &namespace)
             .map(|_| ())
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -20,8 +20,8 @@ use crate::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
-            embeddings::OpenAIEmbeddingsStreamingEngine, images::OpenAIImagesStreamingEngine,
-            videos::OpenAIVideosStreamingEngine,
+            embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
+            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
         },
     },
 };
@@ -46,6 +46,7 @@ pub struct WorkerSet {
     pub(crate) audios_engine: Option<OpenAIAudiosStreamingEngine>,
     pub(crate) tensor_engine: Option<TensorStreamingEngine>,
     pub(crate) realtime_engine: Option<RealtimeBidirectionalEngine>,
+    pub(crate) generate_engine: Option<GenerateStreamingEngine>,
 
     /// KV router for this set's workers (if KV mode)
     pub(crate) kv_router: Option<Arc<KvRouter>>,
@@ -76,6 +77,7 @@ impl WorkerSet {
             audios_engine: None,
             tensor_engine: None,
             realtime_engine: None,
+            generate_engine: None,
             kv_router: None,
             worker_monitor: None,
             prefill_router: None,
@@ -127,6 +129,10 @@ impl WorkerSet {
         self.realtime_engine.is_some()
     }
 
+    pub fn has_generate_engine(&self) -> bool {
+        self.generate_engine.is_some()
+    }
+
     /// Whether this set has any decode engine (chat or completions)
     pub fn has_decode_engine(&self) -> bool {
         self.has_chat_engine() || self.has_completions_engine()
@@ -145,6 +151,7 @@ impl WorkerSet {
             || self.has_videos_engine()
             || self.has_audios_engine()
             || self.has_realtime_engine()
+            || self.has_generate_engine()
     }
 
     /// Whether this set tracks an Encode worker. Encode WorkerSets carry
@@ -213,6 +220,8 @@ impl WorkerSet {
 mod tests {
     use super::*;
     use crate::model_card::ModelDeploymentCard;
+    use crate::protocols::common::llm_backend::LLMEngineOutput;
+    use crate::protocols::common::preprocessor::PreprocessedRequest;
     use crate::types::Annotated;
     use crate::types::generic::tensor::{NvCreateTensorRequest, NvCreateTensorResponse};
     use crate::types::openai::audios::{NvAudioSpeechResponse, NvCreateAudioSpeechRequest};
@@ -280,6 +289,7 @@ mod tests {
         assert!(!ws.has_audios_engine());
         assert!(!ws.has_tensor_engine());
         assert!(!ws.has_realtime_engine());
+        assert!(!ws.has_generate_engine());
         assert!(!ws.has_decode_engine());
         assert!(ws.is_prefill_set());
     }
@@ -351,6 +361,12 @@ mod tests {
             has_realtime_engine,
             Arc::new(crate::engines::EchoBidirectionalEngine),
             "realtime"
+        );
+        check!(
+            generate_engine,
+            has_generate_engine,
+            StubEngine::<PreprocessedRequest, LLMEngineOutput>::new(),
+            "generate"
         );
     }
 

--- a/lib/llm/src/endpoint_type.rs
+++ b/lib/llm/src/endpoint_type.rs
@@ -24,6 +24,8 @@ pub enum EndpointType {
     Responses,
     /// Anthropic Messages API
     AnthropicMessages,
+    /// Generate API (token-in/token-out)
+    Generate,
 }
 
 impl EndpointType {
@@ -38,6 +40,7 @@ impl EndpointType {
             Self::Realtime => "realtime",
             Self::Responses => "responses",
             Self::AnthropicMessages => "anthropic_messages",
+            Self::Generate => "generate",
         }
     }
 
@@ -52,6 +55,7 @@ impl EndpointType {
             Self::Realtime,
             Self::Responses,
             Self::AnthropicMessages,
+            Self::Generate,
         ]
     }
 }
@@ -68,5 +72,15 @@ mod tests {
     #[test]
     fn realtime_in_all() {
         assert!(EndpointType::all().contains(&EndpointType::Realtime));
+    }
+
+    #[test]
+    fn generate_as_str() {
+        assert_eq!(EndpointType::Generate.as_str(), "generate");
+    }
+
+    #[test]
+    fn generate_in_all() {
+        assert!(EndpointType::all().contains(&EndpointType::Generate));
     }
 }

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -25,6 +25,7 @@ mod openai;
 pub mod busy_threshold;
 pub mod disconnect;
 pub mod error;
+pub mod generate;
 pub mod health;
 pub mod metrics;
 pub mod openapi_docs;

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP handler for the token-in/token-out `Generate` API
+//! (`POST /inference/v1/generate`).
+//!
+//! This is an experimental endpoint, enabled by default (matching vLLM,
+//! which mounts `/inference/v1/generate` for any generate-capable model).
+//! It registers the route with a placeholder handler that returns HTTP 501
+//! Not Implemented; the real handler (engine dispatch + `LLMEngineOutput`
+//! accumulation) lands in a follow-up. Disable via `enable_generate_endpoints`.
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    middleware,
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use serde::Serialize;
+
+use super::openai::{get_body_limit, smart_json_error_middleware};
+use super::{RouteDoc, service_v2};
+use crate::protocols::openai::generate::GenerateRequest;
+
+/// vLLM-style nested error body: `{"error": {"message", "type", "code"}}`.
+#[derive(Serialize, Debug)]
+struct GenerateError {
+    error: GenerateErrorBody,
+}
+
+#[derive(Serialize, Debug)]
+struct GenerateErrorBody {
+    message: String,
+    #[serde(rename = "type")]
+    error_type: String,
+    code: u16,
+}
+
+/// Create an Axum [`Router`] for the token-in/token-out `Generate` endpoint.
+/// If no path is provided, the default path is `/inference/v1/generate`.
+pub fn generate_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let path = path.unwrap_or("/inference/v1/generate".to_string());
+    let doc = RouteDoc::new(axum::http::Method::POST, &path);
+    let router = Router::new()
+        .route(&path, post(handler_generate))
+        .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
+        .with_state(state);
+    (vec![doc], router)
+}
+
+/// Placeholder handler for the `Generate` endpoint.
+///
+/// Accepts and validates the request body shape, then returns HTTP 501 with a
+/// vLLM-style nested-`error` body. Real dispatch is implemented in a follow-up.
+async fn handler_generate(
+    State(_state): State<Arc<service_v2::State>>,
+    Json(_request): Json<GenerateRequest>,
+) -> Response {
+    let code = StatusCode::NOT_IMPLEMENTED;
+    (
+        code,
+        Json(GenerateError {
+            error: GenerateErrorBody {
+                message: "The /inference/v1/generate endpoint is not implemented yet".to_string(),
+                error_type: "not_implemented".to_string(),
+                code: code.as_u16(),
+            },
+        }),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StatusCode;
+    use super::service_v2::HttpService;
+    use tokio_util::sync::CancellationToken;
+
+    /// Spin up an `HttpService` bound to an ephemeral port and return the port
+    /// plus the run handle. Mirrors the reqwest-based router tests in
+    /// `service_v2`.
+    async fn serve(enable_generate: bool) -> (u16, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let service = HttpService::builder()
+            .port(port)
+            .enable_generate_endpoints(enable_generate)
+            .build()
+            .unwrap();
+        let cancel_token = CancellationToken::new();
+        let handle = tokio::spawn(async move {
+            service.run_with_listener(cancel_token, listener).await.ok();
+        });
+        // Give the server a moment to start listening.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (port, handle)
+    }
+
+    #[tokio::test]
+    async fn generate_route_returns_501_when_enabled() {
+        let (port, handle) = serve(true).await;
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{}/inference/v1/generate", port))
+            .header("content-type", "application/json")
+            .body(r#"{"token_ids":[1,2,3],"sampling_params":{}}"#)
+            .send()
+            .await
+            .expect("generate request failed");
+        assert_eq!(resp.status().as_u16(), StatusCode::NOT_IMPLEMENTED.as_u16());
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn generate_route_404_when_disabled() {
+        let (port, handle) = serve(false).await;
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{}/inference/v1/generate", port))
+            .header("content-type", "application/json")
+            .body(r#"{"token_ids":[1,2,3],"sampling_params":{}}"#)
+            .send()
+            .await
+            .expect("generate request failed");
+        assert_eq!(resp.status().as_u16(), StatusCode::NOT_FOUND.as_u16());
+        handle.abort();
+    }
+}

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -459,6 +459,9 @@ pub enum Endpoint {
 
     /// Tensor
     Tensor,
+
+    /// Generate (token-in/token-out)
+    Generate,
 }
 
 /// Metrics for the HTTP service
@@ -1412,6 +1415,7 @@ impl std::fmt::Display for Endpoint {
             Endpoint::Responses => write!(f, "responses"),
             Endpoint::AnthropicMessages => write!(f, "anthropic_messages"),
             Endpoint::Tensor => write!(f, "tensor"),
+            Endpoint::Generate => write!(f, "generate"),
         }
     }
 }
@@ -1428,6 +1432,7 @@ impl Endpoint {
             Endpoint::Responses => "responses",
             Endpoint::AnthropicMessages => "anthropic_messages",
             Endpoint::Tensor => "tensor",
+            Endpoint::Generate => "generate",
         }
     }
 }

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -288,6 +288,7 @@ struct StateFlags {
     realtime_endpoints_enabled: AtomicBool,
     responses_endpoints_enabled: AtomicBool,
     anthropic_endpoints_enabled: AtomicBool,
+    generate_endpoints_enabled: AtomicBool,
 }
 
 impl StateFlags {
@@ -304,6 +305,7 @@ impl StateFlags {
             EndpointType::AnthropicMessages => {
                 self.anthropic_endpoints_enabled.load(Ordering::Relaxed)
             }
+            EndpointType::Generate => self.generate_endpoints_enabled.load(Ordering::Relaxed),
         }
     }
 
@@ -336,6 +338,9 @@ impl StateFlags {
             EndpointType::AnthropicMessages => self
                 .anthropic_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
+            EndpointType::Generate => self
+                .generate_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
         }
     }
 }
@@ -363,6 +368,7 @@ impl State {
                 realtime_endpoints_enabled: AtomicBool::new(false),
                 responses_endpoints_enabled: AtomicBool::new(false),
                 anthropic_endpoints_enabled: AtomicBool::new(false),
+                generate_endpoints_enabled: AtomicBool::new(false),
             },
             cancel_token,
             frontend_api_config: config.frontend_api_config,
@@ -527,6 +533,14 @@ pub struct HttpServiceConfig {
 
     #[builder(default = "true")]
     enable_responses_endpoints: bool,
+
+    /// Experimental token-in/token-out `Generate` API
+    /// (`POST /inference/v1/generate`). Enabled by default, matching vLLM,
+    /// which mounts this endpoint for any generate-capable model. The handler
+    /// is a placeholder (HTTP 501) until request dispatch lands; set to
+    /// `false` to hide the route entirely.
+    #[builder(default = "true")]
+    enable_generate_endpoints: bool,
 
     /// API behavior config retained in HTTP state for route and streaming decisions.
     #[builder(default)]
@@ -863,6 +877,8 @@ static HTTP_SVC_EMB_PATH_ENV: &str = "DYN_HTTP_SVC_EMB_PATH";
 static HTTP_SVC_RESPONSES_PATH_ENV: &str = "DYN_HTTP_SVC_RESPONSES_PATH";
 /// Environment variable to set the anthropic messages endpoint path (default: `/v1/messages`)
 static HTTP_SVC_ANTHROPIC_PATH_ENV: &str = "DYN_HTTP_SVC_ANTHROPIC_PATH";
+/// Environment variable to set the generate endpoint path (default: `/inference/v1/generate`)
+static HTTP_SVC_GENERATE_PATH_ENV: &str = "DYN_HTTP_SVC_GENERATE_PATH";
 
 impl HttpServiceConfigBuilder {
     pub fn build(self) -> Result<HttpService, anyhow::Error> {
@@ -870,6 +886,7 @@ impl HttpServiceConfigBuilder {
         let metrics_config = config.metrics_config.clone();
         let frontend_api_config = config.frontend_api_config.clone();
         let anthropic_endpoints_enabled = frontend_api_config.anthropic().enabled();
+        let generate_endpoints_enabled = config.enable_generate_endpoints;
 
         let model_manager = Arc::new(ModelManager::new());
         let cancel_token = config.cancel_token.unwrap_or_default();
@@ -914,6 +931,9 @@ impl HttpServiceConfigBuilder {
             &EndpointType::AnthropicMessages,
             anthropic_endpoints_enabled,
         );
+        state
+            .flags
+            .set(&EndpointType::Generate, generate_endpoints_enabled);
 
         // enable prometheus metrics
         let registry = metrics::Registry::new();
@@ -1012,6 +1032,7 @@ impl HttpServiceConfigBuilder {
             state.clone(),
             &config.request_template,
             anthropic_endpoints_enabled,
+            generate_endpoints_enabled,
         );
         let mut inference_router = axum::Router::new();
         for (route_docs, route) in endpoint_routes {
@@ -1129,6 +1150,7 @@ impl HttpServiceConfigBuilder {
         state: Arc<State>,
         request_template: &Option<RequestTemplate>,
         enable_anthropic_endpoints: bool,
+        enable_generate_endpoints: bool,
     ) -> Vec<(Vec<RouteDoc>, axum::Router)> {
         let mut routes = Vec::new();
         // Add chat completions route with conditional middleware
@@ -1171,6 +1193,17 @@ impl HttpServiceConfigBuilder {
                 EndpointType::AnthropicMessages,
                 (anthropic_docs, anthropic_route),
             );
+        }
+
+        if enable_generate_endpoints {
+            tracing::warn!(
+                "Generate API (/inference/v1/generate) is experimental and not implemented yet."
+            );
+            let (generate_docs, generate_route) = super::generate::generate_router(
+                state.clone(),
+                var(HTTP_SVC_GENERATE_PATH_ENV).ok(),
+            );
+            endpoint_routes.insert(EndpointType::Generate, (generate_docs, generate_route));
         }
 
         for endpoint_type in EndpointType::all() {

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -18,6 +18,7 @@ pub mod common_ext;
 pub mod completions;
 pub(crate) mod delta_common;
 pub mod embeddings;
+pub mod generate;
 pub mod images;
 pub mod models;
 pub mod responses;

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol types for the token-in/token-out `Generate` API
+//! (`POST /inference/v1/generate`).
+//!
+//! These mirror vLLM's `GenerateRequest` / `GenerateResponse` wire contract
+//! (`vllm/entrypoints/serve/disagg/protocol.py`). The text-only subset is
+//! captured here; `sampling_params` is kept opaque (`serde_json::Value`) for
+//! now — the typed sampling envelope lands in a follow-up.
+//!
+//! Deferred to follow-up PRs (intentionally absent here): `features`
+//! (multimodal), `stream_options`, negative-`token_ids` validation-message
+//! parity with vLLM, and auto-generating a `request_id` when absent.
+
+use serde::{Deserialize, Serialize};
+
+/// Token-in/token-out generation request.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GenerateRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+
+    pub token_ids: Vec<u32>,
+
+    pub sampling_params: serde_json::Value,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    #[serde(default)]
+    pub stream: bool,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_salt: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kv_transfer_params: Option<serde_json::Value>,
+}
+
+/// A single choice in a `GenerateResponse`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GenerateResponseChoice {
+    pub index: u32,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_ids: Option<Vec<u32>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<serde_json::Value>,
+
+    pub finish_reason: Option<String>,
+}
+
+/// Token-in/token-out generation response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GenerateResponse {
+    pub request_id: String,
+
+    pub choices: Vec<GenerateResponseChoice>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_logprobs: Option<serde_json::Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kv_transfer_params: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn generate_request_deserializes_from_vllm_json() {
+        let raw = json!({
+            "request_id": "req-123",
+            "token_ids": [1, 2, 3, 4],
+            "sampling_params": {"temperature": 0.7, "max_tokens": 16},
+            "model": "test-model",
+            "stream": false,
+            "cache_salt": "salt",
+            "priority": 0,
+            "kv_transfer_params": null
+        });
+        let req: GenerateRequest = serde_json::from_value(raw).expect("deserialize");
+        assert_eq!(req.request_id.as_deref(), Some("req-123"));
+        assert_eq!(req.token_ids, vec![1, 2, 3, 4]);
+        assert!(!req.stream);
+        assert_eq!(req.model.as_deref(), Some("test-model"));
+    }
+
+    #[test]
+    fn generate_request_minimal_defaults() {
+        // Unknown fields are ignored, stream defaults false, optionals default None.
+        let raw = json!({
+            "token_ids": [5, 6],
+            "sampling_params": {},
+            "future_field": "ignored"
+        });
+        let req: GenerateRequest = serde_json::from_value(raw).expect("deserialize");
+        assert_eq!(req.token_ids, vec![5, 6]);
+        assert!(!req.stream);
+        assert_eq!(req.request_id, None);
+        assert_eq!(req.priority, None);
+    }
+
+    #[test]
+    fn generate_response_round_trips_without_usage_key() {
+        let resp = GenerateResponse {
+            request_id: "req-123".to_string(),
+            choices: vec![GenerateResponseChoice {
+                index: 0,
+                token_ids: Some(vec![10, 11, 12]),
+                logprobs: None,
+                finish_reason: Some("stop".to_string()),
+            }],
+            prompt_logprobs: None,
+            kv_transfer_params: None,
+        };
+
+        let value = serde_json::to_value(&resp).expect("serialize");
+        assert!(
+            value.get("usage").is_none(),
+            "GenerateResponse must not emit a `usage` key"
+        );
+        assert!(value.get("prompt_logprobs").is_none());
+        assert!(value.get("kv_transfer_params").is_none());
+
+        let round: GenerateResponse =
+            serde_json::from_value(value).expect("round-trip deserialize");
+        assert_eq!(round.request_id, "req-123");
+        assert_eq!(round.choices.len(), 1);
+        assert_eq!(round.choices[0].token_ids, Some(vec![10, 11, 12]));
+        assert_eq!(round.choices[0].finish_reason.as_deref(), Some("stop"));
+    }
+}

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -44,6 +44,24 @@ pub mod openai {
         >;
     }
 
+    pub mod generate {
+        use super::*;
+        use crate::protocols::common::llm_backend::LLMEngineOutput;
+        use crate::protocols::common::preprocessor::PreprocessedRequest;
+
+        pub use protocols::openai::generate::{GenerateRequest, GenerateResponse};
+
+        /// A [`ServerStreamingEngine`] implementation for the token-in/token-out
+        /// `Generate` API.
+        ///
+        /// The registered engine is **raw**: it consumes a preprocessed
+        /// [`PreprocessedRequest`] and streams [`LLMEngineOutput`] directly, with
+        /// no Backend/decoder in between. The handler is responsible for
+        /// accumulating engine output into a `GenerateResponse`.
+        pub type GenerateStreamingEngine =
+            ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>;
+    }
+
     pub mod embeddings {
         use super::*;
 

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -215,6 +215,7 @@ fn compute_index(endpoint: &Endpoint, request_type: &RequestType, status: &Statu
         Endpoint::Images => todo!(),
         Endpoint::Videos => todo!(),
         Endpoint::Audios => todo!(),
+        Endpoint::Generate => todo!(),
     };
 
     let request_type = match request_type {


### PR DESCRIPTION
## Why

Main already has a mature worker-side token-in/token-out (TITO) path (`--enable-rl`, `nvext.token_in`, DELTA output), but it is only reachable through Dynamo's own request flavor — nothing speaks vLLM's `POST /inference/v1/generate` wire contract that RL rollout clients (and llm-d, which adopts the same endpoint) target. This adds that endpoint on the Dynamo frontend so a vLLM/llm-d-configured client works with zero reconfiguration, keeping the in-process KV router. It is the first of a stacked series and lands registration only: enabled by default (matching vLLM, which mounts the endpoint for any generate-capable model) with a placeholder handler — so real dispatch, the response accumulator, and the worker envelope branch land in focused follow-ups without re-touching the wiring.

## Effect

```
# enabled by default (no flag)
$ curl -sw '%{http_code}' -XPOST :8000/inference/v1/generate -d '{"token_ids":[1],"sampling_params":{}}'
{"error":{"message":"The /inference/v1/generate endpoint is not implemented yet","type":"not_implemented","code":501}}
501

# hidden only if explicitly disabled (enable_generate_endpoints=false)
404
```

## What Change

- Add `EndpointType::Generate` + metrics variant; enabled by default (disable via `enable_generate_endpoints=false`).
- Register `/inference/v1/generate` with a placeholder 501 handler using a vLLM-style nested-`error` body + shared body-limit/JSON-error middleware.
- Add vLLM-shaped `GenerateRequest`/`GenerateResponse` types and a raw `PreprocessedRequest → LLMEngineOutput` engine slot on `WorkerSet`/`Model`/`ModelManager` (unused this PR).

## Test Plan

- Unit: enum/metrics/protocol round-trip + router 501-default / 404-disabled — `cargo test -p dynamo-llm`.
- Live frontend: `python -m dynamo.frontend` → `/inference/v1/generate` returns 501, `/health` → 200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental Generate API endpoint for token-in/token-out requests.
  * Introduced support for Generate-capable models, including listing, registering, and removing them.
  * Added Generate endpoint coverage in service metrics and endpoint enumeration.

* **Bug Fixes**
  * Improved model and worker selection so Generate-only setups are recognized as serving.
  * Added request/response handling for the new Generate protocol format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->