### PR TITLE
ci(operator): run GPU-free deploy e2e tests

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -834,6 +834,27 @@ jobs:
       copy_timeout_minutes: 20
     secrets: inherit
 
+  planner-copy-to-acr:
+    name: planner
+    needs: [planner-build]
+    if: |
+      always() && !cancelled() &&
+      github.event_name != 'workflow_dispatch' &&
+      needs.planner-build.result == 'success'
+    uses: ./.github/workflows/shared-copy.yml
+    with:
+      target_tag_plain: ${{ needs.planner-build.outputs.target_tag_plain }}
+      target_image: ai-dynamo/dynamo-planner
+      cuda_version: '[""]'
+      override_arch: amd64 # Deploy tests only use AMD64 images.
+      copy_timeout_minutes: 10
+    secrets:
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      AZURE_ACR_HOSTNAME: ${{ secrets.AZURE_ACR_HOSTNAME }}
+      AZURE_ACR_USER: ${{ secrets.AZURE_ACR_USER }}
+      AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
+
   # ============================================================================
   # DEPLOYMENT JOBS
   # Deploy operator and run end-to-end tests on Kubernetes cluster
@@ -895,6 +916,21 @@ jobs:
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
+
+  deploy-test-operator-gpu0:
+    name: Operator E2E
+    needs: [deploy-operator, planner-copy-to-acr]
+    if: github.event_name != 'workflow_dispatch'
+    uses: ./.github/workflows/shared-operator-e2e.yml
+    with:
+      namespace: ${{ needs.deploy-operator.outputs.namespace }}
+      vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+      operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+    secrets:
+      AZURE_ACR_HOSTNAME: ${{ secrets.AZURE_ACR_HOSTNAME }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      DOCKERHUB_LOGIN_USER: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+      DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
   deploy-operator-checkpoint-vllm:
     name: vLLM DynamoCheckpoint Operator Setup
@@ -1309,7 +1345,7 @@ jobs:
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-gaie]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator-gpu0, deploy-test-gaie]
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1429,6 +1465,8 @@ jobs:
       - deploy-test-vllm
       - deploy-test-sglang
       - deploy-test-trtllm
+      - deploy-test-operator-gpu0
+      - planner-copy-to-acr
       - deploy-operator-checkpoint-vllm
       - deploy-operator-checkpoint-sglang
       - deploy-operator-checkpoint-trtllm

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -917,7 +917,7 @@ jobs:
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
 
-  deploy-test-operator-gpu0:
+  deploy-test-operator:
     name: Operator E2E
     needs: [deploy-operator, planner-copy-to-acr]
     if: github.event_name != 'workflow_dispatch'
@@ -1345,7 +1345,7 @@ jobs:
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator-gpu0, deploy-test-gaie]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator, deploy-test-gaie]
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1465,7 +1465,7 @@ jobs:
       - deploy-test-vllm
       - deploy-test-sglang
       - deploy-test-trtllm
-      - deploy-test-operator-gpu0
+      - deploy-test-operator
       - planner-copy-to-acr
       - deploy-operator-checkpoint-vllm
       - deploy-operator-checkpoint-sglang

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -917,7 +917,7 @@ jobs:
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
 
-  deploy-test-operator:
+  deploy-test-operator-e2e:
     name: Operator E2E
     needs: [deploy-operator, planner-copy-to-acr]
     if: github.event_name != 'workflow_dispatch'
@@ -1345,7 +1345,7 @@ jobs:
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator, deploy-test-gaie]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator-e2e, deploy-test-gaie]
     runs-on: prod-deploy-tester-v1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1465,7 +1465,7 @@ jobs:
       - deploy-test-vllm
       - deploy-test-sglang
       - deploy-test-trtllm
-      - deploy-test-operator
+      - deploy-test-operator-e2e
       - planner-copy-to-acr
       - deploy-operator-checkpoint-vllm
       - deploy-operator-checkpoint-sglang

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -100,7 +100,7 @@ jobs:
       - deploy-test-vllm
       - deploy-test-sglang
       - deploy-test-trtllm
-      - deploy-test-operator
+      - deploy-test-operator-e2e
       - deploy-operator-checkpoint-vllm
       - deploy-operator-checkpoint-sglang
       - deploy-operator-checkpoint-trtllm
