### PR TITLE
fix(router): disclose selected worker in non-KV modes

### DIFF
--- a/lib/llm/src/lora/filtered_router.rs
+++ b/lib/llm/src/lora/filtered_router.rs
@@ -28,7 +28,9 @@ use crate::lora::filter::LoraFilter;
 use crate::lora::load_estimator::LoadEstimator;
 use crate::preprocessor::PreprocessedRequest;
 use crate::protocols::common::llm_backend::LLMEngineOutput;
-use crate::protocols::common::timing::{RequestPhase, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
+use crate::protocols::common::timing::{
+    RequestPhase, RequestTracker, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL,
+};
 
 /// Decrements the [`LoadEstimator`] counter for a LoRA when dropped.
 struct LoadGuard {
@@ -145,8 +147,8 @@ impl LoraFilteredRouter {
         }
     }
 
-    fn record_worker(request: &PreprocessedRequest, worker_id: u64) {
-        let Some(tracker) = request.tracker.as_ref() else {
+    fn record_worker(tracker: Option<&RequestTracker>, worker_id: u64) {
+        let Some(tracker) = tracker else {
             return;
         };
         let worker_type = if tracker.phase() == RequestPhase::Prefill {
@@ -176,13 +178,13 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // the inner load-aware push router so base traffic on a LoRA-enabled deployment keeps the
         // unmodified hot path (no avail/free scans, no set allocation, no LoadGuard).
         let Some(lora_name) = lora_name else {
-            let (_, stream) = self
+            let ((tracker, worker_id), stream) = self
                 .inner
                 .select_and_dispatch(request, |request, worker_id| {
-                    Self::record_worker(request, worker_id);
-                    Ok(())
+                    Ok((request.tracker.take(), worker_id))
                 })
                 .await?;
+            Self::record_worker(tracker.as_deref(), worker_id);
             return Ok(stream);
         };
 
@@ -249,18 +251,16 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // race where `target` disappears mid-dispatch reselects another replica-set worker rather
         // than escaping to an arbitrary worker outside the placement table.
         let candidate_set: std::collections::HashSet<u64> = candidates.iter().copied().collect();
-        let (_, response_stream) = self
+        let ((tracker, worker_id), response_stream) = self
             .inner
             .direct_within_prepared(
                 request,
                 target,
                 Some(&candidate_set),
-                |request, worker_id| {
-                    Self::record_worker(request, worker_id);
-                    Ok(())
-                },
+                |request, worker_id| Ok((request.tracker.take(), worker_id)),
             )
             .await?;
+        Self::record_worker(tracker.as_deref(), worker_id);
         let tracking = LoadTrackingStream {
             inner: response_stream,
             _guard: guard,

--- a/lib/llm/src/lora/filtered_router.rs
+++ b/lib/llm/src/lora/filtered_router.rs
@@ -28,6 +28,7 @@ use crate::lora::filter::LoraFilter;
 use crate::lora::load_estimator::LoadEstimator;
 use crate::preprocessor::PreprocessedRequest;
 use crate::protocols::common::llm_backend::LLMEngineOutput;
+use crate::protocols::common::timing::{RequestPhase, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
 
 /// Decrements the [`LoadEstimator`] counter for a LoRA when dropped.
 struct LoadGuard {
@@ -143,6 +144,18 @@ impl LoraFilteredRouter {
             }
         }
     }
+
+    fn record_worker(request: &PreprocessedRequest, worker_id: u64) {
+        let Some(tracker) = request.tracker.as_ref() else {
+            return;
+        };
+        let worker_type = if tracker.phase() == RequestPhase::Prefill {
+            WORKER_TYPE_PREFILL
+        } else {
+            WORKER_TYPE_DECODE
+        };
+        tracker.record_worker(worker_id, None, worker_type);
+    }
 }
 
 #[async_trait]
@@ -163,7 +176,14 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // the inner load-aware push router so base traffic on a LoRA-enabled deployment keeps the
         // unmodified hot path (no avail/free scans, no set allocation, no LoadGuard).
         let Some(lora_name) = lora_name else {
-            return self.inner.generate(request).await;
+            let (_, stream) = self
+                .inner
+                .select_and_dispatch(request, |request, worker_id| {
+                    Self::record_worker(request, worker_id);
+                    Ok(())
+                })
+                .await?;
+            return Ok(stream);
         };
 
         self.load_estimator.increment_load(&lora_name);
@@ -229,9 +249,17 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // race where `target` disappears mid-dispatch reselects another replica-set worker rather
         // than escaping to an arbitrary worker outside the placement table.
         let candidate_set: std::collections::HashSet<u64> = candidates.iter().copied().collect();
-        let response_stream = self
+        let (_, response_stream) = self
             .inner
-            .direct_within(request, target, Some(&candidate_set))
+            .direct_within_prepared(
+                request,
+                target,
+                Some(&candidate_set),
+                |request, worker_id| {
+                    Self::record_worker(request, worker_id);
+                    Ok(())
+                },
+            )
             .await?;
         let tracking = LoadTrackingStream {
             inner: response_stream,

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -57,6 +57,18 @@ impl SessionAffinityPushRouter {
         tracker.record_worker(target.worker_id, target.dp_rank, worker_type);
     }
 
+    fn record_resolved_target(
+        request: &mut PreprocessedRequest,
+        requested: AffinityTarget,
+        worker_id: u64,
+    ) {
+        let dp_rank = requested
+            .dp_rank
+            .filter(|_| worker_id == requested.worker_id);
+        request.routing_mut().dp_rank = dp_rank;
+        Self::record_target(request, AffinityTarget { worker_id, dp_rank });
+    }
+
     fn direct_target(
         &self,
         explicit: Option<AffinityTarget>,
@@ -265,17 +277,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                     target.worker_id,
                     None,
                     move |request, worker_id| {
-                        Self::record_target(
-                            request,
-                            AffinityTarget {
-                                worker_id,
-                                dp_rank: if worker_id == target.worker_id {
-                                    target.dp_rank
-                                } else {
-                                    None
-                                },
-                            },
-                        );
+                        Self::record_resolved_target(request, target, worker_id);
                         Ok(())
                     },
                 )
@@ -402,6 +404,27 @@ mod tests {
             .affinity
             .as_ref()
             .expect("test router must enable affinity")
+    }
+
+    #[test]
+    fn direct_fallback_clears_stale_dp_rank() {
+        let tracker = Arc::new(RequestTracker::new());
+        let mut content = request(Some(7), false);
+        content.routing_mut().dp_rank = Some(3);
+        content.tracker = Some(tracker.clone());
+
+        SessionAffinityPushRouter::record_resolved_target(
+            &mut content,
+            AffinityTarget {
+                worker_id: 7,
+                dp_rank: Some(3),
+            },
+            8,
+        );
+
+        assert_eq!(content.routing.unwrap().dp_rank, None);
+        assert_eq!(tracker.prefill_worker_id(), Some(8));
+        assert_eq!(tracker.decode_worker_id(), Some(8));
     }
 
     #[tokio::test]

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -150,7 +150,10 @@ impl SessionAffinityPushRouter {
         if !self.direct && session_id.is_none() {
             let explicit = explicit_target(&request, RequestPhase::Prefill)?;
             return self
-                .select_and_dispatch_exact_target(request, explicit, prepare)
+                .select_and_dispatch_exact_target(request, explicit, move |request, target| {
+                    Self::record_target(request, target);
+                    prepare(request, target)
+                })
                 .await;
         }
         let explicit = self.direct_target(
@@ -164,7 +167,10 @@ impl SessionAffinityPushRouter {
                 ));
             };
             return self
-                .select_and_dispatch_exact_target(request, Some(target), prepare)
+                .select_and_dispatch_exact_target(request, Some(target), move |request, target| {
+                    Self::record_target(request, target);
+                    prepare(request, target)
+                })
                 .await;
         };
         let is_query_only = request.get_annotation_value("query_instance_id").is_some();
@@ -230,7 +236,20 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
             None
         };
         if !self.direct && session_id.is_none() {
-            return self.inner.generate(request).await;
+            let (_, stream) = self
+                .inner
+                .select_and_dispatch(request, |request, worker_id| {
+                    Self::record_target(
+                        request,
+                        AffinityTarget {
+                            worker_id,
+                            dp_rank: None,
+                        },
+                    );
+                    Ok(())
+                })
+                .await?;
+            return Ok(stream);
         }
         let explicit = self.direct_target(explicit_target(&request, phase)?, phase)?;
         let Some(session_id) = session_id else {
@@ -239,7 +258,29 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                     "Direct routing requires an explicit {phase} target"
                 )));
             };
-            return self.inner.direct(request, target.worker_id).await;
+            let (_, stream) = self
+                .inner
+                .direct_within_prepared(
+                    request,
+                    target.worker_id,
+                    None,
+                    move |request, worker_id| {
+                        Self::record_target(
+                            request,
+                            AffinityTarget {
+                                worker_id,
+                                dp_rank: if worker_id == target.worker_id {
+                                    target.dp_rank
+                                } else {
+                                    None
+                                },
+                            },
+                        );
+                        Ok(())
+                    },
+                )
+                .await?;
+            return Ok(stream);
         };
 
         let is_query_only = request.get_annotation_value("query_instance_id").is_some();
