### PR TITLE
feat(frontend): serve /inference/v1/generate end-to-end (RL TITO)

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -29,6 +29,7 @@ from typing import (
     TypeVar,
 )
 
+import msgspec
 import torch
 from vllm import PoolingParams
 from vllm.config import ModelConfig, VllmConfig
@@ -3448,12 +3449,16 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         parsed = VllmGenerateRequest.model_validate(envelope)
         sampling_params = parsed.sampling_params
         if isinstance(sampling_params, dict):
-            # vLLM's pydantic GenerateRequest does not always coerce the nested
-            # msgspec `SamplingParams` Struct in the worker process (pydantic
-            # schema-resolution timing differs from an isolated import), so
-            # `parsed.sampling_params` can arrive as a raw dict. Construct the
-            # vLLM SamplingParams from it so __post_init__ validation still runs.
-            sampling_params = SamplingParams(**sampling_params)
+            # In the worker process, `GenerateRequest.model_validate` does not
+            # always coerce the nested msgspec `SamplingParams` (pydantic
+            # schema-resolution timing in the worker differs from an isolated
+            # import), so `parsed.sampling_params` can arrive as a raw dict.
+            # Convert via msgspec so vLLM's non-strict wire semantics hold:
+            # unknown keys are DROPPED and `__post_init__` runs (e.g. seed=-1 ->
+            # None). Do NOT use `SamplingParams(**dict)` — its constructor raises
+            # `TypeError` on unknown keys and would break unknown-field-ignore
+            # parity with the pinned vLLM profile.
+            sampling_params = msgspec.convert(sampling_params, type=SamplingParams)
 
         # Prefer core token_ids (authoritative); warn if the envelope disagrees.
         core_token_ids = list(request.get("token_ids", []))

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3170,7 +3170,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         with time_and_log_code_section(
             f"[DECODE] request: {request_id} generate"
         ) as decode_timer:
-            if self.use_vllm_tokenizer:
+            if (
+                isinstance(request, dict)
+                and request.get("extra_args")
+                and request["extra_args"].get("vllm_tito")
+            ):
+                # RL token-in/token-out mode: raw vLLM GenerateRequest envelope.
+                generator = self._generate_tito_mode(request, context, request_id)
+            elif self.use_vllm_tokenizer:
                 # Text-in-text-out mode: use InputParamManager and OpenAI-compatible format
                 generator = self._generate_text_mode(request, context, request_id)
             else:
@@ -3409,6 +3416,90 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                                 accumulated_token_ids,
                                 accumulated_log_probs,
                             )
+                        yield tok
+                except EngineDeadError as e:
+                    logger.error(f"vLLM EngineDeadError: {e}")
+                    logger.warning("Initiating Dynamo Runtime shutdown.")
+                    self.runtime.shutdown()
+                    os._exit(1)
+
+    async def _generate_tito_mode(self, request, context, request_id):
+        """Generate tokens for the RL token-in/token-out (TITO) endpoint.
+
+        The frontend forwards the raw vLLM ``GenerateRequest`` opaquely in
+        ``request["extra_args"]["vllm_tito"]``. We re-parse it against vLLM's
+        typed protocol so the caller's ``sampling_params`` are used verbatim
+        (no ``build_sampling_params`` mapping), and drive the same aggregated
+        generation loop the token-mode path uses.
+        """
+        try:
+            from vllm.entrypoints.serve.disagg.protocol import (
+                GenerateRequest as VllmGenerateRequest,
+            )
+        except ImportError as e:
+            raise RuntimeError(
+                "TITO generate requires vLLM's disagg GenerateRequest protocol "
+                "(vllm.entrypoints.serve.disagg.protocol.GenerateRequest), which "
+                "this engine's vLLM build does not provide. Upgrade the worker's "
+                "vLLM to a version that ships the disagg protocol."
+            ) from e
+
+        envelope = request["extra_args"]["vllm_tito"]
+        parsed = VllmGenerateRequest.model_validate(envelope)
+        sampling_params = parsed.sampling_params
+        if isinstance(sampling_params, dict):
+            # vLLM's pydantic GenerateRequest does not always coerce the nested
+            # msgspec `SamplingParams` Struct in the worker process (pydantic
+            # schema-resolution timing differs from an isolated import), so
+            # `parsed.sampling_params` can arrive as a raw dict. Construct the
+            # vLLM SamplingParams from it so __post_init__ validation still runs.
+            sampling_params = SamplingParams(**sampling_params)
+
+        # Prefer core token_ids (authoritative); warn if the envelope disagrees.
+        core_token_ids = list(request.get("token_ids", []))
+        if list(parsed.token_ids) != core_token_ids:
+            logger.warning(
+                "Request %s: TITO envelope token_ids differ from core token_ids; "
+                "using core token_ids for the engine prompt",
+                request_id,
+            )
+        prompt = TokensPrompt(prompt_token_ids=core_token_ids)
+
+        # DELTA output kind so token_ids stream as per-chunk deltas, matching
+        # the token-mode path and the frontend aggregator's append semantics.
+        sampling_params.output_kind = _DELTA_REQUEST_OUTPUT_KIND
+
+        routing = request.get("routing") or {}
+        dp_rank = self._to_local_dp_rank(routing.get("dp_rank"))
+        # Engine priority rides the vLLM envelope (already vLLM's convention,
+        # lower = earlier), not Dynamo routing hints.
+        priority = int(parsed.priority or 0)
+        trace_headers = context.trace_headers()
+
+        is_decode_only = self.config.disaggregation_mode == DisaggregationMode.DECODE
+
+        async with _deferred_abort_guard(
+            self.engine_client,
+            request_id,
+            is_decode_only,
+            self._deferred_aborts,
+            self._shutdown_on_engine_dead,
+        ) as abort_guard:
+            async with self._abort_monitor(
+                context, request_id, abort_guard=abort_guard
+            ):
+                try:
+                    async for tok in self.generate_tokens(
+                        prompt,
+                        sampling_params,
+                        request_id,
+                        data_parallel_rank=dp_rank,
+                        lora_request=None,
+                        trace_headers=trace_headers,
+                        priority=priority,
+                    ):
+                        if abort_guard is not None:
+                            abort_guard.signal_first_token()
                         yield tok
                 except EngineDeadError as e:
                     logger.error(f"vLLM EngineDeadError: {e}")

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -24,7 +24,8 @@ use crate::types::{
         audios::OpenAIAudiosStreamingEngine,
         chat_completions::OpenAIChatCompletionsStreamingEngine,
         completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
-        images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
+        generate::GenerateStreamingEngine, images::OpenAIImagesStreamingEngine,
+        videos::OpenAIVideosStreamingEngine,
     },
 };
 
@@ -221,6 +222,13 @@ impl Model {
         self.worker_sets
             .iter()
             .any(|entry| entry.value().has_realtime_engine())
+    }
+
+    /// Check if any WorkerSet has a generate engine.
+    pub fn has_generate_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_generate_engine())
     }
 
     // -- Model serving readiness --
@@ -564,6 +572,11 @@ impl Model {
             .ok_or_else(|| self.engine_error(self.has_realtime_engine()))
     }
 
+    pub fn get_generate_engine(&self) -> Result<GenerateStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.generate_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_generate_engine()))
+    }
+
     // -- Combined engine + parsing options (atomically from one WorkerSet) --
 
     pub fn get_chat_engine_with_parsing(
@@ -582,6 +595,17 @@ impl Model {
                 .map(|e| (e, ws.parsing_options()))
         })
         .ok_or_else(|| self.engine_error(self.has_completions_engine()))
