### PR TITLE
docs(kv-router): record rejected CRTC experiments [DYN-3584]

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/matches.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/matches.rs
@@ -142,6 +142,8 @@ impl ConcurrentRadixTreeCompressed {
         }
     }
 
+    // NOTE(perf): A reusable compact result sink reduced result-map work in
+    // profiles but did not improve end-to-end throughput under contention.
     #[cfg_attr(feature = "profile", inline(never))]
     pub fn find_matches_impl(
         &self,

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -33,6 +33,8 @@ fn record_last_matched_hash(
 /// a shared gate.
 #[derive(Debug)]
 pub(super) struct Node {
+    // NOTE(perf): Consolidating the shape gate and version synchronization into
+    // one lock regressed throughput. Re-profile before combining these fields.
     shape_gate: RwLock<()>,
     /// NOTE(concurrency): This is a post-commit validation token, not a seqlock.
     /// Node state and children do not share one immutable publication boundary.
@@ -108,6 +110,8 @@ impl Node {
         // NOTE(perf): Reducing child-map sharding substantially lowered memory
         // usage but regressed throughput. Treat custom sharding as an explicit
         // memory tradeoff rather than a throughput optimization.
+        // NOTE(perf): Lazily allocating this map only after a node became
+        // internal also saved memory but regressed throughput under contention.
         let children_map = DashMap::with_hasher(FxBuildHasher);
         for (key, child) in children {
             children_map.insert(key, child);
@@ -233,6 +237,8 @@ impl Node {
     }
 
     pub(super) fn promote_worker_to_full_edge(&self, worker: WorkerWithDpRank) -> bool {
+        // NOTE(perf): This path is anchor-only today. Removing its shape read
+        // did not improve throughput; re-evaluate if non-anchor callers appear.
         let _gate = self.shape_gate.read();
         self.state.write().promote_to_full(worker)
     }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
@@ -67,6 +67,8 @@ impl ConcurrentRadixTreeCompressed {
     ) -> Result<StoreParentResolution, KvCacheEventError> {
         loop {
             let node = self.lookup_store_parent_node(lookup, worker, parent_hash, op, id)?;
+            // NOTE(perf): Combining coverage rejection and edge planning into
+            // one state snapshot regressed throughput. Keep these phases separate.
             self.reject_uncovered_store_parent(lookup, worker, &node, parent_hash, id)?;
 
             let Some(plan) = node.plan_store_parent_edge(parent_hash, &op.blocks) else {


### PR DESCRIPTION
## Summary

- Record rejected CRTC optimization experiments at the relevant implementation sites.
- Preserve the qualitative benchmark rationale for shape synchronization, child-map allocation, anchor promotion, compact match results, and combined parent-edge planning.
- Avoid embedding benchmark figures that may become stale.

## Validation

- `cargo clippy --no-deps --all-targets -- -D warnings` from `lib/kv-router`
- `cargo fmt` from `lib/kv-router`