@@ -1103,7 +1103,7 @@ jobs:
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
 
-  deploy-test-operator:
+  deploy-test-operator-e2e:
     name: Operator E2E
     needs: [changed-files, deploy-operator, planner-copy-to-acr]
     if: |
@@ -1548,7 +1548,7 @@ jobs:
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator-e2e]
     runs-on: prod-deploy-tester-v1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -100,7 +100,7 @@ jobs:
       - deploy-test-vllm
       - deploy-test-sglang
       - deploy-test-trtllm
-      - deploy-test-operator-gpu0
+      - deploy-test-operator
       - deploy-operator-checkpoint-vllm
       - deploy-operator-checkpoint-sglang
       - deploy-operator-checkpoint-trtllm
@@ -1103,7 +1103,7 @@ jobs:
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
 
-  deploy-test-operator-gpu0:
+  deploy-test-operator:
     name: Operator E2E
     needs: [changed-files, deploy-operator, planner-copy-to-acr]
     if: |
@@ -1548,7 +1548,7 @@ jobs:
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator-gpu0]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator]
     runs-on: prod-deploy-tester-v1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,6 +84,7 @@ jobs:
       - trtllm-efa-build
       - planner-build
       - planner-test
+      - planner-copy-to-acr
       - frontend-build
       - frontend-copy-to-acr
     if: always()
@@ -99,6 +100,7 @@ jobs:
       - deploy-test-vllm
       - deploy-test-sglang
       - deploy-test-trtllm
+      - deploy-test-operator-gpu0
       - deploy-operator-checkpoint-vllm
       - deploy-operator-checkpoint-sglang
       - deploy-operator-checkpoint-trtllm
@@ -535,7 +537,10 @@ jobs:
   planner-build:
     name: planner # This name overlaps with other planner jobs to group them in the UI
     needs: [changed-files]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.planner == 'true'
+    if: |
+      needs.changed-files.outputs.core == 'true' ||
+      needs.changed-files.outputs.planner == 'true' ||
+      needs.changed-files.outputs.operator == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: dynamo
@@ -863,6 +868,27 @@ jobs:
       copy_timeout_minutes: 10
     secrets: inherit
 
+  planner-copy-to-acr:
+    name: planner
+    needs: [changed-files, planner-build]
+    if: |
+      always() && !cancelled() &&
+      needs.changed-files.outputs.operator == 'true' &&
+      needs.planner-build.result == 'success'
+    uses: ./.github/workflows/shared-copy.yml
+    with:
+      target_tag_plain: ${{ needs.planner-build.outputs.target_tag_plain }}
+      target_image: ai-dynamo/dynamo-planner
+      cuda_version: '[""]'
+      override_arch: amd64 # Deploy tests only use AMD64 images.
+      copy_timeout_minutes: 10
+    secrets:
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      AZURE_ACR_HOSTNAME: ${{ secrets.AZURE_ACR_HOSTNAME }}
+      AZURE_ACR_USER: ${{ secrets.AZURE_ACR_USER }}
+      AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
+
   snapshot-placeholder-vllm:
     name: vLLM Snapshot Placeholder
     needs: [changed-files, vllm-copy-to-acr]
@@ -1076,6 +1102,23 @@ jobs:
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
     secrets: inherit
+
+  deploy-test-operator-gpu0:
+    name: Operator E2E
+    needs: [changed-files, deploy-operator, planner-copy-to-acr]
+    if: |
+      !cancelled() && !failure() &&
+      needs.changed-files.outputs.operator == 'true'
+    uses: ./.github/workflows/shared-operator-e2e.yml
+    with:
+      namespace: ${{ needs.deploy-operator.outputs.namespace }}
+      vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
+      operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
+    secrets:
+      AZURE_ACR_HOSTNAME: ${{ secrets.AZURE_ACR_HOSTNAME }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      DOCKERHUB_LOGIN_USER: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+      DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
   deploy-operator-checkpoint-vllm:
     name: vLLM DynamoCheckpoint Operator Setup
@@ -1505,7 +1548,7 @@ jobs:
 
   deploy-cleanup:
     if: always()
-    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm]
+    needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-operator-gpu0]
     runs-on: prod-deploy-tester-v1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -1576,6 +1619,7 @@ jobs:
       - snapshot-placeholder-trtllm
       - power-agent
       - planner-test
