### PR TITLE
fix(ci): reserve VRAM for CUDA-stream logits adapter test

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_trtllm_logits_runtime.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_logits_runtime.py
@@ -391,6 +391,12 @@ def test_adapter_invokes_or_logs_on_bad_shape(shape, expect_invoke, caplog):
         )
 
 
+# Unlike the rest of this module (CPU-only mocks, module-level
+# profiled_vram_gib(0)), this test initializes a real CUDA context, so the
+# GPU-parallel scheduler must reserve VRAM for it instead of packing it onto
+# an already-full GPU as a zero-VRAM filler.
+@pytest.mark.profiled_vram_gib(2.0)
+@pytest.mark.requested_trtllm_vram_gib(2.0)
 def test_adapter_enters_engine_cuda_stream():
     """When `stream_ptr` is non-null, the adapter wraps the processor
     call in `torch.cuda.stream(ExternalStream(stream_ptr))` so the


### PR DESCRIPTION
## Summary

`components/src/dynamo/trtllm/tests/test_trtllm_logits_runtime.py::test_adapter_enters_engine_cuda_stream` is failing deterministically with `torch.AcceleratorError: CUDA error: out of memory` in `trtllm-runtime / Test cuda13.1, amd64` across unrelated PRs today (at least #11014, #10917, #9788, #11020 — same test, same worker slot, OOM at `torch.cuda.Stream()` while the runner GPU sits at 22.3/22 GiB).

Root cause: the whole module is marked `profiled_vram_gib(0)` — correct for its other tests, which are CPU-only mocks — but this one test initializes a real CUDA context (`torch.cuda.Stream()` + a `device="cuda"` tensor). The GPU-parallel scheduler treats `profiled_vram_gib(0)` tests as zero-VRAM fillers that consume no GPU budget, so it packs the test onto a GPU already saturated by real VRAM tests, and CUDA context creation fails.

Fix: override the markers at function level with `profiled_vram_gib(2.0)` / `requested_trtllm_vram_gib(2.0)`, the same reservation pattern `components/src/dynamo/trtllm/tests/multimodal/test_trtllm_cuda_ipc.py` already uses for engine-less CUDA unit tests, so the scheduler reserves VRAM for the CUDA context instead of treating the test as free.

## Evidence

- PR #11014, 3/3 identical failures (original + 2 reruns): https://github.com/ai-dynamo/dynamo/actions/runs/28641762699/job/84940786253
- PR #10917, same failure: https://github.com/ai-dynamo/dynamo/actions/runs/28637908145
- Failure line: `test_trtllm_logits_runtime.py:406` (`engine_stream = torch.cuda.Stream()`), scheduler log shows the test dispatched with `profiled=0.0 GiB, req_kv=None` while `GPU0: 22.3/22 GiB`.

## Validation

- Marker semantics: `write_test_meta` in `tests/utils/vram_utils.py` uses `get_closest_marker`, so the function-level markers override the module-level `pytestmark` for exactly this one test; the other tests in the module stay zero-VRAM fillers.
- With `profiled_vram_gib > 0` the scheduler requires a `requested_*` marker (`tests/utils/pytest_parallel_gpu.py` no-KV gate) — satisfied by `requested_trtllm_vram_gib(2.0)`; no engine is launched so the env override it sets is inert, matching the CUDA IPC test precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GPU-related test coverage to reserve the appropriate amount of VRAM during execution.
  * Clarified handling for a CUDA-based test so it uses a real GPU context safely in scheduler-managed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->