### PR TITLE
fix(kv-router): preserve cold restore ordering

### DIFF
--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -631,14 +631,21 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
                 self.maybe_enqueue_cleanup(idx);
             }
             None => {
-                // Worker was never assigned a thread - broadcast to all
+                // Reserve the sticky queue before broadcasting so the structural
+                // sweep and subsequent events for this worker share one FIFO.
+                let sweep_idx = Self::get_or_assign_thread_idx(
+                    &self.worker_assignments,
+                    &self.worker_assignment_count,
+                    worker_id,
+                    self.num_workers,
+                );
                 for (idx, channel) in self.worker_event_channels.iter().enumerate() {
                     let _ = channel.send(WorkerTask::RemoveWorker {
                         worker_id,
-                        sweep_tree: idx == 0,
+                        sweep_tree: idx == sweep_idx,
                     });
                 }
-                self.maybe_enqueue_cleanup(0);
+                self.maybe_enqueue_cleanup(sweep_idx);
             }
         }
     }
@@ -648,12 +655,14 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
             prune_manager.remove_worker_dp_rank(WorkerWithDpRank::new(worker_id, dp_rank));
         }
 
-        // Broadcast local-map cleanup, but let only the sticky worker thread run
-        // shared structural cleanup so the sweep occurs once and stays FIFO.
-        let sweep_idx = self
-            .worker_assignments
-            .get(&worker_id)
-            .map_or(0, |idx| *idx);
+        // Reserve the sticky queue before broadcasting so the structural sweep
+        // and subsequent events for this worker share one FIFO.
+        let sweep_idx = Self::get_or_assign_thread_idx(
+            &self.worker_assignments,
+            &self.worker_assignment_count,
+            worker_id,
+            self.num_workers,
+        );
         for (idx, channel) in self.worker_event_channels.iter().enumerate() {
             let _ = channel.send(WorkerTask::RemoveWorkerDpRank {
                 worker_id,
@@ -661,7 +670,7 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
                 sweep_tree: idx == sweep_idx,
             });
         }
-        self.maybe_enqueue_cleanup(0);
+        self.maybe_enqueue_cleanup(sweep_idx);
     }
 
     fn shutdown(&self) {
@@ -800,5 +809,54 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
 
     fn node_edge_lengths(&self) -> Vec<usize> {
         self.backend.node_edge_lengths()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ConcurrentRadixTreeCompressed,
+        test_utils::{assert_score, make_store_event},
+    };
+
+    fn assigned_thread(
+        indexer: &ThreadPoolIndexer<ConcurrentRadixTreeCompressed>,
+        worker_id: WorkerId,
+    ) -> Option<usize> {
+        indexer
+            .worker_assignments
+            .get(&worker_id)
+            .map(|entry| *entry)
+    }
+
+    #[tokio::test]
+    async fn cold_worker_remove_reserves_sticky_queue() {
+        let indexer = ThreadPoolIndexer::new(ConcurrentRadixTreeCompressed::new(), 2, 16);
+        indexer.apply_event(make_store_event(1, &[1])).await;
+        assert_eq!(assigned_thread(&indexer, 1), Some(0));
+
+        indexer.remove_worker(2).await;
+
+        assert_eq!(assigned_thread(&indexer, 2), Some(1));
+        indexer.apply_event(make_store_event(2, &[2])).await;
+        assert_eq!(assigned_thread(&indexer, 2), Some(1));
+        indexer.flush().await;
+        assert_score(&indexer, &[2], WorkerWithDpRank::new(2, 0), 1).await;
+    }
+
+    #[tokio::test]
+    async fn cold_rank_remove_reserves_sticky_queue() {
+        let indexer = ThreadPoolIndexer::new(ConcurrentRadixTreeCompressed::new(), 2, 16);
+        indexer.apply_event(make_store_event(1, &[1])).await;
+        assert_eq!(assigned_thread(&indexer, 1), Some(0));
+
+        indexer.remove_worker_dp_rank(2, 0).await;
+
+        assert_eq!(assigned_thread(&indexer, 2), Some(1));
+        indexer.apply_event(make_store_event(2, &[2])).await;
+        assert_eq!(assigned_thread(&indexer, 2), Some(1));
+        indexer.flush().await;
+        assert_score(&indexer, &[2], WorkerWithDpRank::new(2, 0), 1).await;
     }
 }

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -47,9 +47,17 @@ pub struct ThreadPoolIndexer<T: SyncIndexer> {
     /// Shared backend - thread-safe via internal locking.
     backend: Arc<T>,
 
-    /// Maps WorkerId to worker thread index for sticky routing.
+    /// Maps WorkerId to worker thread index for indexer-lifetime sticky routing.
+    ///
+    /// This is not a live-worker registry: entries intentionally remain for the
+    /// indexer's lifetime. Producers read this assignment before enqueueing, so
+    /// removing an entry without a generation-aware handoff could let later work
+    /// overtake tasks already queued on the old thread.
     worker_assignments: Arc<DashMap<WorkerId, usize, FxBuildHasher>>,
-    /// Counter for round-robin assignment of new WorkerIds.
+    /// Monotonic round-robin reservation sequence for new WorkerIds.
+    ///
+    /// This is not an active-worker count: cold removals also reserve a slot so
+    /// the removal sweep and any subsequent restore share one FIFO.
     worker_assignment_count: Arc<AtomicUsize>,
 
     /// Channels to send tasks to worker threads (one per thread).
@@ -306,6 +314,29 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
             let idx = worker_assignment_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             idx % num_workers
         })
