### PR TITLE
test(validation): unify DGD admission coverage

### DIFF
--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler_test.go
@@ -19,40 +19,236 @@ package validation
 
 import (
 	"context"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	k8sptr "k8s.io/utils/ptr"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-func TestDynamoGraphDeploymentV1Alpha1Handler_ValidateCreate(t *testing.T) {
-	dgd := newAlphaDGDForCompatibilityValidation()
-	dgd.Spec.Services["worker"].Replicas = k8sptr.To(int32(-1))
-
+func TestDynamoGraphDeploymentV1Alpha1Handler(t *testing.T) {
 	handler := &dynamoGraphDeploymentV1Alpha1Handler{
-		handler: NewDynamoGraphDeploymentHandler(nil, "", false),
+		handler: NewDynamoGraphDeploymentHandler(newGroveTopologyTestManager(t), "", false),
 	}
-	_, err := handler.ValidateCreate(
-		dgdAdmissionContext(admissionv1.Create, nvidiacomv1alpha1.DynamoGraphDeploymentGVK),
+
+	t.Run("create", func(t *testing.T) {
+		dgd := newAlphaDGDForCompatibilityValidation()
+		dgd.Spec.Services["worker"].Annotations = map[string]string{
+			consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid",
+		}
+
+		_, err := handler.ValidateCreate(
+			dgdAdmissionContext(admissionv1.Create, nvidiacomv1alpha1.DynamoGraphDeploymentGVK),
+			dgd,
+		)
+		if err == nil {
+			t.Fatal("ValidateCreate() error = nil, want preserved v1alpha1 validation error")
+		}
+		if !strings.Contains(err.Error(), "spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend]") {
+			t.Fatalf("ValidateCreate() error = %q, want v1alpha1 service annotation validation error", err)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		oldDGD := newAlphaDGDForCompatibilityValidation()
+		newDGD := oldDGD.DeepCopy()
+		newDGD.Labels = map[string]string{"updated": "true"}
+		warnings, err := handler.ValidateUpdate(
+			dgdAdmissionContext(admissionv1.Update, nvidiacomv1alpha1.DynamoGraphDeploymentGVK),
+			oldDGD,
+			newDGD,
+		)
+		if err != nil || len(warnings) != 0 {
+			t.Fatalf("ValidateUpdate() = (%v, %v), want no warnings or error", warnings, err)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		warnings, err := handler.ValidateDelete(
+			dgdAdmissionContext(admissionv1.Delete, nvidiacomv1alpha1.DynamoGraphDeploymentGVK),
+			newAlphaDGDForCompatibilityValidation(),
+		)
+		if err != nil || len(warnings) != 0 {
+			t.Fatalf("ValidateDelete() = (%v, %v), want no warnings or error", warnings, err)
+		}
+	})
+}
+
+func TestDynamoGraphDeploymentHandlerValidateCreate(t *testing.T) {
+	handler := NewDynamoGraphDeploymentHandler(newGroveTopologyTestManager(t), "system:serviceaccount:dynamo:dynamo-operator", false)
+	dgd := newBetaDGDForValidation()
+
+	warnings, err := handler.ValidateCreate(dgdAdmissionContext(admissionv1.Create, nvidiacomv1beta1.DynamoGraphDeploymentGVK), dgd)
+	if err != nil {
+		t.Fatalf("ValidateCreate() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("ValidateCreate() warnings = %v, want none", warnings)
+	}
+
+	_, err = handler.ValidateCreate(context.Background(), dgd)
+	if err == nil || !strings.Contains(err.Error(), "admission request missing from context") {
+		t.Fatalf("ValidateCreate() error = %v, want missing admission request", err)
+	}
+
+	_, err = handler.ValidateCreate(
+		dgdAdmissionContext(admissionv1.Create, schema.GroupVersionKind{Group: "wrong.example.com", Version: "v1", Kind: "Wrong"}),
 		dgd,
 	)
-	if err == nil {
-		t.Fatal("ValidateCreate() error = nil, want converted v1beta1 validation error")
+	if err == nil || !strings.Contains(err.Error(), "admission requires") {
+		t.Fatalf("ValidateCreate() error = %v, want GVK mismatch", err)
 	}
-	if !strings.Contains(err.Error(), "spec.components[worker].replicas must be non-negative") {
-		t.Fatalf("ValidateCreate() error = %q, want v1beta1 component validation error", err)
+
+	_, err = handler.ValidateCreate(
+		dgdAdmissionContext(admissionv1.Create, nvidiacomv1beta1.DynamoGraphDeploymentGVK),
+		&runtime.Unknown{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "expected v1alpha1 or v1beta1 DynamoGraphDeployment") {
+		t.Fatalf("ValidateCreate() error = %v, want type mismatch", err)
 	}
 }
 
-func dgdAdmissionContext(op admissionv1.Operation, gvk schema.GroupVersionKind) context.Context {
+func TestDynamoGraphDeploymentHandlerValidateUpdate(t *testing.T) {
+	handler := NewDynamoGraphDeploymentHandler(newGroveTopologyTestManager(t), "system:serviceaccount:dynamo:dynamo-operator", false)
+	ctx := dgdAdmissionContext(admissionv1.Update, nvidiacomv1beta1.DynamoGraphDeploymentGVK)
+
+	t.Run("valid", func(t *testing.T) {
+		oldDGD := newBetaDGDForValidation()
+		newDGD := oldDGD.DeepCopy()
+		warnings, err := handler.ValidateUpdate(ctx, oldDGD, newDGD)
+		if err != nil {
+			t.Fatalf("ValidateUpdate() error = %v", err)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("ValidateUpdate() warnings = %v, want none", warnings)
+		}
+	})
+
+	t.Run("deleting", func(t *testing.T) {
+		oldDGD := newBetaDGDForValidation()
+		newDGD := oldDGD.DeepCopy()
+		now := metav1.Now()
+		newDGD.DeletionTimestamp = &now
+		if _, err := handler.ValidateUpdate(ctx, &runtime.Unknown{}, newDGD); err != nil {
+			t.Fatalf("ValidateUpdate() error = %v", err)
+		}
+	})
+
+	t.Run("invalid new object", func(t *testing.T) {
+		_, err := handler.ValidateUpdate(ctx, newBetaDGDForValidation(), &runtime.Unknown{})
+		if err == nil || !strings.Contains(err.Error(), "expected v1alpha1 or v1beta1 DynamoGraphDeployment") {
+			t.Fatalf("ValidateUpdate() error = %v, want new object type mismatch", err)
+		}
+	})
+
+	t.Run("invalid old object", func(t *testing.T) {
+		_, err := handler.ValidateUpdate(ctx, &runtime.Unknown{}, newBetaDGDForValidation())
+		if err == nil || !strings.Contains(err.Error(), "expected v1alpha1 or v1beta1 DynamoGraphDeployment") {
+			t.Fatalf("ValidateUpdate() error = %v, want old object type mismatch", err)
+		}
+	})
+
+	t.Run("stateless validation failure", func(t *testing.T) {
+		invalid := newBetaDGDForValidation()
+		invalid.Spec.Components = nil
+		_, err := handler.ValidateUpdate(ctx, newBetaDGDForValidation(), invalid)
+		assertBetaValidationErrors(t, err, []string{"spec.components must have at least one component"})
+	})
+
+	t.Run("stateful validation failure", func(t *testing.T) {
+		oldDGD := newBetaDGDForValidation()
+		newDGD := oldDGD.DeepCopy()
+		oldDGD.Spec.BackendFramework = "vllm"
+		newDGD.Spec.BackendFramework = sglangBackendFramework
+		_, err := handler.ValidateUpdate(ctx, oldDGD, newDGD)
+		assertBetaValidationErrors(t, err, []string{"spec.backendFramework is immutable and cannot be changed after creation"})
+	})
+}
+
+func TestDynamoGraphDeploymentHandlerValidateDelete(t *testing.T) {
+	handler := NewDynamoGraphDeploymentHandler(newGroveTopologyTestManager(t), "", false)
+	ctx := dgdAdmissionContext(admissionv1.Delete, nvidiacomv1beta1.DynamoGraphDeploymentGVK)
+
+	warnings, err := handler.ValidateDelete(ctx, newBetaDGDForValidation())
+	if err != nil {
+		t.Fatalf("ValidateDelete() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("ValidateDelete() warnings = %v, want none", warnings)
+	}
+
+	_, err = handler.ValidateDelete(ctx, &runtime.Unknown{})
+	if err == nil || !strings.Contains(err.Error(), "expected DynamoGraphDeployment") {
+		t.Fatalf("ValidateDelete() error = %v, want type mismatch", err)
+	}
+}
+
+func TestCastToDynamoGraphDeployment(t *testing.T) {
+	dgd := newBetaDGDForValidation()
+	got, err := castToDynamoGraphDeployment(dgd)
+	if err != nil || got != dgd {
+		t.Fatalf("castToDynamoGraphDeployment() = (%v, %v), want original DGD", got, err)
+	}
+
+	if _, err := castToDynamoGraphDeployment(nil); err == nil {
+		t.Fatal("castToDynamoGraphDeployment() error = nil, want type mismatch")
+	}
+}
+
+func TestDynamoGraphDeploymentHandlerRegisterWithManager(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := nvidiacomv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1alpha1 scheme: %v", err)
+	}
+	if err := nvidiacomv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1beta1 scheme: %v", err)
+	}
+
+	server := ctrlwebhook.NewServer(ctrlwebhook.Options{})
+	mgr := &fakeManager{scheme: scheme, webhookServer: server}
+	handler := NewDynamoGraphDeploymentHandler(mgr, "", false)
+	if err := handler.RegisterWithManager(mgr); err != nil {
+		t.Fatalf("RegisterWithManager() error = %v", err)
+	}
+
+	for _, path := range []string{
+		dynamoGraphDeploymentV1Alpha1WebhookPath,
+		dynamoGraphDeploymentV1Beta1WebhookPath,
+	} {
+		request := httptest.NewRequest("POST", path, nil)
+		_, pattern := server.WebhookMux().Handler(request)
+		if pattern != path {
+			t.Fatalf("registered pattern = %q, want %q", pattern, path)
+		}
+	}
+}
+
+func dgdAdmissionContext(operation admissionv1.Operation, gvk schema.GroupVersionKind) context.Context {
+	return dgdAdmissionContextWithUserInfo(operation, gvk, nil)
+}
+
+func dgdAdmissionContextWithUserInfo(
+	operation admissionv1.Operation,
+	gvk schema.GroupVersionKind,
+	userInfo *authenticationv1.UserInfo,
+) context.Context {
+	requestUserInfo := authenticationv1.UserInfo{}
+	if userInfo != nil {
+		requestUserInfo = *userInfo.DeepCopy()
+	}
 	return admission.NewContextWithRequest(context.Background(), admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
-			Operation: op,
+			Operation: operation,
+			UserInfo:  requestUserInfo,
 			Kind: metav1.GroupVersionKind{
 				Group:   gvk.Group,
 				Version: gvk.Version,

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -18,8 +18,11 @@
 package validation
 
 import (
-	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -30,6 +33,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,26 +42,45 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	apixv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
 )
 
 const (
 	dgdAdmissionWorkerName      = "worker"
 	dgdAdmissionUpperWorkerName = "WORKER"
+	dgdAdmissionOperator        = "system:serviceaccount:dynamo-system:dynamo-operator"
 )
+
+const sglangBackendFramework = "sglang"
 
 func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 	requestValidators := requestValidatorsFromCRD(t, "nvidia.com_dynamographdeployments.yaml")
+	defaultManager := newGroveTopologyTestManager(t, newTestClusterTopology())
+	missingTopologyManager := newGroveTopologyTestManager(t)
+	inferencePoolManager := newInferencePoolTestManager(t)
+	longDGDName := "test-graph-" + strings.Repeat("x", 50)
+	boundaryComponentName := "w" + strings.Repeat("x", 36)
+	tooLongComponentName := boundaryComponentName + "x"
 
 	tests := []struct {
-		name           string
-		deployment     runtime.Object
-		oldDeployment  runtime.Object
-		mutateRequest  func(*testing.T, map[string]any)
-		groveEnabled   bool
-		wantSchemaErr  string
-		wantCELErr     string
-		wantWebhookErr string
+		name          string
+		deployment    runtime.Object
+		oldDeployment runtime.Object
+		mutateRequest func(*testing.T, map[string]any) // mutates the source-version request map
+		manager       ctrl.Manager                     // supplies webhook dependencies
+		groveDisabled bool                             // disables the configured Grove pathway
+		environment   map[string]string                // sets process environment for the case
+		userInfo      *authenticationv1.UserInfo       // supplies the admission request identity
+		operator      string                           // sets the configured operator principal
+
+		wantSchemaErr   string
+		wantCELErr      string
+		wantWebhookErrs []string
+		wantWarnings    []string
+		notWantErr      string
 	}{
+		// Baseline create-path rules.
 		{
 			name:       "valid deployment with components",
 			deployment: betaDGDForAdmission(nil),
@@ -67,7 +90,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.Components = nil
 			}),
-			wantWebhookErr: "spec.components must have at least one component",
+			wantWebhookErrs: []string{"spec.components must have at least one component"},
 		},
 		{
 			name: "component replicas must be non-negative",
@@ -77,11 +100,12 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantSchemaErr: "spec.components[1].replicas: Invalid value: -1: spec.components[1].replicas in body should be greater than or equal to 0",
 		},
 		{
-			name: "component minAvailable requires Grove",
+			name:          "component minAvailable requires Grove",
+			groveDisabled: true,
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
 			}),
-			wantWebhookErr: "spec.components[worker].minAvailable is currently supported only for Grove-backed DynamoGraphDeployment components",
+			wantWebhookErrs: []string{"spec.components[worker].minAvailable is currently supported only for Grove-backed DynamoGraphDeployment components"},
 		},
 		{
 			name: "restart on create is rejected by CEL before webhook validation",
@@ -101,24 +125,23 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				betaWorkerComponent(dgd).TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
 			}),
-			wantWebhookErr: "spec.topologyConstraint with clusterTopologyName is required when any topology constraint is set",
+			wantWebhookErrs: []string{"spec.topologyConstraint with clusterTopologyName is required when any topology constraint is set (at spec or component level)"},
 		},
 		{
-			name:         "inter-pod GMS requires Grove",
-			groveEnabled: false,
+			name:          "inter-pod GMS requires Grove",
+			groveDisabled: true,
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				enableBetaInterPodGMS(betaWorkerComponent(dgd))
 			}),
-			wantWebhookErr: `spec.components[worker]: experimental.gpuMemoryService.mode="InterPod" requires the Grove pathway`,
+			wantWebhookErrs: []string{"spec.components[worker]: experimental.gpuMemoryService.mode=\"InterPod\" requires the Grove pathway, but Grove is disabled in the operator configuration"},
 		},
 		{
-			name:         "inter-pod GMS requires vLLM backend",
-			groveEnabled: true,
+			name: "inter-pod GMS requires vLLM backend",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.BackendFramework = "sglang"
 				enableBetaInterPodGMS(betaWorkerComponent(dgd))
 			}),
-			wantWebhookErr: `spec.components[worker]: the inter-pod GMS layout (experimental.gpuMemoryService.mode="InterPod") is currently supported only for vLLM`,
+			wantWebhookErrs: []string{"spec.components[worker]: the inter-pod GMS layout (experimental.gpuMemoryService.mode=\"InterPod\") is currently supported only for vLLM (detected: sglang); set spec.backendFramework=\"vllm\""},
 		},
 		{
 			name: "KV transfer policy selector is rejected by CEL before webhook validation",
@@ -140,7 +163,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Mode: nvidiacomv1beta1.GMSModeIntraPod,
 				}
 			}),
-			wantWebhookErr: `failover requires per-container K8s discovery; set annotation "nvidia.com/dynamo-kube-discovery-mode" to "container"`,
+			wantWebhookErrs: []string{"failover requires per-container K8s discovery; set annotation \"nvidia.com/dynamo-kube-discovery-mode\" to \"container\" on the DynamoGraphDeployment"},
 		},
 		{
 			name: "checkpoint job with checkpointRef is rejected by CEL before webhook validation",
@@ -166,10 +189,10 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantWebhookErr: "spec.components[worker].experimental.gpuMemoryService: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1",
+			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1"},
 		},
 
