### PR TITLE
fix(test): OPS-7465 give vllm prefill-drain the sglang/trtllm drain budget and short decodes

### DIFF
--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -3,6 +3,7 @@
 
 """Common base classes and utilities for engine tests (vLLM, TRT-LLM, etc.)"""
 
+import collections
 import concurrent.futures
 import dataclasses
 import logging
@@ -403,24 +404,30 @@ def run_prefill_drain_deployment(
 
             # Functional floor: some burst requests served. Requests routed
             # after the prefill unregister legitimately fail, so this is a
-            # floor, not "all succeed".
-            ok = 0
+            # floor, not "all succeed". Tally outcomes by status code (or
+            # exception type) so a 0-OK failure shows how the burst died.
+            outcomes: collections.Counter = collections.Counter()
             try:
                 for fut in concurrent.futures.as_completed(futures, timeout=200):
                     try:
-                        if fut.result().status_code == 200:
-                            ok += 1
-                    except Exception:
-                        pass
+                        outcomes[fut.result().status_code] += 1
+                    except Exception as e:
+                        outcomes[type(e).__name__] += 1
             except concurrent.futures.TimeoutError:
                 logger.warning("burst tally timed out waiting for stragglers")
+            ok = outcomes[200]
             logger.info(
-                "burst: %d/%d returned 200 across prefill drain (drain loop engaged=%s)",
+                "burst: %d/%d returned 200 across prefill drain "
+                "(drain loop engaged=%s, outcomes=%s)",
                 ok,
                 burst_size,
                 drain_engaged,
+                dict(outcomes),
             )
-            assert ok >= 1, "no burst request completed across the prefill drain"
+            assert ok >= 1, (
+                "no burst request completed across the prefill drain "
+                f"(outcomes: {dict(outcomes)})"
+            )
             pool.shutdown(wait=False)
     finally:
         if prep.disagg_bootstrap_port is not None:

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -756,6 +756,13 @@ def test_serve_deployment(
 # gives the prefill worker in-flight work; it's then SIGTERMed mid-flight, and
 # the test asserts the Rust Worker drove a graceful shutdown (drain -> cleanup).
 # vLLM has no is_quiescent() override, so the drain waits the full budget.
+#
+# Timing: the launch script's wait_any_exit tears down the frontend and decode
+# worker as soon as the drained prefill worker exits, so the burst's `ok >= 1`
+# floor must be met inside SIGTERM + drain budget + cleanup. The 30s budget
+# (matching the sglang/trtllm variants) and the small per-request decode at the
+# call site keep that window winnable on L4-class CI GPUs; a 3s budget with
+# 256-token decodes lost the race after the vLLM 0.24.0 bump (#11076).
 # ---------------------------------------------------------------------------
 _PREFILL_DRAIN_CONFIG = VLLMConfig(
     name="prefill_drain_unified",
@@ -768,8 +775,10 @@ _PREFILL_DRAIN_CONFIG = VLLMConfig(
     health_check_workers=True,
     env={
         "DYN_GRACEFUL_SHUTDOWN_GRACE_PERIOD_SECS": "0",
-        "DYN_PREFILL_DRAIN_TIMEOUT_S": "3",
-        "DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT": "30",
+        "DYN_PREFILL_DRAIN_TIMEOUT_S": "30",
+        # Must exceed the drain budget by CLEANUP_RESERVE_S (5s) or the Rust
+        # Worker caps the effective drain at timeout - reserve.
+        "DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT": "60",
         # The unified decode worker disables its health canary by design
         # (NixlConnector has no local-only bypass), so its system /health is
         # gated on starting status, which defaults to NotReady. Mark it
@@ -806,7 +815,12 @@ def test_prefill_drain_unified(
     config = dataclasses.replace(
         _PREFILL_DRAIN_CONFIG, frontend_port=dynamo_dynamic_ports.frontend_port
     )
-    run_prefill_drain_deployment(config, request, ports=dynamo_dynamic_ports)
+    # Short decodes so first completions land well inside the drain window on
+    # slow CI GPUs; the full-size burst still keeps 96 requests in flight when
+    # the SIGTERM lands.
+    run_prefill_drain_deployment(
+        config, request, ports=dynamo_dynamic_ports, burst_max_tokens=32
+    )
 
 
 # LoRA Test Directory


### PR DESCRIPTION
Linear: OPS-7465

## Overview

`tests/serve/test_vllm.py::test_prefill_drain_unified[2]` has failed most post-merge `vllm-runtime / Test cuda13.0, amd64` runs since the vLLM 0.24.0 bump #11076 (first red: [run 28470294938](https://github.com/ai-dynamo/dynamo/actions/runs/28470294938) on `dac7dfb2ec`; the parent commit `938e4467fa` is green). Failure is always the functional floor: `AssertionError: no burst request completed across the prefill drain` with 0/96 bursts returning 200, while the drain machinery itself works (`drain_engaged=True`, cleanup token present). When a job is red the test fails all 7 auto-retries; other runs pass first try in ~97s.

## Root cause

`disagg_same_gpu.sh` ends with `wait_any_exit` + a `kill -TERM 0` EXIT trap, so the frontend and decode worker are torn down as soon as the SIGTERM'd prefill worker finishes drain + cleanup and exits. The burst's `ok >= 1` floor therefore has to be met inside SIGTERM + drain budget + cleanup. The vLLM variant ran with a 3s drain budget (vLLM has no `is_quiescent()`, so the budget is always fully waited) and 256-token decodes — the first completion only just made that window on L4 CI GPUs, and vLLM 0.24.0 shifted burst-phase timing past it. VRAM telemetry in the job logs shows passing and failing runs with identical ~10–20s deployment-teardown timelines; a pass just means one request squeaked through.

Confirmed as a timing race rather than a functional drain regression by running the exact failing CI image (`2c97e2e83f…-vllm-runtime-test`) on an RTX 6000 Ada: the unmodified test passes with **96/96** requests completing across the drain — a functional 0.24 break (e.g. NIXL pull failing after producer death) would fail on any GPU.

## Fix

Adopt the tuning that keeps the sglang/trtllm variants of this same test stable (trtllm's config comments document exactly this failure class):

- `DYN_PREFILL_DRAIN_TIMEOUT_S` 3 → 30 (matches sglang/trtllm)
- `DYN_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT` 30 → 60, so the Rust Worker's `CLEANUP_RESERVE_S` (5s) cap doesn't trim the budget
- `burst_max_tokens=32` at the call site — first completions land seconds into the ~30s window; the full 96-request burst still keeps the SIGTERM mid-flight (in-flight gate unchanged)
- diagnosability: `run_prefill_drain_deployment` now tallies burst outcomes by status code / exception type and includes the tally in the `ok >= 1` assertion message, so a future 0-OK failure shows how the burst died

Deterministic wall-time cost: ~+27s per attempt (vLLM always waits the full drain budget); the test is post_merge-only.

## Verification

Ran the failing CI image on RTX 6000 Ada, baseline vs patched (sed-applied same changes): both pass, 96/96 across the drain; patched adds the expected ~27s of drain wait. On L4-class runners the widened window is what flips the outcome; will watch the next post-merge runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for graceful shutdown and drain behavior during burst traffic.
  * Updated shutdown timing to better reflect the full SIGTERM, drain, and cleanup window.
  * Increased burst consistency on slower environments so completions are more likely to finish within the expected drain period.
  * Enhanced failure reporting to show a fuller breakdown of request outcomes when drain verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
