### PR TITLE
docs: fix zh-CN switcher rendering on the docs site

### DIFF
--- a/docs/components/kvbm/README.md
+++ b/docs/components/kvbm/README.md
@@ -5,9 +5,7 @@ title: KVBM
 subtitle: Unified memory layer and write-through KV cache spanning GPU, host, SSD, and remote storage via NIXL for TensorRT-LLM and vLLM.
 ---
 
-<p align="left">
-  <a href="./README.zh-CN.md" hreflang="zh-CN"><img src="../../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./README.zh-CN.md)
 
 The Dynamo KV Block Manager (KVBM) is a scalable runtime component designed to handle memory allocation, management, and remote sharing of Key-Value (KV) blocks for inference tasks across heterogeneous and distributed environments. It acts as a unified memory layer and write-through cache for frameworks like vLLM and TensorRT-LLM.
 

--- a/docs/components/planner/planner-guide.md
+++ b/docs/components/planner/planner-guide.md
@@ -5,9 +5,7 @@ title: Planner Guide
 subtitle: Configures Planner optimization targets, scaling modes, and PlannerConfig fields for production deployments.
 ---
 
-<p align="left">
-  <a href="./planner-guide.zh-CN.md" hreflang="zh-CN"><img src="../../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./planner-guide.zh-CN.md)
 
 The Dynamo Planner is an autoscaling controller that adjusts prefill and decode engine replica counts at runtime to meet latency SLAs. It reads traffic signals (Prometheus metrics or load predictor output) and engine performance models to decide when to scale up or down.
 

--- a/docs/components/router/README.md
+++ b/docs/components/router/README.md
@@ -5,9 +5,7 @@ title: Router
 subtitle: KV cache-aware router that picks workers by combined prefill and decode cost to maximize throughput and minimize latency.
 ---
 
-<p align="left">
-  <a href="./README.zh-CN.md" hreflang="zh-CN"><img src="../../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./README.zh-CN.md)
 
 The Dynamo KV Router intelligently routes requests by evaluating their computational costs across different workers. It considers both decoding costs (from active blocks) and prefill costs (from newly computed blocks), using KV cache overlap to minimize redundant computation. Optimizing the KV Router is critical for achieving maximum throughput and minimum latency in distributed inference setups.
 

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -6,9 +6,7 @@ subtitle: How to contribute to Dynamo
 max-toc-depth: 3
 ---
 
-<p align="left">
-  <a href="./contribution-guide.zh-CN.md" hreflang="zh-CN"><img src="./assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./contribution-guide.zh-CN.md)
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/main/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 

--- a/docs/contribution-guide.zh-CN.md
+++ b/docs/contribution-guide.zh-CN.md
@@ -10,8 +10,6 @@ max-toc-depth: 3
   <a href="./contribution-guide.md" hreflang="en">English</a> | <strong>简体中文</strong>
 </p>
 
