### PR TITLE
fix(sglang): support profile request object API

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -108,6 +108,49 @@ def filter_supported_async_generate_kwargs(
     return {key: value for key, value in kwargs.items() if key in supported_kwarg_names}
 
 
+@lru_cache(maxsize=32)
+def _start_profile_accepts_request_object(start_profile: Any) -> bool:
+    """Return whether TokenizerManager.start_profile expects a ProfileReq."""
+    try:
+        signature = inspect.signature(start_profile)
+    except (TypeError, ValueError):
+        logger.debug(
+            "Could not inspect SGLang TokenizerManager.start_profile signature; "
+            "using the legacy keyword-argument API"
+        )
+        return False
+
+    return "req" in signature.parameters
+
+
+def _build_profile_request(body: dict[str, Any]) -> Any:
+    from sglang.srt.managers.io_struct import ProfileReq
+
+    return ProfileReq(**body)
+
+
+async def start_profile_compat(tokenizer_manager: Any, body: dict[str, Any]) -> None:
+    """Start profiling across SGLang's old and new control APIs.
+
+    SGLang 0.5.11 accepts profiling fields as keyword arguments. Newer builds
+    accept one ``ProfileReq`` object instead.
+    """
+    start_profile = tokenizer_manager.start_profile
+    signature_source = getattr(start_profile, "__func__", start_profile)
+
+    try:
+        accepts_request_object = _start_profile_accepts_request_object(signature_source)
+    except TypeError:
+        accepts_request_object = _start_profile_accepts_request_object.__wrapped__(
+            signature_source
+        )
+
+    if accepts_request_object:
+        await start_profile(_build_profile_request(body))
+    else:
+        await start_profile(**body)
+
+
 def enable_disjoint_streaming_output(server_args: Any) -> None:
     """Enable SGLang's disjoint streaming output.
 
@@ -122,4 +165,5 @@ __all__ = [
     "enable_disjoint_streaming_output",
     "ensure_sglang_top_level_exports",
     "filter_supported_async_generate_kwargs",
+    "start_profile_compat",
 ]

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -43,6 +43,7 @@ from dynamo.llm import (
 )
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.runtime import DistributedRuntime
+from dynamo.sglang._compat import start_profile_compat
 from dynamo.sglang.args import Config
 from dynamo.sglang.pause import SGLangEnginePauseController
 from dynamo.sglang.publisher import DynamoSglangPublisher
@@ -878,7 +879,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         Args:
             body: Dict with profiling parameters passed to start_profile.
         """
-        await self.engine.tokenizer_manager.start_profile(**body)
+        await start_profile_compat(self.engine.tokenizer_manager, body)
         return {"status": "ok", "message": "Profiling started"}
 
     async def stop_profile(self, body: dict) -> dict:

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -17,6 +17,7 @@ from dynamo.common.constants import EmbeddingTransferMode
 from dynamo.sglang._compat import (
     ensure_sglang_top_level_exports,
     filter_supported_async_generate_kwargs,
+    start_profile_compat,
 )
 from dynamo.sglang.args import (
     _normalize_multimodal_disaggregation_args,
@@ -233,6 +234,46 @@ def test_compat_caches_async_generate_signature_inspection(monkeypatch):
     assert calls == 1
 
     sglang_compat._get_async_generate_supported_kwarg_names.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_compat_starts_profile_with_legacy_kwargs():
+    class LegacyTokenizerManager:
+        received = None
+
+        async def start_profile(self, output_dir=None, start_step=None, num_steps=None):
+            self.received = {
+                "output_dir": output_dir,
+                "start_step": start_step,
+                "num_steps": num_steps,
+            }
+
+    manager = LegacyTokenizerManager()
+    body = {"output_dir": "/tmp/profile", "start_step": 10, "num_steps": 5}
+
+    await start_profile_compat(manager, body)
+
+    assert manager.received == body
+
+
+@pytest.mark.asyncio
+async def test_compat_starts_profile_with_request_object(monkeypatch):
+    class RequestTokenizerManager:
+        received = None
+
+        async def start_profile(self, req=None):
+            self.received = req
+
+    request = SimpleNamespace(output_dir="/tmp/profile", start_step=10, num_steps=5)
+    monkeypatch.setattr(sglang_compat, "_build_profile_request", lambda body: request)
+    manager = RequestTokenizerManager()
+
+    await start_profile_compat(
+        manager,
+        {"output_dir": "/tmp/profile", "start_step": 10, "num_steps": 5},
+    )
+
+    assert manager.received is request
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
[by Codex]

## Summary

- adapt the SGLang profiling route to both the legacy keyword-argument API and the newer `start_profile(ProfileReq)` API
- keep version handling in the existing SGLang compatibility module via signature probing
- add focused async tests for both API shapes

## Validation

- `python3 -m compileall -q components/src/dynamo/sglang/_compat.py components/src/dynamo/sglang/request_handlers/handler_base.py components/src/dynamo/sglang/tests/test_sglang_unit.py`
- `git diff --check`
- standalone compatibility smoke covering both signatures
- regression reproduced in Dynamo 1.1.0 with SGLang commit `5b76f55d`: `/engine/start_profile` returned `TypeError: TokenizerControlMixin.start_profile() got an unexpected keyword argument output_dir` before `cudaProfilerStart`

The focused pytest cases were added but not run locally because this VM does not have the Dynamo/SGLang test environment installed.

## Overview:

Newer SGLang builds changed `TokenizerManager.start_profile` from individual keyword arguments to a single `ProfileReq`. Dynamo still unpacked the HTTP body as kwargs, causing every profiling request to fail with HTTP 500.

## Details:

`start_profile_compat` inspects the installed method signature. It preserves kwargs for SGLang 0.5.11 and constructs `ProfileReq(**body)` for current builds.

## Where should the reviewer start?

`components/src/dynamo/sglang/_compat.py`

## Related Issues

**This PR is NOT linked to an issue**:
- [x] Confirmed - no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profiling setup compatibility so the app works with both newer and older SGLang versions.
  * Added smarter handling when starting profiling, reducing failures caused by differing request formats.
  * Included fallback behavior if signature detection is unavailable, helping keep profiling available in more environments.

* **Tests**
  * Added coverage for both supported profiling call styles to verify consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->