### PR TITLE
feat(router): add session LAS queue policy

### DIFF
--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -245,6 +245,8 @@ pub enum RouterQueuePolicy {
     Fcfs,
     Lcfs,
     Wspt,
+    #[serde(rename = "session_las")]
+    SessionLas,
 }
 
 impl fmt::Display for RouterQueuePolicy {
@@ -253,6 +255,7 @@ impl fmt::Display for RouterQueuePolicy {
             Self::Fcfs => f.write_str("fcfs"),
             Self::Lcfs => f.write_str("lcfs"),
             Self::Wspt => f.write_str("wspt"),
+            Self::SessionLas => f.write_str("session_las"),
         }
     }
 }
@@ -302,8 +305,9 @@ impl FromStr for RouterQueuePolicy {
             "fcfs" => Ok(Self::Fcfs),
             "lcfs" => Ok(Self::Lcfs),
             "wspt" => Ok(Self::Wspt),
+            "session_las" => Ok(Self::SessionLas),
             _ => Err(format!(
-                "unknown queue policy: {s:?}, expected 'fcfs', 'lcfs', or 'wspt'"
+                "unknown queue policy: {s:?}, expected 'fcfs', 'lcfs', 'wspt', or 'session_las'"
             )),
         }
     }

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -239,13 +239,12 @@ impl FromStr for SharedCacheType {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum RouterQueuePolicy {
     #[default]
     Fcfs,
     Lcfs,
     Wspt,
-    #[serde(rename = "session_las")]
     SessionLas,
 }
 

--- a/lib/kv-router/src/scheduling/policy.rs
+++ b/lib/kv-router/src/scheduling/policy.rs
@@ -127,6 +127,9 @@ impl RouterSchedulingPolicy {
             RouterQueuePolicy::Fcfs => Self::Fcfs(FcfsPolicy),
             RouterQueuePolicy::Lcfs => Self::Lcfs(LcfsPolicy),
             RouterQueuePolicy::Wspt => Self::Wspt(WsptPolicy),
+            // The active PolicyQueue supplies session state; this legacy stateless
+            // adapter retains FIFO behavior instead of failing at construction.
+            RouterQueuePolicy::SessionLas => Self::Fcfs(FcfsPolicy),
         }
     }
 }
@@ -285,6 +288,8 @@ mod tests {
 
         let fcfs = RouterSchedulingPolicy::new(RouterQueuePolicy::Fcfs);
         assert!(enqueue_key(&fcfs, early, &req) > enqueue_key(&fcfs, late, &req));
+        let session_las = RouterSchedulingPolicy::new(RouterQueuePolicy::SessionLas);
+        assert!(enqueue_key(&session_las, early, &req) > enqueue_key(&session_las, late, &req));
 
         let lcfs = RouterSchedulingPolicy::new(RouterQueuePolicy::Lcfs);
         assert!(enqueue_key(&lcfs, late, &req) > enqueue_key(&lcfs, early, &req));

--- a/lib/kv-router/src/scheduling/policy.rs
+++ b/lib/kv-router/src/scheduling/policy.rs
@@ -127,9 +127,9 @@ impl RouterSchedulingPolicy {
             RouterQueuePolicy::Fcfs => Self::Fcfs(FcfsPolicy),
             RouterQueuePolicy::Lcfs => Self::Lcfs(LcfsPolicy),
             RouterQueuePolicy::Wspt => Self::Wspt(WsptPolicy),
-            // The active PolicyQueue supplies session state; this legacy stateless
-            // adapter retains FIFO behavior instead of failing at construction.
-            RouterQueuePolicy::SessionLas => Self::Fcfs(FcfsPolicy),
+            RouterQueuePolicy::SessionLas => {
+                panic!("session_las is stateful and only supported by PolicyQueue")
+            }
         }
     }
 }
