### PR TITLE
feat(frontend): RL TITO practical param-set matrix + fidelity tests

### DIFF
--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -469,8 +469,13 @@ mod tests {
         assert_eq!(pre.sampling_options.top_p, None);
         assert_eq!(pre.sampling_options.top_k, None);
         assert_eq!(pre.sampling_options.presence_penalty, None);
+        assert_eq!(pre.sampling_options.seed, None);
         assert_eq!(pre.stop_conditions.stop, None);
         assert_eq!(pre.stop_conditions.stop_token_ids, None);
+        // Engine priority rides the envelope; it must not lower into Dynamo's
+        // routing priority tiers.
+        assert_eq!(pre.routing.as_ref().and_then(|r| r.priority_jump), None);
+        assert_eq!(pre.routing.as_ref().and_then(|r| r.strict_priority), None);
 
         // Envelope fidelity: every sampling knob — including ones NOT shadowed
         // into core (top_p/top_k/seed/stop_token_ids/penalties) — and the

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -462,6 +462,16 @@ mod tests {
             Some(8)
         );
 
+        // Drift-containment (negative): sampling knobs must NOT be lowered into
+        // core — they live only in the envelope. If a future change lowered any
+        // of these, this fails.
+        assert_eq!(pre.sampling_options.temperature, None);
+        assert_eq!(pre.sampling_options.top_p, None);
+        assert_eq!(pre.sampling_options.top_k, None);
+        assert_eq!(pre.sampling_options.presence_penalty, None);
+        assert_eq!(pre.stop_conditions.stop, None);
+        assert_eq!(pre.stop_conditions.stop_token_ids, None);
+
         // Envelope fidelity: every sampling knob — including ones NOT shadowed
         // into core (top_p/top_k/seed/stop_token_ids/penalties) — and the
         // unknown nested field survive verbatim for the worker to reconstruct.
@@ -481,5 +491,11 @@ mod tests {
         // Engine priority rides the envelope, separate from Dynamo routing priority.
         assert_eq!(envelope["priority"], serde_json::json!(3));
         assert_eq!(envelope["token_ids"], serde_json::json!([1, 2, 3]));
+
+        // Strongest fidelity check: the whole envelope equals the raw request
+        // serialized verbatim — covers every field (incl. min_tokens/max_tokens/
+        // ignore_eos), not just the sampled keys above.
+        let expected_envelope = serde_json::to_value(&req).expect("serialize req");
+        assert_eq!(envelope, &expected_envelope);
     }
 }

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -419,4 +419,67 @@ mod tests {
         assert_eq!(resp.status().as_u16(), StatusCode::NOT_FOUND.as_u16());
         handle.abort();
     }
