### PR TITLE
docs(reference): fix NGC release artifact links

### DIFF
--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -996,8 +996,8 @@ uv pip install --pre --extra-index-url https://pypi.nvidia.com/ ai-dynamo-runtim
 
 | Chart | NGC |
 |-------|-----|
-| `dynamo-platform-1.1.0-dev.1` | [NGC Helm: dynamo-platform 1.1.0-dev.1](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-platform?version=1.1.0-dev.1) |
-| `snapshot-1.1.0-dev.1` | [NGC Helm: snapshot 1.1.0-dev.1](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/snapshot?version=1.1.0-dev.1) |
+| `dynamo-platform-1.1.0-dev.1` | [NGC Helm: dynamo-platform 1.1.0-dev.1](https://catalog.ngc.nvidia.com/orgs/nvidia/ai-dynamo/helm-charts/dynamo-platform/1.1.0-dev.1) |
+| `snapshot-1.1.0-dev.1` | [NGC Helm: snapshot 1.1.0-dev.1](https://catalog.ngc.nvidia.com/orgs/nvidia/ai-dynamo/helm-charts/snapshot/1.1.0-dev.1) |
 
 #### Rust Crates
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -212,7 +212,7 @@ For version-specific artifact details, installation commands, and release histor
   - [kvbm](https://pypi.org/project/kvbm/) as a standalone implementation.
 
 - **Dynamo Container Images**: We distribute multi-arch images (x86 & ARM64 compatible) on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo):
-  - [Dynamo Frontend](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/dynamo-frontend) *(New in v0.8.0)*
+  - [Dynamo Frontend](https://catalog.ngc.nvidia.com/orgs/nvidia/ai-dynamo/containers/dynamo-frontend/-) *(New in v0.8.0)*
   - [SGLang Runtime](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime)
   - [SGLang Runtime (CUDA 13)](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/sglang-runtime?version=1.2.1-cuda13)
   - [TensorRT-LLM Runtime](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/tensorrtllm-runtime)


### PR DESCRIPTION
## Summary
- Update the v1.1.0-dev.1 NGC Helm chart links in release artifacts to the current canonical catalog paths.
- Avoid the old teams/query-parameter URLs that can return 503 during lychee link checks.

## Validation
- git diff --check
- curl -I https://catalog.ngc.nvidia.com/orgs/nvidia/ai-dynamo/helm-charts/dynamo-platform/1.1.0-dev.1 returns HTTP 200
- curl -I https://catalog.ngc.nvidia.com/orgs/nvidia/ai-dynamo/helm-charts/snapshot/1.1.0-dev.1 returns HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pre-release artifact links to use the latest Helm chart URL format.
  * Refreshed the `dynamo-platform` and `snapshot` Helm chart references for `v1.1.0-dev.1` to point to the correct NGC locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->