### PR TITLE
fix(global-planner): read GPU pools from v1beta1 `spec.components`

### DIFF
--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -243,23 +243,55 @@ class ScaleRequestHandler:
         Returns a map from sub_component_type to PoolSpec. Pools with 0
         gpu_per_replica are included for completeness but contribute 0 to
         budget math.
+
+        Handles both DGD schemas: v1beta1 (the version the planner requests
+        from the API server) lists workers under ``spec.components`` (sub-type
+        in ``type``, GPU on the pod template containers under the standard
+        ``nvidia.com/gpu`` resource key); legacy v1alpha1 lists them under
+        ``spec.services`` (sub-type in ``subComponentType``, GPU in
+        ``resources.limits.gpu``).
         """
         deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
         pools: dict[str, PoolSpec] = {}
-        services = deployment.get("spec", {}).get("services", {})
-        for svc_spec in services.values():
-            sub_type = svc_spec.get("subComponentType", "")
-            if not sub_type:
+        worker_types = {
+            SubComponentType.PREFILL.value,
+            SubComponentType.DECODE.value,
+        }
+        for component in deployment.get("spec", {}).get("components", []):
+            sub_type = component.get("type", "")
+            if sub_type not in worker_types:
                 continue
-            gpu_per_replica = int(
-                svc_spec.get("resources", {}).get("limits", {}).get("gpu", 0)
+            gpu_per_replica = 0
+            containers = (
+                component.get("podTemplate", {}).get("spec", {}).get("containers", [])
             )
-            replicas = svc_spec.get("replicas", 0)
+            for container in containers:
+                limits = container.get("resources", {}).get("limits", {})
+                gpu_per_replica += int(limits.get("nvidia.com/gpu", 0))
             pools[sub_type] = PoolSpec(
                 sub_type=sub_type,
-                current_replicas=replicas,
+                current_replicas=component.get("replicas", 0),
                 gpu_per_replica=gpu_per_replica,
             )
+        # Legacy v1alpha1 DGDs expose workers under spec.services (a map)
+        # rather than spec.components; without this fallback their GPU budget
+        # reads as zero and the max/min-total-gpus bounds are silently
+        # disabled.
+        if not pools:
+            services = deployment.get("spec", {}).get("services", {})
+            for svc_spec in services.values():
+                sub_type = svc_spec.get("subComponentType", "")
+                if not sub_type:
+                    continue
+                gpu_per_replica = int(
+                    svc_spec.get("resources", {}).get("limits", {}).get("gpu", 0)
+                )
+                replicas = svc_spec.get("replicas", 0)
+                pools[sub_type] = PoolSpec(
+                    sub_type=sub_type,
+                    current_replicas=replicas,
+                    gpu_per_replica=gpu_per_replica,
+                )
         return pools
 
     def _read_all_pools(self) -> dict[str, dict[str, PoolSpec]]:

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -250,16 +250,31 @@ class ScaleRequestHandler:
         ``nvidia.com/gpu`` resource key); legacy v1alpha1 lists them under
         ``spec.services`` (sub-type in ``subComponentType``, GPU in
         ``resources.limits.gpu``).
+
+        v1beta1 ``type: worker`` components are included keyed by
+        ``worker/<name>`` so their GPUs count toward budget totals, while the
+        typed ``prefill``/``decode`` keys remain the only scalable pools.
         """
         deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
         pools: dict[str, PoolSpec] = {}