+    }
+
+    fn enqueue_worker_removal(&self, worker_id: WorkerId, task: WorkerTask) {
+        // All mutations for one WorkerId use this indexer-lifetime assignment,
+        // so the removal and any subsequent restore share one FIFO.
+        let thread_idx = Self::get_or_assign_thread_idx(
+            &self.worker_assignments,
+            &self.worker_assignment_count,
+            worker_id,
+            self.num_workers,
+        );
+
+        if let Err(error) = self.worker_event_channels[thread_idx].send(task) {
+            tracing::error!(
+                worker_id,
+                worker_thread_index = thread_idx,
+                ?error,
+                "Failed to send worker removal task"
+            );
+            return;
+        }
+
+        self.maybe_enqueue_cleanup(thread_idx);
     }
 
     fn next_synthetic_event_id(synthetic_event_id: &AtomicU64) -> u64 {
@@ -611,43 +642,13 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
             prune_manager.remove_worker(worker_id);
         }
 
-        // Route to the worker's assigned thread (if any), otherwise broadcast
-        // to all threads since dp_ranks may be spread across threads.
-        let thread_idx = self.worker_assignments.get(&worker_id).map(|v| *v);
-        match thread_idx {
-            Some(idx) => {
-                if let Err(e) = self.worker_event_channels[idx].send(WorkerTask::RemoveWorker {
-                    worker_id,
-                    sweep_tree: true,
-                }) {
-                    tracing::error!(
-                        "Failed to send RemoveWorker to worker thread {}: {:?}",
-                        idx,
-                        e
-                    );
-                    return;
-                }
-
-                self.maybe_enqueue_cleanup(idx);
-            }
-            None => {
-                // Reserve the sticky queue before broadcasting so the structural
-                // sweep and subsequent events for this worker share one FIFO.
-                let sweep_idx = Self::get_or_assign_thread_idx(
-                    &self.worker_assignments,
-                    &self.worker_assignment_count,
-                    worker_id,
-                    self.num_workers,
-                );
-                for (idx, channel) in self.worker_event_channels.iter().enumerate() {
-                    let _ = channel.send(WorkerTask::RemoveWorker {
-                        worker_id,
-                        sweep_tree: idx == sweep_idx,
-                    });
-                }
-                self.maybe_enqueue_cleanup(sweep_idx);
-            }
-        }
+        self.enqueue_worker_removal(
+            worker_id,
+            WorkerTask::RemoveWorker {
+                worker_id,
+                sweep_tree: true,
+            },
+        );
     }
 
     async fn remove_worker_dp_rank(&self, worker_id: WorkerId, dp_rank: DpRank) {
@@ -655,22 +656,14 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
             prune_manager.remove_worker_dp_rank(WorkerWithDpRank::new(worker_id, dp_rank));
         }
 
