### PR TITLE
fix(mocker): model offline attention DP per rank

### DIFF
--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -465,6 +465,52 @@ def test_replay_engine_args_preserves_explicit_max_model_len():
     assert engine_args.max_model_len == 32768
 
 
+def test_replay_attention_dp_sets_rank_topology_with_explicit_kv_capacity():
+    import dynamo.replay.main as replay_main
+
+    engine_args = replay_main._load_engine_args(
+        json.dumps(
+            {
+                "num_gpu_blocks": 4096,
+                "aic_attention_dp_size": 4,
+            }
+        )
+    )
+
+    assert engine_args.num_gpu_blocks == 4096
+    assert engine_args.dp_size == 4
+
+
+def test_replay_rejects_mismatched_dp_topology():
+    import dynamo.replay.main as replay_main
+
+    with pytest.raises(ValueError, match="dp_size must match"):
+        replay_main._load_engine_args(
+            json.dumps(
+                {
+                    "num_gpu_blocks": 4096,
+                    "dp_size": 2,
+                    "aic_attention_dp_size": 4,
+                }
+            )
+        )
+
+
+def test_replay_rejects_dp_topology_without_aic_attention_dp():
+    import dynamo.replay.main as replay_main
+
+    with pytest.raises(ValueError, match="dp_size must match"):
+        replay_main._load_engine_args(
+            json.dumps(
+                {
+                    "num_gpu_blocks": 4096,
+                    "dp_size": 2,
+                    "aic_backend": "vllm",
+                }
+            )
+        )
+
+
 def test_replay_engine_args_compute_kv_bytes_for_g3_before_validation(monkeypatch):
     import dynamo.replay.main as replay_main
 

--- a/components/src/dynamo/planner/offline/replay_adapter.py
+++ b/components/src/dynamo/planner/offline/replay_adapter.py
@@ -113,20 +113,16 @@ def _build_fpm_from_dict(d: dict[str, Any]) -> ForwardPassMetrics:
 def _update_fpm_cache(
     cache: dict[tuple[str, int], ForwardPassMetrics],
     snapshots: list[dict[str, Any]],
-    active_count: int,
+    active_worker_ids: list[int],
 ) -> None:
     """Update a last-seen FPM cache with new snapshots and prune removed workers."""
     for snap in snapshots:
         fpm = _build_fpm_from_dict(snap)
         cache[(fpm.worker_id, fpm.dp_rank)] = fpm
 
-    # Prune by logical worker, retaining every DP-rank entry for each active
-    # worker. Workers are removed highest-ID-first during scale-down.
-    active_worker_ids = set(
-        sorted({worker_id for worker_id, _ in cache}, key=int)[:active_count]
-    )
+    active_worker_ids_as_str = {str(worker_id) for worker_id in active_worker_ids}
     for key in list(cache):
-        if key[0] not in active_worker_ids:
+        if key[0] not in active_worker_ids_as_str:
             del cache[key]
 
 
@@ -232,8 +228,6 @@ class ReplayPlannerAdapter:
         # Last-seen FPM caches (separate for prefill/decode)
         self._prefill_fpm_cache: dict[tuple[str, int], ForwardPassMetrics] = {}
         self._decode_fpm_cache: dict[tuple[str, int], ForwardPassMetrics] = {}
-        self._pending_prefill_fpm_snaps: list[dict[str, Any]] = []
-        self._pending_decode_fpm_snaps: list[dict[str, Any]] = []
         # Partial traffic window accumulated across ticks until a throughput tick
         # consumes it (``None`` = nothing pending).
         self._pending_traffic: Optional[dict[str, Any]] = None
@@ -520,94 +514,10 @@ class ReplayPlannerAdapter:
             )
         return (target_p, target_d)
 
-    def _feed_extra_fpm_to_regression(
-        self,
-        decode_snaps: list[dict[str, Any]],
-        prefill_snaps: list[dict[str, Any]],
-    ) -> None:
-        """Feed accumulated FPM snapshots to regression, excluding the last
-        per worker (which will be added by _observe_fpm via fpm_observations).
-        This avoids double-counting the cached snapshot.
-
-        Works via ``_get_regression(kind)`` for orchestrator replay. Returns
-        early on easy mode (no regressions) or when the requested regression
-        slot isn't installed.
-        """
-        if self._is_easy_mode():
-            return  # easy mode has no regression models
-
-        if self._config.mode == "agg":
-            agg_reg = self._get_regression("agg")
-            if agg_reg is None:
-                return
-            last_idx_per_worker: dict[tuple[Any, int], int] = {}
-            for i, snap in enumerate(decode_snaps):
-                last_idx_per_worker[
-                    (snap["worker_id"], int(snap.get("dp_rank", 0)))
-                ] = i
-            exclude = set(last_idx_per_worker.values())
-            for i, snap in enumerate(decode_snaps):
-                if i in exclude:
-                    continue
-                fpm = _build_fpm_from_dict(snap)
-                if fpm.wall_time > 0.0:
-                    agg_reg.add_observations({(fpm.worker_id, fpm.dp_rank): fpm})
-        else:
-            has_prefill = self._config.mode in ("prefill", "disagg")
-            has_decode = self._config.mode in ("decode", "disagg")
-            if has_prefill:
-                p_reg = self._get_regression("prefill")
-                if p_reg is not None:
-                    last_idx: dict[tuple[Any, int], int] = {}
-                    for i, snap in enumerate(prefill_snaps):
-                        last_idx[(snap["worker_id"], int(snap.get("dp_rank", 0)))] = i
-                    exclude = set(last_idx.values())
-                    for i, snap in enumerate(prefill_snaps):
-                        if i in exclude:
-                            continue
-                        fpm = _build_fpm_from_dict(snap)
-                        if fpm.wall_time > 0.0:
-                            p_reg.add_observations({(fpm.worker_id, fpm.dp_rank): fpm})
-            if has_decode:
-                d_reg = self._get_regression("decode")
-                if d_reg is not None:
-                    last_idx = {}
-                    for i, snap in enumerate(decode_snaps):
-                        last_idx[(snap["worker_id"], int(snap.get("dp_rank", 0)))] = i
-                    exclude = set(last_idx.values())
-                    for i, snap in enumerate(decode_snaps):
-                        if i in exclude:
-                            continue
-                        fpm = _build_fpm_from_dict(snap)
-                        if fpm.wall_time > 0.0:
-                            d_reg.add_observations({(fpm.worker_id, fpm.dp_rank): fpm})
-
     def _is_easy_mode(self) -> bool:
         """Easy-mode check routed via config — both paths honour this
         the same way (no regression in non-SLA modes)."""
         return self._config.optimization_target != "sla"
-
-    def _get_regression(self, kind: str):
-        """Return the regression model for ``kind`` (``"agg"`` /
-        ``"prefill"`` / ``"decode"``).
-
-        Normal path: read from the orchestrator adapter's shared scaling
-        state. That state owns both benchmark-installed regressions and the
-        empty live-regression slots that replay must feed when no AIC data was
-        installed.
-        """
-        attr = f"_{kind}_regression"
-        state = getattr(self._engine, "_scaling_state", None)
-        if state is not None:
-            regression = getattr(state, attr, None)
-            if regression is not None:
-                return regression
-        # Benchmark regressions are also published to the orchestrator so
-        # external plugins can read them during bootstrap hooks.
-        orch = getattr(self._engine, "_orchestrator", None)
-        if orch is None:
-            return None
-        return orch.get_regression(kind)
 
     def _build_tick_input(
         self, tick: ScheduledTick, result: dict[str, Any]
@@ -649,37 +559,26 @@ class ReplayPlannerAdapter:
             )
 
         fpm_observations = None
-        if not hasattr(self, "_pending_prefill_fpm_snaps"):
-            self._pending_prefill_fpm_snaps = []
-        if not hasattr(self, "_pending_decode_fpm_snaps"):
-            self._pending_decode_fpm_snaps = []
-        self._pending_prefill_fpm_snaps.extend(result.get("prefill_fpm_snapshots", []))
-        self._pending_decode_fpm_snaps.extend(result.get("decode_fpm_snapshots", []))
+        # Merge each callback's latest worker/rank snapshots into the last-seen
+        # cache, then expose the cache only on FPM ticks. This matches the live
+        # subscriber's latest-snapshot semantics.
+        _update_fpm_cache(
+            self._prefill_fpm_cache,
+            result.get("prefill_fpm_snapshots", []),
+            result["active_prefill_ids"],
+        )
+        _update_fpm_cache(
+            self._decode_fpm_cache,
+            result.get("decode_fpm_snapshots", []),
+            result["active_decode_ids"],
+        )
         if tick.need_worker_fpm:
-            prefill_snaps = self._pending_prefill_fpm_snaps
-            decode_snaps = self._pending_decode_fpm_snaps
-            self._pending_prefill_fpm_snaps = []
-            self._pending_decode_fpm_snaps = []
-
-            _update_fpm_cache(
-                self._prefill_fpm_cache, prefill_snaps, result["active_prefill_count"]
-            )
-            _update_fpm_cache(
-                self._decode_fpm_cache, decode_snaps, result["active_decode_count"]
-            )
-
-            # In offline replay, we accumulate many FPM snapshots per tick
-            # (one per engine pass). Feed ALL non-idle snapshots directly to
-            # the regression models for a representative fit. The last-per-worker
-            # cache is only used for the FpmObservations dict (worker count
-            # reconciliation), not as the sole regression input.
             prefill_dict = (
                 dict(self._prefill_fpm_cache) if self._prefill_fpm_cache else None
             )
             decode_dict = (
                 dict(self._decode_fpm_cache) if self._decode_fpm_cache else None
             )