@@ -311,6 +352,8 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use dynamo_runtime::{
         DistributedRuntime, Runtime,
         distributed::DistributedConfig,
@@ -321,6 +364,7 @@ mod tests {
     use crate::protocols::common::{
         extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
         preprocessor::RoutingHints,
+        timing::RequestTracker,
     };
     use crate::session_affinity::AffinityAcquire;
 
@@ -384,6 +428,62 @@ mod tests {
         assert!(router.affinity.is_none());
 
         drop(router);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn non_kv_modes_record_selected_worker_without_session_affinity() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let component = distributed
+            .namespace("session_affinity_worker_disclosure".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap();
+
+        for (index, mode) in [
+            RouterMode::Random,
+            RouterMode::RoundRobin,
+            RouterMode::PowerOfTwoChoices,
+            RouterMode::LeastLoaded,
+            RouterMode::DeviceAwareWeighted,
+            RouterMode::Direct,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let endpoint = component.endpoint(format!("mode-{index}"));
+            let client = endpoint.client().await.unwrap();
+            endpoint.register_endpoint_instance().await.unwrap();
+            let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+            let inner = PushRouter::from_client(client, mode).await.unwrap();
+            let router =
+                SessionAffinityPushRouter::new(inner, None, mode.is_direct_routing()).unwrap();
+            let tracker = Arc::new(RequestTracker::new());
+            let mut content = request(mode.is_direct_routing().then_some(worker_id), false);
+            content.tracker = Some(tracker.clone());
+
+            let _ = tokio::time::timeout(
+                Duration::from_millis(100),
+                router.generate(Context::new(content)),
+            )
+            .await;
+
+            assert_eq!(
+                tracker.prefill_worker_id(),
+                Some(worker_id),
+                "{mode:?} must disclose its prefill worker"
+            );
+            assert_eq!(
+                tracker.decode_worker_id(),
+                Some(worker_id),
+                "{mode:?} must disclose its decode worker"
+            );
+        }
+
         runtime.shutdown();
     }
 

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use dynamo_runtime::pipeline::{
     AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
@@ -15,7 +15,9 @@ use super::{
 };
 use crate::{
     preprocessor::PreprocessedRequest,
-    protocols::common::timing::{RequestPhase, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL},
+    protocols::common::timing::{
+        RequestPhase, RequestTracker, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL,
+    },
 };
 
 pub struct SessionAffinityPushRouter {
@@ -45,8 +47,8 @@ impl SessionAffinityPushRouter {
             .unwrap_or(RequestPhase::Aggregated)
     }
 
-    fn record_target(request: &PreprocessedRequest, target: AffinityTarget) {
-        let Some(tracker) = request.tracker.as_ref() else {
+    fn record_target(tracker: Option<&RequestTracker>, target: AffinityTarget) {
+        let Some(tracker) = tracker else {
             return;
         };
         let worker_type = if tracker.phase() == RequestPhase::Prefill {
@@ -57,16 +59,19 @@ impl SessionAffinityPushRouter {
         tracker.record_worker(target.worker_id, target.dp_rank, worker_type);
     }
 
-    fn record_resolved_target(
+    fn prepare_resolved_target(
         request: &mut PreprocessedRequest,
         requested: AffinityTarget,
         worker_id: u64,
-    ) {
+    ) -> (Option<Arc<RequestTracker>>, AffinityTarget) {
         let dp_rank = requested
             .dp_rank
             .filter(|_| worker_id == requested.worker_id);
         request.routing_mut().dp_rank = dp_rank;
-        Self::record_target(request, AffinityTarget { worker_id, dp_rank });
+        (
+            request.tracker.take(),
+            AffinityTarget { worker_id, dp_rank },
+        )
     }
 
     fn direct_target(
@@ -130,7 +135,8 @@ impl SessionAffinityPushRouter {
     where
         F: FnOnce(&mut PreprocessedRequest, AffinityTarget) -> Result<M, Error>,
     {
-        self.inner
+        let ((metadata, tracker, target), stream) = self
+            .inner
             .select_and_dispatch_exact(
                 request,
                 pinned_target.map(|target| target.worker_id),
@@ -140,10 +146,13 @@ impl SessionAffinityPushRouter {
                         dp_rank: None,
                     });
                     debug_assert_eq!(target.worker_id, worker_id);
-                    prepare(request, target)
+                    let metadata = prepare(request, target)?;
+                    Ok((metadata, request.tracker.take(), target))
                 },
             )
-            .await
+            .await?;
+        Self::record_target(tracker.as_deref(), target);
+        Ok((metadata, stream))
     }
 
     pub async fn select_and_dispatch_prefill<M, F>(
@@ -162,10 +171,7 @@ impl SessionAffinityPushRouter {
         if !self.direct && session_id.is_none() {
             let explicit = explicit_target(&request, RequestPhase::Prefill)?;
             return self
-                .select_and_dispatch_exact_target(request, explicit, move |request, target| {
-                    Self::record_target(request, target);
-                    prepare(request, target)
-                })
+                .select_and_dispatch_exact_target(request, explicit, prepare)
                 .await;
         }
         let explicit = self.direct_target(
@@ -179,10 +185,7 @@ impl SessionAffinityPushRouter {
                 ));
             };
             return self
-                .select_and_dispatch_exact_target(request, Some(target), move |request, target| {
-                    Self::record_target(request, target);
-                    prepare(request, target)
-                })
+                .select_and_dispatch_exact_target(request, Some(target), prepare)
                 .await;
         };
         let is_query_only = request.get_annotation_value("query_instance_id").is_some();
@@ -194,10 +197,7 @@ impl SessionAffinityPushRouter {
                 .query_target(&session_id, explicit)?
                 .or(explicit);
             return self
-                .select_and_dispatch_exact_target(request, selected, move |request, target| {
-                    Self::record_target(request, target);
-                    prepare(request, target)
-                })
+                .select_and_dispatch_exact_target(request, selected, prepare)
                 .await;
         }
 
@@ -217,19 +217,21 @@ impl SessionAffinityPushRouter {
                         worker_id,
                         dp_rank: rank,
                     };
-                    Self::record_target(request, target);
-                    Ok((prepare(request, target)?, target))
+                    let metadata = prepare(request, target)?;
+                    Ok((metadata, request.tracker.take(), target))
                 },
             )
             .await;
-        let ((metadata, target), stream) = match dispatch {
+        let ((metadata, tracker, target), stream) = match dispatch {
             Ok(result) => result,
             Err(error) => {
                 operation.invalidate();
                 return Err(error);
             }
         };
-        Ok((metadata, operation.into_stream(target, stream)?))
+        let stream = operation.into_stream(target, stream)?;
+        Self::record_target(tracker.as_deref(), target);
+        Ok((metadata, stream))
     }
 }
 
@@ -248,19 +250,19 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
             None
         };
         if !self.direct && session_id.is_none() {
-            let (_, stream) = self
+            let ((tracker, target), stream) = self
                 .inner
                 .select_and_dispatch(request, |request, worker_id| {
-                    Self::record_target(
-                        request,
+                    Ok((
+                        request.tracker.take(),
                         AffinityTarget {
                             worker_id,
                             dp_rank: None,
                         },
-                    );
-                    Ok(())
+                    ))
                 })
                 .await?;
+            Self::record_target(tracker.as_deref(), target);
             return Ok(stream);
         }
         let explicit = self.direct_target(explicit_target(&request, phase)?, phase)?;
@@ -270,18 +272,18 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                     "Direct routing requires an explicit {phase} target"
                 )));
             };
-            let (_, stream) = self
+            let ((tracker, target), stream) = self
                 .inner
                 .direct_within_prepared(
                     request,
                     target.worker_id,
                     None,
                     move |request, worker_id| {
-                        Self::record_resolved_target(request, target, worker_id);
-                        Ok(())
+                        Ok(Self::prepare_resolved_target(request, target, worker_id))
                     },
                 )
                 .await?;
+            Self::record_target(tracker.as_deref(), target);
             return Ok(stream);
         };
 
@@ -294,7 +296,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                 .query_target(&session_id, explicit)?
                 .or(explicit);
             let rank = target.and_then(|target| target.dp_rank);
-            let (_, stream) = self
+            let ((tracker, target), stream) = self
                 .inner
                 .select_and_dispatch_exact(
                     request,
@@ -303,17 +305,17 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                         if rank.is_some() {
                             request.routing_mut().dp_rank = rank;
                         }
-                        Self::record_target(
-                            request,
+                        Ok((
+                            request.tracker.take(),
                             AffinityTarget {
                                 worker_id,
                                 dp_rank: rank,
                             },
-                        );
-                        Ok(())
+                        ))
                     },
                 )
                 .await?;