-        worker_types = {
+        typed_workers = {
             SubComponentType.PREFILL.value,
             SubComponentType.DECODE.value,
         }
         for component in deployment.get("spec", {}).get("components", []):
             sub_type = component.get("type", "")
-            if sub_type not in worker_types:
+            if sub_type in typed_workers:
+                key = sub_type
+            elif sub_type == "worker":
+                # Generic workers can't be addressed by SubComponentType, so
+                # requests never scale them through this handler's typed
+                # lookups — but their GPUs are real cluster usage and must
+                # count toward the min/max budget totals. Key them by
+                # component name (prefixed to avoid colliding with the typed
+                # keys); they never enter pairing because intents are only
+                # recorded for typed pools.
+                key = f"worker/{component.get('name', '')}"
+            else:
                 continue
             gpu_per_replica = 0
             containers = (
@@ -268,8 +283,8 @@ class ScaleRequestHandler:
             for container in containers:
                 limits = container.get("resources", {}).get("limits", {})
                 gpu_per_replica += int(limits.get("nvidia.com/gpu", 0))
-            pools[sub_type] = PoolSpec(
-                sub_type=sub_type,
+            pools[key] = PoolSpec(
+                sub_type=key,
                 current_replicas=component.get("replicas", 0),
                 gpu_per_replica=gpu_per_replica,
             )
@@ -1029,15 +1044,14 @@ class ScaleRequestHandler:
                             f"{patch_err}; will self-correct on next tick"
                         )
 
-            # Get current replica counts
-            current_replicas = {}
-            deployment = connector.kube_api.get_graph_deployment(
-                connector.parent_dgd_name
-            )
-            for service_name, service_spec in deployment["spec"]["services"].items():
-                sub_type = service_spec.get("subComponentType", "")
-                if sub_type:
-                    current_replicas[sub_type] = service_spec.get("replicas", 0)
+            # Get current replica counts via the shared schema-aware reader
+            # (v1beta1 spec.components with a v1alpha1 spec.services fallback);
+            # a direct spec.services parse would KeyError on v1beta1 DGDs and
+            # turn a completed scale into an ERROR response.
+            current_replicas = {
+                sub_type: spec.current_replicas
+                for sub_type, spec in self._read_dgd_pools(connector).items()
+            }
 
             logger.info(
                 f"Successfully scaled {request.graph_deployment_name}: {current_replicas}"

--- a/components/src/dynamo/global_planner/tests/unit/test_read_dgd_pools_v1beta1.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_read_dgd_pools_v1beta1.py
@@ -10,11 +10,13 @@ before the fix the GPU budget aggregated to zero and the ``--max-total-gpus``
 schema (the version the planner requests); v1alpha1 remains as a fallback.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from dynamo.global_planner.scale_handler import ScaleRequestHandler
+from dynamo.planner import SubComponentType, TargetReplica
+from dynamo.planner.connectors.protocol import ScaleRequest
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -131,3 +133,110 @@ def test_budget_nonzero_for_v1beta1():
     handler = _handler()
     handler.connectors["default/my-dgd"] = _connector(V1BETA1)
     assert handler._total_gpus_with_overrides({}) == 5
+
+
+# v1beta1 aggregated DGD: both workers declared as the generic `type: worker`
+# (addressable only by component name), 2*1 + 3*1 = 5 GPUs.
+V1BETA1_GENERIC_WORKERS = {
+    "spec": {
+        "components": [
+            _component("Frontend", "frontend", 1, 0),
+            _component("VllmPrefillWorker", "worker", 2, 1),
+            _component("VllmDecodeWorker", "worker", 3, 1),
+        ]
+    }
+}
+
+
+def test_generic_worker_components_count_toward_budget():
+    """`type: worker` components are snapshotted (keyed worker/<name>) and
+    their GPUs count toward the budget total."""
+    handler = _handler()
+    pools = handler._read_dgd_pools(_connector(V1BETA1_GENERIC_WORKERS))
+    assert set(pools) == {"worker/VllmPrefillWorker", "worker/VllmDecodeWorker"}
+    assert pools["worker/VllmPrefillWorker"].current_replicas == 2
+    assert pools["worker/VllmDecodeWorker"].gpu_per_replica == 1
+    handler.connectors["default/my-dgd"] = _connector(V1BETA1_GENERIC_WORKERS)
+    assert handler._total_gpus_with_overrides({}) == 5
+
+
+@pytest.mark.asyncio
+async def test_ceiling_counts_generic_worker_gpus():
+    """A typed scale-up is rejected when generic-worker GPUs already consume
+    the ceiling headroom (regression: type: worker GPUs were invisible to
+    the budget, so this request was admitted)."""
+    mixed = {
+        "spec": {
+            "components": [
+                _component("VllmPrefillWorker", "prefill", 1, 1),
+                _component("VllmDecodeWorker", "decode", 1, 1),
+                _component("VllmExtraWorker", "worker", 3, 1),
+            ]
+        }
+    }
+    handler = ScaleRequestHandler(
+        runtime=MagicMock(),
+        managed_namespaces=["app-ns"],
+        k8s_namespace="default",
+        max_total_gpus=6,
+    )
+    connector = AsyncMock()
+    connector.set_component_replicas = AsyncMock()
+    connector.parent_dgd_name = "my-dgd"
+    connector.kube_api = MagicMock()
+    connector.kube_api.get_graph_deployment = MagicMock(return_value=mixed)
+    handler.connectors["default/my-dgd"] = connector
+
+    request = ScaleRequest(
+        caller_namespace="app-ns",
+        graph_deployment_name="my-dgd",
+        k8s_namespace="default",
+        target_replicas=[
+            TargetReplica(
+                sub_component_type=SubComponentType.PREFILL, desired_replicas=3
+            )
+        ],
+    )
+    # Baseline 1+1+3 = 5 GPUs; prefill 1 -> 3 lands at 7 > ceiling 6.
+    # Without worker counting the total would read 4 and be admitted.
+    results = [r async for r in handler.scale_request(request.model_dump())]
+
+    assert results[0]["status"] == "rejected"
+    connector.set_component_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scale_success_reports_replicas_on_v1beta1():
+    """Post-scale current_replicas read works on a v1beta1 DGD.
+
+    Regression: the success path parsed ``deployment["spec"]["services"]``
+    directly, which raises KeyError on a v1beta1 DGD and turned a completed
+    scale into an ERROR response.
+    """
+    handler = _handler()
+    request = ScaleRequest(
+        caller_namespace="app-ns",
+        graph_deployment_name="my-dgd",
+        k8s_namespace="default",
+        target_replicas=[
+            TargetReplica(
+                sub_component_type=SubComponentType.PREFILL, desired_replicas=2
+            )
+        ],
+    )
+
+    with patch(
+        "dynamo.global_planner.scale_handler.KubernetesConnector"
+    ) as mock_connector_cls:
+        mock_connector = AsyncMock()
+        mock_connector_cls.return_value = mock_connector
+        mock_connector.set_component_replicas = AsyncMock()
+        mock_connector.parent_dgd_name = "my-dgd"
+        mock_connector.kube_api = MagicMock()
+        mock_connector.kube_api.get_graph_deployment = MagicMock(return_value=V1BETA1)
+
+        results = [r async for r in handler.scale_request(request.model_dump())]
+
+    assert len(results) == 1
+    assert results[0]["status"] == "success"
+    assert results[0]["current_replicas"] == {"prefill": 2, "decode": 3}

--- a/components/src/dynamo/global_planner/tests/unit/test_read_dgd_pools_v1beta1.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_read_dgd_pools_v1beta1.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for GlobalPlanner GPU-budget reading across DGD schemas.
+
+Covers v1beta1 support in ``ScaleRequestHandler._read_dgd_pools``: a v1beta1
+DGD exposes its workers under ``spec.components`` (not ``spec.services``), so
+before the fix the GPU budget aggregated to zero and the ``--max-total-gpus``
+/ ``--min-total-gpus`` bounds were silently disabled. v1beta1 is the primary
+schema (the version the planner requests); v1alpha1 remains as a fallback.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dynamo.global_planner.scale_handler import ScaleRequestHandler
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _connector(deployment):
+    connector = MagicMock()
+    connector.parent_dgd_name = "my-dgd"
+    connector.kube_api.get_graph_deployment = MagicMock(return_value=deployment)
+    return connector
+
+
+def _handler():
+    return ScaleRequestHandler(
+        runtime=MagicMock(), managed_namespaces=["app-ns"], k8s_namespace="default"
+    )
+
+
+# v1alpha1 DGD: workers under spec.services, GPU at resources.limits.gpu.
+V1ALPHA1 = {
+    "spec": {
+        "services": {
+            "prefill-svc": {
+                "subComponentType": "prefill",
+                "replicas": 2,
+                "resources": {"limits": {"gpu": "1"}},
+            },
+            "decode-svc": {
+                "subComponentType": "decode",
+                "replicas": 3,
+                "resources": {"limits": {"gpu": "1"}},
+            },
+            # Non-worker service (no subComponentType) is not counted as a pool.
+            "frontend-svc": {"replicas": 1},
+        }
+    }
+}
+
+
+def _component(name, ctype, replicas, gpu):
+    limits = {"nvidia.com/gpu": str(gpu)} if gpu else {}
+    return {
+        "name": name,
+        "type": ctype,
+        "replicas": replicas,
+        "podTemplate": {"spec": {"containers": [{"resources": {"limits": limits}}]}},
+    }
+
+
+# v1beta1 DGD: workers under spec.components, GPU at
+# podTemplate.spec.containers[].resources.limits["nvidia.com/gpu"].
+V1BETA1 = {
+    "spec": {
+        "components": [
+            _component("Frontend", "frontend", 1, 0),
+            _component("Planner", "planner", 1, 0),
+            _component("VllmPrefillWorker", "prefill", 2, 1),
+            _component("VllmDecodeWorker", "decode", 3, 1),
+        ]
+    }
+}
+
+
+def test_read_pools_v1beta1_components():
+    """v1beta1 spec.components workers are read (regression: was {} -> 0 GPU)."""
+    pools = _handler()._read_dgd_pools(_connector(V1BETA1))
+    assert set(pools) == {"prefill", "decode"}
+    assert pools["prefill"].current_replicas == 2
+    assert pools["prefill"].gpu_per_replica == 1
+    assert pools["decode"].current_replicas == 3
+    assert pools["decode"].gpu_per_replica == 1
+
+
+def test_read_pools_v1beta1_skips_non_workers():
+    """Frontend/Planner components carry no GPU and are not counted as pools."""
+    pools = _handler()._read_dgd_pools(_connector(V1BETA1))
+    assert "frontend" not in pools
+    assert "planner" not in pools
+
+
+def test_read_pools_v1alpha1_fallback():
+    """Legacy v1alpha1 spec.services DGDs are still read via the fallback."""
+    pools = _handler()._read_dgd_pools(_connector(V1ALPHA1))
+    assert set(pools) == {"prefill", "decode"}
+    assert pools["prefill"].current_replicas == 2
+    assert pools["prefill"].gpu_per_replica == 1
+    assert pools["decode"].current_replicas == 3
+    assert pools["decode"].gpu_per_replica == 1
+
+
+def test_v1beta1_components_take_precedence():
+    """When both schemas are present, spec.components wins and the
+    spec.services fallback is not consulted."""
+    alpha_services = {
+        "prefill-svc": {
+            "subComponentType": "prefill",
+            "replicas": 9,
+            "resources": {"limits": {"gpu": "8"}},
+        },
+    }
+    both = {"spec": {**V1BETA1["spec"], "services": alpha_services}}
+    pools = _handler()._read_dgd_pools(_connector(both))
+    assert set(pools) == {"prefill", "decode"}
+    assert pools["prefill"].current_replicas == 2  # from components, not 9
+    assert pools["prefill"].gpu_per_replica == 1  # from components, not 8
+
+
+def test_budget_nonzero_for_v1beta1():
+    """Total GPUs across a v1beta1 DGD is the real 5 (2*1 + 3*1), not 0."""
+    handler = _handler()
+    handler.connectors["default/my-dgd"] = _connector(V1BETA1)
+    assert handler._total_gpus_with_overrides({}) == 5


### PR DESCRIPTION
## Overview:

`ScaleRequestHandler._read_dgd_pools` reads a DGD's per-pool GPU count to enforce the `--max-total-gpus` / `--min-total-gpus` budget, but it only understands the v1alpha1 `spec.services` schema. A v1beta1 DGD lists its workers under
`spec.components`, so `_read_dgd_pools` returns an empty map, every pool aggregates to 0 GPUs, and the budget ceiling is silently disabled (fail-open — no error, no log warning). This went unnoticed because delegation and the actual replica-patching path (`kubernetes_api.py`) already handle `spec.components`, so scaling *works* — only the budget guardrail is quietly inert.


## Details:

`_read_dgd_pools` reads exactly one place:

```python
services = deployment.get("spec", {}).get("services", {}) 
for svc_spec in services.values():                       
    ...
```

A v1beta1 DGD has no `spec.services` key; its workers live in a `spec.components` list where the sub-component type is the component's `type` and the GPU limit is on the pod-template container under the standard `nvidia.com/gpu` key:

```yaml
spec:
  components:
    - name: VllmPrefillWorker
      type: prefill
      replicas: 2
      podTemplate:
        spec:
          containers:
            - resources: { limits: { nvidia.com/gpu: "1" } }
    - name: VllmDecodeWorker
      type: decode
      replicas: 3
      podTemplate: { spec: { containers: [ { resources: { limits: { nvidia.com/gpu: "1" } } } ] } }
```

Real total = `2*1 + 3*1 = 5` GPUs. `_read_dgd_pools` reports `{}` → total `0`.

Observed on a live cluster: starting a GlobalPlanner with `--max-total-gpus 6 --min-total-gpus 0` against one real 2-GPU DGD logged:

```
Discovered 1 existing DGDs: ['planner-test']
Initial total GPUs (0) meets floor (0)          # real GPU count is 2
```


## Where should the reviewer start?

`components/src/dynamo/global_planner/scale_handler.py` — `_read_dgd_pools`


## Fix

Read `spec.components` as the primary schema — it matches the v1beta1 API version the planner actually requests (`kubernetes_api.py`, `DYNAMO_API_VERSION = "v1beta1"`): sub-type from `type`, GPU summed from the pod-template containers' `nvidia.com/gpu` limits. Only `prefill`/`decode` (`SubComponentType`) components become pools, matching the v1alpha1 behaviour (frontend/planner are not pools). The legacy v1alpha1 `spec.services` parsing is kept as a fallback that runs only when `spec.components` yields no pools.

- v1beta1 path (the served schema): previously `{}` → `0` GPUs; now the real per-pool GPU counts, so the budget ceiling/floor actually engage.
- v1alpha1 path (`spec.services` present, no `spec.components`): the original parsing is preserved unchanged as the fallback (`if not pools:`), so legacy-shaped objects and existing unit fixtures read the same pools as before.

This looks like a migration gap rather than a deliberate v1alpha1-only budget: #10052 moved the planner
package's Kubernetes calls to v1beta1 and replaced its `spec.services` parsing with `spec.components[]`, but only touched `components/src/dynamo/planner/` —`global_planner/scale_handler.py` kept the v1alpha1 read while the `KubernetesAPI` it uses now serves v1beta1 objects.

## Related Issues

**🔗 This PR is linked to an issue:**
Closes #11220 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker pool detection so deployments using the newer schema now correctly report GPU capacity and replica counts.
  * Added fallback support for the legacy schema, preserving behavior for older deployments.
  * Prevented non-worker components from being counted in pool calculations.

* **Tests**
  * Added regression coverage for both schema variants and priority handling when both formats are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->