### PR TITLE
[WIP] vllm semantic router recipe 

### DIFF
--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/decode_scorer.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/decode_scorer.go
@@ -193,9 +193,12 @@ func (s *DynDecodeScorer) Score(ctx context.Context, cycleState *schedtypes.Cycl
 		s.pluginState.Write(req.RequestId, plugins.StateKey(decodeStateKey), routingState)
 	}
 
-	// Inject pre-computed tokens into the request body so the frontend
-	// sidecar can skip redundant tokenization.
-	setTokenizedPrompt(req, result.TokenData, logger)
+	// Inject tokens only when the parser produced a structured payload. For an
+	// opaque payload, result.TokenData came from the worker-selection placeholder;
+	// the frontend must tokenize the original request itself.
+	if req.Body != nil && req.Body.Payload != nil && req.Body.Payload.IsParsed() {
+		setTokenizedPrompt(req, result.TokenData, logger)
+	}
 
 	return uniformScores(endpoints, 1.0)
 }

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
@@ -304,6 +304,16 @@ func BuildOpenAIRequest(req *schedtypes.InferenceRequest) (map[string]any, error
 		requestBody["messages"] = messages
 	} else if req.Body.Completions != nil && !req.Body.Completions.Prompt.IsEmpty() {
 		addCompletionPrompt(requestBody, req.Body.Completions.Prompt)
+	} else if payload, ok := req.Body.Payload.(fwkrh.RawPayload); ok && len(payload) > 0 {
+		// Opaque protocols still need Dynamo worker IDs for direct-mode
+		// frontends. Use a minimal prompt only for worker selection; the raw
+		// request remains untouched and the frontend performs real tokenization.
+		requestBody["messages"] = []map[string]any{
+			{
+				"role":    "user",
+				"content": "x",
+			},
+		}
 	} else {
 		return nil, fmt.Errorf("no messages or prompt provided")
 	}

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
@@ -64,6 +64,27 @@ func TestBuildOpenAIRequest_ForwardsAgentHintsPriority(t *testing.T) {
 	}
 }
 
