### PR TITLE
feat: support multiple served model names (SGLang)

### DIFF
--- a/components/src/dynamo/common/configuration/utils.py
+++ b/components/src/dynamo/common/configuration/utils.py
@@ -5,9 +5,30 @@
 
 import argparse
 import os
+import re
 from typing import Any, Callable, Optional, TypeVar, Union
 
 T = TypeVar("T")
+
+
+def split_served_model_names(served_model_name: Any) -> list[str]:
+    """Split a ``--served-model-name`` value into individual names.
+
+    Accepts a single string (whitespace- or comma-separated) or a
+    list/tuple of such strings, and returns a flat list of non-empty names
+    in order. The first is the primary served name; any remaining names are
+    aliases. Returns ``[]`` when nothing parses out.
+    """
+    if served_model_name is None:
+        return []
+    if isinstance(served_model_name, (list, tuple)):
+        raw_names = [str(name) for name in served_model_name]
+    else:
+        raw_names = [str(served_model_name)]
+    names: list[str] = []
+    for raw_name in raw_names:
+        names.extend(name for name in re.split(r"[\s,]+", raw_name.strip()) if name)
+    return names
 
 
 def env_or_default(

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -20,6 +20,7 @@ from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 from dynamo.common.config_dump import register_encoder
 from dynamo.common.configuration.groups import DynamoRuntimeConfig
 from dynamo.common.configuration.groups.runtime_args import DynamoRuntimeArgGroup
+from dynamo.common.configuration.utils import split_served_model_names
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.model_fetch import fetch_model
 from dynamo.common.snapshot.lifecycle import (
@@ -428,7 +429,24 @@ async def parse_args(args: list[str]) -> Config:
             )
 
     model_path = parsed_args.model_path
-    # Name the model
+
+    # --served-model-name may pack several names (whitespace-/comma-separated);
+    # the first is the primary, the rest are aliases. Split BEFORE the
+    # model_path fallback so a model path containing whitespace doesn't produce
+    # spurious aliases.
+    served_names = split_served_model_names(parsed_args.served_model_name)
+    if served_names:
+        parsed_args.served_model_name = served_names[0]
+        dynamo_config.served_model_aliases = served_names[1:]
+        if served_names[1:]:
+            logging.info(
+                "Multi-name registration: primary=%r, aliases=%s",
+                served_names[0],
+                served_names[1:],
+            )
+
+    # Name the model — falls back to model_path only if neither
+    # --served-model-name nor an env var supplied one.
     if not parsed_args.served_model_name:
         parsed_args.served_model_name = model_path
     # Download the model if necessary using modelexpress.

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -8,7 +8,7 @@
 import argparse
 import logging
 import warnings
-from typing import Optional
+from typing import List, Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
@@ -185,6 +185,13 @@ class DynamoSGLangConfig(ConfigBase):
     enable_rl: bool
     frontend_decoding: bool = False
     sglang_trace_level: int
+
+    # Additional names this model responds to (aliases). Populated by
+    # parse_args when --served-model-name is given as a whitespace- or
+    # comma-separated string of multiple names; the first becomes the
+    # primary and the rest land here. Plumbed to register_model() so the
+    # Rust ModelManager registers the same WorkerSet under each alias.
+    served_model_aliases: List[str] = []
 
     def validate(self) -> None:
         if not isinstance(self.embedding_transfer_mode, EmbeddingTransferMode):

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -150,6 +150,7 @@ async def _register_model_with_runtime_config(
         else None
     )
 
+    aliases = list(getattr(dynamo_args, "served_model_aliases", []) or [])
     try:
         await register_model(
             input_type,
@@ -166,8 +167,15 @@ async def _register_model_with_runtime_config(
             needs=needs,
             ignore_weights=use_modelexpress_remote_instance(server_args),
             max_gpu_lora_count=max_gpu_lora_count,
+            model_aliases=aliases or None,
         )
-        logging.info("Successfully registered LLM with runtime config")
+        if aliases:
+            logging.info(
+                "Successfully registered LLM with runtime config (aliases: %s)",
+                aliases,
+            )
+        else:
+            logging.info("Successfully registered LLM with runtime config")
         return True
     except Exception as e:
         logging.error(f"Failed to register with runtime config: {e}")

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -281,6 +281,22 @@ async def test_custom_jinja_template_env_var_expansion(monkeypatch, mock_sglang_
     )
 
 
+@pytest.mark.asyncio
+async def test_multiple_served_model_names_register_primary_and_aliases(mock_sglang_cli):
+    """SGLang packed served names split into primary + Dynamo aliases."""
+    mock_sglang_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--served-model-name",
+        "primary,alias-one alias-two",
+    )
+
+    config = await parse_args(sys.argv[1:])
+
+    assert config.server_args.served_model_name == "primary"
+    assert config.dynamo_args.served_model_aliases == ["alias-one", "alias-two"]
+
+
 # --- Tool Call Parser Validation Tests ---
 
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -348,7 +348,7 @@ fn resolve_routing_image_token_id(model_id: &str, model_dir: &str) -> Option<u32
 /// For LoRA mode, both `lora_name` and `base_model_path` must be provided together.
 /// Providing only one of them will result in an error.
 #[pyfunction]
-#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, worker_type=None, needs=None, self_host_metadata=None, *, tensor_model_config=None, ignore_weights=false, max_gpu_lora_count=None))]
+#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, worker_type=None, needs=None, self_host_metadata=None, *, tensor_model_config=None, ignore_weights=false, max_gpu_lora_count=None, model_aliases=None))]
 #[allow(clippy::too_many_arguments)]
 fn register_model<'p>(
     py: Python<'p>,
@@ -372,6 +372,7 @@ fn register_model<'p>(
     tensor_model_config: Option<&Bound<'p, PyDict>>,
     ignore_weights: bool,
     max_gpu_lora_count: Option<u32>,
+    model_aliases: Option<Vec<String>>,
 ) -> PyResult<Bound<'p, PyAny>> {
     // Every worker registers with an explicit `worker_type`. Reject `None`
     // outright — a missing role would produce a card whose readiness math
