### PR TITLE
test(frontend): add CPU-only tool and reasoning e2e matrix

### DIFF
--- a/lib/llm/tests/common/raw_chat_harness.rs
+++ b/lib/llm/tests/common/raw_chat_harness.rs
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Full chat-completions pipeline backed by deterministic raw backend output.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Error, Result, anyhow};
+use dynamo_llm::backend::Backend;
+use dynamo_llm::http::service::service_v2::HttpService;
+use dynamo_llm::model_card::ModelDeploymentCard;
+use dynamo_llm::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
+use dynamo_llm::protocols::{
+    Annotated,
+    common::llm_backend::LLMEngineOutput,
+    openai::chat_completions::{
+        NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
+    },
+};
+use dynamo_runtime::CancellationToken;
+use dynamo_runtime::pipeline::{
+    AsyncEngine, AsyncEngineContextProvider, ManyOut, Operator, ResponseStream, ServiceBackend,
+    ServiceFrontend, SingleIn, Source, async_trait,
+};
+use tokio::sync::Mutex;
+
+use super::ports::bind_random_port;
+
+pub const MODEL: &str = "harness-model";
+pub type WorkerScript = Vec<LLMEngineOutput>;
+
+/// Captures fully preprocessed requests and emits one raw backend script per request.
+pub struct ScriptedBackendEngine {
+    scripts: Mutex<VecDeque<WorkerScript>>,
+    requests: Mutex<Vec<PreprocessedRequest>>,
+}
+
+impl ScriptedBackendEngine {
+    pub fn new(scripts: impl IntoIterator<Item = WorkerScript>) -> Self {
+        Self {
+            scripts: Mutex::new(scripts.into_iter().collect()),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub async fn take_requests(&self) -> Vec<PreprocessedRequest> {
+        std::mem::take(&mut *self.requests.lock().await)
+    }
+
+    pub async fn remaining_scripts(&self) -> usize {
+        self.scripts.lock().await.len()
+    }
+}
+
+#[async_trait]
+impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+    for ScriptedBackendEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+        let (request, context) = request.transfer(());
+        let ctx = context.context();
+        self.requests.lock().await.push(request);
+
+        let script = self
+            .scripts
+            .lock()
+            .await
+            .pop_front()
+            .ok_or_else(|| anyhow!("ScriptedBackendEngine received an unexpected request"))?;
+        let output = futures::stream::iter(script.into_iter().map(Annotated::from_data));
+        Ok(ResponseStream::new(Box::pin(output), ctx))
+    }
+}
+
+/// Real HTTP and preprocessing/postprocessing pipeline with only generation mocked.
+pub struct RawChatHarness {
+    pub base_url: String,
+    pub client: reqwest::Client,
+    pub engine: Arc<ScriptedBackendEngine>,
+    cancel: CancellationToken,
+    join: Option<tokio::task::JoinHandle<Result<()>>>,
+}
+
+impl RawChatHarness {
+    pub async fn start(
+        card: ModelDeploymentCard,
+        scripts: impl IntoIterator<Item = WorkerScript>,
+    ) -> Self {
+        let engine = Arc::new(ScriptedBackendEngine::new(scripts));
+        let frontend = ServiceFrontend::<
+            SingleIn<NvCreateChatCompletionRequest>,
+            ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
+        >::new();
+        let preprocessor = OpenAIPreprocessor::new(card.clone())
+            .expect("failed to build test preprocessor")
+            .into_operator();
+        let token_backend = Backend::from_mdc(&card).into_operator();
+        let worker = ServiceBackend::from_engine(engine.clone());
+        let pipeline = frontend
+            .link(preprocessor.forward_edge())
+            .and_then(|node| node.link(token_backend.forward_edge()))
+            .and_then(|node| node.link(worker))
+            .and_then(|node| node.link(token_backend.backward_edge()))
+            .and_then(|node| node.link(preprocessor.backward_edge()))
+            .and_then(|node| node.link(frontend))
+            .expect("failed to link raw chat test pipeline");
+
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("failed to build harness HTTP client");
+        let (listener, port) = bind_random_port().await;
+        let service = HttpService::builder()
+            .port(port)
+            .host("127.0.0.1")
+            .enable_chat_endpoints(true)
+            .enable_cmpl_endpoints(false)
+            .build()
+            .expect("failed to build harness HTTP service");
+        service
+            .model_manager()
+            .add_chat_completions_model(MODEL, card.mdcsum(), pipeline)
+            .expect("failed to register raw chat harness model");
+
+        let cancel = CancellationToken::new();
+        let join = service.spawn_with_listener(cancel.clone(), listener).await;
+        let base_url = format!("http://127.0.0.1:{port}");
+        wait_for_health(&client, &base_url).await;
+
+        Self {
+            base_url,
+            client,
+            engine,
+            cancel,
+            join: Some(join),
+        }
+    }
+
+    pub async fn shutdown(mut self) {
+        self.cancel.cancel();
+        let join = self.join.take().expect("harness join handle is missing");
+        tokio::time::timeout(Duration::from_secs(2), join)
+            .await
+            .expect("harness HTTP service did not stop within two seconds")
+            .expect("harness HTTP service task panicked")
+            .expect("harness HTTP service returned an error");
+    }
+}
+
+impl Drop for RawChatHarness {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(join) = self.join.take() {
+            join.abort();
+        }
+    }
+}
+
+async fn wait_for_health(client: &reqwest::Client, base_url: &str) {
+    let url = format!("{base_url}/health");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if client
+                .get(&url)
+                .send()
+                .await
+                .is_ok_and(|response| response.status().is_success())
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("harness HTTP service did not become healthy");
+}

--- a/lib/llm/tests/data/replays/tool-calling-cpu-e2e/nemotron-nano-required-guided.json
+++ b/lib/llm/tests/data/replays/tool-calling-cpu-e2e/nemotron-nano-required-guided.json
@@ -1,0 +1,42 @@
+{
+  "provenance": {
+    "model": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
+    "deployment": "Dynamo+vLLM 0.24.0",
+    "captured_at": "2026-07-02",
+    "trace_kind": "raw stream reconstructed from captured OpenAI fields and the Nemotron implicit-start wire format"
+  },
+  "request": {
+    "tool_choice": "required",
+    "parallel_tool_calls": false,
+    "chat_template_kwargs": {
+      "enable_thinking": true
+    }
+  },
+  "raw_backend_stream": [
+    {
+      "text": "Okay, the user is asking about the weather in San Francisco and specifically wants me to use the get_weather function. Let me check the tools available. There's a function called get_weather that takes a location parameter. The required parameter is location, which should be a string. Since the user mentioned San Francisco, I need to call get_weather with \"San Francisco\" as the location. I don't see any other parameters needed, and the function doesn't have any other required fields. So I should generate a tool call with the name get_weather and the arguments as {\"location\": \"San Francisco\"}. That should fetch the current weather for them.\n"
+    },
+    {
+      "text": "</think>"
+    },
+    {
+      "text": "[{\"name\":\"get_weather\",\"parameters\":{\"location\":\"San Francisco\"}}]"
+    },
+    {
+      "finish_reason": "stop"
+    }
+  ],
+  "expected": {
+    "reasoning_contains": "the user is asking about the weather in San Francisco",
+    "content": "",
+    "tool_calls": [
+      {
+        "name": "get_weather",
+        "arguments": {
+          "location": "San Francisco"
+        }
+      }
+    ],
+    "finish_reason": "tool_calls"
+  }
+}

--- a/lib/llm/tests/data/replays/tool-calling-cpu-e2e/prompt-injected/chat_template.jinja
+++ b/lib/llm/tests/data/replays/tool-calling-cpu-e2e/prompt-injected/chat_template.jinja
@@ -1,0 +1,2 @@
+{% for message in messages %}{{ message['role'] }}: {{ message['content'] | trim }}
+{% endfor %}{% if add_generation_prompt %}assistant: <think>{% endif %}

