### PR TITLE
test: rebase #9253 XPU DRA examples onto latest main (deploy-operator repro)

### DIFF
--- a/examples/backends/vllm/deploy/README.md
+++ b/examples/backends/vllm/deploy/README.md
@@ -174,7 +174,7 @@ kubectl apply -f $DEPLOYMENT_FILE -n $NAMESPACE
 
 #### Deploy with Intel XPU
 
-For Intel XPU clusters with DRA support (Kubernetes v1.34+ and [Intel GPU Resource Driver](https://github.com/intel/intel-resource-drivers-for-kubernetes) installed):
+For Intel XPU clusters with DRA support (Kubernetes v1.34+ and [Intel resource drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes) installed):
 
 ```bash
 # Apply any XPU template

--- a/examples/backends/vllm/deploy/README.md
+++ b/examples/backends/vllm/deploy/README.md
@@ -40,20 +40,11 @@ Advanced disaggregated deployment with KV cache routing capabilities.
 ### 5. **Global Planner Deployments** (see [`examples/global_planner/`](../../../global_planner/))
 Centralized scaling across multiple DGDs via GlobalPlanner. Examples include single-endpoint multi-pool and multi-model GPU budget patterns. See the [global planner examples](../../../global_planner/) for details.
 
-### 6. **Deployments with Intel XPU (Optional)** (`agg_xpu_dra.yaml` or `disagg_xpu_dra.yaml`)
-Hardware-specific aggregated/disaggregated deployment using Kubernetes Dynamic Resource Allocation (DRA).
+### 6. **Deployments with Intel XPU** (see [`xpu/`](./xpu/))
 
-**Aggregated Architecture:**
-- `Frontend`: OpenAI-compatible API server
-- `VllmDecodeWorker`: Single worker with XPU target (`VLLM_TARGET_DEVICE=xpu`)
-- GPU allocation via `ResourceClaimTemplate` and pod-level `resourceClaims`
+Hardware-specific templates for Intel XPU GPUs using Kubernetes DRA.
 
-**Disaggregated Architecture:**
-- `Frontend`: HTTP API server coordinating between workers
-- `VllmDecodeWorker`: Specialized decode-only worker with XPU target
-- `VllmPrefillWorker`: Specialized prefill-only worker with XPU target
-- GPU allocation via `ResourceClaimTemplate` and pod-level `resourceClaims`
-- Communication via NIXL transfer backend with XPU buffer
+See [`xpu/README.md`](./xpu/README.md) for available templates, prerequisites, and usage.
 
 ## CRD Structure
 
@@ -141,8 +132,8 @@ Select the deployment pattern that matches your requirements:
 - Use `disagg.yaml` for maximum performance
 - Use `disagg_router.yaml` for high-performance with KV cache routing
 - Use `disagg_planner.yaml` for SLA-optimized performance
-- Use `agg_xpu_dra.yaml` for aggregated deployment on Intel XPU clusters using Kubernetes DRA
-- Use `disagg_xpu_dra.yaml` for disaggregated deployment on Intel XPU clusters using Kubernetes DRA
+- Use `xpu/agg_xpu_dra.yaml` for aggregated deployment on Intel XPU clusters using Kubernetes DRA
+- Use `xpu/disagg_xpu_dra.yaml` for disaggregated deployment on Intel XPU clusters using Kubernetes DRA
 - Use [global planner examples](../../../global_planner/) for centralized scaling across multiple DGDs
 
 ### 2. Customize Configuration
@@ -181,30 +172,20 @@ export DEPLOYMENT_FILE=agg.yaml
 kubectl apply -f $DEPLOYMENT_FILE -n $NAMESPACE
 ```
 
-#### Deploy with Intel XPU  (Optional)
-If your cluster uses Intel GPU devices via Kubernetes Dynamic Resource Allocation (DRA), ensure:
-- Your Kubernetes cluster is **v1.34+** (required for DRA API v1), and
-- The [Intel XPU Resource Driver](https://github.com/intel/intel-resource-drivers-for-kubernetes) is installed.
+#### Deploy with Intel XPU
 
-Deploy the XPU template (includes the ResourceClaimTemplate):
-```bash
-cd <dynamo-source-root>/examples/backends/vllm/deploy
-
-# For aggregated deployment
-kubectl apply -f agg_xpu_dra.yaml -n $NAMESPACE
-
-# OR for disaggregated deployment
-kubectl apply -f disagg_xpu_dra.yaml -n $NAMESPACE
-```
-
-Verify claim allocation:
+For Intel XPU clusters with DRA support (Kubernetes v1.34+ and [Intel GPU Resource Driver](https://github.com/intel/intel-resource-drivers-for-kubernetes) installed):
 
 ```bash
+# Apply any XPU template
+kubectl apply -f xpu/agg_xpu_dra.yaml -n $NAMESPACE
+
+# Verify allocation
 kubectl get resourceclaim -n $NAMESPACE
-kubectl get dynamographdeployment -n $NAMESPACE
+kubectl get resourceslices
 ```
 
-`agg_xpu_dra.yaml` and `disagg_xpu_dra.yaml` are optional hardware-specific templates and do not change the default deployment paths defined by `agg.yaml` and `disagg.yaml`.
+See [`xpu/README.md`](./xpu/README.md) for the full list of XPU templates and requirements.
 
 ### 4. Using Custom Dynamo Frameworks Image for vLLM
 

--- a/examples/backends/vllm/deploy/v1beta1/xpu/agg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/xpu/agg_xpu_dra.yaml
@@ -17,7 +17,7 @@ spec:
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
-  name: vllm-disagg-xpu-dra
+  name: vllm-agg-xpu-dra
 spec:
   components:
   - name: Frontend
@@ -38,8 +38,6 @@ spec:
         - args:
           - --model
           - Qwen/Qwen3-0.6B
-          - --disaggregation-mode
-          - decode
           - --block-size
           - "64"
           command:
@@ -52,7 +50,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:
             claims:
@@ -65,41 +63,4 @@ spec:
         - name: gpu
           resourceClaimTemplateName: gpu-template
     replicas: 1
-    type: decode
-  - name: VllmPrefillWorker
-    podTemplate:
-      spec:
-        containers:
-        - args:
-          - --model
-          - Qwen/Qwen3-0.6B
-          - --disaggregation-mode
-          - prefill
-          - --kv-transfer-config
-          - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"xpu"}'
-          - --block-size
-          - "64"
-          command:
-          - python3
-          - -m
-          - dynamo.vllm
-          env:
-          - name: VLLM_TARGET_DEVICE
-            value: xpu
-          envFrom:
-          - secretRef:
-              name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          name: main
-          resources:
-            claims:
-            - name: gpu
-            requests:
-              # Increase this value for larger models.
-              ephemeral-storage: 2Gi
-          workingDir: /workspace/examples/backends/vllm
-        resourceClaims:
-        - name: gpu
-          resourceClaimTemplateName: gpu-template
-    replicas: 1
-    type: prefill
+    type: worker

--- a/examples/backends/vllm/deploy/v1beta1/xpu/disagg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/xpu/disagg_xpu_dra.yaml
@@ -17,7 +17,7 @@ spec:
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
-  name: vllm-agg-xpu-dra
+  name: vllm-disagg-xpu-dra
 spec:
   components:
   - name: Frontend
@@ -38,6 +38,8 @@ spec:
         - args:
           - --model
           - Qwen/Qwen3-0.6B
+          - --disaggregation-mode
+          - decode
           - --block-size
           - "64"
           command:
@@ -50,7 +52,7 @@ spec:
           envFrom:
           - secretRef:
               name: hf-token-secret
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           name: main
           resources:
             claims:
@@ -63,4 +65,41 @@ spec:
         - name: gpu
           resourceClaimTemplateName: gpu-template
     replicas: 1
-    type: worker
+    type: decode
+  - name: VllmPrefillWorker
+    podTemplate:
+      spec:
+        containers:
+        - args:
+          - --model
+          - Qwen/Qwen3-0.6B
+          - --disaggregation-mode
+          - prefill
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"xpu"}'
+          - --block-size
+          - "64"
+          command:
+          - python3
+          - -m
+          - dynamo.vllm
+          env:
+          - name: VLLM_TARGET_DEVICE
+            value: xpu
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          name: main
+          resources:
+            claims:
+            - name: gpu
+            requests:
+              # Increase this value for larger models.
+              ephemeral-storage: 2Gi
+          workingDir: /workspace/examples/backends/vllm
+        resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: gpu-template
+    replicas: 1
+    type: prefill

--- a/examples/backends/vllm/deploy/v1beta1/xpu/disagg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/xpu/disagg_xpu_dra.yaml
@@ -40,6 +40,8 @@ spec:
           - Qwen/Qwen3-0.6B
           - --disaggregation-mode
           - decode
+          - --kv-transfer-config
+          - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"xpu"}'
           - --block-size
           - "64"
           command:

--- a/examples/backends/vllm/deploy/xpu/README.md
+++ b/examples/backends/vllm/deploy/xpu/README.md
@@ -1,0 +1,73 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Intel XPU Deployment Examples
+
+Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynamic Resource Allocation (DRA).
+
+## Available Templates
+
+| File | Pattern | Description |
+|------|---------|-------------|
+| `agg_xpu_dra.yaml` | Aggregated | Single worker with XPU target |
+| `agg_tracing_xpu_dra.yaml` | Aggregated + Tracing | Single worker with OpenTelemetry tracing |
+| `disagg_xpu_dra.yaml` | Disaggregated | Prefill/decode separation with NixlConnector |
+| `disagg_tracing_xpu_dra.yaml` | Disaggregated + Tracing | Disaggregated with OpenTelemetry tracing |
+| `disagg_planner_xpu_dra.yaml` | Disaggregated + Planner | Global Planner for throughput scaling |
+
+## Prerequisites
+
+1. **Kubernetes v1.34+** with DRA API v1 enabled
+2. **Intel GPU DRA Driver** installed with DeviceClass `gpu.intel.com`
+3. **Custom XPU runtime image** (build from source with `--device xpu`)
+4. **HuggingFace token secret**:
+   ```bash
+   export HF_TOKEN=your_hf_token
+   kubectl create secret generic hf-token-secret \
+     --from-literal=HF_TOKEN=${HF_TOKEN} \
+     -n ${NAMESPACE}
+   ```
+
+## Key Differences from NVIDIA Templates
+
+| Aspect | NVIDIA | Intel XPU |
+|--------|--------|-----------|
+| GPU Allocation | `resources.limits.gpu` | DRA `ResourceClaimTemplate` |
+| Device Target | Default (CUDA) | `VLLM_TARGET_DEVICE: xpu` |
+| KV Transfer | Default buffer | `kv_buffer_device: "xpu"` |
+| DeviceClass | `nvidia.com` | `gpu.intel.com` |
+
+## Deploy
+
+```bash
+# Apply template (includes ResourceClaimTemplate)
+kubectl apply -f xpu/agg_xpu_dra.yaml -n $NAMESPACE
+
+# Verify GPU allocation
+kubectl get resourceclaim -n $NAMESPACE
+kubectl get resourceslices
+
+# Check deployment status
+kubectl get dynamographdeployment -n $NAMESPACE
+kubectl get pods -n $NAMESPACE
+```
+
+## Testing
+
+```bash
+# Port forward to frontend
+kubectl port-forward deployment/vllm-agg-xpu-dra-frontend 8000:8000 -n $NAMESPACE
+
+# Test inference
+curl localhost:8000/v1/models
+curl localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"Qwen/Qwen3-0.6B","prompt":"Hello","max_tokens":20}'
+```
+
+## Further Reading
+
+- [Main Deployment README](../README.md) - Overview of all deployment patterns
+- [Intel XPU Resource Driver](https://github.com/intel/intel-resource-drivers-for-kubernetes)

--- a/examples/backends/vllm/deploy/xpu/README.md
+++ b/examples/backends/vllm/deploy/xpu/README.md
@@ -20,8 +20,14 @@ Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynam
 ## Prerequisites
 
 1. **Kubernetes v1.34+** with DRA API v1 enabled
-2. **Intel GPU DRA Driver** installed with DeviceClass `gpu.intel.com`
-3. **Custom XPU runtime image** (build from source with `--device xpu`)
+2. **[Intel resource drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes)** installed with DeviceClass `gpu.intel.com`
+3. **Custom XPU runtime image** built with Intel XPU support:
+   ```bash
+   python container/render.py --framework=vllm --device=xpu --target=runtime
+   docker build -t nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag \
+     -f container/vllm-runtime-xpu-amd64-rendered.Dockerfile .
+   ```
+   See [container/README.md](../../../../../container/README.md) for complete build instructions.
 4. **HuggingFace token secret**:
    ```bash
    export HF_TOKEN=your_hf_token
@@ -70,4 +76,4 @@ curl localhost:8000/v1/completions \
 ## Further Reading
 
 - [Main Deployment README](../README.md) - Overview of all deployment patterns
-- [Intel XPU Resource Driver](https://github.com/intel/intel-resource-drivers-for-kubernetes)
+- [Intel resource drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes)

--- a/examples/backends/vllm/deploy/xpu/README.md
+++ b/examples/backends/vllm/deploy/xpu/README.md
@@ -13,9 +13,12 @@ Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynam
 |------|---------|-------------|
 | `agg_xpu_dra.yaml` | Aggregated | Single worker with XPU target |
 | `agg_tracing_xpu_dra.yaml` | Aggregated + Tracing | Single worker with OpenTelemetry tracing |
+| `agg_router_xpu_dra.yaml` | Aggregated + KV Router | Aggregated deployment with KV routing |
+| `agg_router_kv_approx_xpu_dra.yaml` | Aggregated + KV Router (Local) | KV routing without NATS dependency |
 | `disagg_xpu_dra.yaml` | Disaggregated | Prefill/decode separation with NixlConnector |
 | `disagg_tracing_xpu_dra.yaml` | Disaggregated + Tracing | Disaggregated with OpenTelemetry tracing |
 | `disagg_planner_xpu_dra.yaml` | Disaggregated + Planner | Global Planner for throughput scaling |
+| `disagg_router_xpu_dra.yaml` | Disaggregated + KV Router | Disaggregated with KV cache routing |
 
 ## Prerequisites
 

--- a/examples/backends/vllm/deploy/xpu/agg_router_kv_approx_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/agg_router_kv_approx_xpu_dra.yaml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# XPU Aggregated Deployment with KV Router (No-KV-Events Mode)
+#
+# This example demonstrates KV-aware routing with the --no-kv-events flag.
+# Instead of receiving KV events from workers, the router predicts cache state
+# locally based on routing decisions with TTL-based expiration and pruning.
+#
+# Benefits:
+# - No NATS or JetStream required
+# - Simpler deployment for lightweight scenarios
+# - Router makes local predictions based on its own routing decisions
+#
+# Requirements:
+# - Intel XPU with DRA (Dynamic Resource Allocation) driver installed
+# - Dynamo Operator with v1alpha1 support
+# - XPU-specific vLLM image (nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag)
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: xpu-agg-kvap
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+          args:
+            - -m
+            - dynamo.frontend
+            - --router-mode
+            - kv
+            - --no-kv-events
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 2
+      resources:
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          imagePullPolicy: IfNotPresent
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --block-size
+            - "64"
+            # Disable KV events - router will use local prediction
+            - --kv-events-config
+            - '{"enable_kv_cache_events": false}'
+            # Enable prefix caching for KV reuse
+            - --enable-prefix-caching

--- a/examples/backends/vllm/deploy/xpu/agg_router_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/agg_router_xpu_dra.yaml
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# XPU Aggregated Deployment with KV Router
+#
+# This example demonstrates aggregated serving (single worker type that handles
+# both prefill and decode) with KV Router enabled.
+#
+# ⚠️ IMPORTANT LIMITATION: In Aggregated mode, VllmDecodeWorker does not generate
+# KV cache events (BlockStored) because these events are only produced during the
+# prefill phase in Disaggregated mode. As a result, KV Router in Aggregated mode
+# cannot perform intelligent routing based on KV cache availability.
+#
+# For full KV-aware routing capabilities, use disagg_router_xpu_dra.yaml instead.
+#
+# Requirements:
+# - Intel XPU with DRA (Dynamic Resource Allocation) driver installed
+# - Dynamo Operator with v1alpha1 support
+# - XPU-specific vLLM image (nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag)
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: xpu-agg-router
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          env:
+            # Enable KV Router for intelligent worker selection
+            - name: DYN_ROUTER_MODE
+              value: kv
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 2
+      resources:
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --block-size
+            - "64"
+            # Enable KV events publishing for router cache tracking
+            - --kv-events-config
+            - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+            # Enable prefix caching for KV reuse
+            - --enable-prefix-caching

--- a/examples/backends/vllm/deploy/xpu/agg_tracing_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/agg_tracing_xpu_dra.yaml
@@ -1,5 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated vLLM deployment with OpenTelemetry tracing on Intel XPU.
+# Base deployment: agg_xpu_dra.yaml
+# See docs/observability/tracing.md for setup instructions.
 
 apiVersion: resource.k8s.io/v1
 kind: ResourceClaimTemplate
@@ -17,8 +21,17 @@ spec:
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
-  name: vllm-disagg-xpu-dra
+  name: vllm-agg-tracing-xpu
 spec:
+  envs:
+    - name: DYN_LOGGING_JSONL
+      value: "true"
+    - name: OTEL_EXPORT_ENABLED
+      value: "true"
+    # NOTE: Update endpoint if observability stack is deployed
+    # Remove or disable if not using tracing
+    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      value: "http://tempo.observability.svc.cluster.local:4317"
   services:
     Frontend:
       envFromSecret: hf-token-secret
@@ -26,29 +39,40 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
+          # NOTE: Frontend doesn't need XPU, use official image
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          env:
+            - name: OTEL_SERVICE_NAME
+              value: "dynamo-frontend"
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
-      subComponentType: decode
       replicas: 1
       resources:
         requests:
           custom:
-            # Increase this value for larger models
             ephemeral-storage: "2Gi"
       extraPodSpec:
         resourceClaims:
           - name: gpu
             resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           resources:
             claims:
               - name: gpu
           env:
             - name: VLLM_TARGET_DEVICE
               value: xpu
+            - name: OTEL_SERVICE_NAME
+              value: "dynamo-worker-vllm"
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -57,43 +81,3 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-0.6B
-            - --disaggregation-mode
-            - decode
-            - --block-size
-            - "64"
-    VllmPrefillWorker:
-      envFromSecret: hf-token-secret
-      componentType: worker
-      subComponentType: prefill
-      replicas: 1
-      resources:
-        requests:
-          custom:
-            # Increase this value for larger models
-            ephemeral-storage: "2Gi"
-      extraPodSpec:
-        resourceClaims:
-          - name: gpu
-            resourceClaimTemplateName: gpu-template
-        mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          resources:
-            claims:
-              - name: gpu
-          env:
-            - name: VLLM_TARGET_DEVICE
-              value: xpu
-          workingDir: /workspace/examples/backends/vllm
-          command:
-            - python3
-            - -m
-            - dynamo.vllm
-          args:
-            - --model
-            - Qwen/Qwen3-0.6B
-            - --disaggregation-mode
-            - prefill
-            - --kv-transfer-config
-            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"xpu"}'
-            - --block-size
-            - "64"

--- a/examples/backends/vllm/deploy/xpu/agg_tracing_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/agg_tracing_xpu_dra.yaml
@@ -81,3 +81,5 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-0.6B
+            - --block-size
+            - "64"

--- a/examples/backends/vllm/deploy/xpu/agg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/agg_xpu_dra.yaml
@@ -40,8 +40,15 @@ spec:
         resourceClaims:
           - name: gpu
             resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
           resources:
             claims:
               - name: gpu

--- a/examples/backends/vllm/deploy/xpu/disagg_planner_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_planner_xpu_dra.yaml
@@ -107,6 +107,8 @@ spec:
             - Qwen/Qwen3-0.6B
             - --disaggregation-mode
             - decode
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"xpu"}'
             - --block-size
             - "64"
     VllmPrefillWorker:

--- a/examples/backends/vllm/deploy/xpu/disagg_planner_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_planner_xpu_dra.yaml
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: planner-profile-data
+data:
+  prefill_raw_data.json: |
+    {
+      "prefill_isl":          [128, 256, 512, 1024, 2048],
+      "prefill_ttft":         [12,  18,  30,  55,   105],
+      "prefill_thpt_per_gpu": [9800, 8500, 6200, 3800, 2000]
+    }
+  decode_raw_data.json: |
+    {
+      "x_kv_usage":       [0.1, 0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, 0.5, 0.5, 0.5, 0.5, 0.7, 0.7, 0.7, 0.7, 0.9, 0.9, 0.9, 0.9],
+      "y_context_length": [128, 512, 1024, 2048, 128, 512, 1024, 2048, 128, 512, 1024, 2048, 128, 512, 1024, 2048, 128, 512, 1024, 2048],
+      "z_itl":            [5, 6, 7, 9, 6, 7, 8, 10, 7, 8, 10, 12, 8, 10, 12, 15, 10, 12, 15, 20],
+      "z_thpt_per_gpu":   [4500, 4000, 3500, 2800, 4200, 3700, 3200, 2500, 3800, 3300, 2800, 2200, 3400, 2900, 2400, 1800, 2800, 2400, 1900, 1400],
+      "max_kv_tokens": 32768
+    }
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-planner-xpu
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    Planner:
+      componentType: planner
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:my-tag
+          command:
+          - python3
+          - -m
+          - dynamo.planner
+          args:
+            - --config
+            # KEY FIX: Add GPU counts here for DRA fallback
+            - '{"environment": "kubernetes", "backend": "vllm", "throughput_adjustment_interval_seconds": 60, "prefill_engine_num_gpu": 1, "decode_engine_num_gpu": 1, "profile_results_dir": "/workspace/profiling_results"}'
+          volumeMounts:
+            - name: planner-profile-data
+              mountPath: /workspace/profiling_results
+              readOnly: true
+        volumes:
+          - name: planner-profile-data
+            configMap:
+              name: planner-profile-data
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - decode
+            - --block-size
+            - "64"
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"xpu"}'
+            - --block-size
+            - "64"

--- a/examples/backends/vllm/deploy/xpu/disagg_router_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_router_xpu_dra.yaml
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# XPU Disaggregated Deployment with KV Router
+#
+# This example demonstrates disaggregated serving (Prefill/Decode separation)
+# with KV Router enabled for inteligent request routing based on KV cache availability.
+#
+# Requirements:
+# - Intel XPU with DRA (Dynamic Resource Allocation) driver installed
+# - Dynamo Operator with v1alpha1 support
+# - XPU-specific vLLM image (nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag)
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: xpu-disagg-router
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          env:
+            # Enable KV Router for intelligent worker selection
+            - name: DYN_ROUTER_MODE
+              value: kv
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 2
+      resources:
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - decode
+            - --block-size
+            - "64"
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 2
+      resources:
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - prefill
+            # Enable KV events publishing for router cache tracking
+            - --kv-events-config
+            - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+            # NixlConnector config for XPU KV transfer
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"xpu"}'
+            - --block-size
+            - "64"
+            # Enable prefix caching for KV reuse
+            - --enable-prefix-caching

--- a/examples/backends/vllm/deploy/xpu/disagg_tracing_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_tracing_xpu_dra.yaml
@@ -83,6 +83,8 @@ spec:
             - Qwen/Qwen3-0.6B
             - --disaggregation-mode
             - decode
+            - --block-size
+            - "64"
     VllmPrefillWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -126,3 +128,5 @@ spec:
             # NOTE: kv_buffer_device must be "xpu" for Intel GPU
             - --kv-transfer-config
             - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"xpu"}'
+            - --block-size
+            - "64"

--- a/examples/backends/vllm/deploy/xpu/disagg_tracing_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_tracing_xpu_dra.yaml
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Disaggregated vLLM deployment with OpenTelemetry tracing on Intel XPU.
+# Base deployment: disagg_xpu_dra.yaml
+# See docs/observability/tracing.md for setup instructions.
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-tracing-xpu
+spec:
+  envs:
+    - name: DYN_LOGGING_JSONL
+      value: "true"
+    - name: OTEL_EXPORT_ENABLED
+      value: "true"
+    # NOTE: Update or remove if observability stack not deployed
+    - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      value: "http://tempo.observability.svc.cluster.local:4317"
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          # NOTE: Frontend doesn't need XPU
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          env:
+            - name: OTEL_SERVICE_NAME
+              value: "dynamo-frontend"
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if needed for your environment
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44
+        #     - 991
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+            - name: OTEL_SERVICE_NAME
+              value: "dynamo-worker-decode"
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - decode
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if needed for your environment
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44
+        #     - 991
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+            - name: OTEL_SERVICE_NAME
+              value: "dynamo-worker-prefill"
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - prefill
+            # NOTE: kv_buffer_device must be "xpu" for Intel GPU
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"xpu"}'

--- a/examples/backends/vllm/deploy/xpu/disagg_tracing_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_tracing_xpu_dra.yaml
@@ -83,6 +83,8 @@ spec:
             - Qwen/Qwen3-0.6B
             - --disaggregation-mode
             - decode
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"xpu"}'
             - --block-size
             - "64"
     VllmPrefillWorker:

--- a/examples/backends/vllm/deploy/xpu/disagg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_xpu_dra.yaml
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-xpu-dra
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - decode
+            - --block-size
+            - "64"
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime-xpu:my-tag
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"xpu"}'
+            - --block-size
+            - "64"

--- a/examples/backends/vllm/deploy/xpu/disagg_xpu_dra.yaml
+++ b/examples/backends/vllm/deploy/xpu/disagg_xpu_dra.yaml
@@ -66,6 +66,8 @@ spec:
             - Qwen/Qwen3-0.6B
             - --disaggregation-mode
             - decode
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"xpu"}'
             - --block-size
             - "64"
     VllmPrefillWorker:

--- a/examples/global_planner/README.md
+++ b/examples/global_planner/README.md
@@ -15,6 +15,7 @@ enforces shared scaling policy across multiple DGDs.
 | `global-planner-gpu-budget.yaml` | Multi-model, GPU budget | vLLM | 2 independent model DGDs + 1 control DGD with `--max-total-gpus` |
 | `global-planner-vllm-test.yaml` | Single-endpoint, multi-pool | vLLM | 1 Frontend + GlobalRouter + GlobalPlanner, 2 prefill pools (TP1, TP2) + 1 decode pool |
 | `global-planner-mocker-test.yaml` | Single-endpoint, multi-pool | Mocker | Same as above with Mocker workers; GlobalPlanner in `--no-operation` mode |
+| `global-planner-vllm-test-xpu-dra.yaml` | Single-endpoint, multi-pool | vLLM (Intel XPU) | Same as `global-planner-vllm-test.yaml` but for Intel XPU using DRA (Dynamic Resource Allocation) |
 
 ## Deployment Patterns
 
@@ -97,6 +98,33 @@ export DYNAMO_IMAGE=<dynamo-image>
 
 envsubst < global-planner-mocker-test.yaml | kubectl apply -n ${K8S_NAMESPACE} -f -
 ```
+
+### Intel XPU with DRA Example
+
+For Intel XPU clusters using [Dynamic Resource Allocation (DRA)](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/):
+
+```bash
+export K8S_NAMESPACE=my-ns
+export DYNAMO_IMAGE=<dynamo-image>
+export DYNAMO_VLLM_IMAGE=<vllm-xpu-image>  # Must be built for XPU
+export MODEL_NAME=Qwen/Qwen3-0.6B
+export STORAGE_CLASS_NAME=<rwx-storage-class>
+
+# Create HF token secret first
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN=<your-token> -n ${K8S_NAMESPACE}
+
+envsubst < global-planner-vllm-test-xpu-dra.yaml | kubectl apply -n ${K8S_NAMESPACE} -f -
+```
+
+**Prerequisites for XPU deployment:**
+- Intel XPU GPU driver and [Intel Resource Drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes) installed
+- DRA enabled on the cluster
+- Container images built for Intel XPU (with `VLLM_TARGET_DEVICE=xpu`)
+
+**Key differences from GPU deployment:**
+- Uses DRA `ResourceClaimTemplate` instead of `resources.limits.gpu`
+- Sets `VLLM_TARGET_DEVICE=xpu` environment variable
 
 ## Verifying
 

--- a/examples/global_planner/README.md
+++ b/examples/global_planner/README.md
@@ -15,7 +15,7 @@ enforces shared scaling policy across multiple DGDs.
 | `global-planner-gpu-budget.yaml` | Multi-model, GPU budget | vLLM | 2 independent model DGDs + 1 control DGD with `--max-total-gpus` |
 | `global-planner-vllm-test.yaml` | Single-endpoint, multi-pool | vLLM | 1 Frontend + GlobalRouter + GlobalPlanner, 2 prefill pools (TP1, TP2) + 1 decode pool |
 | `global-planner-mocker-test.yaml` | Single-endpoint, multi-pool | Mocker | Same as above with Mocker workers; GlobalPlanner in `--no-operation` mode |
-| `global-planner-vllm-test-xpu-dra.yaml` | Single-endpoint, multi-pool | vLLM (Intel XPU) | Same as `global-planner-vllm-test.yaml` but for Intel XPU using DRA (Dynamic Resource Allocation) |
+| `global-planner-vllm-test-xpu-dra.yaml` | Single-endpoint, multi-pool | vLLM (Intel XPU) | XPU/DRA variant with 2 TP1 prefill pools and 1 TP1 decode pool |
 
 ## Deployment Patterns
 
@@ -118,13 +118,14 @@ envsubst < global-planner-vllm-test-xpu-dra.yaml | kubectl apply -n ${K8S_NAMESP
 ```
 
 **Prerequisites for XPU deployment:**
-- Intel XPU GPU driver and [Intel Resource Drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes) installed
+- Intel XPU GPU driver and [Intel resource drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes) installed
 - DRA enabled on the cluster
 - Container images built for Intel XPU (with `VLLM_TARGET_DEVICE=xpu`)
 
 **Key differences from GPU deployment:**
 - Uses DRA `ResourceClaimTemplate` instead of `resources.limits.gpu`
 - Sets `VLLM_TARGET_DEVICE=xpu` environment variable
+- Uses TP1 for both prefill pools because the DRA template requests one XPU per worker
 
 ## Verifying
 

--- a/examples/global_planner/global-planner-vllm-test-xpu-dra.yaml
+++ b/examples/global_planner/global-planner-vllm-test-xpu-dra.yaml
@@ -1,0 +1,471 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# vLLM-based GlobalPlanner test for Intel XPU: 2 prefill pools + 1 decode pool.
+# Using DRA (Dynamic Resource Allocation) for Intel XPU GPU access.
+#
+# Architecture:
+#   DGD gp-ctrl:      Frontend + GlobalRouter + GlobalPlanner
+#   DGD gp-prefill-0: LocalRouter + VllmPrefillWorker (TP1) + Planner
+#   DGD gp-prefill-1: LocalRouter + VllmPrefillWorker (TP1) + Planner
+#   DGD gp-decode-0:  LocalRouter + VllmDecodeWorker  (TP1) + Planner
+#
+# Prerequisites:
+#   - Intel XPU GPU driver and DRA (Dynamic Resource Allocation) configured on the cluster.
+#     See: https://github.com/intel/intel-resource-drivers-for-kubernetes
+#   - HuggingFace token secret: kubectl create secret generic hf-token-secret \
+#       --from-literal=HF_TOKEN=<your-token> -n ${K8S_NAMESPACE}
+#   - A ReadWriteMany StorageClass for the shared model cache PVC
+#
+# Usage:
+#   export K8S_NAMESPACE=... DYNAMO_IMAGE=... DYNAMO_VLLM_IMAGE=... MODEL_NAME=... STORAGE_CLASS_NAME=...
+#   envsubst < global-planner-vllm-test-xpu-dra.yaml | kubectl apply   -n ${K8S_NAMESPACE} -f -
+#   envsubst < global-planner-vllm-test-xpu-dra.yaml | kubectl delete  -n ${K8S_NAMESPACE} -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: planner-profile-data
+data:
+  prefill_raw_data.json: |
+    {
+      "prefill_isl":          [128, 256, 512, 1024, 2048],
+      "prefill_ttft":         [12,  18,  30,  55,   105],
+      "prefill_thpt_per_gpu": [9800, 8500, 6200, 3800, 2000]
+    }
+  decode_raw_data.json: |
+    {
+      "x_kv_usage":       [0.1, 0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, 0.5, 0.5, 0.5, 0.5, 0.7, 0.7, 0.7, 0.7, 0.9, 0.9, 0.9, 0.9],
+      "y_context_length": [128, 512, 1024, 2048, 128, 512, 1024, 2048, 128, 512, 1024, 2048, 128, 512, 1024, 2048, 128, 512, 1024, 2048],
+      "z_itl":            [5, 6, 7, 9, 6, 7, 8, 10, 7, 8, 10, 12, 8, 10, 12, 15, 10, 12, 15, 20],
+      "z_thpt_per_gpu":   [4500, 4000, 3500, 2800, 4200, 3700, 3200, 2500, 3800, 3300, 2800, 2200, 3400, 2900, 2400, 1800, 2800, 2400, 1900, 1400],
+      "max_kv_tokens": 32768
+    }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${K8S_NAMESPACE}-planner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dynamo-platform-dynamo-operator-planner
+subjects:
+  - kind: ServiceAccount
+    name: planner-serviceaccount
+    namespace: ${K8S_NAMESPACE}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gp-global-router-config
+data:
+  global_router_config.json: |
+    {
+      "num_prefill_pools": 2,
+      "num_decode_pools": 1,
+      "prefill_pool_dynamo_namespaces": [
+        "${K8S_NAMESPACE}-gp-prefill-0",
+        "${K8S_NAMESPACE}-gp-prefill-1"
+      ],
+      "decode_pool_dynamo_namespaces": [
+        "${K8S_NAMESPACE}-gp-decode-0"
+      ],
+      "prefill_pool_selection_strategy": {
+        "ttft_min_ms": 10, "ttft_max_ms": 3000, "ttft_resolution": 2,
+        "isl_min": 0,   "isl_max": 32000, "isl_resolution": 2,
+        "prefill_pool_mapping": [[0,1],[0,1]]
+      },
+      "decode_pool_selection_strategy": {
+        "itl_min_ms": 10,  "itl_max_ms": 500,   "itl_resolution": 2,
+        "context_length_min": 0, "context_length_max": 32000, "context_length_resolution": 2,
+        "decode_pool_mapping": [[0,0],[0,0]]
+      }
+    }
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hf-model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ${STORAGE_CLASS_NAME}
+  resources:
+    requests:
+      storage: 50Gi
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: gp-ctrl
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: ${DYNAMO_IMAGE}
+          workingDir: /workspace
+          command:
+            - python3
+            - -m
+            - dynamo.frontend
+          args:
+            - --router-mode
+            - round-robin
+            - --namespace
+            - ${K8S_NAMESPACE}-gp-ctrl
+            - --model-name
+            - ${MODEL_NAME}
+
+    GlobalRouter:
+      componentType: default
+      replicas: 1
+      extraPodSpec:
+        volumes:
+          - name: global-router-config
+            configMap:
+              name: gp-global-router-config
+        mainContainer:
+          image: ${DYNAMO_IMAGE}
+          workingDir: /workspace
+          command:
+            - python3
+            - -m
+            - dynamo.global_router
+          args:
+            - --config
+            - /config/global_router_config.json
+            - --model-name
+            - ${MODEL_NAME}
+            - --namespace
+            - ${K8S_NAMESPACE}-gp-ctrl
+          volumeMounts:
+            - name: global-router-config
+              mountPath: /config
+              readOnly: true
+
+    GlobalPlanner:
+      componentType: planner
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: ${DYNAMO_IMAGE}
+          command:
+            - python3
+            - -m
+            - dynamo.global_planner
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: gp-prefill-0
+spec:
+  services:
+    LocalRouter:
+      componentType: default
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: ${DYNAMO_IMAGE}
+          workingDir: /workspace
+          env:
+            - name: DYN_SYSTEM_PORT
+              value: "9090"
+          command:
+            - python3
+            - -m
+            - dynamo.router
+          args:
+            - --endpoint
+            - ${K8S_NAMESPACE}-gp-prefill-0.prefill.generate
+            - --router-block-size
+            - "16"
+            - --no-router-track-active-blocks
+
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        volumes:
+          - name: hf-model-cache
+            persistentVolumeClaim:
+              claimName: hf-model-cache
+        mainContainer:
+          image: ${DYNAMO_VLLM_IMAGE}
+          workingDir: /workspace/examples/backends/vllm
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - ${MODEL_NAME}
+            - --tensor-parallel-size
+            - "1"
+            - --is-prefill-worker
+            - --block-size
+            - "64"
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_buffer_device":"xpu"}'
+          volumeMounts:
+            - name: hf-model-cache
+              mountPath: /home/dynamo/.cache/huggingface/hub
+
+    Planner:
+      componentType: planner
+      replicas: 1
+      extraPodSpec:
+        volumes:
+          - name: planner-profile-data
+            configMap:
+              name: planner-profile-data
+        mainContainer:
+          image: ${DYNAMO_IMAGE}
+          command:
+            - python3
+            - -m
+            - dynamo.planner
+          args:
+            - --config
+            - '{"environment":"global-planner","global_planner_namespace":"${K8S_NAMESPACE}-gp-ctrl","backend":"vllm","mode":"prefill","optimization_target":"sla","enable_load_scaling":false,"enable_throughput_scaling":true,"throughput_metrics_source":"router","ttft_ms":2000,"max_gpu_budget":-1,"prefill_engine_num_gpu":1,"model_name":"${MODEL_NAME}","profile_results_dir":"/workspace/profiling_results"}'
+          volumeMounts:
+            - name: planner-profile-data
+              mountPath: /workspace/profiling_results
+              readOnly: true
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: gp-prefill-1
+spec:
+  services:
+    LocalRouter:
+      componentType: default
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: ${DYNAMO_IMAGE}
+          workingDir: /workspace
+          env:
+            - name: DYN_SYSTEM_PORT
+              value: "9090"
+          command:
+            - python3
+            - -m
+            - dynamo.router
+          args:
+            - --endpoint
+            - ${K8S_NAMESPACE}-gp-prefill-1.prefill.generate
+            - --router-block-size
+            - "16"
+            - --no-router-track-active-blocks
+
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        volumes:
+          - name: hf-model-cache
+            persistentVolumeClaim:
+              claimName: hf-model-cache
+        mainContainer:
+          image: ${DYNAMO_VLLM_IMAGE}
+          workingDir: /workspace/examples/backends/vllm
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - ${MODEL_NAME}
+            - --tensor-parallel-size
+            - "1"
+            - --is-prefill-worker
+            - --block-size
+            - "64"
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_buffer_device":"xpu"}'
+          volumeMounts:
+            - name: hf-model-cache
+              mountPath: /home/dynamo/.cache/huggingface/hub
+
+    Planner:
+      componentType: planner
+      replicas: 1
+      extraPodSpec:
+        volumes:
+          - name: planner-profile-data
+            configMap:
+              name: planner-profile-data
+        mainContainer:
+          image: ${DYNAMO_IMAGE}
+          command:
+            - python3
+            - -m
+            - dynamo.planner
+          args:
+            - --config
+            - '{"environment":"global-planner","global_planner_namespace":"${K8S_NAMESPACE}-gp-ctrl","backend":"vllm","mode":"prefill","optimization_target":"sla","enable_load_scaling":false,"enable_throughput_scaling":true,"throughput_metrics_source":"router","ttft_ms":2000,"max_gpu_budget":-1,"prefill_engine_num_gpu":1,"model_name":"${MODEL_NAME}","profile_results_dir":"/workspace/profiling_results"}'
+          volumeMounts:
+            - name: planner-profile-data
+              mountPath: /workspace/profiling_results
+              readOnly: true
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: gp-decode-0
+spec:
+  services:
+    LocalRouter:
+      componentType: default
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: ${DYNAMO_IMAGE}
+          workingDir: /workspace
+          env:
+            - name: DYN_SYSTEM_PORT
+              value: "9090"
+          command:
+            - python3
+            - -m
+            - dynamo.router
+          args:
+            - --endpoint
+            - ${K8S_NAMESPACE}-gp-decode-0.backend.generate
+            - --router-block-size
+            - "16"
+            - --router-kv-overlap-score-credit
+            - "0"
+
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # NOTE: Uncomment if your environment requires specific group access
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44   # render group
+        #     - 991  # video group
+        volumes:
+          - name: hf-model-cache
+            persistentVolumeClaim:
+              claimName: hf-model-cache
+        mainContainer:
+          image: ${DYNAMO_VLLM_IMAGE}
+          workingDir: /workspace/examples/backends/vllm
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: VLLM_TARGET_DEVICE
+              value: xpu
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - ${MODEL_NAME}
+            - --tensor-parallel-size
+            - "1"
+            - --block-size
+            - "64"
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"xpu"}'
+          volumeMounts:
+            - name: hf-model-cache
+              mountPath: /home/dynamo/.cache/huggingface/hub
+
+    Planner:
+      componentType: planner
+      replicas: 1
+      extraPodSpec:
+        volumes:
+          - name: planner-profile-data
+            configMap:
+              name: planner-profile-data
+        mainContainer:
+          image: ${DYNAMO_IMAGE}
+          command:
+            - python3
+            - -m
+            - dynamo.planner
+          args:
+            - --config
+            - '{"environment":"global-planner","global_planner_namespace":"${K8S_NAMESPACE}-gp-ctrl","backend":"vllm","mode":"decode","optimization_target":"sla","enable_load_scaling":false,"enable_throughput_scaling":true,"throughput_metrics_source":"router","itl_ms":200,"max_gpu_budget":-1,"decode_engine_num_gpu":1,"model_name":"${MODEL_NAME}","profile_results_dir":"/workspace/profiling_results"}'
+          volumeMounts:
+            - name: planner-profile-data
+              mountPath: /workspace/profiling_results
+              readOnly: true

--- a/examples/global_planner/global-planner-vllm-test-xpu-dra.yaml
+++ b/examples/global_planner/global-planner-vllm-test-xpu-dra.yaml
@@ -11,6 +11,7 @@
 #   DGD gp-decode-0:  LocalRouter + VllmDecodeWorker  (TP1) + Planner
 #
 # Prerequisites:
+#   - Cluster Prometheus deployed and scraping LocalRouter pods via PodMonitor
 #   - Intel XPU GPU driver and DRA (Dynamic Resource Allocation) configured on the cluster.
 #     See: https://github.com/intel/intel-resource-drivers-for-kubernetes
 #   - HuggingFace token secret: kubectl create secret generic hf-token-secret \
@@ -239,7 +240,8 @@ spec:
             - ${MODEL_NAME}
             - --tensor-parallel-size
             - "1"
-            - --is-prefill-worker
+            - --disaggregation-mode
+            - prefill
             - --block-size
             - "64"
             - --kv-transfer-config
@@ -339,7 +341,8 @@ spec:
             - ${MODEL_NAME}
             - --tensor-parallel-size
             - "1"
-            - --is-prefill-worker
+            - --disaggregation-mode
+            - prefill
             - --block-size
             - "64"
             - --kv-transfer-config


### PR DESCRIPTION
## What

Rebases the changes from #9253 (`feat/xpu-dra-examples`, authored by @yao531441) onto latest `main` (`3ee35fc8c3`), dropping the stale merge commits. Same 14-file diff — XPU DRA deployment examples (aggregation, disaggregation, KV router, tracing, global planner) plus README updates. No code changes.

## Why

The CI run on #9253 was from 2026-06-26 and failed `deploy-operator`. Root cause was a **chart-vs-image skew** on the then-current main: the operator Helm chart passed `-conversion-webhook-service-name` to the `crd-apply` init container, but the pinned `dynamo:main-operator` image's `crd-apply` binary didn't define that flag → `flag provided but not defined` → CrashLoopBackOff → operator never Ready → 1800s timeout.

That skew is already resolved on current `main` (recent PRs pass `deploy-operator`). This PR re-runs the same content against fresh `main` to confirm the deployment failure is gone. **Not intended to merge** — it's a CI reproduction of #9253.

## Test plan

- Confirm `deploy-operator` passes (the `crd-apply` flag error should be gone)
- Confirm no new failures introduced by the rebase
