### PR TITLE
fix(profiler): preserve DGDR model identity in thorough sweeps

### DIFF
--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -109,6 +109,16 @@ def _check_auto_backend_support(model: str, system: str) -> bool:
     )
 
 
+def _check_dgdr_aic_support(
+    dgdr: DynamoGraphDeploymentRequestSpec, backend: str, system: str
+) -> bool:
+    """Check AIC support using a mounted model config when one is available."""
+    model_path = resolve_model_path(dgdr)
+    if backend == "auto":
+        return _check_auto_backend_support(model_path, system)
+    return check_model_hardware_support(model_path, system, backend)
+
+
 def _extract_profiler_params(dgdr: DynamoGraphDeploymentRequestSpec) -> tuple:
     """Pull all profiler parameters from dgdr and log them."""
     model = dgdr.model
@@ -395,10 +405,7 @@ async def run_profile(
             search_strategy,
             picking_mode,
         ) = _extract_profiler_params(dgdr)
-        if backend == "auto":
-            aic_supported = _check_auto_backend_support(model, system)
-        else:
-            aic_supported = check_model_hardware_support(model, system, backend)
+        aic_supported = _check_dgdr_aic_support(dgdr, backend, system)
         # then validate DGDR features based on AIC support
         validate_dgdr_dynamo_features(dgdr, aic_supported)
 

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -29,6 +29,7 @@ try:
         PlannerPreDeploymentSweepMode,
     )
     from dynamo.profiler.profile_sla import (
+        _check_dgdr_aic_support,
         _extract_profiler_params,
         _write_final_output,
     )
@@ -46,6 +47,7 @@ try:
         FeaturesSpec,
         HardwareSpec,
         MockerSpec,
+        ModelCacheSpec,
         SLASpec,
         WorkloadSpec,
     )
@@ -101,6 +103,65 @@ def _make_ops(tmp_path, **kwargs) -> ProfilerOperationalConfig:
         output_dir=str(tmp_path / "out"),
         **kwargs,
     )
+
+
+def test_aic_support_check_uses_local_pvc_config(tmp_path) -> None:
+    """Preflight support checks avoid Hugging Face when PVC config is present."""
+    local_dir = tmp_path / "model"
+    local_dir.mkdir()
+    (local_dir / "config.json").write_text("{}")
+    dgdr = _make_dgdr(
+        backend="vllm",
+        modelCache=ModelCacheSpec(
+            pvcName="model-cache",
+            pvcMountPath=str(tmp_path),
+            pvcModelPath="model",
+        ),
+    )
+
+    with patch(
+        "dynamo.profiler.profile_sla.check_model_hardware_support",
+        return_value=True,
+    ) as mock_check:
+        assert _check_dgdr_aic_support(dgdr, "vllm", "h200_sxm")
+
+    mock_check.assert_called_once_with(str(local_dir), "h200_sxm", "vllm")
+
+
+def test_aic_support_check_auto_uses_local_pvc_config(tmp_path) -> None:
+    """Auto backend checks receive the resolved PVC model path."""
+    local_dir = tmp_path / "model"
+    local_dir.mkdir()
+    (local_dir / "config.json").write_text("{}")
+    dgdr = _make_dgdr(
+        backend="auto",
+        modelCache=ModelCacheSpec(
+            pvcName="model-cache",
+            pvcMountPath=str(tmp_path),
+            pvcModelPath="model",
+        ),
+    )
+
+    with patch(
+        "dynamo.profiler.profile_sla._check_auto_backend_support",
+        return_value=True,
+    ) as mock_check:
+        assert _check_dgdr_aic_support(dgdr, "auto", "h200_sxm")
+
+    mock_check.assert_called_once_with(str(local_dir), "h200_sxm")
+
+
+def test_aic_support_check_without_pvc_uses_dgdr_model() -> None:
+    """Preflight falls back to the DGDR model when no PVC is configured."""
+    dgdr = _make_dgdr(backend="vllm")
+
+    with patch(
+        "dynamo.profiler.profile_sla.check_model_hardware_support",
+        return_value=True,
+    ) as mock_check:
+        assert _check_dgdr_aic_support(dgdr, "vllm", "h200_sxm")
+
+    mock_check.assert_called_once_with(dgdr.model, "h200_sxm", "vllm")
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -746,6 +746,114 @@ def test_build_dgd_config_pvc_with_model_path_uses_pvc_path(backend) -> None:
         assert (
             model_path in flat_args
         ), f"Worker '{svc_name}' should use PVC model path '{model_path}'. args={args}"