+    }
+
+    pub fn get_generate_engine_with_parsing(
+        &self,
+    ) -> Result<(GenerateStreamingEngine, ParsingOptions), ModelManagerError> {
+        self.select_worker_set_with(|ws| {
+            ws.generate_engine
+                .clone()
+                .map(|e| (e, ws.parsing_options()))
+        })
+        .ok_or_else(|| self.engine_error(self.has_generate_engine()))
     }
 
     // -- Worker monitoring (aggregated across WorkerSets) --

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -39,8 +39,8 @@ use crate::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
-            embeddings::OpenAIEmbeddingsStreamingEngine, images::OpenAIImagesStreamingEngine,
-            videos::OpenAIVideosStreamingEngine,
+            embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
+            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
         },
     },
 };
@@ -361,6 +361,14 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_generate_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_generate_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_prefill_models(&self) -> Vec<String> {
         self.models
             .iter()
@@ -449,6 +457,16 @@ impl ModelManager {
             .get_realtime_engine()
     }
 
+    pub fn get_generate_engine(
+        &self,
+        model: &str,
+    ) -> Result<GenerateStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_generate_engine()
+    }
+
     // -- Combined engine + parsing options (atomically from one WorkerSet) --
 
     pub fn get_chat_completions_engine_with_parsing(
@@ -481,6 +499,22 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_completions_engine_with_parsing()
+    }
+
+    pub fn get_generate_engine_with_parsing(
+        &self,
+        model: &str,
+    ) -> Result<
+        (
+            GenerateStreamingEngine,
+            crate::protocols::openai::ParsingOptions,
+        ),
+        ModelManagerError,
+    > {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_generate_engine_with_parsing()
     }
 
     // -- Convenience methods for in-process models (http.rs, grpc.rs) --
@@ -669,6 +703,27 @@ impl ModelManager {
         Ok(())
     }
 
+    pub fn add_generate_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: GenerateStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_generate_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_generate_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            Self::aggregated_local_card(),
+        );
+        ws.generate_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
     pub fn add_prefill_model(
         &self,
         model: &str,
@@ -742,6 +797,13 @@ impl ModelManager {
 
     pub fn remove_realtime_model(&self, model: &str) -> Result<(), ModelManagerError> {
         let namespace = format!("__local_realtime_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_generate_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_generate_{}", model);
         self.remove_worker_set(model, &namespace)
             .map(|_| ())
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1189,6 +1189,20 @@ impl ModelWatcher {
                 }
             }
 
+            // Generate (token-in/token-out): raw PreprocessedRequest -> LLMEngineOutput, Backend-free.
+            if let Some(routing) = preprocessed_routing.as_ref() {
+                let generate_engine = routing
+                    .build_preprocessed_pipeline(
+                        card,
+                        self.migration_limit,
+                        self.migration_max_seq_len,
+                        self.metrics.clone(),
+                    )
+                    .context("build generate (preprocessed) pipeline")?;
+                worker_set.generate_engine = Some(generate_engine);
+                tracing::info!("Generate (token-in/token-out) is ready");
+            }
+
             // Verify we built at least one serving engine. A Tokens model that
             // ends up with no chat AND no completions engine (e.g. completions-only
             // model with no tokenizer) should fail fast rather than register an

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -20,8 +20,8 @@ use crate::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
-            embeddings::OpenAIEmbeddingsStreamingEngine, images::OpenAIImagesStreamingEngine,
-            videos::OpenAIVideosStreamingEngine,
+            embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
+            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
         },
     },
 };