-# 贡献指南
-
 Dynamo 是一个开源分布式推理平台，由不断壮大的贡献者社区共同构建。该项目采用 [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/main/LICENSE) 许可证，欢迎各种规模的贡献 -- 从修正错别字到开发重要功能都包括在内。社区贡献已经塑造了 Dynamo 的核心领域，包括后端集成、文档、部署工具和性能改进。
 
 Dynamo 拥有 200 多位外部贡献者、220 多个已合并的社区 PR，并且每月都有新贡献者加入，是增长最快的开源推理项目之一。欢迎查看我们的[提交活动](https://github.com/ai-dynamo/dynamo/graphs/commit-activity)和 [GitHub stars](https://github.com/ai-dynamo/dynamo/stargazers)。本指南将帮助你开始贡献。

--- a/docs/design-docs/architecture.md
+++ b/docs/design-docs/architecture.md
@@ -5,9 +5,7 @@ title: Overall Architecture
 subtitle: Architecture and components of the Dynamo inference runtime
 ---
 
-<p align="left">
-  <a href="./architecture.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./architecture.zh-CN.md)
 
 Dynamo is a distributed inference runtime for generative AI systems that must operate at high throughput, low latency, and high reliability under changing traffic conditions. It is backend-agnostic (SGLang, TRT-LLM, vLLM, and others) and is built around three cooperating concerns:
 

--- a/docs/design-docs/architecture.zh-CN.md
+++ b/docs/design-docs/architecture.zh-CN.md
@@ -9,8 +9,6 @@ subtitle: Dynamo 推理运行时的架构与组件
   <a href="./architecture.md" hreflang="en">English</a> | <strong>简体中文</strong>
 </p>
 
-# Dynamo 架构
-
 Dynamo 是面向生成式 AI 系统的分布式推理运行时，适用于必须在变化的流量条件下保持高吞吐、低延迟和高可靠性的场景。它不绑定具体后端（SGLang、TRT-LLM、vLLM 等），并围绕三个相互协作的关注点构建：
 
 - 用于 token 生成的快速 **request path**

--- a/docs/design-docs/disagg-serving.md
+++ b/docs/design-docs/disagg-serving.md
@@ -4,9 +4,7 @@
 title: Disaggregated Serving
 ---
 
-<p align="left">
-  <a href="./disagg-serving.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./disagg-serving.zh-CN.md)
 
 The prefill and decode phases of LLM requests have different computation characteristics and memory footprints. Disaggregating these phases into specialized llm engines allows for better hardware allocation, improved scalability, and overall enhanced performance. For example, using a larger TP for the memory-bound decoding phase while a smaller TP for the computation-bound prefill phase allows both phases to be computed efficiently. In addition, for requests with long context, separating their prefill phase into dedicated prefill engines allows the ongoing decoding requests to be efficiently processed without being blocked by these long prefills.
 

--- a/docs/design-docs/planner-design.md
+++ b/docs/design-docs/planner-design.md
@@ -4,9 +4,7 @@
 title: Planner Design
 ---
 
-<p align="left">
-  <a href="./planner-design.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./planner-design.zh-CN.md)
 
 > **Tier 3 design documentation** for contributors and architects. For user-facing docs, see [docs/components/planner/](../components/planner/README.md).
 

--- a/docs/fault-tolerance/request-migration.md
+++ b/docs/fault-tolerance/request-migration.md
@@ -5,9 +5,7 @@ title: Request Migration
 subtitle: Preserves token state and reissues in-flight requests on healthy workers when their original worker fails.
 ---
 
-<p align="left">
-  <a href="./request-migration.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./request-migration.zh-CN.md)
 
 This document describes how Dynamo implements request migration to handle worker failures gracefully during LLM text generation. Request migration allows in-progress requests to continue on different workers when the original worker becomes unavailable, providing fault tolerance and improved user experience.
 

--- a/docs/getting-started/building-from-source.md
+++ b/docs/getting-started/building-from-source.md
@@ -6,9 +6,7 @@ sidebar-title: Building from Source
 description: Build Dynamo from source for development and contributions
 ---
 
-<p align="left">
-  <a href="./building-from-source.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./building-from-source.zh-CN.md)
 
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 

--- a/docs/getting-started/building-from-source.zh-CN.md
+++ b/docs/getting-started/building-from-source.zh-CN.md
@@ -10,8 +10,6 @@ description: 从源代码构建 Dynamo，用于开发和贡献
   <a href="./building-from-source.md" hreflang="en">English</a> | <strong>简体中文</strong>
 </p>
 
-# 从源代码构建
-
 当你想贡献代码、测试开发分支上的功能，或自定义构建时，可以从源代码构建 Dynamo。如果你只是想运行 Dynamo，[本地安装](local-installation.zh-CN.md)指南会更快。
 
 本指南涵盖 Ubuntu 和 macOS。如需一个能自动处理所有这些步骤的容器化开发环境，请参阅 [DevContainer](#devcontainer)。

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -6,9 +6,7 @@ subtitle: Overview of Dynamo's design principles, performance techniques, and pr
 sidebar-title: Introduction
 ---
 
-<p align="left">
-  <a href="./introduction.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./introduction.zh-CN.md)
 
 Dynamo is an open-source, high-throughput, low-latency inference framework,
 designed to serve generative AI workloads in distributed environments. It is

--- a/docs/getting-started/introduction.zh-CN.md
+++ b/docs/getting-started/introduction.zh-CN.md
@@ -9,8 +9,6 @@ sidebar-title: 简介
   <a href="./introduction.md" hreflang="en">English</a> | <strong>简体中文</strong>
 </p>
 
-# Dynamo 简介
-
 Dynamo 是一个开源、高吞吐、低延迟的推理框架，专为在分布式环境中服务生成式 AI 工作负载而设计。本页概述 Dynamo 的设计原则、性能优势和生产级功能。
 
 > [!TIP]

--- a/docs/getting-started/local-installation.md
+++ b/docs/getting-started/local-installation.md
@@ -6,9 +6,7 @@ sidebar-title: Local Installation
 description: Install and run Dynamo on a local machine or VM with containers or PyPI
 ---
 
-<p align="left">
-  <a href="./local-installation.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./local-installation.zh-CN.md)
 
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 

--- a/docs/getting-started/local-installation.zh-CN.md
+++ b/docs/getting-started/local-installation.zh-CN.md
@@ -10,8 +10,6 @@ description: 使用容器或 PyPI 在本地机器或 VM 上安装并运行 Dynam
   <a href="./local-installation.md" hreflang="en">English</a> | <strong>简体中文</strong>
 </p>
 
-# 本地安装
-
 本指南介绍如何在配备一个或多个 GPU 的本地机器或 VM 上安装并运行 Dynamo。完成后，你将拥有一个可工作的 OpenAI 兼容端点，用于提供模型服务。
 
 对于生产环境的多节点集群，请参阅 [Kubernetes 部署指南](../kubernetes/README.md)。如需为开发从源码构建，请参阅[从源码构建](building-from-source.zh-CN.md)。

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -7,9 +7,7 @@ subtitle: Get a Dynamo OpenAI-compatible endpoint running in a container in abou
 
 {/* Looking for the project README? See /README.md at the repo root: https://github.com/ai-dynamo/dynamo/blob/main/README.md */}
 
-<p align="left">
-  <a href="./quickstart.zh-CN.mdx" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./quickstart.zh-CN.mdx)
 
 ## Choose Your Path
 

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -5,9 +5,7 @@ title: Tool Call Parsing (Dynamo)
 subtitle: Connect Dynamo to external tools and services using Dynamo's built-in tool call parsers
 ---
 
-<p align="left">
-  <a href="./README.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
-</p>
+[简体中文](./README.zh-CN.md)
 
 You can connect Dynamo to external tools and services using tool calling. By
 providing a list of available functions, Dynamo can choose to output function


### PR DESCRIPTION
## Summary

Follow-up to #11088, addressing rendering issues flagged after merge.

- The language-switcher badge on the 13 translated pages is raw HTML with a relative `<img src>` that the Fern build rewrites to a CI filesystem path, so every English page renders a broken image at the top. The SVG is also `systemLanguage`-gated (a GitHub-README trick), so it draws blank for non-Chinese browser locales even when it resolves. Replaced the badge block with a plain Markdown link (`[简体中文](./page.zh-CN.md)`), which Fern resolves through the nav correctly.
- 5 zh-CN pages had a body H1 duplicating the frontmatter `title`, so the live pages showed the heading twice (e.g. "简介" then "Dynamo 简介"). Dropped the body H1s.

This is an interim fix to unbreak the live site. The real replacement — Fern's native localization / language picker per Neal's suggestion — comes in a follow-up PR that moves the translations into `fern/translations/zh-CN/` and removes these manual links entirely.

The GitHub-facing root `README.md` badge and `README.zh-CN.md` are untouched.

## Test plan

- [ ] Fern preview: English pages show a working 简体中文 text link, no broken image
- [ ] Fern preview: zh-CN pages render a single title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Chinese links across multiple docs were standardized to cleaner Markdown links, improving readability and navigation.
  * Several Chinese pages removed redundant शीर्ष/header titles, reducing duplicate headings and making pages start more cleanly.
  * Updated getting started, design, router, planner, tool-calling, and contribution docs for more consistent language selection and page structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