+        assert args[args.index("--served-model-name") + 1] == model_name
+
+
+@pytest.mark.parametrize(
+    "backend,model_arg",
+    [("vllm", "--model"), ("sglang", "--model-path"), ("trtllm", "--model-path")],
+)
+def test_update_model_from_pvc_canonicalizes_duplicate_model_args(
+    backend, model_arg
+) -> None:
+    """PVC model updates leave exactly one logical name and runtime path."""
+    modifier = CONFIG_MODIFIERS[backend]
+    model_name = "Qwen/Qwen3-32B"
+    mount_path = "/opt/model-cache"
+    model_path = f"{mount_path}/qwen3-32b"
+    dgd_config = modifier.build_dgd_config(
+        mode="agg",
+        model_name="stale/model",
+        image=f"example/{backend}:test",
+        agg_cli_args=[],
+        agg_replicas=1,
+        agg_gpus=1,
+    )
+
+    services = dgd_config["spec"]["services"]
+    worker = next(
+        service
+        for name, service in services.items()
+        if name not in BaseConfigModifier._NON_WORKER_SERVICES
+    )
+    worker_args = worker["extraPodSpec"]["mainContainer"]["args"]
+    worker_args.extend(
+        [
+            f"{model_arg}=/stale/equal-form",
+            model_arg,
+            "/stale/split-form",
+            "--served-model-name=stale-equal",
+            "--served-model-name",
+            "stale-split",
+        ]
+    )
+
+    frontend_container = services["Frontend"]["extraPodSpec"]["mainContainer"]
+    frontend_container["args"] = frontend_container.get("args") or []
+    frontend_args = frontend_container["args"]
+    frontend_args.extend(
+        [
+            "--model-name=stale-equal",
+            "--model-name",
+            "stale-split",
+            "--model-path=/stale/equal-form",
+            "--model-path",
+            "/stale/split-form",
+        ]
+    )
+
+    result = modifier.update_model_from_pvc(
+        dgd_config,
+        model_name=model_name,
+        pvc_name="model-cache",
+        pvc_mount_path=mount_path,
+        pvc_path="qwen3-32b",
+    )
+
+    result_services = result["spec"]["services"]
+    result_worker = next(
+        service
+        for name, service in result_services.items()
+        if name not in BaseConfigModifier._NON_WORKER_SERVICES
+    )
+    result_worker_args = result_worker["extraPodSpec"]["mainContainer"]["args"]
+    assert [
+        arg
+        for arg in result_worker_args
+        if arg == model_arg or arg.startswith(f"{model_arg}=")
+    ] == [model_arg]
+    assert result_worker_args[result_worker_args.index(model_arg) + 1] == model_path
+    assert [
+        arg
+        for arg in result_worker_args
+        if arg == "--served-model-name" or arg.startswith("--served-model-name=")
+    ] == ["--served-model-name"]
+    assert (
+        result_worker_args[result_worker_args.index("--served-model-name") + 1]
+        == model_name
+    )
+
+    result_frontend_args = result_services["Frontend"]["extraPodSpec"]["mainContainer"][
+        "args"
+    ]
+    assert [
+        arg
+        for arg in result_frontend_args
+        if arg == "--model-name" or arg.startswith("--model-name=")
+    ] == ["--model-name"]
+    assert [
+        arg
+        for arg in result_frontend_args
+        if arg == "--model-path" or arg.startswith("--model-path=")
+    ] == ["--model-path"]
+    assert (
+        result_frontend_args[result_frontend_args.index("--model-name") + 1]
+        == model_name
+    )
+    assert (
+        result_frontend_args[result_frontend_args.index("--model-path") + 1]
+        == model_path
+    )
 
 
 def test_build_dgd_config_pvc_without_model_path_sets_hf_home() -> None:

--- a/components/src/dynamo/profiler/tests/unit/test_resolve_model_path.py
+++ b/components/src/dynamo/profiler/tests/unit/test_resolve_model_path.py
@@ -4,6 +4,7 @@
 """Unit tests for resolve_model_path() and the rapid.py / thorough.py call
 sites that feed its result into aiconfigurator."""
 
+import copy
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
@@ -22,11 +23,16 @@ try:
         _run_autoscale_sim,
         _run_default_sim,
     )
-    from dynamo.profiler.thorough import run_thorough
+    from dynamo.profiler.thorough import (
+        _normalize_candidate_model_identity,
+        run_thorough,
+    )
+    from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
     from dynamo.profiler.utils.dgdr_v1beta1_types import (
         DynamoGraphDeploymentRequestSpec,
         HardwareSpec,
         ModelCacheSpec,
+        OverridesSpec,
         SLASpec,
         WorkloadSpec,
     )
@@ -400,6 +406,136 @@ class TestThoroughResolvesModelPath:
         mock_enumerate = await self._capture_enumerate(dgdr, tmp_path)
 
         assert mock_enumerate.call_args.kwargs["model_path"] == _HF_ID
