### PR TITLE
feat(sglang): support multiple served model names

### DIFF
--- a/components/src/dynamo/common/configuration/utils.py
+++ b/components/src/dynamo/common/configuration/utils.py
@@ -5,9 +5,30 @@
 
 import argparse
 import os
+import re
 from typing import Any, Callable, Optional, TypeVar, Union
 
 T = TypeVar("T")
+
+
+def split_served_model_names(served_model_name: Any) -> list[str]:
+    """Split a ``--served-model-name`` value into individual names.
+
+    Accepts a single string (whitespace- or comma-separated) or a
+    list/tuple of such strings, and returns a flat list of non-empty names
+    in order. The first is the primary served name; any remaining names are
+    aliases. Returns ``[]`` when nothing parses out.
+    """
+    if served_model_name is None:
+        return []
+    if isinstance(served_model_name, (list, tuple)):
+        raw_names = [str(name) for name in served_model_name]
+    else:
+        raw_names = [str(served_model_name)]
+    names: list[str] = []
+    for raw_name in raw_names:
+        names.extend(name for name in re.split(r"[\s,]+", raw_name.strip()) if name)
+    return names
 
 
 def env_or_default(

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -20,6 +20,7 @@ from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 from dynamo.common.config_dump import register_encoder
 from dynamo.common.configuration.groups import DynamoRuntimeConfig
 from dynamo.common.configuration.groups.runtime_args import DynamoRuntimeArgGroup
+from dynamo.common.configuration.utils import split_served_model_names
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.model_fetch import fetch_model
 from dynamo.common.snapshot.lifecycle import (
@@ -428,7 +429,24 @@ async def parse_args(args: list[str]) -> Config:
             )
 
     model_path = parsed_args.model_path
-    # Name the model
+
+    # --served-model-name may pack several names (whitespace-/comma-separated);
+    # the first is the primary, the rest are aliases. Split BEFORE the
+    # model_path fallback so a model path containing whitespace doesn't produce
+    # spurious aliases.
+    served_names = split_served_model_names(parsed_args.served_model_name)
+    if served_names:
+        parsed_args.served_model_name = served_names[0]
+        dynamo_config.served_model_aliases = served_names[1:]
+        if served_names[1:]:
+            logging.info(
+                "Multi-name registration: primary=%r, aliases=%s",
+                served_names[0],
+                served_names[1:],
+            )
+
+    # Name the model — falls back to model_path only if neither
+    # --served-model-name nor an env var supplied one.
     if not parsed_args.served_model_name:
         parsed_args.served_model_name = model_path
     # Download the model if necessary using modelexpress.

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -191,7 +191,10 @@ class DynamoSGLangConfig(ConfigBase):
     # comma-separated string of multiple names; the first becomes the
     # primary and the rest land here. Plumbed to register_model() so the
     # Rust ModelManager registers the same WorkerSet under each alias.
-    served_model_aliases: List[str] = []
+    # Default is None (not []): ConfigBase.from_cli_args copies class
+    # defaults onto each instance by reference, so a mutable [] would be
+    # shared across configs.
+    served_model_aliases: Optional[List[str]] = None
 
     def validate(self) -> None:
         if not isinstance(self.embedding_transfer_mode, EmbeddingTransferMode):

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -186,14 +186,8 @@ class DynamoSGLangConfig(ConfigBase):
     frontend_decoding: bool = False
     sglang_trace_level: int
 
-    # Additional names this model responds to (aliases). Populated by
-    # parse_args when --served-model-name is given as a whitespace- or
-    # comma-separated string of multiple names; the first becomes the
-    # primary and the rest land here. Plumbed to register_model() so the
-    # Rust ModelManager registers the same WorkerSet under each alias.
-    # Default is None (not []): ConfigBase.from_cli_args copies class
-    # defaults onto each instance by reference, so a mutable [] would be
-    # shared across configs.
+    # Extra served names beyond the primary, parsed from --served-model-name.
+    # None (not []) since ConfigBase copies class defaults by reference.
     served_model_aliases: Optional[List[str]] = None
 
     def validate(self) -> None:

--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -8,7 +8,7 @@
 import argparse
 import logging
 import warnings
-from typing import Optional
+from typing import List, Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
@@ -185,6 +185,13 @@ class DynamoSGLangConfig(ConfigBase):
     enable_rl: bool
     frontend_decoding: bool = False
     sglang_trace_level: int
+
+    # Additional names this model responds to (aliases). Populated by
+    # parse_args when --served-model-name is given as a whitespace- or
+    # comma-separated string of multiple names; the first becomes the
+    # primary and the rest land here. Plumbed to register_model() so the
+    # Rust ModelManager registers the same WorkerSet under each alias.
+    served_model_aliases: List[str] = []
 
     def validate(self) -> None:
         if not isinstance(self.embedding_transfer_mode, EmbeddingTransferMode):

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -169,13 +169,7 @@ async def _register_model_with_runtime_config(
             max_gpu_lora_count=max_gpu_lora_count,
             model_aliases=aliases or None,
         )
-        if aliases:
-            logging.info(
-                "Successfully registered LLM with runtime config (aliases: %s)",
-                aliases,
-            )
-        else:
-            logging.info("Successfully registered LLM with runtime config")
+        logging.info("Successfully registered LLM with runtime config")
         return True
     except Exception as e:
         logging.error(f"Failed to register with runtime config: {e}")

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -150,6 +150,7 @@ async def _register_model_with_runtime_config(
         else None
     )
 
+    aliases = list(getattr(dynamo_args, "served_model_aliases", []) or [])
     try:
         await register_model(
             input_type,
@@ -166,8 +167,15 @@ async def _register_model_with_runtime_config(
             needs=needs,
             ignore_weights=use_modelexpress_remote_instance(server_args),
             max_gpu_lora_count=max_gpu_lora_count,
+            model_aliases=aliases or None,
         )
-        logging.info("Successfully registered LLM with runtime config")
+        if aliases:
+            logging.info(
+                "Successfully registered LLM with runtime config (aliases: %s)",
+                aliases,
+            )
+        else:
+            logging.info("Successfully registered LLM with runtime config")
         return True
     except Exception as e:
         logging.error(f"Failed to register with runtime config: {e}")

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -282,7 +282,9 @@ async def test_custom_jinja_template_env_var_expansion(monkeypatch, mock_sglang_
 
 
 @pytest.mark.asyncio
-async def test_multiple_served_model_names_register_primary_and_aliases(mock_sglang_cli):
+async def test_multiple_served_model_names_register_primary_and_aliases(
+    mock_sglang_cli,
+):
     """SGLang packed served names split into primary + Dynamo aliases."""
     mock_sglang_cli(
         "--model",

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -281,6 +281,22 @@ async def test_custom_jinja_template_env_var_expansion(monkeypatch, mock_sglang_
     )
 
 
+@pytest.mark.asyncio
+async def test_multiple_served_model_names_register_primary_and_aliases(mock_sglang_cli):
+    """SGLang packed served names split into primary + Dynamo aliases."""
+    mock_sglang_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--served-model-name",
+        "primary,alias-one alias-two",
+    )
+
+    config = await parse_args(sys.argv[1:])
+
+    assert config.server_args.served_model_name == "primary"
+    assert config.dynamo_args.served_model_aliases == ["alias-one", "alias-two"]
+
+
 # --- Tool Call Parser Validation Tests ---
 
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -348,7 +348,7 @@ fn resolve_routing_image_token_id(model_id: &str, model_dir: &str) -> Option<u32
 /// For LoRA mode, both `lora_name` and `base_model_path` must be provided together.
 /// Providing only one of them will result in an error.
 #[pyfunction]
-#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, worker_type=None, needs=None, self_host_metadata=None, *, tensor_model_config=None, ignore_weights=false, max_gpu_lora_count=None))]
+#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, worker_type=None, needs=None, self_host_metadata=None, *, tensor_model_config=None, ignore_weights=false, max_gpu_lora_count=None, model_aliases=None))]
 #[allow(clippy::too_many_arguments)]
 fn register_model<'p>(
     py: Python<'p>,
@@ -372,6 +372,7 @@ fn register_model<'p>(
     tensor_model_config: Option<&Bound<'p, PyDict>>,
     ignore_weights: bool,
     max_gpu_lora_count: Option<u32>,
+    model_aliases: Option<Vec<String>>,
 ) -> PyResult<Bound<'p, PyAny>> {
     // Every worker registers with an explicit `worker_type`. Reject `None`
     // outright — a missing role would produce a card whose readiness math
@@ -476,6 +477,7 @@ fn register_model<'p>(
     // This preserves backward-compat: workers that don't specify router_config continue to
     // fall back to the frontend-level global router config via the watcher.
     let explicit_router_config: Option<RouterConfig> = router_config.map(|rc| rc.into());
+    let model_aliases = model_aliases.unwrap_or_default();
 
     // Early validation of custom template path
     let custom_template_path_owned = custom_template_path
@@ -535,6 +537,9 @@ fn register_model<'p>(
             card.worker_type = worker_type_value;
             card.needs = needs_value.clone();
             card.user_data = user_data_json;
+            if !model_aliases.is_empty() {
+                card.set_aliases(model_aliases);
+            }
 
             card.runtime_config = runtime_config.inner;
             card.tensor_model_config = tensor_model_config;
@@ -574,6 +579,8 @@ fn register_model<'p>(
             .source_path(source_path.clone().into())
             // --served_model_name
             .model_name(model_name.clone())
+            // --served_model_name aliases (additional names this model responds to)
+            .model_aliases(model_aliases)
             .kv_cache_block_size(kv_cache_block_size)
             .router_config(explicit_router_config.clone())
             .runtime_config({

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -537,8 +537,14 @@ fn register_model<'p>(
             card.worker_type = worker_type_value;
             card.needs = needs_value.clone();
             card.user_data = user_data_json;
+            // Aliases are only honored on the LLM surfaces (their handlers
+            // canonicalize alias→primary); ignore them for these types.
             if !model_aliases.is_empty() {
-                card.set_aliases(model_aliases);
+                tracing::warn!(
+                    model_name = %model_name,
+                    "Ignoring served-model-name aliases: not supported for \
+                     tensor/images/videos/realtime models"
+                );
             }
 
             card.runtime_config = runtime_config.inner;

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2245,6 +2245,7 @@ async def register_model(
     self_host_metadata: Optional[bool] = None,
     ignore_weights: bool = False,
     max_gpu_lora_count: Optional[int] = None,
+    model_aliases: Optional[List[str]] = None,
 ) -> None:
     """
     Attach the model at path to the given endpoint, and advertise it as model_type.

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -120,6 +120,14 @@ pub struct ModelManager {
 
     /// Alias → primary model name mapping. Used to normalize metrics labels.
     alias_to_primary: DashMap<String, String>,
+
+    /// Serializes name-reservation transitions — the primary claim in
+    /// [`Self::add_worker_set`] and the alias claim in [`Self::register_alias`] —
+    /// so a name cannot be concurrently claimed as both a primary and an alias.
+    /// A cold-path lock (worker registration, not request serving), uncontended
+    /// in steady state; held only across in-memory map reads/writes, never across
+    /// an `.await`.
+    reservation_lock: parking_lot::Mutex<()>,
 }
 
 impl Default for ModelManager {
@@ -149,6 +157,7 @@ impl ModelManager {
             lora_enabled: crate::lora::lora_serving_enabled(),
             lora_load_feeds: DashMap::new(),
             alias_to_primary: DashMap::new(),
+            reservation_lock: parking_lot::Mutex::new(()),
         }
     }
 
@@ -181,14 +190,37 @@ impl ModelManager {
         }
     }
 
-    /// Add a WorkerSet to a Model under its primary name. Creates the Model if
-    /// it doesn't exist. A real model always wins a name collision with an
-    /// operator-configured alias, so any stale alias claim on `model_name` is
-    /// reclaimed first (see [`Self::reclaim_primary_name`]).
-    pub fn add_worker_set(&self, model_name: &str, namespace: &str, worker_set: WorkerSet) {
-        self.reclaim_primary_name(model_name);
+    /// Add a WorkerSet to a Model under its primary name. Creates the Model if it
+    /// doesn't exist. Returns `false` (registering nothing) when `model_name` is
+    /// already reserved as another deployment's alias.
+    ///
+    /// The names a live deployment holds — its primary plus every alias — are
+    /// globally reserved until it is removed, so a later deployment cannot claim
+    /// any of them, as either a primary or an alias. This is the primary-side
+    /// mirror of [`Self::register_alias`] (which rejects an alias colliding with a
+    /// live primary or another primary's alias); together they make name
+    /// reservation first-come and symmetric across namespaces. A later deployment
+    /// re-using a name fails loudly rather than silently displacing the owner.
+    ///
+    /// Holds [`Self::reservation_lock`] across the reserved-name check and the
+    /// insert so the claim is atomic against a concurrent `register_alias` for
+    /// the same name (a name can never end up both a live primary and an alias).
+    /// The lock is always taken before any map access, so it never inverts with a
+    /// DashMap shard lock.
+    pub fn add_worker_set(&self, model_name: &str, namespace: &str, worker_set: WorkerSet) -> bool {
+        let _reservation = self.reservation_lock.lock();
+        if let Some(reserved_by) = self.alias_to_primary.get(model_name) {
+            tracing::warn!(
+                model_name,
+                reserved_by = reserved_by.value().as_str(),
+                "Model name is already reserved as an alias of another deployment — refusing to \
+                 register. Choose a different name or remove the conflicting deployment."
+            );
+            return false;
+        }
         let model = self.get_or_create_model(model_name);
         model.add_worker_set(namespace.to_string(), Arc::new(worker_set));
+        true
     }
 
     /// Add an already-Arc-wrapped WorkerSet to a Model. Creates the Model if it doesn't exist.
@@ -237,11 +269,13 @@ impl ModelManager {
     /// refused and logged so operators find the collision in the logs rather
     /// than through silent metric re-attribution.
     ///
-    /// The "is this name a live primary" probe is done *before* taking the
-    /// `alias_to_primary` entry so we never hold one map's shard lock while
-    /// acquiring the other's — [`Self::add_worker_set_arc`] takes them in the
-    /// opposite order, and holding across would risk a lock-order inversion.
+    /// Holds [`Self::reservation_lock`] across the live-primary probe and the
+    /// entry insert so the claim is atomic against a concurrent `add_worker_set`
+    /// for the same name. Within that section the `models` guard is dropped before
+    /// touching `alias_to_primary` (via `is_some_and`), and the lock is taken
+    /// before any map access, so no DashMap shard lock is ever held across another.
     pub fn register_alias(&self, alias: &str, primary: &str) -> bool {
+        let _reservation = self.reservation_lock.lock();
         if self
             .models
             .get(alias)
@@ -276,30 +310,6 @@ impl ModelManager {
                 slot.insert(primary.to_string());
                 true
             }
-        }
-    }
-
-    /// Ensure `name` is available as a primary model name. A real model always
-    /// wins a collision with an operator-configured alias: if `name` is currently
-    /// registered as an alias of a *different* model, drop that mapping and the
-    /// shared WorkerSets attached under it so HTTP stops canonicalizing the name
-    /// to the old primary. No-op in the common case where `name` is not an alias.
-    ///
-    /// Reconciliation across the two maps is best-effort: a name being both a
-    /// live primary of one model and an alias of another is an operator
-    /// misconfiguration (a correctly configured fleet never reuses a name), and
-    /// concurrent registration of such a collision may briefly leave a stale
-    /// mapping until the next registration event. It always self-corrects and
-    /// is logged; it cannot happen for distinct, correctly-named models.
-    fn reclaim_primary_name(&self, name: &str) {
-        if let Some((_, previous_primary)) = self.alias_to_primary.remove(name) {
-            tracing::warn!(
-                name,
-                previous_primary = previous_primary.as_str(),
-                "Name registered as a primary model was already an alias — reclaiming it for the \
-                 primary; the alias mapping is dropped."
-            );
-            self.models.remove(name);
         }
     }
 
@@ -1767,23 +1777,32 @@ mod tests {
     }
 
     #[test]
-    fn test_primary_registration_reclaims_alias_name() {
+    fn test_primary_registration_rejected_when_name_reserved_as_alias() {
         let mm = ModelManager::new();
 
-        // Model "a" claims "shared" as an alias and attaches its worker set.
+        // Model "a" reserves "shared" as an alias and attaches its worker set.
         assert!(mm.register_alias("shared", "a"));
         assert!(mm.add_worker_set_arc("shared", "ns1", Arc::new(make_worker_set("ns1", "abc"))));
         assert_eq!(mm.resolve_canonical_name("shared"), "a");
 
-        // A later model registers "shared" as its own primary — it must win the
-        // name back so requests for "shared" stop canonicalizing to "a".
-        mm.add_worker_set("shared", "ns2", make_worker_set("ns2", "def"));
-        assert_eq!(mm.resolve_canonical_name("shared"), "shared");
+        // A later deployment cannot claim "shared" as its own primary — the name
+        // stays reserved for "a" (first-come, symmetric with register_alias).
+        assert!(!mm.add_worker_set("shared", "ns2", make_worker_set("ns2", "def")));
+        assert_eq!(mm.resolve_canonical_name("shared"), "a");
 
-        // The reclaimed model holds only its own worker set, not "a"'s.
-        let model = mm.get_model("shared").expect("primary model present");
-        assert!(model.get_worker_set("ns2").is_some());
-        assert!(model.get_worker_set("ns1").is_none());
+        // "a"'s alias mirror is untouched and no foreign worker set was added.
+        let model = mm.get_model("shared").expect("alias model present");
+        assert!(model.get_worker_set("ns1").is_some());
+        assert!(model.get_worker_set("ns2").is_none());
+    }
+
+    #[test]
+    fn test_primary_registration_succeeds_for_unreserved_name() {
+        let mm = ModelManager::new();
+        assert!(mm.add_worker_set("llama", "ns1", make_worker_set("ns1", "abc")));
+        assert!(mm.get_model("llama").is_some());
+        // A second worker set for the same primary is fine (replicas share a name).
+        assert!(mm.add_worker_set("llama", "ns2", make_worker_set("ns2", "abc")));
     }
 
     #[test]

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -181,8 +181,12 @@ impl ModelManager {
         }
     }
 
-    /// Add a WorkerSet to a Model. Creates the Model if it doesn't exist.
+    /// Add a WorkerSet to a Model under its primary name. Creates the Model if
+    /// it doesn't exist. A real model always wins a name collision with an
+    /// operator-configured alias, so any stale alias claim on `model_name` is
+    /// reclaimed first (see [`Self::reclaim_primary_name`]).
     pub fn add_worker_set(&self, model_name: &str, namespace: &str, worker_set: WorkerSet) {
+        self.reclaim_primary_name(model_name);
         let model = self.get_or_create_model(model_name);
         model.add_worker_set(namespace.to_string(), Arc::new(worker_set));
     }
@@ -200,20 +204,23 @@ impl ModelManager {
         worker_set: Arc<WorkerSet>,
     ) -> bool {
         // Collision check: if `model_name` already exists as a primary (i.e.
-        // not currently mapped to anything in alias_to_primary, AND already
-        // has worker sets), refuse to clobber it.
-        if let Some(existing) = self.models.get(model_name) {
-            if !existing.is_empty()
-                && !self.alias_to_primary.contains_key(model_name)
-            {
-                tracing::warn!(
-                    alias = model_name,
-                    namespace,
-                    "Alias collides with a registered primary model — skipping. \
-                     Choose a different alias or rename the conflicting model."
-                );
-                return false;
-            }
+        // already has worker sets AND is not currently an alias), refuse to
+        // clobber it. The two facts are read one map at a time — the `models`
+        // guard is dropped before touching `alias_to_primary` — so this never
+        // holds one shard lock while acquiring the other (register_alias probes
+        // them in the opposite order; holding across would risk a deadlock).
+        let is_live_primary = self
+            .models
+            .get(model_name)
+            .is_some_and(|existing| !existing.is_empty());
+        if is_live_primary && !self.alias_to_primary.contains_key(model_name) {
+            tracing::warn!(
+                alias = model_name,
+                namespace,
+                "Alias collides with a registered primary model — skipping. \
+                 Choose a different alias or rename the conflicting model."
+            );
+            return false;
         }
 
         let model = self.get_or_create_model(model_name);
@@ -223,40 +230,77 @@ impl ModelManager {
 
     /// Record that `alias` is an alternate name for `primary`. Used to normalize metrics labels.
     ///
-    /// Logs a warning and refuses to overwrite if `alias` is already mapped to a
-    /// *different* primary. First-write-wins semantics so operators can detect
-    /// alias conflicts in logs rather than discovering them by silent metric
-    /// re-attribution.
+    /// The claim is taken atomically through the map entry so two concurrent
+    /// registrations of the same alias cannot both succeed. First-write-wins:
+    /// re-registering the same alias→primary is idempotent, but a conflicting
+    /// primary (or a name already owned by a registered primary model) is
+    /// refused and logged so operators find the collision in the logs rather
+    /// than through silent metric re-attribution.
+    ///
+    /// The "is this name a live primary" probe is done *before* taking the
+    /// `alias_to_primary` entry so we never hold one map's shard lock while
+    /// acquiring the other's — [`Self::add_worker_set_arc`] takes them in the
+    /// opposite order, and holding across would risk a lock-order inversion.
     pub fn register_alias(&self, alias: &str, primary: &str) -> bool {
-        if let Some(existing) = self.alias_to_primary.get(alias) {
-            if existing.value() != primary {
-                tracing::warn!(
-                    alias,
-                    new_primary = primary,
-                    existing_primary = existing.value().as_str(),
-                    "Alias is already claimed by a different primary — refusing to overwrite. \
-                     Existing claim wins."
-                );
-                return false;
-            }
-            // Same alias→same primary — idempotent, no-op.
-            return true;
+        if self
+            .models
+            .get(alias)
+            .is_some_and(|model| !model.is_empty())
+            && !self.alias_to_primary.contains_key(alias)
+        {
+            tracing::warn!(
+                alias,
+                primary,
+                "Alias collides with a registered primary model — refusing to register. \
+                 Choose a different alias or rename the conflicting model."
+            );
+            return false;
         }
 
-        if let Some(existing) = self.models.get(alias) {
-            if !existing.is_empty() {
-                tracing::warn!(
-                    alias,
-                    primary,
-                    "Alias collides with a registered primary model — refusing to register. \
-                     Choose a different alias or rename the conflicting model."
-                );
-                return false;
+        match self.alias_to_primary.entry(alias.to_string()) {
+            Entry::Occupied(existing) => {
+                if existing.get() != primary {
+                    tracing::warn!(
+                        alias,
+                        new_primary = primary,
+                        existing_primary = existing.get().as_str(),
+                        "Alias is already claimed by a different primary — refusing to overwrite. \
+                         Existing claim wins."
+                    );
+                    return false;
+                }
+                // Same alias→same primary — idempotent, no-op.
+                true
+            }
+            Entry::Vacant(slot) => {
+                slot.insert(primary.to_string());
+                true
             }
         }
-        self.alias_to_primary
-            .insert(alias.to_string(), primary.to_string());
-        true
+    }
+
+    /// Ensure `name` is available as a primary model name. A real model always
+    /// wins a collision with an operator-configured alias: if `name` is currently
+    /// registered as an alias of a *different* model, drop that mapping and the
+    /// shared WorkerSets attached under it so HTTP stops canonicalizing the name
+    /// to the old primary. No-op in the common case where `name` is not an alias.
+    ///
+    /// Reconciliation across the two maps is best-effort: a name being both a
+    /// live primary of one model and an alias of another is an operator
+    /// misconfiguration (a correctly configured fleet never reuses a name), and
+    /// concurrent registration of such a collision may briefly leave a stale
+    /// mapping until the next registration event. It always self-corrects and
+    /// is logged; it cannot happen for distinct, correctly-named models.
+    fn reclaim_primary_name(&self, name: &str) {
+        if let Some((_, previous_primary)) = self.alias_to_primary.remove(name) {
+            tracing::warn!(
+                name,
+                previous_primary = previous_primary.as_str(),
+                "Name registered as a primary model was already an alias — reclaiming it for the \
+                 primary; the alias mapping is dropped."
+            );
+            self.models.remove(name);
+        }
     }
 
     /// Remove a previously registered alias mapping once the alias has no WorkerSets.
@@ -1720,6 +1764,26 @@ mod tests {
         assert!(!mm.register_alias("llama-alias", "llama"));
 
         assert_eq!(mm.resolve_canonical_name("llama-alias"), "llama-alias");
+    }
+
+    #[test]
+    fn test_primary_registration_reclaims_alias_name() {
+        let mm = ModelManager::new();
+
+        // Model "a" claims "shared" as an alias and attaches its worker set.
+        assert!(mm.register_alias("shared", "a"));
+        assert!(mm.add_worker_set_arc("shared", "ns1", Arc::new(make_worker_set("ns1", "abc"))));
+        assert_eq!(mm.resolve_canonical_name("shared"), "a");
+
+        // A later model registers "shared" as its own primary — it must win the
+        // name back so requests for "shared" stop canonicalizing to "a".
+        mm.add_worker_set("shared", "ns2", make_worker_set("ns2", "def"));
+        assert_eq!(mm.resolve_canonical_name("shared"), "shared");
+
+        // The reclaimed model holds only its own worker set, not "a"'s.
+        let model = mm.get_model("shared").expect("primary model present");
+        assert!(model.get_worker_set("ns2").is_some());
+        assert!(model.get_worker_set("ns1").is_none());
     }
 
     #[test]

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -117,6 +117,9 @@ pub struct ModelManager {
     /// per component and can restart it if the previous one exited (avoids double counting on
     /// rebuilds while keeping the feed durable).
     lora_load_feeds: DashMap<String, tokio::task::JoinHandle<()>>,
+
+    /// Alias → primary model name mapping. Used to normalize metrics labels.
+    alias_to_primary: DashMap<String, String>,
 }
 
 impl Default for ModelManager {
@@ -145,6 +148,7 @@ impl ModelManager {
             lora_filter,
             lora_enabled: crate::lora::lora_serving_enabled(),
             lora_load_feeds: DashMap::new(),
+            alias_to_primary: DashMap::new(),
         }
     }
 
@@ -181,6 +185,101 @@ impl ModelManager {
     pub fn add_worker_set(&self, model_name: &str, namespace: &str, worker_set: WorkerSet) {
         let model = self.get_or_create_model(model_name);
         model.add_worker_set(namespace.to_string(), Arc::new(worker_set));
+    }
+
+    /// Add an already-Arc-wrapped WorkerSet to a Model. Creates the Model if it doesn't exist.
+    /// Used to register the same WorkerSet under multiple model names (aliases).
+    ///
+    /// Logs a warning and skips if a *different* primary already owns this name —
+    /// this guards against operator misconfiguration where two unrelated models
+    /// declare a colliding alias. The first claim wins; the second is rejected.
+    pub fn add_worker_set_arc(
+        &self,
+        model_name: &str,
+        namespace: &str,
+        worker_set: Arc<WorkerSet>,
+    ) -> bool {
+        // Collision check: if `model_name` already exists as a primary (i.e.
+        // not currently mapped to anything in alias_to_primary, AND already
+        // has worker sets), refuse to clobber it.
+        if let Some(existing) = self.models.get(model_name) {
+            if !existing.is_empty()
+                && !self.alias_to_primary.contains_key(model_name)
+            {
+                tracing::warn!(
+                    alias = model_name,
+                    namespace,
+                    "Alias collides with a registered primary model — skipping. \
+                     Choose a different alias or rename the conflicting model."
+                );
+                return false;
+            }
+        }
+
+        let model = self.get_or_create_model(model_name);
+        model.add_worker_set(namespace.to_string(), worker_set);
+        true
+    }
+
+    /// Record that `alias` is an alternate name for `primary`. Used to normalize metrics labels.
+    ///
+    /// Logs a warning and refuses to overwrite if `alias` is already mapped to a
+    /// *different* primary. First-write-wins semantics so operators can detect
+    /// alias conflicts in logs rather than discovering them by silent metric
+    /// re-attribution.
+    pub fn register_alias(&self, alias: &str, primary: &str) -> bool {
+        if let Some(existing) = self.alias_to_primary.get(alias) {
+            if existing.value() != primary {
+                tracing::warn!(
+                    alias,
+                    new_primary = primary,
+                    existing_primary = existing.value().as_str(),
+                    "Alias is already claimed by a different primary — refusing to overwrite. \
+                     Existing claim wins."
+                );
+                return false;
+            }
+            // Same alias→same primary — idempotent, no-op.
+            return true;
+        }
+
+        if let Some(existing) = self.models.get(alias) {
+            if !existing.is_empty() {
+                tracing::warn!(
+                    alias,
+                    primary,
+                    "Alias collides with a registered primary model — refusing to register. \
+                     Choose a different alias or rename the conflicting model."
+                );
+                return false;
+            }
+        }
+        self.alias_to_primary
+            .insert(alias.to_string(), primary.to_string());
+        true
+    }
+
+    /// Remove a previously registered alias mapping once the alias has no WorkerSets.
+    pub fn unregister_alias_if_empty(&self, alias: &str, primary: &str) {
+        if self
+            .models
+            .get(alias)
+            .is_some_and(|model| !model.is_empty())
+        {
+            return;
+        }
+
+        self.alias_to_primary
+            .remove_if(alias, |_, existing| existing == primary);
+    }
+
+    /// Return the primary (canonical) model name for `model`, resolving aliases.
+    /// Returns `model` unchanged if it is not an alias.
+    pub fn resolve_canonical_name(&self, model: &str) -> String {
+        self.alias_to_primary
+            .get(model)
+            .map(|v| v.value().clone())
+            .unwrap_or_else(|| model.to_string())
     }
 
     /// Remove a WorkerSet from a Model. Removes the Model if it becomes empty.
@@ -1601,6 +1700,51 @@ mod tests {
 
         // Model should still exist (ns1 still there)
         assert!(mm.get_model("llama").is_some());
+    }
+
+    #[test]
+    fn test_alias_resolution_maps_to_primary() {
+        let mm = ModelManager::new();
+
+        assert!(mm.register_alias("llama-alias", "llama"));
+
+        assert_eq!(mm.resolve_canonical_name("llama-alias"), "llama");
+        assert_eq!(mm.resolve_canonical_name("llama"), "llama");
+    }
+
+    #[test]
+    fn test_register_alias_rejects_primary_collision() {
+        let mm = ModelManager::new();
+        mm.add_worker_set("llama-alias", "ns1", make_worker_set("ns1", "abc"));
+
+        assert!(!mm.register_alias("llama-alias", "llama"));
+
+        assert_eq!(mm.resolve_canonical_name("llama-alias"), "llama-alias");
+    }
+
+    #[test]
+    fn test_unregister_alias_if_empty_keeps_mapping_with_remaining_worker_sets() {
+        let mm = ModelManager::new();
+        assert!(mm.register_alias("llama-alias", "llama"));
+
+        assert!(mm.add_worker_set_arc(
+            "llama-alias",
+            "ns1",
+            Arc::new(make_worker_set("ns1", "abc")),
+        ));
+        assert!(mm.add_worker_set_arc(
+            "llama-alias",
+            "ns2",
+            Arc::new(make_worker_set("ns2", "abc")),
+        ));
+
+        mm.remove_worker_set("llama-alias", "ns1");
+        mm.unregister_alias_if_empty("llama-alias", "llama");
+        assert_eq!(mm.resolve_canonical_name("llama-alias"), "llama");
+
+        mm.remove_worker_set("llama-alias", "ns2");
+        mm.unregister_alias_if_empty("llama-alias", "llama");
+        assert_eq!(mm.resolve_canonical_name("llama-alias"), "llama-alias");
     }
 
     #[test]

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -336,6 +336,14 @@ impl ModelManager {
             .unwrap_or_else(|| model.to_string())
     }
 
+    /// Whether `alias` is currently reserved as an alias of `primary`. Teardown
+    /// uses this to clean up only the alias names a deployment actually owns.
+    pub fn alias_belongs_to(&self, alias: &str, primary: &str) -> bool {
+        self.alias_to_primary
+            .get(alias)
+            .is_some_and(|owner| owner.value() == primary)
+    }
+
     /// Remove a WorkerSet from a Model. Removes the Model if it becomes empty.
     pub fn remove_worker_set(&self, model_name: &str, namespace: &str) -> Option<Arc<WorkerSet>> {
         let model = self.models.get(model_name)?;
@@ -1794,6 +1802,23 @@ mod tests {
         let model = mm.get_model("shared").expect("alias model present");
         assert!(model.get_worker_set("ns1").is_some());
         assert!(model.get_worker_set("ns2").is_none());
+    }
+
+    #[test]
+    fn test_alias_belongs_to_identifies_owner() {
+        let mm = ModelManager::new();
+        assert!(mm.register_alias("chat", "llama"));
+
+        assert!(mm.alias_belongs_to("chat", "llama"));
+        // Not owned by a different primary, and a non-alias name is owned by nobody.
+        assert!(!mm.alias_belongs_to("chat", "other"));
+        assert!(!mm.alias_belongs_to("not-an-alias", "llama"));
+
+        // A live primary named "chat" (a different deployment) is not an alias of
+        // "llama" — so a "llama" teardown must not treat "chat" as its own.
+        let mm2 = ModelManager::new();
+        mm2.add_worker_set("chat", "ns1", make_worker_set("ns1", "abc"));
+        assert!(!mm2.alias_belongs_to("chat", "llama"));
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -599,6 +599,14 @@ impl ModelWatcher {
                     namespace = %worker_namespace,
                     "Removed WorkerSet (no remaining instances in namespace)"
                 );
+                // Also remove from alias models
+                for alias in &card.aliases {
+                    if alias != &model_name {
+                        self.manager.remove_worker_set(alias, &ws_key);
+                        self.manager.remove_model_if_empty(alias);
+                        self.manager.unregister_alias_if_empty(alias, &model_name);
+                    }
+                }
             }
 
             // Activator-state cleanup depends on which component just went away.
@@ -669,6 +677,13 @@ impl ModelWatcher {
 
         // No instances remain anywhere — remove the entire Model
         let _ = self.manager.remove_model(&model_name);
+        // Also remove alias models
+        for alias in &card.aliases {
+            if alias != &model_name {
+                let _ = self.manager.remove_model(alias);
+                self.manager.unregister_alias_if_empty(alias, &model_name);
+            }
+        }
 
         if let Some(tx) = &self.model_update_tx {
             for model_type in ALL_MODEL_TYPES {
@@ -1359,9 +1374,40 @@ impl ModelWatcher {
             );
         }
 
+        // Register alias→primary mappings BEFORE the engine becomes visible.
+        // Order matters: any request landing between engine-visible and
+        // alias-mapped would see correct routing but mis-labelled metrics
+        // (and an OpenAI response.model echoing the alias instead of the
+        // primary). Recording the mapping first closes that gap.
+        let mut registered_aliases = Vec::new();
+        for alias in &card.aliases {
+            if alias != card.name() {
+                if self.manager.register_alias(alias, card.name()) {
+                    registered_aliases.push(alias.clone());
+                }
+            }
+        }
+
         // Add the completed WorkerSet to the Model
         self.manager
             .add_worker_set(card.name(), &ws_key, worker_set);
+
+        // Register under aliases — share the same Arc<WorkerSet>
+        if !registered_aliases.is_empty() {
+            if let Some(model) = self.manager.get_model(card.name()) {
+                if let Some(ws_arc) = model.get_worker_set(&ws_key) {
+                    for alias in &registered_aliases {
+                        tracing::info!(
+                            model_name = card.name(),
+                            alias,
+                            "Registering model alias"
+                        );
+                        self.manager
+                            .add_worker_set_arc(alias, &ws_key, ws_arc.clone());
+                    }
+                }
+            }
+        }
 
         if let Some(tx) = &self.model_update_tx {
             tx.send(ModelUpdate::Added(card.clone())).await.ok();

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -955,6 +955,9 @@ impl ModelWatcher {
             // and go.
             self.manager
                 .add_worker_set(card.name(), &ws_key, worker_set);
+            // Mirror the prefill WorkerSet under any aliases so a disaggregated
+            // alias reports readiness like its primary (decode attaches its own).
+            self.attach_aliases(card, &ws_key);
 
             if let Some(tx) = &self.model_update_tx {
                 tx.send(ModelUpdate::Added(card.clone())).await.ok();
@@ -1374,46 +1377,72 @@ impl ModelWatcher {
             );
         }
 
-        // Register alias→primary mappings BEFORE the engine becomes visible.
-        // Order matters: any request landing between engine-visible and
-        // alias-mapped would see correct routing but mis-labelled metrics
-        // (and an OpenAI response.model echoing the alias instead of the
-        // primary). Recording the mapping first closes that gap.
-        let mut registered_aliases = Vec::new();
-        for alias in &card.aliases {
-            if alias != card.name() {
-                if self.manager.register_alias(alias, card.name()) {
-                    registered_aliases.push(alias.clone());
-                }
-            }
-        }
-
-        // Add the completed WorkerSet to the Model
+        // Add the completed WorkerSet to the Model, then mirror it under any
+        // configured aliases so alias names resolve, list, and report readiness
+        // exactly like the primary.
         self.manager
             .add_worker_set(card.name(), &ws_key, worker_set);
-
-        // Register under aliases — share the same Arc<WorkerSet>
-        if !registered_aliases.is_empty() {
-            if let Some(model) = self.manager.get_model(card.name()) {
-                if let Some(ws_arc) = model.get_worker_set(&ws_key) {
-                    for alias in &registered_aliases {
-                        tracing::info!(
-                            model_name = card.name(),
-                            alias,
-                            "Registering model alias"
-                        );
-                        self.manager
-                            .add_worker_set_arc(alias, &ws_key, ws_arc.clone());
-                    }
-                }
-            }
-        }
+        self.attach_aliases(card, &ws_key);
 
         if let Some(tx) = &self.model_update_tx {
             tx.send(ModelUpdate::Added(card.clone())).await.ok();
         }
 
         Ok(())
+    }
+
+    /// Register `card`'s aliases against its primary name and mirror the just-
+    /// added WorkerSet under each, so an alias resolves to the primary and lists
+    /// / reports readiness identically. Shared by the aggregated/decode and the
+    /// disaggregated prefill registration paths so a disaggregated alias gets
+    /// both the decode and prefill WorkerSets (the prefill worker registers on
+    /// its own early-return path and would otherwise skip alias attachment).
+    ///
+    /// `register_alias` reserves the name atomically (rejecting a collision with
+    /// a live primary or a different primary's alias); only a successful
+    /// reservation is followed by the WorkerSet attach. Because the reservation
+    /// already owns the name, the attach cannot lose a collision — the guarded
+    /// rollback is a defensive backstop for a would-be invariant violation, not
+    /// an expected path.
+    fn attach_aliases(&self, card: &ModelDeploymentCard, ws_key: &str) {
+        if card.aliases.is_empty() {
+            return;
+        }
+        let Some(model) = self.manager.get_model(card.name()) else {
+            tracing::warn!(
+                model_name = card.name(),
+                "Model missing right after registration; aliases not attached"
+            );
+            return;
+        };
+        let Some(ws_arc) = model.get_worker_set(ws_key) else {
+            tracing::warn!(
+                model_name = card.name(),
+                ws_key,
+                "WorkerSet missing right after registration; aliases not attached"
+            );
+            return;
+        };
+        for alias in &card.aliases {
+            if alias == card.name() {
+                continue;
+            }
+            if !self.manager.register_alias(alias, card.name()) {
+                continue;
+            }
+            tracing::info!(model_name = card.name(), alias, "Registering model alias");
+            if !self
+                .manager
+                .add_worker_set_arc(alias, ws_key, ws_arc.clone())
+            {
+                tracing::error!(
+                    model_name = card.name(),
+                    alias,
+                    "Alias reserved but WorkerSet attach was refused; rolling back the mapping"
+                );
+                self.manager.unregister_alias_if_empty(alias, card.name());
+            }
+        }
     }
 
     /// All the registered ModelDeploymentCard with the EndpointId they are attached to, one per instance

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -889,6 +889,20 @@ impl ModelWatcher {
         mcid: &ModelCardInstanceId,
         card: &mut ModelDeploymentCard,
     ) -> anyhow::Result<()> {
+        // Fast-fail before any expensive setup when the name is already reserved
+        // as another deployment's alias (`resolve_canonical_name` returns a
+        // different, canonical name only for a reserved alias). `add_worker_set`
+        // re-checks this atomically under `reservation_lock` and is the
+        // authoritative gate; rejecting here just avoids the config download,
+        // card save, and pipeline build for a name that cannot be claimed.
+        if self.manager.resolve_canonical_name(card.name()) != card.name() {
+            tracing::error!(
+                model_name = card.name(),
+                "Refusing to register: name is reserved as an alias of another deployment"
+            );
+            return Ok(());
+        }
+
         card.download_config(self.local_model_path.as_deref())
             .await?;
 
@@ -953,8 +967,17 @@ impl ModelWatcher {
             // No engine on the worker set — just lifecycle tracking so the
             // prefill router can be activated/deactivated as workers come
             // and go.
-            self.manager
-                .add_worker_set(card.name(), &ws_key, worker_set);
+            if !self
+                .manager
+                .add_worker_set(card.name(), &ws_key, worker_set)
+            {
+                tracing::error!(
+                    model_name = card.name(),
+                    "Refusing to register prefill worker: its name is reserved as an alias of \
+                     another deployment"
+                );
+                return Ok(());
+            }
             // Mirror the prefill WorkerSet under any aliases so a disaggregated
             // alias reports readiness like its primary (decode attaches its own).
             self.attach_aliases(card, &ws_key);
@@ -1380,8 +1403,16 @@ impl ModelWatcher {
         // Add the completed WorkerSet to the Model, then mirror it under any
         // configured aliases so alias names resolve, list, and report readiness
         // exactly like the primary.
-        self.manager
-            .add_worker_set(card.name(), &ws_key, worker_set);
+        if !self
+            .manager
+            .add_worker_set(card.name(), &ws_key, worker_set)
+        {
+            tracing::error!(
+                model_name = card.name(),
+                "Refusing to register model: its name is reserved as an alias of another deployment"
+            );
+            return Ok(());
+        }
         self.attach_aliases(card, &ws_key);
 
         if let Some(tx) = &self.model_update_tx {
@@ -1398,12 +1429,11 @@ impl ModelWatcher {
     /// both the decode and prefill WorkerSets (the prefill worker registers on
     /// its own early-return path and would otherwise skip alias attachment).
     ///
-    /// `register_alias` reserves the name atomically (rejecting a collision with
-    /// a live primary or a different primary's alias); only a successful
-    /// reservation is followed by the WorkerSet attach. Because the reservation
-    /// already owns the name, the attach cannot lose a collision — the guarded
-    /// rollback is a defensive backstop for a would-be invariant violation, not
-    /// an expected path.
+    /// `register_alias` atomically reserves the name (rejecting a collision with a
+    /// live primary or a different primary's alias); only a successful reservation
+    /// is followed by the WorkerSet attach. The reservation holds the name against
+    /// any concurrent primary claim, so the subsequent attach cannot be refused —
+    /// a refusal would indicate a broken invariant and is only logged.
     fn attach_aliases(&self, card: &ModelDeploymentCard, ws_key: &str) {
         if card.aliases.is_empty() {
             return;
@@ -1435,12 +1465,13 @@ impl ModelWatcher {
                 .manager
                 .add_worker_set_arc(alias, ws_key, ws_arc.clone())
             {
+                // Unreachable: register_alias reserved this name, so no concurrent
+                // primary can occupy it and the attach cannot be refused.
                 tracing::error!(
                     model_name = card.name(),
                     alias,
-                    "Alias reserved but WorkerSet attach was refused; rolling back the mapping"
+                    "Alias reserved but WorkerSet attach was refused — invariant violated"
                 );
-                self.manager.unregister_alias_if_empty(alias, card.name());
             }
         }
     }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -599,9 +599,10 @@ impl ModelWatcher {
                     namespace = %worker_namespace,
                     "Removed WorkerSet (no remaining instances in namespace)"
                 );
-                // Also remove from alias models
+                // Remove alias mirrors, but only ones this deployment owns — a
+                // declared alias that lost its reservation belongs to another model.
                 for alias in &card.aliases {
-                    if alias != &model_name {
+                    if alias != &model_name && self.manager.alias_belongs_to(alias, &model_name) {
                         self.manager.remove_worker_set(alias, &ws_key);
                         self.manager.remove_model_if_empty(alias);
                         self.manager.unregister_alias_if_empty(alias, &model_name);
@@ -677,9 +678,9 @@ impl ModelWatcher {
 
         // No instances remain anywhere — remove the entire Model
         let _ = self.manager.remove_model(&model_name);
-        // Also remove alias models
+        // Same ownership rule: only remove alias models this deployment owns.
         for alias in &card.aliases {
-            if alias != &model_name {
+            if alias != &model_name && self.manager.alias_belongs_to(alias, &model_name) {
                 let _ = self.manager.remove_model(alias);
                 self.manager.unregister_alias_if_empty(alias, &model_name);
             }

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -159,8 +159,13 @@ async fn handler_anthropic_messages(
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.stream;
     let resolved_model = resolve_request_model(&request.model, template.as_ref());
+    // Canonicalize alias → primary for the metric label (see anthropic_messages).
+    let canonical_model = state.manager().resolve_canonical_name(resolved_model);
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(resolved_model).to_string(),
+        model: state
+            .manager()
+            .metric_model_for(&canonical_model)
+            .to_string(),
         endpoint: Endpoint::AnthropicMessages.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -233,6 +238,14 @@ async fn anthropic_messages(
     // Strip Claude Code billing preamble from system prompt if enabled
     if state.strip_anthropic_preamble_enabled() {
         strip_billing_preamble(&mut request.system);
+    }
+
+    // Resolve an alias to its primary served name and rewrite the request so
+    // engine routing, metrics, and the response model all use the canonical
+    // primary (matching the OpenAI handlers). Non-aliases pass through.
+    let canonical = state.manager().resolve_canonical_name(&request.model);
+    if canonical != request.model {
+        request.model = canonical;
     }
 
     let model = request.model.clone();
@@ -595,12 +608,20 @@ fn model_env_overrides() -> (Option<u64>, Option<u64>) {
 }
 
 /// Resolve context_window for a model: env override takes precedence over MDC.
+/// Aliases have no card of their own (the map is keyed by the primary's
+/// display_name), so fall back to the primary's context length.
 fn resolve_context_window(
+    state: &service_v2::State,
     model_name: &str,
     card_map: &std::collections::HashMap<String, u32>,
     env_override: Option<u64>,
 ) -> Option<u64> {
-    env_override.or_else(|| card_map.get(model_name).map(|&cl| cl as u64))
+    env_override.or_else(|| {
+        card_map
+            .get(model_name)
+            .or_else(|| card_map.get(&state.manager().resolve_canonical_name(model_name)))
+            .map(|&cl| cl as u64)
+    })
 }
 
 /// List all models. Returns Anthropic format when `anthropic-version` header
@@ -636,7 +657,7 @@ async fn list_models(
                     "type": "model",
                     "created_at": created_at,
                 });
-                if let Some(cw) = resolve_context_window(name, &card_map, cw_override) {
+                if let Some(cw) = resolve_context_window(&state, name, &card_map, cw_override) {
                     obj["max_input_tokens"] = serde_json::json!(cw);
                 }
                 if let Some(mot) = mot_override {
@@ -668,7 +689,7 @@ async fn list_models(
                 "created": created,
                 "owned_by": "nvidia",
             });
-            if let Some(cw) = resolve_context_window(name, &card_map, cw_override) {
+            if let Some(cw) = resolve_context_window(&state, name, &card_map, cw_override) {
                 obj["context_window"] = serde_json::json!(cw);
             }
             if let Some(mot) = mot_override {
@@ -714,7 +735,7 @@ async fn get_model(
         .as_secs();
     let card_map = build_model_context_map(&state);
     let (cw_override, mot_override) = model_env_overrides();
-    let context_window = resolve_context_window(model_id, &card_map, cw_override);
+    let context_window = resolve_context_window(&state, model_id, &card_map, cw_override);
 
     if headers.contains_key("anthropic-version") {
         let created_at = chrono::DateTime::from_timestamp(created as i64, 0)

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -648,7 +648,10 @@ async fn handler_completions(
     // Canonicalize alias → primary for the metric label.
     let canonical_model = state.manager().resolve_canonical_name(&request.inner.model);
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(&canonical_model).to_string(),
+        model: state
+            .manager()
+            .metric_model_for(&canonical_model)
+            .to_string(),
         endpoint: Endpoint::Completions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -1273,7 +1276,10 @@ async fn handler_chat_completions(
     // Canonicalize alias → primary for the metric label.
     let canonical_model = state.manager().resolve_canonical_name(resolved_model);
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(&canonical_model).to_string(),
+        model: state
+            .manager()
+            .metric_model_for(&canonical_model)
+            .to_string(),
         endpoint: Endpoint::ChatCompletions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -2188,7 +2194,10 @@ async fn handler_responses(
     // Canonicalize alias → primary for the metric label.
     let canonical_model = state.manager().resolve_canonical_name(resolved_model);
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(&canonical_model).to_string(),
+        model: state
+            .manager()
+            .metric_model_for(&canonical_model)
+            .to_string(),
         endpoint: Endpoint::Responses.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -2833,10 +2842,14 @@ fn get_model_retrieve(
         .unwrap()
         .as_secs();
 
+    // Alias entries have no card of their own (cards are keyed by the primary's
+    // display_name); fall back to the primary so an alias reports the same
+    // context_window that `GET /v1/models` lists for it.
+    let canonical_model = state.manager().resolve_canonical_name(model_id);
     let cards = state.manager().get_model_cards();
     let context_length = cards
         .iter()
-        .find(|c| c.display_name == model_id)
+        .find(|c| c.display_name == model_id || c.display_name == canonical_model)
         .map(|c| c.effective_context_length() as u64);
     let context_window: Option<u64> = std::env::var("DYN_CONTEXT_WINDOW")
         .ok()

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -645,11 +645,10 @@ async fn handler_completions(
     // create the context for the request
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
+    // Canonicalize alias → primary for the metric label.
+    let canonical_model = state.manager().resolve_canonical_name(&request.inner.model);
     let cancellation_labels = CancellationLabels {
-        model: state
-            .manager()
-            .metric_model_for(&request.inner.model)
-            .to_string(),
+        model: state.manager().metric_model_for(&canonical_model).to_string(),
         endpoint: Endpoint::Completions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -715,7 +714,7 @@ async fn completions(
 #[tracing::instrument(skip_all)]
 async fn completions_single(
     state: Arc<service_v2::State>,
-    request: Context<NvCreateCompletionRequest>,
+    mut request: Context<NvCreateCompletionRequest>,
     stream_handle: ConnectionHandle,
 ) -> Result<Response, ErrorResponse> {
     let request_id = request.id().to_string();
@@ -725,6 +724,15 @@ async fn completions_single(
 
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
+    // Resolve an alias to its primary served name and rewrite the request so
+    // engine routing, metrics, and the OpenAI response.model all use the
+    // canonical primary (matching vLLM/SGLang, where an alias request still
+    // responds with the primary served name). Non-aliases pass through, so
+    // metric_model_for still applies its unknown-model cardinality guard.
+    let canonical = state.manager().resolve_canonical_name(&request.inner.model);
+    if canonical != request.inner.model {
+        request.inner.model = canonical;
+    }
     let model = request.inner.model.clone();
     let metric_model = state.manager().metric_model_for(&model).to_string();
 
@@ -866,7 +874,7 @@ async fn completions_single(
 #[tracing::instrument(skip_all)]
 async fn completions_batch(
     state: Arc<service_v2::State>,
-    request: Context<NvCreateCompletionRequest>,
+    mut request: Context<NvCreateCompletionRequest>,
     stream_handle: ConnectionHandle,
     batch_size: usize,
     n: u8,
@@ -876,6 +884,11 @@ async fn completions_batch(
 
     let request_id = request.id().to_string();
     let streaming = request.inner.stream.unwrap_or(false);
+    // Resolve alias → primary served name (see completions_single).
+    let canonical = state.manager().resolve_canonical_name(&request.inner.model);
+    if canonical != request.inner.model {
+        request.inner.model = canonical;
+    }
     let model = request.inner.model.clone();
     let metric_model = state.manager().metric_model_for(&model).to_string();
 
@@ -1071,6 +1084,13 @@ async fn embeddings(
         request.nvext = None;
     }
 
+    // Resolve alias → primary served name before wrapping the request, so
+    // engine routing, metrics, and the response model all use the canonical
+    // primary (see completions_single). `request` is still owned + mutable here.
+    let canonical = state.manager().resolve_canonical_name(&request.inner.model);
+    if canonical != request.inner.model {
+        request.inner.model = canonical;
+    }
     let request_id = get_or_create_request_id(&headers);
     let request = context_from_headers(request, request_id, &headers)?;
     let request_id = request.id().to_string();
@@ -1250,8 +1270,10 @@ async fn handler_chat_completions(
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
     let resolved_model = resolve_request_model(&request.inner.model, template.as_ref());
+    // Canonicalize alias → primary for the metric label.
+    let canonical_model = state.manager().resolve_canonical_name(resolved_model);
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(resolved_model).to_string(),
+        model: state.manager().metric_model_for(&canonical_model).to_string(),
         endpoint: Endpoint::ChatCompletions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -1775,6 +1797,14 @@ async fn chat_completions(
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
     // todo - determine the proper error code for when a request model is not present
+    // Resolve an alias to its primary served name and rewrite the request so
+    // engine routing, metrics, and the OpenAI response.model all use the
+    // canonical primary (matching vLLM/SGLang). Non-aliases pass through so
+    // metric_model_for still applies its unknown-model cardinality guard.
+    let canonical = state.manager().resolve_canonical_name(&request.inner.model);
+    if canonical != request.inner.model {
+        request.inner.model = canonical;
+    }
     let model = request.inner.model.clone();
     let metric_model = state.manager().metric_model_for(&model).to_string();
 
@@ -2155,8 +2185,10 @@ async fn handler_responses(
     let streaming = request.inner.stream.unwrap_or(false);
     let raw_model = request.inner.model.as_deref().unwrap_or("");
     let resolved_model = resolve_request_model(raw_model, template.as_ref());
+    // Canonicalize alias → primary for the metric label.
+    let canonical_model = state.manager().resolve_canonical_name(resolved_model);
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(resolved_model).to_string(),
+        model: state.manager().metric_model_for(&canonical_model).to_string(),
         endpoint: Endpoint::Responses.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -2215,7 +2247,16 @@ async fn responses(
     }
     tracing::trace!("Received responses request: {:?}", request.inner);
 
-    let model = request.inner.model.clone().unwrap_or_default();
+    // Resolve an alias to its primary served name and rewrite the request so
+    // engine routing, metrics, and the response model all use the canonical
+    // primary. The Responses API wraps model in Option<String>, so re-wrap
+    // after resolution. Non-aliases pass through metric_model_for's guard.
+    let original_model = request.inner.model.clone().unwrap_or_default();
+    let canonical = state.manager().resolve_canonical_name(&original_model);
+    if canonical != original_model {
+        request.inner.model = Some(canonical.clone());
+    }
+    let model = canonical;
     let streaming = request.inner.stream.unwrap_or(false);
     let metric_model = state.manager().metric_model_for(&model).to_string();
 
@@ -2618,7 +2659,14 @@ async fn list_models_openai(
     // is hidden until a peer joins.
     let models: HashSet<String> = state.manager().serving_ready_display_names();
     for model_name in models {
-        let context_window = cw_override.or_else(|| card_map.get(&model_name).map(|&cl| cl as u64));
+        // Alias entries have no card of their own (keyed by the primary's
+        // display_name); fall back to the primary's context length.
+        let context_window = cw_override.or_else(|| {
+            card_map
+                .get(&model_name)
+                .or_else(|| card_map.get(&state.manager().resolve_canonical_name(&model_name)))
+                .map(|&cl| cl as u64)
+        });
         data.push(ModelListing {
             id: model_name.clone(),
             object: "model",

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -58,6 +58,7 @@ pub struct LocalModelBuilder {
     model_path: Option<PathBuf>,
     source_path: Option<PathBuf>,
     model_name: Option<String>,
+    model_aliases: Vec<String>,
     endpoint_id: Option<EndpointId>,
     template_file: Option<PathBuf>,
     router_config: Option<RouterConfig>,
@@ -97,6 +98,7 @@ impl Default for LocalModelBuilder {
             model_path: Default::default(),
             source_path: Default::default(),
             model_name: Default::default(),
+            model_aliases: Default::default(),
             endpoint_id: Default::default(),
             template_file: Default::default(),
             router_config: Default::default(),
@@ -133,6 +135,11 @@ impl LocalModelBuilder {
 
     pub fn model_name(&mut self, model_name: Option<String>) -> &mut Self {
         self.model_name = model_name;
+        self
+    }
+
+    pub fn model_aliases(&mut self, aliases: Vec<String>) -> &mut Self {
+        self.model_aliases = aliases;
         self
     }
 
@@ -391,6 +398,9 @@ impl LocalModelBuilder {
         card.media_decoder = self.media_decoder.clone();
         card.media_fetcher = self.media_fetcher.clone();
         card.router_config = self.router_config.clone();
+        if !self.model_aliases.is_empty() {
+            card.set_aliases(self.model_aliases.clone());
+        }
 
         Ok(LocalModel {
             card,

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -345,6 +345,9 @@ impl LocalModelBuilder {
             card.media_decoder = self.media_decoder.clone();
             card.media_fetcher = self.media_fetcher.clone();
             card.router_config = self.router_config.clone();
+            if !self.model_aliases.is_empty() {
+                card.set_aliases(self.model_aliases.clone());
+            }
 
             return Ok(LocalModel {
                 card,

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -794,6 +794,11 @@ pub struct ModelDeploymentCard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lora: Option<LoraInfo>,
 
+    /// Additional names this model responds to (aliases).
+    /// Requests using any of these names will be routed to this worker.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+
     /// User-defined metadata for custom worker behavior
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_data: Option<serde_json::Value>,
@@ -1012,6 +1017,11 @@ impl ModelDeploymentCard {
                     bytes_to_hash.extend(blake3::hash(&bytes).as_bytes());
                 }
 
+                // Aliases are deliberately excluded from the checksum: they are
+                // frontend name mappings that don't affect the serving pipeline,
+                // so a worker that only changes its alias list stays compatible
+                // (watcher.rs::handle_put) instead of forcing a full drain.
+
                 // TODO: Do we want any of user_data or runtime_config?
 
                 blake3::hash(&bytes_to_hash).to_string()
@@ -1214,6 +1224,11 @@ impl ModelDeploymentCard {
 
     pub fn source_path(&self) -> &str {
         self.source_path.as_ref().unwrap_or(&self.display_name)
+    }
+
+    /// Set additional names (aliases) this model responds to.
+    pub fn set_aliases(&mut self, aliases: Vec<String>) {
+        self.aliases = aliases;
     }
 
     /// Build an in-memory ModelDeploymentCard from a folder containing config.json,
@@ -1560,6 +1575,7 @@ impl ModelDeploymentCard {
             worker_type: Default::default(), // set later
             needs: Default::default(),       // set later
             lora: None,
+            aliases: Vec::new(),
             user_data: None,
             runtime_config: ModelRuntimeConfig::default(),
             tensor_model_config: None,

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -1017,10 +1017,24 @@ impl ModelDeploymentCard {
                     bytes_to_hash.extend(blake3::hash(&bytes).as_bytes());
                 }
 
-                // Aliases are deliberately excluded from the checksum: they are
-                // frontend name mappings that don't affect the serving pipeline,
-                // so a worker that only changes its alias list stays compatible
-                // (watcher.rs::handle_put) instead of forcing a full drain.
+                // Aliases participate in the checksum. Every worker in a
+                // deployment carries the same static --served-model-name list,
+                // so their checksums still match and they share one WorkerSet;
+                // changing the alias list rolls a new WorkerSet (consistent per
+                // set) rather than mutating a live one in place. `aliases` holds
+                // only the alternate names (the primary is `display_name`, hashed
+                // above), so order within the list still matters — hash in order.
+                // Skipped entirely when empty so a card without aliases keeps the
+                // same checksum as before this field existed (no spurious
+                // WorkerSet split on upgrade); this is the last hashed field, so
+                // omission is unambiguous.
+                if !self.aliases.is_empty() {
+                    bytes_to_hash.extend((self.aliases.len() as u32).to_be_bytes());
+                    for alias in &self.aliases {
+                        bytes_to_hash.extend((alias.len() as u32).to_be_bytes());
+                        bytes_to_hash.extend(alias.as_bytes());
+                    }
+                }
 
                 // TODO: Do we want any of user_data or runtime_config?
 


### PR DESCRIPTION
## Overview:

Support advertising a model under multiple served names, for the **SGLang** backend. A worker may pass several names via `--served-model-name` (whitespace- or comma-separated). The first is the primary served name; the rest become aliases. The same WorkerSet is registered under every name, and requests for any alias are canonicalized to the primary at the HTTP entrypoint so engine routing, Prometheus metrics, and the OpenAI `response.model` stay consistent.

This PR adds the shared alias core (ModelManager, watcher, HTTP, model card) plus the SGLang wiring. vLLM and TRT-LLM support follow in separate, independent PRs that build on this core.

## Details:

- **Rust core**: `ModelDeploymentCard.aliases`; `ModelManager` `alias_to_primary` map with `register_alias` / `unregister_alias_if_empty` / `resolve_canonical_name` + collision guards; watcher registers aliases before the engine is visible and tears them down when empty. Aliases are excluded from the MDC checksum so an alias-only change doesn't force a worker drain.
- **HTTP**: resolve alias → primary in every handler (composed with the existing `metric_model_for()` unknown-model cardinality guard) and canonicalize the cancellation-metric label; `/v1/models` reports the primary's `context_window` for alias entries.
- **Binding**: `register_model` gains an optional `model_aliases` argument.
- **SGLang**: split a packed `--served-model-name` into primary + aliases via a shared `split_served_model_names` helper, plumbed through `register_model`.

Unit tests added for `ModelManager` (Rust) and SGLang arg parsing (Python).

## Where should the reviewer start?

- `lib/llm/src/discovery/model_manager.rs` — the alias map + collision guards.
- `lib/llm/src/discovery/watcher.rs` — alias registration/teardown ordering.
- `lib/llm/src/http/service/openai.rs` — canonicalization + metric labels + `/v1/models`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple model aliases when registering a served model name.
  * Model requests and listings now recognize aliases and route to the canonical model name.

* **Bug Fixes**
  * Improved consistency so completions, chat, responses, embeddings, and model listings use the same primary model name for routing and metrics.
  * Alias entries are now handled safely when models are removed or updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->