### PR TITLE
perf: Speed up offline replay worker dispatch

### DIFF
--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -76,8 +76,8 @@ impl EngineComponent {
         id
     }
 
-    /// Mark a worker for removal. It will be skipped by `drive_ready` and
-    /// removed once fully drained.
+    /// Mark a worker for removal. It stops receiving newly routed work, but
+    /// remains eligible for `drive_ready` until its existing work drains.
     pub(in crate::replay::offline) fn mark_for_removal(&mut self, worker_id: usize) {
         self.pending_removal.insert(worker_id);
     }
@@ -232,9 +232,7 @@ impl EngineComponent {
         now_ms: f64,
         mut collector: Option<&mut TraceCollector>,
     ) -> anyhow::Result<EngineEffects> {
-        let worker_ids: Vec<usize> = self.workers.keys().copied().collect();
-        for worker_id in worker_ids {
-            let worker = self.workers.get(&worker_id).unwrap();
+        for (&worker_id, worker) in self.workers.iter_mut() {
             if !worker.is_ready() {
                 continue;
             }
@@ -244,16 +242,9 @@ impl EngineComponent {
                     let Some(collector) = collector.as_deref_mut() else {
                         bail!("offline replay visible engine pass requires a collector");
                     };
-                    self.workers
-                        .get_mut(&worker_id)
-                        .unwrap()
-                        .execute_pass(collector, now_ms)
+                    worker.execute_pass(collector, now_ms)
                 }
-                EnginePassMode::Hidden => self
-                    .workers
-                    .get_mut(&worker_id)
-                    .unwrap()
-                    .execute_hidden_pass(now_ms),
+                EnginePassMode::Hidden => worker.execute_hidden_pass(now_ms),
             };
 
             let mut effects = EngineEffects {
@@ -307,7 +298,7 @@ impl EngineComponent {
                 return Ok(effects);
             }
 
-            self.workers.get_mut(&worker_id).unwrap().mark_busy();
+            worker.mark_busy();
             effects
                 .scheduled_completions
                 .push(ScheduledWorkerCompletion {

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -76,8 +76,10 @@ impl EngineComponent {
         id
     }
 
-    /// Mark a worker for removal. It stops receiving newly routed work, but
-    /// remains eligible for `drive_ready` until its existing work drains.
+    /// Mark a worker for removal. Round-robin routing skips marked workers;
+    /// in router mode the caller must also remove the worker from the router
+    /// (see `apply_target_count`). The worker remains eligible for
+    /// `drive_ready` until its existing work drains.
     pub(in crate::replay::offline) fn mark_for_removal(&mut self, worker_id: usize) {
         self.pending_removal.insert(worker_id);
     }


### PR DESCRIPTION
## Summary

- Iterate the offline replay worker map mutably in place in `drive_ready`.
- Remove the temporary worker-ID `Vec` and repeated `BTreeMap::get` / `get_mut` lookups.
- Preserve stable ascending worker-ID ordering and clarify that scaled-down workers remain runnable until drained.

## Motivation

Profiling a saturated 128-worker vLLM KV-router replay showed `EngineComponent::drive_ready` consuming 31.92% self CPU. The replay made 22.84 million calls to this method, including 15.25 million empty scans, and copied 2.92 billion worker IDs.

The existing implementation first copied every map key into a `Vec`, then searched the same `BTreeMap` again for each readiness check and pass execution. Iterating the ordered map directly removes that redundant work without adding cached state or changing scheduling semantics.

## Performance

On the same shard-0 saturated replay (`--replay-concurrency 8192`, 128 workers, CPU affinity 0-15) under `perf record`:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall time | 39.615 s | 29.124 s | -26.5% |
| Processed tokens/s | 24.50 M | 33.32 M | +36.0% |
| `drive_ready` self CPU | 31.92% | 8.07% | -74.7% relative |

These are single comparison runs under sampling rather than a stable multi-run performance gate.

## Validation

- `cargo test -p dynamo-mocker replay::offline` — 140 passed
- `cargo bench --package dynamo-bench --bench offline_replay_bench --no-run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker readiness handling so marked workers continue processing any already-started work until it finishes, avoiding premature exclusion.
* **Refactor**
  * Streamlined internal worker iteration for more efficient readiness processing and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->