### PR TITLE
feat(video): unify diffusion video encoding across backends

### DIFF
--- a/components/src/dynamo/common/tests/test_video_utils.py
+++ b/components/src/dynamo/common/tests/test_video_utils.py
@@ -3,10 +3,18 @@
 
 """Unit tests for dynamo.common.utils.video_utils module."""
 
+import shutil
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+
+from dynamo.common.utils.video_utils import (
+    drop_alpha,
+    encode_video,
+    ensure_uint8_rgb,
+    pil_frames_to_array,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -154,3 +162,276 @@ class TestEncodeToVideoBytes:
 
             assert writer.append_data.call_count == 4
             writer.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Canonical-domain primitives
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalPrimitives:
+    """Tests for the shared canonical-domain primitives."""
+
+    def test_drop_alpha_removes_fourth_channel(self):
+        arr = np.zeros((2, 4, 4, 4), dtype=np.uint8)
+        out = drop_alpha(arr)
+        assert out.shape == (2, 4, 4, 3)
+
+    def test_drop_alpha_passes_rgb_through(self):
+        arr = np.zeros((2, 4, 4, 3), dtype=np.uint8)
+        assert drop_alpha(arr) is arr
+
+    def test_ensure_uint8_rgb_scales_float_0_1(self):
+        arr = np.ones((1, 2, 2, 3), dtype=np.float32)  # 1.0 -> 255
+        out = ensure_uint8_rgb(arr)
+        assert out.dtype == np.uint8
+        assert np.all(out == 255)
+
+    def test_ensure_uint8_rgb_drops_alpha_and_is_contiguous(self):
+        arr = np.zeros((1, 2, 2, 4), dtype=np.uint8)
+        out = ensure_uint8_rgb(arr)
+        assert out.shape == (1, 2, 2, 3)
+        assert out.flags["C_CONTIGUOUS"]
+
+    def test_ensure_uint8_rgb_uint8_roundtrip_is_exact(self):
+        truth = np.arange(1 * 2 * 2 * 3, dtype=np.uint8).reshape(1, 2, 2, 3)
+        assert np.array_equal(ensure_uint8_rgb(truth), truth)
+
+    def test_pil_frames_to_array_from_numpy(self):
+        frames = [np.zeros((4, 4, 3), np.uint8), np.ones((4, 4, 3), np.uint8)]
+        out = pil_frames_to_array(frames)
+        assert out.shape == (2, 4, 4, 3)
+
+    def test_pil_frames_to_array_from_pil_is_exact(self):
+        Image = pytest.importorskip("PIL.Image")
+        truth = np.arange(2 * 4 * 4 * 3, dtype=np.uint8).reshape(2, 4, 4, 3)
+        imgs = [Image.fromarray(truth[i]) for i in range(truth.shape[0])]
+        out = pil_frames_to_array(imgs)
+        assert np.array_equal(out, truth)
+
+
+# ---------------------------------------------------------------------------
+# encode_video — canonical ABI validation
+# ---------------------------------------------------------------------------
+
+
+def canonical_frames(n=2, h=4, w=4) -> np.ndarray:
+    """Return a valid canonical (n, h, w, 3) uint8 frame array."""
+    return np.zeros((n, h, w, 3), dtype=np.uint8)
+
+
+class TestEncodeVideoValidation:
+    """encode_video rejects anything but canonical (T, H, W, 3) uint8."""
+
+    def test_rejects_non_ndarray(self):
+        with pytest.raises(ValueError, match="canonical"):
+            encode_video([canonical_frames()], hw_accel="nvenc")
+
+    def test_rejects_wrong_ndim(self):
+        with pytest.raises(ValueError, match="shape"):
+            encode_video(np.zeros((4, 4, 3), np.uint8), hw_accel="nvenc")
+
+    def test_rejects_wrong_channel_count(self):
+        with pytest.raises(ValueError, match="shape"):
+            encode_video(np.zeros((2, 4, 4, 4), np.uint8), hw_accel="nvenc")
+
+    def test_rejects_wrong_dtype(self):
+        with pytest.raises(ValueError, match="uint8"):
+            encode_video(np.zeros((2, 4, 4, 3), np.float32), hw_accel="nvenc")
+
+
+# ---------------------------------------------------------------------------
+# encode_video — dispatch and control resolution
+# ---------------------------------------------------------------------------
+
+
+class TestEncodeVideoDispatch:
+    """encode_video resolves controls (arg > env > auto) and dispatches paths."""
+
+    def test_nvenc_uses_imageio_path(self):
+        with patch(
+            "dynamo.common.utils.video_utils._encode_video_imageio",
+            return_value=b"nvenc-bytes",
+        ) as m_imageio, patch(
+            "dynamo.common.utils.video_utils._encode_video_ffmpeg_cli"
+        ) as m_cli:
+            out = encode_video(canonical_frames(), fps=8, hw_accel="nvenc")
+
+        assert out == b"nvenc-bytes"
+        m_imageio.assert_called_once()
+        m_cli.assert_not_called()
+
+    def test_cpu_uses_ffmpeg_cli_path(self):
+        with patch(
+            "dynamo.common.utils.video_utils._encode_video_imageio"
+        ) as m_imageio, patch(
+            "dynamo.common.utils.video_utils._encode_video_ffmpeg_cli",
+            return_value=b"cli-bytes",
+        ) as m_cli:
+            out = encode_video(canonical_frames(), fps=8, hw_accel="cpu")
+
+        assert out == b"cli-bytes"
+        m_cli.assert_called_once()
+        m_imageio.assert_not_called()
+
+    def test_auto_selects_nvenc_when_not_xpu(self, monkeypatch):
+        monkeypatch.delenv("DYN_VIDEO_HW_ACCEL", raising=False)
+        with patch(
+            "dynamo.common.utils.video_utils._running_on_xpu", return_value=False
+        ), patch(
+            "dynamo.common.utils.video_utils._encode_video_imageio",
+            return_value=b"x",
+        ) as m_imageio, patch(
+            "dynamo.common.utils.video_utils._encode_video_ffmpeg_cli"
+        ) as m_cli:
+            encode_video(canonical_frames(), fps=8, hw_accel="auto")
+
+        m_imageio.assert_called_once()
+        m_cli.assert_not_called()
+
+    def test_auto_selects_xpu_when_xpu_available(self, monkeypatch):
+        monkeypatch.delenv("DYN_VIDEO_HW_ACCEL", raising=False)
+        with patch(
+            "dynamo.common.utils.video_utils._running_on_xpu", return_value=True
+        ), patch(
+            "dynamo.common.utils.video_utils._encode_video_imageio"
+        ) as m_imageio, patch(
+            "dynamo.common.utils.video_utils._encode_video_ffmpeg_cli",
+            return_value=b"x",
+        ) as m_cli:
+            encode_video(canonical_frames(), fps=8, hw_accel="auto")
+
+        m_cli.assert_called_once()
+        m_imageio.assert_not_called()
+
+    def test_explicit_container_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("DYN_VIDEO_CONTAINER", "mp4")
+        with patch(
+            "dynamo.common.utils.video_utils._encode_video_imageio",
+            return_value=b"x",
+        ) as m_imageio:
+            encode_video(canonical_frames(), fps=8, hw_accel="nvenc", container="webm")
+
+        # _encode_video_imageio(frames, fps, container, codec)
+        assert m_imageio.call_args[0][2] == "webm"
+
+    def test_env_container_used_when_no_arg(self, monkeypatch):
+        monkeypatch.setenv("DYN_VIDEO_CONTAINER", "webm")
+        with patch(
+            "dynamo.common.utils.video_utils._encode_video_imageio",
+            return_value=b"x",
+        ) as m_imageio:
+            encode_video(canonical_frames(), fps=8, hw_accel="nvenc")
+
+        assert m_imageio.call_args[0][2] == "webm"
+
+
+# ---------------------------------------------------------------------------
+# ffmpeg-CLI path (XPU / VA-API)
+# ---------------------------------------------------------------------------
+
+
+class TestFfmpegCliPath:
+    """The ffmpeg-CLI path builds the expected VA-API command line."""
+
+    def test_xpu_path_uses_vaapi_device_and_hwupload(self):
+        """The XPU path must select a VA-API encoder, pass the device, and
+        upload frames to a HW surface -- the reason this path exists at all
+        (imageio cannot express these). Exact argv layout is deliberately not
+        asserted; real bitstream correctness belongs to a hardware-gated
+        (xpu_1) encode/decode roundtrip.
+        """
+        frames = canonical_frames(n=3, h=8, w=8)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stderr = b""
+        with patch(
+            "dynamo.common.utils.video_utils.shutil.which",
+            return_value="/usr/bin/ffmpeg",
+        ), patch(
+            "dynamo.common.utils.video_utils.subprocess.run", return_value=proc
+        ) as m_run:
+            encode_video(
+                frames,
+                fps=12,
+                container="mp4",
+                codec="h264",
+                hw_accel="xpu",
+                device="/dev/dri/renderD129",
+            )
+
+        cmd = m_run.call_args[0][0]
+        assert cmd[cmd.index("-vaapi_device") + 1] == "/dev/dri/renderD129"
+        assert "format=nv12,hwupload" in cmd
+        assert cmd[cmd.index("-c:v") + 1] == "h264_vaapi"
+
+    def test_missing_ffmpeg_raises(self):
+        with patch("dynamo.common.utils.video_utils.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="ffmpeg not found"):
+                encode_video(canonical_frames(), fps=8, hw_accel="xpu")
+
+
+# ---------------------------------------------------------------------------
+# Real encode -> decode round-trip (the one bitstream-touching test)
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_video(num_frames: int, height: int, width: int) -> np.ndarray:
+    """Deterministic, encoder-friendly synthetic clip (T, H, W, 3) uint8.
+
+    A band-limited moving sinusoid ("plasma"): spatially low-frequency and
+    temporally coherent, so a lossy DCT / motion-compensated codec can
+    represent it well. Random pixels are the worst case for such a codec
+    (unrepresentable high-frequency energy, defeats motion estimation) and
+    would give a misleadingly low PSNR.
+    """
+    yy, xx = np.mgrid[0:height, 0:width].astype(np.float32)
+    frames = np.empty((num_frames, height, width, 3), dtype=np.uint8)
+    for t in range(num_frames):
+        phase = t * 0.3  # animate -> real inter-frame motion
+        r = 128 + 127 * np.sin(2 * np.pi * (xx / width) * 3 + phase)
+        g = 128 + 127 * np.sin(2 * np.pi * (yy / height) * 3 + phase * 1.3)
+        b = 128 + 127 * np.sin(
+            2 * np.pi * ((xx + yy) / (width + height)) * 3 + phase * 0.7
+        )
+        frames[t] = np.clip(np.stack([r, g, b], axis=-1), 0, 255).astype(np.uint8)
+    return frames
+
+
+def _psnr(a: np.ndarray, b: np.ndarray) -> float:
+    """Peak signal-to-noise ratio (dB) between two uint8 clips of equal shape."""
+    mse = np.mean((a.astype(np.float64) - b.astype(np.float64)) ** 2)
+    if mse == 0:
+        return float("inf")
+    return 10.0 * np.log10(255.0**2 / mse)
+
+
+class TestEncodeVideoRoundTrip:
+    """Encode a realistic synthetic clip, decode it, and check fidelity."""
+
+    def test_cpu_mp4_roundtrip(self):
+        if shutil.which("ffmpeg") is None:
+            pytest.skip("ffmpeg CLI not available")
+        iio = pytest.importorskip("imageio.v3")
+
+        num_frames, height, width = 30, 144, 176  # QCIF
+        frames = _synthetic_video(num_frames, height, width)
+        try:
+            data = encode_video(frames, fps=30, container="mp4", hw_accel="cpu")
+        except RuntimeError as e:
+            pytest.skip(f"CPU H.264 encoder unavailable: {e}")
+
+        assert b"ftyp" in data[:64]  # mp4 container magic
+
+        try:
+            decoded = iio.imread(data, index=None, extension=".mp4")
+        except Exception as e:  # decoder/plugin not available in this env
+            pytest.skip(f"video decode unavailable: {e}")
+
+        assert decoded.shape[0] == num_frames
+        assert tuple(decoded.shape[1:3]) == (height, width)
+
+        # Fidelity: a smooth clip through H.264 should reconstruct well.
+        # 35 dB is a deliberately lenient floor (real content typically >40 dB).
+        psnr = _psnr(frames, decoded)
+        assert psnr >= 35.0, f"round-trip PSNR too low: {psnr:.1f} dB"

--- a/components/src/dynamo/common/tests/test_video_utils.py
+++ b/components/src/dynamo/common/tests/test_video_utils.py
@@ -240,6 +240,40 @@ class TestEncodeVideoValidation:
             encode_video(np.zeros((2, 4, 4, 3), np.float32), hw_accel="nvenc")
 
 
+class TestEncodeVideoContainerCodec:
+    """encode_video rejects incompatible container/codec combinations."""
+
+    def test_rejects_unknown_container(self):
+        with pytest.raises(ValueError, match="Unsupported container"):
+            encode_video(canonical_frames(), hw_accel="nvenc", container="avi")
+
+    def test_rejects_h264_in_webm(self):
+        with pytest.raises(ValueError, match="not compatible"):
+            encode_video(
+                canonical_frames(), hw_accel="nvenc", container="webm", codec="h264"
+            )
+
+    def test_rejects_vp9_in_mp4(self):
+        with pytest.raises(ValueError, match="not compatible"):
+            encode_video(
+                canonical_frames(), hw_accel="nvenc", container="mp4", codec="vp9"
+            )
+
+    def test_accepts_compatible_non_default_codec(self):
+        with patch(
+            "dynamo.common.utils.video_utils._encode_video_imageio",
+            return_value=b"x",
+        ) as m_imageio:
+            encode_video(
+                canonical_frames(), hw_accel="nvenc", container="mp4", codec="hevc"
+            )
+        m_imageio.assert_called_once()
+
+    def test_rejects_unknown_hw_accel(self):
+        with pytest.raises(ValueError, match="Unsupported hw_accel"):
+            encode_video(canonical_frames(), hw_accel="foo")
+
+
 # ---------------------------------------------------------------------------
 # encode_video — dispatch and control resolution
 # ---------------------------------------------------------------------------
@@ -370,6 +404,24 @@ class TestFfmpegCliPath:
             with pytest.raises(RuntimeError, match="ffmpeg not found"):
                 encode_video(canonical_frames(), fps=8, hw_accel="xpu")
 
+    def test_cpu_path_forces_yuv420p(self):
+        """Software encoding must emit 4:2:0 so the output is broadly playable."""
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stderr = b""
+        with patch(
+            "dynamo.common.utils.video_utils.shutil.which",
+            return_value="/usr/bin/ffmpeg",
+        ), patch(
+            "dynamo.common.utils.video_utils.subprocess.run", return_value=proc
+        ) as m_run:
+            encode_video(canonical_frames(), fps=12, container="mp4", hw_accel="cpu")
+
+        cmd = m_run.call_args[0][0]
+        # The output pix_fmt (after -c:v), not the rawvideo input pix_fmt.
+        out_pix_fmt = cmd.index("-pix_fmt", cmd.index("-c:v"))
+        assert cmd[out_pix_fmt + 1] == "yuv420p"
+
 
 # ---------------------------------------------------------------------------
 # Real encode -> decode round-trip (the one bitstream-touching test)
@@ -409,6 +461,7 @@ def _psnr(a: np.ndarray, b: np.ndarray) -> float:
 class TestEncodeVideoRoundTrip:
     """Encode a realistic synthetic clip, decode it, and check fidelity."""
 
+    @pytest.mark.timeout(30)
     def test_cpu_mp4_roundtrip(self):
         if shutil.which("ffmpeg") is None:
             pytest.skip("ffmpeg CLI not available")

--- a/components/src/dynamo/common/utils/video_utils.py
+++ b/components/src/dynamo/common/utils/video_utils.py
@@ -275,6 +275,13 @@ _FFMPEG_ENCODERS = {
 # Default logical codec per container.
 _DEFAULT_CODEC = {"mp4": "h264", "webm": "vp9"}
 
+# Logical codecs each container can legally mux. Used to reject incompatible
+# (container, codec) combinations before invoking the encoder.
+_CONTAINER_CODECS = {
+    "mp4": ("h264", "hevc"),
+    "webm": ("vp9",),
+}
+
 
 def _video_codec() -> str | None:
     """Codec override from ``DYN_VIDEO_CODEC`` (e.g. ``h264`` / ``hevc`` / ``vp9``)."""
@@ -318,11 +325,40 @@ def _running_on_xpu() -> bool:
 def _resolve_ffmpeg_encoder(container: str, codec: str | None, hw_accel: str) -> str:
     """Map (container, logical codec, hw path) to an ffmpeg encoder name.
 
-    A codec value that is already an ffmpeg encoder name passes through.
+    ``container`` / ``codec`` / ``hw_accel`` are assumed already validated by
+    ``encode_video``. Raises ``ValueError`` if no encoder entry exists for the
+    resolved (hw_accel, codec) pair -- i.e. the lookup tables are inconsistent.
     """
-    codec = codec or _DEFAULT_CODEC.get(container, "h264")
-    table = _FFMPEG_ENCODERS.get(hw_accel, _FFMPEG_ENCODERS["nvenc"])
-    return table.get(codec, codec)
+    codec = codec or _DEFAULT_CODEC[container]
+    table = _FFMPEG_ENCODERS[hw_accel]
+    encoder = table.get(codec)
+    if encoder is None:
+        raise ValueError(
+            f"No ffmpeg encoder for codec {codec!r} on {hw_accel!r}; "
+            f"available: {sorted(table)}"
+        )
+    return encoder
+
+
+def _validate_container_codec(container: str, codec: str | None) -> None:
+    """Reject container/codec pairs that are not muxing-compatible.
+
+    A ``codec`` of ``None`` means "use the container's default", which is
+    compatible by construction. Raises ``ValueError`` for an unknown container
+    or a codec the container cannot carry (e.g. H.264 in webm).
+    """
+    allowed = _CONTAINER_CODECS.get(container)
+    if allowed is None:
+        raise ValueError(
+            f"Unsupported container {container!r}; "
+            f"supported: {sorted(_CONTAINER_CODECS)}"
+        )
+    effective = codec or _DEFAULT_CODEC[container]
+    if effective not in allowed:
+        raise ValueError(
+            f"Codec {effective!r} is not compatible with container "
+            f"{container!r}; supported: {list(allowed)}"
+        )
 
 
 def drop_alpha(frames: np.ndarray) -> np.ndarray:
@@ -388,11 +424,11 @@ def _encode_video_imageio(
     except ImportError:
         try:
             import imageio as iio  # type: ignore[no-redef]
-        except ImportError:
+        except ImportError as err:
             raise ImportError(
                 "imageio is required for video encoding. "
                 "Install with: pip install imageio[ffmpeg]"
-            )
+            ) from err
 
     encoder = _resolve_ffmpeg_encoder(container, codec, "nvenc")
     buffer = io.BytesIO()
@@ -451,6 +487,11 @@ def _encode_video_ffmpeg_cli(
         if hw_accel == "xpu":
             cmd += ["-vf", "format=nv12,hwupload"]
         cmd += ["-c:v", encoder]
+        if hw_accel == "cpu":
+            # Software encoders default to yuv444p from rgb24 input, which most
+            # players (browsers, mobile) cannot decode; force widely-compatible
+            # 4:2:0. The XPU path already gets 4:2:0 via the nv12 hwupload above.
+            cmd += ["-pix_fmt", "yuv420p"]
         if container == "mp4":
             cmd += ["-movflags", "+faststart"]
         cmd += ["-f", container, output_path]
@@ -509,6 +550,8 @@ def encode_video(
         container: ``mp4`` / ``webm`` (env: ``DYN_VIDEO_CONTAINER``).
         codec: Logical codec ``h264`` / ``hevc`` / ``vp9`` (env: ``DYN_VIDEO_CODEC``).
         hw_accel: ``auto`` / ``nvenc`` / ``xpu`` / ``cpu`` (env: ``DYN_VIDEO_HW_ACCEL``).
+            ``auto`` picks a hardware encoder (XPU if present, else NVENC) and
+            never selects CPU -- request ``cpu`` explicitly for software encoding.
         device: HW device / DRM render node (env: ``DYN_VIDEO_DEVICE``).
 
     Returns:
@@ -521,9 +564,20 @@ def encode_video(
 
     container = (container or _video_container()).lower()
     codec = codec.lower() if codec else _video_codec()
+    _validate_container_codec(container, codec)
+
     hw_accel = (hw_accel or _video_hw_accel()).lower()
     if hw_accel == "auto":
+        # "auto" selects a hardware encoder only: XPU when present, otherwise
+        # NVENC. It never resolves to CPU -- software encoding is slow and must
+        # be requested explicitly (hw_accel="cpu" / DYN_VIDEO_HW_ACCEL=cpu). A
+        # deployment with neither NVIDIA nor XPU is unsupported by design.
         hw_accel = "xpu" if _running_on_xpu() else "nvenc"
+    if hw_accel not in _FFMPEG_ENCODERS:
+        raise ValueError(
+            f"Unsupported hw_accel {hw_accel!r}; "
+            f"supported: {sorted(_FFMPEG_ENCODERS)} (or 'auto')"
+        )
 
     logger.info(
         "Encoding %d frames -> %s (hw=%s codec=%s) at %d fps",

--- a/components/src/dynamo/common/utils/video_utils.py
+++ b/components/src/dynamo/common/utils/video_utils.py
@@ -250,10 +250,12 @@ def encode_to_video_bytes(
 # ---------------------------------------------------------------------------
 # Unified video encoding
 #
-# A single shared entry point (``encode_video``) that all backends can call.
-# It absorbs the three different backend output shapes via a thin conversion
-# layer, then dispatches to one of two encode paths (see design doc
-# docs/design/unified_video_encoder.md):
+# A single shared entry point (``encode_video``) that all backends call with a
+# canonical frame array -- ``np.ndarray (T, H, W, 3) uint8`` RGB. Each backend
+# owns a ``to_canonical()`` converter (next to its handler) that maps its native
+# output into this format, composed from the canonical-domain primitives below
+# (``ensure_uint8_rgb`` / ``pil_frames_to_array`` / ``drop_alpha``). The encoder
+# validates the canonical contract on entry and dispatches to one of two paths:
 #
 #   * imageio -> ffmpeg (NVENC)  -- preserves the existing NVIDIA behavior.
 #   * ffmpeg CLI (raw pipe)      -- new hardware (XPU) / codecs that imageio's
@@ -313,9 +315,7 @@ def _running_on_xpu() -> bool:
         return False
 
 
-def _resolve_ffmpeg_encoder(
-    container: str, codec: str | None, hw_accel: str
-) -> str:
+def _resolve_ffmpeg_encoder(container: str, codec: str | None, hw_accel: str) -> str:
     """Map (container, logical codec, hw path) to an ffmpeg encoder name.
 
     A codec value that is already an ffmpeg encoder name passes through.
@@ -325,49 +325,58 @@ def _resolve_ffmpeg_encoder(
     return table.get(codec, codec)
 
 
-def to_canonical_frames(frames) -> np.ndarray:
-    """Thin conversion layer: normalize any backend's raw video output.
+def drop_alpha(frames: np.ndarray) -> np.ndarray:
+    """Drop a trailing alpha channel (RGBA -> RGB) when present."""
+    if frames.shape[-1] == 4:
+        return frames[..., :3]
+    return frames
 
-    Accepts the three shapes that the backends produce and returns a canonical
-    array of shape ``(num_frames, height, width, 3)``, dtype ``uint8``, RGB:
 
-      * ``torch.Tensor`` ``(1, T, H, W, C)`` or ``(T, H, W, C)`` (TRT-LLM)
-      * ``np.ndarray`` ``(1, T, H, W, C)`` / ``(T, H, W, C)``
-      * ``list`` holding a single 5-D / 4-D array (vLLM ``stage_output.images``)
-      * ``list[PIL.Image | np.ndarray]`` (SGLang)
+def ensure_uint8_rgb(frames: np.ndarray) -> np.ndarray:
+    """Normalize an RGB frame array to contiguous ``(T, H, W, 3) uint8``.
+
+    Drops a trailing alpha channel and scales floating-point values in
+    ``[0, 1]`` up to ``[0, 255]``. Channel order and axis layout are assumed to
+    be RGB / ``(T, H, W, C)`` already; this operates purely in the canonical
+    domain and carries no backend-specific knowledge.
     """
-    # torch.Tensor -> numpy (duck-typed to avoid importing torch here).
-    if hasattr(frames, "detach") and hasattr(frames, "cpu"):
-        frames = frames.detach().cpu().numpy()
+    frames = drop_alpha(frames)
+    if np.issubdtype(frames.dtype, np.floating):
+        frames = np.clip(frames * 255.0, 0, 255).round()
+    return np.ascontiguousarray(frames, dtype=np.uint8)
 
-    # Unwrap a single-element list that holds a full-video array/tensor.
-    if isinstance(frames, (list, tuple)) and len(frames) == 1:
-        inner = frames[0]
-        if hasattr(inner, "detach") and hasattr(inner, "cpu"):
-            inner = inner.detach().cpu().numpy()
-        if isinstance(inner, np.ndarray) and inner.ndim >= 4:
-            frames = inner
 
-    if isinstance(frames, np.ndarray):
-        arr = frames[0] if frames.ndim == 5 else frames
-    else:
-        per_frame = []
-        for frame in frames:
-            if isinstance(frame, np.ndarray):
-                per_frame.append(frame)
-            else:
-                # PIL Image (or anything convertible via numpy).
-                per_frame.append(np.array(frame.convert("RGB")))
-        arr = np.stack(per_frame, axis=0)
+def pil_frames_to_array(frames) -> np.ndarray:
+    """Stack a list of per-frame images into a single ``(T, H, W, C)`` array.
 
-    # Drop an alpha channel if present.
-    if arr.shape[-1] == 4:
-        arr = arr[..., :3]
+    Each element may be a ``PIL.Image`` or an ``np.ndarray``; PIL images are
+    converted to RGB numpy arrays first.
+    """
+    per_frame = []
+    for frame in frames:
+        if isinstance(frame, np.ndarray):
+            per_frame.append(frame)
+        else:
+            per_frame.append(np.array(frame.convert("RGB")))
+    return np.stack(per_frame, axis=0)
 
-    if np.issubdtype(arr.dtype, np.floating):
-        arr = np.clip(arr * 255.0, 0, 255).round()
 
-    return np.ascontiguousarray(arr, dtype=np.uint8)
+def _validate_canonical_frames(frames) -> None:
+    """Validate the canonical encoder input contract.
+
+    Raises ``ValueError`` unless ``frames`` is an ``np.ndarray`` of shape
+    ``(T, H, W, 3)`` with dtype ``uint8``.
+    """
+    if not isinstance(frames, np.ndarray):
+        raise ValueError(
+            "encode_video expects canonical frames as np.ndarray (T, H, W, 3) "
+            f"uint8; got {type(frames).__name__}. Convert backend output with "
+            "the backend's to_canonical() first."
+        )
+    if frames.ndim != 4 or frames.shape[-1] != 3:
+        raise ValueError(f"encode_video expects shape (T, H, W, 3); got {frames.shape}")
+    if frames.dtype != np.uint8:
+        raise ValueError(f"encode_video expects dtype uint8; got {frames.dtype}")
 
 
 def _encode_video_imageio(
@@ -428,11 +437,16 @@ def _encode_video_ffmpeg_cli(
         if hw_accel == "xpu":
             cmd += ["-vaapi_device", device]
         cmd += [
-            "-f", "rawvideo",
-            "-pix_fmt", "rgb24",
-            "-s", f"{width}x{height}",
-            "-r", str(fps),
-            "-i", "-",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "rgb24",
+            "-s",
+            f"{width}x{height}",
+            "-r",
+            str(fps),
+            "-i",
+            "-",
         ]
         if hw_accel == "xpu":
             cmd += ["-vf", "format=nv12,hwupload"]
@@ -471,7 +485,7 @@ def _encode_video_ffmpeg_cli(
 
 
 def encode_video(
-    frames,
+    frames: np.ndarray,
     fps: int = DEFAULT_VIDEO_FPS,
     *,
     container: str | None = None,
@@ -479,14 +493,18 @@ def encode_video(
     hw_accel: str | None = None,
     device: str | None = None,
 ) -> bytes:
-    """Unified video encoder: canonicalize frames and encode to video bytes.
+    """Unified video encoder: encode canonical frames to video bytes.
+
+    ``frames`` must already be in the canonical format -- an ``np.ndarray`` of
+    shape ``(T, H, W, 3)``, dtype ``uint8``, RGB. Each backend converts its
+    native output with its own ``to_canonical()`` before calling this.
 
     Any explicit argument overrides its ``DYN_VIDEO_*`` environment variable,
     which in turn overrides platform auto-detection. Dispatches to the imageio
     NVENC path on NVIDIA, or the ffmpeg-CLI path for XPU / CPU.
 
     Args:
-        frames: Raw backend output (see ``to_canonical_frames``).
+        frames: Canonical ``np.ndarray (T, H, W, 3) uint8`` RGB frames.
         fps: Frames per second for the output video.
         container: ``mp4`` / ``webm`` (env: ``DYN_VIDEO_CONTAINER``).
         codec: Logical codec ``h264`` / ``hevc`` / ``vp9`` (env: ``DYN_VIDEO_CODEC``).
@@ -495,17 +513,21 @@ def encode_video(
 
     Returns:
         Encoded video as bytes.
+
+    Raises:
+        ValueError: If ``frames`` is not the canonical ``(T, H, W, 3) uint8`` array.
     """
+    _validate_canonical_frames(frames)
+
     container = (container or _video_container()).lower()
     codec = codec.lower() if codec else _video_codec()
     hw_accel = (hw_accel or _video_hw_accel()).lower()
     if hw_accel == "auto":
         hw_accel = "xpu" if _running_on_xpu() else "nvenc"
 
-    canonical = to_canonical_frames(frames)
     logger.info(
         "Encoding %d frames -> %s (hw=%s codec=%s) at %d fps",
-        len(canonical),
+        len(frames),
         container,
         hw_accel,
         codec or "default",
@@ -513,7 +535,7 @@ def encode_video(
     )
 
     if hw_accel == "nvenc":
-        return _encode_video_imageio(canonical, fps, container, codec)
+        return _encode_video_imageio(frames, fps, container, codec)
 
     device = device or _video_device()
-    return _encode_video_ffmpeg_cli(canonical, fps, container, codec, hw_accel, device)
+    return _encode_video_ffmpeg_cli(frames, fps, container, codec, hw_accel, device)

--- a/components/src/dynamo/common/utils/video_utils.py
+++ b/components/src/dynamo/common/utils/video_utils.py
@@ -10,6 +10,9 @@ video frames to MP4 format.
 import io
 import logging
 import os
+import shutil
+import subprocess
+import tempfile
 from typing import Tuple
 
 import numpy as np
@@ -242,3 +245,275 @@ def encode_to_video_bytes(
     except Exception as e:
         logger.error(f"Failed to encode video to bytes: {e}")
         raise RuntimeError(f"Video encoding to bytes failed: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Unified video encoding
+#
+# A single shared entry point (``encode_video``) that all backends can call.
+# It absorbs the three different backend output shapes via a thin conversion
+# layer, then dispatches to one of two encode paths (see design doc
+# docs/design/unified_video_encoder.md):
+#
+#   * imageio -> ffmpeg (NVENC)  -- preserves the existing NVIDIA behavior.
+#   * ffmpeg CLI (raw pipe)      -- new hardware (XPU) / codecs that imageio's
+#                                   ffmpeg plugin cannot reach.
+#
+# Encoding controls are read from DYN_VIDEO_* environment variables for now.
+# ---------------------------------------------------------------------------
+
+
+# Logical codec name -> ffmpeg encoder, per hardware path.
+_FFMPEG_ENCODERS = {
+    "nvenc": {"h264": "h264_nvenc", "hevc": "hevc_nvenc", "vp9": "libvpx-vp9"},
+    "xpu": {"h264": "h264_vaapi", "hevc": "hevc_vaapi", "vp9": "vp9_vaapi"},
+    "cpu": {"h264": "libx264", "hevc": "libx265", "vp9": "libvpx-vp9"},
+}
+
+# Default logical codec per container.
+_DEFAULT_CODEC = {"mp4": "h264", "webm": "vp9"}
+
+
+def _video_codec() -> str | None:
+    """Codec override from ``DYN_VIDEO_CODEC`` (e.g. ``h264`` / ``hevc`` / ``vp9``)."""
+    val = os.environ.get("DYN_VIDEO_CODEC")
+    return val.strip().lower() if val else None
+
+
+def _video_container() -> str:
+    """Container from ``DYN_VIDEO_CONTAINER`` (default ``mp4``)."""
+    return os.environ.get("DYN_VIDEO_CONTAINER", "mp4").strip().lower()
+
+
+def _video_hw_accel() -> str:
+    """HW accelerator from ``DYN_VIDEO_HW_ACCEL`` (``auto``/``nvenc``/``xpu``/``cpu``)."""
+    return os.environ.get("DYN_VIDEO_HW_ACCEL", "auto").strip().lower()
+
+
+def _video_device() -> str:
+    """DRM render node / device for HW encoding.
+
+    Read from ``DYN_VIDEO_DEVICE``, falling back to the legacy
+    ``DYNAMO_VAAPI_DEVICE`` and finally ``/dev/dri/renderD128``.
+    """
+    return (
+        os.environ.get("DYN_VIDEO_DEVICE")
+        or os.environ.get("DYNAMO_VAAPI_DEVICE")
+        or "/dev/dri/renderD128"
+    )
+
+
+def _running_on_xpu() -> bool:
+    """Return True when torch reports an available XPU backend."""
+    try:
+        import torch
+
+        return bool(hasattr(torch, "xpu") and torch.xpu.is_available())
+    except Exception:
+        return False
+
+
+def _resolve_ffmpeg_encoder(
+    container: str, codec: str | None, hw_accel: str
+) -> str:
+    """Map (container, logical codec, hw path) to an ffmpeg encoder name.
+
+    A codec value that is already an ffmpeg encoder name passes through.
+    """
+    codec = codec or _DEFAULT_CODEC.get(container, "h264")
+    table = _FFMPEG_ENCODERS.get(hw_accel, _FFMPEG_ENCODERS["nvenc"])
+    return table.get(codec, codec)
+
+
+def to_canonical_frames(frames) -> np.ndarray:
+    """Thin conversion layer: normalize any backend's raw video output.
+
+    Accepts the three shapes that the backends produce and returns a canonical
+    array of shape ``(num_frames, height, width, 3)``, dtype ``uint8``, RGB:
+
+      * ``torch.Tensor`` ``(1, T, H, W, C)`` or ``(T, H, W, C)`` (TRT-LLM)
+      * ``np.ndarray`` ``(1, T, H, W, C)`` / ``(T, H, W, C)``
+      * ``list`` holding a single 5-D / 4-D array (vLLM ``stage_output.images``)
+      * ``list[PIL.Image | np.ndarray]`` (SGLang)
+    """
+    # torch.Tensor -> numpy (duck-typed to avoid importing torch here).
+    if hasattr(frames, "detach") and hasattr(frames, "cpu"):
+        frames = frames.detach().cpu().numpy()
+
+    # Unwrap a single-element list that holds a full-video array/tensor.
+    if isinstance(frames, (list, tuple)) and len(frames) == 1:
+        inner = frames[0]
+        if hasattr(inner, "detach") and hasattr(inner, "cpu"):
+            inner = inner.detach().cpu().numpy()
+        if isinstance(inner, np.ndarray) and inner.ndim >= 4:
+            frames = inner
+
+    if isinstance(frames, np.ndarray):
+        arr = frames[0] if frames.ndim == 5 else frames
+    else:
+        per_frame = []
+        for frame in frames:
+            if isinstance(frame, np.ndarray):
+                per_frame.append(frame)
+            else:
+                # PIL Image (or anything convertible via numpy).
+                per_frame.append(np.array(frame.convert("RGB")))
+        arr = np.stack(per_frame, axis=0)
+
+    # Drop an alpha channel if present.
+    if arr.shape[-1] == 4:
+        arr = arr[..., :3]
+
+    if np.issubdtype(arr.dtype, np.floating):
+        arr = np.clip(arr * 255.0, 0, 255).round()
+
+    return np.ascontiguousarray(arr, dtype=np.uint8)
+
+
+def _encode_video_imageio(
+    frames: np.ndarray, fps: int, container: str, codec: str | None
+) -> bytes:
+    """Encode via imageio -> ffmpeg (NVENC path). Preserves existing behavior."""
+    try:
+        import imageio.v3 as iio
+    except ImportError:
+        try:
+            import imageio as iio  # type: ignore[no-redef]
+        except ImportError:
+            raise ImportError(
+                "imageio is required for video encoding. "
+                "Install with: pip install imageio[ffmpeg]"
+            )
+
+    encoder = _resolve_ffmpeg_encoder(container, codec, "nvenc")
+    buffer = io.BytesIO()
+    if hasattr(iio, "imwrite"):
+        iio.imwrite(buffer, frames, extension=f".{container}", fps=fps, codec=encoder)
+    else:
+        writer = iio.get_writer(  # type: ignore[attr-defined]
+            buffer, format="FFMPEG", mode="I", fps=fps, codec=encoder
+        )
+        try:
+            for frame in frames:
+                writer.append_data(frame)
+        finally:
+            writer.close()
+    return buffer.getvalue()
+
+
+def _encode_video_ffmpeg_cli(
+    frames: np.ndarray,
+    fps: int,
+    container: str,
+    codec: str | None,
+    hw_accel: str,
+    device: str,
+) -> bytes:
+    """Encode by piping raw RGB frames to the ffmpeg CLI (XPU / new codecs).
+
+    mp4 needs a seekable output for the moov atom, so we encode to a temp file
+    and read the bytes back.
+    """
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg not found in PATH; required for video encoding")
+
+    num_frames, height, width, _ = frames.shape
+    encoder = _resolve_ffmpeg_encoder(container, codec, hw_accel)
+
+    with tempfile.NamedTemporaryFile(suffix=f".{container}", delete=False) as tmp:
+        output_path = tmp.name
+    try:
+        cmd = [ffmpeg, "-hide_banner", "-loglevel", "error", "-y"]
+        if hw_accel == "xpu":
+            cmd += ["-vaapi_device", device]
+        cmd += [
+            "-f", "rawvideo",
+            "-pix_fmt", "rgb24",
+            "-s", f"{width}x{height}",
+            "-r", str(fps),
+            "-i", "-",
+        ]
+        if hw_accel == "xpu":
+            cmd += ["-vf", "format=nv12,hwupload"]
+        cmd += ["-c:v", encoder]
+        if container == "mp4":
+            cmd += ["-movflags", "+faststart"]
+        cmd += ["-f", container, output_path]
+
+        logger.info(
+            "Encoding %d frames (%dx%d @ %d fps) via %s on %s",
+            num_frames,
+            width,
+            height,
+            fps,
+            encoder,
+            device if hw_accel == "xpu" else hw_accel,
+        )
+        proc = subprocess.run(
+            cmd,
+            input=frames.tobytes(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if proc.returncode != 0:
+            stderr = proc.stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(
+                f"ffmpeg {encoder} encode failed (exit {proc.returncode}): {stderr}"
+            )
+        with open(output_path, "rb") as fh:
+            return fh.read()
+    finally:
+        try:
+            os.unlink(output_path)
+        except OSError:
+            pass
+
+
+def encode_video(
+    frames,
+    fps: int = DEFAULT_VIDEO_FPS,
+    *,
+    container: str | None = None,
+    codec: str | None = None,
+    hw_accel: str | None = None,
+    device: str | None = None,
+) -> bytes:
+    """Unified video encoder: canonicalize frames and encode to video bytes.
+
+    Any explicit argument overrides its ``DYN_VIDEO_*`` environment variable,
+    which in turn overrides platform auto-detection. Dispatches to the imageio
+    NVENC path on NVIDIA, or the ffmpeg-CLI path for XPU / CPU.
+
+    Args:
+        frames: Raw backend output (see ``to_canonical_frames``).
+        fps: Frames per second for the output video.
+        container: ``mp4`` / ``webm`` (env: ``DYN_VIDEO_CONTAINER``).
+        codec: Logical codec ``h264`` / ``hevc`` / ``vp9`` (env: ``DYN_VIDEO_CODEC``).
+        hw_accel: ``auto`` / ``nvenc`` / ``xpu`` / ``cpu`` (env: ``DYN_VIDEO_HW_ACCEL``).
+        device: HW device / DRM render node (env: ``DYN_VIDEO_DEVICE``).
+
+    Returns:
+        Encoded video as bytes.
+    """
+    container = (container or _video_container()).lower()
+    codec = codec.lower() if codec else _video_codec()
+    hw_accel = (hw_accel or _video_hw_accel()).lower()
+    if hw_accel == "auto":
+        hw_accel = "xpu" if _running_on_xpu() else "nvenc"
+
+    canonical = to_canonical_frames(frames)
+    logger.info(
+        "Encoding %d frames -> %s (hw=%s codec=%s) at %d fps",
+        len(canonical),
+        container,
+        hw_accel,
+        codec or "default",
+        fps,
+    )
+
+    if hw_accel == "nvenc":
+        return _encode_video_imageio(canonical, fps, container, codec)
+
+    device = device or _video_device()
+    return _encode_video_ffmpeg_cli(canonical, fps, container, codec, hw_accel, device)

--- a/components/src/dynamo/sglang/request_handlers/video_generation/video_convert.py
+++ b/components/src/dynamo/sglang/request_handlers/video_generation/video_convert.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang video frame conversion to the canonical encoder format."""
+
+import numpy as np
+
+from dynamo.common.utils.video_utils import ensure_uint8_rgb, pil_frames_to_array
+
+
+def to_canonical(frames: list) -> np.ndarray:
+    """Convert ``DiffGenerator`` frames to canonical ``(T, H, W, 3) uint8``.
+
+    ``frames`` is a list of per-frame ``PIL.Image`` or ``np.ndarray`` images.
+    """
+    return ensure_uint8_rgb(pil_frames_to_array(frames))

--- a/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import base64
-import io
 import logging
 import random
 import time
@@ -13,6 +12,7 @@ import torch
 
 from dynamo._core import Context
 from dynamo.common.storage import upload_to_fs
+from dynamo.common.utils.video_utils import encode_video
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import (
     CreateVideoRequest,
@@ -254,69 +254,9 @@ class VideoGenerationWorkerHandler(BaseGenerativeHandler):
         if not frames:
             raise RuntimeError("DiffGenerator returned no frames")
 
-        # Convert frames to video bytes
-        video_bytes = await self._frames_to_video(frames, fps)
+        # Convert frames to video bytes via the shared unified encoder.
+        video_bytes = await asyncio.to_thread(encode_video, frames, fps)
         return video_bytes
-
-    async def _frames_to_video(
-        self, frames: list, fps: int, codec: str = "h264_nvenc"
-    ) -> bytes:
-        """Convert list of frames to video bytes.
-
-        Args:
-            frames: List of frames (PIL Images or numpy arrays).
-            fps: Frames per second.
-            codec: Video codec to use.
-
-        Returns:
-            Video bytes in mp4 format.
-        """
-        try:
-            import numpy as np
-            from PIL import Image
-
-            # Convert frames to numpy arrays if needed
-            np_frames = []
-            for frame in frames:
-                if isinstance(frame, Image.Image):
-                    np_frames.append(np.array(frame))
-                elif isinstance(frame, np.ndarray):
-                    np_frames.append(frame)
-                else:
-                    raise ValueError(f"Unsupported frame type: {type(frame)}")
-
-            import imageio
-
-            def encode_with_codec(codec_name: str) -> bytes:
-                output_buffer = io.BytesIO()
-                with imageio.get_writer(
-                    output_buffer,
-                    format="mp4",  # type: ignore
-                    fps=fps,
-                    codec=codec_name,
-                    output_params=["-pix_fmt", "yuv420p"],
-                ) as writer:
-                    for frame in np_frames:
-                        writer.append_data(frame)  # type: ignore
-
-                output_buffer.seek(0)
-                return output_buffer.read()
-
-            try:
-                return encode_with_codec(codec)
-            except OSError:
-                if codec != "h264_nvenc":
-                    raise
-                logger.warning(
-                    "h264_nvenc failed; retrying video encoding with libx264"
-                )
-                return encode_with_codec("libx264")
-
-        except ImportError as e:
-            raise RuntimeError(
-                f"Missing dependency for video encoding: {e}. "
-                "Install with: pip install imageio imageio-ffmpeg"
-            )
 
     def _parse_size(self, size_str: str) -> tuple[int, int]:
         """Parse 'WxH' -> (width, height)"""

--- a/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
@@ -257,7 +257,9 @@ class VideoGenerationWorkerHandler(BaseGenerativeHandler):
 
         # Convert to canonical frames, then encode via the shared unified encoder.
         canonical = to_canonical(frames)
-        video_bytes = await asyncio.to_thread(encode_video, canonical, fps)
+        video_bytes = await asyncio.to_thread(
+            encode_video, canonical, fps, container="mp4"
+        )
         return video_bytes
 
     def _parse_size(self, size_str: str) -> tuple[int, int]:

--- a/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
@@ -22,6 +22,7 @@ from dynamo.sglang.protocol import (
 )
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseGenerativeHandler
+from dynamo.sglang.request_handlers.video_generation.video_convert import to_canonical
 
 logger = logging.getLogger(__name__)
 
@@ -254,8 +255,9 @@ class VideoGenerationWorkerHandler(BaseGenerativeHandler):
         if not frames:
             raise RuntimeError("DiffGenerator returned no frames")
 
-        # Convert frames to video bytes via the shared unified encoder.
-        video_bytes = await asyncio.to_thread(encode_video, frames, fps)
+        # Convert to canonical frames, then encode via the shared unified encoder.
+        canonical = to_canonical(frames)
+        video_bytes = await asyncio.to_thread(encode_video, canonical, fps)
         return video_bytes
 
     def _parse_size(self, size_str: str) -> tuple[int, int]:

--- a/components/src/dynamo/sglang/tests/test_sglang_video_convert.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_video_convert.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Layer-B tests for the SGLang video path: to_canonical() + handler adapter."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+_HANDLER_MODULE = (
+    "dynamo.sglang.request_handlers.video_generation.video_generation_handler"
+)
+
+
+class TestSglangVideoToCanonical:
+    """to_canonical() maps DiffGenerator frames to canonical frames losslessly."""
+
+    def test_roundtrip_from_pil_is_bit_exact(self):
+        Image = pytest.importorskip("PIL.Image")
+        from dynamo.sglang.request_handlers.video_generation.video_convert import (
+            to_canonical,
+        )
+
+        # Distinctive per-pixel values catch axis / channel-order bugs.
+        truth = np.arange(2 * 4 * 5 * 3, dtype=np.uint8).reshape(2, 4, 5, 3)
+        native = [Image.fromarray(truth[i]) for i in range(truth.shape[0])]
+
+        out = to_canonical(native)
+
+        assert out.dtype == np.uint8
+        assert np.array_equal(out, truth)
+
+    def test_roundtrip_from_numpy_is_bit_exact(self):
+        from dynamo.sglang.request_handlers.video_generation.video_convert import (
+            to_canonical,
+        )
+
+        truth = np.arange(2 * 4 * 5 * 3, dtype=np.uint8).reshape(2, 4, 5, 3)
+        native = [truth[i] for i in range(truth.shape[0])]
+
+        out = to_canonical(native)
+
+        assert np.array_equal(out, truth)
+
+
+class TestSglangVideoHandlerAdapter:
+    """_generate_video converts to canonical frames, then calls encode_video."""
+
+    @pytest.mark.asyncio
+    async def test_converts_then_encodes(self):
+        from dynamo.sglang.request_handlers.video_generation.video_generation_handler import (  # noqa: E501
+            VideoGenerationWorkerHandler,
+        )
+
+        frames = [MagicMock()]
+        handler = object.__new__(VideoGenerationWorkerHandler)
+        handler._generate_lock = asyncio.Lock()
+        handler.generator = SimpleNamespace(
+            generate=lambda **kw: SimpleNamespace(frames=frames)
+        )
+        canonical = np.zeros((2, 4, 4, 3), dtype=np.uint8)
+
+        with patch(
+            f"{_HANDLER_MODULE}.to_canonical", return_value=canonical
+        ) as m_conv, patch(
+            f"{_HANDLER_MODULE}.encode_video", return_value=b"bytes"
+        ) as m_enc:
+            out = await handler._generate_video(
+                prompt="p",
+                width=8,
+                height=8,
+                num_frames=2,
+                fps=16,
+                num_inference_steps=1,
+                guidance_scale=1.0,
+                seed=0,
+                request_id="r",
+            )
+
+        assert out == b"bytes"
+        m_conv.assert_called_once_with(frames)
+        args, _ = m_enc.call_args
+        assert args[0] is canonical
+        assert args[1] == 16

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/video_convert.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/video_convert.py
@@ -15,7 +15,8 @@ def to_canonical(video) -> np.ndarray:
     (uint8) since TRT-LLM rc9. The batch dim is squeezed and the tensor moved to
     host memory before canonicalizing.
     """
-    assert (
-        video.ndim == 5 and video.shape[0] == 1
-    ), f"Expected video shape (1, T, H, W, C), got {tuple(video.shape)}"
+    if video.ndim != 5 or video.shape[0] != 1:
+        raise ValueError(
+            f"Expected video shape (1, T, H, W, C), got {tuple(video.shape)}"
+        )
     return ensure_uint8_rgb(video[0].cpu().numpy())

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/video_convert.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/video_convert.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TRT-LLM video frame conversion to the canonical encoder format."""
+
+import numpy as np
+
+from dynamo.common.utils.video_utils import ensure_uint8_rgb
+
+
+def to_canonical(video) -> np.ndarray:
+    """Convert ``VisualGenOutput.video`` to canonical ``(T, H, W, 3) uint8``.
+
+    ``VisualGenOutput.video`` is a ``torch.Tensor`` of shape ``(1, T, H, W, C)``
+    (uint8) since TRT-LLM rc9. The batch dim is squeezed and the tensor moved to
+    host memory before canonicalizing.
+    """
+    assert (
+        video.ndim == 5 and video.shape[0] == 1
+    ), f"Expected video shape (1, T, H, W, C), got {tuple(video.shape)}"
+    return ensure_uint8_rgb(video[0].cpu().numpy())

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/video_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/video_handler.py
@@ -23,7 +23,7 @@ from dynamo.common.protocols.video_protocol import (
     VideoNvExt,
 )
 from dynamo.common.storage import get_fs, upload_to_fs
-from dynamo.common.utils.video_utils import encode_to_video_bytes
+from dynamo.common.utils.video_utils import encode_video
 from dynamo.trtllm.configs.diffusion_config import DiffusionConfig
 from dynamo.trtllm.engines.diffusion_engine import DiffusionEngine
 from dynamo.trtllm.request_handlers.base_generative_handler import BaseGenerativeHandler
@@ -262,10 +262,10 @@ class VideoGenerationHandler(BaseGenerativeHandler):
                     f"(shape={frames_np.shape}) to MP4 at {fps} fps"
                 )
                 video_bytes = await asyncio.to_thread(
-                    encode_to_video_bytes,
+                    encode_video,
                     frames_np,
-                    fps=fps,
-                    output_format=output_format,
+                    fps,
+                    container=output_format,
                 )
 
             elif output.image is not None:

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/video_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/video_handler.py
@@ -256,8 +256,10 @@ class VideoGenerationHandler(BaseGenerativeHandler):
                 # the frames to host memory as canonical (T, H, W, 3) uint8.
                 frames_np = to_canonical(output.video)
                 logger.info(
-                    f"Request {request_id}: encoding video output "
-                    f"(shape={frames_np.shape}) to MP4 at {fps} fps"
+                    "Request %s: encoding video output (shape=%s) to MP4 at %d fps",
+                    request_id,
+                    frames_np.shape,
+                    fps,
                 )
                 video_bytes = await asyncio.to_thread(
                     encode_video,

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/video_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/video_handler.py
@@ -27,6 +27,7 @@ from dynamo.common.utils.video_utils import encode_video
 from dynamo.trtllm.configs.diffusion_config import DiffusionConfig
 from dynamo.trtllm.engines.diffusion_engine import DiffusionEngine
 from dynamo.trtllm.request_handlers.base_generative_handler import BaseGenerativeHandler
+from dynamo.trtllm.request_handlers.diffusion.video_convert import to_canonical
 
 logger = logging.getLogger(__name__)
 
@@ -250,13 +251,10 @@ class VideoGenerationHandler(BaseGenerativeHandler):
 
             # Encode media based on what the VisualGen returned
             if output.video is not None:
-                # VisualGenOutput.video is (B, T, H, W, C) uint8 since TRT-LLM rc9;
-                # squeeze the batch dim to get (T, H, W, C) for MP4 encoding.
-                video = output.video
-                assert (
-                    video.ndim == 5 and video.shape[0] == 1
-                ), f"Expected video shape (1, T, H, W, C), got {video.shape}"
-                frames_np = video[0].cpu().numpy()
+                # VisualGenOutput.video is (1, T, H, W, C) uint8 since TRT-LLM
+                # rc9; the backend converter squeezes the batch dim and moves
+                # the frames to host memory as canonical (T, H, W, 3) uint8.
+                frames_np = to_canonical(output.video)
                 logger.info(
                     f"Request {request_id}: encoding video output "
                     f"(shape={frames_np.shape}) to MP4 at {fps} fps"

--- a/components/src/dynamo/trtllm/tests/test_trtllm_video_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_video_diffusion.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 import torch
 
@@ -713,7 +714,7 @@ class TestVideoHandlerConcurrency:
             requests = [self._make_request() for _ in range(3)]
 
             with patch(
-                "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_to_video_bytes",
+                "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_video",
                 return_value=b"fake_mp4_bytes",
             ), patch(
                 "dynamo.trtllm.request_handlers.diffusion.video_handler.upload_to_fs",
@@ -785,7 +786,7 @@ class TestVideoHandlerResponseFormats:
         }
 
         with patch(
-            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_to_video_bytes",
+            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_video",
             return_value=b"fake_mp4",
         ), patch(
             "dynamo.trtllm.request_handlers.diffusion.video_handler.upload_to_fs",
@@ -817,7 +818,7 @@ class TestVideoHandlerResponseFormats:
         }
 
         with patch(
-            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_to_video_bytes",
+            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_video",
             return_value=b"fake_mp4_bytes",
         ):
             results = []
@@ -849,7 +850,7 @@ class TestVideoHandlerResponseFormats:
         }
 
         with patch(
-            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_to_video_bytes",
+            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_video",
             return_value=b"fake_mp4",
         ), patch(
             "dynamo.trtllm.request_handlers.diffusion.video_handler.upload_to_fs",
@@ -931,7 +932,7 @@ class TestVideoHandlerOutputFormat:
         """Omitting output_format defaults to mp4."""
         handler = self._make_handler()
         with patch(
-            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_to_video_bytes",
+            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_video",
             return_value=b"bytes",
         ) as mock_enc, patch(
             "dynamo.trtllm.request_handlers.diffusion.video_handler.upload_to_fs",
@@ -942,14 +943,14 @@ class TestVideoHandlerOutputFormat:
         assert results[0]["status"] == "completed"
         mock_enc.assert_called_once()
         _, kwargs = mock_enc.call_args
-        assert kwargs["output_format"] == "mp4"
+        assert kwargs["container"] == "mp4"
 
     @pytest.mark.asyncio
     async def test_url_response_has_output_format_in_video_data(self):
         """URL-mode response includes output_format='mp4' in VideoData."""
         handler = self._make_handler()
         with patch(
-            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_to_video_bytes",
+            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_video",
             return_value=b"bytes",
         ), patch(
             "dynamo.trtllm.request_handlers.diffusion.video_handler.upload_to_fs",
@@ -966,7 +967,7 @@ class TestVideoHandlerOutputFormat:
         """Base64-mode response includes output_format='mp4' in VideoData."""
         handler = self._make_handler()
         with patch(
-            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_to_video_bytes",
+            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_video",
             return_value=b"bytes",
         ):
             results = await self._run(
@@ -976,11 +977,11 @@ class TestVideoHandlerOutputFormat:
         assert results[0]["data"][0]["output_format"] == "mp4"
 
     @pytest.mark.asyncio
-    async def test_encode_called_with_output_format_kwarg(self):
-        """encode_to_video_bytes is always called with output_format='mp4'."""
+    async def test_encode_called_with_container_kwarg(self):
+        """encode_video is always called with container='mp4'."""
         handler = self._make_handler()
         with patch(
-            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_to_video_bytes",
+            "dynamo.trtllm.request_handlers.diffusion.video_handler.encode_video",
             return_value=b"bytes",
         ) as mock_enc, patch(
             "dynamo.trtllm.request_handlers.diffusion.video_handler.upload_to_fs",
@@ -990,5 +991,27 @@ class TestVideoHandlerOutputFormat:
 
         mock_enc.assert_called_once()
         _, kwargs = mock_enc.call_args
-        assert "output_format" in kwargs
-        assert kwargs["output_format"] == "mp4"
+        assert "container" in kwargs
+        assert kwargs["container"] == "mp4"
+
+
+# =============================================================================
+# Part 8: to_canonical() converter (backend -> canonical frames)
+# =============================================================================
+
+
+class TestTrtllmToCanonical:
+    """to_canonical() maps VisualGenOutput.video to canonical frames losslessly."""
+
+    def test_roundtrip_is_bit_exact(self):
+        from dynamo.trtllm.request_handlers.diffusion.video_convert import to_canonical
+
+        # Distinctive per-pixel values catch axis / channel-order bugs.
+        truth = np.arange(2 * 4 * 5 * 3, dtype=np.uint8).reshape(2, 4, 5, 3)
+        native = torch.from_numpy(truth)[None]  # (1, T, H, W, C)
+
+        out = to_canonical(native)
+
+        assert out.dtype == np.uint8
+        assert out.shape == truth.shape
+        assert np.array_equal(out, truth)

--- a/components/src/dynamo/vllm/omni/output_formatter.py
+++ b/components/src/dynamo/vllm/omni/output_formatter.py
@@ -11,7 +11,6 @@ output without creating an engine or loading model weights.
 import asyncio
 import base64
 import logging
-import tempfile
 import time
 import uuid
 from io import BytesIO
@@ -20,7 +19,6 @@ from typing import Any, Dict, Optional
 import numpy as np
 import soundfile as sf
 import torch
-from diffusers.utils.export_utils import export_to_video
 
 from dynamo.common.protocols.audio_protocol import AudioData, NvAudioSpeechResponse
 from dynamo.common.protocols.image_protocol import ImageData, NvImagesResponse
@@ -28,7 +26,7 @@ from dynamo.common.protocols.video_protocol import NvVideosResponse, VideoData
 from dynamo.common.storage import upload_to_fs
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.common.utils.output_modalities import RequestType
-from dynamo.common.utils.video_utils import normalize_video_frames
+from dynamo.common.utils.video_utils import encode_video
 from dynamo.vllm.handlers import build_prompt_tokens_details
 from dynamo.vllm.omni.utils import is_empty_payload
 
@@ -141,12 +139,9 @@ class DiffusionFormatter:
             )
         try:
             start_time = time.time()
-            frame_list = normalize_video_frames(images)
-            with tempfile.NamedTemporaryFile(
-                suffix=f".{output_format}", delete=True
-            ) as tmp:
-                await asyncio.to_thread(export_to_video, frame_list, tmp.name, fps)
-                video_bytes = tmp.read()
+            video_bytes = await asyncio.to_thread(
+                encode_video, images, fps, container=output_format
+            )
 
             if response_format == "b64_json":
                 video_data = VideoData(

--- a/components/src/dynamo/vllm/omni/output_formatter.py
+++ b/components/src/dynamo/vllm/omni/output_formatter.py
@@ -29,6 +29,7 @@ from dynamo.common.utils.output_modalities import RequestType
 from dynamo.common.utils.video_utils import encode_video
 from dynamo.vllm.handlers import build_prompt_tokens_details
 from dynamo.vllm.omni.utils import is_empty_payload
+from dynamo.vllm.omni.video_convert import to_canonical
 
 logger = logging.getLogger(__name__)
 
@@ -139,8 +140,9 @@ class DiffusionFormatter:
             )
         try:
             start_time = time.time()
+            canonical = to_canonical(images)
             video_bytes = await asyncio.to_thread(
-                encode_video, images, fps, container=output_format
+                encode_video, canonical, fps, container=output_format
             )
 
             if response_format == "b64_json":

--- a/components/src/dynamo/vllm/omni/video_convert.py
+++ b/components/src/dynamo/vllm/omni/video_convert.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""vLLM-Omni video frame conversion to the canonical encoder format."""
+
+import numpy as np
+import torch
+
+from dynamo.common.utils.video_utils import ensure_uint8_rgb
+
+
+def to_canonical(images: list) -> np.ndarray:
+    """Convert ``stage_output.images`` to canonical ``(T, H, W, 3) uint8``.
+
+    ``stage_output.images`` is a list holding a single full-video array of shape
+    ``(1, T, H, W, C)`` or ``(T, H, W, C)`` (``np.ndarray`` or ``torch.Tensor``).
+    """
+    array = images[0] if len(images) == 1 else images
+    if isinstance(array, torch.Tensor):
+        array = array.cpu().numpy()
+    array = np.asarray(array)
+    if array.ndim == 5:
+        array = array[0]
+    return ensure_uint8_rgb(array)

--- a/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
+++ b/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
@@ -227,7 +227,7 @@ class TestDiffusionFormatterVideo:
 
         f = _make_diffusion_formatter()
         with patch(
-            "dynamo.vllm.omni.output_formatter.normalize_video_frames",
+            "dynamo.vllm.omni.output_formatter.to_canonical",
             side_effect=RuntimeError("boom"),
         ):
             chunk = await f._encode_video([MagicMock()], "req-1", fps=16)
@@ -528,12 +528,17 @@ class TestDiffusionFormatterVideoOutputFormat:
     def _patches(self):
         from unittest.mock import patch as _patch
 
+        import numpy as np
+
         return (
             _patch(
-                "dynamo.vllm.omni.output_formatter.normalize_video_frames",
-                return_value=[MagicMock()],
+                "dynamo.vllm.omni.output_formatter.to_canonical",
+                return_value=np.zeros((2, 4, 4, 3), dtype=np.uint8),
             ),
-            _patch("dynamo.vllm.omni.output_formatter.export_to_video"),
+            _patch(
+                "dynamo.vllm.omni.output_formatter.encode_video",
+                return_value=b"bytes",
+            ),
             _patch(
                 "dynamo.vllm.omni.output_formatter.upload_to_fs",
                 return_value="http://x/v.mp4",
@@ -616,3 +621,62 @@ class TestDiffusionFormatterVideoOutputFormat:
         assert result is not None
         assert result["data"][0]["url"] == "http://x/v.mp4"
         mock_upload.assert_called_once()
+
+
+# ── DiffusionFormatter — to_canonical converter + encode adapter ────────────
+
+
+class TestVllmVideoToCanonical:
+    """to_canonical() maps stage_output.images to canonical frames losslessly."""
+
+    def test_roundtrip_is_bit_exact(self):
+        import numpy as np
+
+        from dynamo.vllm.omni.video_convert import to_canonical
+
+        # Distinctive per-pixel values catch axis / channel-order bugs.
+        truth = np.arange(2 * 4 * 5 * 3, dtype=np.uint8).reshape(2, 4, 5, 3)
+        native = [truth[None]]  # list holding one (1, T, H, W, C) array
+
+        out = to_canonical(native)
+
+        assert out.dtype == np.uint8
+        assert np.array_equal(out, truth)
+
+    @pytest.mark.asyncio
+    async def test_encode_video_receives_canonical_and_forwards_container(self):
+        from unittest.mock import patch as _patch
+
+        import numpy as np
+
+        from dynamo.common.utils.output_modalities import RequestType
+        from dynamo.vllm.omni.output_formatter import DiffusionFormatter
+
+        f = DiffusionFormatter(model_name="test", media_fs=None, media_http_url=None)
+        stage = MagicMock()
+        stage.images = [MagicMock()]
+        canonical = np.zeros((2, 4, 4, 3), dtype=np.uint8)
+
+        with _patch(
+            "dynamo.vllm.omni.output_formatter.to_canonical", return_value=canonical
+        ), _patch(
+            "dynamo.vllm.omni.output_formatter.encode_video", return_value=b"bytes"
+        ) as m_enc, _patch(
+            "dynamo.vllm.omni.output_formatter.upload_to_fs",
+            return_value="http://x/v.mp4",
+        ), _patch(
+            "dynamo.vllm.omni.output_formatter.asyncio.to_thread",
+            side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+        ):
+            await f.format(
+                stage,
+                "r8",
+                request_type=RequestType.VIDEO_GENERATION,
+                fps=16,
+                response_format="url",
+            )
+
+        args, kwargs = m_enc.call_args
+        assert args[0] is canonical
+        assert args[1] == 16
+        assert kwargs["container"] == "mp4"


### PR DESCRIPTION
## Overview:

This unifies the final "raw frames → encoded video"
step across the three diffusion backends behind a single shared encoder in
`dynamo.common`, so codec / container / hardware support is implemented once and
is trivial to extend (new accelerators, new codecs) without touching
backend-specific code.

Design is tracked in a DEP https://github.com/ai-dynamo/enhancements/pull/93.

### Current flow chart

```mermaid
graph LR
    P[Prompt /v1/videos] --> FE[Dynamo Frontend<br/>shared]

    FE --> V[vLLM<br/>AsyncOmni.generate]
    FE --> T[TRT-LLM<br/>DiffusionEngine.generate]
    FE --> S[SGLang<br/>DiffGenerator.generate]

    V --> Ev[export_to_video<br/>ffmpeg / software H.264]
    T --> Et[imageio + ffmpeg<br/>NVENC H.264]
    S --> Es[imageio + ffmpeg<br/>NVENC H.264]

    Ev --> W[upload_to_fs / fs.pipe<br/>shared]
    Et --> W
    Es --> W
    W --> D[(file:// / s3:// …)]
```

The fork in the middle (three encoders) is the only real divergence — and the
target of this work.

## Proposed Architecture

Insert a single shared encoder between the backends and the existing file
writer. Each backend feeds its raw pixels through a **thin conversion layer**
(normalize to a canonical `np.ndarray (T, H, W, 3) uint8`), then calls the
**unified encoder**, which dispatches to the right backend implementation.

```mermaid
graph LR
    V[vLLM frames] --> C[Thin conversion layer<br/>→ numpy T,H,W,3 uint8]
    T[TRT-LLM frames] --> C
    S[SGLang frames] --> C

    C --> U{Unified encoder<br/>dispatch}
    U -->|NVIDIA| N[imageio → ffmpeg<br/>NVENC]
    U -->|new HW / codecs| F[ffmpeg CLI<br/>raw pipe]

    N --> W[upload_to_fs / fs.pipe<br/>unchanged]
    F --> W
    W --> D[(file:// / s3:// …)]
```

## Details:

- Adds to `dynamo/common/utils/video_utils.py`:
  - **Thin conversion layer** (`to_canonical_frames`) that normalizes each
    backend's raw output — TRT-LLM `torch.Tensor (1,T,H,W,C)`, vLLM
    `stage_output.images` list, SGLang `list[PIL | np.ndarray]` — to a canonical
    `np.ndarray (T, H, W, 3) uint8`.
  - **Unified encoder** (`encode_video`) with two paths: imageio → ffmpeg (NVENC),
    preserving existing NVIDIA behavior; and an ffmpeg-CLI raw-pipe path for new
    hardware (Intel XPU / VA-API) and codecs (HEVC).
  - **Env-var controls**: `DYN_VIDEO_CODEC`, `DYN_VIDEO_CONTAINER`,
    `DYN_VIDEO_HW_ACCEL` (`auto`/`nvenc`/`xpu`/`cpu`, auto-detects XPU),
    `DYN_VIDEO_DEVICE` (falls back to legacy `DYNAMO_VAAPI_DEVICE`).
- Wires all three handlers to `encode_video()`:
  - TRT-LLM `video_handler.py` (was `encode_to_video_bytes`).
  - SGLang `video_generation_handler.py` — removes the duplicated inline
    `_frames_to_video` encoder.
  - vLLM-Omni `output_formatter.py` — replaces the `export_to_video` temp-file path;
    XPU is now auto-detected here.
- The storage stage (`upload_to_fs`) is unchanged. Legacy helpers
  (`encode_to_video_bytes`, `encode_to_mp4`, `normalize_video_frames`,
  `frames_to_numpy`) are intentionally kept for now.
- No tests changed. Known impact: `test_trtllm_video_diffusion.py` patches the old
  `encode_to_video_bytes` symbol and will need repatching to `encode_video`
  (documented in the DEP's Testing Impact section). Test migration is deferred.

## Where should the reviewer start?

- `components/src/dynamo/common/utils/video_utils.py` — the new
  `to_canonical_frames` and `encode_video` (dispatch + two encode paths) are the
  core of the change.
- The three handler call sites:
  - `components/src/dynamo/trtllm/request_handlers/diffusion/video_handler.py`
  - `components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py`
  - `components/src/dynamo/vllm/omni/output_formatter.py`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified video encoding with automatic or explicit CPU, NVENC, and XPU acceleration support.
  * Added consistent conversion for video frames from images, tensors, and arrays into RGB format.
  * Improved video generation across SGLang, TensorRT-LLM, and vLLM-Omni integrations.
  * Added support for configurable containers, codecs, frame rates, and encoding devices.

* **Bug Fixes**
  * Improved validation of video dimensions, channels, and data types.
  * Added clearer handling when required video encoding tools are unavailable.

* **Tests**
  * Expanded coverage for encoding paths, frame conversion, hardware selection, and video round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->