### PR TITLE
ci: stop triggering gitlab pipeline on PRs

### DIFF
--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -20,7 +20,6 @@ on:
     branches:
       - main
       - release/*.*.*
-      - "pull-request/[0-9]+"
     # Docs deployment is handled by fern-docs.yml. Docs-only changes are
     # covered by pre-merge Fern checks, so do not wake this secrets-backed
     # GitLab mirror/Test Lab pipeline for docs metadata/config.


### PR DESCRIPTION
Remove the pull-request/[0-9]+ push trigger from the NVIDIA Test Lab Validation workflow so the GitLab mirror sync and pipeline trigger no longer run on PR branches. The pipeline still runs on main and release/*.*.* pushes.

closes: OPS-7288

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated workflow trigger conditions for push events.
  * The workflow now runs only for the main and release branches, with no other changes to behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->