### PR TITLE
feat: load frontend system route extensions

### DIFF
--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -86,6 +86,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     preprocess_workers: int
     tokenizer_backend: str
     trust_remote_code: bool
+    system_route_extensions: list[str]
 
     _VALID_TOKENIZER_BACKENDS = {"default", "fastokens"}
 
@@ -342,6 +343,19 @@ class FrontendArgGroup(ArgGroup):
             env_var="DYN_DUMP_CONFIG_TO",
             default=None,
             help="Dump config to the specified file path.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--system-route-extension",
+            env_var="DYN_SYSTEM_ROUTE_EXTENSIONS",
+            default=[],
+            dest="system_route_extensions",
+            action="append",
+            help=(
+                "Trusted system route extension entry point name. May be repeated. "
+                "DYN_SYSTEM_ROUTE_EXTENSIONS accepts whitespace-separated names."
+            ),
         )
 
         add_argument(

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -18,6 +18,7 @@
 
 import argparse
 import asyncio
+import importlib.metadata
 import logging
 import os
 import signal
@@ -35,6 +36,7 @@ from dynamo.llm import (
     KvRouterConfig,
     RouterConfig,
     RouterMode,
+    SystemRoute,
     make_engine,
     run_input,
 )
@@ -50,6 +52,7 @@ configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
 MIN_INITIAL_WORKERS_ENV = "DYN_ROUTER_MIN_INITIAL_WORKERS"
+SYSTEM_ROUTE_EXTENSION_ENTRYPOINT_GROUP = "dynamo.system_route_extensions"
 
 
 def setup_engine_factory(
@@ -84,6 +87,65 @@ def setup_sglang_engine_factory(
         tool_call_parser_name=tool_call_parser,
         reasoning_parser_name=reasoning_parser,
     )
+
+
+def _system_route_extension_entry_points():
+    entry_points = importlib.metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        return list(entry_points.select(group=SYSTEM_ROUTE_EXTENSION_ENTRYPOINT_GROUP))
+    return list(entry_points.get(SYSTEM_ROUTE_EXTENSION_ENTRYPOINT_GROUP, ()))
+
+
+def _normalize_system_routes(extension_name: str, provided: Any) -> list[SystemRoute]:
+    if provided is None:
+        return []
+    if isinstance(provided, SystemRoute):
+        return [provided]
+    try:
+        routes = list(provided)
+    except TypeError as exc:
+        raise TypeError(
+            f"System route extension '{extension_name}' must return a SystemRoute "
+            "or an iterable of SystemRoute objects"
+        ) from exc
+    for route in routes:
+        if not isinstance(route, SystemRoute):
+            raise TypeError(
+                f"System route extension '{extension_name}' returned unsupported route "
+                f"object {route!r}; expected dynamo.llm.SystemRoute"
+            )
+    return routes
+
+
+def load_system_route_extensions(extension_names: list[str]) -> list[SystemRoute]:
+    """Load trusted system route extensions by entry point name."""
+
+    if not extension_names:
+        return []
+
+    entry_points = _system_route_extension_entry_points()
+    routes: list[SystemRoute] = []
+    for extension_name in extension_names:
+        matches = [ep for ep in entry_points if ep.name == extension_name]
+        if not matches:
+            available = ", ".join(sorted(ep.name for ep in entry_points)) or "<none>"
+            raise ValueError(
+                f"Unknown system route extension '{extension_name}' in entry point "
+                f"group '{SYSTEM_ROUTE_EXTENSION_ENTRYPOINT_GROUP}'. Available: {available}"
+            )
+        if len(matches) > 1:
+            raise ValueError(
+                f"Ambiguous system route extension '{extension_name}' in entry point "
+                f"group '{SYSTEM_ROUTE_EXTENSION_ENTRYPOINT_GROUP}'"
+            )
+        provider = matches[0].load()
+        if not callable(provider):
+            raise TypeError(
+                f"System route extension '{extension_name}' entry point must load a callable"
+            )
+        routes.extend(_normalize_system_routes(extension_name, provider()))
+
+    return routes
 
 
 def parse_args() -> tuple[FrontendConfig, Optional[Namespace], Optional[Namespace]]:
@@ -292,6 +354,9 @@ async def async_main():
 
     e = EntrypointArgs(EngineType.Dynamic, **kwargs)
     engine = await make_engine(runtime, e)
+    system_route_extensions = load_system_route_extensions(config.system_route_extensions)
+    if system_route_extensions and (config.interactive or config.kserve_grpc_server):
+        raise ValueError("system route extensions are only supported by HTTP frontend mode")
 
     try:
         if config.interactive:
@@ -299,7 +364,7 @@ async def async_main():
         elif config.kserve_grpc_server:
             await run_input(runtime, "grpc", engine)
         else:
-            await run_input(runtime, "http", engine)
+            await run_input(runtime, "http", engine, system_route_extensions)
     except asyncio.exceptions.CancelledError:
         pass
 

--- a/components/src/dynamo/frontend/tests/test_system_route_extension_loader.py
+++ b/components/src/dynamo/frontend/tests/test_system_route_extension_loader.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.frontend import main
+from dynamo.llm import SystemRoute
+
+
+class FakeEntryPoint:
+    def __init__(self, name, value):
+        self.name = name
+        self._value = value
+
+    def load(self):
+        return self._value
+
+
+def test_load_system_route_extensions_by_entry_point(monkeypatch):
+    def handler(ctx):
+        return {"ready": ctx.is_ready()}
+
+    def provider():
+        return [SystemRoute("GET", "/test/ready", handler)]
+
+    monkeypatch.setattr(
+        main,
+        "_system_route_extension_entry_points",
+        lambda: [FakeEntryPoint("test-extension", provider)],
+    )
+
+    routes = main.load_system_route_extensions(["test-extension"])
+
+    assert len(routes) == 1
+    assert routes[0].method == "GET"
+    assert routes[0].path == "/test/ready"
+
+
+def test_load_system_route_extensions_accepts_single_route(monkeypatch):
+    def handler(ctx):
+        return {"ready": ctx.is_ready()}
+
+    def provider():
+        return SystemRoute("GET", "/test/ready", handler)
+
+    monkeypatch.setattr(
+        main,
+        "_system_route_extension_entry_points",
+        lambda: [FakeEntryPoint("test-extension", provider)],
+    )
+
+    routes = main.load_system_route_extensions(["test-extension"])
+
+    assert len(routes) == 1
+    assert routes[0].path == "/test/ready"
+
+
+def test_load_system_route_extensions_rejects_unknown_name(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "_system_route_extension_entry_points",
+        lambda: [FakeEntryPoint("known-extension", lambda: [])],
+    )
+
+    with pytest.raises(ValueError, match="Unknown system route extension 'missing'"):
+        main.load_system_route_extensions(["missing"])
+
+
+def test_load_system_route_extensions_rejects_ambiguous_name(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "_system_route_extension_entry_points",
+        lambda: [
+            FakeEntryPoint("duplicate", lambda: []),
+            FakeEntryPoint("duplicate", lambda: []),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Ambiguous system route extension 'duplicate'"):
+        main.load_system_route_extensions(["duplicate"])
+
+
+def test_load_system_route_extensions_rejects_non_route(monkeypatch):
+    def provider():
+        return [{"method": "GET", "path": "/not-a-system-route"}]
+
+    monkeypatch.setattr(
+        main,
+        "_system_route_extension_entry_points",
+        lambda: [FakeEntryPoint("bad-extension", provider)],
+    )
+
+    with pytest.raises(TypeError, match="expected dynamo.llm.SystemRoute"):
+        main.load_system_route_extensions(["bad-extension"])

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -184,6 +184,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AsyncResponseStream>()?;
     m.add_class::<PyAsyncRequestStream>()?;
     m.add_class::<llm::entrypoint::EntrypointArgs>()?;
+    m.add_class::<llm::system_routes::PySystemRoute>()?;
+    m.add_class::<llm::system_routes::PySystemRouteContext>()?;
     m.add_class::<llm::entrypoint::EngineConfig>()?;
     m.add_class::<llm::entrypoint::EngineType>()?;
     m.add_class::<llm::entrypoint::AicPerfConfig>()?;

--- a/lib/bindings/python/rust/llm.rs
+++ b/lib/bindings/python/rust/llm.rs
@@ -35,3 +35,4 @@ pub mod model_card;
 pub mod preprocessor;
 pub mod replay;
 pub mod routed_engine;
+pub mod system_routes;

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -912,19 +912,23 @@ async fn select_engine(
 }
 
 #[pyfunction]
-#[pyo3(signature = (distributed_runtime, input, engine_config))]
+#[pyo3(signature = (distributed_runtime, input, engine_config, system_route_extensions=None))]
 pub fn run_input<'p>(
     py: Python<'p>,
     distributed_runtime: super::DistributedRuntime,
     input: &str,
     engine_config: EngineConfig,
+    system_route_extensions: Option<PyObject>,
 ) -> PyResult<Bound<'p, PyAny>> {
     let input_enum: Input = input.parse().map_err(to_pyerr)?;
+    let system_route_extensions =
+        super::system_routes::system_route_extensions_from_py(py, system_route_extensions)?;
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        dynamo_llm::entrypoint::input::run_input(
+        dynamo_llm::entrypoint::input::run_input_with_system_route_extensions(
             distributed_runtime.inner.clone(),
             input_enum,
             engine_config.inner,
+            system_route_extensions,
         )
         .await
         .map_err(to_pyerr)?;

--- a/lib/bindings/python/rust/llm/system_routes.rs
+++ b/lib/bindings/python/rust/llm/system_routes.rs
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use dynamo_llm::http::service::axum::{
+    Json, Router,
+    http::{Method, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{delete, get, patch, post, put},
+};
+use dynamo_llm::http::service::{
+    RouteDoc, SystemRouteContext as RsSystemRouteContext, SystemRouteExtension, SystemRouteSet,
+};
+use pyo3::{
+    exceptions::{PyTypeError, PyValueError},
+    prelude::*,
+    types::{PyIterator, PyTuple},
+};
+use pythonize::depythonize;
+use serde_json::{Value, json};
+
+/// A trusted Python-provided system route hosted by the Dynamo HTTP frontend.
+///
+/// Handlers are synchronous and return JSON-serializable values. Returning
+/// `(status_code, body)` overrides the default 200 status code.
+#[pyclass(name = "SystemRoute")]
+#[derive(Clone)]
+pub(crate) struct PySystemRoute {
+    method: Method,
+    path: String,
+    handler: PyObject,
+}
+
+#[pymethods]
+impl PySystemRoute {
+    #[new]
+    pub fn new(py: Python<'_>, method: String, path: String, handler: PyObject) -> PyResult<Self> {
+        if !handler.bind(py).is_callable() {
+            return Err(PyTypeError::new_err("SystemRoute handler must be callable"));
+        }
+        if !path.starts_with('/') {
+            return Err(PyValueError::new_err("SystemRoute path must start with '/'"));
+        }
+        let method = parse_route_method(&method)?;
+        Ok(Self {
+            method,
+            path,
+            handler,
+        })
+    }
+
+    #[getter]
+    pub fn method(&self) -> String {
+        self.method.to_string()
+    }
+
+    #[getter]
+    pub fn path(&self) -> String {
+        self.path.clone()
+    }
+}
+
+/// Read-only live frontend state exposed to Python system route handlers.
+#[pyclass(name = "SystemRouteContext")]
+#[derive(Clone)]
+pub(crate) struct PySystemRouteContext {
+    inner: RsSystemRouteContext,
+}
+
+#[pymethods]
+impl PySystemRouteContext {
+    pub fn is_ready(&self) -> bool {
+        self.inner.is_ready()
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    pub fn has_any_ready_model(&self) -> bool {
+        self.inner.manager().has_any_ready_model()
+    }
+
+    pub fn is_model_ready_to_serve(&self, model: &str) -> bool {
+        self.inner.manager().is_model_ready_to_serve(model)
+    }
+
+    pub fn model_display_names(&self) -> Vec<String> {
+        sorted_strings(self.inner.manager().model_display_names().into_iter())
+    }
+
+    pub fn serving_ready_display_names(&self) -> Vec<String> {
+        sorted_strings(self.inner.manager().serving_ready_display_names().into_iter())
+    }
+}
+
+pub(crate) fn system_route_extensions_from_py(
+    py: Python<'_>,
+    routes: Option<PyObject>,
+) -> PyResult<Vec<SystemRouteExtension>> {
+    let Some(routes) = routes else {
+        return Ok(Vec::new());
+    };
+    if routes.is_none(py) {
+        return Ok(Vec::new());
+    }
+
+    let bound = routes.bind(py);
+    let iter = PyIterator::from_object(bound)?;
+    let mut route_specs = Vec::new();
+    for item in iter {
+        let item = item?;
+        let route = item.extract::<PyRef<'_, PySystemRoute>>()?;
+        route_specs.push(route.clone());
+    }
+
+    if route_specs.is_empty() {
+        Ok(Vec::new())
+    } else {
+        Ok(vec![system_route_extension_from_routes(route_specs)])
+    }
+}
+
+fn system_route_extension_from_routes(routes: Vec<PySystemRoute>) -> SystemRouteExtension {
+    let routes = Arc::new(routes);
+    Arc::new(move |context: RsSystemRouteContext| {
+        let mut docs = Vec::with_capacity(routes.len());
+        let mut router = Router::new();
+
+        for route in routes.iter() {
+            docs.push(RouteDoc::new(route.method.clone(), route.path.clone()));
+            let path = route.path.clone();
+            let handler = route.handler.clone();
+            let route_context = context.clone();
+            router = match route.method {
+                Method::GET => router.route(
+                    &path,
+                    get(move || call_python_system_route(handler.clone(), route_context.clone())),
+                ),
+                Method::POST => router.route(
+                    &path,
+                    post(move || call_python_system_route(handler.clone(), route_context.clone())),
+                ),
+                Method::PUT => router.route(
+                    &path,
+                    put(move || call_python_system_route(handler.clone(), route_context.clone())),
+                ),
+                Method::PATCH => router.route(
+                    &path,
+                    patch(move || call_python_system_route(handler.clone(), route_context.clone())),
+                ),
+                Method::DELETE => router.route(
+                    &path,
+                    delete(move || call_python_system_route(handler.clone(), route_context.clone())),
+                ),
+                _ => unreachable!("SystemRoute constructor restricts methods"),
+            };
+        }
+
+        SystemRouteSet::new(docs, router)
+    })
+}
+
+async fn call_python_system_route(handler: PyObject, context: RsSystemRouteContext) -> Response {
+    match Python::with_gil(|py| call_python_system_route_inner(py, handler, context)) {
+        Ok((status, body)) => (status, Json(body)).into_response(),
+        Err(err) => {
+            tracing::error!(error = %err, "Python system route extension failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "system route extension failed"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+fn call_python_system_route_inner(
+    py: Python<'_>,
+    handler: PyObject,
+    context: RsSystemRouteContext,
+) -> PyResult<(StatusCode, Value)> {
+    let py_context = Py::new(py, PySystemRouteContext { inner: context })?;
+    let result = handler.call1(py, (py_context,))?;
+    normalize_route_response(py, result)
+}
+
+fn normalize_route_response(py: Python<'_>, result: PyObject) -> PyResult<(StatusCode, Value)> {
+    let bound = result.bind(py);
+    if bound.hasattr("__await__")? {
+        return Err(PyTypeError::new_err(
+            "async SystemRoute handlers are not supported; return JSON synchronously",
+        ));
+    }
+
+    if let Ok(tuple) = bound.downcast::<PyTuple>()
+        && tuple.len() == 2
+    {
+        let status_code: u16 = tuple.get_item(0)?.extract()?;
+        let status = StatusCode::from_u16(status_code)
+            .map_err(|e| PyValueError::new_err(format!("invalid status code: {e}")))?;
+        let body: Value = depythonize(&tuple.get_item(1)?).map_err(|e| {
+            PyValueError::new_err(format!("response body must be JSON-serializable: {e}"))
+        })?;
+        return Ok((status, body));
+    }
+
+    let body: Value = depythonize(bound)
+        .map_err(|e| PyValueError::new_err(format!("response body must be JSON-serializable: {e}")))?;
+    Ok((StatusCode::OK, body))
+}
+
+fn parse_route_method(method: &str) -> PyResult<Method> {
+    match method.to_ascii_uppercase().as_str() {
+        "GET" => Ok(Method::GET),
+        "POST" => Ok(Method::POST),
+        "PUT" => Ok(Method::PUT),
+        "PATCH" => Ok(Method::PATCH),
+        "DELETE" => Ok(Method::DELETE),
+        other => Err(PyValueError::new_err(format!(
+            "unsupported SystemRoute method '{other}'; supported methods: GET, POST, PUT, PATCH, DELETE"
+        ))),
+    }
+}
+
+fn sorted_strings(values: impl Iterator<Item = String>) -> Vec<String> {
+    let mut values: Vec<String> = values.collect();
+    values.sort();
+    values
+}

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -34,6 +34,8 @@ from dynamo._core import PythonAsyncEngine as PythonAsyncEngine
 from dynamo._core import RadixTree as RadixTree
 from dynamo._core import RouterConfig as RouterConfig
 from dynamo._core import RouterMode as RouterMode
+from dynamo._core import SystemRoute as SystemRoute
+from dynamo._core import SystemRouteContext as SystemRouteContext
 from dynamo._core import RoutingConstraints as RoutingConstraints
 from dynamo._core import WorkerMetricsPublisher as WorkerMetricsPublisher
 from dynamo._core import WorkerType as WorkerType

--- a/lib/llm/src/entrypoint/input.rs
+++ b/lib/llm/src/entrypoint/input.rs
@@ -22,6 +22,8 @@ pub mod text;
 
 use dynamo_runtime::protocols::ENDPOINT_SCHEME;
 
+use crate::http::service::SystemRouteExtension;
+
 /// The various ways of connecting prompts to an engine
 #[derive(PartialEq)]
 pub enum Input {
@@ -98,6 +100,17 @@ pub async fn run_input(
     in_opt: Input,
     engine_config: super::EngineConfig,
 ) -> anyhow::Result<()> {
+    run_input_with_system_route_extensions(drt, in_opt, engine_config, Vec::new()).await
+}
+
+/// Run the given engine (EngineConfig) connected to an input, with optional
+/// system route extensions for the HTTP frontend.
+pub async fn run_input_with_system_route_extensions(
+    drt: dynamo_runtime::DistributedRuntime,
+    in_opt: Input,
+    engine_config: super::EngineConfig,
+    system_route_extensions: Vec<SystemRouteExtension>,
+) -> anyhow::Result<()> {
     if let Err(e) = crate::request_trace::init_from_env_with_shutdown(drt.child_token()).await {
         tracing::warn!(error = %e, "Request trace initialization failed; continuing without trace sink");
     }
@@ -118,20 +131,33 @@ pub async fn run_input(
 
     match in_opt {
         Input::Http => {
-            http::run(drt, engine_config).await?;
+            http::run_with_system_route_extensions(drt, engine_config, system_route_extensions)
+                .await?;
         }
         Input::Grpc => {
+            if !system_route_extensions.is_empty() {
+                anyhow::bail!("system route extensions are only supported by HTTP input");
+            }
             grpc::run(drt, engine_config).await?;
         }
         Input::Text => {
+            if !system_route_extensions.is_empty() {
+                anyhow::bail!("system route extensions are only supported by HTTP input");
+            }
             text::run(drt, None, engine_config).await?;
         }
         Input::Stdin => {
+            if !system_route_extensions.is_empty() {
+                anyhow::bail!("system route extensions are only supported by HTTP input");
+            }
             let mut prompt = String::new();
             std::io::stdin().read_to_string(&mut prompt).unwrap();
             text::run(drt, Some(prompt), engine_config).await?;
         }
         Input::Endpoint(path) => {
+            if !system_route_extensions.is_empty() {
+                anyhow::bail!("system route extensions are only supported by HTTP input");
+            }
             endpoint::run(drt, path, engine_config).await?;
         }
     }

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -9,7 +9,10 @@ use crate::{
     endpoint_type::EndpointType,
     engines::StreamingEngineAdapter,
     entrypoint::{ChatEngineFactoryCallback, EngineConfig, RouterConfig, input::common},
-    http::service::service_v2::{self, HttpService},
+    http::service::{
+        SystemRouteExtension,
+        service_v2::{self, HttpService},
+    },
     local_model::runtime_config::TokenizerBackend,
     namespace::NamespaceFilter,
     types::openai::{
@@ -24,6 +27,15 @@ use dynamo_runtime::metrics::MetricsHierarchy;
 pub async fn run(
     distributed_runtime: DistributedRuntime,
     engine_config: EngineConfig,
+) -> anyhow::Result<()> {
+    run_with_system_route_extensions(distributed_runtime, engine_config, Vec::new()).await
+}
+
+/// Build and run an HTTP service with additional system route extensions.
+pub async fn run_with_system_route_extensions(
+    distributed_runtime: DistributedRuntime,
+    engine_config: EngineConfig,
+    system_route_extensions: Vec<SystemRouteExtension>,
 ) -> anyhow::Result<()> {
     let local_model = engine_config.local_model();
     let mut http_service_builder = match (local_model.tls_cert_path(), local_model.tls_key_path()) {
@@ -69,6 +81,9 @@ pub async fn run(
         http_service_builder.drt_discovery(Some(distributed_runtime.discovery()));
     http_service_builder =
         http_service_builder.runtime(Some(Arc::new(distributed_runtime.clone())));
+    for extension in system_route_extensions {
+        http_service_builder = http_service_builder.add_system_route_extension_arc(extension);
+    }
 
     let http_service = match engine_config {
         EngineConfig::Dynamic {

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -30,9 +30,11 @@ pub mod metrics;
 pub mod openapi_docs;
 pub mod realtime;
 pub mod service_v2;
+pub mod system_extension;
 
 pub use axum;
 pub use metrics::Metrics;
+pub use system_extension::SystemRouteExtension;
 
 /// Documentation for a route
 #[derive(Debug, Clone)]

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -34,10 +34,10 @@ pub mod system_extension;
 
 pub use axum;
 pub use metrics::Metrics;
-pub use system_extension::SystemRouteExtension;
+pub use system_extension::{SystemRouteContext, SystemRouteExtension, SystemRouteSet};
 
 /// Documentation for a route
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RouteDoc {
     method: axum::http::Method,
     path: String,
@@ -55,5 +55,13 @@ impl RouteDoc {
             method,
             path: path.into(),
         }
+    }
+
+    pub fn method(&self) -> &axum::http::Method {
+        &self.method
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
     }
 }

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -19,7 +19,7 @@ use super::Metrics;
 use super::RouteDoc;
 use super::metrics;
 use super::metrics::{register_lora_allocation_metrics, register_worker_timing_metrics};
-use super::system_extension::SystemRouteExtension;
+use super::system_extension::{SystemRouteContext, SystemRouteExtension, SystemRouteSet};
 use crate::discovery::ModelManager;
 use crate::endpoint_type::EndpointType;
 use crate::kv_router::metrics::{
@@ -870,7 +870,37 @@ static HTTP_SVC_RESPONSES_PATH_ENV: &str = "DYN_HTTP_SVC_RESPONSES_PATH";
 /// Environment variable to set the anthropic messages endpoint path (default: `/v1/messages`)
 static HTTP_SVC_ANTHROPIC_PATH_ENV: &str = "DYN_HTTP_SVC_ANTHROPIC_PATH";
 
+fn append_route_docs(
+    all_docs: &mut Vec<RouteDoc>,
+    seen_routes: &mut HashMap<(axum::http::Method, String), String>,
+    route_docs: Vec<RouteDoc>,
+) -> Result<()> {
+    for route_doc in route_docs {
+        let key = (route_doc.method().clone(), route_doc.path().to_string());
+        if let Some(existing) = seen_routes.get(&key) {
+            anyhow::bail!(
+                "duplicate HTTP route registered: {} conflicts with {}",
+                route_doc,
+                existing
+            );
+        }
+        seen_routes.insert(key, route_doc.to_string());
+        all_docs.push(route_doc);
+    }
+    Ok(())
+}
+
 impl HttpServiceConfigBuilder {
+    pub fn add_system_route_extension<F>(mut self, extension: F) -> Self
+    where
+        F: Fn(SystemRouteContext) -> SystemRouteSet + Send + Sync + 'static,
+    {
+        self.system_route_extensions
+            .get_or_insert_with(Vec::new)
+            .push(Arc::new(extension));
+        self
+    }
+
     pub fn build(self) -> Result<HttpService, anyhow::Error> {
         let config: HttpServiceConfig = self.build_internal()?;
         let metrics_config = config.metrics_config.clone();
@@ -968,6 +998,7 @@ impl HttpServiceConfigBuilder {
         }
 
         let mut all_docs = Vec::new();
+        let mut route_doc_keys = HashMap::new();
 
         // Shared on_response callback for both system and inference routes
         let on_response = |response: &Response<Body>, latency: Duration, _span: &tracing::Span| {
@@ -1010,12 +1041,13 @@ impl HttpServiceConfigBuilder {
             );
         }
         for extension in &config.system_route_extensions {
-            system_routes.push(extension(state.clone()));
+            let route_set = extension(SystemRouteContext::new(state.clone()));
+            system_routes.push(route_set.into_parts());
         }
         let mut system_router = axum::Router::new();
         for (route_docs, route) in system_routes {
+            append_route_docs(&mut all_docs, &mut route_doc_keys, route_docs)?;
             system_router = system_router.merge(route);
-            all_docs.extend(route_docs);
         }
         // Inference routes (completions, chat, embeddings, etc.) — info-level spans
         let endpoint_routes = HttpServiceConfigBuilder::get_endpoints_router(
@@ -1025,8 +1057,8 @@ impl HttpServiceConfigBuilder {
         );
         let mut inference_router = axum::Router::new();
         for (route_docs, route) in endpoint_routes {
+            append_route_docs(&mut all_docs, &mut route_doc_keys, route_docs)?;
             inference_router = inference_router.merge(route);
-            all_docs.extend(route_docs);
         }
         inference_router = inference_router.layer(
             TraceLayer::new_for_http()
@@ -1041,8 +1073,8 @@ impl HttpServiceConfigBuilder {
         // OpenAPI documentation routes (system)
         let (openapi_docs, openapi_route) =
             super::openapi_docs::openapi_router(all_docs.clone(), None);
+        append_route_docs(&mut all_docs, &mut route_doc_keys, openapi_docs)?;
         system_router = system_router.merge(openapi_route);
-        all_docs.extend(openapi_docs);
 
         system_router = system_router.layer(
             TraceLayer::new_for_http()
@@ -1394,7 +1426,14 @@ mod tests {
         handle.abort();
     }
 
-    fn test_system_extension(state: Arc<State>) -> (Vec<RouteDoc>, axum::Router) {
+    fn make_chat_engine()
+    -> crate::types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine {
+        Arc::new(crate::engines::StreamingEngineAdapter::new(
+            crate::engines::make_echo_engine(),
+        ))
+    }
+
+    fn readiness_extension(context: SystemRouteContext) -> SystemRouteSet {
         let route_docs = vec![RouteDoc::new(
             axum::http::Method::GET,
             "/test/system-extension",
@@ -1402,13 +1441,13 @@ mod tests {
         let route = axum::Router::new()
             .route(
                 "/test/system-extension",
-                axum::routing::get(test_system_extension_handler),
+                axum::routing::get(readiness_extension_handler),
             )
-            .with_state(state);
-        (route_docs, route)
+            .with_state(context.state_clone());
+        SystemRouteSet::new(route_docs, route)
     }
 
-    async fn test_system_extension_handler(
+    async fn readiness_extension_handler(
         axum::extract::State(state): axum::extract::State<Arc<State>>,
     ) -> axum::http::StatusCode {
         if state.manager().has_any_ready_model() {
@@ -1418,24 +1457,199 @@ mod tests {
         }
     }
 
+    fn first_test_extension(context: SystemRouteContext) -> SystemRouteSet {
+        test_status_extension(context, "/test/system-extension/one")
+    }
+
+    fn second_test_extension(context: SystemRouteContext) -> SystemRouteSet {
+        test_status_extension(context, "/test/system-extension/two")
+    }
+
+    fn duplicate_health_extension(context: SystemRouteContext) -> SystemRouteSet {
+        test_status_extension(context, "/health")
+    }
+
+    fn duplicate_test_extension(context: SystemRouteContext) -> SystemRouteSet {
+        test_status_extension(context, "/test/system-extension/duplicate")
+    }
+
+    fn draining_extension(context: SystemRouteContext) -> SystemRouteSet {
+        let route_docs = vec![RouteDoc::new(
+            axum::http::Method::GET,
+            "/test/system-extension/draining",
+        )];
+        let route = axum::Router::new()
+            .route(
+                "/test/system-extension/draining",
+                axum::routing::get(draining_extension_handler),
+            )
+            .with_state(context.state_clone());
+        SystemRouteSet::new(route_docs, route)
+    }
+
+    fn test_status_extension(context: SystemRouteContext, path: &str) -> SystemRouteSet {
+        let route_docs = vec![RouteDoc::new(axum::http::Method::GET, path)];
+        let route = axum::Router::new()
+            .route(path, axum::routing::get(no_content_extension_handler))
+            .with_state(context.state_clone());
+        SystemRouteSet::new(route_docs, route)
+    }
+
+    async fn no_content_extension_handler(
+        axum::extract::State(_state): axum::extract::State<Arc<State>>,
+    ) -> axum::http::StatusCode {
+        axum::http::StatusCode::NO_CONTENT
+    }
+
+    async fn draining_extension_handler(
+        axum::extract::State(state): axum::extract::State<Arc<State>>,
+    ) -> axum::http::StatusCode {
+        if state.is_ready() {
+            axum::http::StatusCode::OK
+        } else {
+            axum::http::StatusCode::ACCEPTED
+        }
+    }
+
+    async fn get_status(port: u16, path: &str) -> reqwest::StatusCode {
+        reqwest::Client::new()
+            .get(format!("http://localhost:{}{}", port, path))
+            .send()
+            .await
+            .expect("request failed")
+            .status()
+    }
+
+    fn build_error_message(builder: HttpServiceConfigBuilder) -> String {
+        match builder.build() {
+            Ok(_) => panic!("service build unexpectedly succeeded"),
+            Err(err) => err.to_string(),
+        }
+    }
+
     #[tokio::test]
-    async fn test_system_route_extension_can_serve_from_frontend_state() {
-        let extension: SystemRouteExtension = Arc::new(test_system_extension);
+    async fn test_system_route_extension_uses_live_frontend_state() {
         let cancel_token = Arc::new(CancellationToken::new());
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let service = HttpService::builder()
             .port(port)
-            .system_route_extensions(vec![extension])
+            .add_system_route_extension(readiness_extension)
             .build()
             .unwrap();
 
+        assert!(
+            service
+                .route_docs()
+                .iter()
+                .any(|doc| doc.to_string() == "GET /test/system-extension")
+        );
+
+        let running_service = service.clone();
+        let service_token = cancel_token.clone();
+        let handle = tokio::spawn(async move {
+            running_service
+                .run_with_listener((*service_token).clone(), listener)
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        assert_eq!(
+            get_status(port, "/test/system-extension").await,
+            reqwest::StatusCode::SERVICE_UNAVAILABLE
+        );
+
+        let mut card = crate::model_card::ModelDeploymentCard::default();
+        card.display_name = "pending-llama".to_string();
+        service
+            .model_manager()
+            .save_model_card("instance-pending", card)
+            .unwrap();
+        assert_eq!(
+            get_status(port, "/test/system-extension").await,
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            "card-only model registration must not make the extension report ready"
+        );
+
+        service
+            .model_manager()
+            .add_chat_completions_model("ready-llama", "abc", make_chat_engine())
+            .unwrap();
+        assert_eq!(
+            get_status(port, "/test/system-extension").await,
+            reqwest::StatusCode::OK
+        );
+
+        let openapi = reqwest::Client::new()
+            .get(format!("http://localhost:{}/openapi.json", port))
+            .send()
+            .await
+            .expect("openapi request failed")
+            .text()
+            .await
+            .expect("openapi body failed");
+        assert!(openapi.contains("/test/system-extension"));
+
+        cancel_token.cancel();
+        handle.abort();
+    }
+
+    #[test]
+    fn test_multiple_system_route_extensions_are_registered() {
+        let service = HttpService::builder()
+            .add_system_route_extension(first_test_extension)
+            .add_system_route_extension(second_test_extension)
+            .build()
+            .unwrap();
         let route_doc_strings = service
             .route_docs()
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>();
-        assert!(route_doc_strings.contains(&"GET /test/system-extension".to_string()));
+
+        assert!(route_doc_strings.contains(&"GET /test/system-extension/one".to_string()));
+        assert!(route_doc_strings.contains(&"GET /test/system-extension/two".to_string()));
+    }
+
+    #[test]
+    fn test_system_route_extension_rejects_builtin_route_conflict() {
+        let error = build_error_message(
+            HttpService::builder().add_system_route_extension(duplicate_health_extension),
+        );
+
+        assert!(
+            error.contains("duplicate HTTP route registered: GET /health"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_system_route_extension_rejects_extension_route_conflict() {
+        let error = build_error_message(
+            HttpService::builder()
+                .add_system_route_extension(duplicate_test_extension)
+                .add_system_route_extension(duplicate_test_extension),
+        );
+
+        assert!(
+            error.contains("duplicate HTTP route registered: GET /test/system-extension/duplicate"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_system_route_extension_stays_available_while_draining() {
+        let cancel_token = Arc::new(CancellationToken::new());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let service = HttpService::builder()
+            .port(port)
+            .add_system_route_extension(draining_extension)
+            .build()
+            .unwrap();
+        let state = service.state_clone();
+        let inflight = state.acquire_inflight();
 
         let service_token = cancel_token.clone();
         let handle = tokio::spawn(async move {
@@ -1446,14 +1660,15 @@ mod tests {
         });
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-        let resp = reqwest::Client::new()
-            .get(format!("http://localhost:{}/test/system-extension", port))
-            .send()
-            .await
-            .expect("request failed");
-        assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
-
         cancel_token.cancel();
+        wait_for_service_stage(&state, ServiceStage::Draining).await;
+
+        assert_eq!(
+            get_status(port, "/test/system-extension/draining").await,
+            reqwest::StatusCode::ACCEPTED
+        );
+
+        drop(inflight);
         handle.abort();
     }
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -901,6 +901,13 @@ impl HttpServiceConfigBuilder {
         self
     }
 
+    pub fn add_system_route_extension_arc(mut self, extension: SystemRouteExtension) -> Self {
+        self.system_route_extensions
+            .get_or_insert_with(Vec::new)
+            .push(extension);
+        self
+    }
+
     pub fn build(self) -> Result<HttpService, anyhow::Error> {
         let config: HttpServiceConfig = self.build_internal()?;
         let metrics_config = config.metrics_config.clone();

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -19,6 +19,7 @@ use super::Metrics;
 use super::RouteDoc;
 use super::metrics;
 use super::metrics::{register_lora_allocation_metrics, register_worker_timing_metrics};
+use super::system_extension::SystemRouteExtension;
 use crate::discovery::ModelManager;
 use crate::endpoint_type::EndpointType;
 use crate::kv_router::metrics::{
@@ -514,8 +515,13 @@ pub struct HttpServiceConfig {
     #[builder(default)]
     metrics_config: MetricsConfig,
 
-    // #[builder(default)]
-    // custom: Vec<axum::Router>
+    /// Additional system routes merged with the built-in health, metrics, and model routes.
+    ///
+    /// Extensions receive the shared frontend state, allowing handlers to build
+    /// responses from live model manager and discovery state.
+    #[builder(default)]
+    system_route_extensions: Vec<SystemRouteExtension>,
+
     #[builder(default = "false")]
     enable_chat_endpoints: bool,
 
@@ -1003,6 +1009,9 @@ impl HttpServiceConfigBuilder {
                 "frontend admin API disabled — busy_threshold routes not registered"
             );
         }
+        for extension in &config.system_route_extensions {
+            system_routes.push(extension(state.clone()));
+        }
         let mut system_router = axum::Router::new();
         for (route_docs, route) in system_routes {
             system_router = system_router.merge(route);
@@ -1380,6 +1389,69 @@ mod tests {
             .await
             .expect("request failed");
         assert_eq!(live.status(), reqwest::StatusCode::OK);
+
+        cancel_token.cancel();
+        handle.abort();
+    }
+
+    fn test_system_extension(state: Arc<State>) -> (Vec<RouteDoc>, axum::Router) {
+        let route_docs = vec![RouteDoc::new(
+            axum::http::Method::GET,
+            "/test/system-extension",
+        )];
+        let route = axum::Router::new()
+            .route(
+                "/test/system-extension",
+                axum::routing::get(test_system_extension_handler),
+            )
+            .with_state(state);
+        (route_docs, route)
+    }
+
+    async fn test_system_extension_handler(
+        axum::extract::State(state): axum::extract::State<Arc<State>>,
+    ) -> axum::http::StatusCode {
+        if state.manager().has_any_ready_model() {
+            axum::http::StatusCode::OK
+        } else {
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        }
+    }
+
+    #[tokio::test]
+    async fn test_system_route_extension_can_serve_from_frontend_state() {
+        let extension: SystemRouteExtension = Arc::new(test_system_extension);
+        let cancel_token = Arc::new(CancellationToken::new());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let service = HttpService::builder()
+            .port(port)
+            .system_route_extensions(vec![extension])
+            .build()
+            .unwrap();
+
+        let route_doc_strings = service
+            .route_docs()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        assert!(route_doc_strings.contains(&"GET /test/system-extension".to_string()));
+
+        let service_token = cancel_token.clone();
+        let handle = tokio::spawn(async move {
+            service
+                .run_with_listener((*service_token).clone(), listener)
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let resp = reqwest::Client::new()
+            .get(format!("http://localhost:{}/test/system-extension", port))
+            .send()
+            .await
+            .expect("request failed");
+        assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
 
         cancel_token.cancel();
         handle.abort();

--- a/lib/llm/src/http/service/system_extension.rs
+++ b/lib/llm/src/http/service/system_extension.rs
@@ -6,14 +6,83 @@
 use std::sync::Arc;
 
 use axum::Router;
+use dynamo_runtime::discovery::Discovery;
 
 use super::RouteDoc;
 use super::service_v2::State;
+use crate::discovery::ModelManager;
+
+/// Live frontend context available to system route extensions.
+///
+/// The wrapper keeps the extension API focused on system-route needs. Additional
+/// accessors can be added here as the extension surface matures.
+#[derive(Clone)]
+pub struct SystemRouteContext {
+    state: Arc<State>,
+}
+
+impl SystemRouteContext {
+    pub(crate) fn new(state: Arc<State>) -> Self {
+        Self { state }
+    }
+
+    /// Return the shared Axum state for routes that need to install handlers
+    /// with Router::with_state.
+    pub fn state_clone(&self) -> Arc<State> {
+        self.state.clone()
+    }
+
+    pub fn manager(&self) -> &ModelManager {
+        self.state.manager()
+    }
+
+    pub fn manager_clone(&self) -> Arc<ModelManager> {
+        self.state.manager_clone()
+    }
+
+    pub fn discovery(&self) -> Arc<dyn Discovery> {
+        self.state.discovery()
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.state.is_ready()
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.state.is_cancelled()
+    }
+}
+
+/// Routes and route documentation returned by a system route extension.
+pub struct SystemRouteSet {
+    route_docs: Vec<RouteDoc>,
+    router: Router,
+}
+
+impl SystemRouteSet {
+    pub fn new(route_docs: Vec<RouteDoc>, router: Router) -> Self {
+        Self { route_docs, router }
+    }
+
+    pub fn route_docs(&self) -> &[RouteDoc] {
+        &self.route_docs
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<RouteDoc>, Router) {
+        (self.route_docs, self.router)
+    }
+}
+
+impl From<(Vec<RouteDoc>, Router)> for SystemRouteSet {
+    fn from((route_docs, router): (Vec<RouteDoc>, Router)) -> Self {
+        Self::new(route_docs, router)
+    }
+}
 
 /// Callback used to attach additional system routes during HTTP service build.
 ///
-/// Extensions receive the shared frontend state used by built-in system
-/// handlers, so custom routes can answer from live model manager and discovery
-/// state instead of precomputed startup metadata.
+/// Extensions receive live frontend context used by built-in system handlers,
+/// so custom routes can answer from current model manager and discovery state
+/// instead of precomputed startup metadata.
 pub type SystemRouteExtension =
-    Arc<dyn Fn(Arc<State>) -> (Vec<RouteDoc>, Router) + Send + Sync + 'static>;
+    Arc<dyn Fn(SystemRouteContext) -> SystemRouteSet + Send + Sync + 'static>;

--- a/lib/llm/src/http/service/system_extension.rs
+++ b/lib/llm/src/http/service/system_extension.rs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Extension point for system routes hosted by the HTTP frontend.
+
+use std::sync::Arc;
+
+use axum::Router;
+
+use super::RouteDoc;
+use super::service_v2::State;
+
+/// Callback used to attach additional system routes during HTTP service build.
+///
+/// Extensions receive the shared frontend state used by built-in system
+/// handlers, so custom routes can answer from live model manager and discovery
+/// state instead of precomputed startup metadata.
+pub type SystemRouteExtension =
+    Arc<dyn Fn(Arc<State>) -> (Vec<RouteDoc>, Router) + Send + Sync + 'static>;


### PR DESCRIPTION
## Summary

Follow-up to #11132. This is intentionally a separate draft PR because the loader is the higher-risk/security-review portion of the design, while #11132 should stay as the small Rust hook.

This PR adds an opt-in path for stock `python -m dynamo.frontend` to load trusted system route extensions:

- adds `--system-route-extension` / `DYN_SYSTEM_ROUTE_EXTENSIONS`
- resolves extension names from the Python entry point group `dynamo.system_route_extensions`
- exposes Python-facing `SystemRoute` and read-only `SystemRouteContext`
- threads optional system routes through `run_input(...)` into the Rust HTTP service builder
- keeps default frontend behavior unchanged when no extension is configured

Because #11132 has not merged yet, this PR currently includes the hook commits in its diff. After #11132 lands, this branch should be rebased onto `main` so the visible diff is only the loader.

## Security / Scope

This is disabled by default and intentionally limited to system/control-plane routes. It does not add inference middleware, worker lifecycle plugins, route overriding, or NIM-specific endpoints.

Extensions receive a small read-only context for live frontend state, not the raw runtime or discovery objects.

## Validation

- `cargo fmt --all --check`
- `cargo test -p dynamo-llm system_route_extension`
- `cargo check` in `lib/bindings/python`
- `PROTOC=/tmp/nim-dynamo-protoc-25.3/bin/protoc cargo test` in `lib/bindings/python`
- `PROTOC=/tmp/nim-dynamo-protoc-25.3/bin/protoc cargo clippy --all-targets -- -D warnings` in `lib/bindings/python`
- `PROTOC=/tmp/nim-dynamo-protoc-25.3/bin/protoc cargo clippy -p dynamo-llm --all-targets -- -D warnings`
- `python3 -m py_compile components/src/dynamo/frontend/main.py components/src/dynamo/frontend/frontend_args.py components/src/dynamo/frontend/tests/test_system_route_extension_loader.py lib/bindings/python/src/dynamo/llm/__init__.py`
