### PR TITLE
fix(ci): OPS-7471 make baked /workspace dirs writable in runtime test images

### DIFF
--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -7,12 +7,6 @@
 # For adding specific unique tests software, like in planner, add a target: docker build -f container/Dockerfile.test --target test_distroless --build-arg BASE_IMAGE=<runtime-image> .
 ARG BASE_IMAGE
 
-# Static busybox lends find+chmod to the workspace-perms RUN below via a build
-# mount. The planner runtime base is distroless and ships neither binary; the
-# musl build is fully static so it runs on any base. Mount-only: nothing from
-# this stage lands in the final image.
-FROM busybox:stable-musl AS busybox_tools
-
 FROM ${BASE_IMAGE} AS test_image
 
 # Install test dependencies on top of runtime image
@@ -42,15 +36,16 @@ COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 # /workspace, launch-script ./logs dirs under examples/), so grant others the
 # directory write bit. Directories only: creating a file needs w on its parent
 # dir, and touching file modes would copy every file into a new image layer.
-RUN --mount=type=bind,from=busybox_tools,source=/bin/busybox,target=/usr/local/bin/busybox \
-    busybox find /workspace -type d -exec busybox chmod o+w {} +
+# The distroless planner base has no find here — it takes the skip branch and
+# test_distroless below repeats the chmod after the runner tools land.
+RUN if command -v find; then find /workspace -type d -exec chmod o+w {} +; else echo "skipped (distroless planner)"; fi
 
 USER dynamo
 
 FROM debian:bookworm-slim AS github_runner_tools
 
 RUN set -eux; \
-    tools="bash tail tar gzip cat grep env tr head mkdir chmod mv sleep"; \
+    tools="bash tail tar gzip cat grep env tr head mkdir chmod mv sleep find"; \
     mkdir -p /github-runner-tools/usr/local/bin /github-runner-tools/opt/dynamo/lib; \
     for tool in ${tools}; do \
         tool_path="$(command -v "${tool}")"; \
@@ -69,5 +64,9 @@ FROM test_image AS test_distroless
 USER root
 COPY --from=github_runner_tools /github-runner-tools/usr/local/bin/ /usr/local/bin/
 COPY --from=github_runner_tools /github-runner-tools/opt/dynamo/lib/ /opt/dynamo/lib/
+
+# find/chmod exist now (copied above): apply the /workspace dir-write fix that
+# test_image skipped on this distroless base.
+RUN find /workspace -type d -exec chmod o+w {} +
 
 USER dynamo

--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -7,6 +7,12 @@
 # For adding specific unique tests software, like in planner, add a target: docker build -f container/Dockerfile.test --target test_distroless --build-arg BASE_IMAGE=<runtime-image> .
 ARG BASE_IMAGE
 
+# Static busybox lends find+chmod to the workspace-perms RUN below via a build
+# mount. The planner runtime base is distroless and ships neither binary; the
+# musl build is fully static so it runs on any base. Mount-only: nothing from
+# this stage lands in the final image.
+FROM busybox:stable-musl AS busybox_tools
+
 FROM ${BASE_IMAGE} AS test_image
 
 # Install test dependencies on top of runtime image
@@ -36,18 +42,8 @@ COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 # /workspace, launch-script ./logs dirs under examples/), so grant others the
 # directory write bit. Directories only: creating a file needs w on its parent
 # dir, and touching file modes would copy every file into a new image layer.
-# Python rather than find/chmod: the planner base is distroless and ships
-# neither binary, but every base has the venv python on PATH.
-RUN python3 - <<'PY'
-import os
-
-paths = ["/workspace"]
-for root, dirs, _files in os.walk("/workspace"):
-    paths += [os.path.join(root, d) for d in dirs]
-for p in paths:
-    if not os.path.islink(p):
-        os.chmod(p, os.stat(p).st_mode | 0o002)
-PY
+RUN --mount=type=bind,from=busybox_tools,source=/bin/busybox,target=/usr/local/bin/busybox \
+    busybox find /workspace -type d -exec busybox chmod o+w {} +
 
 USER dynamo
 

--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -24,8 +24,6 @@ RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/
             --requirement /tmp/requirements.test.txt; \
     fi
 
-USER dynamo
-
 # Copy pytest configuration (markers, filterwarnings, asyncio_mode, etc.)
 COPY --chmod=664 --chown=dynamo:0 pyproject.toml /workspace/pyproject.toml
 # Required: blocks dynamo.vllm/sglang from shadowing the installed packages.
@@ -38,8 +36,8 @@ COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 # /workspace, launch-script ./logs dirs under examples/), so grant others the
 # directory write bit. Directories only: creating a file needs w on its parent
 # dir, and touching file modes would copy every file into a new image layer.
-USER root
 RUN find /workspace -type d -exec chmod o+w {} +
+
 USER dynamo
 
 FROM debian:bookworm-slim AS github_runner_tools

--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -32,6 +32,16 @@ COPY --chmod=664 --chown=dynamo:0 pyproject.toml /workspace/pyproject.toml
 COPY --chmod=664 --chown=dynamo:0 conftest.py /workspace/conftest.py
 COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 
