### PR TITLE
feat: add runtime-loadable system route extensions

### DIFF
--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -72,6 +72,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     kserve_grpc_server: bool
     grpc_metrics_port: int
     dump_config_to: Optional[str]
+    system_route_extensions: str
 
     discovery_backend: str
     request_plane: str
@@ -342,6 +343,17 @@ class FrontendArgGroup(ArgGroup):
             env_var="DYN_DUMP_CONFIG_TO",
             default=None,
             help="Dump config to the specified file path.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--system-route-extensions",
+            env_var="DYN_SYSTEM_ROUTE_EXTENSIONS",
+            default="",
+            help=(
+                "Comma or whitespace separated Python import paths for system route "
+                "extension factories. Prototype API: each factory returns route specs."
+            ),
         )
 
         add_argument(

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -18,8 +18,10 @@
 
 import argparse
 import asyncio
+import importlib
 import logging
 import os
+import re
 import signal
 import sys
 from argparse import Namespace
@@ -37,6 +39,7 @@ from dynamo.llm import (
     RouterMode,
     make_engine,
     run_input,
+    run_input_with_system_route_extensions,
 )
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -162,6 +165,30 @@ def parse_args() -> tuple[FrontendConfig, Optional[Namespace], Optional[Namespac
     return config, vllm_flags, sglang_flags
 
 
+def _split_system_route_extension_paths(raw: str) -> list[str]:
+    return [part.strip() for part in re.split(r"[\s,]+", raw or "") if part.strip()]
+
+
+def _load_system_route_extension_factories(raw: str) -> list[Any]:
+    factories: list[Any] = []
+    for import_path in _split_system_route_extension_paths(raw):
+        module_name, separator, attribute_path = import_path.partition(":")
+        if not separator or not module_name or not attribute_path:
+            raise ValueError(
+                "system route extension import paths must use 'module:factory'; "
+                f"got {import_path!r}"
+            )
+        target: Any = importlib.import_module(module_name)
+        for attribute in attribute_path.split("."):
+            target = getattr(target, attribute)
+        if not callable(target):
+            raise ValueError(
+                f"system route extension factory {import_path!r} is not callable"
+            )
+        factories.append(target)
+    return factories
+
+
 async def async_main():
     """Main async entry point for the Dynamo frontend.
 
@@ -176,6 +203,13 @@ async def async_main():
     # wrong metrics endpoint.
     os.environ.pop("DYN_SYSTEM_PORT", None)
     config, vllm_flags, sglang_flags = parse_args()
+    system_route_factories = _load_system_route_extension_factories(
+        config.system_route_extensions
+    )
+    if system_route_factories and (config.interactive or config.kserve_grpc_server):
+        raise ValueError(
+            "system route extensions are only supported by the HTTP frontend"
+        )
     dump_config(config.dump_config_to, config)
     max_seq_info = (
         f", max_seq_len: {config.migration_max_seq_len}"
@@ -298,6 +332,10 @@ async def async_main():
             await run_input(runtime, "text", engine)
         elif config.kserve_grpc_server:
             await run_input(runtime, "grpc", engine)
+        elif system_route_factories:
+            await run_input_with_system_route_extensions(
+                runtime, "http", engine, system_route_factories
+            )
         else:
             await run_input(runtime, "http", engine)
     except asyncio.exceptions.CancelledError:

--- a/components/src/dynamo/frontend/tests/test_system_route_extension_loader.py
+++ b/components/src/dynamo/frontend/tests/test_system_route_extension_loader.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import types
+
+import pytest
+
+from dynamo.frontend.main import (
+    _load_system_route_extension_factories,
+    _split_system_route_extension_paths,
+)
+
+
+def test_split_system_route_extension_paths_accepts_commas_and_whitespace():
+    assert _split_system_route_extension_paths("a:f, b:g\n c:h") == [
+        "a:f",
+        "b:g",
+        "c:h",
+    ]
+
+
+def test_load_system_route_extension_factories_from_import_paths(monkeypatch):
+    module = types.ModuleType("test_route_extension_module")
+
+    def factory():
+        return []
+
+    module.factory = factory
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    assert _load_system_route_extension_factories(f"{module.__name__}:factory") == [
+        factory
+    ]
+
+
+def test_load_system_route_extension_factories_rejects_invalid_path():
+    with pytest.raises(ValueError, match="module:factory"):
+        _load_system_route_extension_factories("missing_separator")

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -176,6 +176,10 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(llm::entrypoint::run_input, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        llm::entrypoint::run_input_with_system_route_extensions,
+        m
+    )?)?;
 
     m.add_class::<DistributedRuntime>()?;
     m.add_class::<Endpoint>()?;

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -5,9 +5,9 @@ use std::fmt::Display;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use pyo3::{exceptions::PyException, exceptions::PyValueError, prelude::*};
+use pyo3::{exceptions::PyException, exceptions::PyValueError, prelude::*, types::{PyDict, PyList}};
 use pyo3_async_runtimes::TaskLocals;
 
 use dynamo_kv_router::config::{
@@ -18,6 +18,13 @@ use dynamo_llm::discovery::LoadThresholdConfig as RsLoadThresholdConfig;
 use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::RouterConfig as RsRouterConfig;
 use dynamo_llm::entrypoint::input::Input;
+use dynamo_llm::http::service::{RouteDoc, SystemRouteContext, SystemRouteExtension, SystemRouteSet};
+use dynamo_llm::http::service::axum::{
+    http::{Method, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
 use dynamo_llm::entrypoint::{ChatEngineFactoryCallback, PrefillRoutedEngine};
 use dynamo_llm::frontend_config::{FrontendApiConfig, MetricsConfig};
 use dynamo_llm::local_model::DEFAULT_HTTP_PORT;
@@ -31,6 +38,8 @@ use dynamo_mocker::common::perf_model::PerfModel;
 use super::aic_callback::{create_aic_callback, create_aic_prefill_load_estimator};
 use super::replay::MockEngineArgs as PyMockEngineArgs;
 use dynamo_mocker::common::protocols::MockEngineArgs as RsMockEngineArgs;
+use pythonize::{depythonize, pythonize};
+use serde_json::{json, Value};
 use dynamo_runtime::discovery::ModelCardInstanceId as RsModelCardInstanceId;
 use dynamo_runtime::protocols::EndpointId;
 
@@ -931,6 +940,174 @@ pub fn run_input<'p>(
         Ok(())
     })
 }
+
+
+#[pyfunction]
+#[pyo3(signature = (distributed_runtime, input, engine_config, system_route_factories))]
+pub fn run_input_with_system_route_extensions<'p>(
+    py: Python<'p>,
+    distributed_runtime: super::DistributedRuntime,
+    input: &str,
+    engine_config: EngineConfig,
+    system_route_factories: Vec<Py<PyAny>>,
+) -> PyResult<Bound<'p, PyAny>> {
+    let input_enum: Input = input.parse().map_err(to_pyerr)?;
+    let mut extensions = Vec::with_capacity(system_route_factories.len());
+    for factory in system_route_factories {
+        let specs = load_python_system_route_specs(py, factory)?;
+        extensions.push(python_system_route_extension(specs));
+    }
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        dynamo_llm::entrypoint::input::run_input_with_system_route_extensions(
+            distributed_runtime.inner.clone(),
+            input_enum,
+            engine_config.inner,
+            extensions,
+        )
+        .await
+        .map_err(to_pyerr)?;
+        Ok(())
+    })
+}
+
+
+#[derive(Clone)]
+struct PythonSystemRouteSpec {
+    path: String,
+    method: Method,
+    handler: Arc<Mutex<Py<PyAny>>>,
+}
+
+fn load_python_system_route_specs(
+    py: Python<'_>,
+    factory: Py<PyAny>,
+) -> PyResult<Vec<PythonSystemRouteSpec>> {
+    let routes_obj = factory.bind(py).call0()?;
+    let routes = routes_obj.downcast::<PyList>()?;
+    let mut specs = Vec::with_capacity(routes.len());
+
+    for item in routes.iter() {
+        let route = item.downcast::<PyDict>()?;
+        let path = route
+            .get_item("path")?
+            .ok_or_else(|| PyValueError::new_err("system route spec is missing path"))?
+            .extract::<String>()?;
+        if !path.starts_with('/') {
+            return Err(PyValueError::new_err(format!(
+                "system route path must start with /: {path}"
+            )));
+        }
+
+        let method = route
+            .get_item("method")?
+            .map(|value| value.extract::<String>())
+            .transpose()?
+            .unwrap_or_else(|| "GET".to_string());
+        if !method.eq_ignore_ascii_case("GET") {
+            return Err(PyValueError::new_err(format!(
+                "only GET system route extensions are supported by this prototype; got {method}"
+            )));
+        }
+
+        let handler = route
+            .get_item("handler")?
+            .ok_or_else(|| PyValueError::new_err("system route spec is missing handler"))?
+            .unbind();
+        if !handler.bind(py).is_callable() {
+            return Err(PyValueError::new_err(format!(
+                "system route handler for {path} is not callable"
+            )));
+        }
+
+        specs.push(PythonSystemRouteSpec {
+            path,
+            method: Method::GET,
+            handler: Arc::new(Mutex::new(handler)),
+        });
+    }
+
+    Ok(specs)
+}
+
+fn python_system_route_extension(specs: Vec<PythonSystemRouteSpec>) -> SystemRouteExtension {
+    Arc::new(move |ctx: SystemRouteContext| {
+        let mut route_docs = Vec::with_capacity(specs.len());
+        let mut router = Router::new();
+
+        for spec in specs.iter().cloned() {
+            let path = spec.path.clone();
+            let method = spec.method.clone();
+            let handler = spec.handler.clone();
+            let route_ctx = ctx.clone();
+            route_docs.push(RouteDoc::new(method, path.clone()));
+            router = router.route(
+                &path,
+                get(move || {
+                    let handler = handler.clone();
+                    let route_ctx = route_ctx.clone();
+                    async move { call_python_system_route(handler, route_ctx).await }
+                }),
+            );
+        }
+
+        SystemRouteSet::new(route_docs, router)
+    })
+}
+
+async fn call_python_system_route(
+    handler: Arc<Mutex<Py<PyAny>>>,
+    ctx: SystemRouteContext,
+) -> Response {
+    let callback = match handler.lock() {
+        Ok(callback) => callback.clone(),
+        Err(err) => {
+            return python_route_error_response(format!("system route handler lock poisoned: {err}"));
+        }
+    };
+
+    let result = Python::with_gil(|py| -> PyResult<(u16, Value)> {
+        let snapshot = json!({
+            "ready": ctx.is_ready(),
+            "cancelled": ctx.is_cancelled(),
+        });
+        let py_snapshot = pythonize(py, &snapshot).map_err(to_pyerr)?;
+        let py_result = callback.bind(py).call1((py_snapshot,))?;
+        let result_json: Value = depythonize(&py_result).map_err(to_pyerr)?;
+        decode_python_route_result(result_json)
+    });
+
+    match result {
+        Ok((status, body)) => {
+            let status_code = StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            (status_code, Json(body)).into_response()
+        }
+        Err(err) => python_route_error_response(err.to_string()),
+    }
+}
+
+fn decode_python_route_result(result: Value) -> PyResult<(u16, Value)> {
+    if let Some(object) = result.as_object() {
+        if object.contains_key("body") || object.contains_key("status") {
+            let status = object.get("status").and_then(Value::as_u64).unwrap_or(200);
+            if status > u16::MAX as u64 {
+                return Err(PyValueError::new_err(format!("invalid route status: {status}")));
+            }
+            let body = object.get("body").cloned().unwrap_or(Value::Null);
+            return Ok((status as u16, body));
+        }
+    }
+    Ok((200, result))
+}
+
+fn python_route_error_response(message: String) -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "error": message })),
+    )
+        .into_response()
+}
+
 
 pub fn to_pyerr<E>(err: E) -> PyErr
 where

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2347,6 +2347,10 @@ async def run_input(runtime: DistributedRuntime, input: str, engine_config: Engi
     """Start an engine, connect it to an input, and run until stopped."""
     ...
 
+async def run_input_with_system_route_extensions(runtime: DistributedRuntime, input: str, engine_config: EngineConfig, system_route_factories: list[Any]) -> None:
+    """Start an HTTP input with Python-backed system route extension factories."""
+    ...
+
 def run_mocker_trace_replay(
     trace_files: Sequence[str | os.PathLike[str]],
     extra_engine_args: Optional[MockEngineArgs] = None,

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -43,6 +43,7 @@ from dynamo._core import lora_name_to_id as lora_name_to_id
 from dynamo._core import make_engine
 from dynamo._core import register_model as register_model
 from dynamo._core import run_input
+from dynamo._core import run_input_with_system_route_extensions
 from dynamo._core import run_kv_indexer as run_kv_indexer
 from dynamo._core import run_select_service as run_select_service
 from dynamo._core import run_slot_tracker as run_slot_tracker

--- a/lib/llm/src/entrypoint/input.rs
+++ b/lib/llm/src/entrypoint/input.rs
@@ -22,6 +22,8 @@ pub mod text;
 
 use dynamo_runtime::protocols::ENDPOINT_SCHEME;
 
+use crate::http::service::SystemRouteExtension;
+
 /// The various ways of connecting prompts to an engine
 #[derive(PartialEq)]
 pub enum Input {
@@ -98,6 +100,16 @@ pub async fn run_input(
     in_opt: Input,
     engine_config: super::EngineConfig,
 ) -> anyhow::Result<()> {
+    run_input_with_system_route_extensions(drt, in_opt, engine_config, Vec::new()).await
+}
+
+/// Run the given engine connected to an input with optional HTTP system route extensions.
+pub async fn run_input_with_system_route_extensions(
+    drt: dynamo_runtime::DistributedRuntime,
+    in_opt: Input,
+    engine_config: super::EngineConfig,
+    system_route_extensions: Vec<SystemRouteExtension>,
+) -> anyhow::Result<()> {
     if let Err(e) = crate::request_trace::init_from_env_with_shutdown(drt.child_token()).await {
         tracing::warn!(error = %e, "Request trace initialization failed; continuing without trace sink");
     }
@@ -118,20 +130,33 @@ pub async fn run_input(
 
     match in_opt {
         Input::Http => {
-            http::run(drt, engine_config).await?;
+            http::run_with_system_route_extensions(drt, engine_config, system_route_extensions)
+                .await?;
         }
         Input::Grpc => {
+            if !system_route_extensions.is_empty() {
+                anyhow::bail!("system route extensions are only supported for HTTP input");
+            }
             grpc::run(drt, engine_config).await?;
         }
         Input::Text => {
+            if !system_route_extensions.is_empty() {
+                anyhow::bail!("system route extensions are only supported for HTTP input");
+            }
             text::run(drt, None, engine_config).await?;
         }
         Input::Stdin => {
+            if !system_route_extensions.is_empty() {
+                anyhow::bail!("system route extensions are only supported for HTTP input");
+            }
             let mut prompt = String::new();
             std::io::stdin().read_to_string(&mut prompt).unwrap();
             text::run(drt, Some(prompt), engine_config).await?;
         }
         Input::Endpoint(path) => {
+            if !system_route_extensions.is_empty() {
+                anyhow::bail!("system route extensions are only supported for HTTP input");
+            }
             endpoint::run(drt, path, engine_config).await?;
         }
     }

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -9,6 +9,7 @@ use crate::{
     endpoint_type::EndpointType,
     engines::StreamingEngineAdapter,
     entrypoint::{ChatEngineFactoryCallback, EngineConfig, RouterConfig, input::common},
+    http::service::SystemRouteExtension,
     http::service::service_v2::{self, HttpService},
     local_model::runtime_config::TokenizerBackend,
     namespace::NamespaceFilter,
@@ -24,6 +25,15 @@ use dynamo_runtime::metrics::MetricsHierarchy;
 pub async fn run(
     distributed_runtime: DistributedRuntime,
     engine_config: EngineConfig,
+) -> anyhow::Result<()> {
+    run_with_system_route_extensions(distributed_runtime, engine_config, Vec::new()).await
+}
+
+/// Build and run an HTTP service with additional system route extensions.
+pub async fn run_with_system_route_extensions(
+    distributed_runtime: DistributedRuntime,
+    engine_config: EngineConfig,
+    system_route_extensions: Vec<SystemRouteExtension>,
 ) -> anyhow::Result<()> {
     let local_model = engine_config.local_model();
     let mut http_service_builder = match (local_model.tls_cert_path(), local_model.tls_key_path()) {
@@ -69,6 +79,10 @@ pub async fn run(
         http_service_builder.drt_discovery(Some(distributed_runtime.discovery()));
     http_service_builder =
         http_service_builder.runtime(Some(Arc::new(distributed_runtime.clone())));
+    if !system_route_extensions.is_empty() {
+        http_service_builder =
+            http_service_builder.system_route_extensions(system_route_extensions);
+    }
 
     let http_service = match engine_config {
         EngineConfig::Dynamic {

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -30,9 +30,11 @@ pub mod metrics;
 pub mod openapi_docs;
 pub mod realtime;
 pub mod service_v2;
+pub mod system_extension;
 
 pub use axum;
 pub use metrics::Metrics;
+pub use system_extension::SystemRouteExtension;
 
 /// Documentation for a route
 #[derive(Debug, Clone)]

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -34,10 +34,10 @@ pub mod system_extension;
 
 pub use axum;
 pub use metrics::Metrics;
-pub use system_extension::SystemRouteExtension;
+pub use system_extension::{SystemRouteContext, SystemRouteExtension, SystemRouteSet};
 
 /// Documentation for a route
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RouteDoc {
     method: axum::http::Method,
     path: String,
@@ -55,5 +55,13 @@ impl RouteDoc {
             method,
             path: path.into(),
         }
+    }
+
+    pub fn method(&self) -> &axum::http::Method {
+        &self.method
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
     }
 }

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -19,7 +19,7 @@ use super::Metrics;
 use super::RouteDoc;
 use super::metrics;
 use super::metrics::{register_lora_allocation_metrics, register_worker_timing_metrics};
-use super::system_extension::SystemRouteExtension;
+use super::system_extension::{SystemRouteContext, SystemRouteExtension, SystemRouteSet};
 use crate::discovery::ModelManager;
 use crate::endpoint_type::EndpointType;
 use crate::kv_router::metrics::{
@@ -870,7 +870,37 @@ static HTTP_SVC_RESPONSES_PATH_ENV: &str = "DYN_HTTP_SVC_RESPONSES_PATH";
 /// Environment variable to set the anthropic messages endpoint path (default: `/v1/messages`)
 static HTTP_SVC_ANTHROPIC_PATH_ENV: &str = "DYN_HTTP_SVC_ANTHROPIC_PATH";
 
+fn append_route_docs(
+    all_docs: &mut Vec<RouteDoc>,
+    seen_routes: &mut HashMap<(axum::http::Method, String), String>,
+    route_docs: Vec<RouteDoc>,
+) -> Result<()> {
+    for route_doc in route_docs {
+        let key = (route_doc.method().clone(), route_doc.path().to_string());
+        if let Some(existing) = seen_routes.get(&key) {
+            anyhow::bail!(
+                "duplicate HTTP route registered: {} conflicts with {}",
+                route_doc,
+                existing
+            );
+        }
+        seen_routes.insert(key, route_doc.to_string());
+        all_docs.push(route_doc);
+    }
+    Ok(())
+}
+
 impl HttpServiceConfigBuilder {
+    pub fn add_system_route_extension<F>(mut self, extension: F) -> Self
+    where
+        F: Fn(SystemRouteContext) -> SystemRouteSet + Send + Sync + 'static,
+    {
+        self.system_route_extensions
+            .get_or_insert_with(Vec::new)
+            .push(Arc::new(extension));
+        self
+    }
+
     pub fn build(self) -> Result<HttpService, anyhow::Error> {
         let config: HttpServiceConfig = self.build_internal()?;
         let metrics_config = config.metrics_config.clone();
@@ -968,6 +998,7 @@ impl HttpServiceConfigBuilder {
         }
 
         let mut all_docs = Vec::new();
+        let mut route_doc_keys = HashMap::new();
 
         // Shared on_response callback for both system and inference routes
         let on_response = |response: &Response<Body>, latency: Duration, _span: &tracing::Span| {
@@ -1010,12 +1041,13 @@ impl HttpServiceConfigBuilder {
             );
         }
         for extension in &config.system_route_extensions {
-            system_routes.push(extension(state.clone()));
+            let route_set = extension(SystemRouteContext::new(state.clone()));
+            system_routes.push(route_set.into_parts());
         }
         let mut system_router = axum::Router::new();
         for (route_docs, route) in system_routes {
+            append_route_docs(&mut all_docs, &mut route_doc_keys, route_docs)?;
             system_router = system_router.merge(route);
-            all_docs.extend(route_docs);
         }
         // Inference routes (completions, chat, embeddings, etc.) — info-level spans
         let endpoint_routes = HttpServiceConfigBuilder::get_endpoints_router(
@@ -1025,8 +1057,8 @@ impl HttpServiceConfigBuilder {
         );
         let mut inference_router = axum::Router::new();
         for (route_docs, route) in endpoint_routes {
+            append_route_docs(&mut all_docs, &mut route_doc_keys, route_docs)?;
             inference_router = inference_router.merge(route);
-            all_docs.extend(route_docs);
         }
         inference_router = inference_router.layer(
             TraceLayer::new_for_http()
@@ -1041,8 +1073,8 @@ impl HttpServiceConfigBuilder {
         // OpenAPI documentation routes (system)
         let (openapi_docs, openapi_route) =
             super::openapi_docs::openapi_router(all_docs.clone(), None);
+        append_route_docs(&mut all_docs, &mut route_doc_keys, openapi_docs)?;
         system_router = system_router.merge(openapi_route);
-        all_docs.extend(openapi_docs);
 
         system_router = system_router.layer(
             TraceLayer::new_for_http()
@@ -1394,7 +1426,14 @@ mod tests {
         handle.abort();
     }
 
-    fn test_system_extension(state: Arc<State>) -> (Vec<RouteDoc>, axum::Router) {
+    fn make_chat_engine()
+    -> crate::types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine {
+        Arc::new(crate::engines::StreamingEngineAdapter::new(
+            crate::engines::make_echo_engine(),
+        ))
+    }
+
+    fn readiness_extension(context: SystemRouteContext) -> SystemRouteSet {
         let route_docs = vec![RouteDoc::new(
             axum::http::Method::GET,
             "/test/system-extension",
@@ -1402,13 +1441,13 @@ mod tests {
         let route = axum::Router::new()
             .route(
                 "/test/system-extension",
-                axum::routing::get(test_system_extension_handler),
+                axum::routing::get(readiness_extension_handler),
             )
-            .with_state(state);
-        (route_docs, route)
+            .with_state(context.state_clone());
+        SystemRouteSet::new(route_docs, route)
     }
 
-    async fn test_system_extension_handler(
+    async fn readiness_extension_handler(
         axum::extract::State(state): axum::extract::State<Arc<State>>,
     ) -> axum::http::StatusCode {
         if state.manager().has_any_ready_model() {
@@ -1418,24 +1457,199 @@ mod tests {
         }
     }
 
+    fn first_test_extension(context: SystemRouteContext) -> SystemRouteSet {
+        test_status_extension(context, "/test/system-extension/one")
+    }
+
+    fn second_test_extension(context: SystemRouteContext) -> SystemRouteSet {
+        test_status_extension(context, "/test/system-extension/two")
+    }
+
+    fn duplicate_health_extension(context: SystemRouteContext) -> SystemRouteSet {
+        test_status_extension(context, "/health")
+    }
+
+    fn duplicate_test_extension(context: SystemRouteContext) -> SystemRouteSet {
+        test_status_extension(context, "/test/system-extension/duplicate")
+    }
+
+    fn draining_extension(context: SystemRouteContext) -> SystemRouteSet {
+        let route_docs = vec![RouteDoc::new(
+            axum::http::Method::GET,
+            "/test/system-extension/draining",
+        )];
+        let route = axum::Router::new()
+            .route(
+                "/test/system-extension/draining",
+                axum::routing::get(draining_extension_handler),
+            )
+            .with_state(context.state_clone());
+        SystemRouteSet::new(route_docs, route)
+    }
+
+    fn test_status_extension(context: SystemRouteContext, path: &str) -> SystemRouteSet {
+        let route_docs = vec![RouteDoc::new(axum::http::Method::GET, path)];
+        let route = axum::Router::new()
+            .route(path, axum::routing::get(no_content_extension_handler))
+            .with_state(context.state_clone());
+        SystemRouteSet::new(route_docs, route)
+    }
+
+    async fn no_content_extension_handler(
+        axum::extract::State(_state): axum::extract::State<Arc<State>>,
+    ) -> axum::http::StatusCode {
+        axum::http::StatusCode::NO_CONTENT
+    }
+
+    async fn draining_extension_handler(
+        axum::extract::State(state): axum::extract::State<Arc<State>>,
+    ) -> axum::http::StatusCode {
+        if state.is_ready() {
+            axum::http::StatusCode::OK
+        } else {
+            axum::http::StatusCode::ACCEPTED
+        }
+    }
+
+    async fn get_status(port: u16, path: &str) -> reqwest::StatusCode {
+        reqwest::Client::new()
+            .get(format!("http://localhost:{}{}", port, path))
+            .send()
+            .await
+            .expect("request failed")
+            .status()
+    }
+
+    fn build_error_message(builder: HttpServiceConfigBuilder) -> String {
+        match builder.build() {
+            Ok(_) => panic!("service build unexpectedly succeeded"),
+            Err(err) => err.to_string(),
+        }
+    }
+
     #[tokio::test]
-    async fn test_system_route_extension_can_serve_from_frontend_state() {
-        let extension: SystemRouteExtension = Arc::new(test_system_extension);
+    async fn test_system_route_extension_uses_live_frontend_state() {
         let cancel_token = Arc::new(CancellationToken::new());
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let service = HttpService::builder()
             .port(port)
-            .system_route_extensions(vec![extension])
+            .add_system_route_extension(readiness_extension)
             .build()
             .unwrap();
 
+        assert!(
+            service
+                .route_docs()
+                .iter()
+                .any(|doc| doc.to_string() == "GET /test/system-extension")
+        );
+
+        let running_service = service.clone();
+        let service_token = cancel_token.clone();
+        let handle = tokio::spawn(async move {
+            running_service
+                .run_with_listener((*service_token).clone(), listener)
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        assert_eq!(
+            get_status(port, "/test/system-extension").await,
+            reqwest::StatusCode::SERVICE_UNAVAILABLE
+        );
+
+        let mut card = crate::model_card::ModelDeploymentCard::default();
+        card.display_name = "pending-llama".to_string();
+        service
+            .model_manager()
+            .save_model_card("instance-pending", card)
+            .unwrap();
+        assert_eq!(
+            get_status(port, "/test/system-extension").await,
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            "card-only model registration must not make the extension report ready"
+        );
+
+        service
+            .model_manager()
+            .add_chat_completions_model("ready-llama", "abc", make_chat_engine())
+            .unwrap();
+        assert_eq!(
+            get_status(port, "/test/system-extension").await,
+            reqwest::StatusCode::OK
+        );
+
+        let openapi = reqwest::Client::new()
+            .get(format!("http://localhost:{}/openapi.json", port))
+            .send()
+            .await
+            .expect("openapi request failed")
+            .text()
+            .await
+            .expect("openapi body failed");
+        assert!(openapi.contains("/test/system-extension"));
+
+        cancel_token.cancel();
+        handle.abort();
+    }
+
+    #[test]
+    fn test_multiple_system_route_extensions_are_registered() {
+        let service = HttpService::builder()
+            .add_system_route_extension(first_test_extension)
+            .add_system_route_extension(second_test_extension)
+            .build()
+            .unwrap();
         let route_doc_strings = service
             .route_docs()
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>();
-        assert!(route_doc_strings.contains(&"GET /test/system-extension".to_string()));
+
+        assert!(route_doc_strings.contains(&"GET /test/system-extension/one".to_string()));
+        assert!(route_doc_strings.contains(&"GET /test/system-extension/two".to_string()));
+    }
+
+    #[test]
+    fn test_system_route_extension_rejects_builtin_route_conflict() {
+        let error = build_error_message(
+            HttpService::builder().add_system_route_extension(duplicate_health_extension),
+        );
+
+        assert!(
+            error.contains("duplicate HTTP route registered: GET /health"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_system_route_extension_rejects_extension_route_conflict() {
+        let error = build_error_message(
+            HttpService::builder()
+                .add_system_route_extension(duplicate_test_extension)
+                .add_system_route_extension(duplicate_test_extension),
+        );
+
+        assert!(
+            error.contains("duplicate HTTP route registered: GET /test/system-extension/duplicate"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_system_route_extension_stays_available_while_draining() {
+        let cancel_token = Arc::new(CancellationToken::new());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let service = HttpService::builder()
+            .port(port)
+            .add_system_route_extension(draining_extension)
+            .build()
+            .unwrap();
+        let state = service.state_clone();
+        let inflight = state.acquire_inflight();
 
         let service_token = cancel_token.clone();
         let handle = tokio::spawn(async move {
@@ -1446,14 +1660,15 @@ mod tests {
         });
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-        let resp = reqwest::Client::new()
-            .get(format!("http://localhost:{}/test/system-extension", port))
-            .send()
-            .await
-            .expect("request failed");
-        assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
-
         cancel_token.cancel();
+        wait_for_service_stage(&state, ServiceStage::Draining).await;
+
+        assert_eq!(
+            get_status(port, "/test/system-extension/draining").await,
+            reqwest::StatusCode::ACCEPTED
+        );
+
+        drop(inflight);
         handle.abort();
     }
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -19,6 +19,7 @@ use super::Metrics;
 use super::RouteDoc;
 use super::metrics;
 use super::metrics::{register_lora_allocation_metrics, register_worker_timing_metrics};
+use super::system_extension::SystemRouteExtension;
 use crate::discovery::ModelManager;
 use crate::endpoint_type::EndpointType;
 use crate::kv_router::metrics::{
@@ -514,8 +515,13 @@ pub struct HttpServiceConfig {
     #[builder(default)]
     metrics_config: MetricsConfig,
 
-    // #[builder(default)]
-    // custom: Vec<axum::Router>
+    /// Additional system routes merged with the built-in health, metrics, and model routes.
+    ///
+    /// Extensions receive the shared frontend state, allowing handlers to build
+    /// responses from live model manager and discovery state.
+    #[builder(default)]
+    system_route_extensions: Vec<SystemRouteExtension>,
+
     #[builder(default = "false")]
     enable_chat_endpoints: bool,
 
@@ -1003,6 +1009,9 @@ impl HttpServiceConfigBuilder {
                 "frontend admin API disabled — busy_threshold routes not registered"
             );
         }
+        for extension in &config.system_route_extensions {
+            system_routes.push(extension(state.clone()));
+        }
         let mut system_router = axum::Router::new();
         for (route_docs, route) in system_routes {
             system_router = system_router.merge(route);
@@ -1380,6 +1389,69 @@ mod tests {
             .await
             .expect("request failed");
         assert_eq!(live.status(), reqwest::StatusCode::OK);
+
+        cancel_token.cancel();
+        handle.abort();
+    }
+
+    fn test_system_extension(state: Arc<State>) -> (Vec<RouteDoc>, axum::Router) {
+        let route_docs = vec![RouteDoc::new(
+            axum::http::Method::GET,
+            "/test/system-extension",
+        )];
+        let route = axum::Router::new()
+            .route(
+                "/test/system-extension",
+                axum::routing::get(test_system_extension_handler),
+            )
+            .with_state(state);
+        (route_docs, route)
+    }
+
+    async fn test_system_extension_handler(
+        axum::extract::State(state): axum::extract::State<Arc<State>>,
+    ) -> axum::http::StatusCode {
+        if state.manager().has_any_ready_model() {
+            axum::http::StatusCode::OK
+        } else {
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        }
+    }
+
+    #[tokio::test]
+    async fn test_system_route_extension_can_serve_from_frontend_state() {
+        let extension: SystemRouteExtension = Arc::new(test_system_extension);
+        let cancel_token = Arc::new(CancellationToken::new());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let service = HttpService::builder()
+            .port(port)
+            .system_route_extensions(vec![extension])
+            .build()
+            .unwrap();
+
+        let route_doc_strings = service
+            .route_docs()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        assert!(route_doc_strings.contains(&"GET /test/system-extension".to_string()));
+
+        let service_token = cancel_token.clone();
+        let handle = tokio::spawn(async move {
+            service
+                .run_with_listener((*service_token).clone(), listener)
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let resp = reqwest::Client::new()
+            .get(format!("http://localhost:{}/test/system-extension", port))
+            .send()
+            .await
+            .expect("request failed");
+        assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
 
         cancel_token.cancel();
         handle.abort();

--- a/lib/llm/src/http/service/system_extension.rs
+++ b/lib/llm/src/http/service/system_extension.rs
@@ -6,14 +6,83 @@
 use std::sync::Arc;
 
 use axum::Router;
+use dynamo_runtime::discovery::Discovery;
 
 use super::RouteDoc;
 use super::service_v2::State;
+use crate::discovery::ModelManager;
+
+/// Live frontend context available to system route extensions.
+///
+/// The wrapper keeps the extension API focused on system-route needs. Additional
+/// accessors can be added here as the extension surface matures.
+#[derive(Clone)]
+pub struct SystemRouteContext {
+    state: Arc<State>,
+}
+
+impl SystemRouteContext {
+    pub(crate) fn new(state: Arc<State>) -> Self {
+        Self { state }
+    }
+
+    /// Return the shared Axum state for routes that need to install handlers
+    /// with Router::with_state.
+    pub fn state_clone(&self) -> Arc<State> {
+        self.state.clone()
+    }
+
+    pub fn manager(&self) -> &ModelManager {
+        self.state.manager()
+    }
+
+    pub fn manager_clone(&self) -> Arc<ModelManager> {
+        self.state.manager_clone()
+    }
+
+    pub fn discovery(&self) -> Arc<dyn Discovery> {
+        self.state.discovery()
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.state.is_ready()
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.state.is_cancelled()
+    }
+}
+
+/// Routes and route documentation returned by a system route extension.
+pub struct SystemRouteSet {
+    route_docs: Vec<RouteDoc>,
+    router: Router,
+}
+
+impl SystemRouteSet {
+    pub fn new(route_docs: Vec<RouteDoc>, router: Router) -> Self {
+        Self { route_docs, router }
+    }
+
+    pub fn route_docs(&self) -> &[RouteDoc] {
+        &self.route_docs
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<RouteDoc>, Router) {
+        (self.route_docs, self.router)
+    }
+}
+
+impl From<(Vec<RouteDoc>, Router)> for SystemRouteSet {
+    fn from((route_docs, router): (Vec<RouteDoc>, Router)) -> Self {
+        Self::new(route_docs, router)
+    }
+}
 
 /// Callback used to attach additional system routes during HTTP service build.
 ///
-/// Extensions receive the shared frontend state used by built-in system
-/// handlers, so custom routes can answer from live model manager and discovery
-/// state instead of precomputed startup metadata.
+/// Extensions receive live frontend context used by built-in system handlers,
+/// so custom routes can answer from current model manager and discovery state
+/// instead of precomputed startup metadata.
 pub type SystemRouteExtension =
-    Arc<dyn Fn(Arc<State>) -> (Vec<RouteDoc>, Router) + Send + Sync + 'static>;
+    Arc<dyn Fn(SystemRouteContext) -> SystemRouteSet + Send + Sync + 'static>;

--- a/lib/llm/src/http/service/system_extension.rs
+++ b/lib/llm/src/http/service/system_extension.rs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Extension point for system routes hosted by the HTTP frontend.
+
+use std::sync::Arc;
+
+use axum::Router;
+
+use super::RouteDoc;
+use super::service_v2::State;
+
+/// Callback used to attach additional system routes during HTTP service build.
+///
+/// Extensions receive the shared frontend state used by built-in system
+/// handlers, so custom routes can answer from live model manager and discovery
+/// state instead of precomputed startup metadata.
+pub type SystemRouteExtension =
+    Arc<dyn Fn(Arc<State>) -> (Vec<RouteDoc>, Router) + Send + Sync + 'static>;


### PR DESCRIPTION
## Summary

This is an experimental standalone alternative to the hook-only system route extension design. It shows an "Option 3" shape where stock `python -m dynamo.frontend` can load Python route-extension factories at runtime.

The PR includes the generic system route hook plus the runtime loader needed for the stock Python frontend to consume it.

Changes:

- Adds the system route extension hook to the Rust LLM HTTP service builder.
- Adds `--system-route-extensions` / `DYN_SYSTEM_ROUTE_EXTENSIONS` to `dynamo.frontend`.
- Loads Python factories from import paths in the form `module:factory`.
- Adds a Python binding `run_input_with_system_route_extensions(...)`.
- Wraps Python route specs as Axum system routes in the frontend process.
- Passes a small live state snapshot to callbacks with `ready` and `cancelled`.

## Prototype factory shape

```python
def factory():
    return [
        {
            "path": "/v1/health/ready",
            "method": "GET",
            "handler": lambda snapshot: {
                "status": 200 if snapshot["ready"] else 503,
                "body": {"ready": snapshot["ready"]},
            },
        }
    ]
```

Then launch with:

```bash
DYN_SYSTEM_ROUTE_EXTENSIONS=my_package.nim_routes:factory python -m dynamo.frontend
```

## Why this is separate from the hook-only PR

The hook-only PR keeps upstream Dynamo small and generic. NIM-LLM would own a Rust frontend/entrypoint that calls the hook.

This PR asks Dynamo to own a runtime loading contract so the stock Python frontend can load extension factories directly. That makes NIM-LLM integration lighter, but it is a larger upstream API surface.

## Open concerns

- Python callbacks run in-process but cross the GIL on each management request.
- This prototype supports GET-only JSON routes.
- The callback receives only a small state snapshot today; production NIM metadata would need a richer stable context contract.
- The plugin API shape needs deeper discussion before this should be considered production-ready.

## Validation

- `cargo fmt --all --check`
- `PROTOC=/home/aniskumar/venv/vllm/lib/python3.12/site-packages/torch/bin/protoc cargo check` from `lib/bindings/python`
- `PROTOC=/home/aniskumar/venv/vllm/lib/python3.12/site-packages/torch/bin/protoc cargo test -p dynamo-llm system_route_extension`
- `python3 -m py_compile components/src/dynamo/frontend/main.py components/src/dynamo/frontend/frontend_args.py components/src/dynamo/frontend/tests/test_system_route_extension_loader.py`

`pytest` was not run locally because pytest is not installed in the base shell.
