### PR TITLE
fix(ci): pass IRSA sccache secrets to compliance-extract rebuilds (OPS-7467)

### DIFF
--- a/.github/actions/compliance-extract/action.yml
+++ b/.github/actions/compliance-extract/action.yml
@@ -50,7 +50,7 @@ inputs:
     required: false
     default: ''
   sccache_bucket:
-    description: 'SCCACHE S3 bucket — must equal what the build passed so wheel_builder_base''s SCCACHE_* ARGs/ENV match and the heavy Rust layer cache-hits (the extract does NOT re-run sccache; it only needs the build-arg VALUES to line up).'
+    description: 'SCCACHE S3 bucket — must equal what the build passed so wheel_builder_base''s SCCACHE_* ARGs/ENV match and the heavy Rust layer cache-hits. Normally the extract never runs sccache (everything cache-hits), but when the shared builder has evicted layers a stage re-runs here for real, so the extract also passes the IRSA secrets (see the buildx steps) to let that sccache authenticate.'
     required: false
     default: ''
   sccache_region:
@@ -102,8 +102,24 @@ runs:
         #   - DYNAMO_COMMIT_SHA: pre_runtime does ENV DYNAMO_COMMIT_SHA=...; licenses
         #     (and compliance_artifact) are FROM pre_runtime.
         #   - USE_SCCACHE/SCCACHE_*: wheel_builder_base bakes them into an ENV, and
-        #     pre_runtime COPYs from wheel_builder. We pass the same VALUES (not to
-        #     run sccache — the layer cache-hits — but so the cache key lines up).
+        #     pre_runtime COPYs from wheel_builder. We pass the same VALUES so the
+        #     cache key lines up and the warm layers cache-hit.
+        # The warm cache is best-effort though: the shared buildkit pods GC under
+        # concurrent load, so a stage can legitimately re-run here (seen post-merge
+        # 2026-07-02). Pass the same IRSA secrets docker-remote-build passes so a
+        # re-run stage's sccache can still authenticate to S3 — without them
+        # `sccache --start-server` fails and the NIXL stage dies in meson's nvcc
+        # sanity check (meson wraps nvcc with the sccache it finds on PATH,
+        # sidestepping use-sccache.sh's no-server fallback). Secret values are not
+        # part of BuildKit's cache key, so this never invalidates the fast path.
+        SECRET_ARGS=""
+        TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE:-}"
+        if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ] && [ -n "${AWS_ROLE_ARN:-}" ]; then
+          SECRET_ARGS+=" --secret id=aws-web-identity-token,src=${TOKEN_FILE}"
+          SECRET_ARGS+=" --secret id=aws-role-arn,env=AWS_ROLE_ARN"
+        else
+          echo "::warning::IRSA web identity token not available; a cache-missed extract rebuild will run without sccache credentials"
+        fi
         docker buildx build \
             --builder ${{ inputs.builder_name }} \
             --platform ${{ inputs.platform }} \
@@ -115,6 +131,7 @@ runs:
             --output type=local,dest=/tmp/compliance \
             --progress=plain \
             -f ${{ steps.render.outputs.rendered }} \
+            $SECRET_ARGS \
             .
 
     # Name the OSRB CSV + CycloneDX per-arch: osrb-<image>-<arch>-<sha8>.{csv,cdx.json}.
@@ -159,7 +176,16 @@ runs:
         mkdir -p /tmp/sources
         # ENABLE_SOURCE_ARCHIVAL=true to actually run sources_collect; the other
         # build-args match the build so this shares the warm cache (same reason
-        # as the compliance_artifact extract above).
+        # as the compliance_artifact extract above). Same IRSA secrets too, so a
+        # cache-missed stage rebuild can still authenticate sccache (see above).
+        SECRET_ARGS=""
+        TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE:-}"
+        if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ] && [ -n "${AWS_ROLE_ARN:-}" ]; then
+          SECRET_ARGS+=" --secret id=aws-web-identity-token,src=${TOKEN_FILE}"
+          SECRET_ARGS+=" --secret id=aws-role-arn,env=AWS_ROLE_ARN"
+        else
+          echo "::warning::IRSA web identity token not available; a cache-missed extract rebuild will run without sccache credentials"
+        fi
         docker buildx build \
             --builder ${{ inputs.builder_name }} \
             --platform ${{ inputs.platform }} \
@@ -172,6 +198,7 @@ runs:
             --output type=local,dest=/tmp/sources \
             --progress=plain \
             -f ${{ steps.render.outputs.rendered }} \
+            $SECRET_ARGS \
             .
 
     - name: Upload compliance artifact (NOTICES + CSV + CycloneDX)

--- a/.github/actions/compliance-extract/action.yml
+++ b/.github/actions/compliance-extract/action.yml
@@ -112,13 +112,17 @@ runs:
         # sanity check (meson wraps nvcc with the sccache it finds on PATH,
         # sidestepping use-sccache.sh's no-server fallback). Secret values are not
         # part of BuildKit's cache key, so this never invalidates the fast path.
