### PR TITLE
fix(frontend): offload prompt tokenization off the async event loop

### DIFF
--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -1156,7 +1156,11 @@ unsafe fn preprocess_request(
         let priority_jump = extract_priority_jump(request.nvext.as_ref());
         let strict_priority = extract_strict_priority(request.nvext.as_ref());
         let routing_constraints = extract_routing_constraints(request.nvext.as_ref());
-        let (token_ids, _) = match preprocessor.gather_tokens(&request, None, None) {
+        let (token_ids, _) = match handles
+            .runtime
+            .secondary()
+            .block_on(preprocessor.gather_tokens(&request, None, None))
+        {
             Ok(tokens) => tokens,
             Err(e) => {
                 tracing::error!(error = ?e, "Failed to collect completion prompt tokens");

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -38,7 +38,6 @@ use dynamo_runtime::metrics::frontend_perf::{
     DETOKENIZE_TOKEN_COUNT, DETOKENIZE_TOTAL_US, STAGE_DURATION_SECONDS, STAGE_PREPROCESS,
     StageGuard, TEMPLATE_SECONDS, TOKENIZE_SECONDS,
 };
-use std::borrow::Cow;
 use std::{any::Any, collections::HashMap, pin::Pin, sync::Arc};
 use tracing;
 
@@ -674,6 +673,7 @@ impl OpenAIPreprocessor {
         let (token_ids, annotations) = {
             let _nvtx = dynamo_nvtx_range!("preprocess.tokenize");
             self.gather_tokens(request, formatted_prompt.as_deref(), tracker)
+                .await
                 .with_context(|| "Failed to gather tokens")?
         };
         TOKENIZE_SECONDS.observe(tokenize_start.elapsed().as_secs_f64());
@@ -1619,7 +1619,7 @@ impl OpenAIPreprocessor {
     /// the caller asked for. The caller owns the result and is responsible for
     /// installing it on the builder via `builder.token_ids(...)` once any
     /// downstream consumers (e.g. MM-routing) have borrowed it.
-    pub fn gather_tokens<
+    pub async fn gather_tokens<
         R: OAIChatLikeRequest
             + AnnotationsProvider
             + SamplingOptionsProvider
@@ -1702,10 +1702,10 @@ impl OpenAIPreprocessor {
                                 tracing::warn!(
                                     "backend_instance_id provided but no token_data; tokenizing prompt"
                                 );
-                                let encoding = self.encode_with_timing(prompt, tracker)?;
+                                let encoding = self.encode_with_timing(prompt, tracker).await?;
                                 (encoding.token_ids().to_vec(), false)
                             } else {
-                                let encoding = self.encode_with_timing(prompt, tracker)?;
+                                let encoding = self.encode_with_timing(prompt, tracker).await?;
                                 (encoding.token_ids().to_vec(), false)
                             };
 
@@ -1723,7 +1723,7 @@ impl OpenAIPreprocessor {
                         }
                         TextInput::Batch(texts) => {
                             if texts.len() == 1 {
-                                let encoding = self.encode_with_timing(&texts[0], tracker)?;
+                                let encoding = self.encode_with_timing(&texts[0], tracker).await?;
                                 let tokens = encoding.token_ids().to_vec();
                                 token_count = Some(tokens.len());
                                 tokens_out = tokens;
@@ -1770,19 +1770,25 @@ impl OpenAIPreprocessor {
         Ok(())
     }
 
-    fn encode_with_timing(
+    async fn encode_with_timing(
         &self,
         prompt: &str,
         tracker: Option<&RequestTracker>,
     ) -> anyhow::Result<Encoding> {
         let encode_start = Instant::now();
-        let prompt = if prompt.contains('\0') {
+        // Offload the CPU-heavy BPE encode to the bounded blocking pool instead of running it on
+        // the async event loop. For long prompts at high concurrency, a synchronous encode here
+        // stalls the frontend tokio runtime for seconds, starving the I/O tasks that share the
+        // runtime. Own the prompt + clone the tokenizer (Arc) so the closure is 'static + Send;
+        // mirrors the embedding path's spawn_blocking offload.
+        let owned = if prompt.contains('\0') {
             tracing::debug!("Prompt contains null bytes; stripping to avoid tokenizer divergence");
-            Cow::Owned(prompt.replace('\0', ""))
+            prompt.replace('\0', "")
         } else {
-            Cow::Borrowed(prompt)
+            prompt.to_string()
         };
-        let encoding = self.tokenizer.encode(prompt.as_ref())?;
+        let tokenizer = self.tokenizer.clone();
+        let encoding = tokio::task::spawn_blocking(move || tokenizer.encode(&owned)).await??;
         if let Some(t) = tracker {
             t.record_tokenize_latency(encode_start.elapsed());
         }
@@ -3197,7 +3203,9 @@ impl
         } else {
             // Normal path: tokenize the prompt; embeddings don't need MM routing,
             // so install tokens on the builder right away.
-            let (token_ids, ann) = self.gather_tokens(&request, None, tracker.as_deref())?;
+            let (token_ids, ann) = self
+                .gather_tokens(&request, None, tracker.as_deref())
+                .await?;
             builder.token_ids(token_ids);
             ann
         };


### PR DESCRIPTION
## What this PR does

Moves prompt tokenization off the frontend's async (tokio) event loop and onto the bounded blocking
thread pool.

## Why / the improvement

The generate path tokenizes the prompt **synchronously on the async event loop**
(`gather_tokens` → `encode_with_timing` → `tokenizer.encode`), unlike the embedding path
(`preprocess_embedding_request`), which already offloads encoding via `spawn_blocking`. For long prompts
under concurrency, the CPU-heavy BPE encode blocks the runtime for multiple seconds, stalling every other
task that shares it.

Offloading the encode keeps the event loop responsive while a prompt is tokenized, so request latency and
throughput no longer degrade when large prompts are encoded under load. In disaggregated serving this also
stops the stall from starving request-plane I/O (which could otherwise cause healthy workers to be wrongly
marked down).

## How

- `encode_with_timing` becomes `async`; `tokenizer.encode` runs inside `tokio::task::spawn_blocking`.
- The prompt is owned and the tokenizer `Arc` is cloned so the closure is `'static + Send`.
- `async` is propagated up through `gather_tokens` and its call sites. The one synchronous FFI consumer
  (`lib/bindings/c` EPP tokenize path) bridges the now-async call via the crate's existing
  `runtime.secondary().block_on(...)`.
- Mirrors the existing embedding-path offload and produces the same `Encoding`; null-byte stripping is
  preserved.

## Scope

2 files — `lib/llm/src/preprocessor.rs` and `lib/bindings/c/src/lib.rs` (+24/−12).

## Testing

`cargo fmt -- --check` and `cargo clippy --no-deps --all-targets -- -D warnings` (full workspace) both pass
on top of `main`.
