### PR TITLE
fix(event-plane): share one ZMQ context across all sockets

### DIFF
--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -19,13 +19,22 @@ use async_stream::stream;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tmq::{
     AsZmqSocket, Context, Multipart, SocketBuilder,
     publish::{Publish, publish},
     subscribe::{Subscribe, subscribe},
 };
 use tokio::sync::{Mutex, broadcast};
+
+/// Returns the process-wide shared ZMQ context.
+///
+/// libzmq spawns background I/O threads per `Context`, so all PUB/SUB sockets
+/// share one. `zmq::Context` is reference-counted; clones drive the same context.
+fn shared_zmq_context() -> Context {
+    static CONTEXT: OnceLock<Context> = OnceLock::new();
+    CONTEXT.get_or_init(Context::new).clone()
+}
 
 /// High Water Mark (HWM) for ZMQ sockets.
 /// This controls the maximum number of messages that can be queued.
@@ -87,7 +96,7 @@ impl ZmqPubTransport {
             endpoint.to_string()
         };
 
-        let ctx = Context::new();
+        let ctx = shared_zmq_context();
         let socket = configure_publish_builder(publish(&ctx)).bind(&actual_endpoint)?;
 
         tracing::info!(
@@ -112,7 +121,7 @@ impl ZmqPubTransport {
 
     /// Connect to single broker XSUB endpoint (broker mode)
     pub async fn connect(xsub_endpoint: &str, topic: &str) -> Result<Self> {
-        let ctx = Context::new();
+        let ctx = shared_zmq_context();
         let socket = configure_publish_builder(publish(&ctx)).connect(xsub_endpoint)?;
 
         tracing::info!(
@@ -135,7 +144,7 @@ impl ZmqPubTransport {
             anyhow::bail!("Cannot connect to zero endpoints");
         };
 
-        let ctx = Context::new();
+        let ctx = shared_zmq_context();
         let socket = configure_publish_builder(publish(&ctx)).connect(first_endpoint)?;
 
         for endpoint in endpoints {
@@ -196,7 +205,7 @@ pub struct ZmqSubTransport {
 impl ZmqSubTransport {
     /// Create a new ZMQ subscriber by connecting to a single endpoint.
     pub async fn connect(endpoint: &str, topic: &str) -> Result<Self> {
-        let ctx = Context::new();
+        let ctx = shared_zmq_context();
         let socket = configure_subscribe_builder(subscribe(&ctx))
             .connect(endpoint)?
             .subscribe(topic.as_bytes())?;
@@ -234,7 +243,7 @@ impl ZmqSubTransport {
             anyhow::bail!("Cannot connect to zero endpoints");
         };
 
-        let ctx = Context::new();
+        let ctx = shared_zmq_context();
         let socket = configure_subscribe_builder(subscribe(&ctx))
             .connect(first_endpoint)?
             .subscribe(topic.as_bytes())?;


### PR DESCRIPTION
## Overview

Fixes #11243.

In DIRECT (broker-less) event-plane mode, `ZmqPubTransport`/`ZmqSubTransport` call `zmq::Context::new()` on every `bind`/`connect`. A `zmq::Context` owns a libzmq background I/O thread pool, so creating one per socket makes the frontend's I/O-thread count grow O(number of connections) instead of O(1). The DIRECT-mode subscriber opens one socket per worker (`dynamic_subscriber.rs::consume_endpoint_stream` → `ZmqSubTransport::connect`), so the frontend's OS-thread count grew linearly with the fleet and was not reclaimed on disconnect, eventually starving the async runtime on CPU-constrained frontends and tripping the liveness probe → SIGKILL/restart loop.

## Change

Back every PUB/SUB socket with a single process-wide `Context` behind a `OnceLock`. `zmq::Context` is internally reference-counted and `Sync`, so cloning is cheap and all clones share one bounded I/O thread pool regardless of fleet size — turning per-worker thread growth into a constant.

All five `Context::new()` call sites in `zmq_transport.rs` now use `shared_zmq_context()`.

## Verification

In our deployment this path previously accumulated ~240 `tokio-runtime-worker` threads for a 55-worker frontend on an 8-core quota (probe failures + restart loop). With this change the same path held flat at ~34 threads through a 16-worker / 33-connection scale-up.

## Details

See #11243 for full root-cause analysis, reproduction, and environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved transport connection handling by reusing a single shared messaging context across publishers and subscribers.
  * Reduced per-connection overhead while keeping message delivery and subscription behavior unchanged.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->