### PR TITLE
feat: Log frontend NUMA CPU affinity

### DIFF
--- a/components/src/dynamo/frontend/cpu_affinity.py
+++ b/components/src/dynamo/frontend/cpu_affinity.py
@@ -204,13 +204,13 @@ def _read_cpu_to_node_map(node_root: Path) -> dict[int, int]:
     return cpu_to_node
 
 
-def log_frontend_cpu_affinity(
+def warn_if_frontend_cpu_affinity_spans_numa_nodes(
     logger: logging.Logger,
     *,
     node_root: Path = _NUMA_NODE_ROOT,
     affinity_getter: AffinityGetter | None = None,
 ) -> CpuNumaAffinity:
-    """Detect and log the frontend CPU affinity without blocking startup."""
+    """Warn if the frontend can run across NUMA nodes without blocking startup."""
 
     try:
         result = detect_cpu_numa_affinity(
@@ -219,34 +219,23 @@ def log_frontend_cpu_affinity(
         )
     except Exception as error:
         result = _unknown(reason=f"unexpected affinity detection error: {error}")
-    available_cpus = format_cpu_list(result.available_cpus)
-    numa_nodes = format_cpu_list(result.numa_nodes)
-
-    if result.status == NumaAffinityStatus.SINGLE_NODE:
-        logger.info(
-            "Frontend CPU affinity is confined to one NUMA node "
-            "(available_cpus=%s, numa_nodes=%s)",
-            available_cpus,
-            numa_nodes,
-        )
-    elif result.status == NumaAffinityStatus.MULTIPLE_NODES:
+    if result.status == NumaAffinityStatus.MULTIPLE_NODES:
+        border = "=" * 80
         logger.warning(
-            "Frontend CPU affinity spans multiple NUMA nodes; Tokio worker "
-            "threads may execute across NUMA domains "
-            "(available_cpus=%s, numa_nodes=%s, unmapped_cpus=%s)",
-            available_cpus,
-            numa_nodes,
+            "%s\n"
+            "WARNING: Frontend CPU affinity spans multiple NUMA nodes!\n"
+            "Tokio worker threads may execute across NUMA domains, which can "
+            "degrade performance.\n"
+            "Available CPUs: %s\n"
+            "NUMA nodes: %s\n"
+            "Unmapped CPUs: %s\n"
+            "Pin the frontend to CPUs from a single NUMA node.\n"
+            "%s",
+            border,
+            format_cpu_list(result.available_cpus),
+            format_cpu_list(result.numa_nodes),
             format_cpu_list(result.unmapped_cpus),
-        )
-    else:
-        logger.warning(
-            "Unable to determine whether frontend CPU affinity spans multiple "
-            "NUMA nodes: %s "
-            "(available_cpus=%s, numa_nodes=%s, unmapped_cpus=%s)",
-            result.reason or "unknown error",
-            available_cpus,
-            numa_nodes,
-            format_cpu_list(result.unmapped_cpus),
+            border,
         )
 
     return result

--- a/components/src/dynamo/frontend/cpu_affinity.py
+++ b/components/src/dynamo/frontend/cpu_affinity.py
@@ -1,241 +1,56 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-"""Detect the CPU and NUMA affinity inherited by the frontend runtime."""
-
-from __future__ import annotations
+"""Warn when the frontend can run across multiple NUMA nodes."""
 
 import logging
 import os
-from collections.abc import Callable, Iterable
-from dataclasses import dataclass
-from enum import Enum
+from collections.abc import Callable
 from pathlib import Path
 
-_NUMA_NODE_ROOT = Path("/sys/devices/system/node")
-
-AffinityGetter = Callable[[int], Iterable[int]]
-
-
-class NumaAffinityStatus(str, Enum):
-    """Classification of the frontend's effective CPU affinity."""
-
-    SINGLE_NODE = "single_node"
-    MULTIPLE_NODES = "multiple_nodes"
-    UNKNOWN = "unknown"
-
-
-@dataclass(frozen=True)
-class CpuNumaAffinity:
-    """Effective CPU affinity and its NUMA-node coverage."""
-
-    available_cpus: tuple[int, ...]
-    numa_nodes: tuple[int, ...]
-    unmapped_cpus: tuple[int, ...]
-    status: NumaAffinityStatus
-    reason: str | None = None
-
-
-def parse_cpu_list(cpu_list: str) -> set[int]:
-    """Parse Linux cpulist syntax such as ``0-3,8,10-11``."""
-
-    value = cpu_list.strip()
-    if not value:
-        return set()
-
-    cpus: set[int] = set()
-    for raw_part in value.split(","):
-        part = raw_part.strip()
-        if not part:
-            raise ValueError(f"invalid empty CPU-list element in {cpu_list!r}")
-
-        if "-" not in part:
-            cpu = _parse_cpu_id(part, cpu_list)
-            cpus.add(cpu)
-            continue
-
-        bounds = part.split("-")
-        if len(bounds) != 2:
-            raise ValueError(f"invalid CPU range {part!r} in {cpu_list!r}")
-        start = _parse_cpu_id(bounds[0], cpu_list)
-        end = _parse_cpu_id(bounds[1], cpu_list)
-        if start > end:
-            raise ValueError(f"descending CPU range {part!r} in {cpu_list!r}")
-        cpus.update(range(start, end + 1))
-
-    return cpus
-
-
-def _parse_cpu_id(value: str, cpu_list: str) -> int:
-    if not value.isdigit():
-        raise ValueError(f"invalid CPU ID {value!r} in {cpu_list!r}")
-    return int(value)
-
-
-def format_cpu_list(cpus: Iterable[int]) -> str:
-    """Format CPU or NUMA-node IDs using compact Linux cpulist syntax."""
-
-    values = sorted(set(cpus))
-    if not values:
-        return "none"
-    if values[0] < 0:
-        raise ValueError("CPU-list values must be non-negative")
-
-    ranges: list[str] = []
-    start = previous = values[0]
-    for value in values[1:]:
-        if value == previous + 1:
-            previous = value
-            continue
-        ranges.append(_format_range(start, previous))
-        start = previous = value
-    ranges.append(_format_range(start, previous))
-    return ",".join(ranges)
-
-
-def _format_range(start: int, end: int) -> str:
-    return str(start) if start == end else f"{start}-{end}"
-
-
-def detect_cpu_numa_affinity(
-    *,
-    node_root: Path = _NUMA_NODE_ROOT,
-    affinity_getter: AffinityGetter | None = None,
-) -> CpuNumaAffinity:
-    """Detect NUMA coverage of the current thread's effective CPU affinity.
-
-    The frontend calls this before constructing ``DistributedRuntime``, so the
-    resulting mask is inherited by the Tokio worker threads.
-    """
-
-    if affinity_getter is None:
-        affinity_getter = getattr(os, "sched_getaffinity", None)
-        if affinity_getter is None:
-            return _unknown(reason="os.sched_getaffinity is unavailable")
-
-    try:
-        available_cpus = tuple(sorted(set(affinity_getter(0))))
-    except (OSError, NotImplementedError) as error:
-        return _unknown(reason=f"sched_getaffinity failed: {error}")
-
-    if not available_cpus:
-        return _unknown(reason="sched_getaffinity returned an empty CPU set")
-
-    try:
-        cpu_to_node = _read_cpu_to_node_map(node_root)
-    except (OSError, ValueError) as error:
-        return _unknown(
-            available_cpus=available_cpus,
-            unmapped_cpus=available_cpus,
-            reason=f"failed to read NUMA topology: {error}",
-        )
-
-    mapped_nodes = {cpu_to_node[cpu] for cpu in available_cpus if cpu in cpu_to_node}
-    unmapped_cpus = tuple(cpu for cpu in available_cpus if cpu not in cpu_to_node)
-    numa_nodes = tuple(sorted(mapped_nodes))
-
-    if len(numa_nodes) > 1:
-        status = NumaAffinityStatus.MULTIPLE_NODES
-        reason = None
-    elif len(numa_nodes) == 1 and not unmapped_cpus:
-        status = NumaAffinityStatus.SINGLE_NODE
-        reason = None
-    else:
-        status = NumaAffinityStatus.UNKNOWN
-        reason = (
-            "NUMA topology did not map all available CPUs "
-            f"({format_cpu_list(unmapped_cpus)})"
-        )
-
-    return CpuNumaAffinity(
-        available_cpus=available_cpus,
-        numa_nodes=numa_nodes,
-        unmapped_cpus=unmapped_cpus,
-        status=status,
-        reason=reason,
-    )
-
-
-def _unknown(
-    *,
-    available_cpus: tuple[int, ...] = (),
-    unmapped_cpus: tuple[int, ...] = (),
-    reason: str,
-) -> CpuNumaAffinity:
-    return CpuNumaAffinity(
-        available_cpus=available_cpus,
-        numa_nodes=(),
-        unmapped_cpus=unmapped_cpus,
-        status=NumaAffinityStatus.UNKNOWN,
-        reason=reason,
-    )
-
-
-def _read_cpu_to_node_map(node_root: Path) -> dict[int, int]:
-    if not node_root.is_dir():
-        raise OSError(f"NUMA node directory does not exist: {node_root}")
-
-    cpu_to_node: dict[int, int] = {}
-    node_paths = sorted(
-        (
-            path
-            for path in node_root.iterdir()
-            if path.is_dir()
-            and path.name.startswith("node")
-            and path.name[4:].isdigit()
-        ),
-        key=lambda path: int(path.name[4:]),
-    )
-    if not node_paths:
-        raise OSError(f"no NUMA nodes found under {node_root}")
-
-    for node_path in node_paths:
-        node = int(node_path.name[4:])
-        node_cpus = parse_cpu_list((node_path / "cpulist").read_text())
-        for cpu in node_cpus:
-            previous = cpu_to_node.setdefault(cpu, node)
-            if previous != node:
-                raise ValueError(
-                    f"CPU {cpu} belongs to both NUMA node {previous} and {node}"
-                )
-
-    if not cpu_to_node:
-        raise ValueError("NUMA topology contains no CPUs")
-    return cpu_to_node
+_CPU_SYSFS_ROOT = Path("/sys/devices/system/cpu")
 
 
 def warn_if_frontend_cpu_affinity_spans_numa_nodes(
     logger: logging.Logger,
     *,
-    node_root: Path = _NUMA_NODE_ROOT,
-    affinity_getter: AffinityGetter | None = None,
-) -> CpuNumaAffinity:
-    """Warn if the frontend can run across NUMA nodes without blocking startup."""
+    cpu_root: Path = _CPU_SYSFS_ROOT,
+    affinity_getter: Callable[[int], set[int]] | None = None,
+) -> None:
+    """Log a warning if the current CPU affinity covers multiple NUMA nodes."""
+
+    affinity_getter = affinity_getter or getattr(os, "sched_getaffinity", None)
+    if affinity_getter is None:
+        return
 
     try:
-        result = detect_cpu_numa_affinity(
-            node_root=node_root,
-            affinity_getter=affinity_getter,
+        cpus = sorted(affinity_getter(0))
+        nodes = sorted(
+            {
+                int(node_path.name[4:])
+                for cpu in cpus
+                for node_path in (cpu_root / f"cpu{cpu}").glob("node[0-9]*")
+                if node_path.name[4:].isdigit()
+            }
         )
-    except Exception as error:
-        result = _unknown(reason=f"unexpected affinity detection error: {error}")
-    if result.status == NumaAffinityStatus.MULTIPLE_NODES:
-        border = "=" * 80
-        logger.warning(
-            "%s\n"
-            "WARNING: Frontend CPU affinity spans multiple NUMA nodes!\n"
-            "Tokio worker threads may execute across NUMA domains, which can "
-            "degrade performance.\n"
-            "Available CPUs: %s\n"
-            "NUMA nodes: %s\n"
-            "Unmapped CPUs: %s\n"
-            "Pin the frontend to CPUs from a single NUMA node.\n"
-            "%s",
-            border,
-            format_cpu_list(result.available_cpus),
-            format_cpu_list(result.numa_nodes),
-            format_cpu_list(result.unmapped_cpus),
-            border,
-        )
+    except Exception:
+        return
 
-    return result
+    if len(nodes) < 2:
+        return
+
+    border = "=" * 80
+    logger.warning(
+        "%s\n"
+        "WARNING: Frontend CPU affinity spans multiple NUMA nodes!\n"
+        "Tokio worker threads may execute across NUMA domains, which can "
+        "degrade performance.\n"
+        "Available CPUs: %s\n"
+        "NUMA nodes: %s\n"
+        "Pin the frontend to CPUs from a single NUMA node.\n"
+        "%s",
+        border,
+        cpus,
+        nodes,
+        border,
+    )

--- a/components/src/dynamo/frontend/cpu_affinity.py
+++ b/components/src/dynamo/frontend/cpu_affinity.py
@@ -5,38 +5,49 @@
 
 import logging
 import os
-from collections.abc import Callable
 from pathlib import Path
 
 _CPU_SYSFS_ROOT = Path("/sys/devices/system/cpu")
 
 
+def _format_cpu_ranges(cpus: list[int]) -> str:
+    ranges: list[tuple[int, int]] = []
+    for cpu in cpus:
+        if ranges and cpu == ranges[-1][1] + 1:
+            ranges[-1] = (ranges[-1][0], cpu)
+        else:
+            ranges.append((cpu, cpu))
+    return ",".join(
+        str(start) if start == end else f"{start}-{end}" for start, end in ranges
+    )
+
+
 def warn_if_frontend_cpu_affinity_spans_numa_nodes(
     logger: logging.Logger,
-    *,
-    cpu_root: Path = _CPU_SYSFS_ROOT,
-    affinity_getter: Callable[[int], set[int]] | None = None,
 ) -> None:
     """Log a warning if the current CPU affinity covers multiple NUMA nodes."""
 
-    affinity_getter = affinity_getter or getattr(os, "sched_getaffinity", None)
-    if affinity_getter is None:
-        return
-
     try:
-        cpus = sorted(affinity_getter(0))
+        cpus = sorted(os.sched_getaffinity(0))
         nodes = sorted(
             {
-                int(node_path.name[4:])
+                node_path.name
                 for cpu in cpus
-                for node_path in (cpu_root / f"cpu{cpu}").glob("node[0-9]*")
-                if node_path.name[4:].isdigit()
+                for node_path in (_CPU_SYSFS_ROOT / f"cpu{cpu}").glob("node[0-9]*")
             }
         )
-    except Exception:
+    except (AttributeError, OSError) as error:
+        logger.debug("NUMA affinity check skipped: %s", error, exc_info=True)
         return
 
-    if len(nodes) < 2:
+    if not nodes:
+        logger.debug(
+            "NUMA affinity check skipped: no NUMA node links found for CPUs %s",
+            _format_cpu_ranges(cpus),
+        )
+        return
+
+    if len(nodes) == 1:
         return
 
     border = "=" * 80
@@ -50,7 +61,7 @@ def warn_if_frontend_cpu_affinity_spans_numa_nodes(
         "Pin the frontend to CPUs from a single NUMA node.\n"
         "%s",
         border,
-        cpus,
-        nodes,
+        _format_cpu_ranges(cpus),
+        ", ".join(nodes),
         border,
     )

--- a/components/src/dynamo/frontend/cpu_affinity.py
+++ b/components/src/dynamo/frontend/cpu_affinity.py
@@ -53,9 +53,10 @@ def warn_if_frontend_cpu_affinity_spans_numa_nodes(
     border = "=" * 80
     logger.warning(
         "%s\n"
-        "WARNING: Frontend CPU affinity spans multiple NUMA nodes!\n"
-        "Tokio worker threads may execute across NUMA domains, which can "
-        "degrade performance.\n"
+        "CRITICAL PERFORMANCE WARNING: Frontend CPU affinity spans "
+        "multiple NUMA nodes!\n"
+        "Running the frontend across multiple NUMA domains is known to cause "
+        "catastrophic performance issues.\n"
         "Available CPUs: %s\n"
         "NUMA nodes: %s\n"
         "Pin the frontend to CPUs from a single NUMA node.\n"

--- a/components/src/dynamo/frontend/cpu_affinity.py
+++ b/components/src/dynamo/frontend/cpu_affinity.py
@@ -1,0 +1,252 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+"""Detect the CPU and NUMA affinity inherited by the frontend runtime."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+_NUMA_NODE_ROOT = Path("/sys/devices/system/node")
+
+AffinityGetter = Callable[[int], Iterable[int]]
+
+
+class NumaAffinityStatus(str, Enum):
+    """Classification of the frontend's effective CPU affinity."""
+
+    SINGLE_NODE = "single_node"
+    MULTIPLE_NODES = "multiple_nodes"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class CpuNumaAffinity:
+    """Effective CPU affinity and its NUMA-node coverage."""
+
+    available_cpus: tuple[int, ...]
+    numa_nodes: tuple[int, ...]
+    unmapped_cpus: tuple[int, ...]
+    status: NumaAffinityStatus
+    reason: str | None = None
+
+
+def parse_cpu_list(cpu_list: str) -> set[int]:
+    """Parse Linux cpulist syntax such as ``0-3,8,10-11``."""
+
+    value = cpu_list.strip()
+    if not value:
+        return set()
+
+    cpus: set[int] = set()
+    for raw_part in value.split(","):
+        part = raw_part.strip()
+        if not part:
+            raise ValueError(f"invalid empty CPU-list element in {cpu_list!r}")
+
+        if "-" not in part:
+            cpu = _parse_cpu_id(part, cpu_list)
+            cpus.add(cpu)
+            continue
+
+        bounds = part.split("-")
+        if len(bounds) != 2:
+            raise ValueError(f"invalid CPU range {part!r} in {cpu_list!r}")
+        start = _parse_cpu_id(bounds[0], cpu_list)
+        end = _parse_cpu_id(bounds[1], cpu_list)
+        if start > end:
+            raise ValueError(f"descending CPU range {part!r} in {cpu_list!r}")
+        cpus.update(range(start, end + 1))
+
+    return cpus
+
+
+def _parse_cpu_id(value: str, cpu_list: str) -> int:
+    if not value.isdigit():
+        raise ValueError(f"invalid CPU ID {value!r} in {cpu_list!r}")
+    return int(value)
+
+
+def format_cpu_list(cpus: Iterable[int]) -> str:
+    """Format CPU or NUMA-node IDs using compact Linux cpulist syntax."""
+
+    values = sorted(set(cpus))
+    if not values:
+        return "none"
+    if values[0] < 0:
+        raise ValueError("CPU-list values must be non-negative")
+
+    ranges: list[str] = []
+    start = previous = values[0]
+    for value in values[1:]:
+        if value == previous + 1:
+            previous = value
+            continue
+        ranges.append(_format_range(start, previous))
+        start = previous = value
+    ranges.append(_format_range(start, previous))
+    return ",".join(ranges)
+
+
+def _format_range(start: int, end: int) -> str:
+    return str(start) if start == end else f"{start}-{end}"
+
+
+def detect_cpu_numa_affinity(
+    *,
+    node_root: Path = _NUMA_NODE_ROOT,
+    affinity_getter: AffinityGetter | None = None,
+) -> CpuNumaAffinity:
+    """Detect NUMA coverage of the current thread's effective CPU affinity.
+
+    The frontend calls this before constructing ``DistributedRuntime``, so the
+    resulting mask is inherited by the Tokio worker threads.
+    """
+
+    if affinity_getter is None:
+        affinity_getter = getattr(os, "sched_getaffinity", None)
+        if affinity_getter is None:
+            return _unknown(reason="os.sched_getaffinity is unavailable")
+
+    try:
+        available_cpus = tuple(sorted(set(affinity_getter(0))))
+    except (OSError, NotImplementedError) as error:
+        return _unknown(reason=f"sched_getaffinity failed: {error}")
+
+    if not available_cpus:
+        return _unknown(reason="sched_getaffinity returned an empty CPU set")
+
+    try:
+        cpu_to_node = _read_cpu_to_node_map(node_root)
+    except (OSError, ValueError) as error:
+        return _unknown(
+            available_cpus=available_cpus,
+            unmapped_cpus=available_cpus,
+            reason=f"failed to read NUMA topology: {error}",
+        )
+
+    mapped_nodes = {cpu_to_node[cpu] for cpu in available_cpus if cpu in cpu_to_node}
+    unmapped_cpus = tuple(cpu for cpu in available_cpus if cpu not in cpu_to_node)
+    numa_nodes = tuple(sorted(mapped_nodes))
+
+    if len(numa_nodes) > 1:
+        status = NumaAffinityStatus.MULTIPLE_NODES
+        reason = None
+    elif len(numa_nodes) == 1 and not unmapped_cpus:
+        status = NumaAffinityStatus.SINGLE_NODE
+        reason = None
+    else:
+        status = NumaAffinityStatus.UNKNOWN
+        reason = (
+            "NUMA topology did not map all available CPUs "
+            f"({format_cpu_list(unmapped_cpus)})"
+        )
+
+    return CpuNumaAffinity(
+        available_cpus=available_cpus,
+        numa_nodes=numa_nodes,
+        unmapped_cpus=unmapped_cpus,
+        status=status,
+        reason=reason,
+    )
+
+
+def _unknown(
+    *,
+    available_cpus: tuple[int, ...] = (),
+    unmapped_cpus: tuple[int, ...] = (),
+    reason: str,
+) -> CpuNumaAffinity:
+    return CpuNumaAffinity(
+        available_cpus=available_cpus,
+        numa_nodes=(),
+        unmapped_cpus=unmapped_cpus,
+        status=NumaAffinityStatus.UNKNOWN,
+        reason=reason,
+    )
+
+
+def _read_cpu_to_node_map(node_root: Path) -> dict[int, int]:
+    if not node_root.is_dir():
+        raise OSError(f"NUMA node directory does not exist: {node_root}")
+
+    cpu_to_node: dict[int, int] = {}
+    node_paths = sorted(
+        (
+            path
+            for path in node_root.iterdir()
+            if path.is_dir()
+            and path.name.startswith("node")
+            and path.name[4:].isdigit()
+        ),
+        key=lambda path: int(path.name[4:]),
+    )
+    if not node_paths:
+        raise OSError(f"no NUMA nodes found under {node_root}")
+
+    for node_path in node_paths:
+        node = int(node_path.name[4:])
+        node_cpus = parse_cpu_list((node_path / "cpulist").read_text())
+        for cpu in node_cpus:
+            previous = cpu_to_node.setdefault(cpu, node)
+            if previous != node:
+                raise ValueError(
+                    f"CPU {cpu} belongs to both NUMA node {previous} and {node}"
+                )
+
+    if not cpu_to_node:
+        raise ValueError("NUMA topology contains no CPUs")
+    return cpu_to_node
+
+
+def log_frontend_cpu_affinity(
+    logger: logging.Logger,
+    *,
+    node_root: Path = _NUMA_NODE_ROOT,
+    affinity_getter: AffinityGetter | None = None,
+) -> CpuNumaAffinity:
+    """Detect and log the frontend CPU affinity without blocking startup."""
+
+    try:
+        result = detect_cpu_numa_affinity(
+            node_root=node_root,
+            affinity_getter=affinity_getter,
+        )
+    except Exception as error:
+        result = _unknown(reason=f"unexpected affinity detection error: {error}")
+    available_cpus = format_cpu_list(result.available_cpus)
+    numa_nodes = format_cpu_list(result.numa_nodes)
+
+    if result.status == NumaAffinityStatus.SINGLE_NODE:
+        logger.info(
+            "Frontend CPU affinity is confined to one NUMA node "
+            "(available_cpus=%s, numa_nodes=%s)",
+            available_cpus,
+            numa_nodes,
+        )
+    elif result.status == NumaAffinityStatus.MULTIPLE_NODES:
+        logger.warning(
+            "Frontend CPU affinity spans multiple NUMA nodes; Tokio worker "
+            "threads may execute across NUMA domains "
+            "(available_cpus=%s, numa_nodes=%s, unmapped_cpus=%s)",
+            available_cpus,
+            numa_nodes,
+            format_cpu_list(result.unmapped_cpus),
+        )
+    else:
+        logger.warning(
+            "Unable to determine whether frontend CPU affinity spans multiple "
+            "NUMA nodes: %s "
+            "(available_cpus=%s, numa_nodes=%s, unmapped_cpus=%s)",
+            result.reason or "unknown error",
+            available_cpus,
+            numa_nodes,
+            format_cpu_list(result.unmapped_cpus),
+        )
+
+    return result

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -41,7 +41,7 @@ from dynamo.llm import (
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
-from .cpu_affinity import log_frontend_cpu_affinity
+from .cpu_affinity import warn_if_frontend_cpu_affinity_spans_numa_nodes
 from .frontend_args import FrontendArgGroup, FrontendConfig
 
 if TYPE_CHECKING:
@@ -198,7 +198,7 @@ async def async_main():
         )
 
     loop = asyncio.get_running_loop()
-    log_frontend_cpu_affinity(logger)
+    warn_if_frontend_cpu_affinity_spans_numa_nodes(logger)
     runtime = DistributedRuntime(
         loop,
         config.discovery_backend,

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -41,6 +41,7 @@ from dynamo.llm import (
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
+from .cpu_affinity import log_frontend_cpu_affinity
 from .frontend_args import FrontendArgGroup, FrontendConfig
 
 if TYPE_CHECKING:
@@ -197,6 +198,7 @@ async def async_main():
         )
 
     loop = asyncio.get_running_loop()
+    log_frontend_cpu_affinity(logger)
     runtime = DistributedRuntime(
         loop,
         config.discovery_backend,

--- a/components/src/dynamo/frontend/tests/test_cpu_affinity.py
+++ b/components/src/dynamo/frontend/tests/test_cpu_affinity.py
@@ -11,8 +11,8 @@ from dynamo.frontend.cpu_affinity import (
     NumaAffinityStatus,
     detect_cpu_numa_affinity,
     format_cpu_list,
-    log_frontend_cpu_affinity,
     parse_cpu_list,
+    warn_if_frontend_cpu_affinity_spans_numa_nodes,
 )
 
 pytestmark = [
@@ -143,7 +143,7 @@ def test_affinity_syscall_error_is_unknown(tmp_path: Path):
     assert result.reason == "sched_getaffinity failed: not permitted"
 
 
-def test_logging_fails_open_on_unexpected_detection_error(
+def test_warning_check_fails_open_silently_on_unexpected_detection_error(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ):
@@ -151,8 +151,8 @@ def test_logging_fails_open_on_unexpected_detection_error(
         raise RuntimeError("unexpected failure")
 
     test_logger = logging.getLogger("test.frontend.cpu_affinity.fail_open")
-    with caplog.at_level(logging.WARNING, logger=test_logger.name):
-        result = log_frontend_cpu_affinity(
+    with caplog.at_level(logging.DEBUG, logger=test_logger.name):
+        result = warn_if_frontend_cpu_affinity_spans_numa_nodes(
             test_logger,
             node_root=tmp_path,
             affinity_getter=fail_affinity,
@@ -161,47 +161,56 @@ def test_logging_fails_open_on_unexpected_detection_error(
     records = [record for record in caplog.records if record.name == test_logger.name]
     assert result.status == NumaAffinityStatus.UNKNOWN
     assert result.reason == "unexpected affinity detection error: unexpected failure"
-    assert len(records) == 1
-    assert records[0].levelno == logging.WARNING
+    assert records == []
 
 
-@pytest.mark.parametrize(
-    ("available_cpus", "expected_status", "expected_level", "expected_message"),
-    [
-        (
-            {0, 1},
-            NumaAffinityStatus.SINGLE_NODE,
-            logging.INFO,
-            "confined to one NUMA node",
-        ),
-        (
-            {1, 4},
-            NumaAffinityStatus.MULTIPLE_NODES,
-            logging.WARNING,
-            "spans multiple NUMA nodes",
-        ),
-        (
-            {1, 8},
-            NumaAffinityStatus.UNKNOWN,
-            logging.WARNING,
-            "Unable to determine",
-        ),
-    ],
-)
-def test_logs_exactly_one_affinity_result(
+def test_logs_loud_warning_when_affinity_spans_multiple_nodes(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
-    available_cpus: set[int],
-    expected_status: NumaAffinityStatus,
-    expected_level: int,
-    expected_message: str,
 ):
     _write_node(tmp_path, 0, "0-3")
     _write_node(tmp_path, 1, "4-7")
     test_logger = logging.getLogger("test.frontend.cpu_affinity")
 
-    with caplog.at_level(logging.INFO, logger=test_logger.name):
-        result = log_frontend_cpu_affinity(
+    with caplog.at_level(logging.WARNING, logger=test_logger.name):
+        result = warn_if_frontend_cpu_affinity_spans_numa_nodes(
+            test_logger,
+            node_root=tmp_path,
+            affinity_getter=lambda _pid: {1, 4},
+        )
+
+    records = [record for record in caplog.records if record.name == test_logger.name]
+    assert result.status == NumaAffinityStatus.MULTIPLE_NODES
+    assert len(records) == 1
+    assert records[0].levelno == logging.WARNING
+    message = records[0].getMessage()
+    assert message.startswith("=" * 80)
+    assert message.endswith("=" * 80)
+    assert "WARNING: Frontend CPU affinity spans multiple NUMA nodes!" in message
+    assert "Available CPUs: 1,4" in message
+    assert "NUMA nodes: 0-1" in message
+    assert "Pin the frontend to CPUs from a single NUMA node." in message
+
+
+@pytest.mark.parametrize(
+    ("available_cpus", "expected_status"),
+    [
+        ({0, 1}, NumaAffinityStatus.SINGLE_NODE),
+        ({1, 8}, NumaAffinityStatus.UNKNOWN),
+    ],
+)
+def test_does_not_log_unless_multiple_nodes_are_detected(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    available_cpus: set[int],
+    expected_status: NumaAffinityStatus,
+):
+    _write_node(tmp_path, 0, "0-3")
+    _write_node(tmp_path, 1, "4-7")
+    test_logger = logging.getLogger("test.frontend.cpu_affinity.silent")
+
+    with caplog.at_level(logging.DEBUG, logger=test_logger.name):
+        result = warn_if_frontend_cpu_affinity_spans_numa_nodes(
             test_logger,
             node_root=tmp_path,
             affinity_getter=lambda _pid: available_cpus,
@@ -209,6 +218,4 @@ def test_logs_exactly_one_affinity_result(
 
     records = [record for record in caplog.records if record.name == test_logger.name]
     assert result.status == expected_status
-    assert len(records) == 1
-    assert records[0].levelno == expected_level
-    assert expected_message in records[0].getMessage()
+    assert records == []

--- a/components/src/dynamo/frontend/tests/test_cpu_affinity.py
+++ b/components/src/dynamo/frontend/tests/test_cpu_affinity.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from dynamo.frontend import cpu_affinity
 from dynamo.frontend.cpu_affinity import warn_if_frontend_cpu_affinity_spans_numa_nodes
 
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
@@ -19,54 +20,75 @@ def _add_cpu(root: Path, cpu: int, node: int) -> None:
 def test_warns_when_affinity_spans_multiple_numa_nodes(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ):
-    _add_cpu(tmp_path, 0, 0)
-    _add_cpu(tmp_path, 4, 1)
+    for cpu in (0, 1, 2, 3):
+        _add_cpu(tmp_path, cpu, 0)
+    for cpu in (8, 9):
+        _add_cpu(tmp_path, cpu, 1)
+    monkeypatch.setattr(cpu_affinity, "_CPU_SYSFS_ROOT", tmp_path)
+    monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2, 3, 8, 9})
     logger = logging.getLogger("test.frontend.cpu_affinity.multiple")
 
     with caplog.at_level(logging.WARNING, logger=logger.name):
-        warn_if_frontend_cpu_affinity_spans_numa_nodes(
-            logger,
-            cpu_root=tmp_path,
-            affinity_getter=lambda _pid: {0, 4},
-        )
+        warn_if_frontend_cpu_affinity_spans_numa_nodes(logger)
 
     assert len(caplog.records) == 1
     message = caplog.records[0].getMessage()
-    assert message.startswith("=" * 80)
-    assert "WARNING: Frontend CPU affinity spans multiple NUMA nodes!" in message
-    assert "Available CPUs: [0, 4]" in message
-    assert "NUMA nodes: [0, 1]" in message
+    assert "Frontend CPU affinity spans multiple NUMA nodes" in message
+    assert "Available CPUs: 0-3,8-9" in message
+    assert "node0" in message
+    assert "node1" in message
 
 
-@pytest.mark.parametrize("cpus", [{0, 1}, {0, 8}])
-def test_stays_silent_without_multiple_detected_nodes(
+@pytest.mark.parametrize(
+    ("cpus", "cpu_nodes", "debug_message"),
+    [
+        pytest.param({0, 1}, [(0, 0), (1, 0)], None, id="same_node"),
+        pytest.param({8}, [], "no NUMA node links found", id="cpu_missing_from_sysfs"),
+    ],
+)
+def test_does_not_warn_without_multiple_detected_nodes(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
     cpus: set[int],
+    cpu_nodes: list[tuple[int, int]],
+    debug_message: str | None,
 ):
-    _add_cpu(tmp_path, 0, 0)
-    _add_cpu(tmp_path, 1, 0)
+    for cpu, node in cpu_nodes:
+        _add_cpu(tmp_path, cpu, node)
+    monkeypatch.setattr(cpu_affinity, "_CPU_SYSFS_ROOT", tmp_path)
+    monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: cpus)
     logger = logging.getLogger("test.frontend.cpu_affinity.silent")
 
     with caplog.at_level(logging.DEBUG, logger=logger.name):
-        warn_if_frontend_cpu_affinity_spans_numa_nodes(
-            logger,
-            cpu_root=tmp_path,
-            affinity_getter=lambda _pid: cpus,
-        )
+        warn_if_frontend_cpu_affinity_spans_numa_nodes(logger)
 
-    assert caplog.records == []
+    assert not [
+        record for record in caplog.records if record.levelno >= logging.WARNING
+    ]
+    if debug_message is None:
+        assert caplog.records == []
+    else:
+        assert len(caplog.records) == 1
+        assert debug_message in caplog.records[0].getMessage()
 
 
-def test_stays_silent_when_affinity_detection_is_unavailable(
+def test_affinity_failure_logs_debug_traceback_without_warning(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ):
-    monkeypatch.delattr(os, "sched_getaffinity", raising=False)
+    def fail_affinity(_pid: int) -> set[int]:
+        raise OSError("not permitted")
 
-    warn_if_frontend_cpu_affinity_spans_numa_nodes(
-        logging.getLogger("test.frontend.cpu_affinity.unavailable")
-    )
+    monkeypatch.setattr(os, "sched_getaffinity", fail_affinity)
+    logger = logging.getLogger("test.frontend.cpu_affinity.failure")
 
-    assert caplog.records == []
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        warn_if_frontend_cpu_affinity_spans_numa_nodes(logger)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.DEBUG
+    assert "not permitted" in caplog.records[0].getMessage()
+    assert caplog.records[0].exc_info is not None

--- a/components/src/dynamo/frontend/tests/test_cpu_affinity.py
+++ b/components/src/dynamo/frontend/tests/test_cpu_affinity.py
@@ -7,215 +7,66 @@ from pathlib import Path
 
 import pytest
 
-from dynamo.frontend.cpu_affinity import (
-    NumaAffinityStatus,
-    detect_cpu_numa_affinity,
-    format_cpu_list,
-    parse_cpu_list,
-    warn_if_frontend_cpu_affinity_spans_numa_nodes,
-)
+from dynamo.frontend.cpu_affinity import warn_if_frontend_cpu_affinity_spans_numa_nodes
 
-pytestmark = [
-    pytest.mark.unit,
-    pytest.mark.gpu_0,
-    pytest.mark.pre_merge,
-]
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
 
-def _write_node(root: Path, node: int, cpus: str) -> None:
-    node_path = root / f"node{node}"
-    node_path.mkdir()
-    (node_path / "cpulist").write_text(cpus)
+def _add_cpu(root: Path, cpu: int, node: int) -> None:
+    (root / f"cpu{cpu}" / f"node{node}").mkdir(parents=True)
 
 
-def test_parse_cpu_list_supports_ranges_and_single_ids():
-    assert parse_cpu_list("0-2,8,16-17\n") == {0, 1, 2, 8, 16, 17}
+def test_warns_when_affinity_spans_multiple_numa_nodes(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    _add_cpu(tmp_path, 0, 0)
+    _add_cpu(tmp_path, 4, 1)
+    logger = logging.getLogger("test.frontend.cpu_affinity.multiple")
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        warn_if_frontend_cpu_affinity_spans_numa_nodes(
+            logger,
+            cpu_root=tmp_path,
+            affinity_getter=lambda _pid: {0, 4},
+        )
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert message.startswith("=" * 80)
+    assert "WARNING: Frontend CPU affinity spans multiple NUMA nodes!" in message
+    assert "Available CPUs: [0, 4]" in message
+    assert "NUMA nodes: [0, 1]" in message
 
 
-@pytest.mark.parametrize("value", ["0-", "2-1", "1--2", "cpu3", "0,,2"])
-def test_parse_cpu_list_rejects_invalid_values(value: str):
-    with pytest.raises(ValueError):
-        parse_cpu_list(value)
+@pytest.mark.parametrize("cpus", [{0, 1}, {0, 8}])
+def test_stays_silent_without_multiple_detected_nodes(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    cpus: set[int],
+):
+    _add_cpu(tmp_path, 0, 0)
+    _add_cpu(tmp_path, 1, 0)
+    logger = logging.getLogger("test.frontend.cpu_affinity.silent")
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        warn_if_frontend_cpu_affinity_spans_numa_nodes(
+            logger,
+            cpu_root=tmp_path,
+            affinity_getter=lambda _pid: cpus,
+        )
+
+    assert caplog.records == []
 
 
-def test_format_cpu_list_compacts_ranges_and_sorts_values():
-    assert format_cpu_list([8, 2, 1, 0, 7, 4]) == "0-2,4,7-8"
-    assert format_cpu_list([]) == "none"
-
-
-def test_detects_affinity_confined_to_one_numa_node(tmp_path: Path):
-    _write_node(tmp_path, 0, "0-3,8-11")
-    _write_node(tmp_path, 1, "4-7,12-15")
-
-    result = detect_cpu_numa_affinity(
-        node_root=tmp_path,
-        affinity_getter=lambda _pid: {0, 2, 8},
-    )
-
-    assert result.status == NumaAffinityStatus.SINGLE_NODE
-    assert result.available_cpus == (0, 2, 8)
-    assert result.numa_nodes == (0,)
-    assert result.unmapped_cpus == ()
-    assert result.reason is None
-
-
-def test_detects_affinity_spanning_multiple_numa_nodes(tmp_path: Path):
-    _write_node(tmp_path, 0, "0-3")
-    _write_node(tmp_path, 1, "4-7")
-
-    result = detect_cpu_numa_affinity(
-        node_root=tmp_path,
-        affinity_getter=lambda _pid: {1, 4, 6},
-    )
-
-    assert result.status == NumaAffinityStatus.MULTIPLE_NODES
-    assert result.available_cpus == (1, 4, 6)
-    assert result.numa_nodes == (0, 1)
-    assert result.unmapped_cpus == ()
-
-
-def test_multiple_nodes_remains_conclusive_with_an_unmapped_cpu(tmp_path: Path):
-    _write_node(tmp_path, 0, "0-3")
-    _write_node(tmp_path, 1, "4-7")
-
-    result = detect_cpu_numa_affinity(
-        node_root=tmp_path,
-        affinity_getter=lambda _pid: {1, 4, 9},
-    )
-
-    assert result.status == NumaAffinityStatus.MULTIPLE_NODES
-    assert result.numa_nodes == (0, 1)
-    assert result.unmapped_cpus == (9,)
-
-
-def test_partial_cpu_mapping_is_unknown(tmp_path: Path):
-    _write_node(tmp_path, 0, "0-3")
-
-    result = detect_cpu_numa_affinity(
-        node_root=tmp_path,
-        affinity_getter=lambda _pid: {1, 4},
-    )
-
-    assert result.status == NumaAffinityStatus.UNKNOWN
-    assert result.numa_nodes == (0,)
-    assert result.unmapped_cpus == (4,)
-    assert result.reason is not None
-    assert "did not map all available CPUs" in result.reason
-
-
-@pytest.mark.parametrize("create_root", [False, True])
-def test_missing_or_empty_topology_is_unknown(tmp_path: Path, create_root: bool):
-    node_root = tmp_path / "nodes"
-    if create_root:
-        node_root.mkdir()
-
-    result = detect_cpu_numa_affinity(
-        node_root=node_root,
-        affinity_getter=lambda _pid: {0, 1},
-    )
-
-    assert result.status == NumaAffinityStatus.UNKNOWN
-    assert result.available_cpus == (0, 1)
-    assert result.unmapped_cpus == (0, 1)
-    assert result.reason is not None
-    assert "failed to read NUMA topology" in result.reason
-
-
-def test_unsupported_affinity_api_is_unknown(monkeypatch: pytest.MonkeyPatch):
+def test_stays_silent_when_affinity_detection_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
     monkeypatch.delattr(os, "sched_getaffinity", raising=False)
 
-    result = detect_cpu_numa_affinity()
-
-    assert result.status == NumaAffinityStatus.UNKNOWN
-    assert result.reason == "os.sched_getaffinity is unavailable"
-
-
-def test_affinity_syscall_error_is_unknown(tmp_path: Path):
-    def fail_affinity(_pid: int) -> set[int]:
-        raise OSError("not permitted")
-
-    result = detect_cpu_numa_affinity(
-        node_root=tmp_path,
-        affinity_getter=fail_affinity,
+    warn_if_frontend_cpu_affinity_spans_numa_nodes(
+        logging.getLogger("test.frontend.cpu_affinity.unavailable")
     )
 
-    assert result.status == NumaAffinityStatus.UNKNOWN
-    assert result.reason == "sched_getaffinity failed: not permitted"
-
-
-def test_warning_check_fails_open_silently_on_unexpected_detection_error(
-    tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
-):
-    def fail_affinity(_pid: int) -> set[int]:
-        raise RuntimeError("unexpected failure")
-
-    test_logger = logging.getLogger("test.frontend.cpu_affinity.fail_open")
-    with caplog.at_level(logging.DEBUG, logger=test_logger.name):
-        result = warn_if_frontend_cpu_affinity_spans_numa_nodes(
-            test_logger,
-            node_root=tmp_path,
-            affinity_getter=fail_affinity,
-        )
-
-    records = [record for record in caplog.records if record.name == test_logger.name]
-    assert result.status == NumaAffinityStatus.UNKNOWN
-    assert result.reason == "unexpected affinity detection error: unexpected failure"
-    assert records == []
-
-
-def test_logs_loud_warning_when_affinity_spans_multiple_nodes(
-    tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
-):
-    _write_node(tmp_path, 0, "0-3")
-    _write_node(tmp_path, 1, "4-7")
-    test_logger = logging.getLogger("test.frontend.cpu_affinity")
-
-    with caplog.at_level(logging.WARNING, logger=test_logger.name):
-        result = warn_if_frontend_cpu_affinity_spans_numa_nodes(
-            test_logger,
-            node_root=tmp_path,
-            affinity_getter=lambda _pid: {1, 4},
-        )
-
-    records = [record for record in caplog.records if record.name == test_logger.name]
-    assert result.status == NumaAffinityStatus.MULTIPLE_NODES
-    assert len(records) == 1
-    assert records[0].levelno == logging.WARNING
-    message = records[0].getMessage()
-    assert message.startswith("=" * 80)
-    assert message.endswith("=" * 80)
-    assert "WARNING: Frontend CPU affinity spans multiple NUMA nodes!" in message
-    assert "Available CPUs: 1,4" in message
-    assert "NUMA nodes: 0-1" in message
-    assert "Pin the frontend to CPUs from a single NUMA node." in message
-
-
-@pytest.mark.parametrize(
-    ("available_cpus", "expected_status"),
-    [
-        ({0, 1}, NumaAffinityStatus.SINGLE_NODE),
-        ({1, 8}, NumaAffinityStatus.UNKNOWN),
-    ],
-)
-def test_does_not_log_unless_multiple_nodes_are_detected(
-    tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
-    available_cpus: set[int],
-    expected_status: NumaAffinityStatus,
-):
-    _write_node(tmp_path, 0, "0-3")
-    _write_node(tmp_path, 1, "4-7")
-    test_logger = logging.getLogger("test.frontend.cpu_affinity.silent")
-
-    with caplog.at_level(logging.DEBUG, logger=test_logger.name):
-        result = warn_if_frontend_cpu_affinity_spans_numa_nodes(
-            test_logger,
-            node_root=tmp_path,
-            affinity_getter=lambda _pid: available_cpus,
-        )
-
-    records = [record for record in caplog.records if record.name == test_logger.name]
-    assert result.status == expected_status
-    assert records == []
+    assert caplog.records == []

--- a/components/src/dynamo/frontend/tests/test_cpu_affinity.py
+++ b/components/src/dynamo/frontend/tests/test_cpu_affinity.py
@@ -1,0 +1,214 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+from dynamo.frontend.cpu_affinity import (
+    NumaAffinityStatus,
+    detect_cpu_numa_affinity,
+    format_cpu_list,
+    log_frontend_cpu_affinity,
+    parse_cpu_list,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def _write_node(root: Path, node: int, cpus: str) -> None:
+    node_path = root / f"node{node}"
+    node_path.mkdir()
+    (node_path / "cpulist").write_text(cpus)
+
+
+def test_parse_cpu_list_supports_ranges_and_single_ids():
+    assert parse_cpu_list("0-2,8,16-17\n") == {0, 1, 2, 8, 16, 17}
+
+
+@pytest.mark.parametrize("value", ["0-", "2-1", "1--2", "cpu3", "0,,2"])
+def test_parse_cpu_list_rejects_invalid_values(value: str):
+    with pytest.raises(ValueError):
+        parse_cpu_list(value)
+
+
+def test_format_cpu_list_compacts_ranges_and_sorts_values():
+    assert format_cpu_list([8, 2, 1, 0, 7, 4]) == "0-2,4,7-8"
+    assert format_cpu_list([]) == "none"
+
+
+def test_detects_affinity_confined_to_one_numa_node(tmp_path: Path):
+    _write_node(tmp_path, 0, "0-3,8-11")
+    _write_node(tmp_path, 1, "4-7,12-15")
+
+    result = detect_cpu_numa_affinity(
+        node_root=tmp_path,
+        affinity_getter=lambda _pid: {0, 2, 8},
+    )
+
+    assert result.status == NumaAffinityStatus.SINGLE_NODE
+    assert result.available_cpus == (0, 2, 8)
+    assert result.numa_nodes == (0,)
+    assert result.unmapped_cpus == ()
+    assert result.reason is None
+
+
+def test_detects_affinity_spanning_multiple_numa_nodes(tmp_path: Path):
+    _write_node(tmp_path, 0, "0-3")
+    _write_node(tmp_path, 1, "4-7")
+
+    result = detect_cpu_numa_affinity(
+        node_root=tmp_path,
+        affinity_getter=lambda _pid: {1, 4, 6},
+    )
+
+    assert result.status == NumaAffinityStatus.MULTIPLE_NODES
+    assert result.available_cpus == (1, 4, 6)
+    assert result.numa_nodes == (0, 1)
+    assert result.unmapped_cpus == ()
+
+
+def test_multiple_nodes_remains_conclusive_with_an_unmapped_cpu(tmp_path: Path):
+    _write_node(tmp_path, 0, "0-3")
+    _write_node(tmp_path, 1, "4-7")
+
+    result = detect_cpu_numa_affinity(
+        node_root=tmp_path,
+        affinity_getter=lambda _pid: {1, 4, 9},
+    )
+
+    assert result.status == NumaAffinityStatus.MULTIPLE_NODES
+    assert result.numa_nodes == (0, 1)
+    assert result.unmapped_cpus == (9,)
+
+
+def test_partial_cpu_mapping_is_unknown(tmp_path: Path):
+    _write_node(tmp_path, 0, "0-3")
+
+    result = detect_cpu_numa_affinity(
+        node_root=tmp_path,
+        affinity_getter=lambda _pid: {1, 4},
+    )
+
+    assert result.status == NumaAffinityStatus.UNKNOWN
+    assert result.numa_nodes == (0,)
+    assert result.unmapped_cpus == (4,)
+    assert result.reason is not None
+    assert "did not map all available CPUs" in result.reason
+
+
+@pytest.mark.parametrize("create_root", [False, True])
+def test_missing_or_empty_topology_is_unknown(tmp_path: Path, create_root: bool):
+    node_root = tmp_path / "nodes"
+    if create_root:
+        node_root.mkdir()
+
+    result = detect_cpu_numa_affinity(
+        node_root=node_root,
+        affinity_getter=lambda _pid: {0, 1},
+    )
+
+    assert result.status == NumaAffinityStatus.UNKNOWN
+    assert result.available_cpus == (0, 1)
+    assert result.unmapped_cpus == (0, 1)
+    assert result.reason is not None
+    assert "failed to read NUMA topology" in result.reason
+
+
+def test_unsupported_affinity_api_is_unknown(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)
+
+    result = detect_cpu_numa_affinity()
+
+    assert result.status == NumaAffinityStatus.UNKNOWN
+    assert result.reason == "os.sched_getaffinity is unavailable"
+
+
+def test_affinity_syscall_error_is_unknown(tmp_path: Path):
+    def fail_affinity(_pid: int) -> set[int]:
+        raise OSError("not permitted")
+
+    result = detect_cpu_numa_affinity(
+        node_root=tmp_path,
+        affinity_getter=fail_affinity,
+    )
+
+    assert result.status == NumaAffinityStatus.UNKNOWN
+    assert result.reason == "sched_getaffinity failed: not permitted"
+
+
+def test_logging_fails_open_on_unexpected_detection_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    def fail_affinity(_pid: int) -> set[int]:
+        raise RuntimeError("unexpected failure")
+
+    test_logger = logging.getLogger("test.frontend.cpu_affinity.fail_open")
+    with caplog.at_level(logging.WARNING, logger=test_logger.name):
+        result = log_frontend_cpu_affinity(
+            test_logger,
+            node_root=tmp_path,
+            affinity_getter=fail_affinity,
+        )
+
+    records = [record for record in caplog.records if record.name == test_logger.name]
+    assert result.status == NumaAffinityStatus.UNKNOWN
+    assert result.reason == "unexpected affinity detection error: unexpected failure"
+    assert len(records) == 1
+    assert records[0].levelno == logging.WARNING
+
+
+@pytest.mark.parametrize(
+    ("available_cpus", "expected_status", "expected_level", "expected_message"),
+    [
+        (
+            {0, 1},
+            NumaAffinityStatus.SINGLE_NODE,
+            logging.INFO,
+            "confined to one NUMA node",
+        ),
+        (
+            {1, 4},
+            NumaAffinityStatus.MULTIPLE_NODES,
+            logging.WARNING,
+            "spans multiple NUMA nodes",
+        ),
+        (
+            {1, 8},
+            NumaAffinityStatus.UNKNOWN,
+            logging.WARNING,
+            "Unable to determine",
+        ),
+    ],
+)
+def test_logs_exactly_one_affinity_result(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    available_cpus: set[int],
+    expected_status: NumaAffinityStatus,
+    expected_level: int,
+    expected_message: str,
+):
+    _write_node(tmp_path, 0, "0-3")
+    _write_node(tmp_path, 1, "4-7")
+    test_logger = logging.getLogger("test.frontend.cpu_affinity")
+
+    with caplog.at_level(logging.INFO, logger=test_logger.name):
+        result = log_frontend_cpu_affinity(
+            test_logger,
+            node_root=tmp_path,
+            affinity_getter=lambda _pid: available_cpus,
+        )
+
+    records = [record for record in caplog.records if record.name == test_logger.name]
+    assert result.status == expected_status
+    assert len(records) == 1
+    assert records[0].levelno == expected_level
+    assert expected_message in records[0].getMessage()

--- a/components/src/dynamo/frontend/tests/test_cpu_affinity.py
+++ b/components/src/dynamo/frontend/tests/test_cpu_affinity.py
@@ -35,7 +35,12 @@ def test_warns_when_affinity_spans_multiple_numa_nodes(
 
     assert len(caplog.records) == 1
     message = caplog.records[0].getMessage()
+    assert "CRITICAL PERFORMANCE WARNING" in message
     assert "Frontend CPU affinity spans multiple NUMA nodes" in message
+    assert (
+        "Running the frontend across multiple NUMA domains is known to cause "
+        "catastrophic performance issues."
+    ) in message
     assert "Available CPUs: 0-3,8-9" in message
     assert "node0" in message
     assert "node1" in message


### PR DESCRIPTION
## Overview:

Warn when the frontend's effective CPU affinity spans multiple NUMA nodes before the Tokio runtime is created.

## Details:

- Read the effective CPU set with `os.sched_getaffinity(0)`.
- Map allowed CPUs through their Linux sysfs `node*` links.
- Emit a prominent warning only when multiple NUMA nodes are definitively detected.
- Render large CPU masks using compact kernel-style ranges.
- Stay fail-open, with debug diagnostics for affinity errors or missing topology.
- Add focused unit coverage for multi-node warnings, same-node silence, missing sysfs, and affinity failures.

Validation:
- `4 passed`: `components/src/dynamo/frontend/tests/test_cpu_affinity.py`
- isort, Black, Flake8, and Ruff passed on all touched files

## Where should the reviewer start?

Start with `components/src/dynamo/frontend/cpu_affinity.py`, then verify the startup call immediately before `DistributedRuntime` construction in `components/src/dynamo/frontend/main.py`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