+      - planner-copy-to-acr
       - vllm-copy-to-acr
       - vllm-multi-gpu-test
       - vllm-efa-build

--- a/.github/workflows/shared-copy.yml
+++ b/.github/workflows/shared-copy.yml
@@ -10,6 +10,11 @@ on:
         description: 'Plain runtime image tag prefix from the build workflow'
         required: true
         type: string
+      target_image:
+        description: 'Target image repository in ACR'
+        required: false
+        type: string
+        default: 'ai-dynamo/dynamo'
       cuda_version:
         description: 'CUDA versions to copy as a JSON array'
         required: true
@@ -76,7 +81,7 @@ jobs:
           source_image: ai-dynamo/dynamo
           source_tag: ${{ steps.calculate-target-tag.outputs.image_tag }}
           target_registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
-          target_image: ai-dynamo/dynamo
+          target_image: ${{ inputs.target_image }}
           target_tag: ${{ steps.calculate-target-tag.outputs.image_tag }}
           source_aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           source_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/shared-operator-e2e.yml
+++ b/.github/workflows/shared-operator-e2e.yml
@@ -30,7 +30,6 @@ on:
 
 jobs:
   deploy-test-operator-e2e:
-    # TODO(sttts): Rework the GPU operator tests to run in CI too; today this lane only covers GPU-free specs.
     name: gpu_0
     runs-on: prod-deploy-tester-v1
     timeout-minutes: 120
@@ -118,6 +117,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p test-results
+          # TODO(sttts): Rework the GPU operator tests to run in CI too; today this filter only selects GPU-free specs.
           make -C deploy/operator test-e2e-dgdr \
             DGDR_NAMESPACE="${E2E_NAMESPACE}" \
             DGDR_IMAGE="${DGDR_IMAGE}" \

