### PR TITLE
fix: Update Qwen Utils to Match DeepStack Vision Embedding Size

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/models/qwen.py
+++ b/components/src/dynamo/vllm/multimodal_utils/models/qwen.py
@@ -23,6 +23,7 @@ class QwenGridParams:
     min_pixels: int
     max_pixels: int
     vision_hidden_dim: int
+    decode_embedding_dim: int
 
 
 def load_qwen_grid_params(model_name: str) -> QwenGridParams | None:
@@ -63,6 +64,10 @@ def load_qwen_grid_params(model_name: str) -> QwenGridParams | None:
         vision_hidden_dim: int = getattr(
             vision_config, "out_hidden_size", vision_config.hidden_size
         )
+        deepstack_visual_indexes = (
+            getattr(vision_config, "deepstack_visual_indexes", []) or []
+        )
+        decode_embedding_dim = vision_hidden_dim * (1 + len(deepstack_visual_indexes))
 
         return QwenGridParams(
             patch_size=patch_size,
@@ -71,6 +76,7 @@ def load_qwen_grid_params(model_name: str) -> QwenGridParams | None:
             min_pixels=min_pixels,
             max_pixels=max_pixels,
             vision_hidden_dim=vision_hidden_dim,
+            decode_embedding_dim=decode_embedding_dim,
         )
     except (OSError, ValueError) as exc:
         logger.warning(
@@ -101,7 +107,7 @@ def _compute_qwen_grid_thw(
     Returns:
         (grid_thw, embeddings_shape) or (None, None) on failure.
         grid_thw: list of [grid_t, grid_h, grid_w] per image.
-        embeddings_shape: [total_tokens, vision_hidden_dim].
+        embeddings_shape: [total_tokens, decode_embedding_dim].
     """
     if isinstance(image_data, Image.Image):
         images = [image_data]
@@ -132,7 +138,7 @@ def _compute_qwen_grid_thw(
         grid_thw.append([grid_t, grid_h, grid_w])
         total_tokens += (grid_t * grid_h * grid_w) // merge_sq
 
-    return grid_thw, [total_tokens, params.vision_hidden_dim]
+    return grid_thw, [total_tokens, params.decode_embedding_dim]
 
 
 def build_qwen_embedding_params(


### PR DESCRIPTION
## Overview:

Current qwen.py generates placeholders that use a fixed vision_embed dimention, which fails on models using deepstack like Qwen3-vl series. It causes a error in later tensor splitting when the placeholder is actually consumed.


## Where should the reviewer start?

components/src/dynamo/vllm/multimodal_utils/models/qwen.py

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated multimodal Qwen embedding shape reporting to use the correct decode embedding dimension.
  * Improved grid parameter handling so image embeddings now reflect the full expected token dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->