### PR TITLE
fix(common): make multimodal media loaders importable without torch

### DIFF
--- a/components/src/dynamo/common/multimodal/__init__.py
+++ b/components/src/dynamo/common/multimodal/__init__.py
@@ -1,43 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Multimodal utilities for Dynamo components."""
+"""Multimodal utilities for Dynamo components.
 
-from collections.abc import Callable
+The media loaders are imported eagerly (they only depend on PIL/numpy and the
+local http helpers). The embedding-transfer and encoder-cache members pull in
+``torch`` transitively, so they are resolved lazily via PEP 562 to keep
+``from dynamo.common.multimodal import ImageLoader`` importable in CPU-only /
+lightweight environments (see issue #11172).
+"""
 
-from dynamo.common.constants import EmbeddingTransferMode
-from dynamo.common.multimodal.async_encoder_cache import AsyncEncoderCache
 from dynamo.common.multimodal.audio_loader import AudioLoader
-from dynamo.common.multimodal.embedding_transfer import (
-    AbstractEmbeddingReceiver,
-    AbstractEmbeddingSender,
-    LocalEmbeddingReceiver,
-    LocalEmbeddingSender,
-    NixlReadEmbeddingReceiver,
-    NixlReadEmbeddingSender,
-    NixlWriteEmbeddingReceiver,
-    NixlWriteEmbeddingSender,
-    TransferRequest,
-)
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.multimodal.video_loader import VideoLoader
 
-EMBEDDING_SENDER_FACTORIES: dict[
-    EmbeddingTransferMode, Callable[[], AbstractEmbeddingSender]
-] = {
-    EmbeddingTransferMode.LOCAL: LocalEmbeddingSender,
-    EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingSender,
-    EmbeddingTransferMode.NIXL_READ: NixlReadEmbeddingSender,
-}
-
-EMBEDDING_RECEIVER_FACTORIES: dict[
-    EmbeddingTransferMode, Callable[[], AbstractEmbeddingReceiver]
-] = {
-    EmbeddingTransferMode.LOCAL: LocalEmbeddingReceiver,
-    EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingReceiver,
-    # [gluo FIXME] can't use pre-registered tensor as NIXL requires descriptors
-    # to be at matching size, need to overwrite nixl connect library
-    EmbeddingTransferMode.NIXL_READ: lambda: NixlReadEmbeddingReceiver(max_items=0),
+_EMBEDDING_TRANSFER_NAMES = {
+    "AbstractEmbeddingReceiver",
+    "AbstractEmbeddingSender",
+    "LocalEmbeddingReceiver",
+    "LocalEmbeddingSender",
+    "NixlReadEmbeddingReceiver",
+    "NixlReadEmbeddingSender",
+    "NixlWriteEmbeddingReceiver",
+    "NixlWriteEmbeddingSender",
+    "TransferRequest",
 }
 
 __all__ = [
@@ -55,3 +41,58 @@ __all__ = [
     "LocalEmbeddingReceiver",
     "LocalEmbeddingSender",
 ]
+
+
+def _build_embedding_factories() -> None:
+    from collections.abc import Callable
+
+    from dynamo.common.constants import EmbeddingTransferMode
+    from dynamo.common.multimodal.embedding_transfer import (
+        AbstractEmbeddingReceiver,
+        AbstractEmbeddingSender,
+        LocalEmbeddingReceiver,
+        LocalEmbeddingSender,
+        NixlReadEmbeddingReceiver,
+        NixlReadEmbeddingSender,
+        NixlWriteEmbeddingReceiver,
+        NixlWriteEmbeddingSender,
+    )
+
+    sender_factories: dict[
+        EmbeddingTransferMode, Callable[[], AbstractEmbeddingSender]
+    ] = {
+        EmbeddingTransferMode.LOCAL: LocalEmbeddingSender,
+        EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingSender,
+        EmbeddingTransferMode.NIXL_READ: NixlReadEmbeddingSender,
+    }
+
+    receiver_factories: dict[
+        EmbeddingTransferMode, Callable[[], AbstractEmbeddingReceiver]
+    ] = {
+        EmbeddingTransferMode.LOCAL: LocalEmbeddingReceiver,
+        EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingReceiver,
+        # [gluo FIXME] can't use pre-registered tensor as NIXL requires descriptors
+        # to be at matching size, need to overwrite nixl connect library
+        EmbeddingTransferMode.NIXL_READ: lambda: NixlReadEmbeddingReceiver(max_items=0),
+    }
+
+    globals()["EMBEDDING_SENDER_FACTORIES"] = sender_factories
+    globals()["EMBEDDING_RECEIVER_FACTORIES"] = receiver_factories
+
+
+def __getattr__(name: str):
+    if name == "AsyncEncoderCache":
+        from dynamo.common.multimodal.async_encoder_cache import AsyncEncoderCache
+
+        globals()[name] = AsyncEncoderCache
+        return AsyncEncoderCache
+    if name in _EMBEDDING_TRANSFER_NAMES:
+        from dynamo.common.multimodal import embedding_transfer
+
+        value = getattr(embedding_transfer, name)
+        globals()[name] = value
+        return value
+    if name in {"EMBEDDING_SENDER_FACTORIES", "EMBEDDING_RECEIVER_FACTORIES"}:
+        _build_embedding_factories()
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/components/src/dynamo/common/multimodal/audio_loader.py
+++ b/components/src/dynamo/common/multimodal/audio_loader.py
@@ -45,21 +45,16 @@ async def read_decoded_media_via_nixl(*args: Any, **kwargs: Any) -> Any:
     return await _read_decoded_media_via_nixl(*args, **kwargs)
 
 
-try:
-    from vllm.multimodal.media import MediaConnector
-    from vllm.multimodal.media.audio import AudioMediaIO
-except ImportError:
-    MediaConnector = None  # type: ignore[assignment]
-    AudioMediaIO = None  # type: ignore[assignment]
-
-
 def _require_vllm_audio_media() -> tuple[Any, Any]:
     """Return vLLM's audio media components, raising if not installed."""
-    if MediaConnector is None or AudioMediaIO is None:
+    try:
+        from vllm.multimodal.media import MediaConnector
+        from vllm.multimodal.media.audio import AudioMediaIO
+    except ImportError as exc:
         raise RuntimeError(
             "vLLM multimodal media components are required to decode `audio_url` "
             "inputs in the vLLM backend."
-        )
+        ) from exc
     return MediaConnector, AudioMediaIO
 
 