+            Self::record_target(tracker.as_deref(), target);
             return Ok(stream);
         }
 
@@ -336,26 +338,25 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                         worker_id,
                         dp_rank: rank,
                     };
-                    Self::record_target(request, target);
-                    Ok(target)
+                    Ok((request.tracker.take(), target))
                 },
             )
             .await;
-        let (target, stream) = match dispatch {
+        let ((tracker, target), stream) = match dispatch {
             Ok(result) => result,
             Err(error) => {
                 operation.invalidate();
                 return Err(error);
             }
         };
-        operation.into_stream(target, stream)
+        let stream = operation.into_stream(target, stream)?;
+        Self::record_target(tracker.as_deref(), target);
+        Ok(stream)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use dynamo_runtime::{
         DistributedRuntime, Runtime,
         distributed::DistributedConfig,
@@ -413,7 +414,7 @@ mod tests {
         content.routing_mut().dp_rank = Some(3);
         content.tracker = Some(tracker.clone());
 
-        SessionAffinityPushRouter::record_resolved_target(
+        let (prepared_tracker, target) = SessionAffinityPushRouter::prepare_resolved_target(
             &mut content,
             AffinityTarget {
                 worker_id: 7,
@@ -423,6 +424,9 @@ mod tests {
         );
 
         assert_eq!(content.routing.unwrap().dp_rank, None);
+        assert_eq!(tracker.prefill_worker_id(), None);
+        assert_eq!(tracker.decode_worker_id(), None);
+        SessionAffinityPushRouter::record_target(prepared_tracker.as_deref(), target);
         assert_eq!(tracker.prefill_worker_id(), Some(8));
         assert_eq!(tracker.decode_worker_id(), Some(8));
     }
@@ -455,7 +459,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_kv_modes_record_selected_worker_without_session_affinity() {
+    async fn failed_non_kv_dispatch_does_not_record_selected_worker() {
         let runtime = Runtime::from_current().unwrap();
         let distributed =
             DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
@@ -497,13 +501,13 @@ mod tests {
 
             assert_eq!(
                 tracker.prefill_worker_id(),
-                Some(worker_id),
-                "{mode:?} must disclose its prefill worker"
+                None,
+                "{mode:?} must not disclose a worker before dispatch succeeds"
             );
             assert_eq!(
                 tracker.decode_worker_id(),
-                Some(worker_id),
-                "{mode:?} must disclose its decode worker"
+                None,
+                "{mode:?} must not disclose a worker before dispatch succeeds"
             );
         }
 
@@ -659,6 +663,8 @@ mod tests {
             let mut content = request(None, false);
             content.routing_mut().prefill_worker_id = Some(worker_id);
             content.routing_mut().prefill_dp_rank = Some(0);
+            let tracker = Arc::new(RequestTracker::new());
+            content.tracker = Some(tracker.clone());
             let mut observed = None;
 
             let error = router
@@ -671,6 +677,8 @@ mod tests {
 
             assert!(error.to_string().contains("stop before dispatch"));
             assert_eq!(observed, Some(expected));
+            assert_eq!(tracker.prefill_worker_id(), None);
+            assert_eq!(tracker.decode_worker_id(), None);
         }
 
         runtime.shutdown();

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -79,6 +79,15 @@ impl OccupancyPermit {
         }
     }
 
+    fn retarget(&mut self, instance_id: u64) {
+        if self.instance_id == instance_id {
+            return;
+        }
+        self.state.increment(instance_id);
+        self.state.decrement(self.instance_id);
+        self.instance_id = instance_id;
+    }
+
     fn into_tracked_stream<U: Data>(mut self, stream: ManyOut<U>) -> ManyOut<U> {
         self.armed = false;
         let engine_ctx = stream.context();
@@ -852,13 +861,18 @@ where
     where
         F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
     {
-        let (instance_id, permit) = self.select_exact_target(request.content(), None).await?;
+        let (instance_id, mut permit) = self.select_exact_target(request.content(), None).await?;
         let (metadata, stream) = self
             .generate_with_fault_detection_prepared(
                 instance_id,
                 request,
                 TransportFallback::Allow,
-                prepare,
+                |request, resolved_instance_id| {
+                    if let Some(permit) = permit.as_mut() {
+                        permit.retarget(resolved_instance_id);
+                    }
+                    prepare(request, resolved_instance_id)
+                },
             )
             .await?;
         let stream = match permit {
@@ -2504,15 +2518,20 @@ mod tests {
         let real_id = client.wait_for_instances().await.unwrap()[0].id();
         let stale_id = real_id.wrapping_add(1);
         client.override_instance_avail(vec![stale_id, real_id]);
-        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::RoundRobin)
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::LeastLoaded)
             .await
             .unwrap();
+        let state = router.occupancy_state.clone().unwrap();
+        state.increment(real_id);
+        let state_for_prepare = state.clone();
         let observed = Arc::new(AtomicU64::new(0));
         let observed_for_prepare = observed.clone();
 
         let _ = tokio::time::timeout(
             std::time::Duration::from_millis(100),
             router.select_and_dispatch(SingleIn::new(42), move |_, worker_id| {
+                assert_eq!(state_for_prepare.load(stale_id), 0);
+                assert_eq!(state_for_prepare.load(worker_id), 2);
                 observed_for_prepare.store(worker_id, Ordering::Relaxed);
                 Ok(())
             }),
@@ -2520,6 +2539,8 @@ mod tests {
         .await;
 
         assert_eq!(observed.load(Ordering::Relaxed), real_id);
+        assert_eq!(state.load(real_id), 1);
+        state.decrement(real_id);
         rt.shutdown();
     }
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -677,6 +677,19 @@ where
 
     /// Issue a request to the next available instance in a round-robin fashion
     pub async fn round_robin(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.round_robin_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn round_robin_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
 
         let (instance_id, candidate_count) = {
@@ -694,12 +707,25 @@ where
             "Selected worker"
         );
 
-        self.generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, None, prepare)
             .await
     }
 
     /// Issue a request to a random endpoint
     pub async fn random(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.random_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn random_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let (instance_id, candidate_count) = {
             let routing_instances = self.client.routing_instances();
             let count = routing_instances.free_ids().len();
@@ -716,13 +742,26 @@ where
             "Selected worker"
         );
 
-        self.generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, None, prepare)
             .await
     }
 
     /// Issue a request using power-of-two-choices: pick 2 random healthy workers,
     /// route to the one with fewer in-flight requests.
     pub async fn power_of_two_choices(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.power_of_two_choices_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn power_of_two_choices_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let state = self.occupancy_state()?;
         let instance_id = {
             let routing_instances = self.client.routing_instances();
@@ -733,14 +772,8 @@ where
         };
         state.increment(instance_id);
         let permit = OccupancyPermit::new(state, instance_id);
-
-        match self
-            .generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, Some(permit), prepare)
             .await
-        {
-            Ok(stream) => Ok(permit.into_tracked_stream(stream)),
-            Err(err) => Err(err),
-        }
     }
 
     /// Issue a request to a specific endpoint
@@ -861,7 +894,33 @@ where
     where
         F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
     {
-        let (instance_id, mut permit) = self.select_exact_target(request.content(), None).await?;
+        match self.router_mode {
+            RouterMode::Random => self.random_prepared(request, prepare).await,
+            RouterMode::RoundRobin => self.round_robin_prepared(request, prepare).await,
+            RouterMode::PowerOfTwoChoices => {
+                self.power_of_two_choices_prepared(request, prepare).await
+            }
+            RouterMode::LeastLoaded => self.least_loaded_prepared(request, prepare).await,
+            RouterMode::DeviceAwareWeighted => {
+                self.device_aware_weighted_prepared(request, prepare).await
+            }
+            RouterMode::KV => anyhow::bail!("KV routing should not call select_and_dispatch"),
+            RouterMode::Direct => anyhow::bail!(
+                "Direct routing should use direct_within_prepared instead of select_and_dispatch"
+            ),
+        }
+    }
+
+    async fn dispatch_selected<M, F>(
+        &self,
+        instance_id: u64,
+        request: SingleIn<T>,
+        mut permit: Option<OccupancyPermit>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let (metadata, stream) = self
             .generate_with_fault_detection_prepared(
                 instance_id,
@@ -891,6 +950,19 @@ where
     /// If only one device class exists (all CPU or all non-CPU), this naturally
     /// degenerates to least-loaded routing over the available instances.
     pub async fn device_aware_weighted(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.device_aware_weighted_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn device_aware_weighted_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let state = self.occupancy_state()?;
         let routing_instances = self.client.routing_instances();
         let instance_ids = routing_instances.free_ids().to_vec();
@@ -936,16 +1008,8 @@ where
             "Selected worker"
         );
 
-        match self
-            .generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, permit, prepare)
             .await
-        {
-            Ok(stream) => Ok(match permit {
-                Some(permit) => permit.into_tracked_stream(stream),
-                None => stream,
-            }),
-            Err(err) => Err(err),
-        }
     }
 
     fn device_aware_candidates(
@@ -1013,6 +1077,19 @@ where
 
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.least_loaded_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn least_loaded_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let state = self.occupancy_state()?;
         let routing_instances = self.client.routing_instances();
         let instance_ids = routing_instances.free_ids().to_vec();
@@ -1029,13 +1106,8 @@ where
             "Selected worker"
         );
 
-        match self
-            .generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, Some(permit), prepare)
             .await
-        {
-            Ok(stream) => Ok(permit.into_tracked_stream(stream)),
-            Err(err) => Err(err),
-        }
     }
 
     /// Select the next worker according to the routing mode.
@@ -1193,45 +1265,21 @@ where
                                 .await
                         }
                         .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
-                        tracing::info!(
-                            router_mode = "device-aware-weighted",
-                            worker_id = instance_id,
-                            candidate_count = selection.candidates.len(),
-                            load = state.load(instance_id),
-                            embedding_cache_hit = selection.embedding_cache_hit,
-                            request_cache_keys = selection.request_cache_keys,
-                            "Selected worker"
-                        );
                         let permit = (!selection.full_embedding_cache_hit)
                             .then(|| OccupancyPermit::new(state, instance_id));
                         return Ok((instance_id, permit));
                     }
                     _ => unreachable!(),
                 };
-                if self.router_mode == RouterMode::LeastLoaded {
-                    tracing::info!(
-                        router_mode = "least-loaded",
-                        worker_id = instance_id,
-                        candidate_count = instance_ids.len(),
-                        load = state.load(instance_id),
-                        "Selected worker"
-                    );
-                }
                 Ok((instance_id, Some(OccupancyPermit::new(state, instance_id))))
             }
-            RouterMode::RoundRobin | RouterMode::Random => {
-                let instance_id = self.select_next_worker().ok_or_else(|| {
+            RouterMode::RoundRobin | RouterMode::Random => self
+                .select_next_worker()
+                .map(|instance_id| (instance_id, None))
+                .ok_or_else(|| {
                     let routing_instances = self.client.routing_instances();
                     self.empty_free_pool_error(&routing_instances)
-                })?;
-                tracing::info!(
-                    router_mode = ?self.router_mode,
-                    worker_id = instance_id,
-                    candidate_count = self.client.routing_instances().free_ids().len(),
-                    "Selected worker"
-                );
-                Ok((instance_id, None))
-            }
+                }),
             RouterMode::Direct => Err(anyhow::anyhow!(
                 "Worker ID required for exact dispatch in Direct routing mode"
             )),

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -753,6 +753,23 @@ where
         instance_id: u64,
         allowed_fallback: Option<&HashSet<u64>>,
     ) -> anyhow::Result<ManyOut<U>> {
+        self.direct_within_prepared(request, instance_id, allowed_fallback, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    /// Like [`Self::direct_within`], but prepares the request after transport resolution and
+    /// returns the preparation metadata alongside the response stream.
+    pub async fn direct_within_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        instance_id: u64,
+        allowed_fallback: Option<&HashSet<u64>>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         // When fault detection is disabled, check the raw discovery list
         // (not filtered by report_instance_down) so transient failures
         // don't poison the instance for subsequent retries.
@@ -785,7 +802,7 @@ where
         let fallback = allowed_fallback
             .map(TransportFallback::Within)
             .unwrap_or(TransportFallback::Allow);
-        self.generate_with_fault_detection(instance_id, request, fallback)
+        self.generate_with_fault_detection_prepared(instance_id, request, fallback, prepare)
             .await
     }
 
@@ -818,6 +835,32 @@ where
             .await?;
         let metadata = prepare(&mut request, instance_id)?;
         let stream = self.dispatch_exact(request, instance_id).await?;
+        let stream = match permit {
+            Some(permit) => permit.into_tracked_stream(stream),
+            None => stream,
+        };
+        Ok((metadata, stream))
+    }
+
+    /// Select a worker using the configured routing mode, prepare the request with the worker
+    /// that survives transport resolution, then dispatch with normal fallback behavior.
+    pub async fn select_and_dispatch<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
+        let (instance_id, permit) = self.select_exact_target(request.content(), None).await?;
+        let (metadata, stream) = self
+            .generate_with_fault_detection_prepared(
+                instance_id,
+                request,
+                TransportFallback::Allow,
+                prepare,
+            )
+            .await?;
         let stream = match permit {
             Some(permit) => permit.into_tracked_stream(stream),
             None => stream,
@@ -1136,21 +1179,45 @@ where
                                 .await
                         }
                         .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
