### PR TITLE
perf(llm): avoid cloning jail metrics

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2472,8 +2472,8 @@ impl OpenAIPreprocessor {
         let pending_in = Arc::clone(&pending);
 
         // dynamo `Annotated<Nv>` -> jail `Annotated<Create>` (buffer llm_metrics)
-        let jail_input = stream.map(move |a| {
-            if let Some(metrics) = a.data.as_ref().and_then(|nv| nv.llm_metrics.clone()) {
+        let jail_input = stream.map(move |mut a| {
+            if let Some(metrics) = a.data.as_mut().and_then(|nv| nv.llm_metrics.take()) {
                 let mut p = pending_in.lock().expect("jail metrics buffer poisoned");
                 p.chunk_tokens = p.chunk_tokens.saturating_add(metrics.chunk_tokens);
                 p.template = Some(metrics);


### PR DESCRIPTION
## Summary

- move the owned `LLMMetricAnnotation` out of each Nv stream item before adapting it for `dynamo-parsers`
- avoid cloning the optional worker-type strings on every jail input chunk while preserving accumulated metrics
- improve long ambiguous-prefix streams by 3.89% and ordinary text by 1.29% in paired current-main microbenchmarks

## Validation

Investigation validation:

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p dynamo-llm --no-default-features --lib -- -D warnings`
- `cargo test --locked --release -p dynamo-llm --no-default-features --test test_streaming_tool_parsers --test test_reasoning_parser --test parallel_tool_call_integration --test tool_choice --test tool_choice_finish_reasons` (99 passed, 1 ignored)
- 20-sample-per-role ABBA/BAAB benchmark matrix across seven stream shapes; no statistically resolved regression

Publication recheck on unchanged `main`:

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-llm --locked --no-default-features --test test_streaming_tool_parsers` (37 passed)

<!-- perf-agent-investigation:8e5cf6d1-c1b7-4a7d-a38e-7a9bd517037a -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed chat responses so usage metrics are preserved more efficiently across tool-calling flows.
  * Reduced unnecessary copying during response processing, which may lower overhead in streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->