+# The ARC runner executes the job pod as uid 1001 with a non-dynamo gid (see
+# shared-test.yml), which lands in "other" perms on this baked dynamo:0 tree.
+# Tests create files in their CWD (fault-tolerance engine configs in
+# /workspace, launch-script ./logs dirs under examples/), so grant others the
+# directory write bit. Directories only: creating a file needs w on its parent
+# dir, and touching file modes would copy every file into a new image layer.
+USER root
+RUN find /workspace -type d -exec chmod o+w {} +
+USER dynamo
+
 FROM debian:bookworm-slim AS github_runner_tools
 
 RUN set -eux; \

--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -36,7 +36,18 @@ COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 # /workspace, launch-script ./logs dirs under examples/), so grant others the
 # directory write bit. Directories only: creating a file needs w on its parent
 # dir, and touching file modes would copy every file into a new image layer.
-RUN find /workspace -type d -exec chmod o+w {} +
+# Python rather than find/chmod: the planner base is distroless and ships
+# neither binary, but every base has the venv python on PATH.
+RUN python3 - <<'PY'
+import os
+
+paths = ["/workspace"]
+for root, dirs, _files in os.walk("/workspace"):
+    paths += [os.path.join(root, d) for d in dirs]
+for p in paths:
+    if not os.path.islink(p):
+        os.chmod(p, os.stat(p).st_mode | 0o002)
+PY
 
 USER dynamo
 

--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -44,6 +44,10 @@ USER dynamo
 
 FROM debian:bookworm-slim AS github_runner_tools
 
+# glibc-family libs (loader, libc, libm) are excluded from the harvest: they
+# must resolve from the base image. A copied bookworm libm shadows the base's
+# newer one via LD_LIBRARY_PATH and breaks its consumers — libpython needs
+# GLIBC_2.38 symbols that bookworm's 2.36 libm lacks.
 RUN set -eux; \
     tools="bash tail tar gzip cat grep env tr head mkdir chmod mv sleep find"; \
     mkdir -p /github-runner-tools/usr/local/bin /github-runner-tools/opt/dynamo/lib; \
@@ -52,7 +56,7 @@ RUN set -eux; \
         cp -L "${tool_path}" "/github-runner-tools/usr/local/bin/${tool}"; \
         ldd "${tool_path}" \
             | awk '/=> \// { print $3 } /^\// { print $1 }' \
-            | grep -Ev '/(ld-linux|libc\.so)' \
+            | grep -Ev '/(ld-linux|libc\.so|libm\.so)' \
             | while read -r lib_path; do \
                 cp -L "${lib_path}" "/github-runner-tools/opt/dynamo/lib/$(basename "${lib_path}")"; \
             done; \


### PR DESCRIPTION
## Summary

29 of the chronic nightly test failures share one root cause: the pytest process cannot create files under `/workspace` inside the runtime test images. The ARC k8s runner executes test job pods as **uid 1001** with a non-dynamo gid, while the images bake `/workspace` as `dynamo`(1000):0 mode 755/775 — uid 1001 lands in "other" perms and gets no write bit anywhere in the tree. (Same uid-mismatch class as the rust-gpu `Cargo.lock` fix in #9986, and already noted in `shared-test.yml`'s `HOME`/`USER` override comment.)

Evidence from nightly run [28578394742](https://github.com/ai-dynamo/dynamo/actions/runs/28578394742) (2026-07-02), reproducing in every nightly since at least June 27:

- **trtllm-runtime / Test**: 24× `test_request_migration_trtllm_decode[*]`, 2× `test_request_cancellation_trtllm_decode_cancel[*]`, 2× etcd_ha tests — all die in setup with `PermissionError: [Errno 13]` writing their engine-config yaml to the pytest CWD `/workspace`
- **vllm-runtime / Multi-GPU Test**: `test_serve_deployment[deepep-2]` — `dsr1_dep.sh` dies on `mkdir ./logs: Permission denied` under `examples/backends/vllm` (failing since ~June 2)

Confirmation it's the write and not the tests: the 12 aggregated migration variants that never write a config file all **passed** in the same session.

## Change

Grant the "other" directory-write bit across `/workspace` in `container/Dockerfile.test` — the shared final layer for all runtime test images (vllm/sglang/trtllm `test_image`, planner `test_distroless`):

```dockerfile
# test_image (all flavors) — native find; distroless planner skips here:
RUN if command -v find; then find /workspace -type d -exec chmod o+w {} +; else echo "skipped (distroless planner)"; fi

# test_distroless (planner) — after the github_runner_tools harvest (find newly added to the tool list):
RUN find /workspace -type d -exec chmod o+w {} +
```

(The planner runtime base is distroless with no `find`, so `test_image` skips there and `test_distroless` applies the same fix once the harvested Debian tools land. The stage already runs as root for the test-deps install and drops to `USER dynamo` once at the end.)

- **Directories only**: creating a file needs the write bit on its parent directory; chmod-ing file contents would additionally copy every file into a new image layer for no benefit.
- `g+w` would not work — the pod's gid is not 0.
- Test-image-only change; no production/runtime image surface.

## Expected impact

Clears 29 chronic nightly test failures (24 migration + 2 cancellation + 2 etcd_ha trtllm, 1 vllm deepep).

Linear: OPS-7471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the test container setup to allow jobs to run correctly in the ARC runner environment.
  * Improved filesystem write access in the test image so workspace directories can be used by the job pod execution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