--- a/.github/workflows/shared-operator-e2e.yml
+++ b/.github/workflows/shared-operator-e2e.yml
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Shared Operator E2E
+
+on:
+  workflow_call:
+    inputs:
+      namespace:
+        description: 'Host namespace where the vCluster lives'
+        type: string
+        required: true
+      vcluster_name:
+        description: 'Name of the vCluster'
+        type: string
+        required: true
+      operator_tag:
+        description: 'Operator image tag used to self-bootstrap a missing vCluster'
+        type: string
+        required: true
+    secrets:
+      AZURE_ACR_HOSTNAME:
+        required: true
+      HF_TOKEN:
+        required: true
+      DOCKERHUB_LOGIN_USER:
+        required: false
+      DOCKERHUB_ACCESS_TOKEN:
+        required: false
+
+jobs:
+  operator-e2e:
+    name: gpu_0
+    runs-on: prod-deploy-tester-v1
+    timeout-minutes: 120
+    env:
+      E2E_NAMESPACE: operator-e2e-${{ github.run_id }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check if vCluster exists
+        id: vcluster-check
+        uses: ./.github/actions/check-vcluster-exists
+        with:
+          vcluster_name: ${{ inputs.vcluster_name }}
+          vcluster_namespace: ${{ inputs.namespace }}
+
+      - name: Self-bootstrap vCluster (rerun)
+        if: steps.vcluster-check.outputs.exists != 'true'
+        uses: ./.github/actions/setup-dynamo-operator
+        with:
+          vcluster_name: ${{ inputs.vcluster_name }}
+          vcluster_namespace: ${{ inputs.namespace }}
+          registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          operator_tag: ${{ inputs.operator_tag }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
+          dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Connect to vCluster
+        id: connect-vcluster
+        uses: ./.github/actions/connect-vcluster
+        with:
+          vcluster_name: ${{ inputs.vcluster_name }}
+          vcluster_namespace: ${{ inputs.namespace }}
+
+      - name: Set up vCluster kubeconfig
+        id: kubeconfig
+        shell: bash
+        env:
+          KUBECONFIG_BASE64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
+        run: |
+          set -euo pipefail
+          echo "${KUBECONFIG_BASE64}" | base64 -d > "${RUNNER_TEMP}/operator-e2e-kubeconfig"
+          chmod 600 "${RUNNER_TEMP}/operator-e2e-kubeconfig"
+          echo "KUBECONFIG=${RUNNER_TEMP}/operator-e2e-kubeconfig" >> "${GITHUB_ENV}"
+
+      - name: Prepare operator E2E namespace
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+          kubectl delete namespace "${E2E_NAMESPACE}" \
+            --ignore-not-found --wait=true --timeout=5m
+          kubectl create namespace "${E2E_NAMESPACE}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create secret generic hf-token-secret \
+            --namespace="${E2E_NAMESPACE}" \
+            --from-literal=HF_TOKEN="${HF_TOKEN}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        with:
+          go-version: '1.26.3'
+          cache-dependency-path: deploy/operator/go.sum
+
+      - name: Verify operator E2E prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          kubectl wait --for=condition=established \
+            crd/dynamographdeploymentrequests.nvidia.com \
+            --timeout=120s
+          kubectl get secret hf-token-secret -n "${E2E_NAMESPACE}" >/dev/null
+
+      - name: Run GPU-free operator E2E tests
+        shell: bash
+        env:
+          DGDR_IMAGE: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo-planner:${{ github.sha }}-dynamo-planner
+        run: |
+          set -euo pipefail
+          mkdir -p test-results
+          make -C deploy/operator test-e2e-dgdr \
+            DGDR_NAMESPACE="${E2E_NAMESPACE}" \
+            DGDR_IMAGE="${DGDR_IMAGE}" \
+            DGDR_TEST_FLAGS="-ginkgo.label-filter='validation || (rapid && gpu_0)' -ginkgo.junit-report=${GITHUB_WORKSPACE}/test-results/operator-e2e-gpu0.xml -dgdr-name-prefix=ci-${{ github.run_id }}-${{ github.run_attempt }}" \
+            2>&1 | tee "${GITHUB_WORKSPACE}/test-results/operator-e2e-gpu0.log"
+
+      - name: Collect failure diagnostics
+        if: failure() && steps.kubeconfig.outcome == 'success'
+        shell: bash
+        run: |
+          set +e
+          mkdir -p test-results
+          {
+            echo '=== DGDRs ==='
+            kubectl get dynamographdeploymentrequests -n "${E2E_NAMESPACE}" -o wide
+            echo '=== DGDs ==='
+            kubectl get dynamographdeployments -n "${E2E_NAMESPACE}" -o wide
+            echo '=== Jobs and pods ==='
+            kubectl get jobs,pods -n "${E2E_NAMESPACE}" -o wide
+            echo '=== Recent events ==='
+            kubectl get events -n "${E2E_NAMESPACE}" --sort-by='.lastTimestamp'
+            echo '=== Operator logs ==='
+            kubectl logs -n default -l control-plane=controller-manager \
+              --all-containers --tail=300
+          } 2>&1 | tee "${GITHUB_WORKSPACE}/test-results/operator-e2e-gpu0-diagnostics.log"
+
+      - name: Upload operator E2E results
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        with:
+          name: operator-e2e-gpu0-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Clean up operator E2E namespace
+        if: always() && steps.kubeconfig.outcome == 'success'
+        shell: bash
+        run: |
+          kubectl delete namespace "${E2E_NAMESPACE}" \
+            --ignore-not-found --wait=true --timeout=5m

--- a/.github/workflows/shared-operator-e2e.yml
+++ b/.github/workflows/shared-operator-e2e.yml
@@ -121,8 +121,8 @@ jobs:
           make -C deploy/operator test-e2e-dgdr \
             DGDR_NAMESPACE="${E2E_NAMESPACE}" \
             DGDR_IMAGE="${DGDR_IMAGE}" \
-            DGDR_TEST_FLAGS="-ginkgo.label-filter='validation || (rapid && gpu_0)' -ginkgo.junit-report=${GITHUB_WORKSPACE}/test-results/operator-e2e-gpu0.xml -dgdr-name-prefix=ci-${{ github.run_id }}-${{ github.run_attempt }}" \
-            2>&1 | tee "${GITHUB_WORKSPACE}/test-results/operator-e2e-gpu0.log"
+            DGDR_TEST_FLAGS="-ginkgo.label-filter='validation || (rapid && gpu_0)' -ginkgo.junit-report=${GITHUB_WORKSPACE}/test-results/operator-e2e.xml -dgdr-name-prefix=ci-${{ github.run_id }}-${{ github.run_attempt }}" \
+            2>&1 | tee "${GITHUB_WORKSPACE}/test-results/operator-e2e.log"
 
       - name: Collect failure diagnostics
         if: failure() && steps.kubeconfig.outcome == 'success'
@@ -142,13 +142,13 @@ jobs:
             echo '=== Operator logs ==='
             kubectl logs -n default -l control-plane=controller-manager \
               --all-containers --tail=300
-          } 2>&1 | tee "${GITHUB_WORKSPACE}/test-results/operator-e2e-gpu0-diagnostics.log"
+          } 2>&1 | tee "${GITHUB_WORKSPACE}/test-results/operator-e2e-diagnostics.log"
 
       - name: Upload operator E2E results
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
-          name: operator-e2e-gpu0-${{ github.run_id }}-${{ github.run_attempt }}
+          name: operator-e2e-${{ github.run_id }}-${{ github.run_attempt }}
           path: test-results/
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/shared-operator-e2e.yml
+++ b/.github/workflows/shared-operator-e2e.yml
@@ -29,7 +29,7 @@ on:
         required: false
 
 jobs:
-  operator-e2e:
+  deploy-test-operator-e2e:
     # TODO(sttts): Rework the GPU operator tests to run in CI too; today this lane only covers GPU-free specs.
     name: gpu_0
     runs-on: prod-deploy-tester-v1

--- a/.github/workflows/shared-operator-e2e.yml
+++ b/.github/workflows/shared-operator-e2e.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   operator-e2e:
+    # TODO(sttts): Rework the GPU operator tests to run in CI too; today this lane only covers GPU-free specs.
     name: gpu_0
     runs-on: prod-deploy-tester-v1
     timeout-minutes: 120

--- a/deploy/helm/charts/platform/components/operator/templates/profiling-job-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/profiling-job-rbac.yaml
@@ -104,9 +104,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods/log"]
   verbs: ["get"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/helm/charts/platform/tests/profiling_job_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/profiling_job_rbac_test.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: profiling job RBAC
+templates:
+  - charts/dynamo-operator/templates/profiling-job-rbac.yaml
+tests:
+  - it: should not grant cluster-scoped node access to profiling jobs
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: kind
+          value: ClusterRole
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes"]
+            verbs: ["get", "list", "watch"]

--- a/deploy/operator/test/e2e/dgdr/dgdr_lifecycle_spec_test.go
+++ b/deploy/operator/test/e2e/dgdr/dgdr_lifecycle_spec_test.go
@@ -151,7 +151,7 @@ func DGDRLifecycleSpec(ctx context.Context, inputGetter func() DGDRLifecycleInpu
 	}
 
 	By("Waiting for DGDR to reach Deployed phase")
-	deployTimeout := time.Duration(flagProfilingTimeout+flagDeployTimeout) * time.Second
+	deployTimeout := time.Duration(flagDeployTimeout) * time.Second
 	dgdrResult = waitForPhase(input.Name, v1beta1.DGDRPhaseDeployed, deployTimeout)
 
 	Expect(dgdrResult.Status.Phase).To(Equal(v1beta1.DGDRPhaseDeployed))

--- a/deploy/operator/test/e2e/dgdr/dgdr_test.go
+++ b/deploy/operator/test/e2e/dgdr/dgdr_test.go
@@ -24,6 +24,35 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const (
+	plannerMockerModel       = "Qwen/Qwen3-32B"
+	plannerMockerProfileData = "/workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D"
+)
+
+// staticPlannerMockerWorker replaces the generated AIC runtime arguments with
+// checked-in profile data until the planner image carries the runtime from #11779.
+func staticPlannerMockerWorker(name, mode string) map[string]interface{} {
+	return map[string]interface{}{
+		"name": name,
+		"podTemplate": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{
+						"name": "main",
+						"args": []string{
+							"--model-path", plannerMockerModel,
+							"--model-name", plannerMockerModel,
+							"--speedup-ratio", "1.0",
+							"--planner-profile-data", plannerMockerProfileData,
+							"--disaggregation-mode", mode,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // DGDR Lifecycle Scenarios exercises the full DGDR lifecycle (create -> profile ->
 // DGD generation -> DGD readiness) across different backend, strategy, and feature
 // configurations. Modeled after the CAAPH helm_test.go pattern: each It block calls
@@ -103,14 +132,40 @@ var _ = Describe("DGDR Lifecycle Scenarios", Label("nightly", "e2e", "integratio
 			DGDRLifecycleSpec(ctx, func() DGDRLifecycleInput {
 				return DGDRLifecycleInput{
 					Name:           uniqueName("planner"),
+					Model:          plannerMockerModel,
 					Backend:        v1beta1.BackendTypeTrtllm,
 					SearchStrategy: v1beta1.SearchStrategyRapid,
 					AutoApply:      ptr.To(true),
+					SLA: &v1beta1.SLASpec{
+						ITL: ptr.To(50.0),
+					},
+					Hardware: &v1beta1.HardwareSpec{
+						GPUSKU:         v1beta1.GPUSKUTypeH200SXM,
+						VRAMMB:         ptr.To(141120.0),
+						NumGPUsPerNode: ptr.To(int32(8)),
+						TotalGPUs:      ptr.To(int32(8)),
+					},
 					Features: &v1beta1.FeaturesSpec{
 						Planner: plannerRawExtension(map[string]interface{}{
 							"enabled":                      true,
 							"optimization_target":          "sla",
 							"pre_deployment_sweeping_mode": "rapid",
+							"enable_throughput_scaling":    true,
+							"enable_load_scaling":          false,
+							"mode":                         "disagg",
+							"backend":                      "trtllm",
+						}),
+					},
+					Overrides: &v1beta1.OverridesSpec{
+						DGD: dgdOverrideRawExtension(map[string]interface{}{
+							"apiVersion": "nvidia.com/v1beta1",
+							"kind":       "DynamoGraphDeployment",
+							"spec": map[string]interface{}{
+								"components": []interface{}{
+									staticPlannerMockerWorker("prefill", "prefill"),
+									staticPlannerMockerWorker("decode", "decode"),
+								},
+							},
 						}),
 					},
 					ExpectDGDReady: true,

--- a/deploy/operator/test/e2e/dgdr/helpers_test.go
+++ b/deploy/operator/test/e2e/dgdr/helpers_test.go
@@ -18,6 +18,7 @@
 package dgdr
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -296,6 +297,9 @@ func createAndCleanup(dgdr *v1beta1.DynamoGraphDeploymentRequest) {
 			Name:      dgdr.Name,
 		}, &current); err == nil && current.Status.DGDName != "" {
 			dgdName := current.Status.DGDName
+			if CurrentSpecReport().Failed() {
+				writeDGDRFailureDiagnostics(&current)
+			}
 
 			// Delete the DGD (it is not owned by the DGDR, so it won't be
 			// garbage-collected automatically).
@@ -337,6 +341,86 @@ func createAndCleanup(dgdr *v1beta1.DynamoGraphDeploymentRequest) {
 		// Delete the DGDR itself.
 		_ = k8sClient.Delete(ctx, dgdr)
 	})
+}
+
+// writeDGDRFailureDiagnostics captures resources and component logs before
+// DeferCleanup removes them, so CI artifacts retain the cause of pod failures.
+func writeDGDRFailureDiagnostics(dgdr *v1beta1.DynamoGraphDeploymentRequest) {
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n=== failure diagnostics for DGDR %s/%s ===\n", dgdr.Namespace, dgdr.Name)
+	writeJSONDiagnostic("DGDR", dgdr)
+
+	dgd := &v1alpha1.DynamoGraphDeployment{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{
+		Namespace: dgdr.Namespace,
+		Name:      dgdr.Status.DGDName,
+	}, dgd); err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "failed to get DGD %s: %v\n", dgdr.Status.DGDName, err)
+	} else {
+		writeJSONDiagnostic("DGD", dgd)
+	}
+
+	dgdLabel := labels.SelectorFromSet(labels.Set{
+		"nvidia.com/dynamo-graph-deployment-name": dgdr.Status.DGDName,
+	})
+	var pods corev1.PodList
+	if err := k8sClient.List(ctx, &pods,
+		client.InNamespace(dgdr.Namespace),
+		client.MatchingLabelsSelector{Selector: dgdLabel},
+	); err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "failed to list DGD pods: %v\n", err)
+		return
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		writeJSONDiagnostic("Pod "+pod.Name, pod)
+		writePodLogs(pod)
+	}
+}
+
+func writeJSONDiagnostic(name string, value interface{}) {
+	raw, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "failed to marshal %s: %v\n", name, err)
+		return
+	}
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n=== %s ===\n%s\n", name, raw)
+}
+
+func writePodLogs(pod *corev1.Pod) {
+	restarts := make(map[string]int32)
+	for _, status := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+		restarts[status.Name] = status.RestartCount
+	}
+
+	containers := append([]corev1.Container{}, pod.Spec.InitContainers...)
+	containers = append(containers, pod.Spec.Containers...)
+	for _, container := range containers {
+		writePodLog(pod, container.Name, false)
+		if restarts[container.Name] > 0 {
+			writePodLog(pod, container.Name, true)
+		}
+	}
+}
+
+func writePodLog(pod *corev1.Pod, container string, previous bool) {
+	logCtx, cancelLog := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelLog()
+	tailLines := int64(300)
+	raw, err := typedClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		Container: container,
+		Previous:  previous,
+		TailLines: &tailLines,
+	}).DoRaw(logCtx)
+	logType := "current"
+	if previous {
+		logType = "previous"
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "failed to get %s logs for %s/%s: %v\n", logType, pod.Name, container, err)
+		return
+	}
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Pod %s / container %s / %s logs ===\n%s\n", pod.Name, container, logType, raw)
 }
 
 // serverDryRun attempts to create a DGDR with server-side dry-run and returns the error (if any).