+
+    /// Fidelity of the ★ envelope: the full practical sampling param set
+    /// (top_p / top_k / seed / stop_token_ids / penalties) plus an unknown
+    /// nested field ride the opaque `vllm_tito` envelope UNCHANGED, while only
+    /// the core scalars Dynamo needs for stop/routing are shadowed. This proves
+    /// PR3's param set flows without any core-type coercion.
+    #[test]
+    fn preprocessed_from_generate_carries_full_param_set() {
+        use crate::protocols::openai::generate::GenerateRequest;
+
+        let req: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2, 3],
+            "sampling_params": {
+                "temperature": 0.8,
+                "top_p": 0.9,
+                "top_k": 50,
+                "seed": 12345,
+                "stop_token_ids": [151643],
+                "presence_penalty": 0.5,
+                "min_tokens": 2,
+                "max_tokens": 8,
+                "ignore_eos": true,
+                "future_nested_field": "ignored"
+            },
+            "priority": 3
+        }))
+        .expect("deserialize GenerateRequest");
+
+        let pre = super::preprocessed_from_generate(&req, "test-model").expect("build");
+
+        // Core token ids are the request token ids.
+        assert_eq!(pre.token_ids, vec![1, 2, 3]);
+
+        // Control shadow: only the scalar knobs core needs are projected.
+        assert_eq!(pre.stop_conditions.max_tokens, Some(8));
+        assert_eq!(pre.stop_conditions.min_tokens, Some(2));
+        assert_eq!(pre.stop_conditions.ignore_eos, Some(true));
+        assert_eq!(pre.sampling_options.n, Some(1));
+        assert_eq!(
+            pre.routing.as_ref().and_then(|r| r.expected_output_tokens),
+            Some(8)
+        );
+
+        // Envelope fidelity: every sampling knob — including ones NOT shadowed
+        // into core (top_p/top_k/seed/stop_token_ids/penalties) — and the
+        // unknown nested field survive verbatim for the worker to reconstruct.
+        let envelope = pre
+            .extra_args
+            .as_ref()
+            .and_then(|e| e.get("vllm_tito"))
+            .expect("vllm_tito envelope present");
+        let sp = &envelope["sampling_params"];
+        assert_eq!(sp["temperature"], serde_json::json!(0.8));
+        assert_eq!(sp["top_p"], serde_json::json!(0.9));
+        assert_eq!(sp["top_k"], serde_json::json!(50));
+        assert_eq!(sp["seed"], serde_json::json!(12345));
+        assert_eq!(sp["stop_token_ids"], serde_json::json!([151643]));
+        assert_eq!(sp["presence_penalty"], serde_json::json!(0.5));
+        assert_eq!(sp["future_nested_field"], serde_json::json!("ignored"));
+        // Engine priority rides the envelope, separate from Dynamo routing priority.
+        assert_eq!(envelope["priority"], serde_json::json!(3));
+        assert_eq!(envelope["token_ids"], serde_json::json!([1, 2, 3]));
+    }
 }

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -437,6 +437,7 @@ mod tests {
                 "top_k": 50,
                 "seed": 12345,
                 "stop_token_ids": [151643],
+                "stop": ["<|endoftext|>"],
                 "presence_penalty": 0.5,
                 "min_tokens": 2,
                 "max_tokens": 8,
@@ -491,6 +492,7 @@ mod tests {
         assert_eq!(sp["top_k"], serde_json::json!(50));
         assert_eq!(sp["seed"], serde_json::json!(12345));
         assert_eq!(sp["stop_token_ids"], serde_json::json!([151643]));
+        assert_eq!(sp["stop"], serde_json::json!(["<|endoftext|>"]));
         assert_eq!(sp["presence_penalty"], serde_json::json!(0.5));
         assert_eq!(sp["future_nested_field"], serde_json::json!("ignored"));
         // Engine priority rides the envelope, separate from Dynamo routing priority.

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -180,6 +180,28 @@ vllm_configs = {
                 },
                 expected_response=[],
                 expected_log=[],
+                expected_finish_reason="length",
+            ),
+            # TITO param-set fidelity: a broad practical sampling set
+            # (top_p/top_k/seed + temperature>0) rides the opaque envelope and
+            # still yields exactly max_tokens tokens under ignore_eos, proving
+            # the params flow through without breaking the path or the count.
+            GeneratePayload(
+                body={
+                    "token_ids": [785, 6722, 315, 9625, 374],
+                    "sampling_params": {
+                        "temperature": 0.7,
+                        "top_p": 0.9,
+                        "top_k": 50,
+                        "seed": 12345,
+                        "min_tokens": 8,
+                        "max_tokens": 8,
+                        "ignore_eos": True,
+                    },
+                },
+                expected_response=[],
+                expected_log=[],
+                expected_finish_reason="length",
             ),
             metric_payload_default(min_num_requests=6, backend="vllm"),
         ],

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -249,18 +249,23 @@ class GeneratePayload(BasePayload):
         sampling = self.body.get("sampling_params", {})
         expected_max = sampling.get("max_tokens")
         if expected_max is not None:
-            if sampling.get("ignore_eos"):
-                # ignore_eos disables early stopping, so the count is exactly
-                # max_tokens regardless of which tokens are sampled (robust to
-                # token values shifting across vLLM builds).
+            # ignore_eos suppresses only the EOS token, not explicit stop
+            # conditions, so the count is exactly max_tokens only when there is
+            # also no stop / stop_token_ids.
+            has_stop = bool(sampling.get("stop_token_ids") or sampling.get("stop"))
+            min_tokens = max(1, sampling.get("min_tokens") or 0)
+            if sampling.get("ignore_eos") and not has_stop:
+                # Deterministic count regardless of which tokens are sampled
+                # (robust to token values shifting across vLLM builds).
                 assert len(token_ids) == expected_max, (
                     f"Expected exactly {expected_max} tokens (max_tokens + "
-                    f"ignore_eos), got {len(token_ids)}: {choice}"
+                    f"ignore_eos, no stop), got {len(token_ids)}: {choice}"
                 )
             else:
