### PR TITLE
perf(kv-router): narrow CRTC worker cleanup sweeps

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
@@ -43,6 +43,10 @@ pub struct ConcurrentRadixTreeCompressed {
     root: SharedNode,
 
     anchor_nodes: DashMap<ExternalSequenceBlockHash, SharedNode, FxBuildHasher>,
+    /// Entry points for every root/anchor forest that may contain a worker.
+    /// Root nodes stay ancestors across splits, so cleanup can start here
+    /// without sweeping unrelated forests.
+    worker_forest_roots: DashMap<WorkerWithDpRank, FxHashSet<WorkerForestRoot>, FxBuildHasher>,
     cleanup: CleanupState,
     #[cfg(feature = "bench")]
     bench_metrics: CrtcBenchMetrics,
@@ -96,6 +100,7 @@ impl ConcurrentRadixTreeCompressed {
         Self {
             root: Arc::new(Node::new()),
             anchor_nodes: DashMap::with_hasher(FxBuildHasher),
+            worker_forest_roots: DashMap::with_hasher(FxBuildHasher),
             cleanup: CleanupState::new(),
             #[cfg(feature = "bench")]
             bench_metrics: CrtcBenchMetrics::new(),
@@ -168,8 +173,16 @@ impl ConcurrentRadixTreeCompressed {
     ) -> Option<SharedNode> {
         let node = self.anchor_nodes.get(&hash)?.clone();
         node.promote_worker_to_full_edge(worker);
+        self.register_worker_forest_root(worker, WorkerForestRoot::Anchor(hash));
         lookup.entry(worker).or_default().insert(hash, node.clone());
         Some(node)
+    }
+
+    fn register_worker_forest_root(&self, worker: WorkerWithDpRank, root: WorkerForestRoot) {
+        self.worker_forest_roots
+            .entry(worker)
+            .or_default()
+            .insert(root);
     }
 
     fn is_anchor_node(&self, hash: ExternalSequenceBlockHash, node: &SharedNode) -> bool {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -224,14 +224,23 @@ impl ConcurrentRadixTreeCompressed {
             return;
         }
 
-        let mut queue = VecDeque::new();
-        self.root.push_children_into(&mut queue);
-        let anchor_roots: Vec<_> = self
-            .anchor_nodes
+        let workers: Vec<_> = self
+            .worker_forest_roots
             .iter()
-            .map(|entry| entry.value().clone())
+            .filter_map(|entry| target.matches(*entry.key()).then_some(*entry.key()))
             .collect();
-        queue.extend(anchor_roots);
+        let mut queue = VecDeque::new();
+        for worker in workers {
+            let Some((_, roots)) = self.worker_forest_roots.remove(&worker) else {
+                continue;
+            };
+            queue.extend(roots.into_iter().filter_map(|root| match root {
+                WorkerForestRoot::Root(key) => self.root.child_snapshot(key),
+                WorkerForestRoot::Anchor(id) => {
+                    self.anchor_nodes.get(&id).map(|node| node.value().clone())
+                }
+            }));
+        }
 
         let mut seen = FxHashSet::<usize>::default();
         while let Some(node) = queue.pop_front() {

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/store.rs
@@ -33,6 +33,17 @@ impl ConcurrentRadixTreeCompressed {
     ) -> Result<(), KvCacheEventError> {
         lookup.entry(worker).or_default();
 
+        let root_key = op
+            .parent_hash
+            .is_none()
+            .then(|| op.blocks.first().map(|block| block.tokens_hash))
+            .flatten();
+        if let Some(root_key) = root_key {
+            // Register before mutation so even a partially applied store that
+            // later returns an error cannot leave unindexed coverage behind.
+            self.register_worker_forest_root(worker, WorkerForestRoot::Root(root_key));
+        }
+
         let parent_resolution = self.resolve_store_parent(lookup, worker, &op, id)?;
         let outcome = self.insert_for_resolved_parent(lookup, worker, parent_resolution, &op)?;
         self.record_store_outcome(&outcome, counters);

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/sync_impl.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/sync_impl.rs
@@ -118,6 +118,7 @@ impl SyncIndexer for ConcurrentRadixTreeCompressed {
         };
 
         anchor_node.promote_worker_to_full_edge(worker);
+        self.register_worker_forest_root(worker, WorkerForestRoot::Anchor(anchor.anchor_id));
         Ok(())
     }
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -522,6 +522,55 @@ mod race_tests {
     mod clear {
         use super::super::*;
 
+        #[test]
+        fn clear_sweeps_registered_anchor_forest() {
+            let index = ConcurrentRadixTreeCompressed::new();
+            let worker = worker(1);
+            let continuation = make_store_event_with_parent(1, &[10], &[20, 30]);
+            let anchor_id = stored_data(continuation.clone())
+                .parent_hash
+                .expect("continuation should have an anchor parent");
+            let anchor = AnchorRef {
+                anchor_id,
+                anchor_local_hash: LocalBlockHash(10),
+                anchor_depth: 1,
+            };
+            let mut lookup = direct_lookup();
+
+            index
+                .apply_anchor(
+                    worker,
+                    AnchorTask {
+                        anchor_id,
+                        anchor_local_hash: anchor.anchor_local_hash,
+                        anchor_depth: anchor.anchor_depth,
+                    },
+                )
+                .unwrap();
+            apply_direct(&index, &mut lookup, continuation);
+            assert_eq!(
+                index
+                    .find_matches_from_anchor(anchor, &[LocalBlockHash(20), LocalBlockHash(30)],)
+                    .unwrap()
+                    .scores
+                    .get(&worker),
+                Some(&3),
+            );
+
+            apply_direct(
+                &index,
+                &mut lookup,
+                make_clear_event_with_dp_rank(worker.worker_id, worker.dp_rank),
+            );
+            assert!(
+                index
+                    .find_matches_from_anchor(anchor, &[LocalBlockHash(20), LocalBlockHash(30)],)
+                    .unwrap()
+                    .scores
+                    .is_empty()
+            );
+        }
+
         #[tokio::test]
         async fn clear_sweeps_split_suffixes_across_event_threads_and_dp_ranks() {
             let index = ThreadPoolIndexer::new(ConcurrentRadixTreeCompressed::new(), 2, 32);

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
@@ -33,6 +33,12 @@ impl WorkerRemovalTarget {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum WorkerForestRoot {
+    Root(LocalBlockHash),
+    Anchor(ExternalSequenceBlockHash),
+}
+
 pub(super) struct MatchWalkResult {
     // NOTE(perf): Replacing this set with a Vec did not improve throughput. Keep
     // uniqueness by construction unless a new profile justifies changing it.


### PR DESCRIPTION
## Summary
- Track conservative CRTC root and anchor forest keys for each worker/DP-rank.
- Start Clear, worker-removal, and exact-rank descendant sweeps only from forests that can contain the target while preserving split-race coverage and FIFO ordering.
- Add anchor-forest cleanup regression coverage.

## Validation
- `cargo test -p dynamo-kv-router --lib` (594 passed)
- `cargo clippy -p dynamo-kv-router --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- 250,002-node current-target clear: 300.949 ms median base, 11.045 us candidate (15 samples)
- Same-owner queue delay: 299.306 ms base, 6.702 us candidate (20 samples)
- 8-writer split-heavy store throughput: 227,483 ops/s base, 227,829 ops/s candidate; 95% bootstrap interval spans no change

<!-- perf-agent-investigation:51f80946-caaf-438b-8f51-af0b167d096c -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clear actions now remove all previously registered anchored content more reliably.
  * Coverage updates are now tracked more accurately, helping searches and matches stay consistent after anchors, continuations, and stored content changes.
  * Improved cleanup behavior so stale results are less likely to appear after worker-related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->