--- a/lib/llm/tests/tool_calling_cpu_e2e.rs
+++ b/lib/llm/tests/tool_calling_cpu_e2e.rs
@@ -1,0 +1,788 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! CPU-only end-to-end coverage for reasoning-aware tool calling.
+//!
+//! The mock boundary is the model worker, not the OpenAI protocol. Every case
+//! traverses the real HTTP service, request preprocessing, guided-decoding or
+//! structural-tag selection, raw backend stream transformation, reasoning
+//! parser, tool parser/jail, finish normalization, and streaming/unary response
+//! serialization.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use dynamo_llm::local_model::runtime_config::StructuralTagMode;
+use dynamo_llm::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
+use dynamo_llm::preprocessor::PreprocessedRequest;
+use dynamo_llm::protocols::codec::create_message_stream;
+use dynamo_llm::protocols::common::FinishReason as BackendFinishReason;
+use dynamo_llm::protocols::common::llm_backend::LLMEngineOutput;
+use dynamo_llm::request_trace::{self, RequestTraceEventType};
+use dynamo_protocols::types::FinishReason as OpenAIFinishReason;
+use dynamo_runtime::config::environment_names::llm::DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS;
+use dynamo_runtime::config::environment_names::llm::request_trace as request_trace_env;
+use futures::StreamExt;
+use serde_json::{Value, json};
+use serial_test::serial;
+use tokio_util::sync::CancellationToken;
+
+#[path = "common/ports.rs"]
+mod ports;
+#[path = "common/raw_chat_harness.rs"]
+mod raw_chat_harness;
+
+use raw_chat_harness::{MODEL, RawChatHarness, WorkerScript};
+
+const ENV: [(&str, Option<&str>); 3] = [
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+    (request_trace_env::DYN_REQUEST_TRACE, Some("1")),
+    (request_trace_env::DYN_REQUEST_TRACE_SINKS, Some("")),
+];
+const REASONING_AWARE_GUIDED_DECODING: &str = "reasoning_aware_guided_decoding";
+const STRUCTURAL_MARKERS: &[&str] = &[
+    "<think>",
+    "</think>",
+    "<tool_call>",
+    "</tool_call>",
+    "<function=",
+    "</function>",
+    "<parameter=",
+    "</parameter>",
+    "<TOOLCALL>",
+    "</TOOLCALL>",
+    "<|channel|>",
+    "<|start|>",
+    "<|constrain|>",
+    "<|message|>",
+    "<|end|>",
+    "<|call|>",
+    "<｜DSML｜tool_calls>",
+    "</｜DSML｜tool_calls>",
+    "<｜DSML｜invoke",
+    "</｜DSML｜invoke>",
+    "<｜DSML｜parameter",
+    "</｜DSML｜parameter>",
+];
+
+#[derive(Clone, Debug)]
+struct ExpectedCall {
+    name: &'static str,
+    arguments: Value,
+}
+
+#[derive(Clone, Debug)]
+enum ContentExpectation {
+    Empty,
+    Exact(&'static str),
+}
+
+#[derive(Clone, Debug)]
+struct ExpectedResponse {
+    reasoning: Option<String>,
+    content: ContentExpectation,
+    calls: Vec<ExpectedCall>,
+    finish_reason: &'static str,
+}
+
+#[derive(Default, Debug)]
+struct ObservedCall {
+    id: String,
+    call_type: String,
+    name: String,
+    arguments: String,
+}
+
+#[derive(Default, Debug)]
+struct ObservedResponse {
+    reasoning: String,
+    unexpected_reasoning_alias: String,
+    content: String,
+    calls: BTreeMap<u64, ObservedCall>,
+    finish_reason: Option<String>,
+    streaming: bool,
+    next_position: usize,
+    last_reasoning_position: Option<usize>,
+    first_tool_position: Option<usize>,
+    finish_position: Option<usize>,
+    last_output_position: Option<usize>,
+    usage_position: Option<usize>,
+    usage_count: usize,
+    finish_count: usize,
+}
+
+impl ObservedResponse {
+    fn ingest_choice(&mut self, choice: &Value, payload_key: &str) {
+        let position = self.next_position;
+        self.next_position += 1;
+        let payload = &choice[payload_key];
+        if let Some(reasoning) = payload.get("reasoning_content").and_then(Value::as_str) {
+            self.reasoning.push_str(reasoning);
+            if !reasoning.is_empty() {
+                self.last_reasoning_position = Some(position);
+                self.last_output_position = Some(position);
+            }
+        }
+        if let Some(reasoning) = payload.get("reasoning").and_then(Value::as_str) {
+            self.unexpected_reasoning_alias.push_str(reasoning);
+        }
+        if let Some(content) = payload.get("content").and_then(Value::as_str) {
+            self.content.push_str(content);
+            if !content.is_empty() {
+                self.last_output_position = Some(position);
+            }
+        }
+
+        if let Some(calls) = payload.get("tool_calls").and_then(Value::as_array) {
+            if !calls.is_empty() {
+                self.first_tool_position.get_or_insert(position);
+                self.last_output_position = Some(position);
+            }
+            for (ordinal, call) in calls.iter().enumerate() {
+                let index = if self.streaming {
+                    call.get("index")
+                        .and_then(Value::as_u64)
+                        .expect("streaming tool-call delta is missing its index")
+                } else {
+                    ordinal as u64
+                };
+                let observed = self.calls.entry(index).or_default();
+                if let Some(id) = call.get("id").and_then(Value::as_str)
+                    && !id.is_empty()
+                {
+                    if observed.id.is_empty() {
+                        observed.id.push_str(id);
+                    } else {
+                        assert_eq!(observed.id, id, "tool call ID changed across deltas");
+                    }
+                }
+                if let Some(call_type) = call.get("type").and_then(Value::as_str)
+                    && !call_type.is_empty()
+                {
+                    if observed.call_type.is_empty() {
+                        observed.call_type.push_str(call_type);
+                    } else {
+                        assert_eq!(observed.call_type, call_type);
+                    }
+                }
+                let function = &call["function"];
+                if let Some(name) = function.get("name").and_then(Value::as_str)
+                    && !name.is_empty()
+                {
+                    if observed.name.is_empty() {
+                        observed.name.push_str(name);
+                    } else if observed.name != name {
+                        observed.name.push_str(name);
+                    }
+                }
+                if let Some(arguments) = function.get("arguments").and_then(Value::as_str) {
+                    observed.arguments.push_str(arguments);
+                }
+            }
+        }
+
+        if let Some(reason) = choice.get("finish_reason").and_then(Value::as_str) {
+            self.finish_reason = Some(reason.to_string());
+            self.finish_position = Some(position);
+            self.finish_count += 1;
+        }
+    }
+
+    fn ingest_usage(&mut self) {
+        self.usage_position = Some(self.next_position);
+        self.usage_count += 1;
+        self.next_position += 1;
+    }
+}
+
+static REQUEST_TRACE_INIT: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
+async fn ensure_request_trace() {
+    REQUEST_TRACE_INIT
+        .get_or_init(|| async {
+            request_trace::init_from_env_with_shutdown(CancellationToken::new())
+                .await
+                .expect("failed to initialize request tracing");
+        })
+        .await;
+}
+
+fn model_card(
+    reasoning_parser: &str,
+    tool_call_parser: &str,
+    structural_tags: bool,
+    reasoning_aware_guided_decoding: bool,
+) -> ModelDeploymentCard {
+    let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
+    let mut card = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
+    card.runtime_config.reasoning_parser = Some(reasoning_parser.to_string());
+    card.runtime_config.tool_call_parser = Some(tool_call_parser.to_string());
+    card.runtime_config.structural_tag_mode = if structural_tags {
+        StructuralTagMode::On
+    } else {
+        StructuralTagMode::Off
+    };
+    card.runtime_config
+        .set_engine_specific(
+            REASONING_AWARE_GUIDED_DECODING,
+            reasoning_aware_guided_decoding,
+        )
+        .unwrap();
+    card.kv_cache_block_size = 16;
+    card
+}
+
+fn model_card_with_prompt_injected_reasoning(
+    reasoning_parser: &str,
+    tool_call_parser: &str,
+    structural_tags: bool,
+) -> ModelDeploymentCard {
+    let mut card = model_card(reasoning_parser, tool_call_parser, structural_tags, true);
+    let template_dir = data_path("replays/tool-calling-cpu-e2e/prompt-injected");
+    card.chat_template_file = PromptFormatterArtifact::chat_template_from_disk(&template_dir)
+        .expect("failed to load prompt-injected chat template");
+    assert!(card.chat_template_file.is_some());
+    card
+}
+
+fn worker_output(
+    text: Option<String>,
+    finish_reason: Option<BackendFinishReason>,
+) -> LLMEngineOutput {
+    LLMEngineOutput {
+        text,
+        finish_reason,
+        index: Some(0),
+        ..Default::default()
+    }
+}
+
+fn scripted_text(parts: &[&str]) -> WorkerScript {
+    scripted_text_with_finish(parts, BackendFinishReason::Stop)
+}
+
+fn scripted_text_with_finish(parts: &[&str], finish_reason: BackendFinishReason) -> WorkerScript {
+    parts
+        .iter()
+        .map(|part| worker_output(Some((*part).to_string()), None))
+        .chain(std::iter::once(worker_output(None, Some(finish_reason))))
+        .collect()
+}
+
+fn data_path(relative: impl AsRef<Path>) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/data")
+        .join(relative)
+}
+
+fn load_data_json(relative: &str) -> Result<Value> {
+    let path = data_path(relative);
+    serde_json::from_str(
+        &fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?,
+    )
+    .with_context(|| format!("failed to parse {}", path.display()))
+}
+
+/// Convert an existing parser trace's raw content chunks into worker outputs.
+fn load_recorded_parser_trace(relative: &str) -> Result<WorkerScript> {
+    let path = data_path(relative);
+    let root = load_data_json(relative)?;
+    let input_stream = root["input_stream"]
+        .as_array()
+        .with_context(|| format!("{} has no input_stream", path.display()))?;
+    let mut script = Vec::new();
+
+    for annotated in input_stream {
+        let Some(choices) = annotated["data"]["choices"].as_array() else {
+            continue;
+        };
+        for choice in choices {
+            let text = choice["delta"]["content"].as_str().map(ToString::to_string);
+            let finish_reason = match choice["finish_reason"].as_str() {
+                Some("length") => Some(BackendFinishReason::Length),
+                Some("content_filter") => Some(BackendFinishReason::ContentFilter),
+                Some(_) => Some(BackendFinishReason::Stop),
+                None => None,
+            };
+            if text.is_some() || finish_reason.is_some() {
+                script.push(worker_output(text, finish_reason));
+            }
+        }
+    }
+
+    anyhow::ensure!(
+        !script.is_empty(),
+        "{} yielded no backend chunks",
+        path.display()
+    );
+    anyhow::ensure!(
+        script.iter().any(|chunk| chunk.finish_reason.is_some()),
+        "{} has no terminal backend chunk",
+        path.display()
+    );
+    Ok(script)
+}
+
+fn load_recorded_expected_text(relative: &str, field: &str) -> Result<String> {
+    load_data_json(relative)?["expected_output"][field]
+        .as_str()
+        .map(ToString::to_string)
+        .with_context(|| format!("{relative} has no expected_output.{field}"))
+}
+
+fn load_nemotron_required_trace() -> Result<WorkerScript> {
+    let root = load_data_json("replays/tool-calling-cpu-e2e/nemotron-nano-required-guided.json")?;
+    root["raw_backend_stream"]
+        .as_array()
+        .context("Nemotron trace has no raw_backend_stream")?
+        .iter()
+        .map(|chunk| {
+            let text = chunk["text"].as_str().map(ToString::to_string);
+            let finish_reason = match chunk["finish_reason"].as_str() {
+                Some("length") => Some(BackendFinishReason::Length),
+                Some(_) => Some(BackendFinishReason::Stop),
+                None => None,
+            };
+            Ok(worker_output(text, finish_reason))
+        })
+        .collect()
+}
+
+fn load_nemotron_expected_reasoning() -> Result<String> {
+    load_data_json("replays/tool-calling-cpu-e2e/nemotron-nano-required-guided.json")?
+        ["raw_backend_stream"][0]["text"]
+        .as_str()
+        .map(ToString::to_string)
+        .context("Nemotron trace has no initial reasoning text")
+}
+
+fn weather_tool() -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a location.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                    "unit": {"type": "string"}
+                },
+                "required": ["location"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn time_tool() -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": "get_time",
+            "description": "Get the time in a timezone.",
+            "parameters": {
+                "type": "object",
+                "properties": {"timezone": {"type": "string"}},
+                "required": ["timezone"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn deepseek_weather_tool() -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": "get_current_weather",
+            "description": "Get weather for a location.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                    "format": {"type": "string"}
+                },
+                "required": ["location", "format"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+fn strict_tool(mut tool: Value) -> Value {
+    tool["function"]["strict"] = Value::Bool(true);
+    tool
+}
+
+fn chat_body(
+    tool_choice: &str,
+    tools: Vec<Value>,
+    parallel_tool_calls: bool,
+    thinking_key: &str,
+    reasoning_enabled: bool,
+) -> Value {
+    json!({
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Use the available tools when appropriate."}],
+        "tools": tools,
+        "tool_choice": tool_choice,
+        "parallel_tool_calls": parallel_tool_calls,
+        "temperature": 0,
+        "max_tokens": 1024,
+        "stream_options": {"include_usage": true},
+        "chat_template_kwargs": {thinking_key: reasoning_enabled}
+    })
+}
+
+async fn post_chat(svc: &RawChatHarness, body: &Value, streaming: bool) -> ObservedResponse {
+    let mut body = body.clone();
+    body["stream"] = Value::Bool(streaming);
+    if !streaming {
+        body.as_object_mut().unwrap().remove("stream_options");
+    }
+    let response = svc
+        .client
+        .post(format!("{}/v1/chat/completions", svc.base_url))
+        .header("x-dynamo-session-id", "cpu-tool-e2e-session")
+        .json(&body)
+        .send()
+        .await
+        .expect("POST /v1/chat/completions failed");
+    if response.status() != reqwest::StatusCode::OK {
+        let status = response.status();
+        let error = response.text().await.unwrap_or_default();
+        panic!("chat request failed with {status}: {error}");
+    }
+
+    let mut observed = ObservedResponse {
+        streaming,
+        ..Default::default()
+    };
+    if streaming {
+        let raw = response.text().await.unwrap();
+        let data_lines: Vec<_> = raw
+            .lines()
+            .filter(|line| line.starts_with("data: "))
+            .collect();
+        assert_eq!(
+            data_lines
+                .iter()
+                .filter(|line| **line == "data: [DONE]")
+                .count(),
+            1,
+            "{raw}"
+        );
+        assert_eq!(
+            data_lines.last().copied(),
+            Some("data: [DONE]"),
+            "SSE data appeared after [DONE]: {raw}"
+        );
+        let mut messages = create_message_stream(&raw);
+        while let Some(message) = messages.next().await {
+            let message = message.expect("invalid SSE response frame");
+            let Some(data) = message.data else {
+                continue;
+            };
+            if data == "[DONE]" {
+                continue;
+            }
+            let chunk: Value = serde_json::from_str(&data).expect("invalid SSE response JSON");
+            if chunk.get("usage").is_some_and(|usage| !usage.is_null()) {
+                assert_eq!(
+                    chunk["choices"].as_array().map(Vec::len),
+                    Some(0),
+                    "streaming usage must be emitted in a choices-free terminal chunk"
+                );
+                observed.ingest_usage();
+            }
+            for choice in chunk["choices"].as_array().into_iter().flatten() {
+                observed.ingest_choice(choice, "delta");
+            }
+        }
+    } else {
+        let response: Value = response.json().await.unwrap();
+        for choice in response["choices"].as_array().into_iter().flatten() {
+            observed.ingest_choice(choice, "message");
+        }
+    }
+    observed
+}
+
+fn assert_response(observed: &ObservedResponse, expected: &ExpectedResponse) {
+    assert!(
+        observed.unexpected_reasoning_alias.is_empty(),
+        "response used nonstandard `reasoning` instead of `reasoning_content`: {:?}",
+        observed.unexpected_reasoning_alias
+    );
+    match expected.reasoning.as_deref() {
+        Some(reasoning) => assert_eq!(observed.reasoning, reasoning),
+        None => assert!(
+            observed.reasoning.is_empty(),
+            "reasoning should be disabled: {:?}",
+            observed.reasoning
+        ),
+    }
+    match expected.content {
+        ContentExpectation::Empty => assert_eq!(
+            observed.content, "",
+            "tool-only response leaked content or separators"
+        ),
+        ContentExpectation::Exact(expected) => assert_eq!(observed.content, expected),
+    }
+    assert_eq!(observed.calls.len(), expected.calls.len(), "{observed:#?}");
+    assert_eq!(
+        observed.calls.keys().copied().collect::<Vec<_>>(),
+        (0..expected.calls.len() as u64).collect::<Vec<_>>(),
+        "tool call indices must be dense and ordered"
+    );
+    let mut ids = HashSet::new();
+    for (observed, expected) in observed.calls.values().zip(&expected.calls) {
+        assert!(!observed.id.is_empty(), "tool call ID is empty");
+        assert!(
+            ids.insert(&observed.id),
+            "duplicate tool call ID: {}",
+            observed.id
+        );
+        assert_eq!(observed.call_type, "function");
+        assert_eq!(observed.name, expected.name);
+        assert_eq!(
+            serde_json::from_str::<Value>(&observed.arguments).unwrap(),
+            expected.arguments
+        );
+    }
+    assert_eq!(
+        observed.finish_reason.as_deref(),
+        Some(expected.finish_reason)
+    );
+    assert_eq!(observed.finish_count, 1, "{observed:#?}");
+    if observed.streaming && observed.last_output_position.is_some() {
+        assert!(
+            observed.last_output_position <= observed.finish_position,
+            "semantic output arrived after the terminal finish: {observed:#?}"
+        );
+    }
+    if observed.streaming && !expected.calls.is_empty() && expected.reasoning.is_some() {
+        assert!(
+            observed.last_reasoning_position < observed.first_tool_position,
+            "tool delta arrived before reasoning completed: {observed:#?}"
+        );
+    }
+    if observed.streaming {
+        assert_eq!(observed.usage_count, 1, "{observed:#?}");
+        assert!(
+            observed.finish_position < observed.usage_position,
+            "usage arrived before the terminal choice: {observed:#?}"
+        );
+    }
+
+    let visible = format!(
+        "{}{}{}",
+        observed.reasoning,
+        observed.content,
+        observed
+            .calls
+            .values()
+            .map(|call| call.arguments.as_str())
+            .collect::<String>()
+    );
+    for marker in STRUCTURAL_MARKERS {
+        assert!(
+            !visible.contains(marker),
+            "marker {marker:?} leaked: {visible:?}"
+        );
+    }
+}
+
+async fn run_streaming_and_unary(
+    card: ModelDeploymentCard,
+    script: WorkerScript,
+    body: Value,
+    expected: ExpectedResponse,
+) -> Vec<PreprocessedRequest> {
+    ensure_request_trace().await;
+    let svc = RawChatHarness::start(card, [script.clone(), script]).await;
+    for streaming in [false, true] {
+        let observed = post_chat(&svc, &body, streaming).await;
+        assert_response(&observed, &expected);
+    }
+    assert_eq!(svc.engine.remaining_scripts().await, 0);
+    let requests = svc.engine.take_requests().await;
+    assert_eq!(requests.len(), 2);
+    svc.shutdown().await;
+    requests
+}
+
+fn assert_json_guidance(requests: &[PreprocessedRequest], tools: &[Value]) {
+    for request in requests {
+        let guided = request
+            .sampling_options
+            .guided_decoding
+            .as_ref()
+            .expect("required tool choice did not create guided decoding");
+        let schema = guided
+            .json
+            .as_ref()
+            .expect("required tool choice has no JSON schema");
+        assert!(guided.structural_tag.is_none());
+        assert!(guided.regex.is_none());
+        assert!(guided.choice.is_none());
+        assert!(guided.grammar.is_none());
+        assert!(guided.backend.is_none());
+        assert!(guided.whitespace_pattern.is_none());
+        assert_eq!(schema["type"], "array");
+        assert_eq!(schema["minItems"], 1);
+        let alternatives = schema["items"]["anyOf"]
+            .as_array()
+            .expect("required tool schema has no alternatives");
+        assert_eq!(alternatives.len(), tools.len());
+        for (alternative, tool) in alternatives.iter().zip(tools) {
+            assert_eq!(
+                alternative["properties"]["name"]["enum"],
+                json!([tool["function"]["name"]])
+            );
+            assert_eq!(
+                alternative["properties"]["parameters"],
+                tool["function"]["parameters"]
+            );
+            assert_eq!(alternative["required"], json!(["name", "parameters"]));
+        }
+    }
+}
+
+fn assert_no_guidance(requests: &[PreprocessedRequest]) {
+    for request in requests {
+        if let Some(guided) = request.sampling_options.guided_decoding.as_ref() {
+            assert!(
+                guided.json.is_none(),
+                "unexpected JSON guidance: {guided:#?}"
+            );
+            assert!(
+                guided.regex.is_none(),
+                "unexpected regex guidance: {guided:#?}"
+            );
+            assert!(
+                guided.choice.is_none(),
+                "unexpected choice guidance: {guided:#?}"
+            );
+            assert!(
+                guided.grammar.is_none(),
+                "unexpected grammar guidance: {guided:#?}"
+            );
+            assert!(
+                guided.structural_tag.is_none(),
+                "unexpected structural guidance: {guided:#?}"
+            );
+            assert!(guided.backend.is_none(), "unexpected backend: {guided:#?}");
+            assert!(
+                guided.whitespace_pattern.is_none(),
+                "unexpected whitespace policy: {guided:#?}"
+            );
+        }
+    }
+}
+
+fn collect_tool_tags<'a>(value: &'a Value, tags: &mut Vec<(&'a str, &'a Value)>) {
+    match value {
+        Value::Object(object) => {
+            if let (Some(begin), Some(content)) = (
+                object.get("begin").and_then(Value::as_str),
+                object.get("content"),
+            ) && content["type"] == "json_schema"
+            {
+                tags.push((begin, &content["json_schema"]));
+            }
+            for child in object.values() {
+                collect_tool_tags(child, tags);
+            }
+        }
+        Value::Array(array) => {
+            for child in array {
+                collect_tool_tags(child, tags);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_structural_guidance(
+    requests: &[PreprocessedRequest],
+    tools: &[Value],
+    required: bool,
+    parallel: bool,
+    starts_in_reasoning: bool,
+) {
+    for request in requests {
+        let guided = request
+            .sampling_options
+            .guided_decoding
+            .as_ref()
+            .expect("structural-tag policy did not create guided decoding");
+        let structural_tag = guided
+            .structural_tag
+            .as_ref()
+            .expect("structural-tag policy did not create a tag");
+        assert!(guided.json.is_none());
+        assert!(guided.regex.is_none());
+        assert!(guided.choice.is_none());
+        assert!(guided.grammar.is_none());
+        assert!(guided.backend.is_none());
+        assert!(guided.whitespace_pattern.is_none());
+        assert_eq!(structural_tag["type"], "structural_tag");
+
+        let mut format = &structural_tag["format"];
+        if starts_in_reasoning {
+            assert_eq!(format["type"], "sequence");
+            assert_eq!(format["elements"][0]["end"], "</think>");
+            format = &format["elements"][1];
+        } else {
+            assert_ne!(format["type"], "sequence");
+        }
+        assert_eq!(format["at_least_one"], required);
+        assert_eq!(format["stop_after_first"], !parallel);
+
+        let mut tool_tags = Vec::new();
+        collect_tool_tags(format, &mut tool_tags);
+        assert_eq!(tool_tags.len(), tools.len(), "{structural_tag:#?}");
+        for ((begin, schema), tool) in tool_tags.into_iter().zip(tools) {
+            let name = tool["function"]["name"].as_str().unwrap();
+            assert!(
+                begin.contains(name),
+                "tool tag {begin:?} does not select {name:?}"
+            );
+            assert_eq!(schema, &tool["function"]["parameters"]);
+        }
+    }
+}
+
+fn assert_reasoning_metadata(
+    requests: &[PreprocessedRequest],
+    ended: bool,
+    expected_chat_template_kwargs: &Value,
+) {
+    for request in requests {
+        let extra = request
+            .extra_args
+            .as_ref()
+            .and_then(Value::as_object)
+            .expect("reasoning-aware backend metadata is missing");
+        assert_eq!(
+            extra
+                .get("reasoning_parser_kwargs")
+                .and_then(|value| value.get("chat_template_kwargs")),
+            Some(expected_chat_template_kwargs),
+            "unexpected native reasoning parser kwargs: {extra:#?}"
+        );
+        assert_eq!(
+            extra.get("reasoning_ended").and_then(Value::as_bool),
+            ended.then_some(true),
+            "unexpected initial reasoning state: {extra:#?}"
+        );
+    }
+}
+
+#[path = "tool_calling_cpu_e2e/cases.rs"]
+mod cases;

--- a/lib/llm/tests/tool_calling_cpu_e2e.rs
+++ b/lib/llm/tests/tool_calling_cpu_e2e.rs
@@ -240,7 +240,26 @@ fn model_card_with_prompt_injected_reasoning(
     tool_call_parser: &str,
     structural_tags: bool,
 ) -> ModelDeploymentCard {
-    let mut card = model_card(reasoning_parser, tool_call_parser, structural_tags, true);
+    model_card_with_prompt_injected_reasoning_capability(
+        reasoning_parser,
+        tool_call_parser,
+        structural_tags,
+        true,
+    )
+}
+
+fn model_card_with_prompt_injected_reasoning_capability(
+    reasoning_parser: &str,
+    tool_call_parser: &str,
+    structural_tags: bool,
+    reasoning_aware_guided_decoding: bool,
+) -> ModelDeploymentCard {
+    let mut card = model_card(
+        reasoning_parser,
+        tool_call_parser,
+        structural_tags,
+        reasoning_aware_guided_decoding,
+    );
     let template_dir = data_path("replays/tool-calling-cpu-e2e/prompt-injected");
     card.chat_template_file = PromptFormatterArtifact::chat_template_from_disk(&template_dir)
         .expect("failed to load prompt-injected chat template");
@@ -450,6 +469,23 @@ fn chat_body_with_template_kwargs(
         "stream_options": {"include_usage": true},
         "chat_template_kwargs": chat_template_kwargs
     })
+}
+
+fn chat_body_with_response_format(
+    tool_choice: &str,
+    tools: Vec<Value>,
+    parallel_tool_calls: bool,
+    chat_template_kwargs: Value,
+    response_format: Value,
+) -> Value {
+    let mut body = chat_body_with_template_kwargs(
+        tool_choice,
+        tools,
+        parallel_tool_calls,
+        chat_template_kwargs,
+    );
+    body["response_format"] = response_format;
+    body
 }
 
 async fn post_chat(svc: &RawChatHarness, body: &Value, streaming: bool) -> ObservedResponse {
@@ -668,6 +704,23 @@ fn assert_json_guidance(requests: &[PreprocessedRequest], tools: &[Value]) {
             );
             assert_eq!(alternative["required"], json!(["name", "parameters"]));
         }
+    }
+}
+
+fn assert_response_format_json_guidance(requests: &[PreprocessedRequest], schema: &Value) {
+    for request in requests {
+        let guided = request
+            .sampling_options
+            .guided_decoding
+            .as_ref()
+            .expect("response_format did not create guided decoding");
+        assert_eq!(guided.json.as_ref(), Some(schema));
+        assert!(guided.structural_tag.is_none());
+        assert!(guided.regex.is_none());
+        assert!(guided.choice.is_none());
+        assert!(guided.grammar.is_none());
+        assert!(guided.backend.is_none());
+        assert!(guided.whitespace_pattern.is_none());
     }
 }
 

--- a/lib/llm/tests/tool_calling_cpu_e2e.rs
+++ b/lib/llm/tests/tool_calling_cpu_e2e.rs
@@ -425,6 +425,20 @@ fn chat_body(
     thinking_key: &str,
     reasoning_enabled: bool,
 ) -> Value {
+    chat_body_with_template_kwargs(
+        tool_choice,
+        tools,
+        parallel_tool_calls,
+        json!({thinking_key: reasoning_enabled}),
+    )
+}
+
+fn chat_body_with_template_kwargs(
+    tool_choice: &str,
+    tools: Vec<Value>,
+    parallel_tool_calls: bool,
+    chat_template_kwargs: Value,
+) -> Value {
     json!({
         "model": MODEL,
         "messages": [{"role": "user", "content": "Use the available tools when appropriate."}],
@@ -434,7 +448,7 @@ fn chat_body(
         "temperature": 0,
         "max_tokens": 1024,
         "stream_options": {"include_usage": true},
-        "chat_template_kwargs": {thinking_key: reasoning_enabled}
+        "chat_template_kwargs": chat_template_kwargs
     })
 }
 
@@ -566,8 +580,12 @@ fn assert_response(observed: &ObservedResponse, expected: &ExpectedResponse) {
         );
     }
     if observed.streaming && !expected.calls.is_empty() && expected.reasoning.is_some() {
+        // force_nonempty_content must buffer reasoning until it knows whether
+        // content or a tool call follows, so the boundary may be coalesced into
+        // one delta. Reasoning may accompany the first tool delta, but must
+        // never arrive after it.
         assert!(
-            observed.last_reasoning_position < observed.first_tool_position,
+            observed.last_reasoning_position <= observed.first_tool_position,
             "tool delta arrived before reasoning completed: {observed:#?}"
         );
     }

--- a/lib/llm/tests/tool_calling_cpu_e2e/cases.rs
+++ b/lib/llm/tests/tool_calling_cpu_e2e/cases.rs
@@ -1,0 +1,780 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+#[tokio::test]
+#[serial]
+async fn required_nemotron_delays_guided_json_until_force_reasoning_ends() {
+    temp_env::async_with_vars(ENV, async {
+        let expected = ExpectedResponse {
+            reasoning: Some(load_nemotron_expected_reasoning().unwrap()),
+            content: ContentExpectation::Empty,
+            calls: vec![ExpectedCall {
+                name: "get_weather",
+                arguments: json!({"location": "San Francisco"}),
+            }],
+            finish_reason: "tool_calls",
+        };
+        let requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, true),
+            load_nemotron_required_trace().unwrap(),
+            chat_body(
+                "required",
+                vec![weather_tool()],
+                false,
+                "enable_thinking",
+                true,
+            ),
+            expected,
+        )
+        .await;
+        assert_json_guidance(&requests, &[weather_tool()]);
+        assert_reasoning_metadata(&requests, false, &json!({"enable_thinking": true}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_guided_json_handles_reasoning_off_and_multiple_tools() {
+    temp_env::async_with_vars(ENV, async {
+        let script = scripted_text(&[
+            r#"[{"name":"get_weather","parameters":{"location":"Tokyo"}},"#,
+            r#"{"name":"get_time","parameters":{"timezone":"UTC"}}]"#,
+        ]);
+        let expected = ExpectedResponse {
+            reasoning: None,
+            content: ContentExpectation::Empty,
+            calls: vec![
+                ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Tokyo"}),
+                },
+                ExpectedCall {
+                    name: "get_time",
+                    arguments: json!({"timezone": "UTC"}),
+                },
+            ],
+            finish_reason: "tool_calls",
+        };
+        let requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, true),
+            script,
+            chat_body(
+                "required",
+                vec![weather_tool(), time_tool()],
+                true,
+                "enable_thinking",
+                false,
+            ),
+            expected,
+        )
+        .await;
+        assert_json_guidance(&requests, &[weather_tool(), time_tool()]);
+        assert_reasoning_metadata(&requests, true, &json!({"enable_thinking": false}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_guided_json_supports_a_second_force_reasoning_family() {
+    temp_env::async_with_vars(ENV, async {
+        let expected = ExpectedResponse {
+            reasoning: Some("I need the weather tool before answering.".to_string()),
+            content: ContentExpectation::Empty,
+            calls: vec![ExpectedCall {
+                name: "get_weather",
+                arguments: json!({"location": "Paris"}),
+            }],
+            finish_reason: "tool_calls",
+        };
+        let requests = run_streaming_and_unary(
+            model_card("deepseek_r1", "qwen3_coder", false, true),
+            scripted_text(&[
+                "I need the weather tool before answering.",
+                "</think>",
+                r#"[{"name":"get_weather","parameters":{"location":"Paris"}}]"#,
+            ]),
+            chat_body("required", vec![weather_tool()], false, "thinking", true),
+            expected,
+        )
+        .await;
+        assert_json_guidance(&requests, &[weather_tool()]);
+        assert_reasoning_metadata(&requests, false, &json!({"thinking": true}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_guided_json_supports_non_force_reasoning() {
+    temp_env::async_with_vars(ENV, async {
+        let requests = run_streaming_and_unary(
+            model_card("qwen3", "hermes", false, true),
+            scripted_text(&[
+                "<think>I need the weather tool.",
+                "</think>",
+                r#"[{"name":"get_weather","parameters":{"location":"Prague"}}]"#,
+            ]),
+            chat_body(
+                "required",
+                vec![weather_tool()],
+                false,
+                "enable_thinking",
+                true,
+            ),
+            ExpectedResponse {
+                reasoning: Some("I need the weather tool.".to_string()),
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Prague"}),
+                }],
+                finish_reason: "tool_calls",
+            },
+        )
+        .await;
+        assert_json_guidance(&requests, &[weather_tool()]);
+        assert_reasoning_metadata(&requests, false, &json!({"enable_thinking": true}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_guided_json_supports_minimax_append_reasoning() {
+    temp_env::async_with_vars(ENV, async {
+        let requests = run_streaming_and_unary(
+            model_card("minimax_append_think", "minimax_m2", false, true),
+            scripted_text(&[
+                "I need the weather tool.",
+                "</think>",
+                r#"[{"name":"get_weather","parameters":{"location":"Osaka"}}]"#,
+            ]),
+            chat_body("required", vec![weather_tool()], false, "thinking", true),
+            ExpectedResponse {
+                reasoning: Some("I need the weather tool.".to_string()),
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Osaka"}),
+                }],
+                finish_reason: "tool_calls",
+            },
+        )
+        .await;
+        assert_json_guidance(&requests, &[weather_tool()]);
+        assert_reasoning_metadata(&requests, false, &json!({"thinking": true}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_prompt_injected_reasoning_covers_json_and_structural_guidance() {
+    temp_env::async_with_vars(ENV, async {
+        let json_requests = run_streaming_and_unary(
+            model_card_with_prompt_injected_reasoning("qwen3", "hermes", false),
+            scripted_text(&[
+                "Reasoning from the prefilled opener.",
+                "</think>",
+                r#"[{"name":"get_weather","parameters":{"location":"Dublin"}}]"#,
+            ]),
+            chat_body(
+                "required",
+                vec![weather_tool()],
+                false,
+                "enable_thinking",
+                true,
+            ),
+            ExpectedResponse {
+                reasoning: Some("Reasoning from the prefilled opener.".to_string()),
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Dublin"}),
+                }],
+                finish_reason: "tool_calls",
+            },
+        )
+        .await;
+        assert_json_guidance(&json_requests, &[weather_tool()]);
+        assert_reasoning_metadata(
+            &json_requests,
+            false,
+            &json!({"enable_thinking": true}),
+        );
+
+        let structural_requests = run_streaming_and_unary(
+            model_card_with_prompt_injected_reasoning("qwen3", "qwen3_coder", true),
+            scripted_text(&[
+                "Reasoning before a structurally guided call.",
+                "</think>",
+                "<tool_call>\n<function=get_weather>\n<parameter=location>\nVienna\n</parameter>\n</function>\n</tool_call>",
+            ]),
+            chat_body(
+                "required",
+                vec![strict_tool(weather_tool())],
+                false,
+                "enable_thinking",
+                true,
+            ),
+            ExpectedResponse {
+                reasoning: Some("Reasoning before a structurally guided call.".to_string()),
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Vienna"}),
+                }],
+                finish_reason: "tool_calls",
+            },
+        )
+        .await;
+        assert_structural_guidance(
+            &structural_requests,
+            &[strict_tool(weather_tool())],
+            true,
+            false,
+            true,
+        );
+        assert_reasoning_metadata(
+            &structural_requests,
+            true,
+            &json!({"enable_thinking": true}),
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_guided_json_fails_closed_without_backend_reasoning_capability() {
+    temp_env::async_with_vars(ENV, async {
+        let expected = ExpectedResponse {
+            reasoning: None,
+            content: ContentExpectation::Empty,
+            calls: vec![ExpectedCall {
+                name: "get_weather",
+                arguments: json!({"location": "Rome"}),
+            }],
+            finish_reason: "tool_calls",
+        };
+        let requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, false),
+            scripted_text(&[r#"[{"name":"get_weather","parameters":{"location":"Rome"}}]"#]),
+            chat_body(
+                "required",
+                vec![weather_tool()],
+                false,
+                "enable_thinking",
+                true,
+            ),
+            expected,
+        )
+        .await;
+        assert_json_guidance(&requests, &[weather_tool()]);
+        for request in requests {
+            assert!(
+                request.extra_args.is_none(),
+                "an unverified backend must not receive native reasoner controls"
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_tool_calls_replay_real_vllm_and_sglang_qwen_streams() {
+    temp_env::async_with_vars(ENV, async {
+        let traces = [
+            (
+                "vllm/qwen3-0.6B/chat_completion_stream_8f33c28b-tool.json",
+                json!({"location": "San Francisco, CA", "unit": "celsius"}),
+            ),
+            (
+                "sglang/qwen3-0.6B/chat_completion_stream_c42ba578-tool.json",
+                json!({"location": "Tokyo", "unit": "celsius"}),
+            ),
+        ];
+        for (trace, arguments) in traces {
+            let expected = ExpectedResponse {
+                reasoning: Some(load_recorded_expected_text(trace, "reasoning_content").unwrap()),
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments,
+                }],
+                finish_reason: "tool_calls",
+            };
+            let requests = run_streaming_and_unary(
+                model_card("qwen3", "hermes", false, true),
+                load_recorded_parser_trace(trace).unwrap(),
+                chat_body("auto", vec![weather_tool()], false, "enable_thinking", true),
+                expected,
+            )
+            .await;
+            assert_no_guidance(&requests);
+            assert_reasoning_metadata(&requests, false, &json!({"enable_thinking": true}));
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_harmony_replays_real_channel_token_stream() {
+    temp_env::async_with_vars(ENV, async {
+        let expected = ExpectedResponse {
+            reasoning: Some(
+                load_recorded_expected_text(
+                    "vllm/gpt-oss-20b/chat_completion_stream_f0c86d72-tool.json",
+                    "reasoning_content",
+                )
+                .unwrap(),
+            ),
+            content: ContentExpectation::Empty,
+            calls: vec![ExpectedCall {
+                name: "get_weather",
+                arguments: json!({"location": "San Francisco, CA", "unit": "celsius"}),
+            }],
+            finish_reason: "tool_calls",
+        };
+        let requests = run_streaming_and_unary(
+            model_card("gpt_oss", "harmony", false, true),
+            load_recorded_parser_trace(
+                "vllm/gpt-oss-20b/chat_completion_stream_f0c86d72-tool.json",
+            )
+            .unwrap(),
+            chat_body("auto", vec![weather_tool()], false, "thinking", true),
+            expected,
+        )
+        .await;
+        for request in &requests {
+            assert_eq!(
+                request.output_options.skip_special_tokens,
+                Some(false),
+                "Harmony markers must survive worker decoding for the parsers"
+            );
+        }
+        assert_no_guidance(&requests);
+        assert_reasoning_metadata(&requests, false, &json!({"thinking": true}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_direct_answer_separates_reasoning_and_honors_reasoning_off() {
+    temp_env::async_with_vars(ENV, async {
+        let qwen_expected = ExpectedResponse {
+            reasoning: Some(
+                load_recorded_expected_text(
+                    "vllm/qwen3-0.6B/chat_completion_stream_5627a4c6-no-tool.json",
+                    "reasoning_content",
+                )
+                .unwrap(),
+            ),
+            content: ContentExpectation::Exact(
+                "\n\nI'm here to help! If you have any questions about NYC, weather, or anything else, feel free to ask! 😊",
+            ),
+            calls: Vec::new(),
+            finish_reason: "stop",
+        };
+        let qwen_requests = run_streaming_and_unary(
+            model_card("qwen3", "hermes", false, true),
+            load_recorded_parser_trace(
+                "vllm/qwen3-0.6B/chat_completion_stream_5627a4c6-no-tool.json",
+            )
+            .unwrap(),
+            chat_body("auto", vec![weather_tool()], false, "enable_thinking", true),
+            qwen_expected,
+        )
+        .await;
+        assert_no_guidance(&qwen_requests);
+        assert_reasoning_metadata(
+            &qwen_requests,
+            false,
+            &json!({"enable_thinking": true}),
+        );
+
+        let direct_expected = ExpectedResponse {
+            reasoning: None,
+            content: ContentExpectation::Exact("37 multiplied by 19 is 703."),
+            calls: Vec::new(),
+            finish_reason: "stop",
+        };
+        let direct_requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, true),
+            scripted_text(&["37 multiplied by 19 is 703."]),
+            chat_body(
+                "auto",
+                vec![weather_tool()],
+                false,
+                "enable_thinking",
+                false,
+            ),
+            direct_expected,
+        )
+        .await;
+        assert_no_guidance(&direct_requests);
+        assert_reasoning_metadata(
+            &direct_requests,
+            true,
+            &json!({"enable_thinking": false}),
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_reasoning_off_still_parses_tool_call() {
+    temp_env::async_with_vars(ENV, async {
+        let requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, true),
+            scripted_text(&[
+                "<tool_call>\n<function=get_weather>\n<parameter=location>\nSeoul\n</parameter>\n</function>\n</tool_call>",
+            ]),
+            chat_body(
+                "auto",
+                vec![weather_tool()],
+                false,
+                "enable_thinking",
+                false,
+            ),
+            ExpectedResponse {
+                reasoning: None,
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Seoul"}),
+                }],
+                finish_reason: "tool_calls",
+            },
+        )
+        .await;
+        assert_no_guidance(&requests);
+        assert_reasoning_metadata(
+            &requests,
+            true,
+            &json!({"enable_thinking": false}),
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_preserves_narration_before_tool_call() {
+    temp_env::async_with_vars(ENV, async {
+        let requests = run_streaming_and_unary(
+            model_card("qwen3", "hermes", false, true),
+            scripted_text(&[
+                "<think>I need current weather.",
+                "</think>",
+                "\n\nI'll check it now.\n",
+                r#"<tool_call>{"name":"get_weather","arguments":{"location":"Lisbon"}}</tool_call>"#,
+            ]),
+            chat_body("auto", vec![weather_tool()], false, "enable_thinking", true),
+            ExpectedResponse {
+                reasoning: Some("I need current weather.".to_string()),
+                content: ContentExpectation::Exact("\n\nI'll check it now.\n"),
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Lisbon"}),
+                }],
+                finish_reason: "tool_calls",
+            },
+        )
+        .await;
+        assert_no_guidance(&requests);
+        assert_reasoning_metadata(
+            &requests,
+            false,
+            &json!({"enable_thinking": true}),
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_structural_tags_allow_direct_answer() {
+    temp_env::async_with_vars(ENV, async {
+        let requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", true, true),
+            scripted_text(&[
+                "I can answer directly without a tool.",
+                "</think>",
+                "The answer is 42.",
+            ]),
+            chat_body(
+                "auto",
+                vec![strict_tool(weather_tool())],
+                false,
+                "enable_thinking",
+                true,
+            ),
+            ExpectedResponse {
+                reasoning: Some("I can answer directly without a tool.".to_string()),
+                content: ContentExpectation::Exact("The answer is 42."),
+                calls: Vec::new(),
+                finish_reason: "stop",
+            },
+        )
+        .await;
+        assert_structural_guidance(
+            &requests,
+            &[strict_tool(weather_tool())],
+            false,
+            false,
+            false,
+        );
+        assert_reasoning_metadata(&requests, false, &json!({"enable_thinking": true}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_structural_tags_parse_reasoning_and_parallel_calls() {
+    temp_env::async_with_vars(ENV, async {
+        let expected = ExpectedResponse {
+            reasoning: Some(
+                load_recorded_expected_text(
+                    "vllm/deepseek-v4/chat_completion_stream_multi_tool.json",
+                    "reasoning_content",
+                )
+                .unwrap(),
+            ),
+            content: ContentExpectation::Empty,
+            calls: vec![
+                ExpectedCall {
+                    name: "get_current_weather",
+                    arguments: json!({"location": "Beijing", "format": "celsius"}),
+                },
+                ExpectedCall {
+                    name: "get_current_weather",
+                    arguments: json!({"location": "Shanghai", "format": "celsius"}),
+                },
+            ],
+            finish_reason: "tool_calls",
+        };
+        let requests = run_streaming_and_unary(
+            model_card("deepseek_v4", "deepseek_v4", true, true),
+            load_recorded_parser_trace("vllm/deepseek-v4/chat_completion_stream_multi_tool.json")
+                .unwrap(),
+            chat_body(
+                "required",
+                vec![strict_tool(deepseek_weather_tool())],
+                true,
+                "thinking",
+                true,
+            ),
+            expected,
+        )
+        .await;
+        assert_structural_guidance(
+            &requests,
+            &[strict_tool(deepseek_weather_tool())],
+            true,
+            true,
+            false,
+        );
+        assert_reasoning_metadata(
+            &requests,
+            false,
+            &json!({"thinking": true, "enable_thinking": true}),
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_structural_tags_require_reasoning_aware_backend_capability() {
+    temp_env::async_with_vars(ENV, async {
+        for capability in [false, true] {
+            let expected = ExpectedResponse {
+                reasoning: Some("I should check the weather.".to_string()),
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Berlin"}),
+                }],
+                finish_reason: "tool_calls",
+            };
+            let requests = run_streaming_and_unary(
+                model_card("nemotron_v3", "nemotron_nano", true, capability),
+                scripted_text(&[
+                    "I should check the weather.",
+                    "</think>",
+                    "<tool_call>\n<function=get_weather>\n<parameter=location>\nBerlin\n</parameter>\n</function>\n</tool_call>",
+                ]),
+                chat_body(
+                    "auto",
+                    vec![strict_tool(weather_tool())],
+                    false,
+                    "enable_thinking",
+                    true,
+                ),
+                expected,
+            )
+            .await;
+            if capability {
+                assert_structural_guidance(
+                    &requests,
+                    &[strict_tool(weather_tool())],
+                    false,
+                    false,
+                    false,
+                );
+                assert_reasoning_metadata(
+                    &requests,
+                    false,
+                    &json!({"enable_thinking": true}),
+                );
+            } else {
+                assert_no_guidance(&requests);
+                for request in requests {
+                    assert!(request.extra_args.is_none());
+                }
+            }
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_guided_json_preserves_length_and_hides_incomplete_json() {
+    temp_env::async_with_vars(ENV, async {
+        let body = chat_body(
+            "required",
+            vec![weather_tool()],
+            false,
+            "enable_thinking",
+            false,
+        );
+        let complete = ExpectedResponse {
+            reasoning: None,
+            content: ContentExpectation::Empty,
+            calls: vec![ExpectedCall {
+                name: "get_weather",
+                arguments: json!({"location": "Madrid"}),
+            }],
+            finish_reason: "length",
+        };
+        let complete_requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, true),
+            scripted_text_with_finish(
+                &[r#"[{"name":"get_weather","parameters":{"location":"Madrid"}}]"#],
+                BackendFinishReason::Length,
+            ),
+            body.clone(),
+            complete,
+        )
+        .await;
+        assert_json_guidance(&complete_requests, &[weather_tool()]);
+        assert_reasoning_metadata(&complete_requests, true, &json!({"enable_thinking": false}));
+
+        let incomplete = ExpectedResponse {
+            reasoning: None,
+            content: ContentExpectation::Empty,
+            calls: Vec::new(),
+            finish_reason: "length",
+        };
+        let incomplete_requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, true),
+            scripted_text_with_finish(
+                &[r#"[{"name":"get_weather","parameters":{"location":"Mad"#],
+                BackendFinishReason::Length,
+            ),
+            body,
+            incomplete,
+        )
+        .await;
+        assert_json_guidance(&incomplete_requests, &[weather_tool()]);
+        assert_reasoning_metadata(
+            &incomplete_requests,
+            true,
+            &json!({"enable_thinking": false}),
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn parsed_tool_response_emits_request_end_trace_metadata() {
+    temp_env::async_with_vars(ENV, async {
+        ensure_request_trace().await;
+        let mut traces = request_trace::subscribe();
+        let svc = RawChatHarness::start(
+            model_card("nemotron_v3", "nemotron_nano", false, true),
+            [scripted_text(&[
+                r#"[{"name":"get_weather","parameters":{"location":"Oslo"}}]"#,
+            ])],
+        )
+        .await;
+        let body = chat_body(
+            "required",
+            vec![weather_tool()],
+            false,
+            "enable_thinking",
+            false,
+        );
+        let observed = post_chat(&svc, &body, true).await;
+        assert_response(
+            &observed,
+            &ExpectedResponse {
+                reasoning: None,
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Oslo"}),
+                }],
+                finish_reason: "tool_calls",
+            },
+        );
+
+        let record = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let record = traces.recv().await.expect("request trace bus closed");
+                if record.event_type == RequestTraceEventType::RequestEnd {
+                    break record;
+                }
+            }
+        })
+        .await
+        .expect("request-end trace was not emitted");
+        assert_eq!(
+            record
+                .agent_context
+                .as_ref()
+                .map(|context| context.session_id.as_str()),
+            Some("cpu-tool-e2e-session")
+        );
+        let metrics = record.request.expect("request-end trace has no metrics");
+        assert_eq!(metrics.model.as_deref(), Some(MODEL));
+        let replay = metrics
+            .replay
+            .expect("request-end trace has no replay data");
+        assert_eq!(replay.trace_block_size, 16);
+        assert!(replay.input_length > 0);
+        let finish = metrics
+            .finish_reason_metadata
+            .expect("request-end trace has no finish metadata");
+        assert_eq!(finish.finish_reason, Some(OpenAIFinishReason::ToolCalls));
+        assert_eq!(finish.backend_finish_reason.as_deref(), Some("stop"));
+        assert_eq!(finish.tool_calls.len(), 1);
+        assert_eq!(finish.tool_calls[0].name.as_deref(), Some("get_weather"));
+
+        assert_eq!(svc.engine.remaining_scripts().await, 0);
+        svc.shutdown().await;
+    })
+    .await;
+}

--- a/lib/llm/tests/tool_calling_cpu_e2e/cases.rs
+++ b/lib/llm/tests/tool_calling_cpu_e2e/cases.rs
@@ -349,6 +349,211 @@ async fn required_prompt_injected_reasoning_covers_json_and_structural_guidance(
 
 #[tokio::test]
 #[serial]
+async fn auto_glm_json_object_response_format_keeps_json_in_content() {
+    temp_env::async_with_vars(ENV, async {
+        let response = r#"{"city":"Paris","temperature_c":18}"#;
+        // JSON guidance may emit a bare object from token zero. Even though
+        // the GLM template prefilled `<think>`, that object is assistant
+        // content and must not be consumed as reasoning.
+        let requests = run_streaming_and_unary(
+            model_card_with_prompt_injected_reasoning_capability("glm45", "glm47", false, false),
+            scripted_text(&[r#"{"city":"Par"#, r#"is","temperature_c":18}"#]),
+            chat_body_with_response_format(
+                "auto",
+                vec![weather_tool()],
+                false,
+                json!({}),
+                json!({"type": "json_object"}),
+            ),
+            ExpectedResponse {
+                reasoning: None,
+                content: ContentExpectation::Exact(response),
+                calls: Vec::new(),
+                finish_reason: "stop",
+            },
+        )
+        .await;
+        assert_response_format_json_guidance(&requests, &json!({"type": "object"}));
+        assert!(requests.iter().all(|request| request.extra_args.is_none()));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_force_reasoning_json_object_response_format_keeps_json_in_content() {
+    temp_env::async_with_vars(ENV, async {
+        let response = r#"{"city":"Lima","temperature_c":24}"#;
+        let requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, false),
+            scripted_text(&[r#"{"city":"Li"#, r#"ma","temperature_c":24}"#]),
+            chat_body_with_response_format(
+                "auto",
+                vec![weather_tool()],
+                false,
+                json!({"enable_thinking": true}),
+                json!({"type": "json_object"}),
+            ),
+            ExpectedResponse {
+                reasoning: None,
+                content: ContentExpectation::Exact(response),
+                calls: Vec::new(),
+                finish_reason: "stop",
+            },
+        )
+        .await;
+        assert_response_format_json_guidance(&requests, &json!({"type": "object"}));
+        assert!(requests.iter().all(|request| request.extra_args.is_none()));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn none_glm_json_schema_response_format_keeps_json_in_content() {
+    temp_env::async_with_vars(ENV, async {
+        let response = r#"{"city":"Tokyo","temperature_c":22}"#;
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "temperature_c": {"type": "integer"}
+            },
+            "required": ["city", "temperature_c"],
+            "additionalProperties": false
+        });
+        let requests = run_streaming_and_unary(
+            model_card_with_prompt_injected_reasoning_capability("glm45", "glm47", false, false),
+            scripted_text(&[r#"{"city":"Tok"#, r#"yo","temperature_c":22}"#]),
+            chat_body_with_response_format(
+                "none",
+                vec![weather_tool()],
+                false,
+                json!({}),
+                json!({
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "weather_response",
+                        "strict": true,
+                        "schema": schema.clone()
+                    }
+                }),
+            ),
+            ExpectedResponse {
+                reasoning: None,
+                content: ContentExpectation::Exact(response),
+                calls: Vec::new(),
+                finish_reason: "stop",
+            },
+        )
+        .await;
+        assert_response_format_json_guidance(&requests, &schema);
+        assert!(requests.iter().all(|request| request.extra_args.is_none()));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_glm_response_format_preserves_reasoning_with_capable_backend() {
+    temp_env::async_with_vars(ENV, async {
+        let response = r#"{"city":"Oslo","temperature_c":12}"#;
+        let requests = run_streaming_and_unary(
+            model_card_with_prompt_injected_reasoning("glm45", "glm47", false),
+            scripted_text(&[
+                "I should answer with structured JSON.",
+                "</thi",
+                "nk>",
+                response,
+            ]),
+            chat_body_with_response_format(
+                "auto",
+                vec![weather_tool()],
+                false,
+                json!({}),
+                json!({"type": "json_object"}),
+            ),
+            ExpectedResponse {
+                reasoning: Some("I should answer with structured JSON.".to_string()),
+                content: ContentExpectation::Exact(response),
+                calls: Vec::new(),
+                finish_reason: "stop",
+            },
+        )
+        .await;
+        assert_response_format_json_guidance(&requests, &json!({"type": "object"}));
+        assert_reasoning_metadata(&requests, false, &json!({}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_response_format_defers_to_tool_guidance() {
+    temp_env::async_with_vars(ENV, async {
+        let requests = run_streaming_and_unary(
+            model_card_with_prompt_injected_reasoning("glm45", "glm47", false),
+            scripted_text(&[
+                "I need the weather tool.",
+                "</think>",
+                r#"[{"name":"get_weather","parameters":{"location":"Berlin"}}]"#,
+            ]),
+            chat_body_with_response_format(
+                "required",
+                vec![weather_tool()],
+                false,
+                json!({}),
+                json!({"type": "json_object"}),
+            ),
+            ExpectedResponse {
+                reasoning: Some("I need the weather tool.".to_string()),
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Berlin"}),
+                }],
+                finish_reason: "tool_calls",
+            },
+        )
+        .await;
+        assert_json_guidance(&requests, &[weather_tool()]);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_text_response_format_does_not_enable_guidance() {
+    temp_env::async_with_vars(ENV, async {
+        let requests = run_streaming_and_unary(
+            model_card_with_prompt_injected_reasoning("glm45", "glm47", false),
+            scripted_text(&[
+                "I can answer directly.",
+                "</think>",
+                "The temperature is 18 C.",
+            ]),
+            chat_body_with_response_format(
+                "auto",
+                vec![weather_tool()],
+                false,
+                json!({}),
+                json!({"type": "text"}),
+            ),
+            ExpectedResponse {
+                reasoning: Some("I can answer directly.".to_string()),
+                content: ContentExpectation::Exact("The temperature is 18 C."),
+                calls: Vec::new(),
+                finish_reason: "stop",
+            },
+        )
+        .await;
+        assert_no_guidance(&requests);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
 async fn required_guided_json_fails_closed_without_backend_reasoning_capability() {
     temp_env::async_with_vars(ENV, async {
         let expected = ExpectedResponse {

--- a/lib/llm/tests/tool_calling_cpu_e2e/cases.rs
+++ b/lib/llm/tests/tool_calling_cpu_e2e/cases.rs
@@ -37,6 +37,105 @@ async fn required_nemotron_delays_guided_json_until_force_reasoning_ends() {
 
 #[tokio::test]
 #[serial]
+async fn auto_force_nonempty_content_only_falls_back_for_reasoning_only_response() {
+    temp_env::async_with_vars(ENV, async {
+        for force_nonempty_content in [false, true] {
+            let requests = run_streaming_and_unary(
+                model_card("nemotron_v3", "nemotron_nano", false, true),
+                scripted_text(&["terminal thought", "</thi", "nk>"]),
+                chat_body_with_template_kwargs(
+                    "auto",
+                    vec![weather_tool()],
+                    false,
+                    json!({"force_nonempty_content": force_nonempty_content}),
+                ),
+                ExpectedResponse {
+                    reasoning: (!force_nonempty_content).then(|| "terminal thought".to_string()),
+                    content: if force_nonempty_content {
+                        ContentExpectation::Exact("terminal thought")
+                    } else {
+                        ContentExpectation::Empty
+                    },
+                    calls: Vec::new(),
+                    finish_reason: "stop",
+                },
+            )
+            .await;
+            assert_no_guidance(&requests);
+            assert_reasoning_metadata(
+                &requests,
+                false,
+                &json!({"force_nonempty_content": force_nonempty_content}),
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn auto_force_nonempty_content_keeps_reasoning_with_direct_answer() {
+    temp_env::async_with_vars(ENV, async {
+        let requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, true),
+            scripted_text(&["I need to calculate.", "</thi", "nk>", "The answer is 42."]),
+            chat_body_with_template_kwargs(
+                "auto",
+                vec![weather_tool()],
+                false,
+                json!({"force_nonempty_content": true}),
+            ),
+            ExpectedResponse {
+                reasoning: Some("I need to calculate.".to_string()),
+                content: ContentExpectation::Exact("The answer is 42."),
+                calls: Vec::new(),
+                finish_reason: "stop",
+            },
+        )
+        .await;
+        assert_no_guidance(&requests);
+        assert_reasoning_metadata(&requests, false, &json!({"force_nonempty_content": true}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn required_force_nonempty_content_keeps_reasoning_with_tool_call() {
+    temp_env::async_with_vars(ENV, async {
+        let requests = run_streaming_and_unary(
+            model_card("nemotron_v3", "nemotron_nano", false, true),
+            scripted_text(&[
+                "I need weather data.",
+                "</thi",
+                "nk>",
+                r#"[{"name":"get_weather","parameters":{"location":"Reykjavik"}}]"#,
+            ]),
+            chat_body_with_template_kwargs(
+                "required",
+                vec![weather_tool()],
+                false,
+                json!({"force_nonempty_content": true}),
+            ),
+            ExpectedResponse {
+                reasoning: Some("I need weather data.".to_string()),
+                content: ContentExpectation::Empty,
+                calls: vec![ExpectedCall {
+                    name: "get_weather",
+                    arguments: json!({"location": "Reykjavik"}),
+                }],
+                finish_reason: "tool_calls",
+            },
+        )
+        .await;
+        assert_json_guidance(&requests, &[weather_tool()]);
+        assert_reasoning_metadata(&requests, false, &json!({"force_nonempty_content": true}));
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
 async fn required_guided_json_handles_reasoning_off_and_multiple_tools() {
     temp_env::async_with_vars(ENV, async {
         let script = scripted_text(&[


### PR DESCRIPTION
## Summary

Adds a CPU-only HTTP end-to-end matrix for tool calling and reasoning. The harness mocks only the model worker; each case traverses the real OpenAI chat endpoint, request preprocessing, prompt rendering/tokenization, guided-decoding or structural-tag selection, raw backend stream transformation, reasoning parsing, tool parsing/jailing, finish normalization, and streaming/unary response serialization.

This is a test-only characterization PR. It intentionally pins desired behavior that current `main` does not fully satisfy, so the draft is expected to remain red until the corresponding production fixes are stacked or merged.

Linear: [DIS-2321](https://linear.app/nvidia/issue/DIS-2321/add-cpu-only-tool-calling-and-reasoning-e2e-matrix)

### Test boundary

```text
OpenAI HTTP request
  -> real Dynamo preprocessing and chat template
  -> guided JSON / structural-tag policy
  -> scripted or captured mock-worker token stream
  -> real reasoning parser
  -> real tool parser and jail
  -> finish/usage normalization
  -> unary or streaming OpenAI response
```

The suite contains:

- 26 Rust test functions.
- 32 logical scenarios.
- 63 HTTP validations: 31 scenarios run unary and streaming; one trace-metadata scenario is streaming-only.
- Six captured real-engine stream shapes and 26 focused synthetic boundary scripts.
- Global assertions that reject leaked reasoning/tool markers such as `</think>`, `<tool_call>`, DSML tags, and Harmony channel tokens from `reasoning_content`, `content`, and tool arguments.

### Coverage matrix

| Dimension | Covered values |
|---|---|
| `tool_choice` | `required` 14, `auto` 17, `none` 1; named remains uncovered |
| Selected guidance | tool-call JSON 12, assistant JSON 4, structural tags 4, no guidance 12 |
| `response_format` | omitted 26, `text` 1, `json_object` 4, `json_schema` 1 |
| Reasoning lifecycle | force-start 18, ordinary/tag/channel non-force 7, prompt-injected non-force 7 |
| Reasoning-aware backend capability | enabled 27, disabled 5 |
| Thinking request controls | `enable_thinking=true` 13, `thinking=true` 4, `enable_thinking=false` 6, omitted 9 |
| `force_nonempty_content` | true 3, false 1, omitted 28 |
| Finish reason | `tool_calls` 19, `stop` 11, `length` 2 |
| Output shapes | reasoning-only, content-only, reasoning+content, reasoning+tool, narration+tool, parallel tools, tool-only, and truncated/no-visible-output |

### Parser/model-family coverage

| Dynamo reasoning parser | Tool parser | Logical scenarios |
|---|---|---:|
| `nemotron_v3` | `nemotron_nano` | 16 |
| `qwen3` | `hermes` | 6 |
| `glm45` | `glm47` | 5 |
| `deepseek_r1` | `qwen3_coder` | 1 |
| `qwen3` | `qwen3_coder` | 1 |
| `minimax_append_think` | `minimax_m2` | 1 |
| `gpt_oss` | `harmony` | 1 |
| `deepseek_v4` | `deepseek_v4` | 1 |

Captured streams include Nemotron required guided decoding, Qwen vLLM and SGLang auto tool calls, Qwen direct content, GPT-OSS/Harmony, and DeepSeek V4 parallel tools.

### Guided decoding and response formats

The response-format cases distinguish assistant JSON guidance from required-tool JSON guidance:

- Capability-off force and prompt-injected parsers receiving token-zero bare JSON must return it as `content`, not `reasoning_content`.
- A capability-on GLM backend emits `reasoning</think>JSON`; Dynamo must preserve both fields and forward generic reasoning metadata.
- `tool_choice=required` replaces an assistant response schema with the required tool-call schema.
- `response_format=text` does not activate guidance.
- `tool_choice=none + json_schema` keeps structured assistant JSON in `content`.

The six targeted response-format cases currently produce:

| Stack | Result |
|---|---:|
| Test-only branch on main behavior | 2 passed, 4 failed |
| Surgical Nemotron fix (`5871d9b4e2`) | 2 passed, 4 failed |
| Full guided-reasoning fix (`915f55cd06`) | 3 passed, 3 failed |

The remaining full-fix gap is capability-off assistant JSON guidance: postprocessing recognizes bare guided JSON only for required/named tool choice, so `response_format=json_object/json_schema` can still be consumed as reasoning.

### Structural-tag coverage

The CPU suite sets structural-tag mode directly rather than exercising backend CLI parsing. It covers:

- Master behavior on and off.
- Default scope `auto` for `required` and eligible `auto` requests.
- Required versus optional grammars through `at_least_one`.
- `parallel_tool_calls=false` versus true through `stop_after_first`.
- Exact strict-tool parameter schemas.
- Prompt-injected reasoning prefixes.
- Direct assistant answers under an optional auto grammar.
- Reasoning-aware backend capability enabled/disabled.

Not yet covered in this matrix:

- `--dyn-structural-tag-scope always`.
- `--dyn-structural-tag-schema strict`.
- The non-strict/unconstrained branch of schema mode `auto`.
- Named tool choice.
- `tool_choice=none` exclusion/token-ban tags.
- `--exclude-tools-when-tool-choice-none` interactions.
- CLI-to-runtime-card propagation or live xgrammar enforcement.

### `force_nonempty_content`

Pins three terminal behaviors, with `</think>` split across worker chunks:

- Reasoning-only response: false keeps `reasoning_content`; true moves terminal reasoning into `content`.
- Reasoning followed by direct content: reasoning remains in `reasoning_content`.
- Reasoning followed by a required tool call: reasoning remains separate and content stays empty.

All paths reject leaked `</think>` markers.

## Validation

- `cargo fmt --all -- --check` — passed.
- Repository pre-commit hooks for the committed files — passed.
- `cargo test -p dynamo-llm --test tool_calling_cpu_e2e response_format -- --nocapture`:
  - current main behavior: expected failure, 2 passed / 4 failed;
  - surgical fix: expected failure, 2 passed / 4 failed;
  - full guided-reasoning fix: expected failure, 3 passed / 3 failed.
- The prior 20-case matrix passed 20/20 on the full fix with the local MiniMax parser patch; the three added `force_nonempty_content` cases also passed 3/3 there.
- No GPU is required for this suite.

## Adding coverage for a new model or parser

At a high level:

1. Identify the Dynamo reasoning parser, tool parser, chat-template behavior, reasoning activation policy, and whether the backend can delay guidance until reasoning ends.
2. Capture at least one real raw backend stream from native vLLM or SGLang in the same environment used for Dynamo. Preserve exact chunk boundaries and terminal finish reason when they expose parser edge cases.
3. Add the replay under `lib/llm/tests/data/replays/tool-calling-cpu-e2e/`; use a compact synthetic script only for boundary conditions that are difficult to reproduce deterministically.
4. Build a model card with the parser pair, structural-tag mode, backend capability, and a prompt-injected fixture when the rendered prompt ends inside reasoning.
5. Add a case in `tool_calling_cpu_e2e/cases.rs` using `run_streaming_and_unary`. Specify the expected `reasoning_content`, `content`, ordered tool calls, arguments, and finish reason.
6. Assert the preprocessed contract as well as the response: selected JSON/structural guidance, parser metadata, initial `reasoning_ended` state, schema shape, `at_least_one`, and `stop_after_first` where applicable.
7. Cover the model’s meaningful request modes: required and auto tool choice, thinking enabled/disabled/default, capability on/off, direct answer versus tool call, `force_nonempty_content` if supported, and assistant JSON response formats.
8. Validate native backend behavior first, then Dynamo with the same backend/parser flags. Keep any backend-specific stream divergence as separate replay cases rather than normalizing it away in the fixture.
