### PR TITLE
feat: PR 8 bookkeeping for the EPP and standalone Selector Router Integration

### DIFF
--- a/deploy/inference-gateway/ext-proc/examples/onramp/ONRAMP.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/ONRAMP.md
@@ -1,0 +1,410 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Dynamo Router on-ramp (raw vLLM workers, no Dynamo control plane)
+
+This directory is the **smallest possible** way to put Dynamo's KV/load-aware
+router in front of an existing **vanilla `vllm serve`** fleet that already sits
+behind a Gateway-API gateway with the Inference Extension (GAIE).
+
+If you already run GAIE + vLLM, you **replace only your EndpointPicker (EPP)**
+with the Dynamo EPP and you are done — no Dynamo operator, no Dynamo runtime,
+no Dynamo worker.
+
+| | This on-ramp (standalone mode) | Full Dynamo (dynamo mode) |
+|---|---|---|
+| Workers | stock `vllm serve` | Dynamo workers (vLLM/SGLang/TRT-LLM) |
+| Discovery | K8s pod reflector; membership comes from the `InferencePool` (selector + target port) | Dynamo discovery (etcd/K8s) |
+| KV events | per-pod vLLM ZMQ → the in-process `SelectionCore` indexer subscribes directly | Dynamo event plane |
+| Runtime | none — runtime-free (no etcd, no NATS, no event plane) | etcd + NATS |
+| Operator | not required | required (DynamoGraphDeployment) |
+| Tokenization | EPP calls vLLM `/v1/chat/completions/render` for routing tokens | model-card preprocessor, no extra render call |
+
+The EPP is served in one of two modes, selected at startup by **`DYN_EPP_MODE`**
+(`dynamo` | `standalone`); the same binary serves both. In
+standalone mode the EPP and a runtime-free `SelectionService` are compiled into
+one process, so there is no separate selection-service Deployment and no HTTP
+hop. It runs single-replica, or **replicated** — set `DYN_EPP_PEER_SERVICE` and
+the replicas discover each other and sync active load (admission/prefill/free)
+over ZMQ.
+
+## Limitations
+
+| Concern | Standalone mode, in-process selector (gap vs full Dynamo) |
+|---|---|
+Duplicate store/remove (vLLM "retries") | parity
+In-stream ordering | parity
+Transient disconnects | The in-process indexer reconnects on its own and keeps routing. KV-cache updates the worker sent during the gap are recovered from the worker's **replay** socket when `DYN_EPP_KV_EVENT_REPLAY_PORT` is set (and the vLLM worker exposes one); otherwise the index refreshes from new traffic.
+Dropped events / gaps | The `SelectionCore` indexer does seq-watermark gap detection and replays missed events from the worker's replay socket when `DYN_EPP_KV_EVENT_REPLAY_PORT` is configured. Without a replay socket, gaps are dropped and the index re-warms from new traffic.
+Initial cache state | A fresh or restarted EPP starts with an empty index and re-warms from live traffic + replay. Replicas share active load (admission/prefill/free) but not KV-index state.
+Backpressure / EPP restart | vLLM PUB drops to slow subscribers (ZMQ HWM) can be silently lost; on restart the index starts empty and re-warms from new traffic.
+Data parallelism | V1 targets DP=1.
+Disaggregated prefill/decode | Not supported by these PRs (aggregated: prefill and decode share one worker). Planned follow-up.
+Multi-replica EPP | Supported: set `DYN_EPP_PEER_SERVICE` so replicas sync active load over ZMQ (`agg.yaml` runs 2 replicas). Cross-replica KV-index warm-up is not wired; a new replica re-warms from live traffic + replay.
+
+## Examples
+
+If you are starting from scratch install the [Prerequisites](#1-prerequisites) and apply the provided example file:
+
+- `agg.yaml` — aggregated: one vLLM pool, KV-aware load balancing, EPP with the in-process selector, replicated (2 replicas with cross-replica active-load sync).
+
+```bash
+kubectl apply -n <ns> -f agg.yaml
+```
+
+Otherwise follow the steps below.
+
+> Disaggregated prefill/decode serving is a planned follow-up and is not covered
+> by this on-ramp.
+
+## Example Progression from vLLM to vLLM + Dynamo + GAIE
+
+### Initial Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-qwen
+spec:
+  selector:
+    app: vllm-qwen
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+```
+
+### 1. Prerequisites
+
+Set up a Gateway-API gateway + Inference Extension (GAIE) if you don't have one
+yet. Follow the instructions for your gateway (e.g. [AgentGateway](https://agentgateway.dev/docs/kubernetes/main/quickstart/install/)) and [Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/guides/).
+
+We provide a convenience script if you are installing from scratch for experimentation.
+```bash
+# Gateway API + Inference Extension CRDs + a gateway named `inference-gateway`
+deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
+```
+
+Create the HuggingFace token secret the vLLM worker uses to download the
+model.
+
+```bash
+# HF token secret for the vLLM worker (required for gated models)
+kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-token>
+```
+
+### 2. Create / Wire the InferencePool and HTTPRoute
+
+Now that Gateway and GAIE is installed, we can create an InferencePool and an accompanying Dynamo EPP.
+
+Point the `InferencePool` at your vLLM workers (see the
+[`vllm-qwen-pool` InferencePool in `agg.yaml`](./agg.yaml#L222) for a complete example):
+
+Specifically, these fields depend on the model you deploy, so make sure the settings below are adjusted to match your workers.
+
+- `spec.selector` — labels matching your vLLM pods.
+```yaml
+  selector:
+    matchLabels:
+      app: vllm-qwen
+```
+
+- `spec.targetPorts[].number` — the vLLM serving port (usually `8000`).
+```yaml
+  targetPorts:
+    - number: 8000
+```
+
+- `spec.endpointPickerRef` (a.k.a. `spec.extensionRef`) — the EPP service + port.
+```yaml
+  endpointPickerRef:
+    kind: Service
+    name: dynamo-epp
+    port:
+      number: 9002
+```
+
+Attach the `HTTPRoute` to the gateway and target the pool (see the
+[`vllm-qwen-route` HTTPRoute in `agg.yaml`](./agg.yaml#L238) for a complete example):
+
+- `spec.rules[].backendRefs[]` — targets the `InferencePool`.
+```yaml
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-qwen-pool
+          port: 8000
+          weight: 1
+```
+
+- `spec.parentRefs[]` — your gateway (set `namespace` + `sectionName` when the
+  gateway lives in another namespace, e.g. `agentgateway-system`).
+```yaml
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+      # Name the Gateway's namespace + listener when it lives elsewhere (drop
+      # `namespace` only if the Gateway is in this namespace). Otherwise the
+      # route silently fails to attach (status.parents stays empty).
+      namespace: agentgateway-system
+      sectionName: http
+```
+
+### 3. Update vLLM deployment
+
+Add labels to your vLLM pods that match `InferencePool.spec.selector` (the EPP
+reads the pool to learn which pods to watch — there is no separate selector env
+var):
+
+```yaml
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+```
+
+or
+```bash
+kubectl -n <ns> label deployment <vllm-deployment> app=vllm-qwen --overwrite
+```
+
+### 4. Add the EPP to your deployment
+
+Remove the vLLM router (if you have it already installed) and replace it with the EPP (Dynamo Router).
+Add the EPP as a `Deployment` + `Service` (see the
+[`dynamo-epp` Deployment in `agg.yaml`](./agg.yaml#L125) for a complete example) and set:
+
+```yaml
+kind: Deployment
+metadata:
+  name: dynamo-epp
+  labels:
+    app: dynamo-epp
+```
+
+1. **Set the EPP image.** The Dynamo EPP ships as the "frontend" image with each
+   release; standalone mode is a pure runtime flag, no special build.
+
+2. **Select standalone mode and point at the pool.** The EPP reads the
+   `InferencePool` it backs (the same object the gateway routes to) to learn the
+   pod selector and HTTP target port — so no pod-selector/target-port env is
+   needed. It watches pods in its own namespace (`POD_NAMESPACE`, via the
+   downward API):
+
+   ```yaml
+   - name: DYN_EPP_MODE
+     value: "standalone"       # in-process selector; no separate service
+   - name: DYN_EPP_INFERENCE_POOL_NAME
+     value: "vllm-qwen-pool"    # the InferencePool this EPP backs
+   - name: POD_NAMESPACE
+     valueFrom:
+       fieldRef:
+         fieldPath: metadata.namespace
+   ```
+
+3. **Point at the workers' KV-event socket.** The worker publishes KV events via
+   `--kv-events-config`; the in-process `SelectionCore` indexer subscribes on the
+   matching port at each Ready pod's IP.
+
+   vLLM worker arg:
+
+   ```text
+   --kv-events-config '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+   ```
+
+   EPP env:
+
+   ```yaml
+   - name: DYN_EPP_KV_EVENT_PORT
+     value: "5557"
+   ```
+
+4. **Set the model, renderer URL, and block size.** The renderer URL points to a
+   vLLM HTTP Service exposing `/v1/chat/completions/render`; it may select the
+   same homogeneous worker pods. The block size MUST equal the vLLM
+   `--block-size`:
+
+   ```yaml
+   - name: DYN_MODEL_NAME
+     value: "Qwen/Qwen3-0.6B"
+   - name: DYN_EPP_VLLM_RENDER_URL
+     value: "http://vllm-qwen-render:8000"
+   - name: DYN_KV_CACHE_BLOCK_SIZE
+     value: "16"
+   ```
+
+5. **(Optional) Tune KV routing and recovery:**
+
+   ```yaml
+   # KV indexer thread pool for the in-process selector.
+   - name: DYN_EPP_SELECTION_INDEXER_THREADS
+     value: "4"
+   # ZMQ replay socket for gap recovery (only if the vLLM worker exposes one).
+   - name: DYN_EPP_KV_EVENT_REPLAY_PORT
+     value: "5558"
+   # Scoring / queueing behavior use the standard router env, e.g.:
+   - name: DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT
+     value: "1.0"
+   ```
+
+   To run **more than one** EPP replica, set `DYN_EPP_PEER_SERVICE` to the EPP's
+   own `Service` so replicas discover each other and sync active load over its
+   required named `replica-agg` port (see the `README.md` "Replicated mode"
+   section), and add `POD_IP` (downward API `status.podIP`) so a replica excludes
+   itself.
+
+   See the full list in the
+   [environment contract](#standalone-mode-environment-contract) below.
+
+In the end your Final vLLM deployment will look like below:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--served-model-name"     # NEW: pin the OpenAI model id
+            - "Qwen/Qwen3-0.6B"
+            - "--port"                  # NEW: explicit (8000 is vLLM's default)
+            - "8000"
+            - "--enable-prefix-caching" # NEW: required so vLLM emits prefix KV events
+            - "--block-size"            # NEW: MUST equal the EPP's DYN_KV_CACHE_BLOCK_SIZE
+            - "16"
+            - "--kv-events-config"      # NEW: publish KV events on a ZMQ PUB socket for the EPP
+            - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: kv-events           # NEW: KV-event PUB port the EPP subscribes to
+              containerPort: 5557
+          env:                          # NEW: HF token lets the worker pull the model (required for gated models)
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+```
+
+## Test
+
+```bash
+# terminal 1
+kubectl -n agentgateway-system port-forward svc/inference-gateway 8000:80
+
+# terminal 2
+GATEWAY_URL=http://localhost:8000
+
+# quick health/smoke first
+curl --max-time 20 -sS "$GATEWAY_URL/v1/models" | jq .
+
+# then chat completion
+curl --max-time 120 -sS "$GATEWAY_URL/v1/chat/completions" \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role":"user","content":"hello"}]
+  }' | jq .
+
+```
+
+## standalone-mode environment contract
+
+Required:
+
+| Env | Meaning |
+|---|---|
+| `DYN_EPP_MODE=standalone` | Select standalone (on-ramp) mode; `dynamo` (default) keeps Dynamo mode |
+| `DYN_EPP_INFERENCE_POOL_NAME` | Name of the `InferencePool` this EPP backs; its selector + target port drive pod discovery |
+| `DYN_MODEL_NAME` | Model id used for worker registration and request selection |
+| `DYN_EPP_VLLM_RENDER_URL` | Base URL of the vLLM `/v1/chat/completions/render` service |
+| `DYN_KV_CACHE_BLOCK_SIZE` | MUST equal vLLM `--block-size` |
+| `POD_NAMESPACE` | The namespace the EPP, its `InferencePool`, worker pods, and sibling replicas all live in (inject via the downward API) |
+
+Optional:
+
+| Env | Default | Meaning |
+|---|---:|---|
+| `DYN_EPP_KV_EVENT_PORT` | `5557` | vLLM `--kv-events-config` PUB port the selector subscribes to |
+| `DYN_EPP_KV_EVENT_REPLAY_PORT` | unset | Per-worker ZMQ replay socket for KV-event gap recovery (requires the vLLM worker to expose one) |
+| `DYN_EPP_SELECTION_INDEXER_THREADS` | `4` | KV indexer thread pool for the in-process selector |
+| `DYN_EPP_TOKENIZATION_TIMEOUT_MS` | `5000` | Deadline for the vLLM render request |
+| `DYN_EPP_PEER_SERVICE` | unset | Replication: the EPP's OWN `Service`; watch its EndpointSlices and resolve the required named `replica-agg` port to discover sibling replicas and sync active load over ZMQ. Set = replicated; unset = single local replica |
+| `POD_IP` | unset | Replication: the EPP's own pod IP (downward API `status.podIP`), so a replica excludes itself from its peer set. Required when `DYN_EPP_PEER_SERVICE` is set |
+| `DYN_EPP_TOTAL_KV_BLOCKS` | unset | Per-worker total KV blocks hint for the load model |
+| `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | unset | Per-worker max batched tokens (needed only when selector queueing is enabled) |
+| `DYN_ROUTER_*` | router defaults | Scoring/queueing knobs parsed by the standard router config (e.g. `DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT`) |
+| `DYN_SECURE_SERVING` | `true` | EPP gRPC TLS toggle |
+
+Not used in this mode (unlike the old inert-runtime design): `DYN_EPP_POD_SELECTOR`,
+`DYN_EPP_TARGET_PORT` (both come from the `InferencePool`), `DYN_DISCOVERY_BACKEND`,
+`DYN_EVENT_PLANE` (no Dynamo runtime/event plane), and the disagg knobs
+(`DYN_EPP_ROLE_LABEL`, `DYN_ENFORCE_DISAGG`, `DYN_EPP_EMIT_PREFILLER_HOST_PORT`).
+
+## How KV events reach the router without NATS
+
+Vanilla vLLM publishes native KV-cache events on a ZMQ PUB socket
+(`--kv-events-config`). In standalone mode there is **no republisher and no
+event plane**: for each Ready pod the EPP registers the pod's KV-event
+endpoint (`tcp://<pod_ip>:<DYN_EPP_KV_EVENT_PORT>`) into the in-process
+`SelectionCore`, whose indexer **subscribes directly** to that PUB socket and
+maintains the KV/prefix index the selector scores against. When
+`DYN_EPP_KV_EVENT_REPLAY_PORT` is set, the indexer also backfills missed events from the
+worker's replay socket.

--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -1,0 +1,160 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Standalone on-ramp (raw vLLM + Dynamo EPP + in-process selector)
+
+This example puts the Dynamo EPP in front of an existing vanilla `vllm serve`
+fleet behind a GAIE gateway, with **no Dynamo operator, no etcd/NATS, and no
+Dynamo runtime**. You replace only your endpoint picker (EPP); your workers stay
+stock vLLM.
+
+KV-aware selection is provided by the runtime-free
+[selection service](../../../../../docs/components/router/standalone-selection.md),
+which the EPP runs **in-process**: the EPP and the selection service are compiled
+into one binary, so there is no separate selector Deployment and no HTTP hop. The
+EPP can run single-replica, or **replicated** with cross-replica active-load sync
+between EPP pods (see [Replicated mode](#replicated-mode)).
+
+## How it works
+
+```text
+                          ┌───────────── Dynamo EPP (standalone, in-process selector) ────────────┐
+client → Gateway/Envoy ──▶│ tokenize → in-process select (Ready subset) → set routing headers      │
+                          │   ▲ reads InferencePool (selector + target port)                        │
+                          │   └ in-process selector subscribes to each pod's KV-event socket        │
+                          └───────────────────────────────────────────────────────────────┬───────┘
+                                                                                            │ endpoint + dp_rank
+        raw vLLM pods ◀───────────────────────────── Envoy forwards HTTP ◀─────────────────┘
+```
+
+1. The EPP reads the `InferencePool` it backs (read-only) to learn the pod
+   selector and HTTP target port — the same object the gateway routes to — and
+   watches those pods, Ready-filtered.
+2. For each Ready pod, the EPP registers a worker into its **in-process**
+   selector with the pod's endpoint, block size, and KV-event socket.
+3. The selector subscribes directly to each pod's KV-cache event socket and
+   maintains the KV index, scheduler, and load accounting.
+4. On each request the EPP sends the unchanged body to the configured vLLM
+   `/v1/chat/completions/render` endpoint, uses the returned tokens to select a
+   currently-Ready worker (booking its load via select-and-reserve), and returns
+   the worker's endpoint and `dp_rank` to Envoy as routing headers. The selected
+   worker processes the original forwarded request.
+
+This is the **aggregated** flow. Disaggregated prefill/decode is a follow-up.
+
+## Prerequisites
+
+- A GAIE-compatible `Gateway` named `inference-gateway`. It need not live in
+  this namespace — the agentgateway controller, for example, installs it in
+  `agentgateway-system`. The `vllm-qwen-route` `parentRefs` in `agg.yaml` must
+  name the Gateway's namespace and listener (`namespace` + `sectionName`), or the
+  route silently fails to attach (its `status.parents` stays empty). It ships
+  pointing at `agentgateway-system`/`http`; edit it to match your Gateway (or
+  drop `namespace` if the Gateway is in this namespace). The Gateway's listener
+  must also allow routes from this namespace.
+- A secret named `hf-token-secret` with key `HF_TOKEN` for the vLLM worker.
+
+## Run
+
+```bash
+kubectl apply -n <ns> -f agg.yaml
+# The Gateway may live in another namespace (e.g. agentgateway-system):
+GW=$(kubectl get gateway inference-gateway -n agentgateway-system -o jsonpath='{.status.addresses[0].value}')
+curl http://$GW/v1/chat/completions -H 'content-type: application/json' -d '{
+  "model": "Qwen/Qwen3-0.6B",
+  "messages": [{"role":"user","content":"hello"}]
+}'
+```
+
+> [!NOTE]
+> The `model` field MUST match `DYN_MODEL_NAME` in the EPP deployment, and the
+> EPP's `DYN_KV_CACHE_BLOCK_SIZE` MUST equal the vLLM `--block-size`.
+
+## EPP environment contract (standalone mode)
+
+| Env | Meaning | Required? |
+|---|---|---|
+| `DYN_EPP_MODE=standalone` | Select standalone (selector) mode | required |
+| `DYN_EPP_INFERENCE_POOL_NAME` | Name of the `InferencePool` this EPP backs (its selector + target port drive pod discovery) | required |
+| `DYN_MODEL_NAME` | Model id (no model card in this mode) | required |
+| `DYN_EPP_VLLM_RENDER_URL` | Base URL of the vLLM `/v1/chat/completions/render` service | required |
+| `DYN_KV_CACHE_BLOCK_SIZE` | MUST equal vLLM `--block-size` | required |
+| `DYN_EPP_KV_EVENT_PORT` | vLLM KV-events PUB port (not in the pool spec) | optional; default 5557 |
+| `DYN_EPP_KV_EVENT_REPLAY_PORT` | ZMQ REQ port for live-stream gap replay | optional |
+| `DYN_EPP_TOKENIZATION_TIMEOUT_MS` | Deadline for the vLLM render request | optional; default 5000 |
+| `DYN_EPP_TOTAL_KV_BLOCKS` | Per-worker total KV blocks hint | optional |
+| `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | Per-worker max batched tokens | optional |
+| `DYN_EPP_SELECTION_INDEXER_THREADS` | KV indexer thread pool | optional; default 4 |
+| `DYN_EPP_PEER_SERVICE` | The EPP's own Service. Set = replicated; the Service must expose named port `replica-agg`. Unset = single local replica | optional; unset by default |
+| `POD_NAMESPACE` | The namespace the EPP, its `InferencePool`, worker pods, and sibling replicas all live in (downward API) | required |
+| `POD_IP` | EPP's own pod IP (downward API); needed only for replication, so a replica excludes itself from its peer set | required when `DYN_EPP_PEER_SERVICE` is set |
+
+## Replicated mode
+
+You can run **more than one** EPP replica. Each replica still runs its own
+in-process selector, but the replicas discover each other and synchronize active
+load so they don't each under-count load and herd onto the same worker. This is
+what `agg.yaml` deploys (`replicas: 2`); set `replicas: 1` and drop
+`DYN_EPP_PEER_SERVICE` for a single local replica.
+
+```yaml
+spec:
+  replicas: 2
+  # ...
+        env:
+          # Watch THIS Deployment's own Service to find sibling replicas:
+          - name: DYN_EPP_PEER_SERVICE
+            value: "dynamo-epp"
+          # Own pod IP, so a replica excludes itself from its peer set:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+        ports:
+          - name: replica-agg
+            containerPort: 9092
+---
+apiVersion: v1
+kind: Service
+spec:
+  ports:
+    - name: replica-agg
+      port: 9092
+      targetPort: replica-agg
+```
+
+How it works:
+
+1. Each replica builds its in-process selector with **replica-sync enabled**
+   (resolving and binding the Service's named `replica-agg` port).
+2. It watches its **own** `Service`'s EndpointSlices (the `DYN_EPP_PEER_SERVICE`
+   above) and registers/deregisters every other replica as a replica-sync peer
+   as pods come and go — excluding itself via `POD_IP`. Peers connect pod-to-pod
+   on the resolved `replica-agg` endpoint port.
+3. Admission (`select_and_reserve`), `prefill_complete`, and `free` are broadcast
+   over ZMQ, so every replica's selector converges on the same active-load view.
+   This is the same consistency model as the standalone selector — output-block
+   growth stays local by design; admission/prefill/free are synchronized.
+
+> [!NOTE]
+> **No cross-peer KV-index warm-up.** A freshly started replica starts
+> subscribing to worker KV events *forward* and relies on live sync + per-worker
+> replay to catch up; it does not pull a peer's index snapshot. Expect a brief
+> cold window on a new replica.
+
+The EPP's `Role` needs `discovery.k8s.io/endpointslices` read access to watch its
+own Service (already included in `agg.yaml`).
+
+Replica synchronization is best-effort; see the
+[selection service docs](../../../../../docs/components/router/standalone-selection.md)
+for the consistency invariants.
+
+## Limitations (V1)
+
+- Aggregated serving only (no disaggregated prefill/decode).
+- Cross-replica sync covers active load (admission/prefill/free), not the KV
+  index — a new replica re-warms its index from live traffic + replay.
+- `worker_id` is a stable hash of the pod name. A pod restart yields a new
+  `worker_id`; sticky routing is preserved separately via `stable_routing_id`.

--- a/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Standalone (selector) on-ramp: aggregated serving, REPLICATED
+# (multiple EPP replicas that sync active load with each other).
+#
+# Puts the Dynamo EPP in front of an existing vanilla `vllm serve` fleet behind
+# a GAIE gateway, with NO Dynamo operator, NO etcd/NATS, and NO Dynamo runtime.
+# The EPP runs the runtime-free selection service in-process, so there is NO
+# separate selection-service Deployment. The EPP discovers raw vLLM pods from the
+# InferencePool it backs, registers them with its in-process selector, and on
+# each request asks the selector for a worker, then tells Envoy where to send the
+# request.
+#
+# Replication: each EPP replica runs its own in-process selector. To keep the
+# load-aware routing view consistent, replicas discover each other from this
+# Deployment's own Service (EndpointSlices) and sync admission/prefill-complete/
+# free over ZMQ. This is enabled by DYN_EPP_PEER_SERVICE below; set replicas: 1
+# and drop that env for a single, fully-local replica. (A freshly started replica
+# has an empty KV index and re-warms from live traffic + replay.)
+#
+# Prerequisites:
+#   - A GAIE-compatible Gateway named `inference-gateway` in this namespace.
+#   - A secret `hf-token-secret` with key `HF_TOKEN` for the vLLM worker.
+# Apply with: kubectl apply -n <ns> -f agg.yaml
+# Test:
+#   GW=$(kubectl get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
+#   curl http://$GW/v1/chat/completions -H 'content-type: application/json' -d '{
+#     "model": "Qwen/Qwen3-0.6B",   # MUST match DYN_MODEL_NAME below
+#     "messages": [{"role":"user","content":"hello"}]
+#   }'
+---
+# Raw vLLM aggregated worker pool. Vanilla image; prefix caching + native
+# KV-cache events on a ZMQ PUB socket the embedded selector subscribes to.
+# --block-size MUST match the EPP's DYN_KV_CACHE_BLOCK_SIZE.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  labels:
+    app: vllm-qwen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  template:
+    metadata:
+      labels:
+        app: vllm-qwen
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--served-model-name"
+            - "Qwen/Qwen3-0.6B"
+            - "--port"
+            - "8000"
+            - "--enable-prefix-caching"
+            - "--block-size"
+            - "16"
+            - "--kv-events-config"
+            - '{"enable_kv_cache_events":true,"endpoint":"tcp://*:5557"}'
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: kv-events
+              containerPort: 5557
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+---
+# Stable renderer address used by the EPP for vLLM's
+# /v1/chat/completions/render tokenization endpoint.
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-qwen-render
+spec:
+  selector:
+    app: vllm-qwen
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+---
+# RBAC: the EPP reads the InferencePool (read-only), lists/watches its pods, and
+# watches EndpointSlices to discover both worker pods and its own sibling EPP
+# replicas (embedded replication peer sync).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynamo-epp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dynamo-epp
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["inference.networking.k8s.io"]
+    resources: ["inferencepools"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dynamo-epp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dynamo-epp
+subjects:
+  - kind: ServiceAccount
+    name: dynamo-epp
+---
+# The Dynamo EPP in standalone mode with the selector EMBEDDED in-process,
+# replicated: DYN_EPP_PEER_SERVICE turns on cross-replica active-load sync so
+# these replicas do not each under-count load and herd onto the same worker.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dynamo-epp
+  labels:
+    app: dynamo-epp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dynamo-epp
+  template:
+    metadata:
+      labels:
+        app: dynamo-epp
+    spec:
+      serviceAccountName: dynamo-epp
+      containers:
+        - name: epp
+          image: docker.io/lambda108/rust-epp:st_1
+          imagePullPolicy: IfNotPresent
+          env:
+            # Standalone mode: runtime-free selector in-process (no Dynamo
+            # runtime, no separate selection-service Deployment).
+            - name: DYN_EPP_MODE
+              value: "standalone"
+            # Replication: watch THIS Deployment's own Service
+            # (EndpointSlices) to find sibling EPP replicas and sync active load
+            # over its required named replica-agg port. Omit this env to run a
+            # single fully-local replica (and set replicas: 1).
+            - name: DYN_EPP_PEER_SERVICE
+              value: "dynamo-epp"
+            # Pod discovery: read the InferencePool this EPP backs. Its selector
+            # and target port are the single source of truth (same object the
+            # gateway routes to). Pool namespace defaults to POD_NAMESPACE.
+            - name: DYN_EPP_INFERENCE_POOL_NAME
+              value: "vllm-qwen-pool"
+            # KV-event port can't live in the InferencePool, so it stays here.
+            - name: DYN_EPP_KV_EVENT_PORT
+              value: "5557"
+            # Model identity and external vLLM renderer used for tokenization.
+            - name: DYN_MODEL_NAME
+              value: "Qwen/Qwen3-0.6B"
+            - name: DYN_EPP_VLLM_RENDER_URL
+              value: "http://vllm-qwen-render:8000"
+            - name: DYN_KV_CACHE_BLOCK_SIZE
+              value: "16"
+            # Per-worker max batched tokens. REQUIRED: the router's
+            # queue-threshold admission is on by default, and a worker missing
+            # this is left unschedulable ("no schedulable workers"). Set it to
+            # the vLLM engine's --max-num-batched-tokens.
+            - name: DYN_EPP_MAX_NUM_BATCHED_TOKENS
+              value: "8192"
+            # The reflector watches pods in the EPP's own namespace.
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # Own pod IP, so a replica excludes itself from its peer set.
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          ports:
+            - name: grpc
+              containerPort: 9002
+            - name: grpc-health
+              containerPort: 9003
+            # ZMQ replica-sync between EPP replicas (embedded replication).
+            - name: replica-agg
+              containerPort: 9092
+          readinessProbe:
+            grpc:
+              port: 9003
+              service: inference-extension
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamo-epp
+spec:
+  selector:
+    app: dynamo-epp
+  ports:
+    - name: grpc
+      appProtocol: http2
+      port: 9002
+      targetPort: 9002
+    - name: replica-agg
+      port: 9092
+      targetPort: replica-agg
+---
+# InferencePool selects the raw vLLM pods and delegates endpoint selection to
+# the EPP. The EPP reads this object (read-only) to learn the pod selector and
+# target port — the same object the gateway routes to.
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: vllm-qwen-pool
+spec:
+  selector:
+    matchLabels:
+      app: vllm-qwen
+  targetPorts:
+    - number: 8000
+  endpointPickerRef:
+    name: dynamo-epp
+    port:
+      number: 9002
+---
+# Route gateway traffic to the pool.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vllm-qwen-route
+spec:
+  parentRefs:
+    # The Gateway commonly lives in its own namespace, separate from this route
+    # (e.g. the agentgateway controller installs `inference-gateway` in
+    # `agentgateway-system`). `namespace` MUST name the Gateway's namespace and
+    # `sectionName` its listener, or the route silently fails to attach
+    # (status.parents stays empty). Change these to match your Gateway; drop
+    # `namespace` only if the Gateway is in THIS namespace. The Gateway listener
+    # must also allow routes from this namespace (allowedRoutes.namespaces).
+    - name: inference-gateway
+      namespace: agentgateway-system
+      sectionName: http
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-qwen-pool
+      timeouts:
+        request: "300s"

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Standalone (selector) endpoint picker.
+//!
+//! This is the runtime-free counterpart to [`crate::epp::Router`]. It runs with
+//! no Dynamo `DistributedRuntime`, no etcd/NATS, and no embedded KV router.
+//! Instead it composes:
+//!
+//! - a [`VllmRenderClient`] configured by `DYN_EPP_VLLM_RENDER_URL`
+//!   (tokenization for routing only),
+//! - a [`PodDiscovery`] that discovers Ready raw vLLM pods from Kubernetes,
+//! - a [`TopologyAdapter`] that registers those pods into the selector, and
+//! - a [`Selector`] (in-process, runtime-free selection service) that picks a
+//!   worker.
+//!
+//! On each request it tokenizes the prompt, asks the selection service for a
+//! worker constrained to the currently-Ready pods, and tells Envoy where to send
+//! the request via routing headers. Aggregated serving only.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+use dynamo_llm::protocols::common::extensions::{HEADER_TENANT_ID, request_cache_salt};
+
+use crate::epp_standalone_config::EppStandaloneConfig;
+use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo};
+use crate::pod_discovery::PodDiscovery;
+use crate::selector::{SelectRequest, Selector};
+use crate::topology_adapter::{RegistrationDefaults, TopologyAdapter};
+use crate::vllm_render_client::VllmRenderClient;
+
+/// Best-effort bound on how long startup waits for a selection-service replica
+/// to report ready before serving anyway (readiness is also enforced per-pick).
+const SELECTOR_READY_WAIT: Duration = Duration::from_secs(30);
+
+/// Standalone endpoint picker backed by the standalone selection service.
+pub struct EppRouter {
+    renderer: VllmRenderClient,
+    reflector: Arc<PodDiscovery>,
+    selector: Arc<Selector>,
+    // Kept alive for the lifetime of the router; the reconcile loop runs on it.
+    _adapter: TopologyAdapter,
+    reflector_ready: Arc<AtomicBool>,
+    model_name: String,
+}
+
+impl EppRouter {
+    /// Assemble the standalone runtime from the validated selector config.
+    pub async fn from_selector(cfg: EppStandaloneConfig) -> Result<Self> {
+        let renderer = VllmRenderClient::new(
+            &cfg.vllm_render_url,
+            Duration::from_millis(cfg.tokenization_timeout_ms),
+        )?;
+
+        let (reflector, reflector_ready) = PodDiscovery::spawn(&cfg).await?;
+        let reflector = Arc::new(reflector);
+
+        let selector = Arc::new(Selector::new(&cfg).await?);
+
+        let defaults = RegistrationDefaults::from_config(&cfg);
+        let adapter =
+            TopologyAdapter::spawn(reflector.as_ref().clone(), selector.clone(), defaults);
+
+        // Best-effort wait for the selector to admit at least one worker. The
+        // reconcile loop must first see Ready pods and register them, after
+        // which the selector reports ready. Per-pick checks still apply, so we
+        // never block startup beyond the bound.
+        wait_for_selector_ready(selector.as_ref()).await;
+
+        Ok(Self {
+            renderer,
+            reflector,
+            selector,
+            _adapter: adapter,
+            reflector_ready,
+            model_name: cfg.model_name,
+        })
+    }
+
+    /// Readiness flag for the pod reflector; gates gRPC health SERVING.
+    pub fn reflector_ready(&self) -> Arc<AtomicBool> {
+        self.reflector_ready.clone()
+    }
+
+    /// Tokenize a chat-completions request body for routing. Returns
+    /// `(token_ids, priority_jump, strict_priority, cache_salt)`, where
+    /// `cache_salt` is the body-derived KV cache namespace (`nvext.cache_salt`,
+    /// with a legacy top-level fallback) via Dynamo's public precedence rules.
+    async fn tokenize(&self, request_body: &[u8]) -> Result<(Vec<u32>, f64, u32, Option<String>)> {
+        let request: dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest =
+            serde_json::from_slice(request_body)?;
+        let priority_jump = extract_priority_jump(&request);
+        let strict_priority = extract_strict_priority(&request);
+        let cache_salt = request_cache_salt(&request).map(str::to_owned);
+        let token_ids = self.renderer.render_chat(request_body).await?;
+        Ok((token_ids, priority_jump, strict_priority, cache_salt))
+    }
+
+    /// Intersect `allowed` Ready worker IDs with an Envoy `candidate_subset`
+    /// (endpoint addresses, `ip:port` or bare `ip`). The reflector's endpoints
+    /// are scheme-less `ip:port`, so a worker matches when the subset contains
+    /// its full `ip:port` or its bare `ip`. An empty result for a non-empty
+    /// subset means no Ready pod matched the hint.
+    fn subset_worker_ids(
+        &self,
+        allowed: &HashSet<u64>,
+        candidate_subset: &[String],
+    ) -> HashSet<u64> {
+        let candidates: HashSet<&str> = candidate_subset.iter().map(String::as_str).collect();
+        allowed
+            .iter()
+            .copied()
+            .filter(|worker_id| {
+                self.reflector
+                    .resolve_endpoint(*worker_id)
+                    .is_some_and(|endpoint| endpoint_in_subset(&endpoint, &candidates))
+            })
+            .collect()
+    }
+}
+
+/// True if a scheme-less `ip:port` endpoint is covered by an Envoy subset,
+/// matching either the full `ip:port` or the bare `ip`.
+fn endpoint_in_subset(endpoint: &str, candidates: &HashSet<&str>) -> bool {
+    let ip = endpoint.split(':').next().unwrap_or("");
+    candidates.contains(endpoint) || candidates.contains(ip)
+}
+
+/// Extract the `x-tenant-id` routing header (case-insensitive, non-empty). The
+/// Dynamo frontend maps this header onto `cache_salt`, taking precedence over
+/// any body value.
+fn tenant_id_header(headers: &[(String, String)]) -> Option<String> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(HEADER_TENANT_ID))
+        .map(|(_, v)| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+async fn wait_for_selector_ready(selector: &Selector) {
+    let deadline = tokio::time::Instant::now() + SELECTOR_READY_WAIT;
+    loop {
+        if selector.any_ready().await {
+            tracing::info!("Selection service reports ready");
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            tracing::warn!(
+                "Selection service not ready after {}s; serving anyway (per-pick checks apply)",
+                SELECTOR_READY_WAIT.as_secs()
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+#[tonic::async_trait]
+impl EndpointPicker for EppRouter {
+    async fn pick(
+        &self,
+        req: &RequestInfo,
+        _endpoints: &[Endpoint],
+    ) -> Result<PickResult, PickError> {
+        if !self.reflector_ready.load(Ordering::Acquire) {
+            return Err(PickError::RoutingFailed(
+                "pod reflector cache not ready".to_string(),
+            ));
+        }
+
+        let mut allowed = self.reflector.ready_worker_ids();
+        if allowed.is_empty() {
+            return Err(PickError::NoEndpoints);
+        }
+
+        // Honor Envoy's InferencePool subset hint
+        // (`x-gateway-destination-endpoint-subset`): constrain routing to Ready
+        // workers inside the requested subset. A non-empty subset that matches no
+        // Ready pod must not fall back to the full set — refuse rather than route
+        // outside the subset.
+        if !req.candidate_subset.is_empty() {
+            allowed = self.subset_worker_ids(&allowed, &req.candidate_subset);
+            if allowed.is_empty() {
+                tracing::warn!(
+                    subset = ?req.candidate_subset,
+                    "No Ready pod matches the subset hint; refusing to route outside the subset"
+                );
+                return Err(PickError::NoEndpoints);
+            }
+        }
+
+        // Body-less requests (no prompt to tokenize) route to any Ready worker.
+        if req.body.is_empty() {
+            let worker_id = *allowed.iter().next().ok_or(PickError::NoEndpoints)?;
+            let endpoint = self
+                .reflector
+                .resolve_endpoint(worker_id)
+                .ok_or(PickError::NoEndpoints)?;
+            return Ok(PickResult {
+                endpoint,
+                headers: vec![
+                    (
+                        "x-dynamo-worker-instance-id".to_string(),
+                        worker_id.to_string(),
+                    ),
+                    (
+                        "x-dynamo-routing-mode".to_string(),
+                        "aggregated".to_string(),
+                    ),
+                ],
+                ..Default::default()
+            });
+        }
+
+        let (tokens, priority_jump, strict_priority, body_salt) = self
+            .tokenize(&req.body)
+            .await
+            .map_err(|e| PickError::TokenizationFailed(e.to_string()))?;
+
+        // KV cache-isolation namespace: the `x-tenant-id` header overrides the
+        // body's `cache_salt`, matching the frontend's header-routing precedence.
+        let cache_salt = tenant_id_header(&req.headers).or(body_salt);
+
+        let select_req = SelectRequest {
+            model_name: self.model_name.clone(),
+            selection_id: Some(req.request_id.clone()),
+            token_ids: tokens,
+            allowed_worker_ids: Some(allowed),
+            priority_jump: (priority_jump > 0.0).then_some(priority_jump),
+            strict_priority: (strict_priority > 0).then_some(strict_priority),
+            cache_salt,
+        };
+
+        // Atomic select-and-reserve: books the request's load on the chosen
+        // worker. Releasing the booking over the request lifecycle
+        // (`on_request_complete` / `on_prefill_complete`) is wired in a follow-up.
+        let resp = self
+            .selector
+            .select_and_reserve(select_req)
+            .await
+            .map_err(|e| PickError::RoutingFailed(e.to_string()))?;
+
+        // The reflector is the source of truth for both the routable address and
+        // readiness. If it can no longer resolve the selected worker, the pod left
+        // Ready/the pool in the race between building `allowed` and now, so the
+        // selection is stale: refuse rather than route to a draining pod or a
+        // stale registration-time address. Mirrors the body-less path above.
+        let Some(endpoint) = self.reflector.resolve_endpoint(resp.worker_id) else {
+            tracing::warn!(
+                worker_id = resp.worker_id,
+                "Selected worker no longer resolvable in reflector; treating selection as stale"
+            );
+            return Err(PickError::NoEndpoints);
+        };
+
+        Ok(PickResult {
+            endpoint,
+            headers: vec![
+                (
+                    "x-dynamo-worker-instance-id".to_string(),
+                    resp.worker_id.to_string(),
+                ),
+                ("x-dynamo-dp-rank".to_string(), resp.dp_rank.to_string()),
+                (
+                    "x-dynamo-routing-mode".to_string(),
+                    "aggregated".to_string(),
+                ),
+            ],
+            // Worker re-tokenizes the forwarded request (llm-d parity); the EPP
+            // tokenizes only for routing, so no token_ids are injected.
+            token_ids: None,
+            ..Default::default()
+        })
+    }
+}
+
+fn extract_priority_jump(
+    request: &dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest,
+) -> f64 {
+    request
+        .nvext
+        .as_ref()
+        .and_then(|n| n.agent_hints.as_ref())
+        .and_then(|h| {
+            h.priority
+                .map(|p| p.max(0) as f64)
+                .or(h.latency_sensitivity)
+        })
+        .unwrap_or(0.0)
+}
+
+fn extract_strict_priority(
+    request: &dynamo_llm::types::openai::chat_completions::NvCreateChatCompletionRequest,
+) -> u32 {
+    request
+        .nvext
+        .as_ref()
+        .and_then(|n| n.agent_hints.as_ref())
+        .and_then(|h| h.strict_priority)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tenant_id_header_is_case_insensitive_and_trims() {
+        let headers = vec![("X-Tenant-Id".to_string(), "  tenant-a  ".to_string())];
+        assert_eq!(tenant_id_header(&headers), Some("tenant-a".to_string()));
+    }
+
+    #[test]
+    fn tenant_id_header_absent_or_empty_is_none() {
+        assert_eq!(tenant_id_header(&[]), None);
+        let empty = vec![("x-tenant-id".to_string(), "   ".to_string())];
+        assert_eq!(tenant_id_header(&empty), None);
+    }
+
+    #[test]
+    fn endpoint_in_subset_matches_ip_port_or_bare_ip() {
+        let candidates: HashSet<&str> = ["10.0.0.1:8000", "10.0.0.2"].into_iter().collect();
+        // Full ip:port match.
+        assert!(endpoint_in_subset("10.0.0.1:8000", &candidates));
+        // Bare-ip match (subset lists just the IP).
+        assert!(endpoint_in_subset("10.0.0.2:8000", &candidates));
+        // Subset pinned a full ip:port, so a different port on that IP does NOT match.
+        assert!(!endpoint_in_subset("10.0.0.1:9999", &candidates));
+        // Unrelated endpoint does not match.
+        assert!(!endpoint_in_subset("10.0.0.3:8000", &candidates));
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/epp_router.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_router.rs
@@ -18,13 +18,14 @@
 //! worker constrained to the currently-Ready pods, and tells Envoy where to send
 //! the request via routing headers. Aggregated serving only.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
 use dynamo_llm::protocols::common::extensions::{HEADER_TENANT_ID, request_cache_salt};
+use tokio::sync::Mutex;
 
 use crate::epp_standalone_config::EppStandaloneConfig;
 use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo};
@@ -46,6 +47,12 @@ pub struct EppRouter {
     _adapter: TopologyAdapter,
     reflector_ready: Arc<AtomicBool>,
     model_name: String,
+    /// `gateway request id -> EPP-minted reservation id` for in-flight bookings.
+    /// The lifecycle callbacks only receive the request id, so this maps it back
+    /// to the reservation the selector booked. Populated in `pick` (before the
+    /// reserve call, so a lost response is still cleaned up on completion) and
+    /// drained in `on_request_complete`.
+    reservations: Mutex<HashMap<String, String>>,
 }
 
 impl EppRouter {
@@ -78,6 +85,7 @@ impl EppRouter {
             _adapter: adapter,
             reflector_ready,
             model_name: cfg.model_name,
+            reservations: Mutex::new(HashMap::new()),
         })
     }
 
@@ -225,9 +233,23 @@ impl EndpointPicker for EppRouter {
         // body's `cache_salt`, matching the frontend's header-routing precedence.
         let cache_salt = tenant_id_header(&req.headers).or(body_salt);
 
+        // Selection and booking are one operation. Book under an EPP-minted
+        // reservation id (not the gateway request id): it decouples the booking
+        // key from client-supplied headers (a reused `x-request-id` can't collide
+        // or 409) and stays EPP-known, so it can be released even if the reserve
+        // response is lost. Recorded before the call; a failed reserve is cleaned
+        // up in the error arm below (a failed pick never triggers
+        // `on_request_complete`).
+        let reservation_id = uuid::Uuid::new_v4().to_string();
+        self.reservations
+            .lock()
+            .await
+            .insert(req.request_id.clone(), reservation_id.clone());
+
         let select_req = SelectRequest {
             model_name: self.model_name.clone(),
             selection_id: Some(req.request_id.clone()),
+            reservation_id: Some(reservation_id.clone()),
             token_ids: tokens,
             allowed_worker_ids: Some(allowed),
             priority_jump: (priority_jump > 0.0).then_some(priority_jump),
@@ -235,14 +257,19 @@ impl EndpointPicker for EppRouter {
             cache_salt,
         };
 
-        // Atomic select-and-reserve: books the request's load on the chosen
-        // worker. Releasing the booking over the request lifecycle
-        // (`on_request_complete` / `on_prefill_complete`) is wired in a follow-up.
-        let resp = self
-            .selector
-            .select_and_reserve(select_req)
-            .await
-            .map_err(|e| PickError::RoutingFailed(e.to_string()))?;
+        let resp = match self.selector.select_and_reserve(select_req).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                // Drop the local mapping and best-effort release any booking the
+                // selector may have created before the response was lost, so
+                // neither the map entry nor a remote reservation leaks.
+                self.reservations.lock().await.remove(&req.request_id);
+                if let Err(cleanup) = self.selector.free_reservation(&reservation_id).await {
+                    tracing::debug!(request_id = %req.request_id, %reservation_id, error = %cleanup, "reservation cleanup after failed reserve");
+                }
+                return Err(PickError::RoutingFailed(e.to_string()));
+            }
+        };
 
         // The reflector is the source of truth for both the routable address and
         // readiness. If it can no longer resolve the selected worker, the pod left
@@ -254,6 +281,13 @@ impl EndpointPicker for EppRouter {
                 worker_id = resp.worker_id,
                 "Selected worker no longer resolvable in reflector; treating selection as stale"
             );
+            // The booking succeeded but we are not routing it: release it so the
+            // stale selection does not leak load (a failed pick never triggers
+            // `on_request_complete`).
+            self.reservations.lock().await.remove(&req.request_id);
+            if let Err(cleanup) = self.selector.free_reservation(&reservation_id).await {
+                tracing::debug!(request_id = %req.request_id, %reservation_id, error = %cleanup, "reservation cleanup after stale selection");
+            }
             return Err(PickError::NoEndpoints);
         };
 
@@ -275,6 +309,34 @@ impl EndpointPicker for EppRouter {
             token_ids: None,
             ..Default::default()
         })
+    }
+
+    /// The gateway signalled the response is complete: release the booking made
+    /// in `pick`. Looks the reservation up by request id and drops the mapping.
+    /// Idempotent for requests that never booked (e.g. body-less routing).
+    async fn on_request_complete(&self, request_id: &str) {
+        let Some(reservation_id) = self.reservations.lock().await.remove(request_id) else {
+            return;
+        };
+        if let Err(e) = self.selector.free_reservation(&reservation_id).await {
+            tracing::warn!(request_id, %reservation_id, error = %e, "Failed to free reservation");
+        }
+    }
+
+    /// The gateway signalled the first token was generated: prefill is done, so
+    /// release this request's prefill load (`prefill_complete`) while leaving its
+    /// decode load booked until `on_request_complete`. This applies in aggregated
+    /// serving too — prefill and decode share a worker, but the prefill
+    /// contribution is transient and should drop at first token to keep the
+    /// worker's load model accurate through decode. The reservation stays mapped
+    /// (it is still live).
+    async fn on_prefill_complete(&self, request_id: &str) {
+        let Some(reservation_id) = self.reservations.lock().await.get(request_id).cloned() else {
+            return;
+        };
+        if let Err(e) = self.selector.prefill_complete(&reservation_id).await {
+            tracing::warn!(request_id, %reservation_id, error = %e, "Failed to mark prefill complete");
+        }
     }
 }
 

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod envoy_helpers;
 pub mod epp;
+pub mod epp_router;
 pub mod epp_standalone_config;
 pub mod inference_pool;
 pub mod peer_discovery;
@@ -26,6 +27,7 @@ pub mod topology_adapter;
 pub mod vllm_render_client;
 
 pub use epp::Router;
+pub use epp_router::EppRouter;
 pub use epp_standalone_config::{EppMode, EppStandaloneConfig};
 pub use inference_pool::PoolState;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};

--- a/deploy/inference-gateway/ext-proc/src/main.rs
+++ b/deploy/inference-gateway/ext-proc/src/main.rs
@@ -136,18 +136,6 @@ async fn main() -> Result<()> {
         "Starting Dynamo Rust EPP"
     );
 
-    // Standalone (selector) mode to be supported in a follow-up PR.
-    if standalone {
-        let selector_cfg = EppStandaloneConfig::from_env()?;
-        tracing::info!(
-            inference_pool_name = %selector_cfg.inference_pool_name,
-            model_name = %selector_cfg.model_name,
-            block_size = selector_cfg.block_size,
-            "Parsed standalone selector configuration"
-        );
-        anyhow::bail!("DYN_EPP_MODE=standalone is not yet supported");
-    }
-
     // Start plaintext gRPC health server immediately (NOT_SERVING until router ready).
     let (health_reporter, health_service) = tonic_health::server::health_reporter();
     health_reporter
@@ -162,19 +150,38 @@ async fn main() -> Result<()> {
             .serve(health_addr),
     );
 
-    tracing::info!("Initializing KV-aware router from discovery...");
-    let router = Router::from_discovery(&config.namespace, &config.component).await?;
+    if standalone {
+        let selector_cfg = EppStandaloneConfig::from_env()?;
+        tracing::info!(
+            inference_pool_name = %selector_cfg.inference_pool_name,
+            model_name = %selector_cfg.model_name,
+            block_size = selector_cfg.block_size,
+            "Initializing standalone selector mode (no Dynamo runtime)..."
+        );
+        let router = dynamo_ext_proc::EppRouter::from_selector(selector_cfg).await?;
+        let ready = router.reflector_ready();
+        serve(Arc::new(router), ready, health_reporter).await
+    } else {
+        tracing::info!("Initializing KV-aware router from discovery...");
+        let router = Router::from_discovery(&config.namespace, &config.component).await?;
+        let ready = router.pod_store_ready();
+        serve(Arc::new(router), ready, health_reporter).await
+    }
+}
 
-    // Gate SERVING on pod-reflector readiness. `from_discovery` returns once
-    // worker discovery and the model card are ready, but the K8s pod reflector's
-    // initial LIST may still be in flight (it has a bounded startup timeout and
-    // then finishes in the background). `pick()` returns 503 until the reflector
-    // is ready, so reporting SERVING here unconditionally would advertise a
-    // healthy pod that rejects every request. Flip to SERVING only once the
-    // reflector cache is usable; in the common path this is already true and the
-    // transition is immediate.
-    let pod_store_ready = router.pod_store_ready();
-    if pod_store_ready.load(std::sync::atomic::Ordering::Acquire) {
+/// Gate gRPC health SERVING on `ready`, then serve the ext_proc endpoint with
+/// the given picker. Shared by both Dynamo-discovery and standalone modes.
+async fn serve<P: dynamo_ext_proc::EndpointPicker>(
+    picker: Arc<P>,
+    ready: Arc<std::sync::atomic::AtomicBool>,
+    health_reporter: tonic_health::server::HealthReporter,
+) -> Result<()> {
+    // Gate SERVING on the picker's readiness flag. The router constructor may
+    // return before the pod reflector's initial LIST lands; `pick()` returns a
+    // routing error until then, so reporting SERVING unconditionally would
+    // advertise a healthy pod that rejects every request. Flip to SERVING once
+    // the reflector cache is usable; in the common path this is immediate.
+    if ready.load(std::sync::atomic::Ordering::Acquire) {
         health_reporter
             .set_service_status(HEALTH_SERVICE_NAME, tonic_health::ServingStatus::Serving)
             .await;
@@ -185,11 +192,9 @@ async fn main() -> Result<()> {
              keeping health NOT_SERVING until the initial LIST completes"
         );
         let health_reporter = health_reporter.clone();
+        let ready = ready.clone();
         tokio::spawn(async move {
-            // Poll the readiness flag; the background reflector task flips it
-            // once the initial LIST lands. Cheap and bounded — the flag is set
-            // exactly once and the loop exits immediately after.
-            while !pod_store_ready.load(std::sync::atomic::Ordering::Acquire) {
+            while !ready.load(std::sync::atomic::Ordering::Acquire) {
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             }
             health_reporter
@@ -199,7 +204,6 @@ async fn main() -> Result<()> {
         });
     }
 
-    let picker = Arc::new(router);
     let server = ExtProcServer::new(picker);
     // Default to TLS to match the Go EPP behavior. Verified working with
     // kGateway (`appProtocol: http2` upstreams negotiate h2 over TLS via ALPN
@@ -268,7 +272,6 @@ async fn main() -> Result<()> {
             .add_service(server.into_service())
             .serve(addr)
             .await?;
+        Ok(())
     }
-
-    Ok(())
 }

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -60,6 +60,10 @@ pub struct WorkerRegistration {
 pub struct SelectRequest {
     pub model_name: String,
     pub selection_id: Option<String>,
+    /// Booking key for the reservation. The EPP mints a fresh UUID per pick and
+    /// tracks `request_id -> reservation_id` so the later `free_reservation`
+    /// call can release it. If `None`, the selector generates one.
+    pub reservation_id: Option<String>,
     pub token_ids: Vec<u32>,
     pub allowed_worker_ids: Option<HashSet<u64>>,
     pub priority_jump: Option<f64>,
@@ -85,6 +89,9 @@ pub struct OverlapSummary {
 #[derive(Debug, Clone)]
 pub struct SelectResponse {
     pub selection_id: Option<String>,
+    /// The booking key the selector recorded (echoes the request's
+    /// `reservation_id`, or the selector-generated one when it was omitted).
+    pub reservation_id: Option<String>,
     pub worker_id: u64,
     pub dp_rank: u32,
     pub endpoint: String,
@@ -254,10 +261,14 @@ impl Selector {
     /// request by value so per-request fields (`token_ids`, `model_name`, ...) are
     /// moved into the core request rather than cloned on the hot path.
     pub async fn select_and_reserve(&self, req: SelectRequest) -> Result<SelectResponse> {
+        let selection_id = req.selection_id;
+        let reservation_id = req.reservation_id.or_else(|| selection_id.clone());
         let core_req = CoreSelectAndReserveRequest {
             model_name: req.model_name,
             routing_group: DEFAULT_ROUTING_GROUP.to_string(),
-            selection_id: req.selection_id,
+            // The core uses one id for both selection-cache lookup and the
+            // scheduler booking. Prefer the EPP-minted reservation id.
+            selection_id: reservation_id,
             prompt: PromptRequest {
                 token_ids: Some(req.token_ids),
                 // KV cache-isolation namespace; keeps EPP block hashing aligned
@@ -280,7 +291,8 @@ impl Selector {
             .await
             .map_err(|e| anyhow!("select_and_reserve failed: {e}"))?;
         Ok(SelectResponse {
-            selection_id: resp.selection_id,
+            selection_id,
+            reservation_id: resp.selection_id,
             worker_id: resp.worker_id,
             dp_rank: resp.dp_rank,
             endpoint: resp.endpoint,
@@ -293,6 +305,33 @@ impl Selector {
             },
             effective_prefill_tokens: resp.effective_prefill_tokens,
         })
+    }
+
+    /// Release a booking, removing the request from the selector's slot tracker /
+    /// active-load accounting. Called when the gateway signals the response is
+    /// complete. Idempotent: an unknown reservation (e.g. a body-less request
+    /// that never booked) is treated as success.
+    pub async fn free_reservation(&self, reservation_id: &str) -> Result<()> {
+        match self.service.free_reservation(reservation_id).await {
+            Ok(()) | Err(SelectionError::NotFound(_)) => Ok(()),
+            Err(e) => Err(anyhow!("free_reservation failed: {e}")),
+        }
+    }
+
+    /// Release *prefill* tokens for a booking from a decode worker's load, called
+    /// when the first token is generated.
+    ///
+    /// Meaningful only for **disaggregated** serving, where prefill and decode
+    /// run on different workers. In **aggregated** serving (the only mode today)
+    /// prefill and decode share one worker, so there is nothing to release and
+    /// the EPP does not call this — see
+    /// [`crate::epp_router::EppRouter::on_prefill_complete`]. Implemented now so
+    /// the disaggregated path is ready when it lands.
+    pub async fn prefill_complete(&self, reservation_id: &str) -> Result<()> {
+        match self.service.prefill_complete(reservation_id).await {
+            Ok(()) | Err(SelectionError::NotFound(_)) => Ok(()),
+            Err(e) => Err(anyhow!("prefill_complete failed: {e}")),
+        }
     }
 
     /// Returns `true` once the selector can schedule at least one worker.


### PR DESCRIPTION
Add the request-lifecycle bookkeeping on top of the atomic select_and_reserve selection: the EPP books load when it picks a worker and releases it as the request progresses, so the selector's active-load accounting stays accurate.

Booking identity (EPP-minted): pick mints a fresh UUID per request as the reservation_id and keeps an in-memory gateway request_id → reservation_id map. Minting EPP-side (rather than using the gateway x-request-id) decouples the booking key from client headers — a reused x-request-id can't collide or cause a 409 — and keeps the id EPP-known, so it can be released even if the reserve response is lost. If the selector mints its own id instead, the EPP only learns it from the response, so a timeout after booking would strand the reservation.

Release lifecycle: on_request_complete drains the map and calls free_reservation. on_prefill_complete calls prefill_complete at first token to drop the transient prefill load (aggregated included), leaving decode load until completion. 

A failed select_and_reserve in pick removes the map entry and best-effort frees the booking, since a failed pick never triggers on_request_complete.

SelectionBackend: adds free_reservation and prefill_complete; SelectRequest/SelectResponse carry reservation_id.
HTTP fleet: tracks reservation_id → booking replica, pre-registered before the POST so a lost response still knows where to send the release; free/prefill target that replica. Embedded backend calls SelectionCore directly.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->