### PR TITLE
fix(lora): reconcile failed LoRA discovery publish in BaseWorkerHandler

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -421,6 +421,15 @@ class LoraMixin:
                                 base_model_path=self.config.server_args.model_path,
                                 worker_type=lora_worker_type,
                                 needs=lora_needs,
+                                # The engine is already serving the base model
+                                # when a LoRA loads, and the card only references
+                                # config/tokenizer/chat-template files — never
+                                # weights. Without this, a cache miss on
+                                # model_path re-downloads the full base repo
+                                # (hundreds of GB for large MoEs) on every
+                                # publish, and any network failure aborts the
+                                # publish.
+                                ignore_weights=True,
                                 # Publish the worker's per-worker LoRA slot budget so the frontend
                                 # allocator sizes placement against real capacity instead of the
                                 # hard-coded default.

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -882,3 +882,6 @@ async def test_lora_registration_model_type_gate(
         str(captured["worker_type"]) == expected_worker_type
     ), f"worker_type {captured['worker_type']} != expected {expected_worker_type}"
     assert captured["lora_name"] == "test_lora"
+    # The engine already owns the base weights; the LoRA card needs only
+    # config/tokenizer files, so the publish must never fetch weights.
+    assert captured["ignore_weights"] is True

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2174,6 +2174,15 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 base_model_path=self.config.model,
                                 worker_type=lora_worker_type,
                                 needs=lora_needs,
+                                # The engine is already serving the base model
+                                # when a LoRA loads, and the card only references
+                                # config/tokenizer/chat-template files — never
+                                # weights. Without this, a cache miss on
+                                # model_path re-downloads the full base repo
+                                # (hundreds of GB for large MoEs) on every
+                                # publish, and any network failure aborts the
+                                # publish.
+                                ignore_weights=True,
                                 # Publish the worker's per-worker LoRA slot budget so the frontend
                                 # allocator sizes placement against real capacity instead of the
                                 # hard-coded default.

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1038,6 +1038,14 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self.enable_multimodal = enable_multimodal
         # LoRA tracking: name -> LoRAInfo(id, path)
         self.loaded_loras: dict[str, LoRAInfo] = {}
+        # Adapters whose discovery ModelDeploymentCard is currently published.
+        # Tracked separately from loaded_loras because the two can diverge:
+        # an adapter can be loaded in the engine with no card (publish failed
+        # and the engine-side rollback also failed). Keeping the two sets
+        # distinct lets load_lora reconcile that state on the next attempt
+        # instead of short-circuiting as "already loaded" with no card, which
+        # left the adapter permanently invisible to the frontend.
+        self._published_loras: set[str] = set()
         # Per-LoRA locks to prevent concurrent load operations for the same LoRA
         self._lora_load_locks: dict[str, asyncio.Lock] = {}
         # Guard lock-map access in case handlers are invoked from multiple threads.
@@ -1918,6 +1926,80 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 self._lora_load_locks[lora_name] = lock
             return lock
 