-        // Reserve the sticky queue before broadcasting so the structural sweep
-        // and subsequent events for this worker share one FIFO.
-        let sweep_idx = Self::get_or_assign_thread_idx(
-            &self.worker_assignments,
-            &self.worker_assignment_count,
+        self.enqueue_worker_removal(
             worker_id,
-            self.num_workers,
-        );
-        for (idx, channel) in self.worker_event_channels.iter().enumerate() {
-            let _ = channel.send(WorkerTask::RemoveWorkerDpRank {
+            WorkerTask::RemoveWorkerDpRank {
                 worker_id,
                 dp_rank,
-                sweep_tree: idx == sweep_idx,
-            });
-        }
-        self.maybe_enqueue_cleanup(sweep_idx);
+                sweep_tree: true,
+            },
+        );
     }
 
     fn shutdown(&self) {
@@ -830,33 +823,35 @@ mod tests {
             .map(|entry| *entry)
     }
 
-    #[tokio::test]
-    async fn cold_worker_remove_reserves_sticky_queue() {
+    enum ColdRemoval {
+        Worker,
+        DpRank,
+    }
+
+    async fn assert_cold_remove_reserves_sticky_queue(removal: ColdRemoval) {
         let indexer = ThreadPoolIndexer::new(ConcurrentRadixTreeCompressed::new(), 2, 16);
         indexer.apply_event(make_store_event(1, &[1])).await;
         assert_eq!(assigned_thread(&indexer, 1), Some(0));
 
-        indexer.remove_worker(2).await;
+        match removal {
+            ColdRemoval::Worker => indexer.remove_worker(2).await,
+            ColdRemoval::DpRank => indexer.remove_worker_dp_rank(2, 0).await,
+        }
 
         assert_eq!(assigned_thread(&indexer, 2), Some(1));
         indexer.apply_event(make_store_event(2, &[2])).await;
-        assert_eq!(assigned_thread(&indexer, 2), Some(1));
         indexer.flush().await;
+        assert_eq!(assigned_thread(&indexer, 2), Some(1));
         assert_score(&indexer, &[2], WorkerWithDpRank::new(2, 0), 1).await;
     }
 
     #[tokio::test]
+    async fn cold_worker_remove_reserves_sticky_queue() {
+        assert_cold_remove_reserves_sticky_queue(ColdRemoval::Worker).await;
+    }
+
+    #[tokio::test]
     async fn cold_rank_remove_reserves_sticky_queue() {
-        let indexer = ThreadPoolIndexer::new(ConcurrentRadixTreeCompressed::new(), 2, 16);
-        indexer.apply_event(make_store_event(1, &[1])).await;
-        assert_eq!(assigned_thread(&indexer, 1), Some(0));
-
-        indexer.remove_worker_dp_rank(2, 0).await;
-
-        assert_eq!(assigned_thread(&indexer, 2), Some(1));
-        indexer.apply_event(make_store_event(2, &[2])).await;
-        assert_eq!(assigned_thread(&indexer, 2), Some(1));
-        indexer.flush().await;
-        assert_score(&indexer, &[2], WorkerWithDpRank::new(2, 0), 1).await;
+        assert_cold_remove_reserves_sticky_queue(ColdRemoval::DpRank).await;
     }
 }


### PR DESCRIPTION
## Overview:

Prevent cold KV-indexer restores from losing worker or DP-rank coverage when a structural removal sweep and restored events are dispatched to different event queues.

## Summary

- Reserve a worker's stable event queue before every worker or DP-rank removal.
- Dispatch the removal sweep and cleanup to that queue instead of broadcasting removal tasks.
- Document that sticky assignments are indexer-lifetime routing identities, not a live-worker registry.
- Add deterministic regressions for both cold worker and cold DP-rank remove-then-restore paths.

## Details:

The full-restore path removes existing worker/rank coverage before replaying the recovered tree. After #11169, a cold removal with no existing sticky assignment defaulted the shared-tree sweep to event queue 0. The first restored event could independently assign that worker to another queue. If the restore ran first, the late queue-0 sweep erased the restored coverage while recovery still advanced its cursor, leaving the router permanently behind.

This change centralizes worker-removal dispatch in a helper that reserves or retrieves the worker's sticky queue, sends one removal task there, and schedules cleanup on the same queue. Every mutating worker task is already routed by `WorkerId`, so a cold worker cannot have per-thread state elsewhere and the previous broadcasts were unnecessary. The removal and every subsequent restore event now share one FIFO.

Sticky assignments intentionally remain for the indexer's lifetime. A producer reads the assignment before enqueueing its task, so deleting the entry after a sweep could let later work select another queue and overtake a task already waiting on the old queue. The round-robin counter is therefore a monotonic reservation sequence rather than an active-worker count.

The regressions each use a fresh two-thread indexer, first occupy queue 0, remove an unseen worker, verify the removal reserves queue 1, immediately restore the worker, then flush and verify both the stable assignment and query score. They fail deterministically before the fix because the cold removal creates no assignment.

## Before / after

**Before** — a removal for a worker with no sticky assignment hard-coded the shared-tree sweep to queue 0 and did not reserve an assignment:

```rust
None => {
    // Worker was never assigned a thread - broadcast to all
    for (idx, channel) in self.worker_event_channels.iter().enumerate() {
        let _ = channel.send(WorkerTask::RemoveWorker {
            worker_id,
            sweep_tree: idx == 0,   // sweep always on queue 0
        });
    }
    self.maybe_enqueue_cleanup(0);
}
```

Because the removal left no assignment behind, the removal's sweep and the worker's next event could land on different FIFOs, and the two queues race:

```text
restore path:  remove_worker(W)          apply_event(W, restored blocks)
                     │                             │
queue 0:       [sweep W from tree]  ←── slow       │
queue 1:                                 [store W's blocks]  ←── W round-robins to queue 1
                     │
               queue 0's late sweep now erases the coverage queue 1 just restored;
               recovery has already advanced its cursor → router permanently behind
```

**After** — removal reserves (or reuses) the worker's sticky queue first, then sends one removal task there, so the sweep and every subsequent event for that worker are ordered on a single FIFO:

```rust
fn enqueue_worker_removal(&self, worker_id: WorkerId, task: WorkerTask) {
    // All mutations for one WorkerId use this indexer-lifetime assignment,
    // so the removal and any subsequent restore share one FIFO.
    let thread_idx = Self::get_or_assign_thread_idx(
        &self.worker_assignments,
        &self.worker_assignment_count,
        worker_id,
        self.num_workers,
    );
    // send WorkerTask::RemoveWorker / RemoveWorkerDpRank to thread_idx only
}
```

```text
restore path:  remove_worker(W)          apply_event(W, restored blocks)
                     │                             │
queue 1:       [sweep W from tree] → [store W's blocks]   ←── same reserved queue, FIFO
                                     restored coverage can never be erased by the sweep
```

## Where should the reviewer start?

- `lib/kv-router/src/indexer/thread_pool.rs`: `enqueue_worker_removal` and its two callers.
- The two tests at the bottom of the same file capture the required queue-affinity and remove-then-restore contract.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

This is a regression follow-up to #11169.

## Validation

- `cargo fmt --check`
- `cargo clippy -p dynamo-kv-router --no-deps --all-targets -- -D warnings`
- `cargo test -p dynamo-kv-router indexer::thread_pool::tests` (2 passed)
- `cargo test -p dynamo-kv-router` (593 passed)
- `cargo test -p dynamo-llm` (passed; 1,517 unit tests plus integration and doc tests)
- 5 consecutive runs of `tests/router/test_router_e2e_with_mockers.py::test_indexers_sync[nats_core]`

No CRTC benchmark was run because this changes cold lifecycle task dispatch, not CRTC locking, tree mutation, lookup repair, or the normal event hot path.

