### PR TITLE
fix(router): report missing KV event publishers

### DIFF
--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -349,6 +349,8 @@ class router:
     REMOTE_INDEXER_QUERY_FAILURES_TOTAL = "router_remote_indexer_query_failures_total"
     # Total number of remote indexer routing-decision writes that failed
     REMOTE_INDEXER_WRITE_FAILURES_TOTAL = "router_remote_indexer_write_failures_total"
+    # Number of workers expected to publish KV events but missing query endpoints
+    KV_EVENT_SOURCE_MISMATCH_WORKERS = "router_kv_event_source_mismatch_workers"
     # Time to first token observed at the router (seconds)
     TIME_TO_FIRST_TOKEN_SECONDS = "router_time_to_first_token_seconds"
     # Average inter-token latency observed at the router (seconds)

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -312,6 +312,8 @@ where
                 &kv_router_config,
                 indexer.clone(),
                 workers_with_configs.clone(),
+                model_name.clone().unwrap_or_else(|| "unknown".to_string()),
+                worker_type,
             )
             .await?;
         } else {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -307,8 +307,13 @@ where
         if kv_router_config.use_remote_indexer {
             tracing::info!("Skipping KV event subscription (using remote indexer)");
         } else if kv_router_config.should_subscribe_to_kv_events() {
-            indexer::start_subscriber(component.clone(), &kv_router_config, indexer.clone())
-                .await?;
+            indexer::start_subscriber(
+                component.clone(),
+                &kv_router_config,
+                indexer.clone(),
+                workers_with_configs.clone(),
+            )
+            .await?;
         } else {
             tracing::info!(
                 "Skipping KV event subscription (use_kv_events={}, overlap_score_credit={})",

--- a/lib/llm/src/kv_router/indexer/recovery/mod.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/mod.rs
@@ -6,6 +6,7 @@ mod subscriber;
 mod worker_query;
 mod worker_query_directory;
 mod worker_query_endpoint;
+mod worker_query_health;
 mod worker_query_state;
 mod worker_query_transport;
 

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -29,6 +29,8 @@ async fn start_kv_router_background_event_plane(
     indexer: Indexer,
     transport_kind: EventTransportKind,
     workers_with_configs: RuntimeConfigWatch,
+    model: String,
+    worker_type: &'static str,
 ) -> Result<()> {
     let cancellation_token = component.drt().primary_token();
 
@@ -47,8 +49,14 @@ async fn start_kv_router_background_event_plane(
 
     // WorkerQueryClient handles its own discovery loop for lifecycle + initial recovery.
     // No blocking wait — recovery happens asynchronously as endpoints are discovered.
-    let worker_query_client =
-        WorkerQueryClient::spawn(component.clone(), indexer, workers_with_configs).await?;
+    let worker_query_client = WorkerQueryClient::spawn(
+        component.clone(),
+        indexer,
+        workers_with_configs,
+        model,
+        worker_type,
+    )
+    .await?;
     let kv_event_subject = format!(
         "namespace.{}.component.{}.{}",
         component.namespace().name(),
@@ -120,6 +128,8 @@ pub async fn start_subscriber(
     kv_router_config: &KvRouterConfig,
     indexer: Indexer,
     workers_with_configs: RuntimeConfigWatch,
+    model: String,
+    worker_type: &'static str,
 ) -> Result<()> {
     let transport_kind = component.drt().default_event_transport_kind();
 
@@ -165,6 +175,8 @@ pub async fn start_subscriber(
             indexer,
             transport_kind,
             workers_with_configs,
+            model,
+            worker_type,
         )
         .await
     }

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::worker_query::WorkerQueryClient;
+use crate::discovery::RuntimeConfigWatch;
 use crate::kv_router::Indexer;
 use anyhow::Result;
 use dynamo_kv_router::{
@@ -27,6 +28,7 @@ async fn start_kv_router_background_event_plane(
     component: Component,
     indexer: Indexer,
     transport_kind: EventTransportKind,
+    workers_with_configs: RuntimeConfigWatch,
 ) -> Result<()> {
     let cancellation_token = component.drt().primary_token();
 
@@ -45,7 +47,8 @@ async fn start_kv_router_background_event_plane(
 
     // WorkerQueryClient handles its own discovery loop for lifecycle + initial recovery.
     // No blocking wait — recovery happens asynchronously as endpoints are discovered.
-    let worker_query_client = WorkerQueryClient::spawn(component.clone(), indexer).await?;
+    let worker_query_client =
+        WorkerQueryClient::spawn(component.clone(), indexer, workers_with_configs).await?;
     let kv_event_subject = format!(
         "namespace.{}.component.{}.{}",
         component.namespace().name(),
@@ -116,6 +119,7 @@ pub async fn start_subscriber(
     component: Component,
     kv_router_config: &KvRouterConfig,
     indexer: Indexer,
+    workers_with_configs: RuntimeConfigWatch,
 ) -> Result<()> {
     let transport_kind = component.drt().default_event_transport_kind();
 
@@ -156,6 +160,12 @@ pub async fn start_subscriber(
             tracing::info!("Using NATS Core subscription (local_indexer mode)");
         }
 
-        start_kv_router_background_event_plane(component, indexer, transport_kind).await
+        start_kv_router_background_event_plane(
+            component,
+            indexer,
+            transport_kind,
+            workers_with_configs,
+        )
+        .await
     }
 }

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -16,8 +16,10 @@ use tokio::sync::{Mutex, Semaphore};
 use super::worker_query_directory::{DiscoveredQueryEndpoint, WorkerQueryEndpointDirectory};
 #[cfg(test)]
 use super::worker_query_endpoint::WorkerKvQueryEngine;
+use super::worker_query_health::spawn_kv_event_source_health_monitor;
 use super::worker_query_state::{LiveEventAction, PendingDrainAction, RecoveryKey, WorkerState};
 use super::worker_query_transport::{RuntimeWorkerQueryTransport, WorkerQueryTransport};
+use crate::discovery::RuntimeConfigWatch;
 use crate::kv_router::Indexer;
 use dynamo_kv_router::{
     indexer::WorkerKvQueryResponse,
@@ -62,7 +64,7 @@ pub struct WorkerQueryClient {
     /// Indexer for applying recovered events and worker removals.
     indexer: Indexer,
     worker_states: DashMap<WorkerId, Arc<Mutex<WorkerState>>>,
-    query_endpoints: WorkerQueryEndpointDirectory,
+    query_endpoints: Arc<WorkerQueryEndpointDirectory>,
     recovery_semaphore: Arc<Semaphore>,
     /// Per-rank cancellation for in-flight recovery tasks; cancelled on rank
     /// removal so retry backoff stops polling workers that no longer exist.
@@ -80,7 +82,7 @@ impl WorkerQueryClient {
             transport,
             indexer,
             worker_states: DashMap::new(),
-            query_endpoints: WorkerQueryEndpointDirectory::default(),
+            query_endpoints: Arc::new(WorkerQueryEndpointDirectory::default()),
             recovery_semaphore: Arc::new(Semaphore::new(RECOVERY_CONCURRENCY_LIMIT)),
             recovery_cancels: DashMap::new(),
         })
@@ -91,9 +93,19 @@ impl WorkerQueryClient {
     /// The background loop watches `ComponentEndpoints` discovery for query endpoints,
     /// recovers each `(worker_id, dp_rank)` as it appears, and sends worker removal
     /// events when all dp_ranks for a worker disappear.
-    pub async fn spawn(component: Component, indexer: Indexer) -> Result<Arc<Self>> {
+    pub async fn spawn(
+        component: Component,
+        indexer: Indexer,
+        workers_with_configs: RuntimeConfigWatch,
+    ) -> Result<Arc<Self>> {
         let transport = Arc::new(RuntimeWorkerQueryTransport::new(&component).await?);
         let client = Self::new(component.clone(), indexer, transport);
+
+        spawn_kv_event_source_health_monitor(
+            component.clone(),
+            workers_with_configs,
+            client.query_endpoints.clone(),
+        );
 
         let client_bg = client.clone();
         let cancel_token = component.drt().primary_token();

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -88,31 +88,51 @@ impl WorkerQueryClient {
         })
     }
 
-    /// Create a new WorkerQueryClient and spawn its background discovery loop.
+    /// Create a new WorkerQueryClient and spawn its background discovery and KV event
+    /// source health-monitor loops.
     ///
     /// The background loop watches `ComponentEndpoints` discovery for query endpoints,
     /// recovers each `(worker_id, dp_rank)` as it appears, and sends worker removal
     /// events when all dp_ranks for a worker disappear.
+    /// The health monitor compares those endpoints with runtime worker configuration
+    /// and reports workers whose expected KV event sources are missing.
     pub async fn spawn(
         component: Component,
         indexer: Indexer,
         workers_with_configs: RuntimeConfigWatch,
+        model: String,
+        worker_type: &'static str,
     ) -> Result<Arc<Self>> {
         let transport = Arc::new(RuntimeWorkerQueryTransport::new(&component).await?);
         let client = Self::new(component.clone(), indexer, transport);
 
+        let discovery_cancel = component.drt().primary_token();
+        // TODO: Parent recovery tasks with a router-scoped token once the subscriber
+        // lifecycle owns one instead of relying on the runtime-wide token.
+        let health_cancel = discovery_cancel.child_token();
         spawn_kv_event_source_health_monitor(
             component.clone(),
             workers_with_configs,
             client.query_endpoints.clone(),
+            model,
+            worker_type,
+            health_cancel.clone(),
         );
 
         let client_bg = client.clone();
-        let cancel_token = component.drt().primary_token();
         tokio::spawn(async move {
-            if let Err(e) = client_bg.run_discovery_loop(cancel_token).await {
-                tracing::error!("WorkerQueryClient discovery loop failed: {e}");
+            match client_bg.run_discovery_loop(discovery_cancel.clone()).await {
+                Err(error) => {
+                    tracing::error!(%error, "WorkerQueryClient discovery loop failed");
+                }
+                Ok(()) if !discovery_cancel.is_cancelled() => {
+                    tracing::error!(
+                        "WorkerQueryClient discovery stream ended unexpectedly; stopping the KV event source health monitor because endpoint state may be stale"
+                    );
+                }
+                Ok(()) => {}
             }
+            health_cancel.cancel();
         });
 
         Ok(client)

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_directory.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_directory.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use dashmap::DashMap;
 use dynamo_kv_router::protocols::{DpRank, WorkerId};
 use dynamo_runtime::component::Instance;
@@ -69,6 +71,10 @@ impl WorkerQueryEndpointDirectory {
         self.targets
             .get(&(worker_id, dp_rank))
             .map(|target| target.value().clone())
+    }
+
+    pub(super) fn keys(&self) -> HashSet<RecoveryKey> {
+        self.targets.iter().map(|entry| *entry.key()).collect()
     }
 
     #[cfg(test)]

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_health.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_health.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use dynamo_kv_router::protocols::{DpRank, WorkerId};
 use dynamo_runtime::component::Component;
-use dynamo_runtime::traits::DistributedRuntimeProvider;
 use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 
 use super::worker_query_directory::WorkerQueryEndpointDirectory;
 use super::worker_query_state::RecoveryKey;
@@ -17,6 +17,7 @@ use crate::kv_router::metrics::RouterWorkerStatusMetrics;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 
 const REGISTRATION_GRACE_PERIOD: Duration = Duration::from_secs(10);
+const EXPECTED_WORKER_ABSENCE_HOLD_DOWN: Duration = Duration::from_secs(10);
 const ERROR_REPEAT_INTERVAL: Duration = Duration::from_secs(60);
 const HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -29,8 +30,14 @@ struct MismatchReport {
 #[derive(Debug, Default, PartialEq, Eq)]
 struct HealthEvaluation {
     reports: Vec<MismatchReport>,
-    recovered_workers: Vec<WorkerId>,
+    cleared_workers: Vec<WorkerId>,
     mismatch_worker_count: usize,
+}
+
+#[derive(Debug)]
+struct MissingEndpoint {
+    missing_since: Instant,
+    unexpected_since: Option<Instant>,
 }
 
 #[derive(Debug)]
@@ -41,7 +48,7 @@ struct ReportedMismatch {
 
 #[derive(Debug, Default)]
 struct KvEventSourceHealthMonitor {
-    missing_since: HashMap<RecoveryKey, Instant>,
+    missing_endpoints: HashMap<RecoveryKey, MissingEndpoint>,
     reported: HashMap<WorkerId, ReportedMismatch>,
 }
 
@@ -53,20 +60,39 @@ impl KvEventSourceHealthMonitor {
         discovered_endpoints: &HashSet<RecoveryKey>,
     ) -> HealthEvaluation {
         let expected_endpoints = expected_query_endpoints(workers_with_configs);
-        let missing_endpoints: HashSet<_> = expected_endpoints
-            .difference(discovered_endpoints)
-            .copied()
-            .collect();
-
-        self.missing_since
-            .retain(|key, _| missing_endpoints.contains(key));
-        for key in &missing_endpoints {
-            self.missing_since.entry(*key).or_insert(now);
+        for key in expected_endpoints.difference(discovered_endpoints) {
+            self.missing_endpoints
+                .entry(*key)
+                .and_modify(|missing| missing.unexpected_since = None)
+                .or_insert(MissingEndpoint {
+                    missing_since: now,
+                    unexpected_since: None,
+                });
         }
 
+        self.missing_endpoints.retain(|key, missing| {
+            if discovered_endpoints.contains(key) {
+                return false;
+            }
+            if expected_endpoints.contains(key) {
+                missing.unexpected_since = None;
+                return true;
+            }
+
+            let unexpected_since = missing.unexpected_since.get_or_insert(now);
+            now.duration_since(*unexpected_since) < EXPECTED_WORKER_ABSENCE_HOLD_DOWN
+        });
+
         let mut matured_by_worker: BTreeMap<WorkerId, Vec<DpRank>> = BTreeMap::new();
-        for (key, missing_since) in &self.missing_since {
-            if now.duration_since(*missing_since) >= REGISTRATION_GRACE_PERIOD {
+        for (key, missing) in &self.missing_endpoints {
+            let worker_is_expected = expected_endpoints.contains(key);
+            let rank_was_reported = self
+                .reported
+                .get(&key.0)
+                .is_some_and(|reported| reported.missing_dp_ranks.contains(&key.1));
+            if now.duration_since(missing.missing_since) >= REGISTRATION_GRACE_PERIOD
+                && (worker_is_expected || rank_was_reported)
+            {
                 matured_by_worker.entry(key.0).or_default().push(key.1);
             }
         }
@@ -74,13 +100,13 @@ impl KvEventSourceHealthMonitor {
             ranks.sort_unstable();
         }
 
-        let recovered_workers: Vec<_> = self
+        let cleared_workers: Vec<_> = self
             .reported
             .keys()
             .filter(|worker_id| !matured_by_worker.contains_key(worker_id))
             .copied()
             .collect();
-        for worker_id in &recovered_workers {
+        for worker_id in &cleared_workers {
             self.reported.remove(worker_id);
         }
 
@@ -109,12 +135,14 @@ impl KvEventSourceHealthMonitor {
 
         HealthEvaluation {
             reports,
-            recovered_workers,
+            cleared_workers,
             mismatch_worker_count: matured_by_worker.len(),
         }
     }
 }
 
+// TODO: Centralize DP-rank expansion with the scheduler/topology code once a shared
+// cross-crate helper exists.
 fn expected_query_endpoints(
     workers_with_configs: &HashMap<WorkerId, ModelRuntimeConfig>,
 ) -> HashSet<RecoveryKey> {
@@ -136,9 +164,13 @@ pub(super) fn spawn_kv_event_source_health_monitor(
     component: Component,
     mut workers_with_configs: RuntimeConfigWatch,
     query_endpoints: Arc<WorkerQueryEndpointDirectory>,
+    model: String,
+    worker_type: &'static str,
+    cancellation_token: CancellationToken,
 ) {
-    let cancellation_token = component.drt().primary_token();
     let metrics = RouterWorkerStatusMetrics::from_component(&component);
+    let target_namespace = component.namespace().name().to_string();
+    let target_component = component.name().to_string();
 
     tokio::spawn(async move {
         let mut monitor = KvEventSourceHealthMonitor::default();
@@ -147,6 +179,7 @@ pub(super) fn spawn_kv_event_source_health_monitor(
 
         loop {
             tokio::select! {
+                biased;
                 _ = cancellation_token.cancelled() => break,
                 _ = interval.tick() => {}
                 result = workers_with_configs.changed() => {
@@ -162,27 +195,37 @@ pub(super) fn spawn_kv_event_source_health_monitor(
                 monitor.evaluate(Instant::now(), &configs, &discovered_endpoints)
             };
 
-            metrics.set_kv_event_source_mismatch_workers(evaluation.mismatch_worker_count);
+            metrics.set_kv_event_source_mismatch_workers(
+                &model,
+                worker_type,
+                &target_namespace,
+                &target_component,
+                evaluation.mismatch_worker_count,
+            );
 
             for report in evaluation.reports {
                 tracing::error!(
                     worker_id = report.worker_id,
                     missing_dp_ranks = ?report.missing_dp_ranks,
-                    "KV EVENT ROUTING MISCONFIGURATION: worker {} is missing worker-local KV indexer query endpoints for DP ranks {:?}. The router expects worker KV events, so cache overlap will remain empty for these ranks and cache-aware routing will be ineffective. For Dynamo vLLM this usually means --kv-events-config was omitted. Add --kv-events-config '{{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:PORT\",\"enable_kv_cache_events\":true}}' to the worker, or intentionally use --no-router-kv-events for approximate routing. Continuing to serve.",
-                    report.worker_id,
-                    report.missing_dp_ranks,
+                    model,
+                    worker_type,
+                    target_namespace,
+                    target_component,
+                    "KV event routing degraded: expected worker-local KV indexer query endpoints were not discovered. Cache overlap will remain empty for the affected ranks and cache-aware routing will be ineffective. For Dynamo vLLM, verify that the worker has --kv-events-config '{{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:PORT\",\"enable_kv_cache_events\":true}}'; if it is configured, check router endpoint discovery health. To intentionally use approximate routing, set --no-router-kv-events. Continuing to serve.",
                 );
             }
 
-            for worker_id in evaluation.recovered_workers {
+            for worker_id in evaluation.cleared_workers {
                 tracing::info!(
                     worker_id,
-                    "KV event source mismatch cleared: all expected worker-local KV indexer query endpoints are now registered"
+                    model,
+                    worker_type,
+                    target_namespace,
+                    target_component,
+                    "KV event source mismatch no longer active; endpoints are registered or the worker is no longer expected"
                 );
             }
         }
-
-        metrics.set_kv_event_source_mismatch_workers(0);
     });
 }
 
@@ -279,11 +322,66 @@ mod tests {
             &discovered,
         );
         assert_eq!(recovered.mismatch_worker_count, 0);
-        assert_eq!(recovered.recovered_workers, vec![7]);
+        assert_eq!(recovered.cleared_workers, vec![7]);
     }
 
     #[test]
-    fn worker_removal_clears_active_mismatch() {
+    fn transient_worker_absence_during_grace_preserves_missing_timer() {
+        let mut monitor = KvEventSourceHealthMonitor::default();
+        let mut configs = HashMap::from([(7, worker_config(0, 1))]);
+        let discovered = HashSet::new();
+        let now = Instant::now();
+
+        monitor.evaluate(now, &configs, &discovered);
+        configs.clear();
+        assert_eq!(
+            monitor.evaluate(now + Duration::from_secs(5), &configs, &discovered),
+            HealthEvaluation::default()
+        );
+        assert_eq!(
+            monitor.evaluate(now + REGISTRATION_GRACE_PERIOD, &configs, &discovered),
+            HealthEvaluation::default()
+        );
+
+        configs.insert(7, worker_config(0, 1));
+        let matured = monitor.evaluate(
+            now + REGISTRATION_GRACE_PERIOD + Duration::from_secs(1),
+            &configs,
+            &discovered,
+        );
+        assert_eq!(matured.mismatch_worker_count, 1);
+        assert_eq!(matured.reports.len(), 1);
+    }
+
+    #[test]
+    fn transient_worker_absence_keeps_reported_mismatch_active() {
+        let mut monitor = KvEventSourceHealthMonitor::default();
+        let mut configs = HashMap::from([(7, worker_config(0, 1))]);
+        let discovered = HashSet::new();
+        let now = Instant::now();
+
+        monitor.evaluate(now, &configs, &discovered);
+        monitor.evaluate(now + REGISTRATION_GRACE_PERIOD, &configs, &discovered);
+
+        let absence_started = now + REGISTRATION_GRACE_PERIOD + Duration::from_secs(1);
+        configs.clear();
+        let absent = monitor.evaluate(absence_started, &configs, &discovered);
+        assert_eq!(absent.mismatch_worker_count, 1);
+        assert!(absent.cleared_workers.is_empty());
+
+        configs.insert(7, worker_config(0, 1));
+        let restored = monitor.evaluate(
+            absence_started + EXPECTED_WORKER_ABSENCE_HOLD_DOWN - Duration::from_secs(1),
+            &configs,
+            &discovered,
+        );
+        assert_eq!(restored.mismatch_worker_count, 1);
+        assert!(restored.reports.is_empty());
+        assert!(restored.cleared_workers.is_empty());
+    }
+
+    #[test]
+    fn sustained_worker_removal_clears_active_mismatch_after_hold_down() {
         let mut monitor = KvEventSourceHealthMonitor::default();
         let mut configs = HashMap::from([(7, worker_config(0, 1))]);
         let discovered = HashSet::new();
@@ -294,13 +392,18 @@ mod tests {
         assert_eq!(matured.mismatch_worker_count, 1);
 
         configs.clear();
-        let recovered = monitor.evaluate(
-            now + REGISTRATION_GRACE_PERIOD + Duration::from_secs(1),
+        let absence_started = now + REGISTRATION_GRACE_PERIOD + Duration::from_secs(1);
+        let held = monitor.evaluate(absence_started, &configs, &discovered);
+        assert_eq!(held.mismatch_worker_count, 1);
+        assert!(held.cleared_workers.is_empty());
+
+        let cleared = monitor.evaluate(
+            absence_started + EXPECTED_WORKER_ABSENCE_HOLD_DOWN,
             &configs,
             &discovered,
         );
-        assert_eq!(recovered.mismatch_worker_count, 0);
-        assert_eq!(recovered.recovered_workers, vec![7]);
+        assert_eq!(cleared.mismatch_worker_count, 0);
+        assert_eq!(cleared.cleared_workers, vec![7]);
     }
 
     #[test]

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_health.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_health.rs
@@ -211,7 +211,7 @@ pub(super) fn spawn_kv_event_source_health_monitor(
                     worker_type,
                     target_namespace,
                     target_component,
-                    "KV event routing degraded: expected worker-local KV indexer query endpoints were not discovered. Cache overlap will remain empty for the affected ranks and cache-aware routing will be ineffective. For Dynamo vLLM, verify that the worker has --kv-events-config '{{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:PORT\",\"enable_kv_cache_events\":true}}'; if it is configured, check router endpoint discovery health. To intentionally use approximate routing, set --no-router-kv-events. Continuing to serve.",
+                    "KV event routing degraded: expected worker-local KV indexer query endpoints were not discovered. Cache overlap will remain empty for the affected ranks and cache-aware routing will be ineffective. For Dynamo vLLM, verify that prefix caching is enabled (--no-enable-prefix-caching is not set) and that the worker has --kv-events-config '{{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:PORT\",\"enable_kv_cache_events\":true}}'; if both are configured, check router endpoint discovery health. To intentionally use approximate routing, set --no-router-kv-events. Continuing to serve.",
                 );
             }
 

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_health.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_health.rs
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use dynamo_kv_router::protocols::{DpRank, WorkerId};
+use dynamo_runtime::component::Component;
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use tokio::time::Instant;
+
+use super::worker_query_directory::WorkerQueryEndpointDirectory;
+use super::worker_query_state::RecoveryKey;
+use crate::discovery::RuntimeConfigWatch;
+use crate::kv_router::metrics::RouterWorkerStatusMetrics;
+use crate::local_model::runtime_config::ModelRuntimeConfig;
+
+const REGISTRATION_GRACE_PERIOD: Duration = Duration::from_secs(10);
+const ERROR_REPEAT_INTERVAL: Duration = Duration::from_secs(60);
+const HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MismatchReport {
+    worker_id: WorkerId,
+    missing_dp_ranks: Vec<DpRank>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct HealthEvaluation {
+    reports: Vec<MismatchReport>,
+    recovered_workers: Vec<WorkerId>,
+    mismatch_worker_count: usize,
+}
+
+#[derive(Debug)]
+struct ReportedMismatch {
+    missing_dp_ranks: Vec<DpRank>,
+    reported_at: Instant,
+}
+
+#[derive(Debug, Default)]
+struct KvEventSourceHealthMonitor {
+    missing_since: HashMap<RecoveryKey, Instant>,
+    reported: HashMap<WorkerId, ReportedMismatch>,
+}
+
+impl KvEventSourceHealthMonitor {
+    fn evaluate(
+        &mut self,
+        now: Instant,
+        workers_with_configs: &HashMap<WorkerId, ModelRuntimeConfig>,
+        discovered_endpoints: &HashSet<RecoveryKey>,
+    ) -> HealthEvaluation {
+        let expected_endpoints = expected_query_endpoints(workers_with_configs);
+        let missing_endpoints: HashSet<_> = expected_endpoints
+            .difference(discovered_endpoints)
+            .copied()
+            .collect();
+
+        self.missing_since
+            .retain(|key, _| missing_endpoints.contains(key));
+        for key in &missing_endpoints {
+            self.missing_since.entry(*key).or_insert(now);
+        }
+
+        let mut matured_by_worker: BTreeMap<WorkerId, Vec<DpRank>> = BTreeMap::new();
+        for (key, missing_since) in &self.missing_since {
+            if now.duration_since(*missing_since) >= REGISTRATION_GRACE_PERIOD {
+                matured_by_worker.entry(key.0).or_default().push(key.1);
+            }
+        }
+        for ranks in matured_by_worker.values_mut() {
+            ranks.sort_unstable();
+        }
+
+        let recovered_workers: Vec<_> = self
+            .reported
+            .keys()
+            .filter(|worker_id| !matured_by_worker.contains_key(worker_id))
+            .copied()
+            .collect();
+        for worker_id in &recovered_workers {
+            self.reported.remove(worker_id);
+        }
+
+        let mut reports = Vec::new();
+        for (worker_id, missing_dp_ranks) in &matured_by_worker {
+            let should_report = self.reported.get(worker_id).is_none_or(|previous| {
+                previous.missing_dp_ranks != *missing_dp_ranks
+                    || now.duration_since(previous.reported_at) >= ERROR_REPEAT_INTERVAL
+            });
+            if !should_report {
+                continue;
+            }
+
+            self.reported.insert(
+                *worker_id,
+                ReportedMismatch {
+                    missing_dp_ranks: missing_dp_ranks.clone(),
+                    reported_at: now,
+                },
+            );
+            reports.push(MismatchReport {
+                worker_id: *worker_id,
+                missing_dp_ranks: missing_dp_ranks.clone(),
+            });
+        }
+
+        HealthEvaluation {
+            reports,
+            recovered_workers,
+            mismatch_worker_count: matured_by_worker.len(),
+        }
+    }
+}
+
+fn expected_query_endpoints(
+    workers_with_configs: &HashMap<WorkerId, ModelRuntimeConfig>,
+) -> HashSet<RecoveryKey> {
+    workers_with_configs
+        .iter()
+        .filter(|(_, config)| config.enable_local_indexer)
+        .flat_map(|(worker_id, config)| {
+            (0..config.data_parallel_size).filter_map(move |offset| {
+                config
+                    .data_parallel_start_rank
+                    .checked_add(offset)
+                    .map(|dp_rank| (*worker_id, dp_rank))
+            })
+        })
+        .collect()
+}
+
+pub(super) fn spawn_kv_event_source_health_monitor(
+    component: Component,
+    mut workers_with_configs: RuntimeConfigWatch,
+    query_endpoints: Arc<WorkerQueryEndpointDirectory>,
+) {
+    let cancellation_token = component.drt().primary_token();
+    let metrics = RouterWorkerStatusMetrics::from_component(&component);
+
+    tokio::spawn(async move {
+        let mut monitor = KvEventSourceHealthMonitor::default();
+        let mut interval = tokio::time::interval(HEALTH_CHECK_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                _ = cancellation_token.cancelled() => break,
+                _ = interval.tick() => {}
+                result = workers_with_configs.changed() => {
+                    if result.is_err() {
+                        break;
+                    }
+                }
+            }
+
+            let evaluation = {
+                let configs = workers_with_configs.borrow_and_update();
+                let discovered_endpoints = query_endpoints.keys();
+                monitor.evaluate(Instant::now(), &configs, &discovered_endpoints)
+            };
+
+            metrics.set_kv_event_source_mismatch_workers(evaluation.mismatch_worker_count);
+
+            for report in evaluation.reports {
+                tracing::error!(
+                    worker_id = report.worker_id,
+                    missing_dp_ranks = ?report.missing_dp_ranks,
+                    "KV EVENT ROUTING MISCONFIGURATION: worker {} is missing worker-local KV indexer query endpoints for DP ranks {:?}. The router expects worker KV events, so cache overlap will remain empty for these ranks and cache-aware routing will be ineffective. For Dynamo vLLM this usually means --kv-events-config was omitted. Add --kv-events-config '{{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:PORT\",\"enable_kv_cache_events\":true}}' to the worker, or intentionally use --no-router-kv-events for approximate routing. Continuing to serve.",
+                    report.worker_id,
+                    report.missing_dp_ranks,
+                );
+            }
+
+            for worker_id in evaluation.recovered_workers {
+                tracing::info!(
+                    worker_id,
+                    "KV event source mismatch cleared: all expected worker-local KV indexer query endpoints are now registered"
+                );
+            }
+        }
+
+        metrics.set_kv_event_source_mismatch_workers(0);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worker_config(data_parallel_start_rank: u32, data_parallel_size: u32) -> ModelRuntimeConfig {
+        ModelRuntimeConfig {
+            data_parallel_start_rank,
+            data_parallel_size,
+            enable_local_indexer: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn missing_endpoint_matures_after_grace_and_repeats_once_per_minute() {
+        let mut monitor = KvEventSourceHealthMonitor::default();
+        let configs = HashMap::from([(7, worker_config(0, 1))]);
+        let discovered = HashSet::new();
+        let now = Instant::now();
+
+        assert_eq!(
+            monitor.evaluate(now, &configs, &discovered),
+            HealthEvaluation::default()
+        );
+
+        let matured = monitor.evaluate(now + REGISTRATION_GRACE_PERIOD, &configs, &discovered);
+        assert_eq!(matured.mismatch_worker_count, 1);
+        assert_eq!(
+            matured.reports,
+            vec![MismatchReport {
+                worker_id: 7,
+                missing_dp_ranks: vec![0],
+            }]
+        );
+
+        let quiet = monitor.evaluate(
+            now + REGISTRATION_GRACE_PERIOD + Duration::from_secs(1),
+            &configs,
+            &discovered,
+        );
+        assert_eq!(quiet.mismatch_worker_count, 1);
+        assert!(quiet.reports.is_empty());
+
+        let repeated = monitor.evaluate(
+            now + REGISTRATION_GRACE_PERIOD + ERROR_REPEAT_INTERVAL,
+            &configs,
+            &discovered,
+        );
+        assert_eq!(repeated.reports.len(), 1);
+    }
+
+    #[test]
+    fn endpoint_registered_during_grace_never_reports() {
+        let mut monitor = KvEventSourceHealthMonitor::default();
+        let configs = HashMap::from([(7, worker_config(0, 1))]);
+        let mut discovered = HashSet::new();
+        let now = Instant::now();
+
+        monitor.evaluate(now, &configs, &discovered);
+        discovered.insert((7, 0));
+
+        let evaluation = monitor.evaluate(
+            now + REGISTRATION_GRACE_PERIOD + Duration::from_secs(1),
+            &configs,
+            &discovered,
+        );
+        assert_eq!(evaluation, HealthEvaluation::default());
+    }
+
+    #[test]
+    fn partial_dp_registration_reports_missing_rank_then_recovers() {
+        let mut monitor = KvEventSourceHealthMonitor::default();
+        let configs = HashMap::from([(7, worker_config(3, 2))]);
+        let mut discovered = HashSet::from([(7, 3)]);
+        let now = Instant::now();
+
+        monitor.evaluate(now, &configs, &discovered);
+        let partial = monitor.evaluate(now + REGISTRATION_GRACE_PERIOD, &configs, &discovered);
+        assert_eq!(
+            partial.reports,
+            vec![MismatchReport {
+                worker_id: 7,
+                missing_dp_ranks: vec![4],
+            }]
+        );
+
+        discovered.insert((7, 4));
+        let recovered = monitor.evaluate(
+            now + REGISTRATION_GRACE_PERIOD + Duration::from_secs(1),
+            &configs,
+            &discovered,
+        );
+        assert_eq!(recovered.mismatch_worker_count, 0);
+        assert_eq!(recovered.recovered_workers, vec![7]);
+    }
+
+    #[test]
+    fn worker_removal_clears_active_mismatch() {
+        let mut monitor = KvEventSourceHealthMonitor::default();
+        let mut configs = HashMap::from([(7, worker_config(0, 1))]);
+        let discovered = HashSet::new();
+        let now = Instant::now();
+
+        monitor.evaluate(now, &configs, &discovered);
+        let matured = monitor.evaluate(now + REGISTRATION_GRACE_PERIOD, &configs, &discovered);
+        assert_eq!(matured.mismatch_worker_count, 1);
+
+        configs.clear();
+        let recovered = monitor.evaluate(
+            now + REGISTRATION_GRACE_PERIOD + Duration::from_secs(1),
+            &configs,
+            &discovered,
+        );
+        assert_eq!(recovered.mismatch_worker_count, 0);
+        assert_eq!(recovered.recovered_workers, vec![7]);
+    }
+
+    #[test]
+    fn workers_without_local_indexers_are_not_expected_to_register() {
+        let mut monitor = KvEventSourceHealthMonitor::default();
+        let mut config = worker_config(0, 1);
+        config.enable_local_indexer = false;
+        let configs = HashMap::from([(7, config)]);
+        let discovered = HashSet::new();
+        let now = Instant::now();
+
+        monitor.evaluate(now, &configs, &discovered);
+        let evaluation = monitor.evaluate(
+            now + REGISTRATION_GRACE_PERIOD + Duration::from_secs(1),
+            &configs,
+            &discovered,
+        );
+        assert_eq!(evaluation, HealthEvaluation::default());
+    }
+}

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -62,6 +62,8 @@ use prometheus::{HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec
 use crate::http::service::metrics::generate_log_buckets;
 
 pub(crate) const ROUTER_WORKER_ID_LABEL: &str = "router_worker_id";
+const TARGET_NAMESPACE_LABEL: &str = "target_namespace";
+const TARGET_COMPONENT_LABEL: &str = "target_component";
 
 /// Buckets for CPU-bound compute phases (block hashing, sequence hashing).
 fn compute_overhead_buckets() -> Vec<f64> {
@@ -196,7 +198,7 @@ pub(crate) fn kv_publisher_metrics() -> Option<Arc<KvPublisherMetrics>> {
 /// Component-scoped router gauges for worker discovery.
 pub(crate) struct RouterWorkerStatusMetrics {
     pub registered: IntGaugeVec,
-    pub kv_event_source_mismatch_workers: IntGauge,
+    pub kv_event_source_mismatch_workers: IntGaugeVec,
 }
 
 static ROUTER_WORKER_STATUS_METRICS: OnceLock<Arc<RouterWorkerStatusMetrics>> = OnceLock::new();
@@ -220,9 +222,15 @@ impl RouterWorkerStatusMetrics {
                     )
                     .expect("failed to create router_worker_registered gauge");
                 let kv_event_source_mismatch_workers = metrics
-                    .create_intgauge(
+                    .create_intgaugevec(
                         router::KV_EVENT_SOURCE_MISMATCH_WORKERS,
                         "Number of workers expected to publish KV events but missing worker-local KV indexer query endpoints",
+                        &[
+                            labels::MODEL,
+                            labels::WORKER_TYPE,
+                            TARGET_NAMESPACE_LABEL,
+                            TARGET_COMPONENT_LABEL,
+                        ],
                         &[],
                     )
                     .expect("failed to create router_kv_event_source_mismatch_workers gauge");
@@ -249,8 +257,17 @@ impl RouterWorkerStatusMetrics {
         let _ = self.registered.remove_label_values(labels);
     }
 
-    pub fn set_kv_event_source_mismatch_workers(&self, count: usize) {
-        self.kv_event_source_mismatch_workers.set(count as i64);
+    pub fn set_kv_event_source_mismatch_workers(
+        &self,
+        model: &str,
+        worker_type: &str,
+        target_namespace: &str,
+        target_component: &str,
+        count: usize,
+    ) {
+        self.kv_event_source_mismatch_workers
+            .with_label_values(&[model, worker_type, target_namespace, target_component])
+            .set(count as i64);
     }
 }
 
@@ -861,13 +878,21 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
                 &[ROUTER_WORKER_ID_LABEL, labels::DP_RANK, labels::WORKER_TYPE],
             )
             .unwrap(),
-            kv_event_source_mismatch_workers: IntGauge::new(
-                format!(
-                    "{}_{}",
-                    name_prefix::COMPONENT,
-                    router::KV_EVENT_SOURCE_MISMATCH_WORKERS
+            kv_event_source_mismatch_workers: IntGaugeVec::new(
+                Opts::new(
+                    format!(
+                        "{}_{}",
+                        name_prefix::COMPONENT,
+                        router::KV_EVENT_SOURCE_MISMATCH_WORKERS
+                    ),
+                    "Number of workers expected to publish KV events but missing worker-local KV indexer query endpoints",
                 ),
-                "Number of workers expected to publish KV events but missing worker-local KV indexer query endpoints",
+                &[
+                    labels::MODEL,
+                    labels::WORKER_TYPE,
+                    TARGET_NAMESPACE_LABEL,
+                    TARGET_COMPONENT_LABEL,
+                ],
             )
             .unwrap(),
         };
@@ -879,7 +904,8 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
             .unwrap();
 
         metrics.set_registered(123, 0, "decode");
-        metrics.set_kv_event_source_mismatch_workers(2);
+        metrics.set_kv_event_source_mismatch_workers("model-a", "decode", "ns-a", "decode", 2);
+        metrics.set_kv_event_source_mismatch_workers("model-a", "prefill", "ns-a", "prefill", 0);
 
         let output = gather_pef(&registry);
         assert!(
@@ -889,7 +915,15 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
             "\nActual PEF:\n{output}"
         );
         assert!(
-            output.contains("dynamo_component_router_kv_event_source_mismatch_workers 2"),
+            output.contains(
+                "dynamo_component_router_kv_event_source_mismatch_workers{model=\"model-a\",target_component=\"decode\",target_namespace=\"ns-a\",worker_type=\"decode\"} 2"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_kv_event_source_mismatch_workers{model=\"model-a\",target_component=\"prefill\",target_namespace=\"ns-a\",worker_type=\"prefill\"} 0"
+            ),
             "\nActual PEF:\n{output}"
         );
 

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -196,6 +196,7 @@ pub(crate) fn kv_publisher_metrics() -> Option<Arc<KvPublisherMetrics>> {
 /// Component-scoped router gauges for worker discovery.
 pub(crate) struct RouterWorkerStatusMetrics {
     pub registered: IntGaugeVec,
+    pub kv_event_source_mismatch_workers: IntGauge,
 }
 
 static ROUTER_WORKER_STATUS_METRICS: OnceLock<Arc<RouterWorkerStatusMetrics>> = OnceLock::new();
@@ -218,8 +219,18 @@ impl RouterWorkerStatusMetrics {
                         &[],
                     )
                     .expect("failed to create router_worker_registered gauge");
+                let kv_event_source_mismatch_workers = metrics
+                    .create_intgauge(
+                        router::KV_EVENT_SOURCE_MISMATCH_WORKERS,
+                        "Number of workers expected to publish KV events but missing worker-local KV indexer query endpoints",
+                        &[],
+                    )
+                    .expect("failed to create router_kv_event_source_mismatch_workers gauge");
 
-                Arc::new(Self { registered })
+                Arc::new(Self {
+                    registered,
+                    kv_event_source_mismatch_workers,
+                })
             })
             .clone()
     }
@@ -236,6 +247,10 @@ impl RouterWorkerStatusMetrics {
         let dp_rank = dp_rank.to_string();
         let labels = &[worker_id.as_str(), dp_rank.as_str(), worker_type];
         let _ = self.registered.remove_label_values(labels);
+    }
+
+    pub fn set_kv_event_source_mismatch_workers(&self, count: usize) {
+        self.kv_event_source_mismatch_workers.set(count as i64);
     }
 }
 
@@ -846,18 +861,35 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
                 &[ROUTER_WORKER_ID_LABEL, labels::DP_RANK, labels::WORKER_TYPE],
             )
             .unwrap(),
+            kv_event_source_mismatch_workers: IntGauge::new(
+                format!(
+                    "{}_{}",
+                    name_prefix::COMPONENT,
+                    router::KV_EVENT_SOURCE_MISMATCH_WORKERS
+                ),
+                "Number of workers expected to publish KV events but missing worker-local KV indexer query endpoints",
+            )
+            .unwrap(),
         };
         registry
             .register(Box::new(metrics.registered.clone()))
             .unwrap();
+        registry
+            .register(Box::new(metrics.kv_event_source_mismatch_workers.clone()))
+            .unwrap();
 
         metrics.set_registered(123, 0, "decode");
+        metrics.set_kv_event_source_mismatch_workers(2);
 
         let output = gather_pef(&registry);
         assert!(
             output.contains(
                 "dynamo_component_router_worker_registered{dp_rank=\"0\",router_worker_id=\"123\",worker_type=\"decode\"} 1"
             ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains("dynamo_component_router_kv_event_source_mismatch_workers 2"),
             "\nActual PEF:\n{output}"
         );
 

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -603,6 +603,9 @@ pub mod router {
     pub const REMOTE_INDEXER_WRITE_FAILURES_TOTAL: &str =
         "router_remote_indexer_write_failures_total";
 
+    /// Number of workers expected to publish KV events but missing query endpoints
+    pub const KV_EVENT_SOURCE_MISMATCH_WORKERS: &str = "router_kv_event_source_mismatch_workers";
+
     /// Time to first token observed at the router (seconds)
     pub const TIME_TO_FIRST_TOKEN_SECONDS: &str = "router_time_to_first_token_seconds";
 


### PR DESCRIPTION
## Overview:

Surface the silent failure where event-driven KV routing discovers workers that advertise a local indexer but never register their worker KV query endpoints. This commonly happens when a Dynamo vLLM worker omits --kv-events-config.

The diagnostic is intentionally loud but non-fatal, and does not add worker registration fields or restore a topology-dependent default port.

## Details:

- Pass the existing runtime-config watch into the non-durable local-indexer recovery path.
- Compare expected worker/DP query endpoints with the endpoints actually discovered.
- After a 10-second grace period, log an actionable error and repeat it once per minute until resolved.
- Clear the diagnostic when endpoints appear or workers disappear.
- Export dynamo_component_router_kv_event_source_mismatch_workers as an aggregate gauge.
- Keep approximate, remote-indexer, zero-overlap, and durable JetStream paths unchanged.

## Where should the reviewer start?

Start with lib/llm/src/kv_router/indexer/recovery/worker_query_health.rs, then follow the RuntimeConfigWatch wiring through recovery/subscriber.rs.

## Validation:

- cargo test -p dynamo-llm kv_router::indexer::recovery --lib
- cargo test -p dynamo-llm kv_router::metrics::tests --lib
- cargo clippy -p dynamo-llm --lib -- -D warnings
- cargo fmt --all -- --check

The unchanged focused vLLM Python unit was not runnable locally because the system Python does not have pytest installed.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new router metric to track workers missing expected KV event query endpoints.
  * Added background monitoring that detects mismatches, waits through a grace period, and reports status changes.
  * Improved router health metrics to show the current count of affected workers.

* **Bug Fixes**
  * Better handles partial registration and recovery so missing workers are cleared once endpoints appear.
  * Avoids reporting workers that are not expected to expose local indexer endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->