### PR TITLE
fix(kv-router): close CRTC stale-shape races [DYN-3584]

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -604,10 +604,12 @@ impl SyncIndexer for ConcurrentRadixTree {
                         tracing::warn!(?error, "Failed to apply anchor");
                     }
                 }
-                WorkerTask::RemoveWorker(worker_id) => {
+                WorkerTask::RemoveWorker { worker_id, .. } => {
                     self.remove_or_clear_worker_blocks(&mut lookup, worker_id, false);
                 }
-                WorkerTask::RemoveWorkerDpRank(worker_id, dp_rank) => {
+                WorkerTask::RemoveWorkerDpRank {
+                    worker_id, dp_rank, ..
+                } => {
                     self.remove_worker_dp_rank(&mut lookup, worker_id, dp_rank);
                 }
                 WorkerTask::CleanupStaleChildren => {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
@@ -44,8 +44,6 @@ pub struct ConcurrentRadixTreeCompressed {
 
     anchor_nodes: DashMap<ExternalSequenceBlockHash, SharedNode, FxBuildHasher>,
     cleanup: CleanupState,
-    #[cfg(test)]
-    worker_removal_sweeps: std::sync::atomic::AtomicUsize,
     #[cfg(feature = "bench")]
     bench_metrics: CrtcBenchMetrics,
 }
@@ -99,8 +97,6 @@ impl ConcurrentRadixTreeCompressed {
             root: Arc::new(Node::new()),
             anchor_nodes: DashMap::with_hasher(FxBuildHasher),
             cleanup: CleanupState::new(),
-            #[cfg(test)]
-            worker_removal_sweeps: std::sync::atomic::AtomicUsize::new(0),
             #[cfg(feature = "bench")]
             bench_metrics: CrtcBenchMetrics::new(),
         }
@@ -162,12 +158,6 @@ impl ConcurrentRadixTreeCompressed {
             .collect();
         children.sort_by(|left, right| left.edge.cmp(&right.edge));
         children
-    }
-
-    #[cfg(test)]
-    pub(crate) fn worker_removal_sweep_count_for_test(&self) -> usize {
-        self.worker_removal_sweeps
-            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     fn resolve_anchor_lookup(

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
@@ -44,6 +44,8 @@ pub struct ConcurrentRadixTreeCompressed {
 
     anchor_nodes: DashMap<ExternalSequenceBlockHash, SharedNode, FxBuildHasher>,
     cleanup: CleanupState,
+    #[cfg(test)]
+    worker_removal_sweeps: std::sync::atomic::AtomicUsize,
     #[cfg(feature = "bench")]
     bench_metrics: CrtcBenchMetrics,
 }
@@ -97,6 +99,8 @@ impl ConcurrentRadixTreeCompressed {
             root: Arc::new(Node::new()),
             anchor_nodes: DashMap::with_hasher(FxBuildHasher),
             cleanup: CleanupState::new(),
+            #[cfg(test)]
+            worker_removal_sweeps: std::sync::atomic::AtomicUsize::new(0),
             #[cfg(feature = "bench")]
             bench_metrics: CrtcBenchMetrics::new(),
         }
@@ -158,6 +162,12 @@ impl ConcurrentRadixTreeCompressed {
             .collect();
         children.sort_by(|left, right| left.edge.cmp(&right.edge));
         children
+    }
+
+    #[cfg(test)]
+    pub(crate) fn worker_removal_sweep_count_for_test(&self) -> usize {
+        self.worker_removal_sweeps
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     fn resolve_anchor_lookup(
@@ -235,7 +245,6 @@ impl ConcurrentRadixTreeCompressed {
             KvCacheEventData::Stored(op) => self.apply_stored(lookup, worker, op, id, counters),
             KvCacheEventData::Removed(op) => self.apply_removed(lookup, worker, op, id),
             KvCacheEventData::Cleared => {
-                lookup.entry(worker).or_default();
                 self.clear_all_blocks(lookup, worker.worker_id);
                 Ok(())
             }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -560,8 +560,11 @@ impl Node {
     ) -> ParentChildPlan {
         self.with_shape_plan(|state, children, shape_version| {
             if let Some(hash) = last_ext_hash
-                && !state.edge_index.contains_key(&hash)
+                && !state.tail_hash_is(hash)
             {
+                if state.edge_index.contains_key(&hash) {
+                    return ParentChildPlan::InteriorParent { shape_version };
+                }
                 return ParentChildPlan::StaleParent { hash };
             }
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -243,14 +243,34 @@ impl Node {
         self.state.write().promote_to_full(worker)
     }
 
-    pub(super) fn drop_worker(&self, worker: WorkerWithDpRank) {
+    pub(super) fn remove_target_and_snapshot_children(
+        &self,
+        target: WorkerRemovalTarget,
+    ) -> Vec<SharedNode> {
         let _gate = self.shape_gate.write();
-        let should_clear_children = {
-            let mut state = self.state.write();
-            state.drop_worker(worker);
-            state.full_edge_workers.is_empty()
-        };
+        let mut state = self.state.write();
+        let old_full_len = state.full_edge_workers.len();
+        let old_cutoff_len = state.worker_cutoffs.len();
+        state
+            .full_edge_workers
+            .retain(|worker| !target.matches(*worker));
+        state
+            .worker_cutoffs
+            .retain(|worker, _| !target.matches(*worker));
+        let removed_worker = old_full_len != state.full_edge_workers.len()
+            || old_cutoff_len != state.worker_cutoffs.len();
+        let should_clear_children = removed_worker && state.full_edge_workers.is_empty();
+
+        // A concurrent split is either visible in this snapshot or starts after
+        // the target coverage is gone and therefore cannot copy it forward.
+        let children = self
+            .children
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        drop(state);
         self.clear_children_if_unreachable(should_clear_children);
+        children
     }
 
     fn clear_children_if_unreachable(&self, should_clear_children: bool) {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -224,10 +224,6 @@ impl ConcurrentRadixTreeCompressed {
             return;
         }
 
-        #[cfg(test)]
-        self.worker_removal_sweeps
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
         let mut queue = VecDeque::new();
         self.root.push_children_into(&mut queue);
         let anchor_roots: Vec<_> = self

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -213,52 +213,39 @@ impl ConcurrentRadixTreeCompressed {
         }
     }
 
-    pub(super) fn remove_or_clear_worker_blocks(
+    pub(super) fn erase_worker_coverage(
         &self,
         lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
-        worker_id: WorkerId,
-        keep_worker: bool,
+        target: WorkerRemovalTarget,
+        sweep_tree: bool,
     ) {
-        let workers: Vec<WorkerWithDpRank> = lookup
-            .keys()
-            .filter(|w| w.worker_id == worker_id)
-            .copied()
-            .collect();
-
-        for worker in workers {
-            if let Some(worker_lookup) = lookup.remove(&worker) {
-                let mut seen = FxHashSet::<usize>::default();
-                for (_, node) in worker_lookup.into_iter() {
-                    let ptr = Arc::as_ptr(&node) as usize;
-                    if !seen.insert(ptr) {
-                        continue;
-                    }
-                    node.drop_worker(worker);
-                }
-
-                if keep_worker {
-                    lookup.insert(worker, FxHashMap::default());
-                }
-            }
+        lookup.retain(|worker, _| !target.matches(*worker));
+        if !sweep_tree {
+            return;
         }
-    }
 
-    pub(super) fn remove_worker_dp_rank(
-        &self,
-        lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
-        worker_id: WorkerId,
-        dp_rank: DpRank,
-    ) {
-        let key = WorkerWithDpRank { worker_id, dp_rank };
-        if let Some(worker_lookup) = lookup.remove(&key) {
-            let mut seen = FxHashSet::<usize>::default();
-            for (_, node) in worker_lookup.into_iter() {
-                let ptr = Arc::as_ptr(&node) as usize;
-                if !seen.insert(ptr) {
-                    continue;
-                }
-                node.drop_worker(key);
+        #[cfg(test)]
+        self.worker_removal_sweeps
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let mut queue = VecDeque::new();
+        self.root.push_children_into(&mut queue);
+        let anchor_roots: Vec<_> = self
+            .anchor_nodes
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        queue.extend(anchor_roots);
+
+        let mut seen = FxHashSet::<usize>::default();
+        while let Some(node) = queue.pop_front() {
+            let ptr = Arc::as_ptr(&node) as usize;
+            if !seen.insert(ptr) {
+                continue;
             }
+
+            let children = node.remove_target_and_snapshot_children(target);
+            queue.extend(children);
         }
     }
 
@@ -267,6 +254,6 @@ impl ConcurrentRadixTreeCompressed {
         lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
         worker_id: WorkerId,
     ) {
-        self.remove_or_clear_worker_blocks(lookup, worker_id, true);
+        self.erase_worker_coverage(lookup, WorkerRemovalTarget::WorkerId(worker_id), true);
     }
 }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
@@ -276,7 +276,8 @@ impl ConcurrentRadixTreeCompressed {
                 });
             }
             ParentChildPlan::Descend(child) => return Ok(StoreInsertStep::Descend(child)),
-            ParentChildPlan::MissingChild { shape_version } => shape_version,
+            ParentChildPlan::InteriorParent { shape_version }
+            | ParentChildPlan::MissingChild { shape_version } => shape_version,
         };
 
         if let Some(parent_hash) = cursor.last_ext_hash

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/sync_impl.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/sync_impl.rs
@@ -47,11 +47,26 @@ impl SyncIndexer for ConcurrentRadixTreeCompressed {
                         tracing::warn!(?error, "Failed to apply anchor");
                     }
                 }
-                WorkerTask::RemoveWorker(worker_id) => {
-                    self.remove_or_clear_worker_blocks(&mut lookup, worker_id, false);
+                WorkerTask::RemoveWorker {
+                    worker_id,
+                    sweep_tree,
+                } => {
+                    self.erase_worker_coverage(
+                        &mut lookup,
+                        WorkerRemovalTarget::WorkerId(worker_id),
+                        sweep_tree,
+                    );
                 }
-                WorkerTask::RemoveWorkerDpRank(worker_id, dp_rank) => {
-                    self.remove_worker_dp_rank(&mut lookup, worker_id, dp_rank);
+                WorkerTask::RemoveWorkerDpRank {
+                    worker_id,
+                    dp_rank,
+                    sweep_tree,
+                } => {
+                    self.erase_worker_coverage(
+                        &mut lookup,
+                        WorkerRemovalTarget::DpRank(WorkerWithDpRank::new(worker_id, dp_rank)),
+                        sweep_tree,
+                    );
                 }
                 WorkerTask::CleanupStaleChildren => {
                     self.run_cleanup_task();

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -359,6 +359,71 @@ mod race_tests {
             assert_direct_score(&index, &[1, 2, 9], worker3, 2);
             assert_direct_score(&index, &[1, 2, 10], worker4, 3);
         }
+
+        #[test]
+        fn stale_tail_cursor_replans_before_descending_same_local_child() {
+            let index = ConcurrentRadixTreeCompressed::new();
+            let worker_a = worker(1);
+            let worker_b = worker(2);
+            let mut lookup_a = direct_lookup();
+            let mut lookup_b = direct_lookup();
+
+            apply_direct(&index, &mut lookup_a, make_store_event(1, &[1]));
+            apply_direct(&index, &mut lookup_b, make_store_event(2, &[1]));
+
+            let stale_parent = index
+                .root
+                .child_snapshot(LocalBlockHash(1))
+                .expect("root child should exist");
+            let continuation = stored_data(make_store_event_with_parent(1, &[1], &[7]));
+            let parent_hash = continuation.parent_hash.expect("continuation has a parent");
+            let plan = stale_parent
+                .plan_store_parent_edge(parent_hash, &continuation.blocks)
+                .expect("tail parent should be present before extension");
+            let action =
+                stale_parent.apply_store_parent_edge_plan(worker_a, plan, &continuation.blocks);
+            assert!(matches!(action, ParentEdgeAction::InsertFromParent(None)));
+
+            let b_extension = make_store_event_with_parent(2, &[1], &[5, 6, 7]);
+            let b_extension_data = stored_data(b_extension.clone());
+            assert_ne!(
+                continuation.blocks[0].block_hash, b_extension_data.blocks[2].block_hash,
+                "same local child must have distinct sequence hashes at different depths",
+            );
+            apply_direct(&index, &mut lookup_b, b_extension);
+            apply_direct(
+                &index,
+                &mut lookup_b,
+                make_store_event_with_parent(2, &[1, 5, 6], &[8]),
+            );
+
+            index
+                .insert_blocks_from_for_test(
+                    &mut lookup_a,
+                    worker_a,
+                    &stale_parent,
+                    parent_hash,
+                    &continuation.blocks,
+                )
+                .unwrap();
+
+            assert_direct_score(&index, &[1, 7], worker_a, 2);
+            assert_direct_score(&index, &[1, 5, 6, 7], worker_b, 4);
+            assert_direct_score(&index, &[1, 5, 6, 8], worker_b, 4);
+            assert_eq!(
+                index.edge_topology_for_test(),
+                vec![edge_topology(
+                    &[1],
+                    vec![
+                        edge_topology(
+                            &[5, 6],
+                            vec![edge_topology(&[7], vec![]), edge_topology(&[8], vec![]),],
+                        ),
+                        edge_topology(&[7], vec![]),
+                    ],
+                )],
+            );
+        }
     }
 
     mod remove {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -545,7 +545,6 @@ mod race_tests {
 
             index.apply_event(make_clear_event_with_dp_rank(1, 0)).await;
             flush_and_settle(&index).await;
-            assert_eq!(index.backend().worker_removal_sweep_count_for_test(), 1);
 
             index
                 .apply_event(make_store_event_with_dp_rank(1, &[1], 0))
@@ -585,7 +584,7 @@ mod race_tests {
         }
 
         #[tokio::test]
-        async fn worker_removal_broadcast_sweeps_once_and_respects_dp_rank_target() {
+        async fn worker_removal_respects_dp_rank_and_worker_targets() {
             let index = ThreadPoolIndexer::new(ConcurrentRadixTreeCompressed::new(), 4, 32);
             let worker_a0 = WorkerWithDpRank::new(1, 0);
             let worker_a1 = WorkerWithDpRank::new(1, 1);
@@ -606,7 +605,6 @@ mod race_tests {
 
             index.remove_worker_dp_rank(1, 0).await;
             flush_and_settle(&index).await;
-            assert_eq!(index.backend().worker_removal_sweep_count_for_test(), 1);
             let scores = index.find_matches(local_hashes(&[1, 2])).await.unwrap();
             assert!(!scores.scores.contains_key(&worker_a0));
             assert_eq!(scores.scores.get(&worker_a1), Some(&2));
@@ -614,7 +612,6 @@ mod race_tests {
 
             index.remove_worker(1).await;
             flush_and_settle(&index).await;
-            assert_eq!(index.backend().worker_removal_sweep_count_for_test(), 2);
             let scores = index.find_matches(local_hashes(&[1, 2])).await.unwrap();
             assert!(!scores.scores.contains_key(&worker_a0));
             assert!(!scores.scores.contains_key(&worker_a1));

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -4,8 +4,9 @@
 use super::*;
 use crate::indexer::{KvIndexerInterface, ThreadPoolIndexer};
 use crate::test_utils::{
-    assert_score, flush_and_settle, make_remove_event_with_parent, make_store_event,
-    make_store_event_with_parent, remove_event, snapshot_events, snapshot_tree,
+    assert_score, flush_and_settle, make_clear_event_with_dp_rank, make_remove_event_with_parent,
+    make_store_event, make_store_event_with_dp_rank, make_store_event_with_parent, remove_event,
+    snapshot_events, snapshot_tree,
 };
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -515,6 +516,109 @@ mod race_tests {
             assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
             assert_direct_score(&index, &[1, 2, 3, 4], worker2, 1);
             assert_direct_score(&index, &[1, 2, 3, 4, 7, 8], worker3, 6);
+        }
+    }
+
+    mod clear {
+        use super::super::*;
+
+        #[tokio::test]
+        async fn clear_sweeps_split_suffixes_across_event_threads_and_dp_ranks() {
+            let index = ThreadPoolIndexer::new(ConcurrentRadixTreeCompressed::new(), 2, 32);
+            let worker_a0 = WorkerWithDpRank::new(1, 0);
+            let worker_a1 = WorkerWithDpRank::new(1, 1);
+            let worker_b = WorkerWithDpRank::new(2, 0);
+
+            index
+                .apply_event(make_store_event_with_dp_rank(1, &[1, 2], 0))
+                .await;
+            index
+                .apply_event(make_store_event_with_dp_rank(1, &[1, 2], 1))
+                .await;
+            index.apply_event(make_store_event(2, &[1, 2])).await;
+            flush_and_settle(&index).await;
+
+            index
+                .apply_event(make_store_event_with_parent(2, &[1], &[3]))
+                .await;
+            flush_and_settle(&index).await;
+
+            index.apply_event(make_clear_event_with_dp_rank(1, 0)).await;
+            flush_and_settle(&index).await;
+            assert_eq!(index.backend().worker_removal_sweep_count_for_test(), 1);
+
+            index
+                .apply_event(make_store_event_with_dp_rank(1, &[1], 0))
+                .await;
+            index
+                .apply_event(make_store_event_with_dp_rank(1, &[1], 1))
+                .await;
+            flush_and_settle(&index).await;
+
+            assert_score(&index, &[1, 2], worker_a0, 1).await;
+            assert_score(&index, &[1, 2], worker_a1, 1).await;
+            assert_score(&index, &[1, 2], worker_b, 2).await;
+            assert_score(&index, &[1, 3], worker_b, 2).await;
+        }
+
+        #[test]
+        fn clear_before_split_prevents_copying_removed_coverage() {
+            let index = ConcurrentRadixTreeCompressed::new();
+            let worker_a = worker(1);
+            let worker_b = worker(2);
+            let mut lookup_a = direct_lookup();
+            let mut lookup_b = direct_lookup();
+
+            apply_direct(&index, &mut lookup_a, make_store_event(1, &[1, 2]));
+            apply_direct(&index, &mut lookup_b, make_store_event(2, &[1, 2]));
+            apply_direct(&index, &mut lookup_a, make_clear_event_with_dp_rank(1, 0));
+            apply_direct(
+                &index,
+                &mut lookup_b,
+                make_store_event_with_parent(2, &[1], &[3]),
+            );
+            apply_direct(&index, &mut lookup_a, make_store_event(1, &[1]));
+
+            assert_direct_score(&index, &[1, 2], worker_a, 1);
+            assert_direct_score(&index, &[1, 2], worker_b, 2);
+            assert_direct_score(&index, &[1, 3], worker_b, 2);
+        }
+
+        #[tokio::test]
+        async fn worker_removal_broadcast_sweeps_once_and_respects_dp_rank_target() {
+            let index = ThreadPoolIndexer::new(ConcurrentRadixTreeCompressed::new(), 4, 32);
+            let worker_a0 = WorkerWithDpRank::new(1, 0);
+            let worker_a1 = WorkerWithDpRank::new(1, 1);
+            let worker_b = WorkerWithDpRank::new(2, 0);
+
+            index
+                .apply_event(make_store_event_with_dp_rank(1, &[1, 2], 0))
+                .await;
+            index
+                .apply_event(make_store_event_with_dp_rank(1, &[1, 2], 1))
+                .await;
+            index.apply_event(make_store_event(2, &[1, 2])).await;
+            flush_and_settle(&index).await;
+            index
+                .apply_event(make_store_event_with_parent(2, &[1], &[3]))
+                .await;
+            flush_and_settle(&index).await;
+
+            index.remove_worker_dp_rank(1, 0).await;
+            flush_and_settle(&index).await;
+            assert_eq!(index.backend().worker_removal_sweep_count_for_test(), 1);
+            let scores = index.find_matches(local_hashes(&[1, 2])).await.unwrap();
+            assert!(!scores.scores.contains_key(&worker_a0));
+            assert_eq!(scores.scores.get(&worker_a1), Some(&2));
+            assert_eq!(scores.scores.get(&worker_b), Some(&2));
+
+            index.remove_worker(1).await;
+            flush_and_settle(&index).await;
+            assert_eq!(index.backend().worker_removal_sweep_count_for_test(), 2);
+            let scores = index.find_matches(local_hashes(&[1, 2])).await.unwrap();
+            assert!(!scores.scores.contains_key(&worker_a0));
+            assert!(!scores.scores.contains_key(&worker_a1));
+            assert_eq!(scores.scores.get(&worker_b), Some(&2));
         }
     }
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
@@ -162,6 +162,7 @@ pub(super) struct ChildEdgeScan {
 pub(super) enum ParentChildPlan {
     Stale,
     StaleParent { hash: ExternalSequenceBlockHash },
+    InteriorParent { shape_version: u64 },
     Descend(SharedNode),
     MissingChild { shape_version: u64 },
 }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
@@ -18,6 +18,21 @@ pub(super) type SharedNode = Arc<Node>;
 /// stored here, keeping the map compact and correct across concurrent splits.
 pub(super) type WorkerLookup = FxHashMap<ExternalSequenceBlockHash, SharedNode>;
 
+#[derive(Clone, Copy)]
+pub(super) enum WorkerRemovalTarget {
+    WorkerId(WorkerId),
+    DpRank(WorkerWithDpRank),
+}
+
+impl WorkerRemovalTarget {
+    pub(super) fn matches(self, worker: WorkerWithDpRank) -> bool {
+        match self {
+            Self::WorkerId(worker_id) => worker.worker_id == worker_id,
+            Self::DpRank(target) => worker == target,
+        }
+    }
+}
+
 pub(super) struct MatchWalkResult {
     // NOTE(perf): Replacing this set with a Vec did not improve throughput. Keep
     // uniqueness by construction unless a new profile justifies changing it.

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -533,10 +533,12 @@ impl SyncIndexer for LowerTierIndexer {
                         tracing::warn!(?error, "Failed to apply anchor");
                     }
                 }
-                WorkerTask::RemoveWorker(worker_id) => {
+                WorkerTask::RemoveWorker { worker_id, .. } => {
                     self.remove_worker(&mut worker_blocks, worker_id);
                 }
-                WorkerTask::RemoveWorkerDpRank(worker_id, dp_rank) => {
+                WorkerTask::RemoveWorkerDpRank {
+                    worker_id, dp_rank, ..
+                } => {
                     self.remove_worker_dp_rank(&mut worker_blocks, worker_id, dp_rank);
                 }
                 WorkerTask::DumpEvents(sender) => {

--- a/lib/kv-router/src/indexer/positional.rs
+++ b/lib/kv-router/src/indexer/positional.rs
@@ -242,10 +242,12 @@ impl SyncIndexer for PositionalIndexer {
                         tracing::warn!(?error, "Failed to apply anchor");
                     }
                 }
-                WorkerTask::RemoveWorker(worker_id) => {
+                WorkerTask::RemoveWorker { worker_id, .. } => {
                     self.remove_or_clear_worker_blocks_impl(&mut worker_blocks, worker_id, false);
                 }
-                WorkerTask::RemoveWorkerDpRank(worker_id, dp_rank) => {
+                WorkerTask::RemoveWorkerDpRank {
+                    worker_id, dp_rank, ..
+                } => {
                     self.remove_worker_dp_rank_impl(&mut worker_blocks, worker_id, dp_rank);
                 }
                 WorkerTask::CleanupStaleChildren => {

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -616,9 +616,10 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
         let thread_idx = self.worker_assignments.get(&worker_id).map(|v| *v);
         match thread_idx {
             Some(idx) => {
-                if let Err(e) =
-                    self.worker_event_channels[idx].send(WorkerTask::RemoveWorker(worker_id))
-                {
+                if let Err(e) = self.worker_event_channels[idx].send(WorkerTask::RemoveWorker {
+                    worker_id,
+                    sweep_tree: true,
+                }) {
                     tracing::error!(
                         "Failed to send RemoveWorker to worker thread {}: {:?}",
                         idx,
@@ -631,8 +632,11 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
             }
             None => {
                 // Worker was never assigned a thread - broadcast to all
-                for channel in &self.worker_event_channels {
-                    let _ = channel.send(WorkerTask::RemoveWorker(worker_id));
+                for (idx, channel) in self.worker_event_channels.iter().enumerate() {
+                    let _ = channel.send(WorkerTask::RemoveWorker {
+                        worker_id,
+                        sweep_tree: idx == 0,
+                    });
                 }
                 self.maybe_enqueue_cleanup(0);
             }
@@ -644,10 +648,18 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
             prune_manager.remove_worker_dp_rank(WorkerWithDpRank::new(worker_id, dp_rank));
         }
 
-        // Broadcast to all threads — the dp_rank may be on any thread.
-        // Don't remove from worker_assignments since other dp_ranks may still exist.
-        for channel in &self.worker_event_channels {
-            let _ = channel.send(WorkerTask::RemoveWorkerDpRank(worker_id, dp_rank));
+        // Broadcast local-map cleanup, but let only the sticky worker thread run
+        // shared structural cleanup so the sweep occurs once and stays FIFO.
+        let sweep_idx = self
+            .worker_assignments
+            .get(&worker_id)
+            .map_or(0, |idx| *idx);
+        for (idx, channel) in self.worker_event_channels.iter().enumerate() {
+            let _ = channel.send(WorkerTask::RemoveWorkerDpRank {
+                worker_id,
+                dp_rank,
+                sweep_tree: idx == sweep_idx,
+            });
         }
         self.maybe_enqueue_cleanup(0);
     }

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -469,10 +469,19 @@ pub enum WorkerTask {
         worker: WorkerWithDpRank,
         anchor: AnchorTask,
     },
-    /// Permanently remove a worker from tracking (keep_worker: false).
-    RemoveWorker(WorkerId),
+    /// Permanently remove a worker from tracking.
+    RemoveWorker {
+        worker_id: WorkerId,
+        /// True for the one shared-state backend task that owns structural cleanup.
+        sweep_tree: bool,
+    },
     /// Remove a single dp_rank for a worker.
-    RemoveWorkerDpRank(WorkerId, DpRank),
+    RemoveWorkerDpRank {
+        worker_id: WorkerId,
+        dp_rank: DpRank,
+        /// True for the one shared-state backend task that owns structural cleanup.
+        sweep_tree: bool,
+    },
     /// Best-effort maintenance task for shared-state backends.
     CleanupStaleChildren,
     DumpEvents(oneshot::Sender<anyhow::Result<Vec<RouterEvent>>>),


### PR DESCRIPTION
## Summary
- Replan delayed stores when a saved compressed-edge parent moves from the tail into the interior, preventing descent into a same-local-hash child at the wrong depth.
- Sweep the complete CRTC root/anchor forest for Clear, RemoveWorker, and exact-rank removal, with one FIFO structural owner for broadcast tasks so stale split descendants cannot reactivate removed coverage.

## Validation
- cargo clippy --no-deps --all-targets -- -D warnings
- cargo test -p dynamo-kv-router stale_tail_cursor_replans_before_descending_same_local_child -- --nocapture
- cargo test -p dynamo-kv-router indexer::concurrent_radix_tree_compressed::tests
- cargo test -p dynamo-kv-router remove_worker
- cargo fmt --all -- --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker removal now includes a more precise cleanup sweep, improving how removed worker coverage is cleared across the index.

* **Bug Fixes**
  * Fixed removal handling so worker cleanup behaves correctly for both worker-level and dp-rank–specific events.
  * Improved stale-parent and child-planning behavior to keep tree updates consistent during inserts and clears.

* **Tests**
  * Added coverage for worker-removal sweeps, split/clear ordering, and stale-parent replanning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->