### PR TITLE
fix(multimodal): lazy load package exports

### DIFF
--- a/components/src/dynamo/common/multimodal/__init__.py
+++ b/components/src/dynamo/common/multimodal/__init__.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from dynamo.common.constants import EmbeddingTransferMode
 
-
 _LAZY_EXPORTS = {
     "AsyncEncoderCache": "dynamo.common.multimodal.async_encoder_cache",
     "AudioLoader": "dynamo.common.multimodal.audio_loader",
@@ -57,7 +56,9 @@ EMBEDDING_SENDER_FACTORIES: dict[EmbeddingTransferMode, Callable[[], Any]] = {
     EmbeddingTransferMode.NIXL_WRITE: _embedding_sender_factory(
         "NixlWriteEmbeddingSender"
     ),
-    EmbeddingTransferMode.NIXL_READ: _embedding_sender_factory("NixlReadEmbeddingSender"),
+    EmbeddingTransferMode.NIXL_READ: _embedding_sender_factory(
+        "NixlReadEmbeddingSender"
+    ),
 }
 
 EMBEDDING_RECEIVER_FACTORIES: dict[EmbeddingTransferMode, Callable[[], Any]] = {

--- a/components/src/dynamo/common/multimodal/__init__.py
+++ b/components/src/dynamo/common/multimodal/__init__.py
@@ -4,40 +4,72 @@
 """Multimodal utilities for Dynamo components."""
 
 from collections.abc import Callable
+from importlib import import_module
+from typing import Any
 
 from dynamo.common.constants import EmbeddingTransferMode
-from dynamo.common.multimodal.async_encoder_cache import AsyncEncoderCache
-from dynamo.common.multimodal.audio_loader import AudioLoader
-from dynamo.common.multimodal.embedding_transfer import (
-    AbstractEmbeddingReceiver,
-    AbstractEmbeddingSender,
-    LocalEmbeddingReceiver,
-    LocalEmbeddingSender,
-    NixlReadEmbeddingReceiver,
-    NixlReadEmbeddingSender,
-    NixlWriteEmbeddingReceiver,
-    NixlWriteEmbeddingSender,
-    TransferRequest,
-)
-from dynamo.common.multimodal.image_loader import ImageLoader
-from dynamo.common.multimodal.video_loader import VideoLoader
 
-EMBEDDING_SENDER_FACTORIES: dict[
-    EmbeddingTransferMode, Callable[[], AbstractEmbeddingSender]
-] = {
-    EmbeddingTransferMode.LOCAL: LocalEmbeddingSender,
-    EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingSender,
-    EmbeddingTransferMode.NIXL_READ: NixlReadEmbeddingSender,
+
+_LAZY_EXPORTS = {
+    "AsyncEncoderCache": "dynamo.common.multimodal.async_encoder_cache",
+    "AudioLoader": "dynamo.common.multimodal.audio_loader",
+    "ImageLoader": "dynamo.common.multimodal.image_loader",
+    "VideoLoader": "dynamo.common.multimodal.video_loader",
+    "AbstractEmbeddingReceiver": "dynamo.common.multimodal.embedding_transfer",
+    "AbstractEmbeddingSender": "dynamo.common.multimodal.embedding_transfer",
+    "LocalEmbeddingReceiver": "dynamo.common.multimodal.embedding_transfer",
+    "LocalEmbeddingSender": "dynamo.common.multimodal.embedding_transfer",
+    "NixlReadEmbeddingReceiver": "dynamo.common.multimodal.embedding_transfer",
+    "NixlReadEmbeddingSender": "dynamo.common.multimodal.embedding_transfer",
+    "NixlWriteEmbeddingReceiver": "dynamo.common.multimodal.embedding_transfer",
+    "NixlWriteEmbeddingSender": "dynamo.common.multimodal.embedding_transfer",
+    "TransferRequest": "dynamo.common.multimodal.embedding_transfer",
 }
 
-EMBEDDING_RECEIVER_FACTORIES: dict[
-    EmbeddingTransferMode, Callable[[], AbstractEmbeddingReceiver]
-] = {
-    EmbeddingTransferMode.LOCAL: LocalEmbeddingReceiver,
-    EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingReceiver,
+
+def _load_export(name: str) -> Any:
+    module = import_module(_LAZY_EXPORTS[name])
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_EXPORTS:
+        return _load_export(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def _lazy_factory(export_name: str, *args: Any, **kwargs: Any) -> Any:
+    return _load_export(export_name)(*args, **kwargs)
+
+
+def _embedding_sender_factory(export_name: str) -> Callable[[], Any]:
+    return lambda: _lazy_factory(export_name)
+
+
+def _embedding_receiver_factory(export_name: str) -> Callable[[], Any]:
+    return lambda: _lazy_factory(export_name)
+
+
+EMBEDDING_SENDER_FACTORIES: dict[EmbeddingTransferMode, Callable[[], Any]] = {
+    EmbeddingTransferMode.LOCAL: _embedding_sender_factory("LocalEmbeddingSender"),
+    EmbeddingTransferMode.NIXL_WRITE: _embedding_sender_factory(
+        "NixlWriteEmbeddingSender"
+    ),
+    EmbeddingTransferMode.NIXL_READ: _embedding_sender_factory("NixlReadEmbeddingSender"),
+}
+
+EMBEDDING_RECEIVER_FACTORIES: dict[EmbeddingTransferMode, Callable[[], Any]] = {
+    EmbeddingTransferMode.LOCAL: _embedding_receiver_factory("LocalEmbeddingReceiver"),
+    EmbeddingTransferMode.NIXL_WRITE: _embedding_receiver_factory(
+        "NixlWriteEmbeddingReceiver"
+    ),
     # [gluo FIXME] can't use pre-registered tensor as NIXL requires descriptors
     # to be at matching size, need to overwrite nixl connect library
-    EmbeddingTransferMode.NIXL_READ: lambda: NixlReadEmbeddingReceiver(max_items=0),
+    EmbeddingTransferMode.NIXL_READ: lambda: _lazy_factory(
+        "NixlReadEmbeddingReceiver", max_items=0
+    ),
 }
 
 __all__ = [

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -40,7 +40,8 @@ pytestmark = [
 _FETCH_BYTES_PATH = "dynamo.common.multimodal.image_loader.fetch_bytes"
 
 
-def test_package_image_loader_import_does_not_import_torch() -> None:
+@pytest.mark.timeout(60)
+async def test_package_image_loader_import_does_not_import_torch() -> None:
     script = textwrap.dedent(
         """
         import importlib.abc
@@ -64,7 +65,9 @@ def test_package_image_loader_import_does_not_import_torch() -> None:
         """
     )
 
-    subprocess.run([sys.executable, "-c", script], check=True)
+    await asyncio.to_thread(
+        subprocess.run, [sys.executable, "-c", script], check=True, timeout=30
+    )
 
 
 def _make_png_bytes() -> bytes:

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -17,6 +17,9 @@
 
 import asyncio
 import base64
+import subprocess
+import sys
+import textwrap
 from io import BytesIO
 from unittest.mock import AsyncMock, patch
 
@@ -35,6 +38,33 @@ pytestmark = [
 ]
 
 _FETCH_BYTES_PATH = "dynamo.common.multimodal.image_loader.fetch_bytes"
+
+
+def test_package_image_loader_import_does_not_import_torch() -> None:
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+
+        class BlockTorchImport(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path, target=None):
+                if fullname == "torch" or fullname.startswith("torch."):
+                    raise AssertionError(f"unexpected import: {fullname}")
+                return None
+
+        sys.meta_path.insert(0, BlockTorchImport())
+
+        from dynamo.common.http.url_validator import validate_media_url
+        from dynamo.common.multimodal import ImageLoader
+
+        assert ImageLoader.__name__ == "ImageLoader"
+        assert callable(validate_media_url)
+        assert "dynamo.common.multimodal.embedding_transfer" not in sys.modules
+        assert "dynamo.common.memory.multimodal_embedding_cache_manager" not in sys.modules
+        """
+    )
+
+    subprocess.run([sys.executable, "-c", script], check=True)
 
 
 def _make_png_bytes() -> bytes:


### PR DESCRIPTION
Fixes https://github.com/ai-dynamo/dynamo/issues/11172

## Summary
- Lazily resolves `dynamo.common.multimodal` re-exports through module-level `__getattr__` so `ImageLoader` does not eagerly import embedding cache/transfer modules.
- Preserves embedding sender/receiver factory APIs with lazy callables that import heavy classes only when instantiated.
- Adds a subprocess regression test that blocks `torch` imports while importing `ImageLoader` from the package.

## Validation
- `PYTHONPATH=components/src python - <<'PY' ... import dynamo.common.multimodal ... PY`
- `python -m compileall -q components/src/dynamo/common/multimodal/__init__.py components/src/dynamo/common/tests/multimodal/test_image_loader.py`
- `git diff --check`

## Notes
- `python -m pytest components/src/dynamo/common/tests/multimodal/test_image_loader.py` could not run in this runner because `pytest`, `pip`, and `ensurepip` are not installed.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multimodal loading so components are imported only when needed, helping avoid unnecessary startup overhead and import-time issues.
  * Updated embedding sender/receiver creation to defer loading until used, making related features more reliable in environments without optional dependencies.

* **Tests**
  * Added coverage to ensure image loading utilities can be imported without pulling in heavyweight ML dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->