### PR TITLE
fix(compliance): run wheel NOTICES bundling with the venv python (OPS-7468)

### DIFF
--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -220,10 +220,12 @@ ENV CUDA_PATH=/usr/local/cuda \
 ARG PYTHON_VERSION
 ENV VIRTUAL_ENV=/workspace/.venv
 # Cache uv downloads; uv handles its own locking for this cache.
+# pyyaml: needed by the compliance NOTICES-bundling steps below (overrides.py
+# imports yaml at module scope); the system python3 doesn't ship it.
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=shared \
     export UV_CACHE_DIR=/root/.cache/uv UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv venv ${VIRTUAL_ENV} --python $PYTHON_VERSION && \
-    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit
+    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit pyyaml
 
 ARG NIXL_UCX_REF
 
@@ -552,11 +554,14 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=shared \
 # machine-readable inventory); this adds the texts the redistributed wheel's
 # MIT/BSD/Apache attribution clauses require. Best-effort + non-fatal: a failure
 # leaves the wheel with its SBOM intact rather than breaking the build.
+# Must run with the build venv's python: bundle_wheel_notices imports
+# compliance.overrides, which needs pyyaml (installed in the venv above);
+# the bare system python3 lacks it and the step would no-op with a warning.
 COPY container/compliance /opt/compliance
 RUN set -u; injected=0; \
     for whl in /opt/dynamo/dist/ai_dynamo_runtime*.whl; do \
         [ -e "$whl" ] || continue; \
-        PYTHONPATH=/opt python3 -m compliance.bundle_wheel_notices \
+        PYTHONPATH=/opt ${VIRTUAL_ENV}/bin/python3 -m compliance.bundle_wheel_notices \
             --wheel "$whl" --licenses-dir /opt/dynamo/rust-licenses -v \
             && injected=$((injected+1)) || echo "::warning::wheel NOTICES bundling failed for $whl (SBOM retained)"; \
     done; \
@@ -755,6 +760,8 @@ COPY --from=runtime_wheel_builder /opt/dynamo/dist/ /opt/dynamo/dist/
 # stage (the ai-dynamo-runtime wheel was already bundled in runtime_wheel_builder
 # and arrives consolidated above). Harvest kvbm's crate licenses from the cargo
 # registry, then inject into its auditwheel-repaired wheel. Best-effort/non-fatal.
+# Venv python required: compliance.overrides needs pyyaml, absent from the
+# system python3 (see the runtime_wheel_builder bundling step).
 COPY container/compliance /opt/compliance
 RUN --mount=type=cache,target=/root/.cargo/registry,sharing=shared \
     set -u; \
@@ -769,7 +776,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry,sharing=shared \
     done; \
     for whl in /opt/dynamo/dist/kvbm*.whl; do \
         [ -e "$whl" ] || continue; \
-        PYTHONPATH=/opt python3 -m compliance.bundle_wheel_notices \
+        PYTHONPATH=/opt ${VIRTUAL_ENV}/bin/python3 -m compliance.bundle_wheel_notices \
             --wheel "$whl" --licenses-dir /opt/dynamo/rust-licenses -v \
             || echo "::warning::kvbm wheel NOTICES bundling failed (SBOM retained)"; \
     done; \


### PR DESCRIPTION
## Overview:

The in-wheel Rust NOTICES bundling (`compliance.bundle_wheel_notices`) has **silently no-op'd in every runtime image** since it landed in #10825 (2026-06-24): every build logs `ModuleNotFoundError: No module named 'yaml'` and `wheel NOTICES bundled into 0 wheel(s)`, so shipped ai-dynamo-runtime and kvbm wheels are missing their bundled `licenses/THIRD-PARTY-RUST-LICENSES.txt` (PEP 639). The wheels' embedded CycloneDX SBOMs and the image-level NOTICES are unaffected.

## Details:

- The bundling RUNs in `container/templates/wheel_builder.Dockerfile` invoke bare `python3` — the **system** interpreter. The import chain `bundle_wheel_notices → generators.rust → compliance.overrides` needs pyyaml, which only exists where the *licenses* stage runs (the framework venv in `pre_runtime`), not in the wheel-builder stages.
- Both sites fail on both arches for all frameworks: `runtime_wheel_builder` (ai_dynamo_runtime wheels) and `wheel_builder` (kvbm wheel).
- It went unnoticed because the step is deliberately best-effort (`|| echo "::warning::..."`), and a `::warning::` emitted inside a buildx RUN carries buildkit's `#N t.ttt` line prefix, so GitHub never surfaces it as an annotation.

Fix:
1. Install `pyyaml` into the `wheel_builder_base` build venv alongside the existing tooling (meson/pybind11/patchelf/maturin/tomlkit) — reuses the uv cache mount.
2. Point both bundling RUNs at `${VIRTUAL_ENV}/bin/python3`.

This keeps `overrides.py`'s fail-loud module-scope `import yaml` untouched (the licenses stage is documented to treat pyyaml as a hard dependency; no lazy-import softening).

Verified by rendering vllm/sglang (cu13.0) and trtllm (cu13.1) runtime Dockerfiles from the edited template: all bundling sites use the venv python, no bare-python invocations remain. Post-merge, the build logs should show `wheel NOTICES bundled into 1 wheel(s)` (and the kvbm tally) instead of 0.

Full investigation: OPS-7468

## Where should the reviewer start?

- `container/templates/wheel_builder.Dockerfile` — the venv tooling install in `wheel_builder_base` and the two `bundle_wheel_notices` RUNs.

## Related Issues

- Relates to OPS-7468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wheel packaging so compliance notices are bundled using the correct Python environment.
  * Ensured required packaging dependencies are available during the build, reducing the chance of failed or incomplete wheel builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->