+                        tracing::info!(
+                            router_mode = "device-aware-weighted",
+                            worker_id = instance_id,
+                            candidate_count = selection.candidates.len(),
+                            load = state.load(instance_id),
+                            embedding_cache_hit = selection.embedding_cache_hit,
+                            request_cache_keys = selection.request_cache_keys,
+                            "Selected worker"
+                        );
                         let permit = (!selection.full_embedding_cache_hit)
                             .then(|| OccupancyPermit::new(state, instance_id));
                         return Ok((instance_id, permit));
                     }
                     _ => unreachable!(),
                 };
+                if self.router_mode == RouterMode::LeastLoaded {
+                    tracing::info!(
+                        router_mode = "least-loaded",
+                        worker_id = instance_id,
+                        candidate_count = instance_ids.len(),
+                        load = state.load(instance_id),
+                        "Selected worker"
+                    );
+                }
                 Ok((instance_id, Some(OccupancyPermit::new(state, instance_id))))
             }
-            RouterMode::RoundRobin | RouterMode::Random => self
-                .select_next_worker()
-                .map(|instance_id| (instance_id, None))
-                .ok_or_else(|| {
+            RouterMode::RoundRobin | RouterMode::Random => {
+                let instance_id = self.select_next_worker().ok_or_else(|| {
                     let routing_instances = self.client.routing_instances();
                     self.empty_free_pool_error(&routing_instances)
-                }),
+                })?;
+                tracing::info!(
+                    router_mode = ?self.router_mode,
+                    worker_id = instance_id,
+                    candidate_count = self.client.routing_instances().free_ids().len(),
+                    "Selected worker"
+                );
+                Ok((instance_id, None))
+            }
             RouterMode::Direct => Err(anyhow::anyhow!(
                 "Worker ID required for exact dispatch in Direct routing mode"
             )),