@@ -46,6 +46,7 @@ pub struct WorkerSet {
     pub(crate) audios_engine: Option<OpenAIAudiosStreamingEngine>,
     pub(crate) tensor_engine: Option<TensorStreamingEngine>,
     pub(crate) realtime_engine: Option<RealtimeBidirectionalEngine>,
+    pub(crate) generate_engine: Option<GenerateStreamingEngine>,
 
     /// KV router for this set's workers (if KV mode)
     pub(crate) kv_router: Option<Arc<KvRouter>>,
@@ -76,6 +77,7 @@ impl WorkerSet {
             audios_engine: None,
             tensor_engine: None,
             realtime_engine: None,
+            generate_engine: None,
             kv_router: None,
             worker_monitor: None,
             prefill_router: None,
@@ -127,6 +129,10 @@ impl WorkerSet {
         self.realtime_engine.is_some()
     }
 
+    pub fn has_generate_engine(&self) -> bool {
+        self.generate_engine.is_some()
+    }
+
     /// Whether this set has any decode engine (chat or completions)
     pub fn has_decode_engine(&self) -> bool {
         self.has_chat_engine() || self.has_completions_engine()
@@ -145,6 +151,7 @@ impl WorkerSet {
             || self.has_videos_engine()
             || self.has_audios_engine()
             || self.has_realtime_engine()
+            || self.has_generate_engine()
     }
 
     /// Whether this set tracks an Encode worker. Encode WorkerSets carry
@@ -213,6 +220,8 @@ impl WorkerSet {
 mod tests {
     use super::*;
     use crate::model_card::ModelDeploymentCard;
+    use crate::protocols::common::llm_backend::LLMEngineOutput;
+    use crate::protocols::common::preprocessor::PreprocessedRequest;
     use crate::types::Annotated;
     use crate::types::generic::tensor::{NvCreateTensorRequest, NvCreateTensorResponse};
     use crate::types::openai::audios::{NvAudioSpeechResponse, NvCreateAudioSpeechRequest};
@@ -280,6 +289,7 @@ mod tests {
         assert!(!ws.has_audios_engine());
         assert!(!ws.has_tensor_engine());
         assert!(!ws.has_realtime_engine());
+        assert!(!ws.has_generate_engine());
         assert!(!ws.has_decode_engine());
         assert!(ws.is_prefill_set());
     }
@@ -351,6 +361,12 @@ mod tests {
             has_realtime_engine,
             Arc::new(crate::engines::EchoBidirectionalEngine),
             "realtime"
+        );
+        check!(
+            generate_engine,
+            has_generate_engine,
+            StubEngine::<PreprocessedRequest, LLMEngineOutput>::new(),
+            "generate"
         );
     }
 

--- a/lib/llm/src/endpoint_type.rs
+++ b/lib/llm/src/endpoint_type.rs
@@ -24,6 +24,8 @@ pub enum EndpointType {
     Responses,
     /// Anthropic Messages API
     AnthropicMessages,
+    /// Generate API (token-in/token-out)
+    Generate,
 }
 
 impl EndpointType {
@@ -38,6 +40,7 @@ impl EndpointType {
             Self::Realtime => "realtime",
             Self::Responses => "responses",
             Self::AnthropicMessages => "anthropic_messages",
+            Self::Generate => "generate",
         }
     }
 
@@ -52,6 +55,7 @@ impl EndpointType {
             Self::Realtime,
             Self::Responses,
             Self::AnthropicMessages,
+            Self::Generate,
         ]
     }
 }
@@ -68,5 +72,15 @@ mod tests {
     #[test]
     fn realtime_in_all() {
         assert!(EndpointType::all().contains(&EndpointType::Realtime));
+    }
+
+    #[test]
+    fn generate_as_str() {
+        assert_eq!(EndpointType::Generate.as_str(), "generate");
+    }
+
+    #[test]
+    fn generate_in_all() {
+        assert!(EndpointType::all().contains(&EndpointType::Generate));
     }
 }

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -25,6 +25,7 @@ mod openai;
 pub mod busy_threshold;
 pub mod disconnect;
 pub mod error;
+pub mod generate;
 pub mod health;
 pub mod metrics;
 pub mod openapi_docs;

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -393,6 +393,103 @@ mod tests {
         (metrics, guard, context, handle)
     }
 
+    /// Engine context that records whether `kill()` was invoked, so the unary
+    /// disconnect path (armed handle dropped before disarm) can be asserted.
+    #[derive(Debug, Default)]
+    struct KillTrackingContext {
+        killed: std::sync::atomic::AtomicBool,
+    }
+    #[async_trait::async_trait]
+    impl dynamo_runtime::engine::AsyncEngineContext for KillTrackingContext {
+        fn id(&self) -> &str {
+            "kill-tracking"
+        }
+        fn stop(&self) {}
+        fn stop_generating(&self) {}
+        fn kill(&self) {
+            self.killed.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+        fn is_stopped(&self) -> bool {
+            false
+        }
+        fn is_killed(&self) -> bool {
+            self.killed.load(std::sync::atomic::Ordering::SeqCst)
+        }
+        async fn stopped(&self) {
+            std::future::pending::<()>().await;
+        }
+        async fn killed(&self) {
+            std::future::pending::<()>().await;
+        }
+        fn link_child(&self, _: Arc<dyn dynamo_runtime::engine::AsyncEngineContext>) {}
+    }
+
+    fn generate_cancellation_labels() -> CancellationLabels {
+        CancellationLabels {
+            model: "test-model".to_string(),
+            endpoint: Endpoint::Generate.to_string(),
+            request_type: "unary".to_string(),
+        }
+    }
+
+    async fn wait_for_kill(ctx: &Arc<KillTrackingContext>) {
+        // Let the detached monitor task observe the dropped handle.
+        for _ in 0..100 {
+            if ctx.is_killed() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// Unary disconnect path (the shape the `/inference/v1/generate` handler
+    /// relies on): dropping the ARMED connection handle without disarming —
+    /// i.e. the client disconnected before the response was produced — must
+    /// kill the engine context so its router reservation is released. The
+    /// disarmed second (stream) handle's `ClosedGracefully` on drop must NOT
+    /// pre-empt the kill (the monitor reads the connection handle first).
+    #[tokio::test]
+    async fn armed_handle_drop_kills_context() {
+        let ctx: Arc<KillTrackingContext> = Arc::new(KillTrackingContext::default());
+        let dyn_ctx: Arc<dyn AsyncEngineContext> = ctx.clone();
+        let (connection_handle, stream_handle) =
+            create_connection_monitor(dyn_ctx, None, generate_cancellation_labels()).await;
+
+        // Client disconnect: the handler future is dropped, taking BOTH handles
+        // with it before `disarm()` is reached.
+        drop(connection_handle);
+        drop(stream_handle);
+
+        wait_for_kill(&ctx).await;
+        assert!(
+            ctx.is_killed(),
+            "armed handle dropped without disarm must kill the engine context"
+        );
+    }
+
+    /// Normal-completion path: disarming the connection handle (the request
+    /// finished) must NOT kill the engine context.
+    #[tokio::test]
+    async fn disarmed_handle_does_not_kill_context() {
+        let ctx: Arc<KillTrackingContext> = Arc::new(KillTrackingContext::default());
+        let dyn_ctx: Arc<dyn AsyncEngineContext> = ctx.clone();
+        let (mut connection_handle, stream_handle) =
+            create_connection_monitor(dyn_ctx, None, generate_cancellation_labels()).await;
+
+        connection_handle.disarm();
+        drop(connection_handle);
+        drop(stream_handle);
+
+        // Give the monitor a chance to (incorrectly) fire before asserting.
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !ctx.is_killed(),
+            "disarmed handle must not kill the engine context"
+        );
+    }
+
     /// Zombie backend with hanging stream is terminated by inactivity timeout.
     #[tokio::test(start_paused = true)]
     async fn test_backend_inactivity_timeout_releases_inflight_gauge() {

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -6,25 +6,36 @@
 //!
 //! This is an experimental endpoint, enabled by default (matching vLLM,
 //! which mounts `/inference/v1/generate` for any generate-capable model).
-//! It registers the route with a placeholder handler that returns HTTP 501
-//! Not Implemented; the real handler (engine dispatch + `LLMEngineOutput`
-//! accumulation) lands in a follow-up. Disable via `enable_generate_endpoints`.
+//! The handler dispatches the raw `token_ids` to the model's Backend-free
+//! `PreprocessedRequest -> LLMEngineOutput` pipeline and folds the streamed
+//! deltas into a single `GenerateResponse`. Disable via
+//! `enable_generate_endpoints`. Streaming (`stream=true`) is not yet
+//! implemented and returns HTTP 501.
 
 use std::sync::Arc;
 
 use axum::{
     Json, Router,
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     middleware,
     response::{IntoResponse, Response},
     routing::post,
 };
+use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
 use serde::Serialize;
 
-use super::openai::{get_body_limit, smart_json_error_middleware};
+use super::disconnect::create_connection_monitor;
+use super::metrics::CancellationLabels;
+use super::openai::{
+    check_model_serving_ready, check_ready, context_from_headers, get_body_limit,
+    get_or_create_request_id, smart_json_error_middleware,
+};
 use super::{RouteDoc, service_v2};
-use crate::protocols::openai::generate::GenerateRequest;
+use crate::protocols::common::preprocessor::PreprocessedRequest;
+use crate::protocols::common::{SamplingOptions, StopConditions};
+use crate::protocols::openai::generate::{GenerateRequest, GenerateResponse};
+use tracing::Instrument;
 
 /// vLLM-style nested error body: `{"error": {"message", "type", "code"}}`.
 #[derive(Serialize, Debug)]
@@ -56,26 +67,259 @@ pub fn generate_router(
     (vec![doc], router)
 }
 
-/// Placeholder handler for the `Generate` endpoint.
-///
-/// Accepts and validates the request body shape, then returns HTTP 501 with a
-/// vLLM-style nested-`error` body. Real dispatch is implemented in a follow-up.
-async fn handler_generate(
-    State(_state): State<Arc<service_v2::State>>,
-    Json(_request): Json<GenerateRequest>,
-) -> Response {
-    let code = StatusCode::NOT_IMPLEMENTED;
+/// Build a vLLM-style nested-`error` [`Response`] with the given status and type.
+fn generate_error_response(code: StatusCode, error_type: &str, message: String) -> Response {
     (
         code,
         Json(GenerateError {
             error: GenerateErrorBody {
-                message: "The /inference/v1/generate endpoint is not implemented yet".to_string(),
-                error_type: "not_implemented".to_string(),
+                message,
+                error_type: error_type.to_string(),
                 code: code.as_u16(),
             },
         }),
     )
         .into_response()
+}
+
+/// vLLM's default `max_tokens` when the request omits it.
+const DEFAULT_MAX_TOKENS: u64 = 16;
+
+/// Build a [`PreprocessedRequest`] from a [`GenerateRequest`].
+///
+/// The whole raw request rides opaquely in `extra_args.vllm_tito` so the
+/// backend worker can re-parse it against vLLM's typed `GenerateRequest`;
+/// the scalar sampling controls that Dynamo core needs for
+/// stop/routing decisions are shadowed into the core fields.
+fn preprocessed_from_generate(
+    req: &GenerateRequest,
+    model: &str,
+) -> anyhow::Result<PreprocessedRequest> {
+    let sampling = &req.sampling_params;
+    let max_tokens = sampling
+        .get("max_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(DEFAULT_MAX_TOKENS);
+    let ignore_eos = sampling
+        .get("ignore_eos")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let min_tokens = sampling
+        .get("min_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    let stop_conditions = StopConditions {
+        max_tokens: Some(max_tokens as u32),
+        min_tokens: Some(min_tokens as u32),
+        ignore_eos: Some(ignore_eos),
+        ..Default::default()
+    };
+
+    // PR2 is n=1; sampling knobs beyond n stay in the opaque envelope.
+    let sampling_options = SamplingOptions {
+        n: Some(1),
+        ..Default::default()
+    };
+
+    let routing = crate::protocols::common::preprocessor::RoutingHints {
+        expected_output_tokens: Some(max_tokens as u32),
+        ..Default::default()
+    };
+
+    PreprocessedRequest::builder()
+        .model(model.to_string())
+        .token_ids(req.token_ids.clone())
+        .stop_conditions(stop_conditions)
+        .sampling_options(sampling_options)
+        .output_options(Default::default())
+        .routing(Some(routing))
+        .extra_args(Some(serde_json::json!({
+            "vllm_tito": serde_json::to_value(req)?,
+        })))
+        .build()
+        .map_err(|e| anyhow::anyhow!("failed to build PreprocessedRequest: {e}"))
+}
+
+/// Handler for the token-in/token-out `Generate` endpoint.
+///
+/// Resolves the target model, dispatches the raw `token_ids` to the model's
+/// Backend-free `PreprocessedRequest -> LLMEngineOutput` pipeline, and folds
+/// the streamed deltas into a single [`GenerateResponse`]. A client disconnect
+/// kills the engine context (mirroring the OpenAI completions path).
+async fn handler_generate(
+    State(state): State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    Json(request): Json<GenerateRequest>,
+) -> Response {
+    // return a 503 if the service is not ready
+    if let Err(err_response) = check_ready(&state) {
+        return err_response.into_response();
+    }
+
+    // Streaming is a later PR.
+    if request.stream {
+        return generate_error_response(
+            StatusCode::NOT_IMPLEMENTED,
+            "not_implemented",
+            "streaming (stream=true) is not implemented for /inference/v1/generate yet".to_string(),
+        );
+    }
+
+    // Resolve the target model: use `request.model` if given, else the sole
+    // registered generate model (error if none or ambiguous).
+    let model = match &request.model {
+        Some(model) => model.clone(),
+        None => {
+            let models = state.manager().list_generate_models();
+            match models.len() {
+                1 => models.into_iter().next().unwrap(),
+                0 => {
+                    return generate_error_response(
+                        StatusCode::NOT_FOUND,
+                        "not_found",
+                        "no generate-capable model is registered".to_string(),
+                    );
+                }
+                _ => {
+                    return generate_error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request_error",
+                        "multiple models are registered; specify `model` in the request"
+                            .to_string(),
+                    );
+                }
+            }
+        }
+    };
+
+    // Gate on per-model serving readiness: an aggregated request routed to a
+    // decode-only / not-yet-ready worker set would otherwise hang on the worker.
+    if let Err(err_response) = check_model_serving_ready(&state, &model) {
+        return err_response.into_response();
+    }
+
+    let (engine, _parsing) = match state.manager().get_generate_engine_with_parsing(&model) {
+        Ok(pair) => pair,
+        Err(e) => {
+            let code = match e {
+                crate::discovery::ModelManagerError::ModelUnavailable(_) => {
+                    StatusCode::SERVICE_UNAVAILABLE
+                }
+                _ => StatusCode::NOT_FOUND,
+            };
+            return generate_error_response(code, "not_found", e.to_string());
+        }
+    };
+
+    let preprocessed = match preprocessed_from_generate(&request, &model) {
+        Ok(preprocessed) => preprocessed,
+        Err(e) => {
+            return generate_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                e.to_string(),
+            );
+        }
+    };
+
+    // Build the request context (carrying the request id) and wire a
+    // connection monitor so a client disconnect kills the engine context.
+    let request_id = get_or_create_request_id(&headers);
+    let context: Context<PreprocessedRequest> =
+        match context_from_headers(preprocessed, request_id.clone(), &headers) {
+            Ok(context) => context,
+            Err(err_response) => {
+                return err_response.into_response();
+            }
+        };
+    let engine_context = context.context();
+    let cancellation_labels = CancellationLabels {
+        model: state.manager().metric_model_for(&model).to_string(),
+        endpoint: super::metrics::Endpoint::Generate.to_string(),
+        request_type: "unary".to_string(),
+    };
+    let (mut connection_handle, _stream_handle) = create_connection_monitor(
+        engine_context.clone(),
+        Some(state.metrics_clone()),
+        cancellation_labels,
+    )
+    .await;
+
+    // Spawn the dispatch so the generation task runs (and cleans up) out of
+    // band from the axum handler future, mirroring the OpenAI handlers.
+    let response = match tokio::spawn(
+        generate_dispatch(engine, context, request_id, model, state.clone()).in_current_span(),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(join_err) => generate_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_error",
+            format!("generate task panicked: {join_err}"),
+        ),
+    };
+
+    // Long-running work completed without needing cancellation.
+    connection_handle.disarm();
+    response
+}
+
+/// Dispatch a prepared [`Context<PreprocessedRequest>`] to the generate engine
+/// and fold the streamed deltas into a single [`GenerateResponse`].
+async fn generate_dispatch(
+    engine: crate::types::openai::generate::GenerateStreamingEngine,
+    context: Context<PreprocessedRequest>,
+    request_id: String,
+    model: String,
+    state: Arc<service_v2::State>,
+) -> Response {
+    let stream = match engine.generate(context).await {
+        Ok(stream) => stream,
+        Err(e) => {
+            if super::metrics::request_was_rejected(e.as_ref()) {
+                state
+                    .metrics_clone()
+                    .inc_rejection(&model, super::metrics::Endpoint::Generate);
+                return generate_error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "service_unavailable",
+                    format!("engine rejected the request: {e:#}"),
+                );
+            }
+            return generate_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                format!("failed to generate: {e:#}"),
+            );
+        }
+    };
+
+    let engine_context = stream.context();
+
+    match GenerateResponse::from_annotated_stream(stream, request_id.clone()).await {
+        Ok(response) => {
+            // If the engine context was killed (client disconnect), the response
+            // was assembled but never delivered.
+            if engine_context.is_killed() {
+                return generate_error_response(
+                    StatusCode::from_u16(499).unwrap_or(StatusCode::BAD_REQUEST),
+                    "request_cancelled",
+                    "request was cancelled".to_string(),
+                );
+            }
+            Json(response).into_response()
+        }
+        Err(e) => {
+            tracing::error!("Failed to fold generate stream for {request_id}: {e:?}");
+            generate_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                format!("failed to fold generate stream for {request_id}"),
+            )
+        }
+    }
 }
 
 #[cfg(test)]
@@ -107,7 +351,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn generate_route_returns_501_when_enabled() {
+    async fn generate_route_no_model_returns_404() {
+        // Endpoint enabled + service ready (default stage) but no model
+        // registered: the handler runs, model resolution finds zero generate
+        // models, and returns a structured 404 nested-`error` body. This proves
+        // the route is mounted AND the real handler executed (a route-not-found
+        // 404 has an empty body).
         let (port, handle) = serve(true).await;
         let resp = reqwest::Client::new()
             .post(format!("http://localhost:{}/inference/v1/generate", port))
@@ -116,7 +365,30 @@ mod tests {
             .send()
             .await
             .expect("generate request failed");
+        assert_eq!(resp.status().as_u16(), StatusCode::NOT_FOUND.as_u16());
+        let body: serde_json::Value = resp.json().await.expect("json body");
+        assert!(
+            body.get("error").is_some(),
+            "expected nested-`error` body, got {body}"
+        );
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn generate_route_streaming_returns_501() {
+        // stream=true is not implemented in this PR: the handler returns a 501
+        // nested-`error` body after the readiness gate passes (default stage).
+        let (port, handle) = serve(true).await;
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{}/inference/v1/generate", port))
+            .header("content-type", "application/json")
+            .body(r#"{"token_ids":[1,2,3],"sampling_params":{},"stream":true}"#)
+            .send()
+            .await
+            .expect("generate request failed");
         assert_eq!(resp.status().as_u16(), StatusCode::NOT_IMPLEMENTED.as_u16());
+        let body: serde_json::Value = resp.json().await.expect("json body");
+        assert_eq!(body["error"]["type"], "not_implemented");
         handle.abort();
     }
 

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -311,6 +311,18 @@ async fn generate_dispatch(
                     "request was cancelled".to_string(),
                 );
             }
+            // Guard the unary n=1 profile: a completed generation must yield at
+            // least one choice, each carrying a terminal finish_reason. An empty
+            // stream or a premature (finish_reason-less) EOF would otherwise
+            // surface as a misleading HTTP 200 with empty/partial choices.
+            if !response.is_complete_unary() {
+                tracing::error!("generate stream for {request_id} ended without a complete choice");
+                return generate_error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal_error",
+                    format!("generation produced no complete choice for {request_id}"),
+                );
+            }
             Json(response).into_response()
         }
         Err(e) => {

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP handler for the token-in/token-out `Generate` API
+//! (`POST /inference/v1/generate`).
+//!
+//! This is an experimental endpoint, enabled by default (matching vLLM,
+//! which mounts `/inference/v1/generate` for any generate-capable model).
+//! It registers the route with a placeholder handler that returns HTTP 501
+//! Not Implemented; the real handler (engine dispatch + `LLMEngineOutput`
+//! accumulation) lands in a follow-up. Disable via `enable_generate_endpoints`.
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    middleware,
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use serde::Serialize;
+
+use super::openai::{get_body_limit, smart_json_error_middleware};
+use super::{RouteDoc, service_v2};
+use crate::protocols::openai::generate::GenerateRequest;
+
+/// vLLM-style nested error body: `{"error": {"message", "type", "code"}}`.
+#[derive(Serialize, Debug)]
+struct GenerateError {
+    error: GenerateErrorBody,
+}
+
+#[derive(Serialize, Debug)]
+struct GenerateErrorBody {
+    message: String,
+    #[serde(rename = "type")]
+    error_type: String,
+    code: u16,
+}
+
+/// Create an Axum [`Router`] for the token-in/token-out `Generate` endpoint.
+/// If no path is provided, the default path is `/inference/v1/generate`.
+pub fn generate_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let path = path.unwrap_or("/inference/v1/generate".to_string());
+    let doc = RouteDoc::new(axum::http::Method::POST, &path);
+    let router = Router::new()
+        .route(&path, post(handler_generate))
+        .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
+        .with_state(state);
+    (vec![doc], router)
+}
+
+/// Placeholder handler for the `Generate` endpoint.
+///
+/// Accepts and validates the request body shape, then returns HTTP 501 with a
+/// vLLM-style nested-`error` body. Real dispatch is implemented in a follow-up.
+async fn handler_generate(
+    State(_state): State<Arc<service_v2::State>>,
+    Json(_request): Json<GenerateRequest>,
+) -> Response {
+    let code = StatusCode::NOT_IMPLEMENTED;
+    (
+        code,
+        Json(GenerateError {
+            error: GenerateErrorBody {
+                message: "The /inference/v1/generate endpoint is not implemented yet".to_string(),
+                error_type: "not_implemented".to_string(),
+                code: code.as_u16(),
+            },
+        }),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StatusCode;
+    use super::service_v2::HttpService;
+    use tokio_util::sync::CancellationToken;
+
+    /// Spin up an `HttpService` bound to an ephemeral port and return the port
+    /// plus the run handle. Mirrors the reqwest-based router tests in
+    /// `service_v2`.
+    async fn serve(enable_generate: bool) -> (u16, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let service = HttpService::builder()
+            .port(port)
+            .enable_generate_endpoints(enable_generate)
+            .build()
+            .unwrap();
+        let cancel_token = CancellationToken::new();
+        let handle = tokio::spawn(async move {
+            service.run_with_listener(cancel_token, listener).await.ok();
+        });
+        // Give the server a moment to start listening.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        (port, handle)
+    }
+
+    #[tokio::test]
+    async fn generate_route_returns_501_when_enabled() {
+        let (port, handle) = serve(true).await;
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{}/inference/v1/generate", port))
+            .header("content-type", "application/json")
+            .body(r#"{"token_ids":[1,2,3],"sampling_params":{}}"#)
+            .send()
+            .await
+            .expect("generate request failed");
+        assert_eq!(resp.status().as_u16(), StatusCode::NOT_IMPLEMENTED.as_u16());
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn generate_route_404_when_disabled() {
+        let (port, handle) = serve(false).await;
+        let resp = reqwest::Client::new()
+            .post(format!("http://localhost:{}/inference/v1/generate", port))
+            .header("content-type", "application/json")
+            .body(r#"{"token_ids":[1,2,3],"sampling_params":{}}"#)
+            .send()
+            .await
+            .expect("generate request failed");
+        assert_eq!(resp.status().as_u16(), StatusCode::NOT_FOUND.as_u16());
+        handle.abort();
+    }
+}

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -202,13 +202,15 @@ async fn handler_generate(
     let (engine, _parsing) = match state.manager().get_generate_engine_with_parsing(&model) {
         Ok(pair) => pair,
         Err(e) => {
-            let code = match e {
+            // Select status and error type together so a 503 (model-removal
+            // race) never carries a "not_found" type, and vice versa.
+            let (code, error_type) = match e {
                 crate::discovery::ModelManagerError::ModelUnavailable(_) => {
-                    StatusCode::SERVICE_UNAVAILABLE
+                    (StatusCode::SERVICE_UNAVAILABLE, "service_unavailable")
                 }
-                _ => StatusCode::NOT_FOUND,
+                _ => (StatusCode::NOT_FOUND, "not_found"),
             };
-            return generate_error_response(code, "not_found", e.to_string());
+            return generate_error_response(code, error_type, e.to_string());
         }
     };
 

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -459,6 +459,9 @@ pub enum Endpoint {
 
     /// Tensor
     Tensor,
+
+    /// Generate (token-in/token-out)
+    Generate,
 }
 
 /// Metrics for the HTTP service
@@ -1412,6 +1415,7 @@ impl std::fmt::Display for Endpoint {
             Endpoint::Responses => write!(f, "responses"),
             Endpoint::AnthropicMessages => write!(f, "anthropic_messages"),
             Endpoint::Tensor => write!(f, "tensor"),
+            Endpoint::Generate => write!(f, "generate"),
         }
     }
 }
@@ -1428,6 +1432,7 @@ impl Endpoint {
             Endpoint::Responses => "responses",
             Endpoint::AnthropicMessages => "anthropic_messages",
             Endpoint::Tensor => "tensor",
+            Endpoint::Generate => "generate",
         }
     }
 }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -539,7 +539,7 @@ pub(super) fn get_or_create_request_id(headers: &HeaderMap) -> String {
     validated_header.unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
 }
 
-fn context_from_headers<T: Send + Sync + 'static>(
+pub(super) fn context_from_headers<T: Send + Sync + 'static>(
     request: T,
     request_id: String,
     headers: &HeaderMap,

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -288,6 +288,7 @@ struct StateFlags {
     realtime_endpoints_enabled: AtomicBool,
     responses_endpoints_enabled: AtomicBool,
     anthropic_endpoints_enabled: AtomicBool,
+    generate_endpoints_enabled: AtomicBool,
 }
 
 impl StateFlags {
@@ -304,6 +305,7 @@ impl StateFlags {
             EndpointType::AnthropicMessages => {
                 self.anthropic_endpoints_enabled.load(Ordering::Relaxed)
             }
+            EndpointType::Generate => self.generate_endpoints_enabled.load(Ordering::Relaxed),
         }
     }
 
@@ -336,6 +338,9 @@ impl StateFlags {
             EndpointType::AnthropicMessages => self
                 .anthropic_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
+            EndpointType::Generate => self
+                .generate_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
         }
     }
 }
@@ -363,6 +368,7 @@ impl State {
                 realtime_endpoints_enabled: AtomicBool::new(false),
                 responses_endpoints_enabled: AtomicBool::new(false),
                 anthropic_endpoints_enabled: AtomicBool::new(false),
+                generate_endpoints_enabled: AtomicBool::new(false),
             },
             cancel_token,
             frontend_api_config: config.frontend_api_config,
@@ -527,6 +533,14 @@ pub struct HttpServiceConfig {
 
     #[builder(default = "true")]
     enable_responses_endpoints: bool,
+
+    /// Experimental token-in/token-out `Generate` API
+    /// (`POST /inference/v1/generate`). Enabled by default, matching vLLM,
+    /// which mounts this endpoint for any generate-capable model. The handler
+    /// is a placeholder (HTTP 501) until request dispatch lands; set to
+    /// `false` to hide the route entirely.
+    #[builder(default = "true")]
+    enable_generate_endpoints: bool,
 
     /// API behavior config retained in HTTP state for route and streaming decisions.
     #[builder(default)]
@@ -863,6 +877,8 @@ static HTTP_SVC_EMB_PATH_ENV: &str = "DYN_HTTP_SVC_EMB_PATH";
 static HTTP_SVC_RESPONSES_PATH_ENV: &str = "DYN_HTTP_SVC_RESPONSES_PATH";
 /// Environment variable to set the anthropic messages endpoint path (default: `/v1/messages`)
 static HTTP_SVC_ANTHROPIC_PATH_ENV: &str = "DYN_HTTP_SVC_ANTHROPIC_PATH";
+/// Environment variable to set the generate endpoint path (default: `/inference/v1/generate`)
+static HTTP_SVC_GENERATE_PATH_ENV: &str = "DYN_HTTP_SVC_GENERATE_PATH";
 
 impl HttpServiceConfigBuilder {
     pub fn build(self) -> Result<HttpService, anyhow::Error> {
@@ -870,6 +886,7 @@ impl HttpServiceConfigBuilder {
         let metrics_config = config.metrics_config.clone();
         let frontend_api_config = config.frontend_api_config.clone();
         let anthropic_endpoints_enabled = frontend_api_config.anthropic().enabled();
+        let generate_endpoints_enabled = config.enable_generate_endpoints;
 
         let model_manager = Arc::new(ModelManager::new());
         let cancel_token = config.cancel_token.unwrap_or_default();
@@ -914,6 +931,9 @@ impl HttpServiceConfigBuilder {
             &EndpointType::AnthropicMessages,
             anthropic_endpoints_enabled,
         );
+        state
+            .flags
+            .set(&EndpointType::Generate, generate_endpoints_enabled);
 
         // enable prometheus metrics
         let registry = metrics::Registry::new();
@@ -1012,6 +1032,7 @@ impl HttpServiceConfigBuilder {
             state.clone(),
             &config.request_template,
             anthropic_endpoints_enabled,
+            generate_endpoints_enabled,
         );
         let mut inference_router = axum::Router::new();
         for (route_docs, route) in endpoint_routes {
@@ -1129,6 +1150,7 @@ impl HttpServiceConfigBuilder {
         state: Arc<State>,
         request_template: &Option<RequestTemplate>,
         enable_anthropic_endpoints: bool,
+        enable_generate_endpoints: bool,
     ) -> Vec<(Vec<RouteDoc>, axum::Router)> {
         let mut routes = Vec::new();
         // Add chat completions route with conditional middleware
@@ -1171,6 +1193,17 @@ impl HttpServiceConfigBuilder {
                 EndpointType::AnthropicMessages,
                 (anthropic_docs, anthropic_route),
             );
+        }
+
+        if enable_generate_endpoints {
+            tracing::warn!(
+                "Generate API (/inference/v1/generate) is experimental and not implemented yet."
+            );
+            let (generate_docs, generate_route) = super::generate::generate_router(
+                state.clone(),
+                var(HTTP_SVC_GENERATE_PATH_ENV).ok(),
+            );
+            endpoint_routes.insert(EndpointType::Generate, (generate_docs, generate_route));
         }
 
         for endpoint_type in EndpointType::all() {

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -184,6 +184,12 @@ impl ModelType {
         if self.contains(Self::Completions) {
             endpoint_types.push(crate::endpoint_type::EndpointType::Completion);
         }
+        // Token-in/token-out Generate endpoint is available for any
+        // generate-capable model (chat or completions), matching the
+        // default-on posture of the `/inference/v1/generate` route.
+        if self.supports_chat() || self.supports_completions() {
+            endpoint_types.push(crate::endpoint_type::EndpointType::Generate);
+        }
         if self.contains(Self::Embedding) {
             endpoint_types.push(crate::endpoint_type::EndpointType::Embedding);
         }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -18,6 +18,7 @@ pub mod common_ext;
 pub mod completions;
 pub(crate) mod delta_common;
 pub mod embeddings;
+pub mod generate;
 pub mod images;
 pub mod models;
 pub mod responses;

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -13,7 +13,14 @@
 //! (multimodal), `stream_options`, negative-`token_ids` validation-message
 //! parity with vLLM, and auto-generating a `request_id` when absent.
 
+use std::collections::HashMap;
+
+use anyhow::Result;
+use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
+
+use crate::protocols::Annotated;
+use crate::protocols::common::llm_backend::LLMEngineOutput;
 
 /// Token-in/token-out generation request.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -67,6 +74,105 @@ pub struct GenerateResponse {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kv_transfer_params: Option<serde_json::Value>,
+}
+
+/// Per-index accumulation state while folding a stream of
+/// [`LLMEngineOutput`] deltas into a single [`GenerateResponse`].
+struct GenerateChoiceAcc {
+    index: u32,
+    token_ids: Vec<crate::protocols::TokenIdType>,
+    finish_reason: Option<String>,
+}
+
+/// Folds a stream of [`Annotated<LLMEngineOutput>`] deltas into a single
+/// [`GenerateResponse`]. Each chunk carries a delta of newly generated
+/// `token_ids` keyed by `index` (default 0); the aggregator appends the
+/// deltas per index and records the terminal `finish_reason`.
+struct GenerateAggregator {
+    request_id: String,
+    choices: HashMap<u32, GenerateChoiceAcc>,
+    error: Option<String>,
+}
+
+impl GenerateAggregator {
+    fn new(request_id: String) -> Self {
+        Self {
+            request_id,
+            choices: HashMap::new(),
+            error: None,
+        }
+    }
+
+    async fn apply(
+        stream: impl Stream<Item = Annotated<LLMEngineOutput>>,
+        request_id: String,
+    ) -> Result<GenerateResponse> {
+        let aggregator = stream
+            .fold(
+                GenerateAggregator::new(request_id),
+                |mut agg, delta| async move {
+                    let delta = match delta.ok() {
+                        Ok(delta) => delta,
+                        Err(error) => {
+                            agg.error = Some(error);
+                            return agg;
+                        }
+                    };
+
+                    if agg.error.is_none()
+                        && let Some(output) = delta.data
+                    {
+                        let index = output.index.unwrap_or(0);
+                        let choice = agg.choices.entry(index).or_insert(GenerateChoiceAcc {
+                            index,
+                            token_ids: Vec::new(),
+                            finish_reason: None,
+                        });
+                        // token_ids are per-chunk deltas; append (never replace).
+                        choice.token_ids.extend(output.token_ids);
+                        if let Some(finish_reason) = output.finish_reason {
+                            choice.finish_reason = Some(finish_reason.to_string());
+                        }
+                    }
+                    agg
+                },
+            )
+            .await;
+
+        if let Some(error) = aggregator.error {
+            return Err(anyhow::anyhow!(error));
+        }
+
+        let mut choices: Vec<GenerateResponseChoice> = aggregator
+            .choices
+            .into_values()
+            .map(|acc| GenerateResponseChoice {
+                index: acc.index,
+                token_ids: Some(acc.token_ids),
+                logprobs: None,
+                finish_reason: acc.finish_reason,
+            })
+            .collect();
+        choices.sort_by_key(|c| c.index);
+
+        Ok(GenerateResponse {
+            request_id: aggregator.request_id,
+            choices,
+            prompt_logprobs: None,
+            kv_transfer_params: None,
+        })
+    }
+}
+
+impl GenerateResponse {
+    /// Aggregate a stream of [`Annotated<LLMEngineOutput>`] deltas into a
+    /// single [`GenerateResponse`] for the non-streaming `Generate` endpoint.
+    pub async fn from_annotated_stream(
+        stream: impl Stream<Item = Annotated<LLMEngineOutput>>,
+        request_id: String,
+    ) -> Result<GenerateResponse> {
+        GenerateAggregator::apply(stream, request_id).await
+    }
 }
 
 #[cfg(test)]
@@ -136,5 +242,47 @@ mod tests {
         assert_eq!(round.choices.len(), 1);
         assert_eq!(round.choices[0].token_ids, Some(vec![10, 11, 12]));
         assert_eq!(round.choices[0].finish_reason.as_deref(), Some("stop"));
+    }
+
+    /// Fold a 4-chunk delta stream (each carrying one token_id) into a single
+    /// choice: assert the deltas are appended (not duplicated), the terminal
+    /// finish_reason is captured, and exactly one choice is emitted.
+    #[tokio::test]
+    async fn from_annotated_stream_appends_deltas() {
+        let chunks = vec![
+            LLMEngineOutput {
+                token_ids: vec![100],
+                index: Some(0),
+                ..Default::default()
+            },
+            LLMEngineOutput {
+                token_ids: vec![101],
+                index: Some(0),
+                ..Default::default()
+            },
+            LLMEngineOutput {
+                token_ids: vec![102],
+                index: Some(0),
+                ..Default::default()
+            },
+            LLMEngineOutput {
+                token_ids: vec![103],
+                index: Some(0),
+                finish_reason: Some(crate::protocols::common::FinishReason::Length),
+                ..Default::default()
+            },
+        ];
+        let stream = futures::stream::iter(chunks.into_iter().map(Annotated::from_data));
+
+        let resp = GenerateResponse::from_annotated_stream(stream, "req-agg".to_string())
+            .await
+            .expect("aggregate");
+
+        assert_eq!(resp.request_id, "req-agg");
+        assert_eq!(resp.choices.len(), 1);
+        let choice = &resp.choices[0];
+        assert_eq!(choice.index, 0);
+        assert_eq!(choice.token_ids, Some(vec![100, 101, 102, 103]));
+        assert_eq!(choice.finish_reason.as_deref(), Some("length"));
     }
 }

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol types for the token-in/token-out `Generate` API
+//! (`POST /inference/v1/generate`).
+//!
+//! These mirror vLLM's `GenerateRequest` / `GenerateResponse` wire contract
+//! (`vllm/entrypoints/serve/disagg/protocol.py`). The text-only subset is
+//! captured here; `sampling_params` is kept opaque (`serde_json::Value`) for
+//! now — the typed sampling envelope lands in a follow-up.
+//!
+//! Deferred to follow-up PRs (intentionally absent here): `features`
+//! (multimodal), `stream_options`, negative-`token_ids` validation-message
+//! parity with vLLM, and auto-generating a `request_id` when absent.
+
+use serde::{Deserialize, Serialize};
+
+/// Token-in/token-out generation request.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GenerateRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+
+    pub token_ids: Vec<u32>,
+
+    pub sampling_params: serde_json::Value,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    #[serde(default)]
+    pub stream: bool,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_salt: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kv_transfer_params: Option<serde_json::Value>,
+}
+
+/// A single choice in a `GenerateResponse`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GenerateResponseChoice {
+    pub index: u32,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_ids: Option<Vec<u32>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<serde_json::Value>,
+
+    pub finish_reason: Option<String>,
+}
+
+/// Token-in/token-out generation response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GenerateResponse {
+    pub request_id: String,
+
+    pub choices: Vec<GenerateResponseChoice>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_logprobs: Option<serde_json::Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kv_transfer_params: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn generate_request_deserializes_from_vllm_json() {
+        let raw = json!({
+            "request_id": "req-123",
+            "token_ids": [1, 2, 3, 4],
+            "sampling_params": {"temperature": 0.7, "max_tokens": 16},
+            "model": "test-model",
+            "stream": false,
+            "cache_salt": "salt",
+            "priority": 0,
+            "kv_transfer_params": null
+        });
+        let req: GenerateRequest = serde_json::from_value(raw).expect("deserialize");
+        assert_eq!(req.request_id.as_deref(), Some("req-123"));
+        assert_eq!(req.token_ids, vec![1, 2, 3, 4]);
+        assert!(!req.stream);
+        assert_eq!(req.model.as_deref(), Some("test-model"));
+    }
+
+    #[test]
+    fn generate_request_minimal_defaults() {
+        // Unknown fields are ignored, stream defaults false, optionals default None.
+        let raw = json!({
+            "token_ids": [5, 6],
+            "sampling_params": {},
+            "future_field": "ignored"
+        });
+        let req: GenerateRequest = serde_json::from_value(raw).expect("deserialize");
+        assert_eq!(req.token_ids, vec![5, 6]);
+        assert!(!req.stream);
+        assert_eq!(req.request_id, None);
+        assert_eq!(req.priority, None);
+    }
+
+    #[test]
+    fn generate_response_round_trips_without_usage_key() {
+        let resp = GenerateResponse {
+            request_id: "req-123".to_string(),
+            choices: vec![GenerateResponseChoice {
+                index: 0,
+                token_ids: Some(vec![10, 11, 12]),
+                logprobs: None,
+                finish_reason: Some("stop".to_string()),
+            }],
+            prompt_logprobs: None,
+            kv_transfer_params: None,
+        };
+
+        let value = serde_json::to_value(&resp).expect("serialize");
+        assert!(
+            value.get("usage").is_none(),
+            "GenerateResponse must not emit a `usage` key"
+        );
+        assert!(value.get("prompt_logprobs").is_none());
+        assert!(value.get("kv_transfer_params").is_none());
+
+        let round: GenerateResponse =
+            serde_json::from_value(value).expect("round-trip deserialize");
+        assert_eq!(round.request_id, "req-123");
+        assert_eq!(round.choices.len(), 1);
+        assert_eq!(round.choices[0].token_ids, Some(vec![10, 11, 12]));
+        assert_eq!(round.choices[0].finish_reason.as_deref(), Some("stop"));
+    }
+}

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -173,6 +173,15 @@ impl GenerateResponse {
     ) -> Result<GenerateResponse> {
         GenerateAggregator::apply(stream, request_id).await
     }
+
+    /// Whether this represents a complete unary generation: at least one
+    /// choice, and every choice carries a terminal `finish_reason`. An empty
+    /// stream (no choices) or a premature clean EOF (a choice with no
+    /// `finish_reason`) is *not* complete — the unary handler rejects these
+    /// rather than returning a misleading HTTP 200 with empty/partial choices.
+    pub fn is_complete_unary(&self) -> bool {
+        !self.choices.is_empty() && self.choices.iter().all(|c| c.finish_reason.is_some())
+    }
 }
 
 #[cfg(test)]
@@ -284,5 +293,49 @@ mod tests {
         assert_eq!(choice.index, 0);
         assert_eq!(choice.token_ids, Some(vec![100, 101, 102, 103]));
         assert_eq!(choice.finish_reason.as_deref(), Some("length"));
+        assert!(resp.is_complete_unary(), "terminal choice is complete");
+    }
+
+    /// An empty engine stream folds to a response with no choices; the unary
+    /// handler must treat this as incomplete (rejected), not a 200 with `[]`.
+    #[tokio::test]
+    async fn from_annotated_stream_empty_is_incomplete() {
+        let stream = futures::stream::iter(Vec::<Annotated<LLMEngineOutput>>::new());
+        let resp = GenerateResponse::from_annotated_stream(stream, "req-empty".to_string())
+            .await
+            .expect("aggregate");
+        assert!(resp.choices.is_empty());
+        assert!(
+            !resp.is_complete_unary(),
+            "empty stream must not be treated as a complete generation"
+        );
+    }
+
+    /// A stream that ends after emitting tokens but WITHOUT a terminal
+    /// `finish_reason` (premature clean EOF) must be treated as incomplete.
+    #[tokio::test]
+    async fn from_annotated_stream_premature_eof_is_incomplete() {
+        let chunks = vec![
+            LLMEngineOutput {
+                token_ids: vec![100],
+                index: Some(0),
+                ..Default::default()
+            },
+            LLMEngineOutput {
+                token_ids: vec![101],
+                index: Some(0),
+                ..Default::default()
+            },
+        ];
+        let stream = futures::stream::iter(chunks.into_iter().map(Annotated::from_data));
+        let resp = GenerateResponse::from_annotated_stream(stream, "req-eof".to_string())
+            .await
+            .expect("aggregate");
+        assert_eq!(resp.choices.len(), 1);
+        assert_eq!(resp.choices[0].finish_reason, None);
+        assert!(
+            !resp.is_complete_unary(),
+            "premature EOF (no finish_reason) must not be treated as complete"
+        );
     }
 }

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -44,6 +44,24 @@ pub mod openai {
         >;
     }
 
+    pub mod generate {
+        use super::*;
+        use crate::protocols::common::llm_backend::LLMEngineOutput;
+        use crate::protocols::common::preprocessor::PreprocessedRequest;
+
+        pub use protocols::openai::generate::{GenerateRequest, GenerateResponse};
+
+        /// A [`ServerStreamingEngine`] implementation for the token-in/token-out
+        /// `Generate` API.
+        ///
+        /// The registered engine is **raw**: it consumes a preprocessed
+        /// [`PreprocessedRequest`] and streams [`LLMEngineOutput`] directly, with
+        /// no Backend/decoder in between. The handler is responsible for
+        /// accumulating engine output into a `GenerateResponse`.
+        pub type GenerateStreamingEngine =
+            ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>;
+    }
+
     pub mod embeddings {
         use super::*;
 

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -215,6 +215,7 @@ fn compute_index(endpoint: &Endpoint, request_type: &RequestType, status: &Statu
         Endpoint::Images => todo!(),
         Endpoint::Videos => todo!(),
         Endpoint::Audios => todo!(),
+        Endpoint::Generate => todo!(),
     };
 
     let request_type = match request_type {

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -42,6 +42,7 @@ from tests.utils.payload_builder import (
 from tests.utils.payloads import (
     EmbeddingMultiWorkerDispatchPayload,
     EmbeddingPayload,
+    GeneratePayload,
     LoraTestChatPayload,
     ToolCallingChatPayload,
 )
@@ -153,6 +154,22 @@ vllm_configs = {
                 expected_response=[],
                 max_tokens=64,
                 extra_body={"nvext": {"max_thinking_tokens": 16}},
+            ),
+            # Token-in/token-out: POST pre-tokenized token_ids to
+            # /inference/v1/generate and assert the vLLM GenerateResponse shape
+            # (raw token_ids back, finish_reason, no usage). Exercises the RL
+            # TITO path end-to-end through a real worker.
+            GeneratePayload(
+                body={
+                    "token_ids": [785, 6722, 315, 9625, 374],
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_tokens": 4,
+                        "ignore_eos": True,
+                    },
+                },
+                expected_response=[],
+                expected_log=[],
             ),
             metric_payload_default(min_num_requests=6, backend="vllm"),
         ],

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -166,7 +166,17 @@ vllm_configs = {
                         "temperature": 0,
                         "max_tokens": 4,
                         "ignore_eos": True,
+                        # Pinned-profile params: seed=-1 (vLLM normalizes to None)
+                        # and an unknown NESTED key that must be ignored (it rides
+                        # the opaque envelope to the worker's model_validate; a
+                        # SamplingParams(**dict) reconstruction would crash on it).
+                        "seed": -1,
+                        "future_nested_field": "ignored",
                     },
+                    # Unknown TOP-level key: the Rust frontend must ignore it
+                    # (serde drops unknown fields; no 400), matching vLLM's
+                    # non-strict GenerateRequest.
+                    "future_top_field": "ignored",
                 },
                 expected_response=[],
                 expected_log=[],

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -197,6 +197,54 @@ class ChatPayload(BasePayload):
         )
 
 
+@dataclass
+class GeneratePayload(BasePayload):
+    """Payload for the token-in/token-out ``/inference/v1/generate`` endpoint.
+
+    Posts pre-tokenized ``token_ids`` and asserts the vLLM ``GenerateResponse``
+    shape: raw ``token_ids`` back, a ``finish_reason``, a fresh ``request_id``,
+    and NO ``usage``. With ``max_tokens`` + ``ignore_eos`` the token count is
+    exact, which is a deterministic check that isn't brittle to the specific
+    token values (which can shift across vLLM builds).
+    """
+
+    endpoint: str = "/inference/v1/generate"
+
+    @staticmethod
+    def extract_content(response):
+        response.raise_for_status()
+        result = response.json()
+        assert (
+            "choices" in result and result["choices"]
+        ), f"Missing/empty 'choices' in GenerateResponse: {result}"
+        token_ids = result["choices"][0].get("token_ids")
+        assert token_ids, f"Empty 'token_ids' in first choice: {result}"
+        return " ".join(str(t) for t in token_ids)
+
+    def response_handler(self, response: Any) -> str:
+        return GeneratePayload.extract_content(response)
+
+    def validate(self, response: Any, content: str) -> None:
+        super().validate(response, content)
+        result = response.json()
+        assert result.get("request_id"), f"Missing request_id: {result}"
+        assert (
+            "usage" not in result
+        ), f"GenerateResponse must not carry 'usage': {result}"
+        choice = result["choices"][0]
+        token_ids = choice.get("token_ids")
+        assert (
+            isinstance(token_ids, list) and token_ids
+        ), f"Empty token_ids in choice: {choice}"
+        assert choice.get("finish_reason"), f"Missing finish_reason: {choice}"
+        expected_max = self.body.get("sampling_params", {}).get("max_tokens")
+        if expected_max is not None:
+            assert len(token_ids) == expected_max, (
+                f"Expected {expected_max} tokens (max_tokens + ignore_eos), "
+                f"got {len(token_ids)}: {choice}"
+            )
+
+
 class RouterNvextChatPayload(ChatPayload):
     """Chat payload that validates structured router metadata in nvext."""
 


### PR DESCRIPTION
## Why

PR1 registered `/inference/v1/generate` as an inert placeholder. This PR makes it serve: a vLLM/llm-d client can POST pre-tokenized `token_ids` and get `token_ids` back, routed through Dynamo's in-process KV router to a vLLM worker — the drop-in token-in/token-out surface RL rollout frameworks target. The request rides opaquely as a vLLM `GenerateRequest` envelope and the worker reconstructs vLLM's own `SamplingParams`, so parameters and unknown-field handling match vLLM exactly with no coercion through Dynamo's narrower core types. **Stacked on the PR1 registration branch** (`qiwa/rl-tito-generate-pr1`).

## Effect

```
$ curl -s :8000/inference/v1/generate \
    -d '{"token_ids":[785,6722,315,9625,374],"sampling_params":{"temperature":0,"max_tokens":4,"ignore_eos":true}}'
{"request_id":"c538...","choices":[{"index":0,"token_ids":[12095,13,576,6722],"finish_reason":"length"}]}
# byte-identical token_ids + finish_reason to vLLM's own /inference/v1/generate for the same request
```

## What Change

- Watcher builds a Backend-free `PreprocessedRequest → LLMEngineOutput` generate engine; handler builds the opaque `vllm_tito` envelope + control shadow, folds deltas into a `GenerateResponse`.
- Worker `_generate_tito_mode` reconstructs vLLM `SamplingParams` via `msgspec.convert` (drops unknown keys, runs `__post_init__`), forces DELTA output.
- Reject incomplete unary results (empty / premature-EOF) and mismatched error types; disconnect → cancel + reservation release.

## Test Plan

- Unit: aggregator fold, empty/premature-EOF, connection-monitor kill-on-disconnect, route/readiness — `cargo test -p dynamo-llm --lib generate` + `--lib disconnect` (15 + 7 pass).
- E2E: `GeneratePayload` on `test_serve_deployment[aggregated-2]` (Qwen3-0.6B) asserts exact `token_ids`/`finish_reason`, no `usage`, and unknown-field ignore (seed=-1 + unknown nested/top-level). Passes locally (~76s); byte-identical to a vLLM golden.
