### PR TITLE
docs(fault-tolerance): correct pod grace default

### DIFF
--- a/docs/fault-tolerance/graceful-shutdown.md
+++ b/docs/fault-tolerance/graceful-shutdown.md
@@ -205,10 +205,10 @@ async def _initiate_shutdown(self, error: Exception):
 3. Dynamo operator-created pods have `terminationGracePeriodSeconds` to complete (default: 60s)
 4. If not terminated, Kubernetes sends `SIGKILL`
 
-### Recommended Configuration
+### Customize the termination grace period
 
-For production deployments, set the termination grace period based on your workloads and utilization. The following
-example uses 180 seconds:
+Set `terminationGracePeriodSeconds` based on your workloads and utilization. For example, use 180 seconds to allow
+more time for request draining:
 
 ```yaml
 apiVersion: nvidia.com/v1alpha1

--- a/docs/fault-tolerance/graceful-shutdown.md
+++ b/docs/fault-tolerance/graceful-shutdown.md
@@ -207,7 +207,8 @@ async def _initiate_shutdown(self, error: Exception):
 
 ### Recommended Configuration
 
-For production deployments, configure adequate termination grace period:
+For production deployments, set the termination grace period based on your workloads and utilization. The following
+example uses 180 seconds:
 
 ```yaml
 apiVersion: nvidia.com/v1alpha1
@@ -216,7 +217,7 @@ spec:
   services:
     VllmWorker:
       extraPodSpec:
-        terminationGracePeriodSeconds: 60  # Allow time for request draining
+        terminationGracePeriodSeconds: 180  # Allow time for request draining
 ```
 
 ### Health Check Integration
@@ -231,9 +232,9 @@ Kubernetes uses health endpoints to determine pod readiness:
 
 ### 1. Set Appropriate Grace Periods
 
-Match `terminationGracePeriodSeconds` to your expected request completion time:
+Match `terminationGracePeriodSeconds` to your expected request completion time and utilization:
 - Short requests (\< 10s): 30s grace period
-- Long generation (> 30s): 120s+ grace period
+- Long generation (> 30s) or high utilization: 120s+ grace period
 
 ### 2. Enable Request Migration
 

--- a/docs/fault-tolerance/graceful-shutdown.md
+++ b/docs/fault-tolerance/graceful-shutdown.md
@@ -202,7 +202,7 @@ async def _initiate_shutdown(self, error: Exception):
 
 1. Kubernetes sends `SIGTERM` to the pod
 2. Dynamo initiates graceful shutdown
-3. Pod has `terminationGracePeriodSeconds` to complete (default: 30s)
+3. Dynamo operator-created pods have `terminationGracePeriodSeconds` to complete (default: 60s)
 4. If not terminated, Kubernetes sends `SIGKILL`
 
 ### Recommended Configuration


### PR DESCRIPTION
## Overview:

Correct the graceful-shutdown documentation so the Dynamo operator pod default matches the implementation and users can customize the termination grace period for their workloads.

## Details:

- Change the documented `terminationGracePeriodSeconds` default for Dynamo operator-created pods from 30 seconds to 60 seconds.
- Describe grace-period selection as a workload- and utilization-specific customization, with 180 seconds as an example.

## Where should the reviewer start?

- `docs/fault-tolerance/graceful-shutdown.md`, in the Pod Termination Flow and termination grace-period customization sections.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Summary

- Correct the operator-created pod default to 60 seconds.
- Document how to customize the grace period for workload duration and utilization.

## Validation

- `fern check`
- `fern docs broken-links`