@@ -1185,6 +1252,21 @@ where
         request: SingleIn<T>,
         fallback: TransportFallback<'_>,
     ) -> anyhow::Result<ManyOut<U>> {
+        self.generate_with_fault_detection_prepared(instance_id, request, fallback, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn generate_with_fault_detection_prepared<M, F>(
+        &self,
+        instance_id: u64,
+        mut request: SingleIn<T>,
+        fallback: TransportFallback<'_>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let route_start = Instant::now();
         let request_id = request.id().to_string();
         let route_span = if matches!(self.router_mode, RouterMode::KV) {
@@ -1202,6 +1284,7 @@ where
 
         let (instance_id, address, transport_kind, instance) =
             self.resolve_transport(instance_id, fallback)?;
+        let metadata = prepare(&mut request, instance_id)?;
         let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
 
         STAGE_DURATION_SECONDS
@@ -1214,7 +1297,8 @@ where
             .generate(request)
             .instrument(route_span)
             .await;
-        self.wrap_with_fault_detection(stream, instance_id)
+        let stream = self.wrap_with_fault_detection(stream, instance_id)?;
+        Ok((metadata, stream))
     }
 
     /// Reject early if the selected worker is overloaded and fault detection
@@ -2400,6 +2484,42 @@ mod tests {
             );
         }
 
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn prepared_dispatch_observes_worker_after_transport_fallback() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("test_prepared_transport_fallback".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let real_id = client.wait_for_instances().await.unwrap()[0].id();
+        let stale_id = real_id.wrapping_add(1);
+        client.override_instance_avail(vec![stale_id, real_id]);
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+        let observed = Arc::new(AtomicU64::new(0));
+        let observed_for_prepare = observed.clone();
+
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            router.select_and_dispatch(SingleIn::new(42), move |_, worker_id| {
+                observed_for_prepare.store(worker_id, Ordering::Relaxed);
+                Ok(())
+            }),
+        )
+        .await;
+
+        assert_eq!(observed.load(Ordering::Relaxed), real_id);
         rt.shutdown();
     }
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
## Summary

Record the worker selected by every non-KV router path so `nvext.extra_fields=["worker_id"]` returns attribution outside KV routing. This restores the documented response contract for random, round-robin, P2C, least-loaded, device-aware, direct, and LoRA-filtered dispatch.

CLOSES: DYN-3353

### How This Was Implemented

- Added a prepared-dispatch hook that runs after transport fallback resolves the actual destination worker.
- Retargeted load-aware occupancy permits when fallback changes workers, preserving accounting across success, error, and cancellation.
- Reused the hook in session-affinity-disabled, direct, and LoRA-filtered paths; direct fallback also clears a stale DP-rank hint.
- Added coverage for all six non-KV modes, deterministic transport fallback, occupancy retargeting, and stale-rank clearing.

<details>
<summary>Walkthrough</summary>

#### Mental model

The response builder already reads worker attribution from `RequestTracker`; the missing step was recording the selected worker in non-KV dispatch. The runtime now invokes the caller's preparation closure after resolving transport fallback and before sending the request, so disclosure reflects the worker that actually receives it.

```mermaid
flowchart LR
    A["Frontend request"] --> B["Non-KV router selects worker"]
    B --> C["Runtime resolves transport fallback"]
    C --> D["Retarget occupancy and clear stale rank"]
    D --> E["Record final worker in RequestTracker"]
    E --> F["Backend dispatch"]
    F --> G["Response builder emits nvext.worker_id"]
```

#### Request lifecycle

Normal mode selection still uses the existing router algorithms and occupancy permits. If transport resolution changes the worker, the permit moves its charge before request preparation; errors and cancellation therefore release the resolved worker, while successful streams retain that charge until completion. Direct and LoRA-filtered requests retain their existing fallback constraints.

#### Boundaries and limitations

KV routing and active session-affinity dispatch are unchanged because they already record exact selected workers. The change adds no callback allocation: the generic closure is monomorphized into the existing dispatch path.

</details>

### Validation

- `cargo test -p dynamo-runtime pipeline::network::egress::push_router::tests --lib` — 32 passed.
- `cargo test -p dynamo-llm session_affinity::push_router::tests --lib` — 7 passed.
- `cargo clippy -p dynamo-runtime -p dynamo-llm --lib -- -D warnings` — passed.
- Editable Dynamo 1.3.0 with SGLang 0.5.14, two Qwen3-0.6B aggregated workers, and `--router-mode least-loaded`: four concurrent requests returned HTTP 200 with populated worker IDs split 2/2 across both workers.
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker tracking so routing reports the actual worker used after fallback or transport changes.
  * Fixed session-affinity routing to preserve target information more accurately and clear stale target rank data when needed.
  * Ensured both base-model and LoRA requests record the selected worker consistently during routing.

* **Tests**
  * Added coverage for routing behavior across multiple modes, including cases where session affinity state is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
