### PR TITLE
perf: Reuse cancellation futures across stream loops

### DIFF
--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -224,6 +224,10 @@ fn monitor_for_disconnects_with_timeout(
 
     async_stream::try_stream! {
         tokio::pin!(stream);
+        // Keep the context's watch-backed cancellation future alive across body frames.
+        // Recreating it for every token repeatedly clones a receiver and churns Notify state.
+        let stopped = context.stopped();
+        tokio::pin!(stopped);
         loop {
             tokio::select! {
                 event = stream.next() => {
@@ -269,7 +273,7 @@ fn monitor_for_disconnects_with_timeout(
                         }
                     }
                 }
-                _ = context.stopped() => {
+                _ = &mut stopped => {
                     // Mark as cancelled when context is stopped (client disconnect or timeout)
                     inflight_guard.mark_error(ErrorType::Cancelled);
                     // Token counts (input_tokens, output_tokens) are recorded on
@@ -322,6 +326,7 @@ mod tests {
     use super::*;
     use crate::http::service::metrics::{Endpoint, ErrorType, RequestType, Status};
     use futures::StreamExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug)]
     struct MockContext;
@@ -345,6 +350,35 @@ mod tests {
             false
         }
         async fn stopped(&self) {
+            std::future::pending::<()>().await;
+        }
+        async fn killed(&self) {
+            std::future::pending::<()>().await;
+        }
+        fn link_child(&self, _: Arc<dyn dynamo_runtime::engine::AsyncEngineContext>) {}
+    }
+
+    #[derive(Debug, Default)]
+    struct CountingContext {
+        stopped_polls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl dynamo_runtime::engine::AsyncEngineContext for CountingContext {
+        fn id(&self) -> &str {
+            "counting-test"
+        }
+        fn stop(&self) {}
+        fn stop_generating(&self) {}
+        fn kill(&self) {}
+        fn is_stopped(&self) -> bool {
+            false
+        }
+        fn is_killed(&self) -> bool {
+            false
+        }
+        async fn stopped(&self) {
+            self.stopped_polls.fetch_add(1, Ordering::Relaxed);
             std::future::pending::<()>().await;
         }
         async fn killed(&self) {
@@ -391,6 +425,42 @@ mod tests {
         let (tx, _rx) = tokio::sync::oneshot::channel();
         let handle = ConnectionHandle::create_disabled(tx);
         (metrics, guard, context, handle)
+    }
+
+    #[tokio::test]
+    async fn test_monitor_reuses_stopped_future_across_events() {
+        let model = "reuse-stopped-future";
+        let metrics = Arc::new(Metrics::new());
+        let guard = metrics.clone().create_inflight_guard(
+            model,
+            Endpoint::ChatCompletions,
+            true,
+            "req-reuse",
+        );
+        let context = Arc::new(CountingContext::default());
+        let engine_context: Arc<dyn AsyncEngineContext> = context.clone();
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+        let handle = ConnectionHandle::create_disabled(tx);
+        let stream = futures::stream::unfold(0, |index| async move {
+            tokio::task::yield_now().await;
+            (index < 4).then(|| {
+                (
+                    Ok(Event::default().data(format!("token-{index}"))),
+                    index + 1,
+                )
+            })
+        });
+
+        let monitored =
+            monitor_for_disconnects_with_timeout(stream, engine_context, guard, handle, None);
+        tokio::pin!(monitored);
+        while monitored.next().await.is_some() {}
+
+        assert_eq!(
+            context.stopped_polls.load(Ordering::Relaxed),
+            1,
+            "the same stopped future should remain pending across all response events"
+        );
     }
 
     /// Zombie backend with hanging stream is terminated by inactivity timeout.

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -328,45 +328,19 @@ mod tests {
     use futures::StreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    #[derive(Debug)]
-    struct MockContext;
+    #[derive(Debug, Default)]
+    struct MockContext {
+        stopped_polls: AtomicUsize,
+    }
     impl MockContext {
         fn new() -> Self {
-            Self
+            Self::default()
         }
     }
     #[async_trait::async_trait]
     impl dynamo_runtime::engine::AsyncEngineContext for MockContext {
         fn id(&self) -> &str {
             "test"
-        }
-        fn stop(&self) {}
-        fn stop_generating(&self) {}
-        fn kill(&self) {}
-        fn is_stopped(&self) -> bool {
-            false
-        }
-        fn is_killed(&self) -> bool {
-            false
-        }
-        async fn stopped(&self) {
-            std::future::pending::<()>().await;
-        }
-        async fn killed(&self) {
-            std::future::pending::<()>().await;
-        }
-        fn link_child(&self, _: Arc<dyn dynamo_runtime::engine::AsyncEngineContext>) {}
-    }
-
-    #[derive(Debug, Default)]
-    struct CountingContext {
-        stopped_polls: AtomicUsize,
-    }
-
-    #[async_trait::async_trait]
-    impl dynamo_runtime::engine::AsyncEngineContext for CountingContext {
-        fn id(&self) -> &str {
-            "counting-test"
         }
         fn stop(&self) {}
         fn stop_generating(&self) {}
@@ -437,7 +411,7 @@ mod tests {
             true,
             "req-reuse",
         );
-        let context = Arc::new(CountingContext::default());
+        let context = Arc::new(MockContext::new());
         let engine_context: Arc<dyn AsyncEngineContext> = context.clone();
         let (tx, _rx) = tokio::sync::oneshot::channel();
         let handle = ConnectionHandle::create_disabled(tx);

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -322,12 +322,16 @@ impl KvPushRouter {
         let context_for_monitoring = stream_context.clone();
         let wrapped_stream = Box::pin(async_stream::stream! {
             let mut guard = guard;
+            // Keep one cancellation future alive for the whole response stream. Calling
+            // `stopped()` for every item repeatedly clones and polls a watch receiver.
+            let stopped = context_for_monitoring.stopped();
+            tokio::pin!(stopped);
 
             loop {
                 tokio::select! {
                     biased;
 
-                    _ = context_for_monitoring.stopped() => {
+                    _ = &mut stopped => {
                         tracing::debug!("Request {context_id} cancelled, ending stream");
                         break;
                     }

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -249,18 +249,28 @@ async fn handle_request_reader(
     context: Arc<dyn AsyncEngineContext>,
     cancellation_counter: Option<IntCounter>,
 ) {
+    // Keep cancellation and receiver-close notifications alive across frames instead of
+    // rebuilding their watch/Notify state for every request-stream message.
+    let killed = context.killed();
+    let stopped = context.stopped();
+    // The function explicitly drops `bytes_tx` after the loop, so let the persistent
+    // `closed()` future borrow a stream-lifetime clone instead.
+    let bytes_closed_tx = bytes_tx.clone();
+    let bytes_closed = bytes_closed_tx.closed();
+    tokio::pin!(killed, stopped, bytes_closed);
+
     // Only mark cancellation on fatal errors or explicit upstream cancellation.
     let mut cancellation_seen = false;
     loop {
         tokio::select! {
             biased;
 
-            _ = context.killed() => {
+            _ = &mut killed => {
                 tracing::trace!("context kill signal received on request stream; shutting down");
                 break;
             }
 
-            _ = context.stopped() => {
+            _ = &mut stopped => {
                 tracing::trace!("context stop signal received on request stream; shutting down");
                 break;
             }
@@ -269,7 +279,7 @@ async fn handle_request_reader(
             // instead of staying parked on `framed_reader.next()` until the
             // socket closes — the data has nowhere to go. This is the consumer's
             // own choice, so it is not a cancellation (no kill, no count).
-            _ = bytes_tx.closed() => {
+            _ = &mut bytes_closed => {
                 tracing::debug!("downstream consumer dropped; exiting request-stream reader");
                 break;
             }
@@ -536,6 +546,12 @@ async fn handle_writer(
     alive_rx: tokio::sync::oneshot::Receiver<()>,
     context: Arc<dyn AsyncEngineContext>,
 ) -> Result<FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>> {
+    // Keep one cancellation future per stream. Recreating these futures for every queued
+    // frame repeatedly clones the context's watch receivers and churns Notify state.
+    let killed = context.killed();
+    let stopped = context.stopped();
+    tokio::pin!(killed, stopped);
+
     // Only send sentinel for normal channel closure
     let mut send_sentinel = true;
 
@@ -543,13 +559,13 @@ async fn handle_writer(
         let msg = tokio::select! {
             biased;
 
-            _ = context.killed() => {
+            _ = &mut killed => {
                 tracing::trace!("context kill signal received; shutting down");
                 send_sentinel = false;
                 break;
             }
 
-            _ = context.stopped() => {
+            _ = &mut stopped => {
                 tracing::trace!("context stop signal received; shutting down");
                 send_sentinel = false;
                 break;

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -249,107 +249,113 @@ async fn handle_request_reader(
     context: Arc<dyn AsyncEngineContext>,
     cancellation_counter: Option<IntCounter>,
 ) {
-    // Keep cancellation and receiver-close notifications alive across frames instead of
-    // rebuilding their watch/Notify state for every request-stream message.
-    let killed = context.killed();
-    let stopped = context.stopped();
-    // The function explicitly drops `bytes_tx` after the loop, so let the persistent
-    // `closed()` future borrow a stream-lifetime clone instead.
-    let bytes_closed_tx = bytes_tx.clone();
-    let bytes_closed = bytes_closed_tx.closed();
-    tokio::pin!(killed, stopped, bytes_closed);
+    let cancellation_seen = {
+        // Keep cancellation and receiver-close notifications alive across frames instead of
+        // rebuilding their watch/Notify state for every request-stream message.
+        let killed = context.killed();
+        let stopped = context.stopped();
+        // The function explicitly drops `bytes_tx` after the loop, so let the persistent
+        // `closed()` future borrow a stream-lifetime clone instead.
+        let bytes_closed_tx = bytes_tx.clone();
+        let bytes_closed = bytes_closed_tx.closed();
+        tokio::pin!(killed, stopped, bytes_closed);
 
-    // Only mark cancellation on fatal errors or explicit upstream cancellation.
-    let mut cancellation_seen = false;
-    loop {
-        tokio::select! {
-            biased;
+        // Only mark cancellation on fatal errors or explicit upstream cancellation.
+        let mut cancellation_seen = false;
+        loop {
+            tokio::select! {
+                biased;
 
-            _ = &mut killed => {
-                tracing::trace!("context kill signal received on request stream; shutting down");
-                break;
-            }
+                _ = &mut killed => {
+                    tracing::trace!("context kill signal received on request stream; shutting down");
+                    break;
+                }
 
-            _ = &mut stopped => {
-                tracing::trace!("context stop signal received on request stream; shutting down");
-                break;
-            }
+                _ = &mut stopped => {
+                    tracing::trace!("context stop signal received on request stream; shutting down");
+                    break;
+                }
 
-            // Downstream consumer dropped the StreamReceiver. Exit promptly
-            // instead of staying parked on `framed_reader.next()` until the
-            // socket closes — the data has nowhere to go. This is the consumer's
-            // own choice, so it is not a cancellation (no kill, no count).
-            _ = &mut bytes_closed => {
-                tracing::debug!("downstream consumer dropped; exiting request-stream reader");
-                break;
-            }
+                // Downstream consumer dropped the StreamReceiver. Exit promptly
+                // instead of staying parked on `framed_reader.next()` until the
+                // socket closes — the data has nowhere to go. This is the consumer's
+                // own choice, so it is not a cancellation (no kill, no count).
+                _ = &mut bytes_closed => {
+                    tracing::debug!("downstream consumer dropped; exiting request-stream reader");
+                    break;
+                }
 
-            msg = framed_reader.next() => {
-                match msg {
-                    Some(Ok(two_part_msg)) => match two_part_msg.into_message_type() {
-                        TwoPartMessageType::HeaderOnly(header) => {
-                            let ctrl = match serde_json::from_slice::<ControlMessage>(&header) {
-                                Ok(c) => c,
-                                Err(e) => {
-                                    tracing::warn!(
-                                        err = ?e,
-                                        "invalid control message, closing connection"
-                                    );
-                                    cancellation_seen = true;
-                                    context.kill();
-                                    break;
+                msg = framed_reader.next() => {
+                    match msg {
+                        Some(Ok(two_part_msg)) => match two_part_msg.into_message_type() {
+                            TwoPartMessageType::HeaderOnly(header) => {
+                                let ctrl = match serde_json::from_slice::<ControlMessage>(&header) {
+                                    Ok(c) => c,
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            err = ?e,
+                                            "invalid control message, closing connection"
+                                        );
+                                        cancellation_seen = true;
+                                        context.kill();
+                                        break;
+                                    }
+                                };
+                                match ctrl {
+                                    ControlMessage::Stop => {
+                                        cancellation_seen = true;
+                                        context.stop();
+                                        break;
+                                    }
+                                    ControlMessage::Kill => {
+                                        cancellation_seen = true;
+                                        context.kill();
+                                        break;
+                                    }
+                                    ControlMessage::Sentinel => {
+                                        tracing::trace!("upstream signaled end of request stream");
+                                        break;
+                                    }
                                 }
-                            };
-                            match ctrl {
-                                ControlMessage::Stop => {
-                                    cancellation_seen = true;
-                                    context.stop();
-                                    break;
-                                }
-                                ControlMessage::Kill => {
-                                    cancellation_seen = true;
-                                    context.kill();
-                                    break;
-                                }
-                                ControlMessage::Sentinel => {
-                                    tracing::trace!("upstream signaled end of request stream");
+                            }
+                            TwoPartMessageType::DataOnly(data) => {
+                                if bytes_tx.send(data).await.is_err() {
+                                    tracing::debug!("downstream consumer dropped; exiting request-stream reader");
                                     break;
                                 }
                             }
-                        }
-                        TwoPartMessageType::DataOnly(data) => {
-                            if bytes_tx.send(data).await.is_err() {
-                                tracing::debug!("downstream consumer dropped; exiting request-stream reader");
+                            _ => {
+                                tracing::warn!("fatal error - unexpected message shape on request stream");
+                                cancellation_seen = true;
+                                context.kill();
                                 break;
                             }
                         }
-                        _ => {
-                            tracing::warn!("fatal error - unexpected message shape on request stream");
+                        Some(Err(e)) => {
+                            tracing::warn!("fatal error - failed to decode message on request stream: {e:?}");
+                            cancellation_seen = true;
+                            context.kill();
+                            break;
+                        }
+                        None => {
+                            // Socket closed before a Sentinel/Stop/Kill: the request
+                            // input is truncated. Kill the context so the consumer
+                            // sees an aborted stream rather than a clean end, and
+                            // count it as a cancellation.
+                            tracing::warn!("request stream closed by upstream before sentinel; treating as truncated");
                             cancellation_seen = true;
                             context.kill();
                             break;
                         }
                     }
-                    Some(Err(e)) => {
-                        tracing::warn!("fatal error - failed to decode message on request stream: {e:?}");
-                        cancellation_seen = true;
-                        context.kill();
-                        break;
-                    }
-                    None => {
-                        // Socket closed before a Sentinel/Stop/Kill: the request
-                        // input is truncated. Kill the context so the consumer
-                        // sees an aborted stream rather than a clean end, and
-                        // count it as a cancellation.
-                        tracing::warn!("request stream closed by upstream before sentinel; treating as truncated");
-                        cancellation_seen = true;
-                        context.kill();
-                        break;
-                    }
                 }
             }
         }
-    }
+
+        // Leaving this scope drops the pinned `closed()` future and its sender clone
+        // before the original sender below signals end-of-stream.
+        cancellation_seen
+    };
 
     if cancellation_seen && let Some(counter) = &cancellation_counter {
         counter.inc();

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -737,16 +737,22 @@ async fn tcp_listener(
         mut request_rx: mpsc::Receiver<TwoPartMessage>,
         context: Arc<dyn AsyncEngineContext>,
     ) {
+        // Construct the cancellation futures once. Recreating them for every frame clones
+        // the context's watch receivers and repeatedly registers/drops Tokio notifications.
+        let killed = context.killed();
+        let stopped = context.stopped();
+        tokio::pin!(killed, stopped);
+
         let closing_msg: Option<ControlMessage> = loop {
             tokio::select! {
                 biased;
 
-                _ = context.killed() => {
+                _ = &mut killed => {
                     tracing::trace!("context kill received in request-stream send handler");
                     break Some(ControlMessage::Kill);
                 }
 
-                _ = context.stopped() => {
+                _ = &mut stopped => {
                     tracing::trace!("context stop received in request-stream send handler");
                     break Some(ControlMessage::Stop);
                 }
@@ -888,25 +894,32 @@ async fn tcp_listener(
         control_tx: mpsc::Sender<ControlMessage>,
         context: Arc<dyn AsyncEngineContext>,
     ) {
+        // These futures stay pending across frames. Constructing them inside the loop clones
+        // watch receivers and registers/drops notifications for every streamed token.
+        let response_closed = response_tx.closed();
+        let killed = context.killed();
+        let stopped = context.stopped();
+        tokio::pin!(response_closed, killed, stopped);
+
         // loop over reading the tcp stream and checking if the writer is closed
         let mut can_stop = true;
         loop {
             tokio::select! {
                 biased;
 
-                _ = response_tx.closed() => {
+                _ = &mut response_closed => {
                     tracing::trace!("response channel closed before the client finished writing data");
                     let _ = control_tx.send(ControlMessage::Kill).await;
                     break;
                 }
 
-                _ = context.killed() => {
+                _ = &mut killed => {
                     tracing::trace!("context kill signal received; shutting down");
                     let _ = control_tx.send(ControlMessage::Kill).await;
                     break;
                 }
 
-                _ = context.stopped(), if can_stop => {
+                _ = &mut stopped, if can_stop => {
                     tracing::trace!("context stop signal received; shutting down");
                     can_stop = false;
                     let _ = control_tx.send(ControlMessage::Stop).await;

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -921,6 +921,8 @@ async fn tcp_listener(
 
                 _ = &mut stopped, if can_stop => {
                     tracing::trace!("context stop signal received; shutting down");
+                    // `stopped` is now complete; keep this branch disabled because polling
+                    // the same completed async future again would panic.
                     can_stop = false;
                     let _ = control_tx.send(ControlMessage::Stop).await;
                 }


### PR DESCRIPTION
## Overview:

At high streaming rates, the TCP, HTTP, and KV response loops reconstructed watch-backed cancellation futures for every frame. Each call to `Controller::stopped()` or `killed()` clones a watch receiver, and dropping the losing `tokio::select!` branches repeatedly tears down Tokio notification state.

This PR constructs and pins those futures once per stream, then polls the same futures across frames.

## Details:

- Reuse `stopped()`, `killed()`, and channel `closed()` futures in the TCP client and server loops.
- Reuse the cancellation future in the HTTP disconnect monitor and KV response wrapper.
- Preserve the existing biased kill-before-stop ordering, graceful-stop `can_stop` behavior, channel shutdown, and inactivity-timeout semantics.
- Add a regression test proving the HTTP monitor reuses one pending `stopped()` future across multiple events.

In a 1k ISL / 1k OSL / concurrency 512 MessagePack profile with the frontend pinned to four CPU cores:

- code-specific cancellation stack presence fell from 12.719% to 4.497% (-64.6%)
- exclusive cancellation construction/drop churn fell from 4.024% to 0.0195% (-99.5%)
- frontend user CPU per request improved by approximately 6.18%
- throughput moved from 610.06 to 620.09 requests/s (+1.64%)

The throughput number is a single saturated-load run, so the exact uplift is not claimed as statistically conclusive. The targeted profile collapse and reduced frontend user CPU/request are the primary evidence.

## Where should the reviewer start?

- `lib/runtime/src/pipeline/network/tcp/server.rs`: response receive loop and graceful-stop handling
- `lib/runtime/src/pipeline/network/tcp/client.rs`: request reader/writer lifetime and channel-close future
- `lib/llm/src/http/service/disconnect.rs`: stream-lifetime cancellation future and regression test

## Validation:

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-runtime test_request_stream_sends --lib -- --nocapture` — 3 passed
- `cargo test -p dynamo-llm http::service::disconnect::tests --lib -- --nocapture` — 6 passed
- Release Python bindings built and imported successfully
- 150-second AIPerf load plus 40-second `cycles:u` profile completed with zero request errors, cancellations, or output-length mismatches

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream cancellation and disconnect handling across network and LLM request flows.
  * Made streaming responses more reliable by keeping shutdown detection active throughout the full response lifecycle.
  * Reduced the chance of missed stop/close signals during long-running requests, especially for TCP client/server and SSE streams.
  * Added coverage for repeated event streaming to verify disconnect detection stays consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->