@@ -288,11 +288,14 @@ mod tests {
 
         let fcfs = RouterSchedulingPolicy::new(RouterQueuePolicy::Fcfs);
         assert!(enqueue_key(&fcfs, early, &req) > enqueue_key(&fcfs, late, &req));
-        let session_las = RouterSchedulingPolicy::new(RouterQueuePolicy::SessionLas);
-        assert!(enqueue_key(&session_las, early, &req) > enqueue_key(&session_las, late, &req));
-
         let lcfs = RouterSchedulingPolicy::new(RouterQueuePolicy::Lcfs);
         assert!(enqueue_key(&lcfs, late, &req) > enqueue_key(&lcfs, early, &req));
+    }
+
+    #[test]
+    #[should_panic(expected = "session_las is stateful and only supported by PolicyQueue")]
+    fn router_scheduling_policy_rejects_session_las() {
+        RouterSchedulingPolicy::new(RouterQueuePolicy::SessionLas);
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/policy_config.rs
+++ b/lib/kv-router/src/scheduling/policy_config.rs
@@ -446,7 +446,7 @@ fn resolve_policy_class(
     }
     if raw.queue_policy == RouterQueuePolicy::Lcfs {
         return Err(RouterPolicyConfigError::Validation(format!(
-            "{location} policy class {:?} queue_policy must be fcfs or wspt",
+            "{location} policy class {:?} queue_policy must be fcfs, wspt, or session_las",
             raw.name
         )));
     }

--- a/lib/kv-router/src/scheduling/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/policy_queue.rs
@@ -10,6 +10,9 @@ use serde::{Deserialize, Serialize};
 use super::config::RouterQueuePolicy;
 use super::policy_config::{PolicyClassConfig, PolicyProfile};
 
+mod session_las;
+use session_las::SessionTable;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QueueSnapshot {
     pub raw_isl_tokens: usize,
@@ -138,6 +141,7 @@ struct PolicyClassQueue<T> {
 
 pub struct PolicyQueue<T> {
     classes: Vec<PolicyClassQueue<T>>,
+    sessions: SessionTable,
     next_class: usize,
     next_enqueue_seq: u64,
     pending_count: usize,
@@ -159,6 +163,7 @@ impl<T> PolicyQueue<T> {
                     deficit: 0,
                 })
                 .collect(),
+            sessions: SessionTable::default(),
             next_class: 0,
             next_enqueue_seq: 0,
             pending_count: 0,
@@ -224,18 +229,42 @@ impl<T> PolicyQueue<T> {
         strict_priority: u32,
         payload: T,
     ) -> Result<(), (QueueRejection, T)> {
-        let class = &mut self.classes[class_index];
-        if let Some(rejection) = queue_rejection(class, worker_count) {
+        self.enqueue_with_score(
+            class_index,
+            worker_count,
+            snapshot,
+            arrival_offset_secs,
+            priority_jump,
+            strict_priority,
+            None,
+            payload,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn enqueue_with_score(
+        &mut self,
+        class_index: usize,
+        worker_count: usize,
+        snapshot: QueueSnapshot,
+        arrival_offset_secs: f64,
+        priority_jump: f64,
+        strict_priority: u32,
+        policy_score: Option<f64>,
+        payload: T,
+    ) -> Result<(), (QueueRejection, T)> {
+        if let Some(rejection) = queue_rejection(&self.classes[class_index], worker_count) {
             return Err((rejection, payload));
         }
-
-        let policy_score = match class.config.queue_policy {
+        let class = &mut self.classes[class_index];
+        let policy_score = policy_score.unwrap_or_else(|| match class.config.queue_policy {
             RouterQueuePolicy::Fcfs => priority_jump.max(0.0) - arrival_offset_secs.max(0.0),
             RouterQueuePolicy::Wspt => {
                 (1.0 + priority_jump.max(0.0)) / snapshot.scheduling_cost_tokens as f64
             }
             RouterQueuePolicy::Lcfs => priority_jump.max(0.0) + arrival_offset_secs.max(0.0),
-        };
+            RouterQueuePolicy::SessionLas => 0.0,
+        });
         let entry = PolicyQueueEntry {
             class_index,
             priority: QueuePriority {

--- a/lib/kv-router/src/scheduling/policy_queue/session_las.rs
+++ b/lib/kv-router/src/scheduling/policy_queue/session_las.rs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use super::{PolicyQueue, QueueRejection, QueueSnapshot};
+
+#[derive(Default)]
+pub(super) struct SessionTable {
+    // ponytail: router-lifetime state; add eviction when session completion reaches scheduling.
+    attained_service: HashMap<String, usize>,
+}
+
+impl<T> PolicyQueue<T> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn enqueue_with_attained_service(
+        &mut self,
+        class_index: usize,
+        worker_count: usize,
+        snapshot: QueueSnapshot,
+        arrival_offset_secs: f64,
+        priority_jump: f64,
+        strict_priority: u32,
+        attained_service: usize,
+        payload: T,
+    ) -> Result<(), (QueueRejection, T)> {
+        self.enqueue_with_score(
+            class_index,
+            worker_count,
+            snapshot,
+            arrival_offset_secs,
+            priority_jump,
+            strict_priority,
+            Some(-(attained_service as f64)),
+            payload,
+        )
+    }
+
+    pub fn session_attained_service(&self, session_id: &str) -> usize {
+        self.sessions
+            .attained_service
+            .get(session_id)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub fn record_session_dispatch(&mut self, session_id: &str, service: usize) {
+        let attained = self
+            .sessions
+            .attained_service
+            .entry(session_id.to_string())
+            .or_default();
+        *attained = attained.saturating_add(service);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RouterQueuePolicy;
+    use crate::scheduling::RouterPolicyConfig;
+
+    fn queue() -> PolicyQueue<&'static str> {
+        let profile = RouterPolicyConfig::from_yaml(
+            r#"
+default_policy_family: session
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: session
+    policy_family: session
+    cache_bucket: all
+    queue_policy: session_las
+    quantum: 1
+"#,
+        )
+        .unwrap()
+        .resolve_profile(None, None, RouterQueuePolicy::Fcfs);
+        PolicyQueue::new(profile)
+    }
+
+    #[test]
+    fn prefers_less_attained_service_within_strict_priority() {
+        let mut queue = queue();
+        queue.record_session_dispatch("heavy", 100);
+        for (attained_service, strict_priority, payload) in
+            [(100, 0, "heavy"), (0, 0, "fresh"), (1_000, 1, "high")]
+        {
+            queue
+                .enqueue_with_attained_service(
+                    0,
+                    1,
+                    QueueSnapshot::new(1, 0),
+                    0.0,
+                    0.0,
+                    strict_priority,
+                    attained_service,
+                    payload,
+                )
+                .unwrap();
+        }
+
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "high"
+        );
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "fresh"
+        );
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "heavy"
+        );
+        assert_eq!(queue.session_attained_service("heavy"), 100);
+    }
+}

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -505,13 +505,26 @@ impl<
             });
             (class_index, Some(snapshot), should_queue)
         };
+        let class = self.profile.class(class_index);
+        let attained_service = if class.queue_policy == RouterQueuePolicy::SessionLas {
+            let Some(session_id) = request.session_id.as_deref() else {
+                let mut request = request;
+                request.respond(Err(KvSchedulerError::BookingFailed(format!(
+                    "router policy class {:?} requires a session ID",
+                    class.name
+                ))));
+                return;
+            };
+            Some(self.pending.session_attained_service(session_id))
+        } else {
+            None
+        };
         if !should_queue {
-            self.admit_one(request, decay_now);
+            self.admit_one(class_index, request, decay_now);
             return;
         }
 
         let snapshot = snapshot.unwrap_or_else(|| self.snapshot_for(&request));
-        let class = self.profile.class(class_index);
         tracing::debug!(policy_class = class.name, "queueing request");
         let arrival_offset = self.start_time.elapsed().as_secs_f64();
         let priority_jump = request.priority_jump;
@@ -522,15 +535,28 @@ impl<
             block_hashes,
         };
         let worker_count = self.workers_with_configs.borrow().len();
-        if let Err((rejection, queued)) = self.pending.enqueue(
-            class_index,
-            worker_count,
-            snapshot,
-            arrival_offset,
-            priority_jump,
-            strict_priority,
-            queued,
-        ) {
+        let enqueue = match attained_service {
+            Some(attained_service) => self.pending.enqueue_with_attained_service(
+                class_index,
+                worker_count,
+                snapshot,
+                arrival_offset,
+                priority_jump,
+                strict_priority,
+                attained_service,
+                queued,
+            ),
+            None => self.pending.enqueue(
+                class_index,
+                worker_count,
+                snapshot,
+                arrival_offset,
+                priority_jump,
+                strict_priority,
+                queued,
+            ),
+        };
+        if let Err((rejection, queued)) = enqueue {
             let mut request = queued.request;
             request.respond(Err(KvSchedulerError::QueueRejected(rejection)));
             return;
@@ -555,6 +581,15 @@ impl<
     fn snapshot_for(&self, request: &SchedulingRequest) -> QueueSnapshot {
         let workers = self.workers_with_configs.borrow();
         Self::snapshot_for_with(request, &workers)
+    }
+
+    fn session_service_tokens(request: &SchedulingRequest) -> usize {
+        if !request.mode.is_tracked() {
+            return 0;
+        }
+        request.isl_tokens.saturating_add(
+            (request.expected_output_tokens.unwrap_or_default() as usize).saturating_mul(2),
+        )
     }
 
     fn snapshot_for_with(
@@ -641,13 +676,18 @@ impl<
                 policy_class = class.name,
                 "scheduling request from pending queue"
             );
-            self.admit_one(request, admit_now);
+            self.admit_one(class_index, request, admit_now);
         }
     }
 
     /// Run the full scheduling pipeline for a single request:
     /// compute projected load -> select worker -> book tracked state -> respond.
-    fn admit_one(&self, mut request: SchedulingRequest, decay_now: Instant) {
+    fn admit_one(
+        &mut self,
+        class_index: usize,
+        mut request: SchedulingRequest,
+        decay_now: Instant,
+    ) {
         request.worker_loads = self
             .slots
             .project_worker_loads(request.token_seq.as_deref(), decay_now);
@@ -693,6 +733,18 @@ impl<
             return;
         }
 
+        let session_dispatch = (self.profile.class(class_index).queue_policy
+            == RouterQueuePolicy::SessionLas)
+            .then(|| {
+                (
+                    request
+                        .session_id
+                        .take()
+                        .expect("session_las request validated before admission"),
+                    Self::session_service_tokens(&request),
+                )
+            });
+
         let request_id = request
             .mode
             .tracked_request_id()
@@ -714,7 +766,11 @@ impl<
             worker: selection.worker,
             lora_name: request.lora_name.take(),
         };
-        self.book_and_respond(request, sequence_request, response);
+        if self.book_and_respond(request, sequence_request, response)
+            && let Some((session_id, service)) = session_dispatch
+        {
+            self.pending.record_session_dispatch(&session_id, service);
+        }
     }
 
     /// Completes the tracked-admission ownership handoff.
@@ -729,30 +785,31 @@ impl<
         mut request: SchedulingRequest,
         sequence_request: SequenceRequest,
         response: SchedulingResponse,
-    ) {
+    ) -> bool {
         if request.response_is_closed() {
             tracing::debug!(
                 request_id = %sequence_request.request_id,
                 "Skipping scheduler booking for cancelled request"
             );
-            return;
+            return false;
         }
 
         let request_id = sequence_request.request_id.clone();
         if let Err(error) = self.slots.add_request(sequence_request, Instant::now()) {
             tracing::warn!(%request_id, %error, "Failed to book scheduler state");
             request.respond(Err(KvSchedulerError::BookingFailed(error.to_string())));
-            return;
+            return false;
         }
 
         if request.respond(Ok(response)) {
-            return;
+            return true;
         }
 
         tracing::debug!(%request_id, "Rolling back undelivered scheduler booking");
         if let Err(error) = self.slots.free(&request_id, Instant::now()) {
             tracing::error!(%request_id, %error, "Failed to roll back scheduler booking");
         }
+        false
     }
 
     fn prefill_load_hint_for(

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
 use dynamo_kv_router::LocalBlockHash;
-use dynamo_kv_router::config::KvRouterConfig;
+use dynamo_kv_router::config::{KvRouterConfig, RouterQueuePolicy};
 use dynamo_kv_router::protocols::{
     BlockHashOptions, OverlapScores, PrefillLoadHint, RouterEvent, RoutingConstraints,
     WorkerConfigLike, WorkerId, WorkerWithDpRank, compute_block_hash_for_seq,
@@ -274,13 +274,33 @@ impl OfflineReplayRouter {
         let class = self.profile.class(class_index);
         let should_queue = class.queueing_enabled()
             && (self.pending.has_backlog(class_index) || self.all_workers_busy(class, decay_now));
+        let is_session_las = class.queue_policy == RouterQueuePolicy::SessionLas;
+        let attained_service = if is_session_las {
+            let session_id = pending.session_id.as_deref().ok_or_else(|| {
+                anyhow!("router policy class {:?} requires a session ID", class.name)
+            })?;
+            Some(self.pending.session_attained_service(session_id))
+        } else {
+            None
+        };
+        let session_service_tokens = Self::session_service_tokens(&pending);
 
         if should_queue {
             let snapshot = snapshot.unwrap_or_else(|| self.snapshot_for(&pending));
             let priority_jump = pending.priority_jump;
             let strict_priority = pending.strict_priority;
-            self.pending
-                .enqueue(
+            let enqueue = match attained_service {
+                Some(attained_service) => self.pending.enqueue_with_attained_service(
+                    class_index,
+                    self.workers_with_configs.len(),
+                    snapshot,
+                    now_ms.max(0.0) / 1000.0,
+                    priority_jump,
+                    strict_priority,
+                    attained_service,
+                    pending,
+                ),
+                None => self.pending.enqueue(
                     class_index,
                     self.workers_with_configs.len(),
                     snapshot,
@@ -288,15 +308,23 @@ impl OfflineReplayRouter {
                     priority_jump,
                     strict_priority,
                     pending,
-                )
-                .map_err(|(rejection, _)| anyhow::Error::new(rejection))?;
+                ),
+            };
+            enqueue.map_err(|(rejection, _)| anyhow::Error::new(rejection))?;
             return Ok(RouterEffects::default());
         }
 
         let uuid = request
             .uuid
             .expect("offline replay requests must have UUIDs before router submission");
+        let session_id = pending.session_id.clone();
         let outcome = self.admit_request(pending, decay_now)?;
+        if is_session_las {
+            self.pending.record_session_dispatch(
+                session_id.as_deref().expect("session ID validated above"),
+                session_service_tokens,
+            );
+        }
         Ok(RouterEffects {
             admissions: vec![WorkerAdmission {
                 uuid,
@@ -473,6 +501,12 @@ impl OfflineReplayRouter {
         self.decay_time_epoch + Duration::from_secs_f64(now_ms.max(0.0) / 1000.0)
     }
 
+    fn session_service_tokens(request: &PendingRequest) -> usize {
+        request.isl_tokens.saturating_add(
+            (request.expected_output_tokens.unwrap_or_default() as usize).saturating_mul(2),
+        )
+    }
+
     fn build_pending_request(
         &self,
         request: &DirectRequest,
@@ -594,9 +628,24 @@ impl OfflineReplayRouter {
             }) else {
                 break;
             };
+            let class_index = popped.class_index();
             let request = popped.into_payload();
             let uuid = request.uuid;
+            let session_dispatch = (self.profile.class(class_index).queue_policy
+                == RouterQueuePolicy::SessionLas)
+                .then(|| {
+                    (
+                        request
+                            .session_id
+                            .clone()
+                            .expect("session_las request validated before queueing"),
+                        Self::session_service_tokens(&request),
+                    )
+                });
             let outcome = self.admit_request(request, decay_now)?;
+            if let Some((session_id, service)) = session_dispatch {
+                self.pending.record_session_dispatch(&session_id, service);
+            }
             admissions.push(WorkerAdmission {
                 uuid,
                 worker_idx: outcome.worker_idx,
@@ -880,6 +929,52 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![Uuid::from_u128(2)]
         );
+    }
+
+    #[test]
+    fn session_las_accounts_for_immediate_dispatches() {
+        let mut router = OfflineReplayRouter::new(
+            &queueing_args(),
+            Some(queueing_router_config_with_policy(
+                RouterQueuePolicy::SessionLas,
+            )),
+            None,
+            1,
+        )
+        .unwrap();
+
+        let first = router
+            .on_request_arrival_for_session(&request(1, 1), None, Some("a".to_string()), 0.0)
+            .unwrap();
+        assert_eq!(first.admissions.len(), 1);
+        router
+            .on_request_arrival_for_session(&request(4, 4), None, Some("blocker".to_string()), 1.0)
+            .unwrap();
+        let blocker = router
+            .on_request_completed(Uuid::from_u128(1), 2.0)
+            .unwrap();
+        assert_eq!(blocker.admissions[0].uuid, Uuid::from_u128(4));
+
+        for (uuid, session_id) in [(2, "a"), (3, "b")] {
+            let queued = router
+                .on_request_arrival_for_session(
+                    &request(uuid, uuid as u32),
+                    None,
+                    Some(session_id.to_string()),
+                    uuid as f64 + 1.0,
+                )
+                .unwrap();
+            assert!(queued.admissions.is_empty());
+        }
+
+        let second = router
+            .on_request_completed(Uuid::from_u128(4), 5.0)
+            .unwrap();
+        assert_eq!(second.admissions[0].uuid, Uuid::from_u128(3));
+        let third = router
+            .on_request_completed(Uuid::from_u128(3), 6.0)
+            .unwrap();
+        assert_eq!(third.admissions[0].uuid, Uuid::from_u128(2));
     }
 
     #[test]


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Adds an opt-in `session_las` queue policy on top of #11089's session-identity plumbing. It provides a minimal session-fairness baseline using the existing policy-class heap and DRR machinery, without per-session queues or changes to worker selection.

CLOSES: DYN-3320

### How This Was Implemented

- Adds `session_las` as a policy-class queue discipline and requires requests in those classes to carry a session ID.
- Keeps one session table in `PolicyQueue`, mapping each session ID to cumulative estimated service already dispatched.
- Reuses each policy class's existing `BinaryHeap`; strict priority remains first, inverse attained service orders requests within a priority tier, and enqueue sequence provides FIFO ties.
- Charges `input_tokens + 2 * expected_output_tokens` only after successful immediate or queued admission, and mirrors the behavior in offline mocker replay.

<details>
<summary>Walkthrough</summary>

#### Mental model

The PR keeps the existing queue and adds one counter per session. `enqueue_with_attained_service()` is not another queue: it inserts into the same policy-class `BinaryHeap`, but derives the entry's score from the session's historical service.

```mermaid
flowchart TD
    A["Request arrives"] --> B["Resolve policy class"]
    B --> C{"queue_policy = session_las?"}
    C -- No --> D["Existing FCFS/WSPT enqueue"]
    C -- Yes --> E["Look up session attained service"]
    E --> F["enqueue_with_attained_service"]
    F --> G["Heap score = -attained_service"]
    D --> H["Existing policy-class BinaryHeap"]
    G --> H
    H --> I["Existing DRR across policy classes"]
    I --> J["Existing worker selection"]
    J --> K{"Admission succeeded?"}
    K -- "Yes, session_las" --> L["Add estimated service to session table"]
```

#### State and ordering

`policy_queue/session_las.rs` owns an actor-local `SessionTable` with one mapping:

```text
session_id -> cumulative estimated tokens already dispatched
```

LAS means Least Attained Service. Because Rust's `BinaryHeap` returns the largest key, the LAS adapter stores `-attained_service` as the policy score:

| Session | Previously dispatched service | Heap score |
|---|---:|---:|
| B | 0 | 0 |
| A | 100 | -100 |

Session B is therefore selected before session A. Queue entry comparison remains, in order: strict priority, policy score, then enqueue sequence for stable FIFO ties. Across policy classes, existing DRR and each class's configured quantum still decide which affordable class advances; LAS only changes the head ordering inside a `session_las` class.

#### Why `enqueue_with_attained_service()` exists

Before this change, `PolicyQueue::enqueue()` could calculate every policy score from request-local data: arrival time for FCFS/LCFS and request size plus priority for WSPT. LAS depends on historical state associated with the session, so the live scheduler first reads the session's current counter and supplies that value to the LAS-specific adapter.

Both paths reuse one private insertion implementation:

```text
enqueue(...)
    -> enqueue_with_score(..., None)

enqueue_with_attained_service(...)
    -> enqueue_with_score(..., Some(-attained_service))
```

This keeps queue-limit checks, accounting, heap entry construction, and enqueue sequencing in one place. For LAS, the explicit score bypasses the default FCFS/WSPT calculation; `arrival_offset_secs` and `priority_jump` do not affect the LAS score.

#### Request lifecycle

1. `queue.rs::handle_enqueue()` resolves the request's policy class.
2. For a `session_las` class, it requires a session ID and reads that session's current attained service. Other policies continue through the existing enqueue path.
3. If capacity is available, the request bypasses the pending queue as before. This immediate dispatch still has to be charged so a session cannot receive uncounted service merely because it avoided queueing.
4. If the request must wait, `enqueue_with_attained_service()` freezes its current LAS score into the existing class heap.
5. Existing DRR selects among policy classes, and the existing worker selector performs placement after the request is popped.
6. After tracked booking and response delivery succeed, the scheduler increments the session counter by `input_tokens + 2 * expected_output_tokens`. Failed bookings, cancelled requests, and failed response handoffs are not charged; `book_and_respond()` returns a boolean only to communicate that outcome.

The offline mocker router mirrors both immediate and queued accounting so trace replay exercises the same queue order as the live scheduler.

#### Boundaries

- There is still one `BinaryHeap` per policy class, not a heap or queue per session.
- Policy-class DRR, configured quantum, queue limits, KV-overlap calculation, and worker selection are unchanged.
- This is an alternative queue discipline to FCFS/WSPT for requests that actually queue. It does not pause sessions, preempt active requests, move KV state, or implement ThunderAgent lifecycle logic.
- The existing stateless `RouterSchedulingPolicy` rejects `SessionLas` instead of silently treating it as FCFS because LAS requires the `PolicyQueue` session table.

#### Current limitations

- Attained service is estimated at dispatch as raw input tokens plus twice the expected output tokens; it is not corrected using actual completion tokens or cache-adjusted input work.
- A request's LAS score is captured when it enters the heap and is not dynamically rekeyed.
- Multiple pending requests for one session are not rejected. The intended workload model assumes a session is normally sequential, so its next turn arrives after the previous turn finishes.
- Session counters currently live for the router lifetime; there is no completion signal, TTL, or opportunistic eviction yet.
- Calling ordinary `PolicyQueue::enqueue()` directly for a `SessionLas` class produces the internal zero-score fallback. The production scheduler and mocker use `enqueue_with_attained_service()`, but the generic API still permits misuse.

</details>

### Validation

- `cargo test -p dynamo-kv-router` — 592 passed.
- `cargo test -p dynamo-mocker` — 497 passed; 1 pre-existing test ignored.
- `cargo clippy -p dynamo-kv-router -p dynamo-mocker --all-targets -- -D warnings`.
- `cargo fmt --all -- --check`.
- Latest review cleanup: `cargo test -p dynamo-kv-router router_scheduling_policy` and `cargo test -p dynamo-kv-router session_las` — 4 focused tests passed.
<!-- codex-pr-description:end -->