+
+    def test_cache_only_pvc_does_not_rewrite_candidate_model(self):
+        """A PVC without pvcModelPath remains an HF_HOME-style cache mount."""
+        dgdr = _make_dgdr(
+            modelCache=ModelCacheSpec(
+                pvcName="model-cache",
+                pvcMountPath="/opt/model-cache",
+            )
+        )
+        candidate_config = {"sentinel": "unchanged"}
+        candidate = MagicMock(dgd_config=candidate_config)
+        modifier = MagicMock()
+
+        _normalize_candidate_model_identity(
+            [candidate], dgdr, dgdr.modelCache, modifier
+        )
+
+        modifier.update_model_from_pvc.assert_not_called()
+        assert candidate.dgd_config is candidate_config
+
+    async def test_candidates_keep_hf_name_and_pvc_runtime_path(self, tmp_path):
+        """Every sweep candidate separates API identity from PVC load path."""
+        pvc_root = tmp_path / "pvc"
+        local_dir = pvc_root / "model"
+        _make_model_dir(local_dir)
+        modifier = CONFIG_MODIFIERS["vllm"]
+        candidate_config = modifier.build_dgd_config(
+            mode="agg",
+            model_name=str(local_dir),
+            image="example/vllm:base",
+            agg_cli_args=[],
+            agg_replicas=1,
+            agg_gpus=1,
+            pvc_name="model-cache",
+            pvc_mount_path=str(pvc_root),
+            model_path=str(local_dir),
+        )
+        worker_name = next(
+            name
+            for name in candidate_config["spec"]["services"]
+            if name not in {"Frontend", "Planner"}
+        )
+        dgdr = _make_dgdr(
+            backend="vllm",
+            modelCache=_pvc_model_cache(str(pvc_root), "model"),
+            overrides=OverridesSpec(
+                dgd={
+                    "spec": {
+                        "services": {
+                            worker_name: {
+                                "extraPodSpec": {
+                                    "mainContainer": {
+                                        "image": "example/vllm:override",
+                                        "args": [
+                                            "--model=/stale/path",
+                                            "--served-model-name=stale/model",
+                                        ],
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ),
+        )
+        prefill = MagicMock(dgd_config=copy.deepcopy(candidate_config))
+        decode = MagicMock(dgd_config=copy.deepcopy(candidate_config))
+        ops = ProfilerOperationalConfig(output_dir=str(tmp_path))
+
+        with (
+            patch(
+                "dynamo.profiler.thorough.enumerate_profiling_configs",
+                return_value=([prefill], [decode], True, 1),
+            ),
+            patch(
+                "dynamo.profiler.thorough._benchmark_prefill_candidates",
+                new=AsyncMock(return_value=pd.DataFrame()),
+            ),
+            patch(
+                "dynamo.profiler.thorough._benchmark_decode_candidates",
+                new=AsyncMock(return_value=pd.DataFrame()),
+            ),
+        ):
+            await run_thorough(
+                dgdr,
+                ops,
+                "default",
+                _HF_ID,
+                "h200_sxm",
+                "vllm",
+                8,
+                4000,
+                1000,
+                2000.0,
+                50.0,
+                None,
+                [],
+            )
+
+        for candidate in (prefill, decode):
+            assert modifier.get_model_name(candidate.dgd_config) == (
+                _HF_ID,
+                str(local_dir),
+            )
+            services = candidate.dgd_config["spec"]["services"]
+            worker = services[worker_name]
+            args = worker["extraPodSpec"]["mainContainer"]["args"]
+            assert worker["extraPodSpec"]["mainContainer"]["image"] == (
+                "example/vllm:override"
+            )
+            assert [
+                arg for arg in args if arg == "--model" or arg.startswith("--model=")
+            ] == ["--model"]
+            assert [
+                arg
+                for arg in args
+                if arg == "--served-model-name"
+                or arg.startswith("--served-model-name=")
+            ] == ["--served-model-name"]
+            frontend_args = services["Frontend"]["extraPodSpec"]["mainContainer"][
+                "args"
+            ]
+            assert frontend_args[frontend_args.index("--model-name") + 1] == _HF_ID
+            assert frontend_args[frontend_args.index("--model-path") + 1] == str(
+                local_dir
+            )
+            assert all(
+                any(vm.get("name") == "model-cache" for vm in service["volumeMounts"])
+                for service in services.values()
+            )
 
     async def _capture_task_config(self, dgdr, output_dir) -> MagicMock:
         """The benchmark stages return non-empty DataFrames so run_thorough gets

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -57,6 +57,26 @@ from dynamo.profiler.utils.profiler_status import ProfilerStatus, write_profiler
 logger = logging.getLogger(__name__)
 
 
+def _normalize_candidate_model_identity(
+    candidates,
+    dgdr: DynamoGraphDeploymentRequestSpec,
+    model_cache: ModelCacheSpec,
+    config_modifier,
+) -> None:
+    """Keep the DGDR model name separate from its PVC runtime path."""
+    if not model_cache.pvcName or not model_cache.pvcModelPath:
+        return
+
+    for candidate in candidates:
+        candidate.dgd_config = config_modifier.update_model_from_pvc(
+            candidate.dgd_config,
+            model_name=dgdr.model,
+            pvc_name=model_cache.pvcName,
+            pvc_mount_path=model_cache.pvcMountPath,
+            pvc_path=model_cache.pvcModelPath,
+        )
+
+
 async def _benchmark_prefill_candidates(
     prefill_candidates,
     ops: ProfilerOperationalConfig,
@@ -410,6 +430,12 @@ async def run_thorough(
         )
 
     config_modifier = CONFIG_MODIFIERS[backend]
+    _normalize_candidate_model_identity(
+        prefill_candidates, dgdr, model_cache, config_modifier
+    )
+    _normalize_candidate_model_identity(
+        decode_candidates, dgdr, model_cache, config_modifier
+    )
     if backend == "vllm" and hasattr(
         config_modifier, "apply_model_runtime_constraints"
     ):

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -490,6 +490,29 @@ def set_argument_value(args: list[str], arg_name: str, value: str) -> list[str]:
     return args
 
 
+def set_unique_argument_value(args: list[str], arg_name: str, value: str) -> list[str]:
+    """Set one canonical value after removing every duplicate occurrence.
+
+    Handles both ``--arg value`` and ``--arg=value`` forms. This is intended
+    for identity-bearing arguments where appended DGD overrides must not leave
+    a later conflicting value for the backend parser to consume.
+    """
+    filtered: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == arg_name:
+            index += 2 if index + 1 < len(args) else 1
+            continue
+        if isinstance(arg, str) and arg.startswith(f"{arg_name}="):
+            index += 1
+            continue
+        filtered.append(arg)
+        index += 1
+
+    return append_argument(filtered, [arg_name, value])
+
+
 def update_image(config: dict, image: str) -> dict:
     """Update container image for non-planner DGD services.
 

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -28,7 +28,7 @@ from dynamo.profiler.utils.config import (
     break_arguments,
     get_service_name_by_type,
     sanitize_cli_args,
-    set_argument_value,
+    set_unique_argument_value,
     setup_worker_service_resources,
     update_image,
 )
@@ -337,8 +337,8 @@ class BaseConfigModifier:
             c.args = []
 
         def _patch(tokens: list[str]) -> list[str]:
-            tokens = set_argument_value(tokens, "--model-name", model_name)
-            tokens = set_argument_value(tokens, "--model-path", model_path)
+            tokens = set_unique_argument_value(tokens, "--model-name", model_name)
+            tokens = set_unique_argument_value(tokens, "--model-path", model_path)
             return tokens
 
         cls._update_container_args_preserving_shell_form(c, _patch)
@@ -365,10 +365,10 @@ class BaseConfigModifier:
             c = service.extraPodSpec.mainContainer
 
             def _patch(tokens: list[str]) -> list[str]:
-                tokens = set_argument_value(
+                tokens = set_unique_argument_value(
                     tokens, cls.WORKER_MODEL_PATH_ARG, model_path
                 )
-                tokens = set_argument_value(
+                tokens = set_unique_argument_value(
                     tokens, cls.WORKER_SERVED_MODEL_NAME_ARG, model_name
                 )
                 return tokens


### PR DESCRIPTION
## Summary

- cherry-pick #11188 to `release/1.3.0`
- keep AIC preflight and thorough enumeration on the PVC-local model config
- preserve the DGDR `spec.model` as the served model identity for sweep candidates and final output
- canonicalize backend model arguments to prevent conflicting runtime values

Relates to [DYN-3357](https://linear.app/nvidia/issue/DYN-3357/dynamo130dgdr-thorough-path-aiperf-fails-when-pvc-model-cache-is-used) and NVBug 6407209.

## Validation

- `/home/hongkuanz/Projects/dynamo/.venv/bin/python -m pytest components/src/dynamo/profiler/tests/unit components/src/dynamo/profiler/tests/integration/test_profile_sla_dgdr.py -q` — 228 passed, 1 skipped (optional AIC SDK unavailable)
- `/home/hongkuanz/Projects/dynamo/.venv/bin/pre-commit run --from-ref origin/release/1.3.0 --to-ref HEAD` — passed
- cherry-pick applied cleanly to `release/1.3.0`