-            self._feed_extra_fpm_to_regression(decode_snaps, prefill_snaps)
             fpm_observations = FpmObservations(
                 prefill=prefill_dict,
                 decode=decode_dict,

--- a/components/src/dynamo/planner/offline/replay_adapter.py
+++ b/components/src/dynamo/planner/offline/replay_adapter.py
@@ -88,7 +88,7 @@ def _build_fpm_from_dict(d: dict[str, Any]) -> ForwardPassMetrics:
     """Convert a bridge FPM snapshot dict into a ForwardPassMetrics struct."""
     return ForwardPassMetrics(
         worker_id=str(d["worker_id"]),
-        dp_rank=0,
+        dp_rank=int(d.get("dp_rank", 0)),
         wall_time=d["wall_time"],
         scheduled_requests=ScheduledRequestMetrics(
             num_prefill_requests=d["num_prefill_requests"],
@@ -120,12 +120,14 @@ def _update_fpm_cache(
         fpm = _build_fpm_from_dict(snap)
         cache[(fpm.worker_id, fpm.dp_rank)] = fpm
 
-    # Prune cache down to active_count entries. Workers are removed
-    # highest-ID-first during scale-down, so keep the lowest IDs.
-    while len(cache) > active_count:
-        # Remove the highest worker ID entry
-        worst_key = max(cache.keys(), key=lambda k: int(k[0]))
-        del cache[worst_key]
+    # Prune by logical worker, retaining every DP-rank entry for each active
+    # worker. Workers are removed highest-ID-first during scale-down.
+    active_worker_ids = set(
+        sorted({worker_id for worker_id, _ in cache}, key=int)[:active_count]
+    )
+    for key in list(cache):
+        if key[0] not in active_worker_ids:
+            del cache[key]
 
 
 def _merge_traffic(
@@ -538,9 +540,11 @@ class ReplayPlannerAdapter:
             agg_reg = self._get_regression("agg")
             if agg_reg is None:
                 return
-            last_idx_per_worker: dict[int, int] = {}
+            last_idx_per_worker: dict[tuple[Any, int], int] = {}
             for i, snap in enumerate(decode_snaps):
-                last_idx_per_worker[snap["worker_id"]] = i
+                last_idx_per_worker[
+                    (snap["worker_id"], int(snap.get("dp_rank", 0)))
+                ] = i
             exclude = set(last_idx_per_worker.values())
             for i, snap in enumerate(decode_snaps):
                 if i in exclude:
@@ -554,9 +558,9 @@ class ReplayPlannerAdapter:
             if has_prefill:
                 p_reg = self._get_regression("prefill")
                 if p_reg is not None:
-                    last_idx: dict[int, int] = {}
+                    last_idx: dict[tuple[Any, int], int] = {}
                     for i, snap in enumerate(prefill_snaps):
-                        last_idx[snap["worker_id"]] = i
+                        last_idx[(snap["worker_id"], int(snap.get("dp_rank", 0)))] = i
                     exclude = set(last_idx.values())
                     for i, snap in enumerate(prefill_snaps):
                         if i in exclude:
@@ -569,7 +573,7 @@ class ReplayPlannerAdapter:
                 if d_reg is not None:
                     last_idx = {}
                     for i, snap in enumerate(decode_snaps):
-                        last_idx[snap["worker_id"]] = i
+                        last_idx[(snap["worker_id"], int(snap.get("dp_rank", 0)))] = i
                     exclude = set(last_idx.values())
                     for i, snap in enumerate(decode_snaps):
                         if i in exclude:

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -1,18 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression test for the replay-path FPM feed.
-
-``ReplayPlannerAdapter._feed_extra_fpm_to_regression`` feeds accumulated
-intra-tick FPM snapshots into the regression model. The regression slots
-hold ``PlannerEnginePerfModel``, which exposes only
-``add_observations(dict)``. The pre-fix singular ``add_observation(fpm)``
-raised ``AttributeError`` on replay ticks that carried more than one FPM
-snapshot per worker.
-
-This test drives the method against a real orchestrator-owned regression and
-asserts it does not raise.
-"""
+"""Regression tests for planner replay FPM handling."""
 
 from __future__ import annotations
 
@@ -91,13 +80,30 @@ def test_fpm_cache_keeps_all_ranks_for_each_active_worker():
         _snap("1", wall_time=1.0, dp_rank=1),
     ]
 
-    _update_fpm_cache(cache, snapshots, active_count=2)
+    _update_fpm_cache(cache, snapshots, active_worker_ids=[0, 1])
 
     assert set(cache) == {("0", 0), ("0", 1), ("1", 0), ("1", 1)}
 
-    _update_fpm_cache(cache, [], active_count=1)
+    _update_fpm_cache(cache, [], active_worker_ids=[0])
 
     assert set(cache) == {("0", 0), ("0", 1)}
+
+
+def test_fpm_cache_prunes_by_active_identity_after_worker_replacement():
+    cache = {}
+    _update_fpm_cache(
+        cache,
+        [_snap("0", wall_time=1.0), _snap("1", wall_time=1.0)],
+        active_worker_ids=[0, 1],
+    )
+
+    _update_fpm_cache(
+        cache,
+        [_snap("2", wall_time=2.0)],
+        active_worker_ids=[0, 2],
+    )
+
+    assert set(cache) == {("0", 0), ("2", 0)}
 
 
 def _orch_agg_config_sla() -> PlannerConfig:
@@ -125,67 +131,21 @@ def test_install_benchmark_fpms_installs_regression_on_orchestrator_path():
     assert adapter._engine._orchestrator.get_regression("agg") is not None
 
 
-def test_get_regression_uses_orchestrator_scaling_state_without_aic_install():
-    """Replay without AIC benchmark FPMs still needs the live regression slot.
-
-    The orchestrator's public regression store is populated during benchmark
-    bootstrap for external-plugin access. No-AIC replay instead starts from
-    the adapter's ``PlannerScalingState`` regression and feeds intra-tick FPMs
-    into it.
-    """
-    cfg = _orch_agg_config_sla()
-    adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
-    adapter._config = cfg
-    adapter._engine = OrchestratorEngineAdapter(cfg, _agg_caps())
-
-    assert adapter._engine._orchestrator.get_regression("agg") is None
-    assert adapter._get_regression("agg") is not None
-
-    decode_snaps = [
-        _snap("1", wall_time=1.0),
-        _snap("1", wall_time=2.0),  # last-per-worker -> excluded
-    ]
-    adapter._feed_extra_fpm_to_regression(
-        decode_snaps=decode_snaps,
-        prefill_snaps=[],
-    )
-
-
-def test_extra_fpm_feed_excludes_last_snapshot_per_worker_rank():
-    class RecordingRegression:
-        def __init__(self):
-            self.keys = []
-
-        def add_observations(self, observations):
-            self.keys.extend(observations)
-
-    regression = RecordingRegression()
-    adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
-    adapter._config = _agg_config_sla()
-    adapter._get_regression = lambda _kind: regression
-
-    adapter._feed_extra_fpm_to_regression(
-        decode_snaps=[
-            _snap("0", wall_time=1.0, dp_rank=0),
-            _snap("0", wall_time=1.0, dp_rank=1),
-            _snap("0", wall_time=2.0, dp_rank=0),
-            _snap("0", wall_time=2.0, dp_rank=1),
-        ],
-        prefill_snaps=[],
-    )
-
-    assert regression.keys == [("0", 0), ("0", 1)]
-
-
 def test_build_tick_input_maps_replay_accept_length():
     # The Rust simulation drains the per-tick traffic window into
     # ``result["traffic"]``; a need_traffic_metrics tick maps it onto
     # ``TickInput.traffic`` (accept_length, isl/osl, kv-hit, latency).
     adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
+    adapter._prefill_fpm_cache = {}
+    adapter._decode_fpm_cache = {}
 
     tick = ScheduledTick(at_s=60.0, need_traffic_metrics=True)
     result = {
         "now_ms": 1_000.0,
+        "active_prefill_count": 0,
+        "active_decode_count": 0,
+        "active_prefill_ids": [],
+        "active_decode_ids": [],
         "traffic": {
             "duration_s": 60.0,
             "num_req": 4,
@@ -205,15 +165,13 @@ def test_build_tick_input_maps_replay_accept_length():
     assert adapter._last_traffic.accept_length == 2.5
 
 
-def test_build_tick_input_buffers_fpm_until_fpm_tick():
+def test_build_tick_input_keeps_only_latest_fpm_until_fpm_tick():
     cfg = PlannerConfig(mode="agg", optimization_target="throughput")
     adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
     adapter._config = cfg
     adapter._is_disagg = False
     adapter._prefill_fpm_cache = {}
     adapter._decode_fpm_cache = {}
-    adapter._pending_prefill_fpm_snaps = []
-    adapter._pending_decode_fpm_snaps = []
     adapter._scaling_target_prefill = None
     adapter._scaling_target_decode = None
 
@@ -222,18 +180,27 @@ def test_build_tick_input_buffers_fpm_until_fpm_tick():
         need_worker_states=True,
         need_worker_fpm=False,
     )
-    snap = _snap("1", wall_time=1.0)
     first = adapter._build_tick_input(
         no_fpm_tick,
         {
             "now_ms": 1_000.0,
             "active_prefill_count": 0,
             "active_decode_count": 1,
-            "decode_fpm_snapshots": [snap],
+            "active_prefill_ids": [],
+            "active_decode_ids": [0],
+            "decode_fpm_snapshots": [
+                _snap("0", wall_time=1.0, dp_rank=0),
+                _snap("0", wall_time=1.0, dp_rank=1),
+                _snap("0", wall_time=2.0, dp_rank=0),
+                _snap("0", wall_time=2.0, dp_rank=1),
+            ],
             "prefill_fpm_snapshots": [],
         },
     )
     assert first.fpm_observations is None
+    assert set(adapter._decode_fpm_cache) == {("0", 0), ("0", 1)}
+    assert adapter._decode_fpm_cache[("0", 0)].wall_time == 2.0
+    assert adapter._decode_fpm_cache[("0", 1)].wall_time == 2.0
 
     fpm_tick = ScheduledTick(
         at_s=7.0,
@@ -246,13 +213,17 @@ def test_build_tick_input_buffers_fpm_until_fpm_tick():
             "now_ms": 7_000.0,
             "active_prefill_count": 0,
             "active_decode_count": 1,
+            "active_prefill_ids": [],
+            "active_decode_ids": [0],
             "decode_fpm_snapshots": [],
             "prefill_fpm_snapshots": [],
         },
     )
 
     assert second.fpm_observations is not None
-    assert ("1", 0) in second.fpm_observations.decode
+    assert set(second.fpm_observations.decode) == {("0", 0), ("0", 1)}
+    assert second.fpm_observations.decode[("0", 0)].wall_time == 2.0
+    assert second.fpm_observations.decode[("0", 1)].wall_time == 2.0
 
 
 def test_replay_engine_caps_exposes_aic_nextn():

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -261,6 +261,27 @@ def test_replay_engine_caps_exposes_aic_nextn():
     assert caps.speculative_nextn == 2
 
 
+def test_replay_engine_caps_aggregates_attention_dp_capacity_and_gpu_width():
+    caps = _engine_caps(
+        MockEngineArgs(
+            num_gpu_blocks=100,
+            block_size=16,
+            dp_size=4,
+            aic_tp_size=2,
+        )
+    )
+
+    assert caps.max_kv_tokens == 100 * 16 * 4
+    assert caps.num_gpu == 2 * 4
+
+
+def test_replay_engine_caps_keeps_single_rank_defaults():
+    caps = _engine_caps(MockEngineArgs(num_gpu_blocks=100, block_size=16))
+
+    assert caps.max_kv_tokens == 100 * 16
+    assert caps.num_gpu == 1
+
+
 def test_merge_traffic_weights_ratio_fields_by_native_counts():
     # kv_hit_rate and accept_length must merge by their true denominators
     # (hit_rate_count / accept_length_forward_count), not num_req, so a window

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -29,6 +29,7 @@ from dynamo.planner.offline.replay_adapter import (
     ReplayPlannerAdapter,
     _build_fpm_from_dict,
     _merge_traffic,
+    _update_fpm_cache,
 )
 from dynamo.planner.plugins.orchestrator.engine_adapter import OrchestratorEngineAdapter
 from dynamo.replay.main import _engine_caps
@@ -59,10 +60,11 @@ def _agg_config_sla() -> PlannerConfig:
     )
 
 
-def _snap(worker_id: str, wall_time: float) -> dict:
+def _snap(worker_id: str, wall_time: float, dp_rank: int = 0) -> dict:
     """A bridge FPM snapshot dict with every key ``_build_fpm_from_dict`` reads."""
     return {
         "worker_id": worker_id,
+        "dp_rank": dp_rank,
         "wall_time": wall_time,
         "num_prefill_requests": 0,
         "sum_prefill_tokens": 0,
@@ -78,6 +80,24 @@ def _snap(worker_id: str, wall_time: float) -> dict:
         "sum_queued_decode_kv_tokens": 0,
         "var_queued_decode_kv_tokens": 0.0,
     }
+
+
+def test_fpm_cache_keeps_all_ranks_for_each_active_worker():
+    cache = {}
+    snapshots = [
+        _snap("0", wall_time=1.0, dp_rank=0),
+        _snap("0", wall_time=1.0, dp_rank=1),
+        _snap("1", wall_time=1.0, dp_rank=0),
+        _snap("1", wall_time=1.0, dp_rank=1),
+    ]
+
+    _update_fpm_cache(cache, snapshots, active_count=2)
+
+    assert set(cache) == {("0", 0), ("0", 1), ("1", 0), ("1", 1)}
+
+    _update_fpm_cache(cache, [], active_count=1)
+
+    assert set(cache) == {("0", 0), ("0", 1)}
 
 
 def _orch_agg_config_sla() -> PlannerConfig:
@@ -129,6 +149,32 @@ def test_get_regression_uses_orchestrator_scaling_state_without_aic_install():
         decode_snaps=decode_snaps,
         prefill_snaps=[],
     )
+
+
+def test_extra_fpm_feed_excludes_last_snapshot_per_worker_rank():
+    class RecordingRegression:
+        def __init__(self):
+            self.keys = []
+
+        def add_observations(self, observations):
+            self.keys.extend(observations)
+
+    regression = RecordingRegression()
+    adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
+    adapter._config = _agg_config_sla()
+    adapter._get_regression = lambda _kind: regression
+
+    adapter._feed_extra_fpm_to_regression(
+        decode_snaps=[
+            _snap("0", wall_time=1.0, dp_rank=0),
+            _snap("0", wall_time=1.0, dp_rank=1),
+            _snap("0", wall_time=2.0, dp_rank=0),
+            _snap("0", wall_time=2.0, dp_rank=1),
+        ],
+        prefill_snaps=[],
+    )
+
+    assert regression.keys == [("0", 0), ("0", 1)]
 
 
 def test_build_tick_input_maps_replay_accept_length():

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -108,6 +108,20 @@ def _aic_quant_mode(raw: dict, name: str) -> str | None:
 
 
 def _resolve_aic_num_gpu_blocks(raw: dict) -> None:
+    attention_dp = raw.get("aic_attention_dp_size")
+    dp = attention_dp or 1
+    configured_dp = raw.get("dp_size") or 1
+    has_aic_config = raw.get("aic_backend") is not None or attention_dp is not None
+    if has_aic_config and configured_dp > 1 and configured_dp != dp:
+        raise ValueError(
+            "dp_size must match aic_attention_dp_size for AIC-backed replay "
+            f"(got dp_size={configured_dp}, aic_attention_dp_size={dp})"
+        )
+    if attention_dp is not None and dp > 1:
+        # AIC attention-DP describes the silicon scheduler topology, independent
+        # of whether KV capacity is explicit or estimated.
+        raw["dp_size"] = dp
+
     if raw.get("num_gpu_blocks") is not None:
         return
 
@@ -163,14 +177,11 @@ def _resolve_aic_num_gpu_blocks(raw: dict) -> None:
         kv_cache_dtype=_aic_quant_mode(raw, "aic_kv_cache_dtype"),
         comm_dtype=_aic_quant_mode(raw, "aic_comm_dtype"),
     )
-    # AIC returns a per-rank (per-GPU) block count. Offline replay models a single KV
-    # pool per engine, so under DP-attention -- where each of the `dp` ranks holds a full
-    # KV replica for its slice of the batch -- the engine-wide pool is per_rank * dp. The
-    # live mocker instead replicates one scheduler per dp rank (lib/llm/src/mocker.rs), so
-    # it keeps the per-rank count; this scaling lives on the offline-replay path, not in
-    # estimate_num_gpu_blocks itself.
-    dp = raw.get("aic_attention_dp_size") or 1
-    raw["num_gpu_blocks"] = per_rank_blocks * dp
+    # AIC returns a per-rank (per-GPU) block count. Under attention-DP the offline runtime
+    # mirrors the live path (lib/llm/src/mocker.rs): each mocker worker owns `dp`
+    # independent per-rank schedulers and KV pools. Keep the per-rank count; engine-wide
+    # capacity stays per_rank * dp, partitioned by rank as on real hardware.
+    raw["num_gpu_blocks"] = per_rank_blocks
 
 
 def _resolve_kv_bytes_per_token(raw: dict) -> None:

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -301,9 +301,10 @@ def _engine_caps(args: MockEngineArgs) -> EngineCapabilities:
     """Derive EngineCapabilities from MockEngineArgs."""
     from dynamo.planner.core.types import EngineCapabilities
 
-    max_kv_tokens = args.num_gpu_blocks * args.block_size
+    dp_size = max(args.dp_size, 1)
+    max_kv_tokens = args.num_gpu_blocks * args.block_size * dp_size
     return EngineCapabilities(
-        num_gpu=1,
+        num_gpu=(args.aic_tp_size or 1) * dp_size,
         max_num_batched_tokens=args.max_num_batched_tokens,
         max_num_seqs=args.max_num_seqs,
         context_length=args.max_model_len,

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -2466,8 +2466,8 @@ impl PlannerHook for PyPlannerHook {
             prefill_fpm,
             decode_fpm,
             traffic,
-            active_prefill,
-            active_decode,
+            active_prefill_ids,
+            active_decode_ids,
             total_prefill,
             total_decode,
         } = metrics;
@@ -2478,8 +2478,10 @@ impl PlannerHook for PyPlannerHook {
                 "now_ms": now_ms,
                 "prefill_fpm_snapshots": fpm_snapshots_to_json(prefill_fpm),
                 "decode_fpm_snapshots": fpm_snapshots_to_json(decode_fpm),
-                "active_prefill_count": active_prefill,
-                "active_decode_count": active_decode,
+                "active_prefill_count": active_prefill_ids.len(),
+                "active_decode_count": active_decode_ids.len(),
+                "active_prefill_ids": active_prefill_ids,
+                "active_decode_ids": active_decode_ids,
                 "total_prefill_count": total_prefill,
                 "total_decode_count": total_decode,
                 "traffic": {

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1576,7 +1576,8 @@ fn validate_disagg_replay_mode(replay_mode: &str) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_disagg_replay_mode;
+    use super::{fpm_snapshots_to_json, reconcile_replay_dp_topology, validate_disagg_replay_mode};
+    use dynamo_mocker::common::protocols::{ForwardPassSnapshot, MockEngineArgs};
 
     #[test]
     fn online_disaggregation_is_rejected_with_stable_message() {
@@ -1587,6 +1588,46 @@ mod tests {
             "disagg replay only supports replay_mode='offline'"
         );
         assert!(validate_disagg_replay_mode("offline").is_ok());
+    }
+
+    #[test]
+    fn programmatic_attention_dp_materializes_without_aic_backend() {
+        let mut args = MockEngineArgs::builder()
+            .dp_size(1)
+            .aic_attention_dp_size(Some(4))
+            .build()
+            .unwrap();
+
+        reconcile_replay_dp_topology(&mut args).unwrap();
+
+        assert_eq!(args.dp_size, 4);
+    }
+
+    #[test]
+    fn programmatic_attention_dp_rejects_mismatched_topology() {
+        let mut args = MockEngineArgs::builder()
+            .dp_size(2)
+            .aic_attention_dp_size(Some(4))
+            .build()
+            .unwrap();
+
+        let error = reconcile_replay_dp_topology(&mut args).unwrap_err();
+
+        assert!(error.to_string().contains("dp_size must match"));
+    }
+
+    #[test]
+    fn fpm_json_preserves_worker_and_dp_rank_identity() {
+        let snapshots = fpm_snapshots_to_json(vec![(
+            2,
+            ForwardPassSnapshot {
+                dp_rank: 3,
+                ..Default::default()
+            },
+        )]);
+
+        assert_eq!(snapshots[0]["worker_id"], 2);
+        assert_eq!(snapshots[0]["dp_rank"], 3);
     }
 }
 
@@ -1643,6 +1684,8 @@ fn materialize_replay_mocker_args(
 ) -> PyResult<RsMockEngineArgs> {
     let mut args = extra_args.inner();
     populate_missing_offload_kv_bytes_per_token(py, &mut args)?;
+    reconcile_replay_dp_topology(&mut args)
+        .map_err(|error| PyException::new_err(error.to_string()))?;
 
     if let Some(ref backend_name) = args.aic_backend.clone() {
         let backend = backend_name.clone();
@@ -1665,7 +1708,11 @@ fn materialize_replay_mocker_args(
         let undiscounted_accept_rates = args.undiscounted_aic_accept_rates();
         // AIC-backed config may intentionally omit num_gpu_blocks. Estimate it
         // here, after candidate TP/backend/model overrides have been applied.
-        if !extra_args.num_gpu_blocks_explicit() {
+        let num_gpu_blocks_explicit = extra_args.num_gpu_blocks_explicit();
+        // Under attention-DP, mirror the live path: one mocker worker owns
+        // `dp_size` independent per-rank schedulers, each with a per-rank KV pool.
+        // The topology applies whether KV capacity is explicit or estimated.
+        if !num_gpu_blocks_explicit {
             let per_rank_blocks = estimate_aic_num_gpu_blocks(
                 py,
                 &backend,
@@ -1695,14 +1742,11 @@ fn materialize_replay_mocker_args(
                     e
                 ))
             })?;
-            // AIC returns a per-rank (per-GPU) block count. Offline replay models a single
-            // KV pool per engine, so under DP-attention -- where each of the `dp` ranks holds
-            // a full KV replica for its slice of the batch -- the engine-wide pool is
-            // `per_rank * dp`. (The live mocker instead replicates one scheduler per dp rank,
-            // see lib/llm/src/mocker.rs, so it must keep the per-rank count; that is why this
-            // scaling lives on the offline-replay path and not inside the estimator.)
-            let dp = attention_dp_size.unwrap_or(1).max(1);
-            args.num_gpu_blocks = per_rank_blocks.saturating_mul(dp);
+            // AIC returns a per-rank (per-GPU) block count. When replicating attention-DP
+            // into per-rank workers, each worker owns this per-rank pool (engine-wide
+            // capacity stays `per_rank * dp`, now partitioned per rank as on real hardware).
+            // With dp == 1 the per-rank pool is the engine-wide pool.
+            args.num_gpu_blocks = per_rank_blocks;
         }
         let callback = create_aic_callback(
             py,
@@ -1735,18 +1779,33 @@ fn materialize_replay_mocker_args(
             model_name,
             backend_version
         );
-        // Offline replay runs a single aggregate engine holding the GLOBAL batch
-        // across all attention-DP ranks (it scales num_gpu_blocks by dp above and
-        // forbids scheduler-level dp_size>1). Record attention_dp_size so the perf
-        // model divides the scheduled batch back to the per-rank batch the AIC SDK
-        // expects. The live path keeps the default of 1 (it replicates per rank).
-        args.perf_model = Arc::new(PerfModel::from_aic_callback_with_attention_dp(
-            callback,
-            attention_dp_size.unwrap_or(1).max(1),
-        ));
+        // Every scheduler sees its own local batch, including under attention-DP.
+        args.perf_model = Arc::new(PerfModel::from_aic_callback(callback));
     }
 
     Ok(args)
+}
+
+/// Reconcile the scheduler topology before optional AIC callback/capacity
+/// materialization. This mirrors the JSON loader: an explicit attention-DP
+/// size defines rank topology even when the caller supplies KV capacity and no
+/// AIC backend.
+fn reconcile_replay_dp_topology(args: &mut RsMockEngineArgs) -> anyhow::Result<()> {
+    let attention_dp = args.aic_attention_dp_size;
+    let dp = attention_dp.unwrap_or(1).max(1);
+    let dp = u32::try_from(dp)
+        .map_err(|_| anyhow::anyhow!("aic_attention_dp_size does not fit into a u32"))?;
+    let has_aic_config = args.aic_backend.is_some() || attention_dp.is_some();
+    if has_aic_config && args.dp_size > 1 && args.dp_size != dp {
+        anyhow::bail!(
+            "dp_size must match aic_attention_dp_size for AIC-backed replay (got dp_size={}, aic_attention_dp_size={dp})",
+            args.dp_size
+        );
+    }
+    if attention_dp.is_some() && dp > 1 {
+        args.dp_size = dp;
+    }
+    Ok(())
 }
 
 fn populate_missing_offload_kv_bytes_per_token(
@@ -2034,6 +2093,7 @@ fn fpm_snapshots_to_json(
         .map(|(worker_id, fpm)| {
             json!({
                 "worker_id": worker_id,
+                "dp_rank": fpm.dp_rank,
                 "wall_time": fpm.wall_time_secs,
                 "num_prefill_requests": fpm.num_prefill_requests,
                 "sum_prefill_tokens": fpm.sum_prefill_tokens,

--- a/lib/bindings/python/tests/replay/test_replay_aic_capacity.py
+++ b/lib/bindings/python/tests/replay/test_replay_aic_capacity.py
@@ -105,12 +105,10 @@ def test_resolve_aic_blocks_preserves_explicit_zero_inputs(monkeypatch):
     assert calls[0]["free_gpu_memory_fraction"] == 0.0
 
 
-def test_resolve_aic_blocks_scales_engine_pool_by_attention_dp(monkeypatch):
-    # estimate_num_gpu_blocks returns a PER-RANK count; offline replay models a single KV
-    # pool per engine, so _resolve_aic_num_gpu_blocks scales it by attention_dp_size to the
-    # engine-wide pool (under DP-attention each rank holds a full KV replica). dp=1/unset is
-    # unchanged. (The live mocker replicates one scheduler per dp rank, so it keeps per-rank
-    # -- this scaling is offline-only.) Regression for DP-attention KV under-provisioning.
+def test_resolve_aic_blocks_keeps_per_rank_capacity_for_attention_dp(monkeypatch):
+    # estimate_num_gpu_blocks returns a per-rank count. Offline replay mirrors the live
+    # mocker by creating one scheduler and KV pool per DP rank, so the block count remains
+    # per-rank while attention_dp_size selects the runtime topology.
     monkeypatch.setattr(replay_main, "estimate_num_gpu_blocks", lambda **kw: 1000)
 
     def _resolve(dp):
@@ -125,11 +123,11 @@ def test_resolve_aic_blocks_scales_engine_pool_by_attention_dp(monkeypatch):
         if dp is not None:
             raw["aic_attention_dp_size"] = dp
         replay_main._resolve_aic_num_gpu_blocks(raw)
-        return raw["num_gpu_blocks"]
+        return raw["num_gpu_blocks"], raw.get("dp_size")
 
-    assert _resolve(8) == 8000  # dp=8 -> engine pool is 8x the per-rank estimate
-    assert _resolve(1) == 1000  # no DP-attention -> per-rank unchanged
-    assert _resolve(None) == 1000  # unset -> per-rank unchanged
+    assert _resolve(8) == (1000, 8)
+    assert _resolve(1) == (1000, None)
+    assert _resolve(None) == (1000, None)
 
 
 def test_programmatic_replay_estimates_unset_aic_blocks(monkeypatch):

--- a/lib/mocker/src/common/perf_model.rs
+++ b/lib/mocker/src/common/perf_model.rs
@@ -84,18 +84,7 @@ pub enum PerfModel {
     },
     /// AI Configurator SDK calls via Python callback.
     /// Passes the reduced prefill inputs (batch_size, effective_isl, prefix).
-    ///
-    /// `attention_dp_size` is the number of attention data-parallel ranks this
-    /// engine aggregates. The offline-replay aggregate engine holds the GLOBAL
-    /// batch across all ranks, but the AIC SDK expects a PER-RANK batch
-    /// (`global_bs = bs * attention_dp_size`), so the scheduled batch is divided
-    /// by this value before each perf query. It is 1 for the live path (which
-    /// replicates one scheduler per rank, so each already sees a per-rank batch)
-    /// and for non-DP configs — making the division a no-op there.
-    Aiconfigurator {
-        callback: Arc<dyn AicCallback>,
-        attention_dp_size: usize,
-    },
+    Aiconfigurator { callback: Arc<dyn AicCallback> },
 }
 
 impl Clone for PerfModel {
@@ -109,12 +98,8 @@ impl Clone for PerfModel {
                 prefill_interp: Arc::clone(prefill_interp),
                 decode_interp: Arc::clone(decode_interp),
             },
-            PerfModel::Aiconfigurator {
-                callback,
-                attention_dp_size,
-            } => PerfModel::Aiconfigurator {
+            PerfModel::Aiconfigurator { callback } => PerfModel::Aiconfigurator {
                 callback: Arc::clone(callback),
-                attention_dp_size: *attention_dp_size,
             },
         }
     }
@@ -223,36 +208,8 @@ impl PerfModel {
     }
 
     /// Create an Aiconfigurator perf model from a callback.
-    ///
-    /// `attention_dp_size` defaults to 1, so the per-rank batch division is a
-    /// no-op. Use [`PerfModel::from_aic_callback_with_attention_dp`] from the
-    /// offline-replay aggregate path, which holds the global multi-rank batch.
     pub fn from_aic_callback(callback: Arc<dyn AicCallback>) -> Self {
-        PerfModel::Aiconfigurator {
-            callback,
-            attention_dp_size: 1,
-        }
-    }
-
-    /// Like [`PerfModel::from_aic_callback`], but records the attention-DP degree
-    /// so the aggregated offline-replay engine queries the AIC SDK with the
-    /// per-rank batch (`scheduled_batch / attention_dp_size`) it expects. The
-    /// live path must NOT use this (it already replicates one scheduler per rank).
-    pub fn from_aic_callback_with_attention_dp(
-        callback: Arc<dyn AicCallback>,
-        attention_dp_size: usize,
-    ) -> Self {
-        PerfModel::Aiconfigurator {
-            callback,
-            attention_dp_size: attention_dp_size.max(1),
-        }
-    }
-
-    /// Global batch -> per-rank batch for the AIC SDK; see the
-    /// `Aiconfigurator { attention_dp_size }` doc. `div_ceil` bounds the step by
-    /// the busiest rank, and dp == 1 (live / non-DP) is a no-op.
-    fn aic_per_rank_batch(batch_size: usize, attention_dp_size: usize) -> usize {
-        batch_size.div_ceil(attention_dp_size.max(1))
+        PerfModel::Aiconfigurator { callback }
     }
 
     /// Predict prefill time in milliseconds.
@@ -276,14 +233,9 @@ impl PerfModel {
                 let tokens = (batch_size * new_tokens_per_req) as f64;
                 prefill_interp.interp(tokens).unwrap_or(0.0)
             }
-            PerfModel::Aiconfigurator {
-                callback,
-                attention_dp_size,
-            } => callback.predict_prefill(
-                Self::aic_per_rank_batch(batch_size, *attention_dp_size),
-                new_tokens_per_req,
-                prefix,
-            ),
+            PerfModel::Aiconfigurator { callback } => {
+                callback.predict_prefill(batch_size, new_tokens_per_req, prefix)
+            }
         };
         time.max(0.0)
     }
@@ -317,14 +269,9 @@ impl PerfModel {
             PerfModel::Interpolated { decode_interp, .. } => decode_interp
                 .interp(active_kv_tokens as f64, context_length as f64)
                 .unwrap_or(0.0),
-            PerfModel::Aiconfigurator {
-                callback,
-                attention_dp_size,
-            } => callback.predict_decode(
-                Self::aic_per_rank_batch(batch_size, *attention_dp_size),
-                context_length,
-                2,
-            ),
+            PerfModel::Aiconfigurator { callback } => {
+                callback.predict_decode(batch_size, context_length, 2)
+            }
         };
         // Token-emitting decode steps should not collapse onto the same timestamp.
         let result = time.max(1.0);
@@ -340,57 +287,28 @@ mod tests {
     use super::{AicCallback, PerfModel};
     use std::sync::Arc;
 
-    #[test]
-    fn fully_cached_prompt_skips_prefill() {
-        assert_eq!(PerfModel::default().predict_prefill_time(1, 128, 128), 0.0);
-    }
-
-    /// Echoes back the batch_size it is called with, so tests can assert exactly
-    /// what batch reached the AIC SDK after any per-rank division.
     struct EchoBatchCallback;
+
     impl AicCallback for EchoBatchCallback {
         fn predict_prefill(&self, batch_size: usize, _effective_isl: usize, _prefix: usize) -> f64 {
             batch_size as f64
         }
+
         fn predict_decode(&self, batch_size: usize, _isl: usize, _osl: usize) -> f64 {
             batch_size as f64
         }
     }
 
-    // The AIC SDK expects a per-rank batch (global_bs = bs * attention_dp_size).
-    // Offline replay holds the global batch in one engine, so the perf model must
-    // divide by attention_dp_size before the AIC call. attention_dp_size=1 (live /
-    // non-DP / `from_aic_callback`) must be a strict no-op.
-
     #[test]
-    fn aic_decode_attention_dp_1_is_noop() {
-        let m = PerfModel::from_aic_callback(Arc::new(EchoBatchCallback));
-        // callback sees the full global batch unchanged
-        assert_eq!(m.predict_decode_time(128, 0, 1024, 0), 128.0);
-        assert_eq!(m.predict_decode_time(1, 0, 1024, 0), 1.0);
+    fn fully_cached_prompt_skips_prefill() {
+        assert_eq!(PerfModel::default().predict_prefill_time(1, 128, 128), 0.0);
     }
 
     #[test]
-    fn aic_decode_divides_batch_by_attention_dp() {
-        let m = PerfModel::from_aic_callback_with_attention_dp(Arc::new(EchoBatchCallback), 8);
-        // 128 sequences across 8 DP ranks -> 16 per rank
-        assert_eq!(m.predict_decode_time(128, 0, 1024, 0), 16.0);
-        // div_ceil: 130/8 = 17 (the busiest rank bounds the step)
-        assert_eq!(m.predict_decode_time(130, 0, 1024, 0), 17.0);
-        // fewer sequences than ranks -> at least 1 per active rank
-        assert_eq!(m.predict_decode_time(4, 0, 1024, 0), 1.0);
-    }
+    fn aic_forwards_scheduler_local_batch() {
+        let model = PerfModel::from_aic_callback(Arc::new(EchoBatchCallback));
 
-    #[test]
-    fn aic_prefill_attention_dp_1_is_noop() {
-        let m = PerfModel::from_aic_callback(Arc::new(EchoBatchCallback));
-        assert_eq!(m.predict_prefill_time(8, 1024, 0), 8.0);
-    }
-
-    #[test]
-    fn aic_prefill_divides_batch_by_attention_dp() {
-        let m = PerfModel::from_aic_callback_with_attention_dp(Arc::new(EchoBatchCallback), 8);
-        assert_eq!(m.predict_prefill_time(8, 1024, 0), 1.0);
-        assert_eq!(m.predict_prefill_time(128, 1024, 0), 16.0);
+        assert_eq!(model.predict_prefill_time(7, 128, 0), 7.0);
+        assert_eq!(model.predict_decode_time(9, 0, 128, 0), 9.0);
     }
 }

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -1277,14 +1277,13 @@ impl MockEngineArgs {
         MockEngineArgsBuilder::default()
     }
 
-    /// GPUs occupied by one worker (engine), derived from the AIC parallelism:
-    /// `aic_tp_size × aic_attention_dp_size` (the attention width, which by the
-    /// MoE constraint equals `aic_moe_tp_size × aic_moe_ep_size`). Falls back to
-    /// 1 when AIC parallelism is not configured (non-AIC / polynomial perf
-    /// model, where a worker is a single logical engine). Used to turn
+    /// GPUs occupied by one worker (engine), derived from tensor parallelism
+    /// and the materialized DP topology. AIC-backed replay uses
+    /// `aic_tp_size × aic_attention_dp_size`; non-AIC replay still counts one
+    /// GPU for every independently modeled `dp_size` rank. Used to turn
     /// provisioned worker-seconds into GPU-hours.
     pub fn aic_gpus_per_worker(&self) -> usize {
-        self.aic_tp_size.unwrap_or(1) * self.aic_attention_dp_size.unwrap_or(1)
+        self.aic_tp_size.unwrap_or(1) * self.dp_size.max(1) as usize
     }
 
     /// Finite ownership bound for live handoff queues and sessions.

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -7,6 +7,8 @@ use serde::ser::{SerializeMap, Serializer};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use uuid::Uuid;
 
+use crate::common::protocols::OutputSignal;
+
 #[derive(Debug, Clone)]
 pub struct TraceSimulationReport {
     pub request_counts: TraceRequestCounts,
@@ -56,8 +58,9 @@ pub struct TraceThroughputStats {
     pub prefill_worker_seconds: f64,
     pub decode_worker_seconds: f64,
     /// GPUs per worker per role, derived from the mocker engine parallelism
-    /// (`MockEngineArgs::aic_gpus_per_worker` = aic_tp × aic_attention_dp); the
-    /// runtime sets it on the collector. 0 when not set (e.g. the online path).
+    /// (`MockEngineArgs::aic_gpus_per_worker` = tensor parallelism × materialized
+    /// DP topology); the runtime sets it on the collector. 0 when not set
+    /// (e.g. the online path).
     pub prefill_gpus_per_worker: usize,
     pub decode_gpus_per_worker: usize,
     /// GPU-hours = Σ_role `worker_seconds × gpus_per_worker / 3600` — the
@@ -753,6 +756,35 @@ impl TraceCollector {
     pub(crate) fn on_token(&mut self, uuid: Uuid, token_time_ms: f64) {
         if let Some(stats) = self.requests.get_mut(&uuid) {
             stats.token_times_ms.push(token_time_ms);
+        }
+    }
+
+    /// Move the tokens emitted by one scheduler pass to a shared completion
+    /// boundary. Scheduler cores record their rank-local end time while the
+    /// pass is formed; attention-DP replay then aligns every rank in the group
+    /// to the slowest rank before the pass becomes externally visible.
+    pub(crate) fn align_pass_token_times(
+        &mut self,
+        output_signals: &[OutputSignal],
+        completion_time_ms: f64,
+    ) {
+        let mut emitted_by_request = FxHashMap::default();
+        for signal in output_signals {
+            if signal.token_id.is_some() {
+                *emitted_by_request.entry(signal.uuid).or_insert(0usize) += 1;
+            }
+        }
+
+        for (uuid, emitted) in emitted_by_request {
+            let Some(stats) = self.requests.get_mut(&uuid) else {
+                continue;
+            };
+            let start = stats
+                .token_times_ms
+                .len()
+                .checked_sub(emitted)
+                .expect("scheduler emitted more output signals than collector tokens");
+            stats.token_times_ms[start..].fill(completion_time_ms);
         }
     }
 

--- a/lib/mocker/src/replay/offline/README.md
+++ b/lib/mocker/src/replay/offline/README.md
@@ -19,7 +19,7 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
 
 `offline/mod.rs` chooses between three implementations:
 
-- `lib/mocker/src/replay/offline/single.rs` for aggregated replay with `num_workers == 1`
+- `lib/mocker/src/replay/offline/single.rs` for aggregated replay with `num_workers == 1` and `dp_size == 1`
 - `lib/mocker/src/replay/offline/agg.rs` for everything else, including aggregated multi-worker replay and `kv_router` replay
 - `lib/mocker/src/replay/offline/disagg.rs` for offline disaggregated prefill/decode replay
 
@@ -54,7 +54,10 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
 ## Single-Worker Fast Path
 
 The single-worker path is intentionally simple and used when `num_workers == 1`
-for vLLM, SGLang, and TRT-LLM engine modes.
+and `dp_size == 1` for vLLM, SGLang, and TRT-LLM engine modes. Multi-rank
+attention-DP uses the general harness so each rank has an independent scheduler
+and KV pool while all ranks still share one deterministic event loop and a
+group-owned iteration clock.
 
 That path avoids the cluster event queue and router machinery entirely, but it now supports both:
 
@@ -93,6 +96,14 @@ The general aggregated harness lives in `lib/mocker/src/replay/offline/agg.rs`. 
 - one [`OfflineWorkerState`](/Users/peabrane/Documents/codes/dynamo/lib/mocker/src/replay/offline/state.rs) per worker
 - a binary heap of future completion events
 - an optional synchronous offline router
+
+For `dp_size > 1`, each mocker worker owns one `OfflineWorkerState` per DP rank.
+The router retains the live `(worker_id, dp_rank)` identity; planner scaling and
+worker accounting continue to count mocker workers rather than rank schedulers.
+At each iteration, every ready rank forms its scheduler-local pass and the logical
+worker completes at the maximum rank latency. Completion-visible tokens, KV events,
+and FPM timing share that boundary; empty ranks also wait at the barrier so arrivals
+during an epoch cannot start early.
 
 ### Main Loop
 
@@ -206,6 +217,11 @@ The disaggregated runtime in `lib/mocker/src/replay/offline/disagg.rs` models tw
 
 - a prefill router and prefill worker pool
 - a decode router and decode worker pool
+
+Attention-DP is currently supported only by aggregated offline replay. Disaggregated replay
+requires both prefill and decode `dp_size` to be `1`; ranked prefill/decode routing and handoff
+semantics are not yet modeled, so larger values are rejected explicitly instead of using the old
+aggregate approximation.
 
 It keeps one logical clock and one completion-event heap, but request ownership moves through a
 two-stage state machine instead of the aggregated single-pool lifecycle.

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -7,7 +7,7 @@ pub(super) use super::components::ReplayMode;
 #[cfg(test)]
 use super::components::TrafficStats;
 use super::events::{SimulationEvent, SimulationWorkerStage};
-use super::planner_hook::{PlannerHook, PlannerTickMetrics};
+use super::planner_hook::{LatestFpmBuffer, PlannerHook, PlannerTickMetrics};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
     next_timestamp as choose_next_timestamp, pop_ready_planner_tick, pop_ready_worker_completion,
@@ -81,8 +81,8 @@ pub(in crate::replay) struct AggRuntime {
     router: Option<OfflineReplayRouter>,
     progress: ReplayProgress,
     stats: AggRuntimeStats,
-    /// Forward pass metrics accumulated between planner ticks.
-    fpm_buffer: Vec<(usize, ForwardPassSnapshot)>,
+    /// Latest forward pass metric per worker/rank since the previous planner tick.
+    fpm_buffer: LatestFpmBuffer,
     /// Traffic statistics accumulated between planner ticks.
     traffic: TrafficAccumulator,
     /// Optional cap on simulated wall-clock time. When set, `run()` exits
@@ -93,9 +93,8 @@ pub(in crate::replay) struct AggRuntime {
     /// calls back into the planner at each tick (the unified replacement for the
     /// old Python-driven `advance_to` stepping loop).
     planner_hook: Option<Box<dyn PlannerHook>>,
-    /// Whether to retain per-pass FPM snapshots. Only the planner consumes them, so
-    /// the plain `run()` path leaves this `false` (otherwise the buffer grows
-    /// unbounded for the whole run with no reader — the leak this gating fixes).
+    /// Whether to retain the latest FPM snapshot per worker/rank. Only the planner
+    /// consumes them, so the plain `run()` path leaves this `false`.
     collect_fpm: bool,
     #[cfg(test)]
     worker_active_requests: Vec<Vec<Uuid>>,
@@ -196,7 +195,7 @@ impl AggRuntime {
             stats: AggRuntimeStats::default(),
             #[cfg(not(test))]
             stats: AggRuntimeStats,
-            fpm_buffer: Vec::new(),
+            fpm_buffer: LatestFpmBuffer::default(),
             traffic: TrafficAccumulator::new(),
             max_sim_time_ms: None,
             planner_hook: None,
@@ -248,6 +247,10 @@ impl AggRuntime {
     /// planner via recurring `PlannerTick` events (one `on_tick` callback per tick).
     pub(in crate::replay) fn with_planner_hook(mut self, hook: Box<dyn PlannerHook>) -> Self {
         self.collect_fpm = true;
+        for worker_id in self.engine.active_group_ids() {
+            self.fpm_buffer
+                .activate_worker(worker_id, self.dp_size, self.now_ms);
+        }
         self.planner_hook = Some(hook);
         self
     }
@@ -331,7 +334,7 @@ impl AggRuntime {
         })?;
         snapshot.worker_id = worker_id.to_string();
         snapshot.dp_rank = dp_rank;
-        self.fpm_buffer.push((worker_id, snapshot));
+        self.fpm_buffer.insert(worker_id, snapshot, self.now_ms);
         Ok(())
     }
 
@@ -690,11 +693,6 @@ impl AggRuntime {
     }
 
     fn handle_engine_effects(&mut self, effects: EngineEffects) -> anyhow::Result<()> {
-        if self.collect_fpm {
-            for (rank_id, fpm) in effects.fpm_snapshots {
-                self.record_fpm(rank_id, fpm)?;
-            }
-        }
         self.apply_router_events(effects.pass_start_kv_events)?;
         for payload in effects.immediate_completions {
             let payload = self.engine.on_scheduled_completion(payload)?;
@@ -724,6 +722,10 @@ impl AggRuntime {
         while let Some((stage, worker_id)) = pop_ready_worker_ready(&mut self.events, self.now_ms) {
             debug_assert_eq!(stage, SimulationWorkerStage::Aggregated);
             if self.engine.mark_worker_ready(worker_id) {
+                if self.collect_fpm {
+                    self.fpm_buffer
+                        .activate_worker(worker_id, self.dp_size, self.now_ms);
+                }
                 if let Some(router) = self.router.as_mut() {
                     router.add_worker(worker_id)?;
                     // Drain any requests that were queued while all workers
@@ -804,13 +806,16 @@ impl AggRuntime {
             if self.is_workload_done() {
                 continue;
             }
+            let active_decode_ids = self.engine.active_group_ids();
+            self.fpm_buffer
+                .emit_idle_due(&active_decode_ids, self.dp_size, self.now_ms);
             let metrics = PlannerTickMetrics {
                 now_ms: self.now_ms,
                 prefill_fpm: Vec::new(),
-                decode_fpm: std::mem::take(&mut self.fpm_buffer),
+                decode_fpm: self.fpm_buffer.take(),
                 traffic: self.traffic.drain(self.now_ms),
-                active_prefill: 0,
-                active_decode: self.active_worker_count(),
+                active_prefill_ids: Vec::new(),
+                active_decode_ids,
                 total_prefill: 0,
                 total_decode: self.total_worker_count(),
             };
@@ -868,6 +873,7 @@ impl AggRuntime {
     }
 
     /// Number of active (non-pending-removal) workers.
+    #[cfg(test)]
     pub(in crate::replay) fn active_worker_count(&self) -> usize {
         self.engine.active_group_ids().len()
     }
@@ -910,6 +916,10 @@ impl AggRuntime {
                     );
                 }
                 None => {
+                    if self.collect_fpm {
+                        self.fpm_buffer
+                            .activate_worker(id, self.dp_size, self.now_ms);
+                    }
                     if let Some(router) = self.router.as_mut() {
                         router.add_worker(id)?;
                     }
@@ -1052,7 +1062,7 @@ impl AggRuntime {
 
     #[cfg(test)]
     fn drain_fpm(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
-        std::mem::take(&mut self.fpm_buffer)
+        self.fpm_buffer.take()
     }
 
     #[cfg(test)]
@@ -1102,6 +1112,27 @@ mod tests {
     use crate::replay::{TraceRequestStatsSnapshot, normalize_trace_requests};
     use dynamo_kv_router::config::{KvRouterConfig, RouterQueuePolicy};
     use rstest::rstest;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    struct CaptureOnceHook {
+        at_ms: f64,
+        captured: Rc<RefCell<Option<PlannerTickMetrics>>>,
+    }
+
+    impl PlannerHook for CaptureOnceHook {
+        fn initial_tick_ms(&mut self) -> anyhow::Result<f64> {
+            Ok(self.at_ms)
+        }
+
+        fn on_tick(
+            &mut self,
+            metrics: PlannerTickMetrics,
+        ) -> anyhow::Result<super::super::planner_hook::PlannerTickDecision> {
+            *self.captured.borrow_mut() = Some(metrics);
+            Ok(super::super::planner_hook::PlannerTickDecision::default())
+        }
+    }
 
     fn replay_args(enable_prefix_caching: bool, enable_chunked_prefill: bool) -> MockEngineArgs {
         MockEngineArgs::builder()
@@ -1445,6 +1476,74 @@ mod tests {
 
         assert!(identities.contains(&(0, "0".to_string(), 0)));
         assert!(identities.contains(&(0, "0".to_string(), 1)));
+    }
+
+    #[test]
+    fn planner_tick_emits_idle_fpm_after_simulated_second() {
+        let mut args = sglang_replay_args();
+        args.dp_size = 2;
+        let pending = normalize_trace_requests(
+            vec![
+                DirectRequest {
+                    tokens: vec![1; 8],
+                    max_output_tokens: 1,
+                    uuid: Some(Uuid::from_u128(9_201)),
+                    arrival_timestamp_ms: Some(0.0),
+                    ..Default::default()
+                },
+                DirectRequest {
+                    tokens: vec![2; 8],
+                    max_output_tokens: 1,
+                    uuid: Some(Uuid::from_u128(9_202)),
+                    arrival_timestamp_ms: Some(3_000.0),
+                    ..Default::default()
+                },
+            ],
+            1.0,
+        )
+        .unwrap();
+        let captured = Rc::new(RefCell::new(None));
+        let hook = CaptureOnceHook {
+            at_ms: 2_000.0,
+            captured: Rc::clone(&captured),
+        };
+
+        AggRuntime::new(
+            &args,
+            None,
+            None,
+            pending,
+            1,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap()
+        .with_planner_hook(Box::new(hook))
+        .run()
+        .unwrap();
+
+        let metrics = captured
+            .borrow_mut()
+            .take()
+            .expect("planner tick must fire");
+        assert_eq!(metrics.now_ms, 2_000.0);
+        assert_eq!(metrics.decode_fpm.len(), 2);
+        assert!(metrics.decode_fpm.iter().all(|(worker_id, snapshot)| {
+            *worker_id == 0
+                && snapshot.wall_time_secs == 0.0
+                && snapshot.num_prefill_requests == 0
+                && snapshot.num_decode_requests == 0
+                && snapshot.num_queued_prefill == 0
+                && snapshot.num_queued_decode == 0
+        }));
+        assert_eq!(
+            metrics
+                .decode_fpm
+                .iter()
+                .map(|(_, snapshot)| snapshot.dp_rank)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -70,6 +70,8 @@ pub(in crate::replay) struct AggRuntimeStats;
 pub(in crate::replay) struct AggRuntime {
     now_ms: f64,
     next_worker_idx: usize,
+    next_dp_rank_by_worker: FxHashMap<usize, u32>,
+    dp_size: u32,
     next_event_seq: u64,
     admission: AdmissionQueue,
     requests: FxHashMap<Uuid, AggRequestState>,
@@ -152,7 +154,6 @@ impl AggRuntime {
         router_mode: ReplayRouterMode,
     ) -> anyhow::Result<Self> {
         let args = args.clone().normalized()?;
-        let decode_gpus_per_worker = args.aic_gpus_per_worker();
         let progress = ReplayProgress::new(admission.total_requests(), "offline replay");
         let router = match router_mode {
             ReplayRouterMode::RoundRobin => None,
@@ -164,29 +165,25 @@ impl AggRuntime {
             )?),
         };
         let capture_kv_events = router.is_some();
-        let mut engine = EngineComponent::new(
+        let mut engine = EngineComponent::new_ranked(
             SimulationWorkerStage::Aggregated,
             EnginePassMode::Visible,
-            (0..num_workers)
-                .map(|worker_idx| {
-                    super::state::OfflineWorkerState::new(
-                        worker_idx,
-                        args.clone(),
-                        capture_kv_events,
-                    )
-                })
-                .collect(),
+            args.clone(),
+            num_workers,
+            capture_kv_events,
         );
-        engine.set_scaling_args(args, capture_kv_events);
+        engine.set_scaling_args(args.clone(), capture_kv_events);
 
         // Aggregated replay has a single (decode) pool; record its GPUs/worker
         // so the report can express GPU-hours from the mocker's own parallelism.
         let mut collector = TraceCollector::default();
-        collector.set_gpus_per_worker(0, decode_gpus_per_worker);
+        collector.set_gpus_per_worker(0, args.aic_gpus_per_worker());
 
         Ok(Self {
             now_ms: 0.0,
             next_worker_idx: 0,
+            next_dp_rank_by_worker: FxHashMap::default(),
+            dp_size: args.dp_size.max(1),
             next_event_seq: 0,
             admission,
             requests: FxHashMap::default(),
@@ -205,7 +202,10 @@ impl AggRuntime {
             planner_hook: None,
             collect_fpm: false,
             #[cfg(test)]
-            worker_active_requests: vec![Vec::new(); num_workers],
+            worker_active_requests: vec![
+                Vec::new();
+                num_workers.saturating_mul(args.dp_size.max(1) as usize)
+            ],
             #[cfg(test)]
             stepped: false,
         })
@@ -293,11 +293,17 @@ impl AggRuntime {
 
     /// Pick the next active worker in round-robin order.
     fn next_worker(&mut self) -> usize {
-        let active = self.engine.active_worker_ids();
+        let active = self.engine.active_group_ids();
         debug_assert!(!active.is_empty(), "no active workers for round-robin");
         let idx = self.next_worker_idx % active.len();
         self.next_worker_idx = idx + 1;
-        active[idx]
+        let worker_id = active[idx];
+        let dp_rank = self.next_dp_rank_by_worker.entry(worker_id).or_default();
+        let rank = *dp_rank % self.dp_size;
+        *dp_rank = rank + 1;
+        self.engine
+            .rank_id(worker_id, rank)
+            .expect("active worker must contain every configured DP rank")
     }
 
     /// Record which worker accepted a request and refresh in-flight stats.
@@ -311,6 +317,22 @@ impl AggRuntime {
                 .insert(_uuid, _worker_idx);
         }
         self.record_in_flight_peak();
+    }
+
+    /// Preserve the live `(worker_id, dp_rank)` identity when forwarding a
+    /// rank-local scheduler snapshot to the planner bridge.
+    fn record_fpm(
+        &mut self,
+        rank_id: usize,
+        mut snapshot: ForwardPassSnapshot,
+    ) -> anyhow::Result<()> {
+        let (worker_id, dp_rank) = self.engine.rank_identity(rank_id).ok_or_else(|| {
+            anyhow::anyhow!("offline replay FPM references unknown rank scheduler {rank_id}")
+        })?;
+        snapshot.worker_id = worker_id.to_string();
+        snapshot.dp_rank = dp_rank;
+        self.fpm_buffer.push((worker_id, snapshot));
+        Ok(())
     }
 
     /// Deliver a request to a worker and update the runtime's bookkeeping for that assignment.
@@ -607,7 +629,7 @@ impl AggRuntime {
             if self.collect_fpm
                 && let Some(fpm) = payload.fpm
             {
-                self.fpm_buffer.push((payload.worker_idx, fpm));
+                self.record_fpm(payload.worker_idx, fpm)?;
             }
             self.process_completed_pass(
                 payload.worker_idx,
@@ -665,7 +687,9 @@ impl AggRuntime {
 
     fn handle_engine_effects(&mut self, effects: EngineEffects) -> anyhow::Result<()> {
         if self.collect_fpm {
-            self.fpm_buffer.extend(effects.fpm_snapshots);
+            for (rank_id, fpm) in effects.fpm_snapshots {
+                self.record_fpm(rank_id, fpm)?;
+            }
         }
         self.apply_router_events(effects.pass_start_kv_events)?;
         for payload in effects.immediate_completions {
@@ -673,7 +697,7 @@ impl AggRuntime {
             if self.collect_fpm
                 && let Some(fpm) = payload.fpm
             {
-                self.fpm_buffer.push((payload.worker_idx, fpm));
+                self.record_fpm(payload.worker_idx, fpm)?;
             }
             self.process_completed_pass(
                 payload.worker_idx,
@@ -725,6 +749,9 @@ impl AggRuntime {
             changed |= self.release_ready_arrivals()?;
             changed |= self.drive_ready_workers()?;
             let removed = self.engine.try_remove_drained();
+            for worker_id in &removed {
+                self.next_dp_rank_by_worker.remove(worker_id);
+            }
             if let Some(router) = self.router.as_mut() {
                 for worker_id in &removed {
                     router.finalize_worker_removal(*worker_id)?;
@@ -838,7 +865,7 @@ impl AggRuntime {
 
     /// Number of active (non-pending-removal) workers.
     pub(in crate::replay) fn active_worker_count(&self) -> usize {
-        self.engine.active_worker_ids().len()
+        self.engine.active_group_ids().len()
     }
 
     /// Total worker count including pending-removal.
@@ -857,9 +884,13 @@ impl AggRuntime {
     /// new requests land on it) and drains in-flight work in the engine.
     pub(in crate::replay) fn apply_scaling(&mut self, target_workers: usize) -> anyhow::Result<()> {
         let (added, newly_marked, removed) = self.engine.apply_target_count(target_workers);
+        let engine = &self.engine;
+        self.next_dp_rank_by_worker
+            .retain(|worker_id, _| engine.rank_id(*worker_id, 0).is_some());
         #[cfg(test)]
-        if let Some(new_len) = added.iter().max().map(|id| id + 1) {
-            self.worker_active_requests.resize(new_len, Vec::new());
+        if !added.is_empty() {
+            self.worker_active_requests
+                .resize(self.engine.rank_id_capacity(), Vec::new());
         }
         let startup_delay_ms = self.engine.startup_time_ms();
 
@@ -1362,6 +1393,78 @@ mod tests {
         assert!(
             !runtime.drain_fpm().is_empty(),
             "SGLang pass-end FPM must become planner-visible at completion"
+        );
+    }
+
+    #[test]
+    fn attention_dp_fpm_preserves_logical_worker_and_rank_identity() {
+        let mut args = sglang_replay_args();
+        args.dp_size = 2;
+        let pending = normalize_trace_requests(
+            vec![
+                DirectRequest {
+                    tokens: vec![1; 8],
+                    max_output_tokens: 2,
+                    uuid: Some(Uuid::from_u128(9_101)),
+                    arrival_timestamp_ms: Some(0.0),
+                    ..Default::default()
+                },
+                DirectRequest {
+                    tokens: vec![2; 8],
+                    max_output_tokens: 2,
+                    uuid: Some(Uuid::from_u128(9_102)),
+                    arrival_timestamp_ms: Some(0.0),
+                    ..Default::default()
+                },
+            ],
+            1.0,
+        )
+        .unwrap();
+        let mut runtime = AggRuntime::new(
+            &args,
+            None,
+            None,
+            pending,
+            1,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap()
+        .with_fpm_capture();
+
+        while runtime.advance_one_timestamp().unwrap() {}
+        let identities = runtime
+            .drain_fpm()
+            .into_iter()
+            .map(|(worker_id, snapshot)| (worker_id, snapshot.worker_id, snapshot.dp_rank))
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert!(identities.contains(&(0, "0".to_string(), 0)));
+        assert!(identities.contains(&(0, "0".to_string(), 1)));
+    }
+
+    #[test]
+    fn generic_attention_dp_counts_rank_resources_in_gpu_hours() {
+        let mut args = fast_router_args();
+        args.dp_size = 4;
+        let runtime = AggRuntime::new(
+            &args,
+            None,
+            None,
+            simple_requests(4, 0.0),
+            1,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        let (collector, _) = runtime.run().unwrap();
+        let report = collector.finish();
+
+        assert_eq!(report.throughput.decode_gpus_per_worker, 4);
+        assert_eq!(
+            report.throughput.gpu_hours,
+            report.throughput.decode_worker_seconds * 4.0 / 3600.0
         );
     }
 
@@ -2064,6 +2167,53 @@ mod tests {
         );
 
         assert_eq!(stats.dispatch_history, vec![0, 1, 2, 3, 0]);
+    }
+
+    #[test]
+    fn test_attention_dp_round_robin_matches_live_worker_then_rank_order() {
+        let mut args = replay_args(false, true);
+        args.dp_size = 2;
+        let requests = (1..=5)
+            .map(|id| DirectRequest {
+                tokens: vec![id as u32; 8],
+                max_output_tokens: 1,
+                uuid: Some(Uuid::from_u128(id)),
+                arrival_timestamp_ms: Some(0.0),
+                ..Default::default()
+            })
+            .collect();
+
+        let (_, stats) =
+            run_trace_multi_collect_with_stats(&args, requests, 2, ReplayRouterMode::RoundRobin);
+
+        // Live routing round-robins mocker workers first, then each worker's
+        // MockEngine independently round-robins its DP ranks.
+        assert_eq!(stats.dispatch_history, vec![0, 2, 1, 3, 0]);
+    }
+
+    #[test]
+    fn test_attention_dp_planner_counts_mocker_workers_not_ranks() {
+        let mut args = replay_args(false, true);
+        args.dp_size = 2;
+        let mut runtime = AggRuntime::new(
+            &args,
+            None,
+            None,
+            VecDeque::new(),
+            2,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        assert_eq!(runtime.active_worker_count(), 2);
+        assert_eq!(runtime.total_worker_count(), 2);
+        assert_eq!(runtime.engine.active_worker_ids(), vec![0, 1, 2, 3]);
+
+        runtime.apply_scaling(3).unwrap();
+        assert_eq!(runtime.active_worker_count(), 3);
+        assert_eq!(runtime.total_worker_count(), 3);
+        assert_eq!(runtime.engine.active_worker_ids(), vec![0, 1, 2, 3, 4, 5]);
     }
 
     #[test]
@@ -3025,6 +3175,30 @@ mod tests {
         // Without startup delay, new worker is immediately active.
         assert_eq!(rt.active_worker_count(), 2);
         assert_eq!(rt.total_worker_count(), 2);
+    }
+
+    #[test]
+    fn scale_down_forgets_retired_round_robin_rank_state() {
+        let args = fast_router_args();
+        let mut rt = AggRuntime::new(
+            &args,
+            None,
+            None,
+            simple_requests(2, 0.0),
+            2,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        assert!(rt.advance_one_timestamp().unwrap());
+        assert_eq!(rt.next_dp_rank_by_worker.len(), 2);
+        while rt.advance_one_timestamp().unwrap() {}
+
+        rt.apply_scaling(1).unwrap();
+
+        assert_eq!(rt.next_dp_rank_by_worker.len(), 1);
+        assert!(!rt.next_dp_rank_by_worker.contains_key(&1));
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -623,6 +623,10 @@ impl AggRuntime {
     /// Drain all worker-completion events scheduled for the current logical timestamp.
     fn apply_worker_completions(&mut self) -> anyhow::Result<bool> {
         let mut changed = false;
+        // TODO: Same-time DP-rank completions settle in deterministic event order, and
+        // each pass may drain router-pending work before its sibling ranks are applied.
+        // Preserve this lower-rank-first tie-break for now. Atomic settlement requires
+        // splitting router state mutation from pending-admission draining.
         while let Some(payload) = pop_ready_worker_completion(&mut self.events, self.now_ms) {
             debug_assert_eq!(payload.stage, SimulationWorkerStage::Aggregated);
             let payload = self.engine.on_scheduled_completion(payload)?;

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -257,6 +257,10 @@ impl EngineComponent {
             .collect()
     }
 
+    pub(in crate::replay::offline) fn dp_size(&self) -> u32 {
+        self.args.dp_size.max(1)
+    }
+
     pub(in crate::replay::offline) fn rank_id(
         &self,
         worker_id: usize,
@@ -473,11 +477,7 @@ impl EngineComponent {
                     || !payload.output_signals.is_empty()
                     || !payload.lifecycle_events.is_empty()
                     || !payload.kv_events.is_empty()
-                    || payload.fpm.as_ref().is_some_and(fpm_has_scheduled_work)
-                    || effects
-                        .fpm_snapshots
-                        .iter()
-                        .any(|(_, snapshot)| fpm_has_scheduled_work(snapshot));
+                    || payload.fpm.as_ref().is_some_and(fpm_has_scheduled_work);
                 if made_progress {
                     effects.immediate_completions.push(payload);
                 }
@@ -807,7 +807,6 @@ mod tests {
         vllm.dispatch(0, request(Uuid::from_u128(10))).unwrap();
         let vllm_start = vllm.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(!vllm_start.pass_start_kv_events.is_empty());
-        assert!(vllm_start.fpm_snapshots.is_empty());
         let vllm_end = take_only_completion(vllm_start);
         assert!(vllm_end.kv_events.is_empty());
         assert!(vllm_end.fpm.is_some());
@@ -816,7 +815,6 @@ mod tests {
         sglang.dispatch(0, request(Uuid::from_u128(11))).unwrap();
         let sglang_start = sglang.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(sglang_start.pass_start_kv_events.is_empty());
-        assert!(sglang_start.fpm_snapshots.is_empty());
         let sglang_end = take_only_completion(sglang_start);
         assert!(!sglang_end.kv_events.is_empty());
         assert!(sglang_end.fpm.is_some());
@@ -918,7 +916,6 @@ mod tests {
         let second = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(second.admissions.is_empty());
         assert!(second.pass_start_kv_events.is_empty());
-        assert!(second.fpm_snapshots.is_empty());
         assert_eq!(second.immediate_completions.len(), 1);
         assert!(second.scheduled_completions.is_empty());
         let second = take_only_completion(second);

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -23,15 +23,19 @@ fn fpm_has_scheduled_work(snapshot: &ForwardPassSnapshot) -> bool {
 pub(in crate::replay::offline) struct EngineComponent {
     stage: SimulationWorkerStage,
     pass_mode: EnginePassMode,
-    /// Workers keyed by stable ID (monotonic, never reused).
+    /// DP-rank schedulers keyed by stable ID (monotonic, never reused).
     workers: BTreeMap<usize, OfflineWorkerState>,
-    /// Counter for generating the next stable worker ID.
+    /// Mocker worker IDs mapped to their per-rank scheduler IDs.
+    worker_groups: BTreeMap<usize, Vec<usize>>,
+    /// Counter for generating the next stable scheduler ID.
     next_id: usize,
-    /// Workers marked for removal — skipped by round-robin, removed when drained.
+    /// Counter for generating the next stable mocker worker ID.
+    next_worker_id: usize,
+    /// Mocker workers marked for removal — skipped by round-robin, removed when drained.
     pending_removal: BTreeSet<usize>,
-    /// Workers still starting up — excluded from active set until ready.
+    /// Mocker workers still starting up — excluded from active set until ready.
     pending_startup: BTreeSet<usize>,
-    /// Engine args used to construct new workers during scale-up.
+    /// Engine args used to construct new DP-rank schedulers during scale-up.
     args: MockEngineArgs,
     /// Whether new workers should capture KV events (true when a router is present).
     capture_kv_events: bool,
@@ -45,15 +49,62 @@ impl EngineComponent {
     ) -> Self {
         let count = workers.len();
         let map: BTreeMap<usize, OfflineWorkerState> = workers.into_iter().enumerate().collect();
+        let worker_groups = (0..count).map(|id| (id, vec![id])).collect();
         Self {
             stage,
             pass_mode,
             workers: map,
+            worker_groups,
             next_id: count,
+            next_worker_id: count,
             pending_removal: BTreeSet::new(),
             pending_startup: BTreeSet::new(),
             args: MockEngineArgs::default(),
             capture_kv_events: false,
+        }
+    }
+
+    /// Build one scheduler core per DP rank while retaining the live mocker's
+    /// `(worker_id, dp_rank)` topology.
+    pub(in crate::replay::offline) fn new_ranked(
+        stage: SimulationWorkerStage,
+        pass_mode: EnginePassMode,
+        args: MockEngineArgs,
+        num_workers: usize,
+        capture_kv_events: bool,
+    ) -> Self {
+        let dp_size = args.dp_size.max(1) as usize;
+        let mut workers = BTreeMap::new();
+        let mut worker_groups = BTreeMap::new();
+        for worker_id in 0..num_workers {
+            let mut rank_ids = Vec::with_capacity(dp_size);
+            for dp_rank in 0..dp_size {
+                let rank_id = worker_id * dp_size + dp_rank;
+                workers.insert(
+                    rank_id,
+                    OfflineWorkerState::new_with_rank(
+                        rank_id,
+                        worker_id as u64,
+                        dp_rank as u32,
+                        args.clone(),
+                        capture_kv_events,
+                    ),
+                );
+                rank_ids.push(rank_id);
+            }
+            worker_groups.insert(worker_id, rank_ids);
+        }
+        Self {
+            stage,
+            pass_mode,
+            workers,
+            worker_groups,
+            next_id: num_workers.saturating_mul(dp_size),
+            next_worker_id: num_workers,
+            pending_removal: BTreeSet::new(),
+            pending_startup: BTreeSet::new(),
+            args,
+            capture_kv_events,
         }
     }
 
@@ -67,13 +118,27 @@ impl EngineComponent {
         self.capture_kv_events = capture_kv_events;
     }
 
-    /// Add a new worker, returning its stable ID.
+    /// Add a new mocker worker and all of its DP-rank schedulers, returning
+    /// the stable mocker worker ID.
     pub(in crate::replay::offline) fn add_worker(&mut self) -> usize {
-        let id = self.next_id;
-        self.next_id += 1;
-        let worker = OfflineWorkerState::new(id, self.args.clone(), self.capture_kv_events);
-        self.workers.insert(id, worker);
-        id
+        let worker_id = self.next_worker_id;
+        self.next_worker_id += 1;
+        let mut rank_ids = Vec::with_capacity(self.args.dp_size.max(1) as usize);
+        for dp_rank in 0..self.args.dp_size.max(1) {
+            let rank_id = self.next_id;
+            self.next_id += 1;
+            let worker = OfflineWorkerState::new_with_rank(
+                rank_id,
+                worker_id as u64,
+                dp_rank,
+                self.args.clone(),
+                self.capture_kv_events,
+            );
+            self.workers.insert(rank_id, worker);
+            rank_ids.push(rank_id);
+        }
+        self.worker_groups.insert(worker_id, rank_ids);
+        worker_id
     }
 
     /// Mark a worker for removal. Round-robin routing skips marked workers;
@@ -88,8 +153,12 @@ impl EngineComponent {
     pub(in crate::replay::offline) fn try_remove_drained(&mut self) -> Vec<usize> {
         let mut removed = Vec::new();
         self.pending_removal.retain(|&id| {
-            if let Some(worker) = self.workers.get(&id) {
-                if worker.is_drained() {
+            if let Some(rank_ids) = self.worker_groups.get(&id) {
+                if rank_ids.iter().all(|rank_id| {
+                    self.workers
+                        .get(rank_id)
+                        .is_none_or(OfflineWorkerState::is_drained)
+                }) {
                     removed.push(id);
                     return false; // remove from pending set
                 }
@@ -100,7 +169,11 @@ impl EngineComponent {
             true // keep in pending set
         });
         for &id in &removed {
-            self.workers.remove(&id);
+            if let Some(rank_ids) = self.worker_groups.remove(&id) {
+                for rank_id in rank_ids {
+                    self.workers.remove(&rank_id);
+                }
+            }
         }
         removed
     }
@@ -119,7 +192,7 @@ impl EngineComponent {
         &mut self,
         target: usize,
     ) -> (Vec<usize>, Vec<usize>, Vec<usize>) {
-        let active_ids = self.active_worker_ids();
+        let active_ids = self.active_group_ids();
         let effective = active_ids.len() + self.pending_startup.len();
         let mut added = Vec::new();
         let mut newly_marked = Vec::new();
@@ -146,7 +219,11 @@ impl EngineComponent {
                 .collect();
             for &id in &to_cancel {
                 self.pending_startup.remove(&id);
-                self.workers.remove(&id);
+                if let Some(rank_ids) = self.worker_groups.remove(&id) {
+                    for rank_id in rank_ids {
+                        self.workers.remove(&rank_id);
+                    }
+                }
             }
 
             // Mark active workers for removal if more excess remains.
@@ -162,20 +239,44 @@ impl EngineComponent {
         (added, newly_marked, removed)
     }
 
-    /// Return stable IDs of all active workers — excludes both pending removal
-    /// and pending startup.
+    /// Return stable scheduler IDs of all active DP ranks — excludes ranks in
+    /// mocker workers pending removal or startup.
     pub(in crate::replay::offline) fn active_worker_ids(&self) -> Vec<usize> {
-        self.workers
+        self.active_group_ids()
+            .into_iter()
+            .flat_map(|worker_id| self.worker_groups[&worker_id].iter().copied())
+            .collect()
+    }
+
+    /// Return stable mocker worker IDs that are active for new admissions.
+    pub(in crate::replay::offline) fn active_group_ids(&self) -> Vec<usize> {
+        self.worker_groups
             .keys()
             .filter(|id| !self.pending_removal.contains(id) && !self.pending_startup.contains(id))
             .copied()
             .collect()
     }
 
+    pub(in crate::replay::offline) fn rank_id(
+        &self,
+        worker_id: usize,
+        dp_rank: u32,
+    ) -> Option<usize> {
+        self.worker_groups
+            .get(&worker_id)
+            .and_then(|rank_ids| rank_ids.get(dp_rank as usize))
+            .copied()
+    }
+
+    /// Return the logical mocker worker and DP rank represented by a stable
+    /// scheduler ID.
+    pub(in crate::replay::offline) fn rank_identity(&self, rank_id: usize) -> Option<(usize, u32)> {
+        let (worker_id, dp_rank) = self.workers.get(&rank_id)?.rank_identity();
+        Some((usize::try_from(worker_id).ok()?, dp_rank))
+    }
+
     pub(in crate::replay::offline) fn has_active_workers(&self) -> bool {
-        self.workers
-            .keys()
-            .any(|id| !self.pending_removal.contains(id) && !self.pending_startup.contains(id))
+        !self.active_group_ids().is_empty()
     }
 
     /// Return the configured startup delay in milliseconds, if any.
@@ -190,7 +291,7 @@ impl EngineComponent {
     /// was actually pending startup (and is now active), `false` if the worker
     /// was already cancelled or unknown (stale event).
     pub(in crate::replay::offline) fn mark_worker_ready(&mut self, worker_id: usize) -> bool {
-        self.pending_startup.remove(&worker_id) && self.workers.contains_key(&worker_id)
+        self.pending_startup.remove(&worker_id) && self.worker_groups.contains_key(&worker_id)
     }
 
     pub(in crate::replay::offline) fn dispatch(
@@ -234,45 +335,126 @@ impl EngineComponent {
         now_ms: f64,
         mut collector: Option<&mut TraceCollector>,
     ) -> anyhow::Result<EngineEffects> {
-        for (&worker_id, worker) in self.workers.iter_mut() {
-            if !worker.is_ready() {
+        let worker_groups: Vec<Vec<usize>> = self.worker_groups.values().cloned().collect();
+        for rank_ids in worker_groups {
+            // A logical attention-DP worker advances in group-owned epochs.
+            // A rank that received work mid-epoch must wait until every sibling
+            // has crossed the prior completion boundary.
+            if rank_ids
+                .iter()
+                .any(|rank_id| self.workers.get(rank_id).unwrap().is_busy())
+            {
+                continue;
+            }
+            if !rank_ids
+                .iter()
+                .any(|rank_id| self.workers.get(rank_id).unwrap().is_ready())
+            {
                 continue;
             }
 
-            let executed = match self.pass_mode {
-                EnginePassMode::Visible => {
-                    let Some(collector) = collector.as_deref_mut() else {
-                        bail!("offline replay visible engine pass requires a collector");
-                    };
-                    worker.execute_pass(collector, now_ms)
+            let mut executed_by_rank = BTreeMap::new();
+            for &rank_id in &rank_ids {
+                if !self.workers.get(&rank_id).unwrap().is_ready() {
+                    continue;
                 }
-                EnginePassMode::Hidden => worker.execute_hidden_pass(now_ms),
-            };
-
-            let mut effects = EngineEffects {
-                admissions: executed.admissions,
-                ..EngineEffects::default()
-            };
-            let completion_kv_events =
-                if executed.router_event_visibility == RouterEventVisibility::PassStart {
-                    effects.pass_start_kv_events = executed.kv_events;
-                    Vec::new()
-                } else {
-                    executed.kv_events
+                let executed = match self.pass_mode {
+                    EnginePassMode::Visible => {
+                        let Some(collector) = collector.as_deref_mut() else {
+                            bail!("offline replay visible engine pass requires a collector");
+                        };
+                        self.workers
+                            .get_mut(&rank_id)
+                            .unwrap()
+                            .execute_pass(collector, now_ms)
+                    }
+                    EnginePassMode::Hidden => self
+                        .workers
+                        .get_mut(&rank_id)
+                        .unwrap()
+                        .execute_hidden_pass(now_ms),
                 };
-            let payload = WorkerCompletionPayload {
-                stage: self.stage,
-                worker_idx: worker_id,
-                completed_requests: executed.completed_requests,
-                output_signals: executed.output_signals,
-                lifecycle_events: executed.lifecycle_events,
-                kv_events: completion_kv_events,
-                fpm: executed.fpm,
-                accept_length_output_tokens: executed.accept_length_output_tokens,
-                accept_length_decode_forwards: executed.accept_length_decode_forwards,
-            };
+                executed_by_rank.insert(rank_id, executed);
+            }
 
-            if executed.end_ms == now_ms {
+            let group_end_ms = executed_by_rank
+                .values()
+                .map(|executed| executed.end_ms)
+                .fold(now_ms, f64::max);
+            let group_wall_time_secs = (group_end_ms - now_ms).max(0.0) / 1000.0;
+            let mut effects = EngineEffects::default();
+
+            for &rank_id in &rank_ids {
+                let Some(mut executed) = executed_by_rank.remove(&rank_id) else {
+                    if group_end_ms > now_ms {
+                        // Empty ranks still participate in the barrier so work
+                        // arriving mid-epoch cannot start ahead of a sibling.
+                        self.workers.get_mut(&rank_id).unwrap().mark_busy();
+                        effects
+                            .scheduled_completions
+                            .push(ScheduledWorkerCompletion {
+                                at_ms: group_end_ms,
+                                payload: WorkerCompletionPayload {
+                                    stage: self.stage,
+                                    worker_idx: rank_id,
+                                    completed_requests: 0,
+                                    output_signals: Vec::new(),
+                                    lifecycle_events: Vec::new(),
+                                    kv_events: Vec::new(),
+                                    fpm: None,
+                                    accept_length_output_tokens: 0,
+                                    accept_length_decode_forwards: 0,
+                                },
+                            });
+                    }
+                    continue;
+                };
+
+                if let Some(fpm) = executed.fpm.as_mut() {
+                    fpm.wall_time_secs = group_wall_time_secs;
+                }
+                if self.pass_mode == EnginePassMode::Visible {
+                    collector
+                        .as_deref_mut()
+                        .expect("visible pass collector checked before execution")
+                        .align_pass_token_times(&executed.output_signals, group_end_ms);
+                }
+
+                let admitted_requests = !executed.admissions.is_empty();
+                effects.admissions.extend(executed.admissions);
+                let published_pass_start_kv = executed.router_event_visibility
+                    == RouterEventVisibility::PassStart
+                    && !executed.kv_events.is_empty();
+                let completion_kv_events =
+                    if executed.router_event_visibility == RouterEventVisibility::PassStart {
+                        effects.pass_start_kv_events.extend(executed.kv_events);
+                        Vec::new()
+                    } else {
+                        executed.kv_events
+                    };
+                let payload = WorkerCompletionPayload {
+                    stage: self.stage,
+                    worker_idx: rank_id,
+                    completed_requests: executed.completed_requests,
+                    output_signals: executed.output_signals,
+                    lifecycle_events: executed.lifecycle_events,
+                    kv_events: completion_kv_events,
+                    fpm: executed.fpm,
+                    accept_length_output_tokens: executed.accept_length_output_tokens,
+                    accept_length_decode_forwards: executed.accept_length_decode_forwards,
+                };
+
+                if group_end_ms > now_ms {
+                    self.workers.get_mut(&rank_id).unwrap().mark_busy();
+                    effects
+                        .scheduled_completions
+                        .push(ScheduledWorkerCompletion {
+                            at_ms: group_end_ms,
+                            payload,
+                        });
+                    continue;
+                }
+
                 // NOTE: Keep both lifecycle extremes in view when changing this gate.
                 // Tight-spin/livelock occurs when an effect-free, queued-only,
                 // zero-duration pass is repeatedly treated as progress at the same
@@ -282,8 +464,8 @@ impl EngineComponent {
                 // same-time iteration when no observable state changed, but only after
                 // the owning subsystem can account for every unfinished request's
                 // future wakeup; an empty event queue alone is not quiescence.
-                let made_progress = !effects.admissions.is_empty()
-                    || !effects.pass_start_kv_events.is_empty()
+                let made_progress = admitted_requests
+                    || published_pass_start_kv
                     || payload.completed_requests > 0
                     || !payload.output_signals.is_empty()
                     || !payload.lifecycle_events.is_empty()
@@ -293,21 +475,14 @@ impl EngineComponent {
                         .fpm_snapshots
                         .iter()
                         .any(|(_, snapshot)| fpm_has_scheduled_work(snapshot));
-                if !made_progress {
-                    continue;
+                if made_progress {
+                    effects.immediate_completions.push(payload);
                 }
-                effects.immediate_completions.push(payload);
-                return Ok(effects);
             }
 
-            worker.mark_busy();
-            effects
-                .scheduled_completions
-                .push(ScheduledWorkerCompletion {
-                    at_ms: executed.end_ms,
-                    payload,
-                });
-            return Ok(effects);
+            if !effects.is_empty() {
+                return Ok(effects);
+            }
         }
 
         Ok(EngineEffects::default())
@@ -352,7 +527,12 @@ impl EngineComponent {
     }
 
     pub(in crate::replay::offline) fn worker_count(&self) -> usize {
-        self.workers.len()
+        self.worker_groups.len()
+    }
+
+    #[cfg(test)]
+    pub(in crate::replay::offline) fn rank_id_capacity(&self) -> usize {
+        self.next_id
     }
 
     #[cfg(feature = "kvbm-offload")]
@@ -399,10 +579,12 @@ impl EngineComponent {
 mod tests {
     use super::*;
     use crate::common::handoff::HandoffId;
+    use crate::common::perf_model::{AicCallback, PerfModel};
     use crate::common::protocols::{
         DirectRequest, EngineType, MockEngineArgs, SglangArgs, WorkerType,
     };
     use crate::scheduler::{SchedulerCommand, SchedulerCommandResult, SchedulerLifecycleEvent};
+    use std::sync::Arc;
     use uuid::Uuid;
 
     #[cfg(feature = "kvbm-offload")]
@@ -449,6 +631,128 @@ mod tests {
             EnginePassMode::Visible,
             vec![OfflineWorkerState::new(0, args, false)],
         )
+    }
+
+    struct LengthLatency;
+
+    impl AicCallback for LengthLatency {
+        fn predict_prefill(&self, _batch_size: usize, effective_isl: usize, _prefix: usize) -> f64 {
+            effective_isl as f64
+        }
+
+        fn predict_decode(&self, _batch_size: usize, _isl: usize, _osl: usize) -> f64 {
+            1.0
+        }
+    }
+
+    fn ranked_timing_engine(dp_size: u32) -> EngineComponent {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(64)
+            .max_num_batched_tokens(Some(64))
+            .max_num_seqs(Some(1))
+            .enable_prefix_caching(false)
+            .speedup_ratio(1.0)
+            .dp_size(dp_size)
+            .perf_model(Arc::new(PerfModel::from_aic_callback(Arc::new(
+                LengthLatency,
+            ))))
+            .build()
+            .unwrap();
+        EngineComponent::new_ranked(
+            SimulationWorkerStage::Aggregated,
+            EnginePassMode::Visible,
+            args,
+            1,
+            false,
+        )
+    }
+
+    fn timed_request(uuid: Uuid, input_length: usize) -> DirectRequest {
+        DirectRequest {
+            tokens: vec![1; input_length],
+            max_output_tokens: 1,
+            uuid: Some(uuid),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn attention_dp_group_completes_at_slowest_rank_boundary() {
+        let mut engine = ranked_timing_engine(2);
+        let fast = Uuid::from_u128(30);
+        let slow = Uuid::from_u128(31);
+        engine.dispatch(0, timed_request(fast, 4)).unwrap();
+        engine.dispatch(1, timed_request(slow, 8)).unwrap();
+        let mut collector = TraceCollector::default();
+        collector.on_arrival(fast, 0.0, 4, 1);
+        collector.on_arrival(slow, 0.0, 8, 1);
+
+        let effects = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+
+        assert_eq!(effects.scheduled_completions.len(), 2);
+        assert!(
+            effects
+                .scheduled_completions
+                .iter()
+                .all(|completion| (completion.at_ms - 9.0).abs() < f64::EPSILON)
+        );
+        assert!(effects.scheduled_completions.iter().all(|completion| {
+            (completion.payload.fpm.as_ref().unwrap().wall_time_secs - 0.009).abs() < f64::EPSILON
+        }));
+        assert_eq!(collector.request_latencies(fast).unwrap().0, 9.0);
+        assert_eq!(collector.request_latencies(slow).unwrap().0, 9.0);
+    }
+
+    #[test]
+    fn attention_dp_empty_rank_blocks_mid_epoch_arrival() {
+        let mut engine = ranked_timing_engine(2);
+        let slow = Uuid::from_u128(40);
+        engine.dispatch(0, timed_request(slow, 8)).unwrap();
+        let mut collector = TraceCollector::default();
+        collector.on_arrival(slow, 0.0, 8, 1);
+
+        let first_epoch = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        assert_eq!(first_epoch.scheduled_completions.len(), 2);
+        assert!(engine.debug_snapshots().iter().all(|rank| rank.busy));
+
+        let mid_epoch = Uuid::from_u128(41);
+        collector.on_arrival(mid_epoch, 4.0, 4, 1);
+        engine.dispatch(1, timed_request(mid_epoch, 4)).unwrap();
+        assert!(
+            engine
+                .drive_ready(4.0, Some(&mut collector))
+                .unwrap()
+                .is_empty()
+        );
+
+        for completion in first_epoch.scheduled_completions {
+            engine.on_scheduled_completion(completion.payload).unwrap();
+        }
+        let second_epoch = engine.drive_ready(9.0, Some(&mut collector)).unwrap();
+        assert_eq!(second_epoch.scheduled_completions.len(), 2);
+        assert!(
+            second_epoch
+                .scheduled_completions
+                .iter()
+                .all(|completion| (completion.at_ms - 14.0).abs() < f64::EPSILON)
+        );
+        assert_eq!(collector.request_latencies(mid_epoch).unwrap().0, 10.0);
+    }
+
+    #[test]
+    fn single_rank_group_keeps_local_completion_time() {
+        let mut engine = ranked_timing_engine(1);
+        let uuid = Uuid::from_u128(50);
+        engine.dispatch(0, timed_request(uuid, 4)).unwrap();
+        let mut collector = TraceCollector::default();
+        collector.on_arrival(uuid, 0.0, 4, 1);
+
+        let effects = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+
+        assert_eq!(effects.scheduled_completions.len(), 1);
+        assert_eq!(effects.scheduled_completions[0].at_ms, 5.0);
+        assert_eq!(collector.request_latencies(uuid).unwrap().0, 5.0);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -401,7 +401,10 @@ impl EngineComponent {
                                     output_signals: Vec::new(),
                                     lifecycle_events: Vec::new(),
                                     kv_events: Vec::new(),
-                                    fpm: None,
+                                    fpm: Some(ForwardPassSnapshot {
+                                        wall_time_secs: group_wall_time_secs,
+                                        ..Default::default()
+                                    }),
                                     accept_length_output_tokens: 0,
                                     accept_length_decode_forwards: 0,
                                 },
@@ -715,6 +718,19 @@ mod tests {
         let first_epoch = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert_eq!(first_epoch.scheduled_completions.len(), 2);
         assert!(engine.debug_snapshots().iter().all(|rank| rank.busy));
+        let idle_fpm = first_epoch
+            .scheduled_completions
+            .iter()
+            .find(|completion| completion.payload.worker_idx == 1)
+            .unwrap()
+            .payload
+            .fpm
+            .as_ref()
+            .expect("idle DP rank must emit an empty FPM");
+        assert!(!fpm_has_scheduled_work(idle_fpm));
+        assert_eq!(idle_fpm.num_queued_prefill, 0);
+        assert_eq!(idle_fpm.num_queued_decode, 0);
+        assert!((idle_fpm.wall_time_secs - 0.009).abs() < f64::EPSILON);
 
         let mid_epoch = Uuid::from_u128(41);
         collector.on_arrival(mid_epoch, 4.0, 4, 1);

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -192,6 +192,7 @@ impl PendingRequest {
 pub(crate) struct OfflineReplayRouter {
     config: KvRouterConfig,
     block_size: u32,
+    dp_size: u32,
     profile: PolicyProfile,
     worker_config_template: ReplayWorkerConfig,
     workers_with_configs: HashMap<WorkerId, ReplayWorkerConfig>,
@@ -222,6 +223,7 @@ impl OfflineReplayRouter {
         Ok(Self {
             config,
             block_size: args.block_size as u32,
+            dp_size: args.dp_size.max(1),
             profile: profile.clone(),
             worker_config_template,
             workers_with_configs,
@@ -283,7 +285,9 @@ impl OfflineReplayRouter {
             self.pending
                 .enqueue(
                     class_index,
-                    self.workers_with_configs.len(),
+                    self.workers_with_configs
+                        .len()
+                        .saturating_mul(self.dp_size as usize),
                     snapshot,
                     now_ms.max(0.0) / 1000.0,
                     priority_jump,
@@ -374,7 +378,10 @@ impl OfflineReplayRouter {
         {
             return Err(anyhow!("router worker {worker_id} already exists"));
         }
-        if let Err(error) = self.slots.upsert_worker(WorkerDpRange::new(wid, 0, 1)) {
+        if let Err(error) = self
+            .slots
+            .upsert_worker(WorkerDpRange::new(wid, 0, self.dp_size))
+        {
             self.workers_with_configs.remove(&wid);
             return Err(error.into());
         }
@@ -551,8 +558,14 @@ impl OfflineReplayRouter {
             eligibility,
             self.block_size,
         )?;
-        let worker_idx = usize::try_from(selection.worker.worker_id)
+        let worker_id = usize::try_from(selection.worker.worker_id)
             .map_err(|_| anyhow!("selected worker id does not fit into usize"))?;
+        let dp_rank = usize::try_from(selection.worker.dp_rank)
+            .map_err(|_| anyhow!("selected dp rank does not fit into usize"))?;
+        let worker_idx = worker_id
+            .checked_mul(self.dp_size as usize)
+            .and_then(|base| base.checked_add(dp_rank))
+            .ok_or_else(|| anyhow!("selected worker/rank index overflow"))?;
         let request_id = request.request_id();
         let prefill_load_hint = self.prefill_load_hint_for(
             request.isl_tokens,
@@ -621,12 +634,16 @@ impl OfflineReplayRouter {
         class: &PolicyClassConfig,
     ) -> bool {
         workers_with_configs.iter().all(|(&worker_id, config)| {
-            let worker = WorkerWithDpRank::new(worker_id, config.data_parallel_start_rank());
-            let max_batched = config
-                .max_num_batched_tokens()
-                .unwrap_or(DEFAULT_MAX_BATCHED_TOKENS);
-            let tokens = active_tokens.get(&worker).copied().unwrap_or(0);
-            class.worker_is_busy(tokens, max_batched)
+            let start = config.data_parallel_start_rank();
+            let end = start.saturating_add(config.data_parallel_size());
+            (start..end).all(|dp_rank| {
+                let worker = WorkerWithDpRank::new(worker_id, dp_rank);
+                let max_batched = config
+                    .max_num_batched_tokens()
+                    .unwrap_or(DEFAULT_MAX_BATCHED_TOKENS);
+                let tokens = active_tokens.get(&worker).copied().unwrap_or(0);
+                class.worker_is_busy(tokens, max_batched)
+            })
         })
     }
 
@@ -784,6 +801,16 @@ mod tests {
         tokens_hash: u64,
         storage_tier: StorageTier,
     ) -> RouterEvent {
+        store_event_for_rank(worker_id, 0, event_id, tokens_hash, storage_tier)
+    }
+
+    fn store_event_for_rank(
+        worker_id: WorkerId,
+        dp_rank: u32,
+        event_id: u64,
+        tokens_hash: u64,
+        storage_tier: StorageTier,
+    ) -> RouterEvent {
         RouterEvent::with_storage_tier(
             worker_id,
             KvCacheEvent {
@@ -797,7 +824,7 @@ mod tests {
                         mm_extra_info: None,
                     }],
                 }),
-                dp_rank: 0,
+                dp_rank,
             },
             storage_tier,
         )
@@ -881,6 +908,63 @@ mod tests {
                 .map(|request| request.uuid)
                 .collect::<Vec<_>>(),
             vec![Uuid::from_u128(2)]
+        );
+    }
+
+    #[test]
+    fn attention_dp_routes_one_mocker_worker_across_rank_targets() {
+        let mut args = queueing_args();
+        args.dp_size = 2;
+        let mut router =
+            OfflineReplayRouter::new(&args, Some(queueing_router_config()), None, 1).unwrap();
+
+        let first = router
+            .on_request_arrival(&request(1, 7), None, 0.0)
+            .unwrap();
+        let second = router
+            .on_request_arrival(&request(2, 8), None, 0.0)
+            .unwrap();
+        let mut targets = first
+            .admissions
+            .into_iter()
+            .chain(second.admissions)
+            .map(|admission| admission.worker_idx)
+            .collect::<Vec<_>>();
+        targets.sort_unstable();
+
+        assert_eq!(targets, vec![0, 1]);
+        assert_eq!(router.pending_count(), 0);
+    }
+
+    #[test]
+    fn attention_dp_kv_router_routes_cached_prefix_to_matching_rank() {
+        let mut args = replay_args();
+        args.dp_size = 2;
+        let mut router = OfflineReplayRouter::new(&args, Some(router_config()), None, 1).unwrap();
+        let target = request(1, 7);
+        let hashes = ReplayRequestHashes::from_tokens(&target.tokens, router.block_size);
+
+        router
+            .on_kv_events(vec![store_event_for_rank(
+                0,
+                1,
+                1,
+                hashes.local_block_hashes[0].0,
+                StorageTier::Device,
+            )])
+            .unwrap();
+
+        let effects = router
+            .on_request_arrival(&target, Some(hashes), 0.0)
+            .unwrap();
+        assert_eq!(
+            effects.admissions,
+            vec![WorkerAdmission {
+                uuid: Uuid::from_u128(1),
+                worker_idx: 1,
+                overlap_blocks: 1,
+                isl_blocks: 1,
+            }]
         );
     }
 

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -5,7 +5,7 @@ use dynamo_kv_router::protocols::RouterEvent;
 use uuid::Uuid;
 
 use super::super::runtime_utils::WorkerCompletionPayload;
-use crate::common::protocols::{DirectRequest, ForwardPassSnapshot};
+use crate::common::protocols::DirectRequest;
 use crate::loadgen::ReplayRequestHashes;
 use crate::scheduler::AdmissionEvent;
 
@@ -46,9 +46,6 @@ pub(in crate::replay::offline) struct EngineEffects {
     pub(in crate::replay::offline) pass_start_kv_events: Vec<RouterEvent>,
     pub(in crate::replay::offline) immediate_completions: Vec<WorkerCompletionPayload>,
     pub(in crate::replay::offline) scheduled_completions: Vec<ScheduledWorkerCompletion>,
-    /// Forward pass metrics snapshots emitted by workers during this drive cycle,
-    /// keyed by worker index. Collected for planner integration.
-    pub(in crate::replay::offline) fpm_snapshots: Vec<(usize, ForwardPassSnapshot)>,
 }
 
 impl EngineEffects {

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -16,7 +16,7 @@ use super::components::{
     ReadyArrival, ScheduledWorkerCompletion, TrafficAccumulator, WorkerAdmission,
 };
 use super::events::{SimulationEvent, SimulationWorkerStage};
-use super::planner_hook::{PlannerHook, PlannerTickMetrics};
+use super::planner_hook::{LatestFpmBuffer, PlannerHook, PlannerTickMetrics};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
     next_timestamp as choose_next_timestamp, pop_ready_planner_tick, pop_ready_transfer_complete,
@@ -31,9 +31,9 @@ use crate::common::handoff::{
     IssuedHandoffAction, NormalizedHandoffConformance, NormalizedHandoffEvent,
     NormalizedStoredTiming,
 };
-use crate::common::protocols::{
-    DirectRequest, EngineType, ForwardPassSnapshot, MockEngineArgs, OutputSignal,
-};
+#[cfg(test)]
+use crate::common::protocols::ForwardPassSnapshot;
+use crate::common::protocols::{DirectRequest, EngineType, MockEngineArgs, OutputSignal};
 use crate::loadgen::{ReplayRequestHashes, WorkloadDriver};
 use crate::replay::{
     OfflineDisaggReplayConfig, ReplayPrefillLoadEstimator, ReplayRouterMode, ReplayTerminalStatus,
@@ -286,9 +286,9 @@ pub(in crate::replay) struct DisaggRuntime {
     progress: ReplayProgress,
     stats: DisaggRuntimeStats,
     conformance_capture: Option<HandoffConformanceCapture>,
-    /// Forward pass metrics accumulated between planner ticks, keyed by (stage, worker_idx).
-    prefill_fpm_buffer: Vec<(usize, ForwardPassSnapshot)>,
-    decode_fpm_buffer: Vec<(usize, ForwardPassSnapshot)>,
+    /// Latest forward pass metric per worker/rank since the previous planner tick.
+    prefill_fpm_buffer: LatestFpmBuffer,
+    decode_fpm_buffer: LatestFpmBuffer,
     /// Traffic statistics accumulated between planner ticks.
     traffic: TrafficAccumulator,
     /// Optional cap on simulated wall-clock time. When set, `run()` exits
@@ -299,10 +299,9 @@ pub(in crate::replay) struct DisaggRuntime {
     /// calls back into the planner at each tick (this is the unified replacement
     /// for the old Python-driven `advance_to` stepping loop).
     planner_hook: Option<Box<dyn PlannerHook>>,
-    /// Whether to retain per-pass FPM snapshots in the buffers above. Only the
-    /// planner consumes them, so the plain `run()` path leaves this `false` —
-    /// otherwise the buffers grow unbounded (one entry per worker pass) for the
-    /// whole run with no reader (the memory leak this gating fixes).
+    /// Whether to retain the latest FPM snapshot per worker/rank in the buffers
+    /// above. Only the planner consumes them, so the plain `run()` path leaves this
+    /// `false`.
     collect_fpm: bool,
 }
 
@@ -470,8 +469,8 @@ impl DisaggRuntime {
             #[cfg(not(test))]
             stats: DisaggRuntimeStats,
             conformance_capture: capture_conformance.then(HandoffConformanceCapture::default),
-            prefill_fpm_buffer: Vec::new(),
-            decode_fpm_buffer: Vec::new(),
+            prefill_fpm_buffer: LatestFpmBuffer::default(),
+            decode_fpm_buffer: LatestFpmBuffer::default(),
             traffic: TrafficAccumulator::new(),
             max_sim_time_ms: None,
             planner_hook: None,
@@ -516,6 +515,16 @@ impl DisaggRuntime {
     /// planner via recurring `PlannerTick` events (one `on_tick` callback per tick).
     pub(in crate::replay) fn with_planner_hook(mut self, hook: Box<dyn PlannerHook>) -> Self {
         self.collect_fpm = true;
+        let prefill_dp_size = self.prefill_engine.dp_size();
+        for worker_id in self.prefill_engine.active_group_ids() {
+            self.prefill_fpm_buffer
+                .activate_worker(worker_id, prefill_dp_size, self.now_ms);
+        }
+        let decode_dp_size = self.decode_engine.dp_size();
+        for worker_id in self.decode_engine.active_group_ids() {
+            self.decode_fpm_buffer
+                .activate_worker(worker_id, decode_dp_size, self.now_ms);
+        }
         self.planner_hook = Some(hook);
         self
     }
@@ -1500,7 +1509,8 @@ impl DisaggRuntime {
                     if self.collect_fpm
                         && let Some(fpm) = payload.fpm
                     {
-                        self.prefill_fpm_buffer.push((payload.worker_idx, fpm));
+                        self.prefill_fpm_buffer
+                            .insert(payload.worker_idx, fpm, self.now_ms);
                     }
                     self.process_prefill_pass(
                         payload.worker_idx,
@@ -1516,7 +1526,8 @@ impl DisaggRuntime {
                     if self.collect_fpm
                         && let Some(fpm) = payload.fpm
                     {
-                        self.decode_fpm_buffer.push((payload.worker_idx, fpm));
+                        self.decode_fpm_buffer
+                            .insert(payload.worker_idx, fpm, self.now_ms);
                     }
                     self.process_decode_pass(
                         payload.output_signals,
@@ -1603,9 +1614,6 @@ impl DisaggRuntime {
     }
 
     fn handle_prefill_engine_effects(&mut self, effects: EngineEffects) -> Result<()> {
-        if self.collect_fpm {
-            self.prefill_fpm_buffer.extend(effects.fpm_snapshots);
-        }
         self.record_prefill_admissions(effects.admissions);
         self.apply_prefill_router_events(effects.pass_start_kv_events)?;
         for payload in effects.immediate_completions {
@@ -1613,7 +1621,8 @@ impl DisaggRuntime {
             if self.collect_fpm
                 && let Some(fpm) = payload.fpm
             {
-                self.prefill_fpm_buffer.push((payload.worker_idx, fpm));
+                self.prefill_fpm_buffer
+                    .insert(payload.worker_idx, fpm, self.now_ms);
             }
             self.process_prefill_pass(
                 payload.worker_idx,
@@ -1667,16 +1676,14 @@ impl DisaggRuntime {
     }
 
     fn handle_decode_engine_effects(&mut self, effects: EngineEffects) -> Result<()> {
-        if self.collect_fpm {
-            self.decode_fpm_buffer.extend(effects.fpm_snapshots);
-        }
         self.record_decode_admissions(effects.admissions)?;
         for payload in effects.immediate_completions {
             let payload = self.decode_engine.on_scheduled_completion(payload)?;
             if self.collect_fpm
                 && let Some(fpm) = payload.fpm
             {
-                self.decode_fpm_buffer.push((payload.worker_idx, fpm));
+                self.decode_fpm_buffer
+                    .insert(payload.worker_idx, fpm, self.now_ms);
             }
             self.process_decode_pass(
                 payload.output_signals,
@@ -1699,6 +1706,13 @@ impl DisaggRuntime {
             match stage {
                 SimulationWorkerStage::Prefill => {
                     if self.prefill_engine.mark_worker_ready(worker_id) {
+                        if self.collect_fpm {
+                            self.prefill_fpm_buffer.activate_worker(
+                                worker_id,
+                                self.prefill_engine.dp_size(),
+                                self.now_ms,
+                            );
+                        }
                         if let Some(router) = self.prefill_router.as_mut() {
                             router.add_worker(worker_id)?;
                             let effects = router.try_drain_pending(self.now_ms)?;
@@ -1710,6 +1724,13 @@ impl DisaggRuntime {
                 }
                 SimulationWorkerStage::Decode => {
                     if self.decode_engine.mark_worker_ready(worker_id) {
+                        if self.collect_fpm {
+                            self.decode_fpm_buffer.activate_worker(
+                                worker_id,
+                                self.decode_engine.dp_size(),
+                                self.now_ms,
+                            );
+                        }
                         if let Some(router) = self.decode_router.as_mut() {
                             router.add_worker(worker_id)?;
                             let effects = router.try_drain_pending(self.now_ms)?;
@@ -1835,13 +1856,25 @@ impl DisaggRuntime {
             if self.is_workload_done() {
                 continue;
             }
+            let active_prefill_ids = self.prefill_engine.active_group_ids();
+            let active_decode_ids = self.decode_engine.active_group_ids();
+            self.prefill_fpm_buffer.emit_idle_due(
+                &active_prefill_ids,
+                self.prefill_engine.dp_size(),
+                self.now_ms,
+            );
+            self.decode_fpm_buffer.emit_idle_due(
+                &active_decode_ids,
+                self.decode_engine.dp_size(),
+                self.now_ms,
+            );
             let metrics = PlannerTickMetrics {
                 now_ms: self.now_ms,
-                prefill_fpm: std::mem::take(&mut self.prefill_fpm_buffer),
-                decode_fpm: std::mem::take(&mut self.decode_fpm_buffer),
+                prefill_fpm: self.prefill_fpm_buffer.take(),
+                decode_fpm: self.decode_fpm_buffer.take(),
                 traffic: self.traffic.drain(self.now_ms),
-                active_prefill: self.active_prefill_count(),
-                active_decode: self.active_decode_count(),
+                active_prefill_ids,
+                active_decode_ids,
                 total_prefill: self.total_prefill_count(),
                 total_decode: self.total_decode_count(),
             };
@@ -1929,10 +1962,7 @@ impl DisaggRuntime {
         self.now_ms = new_now_ms;
     }
 
-    pub(in crate::replay) fn active_prefill_count(&self) -> usize {
-        self.prefill_engine.active_worker_ids().len()
-    }
-
+    #[cfg(test)]
     pub(in crate::replay) fn active_decode_count(&self) -> usize {
         self.decode_engine.active_worker_ids().len()
     }
@@ -1974,6 +2004,13 @@ impl DisaggRuntime {
                     );
                 }
                 None => {
+                    if self.collect_fpm {
+                        self.prefill_fpm_buffer.activate_worker(
+                            id,
+                            self.prefill_engine.dp_size(),
+                            self.now_ms,
+                        );
+                    }
                     if let Some(router) = self.prefill_router.as_mut() {
                         router.add_worker(id)?;
                     }
@@ -2010,6 +2047,13 @@ impl DisaggRuntime {
                     );
                 }
                 None => {
+                    if self.collect_fpm {
+                        self.decode_fpm_buffer.activate_worker(
+                            id,
+                            self.decode_engine.dp_size(),
+                            self.now_ms,
+                        );
+                    }
                     if let Some(router) = self.decode_router.as_mut() {
                         router.add_worker(id)?;
                     }
@@ -2086,12 +2130,12 @@ impl DisaggRuntime {
 
     #[cfg(test)]
     fn drain_prefill_fpm(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
-        std::mem::take(&mut self.prefill_fpm_buffer)
+        self.prefill_fpm_buffer.take()
     }
 
     #[cfg(test)]
     fn drain_decode_fpm(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
-        std::mem::take(&mut self.decode_fpm_buffer)
+        self.decode_fpm_buffer.take()
     }
 
     fn run_to_completion(&mut self) -> Result<()> {

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -1,18 +1,37 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::rc::Rc;
 
 use super::super::entrypoints::{
     run_concurrency_collect, run_concurrency_workload_collect, run_trace_collect,
     run_trace_workload_collect,
 };
+use super::super::planner_hook::PlannerTickDecision;
 use super::*;
 use crate::common::protocols::{
     EngineType, KvTransferTimingMode, MockEngineArgs, SglangArgs, WorkerType,
 };
 use crate::loadgen::{SessionTrace, Trace, TurnTrace};
 use crate::replay::TraceSimulationReport;
+
+struct CaptureOnceHook {
+    at_ms: f64,
+    captured: Rc<RefCell<Option<PlannerTickMetrics>>>,
+}
+
+impl PlannerHook for CaptureOnceHook {
+    fn initial_tick_ms(&mut self) -> anyhow::Result<f64> {
+        Ok(self.at_ms)
+    }
+
+    fn on_tick(&mut self, metrics: PlannerTickMetrics) -> anyhow::Result<PlannerTickDecision> {
+        *self.captured.borrow_mut() = Some(metrics);
+        Ok(PlannerTickDecision::default())
+    }
+}
 
 fn staged_args(worker_type: WorkerType, speedup_ratio: f64) -> MockEngineArgs {
     MockEngineArgs::builder()
@@ -265,6 +284,52 @@ fn request(
         dp_rank: 0,
         arrival_timestamp_ms: Some(arrival_ms),
         ..Default::default()
+    }
+}
+
+#[test]
+fn planner_tick_emits_idle_fpm_for_both_disagg_pools() {
+    let mut config = disagg_config();
+    config.num_prefill_workers = 1;
+    config.num_decode_workers = 1;
+    let pending = crate::replay::normalize_trace_requests(
+        vec![request(9_301, 64, 1, 0.0), request(9_302, 64, 1, 3_000.0)],
+        1.0,
+    )
+    .unwrap();
+    let captured = Rc::new(RefCell::new(None));
+    let hook = CaptureOnceHook {
+        at_ms: 2_000.0,
+        captured: Rc::clone(&captured),
+    };
+
+    DisaggRuntime::new(
+        &config,
+        None,
+        None,
+        pending,
+        ReplayMode::Trace,
+        ReplayRouterMode::RoundRobin,
+    )
+    .unwrap()
+    .with_planner_hook(Box::new(hook))
+    .run()
+    .unwrap();
+
+    let metrics = captured
+        .borrow_mut()
+        .take()
+        .expect("planner tick must fire");
+    assert_eq!(metrics.now_ms, 2_000.0);
+    for snapshots in [&metrics.prefill_fpm, &metrics.decode_fpm] {
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].0, 0);
+        assert_eq!(snapshots[0].1.dp_rank, 0);
+        assert_eq!(snapshots[0].1.wall_time_secs, 0.0);
+        assert_eq!(snapshots[0].1.num_prefill_requests, 0);
+        assert_eq!(snapshots[0].1.num_decode_requests, 0);
+        assert_eq!(snapshots[0].1.num_queued_prefill, 0);
+        assert_eq!(snapshots[0].1.num_queued_decode, 0);
     }
 }
 

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -49,8 +49,10 @@ fn finish_with_replay_wall_time(
     collector.finish().with_wall_time_ms(wall_time_ms)
 }
 
-fn use_single_runtime(num_workers: usize, router_mode: ReplayRouterMode) -> bool {
-    num_workers == 1 && router_mode != ReplayRouterMode::KvRouter
+fn use_single_runtime(num_workers: usize, dp_size: u32, router_mode: ReplayRouterMode) -> bool {
+    // dp_size>1 needs one scheduler/KV pool per rank. They still share one
+    // discrete-event runtime, but require the rank-aware AggRuntime path.
+    num_workers == 1 && dp_size <= 1 && router_mode != ReplayRouterMode::KvRouter
 }
 
 /// Run the deterministic offline half of the live/offline handoff conformance
@@ -203,7 +205,7 @@ pub(crate) fn simulate_trace(
     max_sim_time_ms: Option<f64>,
     sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers, router_mode) {
+    if use_single_runtime(num_workers, args.dp_size, router_mode) {
         simulate_trace_single(
             args,
             requests,
@@ -241,7 +243,7 @@ pub(crate) fn simulate_concurrency(
     max_sim_time_ms: Option<f64>,
     sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers, router_mode) {
+    if use_single_runtime(num_workers, args.dp_size, router_mode) {
         simulate_concurrency_single(
             args,
             requests,
@@ -301,7 +303,7 @@ pub(crate) fn simulate_agentic_trace_workload(
     router_mode: ReplayRouterMode,
     sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers, router_mode) {
+    if use_single_runtime(num_workers, args.dp_size, router_mode) {
         simulate_agentic_trace_workload_single(args, trace, sla)
     } else {
         simulate_agentic_trace_workload_multi(
@@ -355,7 +357,7 @@ fn simulate_trace_workload_with_delta_mode(
     max_sim_time_ms: Option<f64>,
     sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers, router_mode) {
+    if use_single_runtime(num_workers, args.dp_size, router_mode) {
         simulate_trace_workload_single(
             args,
             trace,
@@ -450,7 +452,7 @@ fn simulate_concurrency_workload_with_delta_mode(
     max_sim_time_ms: Option<f64>,
     sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
-    if use_single_runtime(num_workers, router_mode) {
+    if use_single_runtime(num_workers, args.dp_size, router_mode) {
         simulate_concurrency_workload_single(
             args,
             trace,
@@ -1150,23 +1152,104 @@ pub(super) fn run_concurrency_workload_collect(
 mod tests {
     #[cfg(feature = "kvbm-offload")]
     use super::simulate_trace_disagg;
-    use super::{generate_trace_worker_artifacts, use_single_runtime};
-    use crate::common::protocols::MockEngineArgs;
+    use super::{generate_trace_worker_artifacts, simulate_trace, use_single_runtime};
+    use crate::common::perf_model::{AicCallback, PerfModel};
     #[cfg(feature = "kvbm-offload")]
-    use crate::common::protocols::{DirectRequest, WorkerType};
+    use crate::common::protocols::WorkerType;
+    use crate::common::protocols::{DirectRequest, MockEngineArgs};
     use crate::loadgen::{SessionTrace, Trace, TurnTrace};
-    use crate::replay::ReplayRouterMode;
     #[cfg(feature = "kvbm-offload")]
-    use crate::replay::{OfflineDisaggReplayConfig, SlaThresholds};
-    #[cfg(feature = "kvbm-offload")]
+    use crate::replay::OfflineDisaggReplayConfig;
+    use crate::replay::{ReplayRouterMode, SlaThresholds};
+    use std::sync::Arc;
     use uuid::Uuid;
 
     #[test]
     fn single_runtime_selection_excludes_kv_router() {
-        assert!(use_single_runtime(1, ReplayRouterMode::RoundRobin));
-        assert!(!use_single_runtime(1, ReplayRouterMode::KvRouter));
-        assert!(!use_single_runtime(2, ReplayRouterMode::RoundRobin));
-        assert!(!use_single_runtime(2, ReplayRouterMode::KvRouter));
+        assert!(use_single_runtime(1, 1, ReplayRouterMode::RoundRobin));
+        assert!(!use_single_runtime(1, 1, ReplayRouterMode::KvRouter));
+        assert!(!use_single_runtime(2, 1, ReplayRouterMode::RoundRobin));
+        assert!(!use_single_runtime(2, 1, ReplayRouterMode::KvRouter));
+        // dp_size>1 forces the multi (per-rank) path even with a single worker.
+        assert!(!use_single_runtime(1, 8, ReplayRouterMode::RoundRobin));
+    }
+
+    struct LengthLatency;
+
+    impl AicCallback for LengthLatency {
+        fn predict_prefill(&self, _batch_size: usize, effective_isl: usize, _prefix: usize) -> f64 {
+            effective_isl as f64
+        }
+
+        fn predict_decode(&self, _batch_size: usize, _isl: usize, _osl: usize) -> f64 {
+            1.0
+        }
+    }
+
+    fn rank_timing_args(dp_size: u32) -> MockEngineArgs {
+        MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(64)
+            .max_num_batched_tokens(Some(64))
+            .max_num_seqs(Some(1))
+            .enable_prefix_caching(false)
+            .speedup_ratio(1.0)
+            .dp_size(dp_size)
+            .perf_model(Arc::new(PerfModel::from_aic_callback(Arc::new(
+                LengthLatency,
+            ))))
+            .build()
+            .unwrap()
+    }
+
+    fn timed_request(uuid: u128, input_length: usize) -> DirectRequest {
+        DirectRequest {
+            tokens: vec![1; input_length],
+            max_output_tokens: 1,
+            uuid: Some(Uuid::from_u128(uuid)),
+            arrival_timestamp_ms: Some(0.0),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn attention_dp_trace_entrypoint_aligns_skewed_ranks_to_slowest_boundary() {
+        let report = simulate_trace(
+            rank_timing_args(2),
+            None,
+            None,
+            vec![timed_request(30, 4), timed_request(31, 8)],
+            1,
+            1.0,
+            ReplayRouterMode::RoundRobin,
+            true,
+            None,
+            SlaThresholds::default(),
+        )
+        .unwrap();
+
+        assert_eq!(report.request_counts.completed_requests, 2);
+        let mut records = report.per_request;
+        records.sort_by_key(|record| record.input_length);
+        assert_eq!(records[0].decode_worker_idx, Some(0));
+        assert_eq!(records[1].decode_worker_idx, Some(1));
+        assert_eq!(records[0].ttft_ms, Some(9.0));
+        assert_eq!(records[1].ttft_ms, Some(9.0));
+
+        let dp1 = simulate_trace(
+            rank_timing_args(1),
+            None,
+            None,
+            vec![timed_request(32, 4)],
+            1,
+            1.0,
+            ReplayRouterMode::RoundRobin,
+            true,
+            None,
+            SlaThresholds::default(),
+        )
+        .unwrap();
+        assert_eq!(dp1.per_request[0].ttft_ms, Some(5.0));
     }
 
     #[cfg(feature = "kvbm-offload")]

--- a/lib/mocker/src/replay/offline/planner_hook.rs
+++ b/lib/mocker/src/replay/offline/planner_hook.rs
@@ -5,7 +5,7 @@
 //!
 //! A [`PlannerHook`] is invoked once per [`PlannerTick`](super::events::SimulationEventKind::PlannerTick)
 //! event inside the unified `run()` loop: it receives the metrics drained at the tick
-//! (per-pass FPM snapshots accumulated since the last tick, the traffic window, and worker
+//! (the latest FPM snapshot per worker/rank, the traffic window, and worker
 //! counts) and returns a scaling decision plus the time of the next tick. This replaces the
 //! old Python-driven `advance_to`/`apply_scaling` stepping loop — the planner's decision logic
 //! still lives in Python (via a PyO3 wrapper that implements this trait), but the simulation
@@ -13,8 +13,187 @@
 //!
 //! [`NoopPlannerHook`] is the inert stand-in for tests and the no-planner path.
 
+use std::collections::BTreeMap;
+
 use super::components::TrafficStats;
 use crate::common::protocols::ForwardPassSnapshot;
+
+const IDLE_FPM_INTERVAL_MS: f64 = 1_000.0;
+
+/// Latest FPM snapshot for each logical worker and DP rank.
+#[derive(Debug, Default)]
+pub(super) struct LatestFpmBuffer {
+    snapshots: BTreeMap<(usize, u32), ForwardPassSnapshot>,
+    last_publish_ms: BTreeMap<(usize, u32), f64>,
+}
+
+impl LatestFpmBuffer {
+    pub(super) fn activate_worker(&mut self, worker_id: usize, dp_size: u32, now_ms: f64) {
+        for dp_rank in 0..dp_size.max(1) {
+            self.last_publish_ms
+                .entry((worker_id, dp_rank))
+                .or_insert(now_ms);
+        }
+    }
+
+    pub(super) fn insert(&mut self, worker_id: usize, snapshot: ForwardPassSnapshot, now_ms: f64) {
+        let key = (worker_id, snapshot.dp_rank);
+        self.snapshots.insert(key, snapshot);
+        self.last_publish_ms.insert(key, now_ms);
+    }
+
+    pub(super) fn emit_idle_due(&mut self, active_worker_ids: &[usize], dp_size: u32, now_ms: f64) {
+        debug_assert!(active_worker_ids.is_sorted());
+        let dp_size = dp_size.max(1);
+        let is_active = |(worker_id, dp_rank): &(usize, u32)| {
+            *dp_rank < dp_size && active_worker_ids.binary_search(worker_id).is_ok()
+        };
+        self.snapshots.retain(|key, _| is_active(key));
+        self.last_publish_ms.retain(|key, _| is_active(key));
+
+        for &worker_id in active_worker_ids {
+            for dp_rank in 0..dp_size {
+                let key = (worker_id, dp_rank);
+                let last_publish_ms = self.last_publish_ms.entry(key).or_insert(now_ms);
+                let elapsed_ms = now_ms - *last_publish_ms;
+                if elapsed_ms >= IDLE_FPM_INTERVAL_MS {
+                    *last_publish_ms +=
+                        (elapsed_ms / IDLE_FPM_INTERVAL_MS).floor() * IDLE_FPM_INTERVAL_MS;
+                    self.snapshots.insert(
+                        key,
+                        ForwardPassSnapshot {
+                            dp_rank,
+                            ..Default::default()
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    pub(super) fn take(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
+        std::mem::take(&mut self.snapshots)
+            .into_iter()
+            .map(|((worker_id, _), snapshot)| (worker_id, snapshot))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LatestFpmBuffer;
+    use crate::common::protocols::ForwardPassSnapshot;
+
+    #[test]
+    fn latest_fpm_buffer_coalesces_each_worker_rank() {
+        let mut buffer = LatestFpmBuffer::default();
+        buffer.insert(
+            4,
+            ForwardPassSnapshot {
+                dp_rank: 0,
+                wall_time_secs: 1.0,
+                ..Default::default()
+            },
+            100.0,
+        );
+        buffer.insert(
+            4,
+            ForwardPassSnapshot {
+                dp_rank: 0,
+                wall_time_secs: 2.0,
+                ..Default::default()
+            },
+            200.0,
+        );
+        buffer.insert(
+            4,
+            ForwardPassSnapshot {
+                dp_rank: 1,
+                wall_time_secs: 3.0,
+                ..Default::default()
+            },
+            300.0,
+        );
+        buffer.insert(
+            5,
+            ForwardPassSnapshot {
+                dp_rank: 0,
+                wall_time_secs: 4.0,
+                ..Default::default()
+            },
+            400.0,
+        );
+
+        let snapshots = buffer.take();
+
+        assert_eq!(snapshots.len(), 3);
+        assert_eq!(snapshots[0].0, 4);
+        assert_eq!(snapshots[0].1.dp_rank, 0);
+        assert_eq!(snapshots[0].1.wall_time_secs, 2.0);
+        assert_eq!(snapshots[1].0, 4);
+        assert_eq!(snapshots[1].1.dp_rank, 1);
+        assert_eq!(snapshots[1].1.wall_time_secs, 3.0);
+        assert_eq!(snapshots[2].0, 5);
+        assert_eq!(snapshots[2].1.dp_rank, 0);
+        assert_eq!(snapshots[2].1.wall_time_secs, 4.0);
+        assert!(buffer.take().is_empty());
+    }
+
+    #[test]
+    fn latest_fpm_buffer_emits_idle_on_simulated_cadence() {
+        let mut buffer = LatestFpmBuffer::default();
+        buffer.activate_worker(4, 2, 100.0);
+
+        buffer.emit_idle_due(&[4], 2, 1_099.0);
+        assert!(buffer.take().is_empty());
+
+        buffer.emit_idle_due(&[4], 2, 1_100.0);
+        let snapshots = buffer.take();
+        assert_eq!(snapshots.len(), 2);
+        assert!(
+            snapshots
+                .iter()
+                .all(|(worker_id, snapshot)| { *worker_id == 4 && snapshot.wall_time_secs == 0.0 })
+        );
+
+        buffer.insert(
+            4,
+            ForwardPassSnapshot {
+                dp_rank: 1,
+                wall_time_secs: 0.25,
+                ..Default::default()
+            },
+            1_500.0,
+        );
+        buffer.emit_idle_due(&[4], 2, 2_100.0);
+        let snapshots = buffer.take();
+        assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots[0].1.dp_rank, 0);
+        assert_eq!(snapshots[0].1.wall_time_secs, 0.0);
+        assert_eq!(snapshots[1].1.dp_rank, 1);
+        assert_eq!(snapshots[1].1.wall_time_secs, 0.25);
+
+        let mut delayed_observation = LatestFpmBuffer::default();
+        delayed_observation.activate_worker(8, 1, 0.0);
+        delayed_observation.emit_idle_due(&[8], 1, 1_500.0);
+        assert_eq!(delayed_observation.take().len(), 1);
+        delayed_observation.emit_idle_due(&[8], 1, 2_400.0);
+        assert_eq!(delayed_observation.take().len(), 1);
+
+        delayed_observation.insert(
+            8,
+            ForwardPassSnapshot {
+                wall_time_secs: 0.1,
+                ..Default::default()
+            },
+            3_000.0,
+        );
+        delayed_observation.emit_idle_due(&[], 1, 3_500.0);
+        assert!(delayed_observation.take().is_empty());
+        delayed_observation.emit_idle_due(&[8], 1, 4_000.0);
+        assert!(delayed_observation.take().is_empty());
+    }
+}
 
 /// Metrics handed to the planner at one tick. The runtime has already advanced the clock to
 /// `now_ms` and settled all same-timestamp work before this is built, so the planner observes a
@@ -23,18 +202,18 @@ use crate::common::protocols::ForwardPassSnapshot;
 pub struct PlannerTickMetrics {
     /// Simulated clock at this tick (equals the scheduled tick time).
     pub now_ms: f64,
-    /// Every prefill FPM snapshot accumulated since the previous tick (empty in agg mode,
-    /// which routes all passes through `decode_fpm`).
+    /// Latest prefill FPM snapshot per worker/rank observed since the previous tick (empty in
+    /// agg mode, which routes all passes through `decode_fpm`).
     pub prefill_fpm: Vec<(usize, ForwardPassSnapshot)>,
-    /// Every decode (agg: aggregated) FPM snapshot accumulated since the previous tick.
+    /// Latest decode (agg: aggregated) FPM snapshot per worker/rank observed since the previous
+    /// tick.
     pub decode_fpm: Vec<(usize, ForwardPassSnapshot)>,
     /// Traffic stats over `[previous tick, now]`. Drained every tick; the Python side merges
-    /// partial windows across ticks that don't consume traffic (mirrors how it already
-    /// accumulates FPM snapshots).
+    /// partial windows across ticks that don't consume traffic.
     pub traffic: TrafficStats,
-    /// Active (ready, non-draining) worker counts. Agg reports decode only (`active_prefill = 0`).
-    pub active_prefill: usize,
-    pub active_decode: usize,
+    /// Active (ready, non-draining) logical worker IDs. Agg reports decode only.
+    pub active_prefill_ids: Vec<usize>,
+    pub active_decode_ids: Vec<usize>,
     /// Total workers including pending startup + pending removal.
     pub total_prefill: usize,
     pub total_decode: usize,

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -216,6 +216,8 @@ impl DisaggRequestState {
 
 pub(crate) struct OfflineWorkerState {
     core: EngineCore,
+    worker_id: u64,
+    dp_rank: u32,
     busy: bool,
     in_flight: usize,
 }
@@ -231,15 +233,27 @@ pub(crate) struct OfflineWorkerSnapshot {
 
 impl OfflineWorkerState {
     pub(crate) fn new(worker_idx: usize, args: MockEngineArgs, capture_kv_events: bool) -> Self {
+        Self::new_with_rank(worker_idx, worker_idx as u64, 0, args, capture_kv_events)
+    }
+
+    pub(crate) fn new_with_rank(
+        worker_idx: usize,
+        worker_id: u64,
+        dp_rank: u32,
+        args: MockEngineArgs,
+        capture_kv_events: bool,
+    ) -> Self {
         let core = match args.engine_type {
             crate::common::protocols::EngineType::Vllm
             | crate::common::protocols::EngineType::Trtllm => {
                 #[cfg_attr(not(feature = "kvbm-offload"), allow(unused_mut))]
-                let mut core = if capture_kv_events {
-                    crate::scheduler::VllmCore::new_with_kv_capture(args, worker_idx as u64)
-                } else {
-                    crate::scheduler::VllmCore::new_with_worker_id(args, worker_idx as u64)
-                };
+                let mut core = crate::scheduler::VllmCore::new_with_worker_rank(
+                    args,
+                    worker_id,
+                    dp_rank,
+                    worker_idx as u64,
+                    capture_kv_events,
+                );
                 #[cfg(feature = "kvbm-offload")]
                 if let Err(e) = core.init_offload_offline() {
                     tracing::error!(
@@ -249,25 +263,27 @@ impl OfflineWorkerState {
                 EngineCore::Vllm(core)
             }
             crate::common::protocols::EngineType::Sglang => {
-                if capture_kv_events {
-                    EngineCore::Sglang(crate::scheduler::SglangCore::new_with_kv_capture(
-                        args,
-                        worker_idx as u64,
-                    ))
-                } else {
-                    EngineCore::Sglang(crate::scheduler::SglangCore::new_with_worker_id(
-                        args,
-                        worker_idx as u64,
-                    ))
-                }
+                EngineCore::Sglang(crate::scheduler::SglangCore::new_with_worker_rank(
+                    args,
+                    worker_id,
+                    dp_rank,
+                    worker_idx as u64,
+                    capture_kv_events,
+                ))
             }
         };
 
         Self {
             core,
+            worker_id,
+            dp_rank,
             busy: false,
             in_flight: 0,
         }
+    }
+
+    pub(crate) fn rank_identity(&self) -> (u64, u32) {
+        (self.worker_id, self.dp_rank)
     }
 
     pub(crate) fn in_flight(&self) -> usize {
@@ -275,11 +291,12 @@ impl OfflineWorkerState {
         self.in_flight
     }
 
-    pub(crate) fn receive_request(&mut self, request: DirectRequest) {
+    pub(crate) fn receive_request(&mut self, mut request: DirectRequest) {
         self.in_flight = self
             .in_flight
             .checked_add(1)
             .expect("offline worker in-flight request count overflow");
+        request.dp_rank = self.dp_rank;
         self.core.receive(request);
     }
 
@@ -464,6 +481,41 @@ mod tests {
             tokens: (0..tokens as u32).collect(),
             max_output_tokens: 2,
             ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ranked_worker_preserves_router_worker_and_dp_rank_identity() {
+        for engine_type in [EngineType::Vllm, EngineType::Sglang] {
+            let mut builder = MockEngineArgs::builder()
+                .engine_type(engine_type)
+                .block_size(4)
+                .num_gpu_blocks(64)
+                .max_num_batched_tokens(Some(64))
+                .max_num_seqs(Some(4))
+                .dp_size(4)
+                .enable_prefix_caching(true)
+                .speedup_ratio(1000.0);
+            if engine_type == EngineType::Sglang {
+                builder = builder.sglang(Some(Default::default()));
+            }
+            let mut worker =
+                OfflineWorkerState::new_with_rank(3, 7, 3, builder.build().unwrap(), true);
+            worker.receive_request(request(900 + engine_type as u128, 8));
+
+            let mut now_ms = 0.0;
+            let mut events = Vec::new();
+            while !worker.core.is_empty() {
+                let pass = worker.execute_hidden_pass(now_ms);
+                now_ms = pass.end_ms;
+                worker.mark_completed(pass.completed_requests);
+                events.extend(pass.kv_events);
+            }
+            events.extend(worker.drain_kv_events());
+
+            assert!(!events.is_empty());
+            assert!(events.iter().all(|event| event.worker_id == 7));
+            assert!(events.iter().all(|event| event.event.dp_rank == 3));
         }
     }
 

--- a/lib/mocker/src/replay/router_shared.rs
+++ b/lib/mocker/src/replay/router_shared.rs
@@ -35,15 +35,17 @@ impl SequencePublisher for ReplayNoopPublisher {
 pub(super) struct ReplayWorkerConfig {
     pub(super) max_num_batched_tokens: u64,
     pub(super) total_kv_blocks: u64,
+    pub(super) data_parallel_start_rank: u32,
+    pub(super) data_parallel_size: u32,
 }
 
 impl WorkerConfigLike for ReplayWorkerConfig {
     fn data_parallel_start_rank(&self) -> u32 {
-        0
+        self.data_parallel_start_rank
     }
 
     fn data_parallel_size(&self) -> u32 {
-        1
+        self.data_parallel_size
     }
 
     fn max_num_batched_tokens(&self) -> Option<u64> {
@@ -65,6 +67,8 @@ pub(in crate::replay) fn replay_worker_config(args: &MockEngineArgs) -> ReplayWo
             .map(|tokens| tokens as u64)
             .unwrap_or(DEFAULT_MAX_BATCHED_TOKENS),
         total_kv_blocks: args.num_gpu_blocks as u64,
+        data_parallel_start_rank: 0,
+        data_parallel_size: args.dp_size.max(1),
     }
 }
 
@@ -83,9 +87,13 @@ pub(super) fn replay_slots(
     workers_with_configs: &HashMap<WorkerId, ReplayWorkerConfig>,
 ) -> Arc<ActiveSequencesMultiWorker<ReplayNoopPublisher>> {
     let dp_range = workers_with_configs
-        .keys()
-        .copied()
-        .map(|worker_id| (worker_id, (0, 1)))
+        .iter()
+        .map(|(&worker_id, config)| {
+            (
+                worker_id,
+                (config.data_parallel_start_rank, config.data_parallel_size),
+            )
+        })
         .collect();
     // NOTE: Offline replay must retire requests through explicit lifecycle events. Wall-clock
     // expiry is a live-router cleanup heuristic and must not observe simulator CPU time: a

--- a/lib/mocker/src/replay/validate.rs
+++ b/lib/mocker/src/replay/validate.rs
@@ -42,7 +42,12 @@ pub fn validate_replay_args_mode(
     }
 }
 
-fn validate_replay_args(args: &MockEngineArgs, num_workers: usize, mode: &str) -> Result<()> {
+fn validate_replay_args(
+    args: &MockEngineArgs,
+    num_workers: usize,
+    mode: &str,
+    allow_dp_replication: bool,
+) -> Result<()> {
     if num_workers == 0 {
         bail!("{mode} requires num_workers >= 1");
     }
@@ -52,7 +57,10 @@ fn validate_replay_args(args: &MockEngineArgs, num_workers: usize, mode: &str) -
             args.worker_type,
         );
     }
-    if args.dp_size != 1 {
+    // Offline replay treats dp_size>1 as rank topology: each mocker worker gets
+    // that many independent scheduler/KV-pool states, mirroring the live path.
+    // Online replay does not support it.
+    if args.dp_size != 1 && !allow_dp_replication {
         bail!(
             "{mode} only supports data_parallel_size=1, got {}",
             args.dp_size,
@@ -62,15 +70,21 @@ fn validate_replay_args(args: &MockEngineArgs, num_workers: usize, mode: &str) -
     Ok(())
 }
 
-fn validate_offline_router_mode(router_mode: ReplayRouterMode, num_workers: usize) -> Result<()> {
+fn validate_offline_router_mode(
+    router_mode: ReplayRouterMode,
+    num_workers: usize,
+    dp_size: u32,
+) -> Result<()> {
     if router_mode != ReplayRouterMode::KvRouter {
         return Ok(());
     }
-    if num_workers > 1 {
+    if num_workers.saturating_mul(dp_size.max(1) as usize) > 1 {
         return Ok(());
     }
 
-    bail!("offline replay only supports router_mode=kv_router when num_workers > 1");
+    bail!(
+        "offline replay only supports router_mode=kv_router with more than one worker/DP-rank target"
+    );
 }
 
 pub(super) fn validate_offline_replay_args(
@@ -78,8 +92,8 @@ pub(super) fn validate_offline_replay_args(
     num_workers: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<()> {
-    validate_offline_router_mode(router_mode, num_workers)?;
-    validate_replay_args(args, num_workers, "trace replay")
+    validate_offline_router_mode(router_mode, num_workers, args.dp_size)?;
+    validate_replay_args(args, num_workers, "trace replay", true)
 }
 
 pub(super) fn validate_offline_concurrency_args(
@@ -92,12 +106,12 @@ pub(super) fn validate_offline_concurrency_args(
         bail!("concurrency replay requires max_in_flight >= 1");
     }
 
-    validate_offline_router_mode(router_mode, num_workers)?;
-    validate_replay_args(args, num_workers, "concurrency replay")
+    validate_offline_router_mode(router_mode, num_workers, args.dp_size)?;
+    validate_replay_args(args, num_workers, "concurrency replay", true)
 }
 
 pub(super) fn validate_online_replay_args(args: &MockEngineArgs, num_workers: usize) -> Result<()> {
-    validate_replay_args(args, num_workers, "online replay")
+    validate_replay_args(args, num_workers, "online replay", false)
 }
 
 pub(super) fn validate_online_concurrency_args(
@@ -109,7 +123,7 @@ pub(super) fn validate_online_concurrency_args(
         bail!("online concurrency replay requires max_in_flight >= 1");
     }
 
-    validate_replay_args(args, num_workers, "online replay")
+    validate_replay_args(args, num_workers, "online replay", false)
 }
 
 fn validate_disagg_args(config: &OfflineDisaggReplayConfig, mode: &str) -> Result<()> {
@@ -143,15 +157,11 @@ fn validate_disagg_args(config: &OfflineDisaggReplayConfig, mode: &str) -> Resul
             config.decode_args.worker_type,
         );
     }
-    if config.prefill_args.dp_size != 1 {
+    if config.prefill_args.dp_size != 1 || config.decode_args.dp_size != 1 {
         bail!(
-            "{mode} only supports prefill data_parallel_size=1, got {}",
+            "offline disaggregated replay does not support attention DP; prefill/decode dp_size \
+             must both be 1 (got prefill_dp_size={}, decode_dp_size={})",
             config.prefill_args.dp_size,
-        );
-    }
-    if config.decode_args.dp_size != 1 {
-        bail!(
-            "{mode} only supports decode data_parallel_size=1, got {}",
             config.decode_args.dp_size,
         );
     }
@@ -231,5 +241,36 @@ mod tests {
                 .unwrap_err();
             assert!(error.to_string().contains("matching prefill/decode"));
         }
+    }
+
+    #[test]
+    fn disagg_rejects_attention_dp_with_clear_error() {
+        for (prefill_dp_size, decode_dp_size) in [(2, 1), (1, 2), (2, 4)] {
+            let mut config = config(EngineType::Vllm, EngineType::Vllm);
+            config.prefill_args.dp_size = prefill_dp_size;
+            config.decode_args.dp_size = decode_dp_size;
+            let expected = format!(
+                "offline disaggregated replay does not support attention DP; prefill/decode \
+                 dp_size must both be 1 (got prefill_dp_size={prefill_dp_size}, \
+                 decode_dp_size={decode_dp_size})"
+            );
+
+            let trace_error =
+                validate_offline_disagg_replay_args(&config, ReplayRouterMode::RoundRobin)
+                    .unwrap_err();
+            assert_eq!(trace_error.to_string(), expected);
+
+            let concurrency_error =
+                validate_offline_disagg_concurrency_args(&config, 1, ReplayRouterMode::RoundRobin)
+                    .unwrap_err();
+            assert_eq!(concurrency_error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn offline_kv_router_accepts_one_worker_with_multiple_dp_ranks() {
+        let mut args = args(EngineType::Vllm, WorkerType::Aggregated);
+        args.dp_size = 2;
+        validate_offline_replay_args(&args, 1, ReplayRouterMode::KvRouter).unwrap();
     }
 }

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -85,19 +85,24 @@ impl SglangCore {
         Self::new_internal(args, 0, 0, None, KvEventPublishers::default())
     }
 
-    pub(crate) fn new_with_worker_id(args: MockEngineArgs, worker_id: WorkerId) -> Self {
-        Self::new_internal(args, 0, worker_id, None, KvEventPublishers::default())
+    pub(crate) fn new_with_kv_capture(args: MockEngineArgs, worker_id: WorkerId) -> Self {
+        Self::new_with_worker_rank(args, worker_id, 0, worker_id, true)
     }
 
-    pub(crate) fn new_with_kv_capture(args: MockEngineArgs, worker_id: WorkerId) -> Self {
-        let (buffer, sink) = capture_router_event_sink(worker_id);
-        Self::new_internal(
-            args,
-            0,
-            worker_id,
-            Some(buffer),
-            KvEventPublishers::new(Some(sink), None),
-        )
+    pub(crate) fn new_with_worker_rank(
+        args: MockEngineArgs,
+        worker_id: WorkerId,
+        dp_rank: u32,
+        seed_offset: u64,
+        capture_kv_events: bool,
+    ) -> Self {
+        let (buffer, publishers) = if capture_kv_events {
+            let (buffer, sink) = capture_router_event_sink(worker_id);
+            (Some(buffer), KvEventPublishers::new(Some(sink), None))
+        } else {
+            (None, KvEventPublishers::default())
+        };
+        Self::new_internal(args, dp_rank, seed_offset, buffer, publishers)
     }
 
     pub(super) fn new_with_sink(
@@ -111,7 +116,7 @@ impl SglangCore {
     fn new_internal(
         args: MockEngineArgs,
         dp_rank: u32,
-        worker_id: WorkerId,
+        seed_offset: u64,
         kv_event_buffer: Option<CapturedRouterEventBuffer>,
         kv_event_publishers: KvEventPublishers,
     ) -> Self {
@@ -122,7 +127,7 @@ impl SglangCore {
             let rates =
                 normalize_conditional_accept_rates(nextn, args.aic_nextn_accept_rates.as_deref())
                     .expect("normalized MTP acceptance rates");
-            SpeculativeDecodeSampler::new(rates, args.aic_mtp_seed.wrapping_add(worker_id))
+            SpeculativeDecodeSampler::new(rates, args.aic_mtp_seed.wrapping_add(seed_offset))
         });
 
         Self {

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -442,19 +442,24 @@ impl VllmCore {
         Self::new_internal(args, 0, 0, None, KvEventPublishers::default())
     }
 
-    pub(crate) fn new_with_worker_id(args: MockEngineArgs, worker_id: WorkerId) -> Self {
-        Self::new_internal(args, 0, worker_id, None, KvEventPublishers::default())
+    pub(crate) fn new_with_kv_capture(args: MockEngineArgs, worker_id: WorkerId) -> Self {
+        Self::new_with_worker_rank(args, worker_id, 0, worker_id, true)
     }
 
-    pub(crate) fn new_with_kv_capture(args: MockEngineArgs, worker_id: WorkerId) -> Self {
-        let (buffer, sink) = capture_router_event_sink(worker_id);
-        Self::new_internal(
-            args,
-            0,
-            worker_id,
-            Some(buffer),
-            KvEventPublishers::new(Some(sink), None),
-        )
+    pub(crate) fn new_with_worker_rank(
+        args: MockEngineArgs,
+        worker_id: WorkerId,
+        dp_rank: u32,
+        seed_offset: u64,
+        capture_kv_events: bool,
+    ) -> Self {
+        let (buffer, publishers) = if capture_kv_events {
+            let (buffer, sink) = capture_router_event_sink(worker_id);
+            (Some(buffer), KvEventPublishers::new(Some(sink), None))
+        } else {
+            (None, KvEventPublishers::default())
+        };
+        Self::new_internal(args, dp_rank, seed_offset, buffer, publishers)
     }
 
     pub(super) fn new_with_sink(
@@ -468,7 +473,7 @@ impl VllmCore {
     fn new_internal(
         args: MockEngineArgs,
         dp_rank: u32,
-        worker_id: WorkerId,
+        seed_offset: u64,
         kv_event_buffer: Option<CapturedRouterEventBuffer>,
         kv_event_publishers: KvEventPublishers,
     ) -> Self {
@@ -482,7 +487,7 @@ impl VllmCore {
             let rates =
                 normalize_conditional_accept_rates(nextn, args.aic_nextn_accept_rates.as_deref())
                     .expect("normalized MTP acceptance rates");
-            SpeculativeDecodeSampler::new(rates, args.aic_mtp_seed.wrapping_add(worker_id))
+            SpeculativeDecodeSampler::new(rates, args.aic_mtp_seed.wrapping_add(seed_offset))
         });
         Self {
             kv_manager: KvManager::new_with_event_sink(


### PR DESCRIPTION
## Overview:

### Summary

Offline replay modeled attention-DP with one aggregate scheduler and KV pool, while the live mocker creates an independent scheduler and KV pool for each DP rank. This PR makes offline replay use the same per-rank topology while retaining one deterministic discrete-event runtime.

## Details:

- Create one scheduler and per-rank KV pool for every `(worker_id, dp_rank)`.
- Route round-robin traffic by mocker worker and then DP rank, while honoring rank selections from the KV router.
- Execute each logical DP group in epochs gated by its slowest rank. Empty ranks participate in the barrier, mid-epoch arrivals wait for the next epoch, and completion-visible effects are committed at the group boundary.
- Emit a zero-work FPM for every idle rank at the shared group wall time so the planner's latest per-rank observations remain epoch-aligned.
- Preserve `worker_id` and `dp_rank` through request dispatch, KV events, planner accounting, and dynamic worker scaling.
- Keep explicit and AIC-estimated KV capacity per rank, and reject mismatched `dp_size` / `aic_attention_dp_size` configurations.
- Report planner logical-worker capacity as per-rank KV capacity times DP and GPU width as TP times DP, without changing rank-local scheduler capacity.
- Account for every materialized DP-rank resource in worker-seconds and GPU-hours.
- Reject attention-DP for disaggregated offline replay with a clear validation error until ranked prefill/decode handoff semantics are modeled.
- Remove the obsolete single-scheduler attention-DP workarounds from #10964 and #11002: scheduler-local batches now go directly to AIC and KV capacity is no longer aggregated across ranks.

## Where should the reviewer start?

- `lib/mocker/src/replay/offline/components/engine.rs` — per-rank scheduler grouping, group barrier, and lifecycle.
- `lib/mocker/src/replay/offline/agg.rs` — worker/rank routing and event-loop integration.
- `lib/mocker/src/replay/offline/components/router.rs` — KV-router worker/rank identity.
- `lib/bindings/python/rust/llm/replay.rs` and `components/src/dynamo/replay/main.py` — AIC topology and per-rank capacity materialization.
- `lib/mocker/src/common/perf_model.rs` — removal of the aggregate-batch compatibility layer.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- `pre-commit run --from-ref HEAD^ --to-ref HEAD`
- `cargo test -p dynamo-mocker --lib` — 506 passed, 1 ignored
- `cargo test -p dynamo-mocker --features kvbm-offload --lib` — 602 passed, 1 ignored
- `cargo clippy -p dynamo-mocker --lib -- -D warnings`
- Skewed-rank DP2 trace replay — the 5 ms fast rank is held to the 9 ms slow-rank boundary; DP1 remains 5 ms
- Idle-rank DP2 FPM regression — the idle rank emits zero scheduled/queued work at the shared 9 ms group boundary
- Binding replay unit tests — 4 passed
- Planner replay adapter pytest — 10 passed
- Base/head offline timing matrix covering aggregated and disaggregated replay, round-robin and KV-aware routing, KV offload on and off, planner scaling, and DP 1/2/4/8

### DP1 base/head timing parity

The deterministic DP1 cases match to floating-point precision. Completion counts and completion order are unchanged. Times and throughput are rounded to 2 decimals, worker-seconds to 3 decimals, and GPU-hours to 3 significant figures.

| Case | Completed | TTFT base → head (ms) | ITL base → head (ms) | E2E base → head (ms) | Throughput base → head (req/s) | Worker-seconds P/D base → head | GPU-hours base → head |
|---|---:|---:|---:|---:|---:|---:|---:|
| Aggregated, RR, resident | 24/24 → 24/24 | 31.83 → 31.83 | 9.47 → 9.47 | 154.93 → 154.93 | 45.62 → 45.62 | 0/1.052 → 0/1.052 | 2.92e-4 → 2.92e-4 |
| Disaggregated, RR, resident | 24/24 → 24/24 | 33.75 → 33.75 | 6.22 → 6.22 | 114.60 → 114.60 | 57.39 → 57.39 | 0.836/0.836 → same | 4.65e-4 → 4.65e-4 |
| Aggregated, RR, KV offload | 24/24 → 24/24 | 154.84 → 154.84 | 32.00 → 32.00 | 570.87 → 570.87 | 11.81 → 11.81 | 0/4.064 → 0/4.064 | 1.13e-3 → 1.13e-3 |
| Disaggregated, RR, KV offload | 24/24 → 24/24 | 234.35 → 234.35 | 26.99 → 26.99 | 585.27 → 585.27 | 11.04 → 11.04 | 4.346/4.346 → same | 2.41e-3 → 2.41e-3 |
| Aggregated, RR, planner | 192/192 → 192/192 | 3367.18 → 3367.18 | 18.75 → 18.75 | 4548.45 → 4548.45 | 24.84 → 24.84 | 0/14.458 → 0/14.458 | 4.02e-3 → 4.02e-3 |

The planner case remains at 7 ticks with the same decision: aggregated workers scale `1 → 2` at `t=1s`.

KV-aware routing has equal-cost tie-break nondeterminism on both base and head, so it was repeated five times per side:

| Case | Completed | TTFT base → head (ms) | ITL base → head (ms) | E2E base → head (ms) | Throughput base → head (req/s) | Worker-seconds base → head | GPU-hours base → head | Completion order |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Aggregated, KV-aware | 24/24 in all 10 runs | 29.33–29.67 → 29.33–30.00 | 8.84–8.88 → 8.84–8.88 | 144.52–144.73 → 144.52–145.14 | 48.92–49.13 → 47.47–49.13 | 0.977–0.981 → 0.977–1.011 | 2.71e-4–2.73e-4 → 2.71e-4–2.81e-4 | 2 base / 3 head orders; both base orders and 2 exact timing signatures reproduced by head |
| Disaggregated, KV-aware | 24/24 in all 10 runs | 31.75–33.15 → 31.84–32.67 | 6.22–6.25 → 6.22–6.25 | 112.92–114.35 → 112.87–113.95 | 57.11–57.52 → 56.83–58.01 | 0.835–0.840 per role → 0.827–0.845 per role | 4.64e-4–4.67e-4 → 4.60e-4–4.69e-4 | 3 base / 4 head orders; one exact order/timing signature shared |

### Attention-DP base/head timing

All configured requests completed. Exact parity is expected for symmetric low-concurrency batches; material changes at higher contention are intentional consequences of replacing the aggregate scheduler approximation with per-rank scheduling and capacity.

| DP / concurrency / ISL | Requests | TTFT base → head (ms) | TPOT base → head (ms) | E2E base → head (ms) | Output throughput/GPU base → head (tok/s) |
|---|---:|---:|---:|---:|---:|
| DP1 / c1 / 1024 | 16/16 | 41.06 → 41.06 | 4.39 → 4.39 | 4532.38 → 4532.38 | 56.48 → 56.48 |
| DP2 / c128 / 1024 | 128/128 | 525.19 → 415.45 | 12.19 → 12.08 | 12991.27 → 12769.35 | 2508.81 → 2558.95 |
| DP4 / c4 / 1024 | 16/16 | 240.14 → 240.14 | 24.73 → 24.73 | 25541.02 → 25541.02 | 10.02 → 10.02 |
| DP8 / c8 / 1024 | 16/16 | 330.82 → 330.82 | 26.38 → 26.38 | 27321.69 → 27321.69 | 4.68 → 4.68 |
| DP8 / c64 / 1024 | 64/64 | 1989.59 → 1769.74 | 30.32 → 28.66 | 33007.93 → 31087.36 | 30.91 → 32.94 |
| DP8 / c64 / 8192 | 64/64 | 34104.24 → 9343.38 | 57.52 → 33.70 | 92944.46 → 43814.94 | 10.92 → 23.32 |

Generic DP2 replay, which the base rejected, now completes with correct two-rank accounting:

| Case | Completed | TTFT (ms) | ITL (ms) | E2E (ms) | Output throughput (tok/s) | Decode worker-seconds | GPU-hours | Planner |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Round-robin | 64/64 | 35.62 | 7.54 | 510.63 | 1998.40 | 2.050 | 1.14e-3 | — |
| KV-aware | 64/64 | 35.62 | 7.54 | 510.63 | 1998.40 | 2.050 | 1.14e-3 | — |
| Planner | 192/192 | 1488.43 | 18.16 | 2632.56 | 3126.86 | 6.860 | 3.81e-3 | 3 ticks; `1 → 2` at `t=1s` |

### Slowest-rank barrier validation

- End-to-end DP2 trace replay routes a 5 ms request to rank 0 and a 9 ms request to rank 1; both become completion-visible at 9 ms. The DP1 control remains 5 ms.
- An empty sibling rank participates in the epoch: a request arriving at 4 ms waits for the 9 ms boundary and completes at 14 ms (10 ms TTFT).
- Isolating the barrier on the DP2 planner workload changes TTFT `1456.17 → 1488.43 ms`, ITL `17.91 → 18.16 ms`, E2E `2584.51 → 2632.56 ms`, output throughput `3171.01 → 3126.86 tok/s`, and GPU-hours `3.75e-3 → 3.81e-3`; completion count, 3 planner ticks, and the `1 → 2` scaling decision remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline replay now supports data-parallel rank-aware behavior, including per-rank routing, capacity handling, and worker selection.
  * Replay simulations can now use a single-worker fast path only when data parallelism is not enabled.

* **Bug Fixes**
  * Fixed capacity calculations so estimated GPU block counts stay per-rank instead of being multiplied across data-parallel ranks.
  * Added validation to catch mismatched data-parallel settings early and prevent invalid replay configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
