### PR TITLE
fix(vllm): Propagate nvext.cache_salt in Unified vLLM Prompt Construction

### DIFF
--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -73,6 +73,7 @@ from dynamo.vllm.capacity import per_rank_kv_blocks
 
 from .handlers import (
     VllmEnginePauseController,
+    _apply_nvext_cache_salt,
     build_sampling_params,
     get_dp_range_for_worker,
 )
@@ -366,6 +367,7 @@ class VllmLLMEngine(LLMEngine):
 
         token_ids = request.get("token_ids", [])
         prompt = TokensPrompt(prompt_token_ids=token_ids)
+        _apply_nvext_cache_salt(request, prompt)
 
         # TODO: remove dict() once build_sampling_params accepts GenerateRequest
         sampling_params = build_sampling_params(

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -410,6 +410,51 @@ def test_unified_generate_passes_enable_rl_to_sampling_params(monkeypatch):
     assert captured["enable_rl"] is True
 
 
+def test_unified_generate_applies_nvext_cache_salt(monkeypatch):
+    from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
+    from dynamo.vllm import llm_engine
+
+    captured = {}
+
+    def fake_build_sampling_params(
+        request, default_sampling_params, model_max_len=None, *, enable_rl=False
+    ):
+        return SimpleNamespace(extra_args=None)
+
+    async def empty_generation():
+        if False:
+            yield None
+
+    def fake_generate(prompt, *args, **kwargs):
+        captured["prompt"] = prompt
+        return empty_generation()
+
+    engine = llm_engine.VllmLLMEngine(
+        SimpleNamespace(),
+        CommonDisaggregationMode.AGGREGATED,
+        served_model_name="test-model",
+        component="backend",
+    )
+    engine.engine_client = SimpleNamespace(generate=fake_generate)
+    engine._default_sampling_params = {}
+    engine._model_max_len = 4096
+
+    monkeypatch.setattr(llm_engine, "build_sampling_params", fake_build_sampling_params)
+
+    async def run_generate():
+        request = {
+            "token_ids": [1, 2, 3],
+            "extra_args": {"nvext": {"cache_salt": "tenant-a"}},
+        }
+        context = SimpleNamespace(id=lambda: "req", trace_headers=lambda: None)
+        async for _ in engine.generate(request, context):
+            pass
+
+    asyncio.run(run_generate())
+
+    assert captured["prompt"]["cache_salt"] == "tenant-a"
+
+
 @pytest.mark.asyncio
 async def test_unified_start_returns_normalized_served_model_name(monkeypatch):
     """Return the Dynamo-normalized served model name from EngineConfig."""


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Propagate nvext.cache_salt in Unified vLLM Prompt Construction

## Details:
 
A similar nvext.cache_salt issue in PR https://github.com/ai-dynamo/dynamo/pull/11082 exists in a different path components/src/dynamo/vllm/llm_engine.py.
 
Client sends OpenAI chat/completions request with nvext: {"cache_salt": "tenant-a"} through vLLM unified backend. Dynamo preprocesses request into token IDs plus extra_args.nvext.cache_salt, then components/src/dynamo/vllm/llm_engine.py builds fresh TokensPrompt without cache_salt
 
In PR https://github.com/ai-dynamo/dynamo/pull/11082, components/src/dynamo/vllm/handlers.py is handler-based vLLM path , where handler creates TokensPrompt or TextPrompt from OpenAI-style text-mode input.

Regarding the PR, in a different path, components/src/dynamo/vllm/llm_engine.py is unified backend path. It receives already-preprocessed GenerateRequest with token_ids and extra_args, then creates its own TokensPrompt. Fix in handlers.py does not cover llm_engine.py, because unified backend bypasses _generate_text_mode.

Both paths construct vLLM prompt objects independently, so both need to propagate nvext.cache_salt at their own prompt-construction point.


## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generation requests now preserve cache-salt metadata, helping ensure more consistent behavior for tenant-specific prompts.
  * Added coverage for this request path to verify the cache-salt value is applied during generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->