-                # May stop early on EOS / stop_token_ids.
-                assert 0 < len(token_ids) <= expected_max, (
-                    f"Expected 1..={expected_max} tokens, got "
+                # May stop early on EOS / stop / stop_token_ids, but must still
+                # honor min_tokens as the lower bound.
+                assert min_tokens <= len(token_ids) <= expected_max, (
+                    f"Expected {min_tokens}..={expected_max} tokens, got "
                     f"{len(token_ids)}: {choice}"
                 )
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -209,6 +209,9 @@ class GeneratePayload(BasePayload):
     """
 
     endpoint: str = "/inference/v1/generate"
+    # When set, assert the first choice's finish_reason equals this
+    # (e.g. "length" for a max_tokens cutoff, "stop" for an EOS/stop token).
+    expected_finish_reason: Optional[str] = None
 
     @staticmethod
     def extract_content(response):
@@ -236,13 +239,30 @@ class GeneratePayload(BasePayload):
         assert (
             isinstance(token_ids, list) and token_ids
         ), f"Empty token_ids in choice: {choice}"
-        assert choice.get("finish_reason"), f"Missing finish_reason: {choice}"
-        expected_max = self.body.get("sampling_params", {}).get("max_tokens")
-        if expected_max is not None:
-            assert len(token_ids) == expected_max, (
-                f"Expected {expected_max} tokens (max_tokens + ignore_eos), "
-                f"got {len(token_ids)}: {choice}"
+        finish_reason = choice.get("finish_reason")
+        assert finish_reason, f"Missing finish_reason: {choice}"
+        if self.expected_finish_reason is not None:
+            assert finish_reason == self.expected_finish_reason, (
+                f"Expected finish_reason={self.expected_finish_reason!r}, "
+                f"got {finish_reason!r}: {choice}"
             )
+        sampling = self.body.get("sampling_params", {})
+        expected_max = sampling.get("max_tokens")
+        if expected_max is not None:
+            if sampling.get("ignore_eos"):
+                # ignore_eos disables early stopping, so the count is exactly
+                # max_tokens regardless of which tokens are sampled (robust to
+                # token values shifting across vLLM builds).
+                assert len(token_ids) == expected_max, (
+                    f"Expected exactly {expected_max} tokens (max_tokens + "
+                    f"ignore_eos), got {len(token_ids)}: {choice}"
+                )
+            else:
+                # May stop early on EOS / stop_token_ids.
+                assert 0 < len(token_ids) <= expected_max, (
+                    f"Expected 1..={expected_max} tokens, got "
+                    f"{len(token_ids)}: {choice}"
+                )
 
 
 class RouterNvextChatPayload(ChatPayload):

--- a/tests/utils/test_generate_payload.py
+++ b/tests/utils/test_generate_payload.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for GeneratePayload.validate token-count logic (RL TITO)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.utils.payloads import GeneratePayload
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+def _resp(token_ids, finish_reason="stop", request_id="r1"):
+    r = MagicMock()
+    r.json.return_value = {
+        "request_id": request_id,
+        "choices": [
+            {"index": 0, "token_ids": token_ids, "finish_reason": finish_reason}
+        ],
+    }
+    return r
+
+
+def _payload(sampling_params, expected_finish_reason=None):
+    return GeneratePayload(
+        body={"token_ids": [1, 2], "sampling_params": sampling_params},
+        expected_response=[],
+        expected_log=[],
+        expected_finish_reason=expected_finish_reason,
+    )
+
+
+def test_bounded_count_allows_early_stop_within_range():
+    # ignore_eos=false -> bounded; a count within [min_tokens, max_tokens] passes.
+    p = _payload({"max_tokens": 8, "min_tokens": 2}, expected_finish_reason="stop")
+    p.validate(_resp([10, 11, 12], "stop"), "")
+
+
+def test_bounded_count_rejects_below_min_tokens():
+    p = _payload({"max_tokens": 8, "min_tokens": 4})
+    with pytest.raises(AssertionError):
+        p.validate(_resp([10, 11], "stop"), "")  # 2 < min_tokens 4
+
+
+def test_ignore_eos_with_stop_uses_bounded_not_exact():
+    # ignore_eos=true BUT an explicit stop_token_ids -> bounded, so a short
+    # count passes (ignore_eos only suppresses EOS, not explicit stops).
+    p = _payload(
+        {"max_tokens": 8, "ignore_eos": True, "stop_token_ids": [13]},
+        expected_finish_reason="stop",
+    )
+    p.validate(_resp([10, 13], "stop"), "")
+
+
+def test_ignore_eos_no_stop_requires_exact_count():
+    # ignore_eos=true, no stop -> exact count; a non-max count must fail.
+    p = _payload({"max_tokens": 8, "ignore_eos": True}, expected_finish_reason="length")
+    with pytest.raises(AssertionError):
+        p.validate(_resp([1, 2, 3], "length"), "")  # 3 != 8


### PR DESCRIPTION
## Why

PR2 proved the `/inference/v1/generate` spine for one pinned param set. This PR widens coverage to the practical sampling set RL rollouts use (`top_p`/`top_k`/`seed`/`stop_token_ids`/penalties). Because the raw request rides opaquely in the `vllm_tito` envelope and the worker reconstructs vLLM's own `SamplingParams`, those params already reach the engine verbatim with no core-type coercion — so this PR proves and locks that behavior with fidelity + functional tests rather than adding new core lowering. Migration/P·D, streaming, logprobs, and `n>1` remain out of scope. **Stacked on PR2** (`qiwa/rl-tito-generate-pr2`).

## What Change

- Rust fidelity test: the full param set + an unknown nested field ride the `vllm_tito` envelope unchanged; only core scalars (`max_tokens`/`min_tokens`/`ignore_eos`/`n`) are shadowed.
- e2e: a broad sampling payload (`top_p`/`top_k`/`seed` + `temperature>0`) yields exactly `max_tokens` tokens under `ignore_eos`.
- `GeneratePayload` gains an `ignore_eos`-aware token-count check + an optional `expected_finish_reason`.

## Test Plan

- Unit: `cargo test -p dynamo-llm --lib generate` (16 pass, incl. envelope-fidelity + drift-containment negative asserts), `cargo clippy` clean; `pytest tests/utils/test_generate_payload.py` (4 pass, count-branch logic).
- E2E: `test_serve_deployment[aggregated-2]` (Qwen3-0.6B) broad-sampling `GeneratePayload` asserts token count + `finish_reason`. Passes locally (~71s).