+func TestBuildOpenAIRequest_OpaquePayloadUsesSelectionPlaceholder(t *testing.T) {
+	req := &schedtypes.InferenceRequest{
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			Payload: fwkrh.RawPayload(`{"model":"test-model","messages":[{"role":"user","content":"hello"}]}`),
+		},
+	}
+
+	body, err := BuildOpenAIRequest(req)
+	if err != nil {
+		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
+	}
+	if body["model"] != "test-model" {
+		t.Fatalf("model = %v, want test-model", body["model"])
+	}
+	messages, ok := body["messages"].([]map[string]any)
+	if !ok || len(messages) != 1 || messages[0]["content"] != "x" {
+		t.Fatalf("messages = %#v, want one selection placeholder", body["messages"])
+	}
+}
+
 func TestBuildOpenAIRequest_CompletionsTokenPromptUsesPromptIDs(t *testing.T) {
 	req := &schedtypes.InferenceRequest{
 		TargetModel: "test-model",

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -19,6 +19,7 @@ The common identity concept is `session_id`: one stable ID for one agent reasoni
 
 | Concept | Purpose |
 |---------|---------|
+| [Deploy a Mixture of Models](deploy-mixture-of-models.md) | Route agent requests between heterogeneous model deployments through one endpoint. |
 | [Agent Harnesses](agent-harnesses.md) | Quickstart for running popular agent harnesses through Dynamo. |
 | [Session IDs](session-ids.md) | Stable agent identity for tracing and opt-in consumers. |
 | [Agent Tracing](agent-tracing.md) | Request traces, inferred tool calls, optional harness tool spans, and Perfetto conversion. |

--- a/docs/agents/deploy-mixture-of-models.md
+++ b/docs/agents/deploy-mixture-of-models.md
@@ -1,0 +1,146 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Deploy a Mixture of Models
+subtitle: Route agent requests between heterogeneous Dynamo deployments through one endpoint
+---
+
+**Experimental.** Deploy multiple models behind one endpoint when agent requests need different capability, latency, or cost profiles. The reference deployment routes lightweight requests to Qwen on vLLM and technical requests to GLM on SGLang.
+
+## Architecture
+
+The model router selects a concrete model before model-specific tokenization. Gateway API then selects that model's `InferencePool`, and the Dynamo Endpoint Picker Protocol (EPP) selects workers inside the pool.
+
+```mermaid
+flowchart LR
+    C[OpenAI or Anthropic client] --> E[Envoy]
+    E --> S[vLLM Semantic Router]
+    S -->|selected model| E
+    E --> H[HTTPRoute]
+    H --> P[Model-specific InferencePool]
+    P --> EP[Dynamo EPP]
+    EP --> F[Dynamo Frontend]
+    F --> W[vLLM or SGLang workers]
+```
+
+The reference recipe deploys two independent `DynamoGraphDeployment` resources:
+
+| Deployment | Model | Backend | Topology |
+|---|---|---|---|
+| `model-routing-small` | `Qwen/Qwen3.5-122B-A10B-FP8` | vLLM | Aggregated TP8 |
+| `model-routing-large` | `nvidia/GLM-5.2-NVFP4` | SGLang | 1P/1D TP8 with NIXL |
+
+Both deployments share one client endpoint and model-selection policy. Each deployment retains its own backend, scaling, EPP policy, and worker lifecycle.
+
+GlobalRouter is not required because the recipe has one pool per model. GlobalPlanner can scale the pools asynchronously, but it does not participate in model selection or the request path.
+
+## Prerequisites
+
+Prepare the cluster resources listed in the [vLLM Semantic Router mixture recipe](https://github.com/ai-dynamo/dynamo/tree/main/recipes/model-routing/vllm-semantic-router), including:
+
+- three nodes with eight B200 GPUs each;
+- the Dynamo operator and agentgateway with Gateway API Inference Extension support;
+- a ReadWriteMany PVC named `shared-model-cache`;
+- `hf-token-secret` and `ngc-secret` in the deployment namespace; and
+- RDMA devices on the two GLM nodes.
+
+Run the following commands from the Dynamo repository root.
+
+## Cache the Models
+
+```bash
+export NAMESPACE=model-routing
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -n "$NAMESPACE" \
+  -f recipes/model-routing/vllm-semantic-router/model-cache.yaml
+kubectl wait -n "$NAMESPACE" job/model-routing-cache \
+  --for=condition=Complete --timeout=7200s
+```
+
+The cache job reuses the existing `shared-model-cache` PVC.
+
+## Deploy
+
+Install vLLM Semantic Router, then apply the two Dynamo graphs and Gateway resources:
+
+```bash
+git clone --depth 1 --branch v0.3.0 \
+  https://github.com/vllm-project/semantic-router.git /tmp/semantic-router-v0.3.0
+
+helm dependency build \
+  /tmp/semantic-router-v0.3.0/deploy/helm/semantic-router
+
+helm upgrade --install semantic-router \
+  /tmp/semantic-router-v0.3.0/deploy/helm/semantic-router \
+  --namespace "$NAMESPACE" \
+  --values recipes/model-routing/vllm-semantic-router/semantic-router-values.yaml \
+  --wait --timeout 30m
+
+kubectl apply -n "$NAMESPACE" \
+  -f recipes/model-routing/vllm-semantic-router/deploy.yaml
+```
+
+Wait for both graphs and the Gateway:
+
+```bash
+kubectl wait -n "$NAMESPACE" dgd/model-routing-small \
+  --for=condition=Ready --timeout=3600s
+kubectl wait -n "$NAMESPACE" dgd/model-routing-large \
+  --for=condition=Ready --timeout=3600s
+kubectl wait -n "$NAMESPACE" gateway/model-routing-gateway \
+  --for=condition=Programmed --timeout=300s
+```
+
+## Test Model Routing
+
+Forward the shared endpoint:
+
+```bash
+kubectl port-forward -n "$NAMESPACE" service/model-routing-envoy 8000:80
+```
+
+In another terminal, run the smoke test:
+
+```bash
+BASE_URL=http://127.0.0.1:8000 \
+  recipes/model-routing/vllm-semantic-router/smoke.sh
+```
+
+The test checks automatic Qwen and GLM selection, trusted-header handling, unknown-model rejection, OpenAI streaming, and Anthropic Messages streaming.
+
+Inspect both routing stages:
+
+```bash
+kubectl logs -n "$NAMESPACE" deployment/semantic-router --tail=200
+kubectl logs -n "$NAMESPACE" \
+  -l nvidia.com/dynamo-component-type=epp --tail=200
+```
+
+## Run Claude Code
+
+Point Claude Code at the same endpoint and use `auto` as the model name:
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8000
+export ANTHROPIC_MODEL=auto
+export ANTHROPIC_SMALL_FAST_MODEL=auto
+export CLAUDE_CODE_ATTRIBUTION_HEADER=0
+export ANTHROPIC_API_KEY=local-dev-token
+
+claude
+```
+
+Dynamo Frontend terminates the Anthropic Messages API. The semantic router changes only the selected model and preserves the client protocol.
+
+## Clean Up
+
+```bash
+kubectl delete -n "$NAMESPACE" \
+  -f recipes/model-routing/vllm-semantic-router/deploy.yaml
+kubectl delete -n "$NAMESPACE" \
+  -f recipes/model-routing/vllm-semantic-router/model-cache.yaml
+helm uninstall semantic-router -n "$NAMESPACE"
+```
+
+See the [complete recipe](https://github.com/ai-dynamo/dynamo/tree/main/recipes/model-routing/vllm-semantic-router) to change the models, routing policy, or serving topology.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -307,6 +307,8 @@ navigation:
             slug: agents
             path: agents/README.md
             contents:
+              - page: Deploy a Mixture of Models
+                path: agents/deploy-mixture-of-models.md
               - page: Session IDs
                 path: agents/session-ids.md
               - page: Agent Tracing

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -73,6 +73,7 @@ These recipes are under active development and may require additional setup step
 
 | Model | Framework | Mode | GPUs | Deployment | Notes |
 |-------|-----------|------|------|------------|-------|
+| **[GLM-5.2 NVFP4 + Qwen3.5-122B](model-routing/vllm-semantic-router/)** | SGLang + vLLM | Mixture of backends | 24x B200 | ✅ | vLLM Semantic Router model selection, aggregated Qwen, NIXL-disaggregated GLM, Gateway API, and one Dynamo EPP per model. Uses pre-release Dynamo runtimes. |
 | **[GLM-5-NVFP4 (EFA)](glm-5-nvfp4/sglang/disagg/efa/)** | SGLang | Disagg Prefill/Decode over AWS EFA | 20x GB200 | ✅ | KV transfer over AWS EFA via NIXL LIBFABRIC instead of UCX. Patched libfabric baked into image. Requires [custom container build](glm-5-nvfp4/sglang/disagg/efa/Dockerfile.efa). |
 | **[Nemotron-3-Nano-Omni-NVFP4](nemotron-3-nano-omni/vllm/agg/)** | vLLM | Aggregated | 1x GPU | ✅ | Multimodal text/image/video/audio serving. Requires [custom container build](nemotron-3-nano-omni/). |
 | **[nvidia/Kimi-K2.5-NVFP4](kimi-k2.5/tokenspeed/agg/nvidia/)** | TokenSpeed | Aggregated | 4x B200 | ✅ | Text only — MoE model, TP4×EP4, reasoning + tool calling. Requires [custom container build](kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile) (no public Dynamo+TokenSpeed image yet) and raw `Deployment`s/`Service`s instead of `DynamoGraphDeployment` (operator backend support pending). |

--- a/recipes/model-routing/vllm-semantic-router/README.md
+++ b/recipes/model-routing/vllm-semantic-router/README.md
@@ -1,0 +1,138 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# vLLM Semantic Router Mixture of Backends
+
+This experimental recipe serves `nvidia/GLM-5.2-NVFP4` and `Qwen/Qwen3.5-122B-A10B-FP8` behind one endpoint. vLLM Semantic Router selects a model before Gateway API routing. The Dynamo Endpoint Picker Protocol (EPP) then selects a worker inside that model's `InferencePool`.
+
+```text
+client -> Envoy ext_proc -> vLLM Semantic Router -> HTTPRoute -> InferencePool -> Dynamo EPP -> backend graph
+```
+
+The recipe uses a standalone Envoy bridge because agentgateway v1.0 does not rematch an `HTTPRoute` after a request-body external processor selects a model. The bridge owns model selection only; agentgateway and Dynamo EPP retain Kubernetes endpoint selection.
+
+`x-selected-model` is internal routing metadata, not authentication. Envoy removes any client-supplied value before semantic routing. Keep the agentgateway service cluster-internal and restrict direct pod access with your cluster's network policy in a multi-tenant namespace.
+
+The models deliberately use different serving topologies:
+
+- Qwen is an aggregated TP8 vLLM deployment on one B200 node.
+- GLM is a 1P/1D TP8 SGLang deployment on two B200 nodes. Dynamo EPP selects the prefill and decode endpoints, and SGLang transfers KV state with NIXL over RDMA.
+
+The GLM workers follow SGLang's verified single-node B200 NVFP4 configuration: `modelopt_fp4`, TP8, 8K chunked prefill, and 0.85 static memory. The digest-pinned integration image combines current GLM-5.2 NVFP4 support with the Dynamo SGLang entry point; replace it with the next official Dynamo runtime that includes that support.
+
+This split is intentional: the model router selects model capability, while each model's DGD independently selects the inference backend and serving topology. Replacing either DGD does not change the semantic router, Envoy, Gateway API routes, or the other model.
+
+## Router Contract
+
+A replacement global model router does not implement EPP. EPP is the inner contract between each `InferencePool` and its Dynamo worker graph. The outer router only needs to:
+
+- inspect or transform the request before Gateway API matching;
+- select one configured model and set the trusted `x-selected-model` header; and
+- preserve the request and response protocol expected by the client and backend.
+
+The HTTPRoutes map that header to model-specific `InferencePool` resources. A future Switchyard integration can therefore replace the semantic-router `ext_proc` service while preserving the Envoy trust boundary, routes, pools, EPP configuration, and worker graphs. If it uses a protocol other than Envoy `ext_proc`, only the bridge must change.
+
+## Prerequisites
+
+- A Kubernetes cluster with three free 8x B200 nodes.
+- RDMA devices exposed as `rdma/shared_ib` and UCX devices `mlx5_0:1` through `mlx5_3:1` on the GLM nodes.
+- Dynamo operator v1.3.0 and agentgateway v1.0 installed with Gateway API Inference Extension support.
+- Access to the pinned GLM runtime image (`Dynamo 1.3.0.dev20260628`, SGLang `aaa31eb0`) with ModelOpt NVFP4 support.
+- A ReadWriteMany PVC named `shared-model-cache`.
+- Secrets named `hf-token-secret` and `ngc-secret`.
+- `git`, Helm 3, `kubectl`, `curl`, and `jq` on the client.
+
+## Cache the Models
+
+The job reuses files already present in `shared-model-cache`; it does not create a PVC.
+
+```bash
+export NAMESPACE=model-routing
+
+kubectl apply -n "$NAMESPACE" -f model-cache.yaml
+kubectl wait -n "$NAMESPACE" job/model-routing-cache \
+  --for=condition=Complete --timeout=7200s
+```
+
+## Deploy
+
+Install the v0.3.0 Helm chart. `semantic-router-values.yaml` pins a post-v0.3.0 image digest that adds symmetric OpenAI SSE to Anthropic SSE translation:
+
+```bash
+git clone --depth 1 --branch v0.3.0 \
+  https://github.com/vllm-project/semantic-router.git /tmp/semantic-router-v0.3.0
+
+helm dependency build \
+  /tmp/semantic-router-v0.3.0/deploy/helm/semantic-router
+
+helm upgrade --install semantic-router \
+  /tmp/semantic-router-v0.3.0/deploy/helm/semantic-router \
+  --namespace "$NAMESPACE" \
+  --values semantic-router-values.yaml \
+  --wait --timeout 30m
+
+kubectl apply -n "$NAMESPACE" -f deploy.yaml
+```
+
+Wait for the two serving graphs and the gateway:
+
+```bash
+kubectl wait -n "$NAMESPACE" dgd/model-routing-small \
+  --for=condition=Ready --timeout=3600s
+kubectl wait -n "$NAMESPACE" dgd/model-routing-large \
+  --for=condition=Ready --timeout=3600s
+kubectl wait -n "$NAMESPACE" gateway/model-routing-gateway \
+  --for=condition=Programmed --timeout=300s
+kubectl rollout status -n "$NAMESPACE" deployment/model-routing-envoy \
+  --timeout=300s
+```
+
+## Smoke Test
+
+Forward the recipe endpoint:
+
+```bash
+kubectl port-forward -n "$NAMESPACE" service/model-routing-envoy 8000:80
+```
+
+Run the functional checks in another terminal:
+
+```bash
+./smoke.sh
+```
+
+The script checks automatic selection of both model pools, spoofed-header rejection, unknown-model failure, OpenAI streaming, and Anthropic Messages non-streaming and SSE streaming.
+
+Confirm the two routing stages:
+
+```bash
+kubectl logs -n "$NAMESPACE" deployment/semantic-router --tail=200
+kubectl logs -n "$NAMESPACE" \
+  -l nvidia.com/dynamo-component-type=epp --tail=200
+```
+
+## Claude Code
+
+The semantic router translates Anthropic Messages requests and streaming responses around Dynamo's OpenAI-compatible EPP path. Point Claude Code at the forwarded endpoint:
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8000
+export ANTHROPIC_MODEL=auto
+export ANTHROPIC_SMALL_FAST_MODEL=auto
+export CLAUDE_CODE_ATTRIBUTION_HEADER=0
+export ANTHROPIC_API_KEY=local-dev-token
+
+claude
+```
+
+Use `auto` for Anthropic clients so the semantic policy selects the backend. The selected model remains visible in the response and the semantic-router response headers and logs.
+
+## Clean Up
+
+```bash
+kubectl delete -n "$NAMESPACE" -f deploy.yaml
+kubectl delete -n "$NAMESPACE" -f model-cache.yaml
+helm uninstall semantic-router -n "$NAMESPACE"
+```

--- a/recipes/model-routing/vllm-semantic-router/README.md
+++ b/recipes/model-routing/vllm-semantic-router/README.md
@@ -11,7 +11,7 @@ This experimental recipe serves `nvidia/GLM-5.2-NVFP4` and `Qwen/Qwen3.5-122B-A1
 client -> Envoy ext_proc -> vLLM Semantic Router -> HTTPRoute -> InferencePool -> Dynamo EPP -> backend graph
 ```
 
-The recipe uses a standalone Envoy bridge because agentgateway v1.0 does not rematch an `HTTPRoute` after a request-body external processor selects a model. The bridge owns model selection only; agentgateway and Dynamo EPP retain Kubernetes endpoint selection.
+The recipe uses a standalone Envoy bridge because agentgateway v1.0 does not rematch an `HTTPRoute` after a request-body external processor selects a model. The bridge owns model selection only; agentgateway and Dynamo EPP retain Kubernetes endpoint selection, and Dynamo Frontend owns client protocol handling.
 
 `x-selected-model` is internal routing metadata, not authentication. Envoy removes any client-supplied value before semantic routing. Keep the agentgateway service cluster-internal and restrict direct pod access with your cluster's network policy in a multi-tenant namespace.
 
@@ -28,11 +28,13 @@ This split is intentional: the model router selects model capability, while each
 
 A replacement global model router does not implement EPP. EPP is the inner contract between each `InferencePool` and its Dynamo worker graph. The outer router only needs to:
 
-- inspect or transform the request before Gateway API matching;
+- inspect the request before Gateway API matching;
 - select one configured model and set the trusted `x-selected-model` header; and
-- preserve the request and response protocol expected by the client and backend.
+- replace the unresolved `auto` model with the selected model without changing the client wire protocol.
 
 The HTTPRoutes map that header to model-specific `InferencePool` resources. A future Switchyard integration can therefore replace the semantic-router `ext_proc` service while preserving the Envoy trust boundary, routes, pools, EPP configuration, and worker graphs. If it uses a protocol other than Envoy `ext_proc`, only the bridge must change.
+
+The semantic-router image used here adds `api_format: passthrough`. In that mode it preserves the original OpenAI or Anthropic body and response format and changes only `model`. The EPP uses GAIE's `passthrough-parser`; its Dynamo scorers use a minimal placeholder solely to resolve the required Dynamo worker IDs and do not inject placeholder tokens. The selected Dynamo Frontend parses and tokenizes the original request. This intentionally gives up prompt-aware EPP placement for opaque payloads.
 
 ## Prerequisites
 
@@ -58,7 +60,7 @@ kubectl wait -n "$NAMESPACE" job/model-routing-cache \
 
 ## Deploy
 
-Install the v0.3.0 Helm chart. `semantic-router-values.yaml` pins a post-v0.3.0 image digest that adds symmetric OpenAI SSE to Anthropic SSE translation:
+Install the v0.3.0 Helm chart. `semantic-router-values.yaml` pins the selection-only semantic-router image:
 
 ```bash
 git clone --depth 1 --branch v0.3.0 \
@@ -115,7 +117,7 @@ kubectl logs -n "$NAMESPACE" \
 
 ## Claude Code
 
-The semantic router translates Anthropic Messages requests and streaming responses around Dynamo's OpenAI-compatible EPP path. Point Claude Code at the forwarded endpoint:
+Dynamo Frontend terminates the Anthropic Messages API; the semantic router and EPP preserve that protocol. Point Claude Code at the forwarded endpoint:
 
 ```bash
 export ANTHROPIC_BASE_URL=http://127.0.0.1:8000

--- a/recipes/model-routing/vllm-semantic-router/README.md
+++ b/recipes/model-routing/vllm-semantic-router/README.md
@@ -36,6 +36,17 @@ The HTTPRoutes map that header to model-specific `InferencePool` resources. A fu
 
 The semantic-router image used here adds `api_format: passthrough`. In that mode it preserves the original OpenAI or Anthropic body and response format and changes only `model`. The EPP uses GAIE's `passthrough-parser`; its Dynamo scorers use a minimal placeholder solely to resolve the required Dynamo worker IDs and do not inject placeholder tokens. The selected Dynamo Frontend parses and tokenizes the original request. This intentionally gives up prompt-aware EPP placement for opaque payloads.
 
+## Relationship to Dynamo Routing and Planning
+
+Model routing is independent from Dynamo's pool routing and capacity planning:
+
+- vLLM Semantic Router selects the concrete model before model-specific tokenization.
+- The `HTTPRoute` selects that model's `InferencePool`, and Dynamo EPP selects worker endpoints inside the pool.
+- GlobalRouter is optional when one concrete model spans multiple Dynamo pools. This recipe has one pool per model and does not deploy GlobalRouter.
+- GlobalPlanner reconciles pool capacity asynchronously. It does not select a model or participate in the request path.
+
+Keep these stages separate: model selection chooses capability, pool routing chooses placement for one model, and planning changes future capacity.
+
 ## Prerequisites
 
 - A Kubernetes cluster with three free 8x B200 nodes.

--- a/recipes/model-routing/vllm-semantic-router/deploy.yaml
+++ b/recipes/model-routing/vllm-semantic-router/deploy.yaml
@@ -1,0 +1,733 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: model-routing-small
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  backendFramework: vllm
+  components:
+    - name: Epp
+      type: epp
+      replicas: 1
+      minAvailable: 1
+      podTemplate:
+        spec:
+          imagePullSecrets:
+            - name: ngc-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvstaging/ai-dynamo/dynamo-frontend:1.3.0-rc1
+              env:
+                - name: DYN_KV_CACHE_BLOCK_SIZE
+                  value: "16"
+                - name: DYN_MODEL_NAME
+                  value: Qwen/Qwen3.5-122B-A10B-FP8
+                - name: DYN_DECODE_FALLBACK
+                  value: "true"
+      eppConfig:
+        config:
+          plugins:
+            - type: disagg-profile-handler
+            - name: decode-filter
+              type: label-filter
+              parameters:
+                label: nvidia.com/dynamo-component-type
+                validValues: [decode]
+                allowsNoLabel: false
+            - name: picker
+              type: max-score-picker
+            - name: dyn-decode
+              type: dyn-decode-scorer
+          schedulingProfiles:
+            - name: decode
+              plugins:
+                - pluginRef: decode-filter
+                  weight: 1
+                - pluginRef: dyn-decode
+                  weight: 1
+                - pluginRef: picker
+                  weight: 1
+    - name: VllmDecodeWorker
+      type: decode
+      replicas: 1
+      minAvailable: 1
+      sharedMemorySize: 64Gi
+      frontendSidecar: sidecar-frontend
+      podTemplate:
+        spec:
+          imagePullSecrets:
+            - name: ngc-secret
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+          containers:
+            - name: main
+              image: nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.3.0-rc1
+              workingDir: /workspace/examples/backends/vllm
+              command: [python3, -m, dynamo.vllm]
+              args:
+                - --model
+                - Qwen/Qwen3.5-122B-A10B-FP8
+                - --served-model-name
+                - Qwen/Qwen3.5-122B-A10B-FP8
+                - --tensor-parallel-size
+                - "8"
+                - --gpu-memory-utilization
+                - "0.9"
+                - --max-model-len
+                - "262144"
+                - --max-num-seqs
+                - "32"
+                - --language-model-only
+                - --enable-prefix-caching
+                - --kv-events-config
+                - '{"enable_kv_cache_events":true}'
+                - --block-size
+                - "16"
+                - --dyn-tool-call-parser
+                - qwen3_coder
+                - --dyn-reasoning-parser
+                - qwen3
+              env:
+                - name: HF_HOME
+                  value: /opt/models
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+                - name: TRANSFORMERS_OFFLINE
+                  value: "1"
+                - name: DYN_STORE_KV
+                  value: mem
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  memory: 512Gi
+                limits:
+                  nvidia.com/gpu: "8"
+              # FlashInfer 0.6.12 creates MoE cubin symlinks in its package directory.
+              securityContext:
+                runAsUser: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 80
+              volumeMounts:
+                - name: model-cache
+                  mountPath: /opt/models
+            - name: sidecar-frontend
+              image: nvcr.io/nvstaging/ai-dynamo/vllm-runtime:1.3.0-rc1
+              args:
+                - -m
+                - dynamo.frontend
+                - --router-mode
+                - direct
+                - --enable-anthropic-api
+                - --strip-anthropic-preamble
+                - --enable-streaming-tool-dispatch
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: model-routing-large
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  backendFramework: sglang
+  components:
+    - name: Epp
+      type: epp
+      replicas: 1
+      minAvailable: 1
+      podTemplate:
+        spec:
+          imagePullSecrets:
+            - name: ngc-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvstaging/ai-dynamo/dynamo-frontend:1.3.0-rc1
+              env:
+                - name: DYN_KV_CACHE_BLOCK_SIZE
+                  value: "1"
+                - name: DYN_MODEL_NAME
+                  value: nvidia/GLM-5.2-NVFP4
+                - name: DYN_ENFORCE_DISAGG
+                  value: "true"
+      eppConfig:
+        config:
+          plugins:
+            - type: disagg-profile-handler
+            - name: prefill-filter
+              type: label-filter
+              parameters:
+                label: nvidia.com/dynamo-component-type
+                validValues: [prefill]
+                allowsNoLabel: false
+            - name: decode-filter
+              type: label-filter
+              parameters:
+                label: nvidia.com/dynamo-component-type
+                validValues: [decode]
+                allowsNoLabel: false
+            - name: picker
+              type: max-score-picker
+            - name: dyn-prefill
+              type: dyn-prefill-scorer
+            - name: dyn-decode
+              type: dyn-decode-scorer
+          schedulingProfiles:
+            - name: prefill
+              plugins:
+                - pluginRef: prefill-filter
+                  weight: 1
+                - pluginRef: dyn-prefill
+                  weight: 1
+                - pluginRef: picker
+                  weight: 1
+            - name: decode
+              plugins:
+                - pluginRef: decode-filter
+                  weight: 1
+                - pluginRef: dyn-decode
+                  weight: 1
+                - pluginRef: picker
+                  weight: 1
+    - name: SglangDecodeWorker
+      type: decode
+      replicas: 1
+      minAvailable: 1
+      sharedMemorySize: 300Gi
+      frontendSidecar: sidecar-frontend
+      podTemplate:
+        spec:
+          imagePullSecrets:
+            - name: ngc-secret
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+          containers:
+            - name: main
+              image: ishandhanani/sglang:dynamo-e2e-aaa31eb0@sha256:13fe875302a92b68632d2641ef6e2c114b95cd2bbf6d126a4d1eae2b28ab4c18
+              workingDir: /workspace/examples/backends/sglang
+              command: [python3, -m, dynamo.sglang]
+              args:
+                - --model-path
+                - nvidia/GLM-5.2-NVFP4
+                - --served-model-name
+                - nvidia/GLM-5.2-NVFP4
+                - --trust-remote-code
+                - --watchdog-timeout
+                - "100000"
+                - --quantization
+                - modelopt_fp4
+                - --chunked-prefill-size
+                - "8192"
+                - --mem-fraction-static
+                - "0.85"
+                - --tp-size
+                - "8"
+                - --disable-radix-cache
+                - --enable-metrics
+                - --disaggregation-mode
+                - decode
+                - --disaggregation-transfer-backend
+                - nixl
+                - --disaggregation-ib-device
+                - mlx5_0,mlx5_1,mlx5_2,mlx5_3
+                - --disaggregation-bootstrap-port
+                - "8998"
+                - --host
+                - 0.0.0.0
+                - --dyn-tool-call-parser
+                - glm47
+                - --dyn-reasoning-parser
+                - glm45
+              env:
+                - name: HF_HOME
+                  value: /opt/models
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+                - name: TRANSFORMERS_OFFLINE
+                  value: "1"
+                - name: DYN_STORE_KV
+                  value: mem
+                - name: FLASHINFER_WORKSPACE_BASE
+                  value: /tmp/flashinfer-workspace
+                - name: SGLANG_CACHE_DIR
+                  value: /tmp/sglang
+                - name: SGLANG_DG_CACHE_DIR
+                  value: /tmp/deep-gemm
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: GLOO_SOCKET_IFNAME
+                  value: eth0
+                - name: NCCL_SOCKET_IFNAME
+                  value: eth0
+                - name: NCCL_CUMEM_ENABLE
+                  value: "1"
+                - name: TORCH_NCCL_ENABLE_MONITORING
+                  value: "0"
+                - name: UCX_TLS
+                  value: cuda_ipc,cuda_copy,rc
+                - name: UCX_MODULE_DIR
+                  value: /usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx
+                - name: UCX_NET_DEVICES
+                  value: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1
+                - name: NCCL_IB_DISABLE
+                  value: "0"
+                - name: NIXL_LOG_LEVEL
+                  value: INFO
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  rdma/shared_ib: "8"
+                  memory: 512Gi
+                  ephemeral-storage: 80Gi
+                limits:
+                  nvidia.com/gpu: "8"
+                  rdma/shared_ib: "8"
+                  ephemeral-storage: 160Gi
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                capabilities:
+                  add: [IPC_LOCK, SYS_RESOURCE]
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 180
+              volumeMounts:
+                - name: model-cache
+                  mountPath: /opt/models
+            - name: sidecar-frontend
+              image: ishandhanani/sglang:dynamo-e2e-aaa31eb0@sha256:13fe875302a92b68632d2641ef6e2c114b95cd2bbf6d126a4d1eae2b28ab4c18
+              args:
+                - -m
+                - dynamo.frontend
+                - --router-mode
+                - direct
+                - --enable-anthropic-api
+                - --strip-anthropic-preamble
+                - --enable-streaming-tool-dispatch
+    - name: SglangPrefillWorker
+      type: prefill
+      replicas: 1
+      minAvailable: 1
+      sharedMemorySize: 300Gi
+      podTemplate:
+        spec:
+          imagePullSecrets:
+            - name: ngc-secret
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+          containers:
+            - name: main
+              image: ishandhanani/sglang:dynamo-e2e-aaa31eb0@sha256:13fe875302a92b68632d2641ef6e2c114b95cd2bbf6d126a4d1eae2b28ab4c18
+              workingDir: /workspace/examples/backends/sglang
+              command: [python3, -m, dynamo.sglang]
+              args:
+                - --model-path
+                - nvidia/GLM-5.2-NVFP4
+                - --served-model-name
+                - nvidia/GLM-5.2-NVFP4
+                - --trust-remote-code
+                - --watchdog-timeout
+                - "100000"
+                - --quantization
+                - modelopt_fp4
+                - --chunked-prefill-size
+                - "8192"
+                - --mem-fraction-static
+                - "0.85"
+                - --tp-size
+                - "8"
+                - --disable-radix-cache
+                - --enable-metrics
+                - --disaggregation-mode
+                - prefill
+                - --disaggregation-transfer-backend
+                - nixl
+                - --disaggregation-ib-device
+                - mlx5_0,mlx5_1,mlx5_2,mlx5_3
+                - --disaggregation-bootstrap-port
+                - "8998"
+                - --host
+                - 0.0.0.0
+                - --dyn-tool-call-parser
+                - glm47
+                - --dyn-reasoning-parser
+                - glm45
+              env:
+                - name: HF_HOME
+                  value: /opt/models
+                - name: HF_HUB_OFFLINE
+                  value: "1"
+                - name: TRANSFORMERS_OFFLINE
+                  value: "1"
+                - name: DYN_STORE_KV
+                  value: mem
+                - name: FLASHINFER_WORKSPACE_BASE
+                  value: /tmp/flashinfer-workspace
+                - name: SGLANG_CACHE_DIR
+                  value: /tmp/sglang
+                - name: SGLANG_DG_CACHE_DIR
+                  value: /tmp/deep-gemm
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: GLOO_SOCKET_IFNAME
+                  value: eth0
+                - name: NCCL_SOCKET_IFNAME
+                  value: eth0
+                - name: NCCL_CUMEM_ENABLE
+                  value: "1"
+                - name: TORCH_NCCL_ENABLE_MONITORING
+                  value: "0"
+                - name: UCX_TLS
+                  value: cuda_ipc,cuda_copy,rc
+                - name: UCX_MODULE_DIR
+                  value: /usr/local/lib/python3.12/dist-packages/nixl_cu13.libs/ucx
+                - name: UCX_NET_DEVICES
+                  value: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1
+                - name: NCCL_IB_DISABLE
+                  value: "0"
+                - name: NIXL_LOG_LEVEL
+                  value: INFO
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  rdma/shared_ib: "8"
+                  memory: 512Gi
+                  ephemeral-storage: 80Gi
+                limits:
+                  nvidia.com/gpu: "8"
+                  rdma/shared_ib: "8"
+                  ephemeral-storage: 160Gi
+              securityContext:
+                runAsUser: 0
+                runAsGroup: 0
+                capabilities:
+                  add: [IPC_LOCK, SYS_RESOURCE]
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 180
+              volumeMounts:
+                - name: model-cache
+                  mountPath: /opt/models
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayParameters
+metadata:
+  name: model-routing-gateway
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  service:
+    spec:
+      type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: model-routing-gateway
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  gatewayClassName: agentgateway
+  infrastructure:
+    parametersRef:
+      group: agentgateway.dev
+      kind: AgentgatewayParameters
+      name: model-routing-gateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: model-routing-small
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  parentRefs:
+    - name: model-routing-gateway
+      sectionName: http
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+          headers:
+            - name: x-selected-model
+              type: Exact
+              value: Qwen/Qwen3.5-122B-A10B-FP8
+      backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: model-routing-small-pool
+          port: 8000
+      timeouts:
+        request: 600s
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: model-routing-large
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  parentRefs:
+    - name: model-routing-gateway
+      sectionName: http
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+          headers:
+            - name: x-selected-model
+              type: Exact
+              value: nvidia/GLM-5.2-NVFP4
+      backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: model-routing-large-pool
+          port: 8000
+      timeouts:
+        request: 600s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: model-routing-envoy
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+data:
+  envoy.yaml: |
+    admin:
+      access_log_path: /dev/stdout
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9901
+    static_resources:
+      listeners:
+        - name: ingress
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 8080
+          per_connection_buffer_limit_bytes: 52428800
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: model_routing
+                    stream_idle_timeout: 600s
+                    route_config:
+                      name: upstream
+                      virtual_hosts:
+                        - name: gateway
+                          domains: ["*"]
+                          routes:
+                            - match:
+                                prefix: /
+                              route:
+                                cluster: agentgateway
+                                timeout: 600s
+                    http_filters:
+                      - name: envoy.filters.http.lua
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                          inline_code: |
+                            function envoy_on_request(handle)
+                              handle:headers():remove("x-selected-model")
+                              handle:headers():remove("x-dynamo-client-protocol")
+                              handle:headers():remove("x-original-path")
+                              handle:headers():remove("x-forwarded-path")
+                            end
+                      - name: envoy.filters.http.ext_proc
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                          grpc_service:
+                            envoy_grpc:
+                              cluster_name: semantic-router
+                            timeout: 60s
+                          failure_mode_allow: false
+                          allow_mode_override: true
+                          message_timeout: 60s
+                          processing_mode:
+                            request_header_mode: SEND
+                            response_header_mode: SEND
+                            request_body_mode: BUFFERED
+                            response_body_mode: STREAMED
+                            request_trailer_mode: SKIP
+                            response_trailer_mode: SKIP
+                      # semantic-router normalizes Anthropic Messages bodies to OpenAI chat;
+                      # make the path agree before EPP parses and schedules the request.
+                      - name: envoy.filters.http.lua
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                          inline_code: |
+                            function envoy_on_request(handle)
+                              local path = handle:headers():get(":path") or ""
+                              if string.sub(path, 1, 12) == "/v1/messages" then
+                                handle:headers():replace(":path", "/v1/chat/completions")
+                              end
+                            end
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      clusters:
+        - name: agentgateway
+          connect_timeout: 5s
+          type: STRICT_DNS
+          dns_lookup_family: V4_ONLY
+          load_assignment:
+            cluster_name: agentgateway
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: model-routing-gateway
+                          port_value: 80
+        - name: semantic-router
+          connect_timeout: 5s
+          type: STRICT_DNS
+          dns_lookup_family: V4_ONLY
+          http2_protocol_options: {}
+          load_assignment:
+            cluster_name: semantic-router
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: semantic-router
+                          port_value: 50051
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-routing-envoy
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model-routing-envoy
+  template:
+    metadata:
+      labels:
+        app: model-routing-envoy
+        app.kubernetes.io/name: vllm-semantic-router
+        app.kubernetes.io/managed-by: dynamo-recipe
+    spec:
+      containers:
+        - name: envoy
+          image: envoyproxy/envoy:v1.36.4@sha256:ae31562b8cede20913a2d3d6a4f44c8479a50551e033cb8ef7bb8e38cec4b573
+          args: [-c, /etc/envoy/envoy.yaml, --log-level, info]
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: admin
+              containerPort: 9901
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: admin
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: admin
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/envoy
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: model-routing-envoy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: model-routing-envoy
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  type: ClusterIP
+  selector:
+    app: model-routing-envoy
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/recipes/model-routing/vllm-semantic-router/deploy.yaml
+++ b/recipes/model-routing/vllm-semantic-router/deploy.yaml
@@ -650,7 +650,7 @@ data:
                             request_header_mode: SEND
                             response_header_mode: SEND
                             request_body_mode: BUFFERED
-                            response_body_mode: STREAMED
+                            response_body_mode: NONE
                             request_trailer_mode: SKIP
                             response_trailer_mode: SKIP
                       - name: envoy.filters.http.router

--- a/recipes/model-routing/vllm-semantic-router/deploy.yaml
+++ b/recipes/model-routing/vllm-semantic-router/deploy.yaml
@@ -1,5 +1,95 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: model-routing-small-epp
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+data:
+  epp-config-dynamo.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+      - type: disagg-profile-handler
+      - name: decode-filter
+        type: label-filter
+        parameters:
+          label: nvidia.com/dynamo-sub-component-type
+          validValues: [decode]
+          allowsNoLabel: false
+      - name: dyn-decode
+        type: dyn-decode-scorer
+      - name: picker
+        type: max-score-picker
+      - name: passthrough
+        type: passthrough-parser
+    schedulingProfiles:
+      - name: decode
+        plugins:
+          - pluginRef: decode-filter
+            weight: 1
+          - pluginRef: dyn-decode
+            weight: 1
+          - pluginRef: picker
+            weight: 1
+    parser:
+      pluginRef: passthrough
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: model-routing-large-epp
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+data:
+  epp-config-dynamo.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+      - type: disagg-profile-handler
+      - name: prefill-filter
+        type: label-filter
+        parameters:
+          label: nvidia.com/dynamo-component-type
+          validValues: [prefill]
+          allowsNoLabel: false
+      - name: decode-filter
+        type: label-filter
+        parameters:
+          label: nvidia.com/dynamo-component-type
+          validValues: [decode]
+          allowsNoLabel: false
+      - name: dyn-prefill
+        type: dyn-prefill-scorer
+      - name: dyn-decode
+        type: dyn-decode-scorer
+      - name: picker
+        type: max-score-picker
+      - name: passthrough
+        type: passthrough-parser
+    schedulingProfiles:
+      - name: prefill
+        plugins:
+          - pluginRef: prefill-filter
+            weight: 1
+          - pluginRef: dyn-prefill
+            weight: 1
+          - pluginRef: picker
+            weight: 1
+      - name: decode
+        plugins:
+          - pluginRef: decode-filter
+            weight: 1
+          - pluginRef: dyn-decode
+            weight: 1
+          - pluginRef: picker
+            weight: 1
+    parser:
+      pluginRef: passthrough
+---
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
@@ -20,7 +110,7 @@ spec:
             - name: ngc-secret
           containers:
             - name: main
-              image: nvcr.io/nvstaging/ai-dynamo/dynamo-frontend:1.3.0-rc1
+              image: ishandhanani/dynamo-epp:dyn-3380-protocol-passthrough@sha256:c3c15aafaaf8c036aaf20de8dcac857ced901c571e438a0b0281e0fd65b1acc4
               env:
                 - name: DYN_KV_CACHE_BLOCK_SIZE
                   value: "16"
@@ -29,28 +119,9 @@ spec:
                 - name: DYN_DECODE_FALLBACK
                   value: "true"
       eppConfig:
-        config:
-          plugins:
-            - type: disagg-profile-handler
-            - name: decode-filter
-              type: label-filter
-              parameters:
-                label: nvidia.com/dynamo-component-type
-                validValues: [decode]
-                allowsNoLabel: false
-            - name: picker
-              type: max-score-picker
-            - name: dyn-decode
-              type: dyn-decode-scorer
-          schedulingProfiles:
-            - name: decode
-              plugins:
-                - pluginRef: decode-filter
-                  weight: 1
-                - pluginRef: dyn-decode
-                  weight: 1
-                - pluginRef: picker
-                  weight: 1
+        configMapRef:
+          name: model-routing-small-epp
+          key: epp-config-dynamo.yaml
     - name: VllmDecodeWorker
       type: decode
       replicas: 1
@@ -161,7 +232,7 @@ spec:
             - name: ngc-secret
           containers:
             - name: main
-              image: nvcr.io/nvstaging/ai-dynamo/dynamo-frontend:1.3.0-rc1
+              image: ishandhanani/dynamo-epp:dyn-3380-protocol-passthrough@sha256:c3c15aafaaf8c036aaf20de8dcac857ced901c571e438a0b0281e0fd65b1acc4
               env:
                 - name: DYN_KV_CACHE_BLOCK_SIZE
                   value: "1"
@@ -170,44 +241,9 @@ spec:
                 - name: DYN_ENFORCE_DISAGG
                   value: "true"
       eppConfig:
-        config:
-          plugins:
-            - type: disagg-profile-handler
-            - name: prefill-filter
-              type: label-filter
-              parameters:
-                label: nvidia.com/dynamo-component-type
-                validValues: [prefill]
-                allowsNoLabel: false
-            - name: decode-filter
-              type: label-filter
-              parameters:
-                label: nvidia.com/dynamo-component-type
-                validValues: [decode]
-                allowsNoLabel: false
-            - name: picker
-              type: max-score-picker
-            - name: dyn-prefill
-              type: dyn-prefill-scorer
-            - name: dyn-decode
-              type: dyn-decode-scorer
-          schedulingProfiles:
-            - name: prefill
-              plugins:
-                - pluginRef: prefill-filter
-                  weight: 1
-                - pluginRef: dyn-prefill
-                  weight: 1
-                - pluginRef: picker
-                  weight: 1
-            - name: decode
-              plugins:
-                - pluginRef: decode-filter
-                  weight: 1
-                - pluginRef: dyn-decode
-                  weight: 1
-                - pluginRef: picker
-                  weight: 1
+        configMapRef:
+          name: model-routing-large-epp
+          key: epp-config-dynamo.yaml
     - name: SglangDecodeWorker
       type: decode
       replicas: 1
@@ -617,18 +653,6 @@ data:
                             response_body_mode: STREAMED
                             request_trailer_mode: SKIP
                             response_trailer_mode: SKIP
-                      # semantic-router normalizes Anthropic Messages bodies to OpenAI chat;
-                      # make the path agree before EPP parses and schedules the request.
-                      - name: envoy.filters.http.lua
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                          inline_code: |
-                            function envoy_on_request(handle)
-                              local path = handle:headers():get(":path") or ""
-                              if string.sub(path, 1, 12) == "/v1/messages" then
-                                handle:headers():replace(":path", "/v1/chat/completions")
-                              end
-                            end
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/recipes/model-routing/vllm-semantic-router/model-cache.yaml
+++ b/recipes/model-routing/vllm-semantic-router/model-cache.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-routing-cache
+  labels:
+    app.kubernetes.io/name: vllm-semantic-router
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vllm-semantic-router
+        app.kubernetes.io/managed-by: dynamo-recipe
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: downloader
+          image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              set -eu
+              uvx --from 'huggingface_hub[hf_xet]' hf download nvidia/GLM-5.2-NVFP4
+              uvx --from 'huggingface_hub[hf_xet]' hf download Qwen/Qwen3.5-122B-A10B-FP8
+          env:
+            - name: HF_HOME
+              value: /opt/models
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+            limits:
+              cpu: "4"
+              memory: 8Gi
+          volumeMounts:
+            - name: model-cache
+              mountPath: /opt/models
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/model-routing/vllm-semantic-router/semantic-router-values.yaml
+++ b/recipes/model-routing/vllm-semantic-router/semantic-router-values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ishandhanani/vllm-semantic-router
   # Main plus api_format: passthrough for selection-only routing.
-  tag: dyn-3380-selection-only@sha256:2c79dcf541b7f677418fbc31a1bd770315e15a46a8ee683822e6881f65a01dac
+  tag: dyn-3380-selection-only@sha256:6061e137b42734c0117404c120359305e1bcbe08a16d87c9c079f7996ec1671a
   pullPolicy: IfNotPresent
 
 persistence:

--- a/recipes/model-routing/vllm-semantic-router/semantic-router-values.yaml
+++ b/recipes/model-routing/vllm-semantic-router/semantic-router-values.yaml
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+image:
+  repository: ghcr.io/vllm-project/semantic-router/extproc
+  # Main after v0.3.0 adds symmetric OpenAI SSE -> Anthropic SSE translation.
+  tag: latest@sha256:135533c2acf5ec810066ca7d2a277da219c4ece9165411740d668d4603e4f2c2
+  pullPolicy: IfNotPresent
+
+persistence:
+  enabled: true
+  existingClaim: shared-model-cache
+
+resources:
+  requests:
+    cpu: "1"
+    memory: 3Gi
+  limits:
+    cpu: "2"
+    memory: 7Gi
+
+env:
+  - name: LD_LIBRARY_PATH
+    value: /app/lib
+  - name: HF_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: hf-token-secret
+        key: HF_TOKEN
+
+config:
+  version: v0.3
+  listeners:
+    - name: grpc-50051
+      address: 0.0.0.0
+      port: 50051
+      timeout: 300s
+    - name: http-8080
+      address: 0.0.0.0
+      port: 8080
+      timeout: 300s
+  providers:
+    defaults:
+      default_model: Qwen/Qwen3.5-122B-A10B-FP8
+      reasoning_families:
+        glm:
+          type: reasoning_effort
+          parameter: reasoning_effort
+        qwen3:
+          type: chat_template_kwargs
+          parameter: enable_thinking
+    models:
+      - name: nvidia/GLM-5.2-NVFP4
+        reasoning_family: glm
+      - name: Qwen/Qwen3.5-122B-A10B-FP8
+        reasoning_family: qwen3
+  routing:
+    decisions:
+      - name: complex-agentic
+        description: Route quantitative and technical work to GLM-5.2 NVFP4
+        priority: 100
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: math
+            - type: domain
+              name: physics
+            - type: domain
+              name: chemistry
+            - type: domain
+              name: computer science
+            - type: domain
+              name: engineering
+        modelRefs:
+          - model: nvidia/GLM-5.2-NVFP4
+            use_reasoning: true
+      - name: lightweight
+        description: Route other work to Qwen3.5-122B
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: other
+            - type: domain
+              name: business
+            - type: domain
+              name: law
+            - type: domain
+              name: psychology
+            - type: domain
+              name: biology
+            - type: domain
+              name: history
+            - type: domain
+              name: health
+            - type: domain
+              name: economics
+            - type: domain
+              name: philosophy
+        modelRefs:
+          - model: Qwen/Qwen3.5-122B-A10B-FP8
+            use_reasoning: false
+    signals:
+      domains:
+        - name: business
+          description: Business, corporate strategy, management, finance, and marketing
+        - name: law
+          description: Legal principles, case law, and legal procedures
+        - name: psychology
+          description: Cognitive processes, behavior, and mental health
+        - name: biology
+          description: Biology, genetics, ecology, evolution, and anatomy
+        - name: chemistry
+          description: Chemical reactions, molecular structures, and laboratory techniques
+        - name: history
+          description: Historical events, periods, cultures, and civilizations
+        - name: health
+          description: Anatomy, diseases, treatments, preventive care, and nutrition
+        - name: economics
+          description: Economics, financial markets, monetary policy, and trade
+        - name: math
+          description: Mathematics, algebra, calculus, geometry, and statistics
+        - name: physics
+          description: Mechanics, thermodynamics, electromagnetism, and quantum physics
+        - name: computer science
+          description: Algorithms, programming, software engineering, and systems
+        - name: philosophy
+          description: Ethics, logic, metaphysics, and epistemology
+        - name: engineering
+          description: Engineering design, systems, and technical problem solving
+        - name: other
+          description: General knowledge and miscellaneous topics
+    modelCards:
+      - name: nvidia/GLM-5.2-NVFP4
+      - name: Qwen/Qwen3.5-122B-A10B-FP8
+  global:
+    router:
+      strategy: priority
+      auto_model_name: auto
+      include_config_models_in_list: true
+    services:
+      response_api:
+        enabled: false
+      router_replay:
+        store_backend: memory
+        ttl_seconds: 86400
+        async_writes: false
+    stores:
+      semantic_cache:
+        enabled: false
+    integrations:
+      tools:
+        enabled: false

--- a/recipes/model-routing/vllm-semantic-router/semantic-router-values.yaml
+++ b/recipes/model-routing/vllm-semantic-router/semantic-router-values.yaml
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 image:
-  repository: ghcr.io/vllm-project/semantic-router/extproc
-  # Main after v0.3.0 adds symmetric OpenAI SSE -> Anthropic SSE translation.
-  tag: latest@sha256:135533c2acf5ec810066ca7d2a277da219c4ece9165411740d668d4603e4f2c2
+  repository: ishandhanani/vllm-semantic-router
+  # Main plus api_format: passthrough for selection-only routing.
+  tag: dyn-3380-selection-only@sha256:2c79dcf541b7f677418fbc31a1bd770315e15a46a8ee683822e6881f65a01dac
   pullPolicy: IfNotPresent
 
 persistence:
@@ -51,8 +51,10 @@ config:
     models:
       - name: nvidia/GLM-5.2-NVFP4
         reasoning_family: glm
+        api_format: passthrough
       - name: Qwen/Qwen3.5-122B-A10B-FP8
         reasoning_family: qwen3
+        api_format: passthrough
   routing:
     decisions:
       - name: complex-agentic

--- a/recipes/model-routing/vllm-semantic-router/smoke.sh
+++ b/recipes/model-routing/vllm-semantic-router/smoke.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-http://127.0.0.1:8000}
+SMALL_MODEL=Qwen/Qwen3.5-122B-A10B-FP8
+LARGE_MODEL=nvidia/GLM-5.2-NVFP4
+
+request() {
+  local model=$1
+  local prompt=$2
+  curl --fail-with-body --silent --show-error --max-time 600 \
+    "$BASE_URL/v1/chat/completions" \
+    -H 'content-type: application/json' \
+    -d "$(jq -cn --arg model "$model" --arg prompt "$prompt" \
+      '{model:$model,messages:[{role:"user",content:$prompt}],max_tokens:128,stream:false,chat_template_kwargs:{enable_thinking:false}}')"
+}
+
+assert_model() {
+  local expected=$1
+  local response=$2
+  test "$(jq -r '.model' <<<"$response")" = "$expected"
+  test "$(jq -r '[(.choices[0].message.content // ""), (.choices[0].message.reasoning_content // "")] | map(length) | add' <<<"$response")" -gt 0
+}
+
+small=$(request auto 'Say hello in one short sentence.')
+assert_model "$SMALL_MODEL" "$small"
+
+large=$(request auto 'What is 15% of 240? Answer with only the number.')
+assert_model "$LARGE_MODEL" "$large"
+[[ $(jq -r '[(.choices[0].message.content // ""), (.choices[0].message.reasoning_content // "")] | join(" ")' <<<"$large") == *36* ]]
+
+auto=$(request auto 'Write a Python function that computes a matrix determinant.')
+test "$(jq -r '.model' <<<"$auto")" = "$LARGE_MODEL"
+
+spoof=$(curl --fail-with-body --silent --show-error --max-time 600 \
+  "$BASE_URL/v1/chat/completions" \
+  -H 'content-type: application/json' \
+  -H "x-selected-model: $LARGE_MODEL" \
+    -d '{"model":"auto","messages":[{"role":"user","content":"Say hello in one short sentence."}],"max_tokens":64}')
+assert_model "$SMALL_MODEL" "$spoof"
+
+unknown_code=$(curl --silent --output /dev/null --write-out '%{http_code}' --max-time 30 \
+  "$BASE_URL/v1/chat/completions" \
+  -H 'content-type: application/json' \
+  -d '{"model":"unknown/model","messages":[{"role":"user","content":"hello"}]}')
+test "$unknown_code" -ge 400
+
+curl --fail-with-body --silent --show-error --no-buffer --max-time 600 \
+  "$BASE_URL/v1/chat/completions" \
+  -H 'content-type: application/json' \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Say hello briefly."}],"max_tokens":64,"stream":true}' \
+  | awk '/^data:/{found=1} END{exit !found}'
+
+anthropic=$(curl --fail-with-body --silent --show-error --max-time 600 \
+  "$BASE_URL/v1/messages" \
+  -H 'content-type: application/json' \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'x-api-key: local-dev-token' \
+  -d '{"model":"auto","max_tokens":128,"messages":[{"role":"user","content":"What is 15% of 240? Answer with only the number."}]}')
+test "$(jq -r '.type' <<<"$anthropic")" = message
+test "$(jq -r '.model' <<<"$anthropic")" = "$LARGE_MODEL"
+[[ $(jq -r '[.content[]?.text // "", .content[]?.thinking // ""] | join(" ")' <<<"$anthropic") == *36* ]]
+
+curl --fail-with-body --silent --show-error --no-buffer --max-time 600 \
+  "$BASE_URL/v1/messages" \
+  -H 'content-type: application/json' \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'x-api-key: local-dev-token' \
+  -d '{"model":"auto","stream":true,"max_tokens":64,"messages":[{"role":"user","content":"Say hello briefly."}]}' \
+  | awk '/^event: message_start/{start=1} /^event: message_stop/{stop=1} END{exit !(start && stop)}'
+
+printf 'model routing smoke passed\n'


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Adds an experimental Kubernetes recipe that exposes aggregated Qwen on vLLM and disaggregated GLM on SGLang behind one endpoint using vLLM Semantic Router, Gateway API, `InferencePool`, and Dynamo EPP. This provides a backend-neutral model-selection reference while keeping client protocol handling and worker selection in Dynamo.

CLOSES: DYN-3380
CLOSES: DYN-3381

### How This Was Implemented
- Adds two native `nvidia.com/v1beta1` DGDs, model-specific `InferencePool` and EPP configuration, Gateway routes, shared model-cache setup, and an end-to-end smoke test.
- Configures vLLM Semantic Router as a selection-only Envoy `ext_proc`: it rewrites `model` and a trusted routing header while preserving OpenAI and Anthropic payloads and responses.
- Extends Dynamo EPP opaque-payload handling so direct-mode Frontends receive worker IDs without injecting placeholder tokens into the original request.
- Adds the Agents guide **Deploy a Mixture of Models** with deployment, validation, Claude Code, and cleanup steps.

<details>
<summary>Walkthrough</summary>

#### Mental model

The outer router chooses model capability; Gateway API chooses that model's pool; EPP chooses workers inside the pool; Dynamo Frontend owns protocol parsing and tokenization.

```mermaid
flowchart LR
    C[OpenAI or Anthropic client] --> E[Envoy]
    E --> S[vLLM Semantic Router]
    S -->|model plus trusted header| E
    E --> H[HTTPRoute]
    H --> P[Model-specific InferencePool]
    P --> EP[Dynamo EPP]
    EP --> F[Dynamo Frontend]
    F --> W[Aggregated vLLM or SGLang P/D]
```

#### State and ordering

Envoy removes any client-provided `x-selected-model` before classification. Semantic Router selects either `Qwen/Qwen3.5-122B-A10B-FP8` or `nvidia/GLM-5.2-NVFP4`, rewrites the unresolved `auto` model, and sets the trusted header before agentgateway performs `HTTPRoute` matching.

Each route targets a separate operator-generated `InferencePool`. The Qwen pool contains one aggregated TP8 vLLM worker, while the GLM pool contains one TP8 SGLang prefill worker and one TP8 decode worker connected through NIXL.

#### Request lifecycle

EPP uses the GAIE passthrough parser so the original OpenAI or Anthropic body remains opaque. Its Dynamo scorer tokenizes a minimal internal placeholder only to select the direct-mode worker IDs; it does not attach those tokens to the request, so the selected Dynamo Frontend performs the real model-specific parsing and tokenization.

Response bodies bypass Semantic Router. Dynamo Frontend emits the same client protocol that entered the stack, including native Anthropic Messages streaming for Claude Code.

The smoke test covers automatic small and large selection, exact GLM arithmetic, spoofed-header rejection, unknown-model failure, OpenAI streaming, and Anthropic buffered and streaming responses.

#### Boundaries and limitations

This is an experimental functional recipe, not a performance claim. It uses a standalone Envoy bridge because agentgateway 1.0 cannot route on a body-phase header mutation, requires three 8x B200 nodes, and pins pre-release integration images.

Opaque EPP payloads deliberately give up prompt-aware KV placement. GlobalRouter is not deployed because the recipe has one pool per model, and GlobalPlanner remains outside the request path.

</details>

### Validation
- `fern check`
- `fern docs broken-links`
- `python3 docs/recipes/_catalog/validate.py`
- `bash -n recipes/model-routing/vllm-semantic-router/smoke.sh`
- `go test ./pkg/plugins/dynamo_kv_scorer ./pkg/plugins/disagg -count=1` in the EPP Go builder image with the Docker-built Rust FFI library
- `kubectl apply --dry-run=server -n idhanani -f recipes/model-routing/vllm-semantic-router/deploy.yaml`
- `helm lint` and `helm template` with `semantic-router-values.yaml`
- Live B200 deployment: both DGDs Ready; complete smoke suite passed; Claude Code selected and completed against both Qwen and GLM through one endpoint
<!-- codex-pr-description:end -->
