### PR TITLE
fix(runtime): wrap OTLP exporter construction in tokio runtime context

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -24,7 +24,6 @@ use tokio::sync::Mutex;
 use tracing::Instrument;
 
 use dynamo_runtime::config;
-use dynamo_runtime::config::environment_names::logging::otlp as env_otlp;
 use dynamo_runtime::{
     self as rs, logging,
     pipeline::{
@@ -156,12 +155,9 @@ fn create_request_context(
 /// import the module.
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // Initialize logging early unless OTEL export is enabled (which requires tokio runtime)
-    if config::env_is_truthy(env_otlp::OTEL_EXPORT_ENABLED) {
-        eprintln!(
-            "Warning: OTEL_EXPORT_ENABLED detected. Logging initialization deferred until runtime is available. Early logs may be dropped."
-        );
-    } else if std::env::var_os(SKIP_PYTHON_LOG_INIT_ENV).is_none() {
+    // OTLP export no longer requires a pre-existing runtime
+    // so init unconditionally at import
+    if std::env::var_os(SKIP_PYTHON_LOG_INIT_ENV).is_none() {
         rs::logging::init();
     }
 
@@ -1034,14 +1030,6 @@ impl DistributedRuntime {
                 Ok(worker.runtime().clone())
             })
             .map_err(to_pyerr)?;
-
-        // Initialize logging in context where tokio runtime is available
-        // otel exporter requires it
-        if config::env_is_truthy(env_otlp::OTEL_EXPORT_ENABLED) {
-            runtime.secondary().block_on(async {
-                rs::logging::init();
-            });
-        }
 
         let nats_enabled = request_plane.is_nats()
             || matches!(

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -258,10 +258,10 @@ fn trace_sample_ratio_from_env() -> Option<f64> {
 }
 
 fn otel_runtime_handle() -> std::io::Result<tokio::runtime::Handle> {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        return Ok(handle);
-    }
-
+    // Keep our own long-lived runtime for the exporter. Using the ambient one
+    // (Handle::try_current) pins the exporter to whatever runtime is live at init,
+    // since INIT (Once) runs setup once. If that's a #[tokio::test] runtime, export
+    // silently dies when it drops.
     static OTEL_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
     if let Some(rt) = OTEL_RUNTIME.get() {
         return Ok(rt.handle().clone());
@@ -272,8 +272,7 @@ fn otel_runtime_handle() -> std::io::Result<tokio::runtime::Handle> {
         .thread_name("dynamo-otel-export")
         .enable_all()
         .build()?;
-    let _ = OTEL_RUNTIME.set(rt);
-    Ok(OTEL_RUNTIME.get().expect("set above").handle().clone())
+    Ok(OTEL_RUNTIME.get_or_init(|| rt).handle().clone())
 }
 
 fn build_span_exporter(
@@ -1254,7 +1253,8 @@ pub fn get_distributed_tracing_context() -> Option<DistributedTraceContext> {
         })
 }
 
-/// Initialize the logger - must be called when Tokio runtime is available
+/// Initialize logging (idempotent). Safe to call with or without a running
+/// Tokio runtime — OTLP exporters fall back to a persistent background runtime.
 pub fn init() {
     INIT.call_once(|| {
         if let Err(e) = setup_logging() {
@@ -1300,7 +1300,7 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
         let sample_ratio = trace_sample_ratio_from_env();
 
         // Build tracer and logger providers - with or without OTLP export
-        let (tracer_provider, logger_provider_opt, endpoint_opt) = if otlp_exporter_enabled() {
+        let (tracer_provider, logger_provider_opt, endpoint_opt) = if otlp_enabled {
             // Building the OTLP exporters spawns a background flush task, so it needs a
             // live, persistent reactor
             let otel_handle = otel_runtime_handle()?;
@@ -2884,6 +2884,12 @@ pub mod tests {
                 .env("OTEL_EXPORT_ENABLED", "1")
                 .env("DYN_LOGGING_JSONL", jsonl)
                 .env("OTEL_EXPORTER_OTLP_ENDPOINT", format!("http://{addr}"))
+                // Don't let host-inherited per-signal overrides redirect an exporter
+                // away from our listener or change its protocol.
+                .env_remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+                .env_remove("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
+                .env_remove("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
+                .env_remove("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL")
                 .env("OTEL_BSP_SCHEDULE_DELAY", "100") // flush fast (ms) so it connects promptly
                 .output()
                 .expect("failed to run subprocess");
@@ -2921,9 +2927,13 @@ pub mod tests {
 
         init(); // real global init → setup_logging → otel_runtime_handle
 
-        // Emit real span + log data so both exporters have something to flush.
-        let _span = tracing::info_span!("otlp_sync_smoke").entered();
-        tracing::info!("otlp sync-init smoke log");
+        // Emit real span + log data. Close the span (drop the guard) BEFORE the
+        // wait below: a span is only exported when it ends, so an open span would
+        // leave the batch trace exporter with nothing to flush in the window.
+        {
+            let _span = tracing::info_span!("otlp_sync_smoke").entered();
+            tracing::info!("otlp sync-init smoke log");
+        }
 
         // Give the batch exporter's scheduled flush time to fire and connect.
         std::thread::sleep(std::time::Duration::from_secs(2));

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -27,7 +27,7 @@
 //! ```
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::Once;
+use std::sync::{Once, OnceLock};
 
 use figment::{
     Figment,
@@ -255,6 +255,25 @@ fn trace_sample_ratio_from_env() -> Option<f64> {
             .ok()
             .as_deref(),
     )
+}
+
+fn otel_runtime_handle() -> std::io::Result<tokio::runtime::Handle> {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        return Ok(handle);
+    }
+
+    static OTEL_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    if let Some(rt) = OTEL_RUNTIME.get() {
+        return Ok(rt.handle().clone());
+    }
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .thread_name("dynamo-otel-export")
+        .enable_all()
+        .build()?;
+    let _ = OTEL_RUNTIME.set(rt);
+    Ok(OTEL_RUNTIME.get().expect("set above").handle().clone())
 }
 
 fn build_span_exporter(
@@ -1281,8 +1300,11 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
         let sample_ratio = trace_sample_ratio_from_env();
 
         // Build tracer and logger providers - with or without OTLP export
-        let (tracer_provider, logger_provider_opt, endpoint_opt) = if otlp_enabled {
-            // Export enabled: create OTLP exporters with batch processors
+        let (tracer_provider, logger_provider_opt, endpoint_opt) = if otlp_exporter_enabled() {
+            // Building the OTLP exporters spawns a background flush task, so it needs a
+            // live, persistent reactor
+            let otel_handle = otel_runtime_handle()?;
+            let _otel_reactor_guard = otel_handle.enter();
             let protocol = otlp_protocol_from_env();
             let traces_protocol = resolve_signal_otlp_protocol(
                 protocol,
@@ -2826,6 +2848,85 @@ pub mod tests {
 
         init();
         tracing::info!("readable log with OTLP export");
+    }
+
+    #[test]
+    fn otlp_sync_init_connects_without_ambient_runtime() {
+        use std::process::Command;
+        use std::time::Duration;
+
+        // Both settings — JSONL=1 + OTEL=1 is the combo that used to panic.
+        for jsonl in ["0", "1"] {
+            // (a) Parent owns a TCP listener; the child's exporter must connect to it.
+            //     Port 0 = "OS, pick any free port", then read back which one.
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+            let addr = listener.local_addr().expect("get local addr");
+
+            // (b) Accept ONE connection on a helper thread; tell us via a channel.
+            let (tx, rx) = std::sync::mpsc::channel();
+            let accept = std::thread::spawn(move || {
+                if listener.accept().is_ok() {
+                    let _ = tx.send(()); // signal "a connection arrived"
+                }
+            });
+
+            // (c) Re-run as a fresh subprocess, running ONLY the child test.
+            let output = Command::new("cargo")
+                .args([
+                    "test",
+                    "-p",
+                    "dynamo-runtime",
+                    "logging::tests::otlp_sync_init_connects_subprocess",
+                    "--",
+                    "--exact",
+                    "--nocapture",
+                ])
+                .env("OTEL_EXPORT_ENABLED", "1")
+                .env("DYN_LOGGING_JSONL", jsonl)
+                .env("OTEL_EXPORTER_OTLP_ENDPOINT", format!("http://{addr}"))
+                .env("OTEL_BSP_SCHEDULE_DELAY", "100") // flush fast (ms) so it connects promptly
+                .output()
+                .expect("failed to run subprocess");
+
+            // (d) it must NOT panic, for both JSONL modes.
+            assert!(
+                output.status.success(),
+                "sync init subprocess (JSONL={jsonl}) failed:\n{}",
+                String::from_utf8_lossy(&output.stderr),
+            );
+
+            // (e) The real proof: the exporter actually connected → the persistent
+            //     runtime is alive and DRIVEN.
+            rx.recv_timeout(Duration::from_secs(10))
+                .unwrap_or_else(|_| {
+                    panic!("exporter never connected (JSONL={jsonl}); export runtime not driven")
+                });
+
+            let _ = accept.join(); // let the helper thread finish
+        }
+    }
+
+    #[test]
+    fn otlp_sync_init_connects_subprocess() {
+        // When run by a normal `cargo test`, OTEL_EXPORT_ENABLED isn't set → do nothing.
+        // The parent sets it, so only then do we run the real body.
+        if std::env::var("OTEL_EXPORT_ENABLED").is_err() {
+            return;
+        }
+
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "subprocess must run with no ambient Tokio runtime",
+        );
+
+        init(); // real global init → setup_logging → otel_runtime_handle
+
+        // Emit real span + log data so both exporters have something to flush.
+        let _span = tracing::info_span!("otlp_sync_smoke").entered();
+        tracing::info!("otlp sync-init smoke log");
+
+        // Give the batch exporter's scheduled flush time to fire and connect.
+        std::thread::sleep(std::time::Duration::from_secs(2));
     }
 
     // Test functions at different log levels for filtering tests


### PR DESCRIPTION
## Overview:

Fixes a panic when `logging::init()` is called from a synchronous entrypoint (a plain `fn main()`) before a Tokio runtime exists, with `OTEL_EXPORT_ENABLED=1`. Constructing the gRPC/tonic OTLP exporters — and spawning their batch flush tasks — needs an active Tokio reactor, which isn't present yet, so init panics with "there is no reactor running".

## Details:

`setup_logging()` now builds the OTLP exporters through a new `otel_runtime_handle()` helper at the single construction site. It returns the handle of a persistent, multi-threaded runtime created once in a `static OnceLock` and kept alive for the whole process. `setup_logging()` enters that runtime before constructing the exporters, so tonic's channel worker (spawned at construction) and the batch flush tasks are owned by a runtime that stays driven and is never dropped.

The helper deliberately does **not** reuse an ambient runtime via `Handle::try_current()`. Since init runs once (`INIT: Once`), reusing whichever runtime happened to be live would pin the exporter to it for the entire process — and if that runtime is short-lived (e.g. a `#[tokio::test]` reactor dropped on return), export then dies silently: no panic, `init()` still reports success. Owning a dedicated runtime avoids that.

The runtime `build()` error is propagated with `?` (no `expect` in the init path). This covers all four `JSONL=0/1 × OTEL=0/1` combinations at one place.

Because construction no longer requires an ambient reactor, the per-entrypoint deferral in `lib/bindings/python/rust/lib.rs` is removed — both the deferred init at module import and the `block_on(logging::init())` in `DistributedRuntime`. The stale `init()` doc comment (which claimed a Tokio runtime must already be available) is updated to match.

Testing: `otlp_sync_init_connects_without_ambient_runtime` runs the real `logging::init()` in a subprocess with no ambient runtime under both `DYN_LOGGING_JSONL=0` and `1` (JSONL=1 + OTEL=1 previously panicked), emits a span and a log, and asserts the exporter opens a connection. Verified it fails with `exporter never connected` if the runtime is reverted to an undriven current-thread runtime (the original bug), so it's a real regression guard.

## Where should the reviewer start?

`lib/runtime/src/logging.rs` — specifically the new `otel_runtime_handle()` and its use in `setup_logging()`.

## Related Issues

- Closes #11077
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging setup so OTLP exporters can initialize even when the app starts outside an existing Tokio runtime.
  * Made trace and log export initialization more reliable in JSONL logging configurations.
  * Added coverage for runtime-aware exporter setup in both standalone and in-runtime scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

