### PR TITLE
fix(container): make SGLang FlashInfer cubins writable

### DIFF
--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -35,7 +35,11 @@ RUN userdel -r ubuntu > /dev/null 2>&1 || true \
     # NOTE: Setting ENV UMASK=002 does NOT work - umask is a shell builtin, not an environment variable
     && mkdir -p /etc/profile.d && echo 'umask 002' > /etc/profile.d/00-umask.sh
 
-RUN chmod -R 775 /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins || true
+RUN SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')" && \
+    CUBINS_DIR="$SITE_PACKAGES/flashinfer_cubin/cubins" && \
+    if [ -d "$CUBINS_DIR" ]; then \
+        find "$CUBINS_DIR" -type d -exec chmod g+rwx {} + ; \
+    fi
 
 {% if device == "xpu" %}
 {# XPU runtime: NIXL + UCX are needed for P2P transport on Intel GPUs.

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -35,6 +35,8 @@ RUN userdel -r ubuntu > /dev/null 2>&1 || true \
     # NOTE: Setting ENV UMASK=002 does NOT work - umask is a shell builtin, not an environment variable
     && mkdir -p /etc/profile.d && echo 'umask 002' > /etc/profile.d/00-umask.sh
 
+RUN chmod -R 775 /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins || true
+
 {% if device == "xpu" %}
 {# XPU runtime: NIXL + UCX are needed for P2P transport on Intel GPUs.
    CUDA sglang runtime does NOT include NIXL/UCX (matching upstream main);


### PR DESCRIPTION
## Summary

- make the SGLang runtime image mark installed `flashinfer_cubin/cubins` directories writable before switching to the non-root `dynamo` user
- keep the step conditional so images without `flashinfer_cubin` still build

## Why

FlashInfer may create JIT symlink directories under the installed `flashinfer_cubin/cubins` tree at runtime. In non-root runtime containers, that package path can be read-only and fail during server startup with `PermissionError: [Errno 13]`.

Related to #7849.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility by relaxing access permissions for bundled GPU-related assets, helping prevent permission-related failures during startup or deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->