@@ -476,6 +477,7 @@ fn register_model<'p>(
     // This preserves backward-compat: workers that don't specify router_config continue to
     // fall back to the frontend-level global router config via the watcher.
     let explicit_router_config: Option<RouterConfig> = router_config.map(|rc| rc.into());
+    let model_aliases = model_aliases.unwrap_or_default();
 
     // Early validation of custom template path
     let custom_template_path_owned = custom_template_path
@@ -535,6 +537,9 @@ fn register_model<'p>(
             card.worker_type = worker_type_value;
             card.needs = needs_value.clone();
             card.user_data = user_data_json;
+            if !model_aliases.is_empty() {
+                card.set_aliases(model_aliases);
+            }
 
             card.runtime_config = runtime_config.inner;
             card.tensor_model_config = tensor_model_config;
@@ -574,6 +579,8 @@ fn register_model<'p>(
             .source_path(source_path.clone().into())
             // --served_model_name
             .model_name(model_name.clone())
+            // --served_model_name aliases (additional names this model responds to)
+            .model_aliases(model_aliases)
             .kv_cache_block_size(kv_cache_block_size)
             .router_config(explicit_router_config.clone())
             .runtime_config({

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2245,6 +2245,7 @@ async def register_model(
     self_host_metadata: Optional[bool] = None,
     ignore_weights: bool = False,
     max_gpu_lora_count: Optional[int] = None,
+    model_aliases: Optional[List[str]] = None,
 ) -> None:
     """
     Attach the model at path to the given endpoint, and advertise it as model_type.

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -117,6 +117,9 @@ pub struct ModelManager {
     /// per component and can restart it if the previous one exited (avoids double counting on
     /// rebuilds while keeping the feed durable).
     lora_load_feeds: DashMap<String, tokio::task::JoinHandle<()>>,
+
+    /// Alias → primary model name mapping. Used to normalize metrics labels.
+    alias_to_primary: DashMap<String, String>,
 }
 
 impl Default for ModelManager {
@@ -145,6 +148,7 @@ impl ModelManager {
             lora_filter,
             lora_enabled: crate::lora::lora_serving_enabled(),
             lora_load_feeds: DashMap::new(),
+            alias_to_primary: DashMap::new(),
         }
     }
 
@@ -181,6 +185,101 @@ impl ModelManager {
     pub fn add_worker_set(&self, model_name: &str, namespace: &str, worker_set: WorkerSet) {
         let model = self.get_or_create_model(model_name);
         model.add_worker_set(namespace.to_string(), Arc::new(worker_set));
+    }
+
+    /// Add an already-Arc-wrapped WorkerSet to a Model. Creates the Model if it doesn't exist.
+    /// Used to register the same WorkerSet under multiple model names (aliases).
+    ///
+    /// Logs a warning and skips if a *different* primary already owns this name —
+    /// this guards against operator misconfiguration where two unrelated models
+    /// declare a colliding alias. The first claim wins; the second is rejected.
+    pub fn add_worker_set_arc(
+        &self,
+        model_name: &str,
+        namespace: &str,
+        worker_set: Arc<WorkerSet>,
+    ) -> bool {
+        // Collision check: if `model_name` already exists as a primary (i.e.
+        // not currently mapped to anything in alias_to_primary, AND already
+        // has worker sets), refuse to clobber it.
+        if let Some(existing) = self.models.get(model_name) {
+            if !existing.is_empty()
+                && !self.alias_to_primary.contains_key(model_name)
+            {
+                tracing::warn!(
+                    alias = model_name,
+                    namespace,
+                    "Alias collides with a registered primary model — skipping. \
+                     Choose a different alias or rename the conflicting model."
+                );
+                return false;
+            }
+        }
+
+        let model = self.get_or_create_model(model_name);
+        model.add_worker_set(namespace.to_string(), worker_set);
+        true
+    }
+
+    /// Record that `alias` is an alternate name for `primary`. Used to normalize metrics labels.
+    ///
+    /// Logs a warning and refuses to overwrite if `alias` is already mapped to a
+    /// *different* primary. First-write-wins semantics so operators can detect
+    /// alias conflicts in logs rather than discovering them by silent metric
+    /// re-attribution.
+    pub fn register_alias(&self, alias: &str, primary: &str) -> bool {
+        if let Some(existing) = self.alias_to_primary.get(alias) {
+            if existing.value() != primary {
+                tracing::warn!(
+                    alias,
+                    new_primary = primary,
+                    existing_primary = existing.value().as_str(),
+                    "Alias is already claimed by a different primary — refusing to overwrite. \
+                     Existing claim wins."
+                );
+                return false;
+            }
+            // Same alias→same primary — idempotent, no-op.
+            return true;
+        }
+
+        if let Some(existing) = self.models.get(alias) {
+            if !existing.is_empty() {
+                tracing::warn!(
+                    alias,
+                    primary,
+                    "Alias collides with a registered primary model — refusing to register. \
+                     Choose a different alias or rename the conflicting model."
+                );
+                return false;
+            }
+        }
+        self.alias_to_primary
+            .insert(alias.to_string(), primary.to_string());
+        true
+    }
+
+    /// Remove a previously registered alias mapping once the alias has no WorkerSets.
+    pub fn unregister_alias_if_empty(&self, alias: &str, primary: &str) {
+        if self
+            .models
+            .get(alias)
+            .is_some_and(|model| !model.is_empty())
+        {
+            return;
+        }
+
+        self.alias_to_primary
+            .remove_if(alias, |_, existing| existing == primary);
+    }
+
+    /// Return the primary (canonical) model name for `model`, resolving aliases.
+    /// Returns `model` unchanged if it is not an alias.
+    pub fn resolve_canonical_name(&self, model: &str) -> String {
+        self.alias_to_primary
+            .get(model)
+            .map(|v| v.value().clone())
+            .unwrap_or_else(|| model.to_string())
     }
 
     /// Remove a WorkerSet from a Model. Removes the Model if it becomes empty.
@@ -1601,6 +1700,51 @@ mod tests {
 
         // Model should still exist (ns1 still there)
         assert!(mm.get_model("llama").is_some());
+    }
+
+    #[test]
+    fn test_alias_resolution_maps_to_primary() {
+        let mm = ModelManager::new();
+
+        assert!(mm.register_alias("llama-alias", "llama"));
+
+        assert_eq!(mm.resolve_canonical_name("llama-alias"), "llama");
+        assert_eq!(mm.resolve_canonical_name("llama"), "llama");
+    }
+
+    #[test]
+    fn test_register_alias_rejects_primary_collision() {
+        let mm = ModelManager::new();
+        mm.add_worker_set("llama-alias", "ns1", make_worker_set("ns1", "abc"));
+
+        assert!(!mm.register_alias("llama-alias", "llama"));
+
+        assert_eq!(mm.resolve_canonical_name("llama-alias"), "llama-alias");
+    }
+
+    #[test]
+    fn test_unregister_alias_if_empty_keeps_mapping_with_remaining_worker_sets() {
+        let mm = ModelManager::new();
+        assert!(mm.register_alias("llama-alias", "llama"));
+
+        assert!(mm.add_worker_set_arc(
+            "llama-alias",
+            "ns1",
+            Arc::new(make_worker_set("ns1", "abc")),
+        ));
+        assert!(mm.add_worker_set_arc(
+            "llama-alias",
+            "ns2",
+            Arc::new(make_worker_set("ns2", "abc")),
+        ));
+
+        mm.remove_worker_set("llama-alias", "ns1");
+        mm.unregister_alias_if_empty("llama-alias", "llama");
+        assert_eq!(mm.resolve_canonical_name("llama-alias"), "llama");
+
+        mm.remove_worker_set("llama-alias", "ns2");
+        mm.unregister_alias_if_empty("llama-alias", "llama");
+        assert_eq!(mm.resolve_canonical_name("llama-alias"), "llama-alias");
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -599,6 +599,14 @@ impl ModelWatcher {
                     namespace = %worker_namespace,
                     "Removed WorkerSet (no remaining instances in namespace)"
                 );
+                // Also remove from alias models
+                for alias in &card.aliases {
+                    if alias != &model_name {
+                        self.manager.remove_worker_set(alias, &ws_key);
+                        self.manager.remove_model_if_empty(alias);
+                        self.manager.unregister_alias_if_empty(alias, &model_name);
+                    }
+                }
             }
 
             // Activator-state cleanup depends on which component just went away.
@@ -669,6 +677,13 @@ impl ModelWatcher {
 
         // No instances remain anywhere — remove the entire Model
         let _ = self.manager.remove_model(&model_name);
+        // Also remove alias models
+        for alias in &card.aliases {
+            if alias != &model_name {
+                let _ = self.manager.remove_model(alias);
+                self.manager.unregister_alias_if_empty(alias, &model_name);
+            }
+        }
 
         if let Some(tx) = &self.model_update_tx {
             for model_type in ALL_MODEL_TYPES {
@@ -1359,9 +1374,40 @@ impl ModelWatcher {
             );
         }
 
+        // Register alias→primary mappings BEFORE the engine becomes visible.
+        // Order matters: any request landing between engine-visible and
+        // alias-mapped would see correct routing but mis-labelled metrics
+        // (and an OpenAI response.model echoing the alias instead of the
+        // primary). Recording the mapping first closes that gap.
+        let mut registered_aliases = Vec::new();
+        for alias in &card.aliases {
+            if alias != card.name() {
+                if self.manager.register_alias(alias, card.name()) {
+                    registered_aliases.push(alias.clone());
+                }
+            }
+        }
+
         // Add the completed WorkerSet to the Model
         self.manager
             .add_worker_set(card.name(), &ws_key, worker_set);
+
+        // Register under aliases — share the same Arc<WorkerSet>
+        if !registered_aliases.is_empty() {
+            if let Some(model) = self.manager.get_model(card.name()) {
+                if let Some(ws_arc) = model.get_worker_set(&ws_key) {
+                    for alias in &registered_aliases {
+                        tracing::info!(
+                            model_name = card.name(),
+                            alias,
+                            "Registering model alias"
+                        );
+                        self.manager
+                            .add_worker_set_arc(alias, &ws_key, ws_arc.clone());
+                    }
+                }
+            }
+        }
 
         if let Some(tx) = &self.model_update_tx {
             tx.send(ModelUpdate::Added(card.clone())).await.ok();

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -645,11 +645,10 @@ async fn handler_completions(
     // create the context for the request
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
+    // Canonicalize alias → primary for the metric label.
+    let canonical_model = state.manager().resolve_canonical_name(&request.inner.model);
     let cancellation_labels = CancellationLabels {
-        model: state
-            .manager()
-            .metric_model_for(&request.inner.model)
-            .to_string(),
+        model: state.manager().metric_model_for(&canonical_model).to_string(),
         endpoint: Endpoint::Completions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -715,7 +714,7 @@ async fn completions(
 #[tracing::instrument(skip_all)]
 async fn completions_single(
     state: Arc<service_v2::State>,
-    request: Context<NvCreateCompletionRequest>,
+    mut request: Context<NvCreateCompletionRequest>,
     stream_handle: ConnectionHandle,
 ) -> Result<Response, ErrorResponse> {
     let request_id = request.id().to_string();
@@ -725,6 +724,15 @@ async fn completions_single(
 
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
+    // Resolve an alias to its primary served name and rewrite the request so
+    // engine routing, metrics, and the OpenAI response.model all use the
+    // canonical primary (matching vLLM/SGLang, where an alias request still
+    // responds with the primary served name). Non-aliases pass through, so
+    // metric_model_for still applies its unknown-model cardinality guard.
+    let canonical = state.manager().resolve_canonical_name(&request.inner.model);
+    if canonical != request.inner.model {
+        request.inner.model = canonical;
+    }
     let model = request.inner.model.clone();
     let metric_model = state.manager().metric_model_for(&model).to_string();
 
@@ -866,7 +874,7 @@ async fn completions_single(
 #[tracing::instrument(skip_all)]
 async fn completions_batch(
     state: Arc<service_v2::State>,
-    request: Context<NvCreateCompletionRequest>,
+    mut request: Context<NvCreateCompletionRequest>,
     stream_handle: ConnectionHandle,
     batch_size: usize,
     n: u8,
@@ -876,6 +884,11 @@ async fn completions_batch(
 
     let request_id = request.id().to_string();
     let streaming = request.inner.stream.unwrap_or(false);
+    // Resolve alias → primary served name (see completions_single).
+    let canonical = state.manager().resolve_canonical_name(&request.inner.model);
+    if canonical != request.inner.model {
+        request.inner.model = canonical;
+    }
     let model = request.inner.model.clone();
     let metric_model = state.manager().metric_model_for(&model).to_string();
 
@@ -1071,6 +1084,13 @@ async fn embeddings(
         request.nvext = None;
     }
 
+    // Resolve alias → primary served name before wrapping the request, so
+    // engine routing, metrics, and the response model all use the canonical
+    // primary (see completions_single). `request` is still owned + mutable here.
+    let canonical = state.manager().resolve_canonical_name(&request.inner.model);
+    if canonical != request.inner.model {
+        request.inner.model = canonical;
+    }
     let request_id = get_or_create_request_id(&headers);
     let request = context_from_headers(request, request_id, &headers)?;
     let request_id = request.id().to_string();
@@ -1250,8 +1270,10 @@ async fn handler_chat_completions(
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
     let resolved_model = resolve_request_model(&request.inner.model, template.as_ref());
+    // Canonicalize alias → primary for the metric label.
+    let canonical_model = state.manager().resolve_canonical_name(resolved_model);
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(resolved_model).to_string(),
+        model: state.manager().metric_model_for(&canonical_model).to_string(),
         endpoint: Endpoint::ChatCompletions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -1775,6 +1797,14 @@ async fn chat_completions(
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
     // todo - determine the proper error code for when a request model is not present
+    // Resolve an alias to its primary served name and rewrite the request so
+    // engine routing, metrics, and the OpenAI response.model all use the
+    // canonical primary (matching vLLM/SGLang). Non-aliases pass through so
+    // metric_model_for still applies its unknown-model cardinality guard.
+    let canonical = state.manager().resolve_canonical_name(&request.inner.model);
+    if canonical != request.inner.model {
+        request.inner.model = canonical;
+    }
     let model = request.inner.model.clone();
     let metric_model = state.manager().metric_model_for(&model).to_string();
 
@@ -2155,8 +2185,10 @@ async fn handler_responses(
     let streaming = request.inner.stream.unwrap_or(false);
     let raw_model = request.inner.model.as_deref().unwrap_or("");
     let resolved_model = resolve_request_model(raw_model, template.as_ref());
+    // Canonicalize alias → primary for the metric label.
+    let canonical_model = state.manager().resolve_canonical_name(resolved_model);
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(resolved_model).to_string(),
+        model: state.manager().metric_model_for(&canonical_model).to_string(),
         endpoint: Endpoint::Responses.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -2215,7 +2247,16 @@ async fn responses(
     }
     tracing::trace!("Received responses request: {:?}", request.inner);
 
-    let model = request.inner.model.clone().unwrap_or_default();
+    // Resolve an alias to its primary served name and rewrite the request so
+    // engine routing, metrics, and the response model all use the canonical
+    // primary. The Responses API wraps model in Option<String>, so re-wrap
+    // after resolution. Non-aliases pass through metric_model_for's guard.
+    let original_model = request.inner.model.clone().unwrap_or_default();
+    let canonical = state.manager().resolve_canonical_name(&original_model);
+    if canonical != original_model {
+        request.inner.model = Some(canonical.clone());
+    }
+    let model = canonical;
     let streaming = request.inner.stream.unwrap_or(false);
     let metric_model = state.manager().metric_model_for(&model).to_string();
 
@@ -2618,7 +2659,14 @@ async fn list_models_openai(
     // is hidden until a peer joins.
     let models: HashSet<String> = state.manager().serving_ready_display_names();
     for model_name in models {
-        let context_window = cw_override.or_else(|| card_map.get(&model_name).map(|&cl| cl as u64));
+        // Alias entries have no card of their own (keyed by the primary's
+        // display_name); fall back to the primary's context length.
+        let context_window = cw_override.or_else(|| {
+            card_map
+                .get(&model_name)
+                .or_else(|| card_map.get(&state.manager().resolve_canonical_name(&model_name)))
+                .map(|&cl| cl as u64)
+        });
         data.push(ModelListing {
             id: model_name.clone(),
             object: "model",

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -58,6 +58,7 @@ pub struct LocalModelBuilder {
     model_path: Option<PathBuf>,
     source_path: Option<PathBuf>,
     model_name: Option<String>,
+    model_aliases: Vec<String>,
     endpoint_id: Option<EndpointId>,
     template_file: Option<PathBuf>,
     router_config: Option<RouterConfig>,
@@ -97,6 +98,7 @@ impl Default for LocalModelBuilder {
             model_path: Default::default(),
             source_path: Default::default(),
             model_name: Default::default(),
+            model_aliases: Default::default(),
             endpoint_id: Default::default(),
             template_file: Default::default(),
             router_config: Default::default(),
@@ -133,6 +135,11 @@ impl LocalModelBuilder {
 
     pub fn model_name(&mut self, model_name: Option<String>) -> &mut Self {
         self.model_name = model_name;
+        self
+    }
+
+    pub fn model_aliases(&mut self, aliases: Vec<String>) -> &mut Self {
+        self.model_aliases = aliases;
         self
     }
 
@@ -391,6 +398,9 @@ impl LocalModelBuilder {
         card.media_decoder = self.media_decoder.clone();
         card.media_fetcher = self.media_fetcher.clone();
         card.router_config = self.router_config.clone();
+        if !self.model_aliases.is_empty() {
+            card.set_aliases(self.model_aliases.clone());
+        }
 
         Ok(LocalModel {
             card,

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -794,6 +794,11 @@ pub struct ModelDeploymentCard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lora: Option<LoraInfo>,
 
+    /// Additional names this model responds to (aliases).
+    /// Requests using any of these names will be routed to this worker.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+
     /// User-defined metadata for custom worker behavior
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_data: Option<serde_json::Value>,
@@ -1012,6 +1017,11 @@ impl ModelDeploymentCard {
                     bytes_to_hash.extend(blake3::hash(&bytes).as_bytes());
                 }
 
+                // Aliases are deliberately excluded from the checksum: they are
+                // frontend name mappings that don't affect the serving pipeline,
+                // so a worker that only changes its alias list stays compatible
+                // (watcher.rs::handle_put) instead of forcing a full drain.
+
                 // TODO: Do we want any of user_data or runtime_config?
 
                 blake3::hash(&bytes_to_hash).to_string()
@@ -1214,6 +1224,11 @@ impl ModelDeploymentCard {
 
     pub fn source_path(&self) -> &str {
         self.source_path.as_ref().unwrap_or(&self.display_name)
+    }
+
+    /// Set additional names (aliases) this model responds to.
+    pub fn set_aliases(&mut self, aliases: Vec<String>) {
+        self.aliases = aliases;
     }
 
     /// Build an in-memory ModelDeploymentCard from a folder containing config.json,
@@ -1560,6 +1575,7 @@ impl ModelDeploymentCard {
             worker_type: Default::default(), // set later
             needs: Default::default(),       // set later
             lora: None,
+            aliases: Vec::new(),
             user_data: None,
             runtime_config: ModelRuntimeConfig::default(),
             tensor_model_config: None,


### PR DESCRIPTION
## Overview:

Support advertising a model under multiple served names, for the **SGLang** backend. A worker may pass several names via `--served-model-name` (whitespace- or comma-separated). The first is the primary served name; the rest become aliases. The same WorkerSet is registered under every name, and requests for any alias are canonicalized to the primary at the HTTP entrypoint so engine routing, Prometheus metrics, and the OpenAI `response.model` stay consistent.

This PR adds the shared alias core (ModelManager, watcher, HTTP, model card) plus the SGLang wiring. vLLM and TRT-LLM support follow in separate, independent PRs that build on this core.

## Details:

- **Rust core**: `ModelDeploymentCard.aliases`; `ModelManager` `alias_to_primary` map with `register_alias` / `unregister_alias_if_empty` / `resolve_canonical_name` + collision guards; watcher registers aliases before the engine is visible and tears them down when empty. Aliases are excluded from the MDC checksum so an alias-only change doesn't force a worker drain.
- **HTTP**: resolve alias → primary in every handler (composed with the existing `metric_model_for()` unknown-model cardinality guard) and canonicalize the cancellation-metric label; `/v1/models` reports the primary's `context_window` for alias entries.
- **Binding**: `register_model` gains an optional `model_aliases` argument.
- **SGLang**: split a packed `--served-model-name` into primary + aliases via a shared `split_served_model_names` helper, plumbed through `register_model`.

Unit tests added for `ModelManager` (Rust) and SGLang arg parsing (Python).

## Where should the reviewer start?

- `lib/llm/src/discovery/model_manager.rs` — the alias map + collision guards.
- `lib/llm/src/discovery/watcher.rs` — alias registration/teardown ordering.
- `lib/llm/src/http/service/openai.rs` — canonicalization + metric labels + `/v1/models`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