--- a/components/src/dynamo/common/tests/multimodal/test_lazy_imports.py
+++ b/components/src/dynamo/common/tests/multimodal/test_lazy_imports.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Import-hygiene tests for dynamo.common.multimodal (issue #11172).
+
+The media loaders must be importable without pulling in torch; the
+embedding-transfer / encoder-cache members resolve lazily via PEP 562.
+The torch-free checks run in a subprocess so the result is independent of
+whatever the current pytest session has already imported.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+]
+
+
+def _run_in_subprocess(code: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert (
+        result.returncode == 0
+    ), f"subprocess failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def test_package_import_does_not_import_torch():
+    """Importing the package itself must not pull in torch or vllm."""
+    _run_in_subprocess(
+        "import sys\n"
+        "import dynamo.common.multimodal\n"
+        "assert 'torch' not in sys.modules, 'package import pulled in torch'\n"
+        "assert 'vllm' not in sys.modules, 'package import pulled in vllm'\n"
+    )
+
+
+def test_image_loader_import_does_not_import_torch():
+    """The reported case: ImageLoader without torch (issue #11172)."""
+    _run_in_subprocess(
+        "import sys\n"
+        "from dynamo.common.multimodal import ImageLoader\n"
+        "from dynamo.common.multimodal import AudioLoader, VideoLoader\n"
+        "assert 'torch' not in sys.modules, 'loader import pulled in torch'\n"
+        "assert 'vllm' not in sys.modules, 'loader import pulled in vllm'\n"
+    )
+
+
+def test_lazy_members_resolve_and_torch_loads_on_access():
+    """Lazy members still resolve via `from` imports, and only then load torch."""
+    _run_in_subprocess(
+        "import sys\n"
+        "import dynamo.common.multimodal as mm\n"
+        "assert 'torch' not in sys.modules\n"
+        "from dynamo.common.multimodal import AsyncEncoderCache\n"
+        "from dynamo.common.multimodal import TransferRequest\n"
+        "assert 'torch' in sys.modules, 'lazy member access should load torch'\n"
+        "assert AsyncEncoderCache.__name__ == 'AsyncEncoderCache'\n"
+        "assert TransferRequest is not None\n"
+    )
+
+
+def test_factory_dicts_resolve_lazily_with_stable_identity():
+    """Factory dicts build on first access, keep identity, and stay consistent."""
+    _run_in_subprocess(
+        "import sys\n"
+        "import dynamo.common.multimodal as mm\n"
+        "assert 'torch' not in sys.modules\n"
+        "from dynamo.common.constants import EmbeddingTransferMode\n"
+        "senders = mm.EMBEDDING_SENDER_FACTORIES\n"
+        "receivers = mm.EMBEDDING_RECEIVER_FACTORIES\n"
+        "assert senders is mm.EMBEDDING_SENDER_FACTORIES, 'dict identity not cached'\n"
+        "assert receivers is mm.EMBEDDING_RECEIVER_FACTORIES\n"
+        "assert set(senders) == set(EmbeddingTransferMode)\n"
+        "assert set(receivers) == set(EmbeddingTransferMode)\n"
+    )
+
+
+def test_unknown_attribute_raises_attribute_error():
+    with pytest.raises(AttributeError, match="has no attribute"):
+        import dynamo.common.multimodal as mm
+
+        _ = mm.definitely_not_a_real_attribute


### PR DESCRIPTION
## Summary

Fixes #11172.

`from dynamo.common.multimodal import ImageLoader` executed the package `__init__.py` eagerly, which pulled in `torch` through two independent paths:

1. The chain reported in the issue: `__init__.py` -> `async_encoder_cache` -> `dynamo.common.memory.multimodal_embedding_cache_manager` -> `import torch` (plus `embedding_transfer` -> `import torch` / `safetensors` directly at `embedding_transfer.py:17-19`).
2. A second path the issue did not name: `audio_loader.py` did a module-level best-effort `from vllm.multimodal.media import ...`, so in any environment where vllm is installed, importing the package dragged in the whole vllm/torch stack even when only `ImageLoader` was wanted.

## Fix

- `__init__.py`: keep the three media loaders eagerly importable (their footprint is PIL/numpy plus the local http helpers), and resolve the torch-dependent members lazily via a module-level `__getattr__` (PEP 562): `AsyncEncoderCache`, the nine embedding-transfer names, and the two embedding factory dicts. This mirrors the existing house pattern in `dynamo.common.configuration.__init__` and `dynamo.common.__init__` (option 1 from the issue, least churn).
- `audio_loader.py`: move the vllm import from module level into `_require_vllm_audio_media()`, matching the function-level pattern `video_loader.py` already uses (`_require_vllm_video_media`).

Public API is unchanged: every name in `__all__` still resolves through plain `from dynamo.common.multimodal import X`; the factory dicts are built on first access, cached in module globals, and keep stable identity afterwards. The `[gluo FIXME]` note on the NIXL_READ receiver factory is preserved.

## Validation

New CPU-only regression test `components/src/dynamo/common/tests/multimodal/test_lazy_imports.py` (markers `gpu_0`, `pre_merge`, `unit`). The torch-free assertions run in subprocesses so results are independent of what the pytest session already imported:

- importing the package or any loader leaves `torch` and `vllm` out of `sys.modules`;
- lazy members still resolve via from-imports and load torch only on first access;
- factory dicts have stable identity and cover every `EmbeddingTransferMode`;
- unknown attributes raise `AttributeError`.

```
$ PYTHONPATH=components/src python -m pytest components/src/dynamo/common/tests/multimodal/test_lazy_imports.py -q
5 passed in 4.15s

$ PYTHONPATH=components/src python -m pytest components/src/dynamo/common/tests/multimodal/ -q
6 failed, 74 passed in 6.24s
```

The 6 failures are `TestNixlReadEmbeddingTransfer` cases that fail identically on unmodified main in this environment (no NIXL library installed) — verified by stashing the change and rerunning.

`isort`/`black`/`ruff` clean on the three touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multimodal components now load more efficiently with lazy imports, reducing startup overhead.
  * Audio, image, and video loaders remain available without immediately loading heavier dependencies.
  * Embedding transfer helpers and factory mappings are now resolved only when first accessed.
* **Tests**
  * Added coverage to verify lazy-loading behavior and ensure unknown attributes still raise clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->