-		// Pair every validation rule changed by this PR across both served source versions.
+		// Cross-version schema and conversion boundaries.
 		{
 			name: "v1beta1 component name is required by the schema",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
@@ -313,7 +336,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid",
 				}
 			}),
-			wantWebhookErr: `spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value "invalid": must be "mp" or "ray"`,
+			wantWebhookErrs: []string{"spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value \"invalid\": must be \"mp\" or \"ray\""},
 		},
 		{
 			name: "v1beta1 frontend sidecar must reference an existing container",
@@ -324,7 +347,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Containers: []corev1.Container{{Name: consts.MainContainerName}},
 				}}
 			}),
-			wantWebhookErr: `spec.components[worker].frontendSidecar "missing" does not match any podTemplate.spec.containers name`,
+			wantWebhookErrs: []string{"spec.components[worker].frontendSidecar \"missing\" does not match any podTemplate.spec.containers name"},
 		},
 		{
 			name:       "valid v1alpha1 deployment reaches the webhook",
@@ -354,10 +377,1204 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				betaWorkerComponent(dgd).PodTemplate = podTemplate
 			}),
 		},
+
+		// Replica availability rules.
+		{
+			name: "v1beta1 replicas below minAvailable are rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.Replicas = k8sptr.To(int32(1))
+				worker.MinAvailable = k8sptr.To(int32(2))
+			}),
+			wantCELErr: "spec.components[1]: Invalid value: minAvailable must be less than or equal to replicas unless replicas is 0",
+		},
+		{
+			name: "v1beta1 valid replicas and minAvailable reach the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.Replicas = k8sptr.To(int32(2))
+				worker.MinAvailable = k8sptr.To(int32(1))
+			}),
+		},
+		{
+			name: "v1beta1 unchanged minAvailable update reaches the webhook",
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
+			}),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
+			}),
+		},
+		{
+			name: "v1beta1 changed minAvailable update is rejected by CEL",
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
+			}),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(2))
+			}),
+			wantCELErr: "spec.components[1]: Invalid value: minAvailable is immutable after creation",
+		},
+		{
+			name: "v1beta1 removed minAvailable update is rejected by CEL",
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
+			}),
+			deployment: betaDGDForAdmission(nil),
+			wantCELErr: "spec.components[1]: Invalid value: minAvailable is immutable after creation",
+		},
+
+		// Checkpoint rules.
+		{
+			name: "v1beta1 valid checkpoint configuration reaches the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Checkpoint: &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true},
+				}
+			}),
+		},
+
+		// KV-transfer CEL rules.
+		{
+			name: "v1beta1 conflicting KV-transfer selectors are rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:            "topology.kubernetes.io/zone",
+						ClusterTopologyName: "grove-topology",
+						Domain:              "zone",
+					},
+				}
+			}),
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: exactly one of labelKey or clusterTopologyName is required",
+		},
+		{
+			name: "v1beta1 label-key KV-transfer policy reaches the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey: "topology.kubernetes.io/zone",
+						Domain:   "zone",
+					},
+				}
+			}),
+		},
+		{
+			name: "v1beta1 preferred KV-transfer enforcement without weight is rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:    "topology.kubernetes.io/zone",
+						Domain:      "zone",
+						Enforcement: nvidiacomv1beta1.KvTransferEnforcementPreferred,
+					},
+				}
+			}),
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: preferredWeight is required when enforcement is preferred",
+		},
+		{
+			name: "v1beta1 required KV-transfer enforcement with weight is rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:        "topology.kubernetes.io/zone",
+						Domain:          "zone",
+						Enforcement:     nvidiacomv1beta1.KvTransferEnforcementRequired,
+						PreferredWeight: k8sptr.To(float32(1)),
+					},
+				}
+			}),
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: preferredWeight may only be set when enforcement is preferred",
+		},
+		{
+			name: "v1beta1 valid preferred KV-transfer enforcement reaches the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:        "topology.kubernetes.io/zone",
+						Domain:          "zone",
+						Enforcement:     nvidiacomv1beta1.KvTransferEnforcementPreferred,
+						PreferredWeight: k8sptr.To(float32(1)),
+					},
+				}
+			}),
+		},
+		{
+			name: "KV-transfer label key format is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{LabelKey: "bad prefix/zone", Domain: "zone"},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.labelKey: Invalid value: "bad prefix/zone": spec.experimental.kvTransferPolicy.labelKey in body should match '^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)*/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'`,
+		},
+		{
+			name: "KV-transfer label key name segment is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{LabelKey: "topology.kubernetes.io/-zone", Domain: "zone"},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.labelKey: Invalid value: "topology.kubernetes.io/-zone": spec.experimental.kvTransferPolicy.labelKey in body should match '^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)*/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'`,
+		},
+		{
+			name: "KV-transfer cluster topology name must be a DNS-1123 subdomain",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "Bad_Name", Domain: "zone"},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.clusterTopologyName \"Bad_Name\" is not a valid Kubernetes resource name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"},
+		},
+		{
+			name: "KV-transfer cluster topology name requires Grove pathway",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationEnableGrove: consts.KubeLabelValueFalse}
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "grove-topology", Domain: "zone"},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.clusterTopologyName requires the Grove pathway; remove or unset the \"nvidia.com/enable-grove\" annotation (currently \"false\")"},
+		},
+		{
+			name: "KV-transfer domain is required by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{LabelKey: "topology.kubernetes.io/zone"},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.domain: Invalid value: "": spec.experimental.kvTransferPolicy.domain in body should match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'`,
+		},
+		{
+			name: "KV-transfer domain format is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{LabelKey: "topology.kubernetes.io/zone", Domain: "Zone"},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.domain: Invalid value: "Zone": spec.experimental.kvTransferPolicy.domain in body should match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'`,
+		},
+		{
+			name: "KV-transfer enforcement enum is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey: "topology.kubernetes.io/zone", Domain: "zone", Enforcement: "sometimes",
+					},
+				}
+			}),
+			wantSchemaErr: `spec.experimental.kvTransferPolicy.enforcement: Unsupported value: "sometimes": supported values: "required", "preferred"`,
+		},
+		{
+			name: "KV-transfer preferred weight range is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{
+						LabelKey:        "topology.kubernetes.io/zone",
+						Domain:          "zone",
+						Enforcement:     nvidiacomv1beta1.KvTransferEnforcementPreferred,
+						PreferredWeight: k8sptr.To(float32(1.2)),
+					},
+				}
+			}),
+			wantSchemaErr: "spec.experimental.kvTransferPolicy.preferredWeight: Invalid value: 1.2: spec.experimental.kvTransferPolicy.preferredWeight in body should be less than or equal to 1",
+		},
+		{
+			name: "KV-transfer cluster topology policy is valid",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "grove-topology", Domain: "rack"},
+				}
+			}),
+		},
+		{
+			name:    "KV-transfer cluster topology policy rejects missing topology",
+			manager: missingTopologyManager,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "missing-topology", Domain: "rack"},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.clusterTopologyName \"missing-topology\" references a ClusterTopology resource that was not found"},
+		},
+		{
+			name: "KV-transfer cluster topology policy rejects missing domain",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Experimental = &nvidiacomv1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &nvidiacomv1beta1.KvTransferPolicy{ClusterTopologyName: "grove-topology", Domain: "host"},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy.domain \"host\" does not exist in ClusterTopology \"grove-topology\"; available domains: [rack zone]"},
+		},
+
+		// GMS and failover rules.
+		{
+			name: "v1beta1 inter-pod GMS client containers are rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaInterPodGMS(worker)
+				worker.Experimental.GPUMemoryService.ExtraClientContainers = []string{"metrics"}
+			}),
+			wantCELErr: "spec.components[1].experimental.gpuMemoryService: Invalid value: extraClientContainers is only supported with mode=IntraPod",
+		},
+		{
+			name: "v1beta1 non-empty GMS extra client pods are rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaInterPodGMS(worker)
+				worker.Experimental.GPUMemoryService.ExtraClientPods = []nvidiacomv1beta1.GMSClientPodSpec{{Name: "client"}}
+			}),
+			wantCELErr: "spec.components[1].experimental.gpuMemoryService: Invalid value: extraClientPods is reserved for inter-pod GMS and is not implemented yet",
+		},
+		{
+			name: "v1beta1 valid GMS configuration reaches the webhook",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaIntraPodGMS(betaWorkerComponent(dgd))
+			}),
+		},
+		{
+			name: "GMS rejects frontend component",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaIntraPodGMS(&dgd.Spec.Components[0])
+			}),
+			wantWebhookErrs: []string{"spec.components[frontend].experimental.gpuMemoryService: GPU memory service is only supported for worker components (type must be worker, prefill, or decode)"},
+		},
+		{
+			name: "GMS client container names are validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.GPUMemoryService.ExtraClientContainers = []string{"Bad_Name"}
+			}),
+			wantSchemaErr: `spec.components[1].experimental.gpuMemoryService.extraClientContainers[0]: Invalid value: "Bad_Name": spec.components[1].experimental.gpuMemoryService.extraClientContainers[0] in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'`,
+		},
+		{
+			name: "intra-pod failover requires GMS",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaContainerDiscovery(dgd)
+				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeIntraPod},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: intraPod failover requires gpuMemoryService to be set"},
+		},
+		{
+			name: "failover mode must match GMS mode",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
+					Mode:       nvidiacomv1beta1.GMSModeInterPod,
+					NumShadows: 1,
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode=\"InterPod\" (got \"IntraPod\")"},
+		},
+		{
+			name: "intra-pod failover shadow maximum is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				enableBetaContainerDiscovery(dgd)
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
+					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
+					NumShadows: 2,
+				}
+			}),
+			wantSchemaErr: "spec.components[1].experimental.failover.numShadows: Invalid value: 2: spec.components[1].experimental.failover.numShadows in body should be less than or equal to 1",
+		},
+		{
+			name: "inter-pod failover requires GMS",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeInterPod, NumShadows: 1},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode=\"InterPod\"", "spec.components[worker]: GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu"},
+		},
+		{
+			name: "inter-pod failover shadow-count minimum is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaInterPodGMS(worker)
+				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeInterPod, NumShadows: -1}
+			}),
+			wantSchemaErr: "spec.components[1].experimental.failover.numShadows: Invalid value: -1: spec.components[1].experimental.failover.numShadows in body should be greater than or equal to 1",
+		},
+		{
+			name: "inter-pod failover rejects frontend component",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Components[0].Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeInterPod, NumShadows: 1},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[frontend].experimental.failover: interPod failover requires gpuMemoryService.mode=\"InterPod\"", "spec.components[frontend]: GMS failover requires at least 1 GPU in podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu", "spec.components[frontend]: GMS failover is not supported for type \"frontend\""},
+		},
+		{
+			name:        "GMS snapshot combination requires env gate",
+			environment: map[string]string{consts.DynamoOperatorAllowGMSSnapshotEnvVar: ""},
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				enableBetaIntraPodGMS(worker)
+				worker.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.checkpoint: GMS + Snapshot is temporarily disabled; disable gpuMemoryService or enable the internal GMS + Snapshot gate"},
+		},
+
+		// Source-version compatibility rules.
+		{
+			name: "alpha PVC empty name requirement is preserved structurally",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{
+					Name:   k8sptr.To(""),
+					Create: k8sptr.To(false),
+				}}
+			}),
+			wantWebhookErrs: []string{"spec.pvcs[0].name is required"},
+		},
+		{
+			name: "alpha ingress requires host",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				className := "nginx"
+				dgd.Spec.Services["frontend"] = &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: consts.ComponentTypeFrontend,
+					Ingress: &nvidiacomv1alpha1.IngressSpec{
+						Enabled:                    true,
+						IngressControllerClassName: &className,
+					},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.services[frontend].ingress.host is required when ingress is enabled"},
+		},
+		{
+			name: "alpha volume mounts require mount point unless used as compilation cache",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].VolumeMounts = []nvidiacomv1alpha1.VolumeMount{{Name: "cache"}}
+			}),
+			wantWebhookErrs: []string{"spec.services[worker].volumeMounts[0].mountPoint is required when useAsCompilationCache is false"},
+		},
+		{
+			name:    "alpha EPP config sources are mutually exclusive",
+			manager: inferencePoolManager,
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				worker := dgd.Spec.Services["worker"]
+				worker.ComponentType = consts.ComponentTypeEPP
+				worker.EPPConfig = &nvidiacomv1alpha1.EPPConfig{
+					ConfigMapRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "epp"}},
+					Config: &apixv1alpha1.EndpointPickerConfig{
+						Plugins:            []apixv1alpha1.PluginSpec{},
+						SchedulingProfiles: []apixv1alpha1.SchedulingProfile{},
+					},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].eppConfig: configMapRef and config are mutually exclusive, only one can be specified"},
+		},
+		{
+			name: "alpha intra-pod failover shadow maximum is preserved structurally",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].Failover = &nvidiacomv1alpha1.FailoverSpec{
+					Enabled:    true,
+					Mode:       nvidiacomv1alpha1.GMSModeIntraPod,
+					NumShadows: 2,
+				}
+			}),
+			wantWebhookErrs: []string{"failover requires per-container K8s discovery; set annotation \"nvidia.com/dynamo-kube-discovery-mode\" to \"container\" on the DynamoGraphDeployment", "spec.components[worker].experimental.failover: intraPod failover requires gpuMemoryService to be set", "spec.components[worker].experimental.failover.numShadows=2 is invalid for mode=\"IntraPod\": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode=\"InterPod\" to configure numShadows"},
+		},
+		{
+			name: "alpha frontend sidecar rejects generated container name conflict",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["frontend"] = &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: consts.ComponentTypeFrontend,
+					FrontendSidecar: &nvidiacomv1alpha1.FrontendSidecarSpec{
+						Image: "custom/frontend:latest",
+					},
+					ExtraPodSpec: &nvidiacomv1alpha1.ExtraPodSpec{PodSpec: &corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  consts.FrontendSidecarContainerName,
+							Image: "custom/frontend:latest",
+						}},
+					}},
+				}
+			}),
+			wantWebhookErrs: []string{"spec.services[frontend]: cannot inject frontend sidecar: a container named \"sidecar-frontend\" already exists in extraPodSpec.containers"},
+		},
+		{
+			name: "alpha GMS client container names are validated by the source schema",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled:               false,
+					ExtraClientContainers: []string{"Bad_Name"},
+				}
+			}),
+			wantSchemaErr: `spec.services.worker.gpuMemoryService.extraClientContainers[0]: Invalid value: "Bad_Name": spec.services.worker.gpuMemoryService.extraClientContainers[0] in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'`,
+		},
+		{
+			name: "nil alpha service entry is rejected",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["ghost"] = nil
+			}),
+			wantSchemaErr: `spec.services.ghost: Invalid value: "null": spec.services.ghost in body must be of type object: "null"`,
+		},
+		{
+			name: "valid preserved alpha-only fields are accepted",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				host := "worker.example.com"
+				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{Name: k8sptr.To("cache"), Create: k8sptr.To(false)}}
+				service := dgd.Spec.Services["worker"]
+				service.Ingress = &nvidiacomv1alpha1.IngressSpec{Enabled: true, Host: host}
+				service.Annotations = map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "ray"}
+				service.VolumeMounts = []nvidiacomv1alpha1.VolumeMount{{Name: "cache", UseAsCompilationCache: true}}
+				service.SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{Disabled: true}
+				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled:               false,
+					Mode:                  nvidiacomv1alpha1.GMSModeIntraPod,
+					ExtraClientContainers: []string{"metrics"},
+				}
+			}),
+		},
+		{
+			name: "alpha PVC name requirement is preserved structurally",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{}}
+			}),
+			wantSchemaErr: "spec.pvcs[0].name: Required value",
+		},
+		{
+			name: "alpha PVC create value constraints are preserved structurally",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{Name: k8sptr.To("cache"), Create: k8sptr.To(true)}}
+			}),
+			wantCELErr: "spec.pvcs[0]: Invalid value: When create is true, size, storageClass, and volumeAccessMode are required",
+		},
+		{
+			name: "alpha compatibility warnings are preserved",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				legacyNamespace := "legacy-namespace"
+				service := dgd.Spec.Services["worker"]
+				service.DynamoNamespace = &legacyNamespace
+				//nolint:staticcheck // SA1019: Intentionally testing deprecated field warnings.
+				service.Autoscaling = &nvidiacomv1alpha1.Autoscaling{Enabled: true}
+			}),
+			wantWarnings: []string{
+				"spec.services[worker].dynamoNamespace is deprecated and ignored. Value 'legacy-namespace' will be replaced with 'default-test-graph'. Remove this field from your configuration",
+				"spec.services[worker].autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md",
+			},
+		},
+		{
+			name: "GMS accepts GPU from alpha dedicated resources",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				service := dgd.Spec.Services["worker"]
+				service.Resources = &nvidiacomv1alpha1.Resources{Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"}}
+				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true, Mode: nvidiacomv1alpha1.GMSModeIntraPod}
+			}),
+		},
+		{
+			name: "GMS accepts GPU from alpha extraPodSpec main container resources",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				service := dgd.Spec.Services["worker"]
+				service.ExtraPodSpec = &nvidiacomv1alpha1.ExtraPodSpec{MainContainer: &corev1.Container{
+					Resources: corev1.ResourceRequirements{Limits: corev1.ResourceList{
+						corev1.ResourceName(consts.KubeResourceGPUNvidia): resource.MustParse("1"),
+					}},
+				}}
+				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true, Mode: nvidiacomv1alpha1.GMSModeIntraPod}
+			}),
+		},
+		{
+			name: "GMS accepts alpha GPUType resource after conversion",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				service := dgd.Spec.Services["worker"]
+				service.Resources = &nvidiacomv1alpha1.Resources{
+					Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1", GPUType: "example.com/gpu"},
+				}
+				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true, Mode: nvidiacomv1alpha1.GMSModeIntraPod}
+			}),
+		},
+		{
+			name: "v1alpha1 enabled shared memory without a positive size is rejected by source CEL",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{}
+			}),
+			wantCELErr: "spec.services[worker].sharedMemory: Invalid value: size is required when disabled is false",
+		},
+		{
+			name: "v1alpha1 valid shared memory reaches the webhook",
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				dgd.Spec.Services["worker"].SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{
+					Size: resource.MustParse("1Gi"),
+				}
+			}),
+		},
+		{
+			name:    "v1alpha1 EPP config without a source reaches the webhook without v1beta1 CEL",
+			manager: inferencePoolManager,
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				worker := dgd.Spec.Services["worker"]
+				worker.ComponentType = consts.ComponentTypeEPP
+				worker.EPPConfig = &nvidiacomv1alpha1.EPPConfig{}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].eppConfig: either configMapRef or config must be specified (no default configuration provided)"},
+		},
+		{
+			name: "v1beta1 EPP config without a source is rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
+				worker.EPPConfig = &nvidiacomv1beta1.EPPConfig{}
+			}),
+			wantCELErr: "spec.components[1].eppConfig: Invalid value: exactly one of configMapRef or config must be specified",
+		},
+		{
+			name: "v1beta1 EPP config with both sources is rejected by CEL",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
+				worker.EPPConfig = &nvidiacomv1beta1.EPPConfig{
+					ConfigMapRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "epp"}},
+					Config: &apixv1alpha1.EndpointPickerConfig{
+						Plugins:            []apixv1alpha1.PluginSpec{},
+						SchedulingProfiles: []apixv1alpha1.SchedulingProfile{},
+					},
+				}
+			}),
+			wantCELErr: "spec.components[1].eppConfig: Invalid value: exactly one of configMapRef or config must be specified",
+		},
+		{
+			name:    "v1beta1 valid EPP config reaches the webhook",
+			manager: inferencePoolManager,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
+				worker.Replicas = k8sptr.To(int32(1))
+				worker.EPPConfig = &nvidiacomv1beta1.EPPConfig{
+					ConfigMapRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "epp"}},
+				}
+			}),
+		},
+
+		// Structural root and scheduling rules.
+		{
+			name:          "priority class requires Grove",
+			groveDisabled: true,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.PriorityClassName = "high-priority"
+			}),
+			wantWebhookErrs: []string{"spec.priorityClassName requires the Grove pathway, but Grove is disabled in the operator configuration"},
+		},
+		{
+			name: "priority class is allowed with Grove",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.PriorityClassName = "high-priority"
+			}),
+		},
+		{
+			name: "minAvailable must be positive",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(0))
+			}),
+			wantSchemaErr: "spec.components[1].minAvailable: Invalid value: 0: spec.components[1].minAvailable in body should be greater than or equal to 1",
+		},
+		{
+			name: "replicas zero can keep minAvailable for scale-up intent",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.Replicas = k8sptr.To(int32(0))
+				worker.MinAvailable = k8sptr.To(int32(2))
+			}),
+		},
+		{
+			name: "rendered Grove resource name length accepts boundary",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Name = longDGDName
+				betaWorkerComponent(dgd).ComponentName = boundaryComponentName
+			}),
+		},
+		{
+			name: "rendered Grove resource name length rejects overflow",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Name = longDGDName
+				betaWorkerComponent(dgd).ComponentName = tooLongComponentName
+			}),
+			wantWebhookErrs: []string{"spec.components[wxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]: combined resource name length 46 exceeds 45-character limit required for pod naming. Consider shortening the DynamoGraphDeployment name 'test-graph-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' (length 61) or component name 'wxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' (length 38). The combined length of PCS name + component name must not exceed 45 characters. The PCS name 'tes-cafb' was auto-truncated from DGD name 'test-graph-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"},
+		},
+		{
+			name:          "rendered Grove resource name length is skipped outside Grove",
+			groveDisabled: true,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Name = longDGDName
+				betaWorkerComponent(dgd).ComponentName = tooLongComponentName
+			}),
+		},
+
+		// Topology rules.
+		{
+			name: "spec pack domain format is validated by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Generation = 2
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "Bad_Domain",
+				}
+			}),
+			wantSchemaErr: `spec.topologyConstraint.packDomain: Invalid value: "Bad_Domain": spec.topologyConstraint.packDomain in body should match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'`,
+		},
+		{
+			name: "component topology pack domain is required by the schema",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Generation = 2
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
+				dgd.Spec.Components[0].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			wantSchemaErr: `spec.components[0].topologyConstraint.packDomain: Invalid value: "": spec.components[0].topologyConstraint.packDomain in body should match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'`,
+		},
+		{
+			name: "deployment topology without pack domain requires every component topology",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Generation = 2
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			wantWebhookErrs: []string{"spec.components[frontend].topologyConstraint is required because spec.topologyConstraint.packDomain is not set; either set a spec-level packDomain or provide a topologyConstraint for every component"},
+		},
+		{
+			name: "deployment pack domain can be inherited",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+			}),
+		},
+		{
+			name: "deployment pack domain can be mixed with narrower component topology",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "zone",
+				}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+		},
+		{
+			name: "component topology with deployment topology is valid",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
+				dgd.Spec.Components[0].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+		},
+		{
+			name:    "missing cluster topology is rejected",
+			manager: missingTopologyManager,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "missing-topology",
+					PackDomain:          "rack",
+				}
+			}),
+			wantWebhookErrs: []string{"topology-aware scheduling requires a ClusterTopology resource \"missing-topology\" but it was not found; ensure the cluster topology is configured per the framework documentation"},
+		},
+		{
+			name:    "independent topology errors aggregate",
+			manager: missingTopologyManager,
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "missing-topology"}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			wantWebhookErrs: []string{"spec.components[frontend].topologyConstraint is required because spec.topologyConstraint.packDomain is not set; either set a spec-level packDomain or provide a topologyConstraint for every component"},
+		},
+		{
+			name: "pack domain must exist in cluster topology",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "host",
+				}
+			}),
+			wantWebhookErrs: []string{"spec.topologyConstraint.packDomain: domain \"host\" does not exist in ClusterTopology \"grove-topology\"; available domains: [rack zone]"},
+		},
+		{
+			name: "component topology cannot be broader than spec topology",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker]: topologyConstraint.packDomain \"zone\" is broader than spec-level \"rack\"; component constraints must be equal to or narrower than the deployment-level constraint"},
+		},
+
+		// Metadata annotation rules.
+		{
+			name: "origin version accepts semver",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoOperatorOriginVersion: "1.2.3"}
+			}),
+		},
+		{
+			name: "origin version rejects non-semver",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoOperatorOriginVersion: "not-semver"}
+			}),
+			wantWebhookErrs: []string{"annotation nvidia.com/dynamo-operator-origin-version has invalid value \"not-semver\": must be valid semver"},
+		},
+		{
+			name: "vLLM backend annotation accepts mp",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "mp"}
+			}),
+		},
+		{
+			name: "vLLM backend annotation accepts ray case-insensitively",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "RAY"}
+			}),
+		},
+		{
+			name: "vLLM backend annotation rejects unknown value",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "typo"}
+			}),
+			wantWebhookErrs: []string{"annotation nvidia.com/vllm-distributed-executor-backend has invalid value \"typo\": must be \"mp\" or \"ray\""},
+		},
+		{
+			name: "discovery mode accepts pod",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "pod"}
+			}),
+		},
+		{
+			name: "discovery mode accepts container",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "container"}
+			}),
+		},
+		{
+			name: "discovery mode rejects unknown value",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "endpoint"}
+			}),
+			wantWebhookErrs: []string{"annotation nvidia.com/dynamo-kube-discovery-mode has invalid value \"endpoint\": must be \"pod\" or \"container\""},
+		},
+		{
+			name: "independent root errors aggregate with exact field paths",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Components = nil
+				dgd.Annotations = map[string]string{
+					consts.KubeAnnotationDynamoOperatorOriginVersion:    "not-semver",
+					consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid",
+					consts.KubeAnnotationDynamoKubeDiscoveryMode:        "invalid",
+				}
+			}),
+			wantWebhookErrs: []string{"spec.components must have at least one component", "annotation nvidia.com/dynamo-operator-origin-version has invalid value \"not-semver\": must be valid semver", "annotation nvidia.com/vllm-distributed-executor-backend has invalid value \"invalid\": must be \"mp\" or \"ray\"", "annotation nvidia.com/dynamo-kube-discovery-mode has invalid value \"invalid\": must be \"pod\" or \"container\""},
+		},
+
+		// Component-set updates.
+		{
+			name:          "component topology is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Components = append(spec.Components, nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+					ComponentName: "extra",
+					Replicas:      k8sptr.To(int32(1)),
+					PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Name: consts.MainContainerName,
+						Env:  []corev1.EnvVar{{Name: "TOKEN", Value: "do-not-leak-this-value"}},
+					}}}},
+				})
+			}),
+			wantWebhookErrs: []string{"component topology is immutable and cannot be modified after creation: components added: [extra]"},
+			notWantErr:      "do-not-leak-this-value",
+		},
+		{
+			name:          "component removal is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Components = spec.Components[:1]
+			}),
+			wantWebhookErrs: []string{"component topology is immutable and cannot be modified after creation: components removed: [worker]"},
+		},
+		{
+			name:          "component add and remove reports both sides",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Components = []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+					spec.Components[1],
+					{
+						ComponentName: "extra",
+						Replicas:      k8sptr.To(int32(1)),
+					},
+				}
+			}),
+			wantWebhookErrs: []string{"component topology is immutable and cannot be modified after creation: components added: [extra], components removed: [frontend]"},
+		},
+		{
+			name:          "component reorder is allowed",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Components[0], spec.Components[1] = spec.Components[1], spec.Components[0]
+			}),
+		},
+
+		// Multinode updates.
+		{
+			name:          "single-node to multinode transition is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker] cannot change node topology (between single-node and multi-node) after creation"},
+		},
+		{
+			name: "node count-only update remains allowed",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 3}
+			}),
+		},
+
+		// Topology updates.
+		{
+			name:          "spec topology constraint is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+			}),
+			wantWebhookErrs: []string{"spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "spec topology constraint change is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "zone",
+				}
+			}),
+			wantWebhookErrs: []string{"spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "spec topology constraint removal is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
+					ClusterTopologyName: "grove-topology",
+					PackDomain:          "rack",
+				}
+			}),
+			deployment:      newBetaDGDForValidation(),
+			wantWebhookErrs: []string{"spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "unchanged topology constraints are allowed",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+		},
+		{
+			name: "component topology constraint is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "component topology constraint change is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+		{
+			name: "component topology constraint removal is immutable",
+			oldDeployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
+			}),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology", PackDomain: "zone"}
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints"},
+		},
+
+		// KV-transfer updates.
+		{
+			name:          "kv transfer policy is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
+				LabelKey: "topology.kubernetes.io/zone",
+				Domain:   "zone",
+			}),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy"},
+		},
+		{
+			name: "unchanged kv transfer policy is allowed",
+			oldDeployment: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
+				LabelKey: "topology.kubernetes.io/zone",
+				Domain:   "zone",
+			}),
+			deployment: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
+				LabelKey:    "topology.kubernetes.io/zone",
+				Domain:      "zone",
+				Enforcement: nvidiacomv1beta1.KvTransferEnforcementRequired,
+			}),
+		},
+		{
+			name: "kv transfer policy removal is immutable",
+			oldDeployment: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
+				LabelKey: "topology.kubernetes.io/zone",
+				Domain:   "zone",
+			}),
+			deployment:      newBetaDGDForValidation(),
+			wantWebhookErrs: []string{"spec.experimental.kvTransferPolicy is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy"},
+		},
+
+		// GMS and failover updates.
+		{
+			name:          "inter-pod GMS layout is immutable",
+			oldDeployment: newBetaDGDForValidation(),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+		},
+		{
+			name: "inter-pod GMS layout removal is immutable",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+			}),
+			deployment:      newBetaDGDForValidation(),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+		},
+		{
+			name: "inter-pod failover toggle is immutable",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+				enableBetaInterPodFailover(worker, 1)
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover: inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+		},
+		{
+			name: "inter-pod failover removal is immutable",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				enableBetaInterPodGMS(worker)
+				enableBetaInterPodFailover(worker, 1)
+			}),
+			deployment:      newBetaDGDForValidation(),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment", "spec.components[worker].experimental.failover: inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment"},
+		},
+		{
+			name: "inter-pod failover shadow count is immutable",
+			oldDeployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				enableAlphaInterPodGMSFailover(dgd.Spec.Services["worker"], 1)
+			}),
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				enableAlphaInterPodGMSFailover(dgd.Spec.Services["worker"], 2)
+			}),
+			wantWebhookErrs: []string{"spec.components[worker].experimental.failover.numShadows is immutable for inter-pod GMS failover; delete and recreate the DynamoGraphDeployment to change it"},
+		},
+
+		// Scaling adapter updates.
+		{
+			name: "scaling adapter blocks direct replica changes",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(2))
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(3))
+			}),
+			userInfo: &authenticationv1.UserInfo{
+				Username: "system:serviceaccount:default:regular-user",
+			},
+			operator:        dgdAdmissionOperator,
+			wantWebhookErrs: []string{"spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
+		},
+		{
+			name: "scaling adapter fails closed without user info",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(2))
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(3))
+			}),
+			operator:        dgdAdmissionOperator,
+			wantWebhookErrs: []string{"spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
+		},
+		{
+			name: "operator can change scaling-adapter-owned replicas",
+			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(2))
+			}),
+			deployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
+				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+				worker.Replicas = k8sptr.To(int32(3))
+			}),
+			userInfo: &authenticationv1.UserInfo{
+				Username: dgdAdmissionOperator,
+			},
+			operator: dgdAdmissionOperator,
+		},
+
+		// Backend and restart updates.
+		{
+			name: "restart id cannot change during active rolling update",
+			oldDeployment: betaDGDWithStatus(
+				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+					spec.Restart = &nvidiacomv1beta1.Restart{ID: "old"}
+				},
+				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
+					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
+						Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
+					}
+				},
+			),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Restart = &nvidiacomv1beta1.Restart{ID: "new"}
+			}),
+			wantWebhookErrs: []string{"spec.restart.id cannot be changed while a rolling update is InProgress"},
+		},
+		{
+			name: "restart id can stay unchanged during active rolling update",
+			oldDeployment: betaDGDWithStatus(
+				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+					spec.Restart = &nvidiacomv1beta1.Restart{ID: "same"}
+				},
+				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
+					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
+						Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
+					}
+				},
+			),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Restart = &nvidiacomv1beta1.Restart{ID: "same"}
+			}),
+		},
+		{
+			name: "restart id can change after completed rolling update",
+			oldDeployment: betaDGDWithStatus(
+				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+					spec.Restart = &nvidiacomv1beta1.Restart{ID: "old"}
+				},
+				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
+					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
+						Phase: nvidiacomv1beta1.RollingUpdatePhaseCompleted,
+					}
+				},
+			),
+			deployment: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
+				spec.Restart = &nvidiacomv1beta1.Restart{ID: "new"}
+			}),
+		},
+		{
+			name:          "restart id is required on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = &nvidiacomv1beta1.Restart{}
+			}),
+			wantSchemaErr: `spec.restart.id: Invalid value: "": spec.restart.id in body should be at least 1 chars long`,
+		},
+		{
+			name:          "duplicate restart order is rejected on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "worker", "worker")
+			}),
+			wantWebhookErrs: []string{"spec.restart.strategy.order must be unique"},
+		},
+		{
+			name:          "unknown restart order component is rejected on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "ghost")
+			}),
+			wantWebhookErrs: []string{"spec.restart.strategy.order contains unknown component: ghost"},
+		},
+		{
+			name:          "incomplete restart order is rejected on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "worker")
+			}),
+			wantWebhookErrs: []string{"spec.restart.strategy.order must have the same number of unique components as the deployment"},
+		},
+		{
+			name:          "empty sequential restart order is valid on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential)
+			}),
+		},
+		{
+			name:          "complete sequential restart order is valid on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "worker")
+			}),
+		},
+		{
+			name:          "parallel restart without order is valid on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeParallel)
+			}),
+		},
+		{
+			name:          "parallel restart rejects order on update",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeParallel, "frontend", "worker")
+			}),
+			wantWebhookErrs: []string{"spec.restart.strategy.order cannot be specified when strategy is parallel"},
+		},
+		{
+			name:          "v1beta1 backend framework update reaches the webhook and warns",
+			oldDeployment: betaDGDForAdmission(nil),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Spec.BackendFramework = sglangBackendFramework
+			}),
+			wantWebhookErrs: []string{"spec.backendFramework is immutable and cannot be changed after creation"},
+			wantWarnings:    []string{"Changing spec.backendFramework may cause unexpected behavior"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			for name, value := range tt.environment {
+				t.Setenv(name, value)
+			}
 			current := admissionUnstructured(t, tt.deployment)
 			if tt.mutateRequest != nil {
 				tt.mutateRequest(t, current)
@@ -392,1283 +1609,32 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 
 			oldBeta := dgdAdmissionBeta(t, tt.oldDeployment)
 			currentBeta := dgdAdmissionBeta(t, tt.deployment)
-			handler := NewDynamoGraphDeploymentHandler(nil, "", tt.groveEnabled)
-			ctx := dgdAdmissionContext(dgdAdmissionOperation(tt.oldDeployment), nvidiacomv1beta1.DynamoGraphDeploymentGVK)
+			manager := tt.manager
+			if manager == nil {
+				manager = defaultManager
+			}
+			handler := NewDynamoGraphDeploymentHandler(manager, tt.operator, !tt.groveDisabled)
+			ctx := dgdAdmissionContextWithUserInfo(
+				dgdAdmissionOperation(tt.oldDeployment),
+				nvidiacomv1beta1.DynamoGraphDeploymentGVK,
+				tt.userInfo,
+			)
 
-			var err error
+			var (
+				warnings []string
+				err      error
+			)
 			if tt.oldDeployment == nil {
-				_, err = handler.ValidateCreate(ctx, currentBeta)
+				warnings, err = handler.ValidateCreate(ctx, currentBeta)
 			} else {
-				_, err = handler.ValidateUpdate(ctx, oldBeta, currentBeta)
+				warnings, err = handler.ValidateUpdate(ctx, oldBeta, currentBeta)
 			}
-			assertBetaValidationError(t, err, tt.wantWebhookErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateCheckpointFallback(t *testing.T) {
-	deployment := betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-		worker.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-			Checkpoint: &nvidiacomv1beta1.ComponentCheckpointConfig{
-				Enabled:       true,
-				CheckpointRef: k8sptr.To("existing-checkpoint"),
-				Job:           &nvidiacomv1beta1.ComponentCheckpointJobConfig{},
-			},
-		}
-	})
-
-	validator := NewDynamoGraphDeploymentValidator(nil, false)
-	_, err := validator.Validate(context.Background(), deployment)
-	assertBetaValidationError(
-		t,
-		err,
-		"spec.components[worker].experimental.checkpoint.job cannot be set when checkpointRef is specified",
-	)
-}
-
-func TestDynamoGraphDeploymentValidator_GroveSchedulingMatrix(t *testing.T) {
-	longDGDName := "test-graph-" + strings.Repeat("x", 50)
-	boundaryComponentName := "w" + strings.Repeat("x", 36)
-	tooLongComponentName := boundaryComponentName + "x"
-
-	tests := []struct {
-		name         string
-		groveEnabled bool
-		mutate       func(*nvidiacomv1beta1.DynamoGraphDeployment)
-		wantErr      string
-	}{
-		{
-			name:         "priority class requires Grove",
-			groveEnabled: false,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Spec.PriorityClassName = "high-priority"
-			},
-			wantErr: "spec.priorityClassName requires the Grove pathway",
-		},
-		{
-			name:         "priority class is allowed with Grove",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Spec.PriorityClassName = "high-priority"
-			},
-		},
-		{
-			name:         "minAvailable must be positive",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(0))
-			},
-			wantErr: "spec.components[worker].minAvailable must be greater than 0",
-		},
-		{
-			name:         "replicas must cover minAvailable unless scaled to zero",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				worker.Replicas = k8sptr.To(int32(1))
-				worker.MinAvailable = k8sptr.To(int32(2))
-			},
-			wantErr: "spec.components[worker].replicas must be 0 or greater than or equal to minAvailable",
-		},
-		{
-			name:         "replicas zero can keep minAvailable for scale-up intent",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				worker.Replicas = k8sptr.To(int32(0))
-				worker.MinAvailable = k8sptr.To(int32(2))
-			},
-		},
-		{
-			name:         "rendered Grove resource name length accepts boundary",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Name = longDGDName
-				betaWorkerComponent(dgd).ComponentName = boundaryComponentName
-			},
-		},
-		{
-			name:         "rendered Grove resource name length rejects overflow",
-			groveEnabled: true,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Name = longDGDName
-				betaWorkerComponent(dgd).ComponentName = tooLongComponentName
-			},
-			wantErr: "combined resource name length",
-		},
-		{
-			name:         "rendered Grove resource name length is skipped outside Grove",
-			groveEnabled: false,
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Name = longDGDName
-				betaWorkerComponent(dgd).ComponentName = tooLongComponentName
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := newBetaDGDForValidation()
-			tt.mutate(deployment)
-
-			validator := NewDynamoGraphDeploymentValidator(nil, tt.groveEnabled)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateAggregatesErrors(t *testing.T) {
-	deployment := betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-		spec.Restart = &nvidiacomv1beta1.Restart{}
-		spec.Components[0].Replicas = k8sptr.To(int32(-1))
-		spec.Components[1].Replicas = k8sptr.To(int32(-2))
-	})
-	deployment.Annotations = map[string]string{
-		consts.KubeAnnotationDynamoOperatorOriginVersion: "not-semver",
-		consts.KubeAnnotationDynamoKubeDiscoveryMode:     "bad-mode",
-	}
-
-	validator := NewDynamoGraphDeploymentValidator(nil, true)
-	_, err := validator.Validate(context.Background(), deployment)
-	for _, wantErr := range []string{
-		"annotation nvidia.com/dynamo-operator-origin-version has invalid value",
-		"annotation nvidia.com/dynamo-kube-discovery-mode has invalid value",
-		"spec.restart.id is required",
-		"spec.components[frontend].replicas must be non-negative",
-		"spec.components[worker].replicas must be non-negative",
-	} {
-		assertBetaValidationError(t, err, wantErr)
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_AnnotationMatrix(t *testing.T) {
-	tests := []struct {
-		name       string
-		annotation string
-		value      string
-		wantErr    string
-	}{
-		{
-			name:       "origin version accepts semver",
-			annotation: consts.KubeAnnotationDynamoOperatorOriginVersion,
-			value:      "1.2.3",
-		},
-		{
-			name:       "origin version rejects non-semver",
-			annotation: consts.KubeAnnotationDynamoOperatorOriginVersion,
-			value:      "not-semver",
-			wantErr:    "annotation nvidia.com/dynamo-operator-origin-version has invalid value",
-		},
-		{
-			name:       "vLLM backend accepts mp",
-			annotation: consts.KubeAnnotationVLLMDistributedExecutorBackend,
-			value:      "mp",
-		},
-		{
-			name:       "vLLM backend accepts ray case-insensitively",
-			annotation: consts.KubeAnnotationVLLMDistributedExecutorBackend,
-			value:      "RAY",
-		},
-		{
-			name:       "vLLM backend rejects unknown value",
-			annotation: consts.KubeAnnotationVLLMDistributedExecutorBackend,
-			value:      "typo",
-			wantErr:    "annotation nvidia.com/vllm-distributed-executor-backend has invalid value",
-		},
-		{
-			name:       "discovery mode accepts pod",
-			annotation: consts.KubeAnnotationDynamoKubeDiscoveryMode,
-			value:      "pod",
-		},
-		{
-			name:       "discovery mode accepts container",
-			annotation: consts.KubeAnnotationDynamoKubeDiscoveryMode,
-			value:      "container",
-		},
-		{
-			name:       "discovery mode rejects unknown value",
-			annotation: consts.KubeAnnotationDynamoKubeDiscoveryMode,
-			value:      "endpoint",
-			wantErr:    "annotation nvidia.com/dynamo-kube-discovery-mode has invalid value",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := newBetaDGDForValidation()
-			deployment.Annotations = map[string]string{tt.annotation: tt.value}
-
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateAlphaCompatibility(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*nvidiacomv1alpha1.DynamoGraphDeployment)
-		wantErr string
-	}{
-		{
-			name: "alpha PVC create requires storage fields",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{
-					{
-						Name:   k8sptr.To("cache"),
-						Create: k8sptr.To(true),
-					},
-				}
-			},
-			wantErr: "spec.pvcs[0].storageClass is required when create is true",
-		},
-		{
-			name: "alpha ingress requires host",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				className := "nginx"
-				dgd.Spec.Services["frontend"] = &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-					ComponentType: consts.ComponentTypeFrontend,
-					Ingress: &nvidiacomv1alpha1.IngressSpec{
-						Enabled:                    true,
-						IngressControllerClassName: &className,
-					},
-				}
-			},
-			wantErr: "spec.services[frontend].ingress.host is required when ingress is enabled",
-		},
-		{
-			name: "alpha service annotations are validated",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].Annotations = map[string]string{
-					consts.KubeAnnotationVLLMDistributedExecutorBackend: "typo",
-				}
-			},
-			wantErr: `spec.services[worker].annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value "typo"`,
-		},
-		{
-			name: "alpha volume mounts require mount point unless used as compilation cache",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].VolumeMounts = []nvidiacomv1alpha1.VolumeMount{
-					{
-						Name: "cache",
-					},
-				}
-			},
-			wantErr: "spec.services[worker].volumeMounts[0].mountPoint is required when useAsCompilationCache is false",
-		},
-		{
-			name: "alpha sharedMemory requires size when enabled",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{
-					Disabled: false,
-				}
-			},
-			wantErr: "spec.services[worker].sharedMemory.size is required when disabled is false",
-		},
-		{
-			name: "alpha frontend sidecar rejects generated container name conflict",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["frontend"] = &nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-					ComponentType: consts.ComponentTypeFrontend,
-					FrontendSidecar: &nvidiacomv1alpha1.FrontendSidecarSpec{
-						Image: "custom/frontend:latest",
-					},
-					ExtraPodSpec: &nvidiacomv1alpha1.ExtraPodSpec{
-						PodSpec: &corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  consts.FrontendSidecarContainerName,
-									Image: "custom/frontend:latest",
-								},
-							},
-						},
-					},
-				}
-			},
-			wantErr: `spec.services[frontend]: cannot inject frontend sidecar: a container named "sidecar-frontend" already exists in extraPodSpec.containers`,
-		},
-		{
-			name: "disabled alpha GMS still validates extra client container names",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["worker"].GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-					Enabled:               false,
-					ExtraClientContainers: []string{"Bad_Name"},
-				}
-			},
-			wantErr: `spec.services[worker].gpuMemoryService.extraClientContainers[0] "Bad_Name" is not a valid Kubernetes container name`,
-		},
-		{
-			name: "nil alpha service entry is rejected",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				dgd.Spec.Services["ghost"] = nil
-			},
-			wantErr: "spec.services[ghost] must not be null",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDFromAlpha(t, tt.mutate)
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateAlphaCompatibilityAdditionalEdges(t *testing.T) {
-	t.Run("valid preserved alpha-only fields are accepted", func(t *testing.T) {
-		deployment := betaDGDFromAlpha(t, func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-			host := "worker.example.com"
-			dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{
-				{
-					Name:   k8sptr.To("cache"),
-					Create: k8sptr.To(false),
-				},
+			assertBetaValidationErrors(t, err, tt.wantWebhookErrs)
+			if tt.notWantErr != "" && err != nil && strings.Contains(err.Error(), tt.notWantErr) {
+				t.Fatalf("webhook error = %q, must not contain %q", err.Error(), tt.notWantErr)
 			}
-			service := dgd.Spec.Services["worker"]
-			service.Ingress = &nvidiacomv1alpha1.IngressSpec{
-				Enabled: true,
-				Host:    host,
-			}
-			service.Annotations = map[string]string{
-				consts.KubeAnnotationVLLMDistributedExecutorBackend: "ray",
-			}
-			service.VolumeMounts = []nvidiacomv1alpha1.VolumeMount{
-				{
-					Name:                  "cache",
-					UseAsCompilationCache: true,
-				},
-			}
-			service.SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{Disabled: true}
-			service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-				Enabled:               false,
-				ExtraClientContainers: []string{"metrics"},
-			}
-		})
-
-		validator := NewDynamoGraphDeploymentValidator(nil, true)
-		_, err := validator.Validate(context.Background(), deployment)
-		assertBetaValidationError(t, err, "")
-	})
-
-	t.Run("missing alpha PVC name is rejected", func(t *testing.T) {
-		deployment := betaDGDFromAlpha(t, func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-			dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{}}
-		})
-
-		validator := NewDynamoGraphDeploymentValidator(nil, true)
-		_, err := validator.Validate(context.Background(), deployment)
-		assertBetaValidationError(t, err, "spec.pvcs[0].name is required")
-	})
-
-	t.Run("multiple alpha PVC errors are returned together", func(t *testing.T) {
-		deployment := betaDGDFromAlpha(t, func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-			dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{
-				{
-					Create: k8sptr.To(true),
-				},
-			}
-		})
-
-		validator := NewDynamoGraphDeploymentValidator(nil, true)
-		_, err := validator.Validate(context.Background(), deployment)
-		for _, wantErr := range []string{
-			"spec.pvcs[0].name is required",
-			"spec.pvcs[0].storageClass is required when create is true",
-			"spec.pvcs[0].size is required when create is true",
-			"spec.pvcs[0].volumeAccessMode is required when create is true",
-		} {
-			assertBetaValidationError(t, err, wantErr)
-		}
-	})
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateAlphaCompatibilityWarnings(t *testing.T) {
-	legacyNamespace := "legacy-namespace"
-	deployment := betaDGDFromAlpha(t, func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-		service := dgd.Spec.Services["worker"]
-		service.DynamoNamespace = &legacyNamespace
-		//nolint:staticcheck // SA1019: Intentionally testing deprecated field warnings.
-		service.Autoscaling = &nvidiacomv1alpha1.Autoscaling{Enabled: true}
-	})
-
-	validator := NewDynamoGraphDeploymentValidator(nil, true)
-	warnings, err := validator.Validate(context.Background(), deployment)
-	if err != nil {
-		t.Fatalf("Validate() error = %v", err)
-	}
-	assertWarningsContain(t, warnings, "spec.services[worker].dynamoNamespace is deprecated and ignored")
-	assertWarningsContain(t, warnings, "spec.services[worker].autoscaling is deprecated and ignored")
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateConvertedAlphaResourceSemantics(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*nvidiacomv1alpha1.DynamoGraphDeployment)
-		wantErr string
-	}{
-		{
-			name: "GMS accepts GPU from alpha dedicated resources",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				service := dgd.Spec.Services["worker"]
-				service.Resources = &nvidiacomv1alpha1.Resources{
-					Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"},
-				}
-				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-					Enabled: true,
-					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
-				}
-			},
-		},
-		{
-			name: "GMS accepts GPU from alpha extraPodSpec main container resources",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				service := dgd.Spec.Services["worker"]
-				service.ExtraPodSpec = &nvidiacomv1alpha1.ExtraPodSpec{
-					MainContainer: &corev1.Container{
-						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
-								corev1.ResourceName(consts.KubeResourceGPUNvidia): resource.MustParse("1"),
-							},
-						},
-					},
-				}
-				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-					Enabled: true,
-					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
-				}
-			},
-		},
-		{
-			name: "GMS accepts alpha GPUType resource after conversion",
-			mutate: func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
-				service := dgd.Spec.Services["worker"]
-				service.Resources = &nvidiacomv1alpha1.Resources{
-					Limits: &nvidiacomv1alpha1.ResourceItem{
-						GPU:     "1",
-						GPUType: "example.com/gpu",
-					},
-				}
-				service.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-					Enabled: true,
-					Mode:    nvidiacomv1alpha1.GMSModeIntraPod,
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDFromAlpha(t, tt.mutate)
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_RestartMatrix(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*nvidiacomv1beta1.DynamoGraphDeploymentSpec)
-		wantErr string
-	}{
-		{
-			name: "missing restart id",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = &nvidiacomv1beta1.Restart{}
-			},
-			wantErr: "spec.restart.id is required",
-		},
-		{
-			name: "duplicate restart order",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "worker", "worker")
-			},
-			wantErr: "spec.restart.strategy.order must be unique",
-		},
-		{
-			name: "unknown restart order component",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "ghost")
-			},
-			wantErr: "spec.restart.strategy.order contains unknown component: ghost",
-		},
-		{
-			name: "restart order missing component",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "worker")
-			},
-			wantErr: "spec.restart.strategy.order must have the same number of unique components as the deployment",
-		},
-		{
-			name: "empty sequential restart order is valid",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential)
-			},
-		},
-		{
-			name: "complete sequential restart order is valid",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeSequential, "frontend", "worker")
-			},
-		},
-		{
-			name: "parallel restart without order is valid",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeParallel)
-			},
-		},
-		{
-			name: "parallel restart rejects order",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = betaRestart(nvidiacomv1beta1.RestartStrategyTypeParallel, "frontend", "worker")
-			},
-			wantErr: "spec.restart.strategy.order cannot be specified when strategy is parallel",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDWithSpec(tt.mutate)
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_TopologyMatrix(t *testing.T) {
-	topologyManager := newGroveTopologyTestManager(t, newTestClusterTopology())
-	missingTopologyManager := newGroveTopologyTestManager(t)
-
-	tests := []struct {
-		name    string
-		mgr     ctrl.Manager
-		mutate  func(*nvidiacomv1beta1.DynamoGraphDeploymentSpec)
-		wantErr string
-	}{
-		{
-			name: "spec pack domain format is validated",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "Bad_Domain",
-				}
-			},
-			wantErr: `spec.topologyConstraint.packDomain "Bad_Domain" is not a valid topology domain`,
-		},
-		{
-			name: "component topology requires deployment topology",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-			wantErr: "spec.topologyConstraint with clusterTopologyName is required when any topology constraint is set",
-		},
-		{
-			name: "component topology requires pack domain",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[0].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-			wantErr: "spec.components[frontend].topologyConstraint.packDomain is required",
-		},
-		{
-			name: "deployment topology without pack domain requires every component topology",
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-			wantErr: "spec.components[frontend].topologyConstraint is required because spec.topologyConstraint.packDomain is not set",
-		},
-		{
-			name: "deployment pack domain can be inherited",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "rack",
-				}
-			},
-		},
-		{
-			name: "deployment pack domain can be mixed with narrower component topology",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "zone",
-				}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-		},
-		{
-			name: "component topology with deployment topology is valid",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[0].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			},
-		},
-		{
-			name: "missing cluster topology is rejected",
-			mgr:  missingTopologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "missing-topology",
-					PackDomain:          "rack",
-				}
-			},
-			wantErr: `topology-aware scheduling requires a ClusterTopology resource "missing-topology" but it was not found`,
-		},
-		{
-			name: "pack domain must exist in cluster topology",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "host",
-				}
-			},
-			wantErr: `spec.topologyConstraint.packDomain: domain "host" does not exist in ClusterTopology "grove-topology"`,
-		},
-		{
-			name: "component topology cannot be broader than spec topology",
-			mgr:  topologyManager,
-			mutate: func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "rack",
-				}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
-			},
-			wantErr: `spec.components[worker]: topologyConstraint.packDomain "zone" is broader than spec-level "rack"`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDWithSpec(tt.mutate)
-			validator := NewDynamoGraphDeploymentValidator(tt.mgr, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_KvTransferPolicyMatrix(t *testing.T) {
-	topologyManager := newGroveTopologyTestManager(t, newTestClusterTopology())
-	missingTopologyManager := newGroveTopologyTestManager(t)
-
-	tests := []struct {
-		name      string
-		mgr       ctrl.Manager
-		mutateDGD func(*nvidiacomv1beta1.DynamoGraphDeployment)
-		policy    *nvidiacomv1beta1.KvTransferPolicy
-		wantErr   string
-	}{
-		{
-			name:    "missing topology selector",
-			policy:  &nvidiacomv1beta1.KvTransferPolicy{Domain: "zone"},
-			wantErr: "spec.experimental.kvTransferPolicy: exactly one of labelKey or clusterTopologyName is required",
-		},
-		{
-			name: "both topology selectors",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:            "topology.kubernetes.io/zone",
-				ClusterTopologyName: "grove-topology",
-				Domain:              "zone",
-			},
-			wantErr: "spec.experimental.kvTransferPolicy: exactly one of labelKey or clusterTopologyName is required",
-		},
-		{
-			name: "invalid label key",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "bad prefix/zone",
-				Domain:   "zone",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.labelKey "bad prefix/zone" is not a valid Kubernetes label key`,
-		},
-		{
-			name: "invalid label key name segment",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/-zone",
-				Domain:   "zone",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.labelKey "topology.kubernetes.io/-zone" is not a valid Kubernetes label key`,
-		},
-		{
-			name: "label key policy is valid",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-				Domain:   "zone",
-			},
-		},
-		{
-			name: "invalid cluster topology name",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "Bad_Name",
-				Domain:              "zone",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.clusterTopologyName "Bad_Name" is not a valid Kubernetes resource name`,
-		},
-		{
-			name: "cluster topology name requires Grove pathway",
-			mutateDGD: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Annotations = map[string]string{consts.KubeAnnotationEnableGrove: consts.KubeLabelValueFalse}
-			},
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "grove-topology",
-				Domain:              "zone",
-			},
-			wantErr: "spec.experimental.kvTransferPolicy.clusterTopologyName requires the Grove pathway",
-		},
-		{
-			name: "domain is required",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-			},
-			wantErr: "spec.experimental.kvTransferPolicy.domain is required",
-		},
-		{
-			name: "domain format is validated",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-				Domain:   "Zone",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.domain "Zone" is not a valid topology domain`,
-		},
-		{
-			name: "enforcement value is validated",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:    "topology.kubernetes.io/zone",
-				Domain:      "zone",
-				Enforcement: "sometimes",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.enforcement "sometimes" is invalid`,
-		},
-		{
-			name: "preferred enforcement requires weight",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:    "topology.kubernetes.io/zone",
-				Domain:      "zone",
-				Enforcement: nvidiacomv1beta1.KvTransferEnforcementPreferred,
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.preferredWeight is required when enforcement is "preferred"`,
-		},
-		{
-			name: "preferred weight must be in range",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:        "topology.kubernetes.io/zone",
-				Domain:          "zone",
-				Enforcement:     nvidiacomv1beta1.KvTransferEnforcementPreferred,
-				PreferredWeight: k8sptr.To(float32(1.2)),
-			},
-			wantErr: "spec.experimental.kvTransferPolicy.preferredWeight 1.2 is invalid",
-		},
-		{
-			name: "required enforcement cannot set preferred weight",
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:        "topology.kubernetes.io/zone",
-				Domain:          "zone",
-				Enforcement:     nvidiacomv1beta1.KvTransferEnforcementRequired,
-				PreferredWeight: k8sptr.To(float32(0.5)),
-			},
-			wantErr: "spec.experimental.kvTransferPolicy.preferredWeight must not be set when enforcement is \"required\"",
-		},
-		{
-			name: "cluster topology policy is valid",
-			mgr:  topologyManager,
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "grove-topology",
-				Domain:              "rack",
-			},
-		},
-		{
-			name: "cluster topology policy rejects missing topology",
-			mgr:  missingTopologyManager,
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "missing-topology",
-				Domain:              "rack",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.clusterTopologyName "missing-topology" references a ClusterTopology resource that was not found`,
-		},
-		{
-			name: "cluster topology policy rejects missing domain",
-			mgr:  topologyManager,
-			policy: &nvidiacomv1beta1.KvTransferPolicy{
-				ClusterTopologyName: "grove-topology",
-				Domain:              "host",
-			},
-			wantErr: `spec.experimental.kvTransferPolicy.domain "host" does not exist in ClusterTopology "grove-topology"`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := betaDGDWithKvTransferPolicy(tt.policy)
-			if tt.mutateDGD != nil {
-				tt.mutateDGD(deployment)
-			}
-			validator := NewDynamoGraphDeploymentValidator(tt.mgr, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_GMSFailoverMatrix(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*nvidiacomv1beta1.DynamoGraphDeployment)
-		wantErr string
-	}{
-		{
-			name: "GMS rejects frontend component",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				enableBetaIntraPodGMS(&dgd.Spec.Components[0])
-			},
-			wantErr: "spec.components[frontend].experimental.gpuMemoryService: GPU memory service is only supported for worker components",
-		},
-		{
-			name: "GMS requires main container GPU",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				worker.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-					GPUMemoryService: &nvidiacomv1beta1.GPUMemoryServiceSpec{Mode: nvidiacomv1beta1.GMSModeIntraPod},
-				}
-			},
-			wantErr: "spec.components[worker].experimental.gpuMemoryService: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1",
-		},
-		{
-			name: "GMS validates extra client container names",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.GPUMemoryService.ExtraClientContainers = []string{"Bad_Name"}
-			},
-			wantErr: `spec.components[worker].experimental.gpuMemoryService.extraClientContainers[0] "Bad_Name" is not a valid Kubernetes container name`,
-		},
-		{
-			name: "inter-pod GMS rejects extra client containers",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaInterPodGMS(worker)
-				worker.Experimental.GPUMemoryService.ExtraClientContainers = []string{"metrics"}
-			},
-			wantErr: "spec.components[worker].experimental.gpuMemoryService.extraClientContainers is only supported with mode=IntraPod",
-		},
-		{
-			name: "GMS extra client pods are still reserved",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaInterPodGMS(worker)
-				worker.Experimental.GPUMemoryService.ExtraClientPods = []nvidiacomv1beta1.GMSClientPodSpec{
-					{Name: "client"},
-				}
-			},
-			wantErr: "spec.components[worker].experimental.gpuMemoryService.extraClientPods is reserved for inter-pod GMS and is not implemented yet",
-		},
-		{
-			name: "intra-pod failover requires GMS",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				enableBetaContainerDiscovery(dgd)
-				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-					Failover: &nvidiacomv1beta1.FailoverSpec{Mode: nvidiacomv1beta1.GMSModeIntraPod},
-				}
-			},
-			wantErr: "spec.components[worker].experimental.failover: intraPod failover requires gpuMemoryService to be set",
-		},
-		{
-			name: "failover mode must match GMS mode",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-					Mode:       nvidiacomv1beta1.GMSModeInterPod,
-					NumShadows: 1,
-				}
-			},
-			wantErr: `spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode="InterPod"`,
-		},
-		{
-			name: "intra-pod failover rejects custom shadow count",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				enableBetaContainerDiscovery(dgd)
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-					Mode:       nvidiacomv1beta1.GMSModeIntraPod,
-					NumShadows: 2,
-				}
-			},
-			wantErr: `spec.components[worker].experimental.failover.numShadows=2 is invalid for mode="IntraPod"`,
-		},
-		{
-			name: "inter-pod failover requires GMS",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				betaWorkerComponent(dgd).Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-					Failover: &nvidiacomv1beta1.FailoverSpec{
-						Mode:       nvidiacomv1beta1.GMSModeInterPod,
-						NumShadows: 1,
-					},
-				}
-			},
-			wantErr: `spec.components[worker].experimental.failover: interPod failover requires gpuMemoryService.mode="InterPod"`,
-		},
-		{
-			name: "inter-pod failover requires positive shadow count",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				worker := betaWorkerComponent(dgd)
-				enableBetaInterPodGMS(worker)
-				worker.Experimental.Failover = &nvidiacomv1beta1.FailoverSpec{
-					Mode: nvidiacomv1beta1.GMSModeInterPod,
-				}
-			},
-			wantErr: "spec.components[worker].experimental.failover.numShadows must be >= 1",
-		},
-		{
-			name: "inter-pod failover rejects frontend component",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				frontend := &dgd.Spec.Components[0]
-				frontend.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
-					Failover: &nvidiacomv1beta1.FailoverSpec{
-						Mode:       nvidiacomv1beta1.GMSModeInterPod,
-						NumShadows: 1,
-					},
-				}
-			},
-			wantErr: `spec.components[frontend]: GMS failover is not supported for type "frontend"`,
-		},
-		{
-			name: "GMS snapshot combination requires env gate",
-			mutate: func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				t.Setenv(consts.DynamoOperatorAllowGMSSnapshotEnvVar, "")
-				worker := betaWorkerComponent(dgd)
-				enableBetaIntraPodGMS(worker)
-				worker.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{Enabled: true}
-			},
-			wantErr: "spec.components[worker].experimental.checkpoint: GMS + Snapshot is temporarily disabled",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deployment := newBetaDGDForValidation()
-			tt.mutate(deployment)
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			_, err := validator.Validate(context.Background(), deployment)
-			assertBetaValidationError(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestDynamoGraphDeploymentValidator_ValidateUpdate(t *testing.T) {
-	const operatorPrincipal = "system:serviceaccount:dynamo-system:dynamo-operator"
-
-	tests := []struct {
-		name      string
-		oldDGD    *nvidiacomv1beta1.DynamoGraphDeployment
-		newDGD    *nvidiacomv1beta1.DynamoGraphDeployment
-		userInfo  *authenticationv1.UserInfo
-		principal string
-		wantErr   string
-		wantWarns bool
-	}{
-		{
-			name:   "component topology is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components = append(spec.Components, nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
-					ComponentName: "extra",
-					Replicas:      k8sptr.To(int32(1)),
-				})
-			}),
-			wantErr: "component topology is immutable and cannot be modified after creation: components added: [extra]",
-		},
-		{
-			name:   "component removal is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components = spec.Components[:1]
-			}),
-			wantErr: "component topology is immutable and cannot be modified after creation: components removed: [worker]",
-		},
-		{
-			name:   "component add and remove reports both sides",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components = []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
-					spec.Components[1],
-					{
-						ComponentName: "extra",
-						Replicas:      k8sptr.To(int32(1)),
-					},
-				}
-			}),
-			wantErr: "component topology is immutable and cannot be modified after creation: components added: [extra], components removed: [frontend]",
-		},
-		{
-			name:   "component reorder is allowed",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Components[0], spec.Components[1] = spec.Components[1], spec.Components[0]
-			}),
-		},
-		{
-			name:   "single-node to multinode transition is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
-			}),
-			wantErr: "spec.components[worker] cannot change node topology (between single-node and multi-node) after creation",
-		},
-		{
-			name: "node count-only update remains allowed",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 3}
-			}),
-		},
-		{
-			name:   "spec topology constraint is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "rack",
-				}
-			}),
-			wantErr: "spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name: "spec topology constraint change is immutable",
-			oldDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "rack",
-				}
-			}),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{
-					ClusterTopologyName: "grove-topology",
-					PackDomain:          "zone",
-				}
-			}),
-			wantErr: "spec.topologyConstraint is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name: "unchanged topology constraints are allowed",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			}),
-		},
-		{
-			name:   "component topology constraint is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			}),
-			wantErr: "spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name: "component topology constraint change is immutable",
-			oldDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
-			}),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
-				spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "zone"}
-			}),
-			wantErr: "spec.components[worker].topologyConstraint is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name:   "kv transfer policy is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-				Domain:   "zone",
-			}),
-			wantErr: "spec.experimental.kvTransferPolicy is immutable and cannot be added, removed, or changed after creation",
-		},
-		{
-			name: "unchanged kv transfer policy is allowed",
-			oldDGD: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey: "topology.kubernetes.io/zone",
-				Domain:   "zone",
-			}),
-			newDGD: betaDGDWithKvTransferPolicy(&nvidiacomv1beta1.KvTransferPolicy{
-				LabelKey:    "topology.kubernetes.io/zone",
-				Domain:      "zone",
-				Enforcement: nvidiacomv1beta1.KvTransferEnforcementRequired,
-			}),
-		},
-		{
-			name:   "inter-pod GMS layout is immutable",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-			}),
-			wantErr: "spec.components[worker].experimental.gpuMemoryService.mode: the inter-pod GMS layout cannot be toggled after creation",
-		},
-		{
-			name: "inter-pod failover toggle is immutable",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-				enableBetaInterPodFailover(worker, 1)
-			}),
-			wantErr: "spec.components[worker].experimental.failover: inter-pod GMS failover cannot be toggled after creation",
-		},
-		{
-			name: "inter-pod failover shadow count is immutable",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-				enableBetaInterPodFailover(worker, 1)
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				enableBetaInterPodGMS(worker)
-				enableBetaInterPodFailover(worker, 2)
-			}),
-			wantErr: "spec.components[worker].experimental.failover.numShadows is immutable for inter-pod GMS failover",
-		},
-		{
-			name: "scaling adapter blocks direct replica changes",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(2))
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(3))
-			}),
-			userInfo: &authenticationv1.UserInfo{
-				Username: "system:serviceaccount:default:regular-user",
-			},
-			principal: operatorPrincipal,
-			wantErr:   "spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled",
-		},
-		{
-			name: "scaling adapter fails closed without user info",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(2))
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(3))
-			}),
-			principal: operatorPrincipal,
-			wantErr:   "spec.components[worker].replicas cannot be modified directly when scaling adapter is enabled",
-		},
-		{
-			name: "operator can change scaling-adapter-owned replicas",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(2))
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
-				worker.Replicas = k8sptr.To(int32(3))
-			}),
-			userInfo: &authenticationv1.UserInfo{
-				Username: operatorPrincipal,
-			},
-			principal: operatorPrincipal,
-		},
-		{
-			name: "minAvailable is immutable once set",
-			oldDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.MinAvailable = k8sptr.To(int32(1))
-			}),
-			newDGD: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
-				worker.MinAvailable = k8sptr.To(int32(2))
-			}),
-			wantErr: "spec.components[worker].minAvailable is immutable after creation",
-		},
-		{
-			name:   "backend framework changes warn and fail",
-			oldDGD: newBetaDGDForValidation(),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.BackendFramework = "sglang"
-			}),
-			wantErr:   "spec.backendFramework is immutable and cannot be changed after creation",
-			wantWarns: true,
-		},
-		{
-			name: "restart id cannot change during active rolling update",
-			oldDGD: betaDGDWithStatus(
-				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-					spec.Restart = &nvidiacomv1beta1.Restart{ID: "old"}
-				},
-				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
-					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
-						Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
-					}
-				},
-			),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = &nvidiacomv1beta1.Restart{ID: "new"}
-			}),
-			wantErr: "spec.restart.id cannot be changed while a rolling update is InProgress",
-		},
-		{
-			name: "restart id can stay unchanged during active rolling update",
-			oldDGD: betaDGDWithStatus(
-				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-					spec.Restart = &nvidiacomv1beta1.Restart{ID: "same"}
-				},
-				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
-					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
-						Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
-					}
-				},
-			),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = &nvidiacomv1beta1.Restart{ID: "same"}
-			}),
-		},
-		{
-			name: "restart id can change after completed rolling update",
-			oldDGD: betaDGDWithStatus(
-				func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-					spec.Restart = &nvidiacomv1beta1.Restart{ID: "old"}
-				},
-				func(status *nvidiacomv1beta1.DynamoGraphDeploymentStatus) {
-					status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
-						Phase: nvidiacomv1beta1.RollingUpdatePhaseCompleted,
-					}
-				},
-			),
-			newDGD: betaDGDWithSpec(func(spec *nvidiacomv1beta1.DynamoGraphDeploymentSpec) {
-				spec.Restart = &nvidiacomv1beta1.Restart{ID: "new"}
-			}),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			validator := NewDynamoGraphDeploymentValidator(nil, true)
-			warnings, err := validator.ValidateUpdate(tt.oldDGD, tt.newDGD, tt.userInfo, tt.principal)
-			assertBetaValidationError(t, err, tt.wantErr)
-			if tt.wantWarns && len(warnings) == 0 {
-				t.Fatal("ValidateUpdate() expected warnings but got none")
-			}
-			if !tt.wantWarns && len(warnings) != 0 {
-				t.Fatalf("ValidateUpdate() unexpected warnings: %v", warnings)
+			if !slices.Equal(warnings, tt.wantWarnings) {
+				t.Fatalf("warnings = %v, want %v", warnings, tt.wantWarnings)
 			}
 		})
 	}
@@ -1805,22 +1771,6 @@ func newBetaDGDForValidation() *nvidiacomv1beta1.DynamoGraphDeployment {
 	}
 }
 
-func betaDGDFromAlpha(
-	t *testing.T,
-	mutate func(*nvidiacomv1alpha1.DynamoGraphDeployment),
-) *nvidiacomv1beta1.DynamoGraphDeployment {
-	t.Helper()
-
-	alpha := newAlphaDGDForCompatibilityValidation()
-	mutate(alpha)
-
-	beta := &nvidiacomv1beta1.DynamoGraphDeployment{}
-	if err := alpha.ConvertTo(beta); err != nil {
-		t.Fatalf("ConvertTo() error = %v", err)
-	}
-	return beta
-}
-
 func newAlphaDGDForCompatibilityValidation() *nvidiacomv1alpha1.DynamoGraphDeployment {
 	return &nvidiacomv1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1902,6 +1852,24 @@ func enableBetaContainerDiscovery(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 	dgd.Annotations = map[string]string{consts.KubeAnnotationDynamoKubeDiscoveryMode: "container"}
 }
 
+func enableAlphaInterPodGMSFailover(
+	component *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+	numShadows int32,
+) {
+	component.Resources = &nvidiacomv1alpha1.Resources{
+		Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"},
+	}
+	component.GPUMemoryService = &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+		Enabled: true,
+		Mode:    nvidiacomv1alpha1.GMSModeInterPod,
+	}
+	component.Failover = &nvidiacomv1alpha1.FailoverSpec{
+		Enabled:    true,
+		Mode:       nvidiacomv1alpha1.GMSModeInterPod,
+		NumShadows: numShadows,
+	}
+}
+
 func enableBetaInterPodGMS(component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
 	component.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
 		GPUMemoryService: &nvidiacomv1beta1.GPUMemoryServiceSpec{
@@ -1960,13 +1928,17 @@ func enableBetaInterPodFailover(
 }
 
 type fakeManager struct {
-	ctrl.Manager // satisfies the rest of the interface; panics if unexpected methods are used
-	client       client.Client
-	config       *rest.Config
+	ctrl.Manager  // satisfies the rest of the interface; panics if unexpected methods are used
+	client        client.Client
+	config        *rest.Config
+	scheme        *runtime.Scheme
+	webhookServer ctrlwebhook.Server
 }
 
-func (m *fakeManager) GetClient() client.Client { return m.client }
-func (m *fakeManager) GetConfig() *rest.Config  { return m.config }
+func (m *fakeManager) GetClient() client.Client             { return m.client }
+func (m *fakeManager) GetConfig() *rest.Config              { return m.config }
+func (m *fakeManager) GetScheme() *runtime.Scheme           { return m.scheme }
+func (m *fakeManager) GetWebhookServer() ctrlwebhook.Server { return m.webhookServer }
 
 func newGroveTopologyTestManager(t *testing.T, objects ...runtime.Object) ctrl.Manager {
 	t.Helper()
@@ -1981,6 +1953,48 @@ func newGroveTopologyTestManager(t *testing.T, objects ...runtime.Object) ctrl.M
 	}
 }
 
+func newInferencePoolTestManager(t *testing.T) ctrl.Manager {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var response any
+		switch request.URL.Path {
+		case "/api":
+			response = &metav1.APIVersions{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "APIVersions"},
+				Versions: []string{"v1"},
+			}
+		case "/apis":
+			groupVersion := metav1.GroupVersionForDiscovery{
+				GroupVersion: "inference.networking.k8s.io/v1alpha2",
+				Version:      "v1alpha2",
+			}
+			response = &metav1.APIGroupList{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "APIGroupList"},
+				Groups: []metav1.APIGroup{{
+					Name:             "inference.networking.k8s.io",
+					Versions:         []metav1.GroupVersionForDiscovery{groupVersion},
+					PreferredVersion: groupVersion,
+				}},
+			}
+		default:
+			http.NotFound(w, request)
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	manager := newGroveTopologyTestManager(t).(*fakeManager)
+	manager.config = &rest.Config{Host: server.URL}
+	return manager
+}
+
 func newTestClusterTopology() *grovev1alpha1.ClusterTopology {
 	return &grovev1alpha1.ClusterTopology{
 		ObjectMeta: metav1.ObjectMeta{Name: "grove-topology"},
@@ -1993,28 +2007,38 @@ func newTestClusterTopology() *grovev1alpha1.ClusterTopology {
 	}
 }
 
-func assertBetaValidationError(t *testing.T, err error, wantErr string) {
+func assertBetaValidationErrors(t *testing.T, err error, wantErrs []string) {
 	t.Helper()
-	if wantErr == "" {
+	if len(wantErrs) == 0 {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		return
 	}
 	if err == nil {
-		t.Fatalf("expected error containing %q but got nil", wantErr)
+		t.Fatalf("expected errors %v but got nil", wantErrs)
 	}
-	if !strings.Contains(err.Error(), wantErr) {
-		t.Fatalf("error = %q, want to contain %q", err.Error(), wantErr)
-	}
-}
-
-func assertWarningsContain(t *testing.T, warnings []string, want string) {
-	t.Helper()
-	for _, warning := range warnings {
-		if strings.Contains(warning, want) {
-			return
+	statusErr, ok := err.(*k8serrors.StatusError)
+	if !ok || !k8serrors.IsInvalid(err) {
+		gotErrs := strings.Split(err.Error(), "\n")
+		if !slices.Equal(gotErrs, wantErrs) {
+			t.Fatalf("webhook errors = %v, want %v", gotErrs, wantErrs)
 		}
+		return
 	}
-	t.Fatalf("warnings = %v, want one containing %q", warnings, want)
+	if statusErr.ErrStatus.Details == nil {
+		t.Fatalf("error = %v, want typed field causes", err)
+	}
+
+	causes := statusErr.ErrStatus.Details.Causes
+	gotErrs := make([]string, len(causes))
+	for i, cause := range causes {
+		if cause.Field == "" {
+			t.Fatalf("error cause = %#v, want an exact field path", cause)
+		}
+		gotErrs[i] = fmt.Sprintf("%s: %s", cause.Field, cause.Message)
+	}
+	if !slices.Equal(gotErrs, wantErrs) {
+		t.Fatalf("webhook errors = %v, want %v", gotErrs, wantErrs)
+	}
 }


### PR DESCRIPTION
## Overview

Consolidate DynamoGraphDeployment validation coverage into one table-driven admission-chain test without changing production behavior. This prepares the test baseline for the structural validation refactor in #11090.

## Details

- validate each request with the OpenAPI schema and existing CEL rules for its submitted source version
- convert accepted v1alpha1 requests through the real conversion implementation
- invoke the v1beta1 create or update webhook with the real admission context
- support exact schema, CEL, webhook-error, warning, identity, manager, and environment expectations in one table
- retain focused non-table handler lifecycle and registration tests
- provide InferencePool discovery for EPP cases that must reach deeper webhook validation

## Where should the reviewer start?

Start with `TestDynamoGraphDeploymentValidator_Validate` in `deploy/operator/internal/webhook/validation/dynamographdeployment_test.go`, especially the per-row execution flow after the table.

## Related Issues

- [x] Confirmed — no related issue

## Summary

- one DGD admission-chain table with v1alpha1 and v1beta1 source-version coverage
- existing OpenAPI schema and CEL rules remain explicitly tested
- production behavior remains unchanged

## Validation

- `make check`
- `make test`
- `make lint`
- validation package coverage: 76.7% (`main` baseline: 75.7%)
