### PR TITLE
fix(runtime): wrap OTLP exporter construction in tokio runtime context

### DIFF
--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -287,6 +287,25 @@ fn build_log_exporter(
     }
 }
 
+fn with_runtime_context<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    match tokio::runtime::Handle::try_current() {
+        Ok(_) => f(),
+        Err(_) => {
+            let return_value = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect(
+                    "Failed to create temporary Tokio runtime for OTLP exporter initialization",
+                );
+            let _guard = return_value.enter();
+            f()
+        }
+    }
+}
+
 /// Validate a given trace ID according to W3C Trace Context specifications.
 /// A valid trace ID is a 32-character hexadecimal string (lowercase).
 pub fn is_valid_trace_id(trace_id: &str) -> bool {
@@ -1293,7 +1312,8 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
                 .with_service_name(service_name.clone())
                 .build();
 
-            let span_exporter = build_span_exporter(traces_protocol, &traces_endpoint)?;
+            let span_exporter =
+                with_runtime_context(|| build_span_exporter(traces_protocol, &traces_endpoint))?;
 
             let mut tracer_provider_builder =
                 opentelemetry_sdk::trace::SdkTracerProvider::builder()
@@ -1306,7 +1326,8 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
             }
             let tracer_provider = tracer_provider_builder.build();
 
-            let log_exporter = build_log_exporter(logs_protocol, &logs_endpoint)?;
+            let log_exporter =
+                with_runtime_context(|| build_log_exporter(logs_protocol, &logs_endpoint))?;
 
             let logger_provider = SdkLoggerProvider::builder()
                 .with_batch_exporter(log_exporter)
@@ -1973,6 +1994,54 @@ pub mod tests {
             result.push(val);
         }
         Ok(result)
+    }
+
+    #[test] // plain - no Tokio runtime
+    fn with_runtime_context_returns_value_without_existing_runtime() {
+        // Precondition: confirm no runtime is running
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "precondition: test must run outside a Tokio runtime"
+        );
+        let result = with_runtime_context(|| 42u32);
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn with_runtime_context_returns_value_within_existing_runtime() {
+        // Precondition: runtime IS running
+        assert!(tokio::runtime::Handle::try_current().is_ok());
+        let result = with_runtime_context(|| 42u32);
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn grpc_span_exporter_builds_without_tokio_reactor() {
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "precondition: test must run outside a Tokio runtime"
+        );
+        // This panics before the fix: "there is no reactor running"
+        let result = with_runtime_context(|| {
+            build_span_exporter(OtlpProtocol::Grpc, "http://localhost:4317")
+        });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn grpc_log_exporter_builds_without_tokio_reactor() {
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "precondition: test must run outside a Tokio runtime"
+        );
+        let result = with_runtime_context(|| {
+            build_log_exporter(OtlpProtocol::Grpc, "http://localhost:4317")
+        });
+        assert!(
+            result.is_ok(),
+            "log exporter must build without a pre-existing Tokio
+    reactor"
+        );
     }
 
     // Field validators (W3C Trace Context): each rule is tested directly here.


### PR DESCRIPTION
## Overview:

Fixes a panic that occurs when `logging::init()` is called from a synchronous entrypoint (plain `fn main()`) before a Tokio runtime exists, with `OTEL_EXPORT_ENABLED=1`. The gRPC/tonic OTLP exporter construction internally requires an active Tokio reactor, which doesn't exist yet at that point.

## Details:

Adds a `with_runtime_context` helper in `lib/runtime/src/logging.rs` that checks whether a Tokio runtime is already running. If one exists, it calls the closure directly (no overhead). If not, it creates a temporary single-threaded runtime just long enough to construct the OTLP exporters, then drops it.

The two exporter construction calls in `setup_logging()` (`build_span_exporter` and `build_log_exporter`) are now wrapped with this helper. This fixes all four config combinations (`JSONL=0/1 × OTEL=0/1`) at the single construction site, and makes the per-entrypoint deferral workaround in`lib/bindings/python/rust/lib.rs` redundant.

Tests are added to verify:
  - `with_runtime_context_returns_value_without_existing_runtime` executes correctly without a running reactor
  - `with_runtime_context_returns_value_within_existing_runtime` executes correctly within an existing reactor
  - gRPC span and log exporters build successfully without a pre-existing reactor

## Where should the reviewer start?

`lib/runtime/src/logging.rs` - specifically the new function `with_runtime_context` and its two call sites in `setup_logging()`

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #11077 

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging setup so OTLP span and log exporters work reliably even when no Tokio runtime is already running.
  * Reduced startup failures in runtime-dependent export paths by ensuring the needed runtime context is available automatically.
  * Expanded test coverage for exporter setup in both runtime and non-runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->