### PR DESCRIPTION
## Overview

Run the GPU-free Dynamo operator deploy E2E suite in PR and post-merge CI by reusing the deploy vCluster. The lane exercises the installed Helm chart, Kubernetes RBAC, DGDR reconciliation, profiling jobs, and cleanup without allocating GPUs.

## Summary

- add a reusable operator E2E workflow that reconnects to the existing deploy vCluster and self-bootstraps it for reruns after cleanup
- build and copy the commit-scoped planner image needed by mocker-mode DGDR profiling
- run only validation and rapid `gpu_0` specs, excluding the separately labeled H100 support matrix
- collect JUnit results, logs, Kubernetes events, and operator diagnostics on failure
- pass only the secrets required by the new reusable workflow calls and disable persisted checkout credentials
- remove stale cluster-scoped node access from the profiling-job role; GPU discovery runs in the operator, not the profiling job

## Details

The first live CI run caught a real chart/operator integration defect: the operator dynamically binds the profiling-job ClusterRole, but that role included `nodes get/list/watch` while the operator service account held only `nodes get` with GPU discovery disabled. Kubernetes rejected the RoleBinding as privilege escalation. The profiling job does not perform node discovery, so this PR removes that stale permission instead of broadening the operator's access.

## Where should reviewer start?

1. `.github/workflows/shared-operator-e2e.yml` for the test selection, vCluster reuse, and diagnostics.
2. The `planner-copy-to-acr` and `deploy-test-operator-gpu0` jobs in `.github/workflows/pr.yaml` and `.github/workflows/post-merge-ci.yml` for gating and least-privilege secrets.
3. `deploy/helm/charts/platform/components/operator/templates/profiling-job-rbac.yaml` and its Helm regression test for the RBAC correction.

## Related Issues

- [DYN-3452](https://linear.app/nvidia/issue/DYN-3452/expand-operator-live-cluster-e2e-coverage-in-ci-using-the-shared)

## Validation

- pre-commit hooks on all changed files
- Helm unit tests: 16 passed
- actionlint on all three modified workflows, ignoring only repository custom-runner-label warnings
- YAML parsing with `yq`
- `git diff --check`
- dry-run of the exact Make/Ginkgo selection: 27 of 39 specs selected, 0 failed, H100 support matrix excluded, and JUnit XML generated
- live Kubernetes rerun pending the next pushed commit
