### PR TITLE
feat(operator): add CLI for applying DGD overrides

### DIFF
--- a/deploy/operator/Dockerfile
+++ b/deploy/operator/Dockerfile
@@ -50,13 +50,15 @@ RUN make test
 FROM base AS builder
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o manager ./cmd/main.go && \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o crd-apply ./cmd/crd-apply/main.go
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o crd-apply ./cmd/crd-apply/main.go && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o dgd-apply-overrides ./cmd/dgd-apply-overrides
 
 # Runtime stage
 FROM nvcr.io/nvidia/distroless/go:v4.0.3
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/crd-apply .
+COPY --from=builder /workspace/dgd-apply-overrides .
 COPY --from=builder /workspace/config/crd/bases/ /opt/dynamo-operator/crds/
 USER 65532:65532
 

--- a/deploy/operator/cmd/dgd-apply-overrides/main.go
+++ b/deploy/operator/cmd/dgd-apply-overrides/main.go
@@ -6,8 +6,6 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -16,7 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dgdoverride"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
@@ -24,7 +21,7 @@ import (
 
 type options struct {
 	blueprintPath string
-	dgdrSpecPath  string
+	overridePath  string
 	outputPath    string
 	installPath   string
 }
@@ -55,21 +52,9 @@ func run(args []string, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	dgdrSpec, err := readDGDRSpec(opts.dgdrSpecPath)
+	override, err := readDGD(opts.overridePath, "override")
 	if err != nil {
 		return err
-	}
-
-	override := &unstructured.Unstructured{}
-	if dgdrSpec.Overrides == nil ||
-		dgdrSpec.Overrides.DGD == nil ||
-		len(bytes.TrimSpace(dgdrSpec.Overrides.DGD.Raw)) == 0 {
-		override.SetGroupVersionKind(blueprint.GroupVersionKind())
-	} else {
-		override, err = decodeDGD(dgdrSpec.Overrides.DGD.Raw, "DGDR spec overrides.dgd")
-		if err != nil {
-			return err
-		}
 	}
 
 	effective, warnings, err := dgdoverride.Apply(blueprint, override)
@@ -97,7 +82,7 @@ func parseOptions(args []string, stderr io.Writer) (options, error) {
 	flags := flag.NewFlagSet("dgd-apply-overrides", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	flags.StringVar(&opts.blueprintPath, "blueprint", "", "Path to the complete DGD blueprint YAML")
-	flags.StringVar(&opts.dgdrSpecPath, "dgdr-spec", "", "Path to the DGDR spec JSON or YAML")
+	flags.StringVar(&opts.overridePath, "override", "", "Path to the partial DGD override JSON or YAML")
 	flags.StringVar(&opts.outputPath, "output", "", "Path for the effective DGD YAML")
 	flags.StringVar(&opts.installPath, "install-to", "", "Copy this executable to the given path and exit")
 	if err := flags.Parse(args); err != nil {
@@ -107,8 +92,8 @@ func parseOptions(args []string, stderr io.Writer) (options, error) {
 		return options{}, fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
 	}
 	if opts.installPath != "" {
-		if opts.blueprintPath != "" || opts.dgdrSpecPath != "" || opts.outputPath != "" {
-			return options{}, fmt.Errorf("--install-to cannot be combined with --blueprint, --dgdr-spec, or --output")
+		if opts.blueprintPath != "" || opts.overridePath != "" || opts.outputPath != "" {
+			return options{}, fmt.Errorf("--install-to cannot be combined with --blueprint, --override, or --output")
 		}
 		return opts, nil
 	}
@@ -117,8 +102,8 @@ func parseOptions(args []string, stderr io.Writer) (options, error) {
 	if opts.blueprintPath == "" {
 		missing = append(missing, "--blueprint")
 	}
-	if opts.dgdrSpecPath == "" {
-		missing = append(missing, "--dgdr-spec")
+	if opts.overridePath == "" {
+		missing = append(missing, "--override")
 	}
 	if opts.outputPath == "" {
 		missing = append(missing, "--output")
@@ -151,38 +136,6 @@ func decodeDGD(data []byte, role string) (*unstructured.Unstructured, error) {
 		return nil, fmt.Errorf("decode %s: expected an object, got %T", role, object)
 	}
 	return dgd, nil
-}
-
-func readDGDRSpec(path string) (*nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read DGDR spec %q: %w", path, err)
-	}
-	if len(bytes.TrimSpace(data)) == 0 {
-		return nil, fmt.Errorf("decode DGDR spec %q: document is empty", path)
-	}
-	jsonData, err := yaml.YAMLToJSON(data)
-	if err != nil {
-		return nil, fmt.Errorf("decode DGDR spec %q: %w", path, err)
-	}
-	fields := map[string]json.RawMessage{}
-	if err := json.Unmarshal(jsonData, &fields); err != nil {
-		return nil, fmt.Errorf("decode DGDR spec %q: expected an object: %w", path, err)
-	}
-	if fields == nil {
-		return nil, fmt.Errorf("decode DGDR spec %q: expected an object", path)
-	}
-	_, hasSpec := fields["spec"]
-	_, hasAPIVersion := fields["apiVersion"]
-	_, hasKind := fields["kind"]
-	if hasSpec && (hasAPIVersion || hasKind) {
-		return nil, fmt.Errorf("decode DGDR spec %q: expected the spec object, got a complete Kubernetes resource", path)
-	}
-	spec := &nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{}
-	if err := json.Unmarshal(jsonData, spec); err != nil {
-		return nil, fmt.Errorf("decode DGDR spec %q: %w", path, err)
-	}
-	return spec, nil
 }
 
 func installSelf(path string) error {

--- a/deploy/operator/cmd/dgd-apply-overrides/main.go
+++ b/deploy/operator/cmd/dgd-apply-overrides/main.go
@@ -1,0 +1,237 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dgdoverride"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+type options struct {
+	blueprintPath string
+	dgdrSpecPath  string
+	outputPath    string
+	installPath   string
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stderr); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "dgd-apply-overrides: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stderr io.Writer) error {
+	opts, err := parseOptions(args, stderr)
+	if err != nil {
+		return err
+	}
+	if opts.installPath != "" {
+		if err := installSelf(opts.installPath); err != nil {
+			return fmt.Errorf("install dgd-apply-overrides to %q: %w", opts.installPath, err)
+		}
+		return nil
+	}
+
+	blueprint, err := readDGD(opts.blueprintPath, "blueprint")
+	if err != nil {
+		return err
+	}
+	dgdrSpec, err := readDGDRSpec(opts.dgdrSpecPath)
+	if err != nil {
+		return err
+	}
+
+	override := &unstructured.Unstructured{}
+	if dgdrSpec.Overrides == nil ||
+		dgdrSpec.Overrides.DGD == nil ||
+		len(bytes.TrimSpace(dgdrSpec.Overrides.DGD.Raw)) == 0 {
+		override.SetGroupVersionKind(blueprint.GroupVersionKind())
+	} else {
+		override, err = decodeDGD(dgdrSpec.Overrides.DGD.Raw, "DGDR spec overrides.dgd")
+		if err != nil {
+			return err
+		}
+	}
+
+	effective, warnings, err := dgdoverride.Apply(blueprint, override)
+	if err != nil {
+		return fmt.Errorf("apply DGD override: %w", err)
+	}
+	for _, warning := range warnings {
+		if _, err := fmt.Fprintf(stderr, "warning: %s\n", warning); err != nil {
+			return fmt.Errorf("write override warning: %w", err)
+		}
+	}
+
+	manifest, err := yaml.Marshal(effective.Object)
+	if err != nil {
+		return fmt.Errorf("encode effective DGD: %w", err)
+	}
+	if err := writeFileAtomically(opts.outputPath, manifest, 0o644); err != nil {
+		return fmt.Errorf("write effective DGD %q: %w", opts.outputPath, err)
+	}
+	return nil
+}
+
+func parseOptions(args []string, stderr io.Writer) (options, error) {
+	opts := options{}
+	flags := flag.NewFlagSet("dgd-apply-overrides", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	flags.StringVar(&opts.blueprintPath, "blueprint", "", "Path to the complete DGD blueprint YAML")
+	flags.StringVar(&opts.dgdrSpecPath, "dgdr-spec", "", "Path to the DGDR spec JSON or YAML")
+	flags.StringVar(&opts.outputPath, "output", "", "Path for the effective DGD YAML")
+	flags.StringVar(&opts.installPath, "install-to", "", "Copy this executable to the given path and exit")
+	if err := flags.Parse(args); err != nil {
+		return options{}, err
+	}
+	if flags.NArg() != 0 {
+		return options{}, fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if opts.installPath != "" {
+		if opts.blueprintPath != "" || opts.dgdrSpecPath != "" || opts.outputPath != "" {
+			return options{}, fmt.Errorf("--install-to cannot be combined with --blueprint, --dgdr-spec, or --output")
+		}
+		return opts, nil
+	}
+
+	missing := make([]string, 0, 3)
+	if opts.blueprintPath == "" {
+		missing = append(missing, "--blueprint")
+	}
+	if opts.dgdrSpecPath == "" {
+		missing = append(missing, "--dgdr-spec")
+	}
+	if opts.outputPath == "" {
+		missing = append(missing, "--output")
+	}
+	if len(missing) != 0 {
+		return options{}, fmt.Errorf("required flags missing: %s", strings.Join(missing, ", "))
+	}
+	return opts, nil
+}
+
+func readDGD(path string, role string) (*unstructured.Unstructured, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s %q: %w", role, path, err)
+	}
+	return decodeDGD(data, role)
+}
+
+func decodeDGD(data []byte, role string) (*unstructured.Unstructured, error) {
+	jsonData, err := yaml.YAMLToJSON(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s YAML: %w", role, err)
+	}
+	object, _, err := unstructured.UnstructuredJSONScheme.Decode(jsonData, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s object: %w", role, err)
+	}
+	dgd, ok := object.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("decode %s: expected an object, got %T", role, object)
+	}
+	return dgd, nil
+}
+
+func readDGDRSpec(path string) (*nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read DGDR spec %q: %w", path, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, fmt.Errorf("decode DGDR spec %q: document is empty", path)
+	}
+	jsonData, err := yaml.YAMLToJSON(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode DGDR spec %q: %w", path, err)
+	}
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(jsonData, &fields); err != nil {
+		return nil, fmt.Errorf("decode DGDR spec %q: expected an object: %w", path, err)
+	}
+	if fields == nil {
+		return nil, fmt.Errorf("decode DGDR spec %q: expected an object", path)
+	}
+	_, hasSpec := fields["spec"]
+	_, hasAPIVersion := fields["apiVersion"]
+	_, hasKind := fields["kind"]
+	if hasSpec && (hasAPIVersion || hasKind) {
+		return nil, fmt.Errorf("decode DGDR spec %q: expected the spec object, got a complete Kubernetes resource", path)
+	}
+	spec := &nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{}
+	if err := json.Unmarshal(jsonData, spec); err != nil {
+		return nil, fmt.Errorf("decode DGDR spec %q: %w", path, err)
+	}
+	return spec, nil
+}
+
+func installSelf(path string) error {
+	executablePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate current executable: %w", err)
+	}
+	executable, err := os.Open(executablePath)
+	if err != nil {
+		return fmt.Errorf("open current executable: %w", err)
+	}
+	defer func() {
+		_ = executable.Close()
+	}()
+
+	return writeAtomically(path, 0o755, func(destination io.Writer) error {
+		_, err := io.Copy(destination, executable)
+		return err
+	})
+}
+
+func writeFileAtomically(path string, data []byte, mode os.FileMode) error {
+	return writeAtomically(path, mode, func(destination io.Writer) error {
+		_, err := destination.Write(data)
+		return err
+	})
+}
+
+func writeAtomically(path string, mode os.FileMode, write func(io.Writer) error) error {
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		_ = os.Remove(temporaryPath)
+	}()
+
+	if err := write(temporary); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Chmod(mode); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}

--- a/deploy/operator/cmd/dgd-apply-overrides/main_test.go
+++ b/deploy/operator/cmd/dgd-apply-overrides/main_test.go
@@ -1,0 +1,282 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestRunAppliesVersionedOverride(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
+	dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.json", alphaOverrideDGDRSpecJSON)
+	outputPath := filepath.Join(directory, "effective.yaml")
+	stderr := &bytes.Buffer{}
+
+	err := run([]string{
+		"--blueprint", blueprintPath,
+		"--dgdr-spec", dgdrSpecPath,
+		"--output", outputPath,
+	}, stderr)
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String())
+
+	effective := mustReadDGD(t, outputPath)
+	assert.Equal(t, "nvidia.com/v1beta1", effective.GetAPIVersion())
+	assert.Equal(t, "DynamoGraphDeployment", effective.GetKind())
+	assert.Equal(t, "generated", effective.GetName())
+	assert.Equal(t, "new-image", mainContainerImage(t, effective))
+}
+
+func TestRunWithoutOverrideNormalizesBlueprint(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
+	dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", "{}\n")
+	outputPath := filepath.Join(directory, "effective.yaml")
+	stderr := &bytes.Buffer{}
+
+	err := run([]string{
+		"--blueprint", blueprintPath,
+		"--dgdr-spec", dgdrSpecPath,
+		"--output", outputPath,
+	}, stderr)
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String())
+	assert.Equal(t, mustReadDGD(t, blueprintPath), mustReadDGD(t, outputPath))
+}
+
+func TestRunEmitsWarningsForIgnoredTopology(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
+	dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", `
+overrides:
+  dgd:
+    apiVersion: nvidia.com/v1beta1
+    kind: DynamoGraphDeployment
+    spec:
+      components:
+      - name: Missing
+        replicas: 2
+`)
+	outputPath := filepath.Join(directory, "effective.yaml")
+	stderr := &bytes.Buffer{}
+
+	err := run([]string{
+		"--blueprint", blueprintPath,
+		"--dgdr-spec", dgdrSpecPath,
+		"--output", outputPath,
+	}, stderr)
+	require.NoError(t, err)
+	assert.Contains(
+		t,
+		stderr.String(),
+		"warning: spec.components[name=Missing]: ignored because the generated blueprint has no such component",
+	)
+	assert.Equal(t, "old-image", mainContainerImage(t, mustReadDGD(t, outputPath)))
+}
+
+func TestRunDoesNotReplaceOutputOnFailure(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
+	dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", `
+overrides:
+  dgd:
+    apiVersion: nvidia.com/v2
+    kind: DynamoGraphDeployment
+`)
+	outputPath := writeTestFile(t, directory, "effective.yaml", "existing output\n")
+
+	err := run([]string{
+		"--blueprint", blueprintPath,
+		"--dgdr-spec", dgdrSpecPath,
+		"--output", outputPath,
+	}, &bytes.Buffer{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apply DGD override")
+	content, readErr := os.ReadFile(outputPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "existing output\n", string(content))
+}
+
+func TestRunInstallsExecutable(t *testing.T) {
+	t.Parallel()
+
+	installPath := filepath.Join(t.TempDir(), "dgd-apply-overrides")
+	stderr := &bytes.Buffer{}
+	require.NoError(t, run([]string{"--install-to", installPath}, stderr))
+	assert.Empty(t, stderr.String())
+
+	installed, err := os.Stat(installPath)
+	require.NoError(t, err)
+	currentPath, err := os.Executable()
+	require.NoError(t, err)
+	current, err := os.Stat(currentPath)
+	require.NoError(t, err)
+	assert.Equal(t, current.Size(), installed.Size())
+	assert.Equal(t, os.FileMode(0o755), installed.Mode().Perm())
+}
+
+func TestRunRejectsInvalidArgumentsAndInput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing flags", func(t *testing.T) {
+		err := run(nil, &bytes.Buffer{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--blueprint, --dgdr-spec, --output")
+	})
+
+	t.Run("unexpected positional argument", func(t *testing.T) {
+		err := run([]string{"extra"}, &bytes.Buffer{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected positional arguments")
+	})
+
+	t.Run("install mixed with merge flags", func(t *testing.T) {
+		err := run([]string{"--install-to", "/tmp/tool", "--blueprint", "/tmp/blueprint"}, &bytes.Buffer{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--install-to cannot be combined")
+	})
+
+	t.Run("malformed blueprint", func(t *testing.T) {
+		directory := t.TempDir()
+		blueprintPath := writeTestFile(t, directory, "blueprint.yaml", "spec: [\n")
+		dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", "{}\n")
+		err := run([]string{
+			"--blueprint", blueprintPath,
+			"--dgdr-spec", dgdrSpecPath,
+			"--output", filepath.Join(directory, "effective.yaml"),
+		}, &bytes.Buffer{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode blueprint YAML")
+	})
+
+	t.Run("malformed DGDR spec", func(t *testing.T) {
+		directory := t.TempDir()
+		blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
+		dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", "overrides: [\n")
+		err := run([]string{
+			"--blueprint", blueprintPath,
+			"--dgdr-spec", dgdrSpecPath,
+			"--output", filepath.Join(directory, "effective.yaml"),
+		}, &bytes.Buffer{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode DGDR spec")
+	})
+
+	t.Run("complete DGDR resource", func(t *testing.T) {
+		directory := t.TempDir()
+		blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
+		dgdrSpecPath := writeTestFile(t, directory, "dgdr.yaml", `
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+spec: {}
+`)
+		err := run([]string{
+			"--blueprint", blueprintPath,
+			"--dgdr-spec", dgdrSpecPath,
+			"--output", filepath.Join(directory, "effective.yaml"),
+		}, &bytes.Buffer{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected the spec object")
+	})
+}
+
+func writeTestFile(t *testing.T, directory string, name string, content string) string {
+	t.Helper()
+	path := filepath.Join(directory, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func mustReadDGD(t *testing.T, path string) *unstructured.Unstructured {
+	t.Helper()
+	object, err := readDGD(path, "test DGD")
+	require.NoError(t, err)
+	return object
+}
+
+func mainContainerImage(t *testing.T, dgd *unstructured.Unstructured) string {
+	t.Helper()
+	components, found, err := unstructured.NestedSlice(dgd.Object, "spec", "components")
+	require.NoError(t, err)
+	require.True(t, found)
+	for _, value := range components {
+		component, ok := value.(map[string]interface{})
+		if !ok || component["name"] != "Worker" {
+			continue
+		}
+		containers, found, err := unstructured.NestedSlice(component, "podTemplate", "spec", "containers")
+		require.NoError(t, err)
+		require.True(t, found)
+		for _, containerValue := range containers {
+			container, ok := containerValue.(map[string]interface{})
+			if ok && container["name"] == "main" {
+				image, ok := container["image"].(string)
+				require.True(t, ok)
+				return image
+			}
+		}
+	}
+	t.Fatal("main container not found")
+	return ""
+}
+
+const betaBlueprintYAML = `
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: generated
+  namespace: default
+spec:
+  backendFramework: vllm
+  components:
+  - name: Frontend
+    type: frontend
+  - name: Worker
+    type: worker
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: old-image
+`
+
+const alphaOverrideDGDRSpecJSON = `
+{
+  "overrides": {
+    "dgd": {
+      "apiVersion": "nvidia.com/v1alpha1",
+      "kind": "DynamoGraphDeployment",
+      "spec": {
+        "services": {
+          "Worker": {
+            "extraPodSpec": {
+              "mainContainer": {
+                "image": "new-image"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`

--- a/deploy/operator/cmd/dgd-apply-overrides/main_test.go
+++ b/deploy/operator/cmd/dgd-apply-overrides/main_test.go
@@ -21,13 +21,13 @@ func TestRunAppliesVersionedOverride(t *testing.T) {
 
 	directory := t.TempDir()
 	blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
-	dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.json", alphaOverrideDGDRSpecJSON)
+	overridePath := writeTestFile(t, directory, "override.json", alphaOverrideDGDJSON)
 	outputPath := filepath.Join(directory, "effective.yaml")
 	stderr := &bytes.Buffer{}
 
 	err := run([]string{
 		"--blueprint", blueprintPath,
-		"--dgdr-spec", dgdrSpecPath,
+		"--override", overridePath,
 		"--output", outputPath,
 	}, stderr)
 	require.NoError(t, err)
@@ -40,18 +40,21 @@ func TestRunAppliesVersionedOverride(t *testing.T) {
 	assert.Equal(t, "new-image", mainContainerImage(t, effective))
 }
 
-func TestRunWithoutOverrideNormalizesBlueprint(t *testing.T) {
+func TestRunWithEmptyOverridePreservesBlueprint(t *testing.T) {
 	t.Parallel()
 
 	directory := t.TempDir()
 	blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
-	dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", "{}\n")
+	overridePath := writeTestFile(t, directory, "override.yaml", `
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+`)
 	outputPath := filepath.Join(directory, "effective.yaml")
 	stderr := &bytes.Buffer{}
 
 	err := run([]string{
 		"--blueprint", blueprintPath,
-		"--dgdr-spec", dgdrSpecPath,
+		"--override", overridePath,
 		"--output", outputPath,
 	}, stderr)
 	require.NoError(t, err)
@@ -64,22 +67,20 @@ func TestRunEmitsWarningsForIgnoredTopology(t *testing.T) {
 
 	directory := t.TempDir()
 	blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
-	dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", `
-overrides:
-  dgd:
-    apiVersion: nvidia.com/v1beta1
-    kind: DynamoGraphDeployment
-    spec:
-      components:
-      - name: Missing
-        replicas: 2
+	overridePath := writeTestFile(t, directory, "override.yaml", `
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+spec:
+  components:
+  - name: Missing
+    replicas: 2
 `)
 	outputPath := filepath.Join(directory, "effective.yaml")
 	stderr := &bytes.Buffer{}
 
 	err := run([]string{
 		"--blueprint", blueprintPath,
-		"--dgdr-spec", dgdrSpecPath,
+		"--override", overridePath,
 		"--output", outputPath,
 	}, stderr)
 	require.NoError(t, err)
@@ -96,17 +97,15 @@ func TestRunDoesNotReplaceOutputOnFailure(t *testing.T) {
 
 	directory := t.TempDir()
 	blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
-	dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", `
-overrides:
-  dgd:
-    apiVersion: nvidia.com/v2
-    kind: DynamoGraphDeployment
+	overridePath := writeTestFile(t, directory, "override.yaml", `
+apiVersion: nvidia.com/v2
+kind: DynamoGraphDeployment
 `)
 	outputPath := writeTestFile(t, directory, "effective.yaml", "existing output\n")
 
 	err := run([]string{
 		"--blueprint", blueprintPath,
-		"--dgdr-spec", dgdrSpecPath,
+		"--override", overridePath,
 		"--output", outputPath,
 	}, &bytes.Buffer{})
 	require.Error(t, err)
@@ -140,7 +139,7 @@ func TestRunRejectsInvalidArgumentsAndInput(t *testing.T) {
 	t.Run("missing flags", func(t *testing.T) {
 		err := run(nil, &bytes.Buffer{})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--blueprint, --dgdr-spec, --output")
+		assert.Contains(t, err.Error(), "--blueprint, --override, --output")
 	})
 
 	t.Run("unexpected positional argument", func(t *testing.T) {
@@ -158,44 +157,45 @@ func TestRunRejectsInvalidArgumentsAndInput(t *testing.T) {
 	t.Run("malformed blueprint", func(t *testing.T) {
 		directory := t.TempDir()
 		blueprintPath := writeTestFile(t, directory, "blueprint.yaml", "spec: [\n")
-		dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", "{}\n")
+		overridePath := writeTestFile(t, directory, "override.yaml", alphaOverrideDGDJSON)
 		err := run([]string{
 			"--blueprint", blueprintPath,
-			"--dgdr-spec", dgdrSpecPath,
+			"--override", overridePath,
 			"--output", filepath.Join(directory, "effective.yaml"),
 		}, &bytes.Buffer{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode blueprint YAML")
 	})
 
-	t.Run("malformed DGDR spec", func(t *testing.T) {
+	t.Run("malformed override", func(t *testing.T) {
 		directory := t.TempDir()
 		blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
-		dgdrSpecPath := writeTestFile(t, directory, "dgdr-spec.yaml", "overrides: [\n")
+		overridePath := writeTestFile(t, directory, "override.yaml", "spec: [\n")
 		err := run([]string{
 			"--blueprint", blueprintPath,
-			"--dgdr-spec", dgdrSpecPath,
+			"--override", overridePath,
 			"--output", filepath.Join(directory, "effective.yaml"),
 		}, &bytes.Buffer{})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "decode DGDR spec")
+		assert.Contains(t, err.Error(), "decode override YAML")
 	})
 
-	t.Run("complete DGDR resource", func(t *testing.T) {
+	t.Run("DGDR resource instead of DGD override", func(t *testing.T) {
 		directory := t.TempDir()
 		blueprintPath := writeTestFile(t, directory, "blueprint.yaml", betaBlueprintYAML)
-		dgdrSpecPath := writeTestFile(t, directory, "dgdr.yaml", `
+		overridePath := writeTestFile(t, directory, "dgdr.yaml", `
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeploymentRequest
 spec: {}
 `)
 		err := run([]string{
 			"--blueprint", blueprintPath,
-			"--dgdr-spec", dgdrSpecPath,
+			"--override", overridePath,
 			"--output", filepath.Join(directory, "effective.yaml"),
 		}, &bytes.Buffer{})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "expected the spec object")
+		assert.Contains(t, err.Error(), "apply DGD override")
+		assert.Contains(t, err.Error(), `kind "DynamoGraphDeploymentRequest"`)
 	})
 }
 
@@ -259,20 +259,16 @@ spec:
           image: old-image
 `
 
-const alphaOverrideDGDRSpecJSON = `
+const alphaOverrideDGDJSON = `
 {
-  "overrides": {
-    "dgd": {
-      "apiVersion": "nvidia.com/v1alpha1",
-      "kind": "DynamoGraphDeployment",
-      "spec": {
-        "services": {
-          "Worker": {
-            "extraPodSpec": {
-              "mainContainer": {
-                "image": "new-image"
-              }
-            }
+  "apiVersion": "nvidia.com/v1alpha1",
+  "kind": "DynamoGraphDeployment",
+  "spec": {
+    "services": {
+      "Worker": {
+        "extraPodSpec": {
+          "mainContainer": {
+            "image": "new-image"
           }
         }
       }


### PR DESCRIPTION
## Summary

Add `dgd-apply-overrides`, a small Go CLI that exposes the shared DGD override engine to external processes such as the profiler without coupling the executable to DGDR types.

The CLI:

- reads a complete, versioned DGD blueprint from `--blueprint`
- reads a partial, versioned DGD override from `--override`
- applies the override using the shared `dgdoverride` package
- supports all v1alpha1/v1beta1 blueprint and override combinations
- preserves the blueprint's original API version in the effective DGD
- writes the effective DGD YAML to `--output`
- reports non-fatal override warnings on stderr
- writes output atomically so failures do not replace an existing result

The profiler remains responsible for parsing the DGDR and extracting `spec.overrides.dgd`. When no DGD override is present, it can skip invoking the CLI.

The CLI also provides a separate `--install-to` mode that copies the executable to a requested path. This allows an init container using the distroless operator image to place the binary in a shared volume for the profiler container without requiring a shell or `cp`.

The stripped binary is built and included in the operator runtime image. Profiler runtime installation and invocation will follow separately.

## Validation

- `GOCACHE=/tmp/dynamo-go-cache /usr/local/go/bin/go test ./cmd/dgd-apply-overrides ./internal/dgdoverride -count=1`
- `GOCACHE=/tmp/dynamo-go-cache /usr/local/go/bin/go test ./cmd/... ./api/... ./internal/... -count=1`
- `GOCACHE=/tmp/dynamo-go-cache /usr/local/go/bin/go test -race ./cmd/dgd-apply-overrides ./internal/dgdoverride -count=1`
- `GOCACHE=/tmp/dynamo-go-cache /usr/local/go/bin/go vet ./cmd/dgd-apply-overrides ./internal/dgdoverride`
- `docker buildx build --target linter --progress=plain --build-context snapshot=../snapshot .`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->