+        # Only forward the credentials when S3 sccache is actually configured
+        # (bucket set) — a bucket-less caller's build has no use for them.
         SECRET_ARGS=""
-        TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE:-}"
-        if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ] && [ -n "${AWS_ROLE_ARN:-}" ]; then
-          SECRET_ARGS+=" --secret id=aws-web-identity-token,src=${TOKEN_FILE}"
-          SECRET_ARGS+=" --secret id=aws-role-arn,env=AWS_ROLE_ARN"
-        else
-          echo "::warning::IRSA web identity token not available; a cache-missed extract rebuild will run without sccache credentials"
+        if [ -n "${SCCACHE_BUCKET:-}" ]; then
+          TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE:-}"
+          if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ] && [ -n "${AWS_ROLE_ARN:-}" ]; then
+            SECRET_ARGS+=" --secret id=aws-web-identity-token,src=${TOKEN_FILE}"
+            SECRET_ARGS+=" --secret id=aws-role-arn,env=AWS_ROLE_ARN"
+          else
+            echo "::warning::IRSA web identity token not available; a cache-missed extract rebuild will run without sccache credentials"
+          fi
         fi
         docker buildx build \
             --builder ${{ inputs.builder_name }} \
@@ -179,12 +183,14 @@ runs:
         # as the compliance_artifact extract above). Same IRSA secrets too, so a
         # cache-missed stage rebuild can still authenticate sccache (see above).
         SECRET_ARGS=""
-        TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE:-}"
-        if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ] && [ -n "${AWS_ROLE_ARN:-}" ]; then
-          SECRET_ARGS+=" --secret id=aws-web-identity-token,src=${TOKEN_FILE}"
-          SECRET_ARGS+=" --secret id=aws-role-arn,env=AWS_ROLE_ARN"
-        else
-          echo "::warning::IRSA web identity token not available; a cache-missed extract rebuild will run without sccache credentials"
+        if [ -n "${SCCACHE_BUCKET:-}" ]; then
+          TOKEN_FILE="${AWS_WEB_IDENTITY_TOKEN_FILE:-}"
+          if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ] && [ -n "${AWS_ROLE_ARN:-}" ]; then
+            SECRET_ARGS+=" --secret id=aws-web-identity-token,src=${TOKEN_FILE}"
+            SECRET_ARGS+=" --secret id=aws-role-arn,env=AWS_ROLE_ARN"
+          else
+            echo "::warning::IRSA web identity token not available; a cache-missed extract rebuild will run without sccache credentials"
+          fi
         fi
         docker buildx build \
             --builder ${{ inputs.builder_name }} \


### PR DESCRIPTION
## Overview:

Post-merge `Compliance extract` steps intermittently fail after a successful `Build and Push Image` (6/78 executed steps on 2026-07-02, e.g. [vllm-runtime cu13.0](https://github.com/ai-dynamo/dynamo/actions/runs/28591328920/job/84775403457), plus 5 trtllm cu13.1 jobs). This PR makes the extract's buildx rebuild path survive builder-cache eviction by passing the same IRSA secrets the main build passes.

## Details:

The compliance-extract action re-runs `docker buildx build --target compliance_artifact` right after the main build and passes the sccache build-args (`USE_SCCACHE=true`, bucket, region) purely so the cache key lines up — it assumes every stage cache-hits. That assumption is best-effort: the shared buildkit pods GC under concurrent load, and in the failing jobs the extract had only 12 CACHED layers and rebuilt nearly the whole graph on both arches. Because the extract passed **no** `--secret` flags, the re-run stages started sccache without credentials:

```
sccache: error: Server startup failed: cache storage failed to read: Unexpected (temporary) at read => loading credential to sign http request
meson.build:194:4: ERROR: Compiler /usr/local/bin/sccache nvcc cannot compile programs.
```

(`use-sccache.sh`'s no-server fallback doesn't help the NIXL stage: meson auto-wraps nvcc with the sccache it finds on PATH during `add_languages('CUDA')`.)

Fix: derive the same `SECRET_ARGS` block `docker-remote-build` uses (IRSA web-identity token + role ARN) in both extract buildx invocations (`compliance_artifact` and `sources_archive`). Secret values are not part of BuildKit's cache key, so the warm-cache fast path is byte-for-byte unaffected; the cache-miss path now authenticates and succeeds (quickly, via the sccache S3 cache).

Full investigation and follow-up candidates: OPS-7467

## Where should the reviewer start?

- `.github/actions/compliance-extract/action.yml` — the two buildx steps; the `SECRET_ARGS` block is copied verbatim from `.github/actions/docker-remote-build/action.yml`.

## Related Issues

- Relates to OPS-7467

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compliance artifact extraction so cache-missed builds can continue using the required cache backend credentials.
  * Added fallback behavior: if cloud identity details aren’t available, the process now warns and proceeds without those extra secrets instead of failing.
  * Applied the same credential handling to optional source extraction, making both extraction paths more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->