+    async def _publish_lora_card(self, lora_name: str, lora_id: int) -> None:
+        """Publish a LoRA adapter as a ModelDeploymentCard for discovery.
+
+        Assumes ``self.generate_endpoint`` is set (callers gate on it). Raises
+        on failure so callers can roll back or retry; on success the caller is
+        responsible for recording ``lora_name`` in ``self._published_loras``.
+        """
+        assert self.generate_endpoint is not None
+
+        # Mark this as a LoRA in user_data
+        user_data = {
+            "lora_adapter": True,
+            "lora_id": lora_id,
+        }
+
+        runtime_config = ModelRuntimeConfig()
+        runtime_config.context_length = self.model_max_len
+        runtime_config.tool_call_parser = self.config.dyn_tool_call_parser
+        runtime_config.reasoning_parser = self.config.dyn_reasoning_parser
+
+        # Match the base-model registration topology (see
+        # worker_factory.py _create_decode_worker /
+        # _create_prefill_worker) so the router activates for the
+        # LoRA model name the same way it does for the base model.
+        # A prefill worker carries its role via worker_type=Prefill;
+        # we register the legacy ModelType.Prefill marker bit (not a
+        # surface) so an old frontend still detects it during the
+        # cross-version rollout. Decode and aggregated workers expose the
+        # LoRA on the same chat/completions surface.
+        # --route-to-encoder adds Encode to the AND-set of peers.
+        if self.config.disaggregation_mode == DisaggregationMode.PREFILL:
+            lora_model_type = ModelType.Prefill
+            lora_worker_type = WorkerType.Prefill
+            lora_needs_set: list[WorkerType] = [WorkerType.Decode]
+        elif self.config.disaggregation_mode == DisaggregationMode.DECODE:
+            lora_model_type = ModelType.Chat | ModelType.Completions
+            lora_worker_type = WorkerType.Decode
+            lora_needs_set = [WorkerType.Prefill]
+        else:  # AGGREGATED
+            lora_model_type = ModelType.Chat | ModelType.Completions
+            lora_worker_type = WorkerType.Aggregated
+            lora_needs_set = []
+        if self.config.route_to_encoder:
+            lora_needs_set.append(WorkerType.Encode)
+        lora_needs: list[list[WorkerType]] = [lora_needs_set] if lora_needs_set else []
+
+        # Publish with format: v1/mdc/dynamo/backend/generate/{instance_id}/{lora_slug}
+        await register_model(
+            model_input=ModelInput.Tokens,
+            model_type=lora_model_type,
+            endpoint=self.generate_endpoint,
+            model_path=self.config.model,
+            kv_cache_block_size=self.config.engine_args.block_size,
+            runtime_config=runtime_config,
+            user_data=user_data,
+            lora_name=lora_name,
+            base_model_path=self.config.model,
+            worker_type=lora_worker_type,
+            needs=lora_needs,
+            # The engine is already serving the base model
+            # when a LoRA loads, and the card only references
+            # config/tokenizer/chat-template files — never
+            # weights. Without this, a cache miss on
+            # model_path re-downloads the full base repo
+            # (hundreds of GB for large MoEs) on every
+            # publish, and any network failure aborts the
+            # publish.
+            ignore_weights=True,
+            # Publish the worker's per-worker LoRA slot budget so the frontend
+            # allocator sizes placement against real capacity instead of the
+            # hard-coded default.
+            max_gpu_lora_count=getattr(self.config.engine_args, "max_loras", None),
+        )
+
     async def load_lora(self, request=None):
         """
         Load a LoRA adapter dynamically into the vLLM's AsyncLLM engine.
@@ -1964,6 +2046,38 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     is_hot_swap = old_info is not None and hot_swap_enabled
 
                     if old_info is not None and not hot_swap_enabled:
+                        # The adapter is loaded into the engine, but its
+                        # discovery card may be missing (a prior publish failed
+                        # and the engine-side rollback also failed). Reconcile
+                        # by retrying the publish instead of reporting early
+                        # success — otherwise the adapter stays permanently
+                        # invisible to the frontend while every caller is told
+                        # the load succeeded.
+                        if (
+                            self.generate_endpoint is not None
+                            and lora_name not in self._published_loras
+                        ):
+                            logger.info(
+                                f"LoRA '{lora_name}' loaded but unpublished; "
+                                "retrying discovery publish"
+                            )
+                            try:
+                                await self._publish_lora_card(lora_name, old_info.id)
+                                self._published_loras.add(lora_name)
+                            except Exception as e:
+                                logger.exception(
+                                    f"Failed to publish LoRA {lora_name} "
+                                    f"ModelDeploymentCard: {e}"
+                                )
+                                yield {
+                                    "status": "error",
+                                    "message": (
+                                        f"LoRA '{lora_name}' is loaded but "
+                                        f"discovery publish failed: {str(e)}"
+                                    ),
+                                    "lora_name": lora_name,
+                                }
+                                return
                         logger.info(
                             f"LoRA adapter already loaded: {lora_name} "
                             f"with ID {old_info.id}"
@@ -2108,88 +2222,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             f"Publishing LoRA '{lora_name}' ModelDeploymentCard to {self.generate_endpoint}"
                         )
                         try:
-                            logger.debug(
-                                f"Publishing LoRA '{lora_name}' ModelDeploymentCard"
-                            )
-
-                            # Mark this as a LoRA in user_data
-                            user_data = {
-                                "lora_adapter": True,
-                                "lora_id": lora_id,
-                            }
-
-                            runtime_config = ModelRuntimeConfig()
-                            runtime_config.context_length = self.model_max_len
-                            runtime_config.tool_call_parser = (
-                                self.config.dyn_tool_call_parser
-                            )
-                            runtime_config.reasoning_parser = (
-                                self.config.dyn_reasoning_parser
-                            )
-
-                            # Match the base-model registration topology (see
-                            # worker_factory.py _create_decode_worker /
-                            # _create_prefill_worker) so the router activates for the
-                            # LoRA model name the same way it does for the base model.
-                            # A prefill worker carries its role via worker_type=Prefill;
-                            # we register the legacy ModelType.Prefill marker bit (not a
-                            # surface) so an old frontend still detects it during the
-                            # cross-version rollout. Decode and aggregated workers expose the
-                            # LoRA on the same chat/completions surface.
-                            # --route-to-encoder adds Encode to the AND-set of peers.
-                            if (
-                                self.config.disaggregation_mode
-                                == DisaggregationMode.PREFILL
-                            ):
-                                lora_model_type = ModelType.Prefill
-                                lora_worker_type = WorkerType.Prefill
-                                lora_needs_set: list[WorkerType] = [WorkerType.Decode]
-                            elif (
-                                self.config.disaggregation_mode
-                                == DisaggregationMode.DECODE
-                            ):
-                                lora_model_type = ModelType.Chat | ModelType.Completions
-                                lora_worker_type = WorkerType.Decode
-                                lora_needs_set = [WorkerType.Prefill]
-                            else:  # AGGREGATED
-                                lora_model_type = ModelType.Chat | ModelType.Completions
-                                lora_worker_type = WorkerType.Aggregated
-                                lora_needs_set = []
-                            if self.config.route_to_encoder:
-                                lora_needs_set.append(WorkerType.Encode)
-                            lora_needs: list[list[WorkerType]] = (
-                                [lora_needs_set] if lora_needs_set else []
-                            )
-
-                            # Publish with format: v1/mdc/dynamo/backend/generate/{instance_id}/{lora_slug}
-                            await register_model(
-                                model_input=ModelInput.Tokens,
-                                model_type=lora_model_type,
-                                endpoint=self.generate_endpoint,
-                                model_path=self.config.model,
-                                kv_cache_block_size=self.config.engine_args.block_size,
-                                runtime_config=runtime_config,
-                                user_data=user_data,
-                                lora_name=lora_name,
-                                base_model_path=self.config.model,
-                                worker_type=lora_worker_type,
-                                needs=lora_needs,
-                                # The engine is already serving the base model
-                                # when a LoRA loads, and the card only references
-                                # config/tokenizer/chat-template files — never
-                                # weights. Without this, a cache miss on
-                                # model_path re-downloads the full base repo
-                                # (hundreds of GB for large MoEs) on every
-                                # publish, and any network failure aborts the
-                                # publish.
-                                ignore_weights=True,
-                                # Publish the worker's per-worker LoRA slot budget so the frontend
-                                # allocator sizes placement against real capacity instead of the
-                                # hard-coded default.
-                                max_gpu_lora_count=getattr(
-                                    self.config.engine_args, "max_loras", None
-                                ),
-                            )
+                            await self._publish_lora_card(lora_name, lora_id)
+                            self._published_loras.add(lora_name)
                             logger.info(
                                 f"Successfully published LoRA '{lora_name}' ModelDeploymentCard"
                             )
@@ -2198,7 +2232,13 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 f"Failed to publish LoRA {lora_name} ModelDeploymentCard: {e}"
                             )
 
-                            # Rollback: remove the LoRA from the engine to maintain consistency
+                            # Rollback: remove the LoRA from the engine to keep
+                            # engine state and discovery consistent. If the
+                            # rollback itself fails, the entry stays in
+                            # `loaded_loras` but absent from `_published_loras`,
+                            # so a retried load reconciles the publish instead
+                            # of short-circuiting as "already loaded" with no
+                            # card.
                             try:
                                 logger.debug(
                                     f"Rolling back: removing LoRA '{lora_name}' from engine"
@@ -2212,6 +2252,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 logger.exception(
                                     f"Failed to rollback LoRA {lora_name}: {rollback_error}"
                                 )
+                            self._published_loras.discard(lora_name)
 
                             # Return error status since registration failed
                             yield {
@@ -2270,6 +2311,40 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     # Check if the LoRA exists *after* waiting for any in-progress load.
                     lora = self.loaded_loras.get(lora_name)
                     if lora is None:
+                        # The adapter is gone from the engine but may still
+                        # have a stale discovery card (a prior unload's
+                        # unregister failed). Reconcile by retrying the
+                        # unregister so discovery converges.
+                        if (
+                            self.generate_endpoint is not None
+                            and lora_name in self._published_loras
+                        ):
+                            logger.info(
+                                f"LoRA '{lora_name}' not loaded but still "
+                                "published; retrying discovery unregister"
+                            )
+                            try:
+                                await unregister_model(
+                                    endpoint=self.generate_endpoint,
+                                    lora_name=lora_name,
+                                )
+                                self._published_loras.discard(lora_name)
+                                yield {
+                                    "status": "success",
+                                    "message": f"LoRA adapter '{lora_name}' discovery card removed",
+                                    "lora_name": lora_name,
+                                }
+                            except Exception as e:
+                                logger.exception(
+                                    f"Failed to unregister stale LoRA {lora_name} "
+                                    f"ModelDeploymentCard: {e}"
+                                )
+                                yield {
+                                    "status": "error",
+                                    "message": f"Failed to unregister stale LoRA '{lora_name}' from discovery registry: {str(e)}",
+                                    "lora_name": lora_name,
+                                }
+                            return
                         yield {
                             "status": "error",
                             "message": f"LoRA adapter '{lora_name}' not found. Available LoRAs: {list(self.loaded_loras.keys())}",
@@ -2278,15 +2353,19 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
                     logger.debug(f"Unloading LoRA adapter: {lora_name}")
                     lora_id = lora.id
-                    lora_path = lora.path
 
-                    await self.engine_client.remove_lora(lora_id)
-
-                    # Remove from tracking
-                    del self.loaded_loras[lora_name]
-
-                    # Unregister the LoRA model from the model registry
-                    if self.generate_endpoint is not None:
+                    # Stop advertising the adapter *before* removing it from
+                    # the engine, so the frontend stops routing LoRA traffic
+                    # here while the adapter still exists. Removing it first
+                    # would leave a window where requests route to a worker
+                    # that no longer has the adapter — and re-adding the
+                    # adapter as a rollback is unsafe (vLLM's fused-MoE LoRA
+                    # re-activation after a partial remove can assert and take
+                    # down the whole engine).
+                    if (
+                        self.generate_endpoint is not None
+                        and lora_name in self._published_loras
+                    ):
                         logger.debug(
                             f"Unregistering LoRA '{lora_name}' ModelDeploymentCard"
                         )
@@ -2295,49 +2374,50 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 endpoint=self.generate_endpoint,
                                 lora_name=lora_name,
                             )
+                            self._published_loras.discard(lora_name)
                             logger.info(
                                 f"Successfully unregistered LoRA '{lora_name}' ModelDeploymentCard"
                             )
                         except Exception as e:
+                            # Nothing mutated yet: the engine still has the
+                            # adapter and discovery still advertises it
+                            # (consistent and still routable). Surface the
+                            # error and leave state intact for a retry.
                             logger.exception(
                                 f"Failed to unregister LoRA {lora_name} ModelDeploymentCard: {e}"
                             )
-
-                            # Rollback: re-add the LoRA to the engine to maintain consistency
-                            try:
-                                logger.debug(
-                                    f"Rolling back: re-adding LoRA '{lora_name}' to engine"
-                                )
-                                await self.engine_client.add_lora(
-                                    LoRARequest(
-                                        lora_name=lora_name,
-                                        lora_int_id=lora_id,
-                                        lora_path=lora_path,
-                                    )
-                                )
-                                # Re-add to tracking
-                                self.loaded_loras[lora_name] = LoRAInfo(
-                                    id=lora_id, path=lora_path
-                                )
-                                logger.debug(
-                                    f"Successfully rolled back LoRA '{lora_name}'"
-                                )
-                            except Exception as rollback_error:
-                                logger.exception(
-                                    f"Failed to rollback LoRA {lora_name}: {rollback_error}"
-                                )
-
-                            # Return error status since unregistration failed
                             yield {
                                 "status": "error",
                                 "message": f"Failed to unregister LoRA '{lora_name}' from discovery registry: {str(e)}",
                                 "lora_name": lora_name,
                             }
                             return
-                    else:
+                    elif self.generate_endpoint is None:
                         logger.debug(
                             f"Cannot unregister LoRA '{lora_name}': generate_endpoint={self.generate_endpoint}"
                         )
+
+                    # Discovery no longer routes to this adapter; remove it
+                    # from the engine.
+                    try:
+                        await self.engine_client.remove_lora(lora_id)
+                    except Exception as e:
+                        # The discovery card is already gone but the engine
+                        # still holds the adapter (loaded-but-unpublished).
+                        # Leave it in loaded_loras so a retried unload skips
+                        # the unregister and retries only the engine removal.
+                        logger.exception(
+                            f"Failed to remove LoRA {lora_name} from engine: {e}"
+                        )
+                        yield {
+                            "status": "error",
+                            "message": f"Failed to remove LoRA '{lora_name}' from engine: {str(e)}",
+                            "lora_name": lora_name,
+                        }
+                        return
+
+                    # Remove from tracking
+                    del self.loaded_loras[lora_name]
 
                     logger.info(
                         f"Successfully unloaded LoRA adapter: {lora_name} with ID {lora_id}"

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -770,6 +770,12 @@ class VllmLLMEngine(LLMEngine):
             base_model_path=self.engine_args.model,
             worker_type=worker_type,
             needs=needs,
+            # The engine is already serving the base model when a LoRA loads,
+            # and the card only references config/tokenizer/chat-template
+            # files — never weights. Without this, a cache miss on model_path
+            # re-downloads the full base repo (hundreds of GB for large MoEs)
+            # on every publish, and any network failure aborts the publish.
+            ignore_weights=True,
         )
 
     def _lora_registration_topology(

--- a/components/src/dynamo/vllm/tests/test_vllm_handlers_lora.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_handlers_lora.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for BaseWorkerHandler's dynamic-LoRA lifecycle (handlers.py).
+
+Covers the load/unload publish couplings and, in particular, the
+loaded-but-unpublished reconcile: a LoRA whose engine add succeeded but whose
+discovery publish failed (and whose engine-side rollback also failed) must be
+re-published by a retried load instead of short-circuiting as "already
+loaded" with no card — the state that previously left an adapter permanently
+invisible to the frontend while every caller was told the load succeeded.
+
+Mirrors the coverage test_vllm_lora.py provides for VllmLLMEngine.
+Everything is mocked: no GPU, no real AsyncLLM, no real discovery.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("vllm.lora.request")
+pytest.importorskip("vllm.v1.engine.async_llm")
+
+from dynamo.common.lora.manager import LoRAInfo  # noqa: E402
+from dynamo.vllm import handlers as handlers_mod  # noqa: E402
+from dynamo.vllm.constants import DisaggregationMode  # noqa: E402
+from dynamo.vllm.handlers import BaseWorkerHandler  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _StubHandler(BaseWorkerHandler):
+    """Concrete subclass so the ABC can be instantiated without __init__."""
+
+    def generate(self, request, context):  # pragma: no cover - never called
+        raise NotImplementedError
+
+
+def _make_handler(endpoint=object()) -> BaseWorkerHandler:
+    """Build a BaseWorkerHandler with only the LoRA-relevant state populated.
+
+    Skips __init__ (it constructs a VllmEngineMonitor against a live runtime);
+    sets exactly the attributes the LoRA lifecycle paths read.
+    """
+    handler = _StubHandler.__new__(_StubHandler)
+    handler.loaded_loras = {}
+    handler._published_loras = set()
+    handler._lora_load_locks = {}
+    handler._lora_load_locks_guard = threading.Lock()
+    handler.engine_client = SimpleNamespace(
+        add_lora=AsyncMock(),
+        remove_lora=AsyncMock(),
+    )
+    handler.generate_endpoint = endpoint
+    handler.model_max_len = 4096
+    handler.config = SimpleNamespace(
+        model="/models/base",
+        dyn_tool_call_parser=None,
+        dyn_reasoning_parser=None,
+        disaggregation_mode=DisaggregationMode.AGGREGATED,
+        route_to_encoder=False,
+        engine_args=SimpleNamespace(block_size=16, max_loras=4),
+    )
+    return handler
+
+
+def _patch_discovery(monkeypatch, *, manager=None):
+    """Patch discovery + LoRA-manager symbols imported into handlers.
+
+    Returns the (register_model, unregister_model) AsyncMocks for assertions.
+    """
+    if manager is None:
+        manager = SimpleNamespace(
+            download_lora=AsyncMock(
+                return_value={"status": "success", "local_path": "/cache/adapter"}
+            )
+        )
+    register = AsyncMock()
+    unregister = AsyncMock()
+    monkeypatch.setattr(handlers_mod, "get_lora_manager", lambda: manager)
+    monkeypatch.setattr(handlers_mod, "register_model", register)
+    monkeypatch.setattr(handlers_mod, "unregister_model", unregister)
+    monkeypatch.setattr(handlers_mod, "lora_name_to_id", lambda name: 123)
+    monkeypatch.setattr(handlers_mod, "ModelRuntimeConfig", MagicMock())
+    return register, unregister
+
+
+async def _drain(agen):
+    return [chunk async for chunk in agen]
+
+
+LOAD_REQ = {"lora_name": "adapterA", "source": {"uri": "file:///x"}}
+
+
+# --------------------------------------------------------------------------- #
+# load_lora
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_load_lora_happy_path_publishes_and_tracks(monkeypatch):
+    handler = _make_handler()
+    register, _ = _patch_discovery(monkeypatch)
+
+    results = await _drain(handler.load_lora(LOAD_REQ))
+
+    assert results[-1]["status"] == "success"
+    handler.engine_client.add_lora.assert_awaited_once()
+    register.assert_awaited_once()
+    assert register.await_args.kwargs["lora_name"] == "adapterA"
+    # The engine already owns the base weights; the card needs only
+    # config/tokenizer files, so the publish must never fetch weights.
+    assert register.await_args.kwargs["ignore_weights"] is True
+    assert handler.loaded_loras["adapterA"].id == 123
+    assert "adapterA" in handler._published_loras
+
+
+@pytest.mark.asyncio
+async def test_load_lora_already_loaded_and_published_skips_publish(monkeypatch):
+    handler = _make_handler()
+    register, _ = _patch_discovery(monkeypatch)
+    handler.loaded_loras["adapterA"] = LoRAInfo(id=123, path="/cache/adapter")
+    handler._published_loras.add("adapterA")
+
+    results = await _drain(handler.load_lora(LOAD_REQ))
+
+    assert results[-1]["status"] == "success"
+    assert "already loaded" in results[-1]["message"]
+    register.assert_not_awaited()
+    handler.engine_client.add_lora.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_load_lora_reconciles_loaded_but_unpublished(monkeypatch):
+    # A prior publish failed and its engine-side rollback also failed: the
+    # adapter is loaded but has no discovery card. A retried load must
+    # re-publish instead of short-circuiting as "already loaded".
+    handler = _make_handler()
+    register, _ = _patch_discovery(monkeypatch)
+    handler.loaded_loras["adapterA"] = LoRAInfo(id=123, path="/cache/adapter")
+
+    results = await _drain(handler.load_lora(LOAD_REQ))
+
+    assert results[-1]["status"] == "success"
+    register.assert_awaited_once()
+    assert register.await_args.kwargs["lora_name"] == "adapterA"
+    assert "adapterA" in handler._published_loras
+    # No re-download / re-add churn for an adapter the engine already has.
+    handler.engine_client.add_lora.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_load_lora_reconcile_publish_failure_surfaces_error(monkeypatch):
+    handler = _make_handler()
+    register, _ = _patch_discovery(monkeypatch)
+    register.side_effect = RuntimeError("discovery down")
+    handler.loaded_loras["adapterA"] = LoRAInfo(id=123, path="/cache/adapter")
+
+    results = await _drain(handler.load_lora(LOAD_REQ))
+
+    assert results[-1]["status"] == "error"
+    assert "publish failed" in results[-1]["message"]
+    assert "adapterA" not in handler._published_loras
+    # The adapter stays loaded so the next attempt reconciles again.
+    assert "adapterA" in handler.loaded_loras
+
+
+@pytest.mark.asyncio
+async def test_load_lora_publish_failure_with_failed_rollback_stays_reconcilable(
+    monkeypatch,
+):
+    # Publish fails AND the engine-side rollback fails: the adapter must stay
+    # in loaded_loras and out of _published_loras — the exact state the
+    # already-loaded reconcile heals on the next load attempt.
+    handler = _make_handler()
+    register, _ = _patch_discovery(monkeypatch)
+    register.side_effect = RuntimeError("discovery down")
+    handler.engine_client.remove_lora.side_effect = RuntimeError("engine stuck")
+
+    results = await _drain(handler.load_lora(LOAD_REQ))
+
+    assert results[-1]["status"] == "error"
+    assert "adapterA" in handler.loaded_loras
+    assert "adapterA" not in handler._published_loras
+
+
+@pytest.mark.asyncio
+async def test_load_lora_publish_failure_with_successful_rollback(monkeypatch):
+    handler = _make_handler()
+    register, _ = _patch_discovery(monkeypatch)
+    register.side_effect = RuntimeError("discovery down")
+
+    results = await _drain(handler.load_lora(LOAD_REQ))
+
+    assert results[-1]["status"] == "error"
+    handler.engine_client.remove_lora.assert_awaited_once()
+    assert "adapterA" not in handler.loaded_loras
+    assert "adapterA" not in handler._published_loras
+
+
+# --------------------------------------------------------------------------- #
+# unload_lora
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_unregisters_before_engine_removal(monkeypatch):
+    handler = _make_handler()
+    _, unregister = _patch_discovery(monkeypatch)
+    handler.loaded_loras["adapterA"] = LoRAInfo(id=123, path="/cache/adapter")
+    handler._published_loras.add("adapterA")
+
+    order: list[str] = []
+    unregister.side_effect = lambda **kw: order.append("unregister")
+    handler.engine_client.remove_lora = AsyncMock(
+        side_effect=lambda *a: order.append("remove")
+    )
+
+    results = await _drain(handler.unload_lora({"lora_name": "adapterA"}))
+
+    assert results[-1]["status"] == "success"
+    assert order == ["unregister", "remove"]
+    assert "adapterA" not in handler.loaded_loras
+    assert "adapterA" not in handler._published_loras
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_unregister_failure_leaves_state_intact(monkeypatch):
+    # If the unregister fails nothing has mutated: the adapter is still
+    # routable and still loaded. No engine-side re-add rollback is attempted
+    # (re-adding after a partial remove can assert inside vLLM's fused-MoE
+    # LoRA layers and take down the whole engine).
+    handler = _make_handler()
+    _, unregister = _patch_discovery(monkeypatch)
+    unregister.side_effect = RuntimeError("discovery down")
+    handler.loaded_loras["adapterA"] = LoRAInfo(id=123, path="/cache/adapter")
+    handler._published_loras.add("adapterA")
+
+    results = await _drain(handler.unload_lora({"lora_name": "adapterA"}))
+
+    assert results[-1]["status"] == "error"
+    handler.engine_client.remove_lora.assert_not_awaited()
+    handler.engine_client.add_lora.assert_not_awaited()
+    assert "adapterA" in handler.loaded_loras
+    assert "adapterA" in handler._published_loras
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_engine_removal_failure_keeps_tracking(monkeypatch):
+    handler = _make_handler()
+    _, unregister = _patch_discovery(monkeypatch)
+    handler.loaded_loras["adapterA"] = LoRAInfo(id=123, path="/cache/adapter")
+    handler._published_loras.add("adapterA")
+    handler.engine_client.remove_lora.side_effect = RuntimeError("engine stuck")
+
+    results = await _drain(handler.unload_lora({"lora_name": "adapterA"}))
+
+    assert results[-1]["status"] == "error"
+    unregister.assert_awaited_once()
+    # Card gone, engine still holds the adapter: keep it in loaded_loras so a
+    # retried unload skips the unregister and retries only the removal.
+    assert "adapterA" in handler.loaded_loras
+    assert "adapterA" not in handler._published_loras
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_reconciles_stale_card(monkeypatch):
+    # Not loaded but still published (a prior unload unregister failed after
+    # the engine removal): retry the unregister so discovery converges.
+    handler = _make_handler()
+    _, unregister = _patch_discovery(monkeypatch)
+    handler._published_loras.add("adapterA")
+
+    results = await _drain(handler.unload_lora({"lora_name": "adapterA"}))
+
+    assert results[-1]["status"] == "success"
+    unregister.assert_awaited_once()
+    assert "adapterA" not in handler._published_loras
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_unknown_adapter_errors(monkeypatch):
+    handler = _make_handler()
+    _, unregister = _patch_discovery(monkeypatch)
+
+    results = await _drain(handler.unload_lora({"lora_name": "nope"}))
+
+    assert results[-1]["status"] == "error"
+    assert "not found" in results[-1]["message"]
+    unregister.assert_not_awaited()

--- a/components/src/dynamo/vllm/tests/test_vllm_lora.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_lora.py
@@ -262,6 +262,11 @@ async def test_load_lora_happy_path(monkeypatch):
     engine.engine_client.add_lora.assert_awaited_once()
     register.assert_awaited_once()
     assert register.await_args.kwargs["lora_name"] == "adapterA"
+    # The engine already owns the base weights; the card needs only
+    # config/tokenizer files. Fetching weights here would re-download the
+    # full base repo on a cache miss and fail the publish on any network
+    # error.
+    assert register.await_args.kwargs["ignore_weights"] is True
     assert engine.loaded_loras["adapterA"].id == 123
 
 


### PR DESCRIPTION
## Overview

Fixes #11163. Stacked on #11164 (includes its commit; will rebase once it lands).

When a LoRA's engine `add_lora` succeeded but the discovery publish failed — and the engine-side rollback **also** failed — `BaseWorkerHandler.load_lora` left the adapter in `loaded_loras` with no `ModelDeploymentCard`. Every subsequent load then short-circuited as "already loaded" and returned success without re-attempting the publish, so the adapter stayed permanently invisible to the frontend while callers (e.g. a deployment reconciler) were told the load succeeded.

`VllmLLMEngine` already handles this with `_published_loras` tracking and a loaded-but-unpublished reconcile; this PR ports that to `BaseWorkerHandler` (the worker_factory `load_lora`/`unload_lora` endpoint path).

## Details

- Track published cards separately from loaded adapters (`_published_loras`), extracting the publish into `_publish_lora_card` (mirrors `llm_engine.py`).
- On "already loaded": retry the publish when the card is missing instead of reporting early success; surface an error when it fails again so callers don't mark the adapter deployed.
- On unload: unregister the card **before** removing the adapter from the engine (stop routing while the adapter still exists), and drop the re-add rollback — re-adding after a partial remove can assert inside vLLM's fused-MoE LoRA layers (`fused_moe.py set_lora: assert isinstance(lora_a, list)`) and take down the whole engine; we hit exactly that in production.
- Reconcile stale cards on unload (published but not loaded) so discovery converges instead of erroring "not found".

State-machine invariant after this change: every reachable state is converged by retrying the same operation — no state requires manual surgery or a worker restart.

## Testing

New `test_vllm_handlers_lora.py` (mirrors `test_vllm_lora.py`'s coverage of `VllmLLMEngine`) covering: happy path publish tracking, already-loaded skip, loaded-but-unpublished reconcile (success + failure), publish failure with failed/successful rollback, unload ordering (unregister before remove), unregister-failure leaves state intact with no engine re-add, engine-removal failure keeps tracking, stale-card reconcile, unknown adapter.

Run inside the vllm runtime container: `47 passed` (new suite + full existing `test_vllm_lora.py`).

## Production context

A `gpt-oss-120b` MoE-expert LoRA hit this exact sequence: publish died mid-download (#11162), rollback's `remove_lora` failed in the TP workers, and the adapter answered `model_not_found` at the gateway for hours while its deployment showed DEPLOYED — with the reconciler's retries all being told "already loaded" (success).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoRA loading and unloading reliability by keeping published adapters in sync with engine state.
  * LoRA publishing now avoids re-downloading base weights, reducing failures caused by network or cache issues.
  * Unloading now stops routing traffic before removing the adapter, helping prevent request errors during cleanup.
  * Recovered better from partial failures so already-loaded LoRAs can be republished when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->